### PR TITLE
Doctest fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ install:
     fi
   - pip install --quiet xlrd
   - pip install --quiet openpyxl
-  - pip install sphinx_rtd_theme
+  - pip install sphinx sphinx_rtd_theme
   - pip install dill
   - conda install -q -y -c anaconda pandas networkx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -163,7 +163,7 @@ script:
   - test.pyomo -v --cat=$CATEGORY pyomo `pwd`/pyomo-model-libraries
 
   # Run documentation tests
-  - cd doc/OnlineDocs; make doctests -d; cd ../..
+  - cd doc/OnlineDocs && make doctest -d && cd ../..
   # nosetests -v --with-doctest --doctest-extension=.rst doc/OnlineDocs
 
 


### PR DESCRIPTION
## Fixes # .

Fixes execution of doctests

## Summary/Motivation:

 - `make doctests` was failing due to unknown target `doctests` (just needed to remove "s").
 - failure return code was being overwritten by a later command (replaced ; with &&)
 - needed to `pip install sphinx`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
