### PR TITLE
add logfile option to GAMS solver

### DIFF
--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -741,7 +741,10 @@ class GAMSShell(pyomo.util.plugin.Plugin):
         exe = self.executable()
         command = [exe, output_filename, 'o=' + lst_filename]
         if tee and not logfile:
-            pass  # default behaviour of gams is to print to console
+            # default behaviour of gams is to print to console, for
+            # compatability with windows and *nix we want to explicitly log to
+            # stdout (see https://www.gams.com/latest/docs/UG_GamsCall.html)
+            command.append("lo=3")
         elif not tee and not logfile:
             command.append("lo=0")
         elif not tee and logfile:

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -10,7 +10,7 @@
 
 from six import StringIO, iteritems, itervalues
 from tempfile import mkdtemp
-import os, sys, subprocess, math, logging, shutil, time
+import os, sys, math, logging, shutil, time
 
 from pyomo.core.base import (Constraint, Suffix, Var, value,
                              Expression, Objective)
@@ -752,7 +752,7 @@ class GAMSShell(pyomo.util.plugin.Plugin):
             command.append("lf=" + str(logfile))
 
         try:
-            rc = subprocess.call(command)
+            rc, _ = pyutilib.subprocess.run(command)
 
             if keepfiles:
                 print("\nGAMS WORKING DIRECTORY: %s\n" % tmpdir)

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -619,6 +619,8 @@ class GAMSShell(pyomo.util.plugin.Plugin):
 
         tee=False:
             Output GAMS log to stdout.
+        logfile=None:
+            Optionally a logfile can be written.
         load_solutions=True:
             Optionally skip loading solution into model, in which case
             the results object will contain the solution data.
@@ -669,6 +671,7 @@ class GAMSShell(pyomo.util.plugin.Plugin):
 
         load_solutions = kwds.pop("load_solutions", True)
         tee            = kwds.pop("tee", False)
+        logfile        = kwds.pop("logfile", None)
         keepfiles      = kwds.pop("keepfiles", False)
         tmpdir         = kwds.pop("tmpdir", None)
         report_timing  = kwds.pop("report_timing", False)
@@ -733,8 +736,14 @@ class GAMSShell(pyomo.util.plugin.Plugin):
 
         exe = self.executable()
         command = [exe, output_filename, 'o=' + lst_filename]
-        if not tee:
+        if not tee and not logfile:
             command.append("lo=0")
+        elif not tee and logfile:
+            command.append("lo=2")
+        elif tee and logfile:
+            command.append("lo=4")
+        if logfile:
+            command.append("lf=" + str(logfile))
 
         try:
             rc = subprocess.call(command)

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -1075,26 +1075,29 @@ class OutputStream:
 
     def __enter__(self):
         """Enter context of output stream and open logfile if given."""
-        if self.logfile:
+        if self.logfile is not None:
             self.logfile_buffer = open(self.logfile, 'a')
         return self
 
     def __exit__(self, *args, **kwargs):
         """Enter context of output stream and close logfile if necessary."""
-        if self.logfile_buffer:
+        if self.logfile_buffer is not None:
             self.logfile_buffer.close()
         self.logfile_buffer = None
 
     def write(self, message):
         """Write messages to all streams."""
-        if self.tee:
+        if self.tee is not None:
             self.tee.write(message)
-        if self.logfile_buffer:
+        if self.logfile_buffer is not None:
             self.logfile_buffer.write(message)
 
     def flush(self):
         """Needed for python3 compatibility."""
-        pass
+        if self.tee is not None:
+            self.tee.flush()
+        if self.logfile_buffer is not None:
+            self.logfile_buffer.flush()
 
 
 def check_expr_evaluation(model, symbolMap, solver_io):

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -740,7 +740,9 @@ class GAMSShell(pyomo.util.plugin.Plugin):
 
         exe = self.executable()
         command = [exe, output_filename, 'o=' + lst_filename]
-        if not tee and not logfile:
+        if tee and not logfile:
+            pass  # default behaviour of gams is to print to console
+        elif not tee and not logfile:
             command.append("lo=0")
         elif not tee and logfile:
             command.append("lo=2")

