### PR TITLE
Gurobi persistent update

### DIFF
--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -222,15 +222,15 @@ class GurobiDirect(DirectSolver):
         else:
             ub = self._gurobipy.GRB.INFINITY
 
+        if var.is_fixed():
+            lb = var.value
+            ub = var.value
+
         gurobipy_var = self._solver_model.addVar(lb=lb, ub=ub, vtype=vtype, name=varname)
 
         self._pyomo_var_to_solver_var_map[var] = gurobipy_var
         self._solver_var_to_pyomo_var_map[gurobipy_var] = var
         self._referenced_variables[var] = 0
-
-        if var.is_fixed():
-            gurobipy_var.setAttr('lb', var.value)
-            gurobipy_var.setAttr('ub', var.value)
 
     def _set_instance(self, model, kwds={}):
         self._range_constraints = set()
@@ -270,7 +270,6 @@ class GurobiDirect(DirectSolver):
 
     def _add_block(self, block):
         DirectOrPersistentSolver._add_block(self, block)
-        self._solver_model.update()
 
     def _add_constraint(self, con):
         if not con.active:
@@ -698,9 +697,12 @@ class GurobiDirect(DirectSolver):
         return True
 
     def _warm_start(self):
+        if self._version_major < 7:
+            self._solver_model.update()
         for pyomo_var, gurobipy_var in self._pyomo_var_to_solver_var_map.items():
-            if pyomo_var.value is not None:
-                gurobipy_var.setAttr(self._gurobipy.GRB.Attr.Start, value(pyomo_var))
+            if pyomo_var.is_binary():
+                if pyomo_var.value is not None:
+                    gurobipy_var.setAttr(self._gurobipy.GRB.Attr.Start, value(pyomo_var))
 
     def _load_vars(self, vars_to_load=None):
         var_map = self._pyomo_var_to_solver_var_map

--- a/pyomo/solvers/plugins/solvers/gurobi_persistent.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_persistent.py
@@ -48,13 +48,25 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
             self.set_instance(self._pyomo_model, **kwds)
 
     def _remove_constraint(self, solver_con):
-        self._solver_model.remove(solver_con)
+        try:
+            self._solver_model.remove(solver_con)
+        except self._gurobipy.GurobiError:
+            self._solver_model.update()
+            self._solver_model.remove(solver_con)
 
     def _remove_sos_constraint(self, solver_sos_con):
-        self._solver_model.remove(solver_sos_con)
+        try:
+            self._solver_model.remove(solver_sos_con)
+        except self._gurobipy.GurobiError:
+            self._solver_model.update()
+            self._solver_model.remove(solver_sos_con)
 
     def _remove_var(self, solver_var):
-        self._solver_model.remove(solver_var)
+        try:
+            self._solver_model.remove(solver_var)
+        except self._gurobipy.GurobiError:
+            self._solver_model.update()
+            self._solver_model.remove(solver_var)
 
     def add_var(self, var):
         """
@@ -66,7 +78,6 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
             The variable to add to the solver's model.
         """
         PersistentSolver.add_var(self, var)
-        self._solver_model.update()
 
     def add_constraint(self, con):
         """
@@ -77,7 +88,6 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
         con: Constraint
         """
         PersistentSolver.add_constraint(self, con)
-        self._solver_model.update()
 
     def add_sos_constraint(self, con):
         """
@@ -88,7 +98,6 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
         con: SOSConstraint
         """
         PersistentSolver.add_sos_constraint(self, con)
-        self._solver_model.update()
 
     def _warm_start(self):
         GurobiDirect._warm_start(self)

--- a/pyomo/solvers/plugins/solvers/gurobi_persistent.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_persistent.py
@@ -68,37 +68,6 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
             self._solver_model.update()
             self._solver_model.remove(solver_var)
 
-    def add_var(self, var):
-        """
-        Add a variable to the solver's model. This will keep any existing model components intact.
-
-        Parameters
-        ----------
-        var: Var
-            The variable to add to the solver's model.
-        """
-        PersistentSolver.add_var(self, var)
-
-    def add_constraint(self, con):
-        """
-        Add a constraint to the solver's model. This will keep any existing model components intact.
-
-        Parameters
-        ----------
-        con: Constraint
-        """
-        PersistentSolver.add_constraint(self, con)
-
-    def add_sos_constraint(self, con):
-        """
-        Add an SOS constraint to the solver's model (if supported). This will keep any existing model components intact.
-
-        Parameters
-        ----------
-        con: SOSConstraint
-        """
-        PersistentSolver.add_sos_constraint(self, con)
-
     def _warm_start(self):
         GurobiDirect._warm_start(self)
 

--- a/pyomo/solvers/plugins/solvers/gurobi_persistent.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_persistent.py
@@ -50,21 +50,21 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
     def _remove_constraint(self, solver_con):
         try:
             self._solver_model.remove(solver_con)
-        except self._gurobipy.GurobiError:
+        except (self._gurobipy.GurobiError, AttributeError):
             self._solver_model.update()
             self._solver_model.remove(solver_con)
 
     def _remove_sos_constraint(self, solver_sos_con):
         try:
             self._solver_model.remove(solver_sos_con)
-        except self._gurobipy.GurobiError:
+        except (self._gurobipy.GurobiError, AttributeError):
             self._solver_model.update()
             self._solver_model.remove(solver_sos_con)
 
     def _remove_var(self, solver_var):
         try:
             self._solver_model.remove(solver_var)
-        except self._gurobipy.GurobiError:
+        except (self._gurobipy.GurobiError, AttributeError):
             self._solver_model.update()
             self._solver_model.remove(solver_var)
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This PR changes when Gurobi Model.update() gets called in the direct and persistent interfaces. This is both more efficient and accounts for older versions of Gurobi. In particular, the direct and persistent interfaces did not work with Gurobi versions less than 7 if any variables were fixed.

## Changes proposed in this PR:
- See summary/motivation
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
