### PR TITLE
Fixing typo in interscenario.py

### DIFF
--- a/pyomo/pysp/plugins/interscenario.py
+++ b/pyomo/pysp/plugins/interscenario.py
@@ -31,7 +31,7 @@ from pyomo.pysp import phextension
 from pyomo.solvers.plugins.smanager.phpyro import SolverManager_PHPyro
 from pyomo.util.plugin import SingletonPlugin, implements
 
-from pyomo.repn.standard_repn import (preprocess_block_constraints
+from pyomo.repn.standard_repn import (preprocess_block_constraints,
                                       preprocess_block_objectives)
 from pyomo.pysp.phsolverserverutils import (
     InvocationType,


### PR DESCRIPTION
## Summary/Motivation:
All jenkins builds are failing because coverage is failing due to this syntax error.

## Changes proposed in this PR:
- Fix a syntax error

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
