### PR TITLE
Make .name a property method

### DIFF
--- a/doc/GettingStarted/current/examples/block_iter_example.py
+++ b/doc/GettingStarted/current/examples/block_iter_example.py
@@ -26,9 +26,9 @@ model.pprint()
 
 # @compprintloop:
 for v in model.component_objects(Var):
-    print("FOUND VAR:" + v.name(True))
+    print("FOUND VAR:" + v.name)
     v.pprint()
 
 for v_data in model.component_data_objects(Var):
-    print("Found: "+v_data.name(True)+", value = "+str(value(v_data)))
+    print("Found: "+v_data.name+", value = "+str(value(v_data)))
 # @:compprintloop

--- a/examples/dae/run_Path_Constraint.py
+++ b/examples/dae/run_Path_Constraint.py
@@ -31,8 +31,8 @@ def plotter(subplot, x, *y, **kwds):
         if kwds.get('points', False):
             plt.plot(list(x), [value(_y[t]) for t in x], 'o')
     plt.title(kwds.get('title',''))
-    plt.legend(tuple(_y.name() for _y in y))
-    plt.xlabel(x.name())
+    plt.legend(tuple(_y.name for _y in y))
+    plt.xlabel(x.name)
 
 import matplotlib.pyplot as plt
 plotter(121, m.t, m.x1, m.x2, title='Differential Variables')

--- a/examples/doc/pyomobook/blocks/blocks_intro.py
+++ b/examples/doc/pyomobook/blocks/blocks_intro.py
@@ -12,10 +12,10 @@ model.b.b.x = Var()
 # @:hierarchy
 
 # @hierarchyprint:
-print(model.x.name(fully_qualified=False))     # x
-print(model.x.name(fully_qualified=True))      # x
-print(model.b.x.name(fully_qualified=False))   # x
-print(model.b.x.name(fully_qualified=True))    # b.x
-print(model.b.b.x.name(fully_qualified=False)) # x
-print(model.b.b.x.name(fully_qualified=True))  # b.b.x
+print(model.x.local_name)     # x
+print(model.x.name)           # x
+print(model.b.x.local_name)   # x
+print(model.b.x.name)         # b.x
+print(model.b.b.x.local_name) # x
+print(model.b.b.x.name)       # b.b.x
 # @:hierarchyprint

--- a/examples/doc/pyomobook/blocks/blocks_lotsizing.py
+++ b/examples/doc/pyomobook/blocks/blocks_lotsizing.py
@@ -44,4 +44,4 @@ solver.solve(model)
 
 ### print the results
 for v in model.ib[:].y:
-    print(v.name(fully_qualified=True), value(v))
+    print(v.name, value(v))

--- a/examples/doc/pyomobook/blocks/lotsizing.py
+++ b/examples/doc/pyomobook/blocks/lotsizing.py
@@ -46,4 +46,4 @@ solver.solve(model)
 
 ### print the results
 for v in model.y[:]:
-    print(v.name(), value(v))
+    print(v.name, value(v))

--- a/examples/doc/pyomobook/dae/run_path_constraint.py
+++ b/examples/doc/pyomobook/dae/run_path_constraint.py
@@ -21,8 +21,8 @@ def plotter(subplot, x, *y, **kwds):
         if kwds.get('points', False):
             plt.plot(list(x), [value(_y[t]) for t in x], 'o')
     plt.title(kwds.get('title',''))
-    plt.legend(tuple(_y.name() for _y in y))
-    plt.xlabel(x.name())
+    plt.legend(tuple(_y.name for _y in y))
+    plt.xlabel(x.name)
 
 import matplotlib.pyplot as plt
 plotter(121, m.t, m.x1, m.x2, title='Differential Variables')

--- a/examples/doc/pyomobook/ref-modeling/examples.py
+++ b/examples/doc/pyomobook/ref-modeling/examples.py
@@ -68,9 +68,8 @@ model = ConcreteModel()
 model.b = Block()
 model.b.x = Var()
 
-print(model.b.x.name())                        # 'x'
-print(model.b.x.name(True))                    # 'b.x'
-print(model.b.x.name(fully_qualified=True))    # 'b.x'
+print(model.b.x.local_name)   # 'x'
+print(model.b.x.name)         # 'b.x'
 # @:nested1
 
 print("special1")

--- a/examples/doc/pyomobook/scripts/benders/runbenders
+++ b/examples/doc/pyomobook/scripts/benders/runbenders
@@ -56,7 +56,7 @@ for i in range(1, max_iterations+1):
                         suffixes=['rc','dual'])
     for instance in sub_insts:
         print("Profit for scenario=%s is %f"
-              % (instance.name(), instance.Exp_Stage2_Profit()))
+              % (instance.name, instance.Exp_Stage2_Profit()))
     print("")
 
     # if not converged, add store the pricing information

--- a/examples/pyomo/benders/runbenders
+++ b/examples/pyomo/benders/runbenders
@@ -47,7 +47,7 @@ for i in range(1, max_iterations+1):
     # solve the subproblems.
     solve_all_instances(solver_manager, 'cplex', sub_insts)
     for instance in sub_insts:
-        print("Profit for scenario="+instance.name()+" is "+
+        print("Profit for scenario="+instance.name+" is "+
               str(round(instance.Exp_Stage2_Profit(), 4)))
     print("")
 

--- a/examples/pyomo/p-median/solver1.py
+++ b/examples/pyomo/p-median/solver1.py
@@ -29,7 +29,7 @@ class MySolver(object):
         n = value(instance.N)
         # Setup results
         results = SolverResults()
-        results.problem.name = instance.name()
+        results.problem.name = instance.name
         results.problem.sense = ProblemSense.minimize
         results.problem.num_constraints = 1
         results.problem.num_variables = n
@@ -40,7 +40,7 @@ class MySolver(object):
         soln.status = SolutionStatus.feasible
         for j in sequence(n):
             if instance.y[j].value is 1:
-                soln.variable[instance.y[j].name()] = {"Value" : 1, "Id" : j}
+                soln.variable[instance.y[j].name] = {"Value" : 1, "Id" : j}
         return results
 
     # Perform a greedy search

--- a/examples/pyomo/p-median/solver2.py
+++ b/examples/pyomo/p-median/solver2.py
@@ -32,7 +32,7 @@ class MySolver(object):
         n = value(instance.N)
         # Setup results
         results = SolverResults()
-        results.problem.name = instance.name()
+        results.problem.name = instance.name
         results.problem.sense = ProblemSense.minimize
         results.problem.num_constraints = 1
         results.problem.num_variables = n
@@ -42,7 +42,7 @@ class MySolver(object):
         soln.value = val
         soln.status = SolutionStatus.feasible
         for j in sequence(n):
-            soln.variable[instance.y[j].name()] = {"Value" : sol[j-1], "Id" : j}
+            soln.variable[instance.y[j].name] = {"Value" : sol[j-1], "Id" : j}
         # Return results
         return results
 

--- a/examples/pyomo/suffixes/gurobi_ampl_basis.py
+++ b/examples/pyomo/suffixes/gurobi_ampl_basis.py
@@ -100,12 +100,12 @@ results = opt.solve(model,
 print("")
 print("Suffixes After First Solve:")
 for i in model.s:
-    print("%s.sstatus: %s" % (model.x[i].name(),
+    print("%s.sstatus: %s" % (model.x[i].name,
                               model.sstatus.get(model.x[i])))
 for i in model.s:
-    print("%s.sstatus: %s" % (model.con[i].name(),
+    print("%s.sstatus: %s" % (model.con[i].name,
                               model.sstatus.get(model.con[i])))
-    print("%s.dual: %s" % (model.con[i].name(),
+    print("%s.dual: %s" % (model.con[i].name,
                            model.dual.get(model.con[i])))
 print("")
 

--- a/examples/pyomo/suffixes/gurobi_ampl_example.py
+++ b/examples/pyomo/suffixes/gurobi_ampl_example.py
@@ -90,16 +90,16 @@ def print_model_suffixes(model):
             six.print_("%10s" % (name),end='')
     six.print_("")
     for i in model.s:
-        six.print_(model.x[i].name()+"\t",end='')
+        six.print_(model.x[i].name+"\t",end='')
         for name,suffix in active_import_suffix_generator(model):
             six.print_("%10s" % (suffix.get(model.x[i])),end='')
         six.print_("")
     for i in model.s:
-        six.print_(model.con[i].name()+"\t",end='')
+        six.print_(model.con[i].name+"\t",end='')
         for name,suffix in active_import_suffix_generator(model):
             six.print_("%10s" % (suffix.get(model.con[i])),end='')
         six.print_("")
-    six.print_(model.obj.name()+"\t",end='')
+    six.print_(model.obj.name+"\t",end='')
     for name,suffix in active_import_suffix_generator(model):
         six.print_("%10s" % (suffix.get(model.obj)),end='')
     print("")

--- a/examples/pyomo/suffixes/gurobi_ampl_iis.py
+++ b/examples/pyomo/suffixes/gurobi_ampl_iis.py
@@ -64,4 +64,4 @@ results = opt.solve(model,
 print("")
 print("IIS Results")
 for component, value in model.iis.items():
-    print(component.name()+" "+str(value))
+    print(component.name+" "+str(value))

--- a/examples/pysp/scripting/apps/compile_scenario_tree.py
+++ b/examples/pysp/scripting/apps/compile_scenario_tree.py
@@ -64,13 +64,13 @@ def _pickle_compiled_scenario(worker,
     #
     scenario_instance_cost_expression = \
         scenario._instance_cost_expression
-    assert scenario_instance_cost_expression.name() in \
+    assert scenario_instance_cost_expression.local_name in \
         ("_PySP_UserCostExpression", "_PySP_CostExpression")
     scenario_instance.del_component(scenario_instance_cost_expression)
 
     scenario_instance_objective = \
         scenario._instance_objective
-    if scenario_instance_objective.name() == "_PySP_CostObjective":
+    if scenario_instance_objective.local_name == "_PySP_CostObjective":
         scenario_instance.del_component(scenario_instance_objective)
     else:
         scenario_instance_objective.expr = scenario_instance_cost_expression.expr
@@ -120,10 +120,10 @@ def _pickle_compiled_scenario(worker,
     #
     # Re-add PySP generated model components
     #
-    scenario_instance.add_component(scenario_instance_cost_expression.name(),
+    scenario_instance.add_component(scenario_instance_cost_expression.local_name,
                                     scenario_instance_cost_expression)
-    if scenario_instance_objective.name() == "_PySP_CostObjective":
-        scenario_instance.add_component(scenario_instance_objective.name(),
+    if scenario_instance_objective.local_name == "_PySP_CostObjective":
+        scenario_instance.add_component(scenario_instance_objective.local_name,
                                         scenario_instance_objective)
     scenario_instance_objective.expr = scenario_instance_cost_expression
     scenario_instance._ScenarioTreeSymbolMap = scenario_tree_symbol_map

--- a/pyomo/bilevel/plugins/lcp.py
+++ b/pyomo/bilevel/plugins/lcp.py
@@ -102,7 +102,7 @@ class LinearComplementarity_BilevelTransformation(Base_BilevelTransformation):
             o_terms = generate_canonical_repn(odata.expr, compute_values=False)
             for i in range(len(o_terms.variables)):
                 var = o_terms.variables[i]
-                if var.parent_component().name() in self._fixed_upper_vars:
+                if var.parent_component().local_name in self._fixed_upper_vars:
                     #
                     # Skip fixed upper variables
                     #
@@ -123,7 +123,7 @@ class LinearComplementarity_BilevelTransformation(Base_BilevelTransformation):
         # and complementarity slackness conditions for y bound constraints
         #
         for vcomponent in instance.component_objects(Var, active=True):
-            if vcomponent.name() in self._fixed_upper_vars:
+            if vcomponent.local_name in self._fixed_upper_vars:
                 #
                 # Skip fixed upper variables
                 #
@@ -194,7 +194,7 @@ class LinearComplementarity_BilevelTransformation(Base_BilevelTransformation):
             c_terms = generate_canonical_repn(cdata.body, compute_values=False)
             for i in range(len(c_terms.variables)):
                 var = c_terms.variables[i]
-                if var.parent_component().name() in self._fixed_upper_vars:
+                if var.parent_component().local_name in self._fixed_upper_vars:
                     continue
                 id_ = id(var)
                 B2.setdefault(id_,{}).setdefault(id(cdata),c_terms.linear[i])
@@ -218,7 +218,7 @@ class LinearComplementarity_BilevelTransformation(Base_BilevelTransformation):
             B2_ = B2.get(vid,{})
             utmp_keys = list(utmp.keys())
             if self._deterministic:
-                utmp_keys.sort(key=lambda x:utmp[x][0].name() if utmp[x][1] is None else utmp[x][1].name())
+                utmp_keys.sort(key=lambda x:utmp[x][0].local_name if utmp[x][1] is None else utmp[x][1].local_name)
             for uid in utmp_keys:
                 if uid in B2_:
                     lb_dual, ub_dual = utmp[uid]

--- a/pyomo/bilevel/plugins/solver1.py
+++ b/pyomo/bilevel/plugins/solver1.py
@@ -86,7 +86,7 @@ class BILEVEL_Solver1(pyomo.opt.OptSolver):
                 i = 0
                 for v in self._instance.bilinear_data_.vlist.itervalues():
                     #print(v)
-                    #print(v.name())
+                    #print(v.name)
                     #print(type(v))
                     #print(v.value)
                     if abs(v.value) <= 1e-7:
@@ -195,7 +195,7 @@ class BILEVEL_Solver1(pyomo.opt.OptSolver):
         # PROBLEM
         #
         prob = results.problem
-        prob.name = self._instance.name()
+        prob.name = self._instance.name
         prob.number_of_constraints = self._instance.statistics.number_of_constraints
         prob.number_of_variables = self._instance.statistics.number_of_variables
         prob.number_of_binary_variables = self._instance.statistics.number_of_binary_variables

--- a/pyomo/bilevel/plugins/solver2.py
+++ b/pyomo/bilevel/plugins/solver2.py
@@ -107,7 +107,7 @@ class BILEVEL_Solver2(pyomo.opt.OptSolver):
         # PROBLEM
         #
         prob = results.problem
-        prob.name = self._instance.name()
+        prob.name = self._instance.name
         prob.number_of_constraints = self._instance.statistics.number_of_constraints
         prob.number_of_variables = self._instance.statistics.number_of_variables
         prob.number_of_binary_variables = self._instance.statistics.number_of_binary_variables

--- a/pyomo/bilevel/plugins/solver3.py
+++ b/pyomo/bilevel/plugins/solver3.py
@@ -110,7 +110,7 @@ class BILEVEL_Solver3(pyomo.opt.OptSolver):
         # PROBLEM
         #
         prob = results.problem
-        prob.name = self._instance.name()
+        prob.name = self._instance.name
         prob.number_of_constraints = self._instance.statistics.number_of_constraints
         prob.number_of_variables = self._instance.statistics.number_of_variables
         prob.number_of_binary_variables = self._instance.statistics.number_of_binary_variables

--- a/pyomo/bilevel/plugins/transform.py
+++ b/pyomo/bilevel/plugins/transform.py
@@ -43,7 +43,7 @@ class Base_BilevelTransformation(Transformation):
         # Fix variables
         #
         if submodel._fixed:
-            fixed = [i.name() for i in submodel._fixed]
+            fixed = [i.local_name for i in submodel._fixed]
             unfixed = []
             for v in var:
                 if not v in fixed:
@@ -65,7 +65,7 @@ class Base_BilevelTransformation(Transformation):
             unfixed = []
             for (name, data) in submodel.component_map(active=True).items():
                 if isinstance(data,Var):
-                    unfixed.append((data.name(), data.is_indexed()))
+                    unfixed.append((data.local_name, data.is_indexed()))
         #
         self._submodel           = sub
         self._upper_vars         = var

--- a/pyomo/core/base/DataPortal.py
+++ b/pyomo/core/base/DataPortal.py
@@ -344,7 +344,7 @@ class DataPortal(object):
             ans = []
             for item in options.data:
                 try:
-                    ans.append(item.name())
+                    ans.append(item.local_name)
                     self._model = item.model()
                 except:
                     ans.append(item)
@@ -357,7 +357,7 @@ class DataPortal(object):
             #
             try:
                 self._model = options.data.model()
-                options.data = [ self._data_manager.options.data.name() ]
+                options.data = [ self._data_manager.options.data.local_name ]
             except:
                 pass
 

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -210,7 +210,7 @@ class ModelSolutions(object):
         #
         if (results.solver.status == pyomo.opt.SolverStatus.warning):
             print('WARNING - Loading a SolverResults object with a ' \
-                  'warning status into model=%s; message from solver=%s' % (instance.name(),
+                  'warning status into model=%s; message from solver=%s' % (instance.name,
                                                                             results.solver.Message))
         #
         # If the solver status not one of either OK or Warning, then generate an error.
@@ -365,7 +365,7 @@ class ModelSolutions(object):
                             if ignore_invalid_labels:
                                 continue
                             raise RuntimeError("CUID %s is missing from model %s"
-                                               % (str(cuid), instance.name()))
+                                               % (str(cuid), instance.name))
                         tmp[id(obj)] = (weakref_ref(obj), val)
             else:
                 #
@@ -373,11 +373,11 @@ class ModelSolutions(object):
                 #
                 if len(cache) == 0:
                     for obj in instance.component_data_objects(Var):
-                        cache[obj.name(True)] = obj
+                        cache[obj.name] = obj
                     for obj in instance.component_data_objects(Objective, active=True):
-                        cache[obj.name(True)] = obj
+                        cache[obj.name] = obj
                     for obj in instance.component_data_objects(Constraint, active=True):
-                        cache[obj.name(True)] = obj
+                        cache[obj.name] = obj
 
                 for name in ['problem', 'objective', 'variable', 'constraint']:
                     tmp = soln._entry[name]
@@ -387,7 +387,7 @@ class ModelSolutions(object):
                             if ignore_invalid_labels:
                                 continue
                             raise RuntimeError("Symbol %s is missing from model %s"
-                                               % (symb, instance.name()))
+                                               % (symb, instance.name))
                         tmp[id(obj)] = (weakref_ref(obj), val)
         else:
             #
@@ -410,7 +410,7 @@ class ModelSolutions(object):
                         raise RuntimeError(
                             "ERROR: Symbol %s is missing from "
                             "model %s when loading with a symbol map!"
-                            % (symb, instance.name()))
+                            % (symb, instance.name))
 
                     tmp[id(obj())] = (obj, val)
             #
@@ -507,14 +507,14 @@ class ModelSolutions(object):
                 if not allow_consistent_values_for_fixed_vars:
                     msg = "Variable '%s' in model '%s' is currently fixed - new" \
                           ' value is not expected in solution'
-                    raise TypeError(msg % ( vdata.name(), instance.name() ))
+                    raise TypeError(msg % (vdata.name, instance.name))
                 if math.fabs(val - vdata.value) > comparison_tolerance_for_fixed_vars:
                     raise TypeError("Variable '%s' in model '%s' is currently "
                                     "fixed - a value of '%s' in solution is "
                                     "not within tolerance=%s of the current "
                                     "value of '%s'"
-                                    % (vdata.name(),
-                                       instance.name(),
+                                    % (vdata.name,
+                                       instance.name,
                                        str(val),
                                        str(comparison_tolerance_for_fixed_vars),
                                        str(vdata.value)))
@@ -662,7 +662,7 @@ constructed model; returning a clone of the current model instance.""")
 
 
         if name is None:
-            name = self.name()
+            name = self.name
         if filename is not None:
             if data is not None:
                 logger.warning("Model.create_instance() passed both 'filename' "
@@ -785,7 +785,7 @@ from solvers are immediately loaded into the original model instance.""")
         for key in data:
             if type(data[key][0]) is tuple:
                 return data
-            ans[key] = tuplize(data[key], setobj.dimen, setobj.name())
+            ans[key] = tuplize(data[key], setobj.dimen, setobj.local_name)
         return ans
 
     def _load_model_data(self, modeldata, namespaces, **kwds):
@@ -883,7 +883,7 @@ from solvers are immediately loaded into the original model instance.""")
 
             if report_timing is True:
                 total_construction_time = time.time() - construction_start_time
-                print("      %6.2f seconds required to construct instance=%s" % (total_construction_time, self.name()))
+                print("      %6.2f seconds required to construct instance=%s" % (total_construction_time, self.name))
 
             if (pympler_available is True) and (profile_memory >= 2):
                 print("")
@@ -912,17 +912,17 @@ from solvers are immediately loaded into the original model instance.""")
 
         if __debug__ and logger.isEnabledFor(logging.DEBUG):
             _blockName = "Model" if self.parent_block() is None \
-                else "Block '%s'" % self.name(True)
+                else "Block '%s'" % self.name
             logger.debug( "Constructing %s '%s' on %s from data=%s",
                           declaration.__class__.__name__,
-                          declaration.name(), _blockName, str(data) )
+                          declaration.name, _blockName, str(data) )
         try:
             declaration.construct(data)
         except:
             err = sys.exc_info()[1]
             logger.error(
                 "Constructing component '%s' from data=%s failed:\n%s: %s",
-                str(declaration.name(True)), str(data).strip(),
+                str(declaration.name), str(data).strip(),
                 type(err).__name__, err )
             raise
 
@@ -930,7 +930,7 @@ from solvers are immediately loaded into the original model instance.""")
                 _out = StringIO()
                 declaration.pprint(ostream=_out)
                 logger.debug("Constructed component '%s':\n%s"
-                             % ( declaration.name(True), _out.getvalue()))
+                             % ( declaration.name, _out.getvalue()))
 
         if (pympler_available is True) and (profile_memory >= 2):
             mem_used = muppy.get_size(muppy.get_objects())
@@ -981,7 +981,7 @@ from solvers are immediately loaded into the original model instance.""")
         if __debug__ and logger.isEnabledFor(logging.DEBUG):
             logger.debug(
                 "Writing model '%s' to file '%s' with format %s",
-                self.name(),
+                self.name,
                 str(filename),
                 str(format))
         return filename, smap_id

--- a/pyomo/core/base/_pyomo.py
+++ b/pyomo/core/base/_pyomo.py
@@ -13,7 +13,7 @@ def predefined_sets():
     from pyomo.core.base.set_types import _virtual_sets
     ans = []
     for item in _virtual_sets:
-        ans.append( (item.name(), item.doc) )
+        ans.append( (item.name, item.doc) )
     return ans
 
 

--- a/pyomo/core/base/action.py
+++ b/pyomo/core/base/action.py
@@ -47,7 +47,7 @@ class BuildAction(IndexedComponent):
     def construct(self, data=None):
         """ Apply the rule to construct values in this set """
         if __debug__ and logger.isEnabledFor(logging.DEBUG):        #pragma:nocover
-                logger.debug("Constructing Action, name="+self.name())
+                logger.debug("Constructing Action, name="+self.name)
         #
         if self._constructed:                                       #pragma:nocover
             return

--- a/pyomo/core/base/alias.py
+++ b/pyomo/core/base/alias.py
@@ -80,7 +80,7 @@ class Alias(Component):
     def construct(self, data=None):
         if __debug__ and logger.isEnabledFor(logging.DEBUG):   #pragma:nocover
             try:
-                name = str(self.name(True))
+                name = str(self.name)
             except:
                 name = type(self)
                 if logger.isEnabledFor(logging.DEBUG):
@@ -94,7 +94,7 @@ class Alias(Component):
         if self.aliased_object is None:
             return ([("Proxy","None")], (), (), ())
         else:
-            return ([("Proxy", self.aliased_object.name(True))], (), (), ())
+            return ([("Proxy", self.aliased_object.name)], (), (), ())
 
     # Dereference so we can point to a constructed object
     # after model cloning / construction

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -231,7 +231,7 @@ class _BlockData(ActiveComponentData):
                     types = sorted(x.__name__ for x in self._ctypes)
                     msg += '%s or %s ' % (', '.join(types[:-1]), types[-1])
             raise KeyError("%scomponent '%s' not found in block %s"
-                           % (msg, key, self._block.name(True)))
+                           % (msg, key, self._block.name))
 
         def __nonzero__(self):
             """
@@ -357,7 +357,7 @@ class _BlockData(ActiveComponentData):
             # list (so we can sort it) and then iterate over the sorted
             # temporary list
             if self._sorted:
-                return (obj for obj in sorted(walker, key=lambda _x: _x.name()))
+                return (obj for obj in sorted(walker, key=lambda _x: _x.local_name))
             else:
                 return walker
 
@@ -505,7 +505,7 @@ class _BlockData(ActiveComponentData):
                     "\nThis is usually indicative of a modelling error.\n"
                     "To avoid this warning, use block.del_component() and "
                     "block.add_component()."
-                    % (name, type(self.component(name)), self.name(True),
+                    % (name, type(self.component(name)), self.name,
                        type(val)))
                 self.del_component(name)
                 self.add_component(name, val)
@@ -527,7 +527,7 @@ class _BlockData(ActiveComponentData):
                         "Expected component %s (type=%s) on block %s to have a "
                         "'set_value' method, but none was found." %
                         (name, type(self.component(name)),
-                         self.name(True)))
+                         self.name))
                     raise
                 #
                 # Call the set_value method.
@@ -562,7 +562,7 @@ class _BlockData(ActiveComponentData):
                         "Cannot set the '_parent' attribute of Block '%s' "
                         "to a non-Block object (with type=%s); Did you "
                         "try to create a model component named '_parent'?"
-                        % (self.name(), type(val)) )
+                        % (self.name, type(val)) )
                 super(_BlockData, self).__setattr__(name, val)
             elif name == '_component':
                 if val is not None and not isinstance(val(), _BlockData):
@@ -570,7 +570,7 @@ class _BlockData(ActiveComponentData):
                         "Cannot set the '_component' attribute of Block '%s' "
                         "to a non-Block object (with type=%s); Did you "
                         "try to create a model component named '_component'?"
-                        % (self.name(), type(val)) )
+                        % (self.name, type(val)) )
                 super(_BlockData, self).__setattr__(name, val)
             #
             # At this point, we should only be seeing non-component data
@@ -582,7 +582,7 @@ class _BlockData(ActiveComponentData):
                     "Reassigning the non-component attribute %s "
                     "on block %s with a new Component with type %s."
                     "\nThis is usually indicative of a modelling error."
-                    % (name, self.name(True), type(val)) )
+                    % (name, self.name, type(val)) )
                 delattr(self, name)
                 self.add_component(name, val)
             else:
@@ -625,16 +625,16 @@ class _BlockData(ActiveComponentData):
                 if tset._name == "_unknown_":
                     self._construct_temporary_set(
                       tset,
-                      val.name()+"_index_"+str(ctr)
+                      val.local_name+"_index_"+str(ctr)
                     )
         if isinstance(val._index, _SetDataBase) and \
-                val._index.parent_component().name() == "_unknown_":
-            self._construct_temporary_set(val._index,val.name()+"_index")
+                val._index.parent_component().local_name == "_unknown_":
+            self._construct_temporary_set(val._index,val.local_name+"_index")
         if isinstance(getattr(val,'initialize',None), _SetDataBase) and \
-                val.initialize.parent_component().name() == "_unknown_":
-            self._construct_temporary_set(val.initialize, val.name()+"_index_init")
-        if getattr(val,'domain',None) is not None and val.domain.name() == "_unknown_":
-            self._construct_temporary_set(val.domain,val.name()+"_domain")
+                val.initialize.parent_component().local_name == "_unknown_":
+            self._construct_temporary_set(val.initialize, val.local_name+"_index_init")
+        if getattr(val,'domain',None) is not None and val.domain.local_name == "_unknown_":
+            self._construct_temporary_set(val.domain,val.local_name+"_domain")
 
     def _construct_temporary_set(self, obj, name):
         """TODO: This method has known issues (see tickets) and needs to be
@@ -643,7 +643,7 @@ class _BlockData(ActiveComponentData):
             if len(obj) == 1:                #pragma:nocover
                 raise Exception(
                     "Unexpected temporary set construction for set "
-                    "%s on block %s" % ( name, self.name()) )
+                    "%s on block %s" % ( name, self.name) )
             else:
                 tobj = obj[0]
                 for t in obj[1:]:
@@ -700,7 +700,7 @@ class _BlockData(ActiveComponentData):
             raise RuntimeError(
                 "Cannot add component '%s' (type %s) to block '%s': a "
                 "component by that name (type %s) is already defined."
-                % (name, type(val), self.name(), type(getattr(self, name))))
+                % (name, type(val), self.name, type(getattr(self, name))))
         #
         # Skip the add_component() logic if this is a
         # component type that is suppressed.
@@ -716,12 +716,12 @@ class _BlockData(ActiveComponentData):
             if val._parent() is self:
                 msg = """
 Attempting to re-assign the component '%s' to the same
-block under a different name (%s).""" % (val.name(), name)
+block under a different name (%s).""" % (val.name, name)
             else:
                 msg = """
 Re-assigning the component '%s' from block '%s' to
-block '%s' as '%s'.""" % ( val._name, val._parent().name(True),
-                           self.name(True), name )
+block '%s' as '%s'.""" % ( val._name, val._parent().name,
+                           self.name, name )
 
             raise RuntimeError("""%s
 
@@ -785,7 +785,7 @@ component, use the block del_component() and add_component() methods.
         if '_rule' in val.__dict__ and val._rule is None:
             _found = False
             try:
-                _test = val.name()+'_rule'
+                _test = val.local_name+'_rule'
                 for i in (1,2):
                     frame = sys._getframe(i)
                     _found |= _test in frame.f_locals
@@ -801,7 +801,7 @@ component, use the block del_component() and add_component() methods.
 You defined a component (%s) that appears
 to rely on an implicit rule (%s).
 Components must now specify their rules explicitly using 'rule=' keywords.""" %
-                    (val.name(True), _test) )
+                    (val.name, _test) )
         #
         # Don't reconstruct if this component has already been constructed.
         # This allows a user to move a component from one block to
@@ -833,17 +833,17 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
                 # (like pyomo.gdp.Disjunct's indicator_var), name(True)
                 # will fail: this block data exists and has a parent(),
                 # but it has not yet been added to the parent's _data
-                # (so the idx lookup will fail in name()).
+                # (so the idx lookup will fail in name).
                 if self.parent_block() is None:
                     _blockName = "[Model]"
                 else:
                     try:
-                        _blockName = "Block '%s'" % self.name(True)
+                        _blockName = "Block '%s'" % self.name
                     except:
                         _blockName = "Block '%s[...]'" \
-                            % self.parent_component().name(True)
+                            % self.parent_component().name
                 logger.debug( "Constructing %s '%s' on %s from data=%s",
-                              val.__class__.__name__, val.name(),
+                              val.__class__.__name__, val.name,
                               _blockName, str(data) )
             try:
                 val.construct(data)
@@ -851,14 +851,14 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
                 err = sys.exc_info()[1]
                 logger.error(
                     "Constructing component '%s' from data=%s failed:\n%s: %s",
-                    str(val.name(True)), str(data).strip(),
+                    str(val.name), str(data).strip(),
                     type(err).__name__, err )
                 raise
             if __debug__ and logger.isEnabledFor(logging.DEBUG):
                 if _blockName[-1] == "'":
-                    _blockName = _blockName[:-1] + '.' + val.name() + "'"
+                    _blockName = _blockName[:-1] + '.' + val.name + "'"
                 else:
-                    _blockName = "'" + _blockName + '.' + val.name() + "'"
+                    _blockName = "'" + _blockName + '.' + val.name + "'"
                 _out = StringIO()
                 val.pprint(ostream=_out)
                 logger.debug( "Constructed component '%s':\n%s"
@@ -877,7 +877,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         #if name not in self._decl:
         #    return
 
-        name = obj.name()
+        name = obj.local_name
 
         # Replace the component in the master list with a None placeholder
         idx = self._decl[name]
@@ -916,7 +916,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         if obj._type is new_ctype:
             return
 
-        name = obj.name()
+        name = obj.local_name
         if not preserve_declaration_order:
             # if we don't have to preserve the decl order, then the
             # easiest (and fastest) thing to do is just delete it and
@@ -1437,9 +1437,9 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         if ostream is None:
             ostream = sys.stdout
         if self.parent_block() is not None:
-            ostream.write(prefix+"Block "+self.name()+'\n')
+            ostream.write(prefix+"Block "+self.name+'\n')
         else:
-            ostream.write(prefix+"Model "+self.name()+'\n')
+            ostream.write(prefix+"Model "+self.name+'\n')
         #
         # FIXME: We should change the display order (to Obj, Var, Con,
         # Block) and change the printer to only display sections with
@@ -1533,7 +1533,7 @@ class Block(ActiveIndexedComponent):
         """
         if __debug__ and logger.isEnabledFor(logging.DEBUG):
             logger.debug( "Constructing %s '%s', from data=%s",
-                          self.__class__.__name__, self.name(), str(data) )
+                          self.__class__.__name__, self.name, str(data) )
         if self._constructed:
             return
         self._constructed = True
@@ -1582,7 +1582,7 @@ class Block(ActiveIndexedComponent):
                 # of the empty one we just created.
                 for c in list(obj.component_objects(descend_into=False)):
                     obj.del_component(c)
-                    _block.add_component(c.name(), c)
+                    _block.add_component(c.local_name, c)
                 # transfer over any other attributes that are not components
                 for name, val in iteritems(obj.__dict__):
                     if not hasattr(_block, name) and not hasattr(self, name):
@@ -1616,7 +1616,7 @@ class Block(ActiveIndexedComponent):
             b = self[key]
             if subblock and self.is_indexed():
                 ostream.write("%s%s : Active=%s\n" %
-                              (prefix, b.name(True), b.active))
+                              (prefix, b.name, b.active))
             _BlockData.pprint(b, ostream=ostream, verbose=verbose,
                               prefix=prefix+'    ' if subblock else prefix)
 

--- a/pyomo/core/base/check.py
+++ b/pyomo/core/base/check.py
@@ -45,7 +45,7 @@ class BuildCheck(IndexedComponent):
     def construct(self, data=None):
         """ Apply the rule to construct values in this set """
         if __debug__ and logger.isEnabledFor(logging.DEBUG):        #pragma:nocover
-                logger.debug("Constructing Check, name="+self.name())
+                logger.debug("Constructing Check, name="+self.name)
         #
         if self._constructed:                                       #pragma:nocover
             return
@@ -55,12 +55,12 @@ class BuildCheck(IndexedComponent):
             # Scalar component
             res = self._rule(self._parent())
             if not res:
-                raise ValueError("BuildCheck %r identified error" % self.name())
+                raise ValueError("BuildCheck %r identified error" % self.name)
         else:
             # Indexed component
             for index in self._index:
                 res = apply_indexed_rule(self, self._rule, self._parent(), index)
                 if not res:
-                    raise ValueError("BuildCheck %r identified error with index %r" % (self.name(), str(index)))
+                    raise ValueError("BuildCheck %r identified error with index %r" % (self.name, str(index)))
 
 register_component(BuildCheck, "A component that performs tests during model construction.  The action rule is applied to every index value.")

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -284,10 +284,13 @@ class Component(object):
     # never be assigned to by user code.
     @name.setter
     def name(self, val):
-        raise ValueError(
-            "The .name attribute is now a property method "
-            "that returns the fully qualified component name. "
-            "Assignment is not allowed.")
+        if self.parent_block() is None:
+            self._name = val
+        else:
+            raise ValueError(
+                "The .name attribute is not settable when the component "
+                "is assigned to a Block.\nTriggered by attempting to set "
+                "component '%s' to name '%s'" % (self.name,val))
 
     @property
     def local_name(self):

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -50,13 +50,13 @@ def name(component, index=None, fully_qualified=False):
     Return a string representation of component for a specific
     index value.
     """
-    base = component.name(fully_qualified=fully_qualified)
+    base = component.getname(fully_qualified=fully_qualified)
     if index is None:
         return base
     else:
         if index not in component.index_set():
             raise KeyError( "Index %s is not valid for component %s"
-                            % (index, component.name(True)) )
+                            % (index, component.name) )
         return base + _name_index_generator( index )
 
 def cname(*args, **kwds):
@@ -193,7 +193,7 @@ class Component(object):
         if ostream is None:
             ostream = sys.stdout
         tab="    "
-        ostream.write(prefix+self.name()+" : ")
+        ostream.write(prefix+self.local_name+" : ")
         if self.doc is not None:
             ostream.write(self.doc+'\n'+prefix+tab)
 
@@ -245,7 +245,7 @@ class Component(object):
 
     def __str__(self):
         """Return the component name"""
-        return self.name(True)
+        return self.name
 
     def to_string(self, ostream=None, verbose=None, precedence=0):
         """Write the component name to a buffer"""
@@ -253,7 +253,7 @@ class Component(object):
             ostream = sys.stdout
         ostream.write(self.__str__())
 
-    def name(self, fully_qualified=False, name_buffer=None):
+    def getname(self, fully_qualified=False, name_buffer=None):
         """
         Returns the component name associated with this object.
 
@@ -265,7 +265,7 @@ class Component(object):
         if fully_qualified:
             pb = self.parent_block()
             if pb is not None and pb is not self.model():
-                ans = pb.name(fully_qualified, name_buffer) \
+                ans = pb.getname(fully_qualified, name_buffer) \
                       + "." + self._name
             else:
                 ans = self._name
@@ -275,16 +275,40 @@ class Component(object):
             name_buffer[id(self)] = ans
         return ans
 
+    @property
+    def name(self):
+        """Get the fully qualifed component name."""
+        return self.getname(fully_qualified=True)
+    # Adding a setter here to help users adapt to the new
+    # setting. The .name attribute is now ._name. It should
+    # never be assigned to by user code.
+    @name.setter
+    def name(self, val):
+        raise ValueError(
+            "The .name attribute is now a property method "
+            "that returns the fully qualified component name. "
+            "Assignment is not allowed.")
+
+    @property
+    def local_name(self):
+        """Get the component name only within the context of
+        the immediate parent container."""
+        return self.getname(fully_qualified=False)
+
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() method has been renamed to getname(). "
+                       "The preferred method of obtaining a component name is to use the "
+                       ".name property, which returns the fully qualified component name. "
+                       "The .local_name property will return the component name only within "
+                       "the context of the immediate parent container.")
+        return self.getname(*args, **kwds)
 
     def pprint(self, ostream=None, verbose=False, prefix=""):
         """Print component information"""
         if ostream is None:
             ostream = sys.stdout
         tab="    "
-        ostream.write(prefix+self.name()+" : ")
+        ostream.write(prefix+self.local_name+" : ")
         if self.doc is not None:
             ostream.write(self.doc+'\n'+prefix+tab)
 
@@ -491,7 +515,7 @@ class ComponentData(object):
         # Component.
 
         #try:
-        #    print("Component: %s" % (self.name(),))
+        #    print("Component: %s" % (self.name,))
         #except:
         #    print("DANGLING ComponentData: %s on %s" % (
         #        type(self),self.parent_component()))
@@ -593,7 +617,7 @@ class ComponentData(object):
 
     def __str__(self):
         """Return a string with the component name and index"""
-        return self.name(True)
+        return self.name
 
     def to_string(self, ostream=None, verbose=None, precedence=0):
         """Write the component name and index to a buffer"""
@@ -601,7 +625,7 @@ class ComponentData(object):
             ostream = sys.stdout
         ostream.write(self.__str__())
 
-    def name(self, fully_qualified=False, name_buffer=None):
+    def getname(self, fully_qualified=False, name_buffer=None):
         """Return a string with the component name and index"""
         #
         # Using the buffer, which is a dictionary:  id -> string
@@ -612,12 +636,12 @@ class ComponentData(object):
 
         c = self.parent_component()
         if c is self:
-            # This is a scalar component, so call the Component.name() method
-            return super(ComponentData, self).name(fully_qualified, name_buffer)
+            # This is a scalar component, so call the Component.getname() method
+            return super(ComponentData, self).getname(fully_qualified, name_buffer)
         #
         # Get the name of the component
         #
-        base = c.name(fully_qualified, name_buffer)
+        base = c.getname(fully_qualified, name_buffer)
         if name_buffer is not None:
             # Iterate through the dictionary and generate all names in the buffer
             for idx, obj in iteritems(c):
@@ -638,9 +662,33 @@ class ComponentData(object):
         raise RuntimeError("Fatal error: cannot find the component data in "
                            "the owning component's _data dictionary.")
 
+    @property
+    def name(self):
+        """Get the fully qualifed component name."""
+        return self.getname(fully_qualified=True)
+    # Adding a setter here to help users adapt to the new
+    # setting. The .name attribute is now ._name. It should
+    # never be assigned to by user code.
+    @name.setter
+    def name(self, val):
+        raise ValueError(
+            "The .name attribute is now a property method "
+            "that returns the fully qualified component name. "
+            "Assignment is not allowed.")
+
+    @property
+    def local_name(self):
+        """Get the component name only within the context of
+        the immediate parent container."""
+        return self.getname(fully_qualified=False)
+
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() method has been renamed to getname(). "
+                       "The preferred method of obtaining a component name is to use the "
+                       ".name property, which returns the fully qualified component name. "
+                       "The .local_name property will return the component name only within "
+                       "the context of the immediate parent container.")
+        return self.getname(*args, **kwds)
 
     def is_indexed(self):
         """Return true if this component is indexed"""
@@ -904,26 +952,26 @@ class ComponentUID(object):
         orig_component = component
         tDict = ComponentUID.tDict
         if not hasattr(component, '_component'):
-            yield ( component.name(), '**', None )
+            yield ( component.local_name, '**', None )
             component = component.parent_block()
         while component is not context:
             if component is model:
                 raise ValueError("Context '%s' does not apply to component "
-                                 "'%s'" % (context.name(True),
-                                           orig_component.name(True)))
+                                 "'%s'" % (context.name,
+                                           orig_component.name))
             c = component.parent_component()
             if c is component:
-                yield ( c.name(), tuple(), '' )
+                yield ( c.local_name, tuple(), '' )
             elif cuid_buffer is not None:
                 if id(self) not in cuid_buffer:
                     for idx, obj in iteritems(c):
                         cuid_buffer[id(obj)] = \
                             self._partial_cuid_from_index(idx)
-                yield (c.name(),) + cuid_buffer[id(component)]
+                yield (c.local_name,) + cuid_buffer[id(component)]
             else:
                 for idx, obj in iteritems(c):
                     if obj is component:
-                        yield (c.name(),) + self._partial_cuid_from_index(idx)
+                        yield (c.local_name,) + self._partial_cuid_from_index(idx)
                         break
             component = component.parent_block()
 

--- a/pyomo/core/base/connector.py
+++ b/pyomo/core/base/connector.py
@@ -61,14 +61,10 @@ class _ConnectorValue(NumericValue):
         self.aggregators = {}
 
     def __str__(self):
-        return self.name()
+        return self.name
 
-    def name(self):
-        # the name can be None, in which case simply return "".
-        if self._name is None:
-            return ""
-        else:
-            return self.name()
+    def getname(self):
+        return self._name
 
     def __getstate__(self):
         state = super(_ConnectorValue, self).__getstate__()
@@ -85,7 +81,7 @@ class _ConnectorValue(NumericValue):
 
     def set_value(self, value):
         msg = "Cannot specify the value of a connector '%s'"
-        raise ValueError(msg % self.name())
+        raise ValueError(msg % self.name)
 
     def is_fixed(self):
         # The semantics here are not clear, and given how aggressive
@@ -141,14 +137,13 @@ class _ConnectorValue(NumericValue):
 
     def add(self, var, name=None, aggregate=None):
         if name is None:
-            name = var.name()
+            name = var.local_name
         if name in self.vars:
             raise ValueError("Cannot insert duplicate variable name "
-                             "'%s' into Connector '%s'" % ( name, self.name() ))
+                             "'%s' into Connector '%s'" % (name, self.local_name))
         self.vars[name] = var
         if aggregate is not None:
             self.aggregators[var] = aggregate
-
 
 class SimpleConnectorBase(IndexedComponent):
     """A collection of variables, which may be defined over a index"""

--- a/pyomo/core/base/connector.py
+++ b/pyomo/core/base/connector.py
@@ -140,7 +140,7 @@ class _ConnectorValue(NumericValue):
             name = var.local_name
         if name in self.vars:
             raise ValueError("Cannot insert duplicate variable name "
-                             "'%s' into Connector '%s'" % (name, self.local_name))
+                             "'%s' into Connector '%s'" % (name, self.name))
         self.vars[name] = var
         if aggregate is not None:
             self.aggregators[var] = aggregate

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -384,7 +384,7 @@ class _GeneralConstraintData(_ConstraintData):
                             "Constraint '%s' found a 3-tuple (lower,"
                             " expression, upper) but the lower "
                             "value was non-constant."
-                            % (self.name(True)))
+                            % (self.name))
 
                 arg1 = expr[1]
                 if arg1 is not None:
@@ -398,7 +398,7 @@ class _GeneralConstraintData(_ConstraintData):
                             "Constraint '%s' found a 3-tuple (lower,"
                             " expression, upper) but the upper "
                             "value was non-constant."
-                            % (self.name(True)))
+                            % (self.name))
 
                 self._lower = arg0
                 self._body  = arg1
@@ -410,7 +410,7 @@ class _GeneralConstraintData(_ConstraintData):
                     "length 2 or 3:\n"
                     "Equality:   (left, right)\n"
                     "Inequality: (lower, expression, upper)"
-                    % (self.name(True), len(expr)))
+                    % (self.name, len(expr)))
 
             relational_expr = False
         else:
@@ -423,14 +423,14 @@ class _GeneralConstraintData(_ConstraintData):
                         "equation. Examples:"
                         "\n   summation(model.costs) == model.income"
                         "\n   (0, model.price[item], 50)"
-                        % (self.name(True), str(expr)))
+                        % (self.name, str(expr)))
             except AttributeError:
                 msg = ("Constraint '%s' does not have a proper "
                        "value. Found '%s'\nExpecting a tuple or "
                        "equation. Examples:"
                        "\n   summation(model.costs) == model.income"
                        "\n   (0, model.price[item], 50)"
-                       % (self.name(True), str(expr)))
+                       % (self.name, str(expr)))
                 if type(expr) is bool:
                     msg += ("\nNote: constant Boolean expressions "
                             "are not valid constraint expressions. "
@@ -502,7 +502,7 @@ class _GeneralConstraintData(_ConstraintData):
                             "inequality expression ('>' or '<'). All"
                             " constraints must be formulated using "
                             "using '<=', '>=', or '=='."
-                            % (self.name(True)))
+                            % (self.name))
 
                 try:
                     _args = (expr._lhs, expr._rhs)
@@ -527,14 +527,14 @@ class _GeneralConstraintData(_ConstraintData):
                             "inequality expression (lower <= "
                             "expression <= upper) but the lower "
                             "bound was non-constant."
-                            % (self.name(True)))
+                            % (self.name))
                     if not _args[2].is_fixed():
                         raise ValueError(
                             "Constraint '%s' found a double-sided "\
                             "inequality expression (lower <= "
                             "expression <= upper) but the upper "
                             "bound was non-constant."
-                            % (self.name(True)))
+                            % (self.name))
 
                     self._lower = _args[0]
                     self._body  = _args[1]
@@ -571,12 +571,12 @@ class _GeneralConstraintData(_ConstraintData):
                 if val > 0:
                     raise ValueError(
                         "Constraint '%s' created with a +Inf lower "
-                        "bound." % (self.name(True)))
+                        "bound." % (self.name))
                 self._lower = None
             elif bool(val > 0) == bool(val <= 0):
                 raise ValueError(
                     "Constraint '%s' created with a non-numeric "
-                    "lower bound." % (self.name(True)))
+                    "lower bound." % (self.name))
 
         if (self._upper is not None) and \
            is_constant(self._upper):
@@ -585,12 +585,12 @@ class _GeneralConstraintData(_ConstraintData):
                 if val < 0:
                     raise ValueError(
                         "Constraint '%s' created with a -Inf upper "
-                        "bound." % (self.name(True)))
+                        "bound." % (self.name))
                 self._upper = None
             elif bool(val > 0) == bool(val <= 0):
                 raise ValueError(
                     "Constraint '%s' created with a non-numeric "
-                    "upper bound." % (self.name(True)))
+                    "upper bound." % (self.name))
 
         #
         # Error check, to ensure that we don't have a constraint that
@@ -603,7 +603,7 @@ class _GeneralConstraintData(_ConstraintData):
             if self._lower is None:
                 raise ValueError(
                     "Equality constraint '%s' defined with "
-                    "non-finite term." % (self.name(True)))
+                    "non-finite term." % (self.name))
             assert self._lower is self._upper
 
 class Constraint(ActiveIndexedComponent):
@@ -667,7 +667,7 @@ class Constraint(ActiveIndexedComponent):
         """
         if __debug__ and logger.isEnabledFor(logging.DEBUG):
             logger.debug("Constructing constraint %s"
-                         % (self.name(True)))
+                         % (self.name))
         if self._constructed:
             return
         self._constructed=True
@@ -701,13 +701,13 @@ class Constraint(ActiveIndexedComponent):
                     logger.error(
                         "Rule failed when generating expression for "
                         "constraint %s:\n%s: %s"
-                        % (self.name(True),
+                        % (self.name,
                            type(err).__name__,
                            err))
                     raise
                 if tmp is None:
                     raise ValueError(
-                        _rule_returned_none_error % (self.name(True),) )
+                        _rule_returned_none_error % (self.name,) )
 
             assert None not in self._data
             cdata = self._check_skip_add(None, tmp, condata=self)
@@ -726,7 +726,7 @@ class Constraint(ActiveIndexedComponent):
                 raise IndexError(
                     "Constraint '%s': Cannot initialize multiple indices "
                     "of a constraint with a single expression" %
-                    (self.name(True),) )
+                    (self.name,) )
 
             for ndx in self._index:
                 try:
@@ -739,7 +739,7 @@ class Constraint(ActiveIndexedComponent):
                     logger.error(
                         "Rule failed when generating expression for "
                         "constraint %s with index %s:\n%s: %s"
-                        % (self.name(True),
+                        % (self.name,
                            str(ndx),
                            type(err).__name__,
                            err))
@@ -747,7 +747,7 @@ class Constraint(ActiveIndexedComponent):
                 if tmp is None:
                     raise ValueError(
                         _rule_returned_none_error %
-                        ('%s[%s]' % (self.name(True), str(ndx)),) )
+                        ('%s[%s]' % (self.name, str(ndx)),) )
 
                 cdata = self._check_skip_add(ndx, tmp)
                 if cdata is not None:
@@ -784,7 +784,7 @@ class Constraint(ActiveIndexedComponent):
         if ostream is None:
             ostream = sys.stdout
         tab="    "
-        ostream.write(prefix+self.name()+" : ")
+        ostream.write(prefix+self.local_name+" : ")
         ostream.write("Size="+str(len(self)))
 
         ostream.write("\n")
@@ -834,7 +834,7 @@ class Constraint(ActiveIndexedComponent):
                     "object. Please modify your rule to return "
                     "Constraint.Skip instead of None."
                     "\n\nError thrown for Constraint '%s'"
-                    % (self._data[index].name(True)))
+                    % (self._data[index].name))
 
             #
             # There are cases where a user thinks they are generating
