### PR TITLE
Misc Gurobi and Cplex fixes

### DIFF
--- a/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
@@ -85,8 +85,13 @@ def gurobi_run(model_file, warmstart_file, soln_file, mipgap, options, suffixes)
         # setting the parameter fails.
         try:
             model.setParam(key, value)
-        except TypeError:
-            model.setParam(key, float(value))
+        except TypeError as e:
+            try:
+                value = float(value)
+            except ValueError:
+                # raise the original exception
+                raise e
+            model.setParam(key, value)
 
 
     if 'relax_integrality' in options:

--- a/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
@@ -20,7 +20,6 @@ from gurobipy import *
 import sys
 if sys.version_info[0] < 3:
     from itertools import izip as zip
-    
 
 GUROBI_VERSION = gurobi.version()
 
@@ -80,7 +79,15 @@ def gurobi_run(model_file, warmstart_file, soln_file, mipgap, options, suffixes)
     # key is specified, so you have to stare at the
     # output to see if it was accepted.
     for key, value in options.items():
-        model.setParam(key, value)
+        # When options come from the pyomo command, all
+        # values are string types, so we try to cast
+        # them to a numeric value in the event that
+        # setting the parameter fails.
+        try:
+            model.setParam(key, value)
+        except TypeError:
+            model.setParam(key, float(value))
+
 
     if 'relax_integrality' in options:
         for v in model.getVars():

--- a/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
@@ -93,12 +93,12 @@ def gurobi_run(model_file, warmstart_file, soln_file, mipgap, options, suffixes)
         try:
             model.setParam(key, value)
         except TypeError:
-            # note, that we place the exception handling for
-            # checking the cast of value to a float in
-            # another function so that we can simply call
-            # raise here instead of except TypeError as e /
-            # with raise e, because the latter does not
-            # preserve the Gurobi stack trace
+            # we place the exception handling for checking
+            # the cast of value to a float in another
+            # function so that we can simply call raise here
+            # instead of except TypeError as e / raise e,
+            # because the latter does not preserve the
+            # Gurobi stack trace
             if not _is_numeric(value):
                 raise
             model.setParam(key, float(value))

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -150,7 +150,14 @@ class CPLEXDirect(DirectSolver):
             key_pieces = key.split('_')
             for key_piece in key_pieces:
                 opt_cmd = getattr(opt_cmd, key_piece)
-            opt_cmd.set(option)
+            # When options come from the pyomo command, all
+            # values are string types, so we try to cast
+            # them to a numeric value in the event that
+            # setting the parameter fails.
+            try:
+                opt_cmd.set(option)
+            except self._cplex.exceptions.CplexError:
+                opt_cmd.set(float(option))
 
         t0 = time.time()
         self._solver_model.solve()

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -164,11 +164,11 @@ class CPLEXDirect(DirectSolver):
             try:
                 opt_cmd.set(option)
             except self._cplex.exceptions.CplexError:
-                # note, that we place the exception handling
-                # for checking the cast of option to a float
-                # in another function so that we can simply
+                # we place the exception handling for
+                # checking the cast of option to a float in
+                # another function so that we can simply
                 # call raise here instead of except
-                # TypeError as e / with raise e, because the
+                # TypeError as e / raise e, because the
                 # latter does not preserve the Cplex stack
                 # trace
                 if not _is_numeric(option):

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -157,8 +157,13 @@ class CPLEXDirect(DirectSolver):
             # setting the parameter fails.
             try:
                 opt_cmd.set(option)
-            except self._cplex.exceptions.CplexError:
-                opt_cmd.set(float(option))
+            except self._cplex.exceptions.CplexError as e:
+                try:
+                    option = float(option)
+                except ValueError:
+                    # raise the original exception
+                    raise e
+                opt_cmd.set(option)
 
         t0 = time.time()
         self._solver_model.solve()

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -110,7 +110,8 @@ class CPLEXDirect(DirectSolver):
 
         obj_degree = self._objective.expr.polynomial_degree()
         if obj_degree is None or obj_degree > 2:
