### PR TITLE
Fix undefined mutable params

### DIFF
--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -397,11 +397,11 @@ class Param(IndexedComponent):
         # Set the parameter
         #
         if self._mutable:
-            if idx is None:
-                self._raw_setitem(idx, val)
-            else:
+            if self.is_indexed():
                 self._data[idx] = _ParamData(self, val)
                 #self._raw_setitem(idx, _ParamData(self, val), True)
+            else:
+                self._raw_setitem(idx, val)
             return self[idx]
         else:
             #
@@ -486,7 +486,7 @@ class Param(IndexedComponent):
         #
         # Set the value depending on the type of param value.
         #
-        if ndx is None:
+        if not self.is_indexed():
             self.value = val
         elif self._mutable:
             if ndx in self._data:

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -71,6 +71,11 @@ class _ParamData(ComponentData, NumericValue):
         """
         Return the value of this object.
         """
+        if self.value is None:
+            raise ValueError(
+                "Error evaluating Param value (%s):\nThe Param value is "
+                "undefined and no default value is specified"
+                % ( self.name(True), ))
         return self.value
 
     def is_fixed(self):
@@ -370,7 +375,7 @@ class Param(IndexedComponent):
             else:
                 idx_str = '%s' % (self.name(True),)
             raise ValueError(
-                    "Error retrieving Param value (%s): The Param value is "
+                    "Error retrieving Param value (%s):\nThe Param value is "
                     "undefined and no default value is specified"
                     % ( idx_str,) )
         #

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -354,6 +354,17 @@ class Param(IndexedComponent):
                 "Error retrieving Param value (%s): This parameter has "
                 "not been constructed" % ( idx_str,) )
         if val is None:
+            # If the Param is mutable, then it is OK to create a Param
+            # implicitly ... the error will be tossed later when someone
+            # attempts to evaluate the value of the Param
+            if self._mutable:
+                if self.is_indexed():
+                    self._data[idx] = _ParamData(self, val)
+                    #self._raw_setitem(idx, _ParamData(self, val), True)
+                else:
+                    self._raw_setitem(idx, val)
+                return self[idx]
+
             if self.is_indexed():
                 idx_str = '%s[%s]' % (self.name(True), idx,)
             else:

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -288,7 +288,9 @@ class ParamTester(object):
             self.assertEqual( sorted(test), sorted(self.data.keys()) )
 
     def test_values(self):
-        expectException = len(self.sparse_data) < len(self.data) and not self.instance.A._default_val is None
+        expectException = False
+        #    len(self.sparse_data) < len(self.data) and \
+        #    not self.instance.A._mutable
         try:
             test = self.instance.A.values()
             #self.assertEqual( type(test), list )
@@ -297,13 +299,16 @@ class ParamTester(object):
                 self.validateDict(self.sparse_data.items(), test)
             else:
                 self.validateDict(self.data.items(), test)
-            #self.assertFalse(expectException)
+            self.assertFalse(expectException)
         except ValueError:
             if not expectException:
                 raise
 
     def test_items(self):
-        expectException = len(self.sparse_data) < len(self.data) and not self.instance.A._default_val is None
+        expectException = False
+        #                  len(self.sparse_data) < len(self.data) and \
+        #                  not self.instance.A._default_val is None and \
+        #                  not self.instance.A._mutable
         try:
             test = self.instance.A.items()
             #self.assertEqual( type(test), list )
@@ -311,7 +316,7 @@ class ParamTester(object):
                 self.validateDict(self.sparse_data.items(), test)
             else:
                 self.validateDict(self.data.items(), test)
-            #self.assertFalse(expectException)
+            self.assertFalse(expectException)
         except ValueError:
             if not expectException:
                 raise
@@ -321,7 +326,10 @@ class ParamTester(object):
         self.assertEqual( sorted(test), sorted(self.instance.A.keys()) )
 
     def test_itervalues(self):
-        expectException = len(self.sparse_data) < len(self.data) and not self.instance.A._default_val is None
+        expectException = False
+        #                  len(self.sparse_data) < len(self.data) and \
+        #                  not self.instance.A._default_val is None and \
+        #                  not self.instance.A._mutable
         try:
             test = itervalues(self.instance.A)
             test = zip(self.instance.A.keys(), test)
@@ -329,18 +337,23 @@ class ParamTester(object):
                 self.validateDict(self.sparse_data.items(), test)
             else:
                 self.validateDict(self.data.items(), test)