@@ -868,7 +868,7 @@ class Constraint(ActiveIndexedComponent):
                     "\n\nError thrown for Constraint '%s'"
                     "\n\nUnresolved (dangling) inequality "
                     "expression: %s"
-                    % (expr, self._data[index].name(True), buf))
+                    % (expr, self._data[index].name, buf))
             else:
                 raise ValueError(
                     "Invalid constraint expression. The constraint "
@@ -879,7 +879,7 @@ class Constraint(ActiveIndexedComponent):
                     % (expr,
                        expr and "Feasible" or "Infeasible",
                        expr,
-                       self._data[index].name(True)))
+                       self._data[index].name))
 
         #
         # Ignore an 'empty' constraint
@@ -892,7 +892,7 @@ class Constraint(ActiveIndexedComponent):
                 _prep_for_error()
                 raise ValueError(
                     "Constraint '%s' is always infeasible"
-                    % self._data[index].name(True))
+                    % self._data[index].name)
 
         if condata is None:
             self._data[index] = condata = \
@@ -938,13 +938,13 @@ class SimpleConstraint(_GeneralConstraintData, Constraint):
                     "Accessing the body of SimpleConstraint "
                     "'%s' before the Constraint has been assigned "
                     "an expression. There is currently "
-                    "nothing to access." % (self.name(True)))
+                    "nothing to access." % (self.name))
             return _GeneralConstraintData.body.fget(self)
         raise ValueError(
             "Accessing the body of constraint '%s' "
             "before the Constraint has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
     @property
     def lower(self):
@@ -955,13 +955,13 @@ class SimpleConstraint(_GeneralConstraintData, Constraint):
                     "Accessing the lower bound of SimpleConstraint "
                     "'%s' before the Constraint has been assigned "
                     "an expression. There is currently "
-                    "nothing to access." % (self.name(True)))
+                    "nothing to access." % (self.name))
             return _GeneralConstraintData.lower.fget(self)
         raise ValueError(
             "Accessing the lower bound of constraint '%s' "
             "before the Constraint has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
     @property
     def upper(self):
@@ -972,13 +972,13 @@ class SimpleConstraint(_GeneralConstraintData, Constraint):
                     "Accessing the upper bound of SimpleConstraint "
                     "'%s' before the Constraint has been assigned "
                     "an expression. There is currently "
-                    "nothing to access." % (self.name(True)))
+                    "nothing to access." % (self.name))
             return _GeneralConstraintData.upper.fget(self)
         raise ValueError(
             "Accessing the upper bound of constraint '%s' "
             "before the Constraint has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
     @property
     def equality(self):
@@ -989,13 +989,13 @@ class SimpleConstraint(_GeneralConstraintData, Constraint):
                     "Accessing the equality flag of SimpleConstraint "
                     "'%s' before the Constraint has been assigned "
                     "an expression. There is currently "
-                    "nothing to access." % (self.name(True)))
+                    "nothing to access." % (self.name))
             return _GeneralConstraintData.equality.fget(self)
         raise ValueError(
             "Accessing the equality flag of constraint '%s' "
             "before the Constraint has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
     @property
     def strict_lower(self):
@@ -1006,13 +1006,13 @@ class SimpleConstraint(_GeneralConstraintData, Constraint):
                     "Accessing the strict_lower flag of SimpleConstraint "
                     "'%s' before the Constraint has been assigned "
                     "an expression. There is currently "
-                    "nothing to access." % (self.name(True)))
+                    "nothing to access." % (self.name))
             return _GeneralConstraintData.strict_lower.fget(self)
         raise ValueError(
             "Accessing the strict_lower flag of constraint '%s' "
             "before the Constraint has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
     @property
     def strict_upper(self):
@@ -1023,13 +1023,13 @@ class SimpleConstraint(_GeneralConstraintData, Constraint):
                     "Accessing the strict_upper flag of SimpleConstraint "
                     "'%s' before the Constraint has been assigned "
                     "an expression. There is currently "
-                    "nothing to access." % (self.name(True)))
+                    "nothing to access." % (self.name))
             return _GeneralConstraintData.strict_upper.fget(self)
         raise ValueError(
             "Accessing the strict_upper flag of constraint '%s' "
             "before the Constraint has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
     #
     # Singleton constraints are strange in that we want them to be
@@ -1052,7 +1052,7 @@ class SimpleConstraint(_GeneralConstraintData, Constraint):
             "Setting the value of constraint '%s' "
             "before the Constraint has been constructed (there "
             "is currently no object to set)."
-            % (self.name(True)))
+            % (self.name))
 
     #
     # Leaving this method for backward compatibility reasons.
@@ -1064,7 +1064,7 @@ class SimpleConstraint(_GeneralConstraintData, Constraint):
             raise ValueError(
                 "SimpleConstraint object '%s' does not accept "
                 "index values other than None. Invalid value: %s"
-                % (self.name(True), index))
+                % (self.name, index))
         self.set_value(expr)
         return self
 
@@ -1114,7 +1114,7 @@ class ConstraintList(IndexedConstraint):
             __debug__ and logger.isEnabledFor(logging.DEBUG)
         if generate_debug_messages:
             logger.debug("Constructing constraint list %s"
-                         % (self.name(True)))
+                         % (self.name))
 
         if self._constructed:
             return
@@ -1152,7 +1152,7 @@ class ConstraintList(IndexedConstraint):
                 if expr is None:
                     raise ValueError(
                         "ConstraintList '%s': rule returned None "
-                        "instead of ConstraintList.End" % (self.name(True),) )
+                        "instead of ConstraintList.End" % (self.name,) )
                 if (expr.__class__ is tuple) and \
                    (expr == ConstraintList.End):
                     return
@@ -1164,7 +1164,7 @@ class ConstraintList(IndexedConstraint):
                 if expr is None:
                     raise ValueError(
                         "ConstraintList '%s': generator returned None "
-                        "instead of ConstraintList.End" % (self.name(True),) )
+                        "instead of ConstraintList.End" % (self.name,) )
                 if (expr.__class__ is tuple) and \
                    (expr == ConstraintList.End):
                     return

--- a/pyomo/core/base/expr_coopr3.py
+++ b/pyomo/core/base/expr_coopr3.py
@@ -131,7 +131,7 @@ class _ExpressionBase(NumericValue):
             ostream = sys.stdout
         _verbose = pyomo.core.base.expr_common.TO_STRING_VERBOSE \
                    if verbose is None else verbose
-        ostream.write(self.name() + "( ")
+        ostream.write(self.getname() + "( ")
         first = True
         for arg in self._args:
             if first:
@@ -248,12 +248,12 @@ class _ExternalFunctionExpression(_ExpressionBase):
         return self.__class__( self._fcn,
                                tuple(clone_expression(x) for x in self._args) )
 
-    def name(self):
-        return self._fcn.name()
+    def getname(self, *args, **kwds):
+        return self._fcn.getname(*args, **kwds)
 
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
+        return self.getname(*args, **kwds)
 
     def polynomial_degree(self):
         return None
@@ -285,7 +285,7 @@ class _IntrinsicFunctionExpression(_ExpressionBase):
         """Construct an expression with an operation and a set of arguments"""
         if nargs and nargs != len(args):
             raise ValueError("%s() takes exactly %d arguments (%d given)" % \
-                ( self.name(), nargs, len(args) ))
+                ( self.name, nargs, len(args) ))
         _ExpressionBase.__init__(self, args)
         self._operator = operator
         self._name = name
@@ -305,12 +305,12 @@ class _IntrinsicFunctionExpression(_ExpressionBase):
     def _apply_operation(self, values):
         return self._operator(*tuple(values))
 
-    def name(self):
+    def getname(self, *args, **kwds):
         return self._name
 
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
+        return self.getname(*args, **kwds)
 
     def polynomial_degree(self):
         if self.is_fixed():
@@ -520,7 +520,7 @@ class _EqualityExpression(_LinearExpression):
         """Constructor"""
         if 2 != len(args):
             raise ValueError("%s() takes exactly 2 arguments (%d given)" % \
-                ( self.name(), len(args) ))
+                ( self.name, len(args) ))
         _LinearExpression.__init__(self, args)
 
     def __copy__(self):
@@ -821,12 +821,12 @@ class Expr_if(_ExpressionBase):
             result[i] = getattr(self, i)
         return result
 
-    def name(self):
+    def getname(self, *args, **kwds):
         return "Expr_if"
 
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
+        return self.getname(*args, **kwds)
 
     def is_constant(self):
         if self._if.is_constant():
@@ -945,7 +945,7 @@ def generate_expression(etype, _self, other):
         raise TypeError("Argument for expression '%s' is an indexed "\
               "numeric value specified without an index: %s\n    Is "\
               "variable or parameter '%s' defined over an index that "\
-              "you did not specify?" % (etype, _self.name(), _self.name()))
+              "you did not specify?" % (etype, _self.name, _self.name))
 
     self_type = _self.__class__
     # In-place operators should only clone `self` if someone else (other
@@ -1004,7 +1004,7 @@ def generate_expression(etype, _self, other):
                 "Argument for expression '%s' is an indexed numeric "
                 "value\nspecified without an index:\n\t%s\nIs this "
                 "value defined over an index that you did not specify?"
-                % (etype, other.name(), ) )
+                % (etype, other.name, ) )
         if other.is_expression():
             other = _generate_expression__clone_if_needed(other, 0)
         elif other.is_constant():
@@ -1352,7 +1352,7 @@ def generate_relational_expression(etype, lhs, rhs):
             "specified without an index: %s\n    Is variable or parameter "
             "'%s' defined over an index that you did not specify?"
             % ({_eq:'==',_lt:'<',_le:'<='}.get(etype, etype),
-               lhs.name(), lhs.name()))
+               lhs.name, lhs.name))
     elif lhs.is_expression():
         lhs = _generate_relational_expression__clone_if_needed(lhs)
         if lhs.is_relational():
@@ -1365,7 +1365,7 @@ def generate_relational_expression(etype, lhs, rhs):
             "specified without an index: %s\n    Is variable or parameter "
             "'%s' defined over an index that you did not specify?"
             % ({_eq:'==',_lt:'<',_le:'<='}.get(etype, etype),
-               rhs.name(), rhs.name()))
+               rhs.name, rhs.name))
     elif rhs.is_expression():
         rhs = _generate_relational_expression__clone_if_needed(rhs)
         if rhs.is_relational():
@@ -1536,7 +1536,7 @@ def generate_intrinsic_function_expression(arg, name, fcn):
     elif new_arg.is_indexed():
         raise ValueError("Argument for intrinsic function '%s' is an "\
             "n-ary numeric value: %s\n    Have you given variable or "\
-            "parameter '%s' an index?" % (name, new_arg.name(), new_arg.name()))
+            "parameter '%s' an index?" % (name, new_arg.name, new_arg.name))
     return _IntrinsicFunctionExpression(name, 1, (new_arg,), fcn)
 
 # [debugging] clone_counter is a count of the number of calls to

--- a/pyomo/core/base/expr_pyomo4.py
+++ b/pyomo/core/base/expr_pyomo4.py
@@ -224,7 +224,8 @@ class _ExpressionBase(NumericValue):
             "implement getname()" % ( str(self.__class__), ))
 
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
+        logger.warning(
+            "DEPRECATED: The cname() method has been renamed to getname()" )
         return self.getname(*args, **kwds)
 
     #
@@ -406,10 +407,6 @@ class _NegationExpression(_ExpressionBase):
     def getname(self):
         return 'neg'
 
-    def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
-        return self.getname(*args, **kwds)
-
     def _polynomial_degree(self, result):
         return result.pop()
 
@@ -458,10 +455,6 @@ class _UnaryFunctionExpression(_ExpressionBase):
     def getname(self):
         return self._name
 
-    def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
-        return self.getname(*args, **kwds)
-
     def _to_string_prefix(self, ostream, verbose):
         ostream.write(self.getname())
 
@@ -483,10 +476,6 @@ class _ExternalFunctionExpression(_ExpressionBase):
 
     def getname(self):
         return self._fcn.getname()
-
-    def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
-        return self.getname(*args, **kwds)
 
     def _polynomial_degree(self, result):
         if result.pop() == 0:
@@ -572,10 +561,6 @@ class _PowExpression(_ExpressionBase):
 
     def getname(self):
         return 'pow'
-
-    def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
-        return self.getname(*args, **kwds)
 
     def _inline_operator(self):
         return '**'
@@ -698,10 +683,6 @@ class _ProductExpression(_ExpressionBase):
     def getname(self):
         return 'prod'
 
-    def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
-        return self.getname(*args, **kwds)
-
     def _inline_operator(self):
         return ' * '
 
@@ -732,10 +713,6 @@ class _DivisionExpression(_ExpressionBase):
 
     def getname(self):
         return 'div'
-
-    def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
-        return self.getname(*args, **kwds)
 
     def _inline_operator(self):
         return ' / '
@@ -792,10 +769,6 @@ class _SumExpression(_ExpressionBase):
 
     def getname(self):
         return 'sum'
-
-    def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
-        return self.getname(*args, **kwds)
 
     def __iadd__(self, other):
         if safe_mode and self._parent_expr:
@@ -939,10 +912,6 @@ class Expr_if(_ExpressionBase):
     def getname(self):
         return "Expr_if"
 
-    def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
-        return self.getname(*args, **kwds)
-
     def is_constant(self):
         if self._if.is_constant():
             if self._if():
@@ -1082,10 +1051,6 @@ class _LinearExpression(_ExpressionBase):
 
     def getname(self):
         return 'linear'
-
-    def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
-        return self.getname(*args, **kwds)
 
     def is_constant(self):
         if self._const.__class__ not in native_numeric_types \

--- a/pyomo/core/base/expr_pyomo4.py
+++ b/pyomo/core/base/expr_pyomo4.py
@@ -218,14 +218,14 @@ class _ExpressionBase(NumericValue):
         ans._parent_expr = None
         return ans
 
-    def name(self):
+    def getname(self):
         """The text name of this Expression function"""
         raise NotImplementedError("Derived expression (%s) failed to "\
-            "implement name()" % ( str(self.__class__), ))
+            "implement getname()" % ( str(self.__class__), ))
 
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
+        return self.getname(*args, **kwds)
 
     #
     # this method contrast with the is_fixed() method.  This method
@@ -385,11 +385,11 @@ class _ExpressionBase(NumericValue):
         elif _sub.__class__ is NumericConstant:
             ostream.write(str(_sub()))
         else:
-            ostream.write(_sub.name(True, _name_buffer))
+            ostream.write(_sub.getname(True, _name_buffer))
 
     def _to_string_prefix(self, ostream, verbose):
         if verbose:
-            ostream.write(self.name())
+            ostream.write(self.getname())
 
     def _to_string_infix(self, ostream, idx, verbose):
         if verbose:
@@ -403,12 +403,12 @@ class _NegationExpression(_ExpressionBase):
 
     PRECEDENCE = 4
 
-    def name(self):
+    def getname(self):
         return 'neg'
 
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
+        return self.getname(*args, **kwds)
 
     def _polynomial_degree(self, result):
         return result.pop()
@@ -418,7 +418,7 @@ class _NegationExpression(_ExpressionBase):
 
     def _to_string_prefix(self, ostream, verbose):
         if verbose:
-            ostream.write(self.name())
+            ostream.write(self.getname())
         elif not self._args[0].is_expression and _NegationExpression.PRECEDENCE <= self._args[0]._precedence():
             ostream.write("-")
         else:
@@ -455,15 +455,15 @@ class _UnaryFunctionExpression(_ExpressionBase):
             result[i] = getattr(self, i)
         return result
 
-    def name(self):
+    def getname(self):
         return self._name
 
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
+        return self.getname(*args, **kwds)
 
     def _to_string_prefix(self, ostream, verbose):
-        ostream.write(self.name())
+        ostream.write(self.getname())
 
     def _polynomial_degree(self, result):
         if result.pop() == 0:
@@ -481,12 +481,12 @@ _IntrinsicFunctionExpression =  _UnaryFunctionExpression
 class _ExternalFunctionExpression(_ExpressionBase):
     __slots__ = ()
 
-    def name(self):
-        return self._fcn.name()
+    def getname(self):
+        return self._fcn.getname()
 
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
+        return self.getname(*args, **kwds)
 
     def _polynomial_degree(self, result):
         if result.pop() == 0:
@@ -570,12 +570,12 @@ class _PowExpression(_ExpressionBase):
         _l = result.pop()
         return _l ** _r
 
-    def name(self):
+    def getname(self):
         return 'pow'
 
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
+        return self.getname(*args, **kwds)
 
     def _inline_operator(self):
         return '**'
@@ -695,12 +695,12 @@ class _ProductExpression(_ExpressionBase):
             return a + b
 
 
-    def name(self):
+    def getname(self):
         return 'prod'
 
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
+        return self.getname(*args, **kwds)
 
     def _inline_operator(self):
         return ' * '
@@ -730,12 +730,12 @@ class _DivisionExpression(_ExpressionBase):
             return None
 
 
-    def name(self):
+    def getname(self):
         return 'div'
 
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
+        return self.getname(*args, **kwds)
 
     def _inline_operator(self):
         return ' / '
@@ -790,12 +790,12 @@ class _SumExpression(_ExpressionBase):
     def _apply_operation(self, result):
         return sum(result.pop() for x in self._args)
 
-    def name(self):
+    def getname(self):
         return 'sum'
 
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
+        return self.getname(*args, **kwds)
 
     def __iadd__(self, other):
         if safe_mode and self._parent_expr:
@@ -830,7 +830,7 @@ class _SumExpression(_ExpressionBase):
                 "Argument for expression '%s' is an indexed numeric "
                 "value\nspecified without an index:\n\t%s\nIs this "
                 "value defined over an index that you did not specify?"
-                % (etype, other.name(True), ) )
+                % (etype, other.name, ) )
         elif other.is_constant():
             other = other()
 
@@ -882,7 +882,7 @@ class _SumExpression(_ExpressionBase):
                 "Argument for expression '%s' is an indexed numeric "
                 "value\nspecified without an index:\n\t%s\nIs this "
                 "value defined over an index that you did not specify?"
-                % (etype, other.name(), ) )
+                % (etype, other.name, ) )
         elif other.is_constant():
             other = - ( other() )
 
@@ -936,12 +936,12 @@ class Expr_if(_ExpressionBase):
     def _arguments(self):
         return ( self._if, self._then, self._else )
 
-    def name(self):
+    def getname(self):
         return "Expr_if"
 
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
+        return self.getname(*args, **kwds)
 
     def is_constant(self):
         if self._if.is_constant():
@@ -979,7 +979,7 @@ class Expr_if(_ExpressionBase):
         ostream.write(" )")
 
     def _to_string_prefix(self, ostream, verbose):
-        ostream.write(self.name())
+        ostream.write(self.getname())
 
     def _to_string_infix(self, ostream, idx, verbose):
         ostream.write(", ")
@@ -1080,12 +1080,12 @@ class _LinearExpression(_ExpressionBase):
             ans.extend(self._args)
             return ans
 
-    def name(self):
+    def getname(self):
         return 'linear'
 
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
+        return self.getname(*args, **kwds)
 
     def is_constant(self):
         if self._const.__class__ not in native_numeric_types \
@@ -1109,7 +1109,7 @@ class _LinearExpression(_ExpressionBase):
                 if _idx:
                     coef = abs(coef)
                 if coef == 1:
-                    ostream.write(_sub.name(True, _name_buffer))
+                    ostream.write(_sub.getname(True, _name_buffer))
                     return
                 ostream.write(str(coef))
             elif coef.is_expression():
@@ -1117,7 +1117,7 @@ class _LinearExpression(_ExpressionBase):
                                 precedence=_ProductExpression.PRECEDENCE )
             else:
                 ostream.write(str(coef))
-            ostream.write("*%s" % (_sub.name(True, _name_buffer)))
+            ostream.write("*%s" % (_sub.getname(True, _name_buffer)))
 
     def _to_string_infix(self, ostream, idx, verbose):
         if verbose:
@@ -1444,7 +1444,7 @@ def generate_expression(etype, _self, _other):
                 "Argument for expression '%s' is an indexed numeric "
                 "value\nspecified without an index:\n\t%s\nIs this "
                 "value defined over an index that you did not specify?"
-                % (etype, _other.name(), ) )
+                % (etype, _other.name, ) )
         elif _other.is_constant():
             _other = _other()
 
@@ -1666,7 +1666,7 @@ def generate_relational_expression(etype, lhs, rhs):
             "specified without an index: %s\n    Is variable or parameter "
             "'%s' defined over an index that you did not specify?"
             % ({_eq:'==',_lt:'<',_le:'<='}.get(etype, etype),
-               lhs.name(), lhs.name()))
+               lhs.name, lhs.name))
     elif lhs.is_expression():
         if lhs.is_relational():
             lhs_is_relational = True
@@ -1678,7 +1678,7 @@ def generate_relational_expression(etype, lhs, rhs):
             "specified without an index: %s\n    Is variable or parameter "
             "'%s' defined over an index that you did not specify?"
             % ({_eq:'==',_lt:'<',_le:'<='}.get(etype, etype),
-               rhs.name(), rhs.name()))
+               rhs.name, rhs.name))
     elif rhs.is_expression():
         if rhs.is_relational():
             rhs_is_relational = True
@@ -1804,7 +1804,7 @@ def generate_intrinsic_function_expression(arg, name, fcn):
     if arg.is_indexed():
         raise ValueError("Argument for intrinsic function '%s' is an "\
             "n-ary numeric value: %s\n    Have you given variable or "\
-            "parameter '%s' an index?" % (name, arg.name(), arg.name()))
+            "parameter '%s' an index?" % (name, arg.name, arg.name))
     return _UnaryFunctionExpression((arg,), name, fcn)
 
 # [debugging] clone_counter is a count of the number of calls to

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -293,7 +293,7 @@ class Expression(IndexedComponent):
         if ostream is None:
             ostream = sys.stdout
         tab="    "
-        ostream.write(prefix+self.name()+" : ")
+        ostream.write(prefix+self.local_name+" : ")
         ostream.write("Size="+str(len(self)))
 
         ostream.write("\n")
@@ -326,7 +326,7 @@ class Expression(IndexedComponent):
            (not None in new_values):
             raise KeyError(
                 "Cannot store value for scalar Expression"
-                "="+self.name(True)+"; no value with index "
+                "="+self.name+"; no value with index "
                 "None in input new values map.")
 
         for index, new_value in iteritems(new_values):
@@ -350,7 +350,7 @@ class Expression(IndexedComponent):
             raise KeyError(
                 "Cannot set the value of Expression '%s' with "
                 "invalid index '%s'"
-                % (self.name(True), str(ndx)))
+                % (self.name, str(ndx)))
         #
         # Set the value
         #
@@ -362,7 +362,7 @@ class Expression(IndexedComponent):
         if __debug__ and logger.isEnabledFor(logging.DEBUG):
             logger.debug(
                 "Constructing Expression, name=%s, from data=%s"
-                % (self.name(True), str(data)))
+                % (self.name, str(data)))
 
         if self._constructed:
             return
@@ -436,7 +436,7 @@ class SimpleExpression(_GeneralExpressionData, Expression):
             "Accessing the expression of expression '%s' "
             "before the Expression has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
     @expr.setter
     def expr(self, expr):
         """Set the expression on this expression."""
@@ -464,7 +464,7 @@ class SimpleExpression(_GeneralExpressionData, Expression):
             "Setting the expression of expression '%s' "
             "before the Expression has been constructed (there "
             "is currently no object to set)."
-            % (self.name(True)))
+            % (self.name))
 
     def is_constant(self):
         """A boolean indicating whether this expression is constant."""
@@ -474,7 +474,7 @@ class SimpleExpression(_GeneralExpressionData, Expression):
             "Accessing the is_constant flag of expression '%s' "
             "before the Expression has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
     def is_fixed(self):
         """A boolean indicating whether this expression is fixed."""
