### PR TITLE
Reorganize the API documentation.

### DIFF
--- a/doc/OnlineDocs/library_reference/contrib.rst
+++ b/doc/OnlineDocs/library_reference/contrib.rst
@@ -1,5 +1,21 @@
 Third-Party Contributions
 =========================
 
-* `pyomo.contrib.simplemodel <http://pyomocontrib-simplemodel.readthedocs.io/en/latest/>`_
+Pyomo includes a variety of additional features and functionality
+provided by thiry parties through the ``pyomo.contrib`` package.  This
+package includes both contributions included with the main Pyomo
+distribution and wrappers for third-party packages that must be
+installed separately.
+
+These packages are maintained by the original contributors and are
+managed as *optional* Pyomo packages.
+
+Contributed packages distributed with Pyomo:
+
+*
+
+Contributed packages distributed independently of Pyomo, but accessible
+through ``pyomo.contrib``:
+
+* `pyomo.contrib.simplemodel <http://pyomocontrib-simplemodel.readthedocs.io/en/latest/source.html>`_
 

--- a/doc/OnlineDocs/library_reference/contrib.rst
+++ b/doc/OnlineDocs/library_reference/contrib.rst
@@ -2,7 +2,7 @@ Third-Party Contributions
 =========================
 
 Pyomo includes a variety of additional features and functionality
-provided by thiry parties through the ``pyomo.contrib`` package.  This
+provided by third parties through the ``pyomo.contrib`` package.  This
 package includes both contributions included with the main Pyomo
 distribution and wrappers for third-party packages that must be
 installed separately.

--- a/doc/OnlineDocs/library_reference/index.rst
+++ b/doc/OnlineDocs/library_reference/index.rst
@@ -1,14 +1,26 @@
 Library Reference
 =================
 
-Pyomo is being increasingly used as a library to support Python
-scripts.  This section describes library APIs for key elements of Pyomo.
+Pyomo is being increasingly used as a library embedded within larger
+Python scripts or projects.  This section describes the core library
+APIs for key elements of Pyomo useful to application developers.
 
 .. toctree::
    :maxdepth: 1
 
-   kernel/index.rst
    aml/index.rst
    data/index.rst
    solvers/index.rst
+
+Pyomo is under active ongoing development.  The following API
+documentation describes *Beta* functionality.
+
+.. toctree::
+   :maxdepth: 1
+   kernel/index.rst
+
+Finally, Pyomo includes a number of third-party extensions:
+
+.. toctree::
+   :maxdepth: 1
    contrib.rst


### PR DESCRIPTION
Split the API documentation to differentiate between core functionality, beta functionality, and third-party documentation.

## Summary/Motivation:
We are starting to get user questions that reference the online documentation (a good thing!); however, they were referencing the Kernel documentation and implying that it would work for general Pyomo models (https://stackoverflow.com/questions/48538945/access-all-variables-occurring-in-a-pyomo-constraint).  This change highlights that the Kernel is still "beta" -- mostly because that API should not (yet) be expected to work with models that general users would be creating.

## Changes proposed in this PR:
- Reorganize the TOC for the Library Reference to split out beta and third-party documentation.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