--- a/pyomo/solvers/tests/checks/test_GAMS.py
+++ b/pyomo/solvers/tests/checks/test_GAMS.py
@@ -165,14 +165,7 @@ class GAMSTests(unittest.TestCase):
 
             shutil.rmtree(tmpdir)
 
-
-@unittest.skipIf(not gamsgms_available, "The 'gams' executable is not available")
-class GAMSLogfileTests(unittest.TestCase):
-    """Test class for testing permultations of tee and logfile options.
-
-    The tests build a simple model and solve it using the different options.
-    """
-
+class GAMSLogfileTestBase(unittest.TestCase):
     def setUp(self):
         """Set up model and temporary directory."""
         m = ConcreteModel()
@@ -186,62 +179,6 @@ class GAMSLogfileTests(unittest.TestCase):
     def tearDown(self):
         """Clean up temporary directory after tests are over."""
         shutil.rmtree(self.tmpdir)
-
-    def test_no_tee_gms(self):
-        with SolverFactory("gams", solver_io="gms") as opt:
-            with redirected_subprocess_call() as output:
-                opt.solve(self.m, tee=False)
-        self.assertFalse(output.getvalue())
-        self._check_logfile(exists=False)
-
-    def test_tee_gms(self):
-        with SolverFactory("gams", solver_io="gms") as opt:
-            with redirected_subprocess_call() as output:
-                opt.solve(self.m, tee=True)
-        self.assertTrue(output.getvalue())
-        self._check_logfile(exists=False)
-
-    def test_logfile_gms(self):
-        with SolverFactory("gams", solver_io="gms") as opt:
-            with redirected_subprocess_call() as output:
-                opt.solve(self.m, logfile=self.logfile)
-        self.assertFalse(output.getvalue())
-        self._check_logfile(exists=True)
-
-    def test_tee_and_logfile_gms(self):
-        with SolverFactory("gams", solver_io="gms") as opt:
-            with redirected_subprocess_call() as output:
-                opt.solve(self.m, logfile=self.logfile, tee=True)
-        self.assertTrue(output.getvalue())
-        self._check_logfile(exists=True, expected=output.getvalue())
-
-    def test_no_tee_py(self):
-        with SolverFactory("gams", solver_io="python") as opt:
-            with redirected_stdout() as output:
-                opt.solve(self.m, tee=False)
-        self.assertFalse(output.getvalue())
-        self._check_logfile(exists=False)
-
-    def test_tee_py(self):
-        with SolverFactory("gams", solver_io="python") as opt:
-            with redirected_stdout() as output:
-                opt.solve(self.m, tee=True)
-        self.assertTrue(output.getvalue())
-        self._check_logfile(exists=False)
-
-    def test_logfile_py(self):
-        with SolverFactory("gams", solver_io="python") as opt:
-            with redirected_stdout() as output:
-                opt.solve(self.m, logfile=self.logfile)
-        self._check_logfile(exists=True)
-        self.assertFalse(output.getvalue())
-
-    def test_tee_and_logfile_py(self):
-        with SolverFactory("gams", solver_io="python") as opt:
-            with redirected_stdout() as output:
-                opt.solve(self.m, logfile=self.logfile, tee=True)
-        self.assertTrue(output.getvalue())
-        self._check_logfile(exists=True, expected=output.getvalue())
 
     def _check_logfile(self, exists=True, expected=None):
         """Check for logfiles existence and contents.
@@ -262,6 +199,82 @@ class GAMSLogfileTests(unittest.TestCase):
         self.assertTrue(logfile_contents)
         if expected:
             self.assertEqual(logfile_contents, expected)
+
+
+@unittest.skipIf(not gamsgms_available, "The 'gams' executable is not available")
+class GAMSLogfileGmsTests(GAMSLogfileTestBase):
+    """Test class for testing permultations of tee and logfile options.
+
+    The tests build a simple model and solve it using the different options
+    using the gams command directly.
+
+    """
+
+    def test_no_tee(self):
+        with SolverFactory("gams", solver_io="gms") as opt:
+            with redirected_subprocess_call() as output:
+                opt.solve(self.m, tee=False)
+        self.assertFalse(output.getvalue())
+        self._check_logfile(exists=False)
+
+    def test_tee(self):
+        with SolverFactory("gams", solver_io="gms") as opt:
+            with redirected_subprocess_call() as output:
+                opt.solve(self.m, tee=True)
+        self.assertTrue(output.getvalue())
+        self._check_logfile(exists=False)
+
+    def test_logfile(self):
+        with SolverFactory("gams", solver_io="gms") as opt:
+            with redirected_subprocess_call() as output:
+                opt.solve(self.m, logfile=self.logfile)
+        self.assertFalse(output.getvalue())
+        self._check_logfile(exists=True)
+
+    def test_tee_and_logfile(self):
+        with SolverFactory("gams", solver_io="gms") as opt:
+            with redirected_subprocess_call() as output:
+                opt.solve(self.m, logfile=self.logfile, tee=True)
+        self.assertTrue(output.getvalue())
+        self._check_logfile(exists=True, expected=output.getvalue())
+
+
+@unittest.skipIf(not gamspy_available, "The 'gams' python bindings are not available")
+class GAMSLogfilePyTests(GAMSLogfileTestBase):
+    """Test class for testing permultations of tee and logfile options.
+
+    The tests build a simple model and solve it using the different options
+    using the python gams bindings.
+
+    """
+
+    def test_no_tee(self):
+        with SolverFactory("gams", solver_io="python") as opt:
+            with redirected_stdout() as output:
+                opt.solve(self.m, tee=False)
+        self.assertFalse(output.getvalue())
+        self._check_logfile(exists=False)
+
+    def test_tee(self):
+        with SolverFactory("gams", solver_io="python") as opt:
+            with redirected_stdout() as output:
+                opt.solve(self.m, tee=True)
+        self.assertTrue(output.getvalue())
+        self._check_logfile(exists=False)
+
+    def test_logfile(self):
+        with SolverFactory("gams", solver_io="python") as opt:
+            with redirected_stdout() as output:
+                opt.solve(self.m, logfile=self.logfile)
+        self._check_logfile(exists=True)
+        self.assertFalse(output.getvalue())
+
+    def test_tee_and_logfile(self):
+        with SolverFactory("gams", solver_io="python") as opt:
+            with redirected_stdout() as output:
+                opt.solve(self.m, logfile=self.logfile, tee=True)
+        self.assertTrue(output.getvalue())
+        self._check_logfile(exists=True, expected=output.getvalue())
 
 
 @contextlib.contextmanager

--- a/pyomo/solvers/tests/checks/test_GAMS.py
+++ b/pyomo/solvers/tests/checks/test_GAMS.py
@@ -162,5 +162,53 @@ class GAMSTests(unittest.TestCase):
 
             shutil.rmtree(tmpdir)
 
+
+class GAMSTests(unittest.TestCase):
+    """Test class for testing permultations of tee and logfile options.
+
+    The tests build a simple model and solve it using the different options.
+    """
+
+    def setUp(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.c = Constraint(expr= m.x >= 10)
+        m.o = Objective(expr= m.x)
+        self.m = m
+        self.tmpdir = mkdtemp()
+        self.logfile = os.path.join(self.tmpdir, 'logfile.log')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    @unittest.skipIf(not gamsgms_available,
+                     "The 'gams' executable is not available")
+    def test_tee_gms(self):
+        with SolverFactory("gams", solver_io="gms") as opt:
+            opt.solve(self.m, tee=False)
+            self.assertFalse(os.path.exists(self.logfile))
+
+    @unittest.skipIf(not gamsgms_available,
+                     "The 'gams' executable is not available")
+    def test_no_tee_gms(self):
+        with SolverFactory("gams", solver_io="gms") as opt:
+            opt.solve(self.m, tee=True)
+            self.assertFalse(os.path.exists(self.logfile))
+
+    @unittest.skipIf(not gamsgms_available,
+                     "The 'gams' executable is not available")
+    def test_logfile_gms(self):
+        with SolverFactory("gams", solver_io="gms") as opt:
+            opt.solve(self.m, logfile=self.logfile)
+            self.assertTrue(os.path.exists(self.logfile))
+
+    @unittest.skipIf(not gamsgms_available,
+                     "The 'gams' executable is not available")
+    def test_tee_and_logfile_gms(self):
+        with SolverFactory("gams", solver_io="gms") as opt:
+            opt.solve(self.m, logfile=self.logfile, tee=True)
+            self.assertTrue(os.path.exists(self.logfile))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/solvers/tests/checks/test_GAMS.py
+++ b/pyomo/solvers/tests/checks/test_GAMS.py
@@ -176,6 +176,7 @@ class GAMSLogfileTestBase(unittest.TestCase):
         self.tmpdir = mkdtemp()
         self.logfile = os.path.join(self.tmpdir, 'logfile.log')
         self.characteristic_output_string = "Starting compilation"
+
     def tearDown(self):
         """Clean up temporary directory after tests are over."""
         shutil.rmtree(self.tmpdir)
@@ -280,7 +281,6 @@ class GAMSLogfilePyTests(GAMSLogfileTestBase):
                 opt.solve(self.m, logfile=self.logfile)
         self._check_stdout(output.getvalue(), exists=False)
         self._check_logfile(exists=True)
-        self.assertFalse(output.getvalue())
 
     def test_tee_and_logfile(self):
         with SolverFactory("gams", solver_io="python") as opt:

--- a/pyomo/solvers/tests/checks/test_GAMS.py
+++ b/pyomo/solvers/tests/checks/test_GAMS.py
@@ -163,13 +163,15 @@ class GAMSTests(unittest.TestCase):
             shutil.rmtree(tmpdir)
 
 
-class GAMSTests(unittest.TestCase):
+@unittest.skipIf(not gamsgms_available, "The 'gams' executable is not available")
+class GAMSLogfileTests(unittest.TestCase):
     """Test class for testing permultations of tee and logfile options.
 
     The tests build a simple model and solve it using the different options.
     """
 
     def setUp(self):
+        """Set up model and temporary directory."""
         m = ConcreteModel()
         m.x = Var()
         m.c = Constraint(expr= m.x >= 10)
@@ -179,31 +181,24 @@ class GAMSTests(unittest.TestCase):
         self.logfile = os.path.join(self.tmpdir, 'logfile.log')
 
     def tearDown(self):
+        """Clean up temporary directory after tests are over."""
         shutil.rmtree(self.tmpdir)
 
-    @unittest.skipIf(not gamsgms_available,
-                     "The 'gams' executable is not available")
     def test_tee_gms(self):
         with SolverFactory("gams", solver_io="gms") as opt:
             opt.solve(self.m, tee=False)
             self.assertFalse(os.path.exists(self.logfile))
 
-    @unittest.skipIf(not gamsgms_available,
-                     "The 'gams' executable is not available")
     def test_no_tee_gms(self):
         with SolverFactory("gams", solver_io="gms") as opt:
             opt.solve(self.m, tee=True)
             self.assertFalse(os.path.exists(self.logfile))
 
-    @unittest.skipIf(not gamsgms_available,
-                     "The 'gams' executable is not available")
     def test_logfile_gms(self):
         with SolverFactory("gams", solver_io="gms") as opt:
             opt.solve(self.m, logfile=self.logfile)
             self.assertTrue(os.path.exists(self.logfile))
 
-    @unittest.skipIf(not gamsgms_available,
-                     "The 'gams' executable is not available")
     def test_tee_and_logfile_gms(self):
         with SolverFactory("gams", solver_io="gms") as opt:
             opt.solve(self.m, logfile=self.logfile, tee=True)

--- a/pyomo/solvers/tests/checks/test_GAMS.py
+++ b/pyomo/solvers/tests/checks/test_GAMS.py
@@ -184,12 +184,12 @@ class GAMSLogfileTests(unittest.TestCase):
         """Clean up temporary directory after tests are over."""
         shutil.rmtree(self.tmpdir)
 
-    def test_tee_gms(self):
+    def test_no_tee_gms(self):
         with SolverFactory("gams", solver_io="gms") as opt:
             opt.solve(self.m, tee=False)
             self.assertFalse(os.path.exists(self.logfile))
 
-    def test_no_tee_gms(self):
+    def test_tee_gms(self):
         with SolverFactory("gams", solver_io="gms") as opt:
             opt.solve(self.m, tee=True)
             self.assertFalse(os.path.exists(self.logfile))


### PR DESCRIPTION
This would add an option for specifying a custom logfile for the GAMS command line solver.  The other solvers seem to support such an option and it is quite useful if one want more control over the logfiles destination.