### PR TITLE
Add docstring to apply function in Transformation

### DIFF
--- a/pyomo/core/base/plugin.py
+++ b/pyomo/core/base/plugin.py
@@ -2,8 +2,8 @@
 #
 #  Pyomo: Python Optimization Modeling Objects
 #  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
-#  Under the terms of Contract DE-NA0003525 with National Technology and 
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
@@ -41,8 +41,8 @@ logger = logging.getLogger('pyomo.core')
 registered_callback = {}
 
 def pyomo_callback( name ):
-    """This is a decorator that declares a function to be 
-    a callback function.  The callback functions are 
+    """This is a decorator that declares a function to be
+    a callback function.  The callback functions are
     added to the solver when run from the pyomo script.
 
     Example:
@@ -311,6 +311,10 @@ class Transformation(Plugin):
         super(Transformation, self).__init__(**kwds)
 
     def apply(self, model, **kwds):
+        """DEPRECATION WARNING: Transformation.apply() has been deprecated.
+        Please use either Transformation.apply_to() for in-place
+        transformations or Transformation.create_using() for transformations
+        that create a new, independent transformed model instance."""
         logger.warning(
 """DEPRECATION WARNING: Transformation.apply() has been deprecated.
 Please use either Transformation.apply_to() for in-place transformations
@@ -359,5 +363,3 @@ def Xapply_transformation(*args, **kwds):
         return xfrm
     tmp=(args[1],)
     return xfrm.apply(*tmp, **kwds)
-
-


### PR DESCRIPTION
...so that users with IDEs can see the deprecation warning without trying to use the function or digging through the Pyomo codebase.