### PR TITLE
Remove checks for is_indexed from PersistentSolver methods

### DIFF
--- a/pyomo/solvers/plugins/solvers/cplex_persistent.py
+++ b/pyomo/solvers/plugins/solvers/cplex_persistent.py
@@ -84,6 +84,9 @@ class CPLEXPersistent(PersistentSolver, CPLEXDirect):
         ----------
         var: Var
         """
+        # see PR #366 for discussion about handling indexed
+        # objects and keeping compatibility with the
+        # pyomo.kernel objects
         #if var.is_indexed():
         #    for child_var in var.values():
         #        self.compile_var(child_var)

--- a/pyomo/solvers/plugins/solvers/cplex_persistent.py
+++ b/pyomo/solvers/plugins/solvers/cplex_persistent.py
@@ -84,10 +84,10 @@ class CPLEXPersistent(PersistentSolver, CPLEXDirect):
         ----------
         var: Var
         """
-        if var.is_indexed():
-            for child_var in var.values():
-                self.compile_var(child_var)
-            return
+        #if var.is_indexed():
+        #    for child_var in var.values():
+        #        self.compile_var(child_var)
+        #    return
         if var not in self._pyomo_var_to_solver_var_map:
             raise ValueError('The Var provided to compile_var needs to be added first: {0}'.format(var))
         cplex_var = self._pyomo_var_to_solver_var_map[var]

--- a/pyomo/solvers/plugins/solvers/cplex_persistent.py
+++ b/pyomo/solvers/plugins/solvers/cplex_persistent.py
@@ -76,13 +76,15 @@ class CPLEXPersistent(PersistentSolver, CPLEXDirect):
         CPLEXDirect._warm_start(self)
 
     def update_var(self, var):
-        """
-        Update a variable in the solver's model. This will update bounds, fix/unfix the variable as needed, and update
-        the variable type.
+        """Update a single variable in the solver's model.
+
+        This will update bounds, fix/unfix the variable as needed, and
+        update the variable type.
 
         Parameters
         ----------
-        var: Var
+        var: Var (scalar Var or single _VarData)
+
         """
         # see PR #366 for discussion about handling indexed
         # objects and keeping compatibility with the

--- a/pyomo/solvers/plugins/solvers/gurobi_persistent.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_persistent.py
@@ -94,13 +94,15 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
         GurobiDirect._warm_start(self)
 
     def update_var(self, var):
-        """
-        Update a variable in the solver's model. This will update bounds, fix/unfix the variable as needed, and update
-        the variable type.
+        """Update a single variable in the solver's model.
+
+        This will update bounds, fix/unfix the variable as needed, and
+        update the variable type.
 
         Parameters
         ----------
-        var: Var
+        var: Var (scalar Var or single _VarData)
+
         """
         # see PR #366 for discussion about handling indexed
         # objects and keeping compatibility with the

--- a/pyomo/solvers/plugins/solvers/gurobi_persistent.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_persistent.py
@@ -102,10 +102,10 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
         ----------
         var: Var
         """
-        if var.is_indexed():
-            for child_var in var.values():
-                self.update_var(child_var)
-            return
+        #if var.is_indexed():
+        #    for child_var in var.values():
+        #        self.update_var(child_var)
+        #    return
         if var not in self._pyomo_var_to_solver_var_map:
             raise ValueError('The Var provided to update_var needs to be added first: {0}'.format(var))
         gurobipy_var = self._pyomo_var_to_solver_var_map[var]

--- a/pyomo/solvers/plugins/solvers/gurobi_persistent.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_persistent.py
@@ -102,6 +102,9 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
         ----------
         var: Var
         """
+        # see PR #366 for discussion about handling indexed
+        # objects and keeping compatibility with the
+        # pyomo.kernel objects
         #if var.is_indexed():
         #    for child_var in var.values():
         #        self.update_var(child_var)

--- a/pyomo/solvers/plugins/solvers/persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/persistent_solver.py
@@ -80,12 +80,14 @@ class PersistentSolver(DirectOrPersistentSolver):
         return self._set_instance(model, kwds)
 
     def add_block(self, block):
-        """
-        Add a Pyomo Block to the solver's model. This will keep any existing model components intact.
+        """Add a single Pyomo Block to the solver's model.
+
+        This will keep any existing model components intact.
 
         Parameters
         ----------
