### PR TITLE
Fix to kernel linear_constraint when assigning an empty list of terms

### DIFF
--- a/pyomo/core/kernel/component_constraint.py
+++ b/pyomo/core/kernel/component_constraint.py
@@ -789,7 +789,13 @@ class linear_constraint(_MutableBoundsConstraintMixin,
     def terms(self, terms):
         """Set the terms in the body of this constraint
         using an iterable of (variable, coefficient) tuples"""
-        self._variables, self._coefficients = zip(*terms)
+        transpose = tuple(zip(*terms))
+        if len(transpose) == 2:
+            self._variables, self._coefficients = transpose
+        else:
+            assert transpose == ()
+            self._variables = ()
+            self._coefficients = ()
 
     #
     # Override a the default __call__ method on IConstraint

--- a/pyomo/core/tests/unit/test_component_constraint.py
+++ b/pyomo/core/tests/unit/test_component_constraint.py
@@ -1583,6 +1583,14 @@ class Test_linear_constraint(unittest.TestCase):
         self.assertEqual(c.body(), 6)
         self.assertEqual(c(), 6)
 
+        c.terms = ()
+        self.assertEqual(c.lb, 1)
+        self.assertEqual(c.ub, 1)
+        self.assertEqual(c.rhs, 1)
+        self.assertEqual(c.body, 0)
+        self.assertEqual(c(), 0)
+        self.assertEqual(tuple(c.terms), ())
+
     def test_type(self):
         c = linear_constraint([],[])
         self.assertTrue(isinstance(c, ICategorizedObject))


### PR DESCRIPTION
## Fixes # 

Allows assignment of an empty list to the `terms` keyword or property of linear_constraint in the Kernel. Before this fix, this kind of assignment would result in a `ValueError` caused by an attempt to unpack an empty return value from `zip` into two items.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
