### PR TITLE
Adding an option to get the list of trivial constraints back from deactivate_trivial_constraints

### DIFF
--- a/pyomo/contrib/preprocessing/plugins/deactivate_trivial_constraints.py
+++ b/pyomo/contrib/preprocessing/plugins/deactivate_trivial_constraints.py
@@ -37,7 +37,9 @@ class TrivialConstraintDeactivator(IsomorphicTransformation):
                 reversion of the transformation
             ignore_infeasible: True to skip over trivial constraints that are
                 infeasible instead of raising a ValueError.
-            tol: tolerance on constraint violations
+            return_trivial: a list to which the deactivated trivial
+                constraints are appended (side effect)
+            tolerance: tolerance on constraint violations
         """
         tmp = kwargs.pop('tmp', False)
         ignore_infeasible = kwargs.pop('ignore_infeasible', False)

--- a/pyomo/contrib/preprocessing/plugins/deactivate_trivial_constraints.py
+++ b/pyomo/contrib/preprocessing/plugins/deactivate_trivial_constraints.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 """Transformation to deactivate trivial constraints."""
 import textwrap
 from math import fabs
@@ -42,6 +42,7 @@ class TrivialConstraintDeactivator(IsomorphicTransformation):
         tmp = kwargs.pop('tmp', False)
         ignore_infeasible = kwargs.pop('ignore_infeasible', False)
         tol = kwargs.pop('tolerance', 1E-13)
+        trivial = kwargs.pop('return_trivial', [])
         if tmp and not hasattr(instance, '_tmp_trivial_deactivated_constrs'):
             instance._tmp_trivial_deactivated_constrs = ComponentSet()
 
@@ -85,6 +86,7 @@ class TrivialConstraintDeactivator(IsomorphicTransformation):
             # Constraint is not infeasible. Deactivate it.
             if tmp:
                 instance._tmp_trivial_deactivated_constrs.add(constr)
+            trivial.append(constr)
             constr.deactivate()
 
     def revert(self, instance):

--- a/pyomo/contrib/preprocessing/tests/test_deactivate_trivial_constraints.py
+++ b/pyomo/contrib/preprocessing/tests/test_deactivate_trivial_constraints.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 """Tests deactivation of trivial constraints."""
 import pyutilib.th as unittest
 from pyomo.environ import (Constraint, ConcreteModel, TransformationFactory,
@@ -24,6 +24,27 @@ class TestTrivialConstraintDeactivator(unittest.TestCase):
         self.assertTrue(m.c.active)
         self.assertTrue(m.c2.active)
         self.assertFalse(m.c3.active)
+
+    def test_deactivate_trivial_constraints_retur_list(self):
+        """Test for deactivation of trivial constraints."""
+        m = ConcreteModel()
+        m.v1 = Var(initialize=1)
+        m.v2 = Var(initialize=2)
+        m.v3 = Var(initialize=3)
+        m.c = Constraint(expr=m.v1 <= m.v2)
+        m.c2 = Constraint(expr=m.v2 >= m.v3)
+        m.c3 = Constraint(expr=m.v1 <= 5)
+        m.v1.fix()
+
+        trivial = []
+        TransformationFactory(
+            'contrib.deactivate_trivial_constraints').apply_to(
+                m, return_trivial=trivial)
+        self.assertTrue(m.c.active)
+        self.assertTrue(m.c2.active)
+        self.assertFalse(m.c3.active)
+        self.assertEqual(len(trivial), 1)
+        self.assertIs(trivial[0], m.c3)
 
     def test_deactivate_trivial_constraints_revert(self):
         """Test for reversion of trivial constraint deactivation."""


### PR DESCRIPTION
## Summary/Motivation:

This is needed to make managing dual values for deactivated constraints easier for @bernalde

## Changes proposed in this PR:
- Adding an optional argument that can be populated by the transformation to return the list of constraints that were deactivated

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
