### PR TITLE
More cleanup related to what was fixed in #422. Also adding a few uni…

### DIFF
--- a/pyomo/pysp/scenariotree/instance_factory.py
+++ b/pyomo/pysp/scenariotree/instance_factory.py
@@ -220,10 +220,14 @@ def _find_reference_model_or_callback(src):
 
     return module, reference_model, callback
 
-def _find_scenariotree_or_callback(src):
+def _find_scenariotree(src=None, module=None):
     """Tries to find a single reference model or callback for
     generating scenario models."""
-    module, _ = load_external_module(src, clear_cache=True)
+    if module is None:
+        assert src is not None
+        module, _ = load_external_module(src, clear_cache=True)
+    else:
+        assert src is None
     scenario_tree_object = None
     scenario_tree_model = None
     callback = None
@@ -234,30 +238,32 @@ def _find_scenariotree_or_callback(src):
             raise TypeError("'pysp_scenario_tree_model_callback' "
                             "object found in source '%s' is not "
                             "callable" % (src))
+        attrs = [(None, callback())]
     else:
-        matching_names = []
-        for attr_name in dir_module:
-            obj = getattr(module, attr_name)
-            if isinstance(obj, ScenarioTree):
-                scenario_tree_object = obj
-                matching_names.append(attr_name)
-            elif isinstance(obj, (_BlockData, Block)):
-                scenario_tree_model = obj
-                matching_names.append(attr_name)
-            elif has_networkx and \
-                 isinstance(obj, networkx.DiGraph):
-                scenario_tree_model = obj
-                matching_names.append(attr_name)
-        if len(matching_names) > 1:
-            raise ValueError("Multiple objects found in source '%s' "
-                             "that could act as a scenario tree "
-                             "specification. Make sure there is only "
-                             "one Pyomo model, ScenarioTree, or "
-                             "networkx.DiGraph object in the source "
-                             "file. Object names: %s"
-                             % (str(matching_names)))
+        attrs = [(attr_name,getattr(module, attr_name))
+                 for attr_name in dir_module]
+    matching_names = []
+    for attr_name, obj in attrs:
+        if isinstance(obj, ScenarioTree):
+            scenario_tree_object = obj
+            matching_names.append(attr_name)
+        elif isinstance(obj, (_BlockData, Block)):
+            scenario_tree_model = obj
+            matching_names.append(attr_name)
+        elif has_networkx and \
+             isinstance(obj, networkx.DiGraph):
+            scenario_tree_model = obj
+            matching_names.append(attr_name)
+    if len(matching_names) > 1:
+        raise ValueError("Multiple objects found in source '%s' "
+                         "that could act as a scenario tree "
+                         "specification. Make sure there is only "
+                         "one Pyomo model, ScenarioTree, or "
+                         "networkx.DiGraph object in the source "
+                         "file. Object names: %s"
+                         % (str(matching_names)))
 
-    return module, scenario_tree_object, scenario_tree_model, callback
+    return module, scenario_tree_object, scenario_tree_model
 
 class ScenarioTreeInstanceFactory(object):
 