@@ -484,7 +484,7 @@ class SimpleExpression(_GeneralExpressionData, Expression):
             "Accessing the is_fixed flag of expression '%s' "
             "before the Expression has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
     #
     # Leaving this method for backward compatibility reasons.
@@ -496,13 +496,13 @@ class SimpleExpression(_GeneralExpressionData, Expression):
             raise KeyError(
                 "SimpleExpression object '%s' does not accept "
                 "index values other than None. Invalid value: %s"
-                % (self.name(True), index))
+                % (self.name, index))
         if (type(expr) is tuple) and \
            (expr == Expression.Skip):
             raise ValueError(
                 "Expression.Skip can not be assigned "
                 "to an Expression that is not indexed: %s"
-                % (self.name(True)))
+                % (self.name))
         self.set_value(expr)
         return self
 

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -65,16 +65,16 @@ class ExternalFunction(Component):
                 else as_numeric(x)
                 for x in args ) )
 
-    def name(self, fully_qualified=False, name_buffer=None):
+    def getname(self, fully_qualified=False, name_buffer=None):
         if self.name:
-            return super(ExternalFunction, self).name(
+            return super(ExternalFunction, self).getname(
                 fully_qualified, name_buffer )
         else:
             return str(self._library) + ":" + str(self._function)
 
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() function has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() function has been renamed to getname()")
+        return self.getname(*args, **kwds)
 
     def evaluate(self, args):
         raise NotImplementedError(
@@ -161,16 +161,16 @@ class PythonCallbackFunction(ExternalFunction):
     def __call__(self, *args):
         return super(PythonCallbackFunction, self).__call__(self._fcn_id, *args)
 
-    def name(self, fully_qualified=False, name_buffer=None):
+    def getname(self, fully_qualified=False, name_buffer=None):
         if self.name:
-            return super(ExternalFunction, self).name(
-                fully_qualified, name_buffer )
+            return super(ExternalFunction, self).getname(
+                fully_qualified, name_buffer)
         else:
             return "PythonCallback(%s)" % str(self._fcn)
 
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() function has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() function has been renamed to getname()")
+        return self.getname(*args, **kwds)
 
     def evaluate(self, args):
         # Skip the library name and function name

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -380,7 +380,7 @@ You can silence this warning by one of three ways:
     3) If you intend to iterate over a component that may be empty, test
        if the component is empty first and avoid iteration in the case
        where it is empty.
-""" % (self.name(True),) )
+""" % (self.name,) )
 
             if not hasattr(self._index, 'ordered') or not self._index.ordered:
                 #
@@ -456,7 +456,7 @@ You can silence this warning by one of three ways:
                 idx_str = "[" + str(ndx) + "]"
             raise ValueError(
                 "Error retrieving component %s%s: The component has "
-                "not been constructed." % ( self.name(True), idx_str,) )
+                "not been constructed." % ( self.name, idx_str,) )
         if ndx is None and not self.is_indexed():
             self._data[ndx] = self  # FIXME: should this be a weakref?!?
             return self
@@ -495,14 +495,14 @@ You can silence this warning by one of three ways:
         if not self.is_indexed():
             msg = "Error accessing indexed component: " \
                   "Cannot treat the scalar component '%s' as an array" \
-                  % ( self.name(True), )
+                  % ( self.name, )
             raise KeyError(msg)
         #
         # Raise an exception
         #
         msg = "Error accessing indexed component: " \
                   "Index '%s' is not valid for array component '%s'" \
-                  % ( ndx, self.name(True), )
+                  % ( ndx, self.name, )
         raise KeyError(msg)
 
 
@@ -567,7 +567,7 @@ index %s is a fixed but not constant value.  This is likely not what you
 meant to do, as if you later change the fixed value of the object this
 lookup will not change.  If you understand the implications of using
 fixed but not constant values, you can get the current value using the
-value() function.""" % ( self.name(True), i ))
+value() function.""" % ( self.name, i ))
                 else:
                     raise RuntimeError(
 """Error retrieving the value of an indexed item %s:
@@ -575,7 +575,7 @@ index %s is not a constant value.  This is likely not what you meant to
 do, as if you later change the fixed value of the object this lookup
 will not change.  If you understand the implications of using
 non-constant values, you can get the current value of the object using
-the value() function.""" % ( self.name(True), i ))
+the value() function.""" % ( self.name, i ))
             except AttributeError:
                 pass
             if ellipsis is None:
@@ -591,7 +591,7 @@ the value() function.""" % ( self.name(True), i ))
         else:
             raise TypeError(
                 "%s found when trying to retrieve index for component %s"
-                % (_exception, self.name(True)) )
+                % (_exception, self.name) )
 
 
     def _default(self, index):
@@ -608,7 +608,7 @@ the value() function.""" % ( self.name(True), i ))
                 "Cannot set the value for the indexed component '%s' "
                 "without specifying an index value.\n"
                 "\tFor example, model.%s[i] = value"
-                % (self.name(), self.name()))
+                % (self.name, self.name))
         else:
             raise NotImplementedError(
                 "Derived component %s failed to define set_value() "

--- a/pyomo/core/base/label.py
+++ b/pyomo/core/base/label.py
@@ -85,25 +85,25 @@ class CNameLabeler(object):
         self.name_buffer = {}
 
     def __call__(self, obj):
-        return obj.name(True, self.name_buffer)
+        return obj.getname(True, self.name_buffer)
 
 class TextLabeler(object):
     def __init__(self):
         self.name_buffer = {}
 
     def __call__(self, obj):
-        return cpxlp_label_from_name(obj.name(True, self.name_buffer))
+        return cpxlp_label_from_name(obj.getname(True, self.name_buffer))
 
 class AlphaNumTextLabeler(object):
     def __init__(self):
         self.name_buffer = {}
 
     def __call__(self, obj):
-        return alphanum_label_from_name(obj.name(True, self.name_buffer))
+        return alphanum_label_from_name(obj.getname(True, self.name_buffer))
 
 class NameLabeler(object):
     def __init__(self):
         self.name_buffer = {}
 
     def __call__(self, obj):
-        return obj.name(True, self.name_buffer)
+        return obj.getname(True, self.name_buffer)

--- a/pyomo/core/base/numvalue.py
+++ b/pyomo/core/base/numvalue.py
@@ -49,7 +49,7 @@ def _old_value(obj):
     tmp = obj()
     if tmp is None:
         raise ValueError("No value for uninitialized NumericValue object %s"
-                         % (obj.name(),))
+                         % (obj.name,))
     return tmp
 
 # It is *significantly* faster to build the list of types we want to
@@ -156,7 +156,7 @@ def value(obj, exception=True):
 
     if exception and (tmp is None):
         raise ValueError("No value for uninitialized NumericValue object %s"
-                         % (obj.name(),))
+                         % (obj.name,))
     return tmp
 
 
@@ -320,18 +320,26 @@ class NumericValue(object):
                 # of setting self.__dict__[key] = val.
                 object.__setattr__(self, key, val)
 
-    def name(self, fully_qualified=False, name_buffer=None):
+    def getname(self, fully_qualified=False, name_buffer=None):
         """If this is a component, return the component's name on the owning
         block; otherwise return the value converted to a string"""
         _base = super(NumericValue, self)
-        if hasattr(_base,'name'):
-            return _base.name(fully_qualified, name_buffer)
+        if hasattr(_base,'getname'):
+            return _base.getname(fully_qualified, name_buffer)
         else:
             return str(type(self))
 
+    @property
+    def name(self):
+        return self.getname(fully_qualified=True)
+
+    @property
+    def local_name(self):
+        return self.getname(fully_qualified=False)
+
     def cname(self, *args, **kwds):
-        logger.warning("DEPRECATED: The cname() method has been renamed to name()")
-        return self.name(*args, **kwds)
+        logger.warning("DEPRECATED: The cname() method has been renamed to getname()")
+        return self.getname(*args, **kwds)
 
     def is_constant(self):
         """Return True if this numeric value is a constant value"""
@@ -374,7 +382,7 @@ class NumericValue(object):
 disabled. This error is often the result of using Pyomo components as
 arguments to one of the Python built-in math module functions when
 defining expressions. Avoid this error by using Pyomo-provided math
-functions.""" % (self.name(),))
+functions.""" % (self.name,))
 
     def __int__(self):
         """Coerce the value to an integer"""
@@ -383,7 +391,7 @@ functions.""" % (self.name(),))
 disabled. This error is often the result of using Pyomo components as
 arguments to one of the Python built-in math module functions when
 defining expressions. Avoid this error by using Pyomo-provided math
-functions.""" % (self.name(),))
+functions.""" % (self.name,))
 
     def __lt__(self,other):
         """Less than operator

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -274,7 +274,7 @@ class Objective(ActiveIndexedComponent):
         """
         if __debug__ and logger.isEnabledFor(logging.DEBUG):
             logger.debug(
-                "Constructing objective %s" % (self.name(True)))
+                "Constructing objective %s" % (self.name))
         if self._constructed:
             return
         self._constructed = True
@@ -310,7 +310,7 @@ class Objective(ActiveIndexedComponent):
                     logger.error(
                         "Rule failed when generating expression for "
                         "objective %s:\n%s: %s"
-                        % (self.name(True),
+                        % (self.name,
                            type(err).__name__,
                            err))
                     raise
@@ -348,7 +348,7 @@ class Objective(ActiveIndexedComponent):
                     logger.error(
                         "Rule failed when generating expression for"
                         " objective %s with index %s:\n%s: %s"
-                        % (self.name(True),
+                        % (self.name,
                            str(ndx),
                            type(err).__name__,
                            err))
@@ -389,7 +389,7 @@ class Objective(ActiveIndexedComponent):
         tab = "    "
         if ostream is None:
             ostream = sys.stdout
-        ostream.write(prefix+self.name()+" : ")
+        ostream.write(prefix+self.local_name+" : ")
         ostream.write(", ".join("%s=%s" % (k,v) for k,v in [
                     ("Size", len(self)),
                     ("Index", self._index \
@@ -437,7 +437,7 @@ class Objective(ActiveIndexedComponent):
                 "object or numeric value. Please modify your rule "
                 "to return Objective.Skip instead of None."
                 "\n\nError thrown for Objective '%s'"
-                % (self._data[index].name(True)))
+                % (self._data[index].name))
 
         #
         # Ignore an 'empty' objective
@@ -488,13 +488,13 @@ class SimpleObjective(_GeneralObjectiveData, Objective):
                     "Accessing the expression of SimpleObjective "
                     "'%s' before the Objective has been assigned "
                     "a sense or expression. There is currently "
-                    "nothing to access." % (self.name(True)))
+                    "nothing to access." % (self.name))
             return _GeneralObjectiveData.expr.fget(self)
         raise ValueError(
             "Accessing the expression of objective '%s' "
             "before the Objective has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
     @expr.setter
     def expr(self, expr):
         """Set the expression of this objective."""
@@ -523,13 +523,13 @@ class SimpleObjective(_GeneralObjectiveData, Objective):
                     "Accessing the sense of SimpleObjective "
                     "'%s' before the Objective has been assigned "
                     "a sense or expression. There is currently "
-                    "nothing to access." % (self.name(True)))
+                    "nothing to access." % (self.name))
             return _GeneralObjectiveData.sense.fget(self)
         raise ValueError(
             "Accessing the sense of objective '%s' "
             "before the Objective has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
     @sense.setter
     def sense(self, sense):
         """Set the sense (direction) of this objective."""
@@ -556,7 +556,7 @@ class SimpleObjective(_GeneralObjectiveData, Objective):
             "Setting the value of objective '%s' "
             "before the Objective has been constructed (there "
             "is currently no object to set)."
-            % (self.name(True)))
+            % (self.name))
 
     def set_sense(self, sense):
         """Set the sense (direction) of this objective."""
@@ -568,7 +568,7 @@ class SimpleObjective(_GeneralObjectiveData, Objective):
             "Setting the sense of objective '%s' "
             "before the Objective has been constructed (there "
             "is currently no object to set)."
-            % (self.name(True)))
+            % (self.name))
 
     #
     # Leaving this method for backward compatibility reasons.
@@ -580,7 +580,7 @@ class SimpleObjective(_GeneralObjectiveData, Objective):
             raise ValueError(
                 "SimpleObjective object '%s' does not accept "
                 "index values other than None. Invalid value: %s"
-                % (self.name(True), index))
+                % (self.name, index))
         self.set_value(expr)
         return self
 
@@ -626,7 +626,7 @@ class ObjectiveList(IndexedObjective):
             __debug__ and logger.isEnabledFor(logging.DEBUG)
         if generate_debug_messages:
             logger.debug(
-                "Constructing objective %s" % (self.name(True)))
+                "Constructing objective %s" % (self.name))
 
         if self._constructed:
             return

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -276,7 +276,7 @@ class Param(IndexedComponent):
         should only be used by developers!
         """
         if not self._mutable:
-            raise RuntimeError("Cannot call store_values method on immutable Param="+ self.name(True))
+            raise RuntimeError("Cannot call store_values method on immutable Param="+ self.name)
         #
         _srcType = type(new_values)
         _isDict = _srcType is dict or ( \
@@ -329,7 +329,7 @@ class Param(IndexedComponent):
                 if None not in new_values:
                     raise RuntimeError(
                         "Cannot store value for scalar Param="+
-                        self.name(True)+"; no value with index None "
+                        self.name+"; no value with index None "
                         "in input new values map.")
                 new_values = new_values[None]
             # scalars have to be handled differently
@@ -347,17 +347,17 @@ class Param(IndexedComponent):
         #
         if not self._constructed:
             if idx is None:
-                idx_str = '%s' % (self.name(),)
+                idx_str = '%s' % (self.local_name,)
             else:
-                idx_str = '%s[%s]' % (self.name(), idx,)
+                idx_str = '%s[%s]' % (self.local_name, idx,)
             raise ValueError(
                 "Error retrieving Param value (%s): This parameter has "
                 "not been constructed" % ( idx_str,) )
         if val is None:
             if self.is_indexed():
-                idx_str = '%s[%s]' % (self.name(True), idx,)
+                idx_str = '%s[%s]' % (self.name, idx,)
             else:
-                idx_str = '%s' % (self.name(True),)
+                idx_str = '%s' % (self.name,)
             raise ValueError(
                     "Error retrieving Param value (%s): The Param value is "
                     "undefined and no default value is specified"
@@ -392,7 +392,7 @@ class Param(IndexedComponent):
                 raise ValueError(
                     "Invalid default parameter value: %s[%s] = '%s';"
                     " value type=%s.\n\tValue not in parameter domain %s" %
-                    (self.name(True), idx, val, type(val), self.domain.name()) )
+                    (self.name, idx, val, type(val), self.domain.name) )
         #
         # Set the parameter
         #
@@ -439,7 +439,7 @@ class Param(IndexedComponent):
                 and val not in self.domain:
             raise ValueError(
                 "Default value (%s) is not valid for Param domain %s" %
-                ( str(val), self.domain.name() ) )
+                (str(val), self.domain.name))
         self._default_val = val
 
     def default(self):
@@ -482,7 +482,7 @@ class Param(IndexedComponent):
             raise ValueError(
                 "Invalid parameter value: %s[%s] = '%s', value type=%s.\n"
                 "\tValue not in parameter domain %s" %
-                (self.name(True), ndx, val, type(val), self.domain.name()) )
+                (self.name, ndx, val, type(val), self.domain.name))
         #
         # Set the value depending on the type of param value.
         #
@@ -509,7 +509,7 @@ class Param(IndexedComponent):
             raise ValueError(
                 "Invalid parameter value: %s[%s] = '%s', value type=%s.\n"
                 "\tValue failed parameter validation rule" %
-                ( self.name(True), ndx, val, type(val) ) )
+                ( self.name, ndx, val, type(val) ) )
 
     def __setitem__(self, ndx, val):
         """
@@ -526,7 +526,7 @@ class Param(IndexedComponent):
 """Attempting to set the value of the immutable parameter %s after the
 parameter has been constructed.  If you intend to change the value of
 this parameter dynamically, please declare the parameter as mutable
-[i.e., Param(mutable=True)]""" % (self.name(True),))
+[i.e., Param(mutable=True)]""" % (self.name,))
         #
         # Check if we have a valid index.
         # We assume that most calls to this method will send either a
@@ -545,11 +545,11 @@ this parameter dynamically, please declare the parameter as mutable
             if not self.is_indexed():
                 msg = "Error setting parameter value: " \
                       "Cannot treat the scalar Param '%s' as an array" \
-                      % ( self.name(True), )
+                      % ( self.name, )
             else:
                 msg = "Error setting parameter value: " \
                       "Index '%s' is not valid for array Param '%s'" \
-                      % ( ndx, self.name(True), )
+                      % ( ndx, self.name, )
             raise KeyError(msg)
 
         # We have a valid index, so do the actual set operation.
@@ -686,7 +686,7 @@ this parameter dynamically, please declare the parameter as mutable
                 logger.warning("""
 Initializing Param %s using a sparse mutable indexed component (%s).
 This has resulted in the conversion of the source to dense form.
-""" % ( self.name(True), _init.name() ) )
+""" % (self.name, _init.name))
             _init = tmp
             _isDict = True
 
@@ -767,7 +767,7 @@ This has resulted in the conversion of the source to dense form.
         """
         if __debug__ and logger.isEnabledFor(logging.DEBUG):   #pragma:nocover
             logger.debug("Constructing Param, name=%s, from data=%s"
-                         % ( self.name(True), str(data) ))
+                         % ( self.name, str(data) ))
         #
         if self._constructed:
             return
@@ -781,7 +781,7 @@ This has resulted in the conversion of the source to dense form.
                 and val not in self.domain:
             raise ValueError(
                 "Default value (%s) is not valid for Param domain %s" %
-                ( str(val), self.domain.name() ) )
+                (str(val), self.domain.name))
         #
         # Step #1: initialize data from rule value
         #
@@ -801,12 +801,12 @@ This has resulted in the conversion of the source to dense form.
                    raise ValueError(
                        "Attempting to initialize parameter=%s with data=%s.\n"
                        "\tData type is not a dictionary, and a dictionary is "
-                       "expected." % (self.name(True), str(data)) )
+                       "expected." % (self.name, str(data)) )
                 else:
                     raise RuntimeError(
                         "Failed to set value for param=%s, index=%s, value=%s."
                         "\n\tsource error message=%s"
-                        % (self.name(True), str(key), str(val), str(msg)) )
+                        % (self.name, str(key), str(val), str(msg)) )
 
         self._constructed = True
 
@@ -828,7 +828,7 @@ This has resulted in the conversion of the source to dense form.
         or constraints.
         """
         if not self._mutable:
-            raise RuntimeError("Cannot invoke reconstruct method of immutable param="+self.name(True))
+            raise RuntimeError("Cannot invoke reconstruct method of immutable param="+self.name)
         IndexedComponent.reconstruct(self, data=data)
 
     def _pprint(self):
@@ -838,7 +838,7 @@ This has resulted in the conversion of the source to dense form.
         return ( [("Size", len(self)),
                   ("Index", self._index \
                        if self._index != UnindexedComponent_set else None),
-                  ("Domain", self.domain.name()),
+                  ("Domain", self.domain.name),
                   ("Default", "(function)" if type(self._default_val) \
                        is types.FunctionType else self._default_val),
                   ("Mutable", self._mutable),
@@ -875,7 +875,7 @@ class SimpleParam(_ParamData, Param):
             return _ParamData.__call__(self, exception=exception)
         if exception:
             raise ValueError( """Evaluating the numeric value of parameter '%s' before the Param has been
-            constructed (there is currently no value to return).""" % self.name(True) )
+            constructed (there is currently no value to return).""" % self.name )
 
     def set_value(self, value):
         if self._constructed and not self._mutable:
@@ -883,7 +883,7 @@ class SimpleParam(_ParamData, Param):
 """Attempting to set the value of the immutable parameter %s after the
 parameter has been constructed.  If you intend to change the value of
 this parameter dynamically, please declare the parameter as mutable
-[i.e., Param(mutable=True)]""" % (self.name(True),))
+[i.e., Param(mutable=True)]""" % (self.name,))
         self[None] = value
 
     def is_constant(self):

--- a/pyomo/core/base/piecewise.py
+++ b/pyomo/core/base/piecewise.py
@@ -217,7 +217,7 @@ class _PiecewiseData(_BlockData):
         if not _isNonDecreasing(domain_pts):
             msg = "'%s' does not have a list of domain points "\
                   "that is non-decreasing"
-            raise ValueError(msg % (self.name(True),))
+            raise ValueError(msg % (self.name,))
         self._domain_pts = domain_pts
         self._range_pts = range_pts
 
@@ -232,7 +232,7 @@ class _PiecewiseData(_BlockData):
     def __call__(self, x):
         if self._constructed is False:
             raise ValueError("Piecewise component %s has not "
-                             "been constructed yet" % self.name(True))
+                             "been constructed yet" % self.name)
 
         for i in xrange(len(self._domain_pts)-1):
             xL = self._domain_pts[i]
