### PR TITLE
GDP: BigM bugfix for disjuncts containing indexed blocks

### DIFF
--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -492,8 +492,9 @@ class BigM_Transformation(Transformation):
         # directly.  (We are passing the disjunct through so that when
         # we find constraints, _xform_constraint will have access to
         # the correct indicator variable.
-        self._transform_block_components(
-            block, disjunct, infodict, bigMargs, suffix_list)
+        for i in sorted(iterkeys(block)):
+            self._transform_block_components(
+                block[i], disjunct, infodict, bigMargs, suffix_list)
 
     def _xform_constraint(self, obj, disjunct, infodict,
                           bigMargs, suffix_list):

--- a/pyomo/gdp/tests/models.py
+++ b/pyomo/gdp/tests/models.py
@@ -228,6 +228,8 @@ def makeTwoTermDisj_BlockOnDisj():
             d.add_component('b.c', Constraint(expr=m.y >= 9))
             d.b.anotherblock = Block()
             d.b.anotherblock.c = Constraint(expr=m.y >= 11)
+            d.bb = Block([1])
+            d.bb[1].c = Constraint(expr=m.x == 0)
         else:
             d.c = Constraint(expr=m.x >= 80)
     m.evil = Disjunct([0,1], rule=disj_rule)

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -2153,9 +2153,11 @@ class BlocksOnDisjuncts(unittest.TestCase):
         self.assertIsInstance(disjBlock, Block)
         self.assertEqual(len(disjBlock), 2)
         self.assertEqual(len(disjBlock[0].component_map()), 1)
-        self.assertEqual(len(disjBlock[1].component_map()), 3)
+        self.assertEqual(len(disjBlock[1].component_map()), 4)
         self.assertIsInstance(disjBlock[0].component("evil[0].c"), Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].b.c"), Constraint)
+        self.assertIsInstance(disjBlock[1].component("evil[1].bb[1].c"),
+                              Constraint)
         self.assertIsInstance(
             disjBlock[1].component("evil[1].b.c_4"), Constraint)
         self.assertIsInstance(
@@ -2174,9 +2176,11 @@ class BlocksOnDisjuncts(unittest.TestCase):
         self.assertIsInstance(disjBlock, Block)
         self.assertEqual(len(disjBlock), 2)
         self.assertEqual(len(disjBlock[0].component_map()), 1)
-        self.assertEqual(len(disjBlock[1].component_map()), 2)
+        self.assertEqual(len(disjBlock[1].component_map()), 3)
         self.assertIsInstance(disjBlock[0].component("evil[0].c"), Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].b.c"), Constraint)
+        self.assertIsInstance(disjBlock[1].component("evil[1].bb[1].c"),
+                              Constraint)
         self.assertIsInstance(
             disjBlock[1].component("evil[1].b.c_4"), Constraint)
 
@@ -2192,9 +2196,11 @@ class BlocksOnDisjuncts(unittest.TestCase):
         self.assertIsInstance(disjBlock, Block)
         self.assertEqual(len(disjBlock), 2)
         self.assertEqual(len(disjBlock[0].component_map()), 1)
-        self.assertEqual(len(disjBlock[1].component_map()), 2)
+        self.assertEqual(len(disjBlock[1].component_map()), 3)
         self.assertIsInstance(disjBlock[0].component("evil[0].c"), Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].b.c"), Constraint)
+        self.assertIsInstance(disjBlock[1].component("evil[1].bb[1].c"),
+                              Constraint)
         self.assertIsInstance(
             disjBlock[1].component("evil[1].b.c_4"), Constraint)
 


### PR DESCRIPTION
This resolves an error where Disjuncts containing an Indexed Block
generated an exception from the Big-M relaxation.  Updating tests to
cover this case.

## Summary/Motivation:
Fixes a bug reported by @qtothec.

## Changes proposed in this PR:
- Iterate over block datas when a Block is encountered within a Disjunct
- Update the tests to cover this situation

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
