### PR TITLE
Fix handling unbounded constraints

### DIFF
--- a/pyomo/repn/plugins/ampl/ampl_.py
+++ b/pyomo/repn/plugins/ampl/ampl_.py
@@ -948,6 +948,11 @@ class ProblemWriter_nl(AbstractProblemWriter):
                     else:
                         ampl_repn = block_ampl_repn[constraint_data]
 
+                if (not constraint_data.has_lb()) and \
+                   (not constraint_data.has_ub()):
+                    assert not constraint_data.equality
+                    continue  # non-binding, so skip
+
                 ### GAH: Even if this is fixed, it is still useful to
                 ###      write out these types of constraints
                 ###      (trivial) as a feasibility check for fixed

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -457,7 +457,9 @@ class GAMSDirect(pyomo.util.plugin.Plugin):
 
         if extract_dual:
             for c in model.component_data_objects(Constraint, active=True):
-                if c.body.is_fixed():
+                if c.body.is_fixed() or \
+                   (not (c.has_lb() or c.has_ub())):
+                    # the constraint was not sent to GAMS
                     continue
                 sym = symbolMap.getSymbol(c)
                 if c.equality:
@@ -972,7 +974,9 @@ class GAMSShell(pyomo.util.plugin.Plugin):
 
         if extract_dual:
             for c in model.component_data_objects(Constraint, active=True):
-                if c.body.is_fixed():
+                if (c.body.is_fixed()) or \
+                   (not (c.has_lb() or c.has_ub())):
+                    # the constraint was not sent to GAMS
                     continue
                 sym = symbolMap.getSymbol(c)
                 if c.equality:

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -341,18 +341,18 @@ class CPLEXDirect(DirectSolver):
             my_sense = 'E'
             my_rhs = [value(con.lower) - cplex_expr.offset]
             my_range = []
-        elif con.has_lb() and (value(con.lower) > -float('inf')) and con.has_ub() and (value(con.upper) < float('inf')):
+        elif con.has_lb() and con.has_ub():
             my_sense = 'R'
             lb = value(con.lower)
             ub = value(con.upper)
             my_rhs = [ub - cplex_expr.offset]
             my_range = [lb - ub]
             self._range_constraints.add(con)
-        elif con.has_lb() and (value(con.lower) > -float('inf')):
+        elif con.has_lb():
             my_sense = 'G'
             my_rhs = [value(con.lower) - cplex_expr.offset]
             my_range = []
-        elif con.has_ub() and (value(con.upper) < float('inf')):
+        elif con.has_ub():
             my_sense = 'L'
             my_rhs = [value(con.upper) - cplex_expr.offset]
             my_range = []

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -283,8 +283,10 @@ class CPLEXDirect(DirectSolver):
             self._solver_model = self._cplex.Cplex()
         except Exception:
             e = sys.exc_info()[1]
-            msg = ('Unable to create CPLEX model. Have you installed the Python bindings for CPLEX?\n\n\t' +
-                   'Error message: {0}'.format(e))
+            msg = ("Unable to create CPLEX model. "
+                   "Have you installed the Python "
+                   "bindings for CPLEX?\n\n\t"+
+                   "Error message: {0}".format(e))
             raise Exception(msg)
 
         self._add_block(model)
@@ -293,12 +295,15 @@ class CPLEXDirect(DirectSolver):
             if n_ref != 0:
                 if var.fixed:
                     if not self._output_fixed_variable_bounds:
-                        raise ValueError("Encountered a fixed variable (%s) inside an active objective "
-                                         "or constraint expression on model %s, which is usually indicative of "
-                                         "a preprocessing error. Use the IO-option 'output_fixed_variable_bounds=True' "
-                                         "to suppress this error and fix the variable by overwriting its bounds in "
-                                         "the Gurobi instance."
-                                         % (var.name, self._pyomo_model.name,))
+                        raise ValueError(
+                            "Encountered a fixed variable (%s) inside "
+                            "an active objective or constraint "
+                            "expression on model %s, which is usually "
+                            "indicative of a preprocessing error. Use "
+                            "the IO-option 'output_fixed_variable_bounds=True' "
+                            "to suppress this error and fix the variable "
+                            "by overwriting its bounds in the CPLEX instance."
+                            % (var.name, self._pyomo_model.name,))
 
     def _add_constraint(self, con):
         if not con.active:
