### PR TITLE
removing import from GUROBI_RUN.py

### DIFF
--- a/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
@@ -11,7 +11,17 @@
 
 import re
 
+
+"""
+This script is run using the Gurobi/system python. Do not assume any third party packages
+are available!
+"""
 from gurobipy import *
+import sys
+if sys.version_info[0] < 3:
+    from itertools import izip
+    zip = izip
+
 
 GUROBI_VERSION = gurobi.version()
 

--- a/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
@@ -19,9 +19,8 @@ are available!
 from gurobipy import *
 import sys
 if sys.version_info[0] < 3:
-    from itertools import izip
-    zip = izip
-
+    from itertools import izip as zip
+    
 
 GUROBI_VERSION = gurobi.version()
 

--- a/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
@@ -12,7 +12,6 @@
 import re
 
 from gurobipy import *
-from six.moves import zip
 
 GUROBI_VERSION = gurobi.version()
 


### PR DESCRIPTION
## Fixes #343 .

## Summary/Motivation:


## Changes proposed in this PR:
- Remove import of six.moves from GUROBI_RUN.py
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
