### PR TITLE
IndexedComponent.is_indexed performance fix

### DIFF
--- a/pyomo/core/base/action.py
+++ b/pyomo/core/base/action.py
@@ -53,7 +53,7 @@ class BuildAction(IndexedComponent):
             return
         self._constructed=True
         #
-        if None in self._index:
+        if not self.is_indexed():
             # Scalar component
             self._rule(self._parent())
         else:

--- a/pyomo/core/base/action.py
+++ b/pyomo/core/base/action.py
@@ -13,7 +13,7 @@ import logging
 import types
 
 from pyomo.core.base.component import register_component
-from pyomo.core.base.indexed_component import IndexedComponent, UnindexedComponent_set
+from pyomo.core.base.indexed_component import IndexedComponent
 from pyomo.core.base.misc import apply_indexed_rule
 
 logger = logging.getLogger('pyomo.core')
@@ -39,8 +39,7 @@ class BuildAction(IndexedComponent):
 
     def _pprint(self):
         return ([("Size", len(self)),
-                 ("Index", self._index \
-                      if self._index != UnindexedComponent_set else None),
+                 ("Index", self._index if self.is_indexed() else None),
                  ("Active", self.active),]
                  , None, None, None)
 

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1578,7 +1578,7 @@ class Block(ActiveIndexedComponent):
     def __new__(cls, *args, **kwds):
         if cls != Block:
             return super(Block, cls).__new__(cls)
-        if args == () or (type(args[0]) == set and args[0] == UnindexedComponent_set and len(args)==1):
+        if not args or (args[0] is UnindexedComponent_set and len(args)==1):
             return SimpleBlock.__new__(SimpleBlock)
         else:
             return IndexedBlock.__new__(IndexedBlock)

--- a/pyomo/core/base/check.py
+++ b/pyomo/core/base/check.py
@@ -51,7 +51,7 @@ class BuildCheck(IndexedComponent):
             return
         self._constructed=True
         #
-        if None in self._index:
+        if not self.is_indexed():
             # Scalar component
             res = self._rule(self._parent())
             if not res:

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -774,8 +774,7 @@ class Constraint(ActiveIndexedComponent):
         """
         return (
             [("Size", len(self)),
-             ("Index", self._index \
-              if self._index != UnindexedComponent_set else None),
+             ("Index", self._index if self.is_indexed() else None),
              ("Active", self.active),
              ],
             iteritems(self),

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -662,7 +662,7 @@ class Constraint(ActiveIndexedComponent):
     def __new__(cls, *args, **kwds):
         if cls != Constraint:
             return super(Constraint, cls).__new__(cls)
-        if args == () or (type(args[0]) == set and args[0] == UnindexedComponent_set and len(args)==1):
+        if not args or (args[0] is UnindexedComponent_set and len(args)==1):
             return SimpleConstraint.__new__(SimpleConstraint)
         else:
             return IndexedConstraint.__new__(IndexedConstraint)

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -254,7 +254,7 @@ class Expression(IndexedComponent):
     def __new__(cls, *args, **kwds):
         if cls != Expression:
             return super(Expression, cls).__new__(cls)
-        if args == () or (type(args[0]) == set and args[0] == UnindexedComponent_set and len(args)==1):
+        if not args or (args[0] is UnindexedComponent_set and len(args)==1):
             return SimpleExpression.__new__(SimpleExpression)
         else:
             return IndexedExpression.__new__(IndexedExpression)

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -346,7 +346,7 @@ class IndexedComponent(Component):
 
     def dim(self):
         """Return the dimension of the index"""
-        if self.is_indexed():
+        if not self.is_indexed():
             return 0
         return getattr(self._index, 'dimen', 0)
 

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -329,7 +329,7 @@ class IndexedComponent(Component):
 
     def clear(self):
         """Clear the data in this component"""
-        if UnindexedComponent_set != self._index:
+        if self.is_indexed():
             self._data = {}
         else:
             raise DeveloperError(
@@ -346,7 +346,7 @@ class IndexedComponent(Component):
 
     def dim(self):
         """Return the dimension of the index"""
-        if id(UnindexedComponent_set) == id(self._index):
+        if self.is_indexed():
             return 0
         return getattr(self._index, 'dimen', 0)
 
@@ -656,7 +656,7 @@ the value() function.""" % ( self.name, i ))
 
     def set_value(self, value):
         """Set the value of a scalar component."""