-        block: Block
+        block: Block (scalar Block or single _BlockData)
+
         """
         if self._pyomo_model is None:
             raise RuntimeError('You must call set_instance before calling add_block.')
@@ -112,12 +114,14 @@ class PersistentSolver(DirectOrPersistentSolver):
         return self._set_objective(obj)
 
     def add_constraint(self, con):
-        """
-        Add a constraint to the solver's model. This will keep any existing model components intact.
+        """Add a single constraint to the solver's model.
+
+        This will keep any existing model components intact.
 
         Parameters
         ----------
-        con: Constraint
+        con: Constraint (scalar Constraint or single _ConstraintData)
+
         """
         if self._pyomo_model is None:
             raise RuntimeError('You must call set_instance before calling add_constraint.')
@@ -131,12 +135,14 @@ class PersistentSolver(DirectOrPersistentSolver):
         self._add_constraint(con)
 
     def add_var(self, var):
-        """
-        Add a variable to the solver's model. This will keep any existing model components intact.
+        """Add a single variable to the solver's model.
+
+        This will keep any existing model components intact.
 
         Parameters
         ----------
         var: Var
+
         """
         if self._pyomo_model is None:
             raise RuntimeError('You must call set_instance before calling add_var.')
@@ -150,12 +156,14 @@ class PersistentSolver(DirectOrPersistentSolver):
         self._add_var(var)
 
     def add_sos_constraint(self, con):
-        """
-        Add an SOS constraint to the solver's model (if supported). This will keep any existing model components intact.
+        """Add a single SOS constraint to the solver's model (if supported).
+
+        This will keep any existing model components intact.
 
         Parameters
         ----------
         con: SOSConstraint
+
         """
         if self._pyomo_model is None:
             raise RuntimeError('You must call set_instance before calling add_sos_constraint.')
@@ -181,14 +189,16 @@ class PersistentSolver(DirectOrPersistentSolver):
         raise NotImplementedError('This method should be implemented by subclasses.')
 
     def remove_block(self, block):
-        """
-        Remove a block from the solver's model. This will keep any other model components intact.
+        """Remove a single block from the solver's model.
+
+        This will keep any other model components intact.
 
         WARNING: Users must call remove_block BEFORE modifying the block.
 
         Parameters
         ----------
-        block: Block
+        block: Block (scalar Block or a single _BlockData)
+
         """
         # see PR #366 for discussion about handling indexed
         # objects and keeping compatibility with the
@@ -208,12 +218,14 @@ class PersistentSolver(DirectOrPersistentSolver):
             self.remove_var(var)
 
     def remove_constraint(self, con):
-        """
-        Remove a constraint from the solver's model. This will keep any other model components intact.
+        """Remove a single constraint from the solver's model.
+
+        This will keep any other model components intact.
 
         Parameters
         ----------
-        con: Constraint
+        con: Constraint (scalar Constraint or single _ConstraintData)
+
         """
         # see PR #366 for discussion about handling indexed
         # objects and keeping compatibility with the
@@ -233,12 +245,14 @@ class PersistentSolver(DirectOrPersistentSolver):
         del self._solver_con_to_pyomo_con_map[solver_con]
 
     def remove_sos_constraint(self, con):
-        """
-        Remove an SOS constraint from the solver's model. This will keep any other model components intact.
+        """Remove a single SOS constraint from the solver's model.
+
+        This will keep any other model components intact.
 
         Parameters
         ----------
         con: SOSConstraint
+
         """
         # see PR #366 for discussion about handling indexed
         # objects and keeping compatibility with the
@@ -258,12 +272,14 @@ class PersistentSolver(DirectOrPersistentSolver):
         del self._solver_con_to_pyomo_con_map[solver_con]
 
     def remove_var(self, var):
-        """
-        Remove a variable from the solver's model. This will keep any other model components intact.
+        """Remove a single variable from the solver's model.
+
+        This will keep any other model components intact.
 
         Parameters
         ----------
-        var: Var
+        var: Var (scalar Var or single _VarData)
+
         """
         # see PR #366 for discussion about handling indexed
         # objects and keeping compatibility with the

