### PR TITLE
Remove duplicated 'Key' for Expression.display()

### DIFF
--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -330,9 +330,9 @@ class Expression(IndexedComponent):
             ostream,
             prefix+tab,
             ((k,v) for k,v in iteritems(self._data)),
-            ( "Key","Value" ),
+            ( "Value", ),
             lambda k, v: \
-               [k, "Undefined" if v.expr is None else v()])
+               ["Undefined" if v.expr is None else v()])
 
     #
     # A utility to extract all index-value pairs defining this

--- a/pyomo/core/tests/unit/test_expression.py
+++ b/pyomo/core/tests/unit/test_expression.py
@@ -10,10 +10,12 @@
 
 import copy
 
-import pyutilib.th as unittest
-from pyomo.environ import *
 from six import StringIO
 
+import pyutilib.th as unittest
+from pyutilib.misc.redirect_io import capture_output
+
+from pyomo.environ import *
 from pyomo.core.base.expression import _GeneralExpressionData
 
 class TestExpressionData(unittest.TestCase):
@@ -332,17 +334,63 @@ class TestExpression(unittest.TestCase):
     def test_display(self):
         model = ConcreteModel()
         model.e = Expression()
-        model.e.display()
+        with capture_output() as out:
+            model.e.display()
+        self.assertEqual(out.getvalue().strip(), """
+e : Size=1
+    Key  : Value
+    None : Undefined
+        """.strip())
+
         model.e.set_value(1.0)
-        model.e.display()
+        with capture_output() as out:
+            model.e.display()
+        self.assertEqual(out.getvalue().strip(), """
+e : Size=1
+    Key  : Value
+    None :   1.0
+        """.strip())
+
         out = StringIO()
-        model.e.display(ostream=out)
+        with capture_output() as no_out:
+            model.e.display(ostream=out)
+        self.assertEqual(no_out.getvalue(), "")
+        self.assertEqual(out.getvalue().strip(), """
+e : Size=1
+    Key  : Value
+    None :   1.0
+        """.strip())
+
         model.E = Expression([1,2])
-        model.E.display()
+        with capture_output() as out:
+            model.E.display()
+        self.assertEqual(out.getvalue().strip(), """
+E : Size=2
+    Key : Value
+      1 : Undefined
+      2 : Undefined
+        """.strip())
+
         model.E[1].set_value(1.0)
-        model.E.display()
+        with capture_output() as out:
+            model.E.display()
+        self.assertEqual(out.getvalue().strip(), """
+E : Size=2
+    Key : Value
+      1 :       1.0
+      2 : Undefined
+        """.strip())
+
         out = StringIO()
-        model.E.display(ostream=out)
+        with capture_output() as no_out:
+            model.E.display(ostream=out)
+        self.assertEqual(no_out.getvalue(), "")
+        self.assertEqual(out.getvalue().strip(), """
+E : Size=2
+    Key : Value
+      1 :       1.0
+      2 : Undefined
+        """.strip())
 
     def test_extract_values_store_values(self):
         model = ConcreteModel()


### PR DESCRIPTION
## Fixes #348.

## Summary/Motivation:
Remove duplicated 'Key' column in `Expression.display()` [fixes #348].  Also update the Expression.display() tests to verify output.

## Changes proposed in this PR:
- remove duplicated 'Key' column

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