-            raise DegreeError('CPLEXDirect does not support expressions of degree {0}.'.format(obj_degree))
+            raise DegreeError('CPLEXDirect does not support expressions of degree {0}.'\
+                              .format(obj_degree))
         elif obj_degree == 2:
             quadratic_objective = True
         else:
@@ -464,10 +465,12 @@ class CPLEXDirect(DirectSolver):
             if not flag:
                 raise RuntimeError("***The cplex_direct solver plugin cannot extract solution suffix="+suffix)
 
-        gprob = self._solver_model
-        status = gprob.solution.get_status()
+        cpxprob = self._solver_model
+        status = cpxprob.solution.get_status()
 
-        if gprob.get_problem_type() in [gprob.problem_type.MILP, gprob.problem_type.MIQP, gprob.problem_type.MIQCP]:
+        if cpxprob.get_problem_type() in [cpxprob.problem_type.MILP,
+                                          cpxprob.problem_type.MIQP,
+                                          cpxprob.problem_type.MIQCP]:
             if extract_reduced_costs:
                 logger.warning("Cannot get reduced costs for MIP.")
             if extract_duals:
@@ -478,22 +481,23 @@ class CPLEXDirect(DirectSolver):
         self.results = SolverResults()
         soln = Solution()
 
-        self.results.solver.name = ("CPLEX {0}".format(gprob.get_version()))
+        self.results.solver.name = ("CPLEX {0}".format(cpxprob.get_version()))
         self.results.solver.wallclock_time = self._wallclock_time
 
         if status in [1, 101, 102]:
             self.results.solver.status = SolverStatus.ok
             self.results.solver.termination_condition = TerminationCondition.optimal
             soln.status = SolutionStatus.optimal
-        elif status in [2, 118]:
+        elif status in [2, 40, 118, 133, 134]:
             self.results.solver.status = SolverStatus.warning
             self.results.solver.termination_condition = TerminationCondition.unbounded
             soln.status = SolutionStatus.unbounded
-        elif status in [4, 119]:
+        elif status in [4, 119, 134]:
             # Note: status of 4 means infeasible or unbounded
             #       and 119 means MIP infeasible or unbounded
             self.results.solver.status = SolverStatus.warning
-            self.results.solver.termination_condition = TerminationCondition.infeasibleOrUnbounded
+            self.results.solver.termination_condition = \
+                TerminationCondition.infeasibleOrUnbounded
             soln.status = SolutionStatus.unsure
         elif status in [3, 103]:
             self.results.solver.status = SolverStatus.warning
@@ -503,7 +507,7 @@ class CPLEXDirect(DirectSolver):
             self.results.solver.status = SolverStatus.aborted
             self.results.solver.termination_condition = TerminationCondition.maxIterations
             soln.status = SolutionStatus.stoppedByLimit
-        elif status in [11, 25]:
+        elif status in [11, 25, 107, 131]:
             self.results.solver.status = SolverStatus.aborted
             self.results.solver.termination_condition = TerminationCondition.maxTimeLimit
             soln.status = SolutionStatus.stoppedByLimit
@@ -512,61 +516,65 @@ class CPLEXDirect(DirectSolver):
             self.results.solver.termination_condition = TerminationCondition.error
             soln.status = SolutionStatus.error
 
-        if gprob.objective.get_sense() == gprob.objective.sense.minimize:
+        if cpxprob.objective.get_sense() == cpxprob.objective.sense.minimize:
             self.results.problem.sense = pyomo.core.kernel.minimize
-        elif gprob.objective.get_sense() == gprob.objective.sense.maximize:
+        elif cpxprob.objective.get_sense() == cpxprob.objective.sense.maximize:
             self.results.problem.sense = pyomo.core.kernel.maximize
         else:
