### PR TITLE
Fix miscategorization of infeasible problems as unbounded in Gurobi

### DIFF
--- a/pyomo/solvers/plugins/solvers/GUROBI.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI.py
@@ -2,8 +2,8 @@
 #
 #  Pyomo: Python Optimization Modeling Objects
 #  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
-#  Under the terms of Contract DE-NA0003525 with National Technology and 
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
@@ -469,6 +469,16 @@ class GUROBISHELL(ILMLicensedSystemCallSolver):
                     elif (tokens[0] == 'termination_condition'):
                         try:
                             results.solver.termination_condition = getattr(TerminationCondition, tokens[1])
+                            if results.solver.termination_condition == TerminationCondition.unbounded:
+                                # If unbounded, need to check to make sure the
+                                # problem is not actually infeasible.
+                                if (results.problem.sense == ProblemSense.minimize and
+                                    results.problem.lower_bound == float('1e+100')) or \
+                                        (results.problem.sense == ProblemSense.maximize and
+                                         results.problem.upper_bound == float('-1e+100')):
+                                    # Problem is actually infeasible. Update accordingly.
+                                    results.solver.termination_condition = TerminationCondition.infeasible
+
                         except AttributeError:
                             results.solver.termination_condition = TerminationCondition.unknown
                     else:


### PR DESCRIPTION
Gurobi will sometimes report a termination condition of unbounded for problems that are actually infeasible. I had trouble getting a small test case to exhibit this behavior, but below is example output from a slightly larger problem. As you can see, `termination_condition` is `unbounded`, but `lower_bound` is `1e+100`. For comparison, output for an actual unbounded case is also included below. The `lower_bound` in that case is `-inf`. I use this distinction to write a small correction.

CPLEX also exhibits the same behavior, but I couldn't find an easy way to distinguish the infeasible case based on the solver output.

**Infeasible miscategorized as unbounded**
```
section:problem
name: x34
sense:minimize
lower_bound: 1e+100
number_of_objectives: 1
number_of_constraints: 89
number_of_variables: 34
number_of_binary_variables: 8
number_of_integer_variables: 8
number_of_continuous_variables: 26
number_of_nonzeros: 661
section:solver
status: warning
return_code: 0
message: Problem proven to be infeasible or unbounded.
wall_time: 0.00188493728638
termination_condition: unbounded
termination_message: Problem proven to be infeasible or unbounded.
```

**Actually unbounded**
```
section:problem
name: x2
sense:minimize
lower_bound: -inf
number_of_objectives: 1
number_of_constraints: 1
number_of_variables: 2
number_of_binary_variables: 0
number_of_integer_variables: 0
number_of_continuous_variables: 2
number_of_nonzeros: 1
section:solver
status: warning
return_code: 0
message: Problem proven to be infeasible or unbounded.
wall_time: 0.000164985656738
termination_condition: unbounded
termination_message: Problem proven to be infeasible or unbounded.
```