@@ -247,7 +247,7 @@ class _PiecewiseData(_BlockData):
         raise ValueError("The point %s is outside the list of domain "
                          "points for Piecewise component %s. The valid "
                          "point range is [%s,%s]."
-                         % (x, self.name(True),
+                         % (x, self.name,
                             min(self._domain_pts),
                             max(self._domain_pts)))
 
@@ -453,7 +453,7 @@ class _DLOGPiecewise(object):
         if not _isPowerOfTwo(len(pblock._domain_pts)-1):
             msg = "'%s' does not have a list of domain points "\
                   "with length (2^n)+1"
-            raise ValueError(msg % (pblock.name(True),))
+            raise ValueError(msg % (pblock.name,))
         x_pts = pblock._domain_pts
         y_pts = pblock._range_pts
         bound_type = pblock._bound_type
@@ -593,7 +593,7 @@ class _LOGPiecewise(object):
         if not _isPowerOfTwo(len(pblock._domain_pts)-1):
             msg = "'%s' does not have a list of domain points "\
                   "with length (2^n)+1"
-            raise ValueError(msg % (pblock.name(True),))
+            raise ValueError(msg % (pblock.name,))
         x_pts = pblock._domain_pts
         y_pts = pblock._range_pts
         bound_type = pblock._bound_type
@@ -1226,7 +1226,7 @@ class Piecewise(Block):
                       "lower and upper bounds. Refer to the Piecewise help "\
                       "documentation for information on how to disable this "\
                       "restriction"
-                raise ValueError(msg % (self.name(True), index, _self_xvar))
+                raise ValueError(msg % (self.name, index, _self_xvar))
 
         if self._warn_domain_coverage is True:
             # Print a warning when the feasible region created by the piecewise
@@ -1236,14 +1236,14 @@ class Piecewise(Block):
                     "include the lower bound of domain variable: %s.lb = %s < %s. "\
                     "Refer to the Piecewise help documentation for information on "\
                     "how to disable this warning."
-                print(msg % ( self.name(True), index, _self_xvar, _self_xvar.lb,
+                print(msg % ( self.name, index, _self_xvar, _self_xvar.lb,
                               min(_self_domain_pts_index) ))
             if (_self_xvar.ub is not None) and (_self_xvar.ub > max(_self_domain_pts_index)):
                     msg = "**WARNING: Piecewise '%s[%s]' feasible region does not "\
                         "include the upper bound of domain variable: %s.ub = %s > %s. "\
                         "Refer to the Piecewise help documentation for information on "\
                         "how to disable this warning."
-                    print(msg % ( self.name(True), index, _self_xvar, _self_xvar.ub,
+                    print(msg % ( self.name, index, _self_xvar, _self_xvar.ub,
                                   max(_self_domain_pts_index) ))
 
         if len(_self_domain_pts_index) <= 1:
@@ -1258,19 +1258,19 @@ class Piecewise(Block):
                 "Piecewise component '%s[%s]' failed to construct "
                 "piecewise representation. List of breakpoints "
                 "must contain at least two elements. Current list: %s"
-                % (self.name(True), index, str(_self_domain_pts_index)))
+                % (self.name, index, str(_self_domain_pts_index)))
 
         # generate the list of range values using the function rule
         # check if convexity or concavity holds as well
         force_simple = False
         if self.is_indexed() is False:
-            character,range_pts,isStep=_characterize_function(self.name(True),
+            character,range_pts,isStep=_characterize_function(self.name,
                                                               self._warning_tol,
                                                               self._f_rule,
                                                               _self_parent,
                                                               _self_domain_pts_index)
         else:
-            character,range_pts,isStep=_characterize_function(self.name(True),
+            character,range_pts,isStep=_characterize_function(self.name,
                                                               self._warning_tol,
                                                               self._f_rule,
                                                               _self_parent,
@@ -1285,7 +1285,7 @@ class Piecewise(Block):
                   "piecewise representation '%s' does not currently support this "\
                   "functionality. Refer to the Piecewise help documentation for "\
                   "information about which piecewise representations support step functions."
-            raise ValueError(msg % (self.name(True), index, self._pw_rep))
+            raise ValueError(msg % (self.name, index, self._pw_rep))
 
         # Make automatic simplications to the piecewise constraints
         # for the special cases of convexity and lower bound
@@ -1336,7 +1336,7 @@ class Piecewise(Block):
                 else:
                     msg = "Piecewise '%s[%s]' does not have a valid "\
                           "piecewise representation: '%s'"
-                    raise ValueError(msg % (self.name(True), index, self._pw_rep))
+                    raise ValueError(msg % (self.name, index, self._pw_rep))
 
         if self.is_indexed():
             comp = _PiecewiseData(self)
@@ -1359,6 +1359,6 @@ class IndexedPiecewise(Piecewise):
         Piecewise.__init__(self,*args,**kwds)
 
     def __str__(self):
-        return str(self.name())
+        return str(self.name)
 
 register_component(Piecewise, "Constraints that contain piecewise linear expressions.")

--- a/pyomo/core/base/plugin.py
+++ b/pyomo/core/base/plugin.py
@@ -170,7 +170,7 @@ class ExpressionRegistration(Plugin):
 def ExpressionFactory(name=None, args=[]):
     ep = ExpressionFactory.ep
     if name is None:
-        return map(lambda x: x.name(), ep())
+        return map(lambda x: x.name, ep())
     return ep.service(name).create(args)
 ExpressionFactory.ep = ExtensionPoint(IPyomoExpression)
 

--- a/pyomo/core/base/rangeset.py
+++ b/pyomo/core/base/rangeset.py
@@ -124,7 +124,7 @@ class RangeSet(OrderedSimpleSet):
         if not self._constructed:
             raise RuntimeError(
                 "Cannot iterate over abstract RangeSet '%s' before it has "
-                "been constructed (initialized)." % (self.name(True),) )
+                "been constructed (initialized)." % (self.name,) )
         if self.filter is None and self.validate is None:
             #
             # Iterate through all set elements

--- a/pyomo/core/base/sets.py
+++ b/pyomo/core/base/sets.py
@@ -47,7 +47,7 @@ def process_setarg(arg):
     elif isinstance(arg,Component):
         # Argument is some other component
         raise TypeError("Cannot index a component with a non-set "
-                        "component: %s" % (arg.name(True)))
+                        "component: %s" % (arg.name))
     else:
         try:
             #
@@ -154,7 +154,7 @@ class _SetData(_SetDataBase):
 
         This method generates an exception because the set is unordered.
         """
-        raise ValueError("Cannot index an unordered set '%s'" % self._component().name())
+        raise ValueError("Cannot index an unordered set '%s'" % self._component().name)
 
     def bounds(self):
         """
@@ -406,7 +406,7 @@ class _OrderedSetData(_SetDataBase):
         try:
             return self.order_dict[match_element] + 1
         except IndexError:
-            raise IndexError("Unknown input element="+str(match_element)+" provided as input to ord() method for set="+self.name(True))
+            raise IndexError("Unknown input element="+str(match_element)+" provided as input to ord() method for set="+self.name)
 
     def next(self, match_element, k=1):
         """
@@ -421,12 +421,12 @@ class _OrderedSetData(_SetDataBase):
         try:
             element_position = self.ord(match_element)
         except IndexError:
-            raise KeyError("Cannot obtain next() member of set="+self.name(True)+"; input element="+str(match_element)+" is not a member of the set!")
+            raise KeyError("Cannot obtain next() member of set="+self.name+"; input element="+str(match_element)+" is not a member of the set!")
         #
         try:
             return self[element_position+k]
         except KeyError:
-            raise KeyError("Cannot obtain next() member of set="+self.name(True)+"; failed to access item in position="+str(element_position+k))
+            raise KeyError("Cannot obtain next() member of set="+self.name+"; failed to access item in position="+str(element_position+k))
 
     def nextw(self, match_element, k=1):
         """
@@ -442,7 +442,7 @@ class _OrderedSetData(_SetDataBase):
         try:
             element_position = self.ord(match_element)
         except KeyError:
-            raise KeyError("Cannot obtain nextw() member of set="+self.name(True)+"; input element="+str(match_element)+" is not a member of the set!")
+            raise KeyError("Cannot obtain nextw() member of set="+self.name+"; input element="+str(match_element)+" is not a member of the set!")
         #
         return self[(element_position+k-1) % len(self.value) + 1]
 
@@ -639,7 +639,7 @@ class Set(IndexedComponent):
                 raise ValueError(\
                       ("Value of keyword 'dimen', %s, differs from the " + \
                        "dimension of the superset '%s', %s") % \
-                       (str(kwd_dimen), str(self.domain.name()), str(tmp_dimen)))
+                       (str(kwd_dimen), str(self.domain.name), str(tmp_dimen)))
             else:
                 tmp_dimen = kwd_dimen
 
@@ -682,7 +682,7 @@ class Set(IndexedComponent):
             raise ValueError(
                 "The value=%s is not valid for set=%s\n"
                 "because it is not within the domain=%s"
-                % ( element, self.name(True), self.domain.name(True) ) )
+                % ( element, self.name, self.domain.name ) )
         if self.validate is not None:
             flag = False
             try:
@@ -693,15 +693,15 @@ class Set(IndexedComponent):
             except:
                 pass
             if not flag:
-                raise ValueError("The value="+str(element)+" violates the validation rule of set="+self.name(True))
+                raise ValueError("The value="+str(element)+" violates the validation rule of set="+self.name)
         if not self.dimen is None:
             if self.dimen > 1 and type(element) is not tuple:
 
-                raise ValueError("The value="+str(element)+" is not a tuple for set="+self.name(True)+", which has dimen="+str(self.dimen))
+                raise ValueError("The value="+str(element)+" is not a tuple for set="+self.name+", which has dimen="+str(self.dimen))
             elif self.dimen == 1 and type(element) is tuple:
-                raise ValueError("The value="+str(element)+" is a tuple for set="+self.name(True)+", which has dimen="+str(self.dimen))
+                raise ValueError("The value="+str(element)+" is a tuple for set="+self.name+", which has dimen="+str(self.dimen))
             elif type(element) is tuple and len(element) != self.dimen:
-                raise ValueError("The value="+str(element)+" does not have dimension="+str(self.dimen)+", which is needed for set="+self.name(True))
+                raise ValueError("The value="+str(element)+" does not have dimension="+str(self.dimen)+", which is needed for set="+self.name)
         return True
 
 
@@ -728,7 +728,7 @@ class SimpleSetBase(Set):
         Clear that data in this component.
         """
         if self.virtual:
-            raise TypeError("Cannot clear virtual set object `"+self.name(True)+"'")
+            raise TypeError("Cannot clear virtual set object `"+self.name+"'")
         self._clear()
 
     def check_values(self):
@@ -745,7 +745,7 @@ class SimpleSetBase(Set):
         Add one or more elements to a set.
         """
         if self.virtual:
-            raise TypeError("Cannot add elements to virtual set `"+self.name(True)+"'")
+            raise TypeError("Cannot add elements to virtual set `"+self.name+"'")
         for val in args:
             tmp = pyutilib_misc_flatten_tuple(val)
             self._verify(tmp)
@@ -755,11 +755,11 @@ class SimpleSetBase(Set):
                     # Generate a warning, since we expect that users will not plan to
                     # re-add the same element to a set.
                     #
-                    logger.warning("Element "+str(tmp)+" already exists in set "+self.name(True)+"; no action taken.")
+                    logger.warning("Element "+str(tmp)+" already exists in set "+self.name+"; no action taken.")
                     continue
                 self._add(tmp, False)
             except TypeError:
-                raise TypeError("Problem inserting "+str(tmp)+" into set "+self.name(True))
+                raise TypeError("Problem inserting "+str(tmp)+" into set "+self.name)
 
     def remove(self, element):
         """
@@ -768,9 +768,9 @@ class SimpleSetBase(Set):
         If the element is not a member, raise an error.
         """
         if self.virtual:
-            raise KeyError("Cannot remove element `"+str(element)+"' from virtual set "+self.name(True))
+            raise KeyError("Cannot remove element `"+str(element)+"' from virtual set "+self.name)
         if element not in self:
-            raise KeyError("Cannot remove element `"+str(element)+"' from set "+self.name(True))
+            raise KeyError("Cannot remove element `"+str(element)+"' from set "+self.name)
         self._discard(element)
 
     def discard(self, element):
@@ -780,7 +780,7 @@ class SimpleSetBase(Set):
         If the element is not a member, do nothing.
         """
         if self.virtual:
-            raise KeyError("Cannot discard element `"+str(element)+"' from virtual set "+self.name(True))
+            raise KeyError("Cannot discard element `"+str(element)+"' from virtual set "+self.name)
         self._discard(element)
 
     def _pprint(self):
@@ -800,7 +800,7 @@ class SimpleSetBase(Set):
             [("Dim", self.dim()),
              ("Dimen", self.dimen),
              ("Size", len(self)),
-             ("Domain", None if self.domain is None else self.domain.name()),
+             ("Domain", None if self.domain is None else self.domain.name),
              ("Ordered", _ordered),
              ("Bounds", self._bounds)],
             iteritems( {None: self} ),
@@ -835,9 +835,9 @@ class SimpleSetBase(Set):
         if not self._constructed:
             raise RuntimeError(
                 "Cannot iterate over abstract Set '%s' before it has "
-                "been constructed (initialized)." % (self.name(True),) )
+                "been constructed (initialized)." % (self.name,) )
         if not self.concrete:
-            raise TypeError("Cannot iterate over a non-concrete set '%s'" % self.name(True))
+            raise TypeError("Cannot iterate over a non-concrete set '%s'" % self.name)
         return self.value.__iter__()
 
     def __reversed__(self):
@@ -962,7 +962,7 @@ class SimpleSetBase(Set):
             raise TypeError("ERROR: cannot perform \"issubset\" test because the current set is not a concrete set.")
         other = self._set_repn(other)
         if self.dimen != other.dimen:
-            raise ValueError("Cannot perform set operation with sets "+self.name(True)+" and "+other.name(True)+" that have different element dimensions: "+str(self.dimen)+" "+str(other.dimen))
+            raise ValueError("Cannot perform set operation with sets "+self.name+" and "+other.name+" that have different element dimensions: "+str(self.dimen)+" "+str(other.dimen))
         for val in self:
             if val not in other:
                 return False
@@ -977,7 +977,7 @@ class SimpleSetBase(Set):
         """
         other = self._set_repn(other)
         if self.dimen != other.dimen:
-            raise ValueError("Cannot perform set operation with sets "+self.name(True)+" and "+other.name(True)+" that have different element dimensions: "+str(self.dimen)+" "+str(other.dimen))
+            raise ValueError("Cannot perform set operation with sets "+self.name+" and "+other.name+" that have different element dimensions: "+str(self.dimen)+" "+str(other.dimen))
         if not other.concrete:
             raise TypeError("ERROR: cannot perform \"issuperset\" test because the target set is not a concrete set.")
         for val in other:
@@ -1069,7 +1069,7 @@ class SimpleSetBase(Set):
         TODO: rework to avoid redundant code
         """
         if __debug__ and logger.isEnabledFor(logging.DEBUG):
-                logger.debug("Constructing SimpleSet, name="+self.name(True)+", from data="+repr(values))
+                logger.debug("Constructing SimpleSet, name="+self.name+", from data="+repr(values))
         if self._constructed:
             return
         self._constructed=True
@@ -1077,7 +1077,7 @@ class SimpleSetBase(Set):
         if self.initialize is None:                             # TODO: deprecate this functionality
             self.initialize = getattr(self,'rule',None)
             if not self.initialize is None:
-                logger.warning("DEPRECATED: The set 'rule' attribute cannot be used to initialize component "+self.name(True)+". Use the 'initialize' attribute")
+                logger.warning("DEPRECATED: The set 'rule' attribute cannot be used to initialize component "+self.name+". Use the 'initialize' attribute")
         #
         # Construct using the input values list
         #
@@ -1179,7 +1179,7 @@ class SimpleSetBase(Set):
         #
         elif self.initialize is not None:
             if type(self.initialize) is dict:
-                raise ValueError("Cannot initialize set "+self.name(True)+" with dictionary data")
+                raise ValueError("Cannot initialize set "+self.name+" with dictionary data")
             if type(self._bounds) is tuple:
                 first=self._bounds[0]
                 last=self._bounds[1]
@@ -1349,15 +1349,15 @@ class _SetOperator(SimpleSet):
         #
         self._setA = args[0]
         if not self._setA.concrete:
-            raise TypeError("Cannot perform set operations with non-concrete set '"+self._setA.name(True)+"'")
+            raise TypeError("Cannot perform set operations with non-concrete set '"+self._setA.name+"'")
         if isinstance(args[1],Set):
             self._setB = args[1]
         else:
             self._setB = SetOf(args[1])
         if not self._setB.concrete:
-            raise TypeError("Cannot perform set operations with non-concrete set '"+self._setB.name(True)+"'")
+            raise TypeError("Cannot perform set operations with non-concrete set '"+self._setB.name+"'")
         if dimen_test and self._setA.dimen != self._setB.dimen:
-            raise ValueError("Cannot perform set operation with sets "+self._setA.name(True)+" and "+self._setB.name(True)+" that have different element dimensions: "+str(self._setA.dimen)+" "+str(self._setB.dimen))
+            raise ValueError("Cannot perform set operation with sets "+self._setA.name+" and "+self._setB.name+" that have different element dimensions: "+str(self._setA.dimen)+" "+str(self._setB.dimen))
         self.dimen = self._setA.dimen
         #
         self.ordered = self._setA.ordered and self._setB.ordered
@@ -1630,7 +1630,7 @@ class IndexedSet(Set):
         Add a set to the index.
         """
         if key not in self._index:
-            raise KeyError("Cannot set index "+str(key)+" in array set "+self.name(True))
+            raise KeyError("Cannot set index "+str(key)+" in array set "+self.name)
         #
         # Create a _SetData object if one doesn't already exist
         #
@@ -1672,7 +1672,7 @@ class IndexedSet(Set):
             [("Dim", self.dim()),
              ("Dimen", self.dimen),
              ("Size", self.size()),
-             ("Domain", None if self.domain is None else self.domain.name()),
+             ("Domain", None if self.domain is None else self.domain.name),
              ("ArraySize", len(self._data)),
              ("Ordered", _ordered),
              ("Bounds", self._bounds)],
@@ -1687,7 +1687,7 @@ class IndexedSet(Set):
         Apply the rule to construct values in each set
         """
         if __debug__ and logger.isEnabledFor(logging.DEBUG):
-                logger.debug("Constructing IndexedSet, name="+self.name(True)+", from data="+repr(values))
+                logger.debug("Constructing IndexedSet, name="+self.name+", from data="+repr(values))
         if self._constructed:
             return
         self._constructed=True
@@ -1695,7 +1695,7 @@ class IndexedSet(Set):
         if self.initialize is None:             # TODO: deprecate this functionality
             self.initialize = getattr(self,'rule',None)
             if not self.initialize is None:
-                logger.warning("DEPRECATED: The set 'rule' attribute cannot be used to initialize component "+self.name(True)+". Use the 'initialize' attribute")
+                logger.warning("DEPRECATED: The set 'rule' attribute cannot be used to initialize component "+self.name+". Use the 'initialize' attribute")
         #
         # Construct using the values dictionary
         #
@@ -1706,7 +1706,7 @@ class IndexedSet(Set):
                 else:
                     tmpkey=key
                 if tmpkey not in self._index:
-                    raise KeyError("Cannot construct index "+str(tmpkey)+" in array set "+self.name(True))
+                    raise KeyError("Cannot construct index "+str(tmpkey)+" in array set "+self.name)
                 tmp = self._SetData(self, self._bounds)
                 for val in values[key]:
                     tmp._add(val)

--- a/pyomo/core/base/sos.py
+++ b/pyomo/core/base/sos.py
@@ -94,7 +94,7 @@ class _SOSConstraintData(ActiveComponentData):
             self._variables.append(v)
             if w < 0.0:
                 raise ValueError("Cannot set negative weight %f "
-                                 "for variable %s" % (w, v.name(True)))
+                                 "for variable %s" % (w, v.name))
             self._weights.append(w)
 
 
@@ -218,7 +218,7 @@ class SOSConstraint(ActiveIndexedComponent):
         generate_debug_messages = __debug__ and logger.isEnabledFor(logging.DEBUG)
 
         if generate_debug_messages:     #pragma:nocover
-            logger.debug("Constructing SOSConstraint %s",self.name(True))
+            logger.debug("Constructing SOSConstraint %s",self.name)
 
         if self._constructed is True:   #pragma:nocover
             return
@@ -227,7 +227,7 @@ class SOSConstraint(ActiveIndexedComponent):
         if self._rule is None:
             if self._sosSet is None and not None in self._index:
                 if generate_debug_messages:     #pragma:nocover
-                    logger.debug("  Cannot construct "+self.name(True)+".  No rule is defined and no SOS sets are defined.")
+                    logger.debug("  Cannot construct "+self.name+".  No rule is defined and no SOS sets are defined.")
             else:
                 if None in self._index:
                     if self._sosSet is None:
@@ -242,7 +242,7 @@ class SOSConstraint(ActiveIndexedComponent):
 
                 for index, sosSet in six.iteritems(_sosSet):
                     if generate_debug_messages:     #pragma:nocover
-                        logger.debug("  Constructing "+self.name(True)+" index "+str(index))
+                        logger.debug("  Constructing "+self.name+" index "+str(index))
 
                     if self._sosLevel == 2:
                         #
@@ -276,7 +276,7 @@ class SOSConstraint(ActiveIndexedComponent):
                     logger.error(
                         "Rule failed when generating expression for "
                         "sos constraint %s with index %s:\n%s: %s"
-                        % ( self.name(True), str(index), type(err).__name__, err ) )
+                        % ( self.name, str(index), type(err).__name__, err ) )
                     raise
                 if tmp is None:
                     raise ValueError("SOSConstraint rule returned None instead of SOSConstraint.Skip for index %s" % str(index))
@@ -312,13 +312,13 @@ class SOSConstraint(ActiveIndexedComponent):
         """TODO"""
         if ostream is None:
             ostream = sys.stdout
-        ostream.write("   "+self.name()+" : ")
+        ostream.write("   "+self.local_name+" : ")
         if not self.doc is None:
             ostream.write(self.doc+'\n')
             ostream.write("  ")
         ostream.write("\tSize="+str(len(self._data.keys()))+' ')
         if isinstance(self._index,Set):
-            ostream.write("\tIndex= "+self._index.name(True)+'\n')
+            ostream.write("\tIndex= "+self._index.name+'\n')
         else:
             ostream.write("\n")
         for val in self._data:
@@ -327,7 +327,7 @@ class SOSConstraint(ActiveIndexedComponent):
             ostream.write("\t\tType="+str(self._data[val].level)+'\n')
             ostream.write("\t\tWeight : Variable\n")
             for var, weight in self._data[val].get_items():
-                ostream.write("\t\t"+str(weight)+' : '+var.name(True)+'\n')
+                ostream.write("\t\t"+str(weight)+' : '+var.name+'\n')
 
 
 # Since this class derives from Component and Component.__getstate__

--- a/pyomo/core/base/suffix.py
+++ b/pyomo/core/base/suffix.py
@@ -161,7 +161,7 @@ class ComponentMap(MutableMapping):
         String representation of the mapping
         """
         tmp = '{' + \
-              (', '.join(component.name(True)+": "+str(val) \
+              (', '.join(component.name+": "+str(val) \
                         for component, val \
                         in itervalues(self._dict))) + \
               '}'
@@ -172,11 +172,11 @@ class ComponentMap(MutableMapping):
         Pretty-print a Python object to a stream [default is sys.stdout].
         """
         if verbose:
-            tmp = dict((repr(component.name(True))+" (id="+str(id(component))+")", val)
+            tmp = dict((repr(component.name)+" (id="+str(id(component))+")", val)
                            for component, val \
                            in itervalues(self._dict))
         else:
-            tmp = dict((repr(component.name(True))+" (id="+str(id(component))+")", val)
+            tmp = dict((repr(component.name)+" (id="+str(id(component))+")", val)
                            for component, val \
                            in itervalues(self._dict))
         pprint.pprint(tmp,
@@ -193,7 +193,7 @@ class ComponentMap(MutableMapping):
         try:
             return self._dict[id(component)][1]
         except KeyError:
-            cname = component.name(True)
+            cname = component.name
             raise KeyError("Component with name: "
                            +cname+
                            " (id=%s)" % id(component))
@@ -205,7 +205,7 @@ class ComponentMap(MutableMapping):
         try:
             del self._dict[id(component)]
         except KeyError:
-            cname = component.name(True)
+            cname = component.name
             raise KeyError("Component with name: "
                            +cname+
                            " (id=%s)" % id(component))
@@ -339,7 +339,7 @@ class Suffix(ComponentMap, ActiveComponent):
         Constructs this component, applying rule if it exists.
         """
         if __debug__ and logger.isEnabledFor(logging.DEBUG):
-            logger.debug("Constructing suffix %s",self.name())
+            logger.debug("Constructing suffix %s",self.name)
 
         if self._constructed is True:
             return
@@ -524,7 +524,10 @@ class Suffix(ComponentMap, ActiveComponent):
         Return a string representation of the suffix.  If the name
         attribute is None, then return ''
         """
-        return self.name()
+        name = self.name
+        if name is None:
+            return ''
+        return name
 
     def _pprint(self):
         return (

--- a/pyomo/core/base/symbol_map.py
+++ b/pyomo/core/base/symbol_map.py
@@ -145,14 +145,14 @@ class SymbolMap(object):
         if labeler is None:
             raise RuntimeError("Object %s is not in the symbol map. "
                                "Cannot create a new symbol without "
-                               "a labeler." % obj.name(True))
+                               "a labeler." % obj.name)
         symb = labeler(obj)
         if symb in self.bySymbol:
             if self.bySymbol[symb]() is not obj:
                 raise RuntimeError(
                     "Duplicate symbol '%s' already associated with "
                     "component '%s' (conflicting component: '%s')"
-                    % (symb, self.bySymbol[symb]().name(True), obj.name(True)) )
+                    % (symb, self.bySymbol[symb]().name, obj.name) )
         self.bySymbol[symb] = weakref_ref(obj)
         self.byObject[obj_id] = symb
         return symb
@@ -174,7 +174,7 @@ class SymbolMap(object):
                 raise RuntimeError(
                     "Duplicate alias '%s' already associated with "
                     "component '%s' (conflicting component: '%s')"
-                    % (name, "UNKNOWN" if obj_object is None else old_object.name(True), obj.name(True)) )
+                    % (name, "UNKNOWN" if obj_object is None else old_object.name, obj.name) )
         else:
             #
             # Add the alias

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -529,7 +529,7 @@ class Var(IndexedComponent):
                 vardata = self.add(ndx)
             else:
                 msg = "Cannot set the value of a simple variable '%s' with index '%s'"
-                raise KeyError(msg % ( self.name(True), str(ndx) ))
+                raise KeyError(msg % (self.name, str(ndx)))
         #
         # Set the value
         #
@@ -540,7 +540,7 @@ class Var(IndexedComponent):
 
         if __debug__ and logger.isEnabledFor(logging.DEBUG):   #pragma:nocover
             try:
-                name = str(self.name(True))
+                name = str(self.name)
             except:
                 # Some Var components don't have a name yet, so just use the type
                 name = type(self)
@@ -745,7 +745,7 @@ class SimpleVar(_GeneralVarData, Var):
             "Accessing the value of variable '%s' "
             "before the Var has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
     @value.setter
     def value(self, val):
         """Set the value for this variable."""
@@ -755,7 +755,7 @@ class SimpleVar(_GeneralVarData, Var):
             "Setting the value of variable '%s' "
             "before the Var has been constructed (there "
             "is currently nothing to set."
-            % (self.name(True)))
+            % (self.name))
 
     @property
     def domain(self):
@@ -769,7 +769,7 @@ class SimpleVar(_GeneralVarData, Var):
         #    "Accessing the domain of variable '%s' "
         #    "before the Var has been constructed (there "
         #    "is currently no domain to return)."
-        #    % (self.name(True)))
+        #    % (self.name))
     @domain.setter
     def domain(self, domain):
         """Set the domain for this variable."""
@@ -779,7 +779,7 @@ class SimpleVar(_GeneralVarData, Var):
             "Setting the domain of variable '%s' "
             "before the Var has been constructed (there "
             "is currently nothing to set."
-            % (self.name(True)))
+            % (self.name))
 
     @property
     def lb(self):
@@ -790,7 +790,7 @@ class SimpleVar(_GeneralVarData, Var):
             "Accessing the lower bound of variable '%s' "
             "before the Var has been constructed (there "
             "is currently nothing to return)."
-            % (self.name(True)))
+            % (self.name))
     @lb.setter
     def lb(self, lb):
         raise AttributeError("Assignment not allowed. Use the setlb method")
@@ -804,7 +804,7 @@ class SimpleVar(_GeneralVarData, Var):
             "Accessing the upper bound of variable '%s' "
             "before the Var has been constructed (there "
             "is currently nothing to return)."
-            % (self.name(True)))
+            % (self.name))
     @ub.setter
     def ub(self, ub):
         raise AttributeError("Assignment not allowed. Use the setub method")
@@ -820,7 +820,7 @@ class SimpleVar(_GeneralVarData, Var):
             "Setting the lower bound of variable '%s' "
             "before the Var has been constructed (there "
             "is currently nothing to set)."
-            % (self.name(True)))
+            % (self.name))
 
     def setub(self, val):
         """
@@ -833,7 +833,7 @@ class SimpleVar(_GeneralVarData, Var):
             "Setting the upper bound of variable '%s' "
             "before the Var has been constructed (there "
             "is currently nothing to set)."
-            % (self.name(True)))
+            % (self.name))
 
     def fix(self, *val):
         """
@@ -846,7 +846,7 @@ class SimpleVar(_GeneralVarData, Var):
             "Fixing variable '%s' "
             "before the Var has been constructed (there "
             "is currently nothing to set)."
-            % (self.name(True)))
+            % (self.name))
 
     def unfix(self):
         """Sets the fixed indicator to False."""
@@ -856,7 +856,7 @@ class SimpleVar(_GeneralVarData, Var):
             "Freeing variable '%s' "
             "before the Var has been constructed (there "
             "is currently nothing to set)."
-            % (self.name(True)))
+            % (self.name))
 
     free=unfix
 
@@ -912,7 +912,7 @@ class VarList(IndexedVar):
     def construct(self, data=None):
         """Construct this component."""
         if __debug__ and logger.isEnabledFor(logging.DEBUG):
-            logger.debug("Constructing variable list %s",self.name(True))
+            logger.debug("Constructing variable list %s", self.name)
         IndexedVar.construct(self, data)
 
     def add(self):

--- a/pyomo/core/beta/dict_objects.py
+++ b/pyomo/core/beta/dict_objects.py
@@ -48,7 +48,7 @@ class ComponentDict(collections.MutableMapping):
         if __debug__ and logger.isEnabledFor(logging.DEBUG):
             logger.debug(   #pragma:nocover
                 "Constructing ComponentDict object, name=%s, from data=%s"
-                % (self.name(True), str(data)))
+                % (self.name, str(data)))
         if self._constructed:   #pragma:nocover
             return
         self._constructed = True
@@ -120,9 +120,9 @@ class ComponentDict(collections.MutableMapping):
                 "Invalid component object assignment to ComponentDict "
                 "%s at key %s. A parent component has already been "
                 "assigned the object: %s"
-                % (self.name(True),
+                % (self.name,
                    key,
-                   val.parent_component().name(True)))
+                   val.parent_component().name))
         # see note about implicit assignment and update
         raise TypeError(
             "ComponentDict must be assigned objects "

--- a/pyomo/core/beta/list_objects.py
+++ b/pyomo/core/beta/list_objects.py
@@ -49,7 +49,7 @@ class ComponentList(collections.MutableSequence):
         if __debug__ and logger.isEnabledFor(logging.DEBUG):
             logger.debug(   #pragma:nocover
                 "Constructing ComponentList object, name=%s, from data=%s"
-                % (self.name(True), str(data)))
+                % (self.name, str(data)))
         if self._constructed:   #pragma:nocover
             return
         self._constructed = True
@@ -110,9 +110,9 @@ class ComponentList(collections.MutableSequence):
                 "Invalid component object assignment to ComponentList "
                 "%s at index %s. A parent component has already been "
                 "assigned the object: %s"
-                % (self.name(True),
+                % (self.name,
                    i,
-                   item.parent_component().name(True)))
+                   item.parent_component().name))
         # see note about implicit assignment and update
         raise TypeError(
             "ComponentList must be assigned objects "
@@ -137,9 +137,9 @@ class ComponentList(collections.MutableSequence):
                 "Invalid component object assignment to ComponentList "
                 "%s at index %s. A parent component has already been "
                 "assigned the object: %s"
-                % (self.name(True),
+                % (self.name,
                    i,
-                   item.parent_component().name(True)))
+                   item.parent_component().name))
         # see note about implicit assignment and update
         raise TypeError(
             "ComponentList must be assigned objects "

--- a/pyomo/core/data/TableData.py
+++ b/pyomo/core/data/TableData.py
@@ -88,8 +88,7 @@ class TableData(Plugin):
           index=self.options.index,
           set=self.options.set,
           param=self.options.param,
-          ncolumns = self.options.ncolumns
-        )
+          ncolumns = self.options.ncolumns)
 
     def clear(self):
         """
@@ -104,28 +103,28 @@ class TableData(Plugin):
                 header_index.append(i)
         else:
             for i in self.options.select:
-                header_index.append( headers.index(str(i)) )
+                header_index.append(headers.index(str(i)))
         self.options.ncolumns = len(headers)
 
         if not self.options.param is None:
             if not type(self.options.param) in (list, tuple):
-                self.options.param = (self.options.param, )
+                self.options.param = (self.options.param,)
             _params = []
             for p in self.options.param:
                 if isinstance(p, Param):
                     self.options.model = p.model()
-                    _params.append( p.name() )
+                    _params.append(p.local_name)
                 else:
-                    _params.append( p )
+                    _params.append(p)
             self.options.param = tuple(_params)
 
         if isinstance(self.options.set, Set):
             self.options.model = self.options.set.model()
-            self.options.set = self.options.set.name()
+            self.options.set = self.options.set.local_name
 
         if isinstance(self.options.index, Set):
             self.options.model = self.options.index.model()
-            self.options.index = self.options.index.name()
+            self.options.index = self.options.index.local_name
 
         if self.options.format is None:
             if not self.options.set is None:
@@ -141,7 +140,7 @@ class TableData(Plugin):
         if self.options.format == 'set':
             if not self.options.index is None:
                 msg = "Cannot specify index for data with the 'set' format: %s"
-                raise IOError(msg % str( self.options.index ))
+                raise IOError(msg % str(self.options.index))
 
             self._info = ["set",self.options.set,":="]
             for row in rows:
@@ -154,24 +153,24 @@ class TableData(Plugin):
             if not self.options.index is None:
                 msg = "Cannot specify index for data with the 'set_array' "   \
                       'format: %s'
-                raise IOError(msg % str( self.options.index ))
+                raise IOError(msg % str(self.options.index))
 
             self._info = ["set",self.options.set, ":"]
-            self._info.extend( headers[1:] )
-            self._info.append( ":=" )
+            self._info.extend(headers[1:])
+            self._info.append(":=")
             for row in rows:
-                self._info.extend( row )
+                self._info.extend(row)
 
         elif self.options.format == 'transposed_array':
             self._info = ["param",self.options.param[0],"(tr)",":"]
-            self._info.extend( headers[1:] )
+            self._info.extend(headers[1:])
             self._info.append(":=")
             for row in rows:
                 self._info.extend(row)
 
         elif self.options.format == 'array':
             self._info = ["param",self.options.param[0],":"]
-            self._info.extend( headers[1:] )
+            self._info.extend(headers[1:])
             self._info.append(":=")
             for row in rows:
                 self._info.extend(row)
@@ -186,7 +185,7 @@ class TableData(Plugin):
             self._info.append(":=")
             for row in rows:
                 for i in header_index:
-                    self._info.append( row[i] )
+                    self._info.append(row[i])
             self.options.ncolumns = len(header_index)
         else:
             msg = "Unknown parameter format: '%s'"
@@ -201,21 +200,21 @@ class TableData(Plugin):
             if self.options.columns is None:
                 cols = []
                 for i in xrange(self.options.set.dimen):
-                    cols.append(self.options.set.name()+str(i))
+                    cols.append(self.options.set.local_name+str(i))
                 tmp.append(cols)
             # Get rows
             if not self.options.sort is None:
                 for data in sorted(self.options.set):
                     if self.options.set.dimen > 1:
-                        tmp.append( list(data) )
+                        tmp.append(list(data))
                     else:
-                        tmp.append( [data] )
+                        tmp.append([data])
             else:
                 for data in self.options.set:
                     if self.options.set.dimen > 1:
-                        tmp.append( list(data) )
+                        tmp.append(list(data))
                     else:
-                        tmp.append( [data] )
+                        tmp.append([data])
         elif not self.options.param is None:
             if type(self.options.param) in (list,tuple):
                 _param = self.options.param
@@ -231,7 +230,7 @@ class TableData(Plugin):
                 else:
                     row = [index]
                 for param in _param:
-                    row.append( value(param[index]) )
+                    row.append(value(param[index]))
                 tmp.append(row)
             # Create column names
             if self.options.columns is None:
@@ -239,7 +238,7 @@ class TableData(Plugin):
                 for i in xrange(len(tmp[0])-len(_param)):
                     cols.append('I'+str(i))
                 for param in _param:
-                    cols.append( param)
+                    cols.append(param)
                 tmp = [cols] + tmp
         return tmp
 

--- a/pyomo/core/plugins/data/csv_table.py
+++ b/pyomo/core/plugins/data/csv_table.py
@@ -49,7 +49,7 @@ class CSVTable(TableData):
                     p = self.options.param
                 if isinstance(p, Param):
                     self.options.model = p.model()
-                    p = p.name()
+                    p = p.local_name
                 self._info = ["param",p,":=",tmp[0][0]]
             elif len(self.options.symbol_map) == 1:
                 self._info = ["param",self.options.symbol_map[self.options.symbol_map.keys()[0]],":=",tmp[0][0]]

--- a/pyomo/core/plugins/data/db_table.py
+++ b/pyomo/core/plugins/data/db_table.py
@@ -167,7 +167,7 @@ or that there is a bug in the ODBC connector.
         #
         if type(tmp) in (int,long,float):
             if not self.options.param is None:
-                self._info = ["param", self.options.param.name(), ":=", tmp]
+                self._info = ["param", self.options.param.local_name, ":=", tmp]
             elif len(self.options.symbol_map) == 1:
                 self._info = ["param", self.options.symbol_map[self.options.symbol_map.keys()[0]], ":=", tmp]
             else:

--- a/pyomo/core/plugins/data/text.py
+++ b/pyomo/core/plugins/data/text.py
@@ -54,7 +54,7 @@ class TextTable(TableData):
                         p = self.options.param
                     if isinstance(p, Param):
                         self.options.model = p.model()
-                        p = p.name()
+                        p = p.local_name
                     self._info = ["param",p,":=",tmp[0][0]]
                 elif len(self.options.symbol_map) == 1:
                     self._info = ["param",self.options.symbol_map[self.options.symbol_map.keys()[0]],":=",tmp[0][0]]

--- a/pyomo/core/plugins/data/xml_table.py
+++ b/pyomo/core/plugins/data/xml_table.py
@@ -40,7 +40,7 @@ class XMLTable(TableData):
             if self.options.query[0] == '"' or self.options.query[0] == "'":
                 self.options.query = self.options.query[1:-1]
             parents = [parent for parent in tree.findall(self.options.query)]
-        else:    
+        else:
             parents = [parent for parent in tree.getroot()]
         tmp=[]
         labels = []
@@ -67,7 +67,7 @@ class XMLTable(TableData):
                     p = self.options.param
                 if isinstance(p, Param):
                     self.options.model = p._model()
-                    p = p.name()
+                    p = p.local_name
                 self._info = ["param",p,":=",tmp[0][0]]
             elif len(self.options.symbol_map) == 1:
                 self._info = ["param",self.options.symbol_map[self.options.symbol_map.keys()[0]],":=",tmp[0][0]]

--- a/pyomo/core/plugins/transform/dual_transformation.py
+++ b/pyomo/core/plugins/transform/dual_transformation.py
@@ -85,7 +85,7 @@ class DualTransformation(IsomorphicTransformation):
         for (con_name, con_array) in sf.component_map(Constraint, active=True).items():
             for con in (con_array[ndx] for ndx in con_array._index):
                 # The qualified constraint name
-                cname = "%s%s" % (variable_prefix, con.name())
+                cname = "%s%s" % (variable_prefix, con.local_name)
 
                 # Process the body of the constraint
                 body_terms = process_canonical_repn(
@@ -136,15 +136,15 @@ class DualTransformation(IsomorphicTransformation):
         for (var_name, var_array) in sf.component_map(Var, active=True).items():
             for var in (var_array[ndx] for ndx in var_array._index):
                 constraint_set_init.append("%s%s" %
-                                           (var.name(), constraint_suffix))
+                                           (var.local_name, constraint_suffix))
 
         # Make variable index set
         variable_set_init = []
         dual_variable_roots = []
         for (con_name, con_array) in sf.component_map(Constraint, active=True).items():
             for con in (con_array[ndx] for ndx in con_array._index):
-                dual_variable_roots.append(con.name())
-                variable_set_init.append("%s%s" % (variable_prefix, con.name()))
+                dual_variable_roots.append(con.local_name)
+                variable_set_init.append("%s%s" % (variable_prefix, con.local_name))
 
         # Create the dual Set and Var objects
         dual.var_set = Set(initialize=variable_set_init)

--- a/pyomo/core/plugins/transform/nonnegative_transform.py
+++ b/pyomo/core/plugins/transform/nonnegative_transform.py
@@ -353,15 +353,15 @@ class NonNegativeTransformation(IsomorphicTransformation):
 
         # Attempt to replace a simple variable
         if isinstance(expr, SimpleVar):
-            if expr.name() in varMap:
-                return varMap[expr.name()]
+            if expr.local_name in varMap:
+                return varMap[expr.local_name]
             else:
                 return expr
 
         # Attempt to replace an indexed variable
         if isinstance(expr, _VarData):
-            if expr.name() in varMap:
-                return varMap[expr.name()]
+            if expr.local_name in varMap:
+                return varMap[expr.local_name]
             else:
                 return expr
 

--- a/pyomo/core/plugins/transform/radix_linearization.py
+++ b/pyomo/core/plugins/transform/radix_linearization.py
@@ -46,7 +46,7 @@ class RadixLinearization(Transformation):
         _discretize = {}
         if user_discretize:
             for _var in user_discretize:
-                _v = M.find_component(_var.name(True))
+                _v = M.find_component(_var.name)
                 if _v.component() is _v:
                     for _vv in _v.itervalues():
                         _discretize.setdefault(id(_vv), len(_discretize))
@@ -139,7 +139,7 @@ class RadixLinearization(Transformation):
         for _id, _idx in iteritems(_discretize):
             if verbose:
                 logger.info("Discretizing variable %s as %s" %
-                            (_counts[_id][0].name(True), _idx))
+                            (_counts[_id][0].name, _idx))
             self._discretize_variable(_block, _counts[_id][0], _idx)
 
         _known_bilinear = {}
@@ -164,7 +164,7 @@ class RadixLinearization(Transformation):
         _lb, _ub = v.bounds
         if _lb is None or _ub is None:
             raise RuntimeError("Couldn't discretize variable %s: missing "
-                               "finite lower/upper bounds." % (v.name(True)))
+                               "finite lower/upper bounds." % (v.name))
         _c = Constraint(
             expr= v == _lb + (_ub-_lb) * ( b.dv[idx] +
                 sum(b.z[idx,k] * 2**-k for k in b.DISCRETIZATION) ) )
@@ -194,13 +194,13 @@ class RadixLinearization(Transformation):
         _z = b.z
         _dv = b.dv[v_idx]
         _u = Var(b.DISCRETIZATION, within=u.domain, bounds=u.bounds)
-        logger.info("Discretizing (v=%s)*(u=%s) as u%s_v%s" % (
-                v.name(True), u.name(True), u_idx, v_idx ))
+        logger.info("Discretizing (v=%s)*(u=%s) as u%s_v%s"
+                    % (v.name, u.name, u_idx, v_idx ))
         b.add_component( "u%s_v%s" % (u_idx, v_idx), _u)
         _lb, _ub = u.bounds
         if _lb is None or _ub is None:
              raise RuntimeError("Couldn't relax variable %s: missing "
-                               "finite lower/upper bounds." % (u.name(True)))
+                               "finite lower/upper bounds." % (u.name))
         _c = ConstraintList()
         b.add_component( "c_disaggregate_u%s_v%s" % (u_idx, v_idx), _c )
         for k in b.DISCRETIZATION:

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -181,8 +181,8 @@ class TestGenerators(unittest.TestCase):
                 # failure message. I leave comparison of ids in the
                 # second assertEqual to make sure the tests are working
                 # as expected
-                self.assertEqual([comp.name(True) for comp in generator],
-                                 [comp.name(True) for comp in block.component_lists[ctype]])
+                self.assertEqual([comp.name for comp in generator],
+                                 [comp.name for comp in block.component_lists[ctype]])
                 self.assertEqual([id(comp) for comp in generator],
                                  [id(comp) for comp in block.component_lists[ctype]])
 
@@ -200,8 +200,8 @@ class TestGenerators(unittest.TestCase):
                 # failure message. I leave comparison of ids in the
                 # second assertEqual to make sure the tests are working
                 # as expected
-                self.assertEqual([comp.name(True) for comp in generator],
-                                 [comp.name(True) for comp in block.component_lists[ctype]])
+                self.assertEqual([comp.name for comp in generator],
+                                 [comp.name for comp in block.component_lists[ctype]])
                 self.assertEqual([id(comp) for comp in generator],
                                  [id(comp) for comp in block.component_lists[ctype]])
 
@@ -219,8 +219,8 @@ class TestGenerators(unittest.TestCase):
                 # failure message. I leave comparison of ids in the
                 # second assertEqual to make sure the tests are working
                 # as expected
-                self.assertEqual([comp.name(True) for name, comp in generator],
-                                 [comp.name(True) for comp in block.component_data_lists[ctype]])
+                self.assertEqual([comp.name for name, comp in generator],
+                                 [comp.name for comp in block.component_data_lists[ctype]])
                 self.assertEqual([id(comp) for name, comp in generator],
                                  [id(comp) for comp in block.component_data_lists[ctype]])
 
@@ -238,8 +238,8 @@ class TestGenerators(unittest.TestCase):
                 # failure message. I leave comparison of ids in the
                 # second assertEqual to make sure the tests are working
                 # as expected
-                self.assertEqual(sorted([comp.name(True) for name, comp in generator]),
-                                 sorted([comp.name(True) for comp in block.component_data_lists[ctype]]))
+                self.assertEqual(sorted([comp.name for name, comp in generator]),
+                                 sorted([comp.name for comp in block.component_data_lists[ctype]]))
                 self.assertEqual(sorted([id(comp) for name, comp in generator]),
                                  sorted([id(comp) for comp in block.component_data_lists[ctype]]))
 
@@ -257,8 +257,8 @@ class TestGenerators(unittest.TestCase):
                 # failure message. I leave comparison of ids in the
                 # second assertEqual to make sure the tests are working
                 # as expected
-                self.assertEqual([comp.name(True) for name, comp in generator],
-                                 [comp.name(True) for comp in block.component_data_lists[ctype]])
+                self.assertEqual([comp.name for name, comp in generator],
+                                 [comp.name for comp in block.component_data_lists[ctype]])
                 self.assertEqual([id(comp) for name, comp in generator],
                                  [id(comp) for comp in block.component_data_lists[ctype]])
 
@@ -276,8 +276,8 @@ class TestGenerators(unittest.TestCase):
                 # failure message. I leave comparison of ids in the
                 # second assertEqual to make sure the tests are working
                 # as expected
-                self.assertEqual(sorted([comp.name(True) for name, comp in generator]),
-                                 sorted([comp.name(True) for comp in block.component_data_lists[ctype]]))
+                self.assertEqual(sorted([comp.name for name, comp in generator]),
+                                 sorted([comp.name for comp in block.component_data_lists[ctype]]))
                 self.assertEqual(sorted([id(comp) for name, comp in generator]),
                                  sorted([id(comp) for comp in block.component_data_lists[ctype]]))
 
@@ -500,38 +500,38 @@ class TestBlock(unittest.TestCase):
         """ Coverage of the _clear_attribute method """
         obj = Set()
         self.block.A = obj
-        self.assertEqual(self.block.A.name(), "A")
-        self.assertEqual(obj.name(), "A")
+        self.assertEqual(self.block.A.local_name, "A")
+        self.assertEqual(obj.local_name, "A")
         self.assertIs(obj, self.block.A)
 
         obj = Var()
         self.block.A = obj
-        self.assertEqual(self.block.A.name(), "A")
-        self.assertEqual(obj.name(), "A")
+        self.assertEqual(self.block.A.local_name, "A")
+        self.assertEqual(obj.local_name, "A")
         self.assertIs(obj, self.block.A)
 
         obj = Param()
         self.block.A = obj
-        self.assertEqual(self.block.A.name(), "A")
-        self.assertEqual(obj.name(), "A")
+        self.assertEqual(self.block.A.local_name, "A")
+        self.assertEqual(obj.local_name, "A")
         self.assertIs(obj, self.block.A)
 
         obj = Objective()
         self.block.A = obj
-        self.assertEqual(self.block.A.name(), "A")
-        self.assertEqual(obj.name(), "A")
+        self.assertEqual(self.block.A.local_name, "A")
+        self.assertEqual(obj.local_name, "A")
         self.assertIs(obj, self.block.A)
 
         obj = Constraint()
         self.block.A = obj
-        self.assertEqual(self.block.A.name(), "A")
-        self.assertEqual(obj.name(), "A")
+        self.assertEqual(self.block.A.local_name, "A")
+        self.assertEqual(obj.local_name, "A")
         self.assertIs(obj, self.block.A)
 
         obj = Set()
         self.block.A = obj
-        self.assertEqual(self.block.A.name(), "A")
-        self.assertEqual(obj.name(), "A")
+        self.assertEqual(self.block.A.local_name, "A")
+        self.assertEqual(obj.local_name, "A")
         self.assertIs(obj, self.block.A)
 
     def test_set_attr(self):
@@ -564,20 +564,20 @@ class TestBlock(unittest.TestCase):
 
         HM = HierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator()]
+        result = [x.name for x in m._tree_iterator()]
         self.assertEqual(HM.PrefixDFS, result)
 
     def test_iterate_hierarchy_PrefixDFS(self):
         HM = HierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.PrefixDepthFirstSearch)]
         self.assertEqual(HM.PrefixDFS, result)
 
     def test_iterate_hierarchy_PrefixDFS_sortIndex(self):
         HM = HierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.PrefixDepthFirstSearch,
             sort=SortComponents.indices,
         )]
@@ -585,7 +585,7 @@ class TestBlock(unittest.TestCase):
     def test_iterate_hierarchy_PrefixDFS_sortName(self):
         HM = HierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.PrefixDepthFirstSearch,
             sort=SortComponents.alphaOrder,
         )]
@@ -593,7 +593,7 @@ class TestBlock(unittest.TestCase):
     def test_iterate_hierarchy_PrefixDFS_sort(self):
         HM = HierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.PrefixDepthFirstSearch,
             sort=True
         )]
@@ -603,14 +603,14 @@ class TestBlock(unittest.TestCase):
     def test_iterate_hierarchy_PostfixDFS(self):
         HM = HierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.PostfixDepthFirstSearch)]
         self.assertEqual(HM.PostfixDFS, result)
 
     def test_iterate_hierarchy_PostfixDFS_sortIndex(self):
         HM = HierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.PostfixDepthFirstSearch,
             sort=SortComponents.indices,
         )]
@@ -618,7 +618,7 @@ class TestBlock(unittest.TestCase):
     def test_iterate_hierarchy_PostfixDFS_sortName(self):
         HM = HierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.PostfixDepthFirstSearch,
             sort=SortComponents.alphaOrder,
         )]
@@ -626,7 +626,7 @@ class TestBlock(unittest.TestCase):
     def test_iterate_hierarchy_PostfixDFS_sort(self):
         HM = HierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.PostfixDepthFirstSearch,
             sort=True
         )]
@@ -635,14 +635,14 @@ class TestBlock(unittest.TestCase):
     def test_iterate_hierarchy_BFS(self):
         HM = HierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.BreadthFirstSearch)]
         self.assertEqual(HM.BFS, result)
 
     def test_iterate_hierarchy_BFS_sortIndex(self):
         HM = HierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.BreadthFirstSearch,
             sort=SortComponents.indices,
         )]
@@ -651,7 +651,7 @@ class TestBlock(unittest.TestCase):
     def test_iterate_hierarchy_BFS_sortName(self):
         HM = HierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.BreadthFirstSearch,
             sort=SortComponents.alphaOrder,
         )]
@@ -660,7 +660,7 @@ class TestBlock(unittest.TestCase):
     def test_iterate_hierarchy_BFS_sort(self):
         HM = HierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.BreadthFirstSearch,
             sort=True
         )]
@@ -669,7 +669,7 @@ class TestBlock(unittest.TestCase):
     def test_iterate_mixed_hierarchy_PrefixDFS_block(self):
         HM = MixedHierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.PrefixDepthFirstSearch,
             ctype=Block,
         )]
@@ -677,7 +677,7 @@ class TestBlock(unittest.TestCase):
     def test_iterate_mixed_hierarchy_PrefixDFS_both(self):
         HM = MixedHierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.PrefixDepthFirstSearch,
             ctype=(Block,DerivedBlock),
         )]