@@ -311,19 +316,26 @@ class CPLEXDirect(DirectSolver):
         conname = self._symbol_map.getSymbol(con, self._labeler)
 
         if con._linear_canonical_form:
-            cplex_expr, referenced_vars = self._get_expr_from_pyomo_repn(con.canonical_form(),
-                                                                         self._max_constraint_degree)
+            cplex_expr, referenced_vars = self._get_expr_from_pyomo_repn(
+                con.canonical_form(),
+                self._max_constraint_degree)
         elif isinstance(con, LinearCanonicalRepn):
-            cplex_expr, referenced_vars = self._get_expr_from_pyomo_repn(con, self._max_constraint_degree)
+            cplex_expr, referenced_vars = self._get_expr_from_pyomo_repn(
+                con,
+                self._max_constraint_degree)
         else:
-            cplex_expr, referenced_vars = self._get_expr_from_pyomo_expr(con.body, self._max_constraint_degree)
+            cplex_expr, referenced_vars = self._get_expr_from_pyomo_expr(
+                con.body,
+                self._max_constraint_degree)
 
         if con.has_lb():
             if not is_fixed(con.lower):
-                raise ValueError('Lower bound of constraint {0} is not constant.'.format(con))
+                raise ValueError("Lower bound of constraint {0} "
+                                 "is not constant.".format(con))
         if con.has_ub():
             if not is_fixed(con.upper):
-                raise ValueError('Upper bound of constraint {0} is not constant.'.format(con))
+                raise ValueError("Upper bound of constraint {0} "
+                                 "is not constant.".format(con))
 
         if con.equality:
             my_sense = 'E'
@@ -345,21 +357,31 @@ class CPLEXDirect(DirectSolver):
             my_rhs = [value(con.upper) - cplex_expr.offset]
             my_range = []
         else:
-            raise ValueError('Constraint does not have a lower or an upper bound: {0} \n'.format(con))
+            raise ValueError("Constraint does not have a lower "
+                             "or an upper bound: {0} \n".format(con))
 
         if len(cplex_expr.q_coefficients) == 0:
-            self._solver_model.linear_constraints.add(lin_expr=[[cplex_expr.variables, cplex_expr.coefficients]],
-                                                      senses=my_sense, rhs=my_rhs, range_values=my_range,
-                                                      names=[conname])
+            self._solver_model.linear_constraints.add(
+                lin_expr=[[cplex_expr.variables,
+                           cplex_expr.coefficients]],
+                senses=my_sense,
+                rhs=my_rhs,
+                range_values=my_range,
+                names=[conname])
         else:
             if my_sense == 'R':
-                raise ValueError('The CPLEXDirect interface does not support quadratic ' +
-                                 'range constraints: {0}'.format(con))
-            self._solver_model.quadratic_constraints.add(lin_expr=[cplex_expr.variables, cplex_expr.coefficients],
-                                                         quad_expr=[cplex_expr.q_variables1,
-                                                                    cplex_expr.q_variables2,
-                                                                    cplex_expr.q_coefficients],
-                                                         sense=my_sense, rhs=my_rhs[0], name=conname)
+                raise ValueError("The CPLEXDirect interface does not "
+                                 "support quadratic range constraints: "
+                                 "{0}".format(con))
+            self._solver_model.quadratic_constraints.add(
+                lin_expr=[cplex_expr.variables,
+                          cplex_expr.coefficients],
+                quad_expr=[cplex_expr.q_variables1,
+                           cplex_expr.q_variables2,
+                           cplex_expr.q_coefficients],
+                sense=my_sense,
+                rhs=my_rhs[0],
+                name=conname)
 
         for var in referenced_vars:
             self._referenced_variables[var] += 1
@@ -378,7 +400,8 @@ class CPLEXDirect(DirectSolver):
         elif level == 2:
             sos_type = self._solver_model.SOS.type.SOS2
         else:
-            raise ValueError('Solver does not support SOS level {0} constraints'.format(level))
+            raise ValueError("Solver does not support SOS "
+                             "level {0} constraints".format(level))
 
         cplex_vars = []
         weights = []

