### PR TITLE
Fix intermittent "unclonable" component error

### DIFF
--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1123,9 +1123,22 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         # NonNegativeReals, etc) that are not "owned" by any blocks and
         # should be preserved as singletons.
         #
-        new_block = copy.deepcopy(
-            self, {'__block_scope__': {id(self): True, id(None): False}})
-        new_block._parent = None
+        save_parent, self._parent = self._parent, None
+        try:
+            new_block = copy.deepcopy(
+                self, {
+                    '__block_scope__': {id(self): True, id(None): False},
+                    '__paranoid__': False,
+                    })
+        except:
+            new_block = copy.deepcopy(
+                self, {
+                    '__block_scope__': {id(self): True, id(None): False},
+                    '__paranoid__': True,
+                    })
+        finally:
+            self._parent = save_parent
+
         return new_block
 
     def contains_component(self, ctype):

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -15,6 +15,7 @@ import six
 from weakref import ref as weakref_ref
 import sys
 from copy import deepcopy
+from pickle import PickleError
 
 import pyomo.util
 from pyomo.core.base.misc import tabular_writer
@@ -128,7 +129,25 @@ class _ComponentBase(object):
                 ans = memo[id(self)] = self
                 return ans
 
-        paranoid = memo.get('__paranoid__', False)
+        #
+        # There is a particularly subtle bug with 'uncopyable'
+        # attributes: if the exception is thrown while copying a complex
+        # data structure, we can be in a state where objects have been
+        # created and assigned to the memo in the try block, but they
+        # haven't had their state set yet.  When the exception moves us
+        # into the except block, we need to effectively "undo" those
+        # partially copied classes.  The only way is to restore the memo
+        # to the state it was in before we started.  Right now, our
+        # solution is to make a (shallow) copy of the memo before each
+        # operation and restoring it in the case of exception.
+        # Unfortunately that is a lot of usually unnecessary work.
+        # Since *most* classes are copyable, we will avoid that
+        # "paranoia" unless the naive clone generated an error - in
+        # which case Block.clone() will switch over to the more
+        # "paranoid" mode.
+        #
+        paranoid = memo.get('__paranoid__', None)
+
         ans = memo[id(self)] = self.__class__.__new__(self.__class__)
         # We can't do the "obvious", since this is a (partially)
         # slot-ized class and the __dict__ structure is
@@ -156,7 +175,13 @@ class _ComponentBase(object):
             new_state = deepcopy(state, memo)
         except:
             if paranoid:
-                memo = dict(saved_memo)
+                # Note: memo is intentionally pass-by-reference.  We
+                # need to clear and reset the object we were handed (and
+                # not overwrite it)
+                memo.clear()
+                memo.update(saved_memo)
+            elif paranoid is not None:
+                raise PickleError()
             new_state = {}
             for k,v in iteritems(state):
                 try:
@@ -165,12 +190,9 @@ class _ComponentBase(object):
                     new_state[k] = deepcopy(v, memo)
                 except:
                     if paranoid:
-                        memo = dict(saved_memo)
-                    logger.error(
-                        "Unable to clone Pyomo component attribute.\n"
-                        "Component '%s' contains an uncopyable field '%s' (%s)"
-                        % ( self.name, k, type(v) ))
-                    if '__paranoid__' not in memo:
+                        memo.clear()
+                        memo.update(saved_memo)
+                    elif paranoid is None:
                         logger.warning("""
                             Uncopyable field encountered when deep
                             copying outside the scope of Block.clone().
@@ -180,6 +202,10 @@ class _ComponentBase(object):
                             'paranoid' mode by adding '__paranoid__' ==
                             True to the memo before calling
                             copy.deepcopy.""")
+                    logger.error(
+                        "Unable to clone Pyomo component attribute.\n"
+                        "Component '%s' contains an uncopyable field '%s' (%s)"
+                        % ( self.name, k, type(v) ))
         ans.__setstate__(new_state)
         return ans
 

--- a/pyomo/core/kernel/component_block.py
+++ b/pyomo/core/kernel/component_block.py
@@ -92,9 +92,22 @@ class IBlockStorage(IComponent,
         block will be deepcopied, otherwise a reference to
         the original component is retained.
         """
-        new_block = copy.deepcopy(
-            self, {'__block_scope__': {id(self):True, id(None):False}} )
-        new_block._parent = None
+        save_parent, self._parent = self._parent, None
+        try:
+            new_block = copy.deepcopy(
+                self, {
+                    '__block_scope__': {id(self): True, id(None): False},
+                    '__paranoid__': False,
+                    })
+        except:
+            new_block = copy.deepcopy(
+                self, {
+                    '__block_scope__': {id(self): True, id(None): False},
+                    '__paranoid__': True,
+                    })
+        finally:
+            self._parent = save_parent
+
         return new_block
 
     @abc.abstractmethod

--- a/pyomo/core/kernel/expr_common.py
+++ b/pyomo/core/kernel/expr_common.py
@@ -35,6 +35,8 @@ else:
     mode = _default_mode = Mode.pyomo4_trees
 
 def clone_expression(exp, substitute=None):
+    # Note that setting the __block_scope__ will prevent any cComponents
+    # encountered in the tree from being copied.
     memo = {'__block_scope__': { id(None): False }}
     if substitute:
         memo.update(substitute)


### PR DESCRIPTION
## Fixes #334.

## Summary/Motivation:
This fixed the intermittent error where attempting to clone a model with an unclonable attribute left the model in a bad state.

## Changes proposed in this PR:
- Add a "paranoid" mode to model cloning that correctly clones blocks with unclonable attributes.

### Legal Acknowledgment

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
