### PR TITLE
Propagating the AMPLFUNC env management to solver-specific interfaces

### DIFF
--- a/pyomo/solvers/plugins/solvers/CONOPT.py
+++ b/pyomo/solvers/plugins/solvers/CONOPT.py
@@ -110,6 +110,16 @@ class CONOPT(SystemCallSolver):
         # Define command line
         #
         env=os.environ.copy()
+        #
+        # Merge the PYOMO_AMPLFUNC (externals defined within
+        # Pyomo/Pyomo) with any user-specified external function
+        # libraries
+        #
+        if 'PYOMO_AMPLFUNC' in env:
+            if 'AMPLFUNC' in env:
+                env['AMPLFUNC'] += "\n" + env['PYOMO_AMPLFUNC']
+            else:
+                env['AMPLFUNC'] = env['PYOMO_AMPLFUNC']
 
         cmd = [executable, problem_files[0], '-AMPL']
         if self._timer:

--- a/pyomo/solvers/plugins/solvers/IPOPT.py
+++ b/pyomo/solvers/plugins/solvers/IPOPT.py
@@ -112,6 +112,16 @@ class IPOPT(SystemCallSolver):
         # Define command line
         #
         env=os.environ.copy()
+        #
+        # Merge the PYOMO_AMPLFUNC (externals defined within
+        # Pyomo/Pyomo) with any user-specified external function
+        # libraries
+        #
+        if 'PYOMO_AMPLFUNC' in env:
+            if 'AMPLFUNC' in env:
+                env['AMPLFUNC'] += "\n" + env['PYOMO_AMPLFUNC']
+            else:
+                env['AMPLFUNC'] = env['PYOMO_AMPLFUNC']
 
         cmd = [executable, problem_files[0], '-AMPL']
         if self._timer:

--- a/pyomo/solvers/plugins/solvers/SCIPAMPL.py
+++ b/pyomo/solvers/plugins/solvers/SCIPAMPL.py
@@ -109,6 +109,16 @@ class SCIPAMPL(SystemCallSolver):
         # Define command line
         #
         env=os.environ.copy()
+        #
+        # Merge the PYOMO_AMPLFUNC (externals defined within
+        # Pyomo/Pyomo) with any user-specified external function
+        # libraries
+        #
+        if 'PYOMO_AMPLFUNC' in env:
+            if 'AMPLFUNC' in env:
+                env['AMPLFUNC'] += "\n" + env['PYOMO_AMPLFUNC']
+            else:
+                env['AMPLFUNC'] = env['PYOMO_AMPLFUNC']
 
         cmd = [executable, problem_files[0], '-AMPL']
         if self._timer:


### PR DESCRIPTION
## Fixes #73

## Summary/Motivation:
This fixes #73.  The solver-specific ASL interfaces reimplement the ASL interface instead of inheriting, so we need to copy over the AMPLFUNC environment variable management from `ASL.py` into those solvers as well.

This highlights problems with our solver interfaces, but fixing that is a major undertaking.

## Changes proposed in this PR:
- Propagate `AMPLFUNC` management from ASL.py to other ("derived") solvers.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