@@ -414,44 +420,21 @@ class ScenarioTreeInstanceFactory(object):
                 if self._scenario_tree_filename == self._model_filename:
                     # try not to clobber the model import
                     (self._scenario_tree_module,
-                     scenario_tree_object,
-                     scenario_tree_model,
-                     scenario_tree_callback) = \
-                        _find_scenariotree_or_callback(
-                            self._model_filename)
+                     self._scenario_tree,
+                     self._scenario_tree_model) = \
+                        _find_scenariotree(module=self._model_module)
                 else:
                     (self._scenario_tree_module,
-                     scenario_tree_object,
-                     scenario_tree_model,
-                     scenario_tree_callback) = \
-                        _find_scenariotree_or_callback(
-                            self._scenario_tree_filename)
-                if scenario_tree_callback is not None:
-                    assert scenario_tree_object is None
-                    assert scenario_tree_model is None
-                    obj = scenario_tree_callback()
-                    if isinstance(obj, ScenarioTree):
-                        self._scenario_tree = obj
-                    else:
-                        assert isinstance(obj, (_BlockData, Block)) or \
-                            (has_networkx and \
-                             isinstance(obj, networkx.DiGraph))
-                        self._scenario_tree_model = obj
-                elif scenario_tree_model is not None:
-                    assert scenario_tree_object is None
-                    assert scenario_tree_callback is None
-                    self._scenario_tree_model = scenario_tree_model
-                elif scenario_tree_object is not None:
-                    assert scenario_tree_model is None
-                    assert scenario_tree_callback is None
-                    self._scenario_tree = scenario_tree_object
-                else:
+                     self._scenario_tree,
+                     self._scenario_tree_model) = \
+                        _find_scenariotree(src=self._scenario_tree_filename)
+                if (self._scenario_tree is None) and \
+                   (self._scenario_tree_model is None):
                     raise AttributeError(
                         "No scenario tree or "
                         "'pysp_scenario_tree_model_callback' "
                         "function found in src: %s"
                         % (self._scenario_tree_filename))
-
             elif self._scenario_tree_filename.endswith(".dat"):
                 self._scenario_tree_model = \
                     CreateAbstractScenarioTreeModel().\
@@ -460,21 +443,13 @@ class ScenarioTreeInstanceFactory(object):
                 assert False
         elif scenario_tree is None:
             if self._model_module is not None:
