### PR TITLE
Support solving Blocks as if they were Models

### DIFF
--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -53,7 +53,6 @@ from pyomo.core.base.component import register_component, Component, ComponentUI
 from pyomo.core.base.plugin import TransformationFactory
 from pyomo.core.base.label import CNameLabeler, CuidLabeler
 import pyomo.opt
-from pyomo.opt.base import ProblemFormat, guess_format
 from pyomo.opt.results import SolverResults, Solution, SolutionStatus, UndefinedData
 
 from six import itervalues, iteritems, StringIO, string_types
@@ -601,10 +600,6 @@ use the AbstractModel or ConcreteModel class instead.""")
         self.compute_statistics()
         return self.statistics.number_of_objectives
 
-    def valid_problem_types(self):
-        """This method allows the pyomo.opt convert function to work with a Model object."""
-        return [ProblemFormat.pyomo]
-
     def create_instance( self, filename=None, data=None, name=None,
                          namespace=None, namespaces=None,
                          profile_memory=0, report_timing=False,
@@ -941,50 +936,6 @@ from solvers are immediately loaded into the original model instance.""")
             mem_used = muppy.get_size(muppy.get_objects())
             print("      Total memory = %d bytes following construction of component=%s (after garbage collection)" % (mem_used, component_name))
 
