### PR TITLE
Remove API url from GAMS solver docstring

### DIFF
--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -43,7 +43,7 @@ class GAMSSolver(pyomo.util.plugin.Plugin):
 
     Pass solver_io keyword arg to SolverFactory to choose solver mode:
         solver_io='direct' or 'python' to use GAMS Python API
-            Requires installation, visit online docs for help.
+            Requires installation, visit https://www.gams.com for help.
         solver_io='shell' or 'gms' to use command line to call gams
             Requires the gams executable be on your system PATH.
     """
@@ -132,7 +132,7 @@ class GAMSDirect(pyomo.util.plugin.Plugin):
 
     def solve(self, *args, **kwds):
         """
-        Uses GAMS Python API. Visit online docs for installation help.
+        Uses GAMS Python API. Visit https://www.gams.com for installation help.
 
         tee=False:
             Output GAMS log to stdout.

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -43,8 +43,7 @@ class GAMSSolver(pyomo.util.plugin.Plugin):
 
     Pass solver_io keyword arg to SolverFactory to choose solver mode:
         solver_io='direct' or 'python' to use GAMS Python API
-            Requires installation, visit this url for help:
-            https://www.gams.com/latest/docs/apis/examples_python/index.html
+            Requires installation, visit online docs for help.
         solver_io='shell' or 'gms' to use command line to call gams
             Requires the gams executable be on your system PATH.
     """
@@ -133,8 +132,7 @@ class GAMSDirect(pyomo.util.plugin.Plugin):
 
     def solve(self, *args, **kwds):
         """
-        Uses GAMS Python API. For installation help visit:
-        https://www.gams.com/latest/docs/apis/examples_python/index.html
+        Uses GAMS Python API. Visit online docs for installation help.
 
         tee=False:
             Output GAMS log to stdout.


### PR DESCRIPTION
The GAMS online docs changed the appropriate url to lead to installation help for the Python API, so I figured it would be better to just make the docstring generic in case they change it again in the future. Very minor change.