### PR TITLE
Better CL options and faster soln file parsing

### DIFF
--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -546,8 +546,16 @@ class CBCSHELL(SystemCallSolver):
                 elif constraint[:2] == 'r_':
                     # For the range constraints, supply only the dual with the largest
                     # magnitude (at least one should always be numerically zero)
-                    if abs(constraint_dual) > 0:
-                        #use same key for r_u_ and r_l_
+                    existing_constraint_dual_dict = solution.constraint.get( 'r_l_' + constraint[4:], None )
+                    if existing_constraint_dual_dict:
+                        # if a constraint dual is already saved, then update it if its
+                        # magnitude is larger than existing; this avoids checking vs
+                        # zero (avoiding problems with solver tolerances)
+                        existing_constraint_dual = existing_constraint_dual_dict["Dual"]
+                        if abs( constraint_dual) > abs(existing_constraint_dual):
+                            solution.constraint[ 'r_l_' + constraint[4:] ] = {"Dual": constraint_dual}
+                    else:
+                        # if no constraint with that name yet, just save it in the solution constraint dictionary
                         solution.constraint[ 'r_l_' + constraint[4:] ] = {"Dual": constraint_dual}
 
             elif processing_constraints is False:

--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -561,10 +561,10 @@ class CBCSHELL(SystemCallSolver):
                                        "in CBC solution file - line="+line)
 
                 variable_name = tokens[1]
-                variable_value = eval(tokens[2])
+                variable_value = float(tokens[2])
                 variable = solution.variable[variable_name] = {"Value" : variable_value}
                 if extract_reduced_costs is True:
-                    variable_reduced_cost = eval(tokens[3]) # currently ignored.
+                    variable_reduced_cost = float(tokens[3]) # currently ignored.
                     variable["Rc"] = variable_reduced_cost
 
             elif header_processed is True:

--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -544,11 +544,12 @@ class CBCSHELL(SystemCallSolver):
                 constraint = tokens[1]
                 constraint_ax = float(tokens[2]) # CBC reports the constraint row times the solution vector - not the slack.
                 constraint_dual = float(tokens[3])
-                if constraint.startswith('c_'):
+#                print( range_duals)
+                if constraint[:2] == 'c_':
                     solution.constraint[constraint] = {"Dual" : constraint_dual}
-                elif constraint.startswith('r_l_'):
+                elif constraint[:4] == 'r_l_':
                     range_duals.setdefault(constraint[4:],[0,0])[0] = constraint_dual
-                elif constraint.startswith('r_u_'):
+                elif constraint[:4] == 'r_u_':
                     range_duals.setdefault(constraint[4:],[0,0])[1] = constraint_dual
 
             elif processing_constraints is False:

--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -546,10 +546,10 @@ class CBCSHELL(SystemCallSolver):
                 constraint_dual = float(tokens[3])
                 if constraint.startswith('c_'):
                     solution.constraint[constraint] = {"Dual" : constraint_dual}
-                # elif constraint.startswith('r_l_'):
-                #     range_duals.setdefault(constraint[4:],[0,0])[0] = constraint_dual
-                # elif constraint.startswith('r_u_'):
-                #     range_duals.setdefault(constraint[4:],[0,0])[1] = constraint_dual
+                elif constraint.startswith('r_l_'):
+                    range_duals.setdefault(constraint[4:],[0,0])[0] = constraint_dual
+                elif constraint.startswith('r_u_'):
+                    range_duals.setdefault(constraint[4:],[0,0])[1] = constraint_dual
 
             elif processing_constraints is False:
                 if len(tokens) == 4:
@@ -581,12 +581,12 @@ class CBCSHELL(SystemCallSolver):
 
         # For the range constraints, supply only the dual with the largest
         # magnitude (at least one should always be numerically zero)
-        # soln_constraints = solution.constraint
-        # for key,(ld,ud) in iteritems(range_duals):
-        #     if abs(ld) > abs(ud):
-        #         soln_constraints['r_l_'+key] = {"Dual" : ld}
-        #     else:
-        #         soln_constraints['r_l_'+key] = {"Dual" : ud}        # Use the same key
+        soln_constraints = solution.constraint
+        for key,(ld,ud) in iteritems(range_duals):
+            if abs(ld) > abs(ud):
+                soln_constraints['r_l_'+key] = {"Dual" : ld}
+            else:
+                soln_constraints['r_l_'+key] = {"Dual" : ud}        # Use the same key
 
 
 class MockCBC(CBCSHELL,MockMIP):

--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -361,11 +361,8 @@ class CBCSHELL(SystemCallSolver):
                 soln.objective['__default_objective__']['Value'] = float(tokens[2])
             if len(tokens) > 4 and tokens[0] == "Optimal" and tokens[2] == "objective":
                 # parser for log file generetated without discrete variable
-                try:
-                    soln.status = SolutionStatus.optimal
-                    soln.objective['__default_objective__']['Value'] = float(tokens[4])
-                except:
-                    print( "skipped the bad one!")
+                soln.status = SolutionStatus.optimal
+                soln.objective['__default_objective__']['Value'] = float(tokens[4])
             if len(tokens) > 6 and tokens[4] == "best" and tokens[5] == "objective":
                 if tokens[6].endswith(','):
                     tokens[6] = tokens[6][:-1]


### PR DESCRIPTION
This PR makes some improvements to the ```CBCplugin.py```.

First, it fixes the command line parsing to work with some additional options (CBC is quite finicky).  In particular, one can now run using the barrier method, which did not work for me on the master branch.

Second, it makes significant speedups to the soln parsing code, by avoiding unnecessarily running many string comparisons at the beginning of the file lines loop, as we only need to parse the header once.  We don't see the header again, so these string checks are wrapped inside the ```if not header_processed``` statement.  I think additional improvements could also be made here, but this is already significantly faster from my testing ( > 50% on a 10 MB soln file).  

Please let me know if there are additional checks, tests, or code I can add.  Thanks.