### PR TITLE
Adding support for decorating rules to simplify syntax.

### DIFF
--- a/examples/pyomo/p-median/decorated_pmedian.py
+++ b/examples/pyomo/p-median/decorated_pmedian.py
@@ -1,0 +1,39 @@
+from pyomo.environ import *
+
+import random
+random.seed(1000)
+
+model = AbstractModel()
+
+model.N = Param(within=PositiveIntegers)
+model.P = Param(within=RangeSet(1,model.N))
+model.M = Param(within=PositiveIntegers)
+
+model.Locations = RangeSet(1,model.N)
+model.Customers = RangeSet(1,model.M)
+
+model.d = Param( model.Locations, model.Customers, 
+                 initialize=lambda n, m, model : random.uniform(1.0,2.0), 
+                 within=Reals)
+
+model.x = Var(model.Locations, model.Customers, bounds=(0.0,1.0))
+model.y = Var(model.Locations, within=Binary)
+
+@model.Objective()
+def obj(model):
+    return sum( model.d[n,m]*model.x[n,m] for n in model.Locations 
+                for m in model.Customers )
+
+@model.Constraint(model.Customers)
+def single_x(model, m):
+    return (sum( model.x[n,m] for n in model.Locations ), 1.0)
+
+@model.Constraint(model.Locations, model.Customers)
+def bound_y(model, n,m):
+    return model.x[n,m] - model.y[n] <= 0.0
+
+@model.Constraint()
+def num_facilities(model):
+    return sum( model.y[n] for n in model.Locations ) == model.P
+
+#model.pprint()

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -1766,5 +1766,26 @@ class TestBlock(unittest.TestCase):
         model.C = model.A | model.B
         model.x = Block(model.C)
 
+    def test_decorated_definition(self):
+        model = ConcreteModel()
+        model.I = Set(initialize=[1,2,3])
+        model.x = Var(model.I)
+
+        @model.Constraint()
+        def scalar_constraint(m):
+            return m.x[1]**2 <= 0
+
+        self.assertTrue(hasattr(model, 'scalar_constraint'))
+        self.assertIs(model.scalar_constraint._type, Constraint)
+        self.assertEqual(len(model.scalar_constraint), 1)
+
+        @model.Constraint(model.I)
+        def vector_constraint(m, i):
+            return m.x[i]**2 <= 0
+
+        self.assertTrue(hasattr(model, 'vector_constraint'))
+        self.assertIs(model.vector_constraint._type, Constraint)
+        self.assertEqual(len(model.vector_constraint), 3)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This adds support for declaring components on a model by decorating the
rule instead of explicitly invoking the setattr method on the block.
This "fixes" the normal pattern of the component name appearing in three
places.

This is an implementation of a feature requested by Ned Dimitrov at the PyomoFEST/Austin.