@@ -686,7 +686,7 @@ class TestBlock(unittest.TestCase):
     def test_iterate_mixed_hierarchy_PostfixDFS_block(self):
         HM = MixedHierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.PostfixDepthFirstSearch,
             ctype=Block,
         )]
@@ -694,7 +694,7 @@ class TestBlock(unittest.TestCase):
     def test_iterate_mixed_hierarchy_PostfixDFS_both(self):
         HM = MixedHierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.PostfixDepthFirstSearch,
             ctype=(Block,DerivedBlock),
         )]
@@ -703,7 +703,7 @@ class TestBlock(unittest.TestCase):
     def test_iterate_mixed_hierarchy_BFS_block(self):
         HM = MixedHierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.BFS,
             ctype=Block,
         )]
@@ -711,7 +711,7 @@ class TestBlock(unittest.TestCase):
     def test_iterate_mixed_hierarchy_BFS_both(self):
         HM = MixedHierarchicalModel()
         m = HM.model
-        result = [x.name(True) for x in m._tree_iterator(
+        result = [x.name for x in m._tree_iterator(
             traversal=TraversalStrategy.BFS,
             ctype=(Block,DerivedBlock),
         )]
@@ -1026,10 +1026,10 @@ class TestBlock(unittest.TestCase):
         m.z.deactivate()
 
         def assertWorks(self, key, pm):
-            self.assertIs(pm[key.name()], key)
+            self.assertIs(pm[key.local_name], key)
         def assertFails(self, key, pm):
             if not isinstance(key, six.string_types):
-                key = key.name()
+                key = key.local_name
             self.assertRaises(KeyError, pm.__getitem__, key)
 
         pm = m.component_map()

--- a/pyomo/core/tests/unit/test_con.py
+++ b/pyomo/core/tests/unit/test_con.py
@@ -1138,7 +1138,7 @@ class MiscConTests(unittest.TestCase):
 
     def test_constructor(self):
         a = Constraint(name="b")
-        self.assertEqual(a.name(), "b")
+        self.assertEqual(a.local_name, "b")
         try:
             a = Constraint(foo="bar")
             self.fail("Can't specify an unexpected constructor option")

--- a/pyomo/core/tests/unit/test_dict_objects.py
+++ b/pyomo/core/tests/unit/test_dict_objects.py
@@ -269,10 +269,10 @@ class _TestComponentDictBase(object):
         prefix = "c"
         for i in index:
             cdata = model.c[i]
-            self.assertEqual(cdata.name(False),
-                             cdata.name(True))
+            self.assertEqual(cdata.local_name,
+                             cdata.name)
             cname = prefix + index_to_string[i]
-            self.assertEqual(cdata.name(False),
+            self.assertEqual(cdata.local_name,
                              cname)
 
     def test_clear(self):

--- a/pyomo/core/tests/unit/test_indexed.py
+++ b/pyomo/core/tests/unit/test_indexed.py
@@ -30,7 +30,7 @@ class TestSimpleVar(unittest.TestCase):
 
         names = set()
         for var in m.x[:]:
-            names.add(var.name(True))
+            names.add(var.name)
         self.assertEqual(names, set(['x']))
 
     def test1(self):
@@ -40,7 +40,7 @@ class TestSimpleVar(unittest.TestCase):
 
         names = set()
         for var in m.x[:]:
-            names.add(var.name(True))
+            names.add(var.name)
         self.assertEqual(names, set(['x[0]', 'x[1]', 'x[2]']))
 
     def test2a(self):
@@ -50,7 +50,7 @@ class TestSimpleVar(unittest.TestCase):
 
         names = set()
         for var in m.x[:, 1]:
-            names.add(var.name(True))
+            names.add(var.name)
         self.assertEqual(names, set(['x[0,1]', 'x[1,1]', 'x[2,1]']))
 
     def test2b(self):
@@ -60,7 +60,7 @@ class TestSimpleVar(unittest.TestCase):
 
         names = set()
         for var in m.x[2, :]:
-            names.add(var.name(True))
+            names.add(var.name)
         self.assertEqual(names, set(['x[2,0]', 'x[2,1]', 'x[2,2]']))
 
     def test2c(self):
@@ -70,7 +70,7 @@ class TestSimpleVar(unittest.TestCase):
 
         names = set()
         for var in m.x[3, :]:
-            names.add(var.name(True))
+            names.add(var.name)
         self.assertEqual(names, set())
 
     def test3a(self):
@@ -80,7 +80,7 @@ class TestSimpleVar(unittest.TestCase):
 
         names = set()
         for var in m.x[:, 1, :]:
-            names.add(var.name(True))
+            names.add(var.name)
         self.assertEqual(names, set(['x[0,1,0]', 'x[0,1,1]', 'x[0,1,2]', 'x[1,1,0]', 'x[1,1,1]', 'x[1,1,2]', 'x[2,1,0]', 'x[2,1,1]', 'x[2,1,2]' ]))
 
     def test3b(self):
@@ -90,7 +90,7 @@ class TestSimpleVar(unittest.TestCase):
 
         names = set()
         for var in m.x[0, :, 2]:
-            names.add(var.name(True))
+            names.add(var.name)
         self.assertEqual(names, set(['x[0,0,2]', 'x[0,1,2]', 'x[0,2,2]']))
 
 

--- a/pyomo/core/tests/unit/test_list_objects.py
+++ b/pyomo/core/tests/unit/test_list_objects.py
@@ -309,10 +309,10 @@ class _TestComponentListBase(object):
         prefix = "c"
         for i in index:
             cdata = model.c[i]
-            self.assertEqual(cdata.name(False),
-                             cdata.name(True))
+            self.assertEqual(cdata.local_name,
+                             cdata.name)
             cname = prefix + "["+str(i)+"]"
-            self.assertEqual(cdata.name(False),
+            self.assertEqual(cdata.local_name,
                              cname)
 
 class _TestActiveComponentListBase(_TestComponentListBase):

--- a/pyomo/core/tests/unit/test_model.py
+++ b/pyomo/core/tests/unit/test_model.py
@@ -133,38 +133,38 @@ class Test(unittest.TestCase):
         model = ConcreteModel()
         obj = Set()
         model.A = obj
-        self.assertEqual(model.A.name(), "A")
-        self.assertEqual(obj.name(), "A")
+        self.assertEqual(model.A.local_name, "A")
+        self.assertEqual(obj.local_name, "A")
         self.assertIs(obj, model.A)
 
         obj = Var()
         model.A = obj
-        self.assertEqual(model.A.name(), "A")
-        self.assertEqual(obj.name(), "A")
+        self.assertEqual(model.A.local_name, "A")
+        self.assertEqual(obj.local_name, "A")
         self.assertIs(obj, model.A)
 
         obj = Param()
         model.A = obj
-        self.assertEqual(model.A.name(), "A")
-        self.assertEqual(obj.name(), "A")
+        self.assertEqual(model.A.local_name, "A")
+        self.assertEqual(obj.local_name, "A")
         self.assertIs(obj, model.A)
 
         obj = Objective()
         model.A = obj
-        self.assertEqual(model.A.name(), "A")
-        self.assertEqual(obj.name(), "A")
+        self.assertEqual(model.A.local_name, "A")
+        self.assertEqual(obj.local_name, "A")
         self.assertIs(obj, model.A)
 
         obj = Constraint()
         model.A = obj
-        self.assertEqual(model.A.name(), "A")
-        self.assertEqual(obj.name(), "A")
+        self.assertEqual(model.A.local_name, "A")
+        self.assertEqual(obj.local_name, "A")
         self.assertIs(obj, model.A)
 
         obj = Set()
         model.A = obj
-        self.assertEqual(model.A.name(), "A")
-        self.assertEqual(obj.name(), "A")
+        self.assertEqual(model.A.local_name, "A")
+        self.assertEqual(obj.local_name, "A")
         self.assertIs(obj, model.A)
 
     def test_set_attr(self):
@@ -630,7 +630,7 @@ class Test(unittest.TestCase):
             m.x = Var(m.I)
             m.c = Constraint( expr=sum(m.x[i] for i in m.I) >= 0 )
         model = ConcreteModel(rule=make)
-        self.assertEqual( [x.name() for x in model.component_objects()],
+        self.assertEqual( [x.local_name for x in model.component_objects()],
                           ['I','x','c'] )
         self.assertEqual( len(list(identify_variables(model.c.body))), 3 )
 
@@ -653,16 +653,16 @@ class Test(unittest.TestCase):
 
         model = AbstractModel(rule=make)
         instance = model.create_instance()
-        self.assertEqual( [x.name() for x in model.component_objects()],
+        self.assertEqual( [x.local_name for x in model.component_objects()],
                           [] )
-        self.assertEqual( [x.name() for x in instance.component_objects()],
+        self.assertEqual( [x.local_name for x in instance.component_objects()],
                           ['I','x','c'] )
         self.assertEqual( len(list(identify_variables(instance.c.body))), 3 )
 
         model = AbstractModel(rule=make)
         model.y = Var()
         instance = model.create_instance()
-        self.assertEqual( [x.name() for x in instance.component_objects()],
+        self.assertEqual( [x.local_name for x in instance.component_objects()],
                           ['y','I','x','c'] )
         self.assertEqual( len(list(identify_variables(instance.c.body))), 3 )
 

--- a/pyomo/core/tests/unit/test_obj.py
+++ b/pyomo/core/tests/unit/test_obj.py
@@ -714,7 +714,7 @@ class MiscObjTests(unittest.TestCase):
 
     def test_constructor(self):
         a = Objective(name="b")
-        self.assertEqual(a.name(), "b")
+        self.assertEqual(a.local_name, "b")
         try:
             a = Objective(foo="bar")
             self.fail("Can't specify an unexpected constructor option")

--- a/pyomo/core/tests/unit/test_sos.py
+++ b/pyomo/core/tests/unit/test_sos.py
@@ -114,16 +114,16 @@ class TestExamples(unittest.TestCase):
         M = ConcreteModel()
         M.x = Var(xrange(20))
         M.c = SOSConstraint(var=M.x, sos=1)
-        self.assertEqual(set((v.name(True),w) for v,w in M.c.get_items()),
-                         set((M.x[i].name(True), i+1) for i in xrange(20)))
+        self.assertEqual(set((v.name,w) for v,w in M.c.get_items()),
+                         set((M.x[i].name, i+1) for i in xrange(20)))
 
     def test2(self):
         # Use an index set, which is a subset of M.x.index_set()
         M = ConcreteModel()
         M.x = Var(xrange(20))
         M.c = SOSConstraint(var=M.x, index=list(xrange(10)), sos=1)
-        self.assertEqual(set((v.name(True),w) for v,w in M.c.get_items()),
-                         set((M.x[i].name(True), i+1) for i in xrange(10)))
+        self.assertEqual(set((v.name,w) for v,w in M.c.get_items()),
+                         set((M.x[i].name, i+1) for i in xrange(10)))
 
     def test3(self):
         # User-specified weights
@@ -131,8 +131,8 @@ class TestExamples(unittest.TestCase):
         M = ConcreteModel()
         M.x = Var([1,2,3])
         M.c = SOSConstraint(var=M.x, weights=w, sos=1)
-        self.assertEqual(set((v.name(True),w) for v,w in M.c.get_items()),
-                         set((M.x[i].name(True), w[i]) for i in [1,2,3]))
+        self.assertEqual(set((v.name,w) for v,w in M.c.get_items()),
+                         set((M.x[i].name, w[i]) for i in [1,2,3]))
 
     def test4(self):
         # User-specified weights
@@ -142,27 +142,27 @@ class TestExamples(unittest.TestCase):
         M = ConcreteModel()
         M.x = Var([1,2,3], dense=True)
         M.c = SOSConstraint(rule=rule, sos=1)
-        self.assertEqual(set((v.name(True),w) for v,w in M.c.get_items()),
-                         set((M.x[i].name(True), w[i]) for i in [1,2,3]))
+        self.assertEqual(set((v.name,w) for v,w in M.c.get_items()),
+                         set((M.x[i].name, w[i]) for i in [1,2,3]))
 
     def test10(self):
         M = ConcreteModel()
         M.x = Var([1,2,3])
         M.c = SOSConstraint([0,1], var=M.x, sos=1, index={0:[1,2], 1:[2,3]})
-        self.assertEqual(set((v.name(True),w) for v,w in M.c[0].get_items()),
-                         set((M.x[i].name(True), i) for i in [1,2]))
-        self.assertEqual(set((v.name(True),w) for v,w in M.c[1].get_items()),
-                         set((M.x[i].name(True), i-1) for i in [2,3]))
+        self.assertEqual(set((v.name,w) for v,w in M.c[0].get_items()),
+                         set((M.x[i].name, i) for i in [1,2]))
+        self.assertEqual(set((v.name,w) for v,w in M.c[1].get_items()),
+                         set((M.x[i].name, i-1) for i in [2,3]))
 
     def test11(self):
         w = {1:10, 2:2, 3:30}
         M = ConcreteModel()
         M.x = Var([1,2,3], dense=True)
         M.c = SOSConstraint([0,1], var=M.x, weights=w, sos=1, index={0:[1,2], 1:[2,3]})
-        self.assertEqual(set((v.name(True),w) for v,w in M.c[0].get_items()),
-                         set((M.x[i].name(True), w[i]) for i in [1,2]))
-        self.assertEqual(set((v.name(True),w) for v,w in M.c[1].get_items()),
-                         set((M.x[i].name(True), w[i]) for i in [2,3]))
+        self.assertEqual(set((v.name,w) for v,w in M.c[0].get_items()),
+                         set((M.x[i].name, w[i]) for i in [1,2]))
+        self.assertEqual(set((v.name,w) for v,w in M.c[1].get_items()),
+                         set((M.x[i].name, w[i]) for i in [2,3]))
 
     def test12(self):
         def rule(model, i):
@@ -174,20 +174,20 @@ class TestExamples(unittest.TestCase):
         M = ConcreteModel()
         M.x = Var([1,2,3], dense=True)
         M.c = SOSConstraint([0,1], rule=rule, sos=1)
-        self.assertEqual(set((v.name(True),w) for v,w in M.c[0].get_items()),
-                         set((M.x[i].name(True), w[0][i]) for i in [1,2,3]))
-        self.assertEqual(set((v.name(True),w) for v,w in M.c[1].get_items()),
-                         set((M.x[i].name(True), w[1][i]) for i in [1,2,3]))
+        self.assertEqual(set((v.name,w) for v,w in M.c[0].get_items()),
+                         set((M.x[i].name, w[0][i]) for i in [1,2,3]))
+        self.assertEqual(set((v.name,w) for v,w in M.c[1].get_items()),
+                         set((M.x[i].name, w[1][i]) for i in [1,2,3]))
 
     def test13(self):
         I = {0:[1,2], 1:[2,3]}
         M = ConcreteModel()
         M.x = Var([1,2,3], dense=True)
         M.c = SOSConstraint([0,1], var=M.x, index=I, sos=1)
-        self.assertEqual(set((v.name(True),w) for v,w in M.c[0].get_items()),
-                         set((M.x[i].name(True), i) for i in I[0]))
-        self.assertEqual(set((v.name(True),w) for v,w in M.c[1].get_items()),
-                         set((M.x[i].name(True), i-1) for i in I[1]))
+        self.assertEqual(set((v.name,w) for v,w in M.c[0].get_items()),
+                         set((M.x[i].name, i) for i in I[0]))
+        self.assertEqual(set((v.name,w) for v,w in M.c[1].get_items()),
+                         set((M.x[i].name, i-1) for i in I[1]))
 
     def test14(self):
         def rule(model, i):
@@ -200,8 +200,8 @@ class TestExamples(unittest.TestCase):
         M.x = Var([1,2,3], dense=True)
         M.c = SOSConstraint([0,1], rule=rule, sos=1)
         self.assertEqual(list(M.c.keys()), [1])
-        self.assertEqual(set((v.name(True),w) for v,w in M.c[1].get_items()),
-                         set((M.x[i].name(True), w[1][i]) for i in [1,2,3]))
+        self.assertEqual(set((v.name,w) for v,w in M.c[1].get_items()),
+                         set((M.x[i].name, w[1][i]) for i in [1,2,3]))
 
 
 if __name__ == "__main__":

--- a/pyomo/core/tests/unit/test_var.py
+++ b/pyomo/core/tests/unit/test_var.py
@@ -207,7 +207,7 @@ class TestSimpleVar(PyomoModel):
         #
         self.model.x = Var()
         self.model.x._name = "foo"
-        self.assertEqual(self.model.x.name(), "foo")
+        self.assertEqual(self.model.x.name, "foo")
 
     def test_lb_attr1(self):
         """Test lb attribute"""

--- a/pyomo/dae/contset.py
+++ b/pyomo/dae/contset.py
@@ -19,7 +19,7 @@ logger = logging.getLogger('pyomo.core')
 
 class ContinuousSet(OrderedSimpleSet):
     """ ContinuousSet objects are used to represent bounded continuous domains
-    
+
         Minimally, this set must contain two numeric values defining the
         bounds of a continuous range. Discrete points of interest may
         be added to the continuous set. A continuous set is one
@@ -28,28 +28,27 @@ class ContinuousSet(OrderedSimpleSet):
         Constructor Arguments:
             initialize  Default discretization points to be included
 
-            bounds      Specify bounding points for the continuous domain. 
-                        The bounds will be included as discrete points in 
+            bounds      Specify bounding points for the continuous domain.
+                        The bounds will be included as discrete points in
                         the continuous set but will not be used to restrict
-                        points added to the continuous set through the 
+                        points added to the continuous set through the
                         'initialize' argument, a data file, or the add() method
 
         Private Attributes:
             _changed   This keeps track of whether or not the ContinuousSet was
-                       changed during discretization. If the user specifies 
-                       all of the needed discretization points before the 
+                       changed during discretization. If the user specifies
+                       all of the needed discretization points before the
                        discretization then there is no need to go back through
                        the model and reconstruct things indexed by the ContinuousSet
-                      
             _fe        This is a sorted list of the finite element points in the
-                       ContinuousSet. i.e. this list contains all the discrete 
+                       ContinuousSet. i.e. this list contains all the discrete
                        points in the ContinuousSet that are not collocation points.
                        Points that are both finite element points and collocation
                        points will be included in this list.
 
             _discretization_info
-                       This is a dictionary which contains information on the 
-                       discretization transformation which has been applied to 
+                       This is a dictionary which contains information on the
+                       discretization transformation which has been applied to
                        the ContinuousSet.
     """
 
@@ -67,7 +66,7 @@ class ContinuousSet(OrderedSimpleSet):
             raise TypeError("'validate' is not a valid keyword argument for ContinuousSet")
         if len(args) != 0:
             raise TypeError("A ContinuousSet expects no arguments")
-        
+
         kwds.setdefault('ctype',ContinuousSet)
         kwds.setdefault('ordered',Set.SortedOrder)
         self._type=ContinuousSet
@@ -95,14 +94,14 @@ class ContinuousSet(OrderedSimpleSet):
 
     def get_upper_element_boundary(self, value):
         """
-        This function returns the first finite element that is greater 
+        This function returns the first finite element that is greater
         or equal to the value sent to the function
         """
         if value in self._fe:
             return value
         elif value > max(self._fe):
             print("****WARNING: The value '%s' exceeds the upper bound "\
-                  "of the ContinuousSet '%s'. Returning the upper bound" %(str(value),self.name()))
+                  "of the ContinuousSet '%s'. Returning the upper bound" %(str(value),self.name))
             return max(self._fe)
         else :
             for i in self._fe:
@@ -111,22 +110,22 @@ class ContinuousSet(OrderedSimpleSet):
 
     def get_lower_element_boundary(self, value):
         """
-        This function returns the first finite element that is less than 
+        This function returns the first finite element that is less than
         or equal to the value sent to the function
         """
         if value in self._fe:
             if 'scheme' in self._discretization_info:
                 if self._discretization_info['scheme'] == 'LAGRANGE-RADAU':
-                    # Because Radau Collocation has a collocation point on the 
+                    # Because Radau Collocation has a collocation point on the
                     # upper finite element bound this if statement ensures that
                     # the desired finite element bound is returned
                     tmp = self._fe.index(value)
                     if tmp != 0:
                         return self._fe[tmp-1]
-            return value 
+            return value
         elif value < min(self._fe):
             print("****WARNING: The value '%s' is less than the lower bound "\
-                  "of the ContinuousSet '%s'. Returning the lower bound" %(str(value),self.name()))
+                  "of the ContinuousSet '%s'. Returning the lower bound" %(str(value),self.name))
             return min(self._fe)
         else:
             rev_fe = list(self._fe)
@@ -137,7 +136,7 @@ class ContinuousSet(OrderedSimpleSet):
 
     def construct(self, values=None):
         OrderedSimpleSet.construct(self, values)
-         
+
         for val in self.value:
             if type(val) is tuple:
                 raise ValueError("ContinuousSet cannot contain tuples")
@@ -146,7 +145,7 @@ class ContinuousSet(OrderedSimpleSet):
 
         if self._bounds is None:
             raise ValueError("ContinuousSet '%s' must have at least two values indicating "\
-                             "the range over which a differential equation is to be discretized" % (self.name()))
+                             "the range over which a differential equation is to be discretized" % (self.name))
 
         # If bounds were set using pyomo parameters, get their values
         lb = value(self._bounds[0])
@@ -159,21 +158,21 @@ class ContinuousSet(OrderedSimpleSet):
             raise ValueError("Bounds on ContinuousSet must be numeric values")
 
         # TBD: If a user specifies bounds they will be added to the set
-        # unless the user specified bounds have been overwritten during 
+        # unless the user specified bounds have been overwritten during
         # OrderedSimpleSet construction. This can lead to some unintuitive
         # behavior when the ContinuousSet is both initialized with values and
-        # bounds are specified. The current implementation is consistent 
-        # with how 'Set' treats this situation. 
+        # bounds are specified. The current implementation is consistent
+        # with how 'Set' treats this situation.
         if self._bounds[0] not in self.value:
             self.add(self._bounds[0])
             self._sort()
         if self._bounds[1] not in self.value:
             self.add(self._bounds[1])
             self._sort()
-        
+
         if len(self) < 2:
             raise ValueError("ContinuousSet '%s' must have at least two values indicating "\
-                             "the range over which a differential equation is to be discretized" % (self.name()))
+                             "the range over which a differential equation is to be discretized" % (self.name))
         self._fe = sorted(self)
 
 register_component(ContinuousSet, "A bounded continuous numerical range optionally containing discrete points of interest.")

--- a/pyomo/dae/diffvar.py
+++ b/pyomo/dae/diffvar.py
@@ -72,8 +72,8 @@ def derivative(self,*args):
     except:
         nme = '_'
         for i in args:
-            nme = nme+'d'+i.name()
-        self.model().add_component('d'+svar.name()+nme,DerivativeVar(svar,wrt=args))
+            nme = nme+'d'+i.local_name
+        self.model().add_component('d'+svar.local_name+nme,DerivativeVar(svar,wrt=args))
         deriv = svar.get_derivative(*args)
 
     try:
@@ -212,7 +212,7 @@ class DerivativeVar(Var):
             raise DAE_Error(
                 "Cannot create a new derivative variable for variable "
                 "%s: derivative already defined as %s"
-                % ( sVar.name(True), sVar.get_derivative(*tuple(wrt)).name(True) ) )
+                % ( sVar.name, sVar.get_derivative(*tuple(wrt)).name ) )
 
         sVar._derivative[wrtkey] = weakref.ref(self)
         self._sVar = sVar

--- a/pyomo/dae/integral.py
+++ b/pyomo/dae/integral.py
@@ -65,7 +65,7 @@ class Integral(Expression):
             if len(args) != 1:
                 raise ValueError(
                     "The Integral %s is indexed by multiple ContinuousSets. The desired "
-                    "ContinuousSet must be specified using the keyword argument 'wrt'" % (self.name(True)))
+                    "ContinuousSet must be specified using the keyword argument 'wrt'" % (self.name))
             wrt = args[0]
 
         if type(wrt) is not ContinuousSet:
@@ -83,7 +83,7 @@ class Integral(Expression):
         if loc is None:
             raise ValueError(
                 "The ContinuousSet '%s' was not found in the indexing sets of the "
-                "Integral '%s'" %(wrt.name(True),self.name(True)))
+                "Integral '%s'" %(wrt.name,self.name))
         self.loc = loc
 
         # Remove the index that the integral is being expanded over
@@ -104,7 +104,7 @@ class Integral(Expression):
                 "Must specify an integral expression for Integral '%s'" %(self))
 
         def _trap_rule(m,*a):
-            ds = sorted(m.find_component(wrt.name()))
+            ds = sorted(m.find_component(wrt.local_name))
             return sum(0.5*(ds[i+1]-ds[i])*
                       (intexp(m,*(a[0:loc]+(ds[i+1],)+a[loc:]))+intexp(m,*(a[0:loc]+(ds[i],)+a[loc:])))
                       for i in range(len(ds)-1))
@@ -146,7 +146,7 @@ class SimpleIntegral(_GeneralExpressionData, Integral):
             "Accessing the expression of integral '%s' "
             "before the Integral has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
     def set_value(self, expr):
         """Set the expression on this expression."""
@@ -156,7 +156,7 @@ class SimpleIntegral(_GeneralExpressionData, Integral):
             "Setting the expression of integral '%s' "
             "before the Integral has been constructed (there "
             "is currently no object to set)."
-            % (self.name(True)))
+            % (self.name))
 
     def is_constant(self):
         """A boolean indicating whether this expression is constant."""
@@ -166,7 +166,7 @@ class SimpleIntegral(_GeneralExpressionData, Integral):
             "Accessing the is_constant flag of integral '%s' "
             "before the Integral has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
     def is_fixed(self):
         """A boolean indicating whether this expression is fixed."""
@@ -176,7 +176,7 @@ class SimpleIntegral(_GeneralExpressionData, Integral):
             "Accessing the is_fixed flag of integral '%s' "
             "before the Integral has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
 class IndexedIntegral(Integral):
 

--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -19,21 +19,21 @@ from six import iterkeys, itervalues
 logger = logging.getLogger('pyomo.core')
 
 def generate_finite_elements(ds,nfe):
-    """ 
+    """
     This function first checks to see if the number of finite elements
     in the differential set is equal to nfe. If the number of finite
     elements is less than nfe, additional points will be generated. If
-    the number of finite elements is greater than or equal to nfe the 
+    the number of finite elements is greater than or equal to nfe the
     differential set will not be modified
     """
     if (len(ds)-1) >= nfe:
         # In this case the differentialset already contains the
         # desired number or more than the desired number of finite
         # elements so no additional points are needed.
-        return     
+        return
     elif len(ds) == 2:
         # If only bounds have been specified on the differentialset we
-        # generate the desired number of finite elements by 
+        # generate the desired number of finite elements by
         # spreading them evenly over the interval
         step = (max(ds)-min(ds))/float(nfe)
         tmp = min(ds)+step
@@ -46,11 +46,11 @@ def generate_finite_elements(ds,nfe):
         return
     else:
         # This is the case where some points have been specified
-        # inside of the bounds however the desired number of finite 
+        # inside of the bounds however the desired number of finite
         # elements has not been met. We first look at the step sizes
         # between the existing points. Then an additional point
         # is placed at the midpoint of the largest step. This
-        # process is repeated until we have achieved the desired 
+        # process is repeated until we have achieved the desired
         # number of finite elements. If there are multiple "largest steps"
         # the point will be placed at the first occurance of the
         # largest step
@@ -72,7 +72,7 @@ def _add_point(ds):
         if (sortds[i]-sortds[i-1])>maxstep:
             maxstep = sortds[i]-sortds[i-1]
             maxloc = i-1
-            
+
     ds.add(round((sortds[maxloc]+maxstep/2.0),6))
 
 def generate_colloc_points(ds,tau):
@@ -99,13 +99,13 @@ def update_contset_indexed_component(comp):
     that has changed
     """
     # FIXME: This implementation is a hack until Var and Constraint get
-    # moved over to Indexed_Component. The update methods below are 
+    # moved over to Indexed_Component. The update methods below are
     # roughly what the '_default' method in Var and Constraint should
     # do when they get reimplemented.
 
     # This implementation also assumes that only Var and Constraint components
-    # will be explicitly indexed by a ContinuousSet and thus only checks for 
-    # these two components. 
+    # will be explicitly indexed by a ContinuousSet and thus only checks for
+    # these two components.
 
     # Additionally, this implemenation will *NOT* check for or update
     # components which use a ContinuousSet implicitly. ex) an
@@ -117,7 +117,7 @@ def update_contset_indexed_component(comp):
     if comp.type() is Suffix:
         return
     if comp.dim() == 1:
-        if comp._index.type() == ContinuousSet: 
+        if comp._index.type() == ContinuousSet:
             if comp._index.get_changed():
                 if isinstance(comp, Var):
                     _update_var(comp)
@@ -139,11 +139,11 @@ def update_contset_indexed_component(comp):
                     _update_constraint(comp)
                 elif comp.type() == Expression:
                     _update_expression(comp)
-                                  
+
 def _update_var(v):
     """
-    This method will construct any additional indices in a variable 
-    resulting from the discretization of ContinuousSet 
+    This method will construct any additional indices in a variable
+    resulting from the discretization of ContinuousSet
     """
 
     # Note: This is not required it is handled by the _default method on
@@ -167,11 +167,11 @@ def _update_constraint(con):
             # Code taken from the construct() method of Constraint
             con.add(i,apply_indexed_rule(con,_rule,_parent,i))
 
-def _update_expression(expre): 
-    """ 
-    This method will construct any additional indices in a expression 
-    resulting from the discretization 
-    """ 
+def _update_expression(expre):
+    """
+    This method will construct any additional indices in a expression
+    resulting from the discretization
+    """
     _rule=expre._init_rule
     _parent=expre._parent()
     for i in expre.index_set():
@@ -181,7 +181,7 @@ def _update_expression(expre):
 
 def create_access_function(var):
     """
-    This method returns a function that returns a component by calling 
+    This method returns a function that returns a component by calling
     it rather than indexing it
     """
     def _fun(*args):
@@ -190,10 +190,10 @@ def create_access_function(var):
 
 def create_partial_expression(scheme,expr,ind,loc):
     """
-    This method returns a function which applies a discretization scheme 
+    This method returns a function which applies a discretization scheme
     to an expression along a particular indexind set. This is admittedly a
-    convoluted looking implementation. The idea is that we only apply a 
-    discretization scheme to one indexing set at a time but we also want 
+    convoluted looking implementation. The idea is that we only apply a
+    discretization scheme to one indexing set at a time but we also want
     the function to be expanded over any other indexing sets.
     """
     def _fun(*args):
@@ -203,10 +203,10 @@ def create_partial_expression(scheme,expr,ind,loc):
 def add_discretization_equations(block,d):
     """
     Adds the discretization equations for DerivativeVar d to the Block block.
-    Because certain indices will be valid for some discretization schemes and 
+    Because certain indices will be valid for some discretization schemes and
     not others, we skip any constraints which raise an IndexError.
     """
-        
+
     def _disc_eq(m,*args):
         try:
             return d[args] == d._expr(*args)
@@ -214,9 +214,9 @@ def add_discretization_equations(block,d):
             return Constraint.Skip
 
     if d.dim() == 1:
-        block.add_component(d.name()+'_disc_eq',Constraint(d._index,rule=_disc_eq))
+        block.add_component(d.local_name+'_disc_eq',Constraint(d._index,rule=_disc_eq))
     else:
-        block.add_component(d.name()+'_disc_eq',Constraint(*d._implicit_subsets,rule=_disc_eq))
+        block.add_component(d.local_name+'_disc_eq',Constraint(*d._implicit_subsets,rule=_disc_eq))
 
 def add_continuity_equations(block,d,i,loc):
     """
@@ -224,10 +224,10 @@ def add_continuity_equations(block,d,i,loc):
     does not have a root at the finite element boundary
     """
     svar = d.get_state_var()
-    nme = svar.name()+'_'+i.name()+'_cont_eq'
+    nme = svar.local_name+'_'+i.local_name+'_cont_eq'
     if block.find_component(nme) is not None:
         return
-    
+
     def _cont_exp(v,s):
         ncp = s.get_discretization_info()['ncp']
         afinal = s.get_discretization_info()['afinal']
@@ -264,76 +264,76 @@ def block_fully_discretized(b):
             return False
     return True
 
-def get_index_information(var,ds): 
-    """ 
-    This method will find the index location of the set ds in the var, return 
-    a list of the non_ds indices and return a function that can be used to 
-    access specific indices in var indexed by a ContinuousSet by specifying the 
-    finite element and collocation point. Users of this method should have 
-    already confirmed that ds is an indexing set of var and that it's a ContinuousSet 
-    """ 
+def get_index_information(var,ds):
+    """
+    This method will find the index location of the set ds in the var, return
+    a list of the non_ds indices and return a function that can be used to
+    access specific indices in var indexed by a ContinuousSet by specifying the
+    finite element and collocation point. Users of this method should have
+    already confirmed that ds is an indexing set of var and that it's a ContinuousSet
+    """
 
-    # Find index order of ContinuousSet in the variable 
-    indargs=[] 
-    dsindex=0 
-    tmpds2=None 
+    # Find index order of ContinuousSet in the variable
+    indargs=[]
+    dsindex=0
+    tmpds2=None
 
-    if var.dim() != 1: 
-        # If/when Var is changed to SparseIndexedComponent, the _index_set 
-        # attribute below may need to be changed 
-        indCount = 0 
-        for index in var._index_set: 
-            if isinstance(index,ContinuousSet): 
-                if index ==ds: 
-                    dsindex = indCount 
-                else: 
-                    indargs.append(index)  # If var is indexed by multiple ContinuousSets treat 
-                                           # other ContinuousSets like a normal indexing set 
-                indCount += 1     # A ContinuousSet must be one dimensional 
-            else: 
-                indargs.append(index) 
-                indCount += index.dimen 
+    if var.dim() != 1:
+        # If/when Var is changed to SparseIndexedComponent, the _index_set
+        # attribute below may need to be changed
+        indCount = 0
+        for index in var._index_set:
+            if isinstance(index,ContinuousSet):
+                if index ==ds:
+                    dsindex = indCount
+                else:
+                    indargs.append(index)  # If var is indexed by multiple ContinuousSets treat
+                                           # other ContinuousSets like a normal indexing set
+                indCount += 1     # A ContinuousSet must be one dimensional
+            else:
+                indargs.append(index)
+                indCount += index.dimen
 
-    if indargs == []: 
-        non_ds = (None,) 
-    elif len(indargs)>1: 
-        non_ds = tuple(a for a in indargs) 
-    else: 
-        non_ds = (indargs[0],) 
- 
-    if None in non_ds: 
-        tmpidx = (None,) 
-    elif len(non_ds)==1: 
-        tmpidx = non_ds[0] 
-    else: 
-        tmpidx = non_ds[0].cross(*non_ds[1:]) 
+    if indargs == []:
+        non_ds = (None,)
+    elif len(indargs)>1:
+        non_ds = tuple(a for a in indargs)
+    else:
+        non_ds = (indargs[0],)
 
-    # Lambda function used to generate the desired index 
-    # more concisely 
-    idx = lambda n,i,k: _get_idx(dsindex,ds,n,i,k) 
+    if None in non_ds:
+        tmpidx = (None,)
+    elif len(non_ds)==1:
+        tmpidx = non_ds[0]
+    else:
+        tmpidx = non_ds[0].cross(*non_ds[1:])
 
-    info = {} 
-    info['non_ds']=tmpidx 
-    info['index function'] = idx 
-    return info 
+    # Lambda function used to generate the desired index
+    # more concisely
+    idx = lambda n,i,k: _get_idx(dsindex,ds,n,i,k)
+
+    info = {}
+    info['non_ds']=tmpidx
+    info['index function'] = idx
+    return info
 
 
-def _get_idx(l,ds,n,i,k): 
-    """ 
-    This function returns the appropriate index for a variable 
-    indexed by a differential set. It's needed because the collocation 
-    constraints are indexed by finite element and collocation point 
-    however a ContinuousSet contains a list of all the discretization 
-    points and is not separated into finite elements and collocation 
-    points. 
-    """ 
-    t = sorted(ds) 
-    tmp = t.index(ds._fe[i]) 
-    tik = t[tmp+k] 
-    if n is None: 
-        return tik 
-    else: 
-        tmpn=n 
-        if not isinstance(n,tuple): 
-            tmpn = (n,) 
-    return tmpn[0:l]+(tik,)+tmpn[l:]   
+def _get_idx(l,ds,n,i,k):
+    """
+    This function returns the appropriate index for a variable
+    indexed by a differential set. It's needed because the collocation
+    constraints are indexed by finite element and collocation point
+    however a ContinuousSet contains a list of all the discretization
+    points and is not separated into finite elements and collocation
+    points.
+    """
+    t = sorted(ds)
+    tmp = t.index(ds._fe[i])
+    tik = t[tmp+k]
+    if n is None:
+        return tik
+    else:
+        tmpn=n
+        if not isinstance(n,tuple):
+            tmpn = (n,)
+    return tmpn[0:l]+(tik,)+tmpn[l:]

