### PR TITLE
cplex 12.6 raises an error if you call objective.get_quadratic() when…

### DIFF
--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -108,7 +108,11 @@ class CPLEXDirect(DirectSolver):
         if self._keepfiles:
             print("Solver log file: "+self._log_file)
 
-        if len(self._solver_model.objective.get_quadratic()) != 0:
+        obj_repn = generate_canonical_repn(self._objective.expr)
+        obj_degree = canonical_degree(obj_repn)
+        if obj_degree > 2:
+            raise DegreeError('CPLEXDirect does not support expressions of degree {0}.'.format(obj_degree))
+        elif obj_degree == 2:
             quadratic_objective = True
         else:
             quadratic_objective = False

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -108,9 +108,8 @@ class CPLEXDirect(DirectSolver):
         if self._keepfiles:
             print("Solver log file: "+self._log_file)
 
-        obj_repn = generate_canonical_repn(self._objective.expr)
-        obj_degree = canonical_degree(obj_repn)
-        if obj_degree > 2:
+        obj_degree = self._objective.expr.polynomial_degree()
+        if obj_degree is None or obj_degree > 2:
             raise DegreeError('CPLEXDirect does not support expressions of degree {0}.'.format(obj_degree))
         elif obj_degree == 2:
             quadratic_objective = True


### PR DESCRIPTION
… the objective is linear

## Fixes tests for Cplex12.6.

## Summary/Motivation:
Tests were failing for Cplex 12.6

## Changes proposed in this PR:
- Use pyomo to check the degree of the objective instead of cplex
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
