### PR TITLE
Fix GAMS interface ignoring `tee`

### DIFF
--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -753,7 +753,7 @@ class GAMSShell(pyomo.util.plugin.Plugin):
             command.append("lf=" + str(logfile))
 
         try:
-            rc, _ = pyutilib.subprocess.run(command)
+            rc, _ = pyutilib.subprocess.run(command, tee=tee)
 
             if keepfiles:
                 print("\nGAMS WORKING DIRECTORY: %s\n" % tmpdir)


### PR DESCRIPTION
## Fixes #347 

## Summary/Motivation:
The changes in #302 forgot to pass the `tee` option in to the call to `pyutilib.subprocess.run`.  This had two bad effects:
- the testing infrastructure was far more complicated than it needed to be
- `tee` didn't actully work.

## Changes proposed in this PR:
- pass the `tee` option into `pyutilib.subprocess.run`
- simplify tests for GAMS `tee`/`logfile` options

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