--- a/pyomo/dae/plugins/finitedifference.py
+++ b/pyomo/dae/plugins/finitedifference.py
@@ -142,7 +142,7 @@ class Finite_Difference_Transformation(Transformation):
                      "must be a differential set")
             elif 'scheme' in tmpds.get_discretization_info():
                 raise ValueError("The discretization scheme '%s' has already been applied "\
-                     "to the ContinuousSet '%s'" %(tmpds.get_discretization_info()['scheme'],tmpds.name(True)))
+                     "to the ContinuousSet '%s'" %(tmpds.get_discretization_info()['scheme'],tmpds.name))
 
         if None in self._nfe:
             raise ValueError("A general discretization scheme has already been applied to "\
@@ -157,8 +157,8 @@ class Finite_Difference_Transformation(Transformation):
             self._nfe[None] = tmpnfe
             currentds = None
         else :
-            self._nfe[tmpds.name(True)]=tmpnfe
-            currentds = tmpds.name(True)
+            self._nfe[tmpds.name]=tmpnfe
+            currentds = tmpds.name
 
         self._scheme = self.all_schemes.get(self._scheme_name,None)
         if self._scheme is None:
@@ -175,20 +175,20 @@ class Finite_Difference_Transformation(Transformation):
 
         self._fe = {}
         for ds in itervalues(block.component_map(ContinuousSet)):
-            if currentds is None or currentds == ds.name(True):
+            if currentds is None or currentds == ds.name:
                 generate_finite_elements(ds,self._nfe[currentds])
                 if not ds.get_changed():
                     if len(ds)-1 > self._nfe[currentds]:
                         print("***WARNING: More finite elements were found in ContinuousSet "\
                             "'%s' than the number of finite elements specified in apply. "\
-                            "The larger number of finite elements will be used." %(ds.name(True)))
+                            "The larger number of finite elements will be used." %(ds.name))
 
-                self._nfe[ds.name(True)]=len(ds)-1
-                self._fe[ds.name(True)]=sorted(ds)
+                self._nfe[ds.name]=len(ds)-1
+                self._fe[ds.name]=sorted(ds)
                 # Adding discretization information to the differentialset object itself
                 # so that it can be accessed outside of the discretization object
                 disc_info = ds.get_discretization_info()
-                disc_info['nfe']=self._nfe[ds.name(True)]
+                disc_info['nfe']=self._nfe[ds.name]
                 disc_info['scheme']=self._scheme_name + ' Difference'
 
         # Maybe check to see if any of the ContinuousSets have been changed,
@@ -201,7 +201,7 @@ class Finite_Difference_Transformation(Transformation):
         for d in itervalues(block.component_map(DerivativeVar)):
             dsets = d.get_continuousset_list()
             for i in set(dsets):
-                if currentds is None or i.name(True) == currentds:
+                if currentds is None or i.name == currentds:
                     oldexpr = d.get_derivative_expression()
                     loc = d.get_state_var()._contset[i]
                     count = dsets.count(i)
@@ -209,7 +209,7 @@ class Finite_Difference_Transformation(Transformation):
                         raise DAE_Error(
                             "Error discretizing '%s' with respect to '%s'. Current implementation "\
                             "only allows for taking the first or second derivative with respect to "\
-                            "a particular ContinuousSet" %(d.name(True),i.name(True)))
+                            "a particular ContinuousSet" %(d.name,i.name))
                     scheme = self._scheme[count-1]
                     newexpr = create_partial_expression(scheme,oldexpr,i,loc)
                     d.set_derivative_expression(newexpr)

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -46,10 +46,10 @@ class _DisjunctData(_BlockData):
     def Xpprint(self, ostream=None, verbose=False, prefix=""):
         if ostream is None:
             ostream = sys.stdout
-        ostream.write("    %s :" % self.name())
+        ostream.write("    %s :" % self.local_name)
         ostream.write("\tSize= %s" % str(len(self._data.keys())))
         if isinstance(self._index,Set):
-            ostream.write("\tIndex= %s\n" % self._index.name())
+            ostream.write("\tIndex= %s\n" % self._index.name)
         else:
             ostream.write("\n")
         if self._M is not None:
@@ -82,7 +82,7 @@ class _DisjunctData(_BlockData):
 
     def set_M(self, M_list):
         if self._M is not None:
-            logger.warning("Discarding pre-defined M values for %s", self.name())
+            logger.warning("Discarding pre-defined M values for %s", self.name)
         self._M = M_list
 
 
@@ -190,13 +190,13 @@ class SimpleDisjunction(_GeneralConstraintData, Disjunction):
                     "Accessing the body of SimpleConstraint "
                     "'%s' before the Constraint has been assigned "
                     "an expression. There is currently "
-                    "nothing to access." % (self.name(True)))
+                    "nothing to access." % (self.name))
             return _GeneralConstraintData.body.fget(self)
         raise ValueError(
             "Accessing the body of constraint '%s' "
             "before the Constraint has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
     @property
     def lower(self):
@@ -207,13 +207,13 @@ class SimpleDisjunction(_GeneralConstraintData, Disjunction):
                     "Accessing the lower bound of SimpleConstraint "
                     "'%s' before the Constraint has been assigned "
                     "an expression. There is currently "
-                    "nothing to access." % (self.name(True)))
+                    "nothing to access." % (self.name))
             return _GeneralConstraintData.lower.fget(self)
         raise ValueError(
             "Accessing the lower bound of constraint '%s' "
             "before the Constraint has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
     @property
     def upper(self):
@@ -224,13 +224,13 @@ class SimpleDisjunction(_GeneralConstraintData, Disjunction):
                     "Accessing the upper bound of SimpleConstraint "
                     "'%s' before the Constraint has been assigned "
                     "an expression. There is currently "
-                    "nothing to access." % (self.name(True)))
+                    "nothing to access." % (self.name))
             return _GeneralConstraintData.upper.fget(self)
         raise ValueError(
             "Accessing the upper bound of constraint '%s' "
             "before the Constraint has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
     @property
     def equality(self):
@@ -241,13 +241,13 @@ class SimpleDisjunction(_GeneralConstraintData, Disjunction):
                     "Accessing the equality flag of SimpleConstraint "
                     "'%s' before the Constraint has been assigned "
                     "an expression. There is currently "
-                    "nothing to access." % (self.name(True)))
+                    "nothing to access." % (self.name))
             return _GeneralConstraintData.equality.fget(self)
         raise ValueError(
             "Accessing the equality flag of constraint '%s' "
             "before the Constraint has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
     @property
     def strict_lower(self):
@@ -258,13 +258,13 @@ class SimpleDisjunction(_GeneralConstraintData, Disjunction):
                     "Accessing the strict_lower flag of SimpleConstraint "
                     "'%s' before the Constraint has been assigned "
                     "an expression. There is currently "
-                    "nothing to access." % (self.name(True)))
+                    "nothing to access." % (self.name))
             return _GeneralConstraintData.strict_lower.fget(self)
         raise ValueError(
             "Accessing the strict_lower flag of constraint '%s' "
             "before the Constraint has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
     @property
     def strict_upper(self):
@@ -275,13 +275,13 @@ class SimpleDisjunction(_GeneralConstraintData, Disjunction):
                     "Accessing the strict_upper flag of SimpleConstraint "
                     "'%s' before the Constraint has been assigned "
                     "an expression. There is currently "
-                    "nothing to access." % (self.name(True)))
+                    "nothing to access." % (self.name))
             return _GeneralConstraintData.strict_upper.fget(self)
         raise ValueError(
             "Accessing the strict_upper flag of constraint '%s' "
             "before the Constraint has been constructed (there "
             "is currently no value to return)."
-            % (self.name(True)))
+            % (self.name))
 
     #
     # Singleton constraints are strange in that we want them to be
@@ -304,7 +304,7 @@ class SimpleDisjunction(_GeneralConstraintData, Disjunction):
             "Setting the value of constraint '%s' "
             "before the Constraint has been constructed (there "
             "is currently no object to set)."
-            % (self.name(True)))
+            % (self.name))
 
 class IndexedDisjunction(Disjunction):
     pass
@@ -347,7 +347,7 @@ class _disjunctiveRuleMapper(object):
             if not isinstance(d, _DisjunctData):
                 msg = 'Non-disjunct (type="%s") found in ' \
                     'disjunctive set for disjunction %s' % \
-                    ( type(d), self.disj.name() )
+                    (type(d), self.disj.name)
                 raise ValueError(msg)
 
         self.disj._disjuncts[normalize_index(idx)] = disjuncts

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -74,13 +74,13 @@ class BigM_Transformation(Transformation):
                 if not _t.active:
                     continue
                 if _t.parent_component() is _t:
-                    _name = _t.name()
+                    _name = _t.local_name
                     for _idx, _obj in _t.iteritems():
                         if _obj.active:
                             self._transformDisjunction(_name, _idx, _obj)
                 else:
                     self._transformDisjunction(
-                        _t.parent_component().name(), _t.index(), _t )
+                        _t.parent_component().local_name, _t.index(), _t)
 
     def _transformBlock(self, block):
         # For every (active) disjunction in the block, convert it to a
@@ -101,7 +101,7 @@ class BigM_Transformation(Transformation):
         # able to get to the _disjuncts map from the other component).
         #
         # FIXME: the disjuncts list should just be on the _DisjunctData
-        if obj.parent_block().name().startswith('_gdp_relax'):
+        if obj.parent_block().local_name.startswith('_gdp_relax'):
             # Do not transform a block more than once
             return
 
@@ -139,7 +139,7 @@ class BigM_Transformation(Transformation):
         if not disjunct.active:
             disjunct.indicator_var.fix(0)
             return
-        if disjunct.parent_block().name().startswith('_gdp_relax'):
+        if disjunct.parent_block().local_name.startswith('_gdp_relax'):
             # Do not transform a block more than once
             return
 
@@ -155,13 +155,13 @@ class BigM_Transformation(Transformation):
             # SimpleDisjunct, then we can just reclassify the entire
             # component into our scratch space
             disjunct.parent_block().del_component(disjunct)
-            _tmp.add_component(disjunct.name(), disjunct)
+            _tmp.add_component(disjunct.local_name, disjunct)
             _tmp.reclassify_component_type(disjunct, Block)
         else:
-            _block = _tmp.component(disjunct.parent_component().name())
+            _block = _tmp.component(disjunct.parent_component().local_name)
             if _block is None:
                 _block = Block(disjunct.parent_component().index_set())
-                _tmp.add_component(disjunct.parent_component().name(), _block)
+                _tmp.add_component(disjunct.parent_component().local_name, _block)
             # Move this disjunction over to the Constraint
             idx = disjunct.index()
             _block._data[idx] = disjunct.parent_component()._data.pop(idx)
@@ -231,7 +231,7 @@ class BigM_Transformation(Transformation):
 
                 if __debug__ and logger.isEnabledFor(logging.DEBUG):
                     logger.debug("GDP(BigM): Promoting local constraint "
-                                 "'%s' as '%s'", constraint.name(), n)
+                                 "'%s' as '%s'", constraint.local_name, n)
                 M_expr = (m[i]-bounds[i])*(1-disjunct.indicator_var)
                 if i == 0:
                     newC = Constraint(expr=c.lower <= c.body - M_expr)

--- a/pyomo/gdp/plugins/chull.py
+++ b/pyomo/gdp/plugins/chull.py
@@ -90,13 +90,13 @@ class ConvexHull_Transformation(Transformation):
                 if not _t.active:
                     continue
                 if _t.parent_component() is _t:
-                    _name = _t.name()
+                    _name = _t.local_name
                     for _idx, _obj in _t.iteritems():
                         if _obj.active:
                             self._transformDisjunction(_name, _idx, _obj)
                 else:
                     self._transformDisjunction(
-                        _t.parent_component().name(), _t.index(), _t )
+                        _t.parent_component().local_name, _t.index(), _t)
 
     def _transformBlock(self, block):
         # For every (active) disjunction in the block, convert it to a
@@ -136,7 +136,7 @@ class ConvexHull_Transformation(Transformation):
                 disjuncts = [ d for d in obj.parent_component()._disjuncts[idx] if d.active ]
                 localVars = {}
                 cName = _generate_name(idx)
-                cName = Disj.parent_component().name() + (".%s"%(cName,) if cName else "")
+                cName = Disj.parent_component().local_name + (".%s"%(cName,) if cName else "")
                 for d in disjuncts:
                     for eid, e in iteritems(disaggregatedVars.get(id(d), ['',{}])[1]):
                         localVars.setdefault(eid, (e[0],[]))[1].append(e[2])
@@ -148,16 +148,16 @@ class ConvexHull_Transformation(Transformation):
                                               max(0,value(v[0].ub))))
                             disaggregatedVars[id(d)][1][eid] = (v[0], d.indicator_var, tmp)
                             v[1].append(tmp)
-                for v in sorted(localVars.values(), key=lambda x: x[0].name(True)):
+                for v in sorted(localVars.values(), key=lambda x: x[0].name):
                     newC = Constraint( expr = v[0] == sum(v[1]) )
-                    block.add_component( "%s.%s" % (cName, v[0].name(True)), newC )
+                    block.add_component( "%s.%s" % (cName, v[0].name), newC )
                     newC.construct()
 
         # Promote the local disaggregated variables and add BigM
         # constraints to force them to 0 when not active.
         for d_data in sorted(disaggregatedVars.values(), key=lambda x: x[0]):
-            for e in sorted(d_data[1].values(), key=lambda x: x[0].name()):
-                v_name = "%s%s" % (d_data[0],e[0].name())
+            for e in sorted(d_data[1].values(), key=lambda x: x[0].local_name):
+                v_name = "%s%s" % (d_data[0],e[0].local_name)
                 # add the disaggregated variable
                 block.add_component( v_name, e[2] )
                 e[2].construct()
@@ -201,7 +201,7 @@ class ConvexHull_Transformation(Transformation):
             # Since there can't be more than one Disjunction in a
             # SimpleDisjunction, then we can just reclassify the entire
             # component in place
-            obj.parent_block().del_component(obj.name())
+            obj.parent_block().del_component(obj.local_name)
             _tmp.add_component(name, obj)
             _tmp.reclassify_component_type(obj, Constraint)
         else:
@@ -219,19 +219,19 @@ class ConvexHull_Transformation(Transformation):
 
         # Promote the indicator variables up into the model
         for var, block, name in self._promote_vars:
-            var.parent_block().del_component(var.name())
+            var.parent_block().del_component(var.local_name)
             block.add_component(name, var)
 
     def _transform_disjunct(self, disjunct, block, disaggregatedVars):
         if not disjunct.active:
             disjunct.indicator_var.fix(0)
             return
-        if disjunct.parent_block().name().startswith('_gdp_relax'):
+        if disjunct.parent_block().local_name.startswith('_gdp_relax'):
             # Do not transform a block more than once
             return
 
         # Calculate a unique name by concatenating all parent block names
-        fullName = disjunct.name(True)
+        fullName = disjunct.name
 
         varMap = disaggregatedVars.setdefault(id(disjunct), [fullName,{}])[1]
 
@@ -251,11 +251,11 @@ class ConvexHull_Transformation(Transformation):
         # "Promote" the local variables up to the main model
         if __debug__ and logger.isEnabledFor(logging.DEBUG):
             logger.debug("GDP(cHull): Promoting local variable '%s' as '%s'",
-                         var.name(), name)
+                         var.local_name, name)
         # This is a bit of a hack until we can re-think the chull
         # transformation in the context of Pyomo fully-supporting nested
         # block models
-        #var.parent_block().del_component(var.name())
+        #var.parent_block().del_component(var.local_name)
         #block.add_component(name, var)
         var.construct()
         self._promote_vars.append((var,block,name))
@@ -370,7 +370,7 @@ class ConvexHull_Transformation(Transformation):
                         "Disjunct constraint referenced unbounded model "
                         "variable.\nAll variables must be bounded to use "
                         "the Convex Hull transformation.\n\t"
-                        "Variable: %s" % (expr.name(True),) )
+                        "Variable: %s" % (expr.name,) )
                 v = Var( domain=expr.domain,
                          bounds=(min(0,value(expr.lb)),
                                  max(0,value(expr.ub))))

--- a/pyomo/mpec/complementarity.py
+++ b/pyomo/mpec/complementarity.py
@@ -98,7 +98,7 @@ class _ComplementarityData(_BlockData):
             return
         #
         if (_e1[0] is None) + (_e1[2] is None) + (_e2[0] is None) + (_e2[2] is None) != 2:
-            raise RuntimeError("Complementarity condition %s must have exactly two finite bounds" % self.name(True))
+            raise RuntimeError("Complementarity condition %s must have exactly two finite bounds" % self.name)
         #
         if _e1[0] is None and _e1[2] is None:
             # Only e2 will be an unconstrained expression
@@ -153,8 +153,8 @@ class Complementarity(Block):
 
     def construct(self, data=None):
         if __debug__ and logger.isEnabledFor(logging.DEBUG):        #pragma:nocover
-            logger.debug( "Constructing %s '%s', from data=%s",
-                          self.__class__.__name__, self.name(), str(data) )
+            logger.debug("Constructing %s '%s', from data=%s",
+                         self.__class__.__name__, self.name, str(data))
         if self._constructed:                                       #pragma:nocover
             return
         #
@@ -182,7 +182,7 @@ class Complementarity(Block):
                     logger.error(
                         "Rule failed when generating expression for "
                         "complementarity %s:\n%s: %s"
-                        % ( self.name(True), type(err).__name__, err ) )
+                        % ( self.name, type(err).__name__, err ) )
                     raise
         else:
             if not self._expr is None:
@@ -199,7 +199,7 @@ class Complementarity(Block):
                     logger.error(
                         "Rule failed when generating expression for "
                         "complementarity %s with index %s:\n%s: %s"
-                        % ( self.name(True), idx, type(err).__name__, err ) )
+                        % ( self.name, idx, type(err).__name__, err ) )
                     raise
 
     def add(self, index, cc):
@@ -220,7 +220,7 @@ class Complementarity(Block):
             elif len(cc) != 2:
                 raise ValueError(
                     "Invalid tuple for Complementarity %s (expected 2-tuple):"
-                    "\n\t%s" % (self.name(True), cc) )
+                    "\n\t%s" % (self.name, cc) )
         elif cc.__class__ is list:
             #
             # Call add() recursively to apply the error same error
@@ -234,11 +234,11 @@ is None instead of a 2-tuple.  Please modify your rule to return
 Complementarity.Skip instead of None.
 
 Error thrown for Complementarity "%s"
-""" % ( self.name(True), ) )
+""" % ( self.name, ) )
         else:
             raise ValueError(
                 "Unexpected argument declaring Complementarity %s:\n\t%s"
-                % (self.name(True), cc) )
+                % (self.name, cc) )
         #
         self[index]._args = tuple( as_numeric(x) for x in cc )
         return self[index]
@@ -315,7 +315,7 @@ class ComplementarityList(IndexedComplementarity):
         """
         generate_debug_messages = __debug__ and logger.isEnabledFor(logging.DEBUG)
         if generate_debug_messages:         #pragma:nocover
-            logger.debug("Constructing complementarity list %s", self.name(True))
+            logger.debug("Constructing complementarity list %s", self.name)
         if self._constructed:               #pragma:nocover
             return
         _self_rule = self._rule

--- a/pyomo/mpec/plugins/mpec2.py
+++ b/pyomo/mpec/plugins/mpec2.py
@@ -50,7 +50,7 @@ class MPEC2_Transformation(Transformation):
                     _e1 = _data._canonical_expression(_data._args[0])
                     _e2 = _data._canonical_expression(_data._args[1])
                     if len(_e1)==3 and len(_e2) == 3 and (_e1[0] is None) + (_e1[2] is None) + (_e2[0] is None) + (_e2[2] is None) != 2:
-                        raise RuntimeError("Complementarity condition %s must have exactly two finite bounds" % _data.name(True))
+                        raise RuntimeError("Complementarity condition %s must have exactly two finite bounds" % _data.name)
                     if len(_e1) == 3 and _e1[0] is None and _e1[2] is None:
                         #
                         # Swap _e1 and _e2.  The ensures that 

--- a/pyomo/mpec/plugins/mpec4.py
+++ b/pyomo/mpec/plugins/mpec4.py
@@ -122,7 +122,7 @@ class MPEC4_Transformation(Transformation):
             cdata.c = Constraint(expr=_e2)
             return
         if (_e1[0] is None) + (_e1[2] is None) + (_e2[0] is None) + (_e2[2] is None) != 2:
-            raise RuntimeError("Complementarity condition %s must have exactly two finite bounds" % cdata.name(True))
+            raise RuntimeError("Complementarity condition %s must have exactly two finite bounds" % cdata.name)
         #
         # Swap if the body of the second constraint is not a free variable
         #

--- a/pyomo/mpec/plugins/solver1.py
+++ b/pyomo/mpec/plugins/solver1.py
@@ -108,7 +108,7 @@ class MPEC_Solver1(pyomo.opt.OptSolver):
         #
         self._instance.compute_statistics()
         prob = results.problem
-        prob.name = self._instance.name()
+        prob.name = self._instance.name
         prob.number_of_constraints = self._instance.statistics.number_of_constraints
         prob.number_of_variables = self._instance.statistics.number_of_variables
         prob.number_of_binary_variables = self._instance.statistics.number_of_binary_variables

--- a/pyomo/openopt/func_designer.py
+++ b/pyomo/openopt/func_designer.py
@@ -79,15 +79,15 @@ id_counter=0
 
 def Pyomo2FD_expression(exp, ipoint, vars, symbol_map):
     if isinstance(exp, expr._IntrinsicFunctionExpression):
-        if not exp.name() in intrinsic_function_expressions:
-            logger.error("Unsupported intrinsic function (%s)", exp.name(True))
-            raise TypeError("FuncDesigner does not support '{0}' expressions".format(exp.name(True)))
+        if not exp.name in intrinsic_function_expressions:
+            logger.error("Unsupported intrinsic function (%s)", exp.name)
+            raise TypeError("FuncDesigner does not support '{0}' expressions".format(exp.name))
 
         args = []
         for child_exp in exp._args:
-            args.append( Pyomo2FD_expression(child_exp, ipoint, vars, symbol_map) )
+            args.append( Pyomo2FD_expression(child_exp, ipoint, vars, symbol_map))
 
-        fn = intrinsic_function_expressions[exp.name()]
+        fn = intrinsic_function_expressions[exp.name]
         return fn(*tuple(args))
 
     elif isinstance(exp, expr._SumExpression):
@@ -190,8 +190,8 @@ def Pyomo2FuncDesigner(instance):
             _f.append( Pyomo2FD_expression(obj.expr, ipoint, vars, smap) )
         else:
             _f.append( - Pyomo2FD_expression(obj.expr, ipoint, vars, smap) )
-        _f_name.append( obj.name(True) )
-        smap.getSymbol(obj, lambda objective: objective.name(True))
+        _f_name.append(obj.name)
+        smap.getSymbol(obj, lambda objective: objective.name)
 
     # TODO - use 0.0 for default values???
     # TODO - create results map

--- a/pyomo/openopt/plugins/OPEN_OPT.py
+++ b/pyomo/openopt/plugins/OPEN_OPT.py
@@ -193,7 +193,7 @@ class OpenOptSolver(OptSolver):
             raise ApplicationError("Unexpected OpenOpt termination code: '%d'" % istop)
 
         prob = results.problem
-        prob.name = self._instance.name()
+        prob.name = self._instance.name
         prob.number_of_constraints = self._instance.statistics.number_of_constraints
         prob.number_of_variables = self._instance.statistics.number_of_variables
         prob.number_of_binary_variables = self._instance.statistics.number_of_binary_variables

--- a/pyomo/pysp/annotations.py
+++ b/pyomo/pysp/annotations.py
@@ -29,7 +29,7 @@ def locate_annotations(model, annotation_type, max_allowed=None):
         raise ValueError("Too many annotations of type %s found on "
                          "model %s. The maximum allowed is %s."
                          % (annotation_type.__name__,
-                            model.name(True),
+                            model.name,
                             max_allowed))
     return annotations
 
@@ -86,7 +86,7 @@ class PySP_Annotation(object):
                     "in annotation type %s. To correct this issue, ensure that "
                     "multiple container components under which the component might "
                     "be stored (such as a Block and an indexed Constraint) are not "
-                    "simultaneously set in this annotation." % (component.name(True),
+                    "simultaneously set in this annotation." % (component.name,
                                                                 self.__class__.__name__))
             component_ids.add(id(component))
 

--- a/pyomo/pysp/implicitsp.py
+++ b/pyomo/pysp/implicitsp.py
@@ -248,9 +248,9 @@ class ImplicitSP(object):
                                      "not supported in implicit stochastic programs. The "
                                      "SOS constraint component '%s' has a weight term for "
                                      "variable '%s' that references stochastic parameter '%s'"
-                                     % (soscondata.name(True),
-                                        vardata.name(True),
-                                        paramdata.name(True)))
+                                     % (soscondata.name,
+                                        vardata.name,
+                                        paramdata.name))
                 self.variable_to_constraints_map.\
                     setdefault(vardata, []).append(condata)
                 self.constraint_to_variables_map.\
@@ -306,7 +306,7 @@ class ImplicitSP(object):
                 raise ValueError(
                     "Stochastic data entry with name '%s' is not mutable. "
                     "All stochastic data parameters must be initialized with "
-                    "the mutable keyword set to True." % (paramdata.name(True)))
+                    "the mutable keyword set to True." % (paramdata.name))
         return stochastic_data
 
     def _map_variable_stages(self, model):
@@ -338,7 +338,7 @@ class ImplicitSP(object):
                     raise ValueError(
                         "Implicit stochastic programs must be two-stage, "
                         "but variable with name '%s' has been annotated with "
-                        "stage number: %s" % (vardata.name(True), stagenum))
+                        "stage number: %s" % (vardata.name, stagenum))
 
         stage_to_variables_map = {}
         stage_to_variables_map[1] = []
@@ -353,7 +353,7 @@ class ImplicitSP(object):
                 raise ValueError("Invalid stage annotation for variable with "
                                  "name '%s'. Stage assignment must be 1 or 2. "
                                  "Current value: %s"
-                                 % (vardata.name(True), stagenumber))
+                                 % (vardata.name, stagenumber))
             if (stagenumber == 1):
                 stage_to_variables_map[1].append((vardata, derived))
             else:
@@ -416,14 +416,14 @@ class ImplicitSP(object):
         stm.ConditionalProbability['LeafNode'] = 1.0
         stm.ScenarioLeafNode['ReferenceScenario'] = 'LeafNode'
 
-        stm.StageCost['Stage1'] = stage1_cost.name(True)
-        stm.StageCost['Stage2'] = stage2_cost.name(True)
+        stm.StageCost['Stage1'] = stage1_cost.name
+        stm.StageCost['Stage2'] = stage2_cost.name
         for var, (stagenum, derived) in variable_stage_assignments.items():
             stagelabel = 'Stage'+str(stagenum)
             if not derived:
-                stm.StageVariables[stagelabel].add(var.name(True))
+                stm.StageVariables[stagelabel].add(var.name)
             else:
-                stm.StageDerivedVariables[second_stage].add(var.name(True))
+                stm.StageDerivedVariables[second_stage].add(var.name)
 
         scenario_tree = ScenarioTree(scenariotreeinstance=stm)
         scenario_tree.linkInInstances(

--- a/pyomo/pysp/ph.py
+++ b/pyomo/pysp/ph.py
@@ -417,7 +417,7 @@ class _PHBase(object):
 
             scenario_instance = scenario._instance
 
-            assert scenario_instance.name() == scenario.name
+            assert scenario_instance.name == scenario.name
 
             if scenario_instance is None:
                 raise RuntimeError("ScenarioTree has not been linked "

--- a/pyomo/pysp/phobjective.py
+++ b/pyomo/pysp/phobjective.py
@@ -217,7 +217,7 @@ def create_piecewise_constraint_tuple(lb, ub, instance_variable, variable_averag
 
 def add_ph_objective_weight_terms(instance_name, instance, scenario_tree):
 
-    scenario = scenario_tree.get_scenario(instance.name())
+    scenario = scenario_tree.get_scenario(instance.name)
 
     # cache for efficiency purposes.
     objective = scenario._instance_objective
@@ -262,7 +262,7 @@ def add_ph_objective_proximal_terms(instance_name,
                                     linearize_nonbinary_penalty_terms,
                                     retain_quadratic_binary_terms):
 
-    scenario = scenario_tree.get_scenario(instance.name())
+    scenario = scenario_tree.get_scenario(instance.name)
 
     # cache for efficiency purposes.
     objective = scenario._instance_objective
@@ -449,7 +449,7 @@ def form_linearized_objective_constraints(instance_name,
                               'Both lower and upper bounds required when' \
                               ' piece-wise approximating quadratic '      \
                               'penalty terms'
-                        raise ValueError(msg % instance_vardata.name(True))
+                        raise ValueError(msg % instance_vardata.name)
                     lb = value(x.lb)
                     ub = value(x.ub)
 

--- a/pyomo/pysp/phsolverserver.py
+++ b/pyomo/pysp/phsolverserver.py
@@ -660,7 +660,7 @@ class _PHSolverServer(_PHBase):
                             this_constraint_suffix_map = {}
                             for index, constraint_data in iteritems(constraint):
                                 this_constraint_suffix_map[index] = suffix.get(constraint_data)
-                            this_suffix_map[constraint.name()] = this_constraint_suffix_map
+                            this_suffix_map[constraint.name] = this_constraint_suffix_map
                         this_scenario_suffix_values[suffix_name] = this_suffix_map
                     suffix_values[scenario._name] = this_scenario_suffix_values
 

--- a/pyomo/pysp/phutils.py
+++ b/pyomo/pysp/phutils.py
@@ -76,7 +76,7 @@ class BasicSymbolMap(object):
 
     def pprint(self, **kwds):
         print("BasicSymbolMap:")
-        lines = [repr(label)+" <-> "+obj.name(True)+" (id="+str(id(obj))+")"
+        lines = [repr(label)+" <-> "+obj.name+" (id="+str(id(obj))+")"
                  for label, obj in iteritems(self.bySymbol)]
         print('\n'.join(sorted(lines)))
         print("")
@@ -112,7 +112,7 @@ def create_block_symbol_maps(owner_block,
 
     if owner_block.is_constructed() is False:
         raise ValueError("Failed to create _PHInstanceSymbolMap on Block %s. "\
-                         "This Block has not been fully construced." % owner_block.name(True))
+                         "This Block has not been fully construced." % owner_block.name)
 
     # The ctypes input may be iterable or a single type.
     # Either way turn it into a tuple of type(s)
@@ -127,13 +127,13 @@ def create_block_symbol_maps(owner_block,
     if phinst_sm_dict is not None:
         if (update_new is False) and (update_all is False):
             print("***WARNING - Attribute with name _PHInstanceSymbolMaps already exists " \
-                  "on Block %s. This Attribute will be overwritten" % owner_block.name(True))
+                  "on Block %s. This Attribute will be overwritten" % owner_block.name)
             phinst_sm_dict = owner_block._PHInstanceSymbolMaps = {}
         else:
             if type(phinst_sm_dict) is not dict:
                 raise TypeError("Failed to update _PHInstanceSymbolMaps attribute "\
                                 "on Block %s. Expected to find object with type %s "\
-                                "but existing object is of type %s." % (owner_block.name(True),
+                                "but existing object is of type %s." % (owner_block.name,
                                                                         dict,
                                                                         type(phinst_sm_dict)))
 
@@ -412,7 +412,7 @@ def extractComponentIndices(component, index_template):
        if (index_template != '') and (index_template != "*"):
           raise RuntimeError(
               "Index template=%r specified for scalar object=%s"
-              % (index_template, component.name(True)))
+              % (index_template, component.name))
        return [None]
 
     # from this point on, we're dealing with an indexed component.
@@ -431,7 +431,7 @@ def extractComponentIndices(component, index_template):
             "the dimension of component=%s (%s)"
             % (index_template,
                len(index_template),
-               component.name(True),
+               component.name,
                component_index_dimension))
 
     # cache for efficiency
@@ -527,9 +527,11 @@ def create_ph_parameters(instance, scenario_tree, default_rho, linearizing_penal
     # leaf tree node (where PH doesn't blend variables).
     instance_variables = {}  # map between variable names and sets of indices
 
-    scenario = scenario_tree.get_scenario(instance.name())
+    scenario = scenario_tree.get_scenario(instance.name)
     if scenario == None:
-        raise RuntimeError("Scenario corresponding to instance name="+instance.name()+" not present in scenario tree - could not create PH parameters for instance")
+        raise RuntimeError("Scenario corresponding to instance name="
+                           +instance.name+" not present in scenario tree "
+                           "- could not create PH parameters for instance")
 
     for tree_node in scenario._node_list[:-1]:
 
@@ -754,10 +756,10 @@ def find_active_objective(instance, safety_checks=False):
                                                               descend_into=True):
             objectives.append(objective_data)
         if len(objectives) > 1:
-            names = [o.name(True) for o in objectives]
+            names = [o.name for o in objectives]
             raise AssertionError("More than one active objective was "
                                  "found on instance %s: %s"
-                                 % (instance.name(True), names))
+                                 % (instance.name, names))
         if len(objectives) > 0:
             return objectives[0]
     return None

--- a/pyomo/pysp/plugins/ddextensionnew.py
+++ b/pyomo/pysp/plugins/ddextensionnew.py
@@ -595,7 +595,7 @@ class DDSIP_Input(object):
                 raise ValueError("Variable with name '%s' was declared "
                                  "on the scenario tree but did not appear "
                                  "in the reference scenario LP file."
-                                 % (vardata.name(True)))
+                                 % (vardata.name))
             if scenario_tree_id in rootnode._standard_variable_ids:
                 self._FirstStageVars.append(LP_name)
                 self._FirstStageVarIdMap[LP_name] = scenario_tree_id
@@ -606,7 +606,7 @@ class DDSIP_Input(object):
                 self._SecondStageVars.append(LP_name)
                 self._SecondStageVarIdMap[LP_name] = scenario_tree_id
             else:
-                print(("%s %s" % (str(scenario_tree_id), str(vardata.name(True)))))
+                print(("%s %s" % (str(scenario_tree_id), str(vardata.name))))
                 # More than two stages?
                 assert False
             self._AllVars.append(LP_name)
@@ -650,7 +650,7 @@ class DDSIP_Input(object):
             all_vars = set()
             tmp_buffer = {}
             for block in self._reference_scenario_instance.block_data_objects(active=True):
-                all_vars.update(vardata.name(True, tmp_buffer) \
+                all_vars.update(vardata.getname(True, tmp_buffer) \
                                 for vardata in block.component_data_objects(Var, descend_into=False))
             print(("Number of Variables Found on Model: "+str(len(all_vars))))
             print ("writing all_vars.dat")
@@ -662,7 +662,7 @@ class DDSIP_Input(object):
             for scenario_tree_id, vardata in \
                 iteritems(self._reference_scenario_instance.\
                           _ScenarioTreeSymbolMap.bySymbol):
-                tree_vars.add(vardata.name(True))
+                tree_vars.add(vardata.name)
             print(("Number of Scenario Tree Variables (found in ddsip LP file): "+str(len(tree_vars))))
             print ("writing tree_vars.dat")
             with open("tree_vars.dat",'w') as f:
@@ -677,7 +677,7 @@ class DDSIP_Input(object):
                     self._reference_scenario_instance.\
                     find_component(cost_variable_name)
                 if stage_cost_component.type() is not Expression:
-                    cost_vars.add(stage_cost_component[cost_variable_index].name(True))
+                    cost_vars.add(stage_cost_component[cost_variable_index].name)
             print(("Number of Scenario Tree Cost Variables (found in ddsip LP file): "+str(len(cost_vars))))
             print ("writing cost_vars.dat")
             with open("cost_vars.dat","w") as f:
@@ -739,7 +739,7 @@ class DDSIP_Input(object):
             block_canonical_repn = getattr(block, "_canonical_repn", None)
             if block_canonical_repn is None:
                 raise ValueError("Unable to find _canonical_repn ComponentMap "
-                                 "on block %s" % (block.name(True)))
+                                 "on block %s" % (block.name))
             isPiecewise = False
             if isinstance(block, (Piecewise, _PiecewiseData)):
                 isPiecewise = True
@@ -749,7 +749,7 @@ class DDSIP_Input(object):
                     descend_into=False):
                 raise TypeError("SOSConstraints are not handled by the "
                                 "DDSIP interface: %s"
-                                % (constraint_data.name(True)))
+                                % (constraint_data.name))
             for constraint_data in block.component_data_objects(
                     Constraint,
                     active=True,
@@ -1458,7 +1458,7 @@ class ddextension(pyomo.util.plugin.SingletonPlugin):
         # were not variables in the model (and DDSIP solution)
         for scenario in ph._scenario_tree._scenarios:
             if scenario._instance is not None:
-                print(("%s %s" % list(map(str(scenario._name, scenario._instance.name())))))
+                print(("%s %s" % list(map(str(scenario._name, scenario._instance.name)))))
                 scenario.push_solution_to_instance()
                 scenario.update_solution_from_instance()
                 """

--- a/pyomo/pysp/plugins/ddextensionold.py
+++ b/pyomo/pysp/plugins/ddextensionold.py
@@ -256,7 +256,7 @@ class ddextension_base(object):
             try:
                 LP_name = LP_byObject[id(vardata)]
             except:
-                print(("FAILED ON VAR DATA= "+vardata.name(True)))
+                print(("FAILED ON VAR DATA= "+vardata.name))
                 foobar
             if scenario_tree_id in firststage_blended_variables:
                 self._FirstStageVars.append(LP_name)
@@ -290,13 +290,13 @@ class ddextension_base(object):
             print("Not all model variables are on the scenario tree. Investigating...")
             all_vars = set()
             for block in self._reference_scenario_instance.block_data_objects(active=True):