-        if UnindexedComponent_set != self._index:
+        if self.is_indexed()
             raise ValueError(
                 "Cannot set the value for the indexed component '%s' "
                 "without specifying an index value.\n"

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -306,6 +306,21 @@ class IndexedComponent(Component):
             self._implicit_subsets = tmp
             self._index = tmp[0].cross(*tmp[1:])
 
+    def __getstate__(self):
+        # Special processing of getstate so that we never copy the
+        # UnindexedComponent_set set
+        state = super(IndexedComponent, self).__getstate__()
+        if not self.is_indexed():
+            state['_index'] = None
+        return state
+
+    def __setstate__(self, state):
+        # Special processing of setstate so that we never copy the
+        # UnindexedComponent_set set
+        if state['_index'] is None:
+            state['_index'] = UnindexedComponent_set
+        return super(IndexedComponent, self).__setstate__(state)
+
     def to_dense_data(self):
         """TODO"""
         for ndx in self._index:
@@ -327,7 +342,7 @@ class IndexedComponent(Component):
 
     def is_indexed(self):
         """Return true if this component is indexed"""
-        return UnindexedComponent_set != self._index
+        return self._index is not UnindexedComponent_set
 
     def dim(self):
         """Return the dimension of the index"""

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -656,7 +656,7 @@ the value() function.""" % ( self.name, i ))
 
     def set_value(self, value):
         """Set the value of a scalar component."""
-        if self.is_indexed()
+        if self.is_indexed():
             raise ValueError(
                 "Cannot set the value for the indexed component '%s' "
                 "without specifying an index value.\n"

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -256,7 +256,7 @@ class Objective(ActiveIndexedComponent):
     def __new__(cls, *args, **kwds):
         if cls != Objective:
             return super(Objective, cls).__new__(cls)
-        if args == () or (type(args[0]) == set and args[0] == UnindexedComponent_set and len(args)==1):
+        if not args or (args[0] is UnindexedComponent_set and len(args)==1):
             return SimpleObjective.__new__(SimpleObjective)
         else:
             return IndexedObjective.__new__(IndexedObjective)

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -369,8 +369,7 @@ class Objective(ActiveIndexedComponent):
         """
         return (
             [("Size", len(self)),
-             ("Index", self._index \
-                       if self._index != UnindexedComponent_set else None),
+             ("Index", self._index if self.is_indexed() else None),
              ("Active", self.active)
              ],
             iteritems(self._data),
@@ -391,8 +390,7 @@ class Objective(ActiveIndexedComponent):
         ostream.write(prefix+self.local_name+" : ")
         ostream.write(", ".join("%s=%s" % (k,v) for k,v in [
                     ("Size", len(self)),
-                    ("Index", self._index \
-                     if self._index != UnindexedComponent_set else None),
+                    ("Index", self._index if self.is_indexed() else None),
                     ("Active", self.active),
                     ] ))
 

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -138,7 +138,7 @@ class Param(IndexedComponent):
     def __new__(cls, *args, **kwds):
         if cls != Param:
             return super(Param, cls).__new__(cls)
-        if args == () or (type(args[0]) is set and args[0] == UnindexedComponent_set and len(args)==1):
+        if not args or (args[0] is UnindexedComponent_set and len(args)==1):
             return SimpleParam.__new__(SimpleParam)
         else:
             return IndexedParam.__new__(IndexedParam)

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -864,8 +864,7 @@ This has resulted in the conversion of the source to dense form.
         Return data that will be printed for this component.
         """
         return ( [("Size", len(self)),
-                  ("Index", self._index \
-                       if self._index != UnindexedComponent_set else None),
+                  ("Index", self._index if self.is_indexed() else None),
                   ("Domain", self.domain.name),
                   ("Default", "(function)" if type(self._default_val) \
                        is types.FunctionType else self._default_val),

--- a/pyomo/core/base/sets.py
+++ b/pyomo/core/base/sets.py
@@ -1608,7 +1608,7 @@ class IndexedSet(Set):
         """
         Clear that data in this component.
         """
-        if UnindexedComponent_set != self._index:
+        if self.is_indexed():
             self._data = {}
         else:
             #

--- a/pyomo/core/base/sets.py
+++ b/pyomo/core/base/sets.py
@@ -598,7 +598,7 @@ class Set(IndexedComponent):
     def __new__(cls, *args, **kwds):
         if cls != Set:
             return super(Set, cls).__new__(cls)
-        if args == () or (type(args[0]) is set and args[0] == UnindexedComponent_set and len(args)==1):
+        if not args or (args[0] is UnindexedComponent_set and len(args)==1):
             if kwds.get('ordered',False) is False:
                 return SimpleSet.__new__(SimpleSet)
             else:

--- a/pyomo/core/base/sos.py
+++ b/pyomo/core/base/sos.py
@@ -149,7 +149,7 @@ class SOSConstraint(ActiveIndexedComponent):
     def __new__(cls, *args, **kwds):
         if cls != SOSConstraint:
             return super(SOSConstraint, cls).__new__(cls)
-        if args == () or (type(args[0]) == set and args[0] == UnindexedComponent_set and len(args)==1):
+        if not args or (args[0] is UnindexedComponent_set and len(args)==1):
             return SimpleSOSConstraint.__new__(SimpleSOSConstraint)
         else:
             return IndexedSOSConstraint.__new__(IndexedSOSConstraint)
@@ -249,7 +249,7 @@ class SOSConstraint(ActiveIndexedComponent):
                         # Check that the sets are ordered.
                         #
                         ordered=False
-                        if type(sosSet) is list or sosSet == UnindexedComponent_set or len(sosSet) == 1:
+                        if type(sosSet) is list or sosSet is UnindexedComponent_set or len(sosSet) == 1:
                             ordered=True
                         if hasattr(sosSet, 'ordered') and sosSet.ordered:
                             ordered=True

--- a/pyomo/core/base/sos.py
+++ b/pyomo/core/base/sos.py
@@ -225,11 +225,11 @@ class SOSConstraint(ActiveIndexedComponent):
         self._constructed = True
 
         if self._rule is None:
-            if self._sosSet is None and not None in self._index:
+            if self._sosSet is None and self.is_indexed():
                 if generate_debug_messages:     #pragma:nocover
                     logger.debug("  Cannot construct "+self.name+".  No rule is defined and no SOS sets are defined.")
             else:
-                if None in self._index:
+                if not self.is_indexed():
                     if self._sosSet is None:
                         if getattr(self._sosVars.index_set(), 'ordered', False):
                             _sosSet = {None: list(self._sosVars.index_set())}

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -433,7 +433,7 @@ class Var(IndexedComponent):
     def __new__(cls, *args, **kwds):
         if cls != Var:
             return super(Var, cls).__new__(cls)
-        if args == () or (type(args[0]) == set and args[0] == UnindexedComponent_set and len(args)==1):
+        if not args or (args[0] is UnindexedComponent_set and len(args)==1):
             return SimpleVar.__new__(SimpleVar)
         else:
             return IndexedVar.__new__(IndexedVar)

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -699,8 +699,7 @@ class Var(IndexedComponent):
     def _pprint(self):
         """Print component information."""
         return ( [("Size", len(self)),
-                  ("Index", self._index \
-                       if self._index != UnindexedComponent_set else None),
+                  ("Index", self._index if self.is_indexed() else None),
                   ],
                  iteritems(self._data),
                  ( "Lower","Value","Upper","Fixed","Stale","Domain"),

--- a/pyomo/mpec/complementarity.py
+++ b/pyomo/mpec/complementarity.py
@@ -16,7 +16,6 @@ from pyomo.core import *
 from pyomo.core.base.numvalue import ZeroConstant, _sub
 from pyomo.core.base.misc import apply_indexed_rule
 from pyomo.core.base.block import _BlockData
-from pyomo.core.base.indexed_component import UnindexedComponent_set
 import pyomo.core.base.expr as EXPR
 
 import logging
@@ -255,8 +254,7 @@ Error thrown for Complementarity "%s"
         """
         return (
             [("Size", len(self)),
-             ("Index", self._index \
-                  if self._index != UnindexedComponent_set else None),
+             ("Index", self._index if self.is_indexed() else None),
              ("Active", self.active),
              ],
             iteritems(self._data),


### PR DESCRIPTION
This makes `UnindexedComponent_set` behave like a singleton so that `IndexedCOmponent.is_indexed()` can be more efficient (using `is` instead of `!=`.