### PR TITLE
Ignore IDE hidden directory for ropeproject in Atom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # IDE configuration files
 .idea
 .spyder*
+.ropeproject
 
 # Python generates numerous files when byte compiling / installing packages
 *.pyc


### PR DESCRIPTION
This is a really simple one.