### PR TITLE
Restrict component names

### DIFF
--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -546,6 +546,8 @@ class Model(SimpleBlock):
 
     preprocessor_ep = ExtensionPoint(IPyomoPresolver)
 
+    _Block_reserved_words = set()
+
     def __new__(cls, *args, **kwds):
         if cls != Model:
             return super(Model, cls).__new__(cls)
@@ -980,6 +982,12 @@ class AbstractModel(Model):
     def __init__(self, *args, **kwds):
         Model.__init__(self, *args, **kwds)
 
+
+#
+# Create a Model and record all the default attributes, methods, etc.
+# These will be assumes to be the set of illegal component names.
+#
+Model._Block_reserved_words = set(dir(Model()))
 
 
 register_component(Model, 'Model objects can be used as a component of other models.')

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -987,7 +987,11 @@ class AbstractModel(Model):
 # Create a Model and record all the default attributes, methods, etc.
 # These will be assumes to be the set of illegal component names.
 #
-Model._Block_reserved_words = set(dir(Model()))
+# Note that creating a Model will result in a warning, so we will
+# (arbitrarily) choose a ConcreteModel as the definitive list of
+# reserved names.
+#
+Model._Block_reserved_words = set(dir(ConcreteModel()))
 
 
 register_component(Model, 'Model objects can be used as a component of other models.')

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -228,6 +228,7 @@ class _BlockData(ActiveComponentData):
     """
     This class holds the fundamental block data.
     """
