### PR TITLE
adding additional check to skip complementarity gap lines

### DIFF
--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -363,7 +363,7 @@ class CBCSHELL(SystemCallSolver):
                 soln.objective['__default_objective__']['Value'] = float(tokens[2])
             if len(tokens) > 4 and tokens[0] == "Optimal" and tokens[2] == "objective" and tokens[4] != "and":
                 # parser for log file generetated without discrete variable
-                # last check avoids lines like "Optimal - objective gap and complementarity gap both smallish and small steps"
+                # see pull request #339: last check avoids lines like "Optimal - objective gap and complementarity gap both smallish and small steps"
                 soln.status = SolutionStatus.optimal
                 soln.objective['__default_objective__']['Value'] = float(tokens[4])
             if len(tokens) > 6 and tokens[4] == "best" and tokens[5] == "objective":

--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -361,8 +361,9 @@ class CBCSHELL(SystemCallSolver):
             if len(tokens) >= 3 and tokens[0] == "Objective" and tokens[1] == "value:":
                 # parser for log file generetated with discrete variable
                 soln.objective['__default_objective__']['Value'] = float(tokens[2])
-            if len(tokens) > 4 and tokens[0] == "Optimal" and tokens[2] == "objective":
+            if len(tokens) > 4 and tokens[0] == "Optimal" and tokens[2] == "objective" and tokens[4] != "and":
                 # parser for log file generetated without discrete variable
+                # last check avoids lines like "Optimal - objective gap and complementarity gap both smallish and small steps"
                 soln.status = SolutionStatus.optimal
                 soln.objective['__default_objective__']['Value'] = float(tokens[4])
             if len(tokens) > 6 and tokens[4] == "best" and tokens[5] == "objective":


### PR DESCRIPTION
## Fixes # .

When running cbc with the barrier method, you can get lines like : 
```Optimal - objective gap and complementarity gap```
which are tripped by the condition below in the PR.

## Summary/Motivation:

Fix for this input, as it causes a ValueError (```float("and")```).

## Changes proposed in this PR:
Adds a check on "and" to skip these lines.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
