### PR TITLE
Fix to gurobi_direct initialization when gurobipy is not available.

### DIFF
--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -73,27 +73,31 @@ class GurobiDirect(DirectSolver):
 
         self._range_constraints = set()
 
-        if self._version_major < 5:
-            self._max_constraint_degree = 1
-        else:
-            self._max_constraint_degree = 2
         self._max_obj_degree = 2
+        self._max_constraint_degree = 2
 
         # Note: Undefined capabilites default to None
         self._capabilities.linear = True
         self._capabilities.quadratic_objective = True
-        if self._version_major < 5:
-            self._capabilities.quadratic_constraint = False
-        else:
-            self._capabilities.quadratic_constraint = True
+        self._capabilities.quadratic_constraint = True
         self._capabilities.integer = True
         self._capabilities.sos1 = True
         self._capabilities.sos2 = True
 
+        # fix for compatibility with pre-5.0 Gurobi
+        if self._python_api_exists and \
+           (self._version_major < 5):
+            self._max_constraint_degree = 1
+            self._capabilities.quadratic_constraint = False
+
     def _apply_solver(self):
         if not self._save_results:
-            for block in self._pyomo_model.block_data_objects(descend_into=True, active=True):
-                for var in block.component_data_objects(ctype=pyomo.core.base.var.Var, descend_into=False, active=True, sort=False):
+            for block in self._pyomo_model.block_data_objects(descend_into=True,
+                                                              active=True):
+                for var in block.component_data_objects(ctype=pyomo.core.base.var.Var,
+                                                        descend_into=False,
+                                                        active=True,
+                                                        sort=False):
                     var.stale = True
         if self._tee:
             self._solver_model.setParam('OutputFlag', 1)


### PR DESCRIPTION
In this case, the solver version was None and it was being compared to an integer, leading to a confusing warning message (probably for Python 3+ only) when calling SolverFactory that looked something like:

WARNING: Gurobi direct solver plugin could not be created: '<' is invalid for 'Nonetype' and int

## Fixes # .

## Summary/Motivation:


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
