### PR TITLE
wrap Vars in value() for assignment to numpy vectors; also drop the p…

### DIFF
--- a/examples/pyomo/suffixes/sipopt_hicks.py
+++ b/examples/pyomo/suffixes/sipopt_hicks.py
@@ -184,14 +184,14 @@ cperturbed = np.zeros((nfe*ncp,1))
 tnominal = np.zeros((nfe*ncp,1))
 tperturbed = np.zeros((nfe*ncp,1))
 for k,(i,j) in enumerate(collocation_idx(nfe, ncp)):
-    cnominal[k] = model.c[i,j]
-    tnominal[k] = model.t[i,j]
-    cperturbed[k] = model.sens_sol_state_1[model.c[i,j]]
-    tperturbed[k] = model.sens_sol_state_1[model.t[i,j]]
+    cnominal[k] = value(model.c[i,j])
+    tnominal[k] = value(model.t[i,j])
+    cperturbed[k] = value(model.sens_sol_state_1[model.c[i,j]])
+    tperturbed[k] = value(model.sens_sol_state_1[model.t[i,j]])
 
 plt.subplot(2,1,1)
 plt.plot(times, cnominal, label='c_nominal')
-plt.hold(True)
+#plt.hold(True)
 plt.plot(times, cperturbed, label='c_perturbed')
 plt.xlim([min(times),max(times)])
 plt.legend(loc=0)


### PR DESCRIPTION
…lot hold

## Fixes #  errors and warnings in sipopt-hicks example.

## Summary/Motivation:
Assignment of Vars to arrays was causing an error and the plot hold was causing a warnging.

## Changes proposed in this PR:
- wrap Vars in value() before assignment
- comment out the plot hold

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
