### PR TITLE
Gams writer fix for expr_dev

### DIFF
--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -68,8 +68,9 @@ class ToGamsVisitor(EXPR.ExpressionValueVisitor):
         if node.__class__ is EXPR.PowExpression:
             # If the exponent is a positive integer, use the power() function.
             # Otherwise, use the ** operator.
-            if (tmp[1].__class__ in native_numeric_types and
-                    tmp[1] == int(tmp[1])):
+            exponent = node.arg(1)
+            if (exponent.__class__ in native_numeric_types and
+                    exponent == int(exponent)):
                 return "power({0}, {1})".format(tmp[0], tmp[1])
             else:
                 return "{0} ** {1}".format(tmp[0], tmp[1])

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -66,8 +66,10 @@ class ToGamsVisitor(EXPR.ExpressionValueVisitor):
                 tmp.append(val)
 
         if node.__class__ is EXPR.PowExpression:
+            # If the exponent is a positive integer, use the power() function.
+            # Otherwise, use the ** operator.
             if (tmp[1].__class__ in native_numeric_types and
-                    tmp[1] == int(tmp[1])):
+                    tmp[1] == int(tmp[1]) and tmp[1] > 0):
                 return "power({0}, {1})".format(tmp[0], tmp[1])
             else:
                 return "{0} ** {1}".format(tmp[0], tmp[1])

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -66,12 +66,16 @@ class ToGamsVisitor(EXPR.ExpressionValueVisitor):
                 tmp.append(val)
 
         if node.__class__ is EXPR.PowExpression:
-            return "power({0}, {1})".format(tmp[0], tmp[1])
+            if (tmp[1].__class__ in native_numeric_types and
+                    tmp[1] == int(tmp[1])):
+                return "power({0}, {1})".format(tmp[0], tmp[1])
+            else:
+                return "{0} ** {1}".format(tmp[0], tmp[1])
         else:
             return node._to_string(tmp, None, self.smap, True)
 
     def visiting_potential_leaf(self, node):
-        """ 
+        """
         Visiting a potential leaf.
 
         Return True if the node is not expanded.

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -69,7 +69,7 @@ class ToGamsVisitor(EXPR.ExpressionValueVisitor):
             # If the exponent is a positive integer, use the power() function.
             # Otherwise, use the ** operator.
             if (tmp[1].__class__ in native_numeric_types and
-                    tmp[1] == int(tmp[1]) and tmp[1] > 0):
+                    tmp[1] == int(tmp[1])):
                 return "power({0}, {1})".format(tmp[0], tmp[1])
             else:
                 return "{0} ** {1}".format(tmp[0], tmp[1])

--- a/pyomo/repn/tests/test_gams.py
+++ b/pyomo/repn/tests/test_gams.py
@@ -14,9 +14,10 @@
 
 
 import pyutilib.th as unittest
-from pyomo.repn.plugins.gams_writer import replace_power
-from pyomo.environ import (ConcreteModel, Block, Var, Connector, Constraint,
-                           Objective)
+from pyomo.core.base import NumericLabeler, SymbolMap
+from pyomo.environ import (Block, ConcreteModel, Connector, Constraint,
+                           Objective, Var)
+from pyomo.repn.plugins.gams_writer import expression_to_string, replace_power
 
 
 class GAMSTests(unittest.TestCase):
@@ -43,6 +44,18 @@ class GAMSTests(unittest.TestCase):
 
         line6 = "log( abc**2.0 )**4.5"
         self.assertTrue(replace_power(line6) == line6)
+
+    def test_power_function_to_string(self):
+        m = ConcreteModel()
+        m.x = Var()
+        lbl = NumericLabeler('x')
+        smap = SymbolMap(lbl)
+        # self.assertEquals(expression_to_string(
+        #     m.x ** -3, lbl, smap=smap), "power(x1, -3)")
+        self.assertEquals(expression_to_string(
+            m.x ** 0.33, smap=smap), "x1 ** 0.33")
+        # self.assertEquals(expression_to_string(
+        #     pow(m.x, 2), smap=smap), "power(x1, 2)")
 
     def test_gams_connector_in_active_constraint(self):
         """Test connector in active constraint for GAMS writer."""

--- a/pyomo/repn/tests/test_gams.py
+++ b/pyomo/repn/tests/test_gams.py
@@ -2,8 +2,8 @@
 #
 #  Pyomo: Python Optimization Modeling Objects
 #  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
-#  Under the terms of Contract DE-NA0003525 with National Technology and 
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
@@ -50,12 +50,12 @@ class GAMSTests(unittest.TestCase):
         m.x = Var()
         lbl = NumericLabeler('x')
         smap = SymbolMap(lbl)
-        # self.assertEquals(expression_to_string(
-        #     m.x ** -3, lbl, smap=smap), "power(x1, -3)")
+        self.assertEquals(expression_to_string(
+            m.x ** -3, lbl, smap=smap), "power(x1, -3)")
         self.assertEquals(expression_to_string(
             m.x ** 0.33, smap=smap), "x1 ** 0.33")
-        # self.assertEquals(expression_to_string(
-        #     pow(m.x, 2), smap=smap), "power(x1, 2)")
+        self.assertEquals(expression_to_string(
+            pow(m.x, 2), smap=smap), "power(x1, 2)")
 
     def test_gams_connector_in_active_constraint(self):
         """Test connector in active constraint for GAMS writer."""

--- a/pyomo/repn/tests/test_gams.py
+++ b/pyomo/repn/tests/test_gams.py
@@ -51,11 +51,11 @@ class GAMSTests(unittest.TestCase):
         lbl = NumericLabeler('x')
         smap = SymbolMap(lbl)
         self.assertEquals(expression_to_string(
-            m.x ** -3, lbl, smap=smap), "power(x1, -3)")
+            m.x ** -3, lbl, smap=smap), "power(x, -3)")
         self.assertEquals(expression_to_string(
-            m.x ** 0.33, smap=smap), "x1 ** 0.33")
+            m.x ** 0.33, smap=smap), "x ** 0.33")
         self.assertEquals(expression_to_string(
-            pow(m.x, 2), smap=smap), "power(x1, 2)")
+            pow(m.x, 2), smap=smap), "power(x, 2)")
 
     def test_gams_connector_in_active_constraint(self):
         """Test connector in active constraint for GAMS writer."""


### PR DESCRIPTION
## Summary/Motivation:
The GAMS `power(x, y)` function is intended only for integer `y` exponent values. This change uses the GAMS `x ** y` operator for real number `y` exponents. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