-            raise RuntimeError('Unrecognized cplex objective sense: {0}'.format(gprob.objective.get_sense()))
+            raise RuntimeError('Unrecognized cplex objective sense: {0}'.\
+                               format(cpxprob.objective.get_sense()))
 
         self.results.problem.upper_bound = None
         self.results.problem.lower_bound = None
-        if (gprob.variables.get_num_binary() + gprob.variables.get_num_integer()) == 0:
+        if (cpxprob.variables.get_num_binary() + cpxprob.variables.get_num_integer()) == 0:
             try:
-                self.results.problem.upper_bound = gprob.solution.get_objective_value()
-                self.results.problem.lower_bound = gprob.solution.get_objective_value()
+                self.results.problem.upper_bound = cpxprob.solution.get_objective_value()
+                self.results.problem.lower_bound = cpxprob.solution.get_objective_value()
             except self._cplex.exceptions.CplexError:
                 pass
-        elif gprob.objective.get_sense() == gprob.objective.sense.minimize:
+        elif cpxprob.objective.get_sense() == cpxprob.objective.sense.minimize:
             try:
-                self.results.problem.upper_bound = gprob.solution.get_objective_value()
-            except self._cplex.exceptions.CplexError:
-                pass
-            try:
-                self.results.problem.lower_bound = gprob.solution.MIP.get_best_objective()
-            except self._cplex.exceptions.CplexError:
-                pass
-        elif gprob.objective.get_sense() == gprob.objective.sense.maximize:
-            try:
-                self.results.problem.upper_bound = gprob.solution.MIP.get_best_objective()
+                self.results.problem.upper_bound = cpxprob.solution.get_objective_value()
             except self._cplex.exceptions.CplexError:
                 pass
             try:
-                self.results.problem.lower_bound = gprob.solution.get_objective_value()
+                self.results.problem.lower_bound = cpxprob.solution.MIP.get_best_objective()
+            except self._cplex.exceptions.CplexError:
+                pass
+        elif cpxprob.objective.get_sense() == cpxprob.objective.sense.maximize:
+            try:
+                self.results.problem.upper_bound = cpxprob.solution.MIP.get_best_objective()
+            except self._cplex.exceptions.CplexError:
+                pass
+            try:
+                self.results.problem.lower_bound = cpxprob.solution.get_objective_value()
             except self._cplex.exceptions.CplexError:
                 pass
         else:
-            raise RuntimeError('Unrecognized cplex objective sense: {0}'.format(gprob.objective.get_sense()))
+            raise RuntimeError('Unrecognized cplex objective sense: {0}'.\
+                               format(cpxprob.objective.get_sense()))
 
         try:
             soln.gap = self.results.problem.upper_bound - self.results.problem.lower_bound
         except TypeError:
             soln.gap = None
 
-        self.results.problem.name = gprob.get_problem_name()
-        assert gprob.indicator_constraints.get_num() == 0
-        self.results.problem.number_of_constraints = (gprob.linear_constraints.get_num() +
-                                                      gprob.quadratic_constraints.get_num() +
-                                                      gprob.SOS.get_num())
+        self.results.problem.name = cpxprob.get_problem_name()
+        assert cpxprob.indicator_constraints.get_num() == 0
+        self.results.problem.number_of_constraints = \
+            (cpxprob.linear_constraints.get_num() +
+             cpxprob.quadratic_constraints.get_num() +
+             cpxprob.SOS.get_num())
         self.results.problem.number_of_nonzeros = None
