### PR TITLE
Changes to correct the settimelimit option

### DIFF
--- a/pyomo/opt/solver/shellcmd.py
+++ b/pyomo/opt/solver/shellcmd.py
@@ -300,7 +300,7 @@ class SystemCallSolver(OptSolver):
             [rc, log] = run(
                 command.cmd,
                 stdin = _input,
-                timelimit = self._timelimit,
+                timelimit = self._timelimit + max(1, 0.01*self._timelimit),
                 env   = command.env,
                 tee   = self._tee
              )

--- a/pyomo/opt/solver/shellcmd.py
+++ b/pyomo/opt/solver/shellcmd.py
@@ -300,7 +300,7 @@ class SystemCallSolver(OptSolver):
             [rc, log] = run(
                 command.cmd,
                 stdin = _input,
-                timelimit = self._timelimit + max(1, 0.01*self._timelimit),
+                timelimit = self._timelimit if self._timelimit is None else self._timelimit + max(1, 0.01*self._timelimit),
                 env   = command.env,
                 tee   = self._tee
              )

--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -266,7 +266,6 @@ class CBCSHELL(SystemCallSolver):
             if self._timelimit is not None and self._timelimit > 0.0:
                 cmd.extend(['-sec', str(self._timelimit)])
                 cmd.extend(['-timeMode', "elapsed"])
-                self._timelimit+=1
             if "debug" in self.options:
                 cmd.extend(["-log","5"])
             for key, val in _check_and_escape_options(self.options):
@@ -280,7 +279,6 @@ class CBCSHELL(SystemCallSolver):
             if self._timelimit is not None and self._timelimit > 0.0:
                 cmd.extend(['-sec', str(self._timelimit)])
                 cmd.extend(['-timeMode', "elapsed"])
-                self._timelimit+=1
             if "debug" in self.options:
                 cmd.extend(["-log","5"])
             # these must go after options that take a value

--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -264,7 +264,8 @@ class CBCSHELL(SystemCallSolver):
             cmd.append('-AMPL')
 
             if self._timelimit is not None and self._timelimit > 0.0:
-                cmd.extend(['-sec', str(self._timelimit)])
+                cmd.extend(['-sec', str(self._timelimit - 1 )])
+                cmd.extend(['-timeMode', "elapsed"])
             if "debug" in self.options:
                 cmd.extend(["-log","5"])
             for key, val in _check_and_escape_options(self.options):
@@ -276,7 +277,8 @@ class CBCSHELL(SystemCallSolver):
                         #"-stat"])
         else:
             if self._timelimit is not None and self._timelimit > 0.0:
-                cmd.extend(['-sec', str(self._timelimit)])
+                cmd.extend(['-sec', str(self._timelimit - 1 )])
+                cmd.extend(['-timeMode', "elapsed"])
             if "debug" in self.options:
                 cmd.extend(["-log","5"])
             # these must go after options that take a value

--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -264,8 +264,9 @@ class CBCSHELL(SystemCallSolver):
             cmd.append('-AMPL')
 
             if self._timelimit is not None and self._timelimit > 0.0:
-                cmd.extend(['-sec', str(self._timelimit - 1 )])
+                cmd.extend(['-sec', str(self._timelimit)])
                 cmd.extend(['-timeMode', "elapsed"])
+                self._timelimit+=1
             if "debug" in self.options:
                 cmd.extend(["-log","5"])
             for key, val in _check_and_escape_options(self.options):
@@ -277,8 +278,9 @@ class CBCSHELL(SystemCallSolver):
                         #"-stat"])
         else:
             if self._timelimit is not None and self._timelimit > 0.0:
-                cmd.extend(['-sec', str(self._timelimit - 1 )])
+                cmd.extend(['-sec', str(self._timelimit)])
                 cmd.extend(['-timeMode', "elapsed"])
+                self._timelimit+=1
             if "debug" in self.options:
                 cmd.extend(["-log","5"])
             # these must go after options that take a value


### PR DESCRIPTION
The timelimit is set to 1 sec lower than provided option to ensure CBC process gets time to exit properly before the pyutilib.subprocess.processmngr checks the exit code. In my test runs the process manager checked the exit status at T+0.02 seconds and CBC process typically exited after T+0.1 seconds.
Also changed the CBC code to use the wallclock seconds from the default of CPU seconds as the process manager is also checking the same.