+    _Block_reserved_words = set()
 
     class PseudoMap(object):
         """
@@ -793,9 +794,9 @@ class _BlockData(ActiveComponentData):
         if not val.valid_model_component():
             raise RuntimeError(
                 "Cannot add '%s' as a component to a block" % str(type(val)) )
-        if name in _Block_reserved_words:
+        if name in self._Block_reserved_words:
             raise ValueError("Attempting to declare a block component using "
-                             "the name of a reserved function:\n\t%s"
+                             "the name of a reserved attribute:\n\t%s"
                              % (name,) )
         if name in self.__dict__:
             raise RuntimeError(
@@ -1944,8 +1945,11 @@ def components_data( block, ctype, sort=None, sort_by_keys=False, sort_by_names=
     logger.warning("DEPRECATED: The components_data function is deprecated.  Use the Block.component_data_objects() method.")
     return block.component_data_objects(ctype=ctype, active=False, sort=sort)
 
-
-_Block_reserved_words = set(dir(Block()))
+#
+# Create a Block and record all the default attributes, methods, etc.
+# These will be assumes to be the set of illegal component names.
+#
+_BlockData._Block_reserved_words = set(dir(Block()))
 
 register_component(
     Block, "A component that contains one or more model components." )

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -792,7 +792,11 @@ class _BlockData(ActiveComponentData):
         #
         if not val.valid_model_component():
             raise RuntimeError(
-                "Cannot add '%s' as a component to a model" % str(type(val)) )
+                "Cannot add '%s' as a component to a block" % str(type(val)) )
+        if name in _Block_reserved_words:
+            raise ValueError("Attempting to declare a block component using "
+                             "the name of a reserved function:\n\t%s"
+                             % (name,) )
         if name in self.__dict__:
             raise RuntimeError(
                 "Cannot add component '%s' (type %s) to block '%s': a "
@@ -1940,6 +1944,8 @@ def components_data( block, ctype, sort=None, sort_by_keys=False, sort_by_names=
     logger.warning("DEPRECATED: The components_data function is deprecated.  Use the Block.component_data_objects() method.")
     return block.component_data_objects(ctype=ctype, active=False, sort=sort)
 
+
+_Block_reserved_words = set(dir(Block()))
 
 register_component(
     Block, "A component that contains one or more model components." )

--- a/pyomo/core/tests/unit/test_expression.py
+++ b/pyomo/core/tests/unit/test_expression.py
@@ -372,8 +372,8 @@ class TestExpression(unittest.TestCase):
         with self.assertRaises(KeyError):
             model.E[2] = 1
         model.del_component(model.E)
-        model.index = Set(dimen=3, initialize=[(1,2,3)])
-        model.E = Expression(model.index)
+        model.Index = Set(dimen=3, initialize=[(1,2,3)])
+        model.E = Expression(model.Index)
         model.E[(1,2,3)] = 1
         self.assertEqual(model.E[(1,2,3)], 1)
         # GH: testing this ludicrous behavior simply for
@@ -424,13 +424,13 @@ class TestExpression(unittest.TestCase):
 
     def test_indexed_construct_rule(self):
         model = ConcreteModel()
-        model.index = Set(initialize=[1,2,3])
+        model.Index = Set(initialize=[1,2,3])
         def _some_rule(model, i):
             if i == 1:
                 return Expression.Skip
             else:
                 return i
-        model.E = Expression(model.index,
+        model.E = Expression(model.Index,
                              rule=_some_rule)
         self.assertEqual(model.E.extract_values(),
                          {2:2, 3:3})
@@ -440,19 +440,19 @@ class TestExpression(unittest.TestCase):
 
     def test_indexed_construct_expr(self):
         model = ConcreteModel()
-        model.index = Set(initialize=[1,2,3])
-        model.E = Expression(model.index,
+        model.Index = Set(initialize=[1,2,3])
+        model.E = Expression(model.Index,
                              expr=Expression.Skip)
         self.assertEqual(len(model.E), 0)
-        model.E = Expression(model.index)
+        model.E = Expression(model.Index)
         self.assertEqual(model.E.extract_values(),
                          {1:None, 2:None, 3:None})
         model.del_component(model.E)
-        model.E = Expression(model.index, expr=1.0)
+        model.E = Expression(model.Index, expr=1.0)
         self.assertEqual(model.E.extract_values(),
                          {1:1.0, 2:1.0, 3:1.0})
         model.del_component(model.E)
-        model.E = Expression(model.index,
+        model.E = Expression(model.Index,
                              expr={1: Expression.Skip,
                                    2: Expression.Skip,
                                    3: 1.0})

--- a/pyomo/gdp/plugins/bilinear.py
+++ b/pyomo/gdp/plugins/bilinear.py
@@ -35,8 +35,8 @@ class Bilinear_Transformation(Transformation):
             instance.bilinear_data_ = Block()
             instance.bilinear_data_.vlist = VarList()
             instance.bilinear_data_.vlist_boolean = []
-            instance.bilinear_data_.index = Set()
-            instance.bilinear_data_.disjuncts_   = Disjunct(instance.bilinear_data_.index*[0,1])
+            instance.bilinear_data_.IDX = Set()
+            instance.bilinear_data_.disjuncts_   = Disjunct(instance.bilinear_data_.IDX*[0,1])
             instance.bilinear_data_.disjunction_data = {}
             instance.bilinear_data_.o_expr = {}
             instance.bilinear_data_.c_body = {}
@@ -51,7 +51,7 @@ class Bilinear_Transformation(Transformation):
         #
         def rule(block, i):
             return instance.bilinear_data_.disjunction_data[i]
-        instance.bilinear_data_.disjunction_ = Disjunction(instance.bilinear_data_.index, rule=rule)
+        instance.bilinear_data_.disjunction_ = Disjunction(instance.bilinear_data_.IDX, rule=rule)
 
     def _transformBlock(self, block, instance):
         for component in block.component_objects(Objective, active=True, descend_into=False):
@@ -99,7 +99,7 @@ class Bilinear_Transformation(Transformation):
                     v.setlb(bounds[0])
                     v.setub(bounds[1])
                     id = len(instance.bilinear_data_.vlist)
-                    instance.bilinear_data_.index.add(id)
+                    instance.bilinear_data_.IDX.add(id)
                     # First disjunct
                     d0 = instance.bilinear_data_.disjuncts_[id,0]
                     d0.c1 = Constraint(expr=vars[0] == 1)
@@ -121,7 +121,7 @@ class Bilinear_Transformation(Transformation):
                     v.setlb(bounds[0])
                     v.setub(bounds[1])
                     id = len(instance.bilinear_data_.vlist)
-                    instance.bilinear_data_.index.add(id)
+                    instance.bilinear_data_.IDX.add(id)
                     # First disjunct
                     d0 = instance.bilinear_data_.disjuncts_[id,0]
                     d0.c1 = Constraint(expr=vars[1] == 1)

--- a/pyomo/solvers/tests/core/test_component_perf.py
+++ b/pyomo/solvers/tests/core/test_component_perf.py
@@ -19,10 +19,10 @@ class ComponentPerformanceBase(object):
     def _create_model(self, ctype, **kwds):
         self.model = ConcreteModel()
         self.model.x = Var()
-        self.model.index = Set(initialize=sorted(range(1000000)))
+        self.model.IDX = Set(initialize=sorted(range(1000000)))
         self.model.del_component('test_component')
         self.model.test_component = \
-            ctype(self.model.index, **kwds)
+            ctype(self.model.IDX, **kwds)
 
     @classmethod
     def setUp(self):


### PR DESCRIPTION
We recently had a [question on StackOverflow](http://stackoverflow.com/questions/42834501/typeerror-cannot-compute-the-value-of-an-array-of-parameters) that highlighted a source of confusion with component names.  In this case, the user creates a Param names `type`.  This hid the `Block.type()` method which resulted in a very uninformative error message when the user attempted to solve the model.

This PR prevents users from declaring *components* that would override standard `Block` methods.  I originally thought about preventing ANY user-defined attributes from overriding built-in methods, but that proved to be difficult to implement (it causes a bit of a chicken & egg issue when `Block` methods update their own attributes).  So, a user could still shoot themselves in the foot by declaring non-component attributes that override the built-in methods.  I figure that that (a) is a pretty uncommon situation and (b) would be un-Pythonic if we prevented it.