-                all_vars.update(vardata.name(True) \
+                all_vars.update(vardata.name \
                                 for vardata in components_data(block, Var))
             tree_vars = set()
             for scenario_tree_id, vardata in \
                 iteritems(self._reference_scenario_instance.\
                           _ScenarioTreeSymbolMap.bySymbol):
-                tree_vars.add(vardata.name(True))
+                tree_vars.add(vardata.name)
             cost_vars = set()
             for stage in ph._scenario_tree._stages:
                 cost_variable_name, cost_variable_index = \
@@ -305,7 +305,7 @@ class ddextension_base(object):
                     self._reference_scenario_instance.\
                     find_component(cost_variable_name)
                 if stage_cost_component.type() is not Expression:
-                    cost_vars.add(stage_cost_component[cost_variable_index].name(True))
+                    cost_vars.add(stage_cost_component[cost_variable_index].name)
             print(("Number of Scenario Tree Variables (found ddsip LP file): "+str(len(tree_vars))))
             print(("Number of Scenario Tree Cost Variables (found ddsip LP file): "+str(len(cost_vars))))
             print(("Number of Variables Found on Model: "+str(len(all_vars))))
@@ -361,13 +361,13 @@ class ddextension_base(object):
             block_canonical_repn = getattr(block, "_canonical_repn",None)
             if block_canonical_repn is None:
                 raise ValueError("Unable to find _canonical_repn ComponentMap "
-                                 "on block %s" % (block.name(True)))
+                                 "on block %s" % (block.name))
             isPiecewise = False
             if isinstance(block, (Piecewise, _PiecewiseData)):
                 isPiecewise = True
             for constraint_data in block.component_data_objects(SOSConstraint, active=True, descend_into=False):
                 raise TypeError("SOSConstraints are not handled by the DDSIP interface: %s"
-                                % (constraint_data.name(True)))
+                                % (constraint_data.name))
             for constraint_data in block.component_data_objects(Constraint, active=True, descend_into=False):
                 LP_name = LP_byObject[id(constraint_data)]
                 # if it is a range constraint this will account for

--- a/pyomo/pysp/scenariotree/instance_factory.py
+++ b/pyomo/pysp/scenariotree/instance_factory.py
@@ -671,7 +671,7 @@ class ScenarioTreeInstanceFactory(object):
                         verbose=verbose)
 
             scenario_instances[scenario._name] = scenario_instance
-            assert scenario_instance.name() == scenario.name
+            assert scenario_instance.local_name == scenario.name
 
         return scenario_instances
 

--- a/pyomo/pysp/scenariotree/tree_structure.py
+++ b/pyomo/pysp/scenariotree/tree_structure.py
@@ -248,7 +248,7 @@ class ScenarioTreeNode(object):
                     "is not present in instance=%s"
                     % (component_name,
                        self._stage._name,
-                       scenario_instance.name()))
+                       scenario_instance.name))
 
             if component_object.type() is not Block:
                 isVar = (component_object.type() is Var)
@@ -260,7 +260,7 @@ class ScenarioTreeNode(object):
                                            "but is not a variable - type=%s"
                                            % (component_name,
                                               self._stage._name,
-                                              scenario_instance.name(),
+                                              scenario_instance.name,
                                               type(component_object)))
                 else:
                     if (not isVar) and \
@@ -273,7 +273,7 @@ class ScenarioTreeNode(object):
                                            "- type=%s"
                                            % (component_name,
                                               self._stage._name,
-                                              scenario_instance.name(),
+                                              scenario_instance.name,
                                               type(component_object)))
             else:
                 tmp_match_template = ("",)
@@ -286,7 +286,7 @@ class ScenarioTreeNode(object):
                                    component_objects(Var,
                                                      descend_into=True):
                                 self.updateVariableIndicesAndValues(
-                                    variable.name(True),
+                                    variable.name,
                                     tmp_match_template,
                                     derived=derived,
                                     id_labeler=id_labeler,
@@ -413,21 +413,21 @@ class ScenarioTreeNode(object):
                                  "scenario tree construction failed"
                                  % (cost_variable_name,
                                     self._stage._name,
-                                    scenario_instance.name()))
+                                    scenario_instance.name))
             if not cost_variable.type() in [Var,Expression,Objective]:
                 raise RuntimeError("The component=%s associated with stage=%s "
                                    "is present in model=%s but is not a "
                                    "variable or expression - type=%s"
                                    % (cost_variable_name,
                                       self._stage._name,
-                                      scenario_instance.name(),
+                                      scenario_instance.name,
                                       cost_variable.type()))
             if cost_variable_index not in cost_variable:
                 raise RuntimeError("The index %s is not defined for cost "
                                    "variable=%s on model=%s"
                                    % (cost_variable_index,
                                       cost_variable_name,
-                                      scenario_instance.name()))
+                                      scenario_instance.name))
             self._cost_variable_datas.append(
                 (cost_variable[cost_variable_index],
                  scenario._probability))
@@ -552,8 +552,8 @@ class ScenarioTreeNode(object):
                     # or the scenario name The important thing is that
                     # we always have the scenario name somewhere in
                     # the variable name we print
-                    model_name = var_data.model().name(True)
-                    full_name = model_name+"."+var_data.name(True)
+                    model_name = var_data.model().name
+                    full_name = model_name+"."+var_data.name
                     if not self.is_leaf_node():
                         print("CAUTION: Encountered variable=%s "
                               "on node %s that is not in use within its "
@@ -1170,7 +1170,7 @@ class Scenario(object):
                            stage_cost_variable[0])[stage_cost_variable[1]]:
                         return this_node
 
-        raise KeyError("Variable="+str(vardata.name(True))+" does "
+        raise KeyError("Variable="+str(vardata.name)+" does "
                        "not belong to any node in the scenario tree")
 
     def variableNode_byNameIndex(self, variable_name, index):
@@ -1239,8 +1239,8 @@ class Scenario(object):
             except KeyError:
                 if assume_last_stage_if_missing:
                     return self._leaf_node
-                model_name = var_data.model().name(True)
-                full_name = model_name+"."+var_data.name(True)
+                model_name = var_data.model().name
+                full_name = model_name+"."+var_data.name
                 raise RuntimeError("Method constraintNode in class "
                                    "ScenarioTree encountered a constraint "
                                    "with variable %s "
@@ -1736,14 +1736,14 @@ class ScenarioTree(object):
                     scenario._instance_objective = user_objective
                     scenario._objective_sense = user_objective.sense
                     scenario._objective_name = \
-                        scenario._instance_objective.name(True)
+                        scenario._instance_objective.name
 
                 else:
 
                     if user_objective is not None:
                         print("*** Active Objective \'%s\' on scenario "
                               "instance \'%s\' will not be used. ***"
-                              % (user_objective.name(True), scenario_name))
+                              % (user_objective.name, scenario_name))
                         user_objective.deactivate()
 
                     cost = 0.0
@@ -1769,7 +1769,7 @@ class ScenarioTree(object):
                         user_objective
                     scenario._objective_sense = objective_sense
                     scenario._objective_name = \
-                        scenario._instance_objective.name(True)
+                        scenario._instance_objective.name
 
     #
     # compute the set of variable indices being blended at each

--- a/pyomo/pysp/smps/smpsutils.py
+++ b/pyomo/pysp/smps/smpsutils.py
@@ -112,13 +112,13 @@ def map_constraint_stages(scenario,
                 descend_into=False):
             raise TypeError("SOSConstraints are not allowed with the "
                             "SMPS format. Invalid constraint: %s"
-                            % (constraint_data.name(True)))
+                            % (constraint_data.name))
 
         block_canonical_repn = getattr(block, "_canonical_repn", None)
         if block_canonical_repn is None:
             raise ValueError(
                 "Unable to find _canonical_repn ComponentMap "
-                "on block %s" % (block.name(True)))
+                "on block %s" % (block.name))
 
         piecewise_stage = None
         if isinstance(block, (Piecewise, _PiecewiseData)):
@@ -159,14 +159,14 @@ def map_constraint_stages(scenario,
                         "The %s annotation type was found on the model but "
                         "no stage declaration was provided for constraint %s."
                         % (PySP_ConstraintStageAnnotation.__name__,
-                           constraint_data.name(True)))
+                           constraint_data.name))
                 elif assigned_constraint_stage_id == 1:
                     if constraint_stage is secondstage:
                         raise RuntimeError(
                             "The %s annotation declared constraint %s as first-stage, "
                             "but this constraint contains references to second-stage variables."
                             % (PySP_ConstraintStageAnnotation.__name__,
-                               constraint_data.name(True)))
+                               constraint_data.name))
                 elif assigned_constraint_stage_id == 2:
                     # override the inferred stage-ness (whether or not it was first- or second-stage)
                     constraint_stage = secondstage
@@ -176,7 +176,7 @@ def map_constraint_stages(scenario,
                         "for constraint %s. Valid values are 1 or 2."
                         % (PySP_ConstraintStageAnnotation.__name__,
                            assigned_constraint_stage_id,
-                           constraint_data.name(True)))
+                           constraint_data.name))
 
             StageToConstraintMap[constraint_stage.name].\
                 append((aliases, constraint_data))
@@ -228,7 +228,7 @@ def map_variable_stages(scenario, scenario_tree, symbol_map):
             raise ValueError("Variable with name '%s' was declared "
                              "on the scenario tree but did not appear "
                              "in the reference scenario LP/MPS file."
-                             % (vardata.name(True)))
+                             % (vardata.name))
         if symbol == "RHS":
             raise RuntimeError(
                 "Congratulations! You have hit an edge case. The "
@@ -281,7 +281,7 @@ def map_variable_stages(scenario, scenario_tree, symbol_map):
                 active=True,
                 descend_into=True):
             all_vars.update(
-                vardata.name(True, tmp_buffer) \
+                vardata.getname(True, tmp_buffer) \
                 for vardata in block.component_data_objects
                 (Var, descend_into=False))
 
@@ -289,7 +289,7 @@ def map_variable_stages(scenario, scenario_tree, symbol_map):
         for scenario_tree_id, vardata in \
             iteritems(reference_model.\
                       _ScenarioTreeSymbolMap.bySymbol):
-            tree_vars.add(vardata.name(True, tmp_buffer))
+            tree_vars.add(vardata.getname(True, tmp_buffer))
         cost_vars = set()
         for stage in scenario_tree.stages:
             cost_variable_name, cost_variable_index = \
@@ -760,7 +760,7 @@ def _convert_explicit_setup_without_cleanup(worker,
                     empty_rhs_annotation = False
                     sorted_values = stochastic_rhs.expand_entries()
                     sorted_values.sort(
-                        key=lambda x: x[0].name(True, constraint_name_buffer))
+                        key=lambda x: x[0].getname(True, constraint_name_buffer))
                     if len(sorted_values) == 0:
                         raise RuntimeError(
                             "The %s annotation was declared "
@@ -786,7 +786,7 @@ def _convert_explicit_setup_without_cleanup(worker,
                                 "either remove the constraint from this annotation "
                                 "or manually declare it as second-stage using the "
                                 "%s annotation."
-                                % (constraint_data.name(True),
+                                % (constraint_data.name,
                                    PySP_StochasticRHSAnnotation.__name__,
                                    PySP_ConstraintStageAnnotation.__name__))
 
@@ -796,7 +796,7 @@ def _convert_explicit_setup_without_cleanup(worker,
                         raise RuntimeError("Only linear constraints are "
                                            "accepted for conversion to SMPS format. "
                                            "Constraint %s is not linear."
-                                           % (constraint_data.name(True)))
+                                           % (constraint_data.name))
 
                     body_constant = constraint_repn.constant
                     # We are going to rewrite the core problem file
@@ -894,7 +894,7 @@ def _convert_explicit_setup_without_cleanup(worker,
                     empty_matrix_annotation = False
                     sorted_values = stochastic_matrix.expand_entries()
                     sorted_values.sort(
-                        key=lambda x: x[0].name(True, constraint_name_buffer))
+                        key=lambda x: x[0].getname(True, constraint_name_buffer))
                     if len(sorted_values) == 0:
                         raise RuntimeError(
                             "The %s annotation was declared "
@@ -920,7 +920,7 @@ def _convert_explicit_setup_without_cleanup(worker,
                                 "either remove the constraint from this annotation "
                                 "or manually declare it as second-stage using the "
                                 "%s annotation."
-                                % (constraint_data.name(True),
+                                % (constraint_data.name,
                                    PySP_StochasticMatrixAnnotation.__name__,
                                    PySP_ConstraintStageAnnotation.__name__))
                     constraint_repn = \
@@ -929,7 +929,7 @@ def _convert_explicit_setup_without_cleanup(worker,
                         raise RuntimeError("Only linear constraints are "
                                            "accepted for conversion to SMPS format. "
                                            "Constraint %s is not linear."
-                                           % (constraint_data.name(True)))
+                                           % (constraint_data.name))
                     assert len(constraint_repn.variables) > 0
                     if var_list is None:
                         var_list = constraint_repn.variables
@@ -960,8 +960,8 @@ def _convert_explicit_setup_without_cleanup(worker,
                                 "been marked as stochastic in constraint %s using "
                                 "the %s annotation, but the variable does not appear"
                                 " in the canonical constraint expression."
-                                % (var_data.name(True),
-                                   constraint_data.name(True),
+                                % (var_data.name,
+                                   constraint_data.name,
                                    PySP_StochasticMatrixAnnotation.__name__))
                         var_label = symbol_map.byObject[id(var_data)]
                         for con_label in symbols:
@@ -1005,7 +1005,7 @@ def _convert_explicit_setup_without_cleanup(worker,
                     raise RuntimeError("Only linear objectives are "
                                        "accepted for conversion to SMPS format. "
                                        "Objective %s is not linear."
-                                       % (objective_data.name(True)))
+                                       % (objective_data.name))
                 if objective_variables is None:
                     objective_variables = objective_repn.variables
                 stochastic_objective_label = symbol_map.byObject[id(objective_data)]
@@ -1034,8 +1034,8 @@ def _convert_explicit_setup_without_cleanup(worker,
                             "been marked as stochastic in objective %s using "
                             "the %s annotation, but the variable does not appear"
                             " in the canonical objective expression."
-                            % (var_data.name(True),
-                               objective_data.name(True),
+                            % (var_data.name,
+                               objective_data.name,
                                PySP_StochasticObjectiveAnnotation.__name__))
                     var_label = symbol_map.byObject[id(var_data)]
                     if id(var_data) in firststage_variable_ids:
@@ -1071,7 +1071,7 @@ def _convert_explicit_setup_without_cleanup(worker,
     # Write the deterministic part of the LP/MPS-file to its own
     # file for debugging purposes
     #
-    reference_model_name = reference_model.name()
+    reference_model_name = reference_model.getname()
     reference_model._name = "ZeroStochasticData"
     det_output_filename = \
         os.path.join(output_directory,
@@ -1521,9 +1521,9 @@ def convert_implicit(output_directory,
         second_stage_variable_ids.add(id(vardata))
     # sort things to keep file output deterministic
     name_buffer = {}
-    first_stage_variables.sort(key=lambda x: x.name(True, name_buffer))
+    first_stage_variables.sort(key=lambda x: x.getname(True, name_buffer))
     name_buffer = {}
-    second_stage_variables.sort(key=lambda x: x.name(True, name_buffer))
+    second_stage_variables.sort(key=lambda x: x.getname(True, name_buffer))
 
     assert len(first_stage_variables) == \
         len(first_stage_variable_ids)
@@ -1556,9 +1556,9 @@ def convert_implicit(output_directory,
             first_stage_constraint_ids.add(id(condata))
     # sort things to keep file output deterministic
     name_buffer = {}
-    first_stage_constraints.sort(key=lambda x: x.name(True, name_buffer))
+    first_stage_constraints.sort(key=lambda x: x.getname(True, name_buffer))
     name_buffer = {}
-    second_stage_constraints.sort(key=lambda x: x.name(True, name_buffer))
+    second_stage_constraints.sort(key=lambda x: x.getname(True, name_buffer))
 
     #
     # Create column (variable) ordering maps for LP/MPS files
@@ -1802,7 +1802,7 @@ def convert_implicit(output_directory,
                     "Cannot output implicit SP representation for component "
                     "'%s'. The implicit SMPS writer does not yet handle "
                     "stochastic constraints within nonlinear expressions."
-                    % (condata.name(True)))
+                    % (condata.name))
 
             # sort the variable list by the column ordering
             # so that we have deterministic output
@@ -1830,10 +1830,10 @@ def convert_implicit(output_directory,
                             "parameter '%s' appearing in component '%s' was "
                             "previously encountered in another location in "
                             "component %s."
-                            % (sp.objective.name(True),
-                               pdata.name(True),
-                               sp.objective.name(True),
-                               stochastic_data_seen[pdata].name(True)))
+                            % (sp.objective.name,
+                               pdata.name,
+                               sp.objective.name,
+                               stochastic_data_seen[pdata].name))
                     else:
                         stochastic_data_seen[pdata] = sp.objective
 
@@ -1851,9 +1851,9 @@ def convert_implicit(output_directory,
                             "in an expression that defines a single variable's "
                             "coefficient. The coefficient for variable '%s' must be "
                             "exactly set to parameters '%s' in the expression."
-                            % (sp.objective.name(True),
-                               (vardata.name(True) if vardata != "ONE_VAR_CONSTANT" else "ONE_VAR_CONSTANT"),
-                               paramdata.name(True)))
+                            % (sp.objective.name,
+                               (vardata.name if vardata != "ONE_VAR_CONSTANT" else "ONE_VAR_CONSTANT"),
+                               paramdata.name))
 
                     # output the parameter's distribution (provided by the user)
                     distribution = sp.stochastic_data[paramdata]
@@ -1896,9 +1896,9 @@ def convert_implicit(output_directory,
                         "in an expression that defines a single variable's "
                         "coefficient. The coefficient for variable '%s' involves "
                         "stochastic parameters: %s"
-                        % (sp.objective.name(True),
-                           vardata.name(True),
-                           [p.name(True) for p in stochastic_params]))
+                        % (sp.objective.name,
+                           vardata.name,
+                           [p.name for p in stochastic_params]))
 
         #
         # Stochastic constraint matrix and rhs elements
@@ -1918,7 +1918,7 @@ def convert_implicit(output_directory,
                     "Cannot output implicit SP representation for component "
                     "'%s'. The implicit SMPS writer does not yet handle "
                     "stochastic constraints within nonlinear expressions."
-                    % (condata.name(True)))
+                    % (condata.name))
 
             # sort the variable list by the column ordering
             # so that we have deterministic output
@@ -1946,8 +1946,8 @@ def convert_implicit(output_directory,
                             "constraint expression that must be moved to the bounds. "
                             "The constraint must be written so that the stochastic "
                             "element '%s' is a simple bound or a simple variable "
-                            "coefficient." % (condata.name(True),
-                                              pdata.name(True)))
+                            "coefficient." % (condata.name,
+                                              pdata.name))
 
             symbols = constraint_symbols[condata]
             if len(symbols) == 2:
@@ -1958,7 +1958,7 @@ def convert_implicit(output_directory,
                     "Cannot output implicit SP representation for component "
                     "'%s'. The implicit SMPS writer does not yet handle range "
                     "constraints that have stochastic data."
-                    % (condata.name(True)))
+                    % (condata.name))
 
             # fix this later, for now we assume it is not a range constraint
             assert len(symbols) == 1
@@ -1986,10 +1986,10 @@ def convert_implicit(output_directory,
                             "parameter '%s' appearing in component '%s' was "
                             "previously encountered in another location in "
                             "component %s."
-                            % (condata.name(True),
-                               pdata.name(True),
-                               condata.name(True),
-                               stochastic_data_seen[pdata].name(True)))
+                            % (condata.name,
+                               pdata.name,
+                               condata.name,
+                               stochastic_data_seen[pdata].name))
                     else:
                         stochastic_data_seen[pdata] = condata
 
@@ -2007,9 +2007,9 @@ def convert_implicit(output_directory,
                             "in an expression that defines a single variable's "
                             "coefficient. The coefficient for variable '%s' must be "
                             "exactly set to parameters '%s' in the expression."
-                            % (condata.name(True),
-                               (vardata.name(True) if vardata != "RHS" else "RHS"),
-                               paramdata.name(True)))
+                            % (condata.name,
+                               (vardata.name if vardata != "RHS" else "RHS"),
+                               paramdata.name))
 
                     # output the parameter's distribution (provided by the user)
                     distribution = sp.stochastic_data[paramdata]
@@ -2047,9 +2047,9 @@ def convert_implicit(output_directory,
                         "in an expression that defines a single variable's "
                         "coefficient. The coefficient for variable '%s' involves "
                         "stochastic parameters: %s"
-                        % (condata.name(True),
-                           vardata.name(True),
-                           [p.name(True) for p in stochastic_params]))
+                        % (condata.name,
+                           vardata.name,
+                           [p.name for p in stochastic_params]))
         f_sto.write("ENDATA\n")
 
     return symbol_map

