### PR TITLE
Adding support for the AMPL GSL library

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -113,6 +113,7 @@ install:
   - "SET PATH=%cd%\\bin;%PATH%"
   - "python pyomo\\contrib\\trustregion\\getGJH.py %cd%\\bin"
   - "gjh -v"
+  - "python pyomo\\util\\getGSL.py %cd%\\bin"
   #
   # Verify the python version
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,6 +143,7 @@ install:
   - export PATH="$PWD/bin:$PATH"
   - python pyomo/contrib/trustregion/getGJH.py $PWD/bin
   - gjh -v
+  - python pyomo/util/getGSL.py $PWD/bin
   #
   # Verify that the Python interpreter hasn't changed (occasionally conda
   # installers will change the installed Python!!)

--- a/pyomo/contrib/trustregion/getGJH.py
+++ b/pyomo/contrib/trustregion/getGJH.py
@@ -56,9 +56,9 @@ def get_gjh(fname=None, insecure=False):
     os.chmod(fname, mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 if __name__ == '__main__':
-    if len(sys.argv) > 1 and sys.argv[1] == '--insecure':
+    if len(sys.argv) > 1 and '--insecure' in sys.argv:
         insecure = True
-        sys.argv.pop(1)
+        sys.argv.remove('--insecure')
     else:
         insecure = False
     if len(sys.argv) > 1:

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -16,7 +16,7 @@ import weakref
 
 from ctypes import (
     Structure, POINTER, CFUNCTYPE, cdll, byref,
-    c_int, c_long, c_double, c_byte, c_char_p, c_void_p )
+    c_int, c_long, c_ulong, c_double, c_byte, c_char_p, c_void_p )
 
 from pyomo.core.base.numvalue import as_numeric
 from pyomo.core.base.component import Component
@@ -106,14 +106,25 @@ class AMPLExternalFunction(ExternalFunction):
                 self._so = cdll.LoadLibrary(self._library)
 
         self._known_functions = {}
+        AE = _AMPLEXPORTS()
+        AE.ASLdate = 20160307
         def addfunc(name, f, _type, nargs, funcinfo, ae):
             # trap for Python 3, where the name comes in as bytes() and
             # not a string
             if not isinstance(name, six.string_types):
                 name = name.decode()
             self._known_functions[str(name)] = (f, _type, nargs, funcinfo, ae)
-        AE = _AMPLEXPORTS()
         AE.Addfunc = _AMPLEXPORTS.ADDFUNC(addfunc)
+        def addrandinit(ae, rss, v):
+            # TODO: This should support the randinit ASL option
+            rss(v, 1)
+        AE.Addrandinit = _AMPLEXPORTS.ADDRANDINIT(addrandinit)
+        def atreset(ae, a, b):
+            logger.warning(
+                "AMPL External function: ignoring AtReset call in external "
+                "library.  This may result in a memory leak or other "
+                "undesirable behavior.")
+        AE.AtReset = _AMPLEXPORTS.ATRESET(atreset)
 
         FUNCADD = CFUNCTYPE( None, POINTER(_AMPLEXPORTS) )
         FUNCADD(('funcadd_ASL', self._so))(byref(AE))
@@ -248,6 +259,18 @@ class _AMPLEXPORTS(Structure):
         c_char_p, AMPLFUNC, c_int, c_int, c_void_p,
         POINTER(_AMPLEXPORTS) )
 
+    RANDSEEDSETTER = CFUNCTYPE(
+        None,
+        c_void_p, c_ulong )
+
+    ADDRANDINIT = CFUNCTYPE(
+        None,
+        POINTER(_AMPLEXPORTS), RANDSEEDSETTER, c_void_p )
+
+    ATRESET = CFUNCTYPE(
+        None,
+        POINTER(_AMPLEXPORTS), c_void_p, c_void_p )
+
     _fields_ = [
 	('StdErr', c_void_p),
 	('Addfunc', ADDFUNC),
@@ -261,7 +284,7 @@ class _AMPLEXPORTS(Structure):
 	('Crypto', c_void_p),
 	('asl', c_char_p),
 	('AtExit', c_void_p),
-	('AtReset', c_void_p),
+	('AtReset', ATRESET),
 	('Tempmem', c_void_p),
 	('Add_table_handler', c_void_p),
 	('Private', c_char_p),
@@ -308,5 +331,5 @@ class _AMPLEXPORTS(Structure):
 	('SnprintF', c_void_p),
 	('VsnprintF', c_void_p),
 	('Addrand', c_void_p),
-	('Addrandinit', c_void_p),
+	('Addrandinit', ADDRANDINIT),
 	]

--- a/pyomo/core/tests/unit/test_external.py
+++ b/pyomo/core/tests/unit/test_external.py
@@ -8,13 +8,14 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 #
-
+import os
 import pyutilib.th as unittest
 
 from pyomo.core.base import IntegerSet
 from pyomo.environ import *
 from pyomo.core.base.external import (PythonCallbackFunction,
                                       AMPLExternalFunction)
+from pyomo.opt import check_available_solvers
 
 def _g(*args):
     return len(args)