--- a/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
@@ -214,6 +214,10 @@ class DirectOrPersistentSolver(OptSolver):
                     descend_into=False,
                     active=True,
                     sort=True):
+                if (not con.has_lb()) and \
+                   (not con.has_ub()):
+                    assert not con.equality
+                    continue  # non-binding, so skip
                 self._add_constraint(con)
 
             for con in sub_block.component_data_objects(

--- a/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
@@ -200,54 +200,74 @@ class DirectOrPersistentSolver(OptSolver):
             self._labeler = NumericLabeler('x')
 
     def _add_block(self, block):
-        for var in block.component_data_objects(ctype=pyomo.core.base.var.Var, descend_into=True,
-                                                active=True, sort=True):
+        for var in block.component_data_objects(
+                ctype=pyomo.core.base.var.Var,
+                descend_into=True,
+                active=True,
+                sort=True):
             self._add_var(var)
 
-        for sub_block in block.block_data_objects(descend_into=True, active=True):
-            for con in sub_block.component_data_objects(ctype=pyomo.core.base.constraint.Constraint,
-                                                        descend_into=False, active=True, sort=True):
+        for sub_block in block.block_data_objects(descend_into=True,
+                                                  active=True):
+            for con in sub_block.component_data_objects(
+                    ctype=pyomo.core.base.constraint.Constraint,
+                    descend_into=False,
+                    active=True,
+                    sort=True):
                 self._add_constraint(con)
 
-            for con in sub_block.component_data_objects(ctype=pyomo.core.base.sos.SOSConstraint,
-                                                        descend_into=False, active=True, sort=True):
+            for con in sub_block.component_data_objects(
+                    ctype=pyomo.core.base.sos.SOSConstraint,
+                    descend_into=False,
+                    active=True,
+                    sort=True):
                 self._add_sos_constraint(con)
 
             obj_counter = 0
-            for obj in sub_block.component_data_objects(ctype=pyomo.core.base.objective.Objective, descend_into=False,
-                                                        active=True):
+            for obj in sub_block.component_data_objects(
+                    ctype=pyomo.core.base.objective.Objective,
+                    descend_into=False,
+                    active=True):
                 obj_counter += 1
                 if obj_counter > 1:
-                    raise ValueError('Solver interface does not support multiple objectives.')
+                    raise ValueError("Solver interface does not "
+                                     "support multiple objectives.")
                 self._set_objective(obj)
 
     """ This method should be implemented by subclasses."""
     def _set_objective(self, obj):
-        raise NotImplementedError('This method should be implemented by subclasses')
+        raise NotImplementedError("This method should be implemented "
+                                  "by subclasses")
 
     """ This method should be implemented by subclasses."""
     def _add_constraint(self, con):
-        raise NotImplementedError('This method should be implemented by subclasses')
+        raise NotImplementedError("This method should be implemented "
+                                  "by subclasses")
 
     """ This method should be implemented by subclasses."""
     def _add_sos_constraint(self, con):
-        raise NotImplementedError('This method should be implemented by subclasses')
+        raise NotImplementedError("This method should be implemented "
+                                  "by subclasses")
 
     """ This method should be implemented by subclasses."""
     def _add_var(self, var):
-        raise NotImplementedError('This method should be implemented by subclasses')
+        raise NotImplementedError("This method should be implemented "
+                                  "by subclasses")
 
     """ This method should be implemented by subclasses."""
     def _get_expr_from_pyomo_repn(self, repn, max_degree=None):
-        raise NotImplementedError('This method should be implemented by subclasses')
+        raise NotImplementedError("This method should be implemented "
+                                  "by subclasses")
 
     """ This method should be implemented by subclasses."""
     def _get_expr_from_pyomo_expr(self, expr, max_degree=None):
-        raise NotImplementedError('This method should be implemented by subclasses')
+        raise NotImplementedError("This method should be implemented "
+                                  "by subclasses")
 
     """ This method should be implemented by subclasses."""
     def _load_vars(self, vars_to_load):
-        raise NotImplementedError('This method should be implemented by subclasses')
+        raise NotImplementedError("This method should be implemented "
+                                  "by subclasses")
 
     def load_vars(self, vars_to_load=None):
         """

--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -305,17 +305,26 @@ class GurobiDirect(DirectSolver):
                                  "is not constant.".format(con))
 
         if con.equality:
-            gurobipy_con = self._solver_model.addConstr(lhs=gurobi_expr, sense=self._gurobipy.GRB.EQUAL,
-                                                        rhs=value(con.lower), name=conname)
-        elif con.has_lb() and (value(con.lower) > -float('inf')) and con.has_ub() and (value(con.upper) < float('inf')):
-            gurobipy_con = self._solver_model.addRange(gurobi_expr, value(con.lower), value(con.upper), name=conname)
+            gurobipy_con = self._solver_model.addConstr(lhs=gurobi_expr,
+                                                        sense=self._gurobipy.GRB.EQUAL,
+                                                        rhs=value(con.lower),
+                                                        name=conname)
+        elif con.has_lb() and con.has_ub():
+            gurobipy_con = self._solver_model.addRange(gurobi_expr,
+                                                       value(con.lower),
+                                                       value(con.upper),
+                                                       name=conname)
             self._range_constraints.add(con)
-        elif con.has_lb() and (value(con.lower) > -float('inf')):
-            gurobipy_con = self._solver_model.addConstr(lhs=gurobi_expr, sense=self._gurobipy.GRB.GREATER_EQUAL,
-                                                        rhs=value(con.lower), name=conname)
-        elif con.has_ub() and (value(con.upper) < float('inf')):
-            gurobipy_con = self._solver_model.addConstr(lhs=gurobi_expr, sense=self._gurobipy.GRB.LESS_EQUAL,
-                                                        rhs=value(con.upper), name=conname)
+        elif con.has_lb():
+            gurobipy_con = self._solver_model.addConstr(lhs=gurobi_expr,
+                                                        sense=self._gurobipy.GRB.GREATER_EQUAL,
+                                                        rhs=value(con.lower),
+                                                        name=conname)
+        elif con.has_ub():
+            gurobipy_con = self._solver_model.addConstr(lhs=gurobi_expr,
+                                                        sense=self._gurobipy.GRB.LESS_EQUAL,
+                                                        rhs=value(con.upper),
+                                                        name=conname)
         else:
             raise ValueError("Constraint does not have a lower "
                              "or an upper bound: {0} \n".format(con))

--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -246,8 +246,10 @@ class GurobiDirect(DirectSolver):
                 self._solver_model = self._gurobipy.Model()
         except Exception:
             e = sys.exc_info()[1]
-            msg = ('Unable to create Gurobi model. Have you installed the Python bindings for Gurboi?\n\n\t' +
-                   'Error message: {0}'.format(e))
+            msg = ("Unable to create Gurobi model. "
+                   "Have you installed the Python "
+                   "bindings for Gurboi?\n\n\t"+
+                   "Error message: {0}".format(e))
             raise Exception(msg)
 
         self._add_block(model)
@@ -256,12 +258,15 @@ class GurobiDirect(DirectSolver):
             if n_ref != 0:
                 if var.fixed:
                     if not self._output_fixed_variable_bounds:
-                        raise ValueError("Encountered a fixed variable (%s) inside an active objective "
-                                         "or constraint expression on model %s, which is usually indicative of "
-                                         "a preprocessing error. Use the IO-option 'output_fixed_variable_bounds=True' "
-                                         "to suppress this error and fix the variable by overwriting its bounds in "
-                                         "the Gurobi instance."
-                                         % (var.name, self._pyomo_model.name,))
+                        raise ValueError(
+                            "Encountered a fixed variable (%s) inside "
+                            "an active objective or constraint "
+                            "expression on model %s, which is usually "
+                            "indicative of a preprocessing error. Use "
+                            "the IO-option 'output_fixed_variable_bounds=True' "
+                            "to suppress this error and fix the variable "
+                            "by overwriting its bounds in the Gurobi instance."
+                            % (var.name, self._pyomo_model.name,))
 
     def _add_block(self, block):
         DirectOrPersistentSolver._add_block(self, block)
@@ -278,19 +283,26 @@ class GurobiDirect(DirectSolver):
         conname = self._symbol_map.getSymbol(con, self._labeler)
 
         if con._linear_canonical_form:
-            gurobi_expr, referenced_vars = self._get_expr_from_pyomo_repn(con.canonical_form(),
-                                                                          self._max_constraint_degree)
+            gurobi_expr, referenced_vars = self._get_expr_from_pyomo_repn(
+                con.canonical_form(),
+                self._max_constraint_degree)
         elif isinstance(con, LinearCanonicalRepn):
-            gurobi_expr, referenced_vars = self._get_expr_from_pyomo_repn(con, self._max_constraint_degree)
+            gurobi_expr, referenced_vars = self._get_expr_from_pyomo_repn(
+                con,
+                self._max_constraint_degree)
         else:
-            gurobi_expr, referenced_vars = self._get_expr_from_pyomo_expr(con.body, self._max_constraint_degree)
+            gurobi_expr, referenced_vars = self._get_expr_from_pyomo_expr(
+                con.body,
+                self._max_constraint_degree)
 
         if con.has_lb():
             if not is_fixed(con.lower):
-                raise ValueError('Lower bound of constraint {0} is not constant.'.format(con))
+                raise ValueError("Lower bound of constraint {0} "
+                                 "is not constant.".format(con))
         if con.has_ub():
             if not is_fixed(con.upper):
-                raise ValueError('Upper bound of constraint {0} is not constant.'.format(con))
+                raise ValueError("Upper bound of constraint {0} "
+                                 "is not constant.".format(con))
 
         if con.equality:
             gurobipy_con = self._solver_model.addConstr(lhs=gurobi_expr, sense=self._gurobipy.GRB.EQUAL,
@@ -305,7 +317,8 @@ class GurobiDirect(DirectSolver):
             gurobipy_con = self._solver_model.addConstr(lhs=gurobi_expr, sense=self._gurobipy.GRB.LESS_EQUAL,
                                                         rhs=value(con.upper), name=conname)
         else:
-            raise ValueError('Constraint does not have a lower or an upper bound: {0} \n'.format(con))
+            raise ValueError("Constraint does not have a lower "
+                             "or an upper bound: {0} \n".format(con))
 
         for var in referenced_vars:
             self._referenced_variables[var] += 1
@@ -324,7 +337,8 @@ class GurobiDirect(DirectSolver):
         elif level == 2:
             sos_type = self._gurobipy.GRB.SOS_TYPE2
         else:
-            raise ValueError('Solver does not support SOS level {0} constraints'.format(level))
+            raise ValueError("Solver does not support SOS "
+                             "level {0} constraints".format(level))
 
         gurobi_vars = []
         weights = []

--- a/pyomo/solvers/tests/models/LP_trivial_constraints.json
+++ b/pyomo/solvers/tests/models/LP_trivial_constraints.json
@@ -34,6 +34,10 @@
     "slack": 0.0, 
     "value": 1.0
   }, 
+  "d": {
+    "dual": null, 
+    "value": -2.0
+  }, 
   "obj": {
     "value": -5.0
   }, 

--- a/pyomo/solvers/tests/models/LP_trivial_constraints.py
+++ b/pyomo/solvers/tests/models/LP_trivial_constraints.py
@@ -63,6 +63,9 @@ class LP_trivial_constraints(_BaseTestModel):
         assert cdata.upper == 1
         assert cdata.body() == 1
         assert cdata.equality
+        model.d = Constraint(
+            rule=lambda m: (float('-inf'), m.x, float('inf')))
+        assert not model.d.equality
 
     def warmstart_model(self):
         assert self.model is not None
@@ -74,9 +77,11 @@ class LP_trivial_constraints(_BaseTestModel):
         if tester is None:
             for i in self.model.c:
                 assert id(self.model.c[i]) in symbol_map.byObject
+            assert id(self.model.d[i]) not in symbol_map.byObject
         else:
             for i in self.model.c:
                 tester.assertTrue(id(self.model.c[i]) in symbol_map.byObject)
+            tester.assertTrue(id(self.model.d) not in symbol_map.byObject)
 
 @register_model
 class LP_trivial_constraints_kernel(LP_trivial_constraints):


### PR DESCRIPTION
## Fixes # .

Makes the behavior of solvers interfaces consistent in how unbounded constraints are handled. Some interfaces would raise an exception and others would skip them. All solver interfaces now skip over them.

Fixes #388.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
