### PR TITLE
Update unsupported dict iteritems()

### DIFF
--- a/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
@@ -69,7 +69,7 @@ def gurobi_run(model_file, warmstart_file, soln_file, mipgap, options, suffixes)
     # GUROBI doesn't throw an exception if an unknown
     # key is specified, so you have to stare at the
     # output to see if it was accepted.
-    for key, value in options.iteritems():
+    for key, value in options.items():
         model.setParam(key, value)
 
     if 'relax_integrality' in options:

--- a/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
@@ -9,6 +9,7 @@
 
 
 import re
+import six
 
 from gurobipy import *
 
@@ -69,7 +70,7 @@ def gurobi_run(model_file, warmstart_file, soln_file, mipgap, options, suffixes)
     # GUROBI doesn't throw an exception if an unknown
     # key is specified, so you have to stare at the
     # output to see if it was accepted.
-    for key, value in options.items():
+    for key, value in six.iteritems(options):
         model.setParam(key, value)
 
     if 'relax_integrality' in options:


### PR DESCRIPTION
options.iteritems() fails in Python 3+.
options.items() will work in both (albeit taking longer than iteritems() would in Python 2.7), so just updated to that rather than having a try/except.