### PR TITLE
Neos fixes: timeouts, error messages, CPLEX results

### DIFF
--- a/pyomo/neos/__init__.py
+++ b/pyomo/neos/__init__.py
@@ -33,3 +33,5 @@ doc = {
 'path':     'Nonlinear MCP solver',
 'snopt':    'SQP NLP solver'
 }
+
+import pyomo.neos.log_config

--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -66,9 +66,19 @@ class kestrelAMPL:
         self.setup_connection()
 
     def setup_connection(self):
-        if 'HTTP_PROXY' in os.environ:
+        # on *NIX, the proxy can show up either upper or lowercase.
+        # Prefer lower case, and prefer HTTPS over HTTP if the urlscheme
+        # is https.
+        proxy = os.environ.get(
+            'http_proxy', os.environ.get(
+                'HTTP_PROXY', ''))
+        if urlscheme == 'https':
+            proxy = os.environ.get(
+                'https_proxy', os.environ.get(
+                    'HTTPS_PROXY', proxy))
+        if proxy:
             p = ProxiedTransport()
-            p.set_proxy(os.environ['HTTP_PROXY'])
+            p.set_proxy(proxy)
             self.neos = xmlrpclib.ServerProxy(urlscheme+"://www.neos-server.org:"+port,transport=p)
         else:
             self.neos = xmlrpclib.ServerProxy(urlscheme+"://www.neos-server.org:"+port)

--- a/pyomo/neos/log_config.py
+++ b/pyomo/neos/log_config.py
@@ -8,8 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['DeveloperError']
-
 
 import logging
 from os.path import abspath, dirname, join, normpath
@@ -17,24 +15,7 @@ pyomo_base = normpath(join(dirname(abspath(__file__)), '..', '..', '..'))
 
 from pyutilib.misc import LogHandler
 
-logger = logging.getLogger('pyomo.util')
+logger = logging.getLogger('pyomo.neos')
 logger.setLevel( logging.WARNING )
 logger.addHandler( LogHandler(pyomo_base, verbosity=lambda: logger.isEnabledFor(logging.DEBUG)) )
-
-
-class DeveloperError(NotImplementedError):
-    """
-    Exception class used to throw errors that result from Pyomo
-    programming errors, rather than user modeling errors (e.g., a
-    component not declaring a 'ctype').
-    """
-
-    def __init__(self, val):
-        self.parameter = val
-
-    def __str__(self):
-        return ( "Internal Pyomo implementation error:\n\t%s\n"
-                 "\tPlease report this to the Pyomo Developers."
-                 % ( repr(self.parameter), ) )
-
 

--- a/pyomo/neos/plugins/kestrel_plugin.py
+++ b/pyomo/neos/plugins/kestrel_plugin.py
@@ -86,6 +86,14 @@ class SolverManager_NEOS(AsynchronousSolverManager):
         user_solver_options.update(
             OptSolver._options_string_to_dict(kwds.pop('options_string', '')))
 
+        # JDS: [5/13/17] The following is a HACK.  This timeout flag is
+        # set by pyomo/scripting/util.py:apply_optimizer.  If we do not
+        # remove it, it will get passed to the NEOS solver.  For solvers
+        # like CPLEX 12.7.0, this will cause a fatal error as it is not
+        # a known option.
+        if 'timelimit' in user_solver_options:
+            del user_solver_options['timelimit']
+
         opt = SolverFactory('_neos')
         opt._presolve(*args, **kwds)
         #

--- a/pyomo/neos/plugins/kestrel_plugin.py
+++ b/pyomo/neos/plugins/kestrel_plugin.py
@@ -93,8 +93,10 @@ class SolverManager_NEOS(AsynchronousSolverManager):
         # options must also go after these.
         if solver is not None:
             user_solver_options.update(solver.options)
-        user_solver_options.update(
-            kwds.pop('options', {}))
+        _options = kwds.pop('options', {})
+        if isinstance(_options, six.string_types):
+            _options = OptSolver._options_string_to_dict(_options)
+        user_solver_options.update(_options)
         user_solver_options.update(
             OptSolver._options_string_to_dict(kwds.pop('options_string', '')))
 

--- a/pyomo/neos/plugins/kestrel_plugin.py
+++ b/pyomo/neos/plugins/kestrel_plugin.py
@@ -203,11 +203,12 @@ class SolverManager_NEOS(AsynchronousSolverManager):
 
                 return ah
             else:
-                # Grab the partial messages from NEOS as you go, in case you want
-                # to output on-the-fly. We don't currently do this, but the infrastructure
-                # is in place.
+                # Grab the partial messages from NEOS as you go, in case
+                # you want to output on-the-fly. We don't currently do
+                # this, but the infrastructure is in place.
                 (current_offset, current_message) = self._neos_log[jobNumber]
-                # TBD: blocking isn't the way to go, but non-blocking was triggering some exception in kestrel.
+                # TBD: blocking isn't the way to go, but non-blocking
+                # was triggering some exception in kestrel.
                 (message_fragment, new_offset) = \
                     self.kestrel.neos.getIntermediateResults(jobNumber,
                                                              self._ah[jobNumber].password,

--- a/pyomo/neos/plugins/kestrel_plugin.py
+++ b/pyomo/neos/plugins/kestrel_plugin.py
@@ -91,7 +91,7 @@ class SolverManager_NEOS(AsynchronousSolverManager):
         # remove it, it will get passed to the NEOS solver.  For solvers
         # like CPLEX 12.7.0, this will cause a fatal error as it is not
         # a known option.
-        if 'timelimit' in user_solver_options:
+        if user_solver_options.get('timelimit',0) is None:
             del user_solver_options['timelimit']
 
         opt = SolverFactory('_neos')

--- a/pyomo/neos/plugins/kestrel_plugin.py
+++ b/pyomo/neos/plugins/kestrel_plugin.py
@@ -180,8 +180,7 @@ class SolverManager_NEOS(AsynchronousSolverManager):
             status = self.kestrel.neos.getJobStatus(jobNumber,
                                                     self._ah[jobNumber].password)
 
-            if not status in ("Running", "Waiting"):
-
+            if status not in ("Running", "Waiting"):
                 # the job is done.
                 ah = self._ah[jobNumber]
                 del self._ah[jobNumber]

--- a/pyomo/util/_config.py
+++ b/pyomo/util/_config.py
@@ -17,6 +17,10 @@ pyomo_base = normpath(join(dirname(abspath(__file__)), '..', '..', '..'))
 
 from pyutilib.misc import LogHandler
 
+logger = logging.getLogger('pyomo')
+logger.setLevel( logging.WARNING )
+logger.addHandler( LogHandler(pyomo_base, verbosity=lambda: logger.isEnabledFor(logging.DEBUG)) )
+
 logger = logging.getLogger('pyomo.util')
 logger.setLevel( logging.WARNING )
 logger.addHandler( LogHandler(pyomo_base, verbosity=lambda: logger.isEnabledFor(logging.DEBUG)) )


### PR DESCRIPTION
This has become a bit of an omnibus PR to fix problems with the NEOS interface:

* Define a log handler so we see logging information from namespaces other than `pyomo.core` and `pyomo.opt`
* Provide extra debugging information when things go bad
* remove the `timelimit` option from the solver options when its value is `None` (the default).  This fixes problems with running CPLEX without an explicit time limit (fixes the last of #122)
* improved proxy settings detection
* timeouts getting intermediate solutions for long-running jobs should not be fatal (fixes #125)