### PR TITLE
Add exponential function support to symbolic module and add documentation

### DIFF
--- a/pyomo/core/base/symbolic.py
+++ b/pyomo/core/base/symbolic.py
@@ -34,7 +34,8 @@ try:
     _operatorMap = {
         sympy.Add: _sum,
         sympy.Mul: _prod,
-        sympy.Pow: lambda x,y: x**y,
+        sympy.Pow: lambda x, y: x**y,
+        sympy.exp: lambda x: core.exp(x),
         sympy.log: lambda x: core.log(x),
         sympy.sin: lambda x: core.sin(x),
         sympy.asin: lambda x: core.asin(x),

--- a/pyomo/core/base/symbolic.py
+++ b/pyomo/core/base/symbolic.py
@@ -2,8 +2,8 @@
 #
 #  Pyomo: Python Optimization Modeling Objects
 #  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
-#  Under the terms of Contract DE-NA0003525 with National Technology and 
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
@@ -62,6 +62,21 @@ class NondifferentiableError(ValueError):
 
 
 def differentiate(expr, wrt=None, wrt_list=None):
+    """Return derivative of expression.
+
+    This function returns an expression or list of expression objects
+    corresponding to the derivative of the passed expression 'expr' with
+    respect to a variable 'wrt' or list of variables 'wrt_list'
+
+    Args:
+        expr (Expression): Pyomo expression
+        wrt (Var): Pyomo variable
+        wrt_list (list): list of Pyomo variables
+
+    Returns:
+        Expression or list of Expression objects
+
+    """
     if not _sympy_available:
         raise RuntimeError(
             "The sympy module is not available.  "

--- a/pyomo/core/tests/unit/test_symbolic.py
+++ b/pyomo/core/tests/unit/test_symbolic.py
@@ -2,8 +2,8 @@
 #
 #  Pyomo: Python Optimization Modeling Objects
 #  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
-#  Under the terms of Contract DE-NA0003525 with National Technology and 
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
@@ -21,7 +21,7 @@ def s(e):
     return str(e).replace(' ','')
 
 @unittest.skipIf( not _sympy_available,
-                  "Symbolic derivatives require teh sympy package" )
+                  "Symbolic derivatives require the sympy package" )
 class SymbolicDerivatives(unittest.TestCase):
     def test_single_derivatives(self):
         m = ConcreteModel()
@@ -176,6 +176,13 @@ class SymbolicDerivatives(unittest.TestCase):
         e = differentiate(log10(log10(m.x)), wrt=m.x)
         self.assertTrue(e.is_expression())
         self.assertEqual(s(e), s(1./log(10)*m.x**-1.*log(m.x)**-1.))
+
+        e = differentiate(exp(m.x), wrt=m.x)
+        self.assertTrue(e.is_expression())
+        self.assertEqual(s(e), s(exp(m.x)))
+
+        e = differentiate(exp(2 * m.x), wrt=m.x)
+        self.assertEqual(s(e), s(2 * exp(2 * m.x)))
 
 
     def test_nondifferentiable(self):


### PR DESCRIPTION
[Edit]: Also found out that for some reason, exp() wasn't in the operator map yet. This should fix that omission.

Documentation on differentiate() because I've had to explain to several people now what the function does.