-
-    def write(self,
-              filename=None,
-              format=None,
-              solver_capability=None,
-              io_options={}):
-        """
-        Write the model to a file, with a given format.
-        """
-        #
-        # Guess the format if none is specified
-        #
-        if (filename is None) and (format is None):
-            # Preserving backwards compatibility here.
-            # The function used to be defined with format='lp' by
-            # default, but this led to confusing behavior when a
-            # user did something like 'model.write("f.nl")' and
-            # expected guess_format to create an NL file.
-            format = ProblemFormat.cpxlp
-        if (filename is not None) and (format is None):
-            format = guess_format(filename)
-        problem_writer = pyomo.opt.WriterFactory(format)
-        if problem_writer is None:
-            raise ValueError(
-                "Cannot write model in format '%s': no model "
-                "writer registered for that format"
-                % str(format))
-
-        if solver_capability is None:
-            solver_capability = lambda x: True
-        (filename, smap) = problem_writer(self,
-                                          filename,
-                                          solver_capability,
-                                          io_options)
-        smap_id = id(smap)
-        self.solutions.add_symbol_map(smap)
-
-        if __debug__ and logger.isEnabledFor(logging.DEBUG):
-            logger.debug(
-                "Writing model '%s' to file '%s' with format %s",
-                self.name,
-                str(filename),
-                str(format))
-        return filename, smap_id
 
     def create(self, filename=None, **kwargs):
         """

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -30,6 +30,9 @@ from pyomo.core.base.suffix import ComponentMap
 from pyomo.core.base.indexed_component import IndexedComponent, \
     ActiveIndexedComponent, UnindexedComponent_set
 
+from pyomo.opt.base import ProblemFormat, guess_format
+from pyomo.opt import WriterFactory
+
 logger = logging.getLogger('pyomo.core')
 
 
@@ -1567,6 +1570,72 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
                 pyomo.core.base.component_order.display_name[item] )
             for obj in itervalues(ACTIVE):
                 obj.display(prefix=prefix+"    ",ostream=ostream)
+
+
+    #
+    # The following methods are needed to support passing blocks as
+    # models to a solver.
+    #
+
+    def valid_problem_types(self):
+        """This method allows the pyomo.opt convert function to work with a
+        Model object."""
+        return [ProblemFormat.pyomo]
+
+    def write(self,
+              filename=None,
+              format=None,
+              solver_capability=None,
+              io_options={}):
+        """
+        Write the model to a file, with a given format.
+        """
+        #
+        # Guess the format if none is specified
+        #
+        if (filename is None) and (format is None):
+            # Preserving backwards compatibility here.
+            # The function used to be defined with format='lp' by
+            # default, but this led to confusing behavior when a
+            # user did something like 'model.write("f.nl")' and
+            # expected guess_format to create an NL file.
+            format = ProblemFormat.cpxlp
+        if (filename is not None) and (format is None):
+            format = guess_format(filename)
+        problem_writer = WriterFactory(format)
+        if problem_writer is None:
+            raise ValueError(
+                "Cannot write model in format '%s': no model "
+                "writer registered for that format"
+                % str(format))
+
+        if solver_capability is None:
+            solver_capability = lambda x: True
+        (filename, smap) = problem_writer(self,
+                                          filename,
+                                          solver_capability,
+                                          io_options)
+        smap_id = id(smap)
+        if not hasattr(self, 'solutions'):
+            # This is a bit of a hack.  The write() method was moved
+            # here from PyomoModel to support the solution of arbitrary
+            # blocks in a hierarchical model.  However, we cannot import
+            # PyomoModel at the beginning of the file due to a circular
+            # import.  When we rearchitect the solution writers/solver
+            # API, we should revisit this and remove the circular
+            # dependency (we only need it here because we store the
+            # SymbolMap returned by the writer in the solutions).
+            from pyomo.core.base.PyomoModel import ModelSolutions
+            self.solutions = ModelSolutions(self)
+        self.solutions.add_symbol_map(smap)
+
+        if __debug__ and logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Writing model '%s' to file '%s' with format %s",
+                self.name,
+                str(filename),
+                str(format))
+        return filename, smap_id
 
 
 class Block(ActiveIndexedComponent):

--- a/pyomo/core/tests/unit/solve1b.txt
+++ b/pyomo/core/tests/unit/solve1b.txt
@@ -1,58 +1,41 @@
 {
     "Problem": [
         {
-            "Lower bound": -1.33333333333333,
-            "Name": "unknown",
-            "Number of constraints": 2,
-            "Number of nonzeros": 5,
-            "Number of objectives": 1,
-            "Number of variables": 5,
-            "Sense": "minimize",
-            "Upper bound": -1.33333333333333
+            "Lower bound": 0.0, 
+            "Name": "unknown", 
+            "Number of constraints": 6, 
+            "Number of nonzeros": 9, 
+            "Number of objectives": 1, 
+            "Number of variables": 5, 
+            "Sense": "minimize", 
+            "Upper bound": 0.0
         }
-    ],
+    ], 
     "Solution": [
         {
-            "number of solutions": 1,
+            "number of solutions": 1, 
             "number of solutions displayed": 1
-        },
+        }, 
         {
-            "Constraint": "No values",
-            "Gap": 0.0,
-            "Message": null,
-            "Objective": {
-                "obj": {
-                    "Value": -1.333333333333333
-                }
-            },
-            "Problem": {},
-            "Status": "feasible",
-            "Variable": {
-                "x[1]": {
-                    "Value": -1.0
-                },
-                "x[2]": {
-                    "Value": -1.0
-                },
-                "x[3]": {
-                    "Value": -0.333333333333333
-                },
-                "x[4]": {
-                    "Value": 1.0
-                }
-            }
+            "Constraint": "No values", 
+            "Gap": 0.0, 
+            "Message": null, 
+            "Objective": {}, 
+            "Problem": {}, 
+            "Status": "feasible", 
+            "Variable": {}
         }
-    ],
+    ], 
     "Solver": [
         {
-            "Error rc": 0,
+            "Error rc": 0, 
             "Statistics": {
                 "Branch and bound": {
-                    "Number of bounded subproblems": 0,
+                    "Number of bounded subproblems": 0, 
                     "Number of created subproblems": 0
                 }
-            },
-            "Status": "ok",
+            }, 
+            "Status": "ok", 
             "Termination condition": "optimal"
         }
     ]

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -30,6 +30,8 @@ from pyomo.core.base.block import SimpleBlock
 from pyomo.core.base.expr import identify_variables
 from pyomo.opt import *
 
+solvers = check_available_solvers('glpk')
+
 
 class DerivedBlock(SimpleBlock):
     def __init__(self, *args, **kwargs):
@@ -1624,140 +1626,149 @@ class TestBlock(unittest.TestCase):
             sorted(id(x) for x in (m.x, m.y[1], nb.x, nb.y[1])),
         )
 
-
-    def Xtest_display(self):
-        self.block.A = RangeSet(1,4)
-        self.block.x = Var(self.block.A, bounds=(-1,1))
-        def obj_rule(block):
-            return summation(block.x)
-        self.block.obj = Objective(rule=obj_rule)
-        #self.instance = self.block.create_instance()
-        #self.block.pprint()
-        #self.block.display()
-
-    def Xtest_write2(self):
-        self.model.A = RangeSet(1,4)
-        self.model.x = Var(self.model.A, bounds=(-1,1))
+    @unittest.skipIf(not 'glpk' in solvers, "glpk solver is not available")
+    def test_solve1(self):
+        model = Block(concrete=True)
+        model.A = RangeSet(1,4)
+        model.x = Var(model.A, bounds=(-1,1))
         def obj_rule(model):
             return summation(model.x)
-        self.model.obj = Objective(rule=obj_rule)
-        def c_rule(model):
-            return (1, model.x[1]+model.x[2], 2)
-        self.model.c = Constraint(rule=c_rule)
-        self.instance = self.model.create_instance()
-        self.instance.write()
-
-    def Xtest_write3(self):
-        """Test that the summation works correctly, even though param 'w' has a default value"""
-        self.model.J = RangeSet(1,4)
-        self.model.w=Param(self.model.J, default=4)
-        self.model.x=Var(self.model.J)
-        def obj_rule(instance):
-            return summation(instance.x, instance.w)
-        self.model.obj = Objective(rule=obj_rule)
-        self.instance = self.model.create_instance()
-        self.assertEqual(len(self.instance.obj[None].expr._args), 4)
-
-    def Xtest_solve1(self):
-        self.model.A = RangeSet(1,4)
-        self.model.x = Var(self.model.A, bounds=(-1,1))
-        def obj_rule(model):
-            return summation(model.x)
-        self.model.obj = Objective(rule=obj_rule)
+        model.obj = Objective(rule=obj_rule)
         def c_rule(model):
             expr = 0
             for i in model.A:
                 expr += i*model.x[i]
             return expr == 0
-        self.model.c = Constraint(rule=c_rule)
-        self.instance = self.model.create_instance()
-        #self.instance.pprint()
-        opt = solver['glpk']
-        solutions = opt.solve(self.instance, keepfiles=True)
-        self.instance.load(solutions)
-        self.instance.display(join(currdir,"solve1.out"))
-        self.assertFileEqualsBaseline(join(currdir,"solve1.out"),join(currdir,"solve1.txt"))
+        model.c = Constraint(rule=c_rule)
+        opt = SolverFactory('glpk')
+        results = opt.solve(model, symbolic_solver_labels=True)
+        model.solutions.store_to(results)
+        results.write(filename=join(currdir,"solve1.out"), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve1.out"), join(currdir,"solve1.txt"),
+            tolerance=1e-4)
         #
         def d_rule(model):
-            return model.x[1] > 0
-        self.model.d = Constraint(rule=d_rule)
-        self.model.d.deactivate()
-        self.instance = self.model.create_instance()
-        solutions = opt.solve(self.instance, keepfiles=True)
-        self.instance.load(solutions)
-        self.instance.display(currdir+"solve1.out")
-        self.assertFileEqualsBaseline(currdir+"solve1.out",currdir+"solve1.txt")
+            return model.x[1] >= 0
+        model.d = Constraint(rule=d_rule)
+        model.d.deactivate()
+        results = opt.solve(model)
+        model.solutions.store_to(results)
+        results.write(filename=join(currdir,"solve1x.out"), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve1x.out"), join(currdir,"solve1.txt"),
+            tolerance=1e-4)
         #
-        self.model.d.activate()
-        self.instance = self.model.create_instance()
-        solutions = opt.solve(self.instance, keepfiles=True)
-        self.instance.load(solutions)
-        self.instance.display(join(currdir,"solve1.out"))
-        self.assertFileEqualsBaseline(join(currdir,"solve1.out"),join(currdir,"solve1a.txt"))
+        model.d.activate()
+        results = opt.solve(model)
+        model.solutions.store_to(results)
+        results.write(filename=join(currdir,"solve1a.out"), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve1a.out"), join(currdir,"solve1a.txt"),
+            tolerance=1e-4)
         #
-        self.model.d.deactivate()
-        def e_rule(i, model):
-            return model.x[i] > 0
-        self.model.e = Constraint(self.model.A, rule=e_rule)
-        self.instance = self.model.create_instance()
-        for i in self.instance.A:
-            self.instance.e[i].deactivate()
-        solutions = opt.solve(self.instance, keepfiles=True)
-        self.instance.load(solutions)
-        self.instance.display(join(currdir,"solve1.out"))
-        self.assertFileEqualsBaseline(join(currdir,"solve1.out"),join(currdir,"solve1b.txt"))
+        model.d.deactivate()
+        def e_rule(model, i):
+            return model.x[i] >= 0
+        model.e = Constraint(model.A, rule=e_rule)
+        for i in model.A:
+            model.e[i].deactivate()
+        results = opt.solve(model)
+        model.solutions.store_to(results)
+        results.write(filename=join(currdir,"solve1y.out"), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve1y.out"), join(currdir,"solve1.txt"),
+            tolerance=1e-4)
+        #
+        model.e.activate()
+        results = opt.solve(model)
+        model.solutions.store_to(results)
+        results.write(filename=join(currdir,"solve1b.out"), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve1b.out"), join(currdir,"solve1b.txt"),
+            tolerance=1e-4)
 
-    def Xtest_load1(self):
-        """Testing loading of vector solutions"""
-        self.model.A = RangeSet(1,4)
-        self.model.x = Var(self.model.A, bounds=(-1,1))
+    @unittest.skipIf(not 'glpk' in solvers, "glpk solver is not available")
+    def test_solve4(self):
+        model = Block(concrete=True)
+        model.A = RangeSet(1,4)
+        model.x = Var(model.A, bounds=(-1,1))
         def obj_rule(model):
             return summation(model.x)
-        self.model.obj = Objective(rule=obj_rule)
+        model.obj = Objective(rule=obj_rule)
         def c_rule(model):
             expr = 0
             for i in model.A:
                 expr += i*model.x[i]
             return expr == 0
-        self.model.c = Constraint(rule=c_rule)
-        self.instance = self.model.create_instance()
-        ans = [0.75]*4
-        self.instance.load(ans)
-        self.instance.display(join(currdir,"solve1.out"))
-        self.assertFileEqualsBaseline(join(currdir,"solve1.out"),join(currdir,"solve1c.txt"))
+        model.c = Constraint(rule=c_rule)
+        opt = SolverFactory('glpk')
+        results = opt.solve(model, symbolic_solver_labels=True)
+        model.solutions.store_to(results)
+        results.write(filename=join(currdir,'solve4.out'), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve4.out"), join(currdir,"solve1.txt"),
+            tolerance=1e-4)
 
-    def Xtest_solve3(self):
-        self.model.A = RangeSet(1,4)
-        self.model.x = Var(self.model.A, bounds=(-1,1))
-        def obj_rule(model):
-            expr = 0
-            for i in model.A:
-                expr += model.x[i]
-            return expr
-        self.model.obj = Objective(rule=obj_rule)
-        self.instance = self.model.create_instance()
-        self.instance.display(join(currdir,"solve1.out"))
-        self.assertFileEqualsBaseline(join(currdir,"solve1.out"),join(currdir,"solve3.txt"))
+    @unittest.skipIf(not 'glpk' in solvers, "glpk solver is not available")
+    def test_solve6(self):
+        #
+        # Test that solution values have complete block names:
+        #   b.obj
+        #   b.x
+        #
+        model = Block(concrete=True)
+        model.y = Var(bounds=(-1,1))
+        model.b = Block()
+        model.b.A = RangeSet(1,4)
+        model.b.x = Var(model.b.A, bounds=(-1,1))
+        def obj_rule(block):
+            return summation(block.x)
+        model.b.obj = Objective(rule=obj_rule)
+        def c_rule(model):
+            expr = model.y
+            for i in model.b.A:
+                expr += i*model.b.x[i]
+            return expr == 0
+        model.c = Constraint(rule=c_rule)
+        opt = SolverFactory('glpk')
+        results = opt.solve(model, symbolic_solver_labels=True)
+        model.solutions.store_to(results)
+        results.write(filename=join(currdir,'solve6.out'), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve6.out"), join(currdir,"solve6.txt"),
+            tolerance=1e-4)
 
-    def Xtest_solve4(self):
-        self.model.A = RangeSet(1,4)
-        self.model.x = Var(self.model.A, bounds=(-1,1))
+    @unittest.skipIf(not 'glpk' in solvers, "glpk solver is not available")
+    def test_solve7(self):
+        #
+        # Test that solution values are writen with appropriate
+        # quotations in results
+        #
+        model = Block(concrete=True)
+        model.y = Var(bounds=(-1,1))
+        model.A = RangeSet(1,4)
+        model.B = Set(initialize=['A B', 'C,D', 'E'])
+        model.x = Var(model.A, model.B, bounds=(-1,1))
         def obj_rule(model):
             return summation(model.x)
-        self.model.obj = Objective(rule=obj_rule)
+        model.obj = Objective(rule=obj_rule)
         def c_rule(model):
-            expr = 0
+            expr = model.y
             for i in model.A:
-                expr += i*model.x[i]
+                for j in model.B:
+                    expr += i*model.x[i,j]
             return expr == 0
-        self.model.c = Constraint(rule=c_rule)
-        self.instance = self.model.create_instance()
-        #self.instance.pprint()
-        opt = solver['glpk']
-        solutions = opt.solve(self.instance)
-        self.instance.load(solutions.solution(0))
-        self.instance.display(join(currdir,"solve1.out"))
-        self.assertFileEqualsBaseline(join(currdir,"solve1.out"),join(currdir,"solve1.txt"))
+        model.c = Constraint(rule=c_rule)
+        opt = SolverFactory('glpk')
+        results = opt.solve(model, symbolic_solver_labels=True)
+        #model.display()
+        model.solutions.store_to(results)
+        results.write(filename=join(currdir,'solve7.out'), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve7.out"), join(currdir,"solve7.txt"),
+            tolerance=1e-4)
+
 
     def test_abstract_index(self):
         model = AbstractModel()

--- a/pyomo/core/tests/unit/test_model.py
+++ b/pyomo/core/tests/unit/test_model.py
@@ -14,8 +14,8 @@
 
 import os
 import sys
-from os.path import abspath, dirname
-currdir = dirname(abspath(__file__))+os.sep
+from os.path import abspath, dirname, join
+currdir = dirname(abspath(__file__))
 import pickle
 import pyutilib.th as unittest
 import pyutilib.services
@@ -226,8 +226,10 @@ class Test(unittest.TestCase):
         opt = SolverFactory('glpk')
         results = opt.solve(model, keepfiles=True, symbolic_solver_labels=True)
         model.solutions.store_to(results)
-        results.write(filename=currdir+"solve1.out", format='json')
-        self.assertMatchesJsonBaseline(currdir+"solve1.out",currdir+"solve1.txt", tolerance=1e-4)
+        results.write(filename=join(currdir,"solve1.out"), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve1.out"), join(currdir,"solve1.txt"),
+            tolerance=1e-4)
         #
         def d_rule(model):
             return model.x[1] >= 0
@@ -235,14 +237,18 @@ class Test(unittest.TestCase):
         model.d.deactivate()
         results = opt.solve(model, keepfiles=True)
         model.solutions.store_to(results)
-        results.write(filename=currdir+"solve1x.out", format='json')
-        self.assertMatchesJsonBaseline(currdir+"solve1x.out",currdir+"solve1.txt", tolerance=1e-4)
+        results.write(filename=join(currdir,"solve1x.out"), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve1x.out"), join(currdir,"solve1.txt"),
+            tolerance=1e-4)
         #
         model.d.activate()
         results = opt.solve(model, keepfiles=True)
         model.solutions.store_to(results)
-        results.write(filename=currdir+"solve1a.out", format='json')
-        self.assertMatchesJsonBaseline(currdir+"solve1a.out",currdir+"solve1a.txt", tolerance=1e-4)
+        results.write(filename=join(currdir,"solve1a.out"), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve1a.out"), join(currdir,"solve1a.txt"),
+            tolerance=1e-4)
         #
         model.d.deactivate()
         def e_rule(model, i):
@@ -252,10 +258,20 @@ class Test(unittest.TestCase):
             model.e[i].deactivate()
         results = opt.solve(model, keepfiles=True)
         model.solutions.store_to(results)
-        results.write(filename=currdir+"solve1b.out", format='json')
-        self.assertMatchesJsonBaseline(currdir+"solve1b.out",currdir+"solve1b.txt", tolerance=1e-4)
+        results.write(filename=join(currdir,"solve1y.out"), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve1y.out"), join(currdir,"solve1.txt"),
+            tolerance=1e-4)
+        #
+        model.e.activate()
+        results = opt.solve(model, keepfiles=True)
+        model.solutions.store_to(results)
+        results.write(filename=join(currdir,"solve1b.out"), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve1b.out"), join(currdir,"solve1b.txt"),
+            tolerance=1e-4)
 
-    def test_solve3(self):
+    def test_display(self):
         model = ConcreteModel()
         model.A = RangeSet(1,4)
         model.x = Var(model.A, bounds=(-1,1))
@@ -265,8 +281,9 @@ class Test(unittest.TestCase):
                 expr += model.x[i]
             return expr
         model.obj = Objective(rule=obj_rule)
-        model.display(currdir+"solve3.out")
-        self.assertFileEqualsBaseline(currdir+"solve3.out",currdir+"solve3.txt")
+        model.display(join(currdir,"solve3.out"))
+        self.assertFileEqualsBaseline(
+            join(currdir,"solve3.out"), join(currdir,"solve3.txt"))
 
     @unittest.skipIf(not 'glpk' in solvers, "glpk solver is not available")
     def test_solve4(self):
@@ -285,8 +302,10 @@ class Test(unittest.TestCase):
         opt = SolverFactory('glpk')
         results = opt.solve(model, symbolic_solver_labels=True)
         model.solutions.store_to(results)
-        results.write(filename=currdir+'solve4.out', format='json')
-        self.assertMatchesJsonBaseline(currdir+"solve4.out",currdir+"solve1.txt", tolerance=1e-4)
+        results.write(filename=join(currdir,'solve4.out'), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve4.out"), join(currdir,"solve1.txt"),
+            tolerance=1e-4)
 
     @unittest.skipIf(not 'glpk' in solvers, "glpk solver is not available")
     def test_solve6(self):
@@ -312,13 +331,16 @@ class Test(unittest.TestCase):
         opt = SolverFactory('glpk')
         results = opt.solve(model, symbolic_solver_labels=True)
         model.solutions.store_to(results)
-        results.write(filename=currdir+'solve6.out', format='json')
-        self.assertMatchesJsonBaseline(currdir+"solve6.out", currdir+"solve6.txt", tolerance=1e-4)
+        results.write(filename=join(currdir,'solve6.out'), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve6.out"), join(currdir,"solve6.txt"),
+            tolerance=1e-4)
 
     @unittest.skipIf(not 'glpk' in solvers, "glpk solver is not available")
     def test_solve7(self):
         #
-        # Test that solution values are writen with appropriate quotations in results
+        # Test that solution values are writen with appropriate
+        # quotations in results
         #
         model = ConcreteModel()
         model.y = Var(bounds=(-1,1))
@@ -339,8 +361,10 @@ class Test(unittest.TestCase):
         results = opt.solve(model, symbolic_solver_labels=True)
         #model.display()
         model.solutions.store_to(results)
-        results.write(filename=currdir+'solve7.out', format='json')
-        self.assertMatchesJsonBaseline(currdir+"solve7.out", currdir+"solve7.txt", tolerance=1e-4)
+        results.write(filename=join(currdir,'solve7.out'), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve7.out"), join(currdir,"solve7.txt"),
+            tolerance=1e-4)
 
     def test_stats1(self):
         model = ConcreteModel()
@@ -449,12 +473,18 @@ class Test(unittest.TestCase):
         opt = SolverFactory('glpk')
         results = opt.solve(model, symbolic_solver_labels=True)
         #
-        results.write(filename=currdir+'solve_with_store1.out', format='yaml')
-        self.assertMatchesYamlBaseline(currdir+"solve_with_store1.out", currdir+"solve_with_store1.txt")
+        results.write(filename=join(currdir,'solve_with_store1.out'),
+                      format='yaml')
+        self.assertMatchesYamlBaseline(
+            join(currdir,"solve_with_store1.out"),
+            join(currdir,"solve_with_store1.txt"))
         model.solutions.store_to(results)
         #
-        results.write(filename=currdir+'solve_with_store2.out', format='yaml')
-        self.assertMatchesYamlBaseline(currdir+"solve_with_store2.out", currdir+"solve_with_store2.txt")
+        results.write(filename=join(currdir,'solve_with_store2.out'),
+                      format='yaml')
+        self.assertMatchesYamlBaseline(
+            join(currdir,"solve_with_store2.out"),
+            join(currdir,"solve_with_store2.txt"))
         #
         # Load results with string indices
         #
@@ -481,12 +511,18 @@ class Test(unittest.TestCase):
         opt = SolverFactory('glpk')
         results = opt.solve(model, symbolic_solver_labels=False)
         #
-        results.write(filename=currdir+'solve_with_store1.out', format='yaml')
-        self.assertMatchesYamlBaseline(currdir+"solve_with_store1.out", currdir+"solve_with_store1.txt")
+        results.write(filename=join(currdir,'solve_with_store1.out'),
+                      format='yaml')
+        self.assertMatchesYamlBaseline(
+            join(currdir,"solve_with_store1.out"),
+            join(currdir,"solve_with_store1.txt"))
         model.solutions.store_to(results)
         #
-        results.write(filename=currdir+'solve_with_store2.out', format='yaml')
-        self.assertMatchesYamlBaseline(currdir+"solve_with_store2.out", currdir+"solve_with_store2.txt")
+        results.write(filename=join(currdir,'solve_with_store2.out'),
+                      format='yaml')
+        self.assertMatchesYamlBaseline(
+            join(currdir,"solve_with_store2.out"),
+            join(currdir,"solve_with_store2.txt"))
         #
         # Load results with string indices
         #
@@ -512,19 +548,28 @@ class Test(unittest.TestCase):
         opt = SolverFactory('glpk')
         results = opt.solve(model)
         #
-        results.write(filename=currdir+'solve_with_store3.out', format='json')
-        self.assertMatchesYamlBaseline(currdir+"solve_with_store3.out", currdir+"solve_with_store3.txt")
+        results.write(filename=join(currdir,'solve_with_store3.out'),
+                      format='json')
+        self.assertMatchesYamlBaseline(
+            join(currdir,"solve_with_store3.out"),
+            join(currdir,"solve_with_store3.txt"))
         #
         model.solutions.store_to(results)
-        results.write(filename=currdir+'solve_with_store4.out', format='json')
-        self.assertMatchesYamlBaseline(currdir+"solve_with_store4.out", currdir+"solve_with_store4.txt")
+        results.write(filename=join(currdir,'solve_with_store4.out'),
+                      format='json')
+        self.assertMatchesYamlBaseline(
+            join(currdir,"solve_with_store4.out"),
+            join(currdir,"solve_with_store4.txt"))
         #
         # Test that we can pickle the results object
         #
         buf = pickle.dumps(results)
         results_ = pickle.loads(buf)
-        results.write(filename=currdir+'solve_with_store4.out', format='json')
-        self.assertMatchesYamlBaseline(currdir+"solve_with_store4.out", currdir+"solve_with_store4.txt")
+        results.write(filename=join(currdir,'solve_with_store4.out'),
+                      format='json')
+        self.assertMatchesYamlBaseline(
+            join(currdir,"solve_with_store4.out"),
+            join(currdir,"solve_with_store4.txt"))
         #
         # Load results with string indices
         #
@@ -551,16 +596,22 @@ class Test(unittest.TestCase):
         results = opt.solve(model)
         #
         model.solutions.store_to(results)
-        results.write(filename=currdir+'solve_with_store5.out', format='json')
-        self.assertMatchesYamlBaseline(currdir+"solve_with_store5.out", currdir+"solve_with_store4.txt")
+        results.write(filename=join(currdir,'solve_with_store5.out'),
+                      format='json')
+        self.assertMatchesYamlBaseline(
+            join(currdir,"solve_with_store5.out"),
+            join(currdir,"solve_with_store4.txt"))
         #
         model.solutions.store_to(results, cuid=True)
         buf = pickle.dumps(results)
         results_ = pickle.loads(buf)
         model.solutions.load_from(results_)
         model.solutions.store_to(results_)
-        results_.write(filename=currdir+'solve_with_store6.out', format='json')
-        self.assertMatchesYamlBaseline(currdir+"solve_with_store6.out", currdir+"solve_with_store4.txt")
+        results_.write(filename=join(currdir,'solve_with_store6.out'),
+                       format='json')
+        self.assertMatchesYamlBaseline(
+            join(currdir,"solve_with_store6.out"),
+            join(currdir,"solve_with_store4.txt"))
         #
         # Load results with string indices
         #
@@ -574,8 +625,11 @@ class Test(unittest.TestCase):
         tmodel.solutions.load_from(results)
         self.assertEqual(len(tmodel.solutions), 1)
         tmodel.solutions.store_to(results)
-        results.write(filename=currdir+'solve_with_store7.out', format='json')
-        self.assertMatchesYamlBaseline(currdir+"solve_with_store7.out", currdir+"solve_with_store4.txt")
+        results.write(filename=join(currdir,'solve_with_store7.out'),
+                      format='json')
+        self.assertMatchesYamlBaseline(
+            join(currdir,"solve_with_store7.out"),
+            join(currdir,"solve_with_store4.txt"))
 
     @unittest.skipIf(not 'glpk' in solvers, "glpk solver is not available")
     @unittest.skipIf(not yaml_available, "YAML not available available")
@@ -595,8 +649,11 @@ class Test(unittest.TestCase):
         self.assertEqual(len(results.solution), 1)
         #
         model.solutions.store_to(results)
-        results.write(filename=currdir+'solve_with_store8.out', format='json')
-        self.assertMatchesYamlBaseline(currdir+"solve_with_store8.out", currdir+"solve_with_store4.txt")
+        results.write(filename=join(currdir,'solve_with_store8.out'),
+                      format='json')
+        self.assertMatchesYamlBaseline(
+            join(currdir,"solve_with_store8.out"),
+            join(currdir,"solve_with_store4.txt"))
 
     @unittest.skipIf(not 'glpk' in solvers, "glpk solver is not available")
     @unittest.skipIf(not yaml_available, "YAML not available available")
@@ -618,8 +675,11 @@ class Test(unittest.TestCase):
         self.assertEqual(len(results.solution), 1)
         #
         model.solutions.store_to(results)
-        results.write(filename=currdir+'solve_with_store8.out', format='json')
-        self.assertMatchesYamlBaseline(currdir+"solve_with_store8.out", currdir+"solve_with_store4.txt")
+        results.write(filename=join(currdir,'solve_with_store8.out'),
+                      format='json')
+        self.assertMatchesYamlBaseline(
+            join(currdir,"solve_with_store8.out"),
+            join(currdir,"solve_with_store4.txt"))
 
 
     def test_create_concrete_from_rule(self):

--- a/pyomo/core/tests/unit/test_model.py
+++ b/pyomo/core/tests/unit/test_model.py
@@ -224,7 +224,7 @@ class Test(unittest.TestCase):
             return expr == 0
         model.c = Constraint(rule=c_rule)
         opt = SolverFactory('glpk')
-        results = opt.solve(model, keepfiles=True, symbolic_solver_labels=True)
+        results = opt.solve(model, symbolic_solver_labels=True)
         model.solutions.store_to(results)
         results.write(filename=join(currdir,"solve1.out"), format='json')
         self.assertMatchesJsonBaseline(
@@ -235,7 +235,7 @@ class Test(unittest.TestCase):
             return model.x[1] >= 0
         model.d = Constraint(rule=d_rule)
         model.d.deactivate()
-        results = opt.solve(model, keepfiles=True)
+        results = opt.solve(model)
         model.solutions.store_to(results)
         results.write(filename=join(currdir,"solve1x.out"), format='json')
         self.assertMatchesJsonBaseline(
@@ -243,7 +243,7 @@ class Test(unittest.TestCase):
             tolerance=1e-4)
         #
         model.d.activate()
-        results = opt.solve(model, keepfiles=True)
+        results = opt.solve(model)
         model.solutions.store_to(results)
         results.write(filename=join(currdir,"solve1a.out"), format='json')
         self.assertMatchesJsonBaseline(
@@ -256,7 +256,7 @@ class Test(unittest.TestCase):
         model.e = Constraint(model.A, rule=e_rule)
         for i in model.A:
             model.e[i].deactivate()
-        results = opt.solve(model, keepfiles=True)
+        results = opt.solve(model)
         model.solutions.store_to(results)
         results.write(filename=join(currdir,"solve1y.out"), format='json')
         self.assertMatchesJsonBaseline(
@@ -264,7 +264,7 @@ class Test(unittest.TestCase):
             tolerance=1e-4)
         #
         model.e.activate()
-        results = opt.solve(model, keepfiles=True)
+        results = opt.solve(model)
         model.solutions.store_to(results)
         results.write(filename=join(currdir,"solve1b.out"), format='json')
         self.assertMatchesJsonBaseline(


### PR DESCRIPTION
This allows arbitrary blocks to be solved as if they were models.

This addresses an IDAES need where we would like to be able to send arbitrary sub-blocks of a model to a solver (e.g., for sequential initialization of complex nonlinear models).  The fix is conceptually simple: just promote two methods from `Model` up to `_BlockData` (`valid_problem_types` and `write`).

This isn't the cleanest solution (in particular, it has a rather ugly circular import dependency).  However, it is simple and should work, at least until we have a chance / opportunity to re-architect the solver plugins and problem writers (ideally, this would eliminate the need for attaching `SymbolMap`s to the model (the cause of the circular imports).