### PR TITLE
Baron format fix

### DIFF
--- a/pyomo/repn/plugins/baron_writer.py
+++ b/pyomo/repn/plugins/baron_writer.py
@@ -316,7 +316,7 @@ class ProblemWriter_bar(AbstractProblemWriter):
                 else:
                     assert var_data.value is not None
                     vstring_to_bar_dict[variable_string] = \
-                        (' %.17r ' % (var_data.value))
+                        (' %'+self._precision_string+' ' % (var_data.value))
 
             for param_data in mutable_param_gen(block):
                 param_stream = StringIO()
@@ -325,7 +325,7 @@ class ProblemWriter_bar(AbstractProblemWriter):
 
                 param_string = ' '+param_string+' '
                 pstring_to_bar_dict[param_string] = \
-                    (' %.17r ' % (param_data()))
+                    (' %'+self._precision_string+' ' % (param_data()))
 
         # Equation Definition
         string_template = '%'+self._precision_string

--- a/pyomo/repn/plugins/baron_writer.py
+++ b/pyomo/repn/plugins/baron_writer.py
@@ -302,8 +302,8 @@ class ProblemWriter_bar(AbstractProblemWriter):
         vstring_to_var_dict = {}
         vstring_to_bar_dict = {}
         pstring_to_bar_dict = {}
+        _val_template = ' %'+self._precision_string+' '
         for block in all_blocks_list:
-
             for var_data in active_components_data_var[id(block)]:
                 variable_stream = StringIO()
                 var_data.to_string(ostream=variable_stream, verbose=False)
@@ -316,7 +316,7 @@ class ProblemWriter_bar(AbstractProblemWriter):
                 else:
                     assert var_data.value is not None
                     vstring_to_bar_dict[variable_string] = \
-                        (' %'+self._precision_string+' ' % (var_data.value))
+                        (_val_template % (var_data.value,))
 
             for param_data in mutable_param_gen(block):
                 param_stream = StringIO()
@@ -325,7 +325,7 @@ class ProblemWriter_bar(AbstractProblemWriter):
 
                 param_string = ' '+param_string+' '
                 pstring_to_bar_dict[param_string] = \
-                    (' %'+self._precision_string+' ' % (param_data()))
+                    (_val_template % (param_data(),))
 
         # Equation Definition
         string_template = '%'+self._precision_string


### PR DESCRIPTION
## Summary/Motivation:
This fixes an issue reported [on the forum](https://groups.google.com/d/msg/pyomo-forum/uG8auFMqG9M/klEcQdUCCQAJ) where small floating point numbers were be written incorrectly.  I am not sure why the writer originally used %r for these two lines... but there is a very nice discussion of the relative merits for formatting strings from Kevin Hunter back on [Trac issue 4319](https://software.sandia.gov/trac/pyomo/ticket/4319).

## Changes proposed in this PR:
- always use %g instead of %r for formatting

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
