### PR TITLE
NFC: updating baseline for logger message line wrapping

### DIFF
--- a/examples/doc/pyomobook/scripts-ch/sudoku/sudoku_run.txt
+++ b/examples/doc/pyomobook/scripts-ch/sudoku/sudoku_run.txt
@@ -1,4 +1,5 @@
-WARNING: Constant objective detected, replacing with a placeholder to prevent solver failure.
+WARNING: Constant objective detected, replacing with a placeholder to prevent
+    solver failure.
 Solution #1
 5   3   4   6   7   8   9   1   2
 6   7   2   1   9   5   3   4   8
@@ -9,5 +10,6 @@ Solution #1
 9   6   1   5   3   7   2   8   4
 2   8   7   4   1   9   6   3   5
 3   4   5   2   8   6   1   7   9
-WARNING: Constant objective detected, replacing with a placeholder to prevent solver failure.
+WARNING: Constant objective detected, replacing with a placeholder to prevent
+    solver failure.
 All board solutions have been found


### PR DESCRIPTION
## Fixes book test regression

## Summary/Motivation:
This resolves a book test regression.  This is an NFC that is only required due to the fragility in the book regression diffs (i.e., it does not impact the correctness of anything printed in the Book).

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