@@ -73,6 +74,42 @@ class TestAMPLExternalFunction(unittest.TestCase):
         self.assertEqual(M.m.f.local_name, "f")
         self.assertEqual(M.m.f.getname(), "f")
         self.assertEqual(M.m.f.getname(True), "m.f")
+
+    def getGSL(self):
+        # Find the GSL DLL
+        DLL = None
+        for path in [os.getcwd()] + os.environ['PATH'].split(os.pathsep):
+            test = os.path.join(path, 'amplgsl.dll')
+            if os.path.isfile(test):
+                DLL = test
+                break
+        print("GSL found here: %s" % DLL)
+        return DLL
+
+    def test_eval_gsl_function(self):
+        DLL = self.getGSL()
+        if not DLL:
+            self.skipTest("Could not find the amplgsl.dll library in the PATH")
+        model = ConcreteModel()
+        model.z_func = ExternalFunction(library=DLL, function="gsl_sf_gamma")
+        model.x = Var(initialize=3, bounds=(1e-5,None))
+        model.o = Objective(expr=model.z_func(model.x))
+        self.assertAlmostEqual(value(model.o), 2.0, 7)
+
+    @unittest.skipIf(not check_available_solvers('ipopt'),
+                     "The 'ipopt' solver is not available")
+    def test_solve_gsl_function(self):
+        DLL = self.getGSL()
+        if not DLL:
+            self.skipTest("Could not find the amplgsl.dll library in the PATH")
+        model = ConcreteModel()
+        model.z_func = ExternalFunction(library=DLL, function="gsl_sf_gamma")
+        model.x = Var(initialize=3, bounds=(1e-5,None))
+        model.o = Objective(expr=model.z_func(model.x))
+        opt = SolverFactory('ipopt')
+        res = opt.solve(model, tee=True)
+        self.assertAlmostEqual(value(model.o), 0.885603194411, 7)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/util/getGSL.py
+++ b/pyomo/util/getGSL.py
@@ -1,0 +1,66 @@
+import zipfile
+import io
+import os
+import platform
+import ssl
+import stat
+import sys
+from six.moves.urllib.request import urlopen
+
+# These URLs were retrieved from
+#     https://ampl.com/resources/extended-function-library/
+urlmap = {
+    'linux':   'https://www.ampl.com/NEW/amplgsl/amplgsl.linux-intel%s.zip',
+    'windows': 'https://www.ampl.com/NEW/amplgsl/amplgsl.mswin%s.zip',
+    'cygwin':  'https://www.ampl.com/NEW/amplgsl/amplgsl.mswin%s.zip',
+    'darwin':  'https://www.ampl.com/NEW/amplgsl/amplgsl.macosx%s.zip'
+}
+
+def get_gsl(fname=None, insecure=False):
+    system = platform.system().lower()
+    for c in '.-_':
+        system = system.split(c)[0]
+    bits = 64 if sys.maxsize > 2**32 else 32
+    url = urlmap.get(system, None)
+    if url is None:
+        raise RuntimeError(
+            "ERROR: cannot infer the correct url for platform '%s'" % platform)
+    url = url % bits
+
+    if fname is None:
+        fname = '.'
+    if os.path.isdir(fname):
+        fname = os.path.join(fname, 'amplgsl.dll')
+
+    print("Fetching GSL from %s and installing it to %s" % (url, fname))
+    with open(fname, 'wb') as FILE:
+        try:
+            ctx = ssl.create_default_context()
+            if insecure:
+                ctx.check_hostname = False
+                ctx.verify_mode = ssl.CERT_NONE
+            fetch = urlopen(url, context=ctx)
+        except AttributeError:
+            # Revert to pre-2.7.9 syntax
+            fetch = urlopen(url)
+        zipped_file = io.BytesIO(fetch.read())
+        print("  ...downloaded %s bytes" % (len(zipped_file.getvalue()),))
+        raw_file = zipfile.ZipFile(zipped_file).open('amplgsl.dll').read()
+        FILE.write(raw_file)
+        print("  ...wrote %s bytes" % (len(raw_file),))
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1 and '--insecure' in sys.argv:
+        insecure = True
+        sys.argv.remove('--insecure')
+    else:
+        insecure = False
+    if len(sys.argv) > 1:
+        fname = sys.argv.pop(1)
+    else:
+        fname = None
+    if len(sys.argv) > 1:
+        print("Usage: %s [--insecure] target" % sys.argv[0])
+        sys.exit(1)
+    get_gsl(fname=fname, insecure=insecure)
+


### PR DESCRIPTION
## Summary/Motivation:
Our ASL External Function interface never supported the pre-built "amplgsl.dll" library distributed by AMPL.  This stubs in more of the AMPL "AmpleExports" data structure used in the External function interface.  We can now build, solve, and evaluate external functions in the library.

## Changes proposed in this PR:
- Extending the definition for the AmplExports data structure
- Adding a `getGSL.py` helper script
- Adding tests that both evaluate functions from the amplgsl.dll library and solve a model using ipopt
  - These tests exercise the problem reported in the recently-closed/resolved #73/#423 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