-                if ("pysp_scenario_tree_model_callback" in dir(self._model_module)):
-                    self._scenario_tree_model = \
-                        self._model_module.pysp_scenario_tree_model_callback()
-                else:
-                    for attr_name in dir(self._model_module):
-                        obj = getattr(self._model_module, attr_name)
-                        if isinstance(obj, ScenarioTree):
-                            self._scenario_tree = obj
-                            break
-                        elif has_networkx and \
-                             isinstance(obj, networkx.DiGraph):
-                            self._scenario_tree_model = obj
-                            break
-                if (self._scenario_tree_model is None) and \
-                   (self._scenario_tree is None):
+                self._scenario_tree_filename = self._model_filename
+                (self._scenario_tree_module,
+                 self._scenario_tree,
+                 self._scenario_tree_model) = \
+                    _find_scenariotree(module=self._model_module)
+                if (self._scenario_tree is None) and \
+                   (self._scenario_tree_model is None):
                     raise ValueError(
                         "No input was provided for the scenario tree "
                         "and no callback or scenario tree object was "
@@ -489,8 +464,11 @@ class ScenarioTreeInstanceFactory(object):
             self._scenario_tree_model = scenario_tree
 
         if self._scenario_tree is None:
-            if (not isinstance(self._scenario_tree_model, (_BlockData, Block))) and \
-               (has_networkx and (not isinstance(self._scenario_tree_model, networkx.DiGraph))):
+            if (not isinstance(self._scenario_tree_model,
+                               (_BlockData, Block))) and \
+               (has_networkx and \
+                (not isinstance(self._scenario_tree_model,
+                                networkx.DiGraph))):
                 raise TypeError(
                     "scenario tree model object has incorrect type: %s. "
                     "Must be a string type,  Pyomo model, or a "

--- a/pyomo/pysp/tests/unit/test_instancefactory.py
+++ b/pyomo/pysp/tests/unit/test_instancefactory.py
@@ -62,6 +62,8 @@ class Test(unittest.TestCase):
             del sys.modules["reference_test_scenario_tree_model"]
         if "ScenarioStructure" in sys.modules:
             del sys.modules["ScenarioStructure"]
+        if "both_callbacks" in sys.modules:
+            del sys.modules["both_callbacks"]
 
     def _get_testfname_prefix(self):
         class_name, test_name = self.id().split('.')[-2:]
@@ -666,6 +668,39 @@ class Test(unittest.TestCase):
             self._check_factory(factory)
         self.assertEqual(factory._closed, True)
         self.assertEqual(len(factory._archives), 0)
+
+    # model: name of .py file with model callback
+    # scenario_tree: name of same .py file with scenario tree callback
+    @unittest.skipIf(not has_networkx, "Requires networkx module")
+    def test_init21(self):
+        self.assertTrue("both_callbacks" not in sys.modules)
+        with ScenarioTreeInstanceFactory(
+                model=join(testdatadir,
+                           "both_callbacks.py"),
+                scenario_tree=join(testdatadir,
+                                   "both_callbacks.py")) as factory:
+            self.assertEqual(len(factory._archives), 0)
+            self.assertTrue(factory.model_directory() is not None)
+            self.assertTrue(factory.scenario_tree_directory() is not None)
+            self._check_factory(factory)
+        self.assertEqual(len(factory._archives), 0)
+        self.assertTrue("both_callbacks" in sys.modules)
+
+    # model: name of .py file with model callback
+    # scenario_tree: None (which implies the model filename)
+    @unittest.skipIf(not has_networkx, "Requires networkx module")
+    def test_init22(self):
+        self.assertTrue("both_callbacks" not in sys.modules)
+        with ScenarioTreeInstanceFactory(
+                model=join(testdatadir,
+                           "both_callbacks.py"),
+                scenario_tree=None) as factory:
+            self.assertEqual(len(factory._archives), 0)
+            self.assertTrue(factory.model_directory() is not None)
+            self.assertTrue(factory.scenario_tree_directory() is not None)
+            self._check_factory(factory)
+        self.assertEqual(len(factory._archives), 0)
+        self.assertTrue("both_callbacks" in sys.modules)
 
 Test = unittest.category('smoke','nightly','expensive')(Test)
 

--- a/pyomo/pysp/tests/unit/testdata/both_callbacks.py
+++ b/pyomo/pysp/tests/unit/testdata/both_callbacks.py
@@ -1,0 +1,55 @@
+from pyomo.environ import *
+
+model = AbstractModel()
+model.x = Var()
+model.p = Param(mutable=True, initialize=1.0)
+def cost_rule(model, i):
+    if i == 1:
+        return model.x
+    else:
+        return 0.0
+model.cost = Expression([1,2], rule=cost_rule)
+def o_rule(model):
+    return model.x
+model.o = Objective(rule=o_rule)
+def c_rule(model):
+    return model.x >= model.p
+model.c = Constraint(rule=c_rule)
+
+def pysp_instance_creation_callback(scenario_tree, scenario_name, node_names):
+    instance = model.create_instance()
+    if scenario_name == "s1":
+        instance.p.value = 1.0
+    elif scenario_name == "s2":
+        instance.p.value = 2.0
+    else:
+        assert scenario_name == "s3"
+        instance.p.value = 3.0
+    return instance
+
+def pysp_scenario_tree_model_callback():
+    import networkx
+
+    G = networkx.DiGraph()
+    G.add_node("root",
+               variables=["x"],
+               cost="cost[1]")
+
+    G.add_node("s1",
+               cost="cost[2]")
+    G.add_edge("root",
+               "s1",
+               weight=0.33333333)
+
+    G.add_node("s2",
+               cost="cost[2]")
+    G.add_edge("root",
+               "s2",
+               weight=0.33333334)
+
+    G.add_node("s3",
+               cost="cost[2]")
+    G.add_edge("root",
+               "s3",
+               weight=0.33333333)
+    return G


### PR DESCRIPTION
## Fixes # .

The code prior to #422 had intended to prevent doing a forced module import twice, but the typo broke that execution path. The change in #422 fixed the typo, but did so in a way that introduced the possibility of doing a forceful import twice (which might have bad side effects).

These changes fix that problem. They also add some additional unit tests to cover these cases.

## Summary/Motivation:

- to keep Dave Woodruff happy

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