+            self.assertFalse(expectException)
         except ValueError:
             if not expectException:
                 raise
 
     def test_iteritems(self):
-        expectException = len(self.sparse_data) < len(self.data) and not self.instance.A._default_val is None
+        expectException = False
+        #                  len(self.sparse_data) < len(self.data) and \
+        #                  not self.instance.A._default_val is None and \
+        #                  not self.instance.A._mutable
         try:
             test = iteritems(self.instance.A)
             if self.instance.A._default_val is None:
                 self.validateDict(self.sparse_data.items(), test)
             else:
                 self.validateDict(self.data.items(), test)
+            self.assertFalse(expectException)
         except ValueError:
             if not expectException:
                 raise

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -866,7 +866,7 @@ class ScalarParam_mutable_noDefault(ScalarTester, unittest.TestCase):
         self.data = {None:None}
 
 
-class ScalarParam_mutable_floatDefault(ScalarTester, unittest.TestCase):
+class ScalarParam_mutable_init(ScalarTester, unittest.TestCase):
 
     def setUp(self, **kwds):
         #
@@ -874,6 +874,19 @@ class ScalarParam_mutable_floatDefault(ScalarTester, unittest.TestCase):
         #
         self.model = AbstractModel()
         ScalarTester.setUp(self, mutable=True, initialize=1.3, **kwds)
+
+        self.sparse_data = {None:1.3}
+        self.data = {None:1.3}
+
+
+class ScalarParam_mutable_floatDefault(ScalarTester, unittest.TestCase):
+
+    def setUp(self, **kwds):
+        #
+        # Sparse single-index Param, no default
+        #
+        self.model = AbstractModel()
+        ScalarTester.setUp(self, mutable=True, default=1.3, **kwds)
 
         self.sparse_data = {None:1.3}
         self.data = {None:1.3}

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -811,8 +811,10 @@ class ScalarTester(ParamTester):
 
     def test_call(self):
         #"""Check the use of the __call__ method"""
-        if not self.sparse_data:
-            self.assertRaises(ValueError, self.instance.A)
+        if self.sparse_data.get(None,None) is None: #not self.sparse_data:
+            self.assertRaisesRegexp(
+                ValueError, ".*undefined and no default value",
+                self.instance.A.__call__ )
         else:
             self.assertEqual(self.instance.A(), self.data[None])
 

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -407,6 +407,30 @@ class ParamTester(object):
         #"""Check the use of index"""
         self.assertEqual( len(self.instance.A.index_set()), len(list(self.data.keys())) )
 
+    def test_get_default(self):
+        if len(self.sparse_data) == len(self.data):
+            # nothing to test
+            return
+        idx = list(set(self.data) - set(self.sparse_data))[0]
+        expectException = self.instance.A._default_val is None and \
+                          not self.instance.A._mutable
+        try:
+            test = self.instance.A[idx]
+            if expectException:
+                self.fail("Expected the test to raise an exception")
+            self.assertFalse(expectException)
+            expectException = self.instance.A._default_val is None
+            try:
+                ans = value(test)
+                self.assertEquals(ans, value(self.instance.A._default_val))
+                self.assertFalse(expectException)
+            except:
+                if not expectException:
+                    raise
+        except ValueError:
+            if not expectException:
+                raise
+
 
 class ArrayParam_mutable_sparse_noDefault\
           (ParamTester, unittest.TestCase):


### PR DESCRIPTION
This change started with @ghackebeil observing that the following seemingly innocuous example generates an exception:

```
from pyomo.environ import *

model = ConcreteModel()

model.p_index = Set(initialize=list(range(100)))
model.p = Param(model.p_index, mutable=True)
model.e = Expression(
    expr= sum(1 - model.p[i] for i in model.p_index))
```

His original argument was that as a _mutable_ `Param`, it should be OK to implicitly declare the Param without providing any initial value (leaving it to the user to set the value some time later before sending the model to the writer/solver).  He also pointed out that this kind of behavior _is_ supported for Simple Params, so it should work for Indexed Params.

Originally, I agreed that this was a "no brainer" change, but then fell back to how we explain "Abstract vs Concrete Models": with abstract models, we parse the model first and then load the data into it; and with concrete models, all the data is present when the model is constructed.  This change request is effectively asking for a third mode where not all of the the necessary data is present when the model is constructed.

Is this a change we want to make?