### PR TITLE
Remove floating return statement in XPRESS.py solver plugin

### DIFF
--- a/pyomo/solvers/plugins/solvers/XPRESS.py
+++ b/pyomo/solvers/plugins/solvers/XPRESS.py
@@ -198,8 +198,6 @@ class XPRESS_shell(ILMLicensedSystemCallSolver):
         log_file_contents = "".join(log_file.readlines())
         log_file.close()
 
-        return
-
         for line in log_file_contents.split("\n"):
             tokens = re.split('[ \t]+',line.strip())
 


### PR DESCRIPTION
This problem is because of a floating `return` statement in the `process_logfile` function in the [xpress solver plugin](https://github.com/Pyomo/pyomo/blob/master/pyomo/solvers/plugins/solvers/XPRESS.py#L201). This returns a `None` object instead of the `results` which causes the function `process_soln_file` to error. This patch removes the floating `return` and fixes #55.