--- a/pyomo/solvers/plugins/solvers/persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/persistent_solver.py
@@ -89,10 +89,10 @@ class PersistentSolver(DirectOrPersistentSolver):
         """
         if self._pyomo_model is None:
             raise RuntimeError('You must call set_instance before calling add_block.')
-        if block.is_indexed():
-            for sub_block in block.values():
-                self._add_block(block)
-            return
+        #if block.is_indexed():
+        #    for sub_block in block.values():
+        #        self._add_block(block)
+        #    return
         self._add_block(block)
 
     def set_objective(self, obj):
@@ -118,11 +118,11 @@ class PersistentSolver(DirectOrPersistentSolver):
         """
         if self._pyomo_model is None:
             raise RuntimeError('You must call set_instance before calling add_constraint.')
-        if con.is_indexed():
-            for child_con in con.values():
-                self._add_constraint(child_con)
-        else:
-            self._add_constraint(con)
+        #if con.is_indexed():
+        #    for child_con in con.values():
+        #        self._add_constraint(child_con)
+        #else:
+        self._add_constraint(con)
 
     def add_var(self, var):
         """
@@ -134,11 +134,11 @@ class PersistentSolver(DirectOrPersistentSolver):
         """
         if self._pyomo_model is None:
             raise RuntimeError('You must call set_instance before calling add_var.')
-        if var.is_indexed():
-            for child_var in var.values():
-                self._add_var(child_var)
-        else:
-            self._add_var(var)
+        #if var.is_indexed():
+        #    for child_var in var.values():
+        #        self._add_var(child_var)
+        #else:
+        self._add_var(var)
 
     def add_sos_constraint(self, con):
         """
@@ -150,11 +150,11 @@ class PersistentSolver(DirectOrPersistentSolver):
         """
         if self._pyomo_model is None:
             raise RuntimeError('You must call set_instance before calling add_sos_constraint.')
-        if con.is_indexed():
-            for child_con in con.values():
-                self._add_sos_constraint(child_con)
-        else:
-            self._add_sos_constraint(con)
+        #if con.is_indexed():
+        #    for child_con in con.values():
+        #        self._add_sos_constraint(child_con)
+        #else:
+        self._add_sos_constraint(con)
 
     """ This method should be implemented by subclasses."""
     def _remove_constraint(self, solver_con):
@@ -178,10 +178,10 @@ class PersistentSolver(DirectOrPersistentSolver):
         ----------
         block: Block
         """
-        if block.is_indexed():
-            for sub_block in block.values():
-                self.remove_block(sub_block)
-            return
+        #if block.is_indexed():
+        #    for sub_block in block.values():
+        #        self.remove_block(sub_block)
+        #    return
         for sub_block in block.block_data_objects(descend_into=True, active=True):
             for con in sub_block.component_data_objects(ctype=Constraint, descend_into=False, active=True):
                 self.remove_constraint(con)
@@ -200,10 +200,10 @@ class PersistentSolver(DirectOrPersistentSolver):
         ----------
         con: Constraint
         """
-        if con.is_indexed():
-            for child_con in con.values():
-                self.remove_constraint(child_con)
-            return
+        #if con.is_indexed():
+        #    for child_con in con.values():
+        #        self.remove_constraint(child_con)
+        #    return
         solver_con = self._pyomo_con_to_solver_con_map[con]
         self._remove_constraint(solver_con)
         self._symbol_map.removeSymbol(con)
@@ -222,10 +222,10 @@ class PersistentSolver(DirectOrPersistentSolver):
         ----------
         con: SOSConstraint
         """
-        if con.is_indexed():
-            for child_con in con.values():
-                self.remove_sos_constraint(child_con)
-            return
+        #if con.is_indexed():
+        #    for child_con in con.values():
+        #        self.remove_sos_constraint(child_con)
+        #    return
         solver_con = self._pyomo_con_to_solver_con_map[con]
         self._remove_sos_constraint(solver_con)
         self._symbol_map.removeSymbol(con)
@@ -244,10 +244,10 @@ class PersistentSolver(DirectOrPersistentSolver):
         ----------
         var: Var
         """
-        if var.is_indexed():
-            for child_var in var.values():
-                self.remove_var(child_var)
-            return
+        #if var.is_indexed():
+        #    for child_var in var.values():
+        #        self.remove_var(child_var)
+        #    return
         if self._referenced_variables[var] != 0:
             raise ValueError('Cannot remove Var {0} because it is still referenced by the '.format(var) +
                              'objective or one or more constraints')