-        self.results.problem.number_of_variables = gprob.variables.get_num()
-        self.results.problem.number_of_binary_variables = gprob.variables.get_num_binary()
-        self.results.problem.number_of_integer_variables = gprob.variables.get_num_integer()
-        assert gprob.variables.get_num_semiinteger() == 0
-        assert gprob.variables.get_num_semicontinuous() == 0
-        self.results.problem.number_of_continuous_variables = (gprob.variables.get_num() -
-                                                               gprob.variables.get_num_binary() -
-                                                               gprob.variables.get_num_integer())
+        self.results.problem.number_of_variables = cpxprob.variables.get_num()
+        self.results.problem.number_of_binary_variables = cpxprob.variables.get_num_binary()
+        self.results.problem.number_of_integer_variables = cpxprob.variables.get_num_integer()
+        assert cpxprob.variables.get_num_semiinteger() == 0
+        assert cpxprob.variables.get_num_semicontinuous() == 0
+        self.results.problem.number_of_continuous_variables = \
+            (cpxprob.variables.get_num() -
+             cpxprob.variables.get_num_binary() -
+             cpxprob.variables.get_num_integer())
         self.results.problem.number_of_objectives = 1
 
         # only try to get objective and variable values if a solution exists
@@ -575,7 +583,7 @@ class CPLEXDirect(DirectSolver):
             This code in this if statement is only needed for backwards compatability. It is more efficient to set
             _save_results to False and use load_vars, load_duals, etc.
             """
-            if gprob.solution.get_solution_type() > 0:
+            if cpxprob.solution.get_solution_type() > 0:
                 soln_variables = soln.variable
                 soln_constraints = soln.constraint
 
@@ -631,7 +639,7 @@ class CPLEXDirect(DirectSolver):
                     for i, con_name in enumerate(self._solver_model.quadratic_constraints.get_names()):
                         soln_constraints[con_name]["Slack"] = qudratic_slacks[i]
         elif self._load_solutions:
-            if gprob.solution.get_solution_type() > 0:
+            if cpxprob.solution.get_solution_type() > 0:
                 self._load_vars()
 
                 if extract_reduced_costs:

--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -137,11 +137,11 @@ class GurobiDirect(DirectSolver):
             try:
                 self._solver_model.setParam(key, option)
             except TypeError:
-                # note, that we place the exception handling
-                # for checking the cast of option to a float
-                # in another function so that we can simply
+                # we place the exception handling for
+                # checking the cast of option to a float in
+                # another function so that we can simply
                 # call raise here instead of except
-                # TypeError as e / with raise e, because the
+                # TypeError as e / raise e, because the
                 # latter does not preserve the Gurobi stack
                 # trace
                 if not _is_numeric(option):

--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -124,7 +124,14 @@ class GurobiDirect(DirectSolver):
         #  'LogFile', 'PreCrush', 'PreDepRow', 'PreMIQPMethod', 'PrePasses', 'Presolve',
         #  'ResultFile', 'ImproveStartTime', 'ImproveStartGap', 'Threads', 'Dummy', 'OutputFlag']
         for key, option in self.options.items():
-            self._solver_model.setParam(key, option)
+            # When options come from the pyomo command, all
+            # values are string types, so we try to cast
+            # them to a numeric value in the event that
+            # setting the parameter fails.
+            try:
+                self._solver_model.setParam(key, option)
+            except TypeError:
+                self._solver_model.setParam(key, float(option))
 
         if self._version_major >= 5:
             for suffix in self._suffixes:

--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -130,8 +130,13 @@ class GurobiDirect(DirectSolver):
             # setting the parameter fails.
             try:
                 self._solver_model.setParam(key, option)
-            except TypeError:
-                self._solver_model.setParam(key, float(option))
+            except TypeError as e:
+                try:
+                    option = float(option)
+                except ValueError:
+                    # raise the original exception
+                    raise e
+                self._solver_model.setParam(key, option)
 
         if self._version_major >= 5:
             for suffix in self._suffixes:


### PR DESCRIPTION
## Fixes ##

Handles options coming from the `pyomo` command, which all have values stored as string types. In the event that setting the option fails, we now cast the option value to a numeric type and retry. Fixes the Gurobi-Python interface, Gurobi-LP interface, and Cplex-Python interface.

Updates the cplex_direct plugin to check for a few more Cplex statuses and maps them to sane statuses on the results object. In particular, when a MIP was stopped early due to a time limit and returned a feasible solution, we were mapping this to error statuses on the results object.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