--- a/pyomo/repn/beta/matrix.py
+++ b/pyomo/repn/beta/matrix.py
@@ -58,7 +58,7 @@ def compile_block_linear_constraints(parent_block,
     if verbose:
         print("")
         print("Compiling linear constraints on block with name: %s"
-              % (parent_block.name(True)))
+              % (parent_block.name))
 
     if not parent_block.is_constructed():
         raise RuntimeError(
@@ -649,7 +649,7 @@ class MatrixConstraint(collections.Mapping,
         """
         if __debug__ and logger.isEnabledFor(logging.DEBUG):
             logger.debug("Constructing constraint %s"
-                         % (self.name(True)))
+                         % (self.name))
         if self._constructed:
             return
         self._constructed=True

--- a/pyomo/repn/canonical_repn.py
+++ b/pyomo/repn/canonical_repn.py
@@ -476,7 +476,7 @@ class coopr3_CompiledLinearCanonicalRepn(LinearCanonicalRepn):
         ordered_vars = None
         if self.variables is not None:
             ordered_vars = sorted(
-                (v.name(True), i) for i,v in enumerate(self.variables) )
+                (v.name, i) for i,v in enumerate(self.variables) )
         tmp_str = str(self.constant) if (self.constant) else ("")
         tmp_str += (" + ") if (self.constant and self.variables) else ("")
         tmp_str += (" + ".join("%s*%s"%(self.linear[i], v) for v,i in ordered_vars)) if (self.variables) else ("")

--- a/pyomo/repn/collect.py
+++ b/pyomo/repn/collect.py
@@ -44,7 +44,7 @@ def collect_linear_terms(block, unfixed):
                 o_terms = generate_canonical_repn(odata[ndx].expr, compute_values=False)
                 d_sense = maximize
             for i in range(len(o_terms.variables)):
-                c_rhs[ o_terms.variables[i].parent_component().name(), o_terms.variables[i].index() ] = o_terms.linear[i]
+                c_rhs[ o_terms.variables[i].parent_component().local_name, o_terms.variables[i].index() ] = o_terms.linear[i]
         # Stop after the first objective
         break
     #
@@ -65,9 +65,9 @@ def collect_linear_terms(block, unfixed):
                 raise(RuntimeError, "Error during dualization:  Constraint '%s' has an upper bound that is non-constant")
             #
             for i in range(len(body_terms.variables)):
-                varname = body_terms.variables[i].parent_component().name()
+                varname = body_terms.variables[i].parent_component().local_name
                 varndx = body_terms.variables[i].index()
-                A.setdefault(body_terms.variables[i].parent_component().name(), {}).setdefault(varndx,[]).append( Bunch(coef=body_terms.linear[i], var=name, ndx=ndx) )
+                A.setdefault(body_terms.variables[i].parent_component().local_name, {}).setdefault(varndx,[]).append( Bunch(coef=body_terms.linear[i], var=name, ndx=ndx) )
 
             #
             if not con.equality:
@@ -143,7 +143,7 @@ def collect_linear_terms(block, unfixed):
                     # Add constraint that defines the upper bound
                     #
                     name_ = name + "_upper_"
-                    varname = data.parent_component().name()
+                    varname = data.parent_component().local_name
                     varndx = data[ndx].index()
                     A.setdefault(varname, {}).setdefault(varndx,[]).append( Bunch(coef=1.0, var=name_, ndx=ndx) )
                     #
@@ -158,7 +158,7 @@ def collect_linear_terms(block, unfixed):
                     # Add constraint that defines the lower bound
                     #
                     name_ = name + "_lower_"
-                    varname = data.parent_component().name()
+                    varname = data.parent_component().local_name
                     varndx = data[ndx].index()
                     A.setdefault(varname, {}).setdefault(varndx,[]).append( Bunch(coef=1.0, var=name_, ndx=ndx) )
                     #
@@ -171,7 +171,7 @@ def collect_linear_terms(block, unfixed):
                 # Add constraint that defines the upper bound
                 #
                 name_ = name + "_upper_"
-                varname = data.parent_component().name()
+                varname = data.parent_component().local_name
                 varndx = data[ndx].index()
                 A.setdefault(varname, {}).setdefault(varndx,[]).append( Bunch(coef=1.0, var=name_, ndx=ndx) )
                 #
@@ -181,7 +181,7 @@ def collect_linear_terms(block, unfixed):
                 # Add constraint that defines the lower bound
                 #
                 name_ = name + "_lower_"
-                varname = data.parent_component().name()
+                varname = data.parent_component().local_name
                 varndx = data[ndx].index()
                 A.setdefault(varname, {}).setdefault(varndx,[]).append( Bunch(coef=1.0, var=name_, ndx=ndx) )
                 #

--- a/pyomo/repn/compute_ampl_repn.py
+++ b/pyomo/repn/compute_ampl_repn.py
@@ -32,7 +32,7 @@ def preprocess_block_objectives(block, idMap=None):
 
         if objective_data.expr is None:
             raise ValueError("No expression has been defined for objective %s"
-                             % (objective_data.name(True)))
+                             % (objective_data.name))
 
         try:
             ampl_repn = generate_ampl_repn(objective_data.expr,
@@ -41,7 +41,7 @@ def preprocess_block_objectives(block, idMap=None):
             err = sys.exc_info()[1]
             logging.getLogger('pyomo.core').error\
                 ( "exception generating a ampl representation for objective %s: %s" \
-                      % (objective_data.name(True), str(err)) )
+                      % (objective_data.name, str(err)) )
             raise
 
         block_ampl_repn[objective_data] = ampl_repn
@@ -87,7 +87,7 @@ def preprocess_constraint(block,
         if constraint_data.body is None:
             raise ValueError(
                 "No expression has been defined for the body "
-                "of constraint %s" % (constraint_data.name(True)))
+                "of constraint %s" % (constraint_data.name))
 
         try:
             ampl_repn = generate_ampl_repn(constraint_data.body,
@@ -97,7 +97,7 @@ def preprocess_constraint(block,
             logging.getLogger('pyomo.core').error(
                 "exception generating a ampl representation for "
                 "constraint %s: %s"
-                % (constraint_data.name(True), str(err)))
+                % (constraint_data.name, str(err)))
             raise
 
         block_ampl_repn[constraint_data] = ampl_repn
@@ -118,7 +118,7 @@ def preprocess_constraint_data(block,
     if constraint_data.body is None:
         raise ValueError(
             "No expression has been defined for the body "
-            "of constraint %s" % (constraint_data.name(True)))
+            "of constraint %s" % (constraint_data.name))
 
     try:
         ampl_repn = generate_ampl_repn(constraint_data.body,
@@ -128,7 +128,7 @@ def preprocess_constraint_data(block,
         logging.getLogger('pyomo.core').error(
             "exception generating a ampl representation for "
             "constraint %s: %s"
-            % (constraint_data.name(True), str(err)))
+            % (constraint_data.name, str(err)))
         raise
 
     block_ampl_repn[constraint_data] = ampl_repn

--- a/pyomo/repn/compute_canonical_repn.py
+++ b/pyomo/repn/compute_canonical_repn.py
@@ -31,7 +31,7 @@ def preprocess_block_objectives(block, idMap=None):
 
         if objective_data.expr is None:
             raise ValueError("No expression has been defined for objective %s"
-                             % (objective_data.name(True)))
+                             % (objective_data.name))
 
         try:
             objective_data_repn = generate_canonical_repn(objective_data.expr, idMap=idMap)
@@ -39,7 +39,7 @@ def preprocess_block_objectives(block, idMap=None):
             err = sys.exc_info()[1]
             logging.getLogger('pyomo.core').error(
                 "exception generating a canonical representation for objective %s: %s"
-                % (objective_data.name(True), str(err)))
+                % (objective_data.name, str(err)))
             raise
 
         block_canonical_repn[objective_data] = objective_data_repn
@@ -129,7 +129,7 @@ def preprocess_constraint_data(block,
     if constraint_data.body is None:
         raise ValueError("No expression has been defined for "
                          "the body of constraint %s"
-                         % (constraint_data.name(True)))
+                         % (constraint_data.name))
 
     # FIXME: This is a huge hack to keep canonical_repn from trying to generate representations
     #        representations of Constraints with Connectors (which will be deactivated once they
@@ -149,7 +149,7 @@ def preprocess_constraint_data(block,
     except Exception:
         logging.getLogger('pyomo.core').error \
             ( "exception generating a canonical representation for constraint %s" \
-              % (constraint_data.name(True)))
+              % (constraint_data.name))
         raise
 
     block_canonical_repn[constraint_data] = canonical_repn

--- a/pyomo/repn/plugins/ampl/ampl_.py
+++ b/pyomo/repn/plugins/ampl/ampl_.py
@@ -214,7 +214,7 @@ class ModelSOS(object):
         else:
             raise ValueError("SOSContraint '%s' has sos type='%s', "
                              "which is not supported by the NL file interface" \
-                                 % (soscondata.name(True), level))
+                                 % (soscondata.name, level))
 
         for vardata, weight in soscondata.get_items():
             if vardata.fixed:
@@ -222,7 +222,7 @@ class ModelSOS(object):
                     "SOSConstraint '%s' includes a fixed Variable '%s'. "
                     "This is currently not supported. Deactivate this constraint "
                     "in order to proceed"
-                    % (soscondata.name(True), vardata.name(True)))
+                    % (soscondata.name, vardata.name))
 
             ID = ampl_var_id[varID_map[id(vardata)]]
             self.sosno.add(ID,self.block_cntr*sign_tag)
@@ -306,7 +306,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
                 "\n\t".join("%s = %s" % (k,v) for k,v in iteritems(io_options)))
 
         if filename is None:
-            filename = model.name() + ".nl"
+            filename = model.name + ".nl"
 
         # Generate the operator strings templates. The value of
         # symbolic_solver_labels determines whether or not to
@@ -547,11 +547,11 @@ class ProblemWriter_nl(AbstractProblemWriter):
                                  % (self.external_byFcn[exp._fcn._function][1],
                                     len(exp._args)))
                 else:
-                    # Note: exp.name(True) fails
+                    # Note: exp.name fails
                     OUTPUT.write(fun_str
                                  % (self.external_byFcn[exp._fcn._function][1],
                                     len(exp._args),
-                                    exp.name()))
+                                    exp.name))
                 for arg in exp._args:
                     if isinstance(arg, basestring):
                         OUTPUT.write(string_arg_str % (len(arg), arg))
@@ -559,14 +559,14 @@ class ProblemWriter_nl(AbstractProblemWriter):
                         self._print_nonlinear_terms_NL(arg)
             elif (exp_type is expr._PowExpression) or \
                  isinstance(exp, expr._IntrinsicFunctionExpression):
-                intr_expr_str = self._op_string.get(exp.name())
+                intr_expr_str = self._op_string.get(exp.name)
                 if intr_expr_str is not None:
                     OUTPUT.write(intr_expr_str)
                 else:
                     logger.error("Unsupported intrinsic function ({0})",
-                                 exp.name(True))
+                                 exp.name)
                     raise TypeError("ASL writer does not support '%s' expressions"
-                                    % (exp.name(True)))
+                                    % (exp.name))
 
                 for child_exp in exp._args:
                     self._print_nonlinear_terms_NL(child_exp)
@@ -699,9 +699,9 @@ class ProblemWriter_nl(AbstractProblemWriter):
                     "correctly." %
                     (fcn._function,
                      self.external_byFcn[fcn._function]._library,
-                     self.external_byFcn[fcn._function]._library.name(True),
+                     self.external_byFcn[fcn._function]._library.name,
                      fcn._library,
-                     fcn.name(True)))
+                     fcn.name))
             self.external_byFcn[fcn._function] = (fcn, len(self.external_byFcn))
             external_Libs.add(fcn._library)
         if external_Libs:
@@ -787,7 +787,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
             raise ValueError(
                 "The NL writer has detected multiple active objective functions "
                 "on model %s, but currently only handles a single objective."
-                % (model.name(True)))
+                % (model.name))
         elif n_objs == 1:
             symbol_map.alias(symbol_map.bySymbol["o0"](),"__default_objective__")
 
@@ -975,7 +975,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
                 L = var.lb
                 U = var.ub
                 if L is None or U is None:
-                    raise ValueError("Variable " + str(var.name(True)) +\
+                    raise ValueError("Variable " + str(var.name) +\
                                      "is binary, but does not have lb and ub set")
                 LinearVarsBool.add(var_ID)
             elif not var.is_continuous():
@@ -1118,7 +1118,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
         #
         # LINE 1
         #
-        OUTPUT.write("g3 1 1 0\t# problem {0}\n".format(model.name()))
+        OUTPUT.write("g3 1 1 0\t# problem {0}\n".format(model.name))
         #
         # LINE 2
         #
@@ -1359,7 +1359,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
                     logger.warning(
                         "ProblemWriter_nl: Collected multiple values for Suffix %s "
                         "referencing model %s. This is likely a bug."
-                        % (suffix_name, model.name(True)))
+                        % (suffix_name, model.name))
                 OUTPUT.write(suffix_header_line.format(prob_tag | float_tag,
                                                        len(mod_s_lines),
                                                        suffix_name))
@@ -1496,7 +1496,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
                         "indicative of a preprocessing error. Use the IO-option "
                         "'output_fixed_variable_bounds=True' to suppress this error "
                         "and fix the variable by overwriting its bounds in the NL "
-                        "file." % (var.name(True), model.name(True)))
+                        "file." % (var.name, model.name))
                 if var.value is None:
                     raise ValueError("Variable cannot be fixed to a value of None.")
                 L = var.value

--- a/pyomo/repn/plugins/baron_writer.py
+++ b/pyomo/repn/plugins/baron_writer.py
@@ -38,7 +38,7 @@ from six.moves import xrange
 logger = logging.getLogger('pyomo.core')
 
 # TODO: The to_string function is handy, but the fact that
-#       it calls .name(True) under the hood for all components
+#       it calls .name under the hood for all components
 #       everywhere they are used will present ENORMOUS
 #       overhead for components that have a large index set.
 #       It might be worth adding an extra keyword to that
@@ -144,7 +144,7 @@ class ProblemWriter_bar(AbstractProblemWriter):
                              "I/O options is forbidden")
 
         if output_filename is None:
-            output_filename = model.name() + ".bar"
+            output_filename = model.name + ".bar"
 
         output_file=open(output_filename, "w")
 
@@ -241,12 +241,12 @@ class ProblemWriter_bar(AbstractProblemWriter):
                                 raise ValueError(
                                     "A suffix '%s' contained an invalid value: %s\n"
                                     "Choices are: [relaxationonly, convex, local]"
-                                    % (suffix.name(True), constraint_type))
+                                    % (suffix.name, constraint_type))
                 else:
                     raise ValueError(
                         "The BARON writer can not export suffix with name '%s'. "
                         "Either remove it from block '%s' or deactivate it."
-                        % (block.name(True), name))
+                        % (block.name, name))
 
         non_standard_eqns = r_o_eqns + c_eqns + l_eqns
 
@@ -291,7 +291,7 @@ class ProblemWriter_bar(AbstractProblemWriter):
                 #    logger.warning(
                 #        "Variable symbol '%s' for variable %s exceeds maximum "
                 #        "character limit for BARON. Solver may fail"
-                #        % (var_name, var_data.name(True)))
+                #        % (var_name, var_data.name))
 
                 TypeList.append(var_name)
 
@@ -650,7 +650,7 @@ class ProblemWriter_bar(AbstractProblemWriter):
                     raise ValueError("The BARON writer has detected multiple active "
                                      "objective functions on model %s, but "
                                      "currently only handles a single objective."
-                                     % (model.name(True)))
+                                     % (model.name))
 
                 # create symbol
                 create_symbol_func(symbol_map, objective_data, labeler)

--- a/pyomo/repn/plugins/cpxlp.py
+++ b/pyomo/repn/plugins/cpxlp.py
@@ -138,7 +138,7 @@ class ProblemWriter_cpxlp(AbstractProblemWriter):
         self._referenced_variable_ids.clear()
 
         if output_filename is None:
-            output_filename = model.name() + ".lp"
+            output_filename = model.name + ".lp"
 
         # when sorting, there are a non-trivial number of
         # temporary objects created. these all yield
@@ -405,7 +405,7 @@ class ProblemWriter_cpxlp(AbstractProblemWriter):
                 raise RuntimeError(
                     "SOSConstraint '%s' includes a fixed variable '%s'. This is "
                     "currently not supported. Deactive this constraint in order to "
-                    "proceed." % (soscondata.name(True), vardata.name(True)))
+                    "proceed." % (soscondata.name, vardata.name))
             self._referenced_variable_ids[id(vardata)] = vardata
             output_file.write(sos_template_string
                               % (variable_symbol_map.getSymbol(vardata),
@@ -485,7 +485,7 @@ class ProblemWriter_cpxlp(AbstractProblemWriter):
         # NOTE: this *must* use the "\* ... *\" comment format: the GLPK
         # LP parser does not correctly handle other formats (notably, "%").
         output_file.write(
-            "\\* Source Pyomo model name=%s *\\\n\n" % (model.name(),) )
+            "\\* Source Pyomo model name=%s *\\\n\n" % (model.name,) )
 
         #
         # Objective
@@ -513,12 +513,12 @@ class ProblemWriter_cpxlp(AbstractProblemWriter):
                     descend_into=False):
 
                 numObj += 1
-                onames.append(objective_data.name())
+                onames.append(objective_data.name)
                 if numObj > 1:
                     raise ValueError(
                         "More than one active objective defined for input "
                         "model '%s'; Cannot write legal LP file\n"
-                        "Objectives: %s" % (model.name(True), ' '.join(onames)))
+                        "Objectives: %s" % (model.name, ' '.join(onames)))
 
                 create_symbol_func(symbol_map,
                                    objective_data,
@@ -549,12 +549,12 @@ class ProblemWriter_cpxlp(AbstractProblemWriter):
                             "Selected solver is unable to handle "
                             "objective functions with quadratic terms. "
                             "Objective at issue: %s."
-                            % objective_data.name())
+                            % objective_data.name)
                 elif degree != 1:
                     raise RuntimeError(
                         "Cannot write legal LP file.  Objective '%s' "
                         "has nonlinear terms that are not quadratic."
-                        % objective_data.name(True))
+                        % objective_data.name)
 
                 output_file.write(
                     object_symbol_dictionary[id(objective_data)]+':\n')
@@ -571,7 +571,7 @@ class ProblemWriter_cpxlp(AbstractProblemWriter):
         if numObj == 0:
             raise ValueError(
                 "ERROR: No objectives defined for input model '%s'; "
-                " cannot write legal LP file" % str(model.name()))
+                " cannot write legal LP file" % str(model.name))
 
         # Constraints
         #
@@ -652,11 +652,11 @@ class ProblemWriter_cpxlp(AbstractProblemWriter):
                 if not supports_quadratic_constraint:
                     raise ValueError(
                         "Solver unable to handle quadratic expressions. Constraint"
-                        " at issue: '%s'" % (constraint_data.name(True)))
+                        " at issue: '%s'" % (constraint_data.name))
             elif degree != 1:
                 raise ValueError(
                     "Cannot write legal LP file.  Constraint '%s' has a body "
-                    "with nonlinear terms." % (constraint_data.name(True)))
+                    "with nonlinear terms." % (constraint_data.name))
 
             # Create symbol
             con_symbol = create_symbol_func(symbol_map, constraint_data, labeler)
@@ -809,7 +809,7 @@ class ProblemWriter_cpxlp(AbstractProblemWriter):
                         "usually indicative of a preprocessing error. Use the "
                         "IO-option 'output_fixed_variable_bounds=True' to suppress "
                         "this error and fix the variable by overwriting its bounds "
-                        "in the LP file." % (vardata.name(True), model.name(True)))
+                        "in the LP file." % (vardata.name, model.name))
                 if vardata.value is None:
                     raise ValueError("Variable cannot be fixed to a value of None.")
                 vardata_lb = value(vardata.value)
@@ -829,7 +829,7 @@ class ProblemWriter_cpxlp(AbstractProblemWriter):
             elif not vardata.is_continuous():
                 raise TypeError("Invalid domain type for variable with name '%s'. "
                                 "Variable is not continuous, integer, or binary."
-                                % (vardata.name(True)))
+                                % (vardata.name))
 
             # in the CPLEX LP file format, the default variable
             # bounds are 0 and +inf.  These bounds are in

--- a/pyomo/repn/plugins/mps.py
+++ b/pyomo/repn/plugins/mps.py
@@ -144,7 +144,7 @@ class ProblemWriter_mps(AbstractProblemWriter):
         self._referenced_variable_ids.clear()
 
         if output_filename is None:
-            output_filename = model.name() + ".mps"
+            output_filename = model.name + ".mps"
 
         # when sorting, there are a non-trivial number of
         # temporary objects created. these all yield
@@ -265,7 +265,7 @@ class ProblemWriter_mps(AbstractProblemWriter):
                 raise RuntimeError(
                     "SOSConstraint '%s' includes a fixed variable '%s'. This is "
                     "currently not supported. Deactive this constraint in order to "
-                    "proceed." % (soscondata.name(True), vardata.name(True)))
+                    "proceed." % (soscondata.name, vardata.name))
             self._referenced_variable_ids[id(vardata)] = vardata
             output_file.write(sos_template_string
                               % (variable_symbol_map.getSymbol(vardata),
@@ -351,7 +351,7 @@ class ProblemWriter_mps(AbstractProblemWriter):
         output_file.write("* Source:     Pyomo MPS Writer\n")
         output_file.write("* Format:     Free MPS\n")
         output_file.write("*\n")
-        output_file.write("NAME %s\n" % (model.name(),))
+        output_file.write("NAME %s\n" % (model.name,))
 
         #
         # ROWS section
@@ -376,12 +376,12 @@ class ProblemWriter_mps(AbstractProblemWriter):
                     descend_into=False):
 
                 numObj += 1
-                onames.append(objective_data.name())
+                onames.append(objective_data.name)
                 if numObj > 1:
                     raise ValueError(
                         "More than one active objective defined for input "
                         "model '%s'; Cannot write legal MPS file\n"
-                        "Objectives: %s" % (model.name(True), ' '.join(onames)))
+                        "Objectives: %s" % (model.name, ' '.join(onames)))
 
                 objective_label = create_symbol_func(symbol_map,
                                                      objective_data,
@@ -417,7 +417,7 @@ class ProblemWriter_mps(AbstractProblemWriter):
                     raise RuntimeError(
                         "Cannot write legal MPS file. Objective '%s' "
                         "has nonlinear terms that are not quadratic."
-                        % objective_data.name(True))
+                        % objective_data.name)
 
                 constant = extract_variable_coefficients(
                     objective_label,
@@ -486,7 +486,7 @@ class ProblemWriter_mps(AbstractProblemWriter):
                 raise RuntimeError(
                     "Cannot write legal MPS file. Constraint '%s' "
                     "has nonlinear terms that are not quadratic."
-                    % constraint_data.name(True))
+                    % constraint_data.name)
 
             # Create symbol
             con_symbol = create_symbol_func(symbol_map,
@@ -643,7 +643,7 @@ class ProblemWriter_mps(AbstractProblemWriter):
                             "usually indicative of a preprocessing error. Use the "
                             "IO-option 'output_fixed_variable_bounds=True' to suppress "
                             "this error and fix the variable by overwriting its bounds "
-                            "in the MPS file." % (vardata.name(True), model.name(True)))
+                            "in the MPS file." % (vardata.name, model.name))
                     if vardata.value is None:
                         raise ValueError("Variable cannot be fixed to a value of None.")
                     output_file.write((" FX BOUND "+entry_template)

--- a/pyomo/repn/tests/ampl/test_cAmpl.py
+++ b/pyomo/repn/tests/ampl/test_cAmpl.py
@@ -146,7 +146,7 @@ class CAmplBasicTest(unittest.TestCase):
         self.assertIsInstance(exp_ar, pyomo.core.ampl.ampl_representation)
 
         self.assertEquals(type(exp), type(exp_ar._nonlinear_expr))
-        self.assertEquals(exp.name(), exp_ar._nonlinear_expr.name())
+        self.assertEquals(exp.name, exp_ar._nonlinear_expr.name)
         self.assertEquals(0, len(exp_ar._nonlinear_vars))
 
     def testFixedValue(self):

--- a/pyomo/repn/tests/test_canonical.py
+++ b/pyomo/repn/tests/test_canonical.py
@@ -407,12 +407,14 @@ class Test(unittest.TestCase):
         idMap_1 = {}
         rep_A = generate_canonical_repn(exprA, idMap_1)
         rep_B = generate_canonical_repn(exprB, idMap_1)
-        self.assertEqual(set(map(lambda x: x.name(), rep_A.variables)), set(map(lambda x: x.name(), rep_B.variables)))
+        self.assertEqual(set(map(lambda x: x.name, rep_A.variables)),
+                         set(map(lambda x: x.name, rep_B.variables)))
 
         idMap_2 = {}
         rep_B = generate_canonical_repn(exprB, idMap_2)
         rep_A = generate_canonical_repn(exprA, idMap_2)
-        self.assertEqual(set(map(lambda x: x.name(), rep_A.variables)), set(map(lambda x: x.name(), rep_B.variables)))
+        self.assertEqual(set(map(lambda x: x.name, rep_A.variables)),
+                         set(map(lambda x: x.name, rep_B.variables)))
 
         self.assertNotEqual( idMap_1, idMap_2 )
 

--- a/pyomo/scripting/convert.py
+++ b/pyomo/scripting/convert.py
@@ -128,7 +128,7 @@ def convert_dakota(options=Options(), parser=None):
     for var in model.component_data_objects(Var, active=True):
         if id(var) in tmpDict:
             variables += 1
-            var_descriptors.append(var.name(True))
+            var_descriptors.append(var.name)
 
             # apply user bound, domain bound, or infinite
             _lb, _ub = var.bounds
@@ -152,7 +152,7 @@ def convert_dakota(options=Options(), parser=None):
     obj_descriptors = []
     for obj in model.component_data_objects(Objective, active=True):
         objectives += 1
-        obj_descriptors.append(obj.name(True))
+        obj_descriptors.append(obj.name)
 
     constraints = 0
     cons_descriptors = []
@@ -160,7 +160,7 @@ def convert_dakota(options=Options(), parser=None):
     cons_ub = []
     for con in model.component_data_objects(Constraint, active=True):
         constraints += 1
-        cons_descriptors.append(con.name(True))
+        cons_descriptors.append(con.name)
         if con.lower is not None:
             cons_lb.append(str(con.lower))
         else:

--- a/pyomo/solvers/plugins/solvers/CPLEXDirect.py
+++ b/pyomo/solvers/plugins/solvers/CPLEXDirect.py
@@ -108,7 +108,7 @@ class ModelSOS(object):
             if vardata.fixed:
                 raise RuntimeError("SOSConstraint '%s' includes a fixed variable '%s'. "
                                    "This is currently not supported. Deactivate this constraint "
-                                   "in order to proceed" % (soscondata.name(True), vardata.name(True)))
+                                   "in order to proceed" % (soscondata.name, vardata.name))
             varids.append(id(vardata))
             varnames.append(variable_symbol_map.getSymbol(vardata))
             weights.append(weight)
@@ -483,7 +483,7 @@ class CPLEXDirect(OptSolver):
                     raise ValueError(
                         "Multiple active objectives found on Pyomo instance '%s'. "
                         "Solver '%s' will only handle a single active objective" \
-                        % (pyomo_instance.name(True), self.type))
+                        % (pyomo_instance.name, self.type))
 
                 if obj_data.is_minimizing():
                     cplex_instance.objective.\
@@ -558,7 +558,7 @@ class CPLEXDirect(OptSolver):
                             raise ValueError(
                                 "CPLEXDirect plugin does not support general nonlinear "
                                 "objective expressions (only linear or quadratic).\n"
-                                "Objective: %s" % (obj_data.name(True)))
+                                "Objective: %s" % (obj_data.name))
 
             # Constraint
             for con in block.component_data_objects(Constraint,
@@ -610,7 +610,7 @@ class CPLEXDirect(OptSolver):
                         raise ValueError(
                             "CPLEXDirect plugin does not support general nonlinear "
                             "constraint expressions (only linear or quadratic).\n"
-                            "Constraint: %s" % (con.name(True)))
+                            "Constraint: %s" % (con.name))
                     expr, offset = self._encode_constraint_body_linear(con_repn,
                                                                        labeler)
 
@@ -695,7 +695,7 @@ class CPLEXDirect(OptSolver):
                         "indicative of a preprocessing error. Use the IO-option "
                         "'output_fixed_variable_bounds=True' to suppress this error "
                         "and fix the variable by overwriting its bounds in the Cplex "
-                        "instance." % (vardata.name(True),pyomo_instance.name(True)))
+                        "instance." % (vardata.name,pyomo_instance.name))
 
                 fixed_lower_bounds.append((varname,vardata.value))
                 fixed_upper_bounds.append((varname,vardata.value))
@@ -990,43 +990,43 @@ class CPLEXDirect(OptSolver):
                     "***The CPLEXDirect solver plugin cannot "
                     "extract solution suffix="+suffix)
 
-        instance = self._active_cplex_instance
+        cplex_instance = self._active_cplex_instance
 
-        if instance.get_problem_type() in [instance.problem_type.MILP,
-                                           instance.problem_type.MIQP,
-                                           instance.problem_type.MIQCP]:
+        if cplex_instance.get_problem_type() in [cplex_instance.problem_type.MILP,
+                                                 cplex_instance.problem_type.MIQP,
+                                                 cplex_instance.problem_type.MIQCP]:
             extract_reduced_costs = False
             extract_duals = False
 
         # Remove variables whose absolute value is smaller than
         # CPLEX's epsilon from the results data
-        #instance.cleanup()
+        #cplex_instance.cleanup()
 
         results = SolverResults()
-        results.problem.name = instance.get_problem_name()
-        results.problem.lower_bound = None #instance.solution.
+        results.problem.name = cplex_instance.get_problem_name()
+        results.problem.lower_bound = None #cplex_instance.solution.
         results.problem.upper_bound = None
-        results.problem.number_of_variables = instance.variables.get_num()
+        results.problem.number_of_variables = cplex_instance.variables.get_num()
         results.problem.number_of_constraints = \
-            instance.linear_constraints.get_num() \
-            + instance.quadratic_constraints.get_num() \
-            + instance.indicator_constraints.get_num() \
-            + instance.SOS.get_num()
+            cplex_instance.linear_constraints.get_num() \
+            + cplex_instance.quadratic_constraints.get_num() \
+            + cplex_instance.indicator_constraints.get_num() \
+            + cplex_instance.SOS.get_num()
         results.problem.number_of_nonzeros = None
         results.problem.number_of_binary_variables = \
-            instance.variables.get_num_binary()
+            cplex_instance.variables.get_num_binary()
         results.problem.number_of_integer_variables = \
-            instance.variables.get_num_integer()
+            cplex_instance.variables.get_num_integer()
         results.problem.number_of_continuous_variables = \
-            instance.variables.get_num() \
-            - instance.variables.get_num_binary() \
-            - instance.variables.get_num_integer() \
-            - instance.variables.get_num_semiinteger()
+            cplex_instance.variables.get_num() \
+            - cplex_instance.variables.get_num_binary() \
+            - cplex_instance.variables.get_num_integer() \
+            - cplex_instance.variables.get_num_semiinteger()
         #TODO: Does this double-count semi-integers?
         #Should we also remove semi-continuous?
         results.problem.number_of_objectives = 1
 
-        results.solver.name = "CPLEX "+instance.get_version()
+        results.solver.name = "CPLEX "+cplex_instance.get_version()
 #        results.solver.status = None
         results.solver.return_code = None
         results.solver.message = None
@@ -1043,7 +1043,7 @@ class CPLEXDirect(OptSolver):
 
         #Get solution status -- for now, if CPLEX returns anything we
         #don't recognize, mark as an error
-        soln_status = instance.solution.get_status()
+        soln_status = cplex_instance.solution.get_status()
         if soln_status in [1, 101, 102]:
             results.solver.termination_condition = TerminationCondition.optimal
             soln.status = SolutionStatus.optimal
@@ -1058,13 +1058,13 @@ class CPLEXDirect(OptSolver):
         else:
             soln.status = SolutionStatus.error
 
-        if instance.get_problem_type() in [instance.problem_type.MILP,
-                                           instance.problem_type.MIQP,
-                                           instance.problem_type.MIQCP]:
+        if cplex_instance.get_problem_type() in [cplex_instance.problem_type.MILP,
+                                                 cplex_instance.problem_type.MIQP,
+                                                 cplex_instance.problem_type.MIQCP]:
             try:
-                upper_bound = instance.solution.get_objective_value()
-                lower_bound = instance.solution.MIP.get_best_objective() # improperly named, IM(JPW)HO.
-                relative_gap = instance.solution.MIP.get_mip_relative_gap()
+                upper_bound = cplex_instance.solution.get_objective_value()
+                lower_bound = cplex_instance.solution.MIP.get_best_objective() # improperly named, IM(JPW)HO.
+                relative_gap = cplex_instance.solution.MIP.get_mip_relative_gap()
                 absolute_gap = upper_bound - lower_bound
                 soln.gap = absolute_gap
             except CplexSolverError:
@@ -1073,37 +1073,37 @@ class CPLEXDirect(OptSolver):
                 pass
 
         #Only try to get objective and variable values if a solution exists
-        soln_type = instance.solution.get_solution_type()
+        soln_type = cplex_instance.solution.get_solution_type()
         if soln_type > 0:
-            soln.objective[instance.objective.get_name()] = \
-                {'Value': instance.solution.get_objective_value()}
-            num_variables = instance.variables.get_num()
-            variable_names = instance.variables.get_names()
-            variable_values = instance.solution.get_values()
+            soln.objective[cplex_instance.objective.get_name()] = \
+                {'Value': cplex_instance.solution.get_objective_value()}
+            num_variables = cplex_instance.variables.get_num()
+            variable_names = cplex_instance.variables.get_names()
+            variable_values = cplex_instance.solution.get_values()
             for i in xrange(num_variables):
                 variable_name = variable_names[i]
                 soln_variable[variable_name] = {"Value" : variable_values[i]}
 
             if extract_reduced_costs:
                 # get variable reduced costs
-                rc_values = instance.solution.get_reduced_costs()
+                rc_values = cplex_instance.solution.get_reduced_costs()
                 for i in xrange(num_variables):
                     soln_variable[variable_names[i]]["Rc"] = rc_values[i]
 
             if extract_slacks or extract_duals:
 
-                num_linear_constraints = instance.linear_constraints.get_num()
-                constraint_names = instance.linear_constraints.get_names()
+                num_linear_constraints = cplex_instance.linear_constraints.get_num()
+                constraint_names = cplex_instance.linear_constraints.get_names()
 
-                num_quadratic_constraints = instance.quadratic_constraints.get_num()
-                q_constraint_names = instance.quadratic_constraints.get_names()
+                num_quadratic_constraints = cplex_instance.quadratic_constraints.get_num()
+                q_constraint_names = cplex_instance.quadratic_constraints.get_names()
 
                 for i in xrange(num_linear_constraints):
                     soln_constraint[constraint_names[i]] = {}
 
             if extract_duals:
                 # get duals (linear constraints only)
-                dual_values = instance.solution.get_dual_values()
+                dual_values = cplex_instance.solution.get_dual_values()
                 for i in xrange(num_linear_constraints):
                     soln_constraint[constraint_names[i]]["Dual"] = dual_values[i]
 
@@ -1111,11 +1111,11 @@ class CPLEXDirect(OptSolver):
 
             if extract_slacks:
                 # get linear slacks
-                slack_values = instance.solution.get_linear_slacks()
+                slack_values = cplex_instance.solution.get_linear_slacks()
                 for i in xrange(num_linear_constraints):
                     # if both U and L exist (i.e., a range constraint) then
                     # R_ = U-L
-                    R_ = instance.linear_constraints.get_range_values(i)
+                    R_ = cplex_instance.linear_constraints.get_range_values(i)
                     if R_ == 0.0:
                         soln_constraint[constraint_names[i]]["Slack"] = slack_values[i]
                     else:
@@ -1132,7 +1132,7 @@ class CPLEXDirect(OptSolver):
                             soln_constraint[constraint_names[i]]["Slack"] = -Ls_
 
                 # get quadratic slacks
-                slack_values = instance.solution.get_quadratic_slacks()
+                slack_values = cplex_instance.solution.get_quadratic_slacks()
                 for i in xrange(num_quadratic_constraints):
                     # if both U and L exist (i.e., a range constraint) then
                     # R_ = U-L

--- a/pyomo/solvers/plugins/solvers/CPLEXPersistent.py
+++ b/pyomo/solvers/plugins/solvers/CPLEXPersistent.py
@@ -189,7 +189,7 @@ class CPLEXPersistent(CPLEXDirect, PersistentSolver):
                     raise ValueError(
                         "Multiple active objectives found on Pyomo instance '%s'. "
                         "Solver '%s' will only handle a single active objective" \
-                        % (pyomo_instance.name(True), self.type))
+                        % (pyomo_instance.name, self.type))
 
                 if obj_data.is_minimizing():
                     cplex_instance.objective.set_sense(
@@ -261,7 +261,7 @@ class CPLEXPersistent(CPLEXDirect, PersistentSolver):
                             raise ValueError(
                                 "CPLEXPersistent plugin does not support general nonlinear "
                                 "objective expressions (only linear or quadratic).\n"
-                                "Objective: %s" % (obj_data.name(True)))
+                                "Objective: %s" % (obj_data.name))
 
     #
     # method to populate the CPLEX problem instance (interface) from
@@ -453,7 +453,7 @@ class CPLEXPersistent(CPLEXDirect, PersistentSolver):
                         raise ValueError(
                             "CPLEXPersistent plugin does not support general nonlinear "
                             "constraint expression (only linear or quadratic).\n"
-                            "Constraint: %s" % (con.name(True)))
+                            "Constraint: %s" % (con.name))
                     expr, offset = self._encode_constraint_body_linear(con_repn,
                                                                        labeler)
 

--- a/pyomo/solvers/plugins/solvers/glpk_direct.py
+++ b/pyomo/solvers/plugins/solvers/glpk_direct.py
@@ -145,7 +145,7 @@ class GLPKDirect ( OptSolver ):
         for soscondata in model.component_data_objects(SOSConstraint, active=True):
             raise Exception("Solver: glpk_direct does not support SOSConstraint declarations")
 
-        glp_set_prob_name(lp, model.name())
+        glp_set_prob_name(lp, model.name)
 
         glp_set_obj_dir( lp, sense )
         glp_add_rows( lp, num_constraints )
@@ -205,7 +205,7 @@ class GLPKDirect ( OptSolver ):
         if model_canonical_repn is None:
             raise ValueError("No _canonical_repn ComponentMap was found on "
                              "block with name %s. Did you forget to preprocess?"
-                             % (model.name(True)))
+                             % (model.name))
 
         for name in constraint_list:
             constraint_set = constraint_list[ name ]
@@ -221,7 +221,7 @@ class GLPKDirect ( OptSolver ):
                     raise ValueError("No entry found in _canonical_repn ComponentMap on "
                                      "block %s for active constraint with name %s. "
                                      "Did you forget to preprocess?"
-                                     % (model.name(True), constraint.name(True)))
+                                     % (model.name, constraint.name))
 
                 offset = 0.0
                 if 0 in expression:
@@ -273,7 +273,7 @@ class GLPKDirect ( OptSolver ):
                 raise ValueError("No entry found in _canonical_repn ComponentMap on "
                                  "block %s for active objective with name %s. "
                                  "Did you forget to preprocess?"
-                                 % (model.name(True), objective[key].name(True)))
+                                 % (model.name, objective[key].name))
 
             if expression.is_constant():
                 msg = "Ignoring objective '%s[%s]' which is constant"
@@ -542,9 +542,9 @@ class GLPKDirect ( OptSolver ):
         # solv.termination_condition = None
         # solv.termination_message = None
 
-        prob.name = glp_get_prob_name( lp )
-        prob.number_of_constraints = glp_get_num_rows( lp )
-        prob.number_of_nonzeros = glp_get_num_nz( lp )
+        prob.name = glp_get_prob_name(lp)
+        prob.number_of_constraints = glp_get_num_rows(lp)
+        prob.number_of_nonzeros = glp_get_num_nz(lp)
         prob.number_of_variables = num_variables
         prob.number_of_binary_variables = bin_variables
         prob.number_of_integer_variables = int_variables

--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -97,8 +97,8 @@ class ModelSOS(object):
                 raise RuntimeError("SOSConstraint '%s' includes a fixed variable "
                                    "'%s'. This is currently not supported. "
                                    "Deactivate this constraint in order to "
-                                   "proceed." % (soscondata.name(True),
-                                                 vardata.name(True)))
+                                   "proceed." % (soscondata.name,
+                                                 vardata.name))
             varids.append(id(vardata))
             varnames.append(gurobi_var_map[variable_symbol_map.getSymbol(vardata)])
             weights.append(weight)
@@ -203,7 +203,7 @@ class gurobi_direct ( OptSolver ):
         from pyomo.repn import LinearCanonicalRepn, canonical_degree
 
         try:
-            grbmodel = Model(name=pyomo_instance.name())
+            grbmodel = Model(name=pyomo_instance.name)
         except Exception:
             e = sys.exc_info()[1]
             msg = 'Unable to create Gurobi model.  Have you installed the Python'\
@@ -318,7 +318,7 @@ class gurobi_direct ( OptSolver ):
                     raise ValueError(
                         "Multiple active objectives found on Pyomo instance '%s'. "
                         "Solver '%s' will only handle a single active objective" \
-                        % (pyomo_instance.name(True), self.type))
+                        % (pyomo_instance.name, self.type))
 
                 sense = GRB_MIN if (obj_data.is_minimizing()) else GRB_MAX
                 grbmodel.ModelSense = sense
@@ -379,7 +379,7 @@ class gurobi_direct ( OptSolver ):
                         raise ValueError(
                             "gurobi_direct plugin does not support general nonlinear "
                             "objective expressions (only linear or quadratic).\n"
-                            "Objective: %s" % (obj_data.name(True)))
+                            "Objective: %s" % (obj_data.name))
 
                 # need to cache the objective label, because the
                 # GUROBI python interface doesn't track this.
@@ -498,7 +498,7 @@ class gurobi_direct ( OptSolver ):
                         raise ValueError(
                             "gurobi_direct plugin does not support general nonlinear "
                             "constraint expressions (only linear or quadratic).\n"
-                            "Constraint: %s" % (constraint_data.name(True)))
+                            "Constraint: %s" % (constraint_data.name))
 
                 if (not trivial) or (not self._skip_trivial_constraints):
 
@@ -558,7 +558,7 @@ class gurobi_direct ( OptSolver ):
                                      "a preprocessing error. Use the IO-option 'output_fixed_variable_bounds=True' "
                                      "to suppress this error and fix the variable by overwriting its bounds in "
                                      "the Gurobi instance."
-                                     % (vardata.name(True),pyomo_instance.name(True),))
+                                     % (vardata.name,pyomo_instance.name,))
 
                 grbvar = pyomo_gurobi_variable_map[varname]
                 grbvar.setAttr(GRB.Attr.UB, vardata.value)

--- a/pyomo/solvers/tests/io/model_types.py
+++ b/pyomo/solvers/tests/io/model_types.py
@@ -45,31 +45,31 @@ class _ModelClassBase(object):
         with open(filename,'w') as f:
             soln = {}
             for block in model.block_data_objects():
-                soln[block.name(True)] = {}
+                soln[block.name] = {}
                 for suffix_name, suffix in suffixes.items():
                     if suffix.get(block) is not None:
-                        soln[block.name(True)][suffix_name] = suffix.get(block)
+                        soln[block.name][suffix_name] = suffix.get(block)
             for var in model.component_data_objects(Var):
-                soln[var.name(True)] = {}
-                soln[var.name(True)]['value'] = var.value
-                soln[var.name(True)]['stale'] = var.stale
+                soln[var.name] = {}
+                soln[var.name]['value'] = var.value
+                soln[var.name]['stale'] = var.stale
                 for suffix_name, suffix in suffixes.items():
                     if suffix.get(var) is not None:
-                        soln[var.name(True)][suffix_name] = suffix.get(var)
+                        soln[var.name][suffix_name] = suffix.get(var)
             for con in model.component_data_objects(Constraint):
-                soln[con.name(True)] = {}
+                soln[con.name] = {}
                 con_value = con(exception=False)
-                soln[con.name(True)]['value'] = con_value
+                soln[con.name]['value'] = con_value
                 for suffix_name, suffix in suffixes.items():
                     if suffix.get(con) is not None:
-                        soln[con.name(True)][suffix_name] = suffix.get(con)
+                        soln[con.name][suffix_name] = suffix.get(con)
             for obj in model.component_data_objects(Objective):
-                soln[obj.name(True)] = {}
+                soln[obj.name] = {}
                 obj_value = obj(exception=False)
-                soln[obj.name(True)]['value'] = obj_value
+                soln[obj.name]['value'] = obj_value
                 for suffix_name, suffix in suffixes.items():
                     if suffix.get(obj) is not None:
-                        soln[obj.name(True)][suffix_name] = suffix.get(obj)
+                        soln[obj.name][suffix_name] = suffix.get(obj)
             json.dump(soln, f, indent=2, sort_keys=True)
 
     def validateCurrentSolution(self,**kwds):
@@ -90,121 +90,121 @@ class _ModelClassBase(object):
             except:
                 return (False,"Problem reading file "+self.results_file)
         for var in model.component_data_objects(Var):
-            var_value_sol = solution[var.name(True)]['value']
+            var_value_sol = solution[var.name]['value']
             var_value = var.value
             if not ((var_value is None) and (var_value_sol is None)):
                 if ((var_value is None) ^ (var_value_sol is None)) or \
                    (abs(var_value_sol - var_value) > self.diff_tol):
                     return (False,
-                            error_str.format(var.name(True),
+                            error_str.format(var.name,
                                              'value',
                                              var_value_sol,
                                              var_value))
-            if not (solution[var.name(True)]['stale'] is var.stale):
+            if not (solution[var.name]['stale'] is var.stale):
                 return (False,
-                        error_str.format(var.name(True),
+                        error_str.format(var.name,
                                          'stale',
-                                         solution[var.name(True)]['stale'],
+                                         solution[var.name]['stale'],
                                          var.stale))
             for suffix_name, suffix in suffixes.items():
-                if suffix_name in solution[var.name(True)]:
+                if suffix_name in solution[var.name]:
                     if suffix.get(var) is None:
-                        if not(solution[var.name(True)][suffix_name] in \
+                        if not(solution[var.name][suffix_name] in \
                                solution["suffix defaults"][suffix_name]):
                             return (False,
                                     error_str.format(
-                                        var.name(True),
+                                        var.name,
                                         suffix,
-                                        solution[var.name(True)][suffix_name],
+                                        solution[var.name][suffix_name],
                                         "none defined"))
-                    elif not abs(solution[var.name(True)][suffix_name] - \
+                    elif not abs(solution[var.name][suffix_name] - \
                                  suffix.get(var)) < self.diff_tol:
                         return (False,
                                 error_str.format(
-                                    var.name(True),
+                                    var.name,
                                     suffix,
-                                    solution[var.name(True)][suffix_name],
+                                    solution[var.name][suffix_name],
                                     suffix.get(var)))
         for con in model.component_data_objects(Constraint):
-            con_value_sol = solution[con.name(True)]['value']
+            con_value_sol = solution[con.name]['value']
             con_value = con(exception=False)
             if not ((con_value is None) and (con_value_sol is None)):
                 if ((con_value is None) ^ (con_value_sol is None)) or \
                    (abs(con_value_sol - con_value) > self.diff_tol):
                     return (False,
-                            error_str.format(con.name(True),
+                            error_str.format(con.name,
                                              'value',
                                              con_value_sol,
                                              con_value))
             for suffix_name, suffix in suffixes.items():
-                if suffix_name in solution[con.name(True)]:
+                if suffix_name in solution[con.name]:
                     if suffix.get(con) is None:
-                        if not (solution[con.name(True)][suffix_name] in \
+                        if not (solution[con.name][suffix_name] in \
                                 solution["suffix defaults"][suffix_name]):
                             return (False,
                                     error_str.format(
-                                        con.name(True),
+                                        con.name,
                                         suffix,
-                                        solution[con.name(True)][suffix_name],
+                                        solution[con.name][suffix_name],
                                         "none defined"))
-                    elif not abs(solution[con.name(True)][suffix_name] - \
+                    elif not abs(solution[con.name][suffix_name] - \
                                  suffix.get(con)) < self.diff_tol:
                         return (False,
                                 error_str.format(
-                                    con.name(True),
+                                    con.name,
                                     suffix,
-                                    solution[con.name(True)][suffix_name],
+                                    solution[con.name][suffix_name],
                                     suffix.get(con)))
         for obj in model.component_data_objects(Objective):
-            obj_value_sol = solution[obj.name(True)]['value']
+            obj_value_sol = solution[obj.name]['value']
             obj_value = obj(exception=False)
             if not ((obj_value is None) and (obj_value_sol is None)):
                 if ((obj_value is None) ^ (obj_value_sol is None)) or \
                    (abs(obj_value_sol - obj_value) > self.diff_tol):
                     return (False,
-                            error_str.format(obj.name(True),
+                            error_str.format(obj.name,
                                              'value',
                                              obj_value_sol,
                                              obj_value))
             for suffix_name, suffix in suffixes.items():
-                if suffix_name in solution[obj.name(True)]:
+                if suffix_name in solution[obj.name]:
                     if suffix.get(obj) is None:
-                        if not(solution[obj.name(True)][suffix_name] in \
+                        if not(solution[obj.name][suffix_name] in \
                                solution["suffix defaults"][suffix_name]):
                             return (False,
                                     error_str.format(
-                                        obj.name(True),
+                                        obj.name,
                                         suffix,
-                                        solution[obj.name(True)][suffix_name],
+                                        solution[obj.name][suffix_name],
                                         "none defined"))
-                    elif not abs(solution[obj.name(True)][suffix_name] - \
+                    elif not abs(solution[obj.name][suffix_name] - \
                                  suffix.get(obj)) < self.diff_tol:
                         return (False,
                                 error_str.format(
-                                    obj.name(True),
+                                    obj.name,
                                     suffix,
-                                    solution[obj.name(True)][suffix_name],
+                                    solution[obj.name][suffix_name],
                                     suffix.get(obj)))
         for block in model.block_data_objects():
             for suffix_name, suffix in suffixes.items():
-                if (solution[block.name(True)] is not None) and \
-                   (suffix_name in solution[block.name(True)]):
+                if (solution[block.name] is not None) and \
+                   (suffix_name in solution[block.name]):
                     if suffix.get(block) is None:
-                        if not(solution[block.name(True)][suffix_name] in \
+                        if not(solution[block.name][suffix_name] in \
                                solution["suffix defaults"][suffix_name]):
                             return (False,
                                     error_str.format(
-                                        block.name(True),
+                                        block.name,
                                         suffix,
-                                        solution[block.name(True)][suffix_name],
+                                        solution[block.name][suffix_name],
                                         "none defined"))
-                    elif not abs(solution[block.name(True)][suffix_name] - \
+                    elif not abs(solution[block.name][suffix_name] - \
                                  suffix.get(block)) < sefl.diff_tol:
                         return (False,
                                 error_str.format(
-                                    block.name(True),
+                                    block.name,
                                     suffix,
-                                    solution[block.name(True)][suffix_name],
+                                    solution[block.name][suffix_name],
                                     suffix.get(block)))
         return (True,"")
 
@@ -1337,7 +1337,7 @@ if __name__ == "__main__":
 
     #model.preprocess()
     #for block in model.block_data_objects(active=True):
-    #    print(block.name(True))
+    #    print(block.name)
     #    block._canonical_repn.pprint()
 
     #model.write(format=None,filename="junk.nl",symbolic_solver_labels=True)
@@ -1394,9 +1394,9 @@ if __name__ == "__main__":
             results = json.load(f)
         for block in model.block_data_objects():
             for var in components_data(block,Var):
-                if 'stale' not in results[var.name(True)]:
-                    results[var.name(True)]['stale'] = var.stale
-                print '\t%18s'%var.name(True), results[var.name(True)]
+                if 'stale' not in results[var.name]:
+                    results[var.name]['stale'] = var.stale
+                print '\t%18s'%var.name, results[var.name]
         with open(name,'w') as f:
             json.dump(results, f, indent=2)
     """

--- a/pyomo/solvers/tests/piecewise_linear/problems/tester.py
+++ b/pyomo/solvers/tests/piecewise_linear/problems/tester.py
@@ -49,7 +49,7 @@ for problem_name in problem_names:
     for block in inst.block_data_objects(active=True):
         for variable in itervalues(block.component_map(Var, active=True)):
             for var in itervalues(variable):
-                name = var.name(True)
+                name = var.name
                 if (name[:2] == 'Fx') or (name[:1] == 'x'):
                     res[name] = value(var)
     print(res)

--- a/pyomo/solvers/tests/piecewise_linear/test_piecewise_linear.py
+++ b/pyomo/solvers/tests/piecewise_linear/test_piecewise_linear.py
@@ -67,7 +67,7 @@ def createTestMethod(pName,problem,solver,writer,kwds):
         results = opt.solve(model)
 
         # non-recursive
-        new_results = ((var.name(),var.value)
+        new_results = ((var.name, var.value)
                        for var in model.component_data_objects(Var,
                                                                active=True,
                                                                descend_into=False))


### PR DESCRIPTION
This PR includes three major changes:

- Renames the current `name` method to `getname`.
- Creates a `name` property method that returns the fully qualified name.
- Creates a `local_name` property method that returns the shortened name (only the immediate parent is taken into account).

Additionally, a setter has been defined for the `name` property method that raises an exception telling users that `.name` is no longer a public writable attribute. When I did the original `cname` -> `name` method rename, I encountered many examples where model names were being set by setting this public attribute. I changed those examples to use the `name` constructor keyword instead.