--- a/pyomo/solvers/plugins/solvers/persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/persistent_solver.py
@@ -89,6 +89,9 @@ class PersistentSolver(DirectOrPersistentSolver):
         """
         if self._pyomo_model is None:
             raise RuntimeError('You must call set_instance before calling add_block.')
+        # see PR #366 for discussion about handling indexed
+        # objects and keeping compatibility with the
+        # pyomo.kernel objects
         #if block.is_indexed():
         #    for sub_block in block.values():
         #        self._add_block(block)
@@ -118,6 +121,9 @@ class PersistentSolver(DirectOrPersistentSolver):
         """
         if self._pyomo_model is None:
             raise RuntimeError('You must call set_instance before calling add_constraint.')
+        # see PR #366 for discussion about handling indexed
+        # objects and keeping compatibility with the
+        # pyomo.kernel objects
         #if con.is_indexed():
         #    for child_con in con.values():
         #        self._add_constraint(child_con)
@@ -134,6 +140,9 @@ class PersistentSolver(DirectOrPersistentSolver):
         """
         if self._pyomo_model is None:
             raise RuntimeError('You must call set_instance before calling add_var.')
+        # see PR #366 for discussion about handling indexed
+        # objects and keeping compatibility with the
+        # pyomo.kernel objects
         #if var.is_indexed():
         #    for child_var in var.values():
         #        self._add_var(child_var)
@@ -150,6 +159,9 @@ class PersistentSolver(DirectOrPersistentSolver):
         """
         if self._pyomo_model is None:
             raise RuntimeError('You must call set_instance before calling add_sos_constraint.')
+        # see PR #366 for discussion about handling indexed
+        # objects and keeping compatibility with the
+        # pyomo.kernel objects
         #if con.is_indexed():
         #    for child_con in con.values():
         #        self._add_sos_constraint(child_con)
@@ -178,6 +190,9 @@ class PersistentSolver(DirectOrPersistentSolver):
         ----------
         block: Block
         """
+        # see PR #366 for discussion about handling indexed
+        # objects and keeping compatibility with the
+        # pyomo.kernel objects
         #if block.is_indexed():
         #    for sub_block in block.values():
         #        self.remove_block(sub_block)
@@ -200,6 +215,9 @@ class PersistentSolver(DirectOrPersistentSolver):
         ----------
         con: Constraint
         """
+        # see PR #366 for discussion about handling indexed
+        # objects and keeping compatibility with the
+        # pyomo.kernel objects
         #if con.is_indexed():
         #    for child_con in con.values():
         #        self.remove_constraint(child_con)
@@ -222,6 +240,9 @@ class PersistentSolver(DirectOrPersistentSolver):
         ----------
         con: SOSConstraint
         """
+        # see PR #366 for discussion about handling indexed
+        # objects and keeping compatibility with the
+        # pyomo.kernel objects
         #if con.is_indexed():
         #    for child_con in con.values():
         #        self.remove_sos_constraint(child_con)
@@ -244,6 +265,9 @@ class PersistentSolver(DirectOrPersistentSolver):
         ----------
         var: Var
         """
+        # see PR #366 for discussion about handling indexed
+        # objects and keeping compatibility with the
+        # pyomo.kernel objects
         #if var.is_indexed():
         #    for child_var in var.values():
         #        self.remove_var(child_var)


### PR DESCRIPTION
Change methods such as {add,remove,update}_{var,constraint,block} on PersistentSolver to no longer check for indexed objects. That is, `solver.add_var(<singleton_variable>)` continues to work, but `solver.add_var(<indexed_variable>)` no longer works.

## Fixes # .

Allows all methods to work with objects from pyomo.kernel that do no support the same indexed API. In particular, indexed objects in the kernel do not have an is_indexed method, and only singleton objects from the kernel that inherit from NumericValue have an is_indexed method that returns False (i.e., single and indexed constraints do not have is_indexed methods).

Additionally, the current implementations of these PersistentSolver methods use .values() to iterate over indexed objects, but this would not work with all container implementations in kernel (e.g., list-like containers).

## Summary/Motivation:

This removes trivial functionality from this API before it appears in its first release, while expanding the set of modeling objects this API is compatible with.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
