### PR TITLE
Fixing some cut+paste issues when using atypical methods to create a …

### DIFF
--- a/pyomo/pysp/scenariotree/instance_factory.py
+++ b/pyomo/pysp/scenariotree/instance_factory.py
@@ -418,7 +418,7 @@ class ScenarioTreeInstanceFactory(object):
                      scenario_tree_model,
                      scenario_tree_callback) = \
                         _find_scenariotree_or_callback(
-                            self._model_module)
+                            self._model_filename)
                 else:
                     (self._scenario_tree_module,
                      scenario_tree_object,
@@ -433,7 +433,7 @@ class ScenarioTreeInstanceFactory(object):
                     if isinstance(obj, ScenarioTree):
                         self._scenario_tree = obj
                     else:
-                        assert isinstance(model, (_BlockData, Block)) or \
+                        assert isinstance(obj, (_BlockData, Block)) or \
                             (has_networkx and \
                              isinstance(obj, networkx.DiGraph))
                         self._scenario_tree_model = obj


### PR DESCRIPTION
## Fixes # 
- Corrects some cut+paste issues that are incurred when using atypical methods (and untested methods) to create a scenario tree and all associated instances.

## Summary/Motivation:
- To make Dave Woodruff happy.

## Changes proposed in this PR:
- See above - minor syntax error fixes.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
