### PR TITLE
Bounds to vars transformation bugfix

### DIFF
--- a/pyomo/core/plugins/transform/bounds_to_vars.py
+++ b/pyomo/core/plugins/transform/bounds_to_vars.py
@@ -80,7 +80,9 @@ class ConstraintToVarBoundTransform(IsomorphicTransformation):
                     # within its implied bounds, as the constraint we are
                     # deactivating is not an invalid constraint, but rather we
                     # are moving its implied bound directly onto the variable.
-                    if var.has_lb() and var.value < var.lb:
+                    if (var.has_lb() and var.value is not None
+                            and var.value < var.lb):
                         var.set_value(var.lb)
-                    if var.has_ub() and var.value > var.ub:
+                    if (var.has_ub() and var.value is not None
+                            and var.value > var.ub):
                         var.set_value(var.ub)

--- a/pyomo/core/tests/transform/test_bounds_to_vars_xfrm.py
+++ b/pyomo/core/tests/transform/test_bounds_to_vars_xfrm.py
@@ -17,11 +17,13 @@ class TestConstraintToVarBoundTransform(unittest.TestCase):
         m.v3 = Var(initialize=3)
         m.v4 = Var(initialize=4)
         m.v5 = Var(initialize=5)
+        m.v6 = Var()
         m.c1 = Constraint(expr=m.v1 == 2)
         m.c2 = Constraint(expr=m.v2 >= -2)
         m.c3 = Constraint(expr=m.v3 <= 5)
         m.c4 = Constraint(expr=m.v4 <= m.v5)
         m.v5.fix()
+        m.c6 = Constraint(expr=m.v6 >= 2)
 
         m2 = TransformationFactory(
             'core.constraints_to_var_bounds').create_using(m)
@@ -38,6 +40,10 @@ class TestConstraintToVarBoundTransform(unittest.TestCase):
 
         self.assertEquals(value(m2.v4.ub), 5)
         self.assertFalse(m2.v4.has_lb())
+
+        self.assertEquals(value(m2.v6.lb), 2)
+        self.assertFalse(m2.v6.has_ub())
+        self.assertEqual(value(m2.v6, exception=False), None)
 
         del m2  # to keep from accidentally using it below
 


### PR DESCRIPTION
Fixes bug that causes `None < float` comparison if `var.value` is `None`. Adds test to detect this condition.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
