### PR TITLE
Fix to expand Blocks indexed by a ContinuousSet

### DIFF
--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -15,7 +15,7 @@ from pyomo.core.base.misc import apply_indexed_rule
 from pyomo.core.base.block import _BlockData, IndexedBlock
 from pyomo.dae import *
 
-from six import iterkeys, itervalues
+from six import iterkeys, itervalues, iteritems
 
 logger = logging.getLogger('pyomo.core')
 
@@ -210,7 +210,7 @@ def _update_block(blk):
     
     # Code taken from the construct() method of Block
     missing_idx = set(blk._index)-set(iterkeys(blk._data))
-    for idx in missing_idx:
+    for idx in list(missing_idx):
         _block = blk[idx]
         obj = apply_indexed_rule(
             None, blk._rule, _block, idx, blk._options )
@@ -222,9 +222,9 @@ def _update_block(blk):
                 obj.del_component(c)
                 _block.add_component(c.local_name, c)
                 # transfer over any other attributes that are not components
-                for name, val in iteritems(obj.__dict__):
-                    if not hasattr(_block, name) and not hasattr(blk, name):
-                        super(_BlockData, _block).__setattr__(name, val)
+            for name, val in iteritems(obj.__dict__):
+                if not hasattr(_block, name) and not hasattr(blk, name):
+                    super(_BlockData, _block).__setattr__(name, val)
 
 def _update_piecewise(pw):
     """

--- a/pyomo/dae/tests/test_misc.py
+++ b/pyomo/dae/tests/test_misc.py
@@ -84,7 +84,7 @@ class TestDaeMisc(unittest.TestCase):
         self.assertTrue(t[1] == 0.4)
         self.assertTrue(t[13] == 5.4)
 
-    # test Params indexed only by a differentialset after discretizing
+    # test Params indexed only by a ContinuousSet after discretizing
     def test_discretized_params_single(self):
         m = ConcreteModel()
         m.t = ContinuousSet(bounds=(0,10))
@@ -166,7 +166,7 @@ class TestDaeMisc(unittest.TestCase):
         
         
     # test update_contset_indexed_component method for Vars with 
-    # single index of the differentialset
+    # single index of the ContinuousSet
     def test_update_contset_indexed_component_vars_single(self):
         m = ConcreteModel()
         m.t = ContinuousSet(bounds=(0,10))
@@ -248,7 +248,7 @@ class TestDaeMisc(unittest.TestCase):
         self.assertTrue(value(m.v3[6,1,1]) == 6)
 
     # test update_contset_indexed_component method for Constraints with
-    # single index of the differentialset
+    # single index of the ContinuousSet
     def test_update_contset_indexed_component_constraints_single(self):
         m = ConcreteModel()
         m.t = ContinuousSet(bounds=(0,10))
@@ -259,7 +259,7 @@ class TestDaeMisc(unittest.TestCase):
             return m.p[i]*m.v[i] <= 20
         m.con1 = Constraint(m.t, rule=_con1)
         
-        # Rules that iterate over a differentialset implicitly are not updated
+        # Rules that iterate over a ContinuouSet implicitly are not updated
         # after the discretization
         def _con2(m):
             return sum(m.v[i] for i in m.t) >= 0
@@ -335,8 +335,8 @@ class TestDaeMisc(unittest.TestCase):
         self.assertTrue(value(m.con3[2,0,2,1,1].lower) == None)
         self.assertTrue(value(m.con3[3,2,3,2,2].upper) == 20)                   
  
-    # test update_contset_indexed_component method for Constraints with
-    # single index of the differentialset
+    # test update_contset_indexed_component method for Expression with
+    # single index of the ContinuouSet
     def test_update_contset_indexed_component_expressions_single(self):
         m = ConcreteModel()
         m.t = ContinuousSet(bounds=(0,10))
@@ -347,7 +347,7 @@ class TestDaeMisc(unittest.TestCase):
             return m.p[i]*m.v[i]
         m.con1 = Expression(m.t, rule=_con1)
 
-        # Rules that iterate over a differentialset implicitly are not updated
+        # Rules that iterate over a ContinuousSet implicitly are not updated
         # after the discretization
         def _con2(m):
             return sum(m.v[i] for i in m.t)
@@ -364,7 +364,7 @@ class TestDaeMisc(unittest.TestCase):
         self.assertEqual(m.con1[8](), 15)
         self.assertEqual(m.con2(), 10)
 
-    # test update_contset_indexed_component method for Constraints with
+    # test update_contset_indexed_component method for Expressions with
     # multiple indices
     def test_update_contset_indexed_component_expressions_multiple(self):
         m = ConcreteModel()
@@ -416,6 +416,53 @@ class TestDaeMisc(unittest.TestCase):
         self.assertEqual(m.con3[1,4,1,2,2](), 0)
         self.assertEqual(m.con3[2,6,3,1,1](), -3)
         self.assertEqual(m.con3[3,8,2,2,2](), -6)
+
+    # test update_contset_indexed_component method for Blocks with
+    # multiple indices
+    def test_update_contset_indexed_component_block_multiple(self):
+        model = ConcreteModel()
+        model.t = ContinuousSet(bounds=(0,10))
+        model.s1 = Set(initialize=['A','B','C'])
+        model.s2 = Set(initialize=[('x1','x1'),('x2','x2')])
+
+        def _block_rule(b, t, s1):
+            m = b.model()
+            
+            def _init(m,i,j):
+                return j*2
+            b.p1 = Param(m.s1,m.t,mutable=True,default=_init)
+            b.v1 = Var(m.s1, m.t, initialize=5)
+            b.v2 = Var(m.s2,m.t,initialize=2)
+            b.v3 = Var(m.t,m.s2, initialize=1)
+
+            def _con1(_b,si,ti):
+                return _b.v1[si,ti]*_b.p1[si,ti] == _b.v1[si,t]**2
+            b.con1 = Constraint(m.s1,m.t,rule=_con1)
+
+            def _con2(_b,i,j,ti):
+                return _b.v2[i,j,ti] - _b.v3[ti,i,j] +_b.p1['A',ti]
+            b.con2 = Expression(m.s2,m.t,rule=_con2)
+    
+        model.blk = Block(model.t, model.s1, rule=_block_rule)
+        
+        self.assertTrue(len(model.blk),6)
+
+        generate_finite_elements(model.t,5)
+        update_contset_indexed_component(model.blk)
+
+        self.assertTrue(len(model.blk),18)
+        self.assertTrue(len(model.blk[10,'C'].con1),6)
+        self.assertTrue(len(model.blk[2,'B'].con1),18)
+        self.assertTrue(len(model.blk[10,'C'].v2),4)
+
+        self.assertEqual(model.blk[2,'A'].p1['A',2], 4)
+        self.assertEqual(model.blk[8,'C'].p1['B',6], 12)
+        
+        self.assertEqual(model.blk[4,'B'].con1['B',4](), 15)
+        self.assertEqual(model.blk[6,'A'].con1['C',8](), 55)
+
+        self.assertEqual(model.blk[0,'A'].con2['x1','x1',10](), 21)
+        self.assertEqual(model.blk[4,'C'].con2['x2','x2',6](), 13)
 
     # test update_contset_indexed_component method for other components
     def test_update_contset_indexed_component_other(self):


### PR DESCRIPTION
This pull request fixes #89 and modifies the "update ContinuousSet indexed component" logic to throw an error when an unrecognized ContinuousSet indexed component is encountered as suggested in #52. 