### PR TITLE
Allow file objects for Data Input

### DIFF
--- a/pyomo/core/base/DataPortal.py
+++ b/pyomo/core/base/DataPortal.py
@@ -61,6 +61,12 @@ class DataPortal(object):
             self.connect(filename=filename, **kwds)
             self.load()
             self.disconnect()
+        # Or load data from a file object (e.g. StringIO)
+        if 'file_object' in kwds:
+            file_object = kwds.pop('file_object')
+            self.connect(file_object=file_object, **kwds)
+            self.load()
+            self.disconnect()
         # Or load data from a dictionary
         elif 'data_dict' in kwds:
             data = kwds.pop('data_dict')
@@ -87,6 +93,8 @@ class DataPortal(object):
             data = kwds.get('filename',None)
         if data is None:
             data = kwds.get('server',None)
+        if data is None:
+            data = 'file_object'
         if '.' in data:
             tmp = data.split(".")[-1]
         else:

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -785,6 +785,8 @@ arguments (which have been ignored):"""
             dp = arg
         elif type(arg) is dict:
             dp = DataPortal(data_dict=arg, model=self)
+        elif hasattr(arg, 'read'):
+            dp = DataPortal(file_object=arg, model=self)
         elif isinstance(arg, SolverResults):
             if len(arg.solution):
                 logger.warning(

--- a/pyomo/core/data/process_data.py
+++ b/pyomo/core/data/process_data.py
@@ -586,7 +586,10 @@ def _process_include(cmd, _model, _data, _default, options=None):
     Lineno = 0
 
     try:
-        scenarios = parse_data_commands(filename=cmd[1])
+        if 'file_object' in cmd:
+            scenarios = parse_data_commands(data=options['file_object'].read())
+        else:
+            scenarios = parse_data_commands(filename=cmd[1])
     except IOError:
         raise
         err = sys.exc_info()[1]

--- a/pyomo/core/plugins/data/datacommands.py
+++ b/pyomo/core/plugins/data/datacommands.py
@@ -67,3 +67,51 @@ class PyomoDataCommands(Plugin):
 
     def clear(self):
         self._info = []
+
+
+class PyomoDataCommandsFileObject(Plugin):
+
+    alias("file_object", "Pyomo data command file object interface")
+
+    implements(IDataManager, service=False)
+
+    def __init__(self):
+        self._info = []
+        self.options = Options()
+
+    def available(self):
+        return True
+
+    def initialize(self, **kwds):
+        self.add_options(**kwds)
+
+    def add_options(self, **kwds):
+        self.options.update(kwds)
+
+    def open(self):
+        pass
+
+    def close(self):
+        pass
+
+    def read(self):
+        """
+        This function does nothing, since executing Pyomo data commands
+        both reads and processes the data all at once.
+        """
+        pass
+
+    def write(self, data):                      #pragma:nocover
+        """
+        This function does nothing, because we cannot write to a *.dat file.
+        """
+        pass
+
+    def process(self, model, data, default):
+        """
+        Read Pyomo data commands and process the data.
+        """
+        _process_include(['include', 'file_object'], model, data, default, self.options)
+
+    def clear(self):
+        self._info = []

--- a/pyomo/core/tests/unit/test_file_object.py
+++ b/pyomo/core/tests/unit/test_file_object.py
@@ -1,0 +1,36 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+import io
+import unittest
+
+import pyomo.environ as pe
+
+
+class TestFileObject(unittest.TestCase):
+
+    @staticmethod
+    def test_file_object():
+        model = pe.AbstractModel()
+
+        model.n = pe.Param()
+        model.days_horizon = pe.Param()
+        model.delta_t = pe.Param()
+
+        input_dat = io.StringIO("""
+        param n := 672 ;
+        param days_horizon := 7 ;
+        param delta_t := 0.25 ;
+        """)
+        model.create_instance(input_dat)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* pyomo/core/base/PyomoModel.py (Model.load): DataPortal init for file
  object.

* pyomo/core/base/DataPortal.py (DataPortal.__init__): Discriminate on
  file object in kwargs and pass to DataManagerFactory.

* pyomo/core/data/process_data.py (_process_include): Pass data directly
  from file object to parse_data_commands.

* pyomo/core/plugins/data/datacommands.py: Explicit new file object to
  distinguish between .dat files and file objects.

* pyomo/core/tests/unit/test_file_object.py: Test if io.StringIO file object is
  valid for creating an abstract model instance.

Closes #283