### PR TITLE
Adding TerminationCondition to pyomo.environ

### DIFF
--- a/pyomo/environ/__init__.py
+++ b/pyomo/environ/__init__.py
@@ -93,4 +93,4 @@ _PG.pop_env()
 # Expose the symbols from pyomo.core
 #
 from pyomo.core import *
-from pyomo.opt import SolverFactory, SolverManagerFactory, UnknownSolver
+from pyomo.opt import SolverFactory, SolverManagerFactory, UnknownSolver, TerminationCondition

--- a/pyomo/environ/__init__.py
+++ b/pyomo/environ/__init__.py
@@ -93,4 +93,7 @@ _PG.pop_env()
 # Expose the symbols from pyomo.core
 #
 from pyomo.core import *
-from pyomo.opt import SolverFactory, SolverManagerFactory, UnknownSolver, TerminationCondition
+from pyomo.opt import (
+    SolverFactory, SolverManagerFactory, UnknownSolver,
+    TerminationCondition, SolverStatus,
+)


### PR DESCRIPTION
## Fixes #390 .

## Summary/Motivation:

Adding expected symbols to pyomo.environ.

There are some unexpected symbols in pyomo.environ, which are pulled-in from pyomo.core.  I recommend delaying finalization of this PR until we finalize the merge of the expr_dev branch.

## Changes proposed in this PR:
- Adding TerminationCondition

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
