### PR TITLE
Fixing bug in Eckstein-Combettes extension to properly handle stale v…

### DIFF
--- a/pyomo/pysp/plugins/ecksteincombettesextension.py
+++ b/pyomo/pysp/plugins/ecksteincombettesextension.py
@@ -209,15 +209,12 @@ class EcksteinCombettesExtension(pyomo.util.plugin.SingletonPlugin):
             for tree_node in scenario._node_list[:-1]:
                 tree_node_zs = tree_node._z
                 for variable_id in tree_node._standard_variable_ids:
-                        var_values = scenario._x[tree_node._name]
-                        varval = var_values[variable_id]
-                        weight_values = scenario._w[tree_node._name]
-                        if varval is not None:
-                            this_sub_phi_term = scenario._probability * ((tree_node_zs[variable_id] - varval) * (scenario._y[variable_id] + weight_values[variable_id]))
-                            cumulative_sub_phi += this_sub_phi_term
-                            
-                        else:
-                            foobar # HEY! Fix this!
+                    var_values = scenario._x[tree_node._name]
+                    varval = var_values[variable_id]
+                    weight_values = scenario._w[tree_node._name]
+                    if not scenario.is_variable_stale(tree_node, variable_id):
+                        this_sub_phi_term = scenario._probability * ((tree_node_zs[variable_id] - varval) * (scenario._y[variable_id] + weight_values[variable_id]))
+                        cumulative_sub_phi += this_sub_phi_term
 
             with open(self._JName,"a") as f:
                 f.write(", %10f" % (cumulative_sub_phi))
@@ -346,11 +343,9 @@ class EcksteinCombettesExtension(pyomo.util.plugin.SingletonPlugin):
                     var_values = scenario._x[tree_node._name]
                     varval = var_values[variable_id]
                     weight_values = scenario._w[tree_node._name]
-                    if varval is not None:
+                    if not scenario.is_variable_stale(tree_node, variable_id):
                         this_sub_phi_term = scenario._probability * ((tree_node_zs[variable_id] - varval) * (scenario._y[variable_id] + weight_values[variable_id]))
                         cumulative_sub_phi += this_sub_phi_term
-                    else:
-                        foobar # HEY! Fix this!
 
             with open(self._JName,"a") as f:
                 f.write(", %10f" % (cumulative_sub_phi))


### PR DESCRIPTION
## Fixes: 
Unreferenced variables in the Eckstein-Combettes extension were causing exception conditions, as the variable values were stale, i.e., equal to None.

## Summary/Motivation: 
Corrects minor issue that lazy modelers :) would encounter when using the PH Eckstein-Combettes asynchronous extension. See above.

## Changes proposed in this PR:
- Places is-stale gate check around relevant processing in Eckstein-Combettes extension.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.