### PR TITLE
Remove duplicate pprint function. Fixes #445

### DIFF
--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -474,26 +474,6 @@ class Component(_ComponentBase):
                 "is assigned to a Block.\nTriggered by attempting to set "
                 "component '%s' to name '%s'" % (self.name,val))
 
-    def pprint(self, ostream=None, verbose=False, prefix=""):
-        """Print component information"""
-        if ostream is None:
-            ostream = sys.stdout
-        tab="    "
-        ostream.write(prefix+self.local_name+" : ")
-        if self.doc is not None:
-            ostream.write(self.doc+'\n'+prefix+tab)
-
-        _attr, _data, _header, _fcn = self._pprint()
-
-        ostream.write(", ".join("%s=%s" % (k,v) for k,v in _attr))
-        ostream.write("\n")
-        if not self._constructed:
-            ostream.write(prefix+tab+"Not constructed\n")
-            return
-
-        if _data is not None:
-            tabular_writer( ostream, prefix+tab, _data, _header, _fcn )
-
     def is_indexed(self):
         """Return true if this component is indexed"""
         return False


### PR DESCRIPTION
## Fixes #445 .

## Summary/Motivation:
Looks like we've had a duplicate `pprint` function since the dawn of time (moving to GitHub)

## Changes proposed in this PR:
- remove duplicate `pprint` function

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
