### PR TITLE
Preemptive Python-3.7 fixes in PySP

### DIFF
--- a/examples/pysp/scripting/apps/compile_scenario_tree.py
+++ b/examples/pysp/scripting/apps/compile_scenario_tree.py
@@ -150,7 +150,7 @@ def pickle_compiled_scenario_tree(manager,
             thisfile,
             function_args=(os.path.join(output_directory),),
             invocation_type=InvocationType.PerScenario,
-            async=True)
+            async_call=True)
 
     filename = os.path.join(output_directory,
                             compiled_reference_model_filename)

--- a/pyomo/pysp/embeddedsp.py
+++ b/pyomo/pysp/embeddedsp.py
@@ -795,7 +795,7 @@ class EmbeddedSP(object):
             options,
             factory=factory)
         try:
-            init = manager.initialize(async=True)
+            init = manager.initialize(async_call=True)
             pcuids = ComponentMap()
             for param in self.stochastic_data:
                 pcuids[param] = ComponentUID(param)
@@ -809,7 +809,7 @@ class EmbeddedSP(object):
                     thisfile,
                     invocation_type=InvocationType.OnScenario(scenario.name),
                     function_args=(data,),
-                    oneway=True)
+                    oneway_call=True)
             manager.reference_model = model
         except:
             manager.close()

--- a/pyomo/pysp/ph.py
+++ b/pyomo/pysp/ph.py
@@ -1835,7 +1835,7 @@ class ProgressiveHedging(_PHBase):
         # after all scenarios are available.
         self._bound_setter = None
         self._max_iterations = 0
-        self._async = False
+        self._async_mode = False
         self._async_buffer_length = 1
 
         # it may be the case that some plugins think they can do a
@@ -1931,7 +1931,7 @@ class ProgressiveHedging(_PHBase):
         self._max_iterations                      = options.max_iterations
         self._overrelax                           = options.overrelax
         self._nu                                  = options.nu
-        self._async                               = options.async
+        self._async_mode                          = options.async_mode
         self._async_buffer_length                 = options.async_buffer_length
         self._rho                                 = options.default_rho
         self._rho_setter_file                     = options.rho_cfgfile
@@ -2155,7 +2155,7 @@ class ProgressiveHedging(_PHBase):
         if self._verbose:
             print("PH solver configuration: ")
             print("   Max iterations="+str(self._max_iterations))
-            print("   Async mode=" + str(self._async))
+            print("   Async mode=" + str(self._async_mode))
             print("   Async buffer length=" + str(self._async_buffer_length))
             print("   Default global rho=" + str(self._rho))
             print("   Over-relaxation enabled="+str(self._overrelax))
@@ -4164,7 +4164,7 @@ class ProgressiveHedging(_PHBase):
         ####################################################################################################
         # major logic branch - if we are not running async, do the usual PH - otherwise, invoke the async. #
         ####################################################################################################
-        if self._async is False:
+        if self._async_mode is False:
 
             ####################################################################################################
 

--- a/pyomo/pysp/phinit.py
+++ b/pyomo/pysp/phinit.py
@@ -179,7 +179,7 @@ def construct_ph_options_parser(usage_string):
     phOpts.add_argument("--async",
       help="Run PH in asychronous mode after iteration 0. Default is False.",
       action="store_true",
-      dest="async",
+      dest="async_mode",
       default=False)
     phOpts.add_argument("--async-buffer-length",
       help="Number of scenarios to collect, if in async mode, before doing statistics and weight updates. Default is 1.",

--- a/pyomo/pysp/plugins/ecksteincombettesextension.py
+++ b/pyomo/pysp/plugins/ecksteincombettesextension.py
@@ -419,7 +419,7 @@ class EcksteinCombettesExtension(pyomo.util.plugin.SingletonPlugin):
         # IMPORTANT: if the Eckstein-Combettes extension plugin is enabled,
         #            then make sure PH is in async mode - otherwise, nothing
         #            will work!
-        if not ph._async:
+        if not ph._async_mode:
             raise RuntimeError("PH is not in async mode - this is required for the Eckstein-Combettes extension")
 
         self._total_projection_steps = 0

--- a/pyomo/pysp/scenariotree/manager.py
+++ b/pyomo/pysp/scenariotree/manager.py
@@ -966,8 +966,8 @@ class ScenarioTreeManager(PySPConfiguredObject):
                         invocation_type=InvocationType.Single,
                         function_args=(),
                         function_kwds=None,
-                        async=False,
-                        oneway=False):
+                        async_call=False,
+                        oneway_call=False):
         """Invokes a function on scenario tree constructs
         managed by this scenario tree manager. The first
         argument accepted by the function must always be the
@@ -1005,21 +1005,20 @@ class ScenarioTreeManager(PySPConfiguredObject):
             function_kwds:
                  Additional keywords to pass to the function
                  when it is invoked.
-            async:
+            async_call:
                  When set to True, the return value will be
                  an asynchronous object. Invocation results
                  can be obtained at any point by calling the
                  complete() method on this object, which
                  will block until all associated action
                  handles are collected.f
-            oneway:
-                 When set to True, it will be assumed no
-                 return value is expected from this function
-                 (async is implied). Setting both async and
-                 oneway to True will result in an exception
-                 being raised.
+            oneway_call:
+                 When set to True, it will be assumed no return value
+                 is expected from this function (async_call is
+                 implied). Setting both async_call and oneway_call to
+                 True will result in an exception being raised.
 
-            *Note: The 'oneway' and 'async' keywords are
+            *Note: The 'oneway_call' and 'async_call' keywords are
                    valid for all scenario tree manager
                    implementations. However, they are
                    designed for use with Pyro-based
@@ -1030,16 +1029,16 @@ class ScenarioTreeManager(PySPConfiguredObject):
                    written around.
 
         Returns:
-            If 'oneway' is True, this function will always
+            If 'oneway_call' is True, this function will always
             return None. Otherwise, the return value type is
             governed by the 'invocation_type' keyword, which
             will be nested inside an asynchronous object if
-            'async' is set to True.
+            'async_call' is set to True.
         """
         if not self.initialized:
             raise RuntimeError(
                 "The scenario tree manager is not initialized.")
-        if async and oneway:
+        if async_call and oneway_call:
             raise ValueError("async oneway calls do not make sense")
         invocation_type = _map_deprecated_invocation_type(invocation_type)
         if (invocation_type == InvocationType.PerBundle) or \
@@ -1056,15 +1055,15 @@ class ScenarioTreeManager(PySPConfiguredObject):
                                           invocation_type=invocation_type,
                                           function_args=function_args,
                                           function_kwds=function_kwds,
-                                          async=async,
-                                          oneway=oneway)
+                                          async_call=async_call,
+                                          oneway_call=oneway_call)
 
     def invoke_method(self,
                       method_name,
                       method_args=(),
                       method_kwds=None,
-                      async=False,
-                      oneway=False):
+                      async_call=False,
+                      oneway_call=False):
         """Invokes a method on a scenario tree constructs managed
            by this scenario tree manager client. This may or may not
            take place on this client itself.
@@ -1076,20 +1075,20 @@ class ScenarioTreeManager(PySPConfiguredObject):
                  Arguments passed to the method when it is invoked.
             method_kwds:
                  Keywords to pass to the method when it is invoked.
-            async:
+            async_call:
                  When set to True, the return value will be an
                  asynchronous object. Invocation results can be
                  obtained at any point by calling the complete()
                  method on this object, which will block until all
                  associated action handles are collected.
-            oneway:
+            oneway_call:
                  When set to True, it will be assumed no return value
-                 is expected from this method (async is
-                 implied). Setting both async and oneway to True will
-                 result in an exception being raised.
+                 is expected from this method (async_call is
+                 implied). Setting both async_call and oneway_call to True
+                 will result in an exception being raised.
 
-            *Note: The 'oneway' and 'async' keywords are valid for all
-                   scenario tree manager client
+            *Note: The 'oneway_call' and 'async_call' keywords are valid
+                   for all scenario tree manager client
                    implementations. However, they are designed for use
                    with Pyro-based implementations. Their existence in
                    other implementations is not meant to guarantee
@@ -1097,21 +1096,21 @@ class ScenarioTreeManager(PySPConfiguredObject):
                    interface for code to be written around.
 
         Returns:
-            If 'oneway' is True, this function will always return
+            If 'oneway_call' is True, this function will always return
             None. Otherwise, the return corresponds exactly to the
             method's return value, which will be nested inside an
-            asynchronous object if 'async' is set to True.
+            asynchronous object if 'async_call' is set to True.
         """
         if not self.initialized:
             raise RuntimeError(
                 "The scenario tree manager is not initialized.")
-        if async and oneway:
+        if async_call and oneway_call:
             raise ValueError("async oneway calls do not make sense")
         return self._invoke_method_impl(method_name,
                                         method_args=method_args,
                                         method_kwds=method_kwds,
-                                        async=async,
-                                        oneway=oneway)
+                                        async_call=async_call,
+                                        oneway_call=oneway_call)
 
     def push_fix_queue_to_instances(self):
         """Push the fixed queue on the scenario tree nodes onto the
@@ -1366,7 +1365,7 @@ class ScenarioTreeManagerClient(ScenarioTreeManager,
         return self._modules_imported
 
     # override initialize on ScenarioTreeManager for documentation purposes
-    def initialize(self, async=False):
+    def initialize(self, async_call=False):
         """Initialize the scenario tree manager client.
 
         Note: Calling complete() on an asynchronous result
@@ -1376,7 +1375,7 @@ class ScenarioTreeManagerClient(ScenarioTreeManager,
               complete.
 
         Args:
-            async:
+            async_call:
                  When set to True, the return value will be an
                  asynchronous object. Invocation results can be
                  obtained at any point by calling the complete()
@@ -1385,11 +1384,11 @@ class ScenarioTreeManagerClient(ScenarioTreeManager,
 
         Returns:
             A dictionary mapping scenario tree worker names to their
-            initial return value (True is most cases). If 'async' is
-            set to True, this return value will be nested inside an
+            initial return value (True is most cases). If 'async_call'
+            is set to True, this return value will be nested inside an
             asynchronous object.
         """
-        return super(ScenarioTreeManagerClient, self).initialize(async=async)
+        return super(ScenarioTreeManagerClient, self).initialize(async_call=async_call)
 
     def invoke_function_on_worker(self,
                                   worker_name,
@@ -1398,8 +1397,8 @@ class ScenarioTreeManagerClient(ScenarioTreeManager,
                                   invocation_type=InvocationType.Single,
                                   function_args=(),
                                   function_kwds=None,
-                                  async=False,
-                                  oneway=False):
+                                  async_call=False,
+                                  oneway_call=False):
         """Invokes a function on a scenario tree worker
         managed by this scenario tree manager client. The
         first argument accepted by the function must always
@@ -1441,41 +1440,38 @@ class ScenarioTreeManagerClient(ScenarioTreeManager,
             function_kwds:
                  Additional keywords to pass to the function
                  when it is invoked.
-            async:
+            async_call:
                  When set to True, the return value will be
                  an asynchronous object. Invocation results
                  can be obtained at any point by calling the
                  complete() method on this object, which
                  will block until all associated action
                  handles are collected.
-            oneway:
-                 When set to True, it will be assumed no
-                 return value is expected from this function
-                 (async is implied). Setting both async and
-                 oneway to True will result in an exception
-                 being raised.
+            oneway_call:
+                 When set to True, it will be assumed no return value
+                 is expected from this function (async_call is
+                 implied). Setting both async and oneway_call to True will
+                 result in an exception being raised.
 
-            *Note: The 'oneway' and 'async' keywords are
-                   valid for all scenario tree manager
-                   implementations. However, they are
-                   designed for use with Pyro-based
-                   implementations. Their existence in other
-                   implementations is not meant to guarantee
-                   asynchronicity, but rather to provide a
-                   consistent interface for code to be
-                   written around.
+            *Note: The 'oneway_call' and 'async_call' keywords are valid
+                   for all scenario tree manager
+                   implementations. However, they are designed for use
+                   with Pyro-based implementations. Their existence in
+                   other implementations is not meant to guarantee
+                   asynchronicity, but rather to provide a consistent
+                   interface for code to be written around.
 
         Returns:
-            If 'oneway' is True, this function will always
+            If 'oneway_call' is True, this function will always
             return None. Otherwise, the return value type is
             governed by the 'invocation_type' keyword, which
             will be nested inside an asynchronous object if
-            'async' is set to True.
+            'async_call' is set to True.
         """
         if not self.initialized:
             raise RuntimeError(
                 "The scenario tree manager is not initialized.")
-        if async and oneway:
+        if async_call and oneway_call:
             raise ValueError("async oneway calls do not make sense")
         invocation_type = _map_deprecated_invocation_type(invocation_type)
         if (invocation_type == InvocationType.PerBundle) or \
@@ -1493,16 +1489,16 @@ class ScenarioTreeManagerClient(ScenarioTreeManager,
                                                     invocation_type=invocation_type,
                                                     function_args=function_args,
                                                     function_kwds=function_kwds,
-                                                    async=async,
-                                                    oneway=oneway)
+                                                    async_call=async_call,
+                                                    oneway_call=oneway_call)
 
     def invoke_method_on_worker(self,
                                 worker_name,
                                 method_name,
                                 method_args=(),
                                 method_kwds=None,
-                                async=False,
-                                oneway=False):
+                                async_call=False,
+                                oneway_call=False):
         """Invokes a method on a scenario tree worker managed
            by this scenario tree manager client. The worker
            may or may not be this client.
@@ -1517,20 +1513,20 @@ class ScenarioTreeManagerClient(ScenarioTreeManager,
                  Arguments passed to the method when it is invoked.
             method_kwds:
                  Keywords to pass to the method when it is invoked.
-            async:
+            async_call:
                  When set to True, the return value will be an
                  asynchronous object. Invocation results can be
                  obtained at any point by calling the complete()
                  method on this object, which will block until all
                  associated action handles are collected.
-            oneway:
+            oneway_call:
                  When set to True, it will be assumed no return value
-                 is expected from this method (async is
-                 implied). Setting both async and oneway to True will
+                 is expected from this method (async_call is
+                 implied). Setting both async and oneway_call to True will
                  result in an exception being raised.
 
-            *Note: The 'oneway' and 'async' keywords are valid for all
-                   scenario tree manager client
+            *Note: The 'oneway_call' and 'async_call' keywords are valid
+                   for all scenario tree manager client
                    implementations. However, they are designed for use
                    with Pyro-based implementations. Their existence in
                    other implementations is not meant to guarantee
@@ -1538,22 +1534,22 @@ class ScenarioTreeManagerClient(ScenarioTreeManager,
                    interface for code to be written around.
 
         Returns:
-            If 'oneway' is True, this function will always return
+            If 'oneway_call' is True, this function will always return
             None. Otherwise, the return corresponds exactly to the
             method's return value, which will be nested inside an
-            asynchronous object if 'async' is set to True.
+            asynchronous object if 'async_call' is set to True.
         """
         if not self.initialized:
             raise RuntimeError(
                 "The scenario tree manager is not initialized.")
-        if async and oneway:
+        if async_call and oneway_call:
             raise ValueError("async oneway calls do not make sense")
         return self._invoke_method_on_worker_impl(worker_name,
                                                   method_name,
                                                   method_args=method_args,
                                                   method_kwds=method_kwds,
-                                                  async=async,
-                                                  oneway=oneway)
+                                                  async_call=async_call,
+                                                  oneway_call=oneway_call)
 
     @property
     def worker_names(self):
@@ -1595,9 +1591,9 @@ class ScenarioTreeManagerClient(ScenarioTreeManager,
     # subclasses are now expected to generate a (possibly
     # dummy) async object during _init_client
     #
-    def _init(self, async=False):
+    def _init(self, async_call=False):
         async_handle = self._init_client()
-        if async:
+        if async_call:
             result = async_handle
         else:
             result = async_handle.complete()
@@ -2259,8 +2255,8 @@ class ScenarioTreeManagerClientSerial(_ScenarioTreeManagerWorker,
                                         invocation_type=InvocationType.Single,
                                         function_args=(),
                                         function_kwds=None,
-                                        async=False,
-                                        oneway=False):
+                                        async_call=False,
+                                        oneway_call=False):
 
         assert worker_name == self._worker_name
         start_time = time.time()
@@ -2276,9 +2272,9 @@ class ScenarioTreeManagerClientSerial(_ScenarioTreeManagerWorker,
                                                  function_args=function_args,
                                                  function_kwds=function_kwds)
 
-        if oneway:
+        if oneway_call:
             result = None
-        if async:
+        if async_call:
             result = self.AsyncResult(None, result=result)
 
         end_time = time.time()
@@ -2294,8 +2290,8 @@ class ScenarioTreeManagerClientSerial(_ScenarioTreeManagerWorker,
                                       method_name,
                                       method_args=(),
                                       method_kwds=None,
-                                      async=False,
-                                      oneway=False):
+                                      async_call=False,
+                                      oneway_call=False):
 
         assert worker_name == self._worker_name
         start_time = time.time()
@@ -2308,9 +2304,9 @@ class ScenarioTreeManagerClientSerial(_ScenarioTreeManagerWorker,
             method_kwds = {}
         result = getattr(self, method_name)(*method_args, **method_kwds)
 
-        if oneway:
+        if oneway_call:
             result = None
-        if async:
+        if async_call:
             result = self.AsyncResult(None, result=result)
 
         end_time = time.time()
@@ -2353,9 +2349,9 @@ class ScenarioTreeManagerClientSerial(_ScenarioTreeManagerWorker,
                               invocation_type=InvocationType.Single,
                               function_args=(),
                               function_kwds=None,
-                              async=False,
-                              oneway=False):
-        assert not (async and oneway)
+                              async_call=False,
+                              oneway_call=False):
+        assert not (async_call and oneway_call)
 
         result = self._invoke_function_on_worker_impl(
             self._worker_name,
@@ -2364,13 +2360,13 @@ class ScenarioTreeManagerClientSerial(_ScenarioTreeManagerWorker,
             invocation_type=invocation_type,
             function_args=function_args,
             function_kwds=function_kwds,
-            async=False,
-            oneway=oneway)
+            async_call=False,
+            oneway_call=oneway_call)
 
-        if not oneway:
+        if not oneway_call:
             if invocation_type == InvocationType.Single:
                 result = {self._worker_name: result}
-        if async:
+        if async_call:
             result = self.AsyncResult(None, result=result)
 
         return result
@@ -2379,21 +2375,21 @@ class ScenarioTreeManagerClientSerial(_ScenarioTreeManagerWorker,
                             method_name,
                             method_args=(),
                             method_kwds=None,
-                            async=False,
-                            oneway=False):
-        assert not (async and oneway)
+                            async_call=False,
+                            oneway_call=False):
+        assert not (async_call and oneway_call)
 
         result =  self._invoke_method_on_worker_impl(
             self._worker_name,
             method_name,
             method_args=method_args,
             method_kwds=method_kwds,
-            async=False,
-            oneway=oneway)
+            async_call=False,
+            oneway_call=oneway_call)
 
-        if not oneway:
+        if not oneway_call:
             result = {self._worker_name: result}
-        if async:
+        if async_call:
             result = self.AsyncResult(None, result=result)
 
         return result
@@ -2445,13 +2441,13 @@ class _ScenarioTreeManagerClientPyroAdvanced(ScenarioTreeManagerClient,
                                         invocation_type=InvocationType.Single,
                                         function_args=(),
                                         function_kwds=None,
-                                        oneway=False):
+                                        oneway_call=False):
 
         return self._action_manager.queue(
             queue_name=self.get_server_for_worker(worker_name),
             worker_name=worker_name,
             action="_invoke_function_impl",
-            generate_response=not oneway,
+            generate_response=not oneway_call,
             args=(function,),
             kwds={'module_name': module_name,
                   'invocation_type': (invocation_type.key,
@@ -2465,13 +2461,13 @@ class _ScenarioTreeManagerClientPyroAdvanced(ScenarioTreeManagerClient,
             method_name,
             method_args=(),
             method_kwds=None,
-            oneway=False):
+            oneway_call=False):
 
         return self._action_manager.queue(
             queue_name=self.get_server_for_worker(worker_name),
             worker_name=worker_name,
             action="_invoke_method_impl",
-            generate_response=not oneway,
+            generate_response=not oneway_call,
             args=(method_name,),
             kwds={'method_args': method_args,
                   'method_kwds': method_kwds})
@@ -2491,9 +2487,9 @@ class _ScenarioTreeManagerClientPyroAdvanced(ScenarioTreeManagerClient,
                                         invocation_type=InvocationType.Single,
                                         function_args=(),
                                         function_kwds=None,
-                                        async=False,
-                                        oneway=False):
-        assert not (async and oneway)
+                                        async_call=False,
+                                        oneway_call=False):
+        assert not (async_call and oneway_call)
         assert self._action_manager is not None
         assert worker_name in self._pyro_worker_list
         start_time = time.time()
@@ -2526,15 +2522,15 @@ class _ScenarioTreeManagerClientPyroAdvanced(ScenarioTreeManagerClient,
             invocation_type=invocation_type,
             function_args=function_args,
             function_kwds=function_kwds,
-            oneway=oneway)
+            oneway_call=oneway_call)
 
-        if oneway:
+        if oneway_call:
             action_handle = None
 
         result = self.AsyncResult(
             self._action_manager, action_handle_data=action_handle)
 
-        if not async:
+        if not async_call:
             result = result.complete()
 
         end_time = time.time()
@@ -2550,8 +2546,8 @@ class _ScenarioTreeManagerClientPyroAdvanced(ScenarioTreeManagerClient,
                                       method_name,
                                       method_args=(),
                                       method_kwds=None,
-                                      async=False,
-                                      oneway=False):
+                                      async_call=False,
+                                      oneway_call=False):
 
         assert self._action_manager is not None
         assert worker_name in self._pyro_worker_list
@@ -2566,15 +2562,15 @@ class _ScenarioTreeManagerClientPyroAdvanced(ScenarioTreeManagerClient,
             method_name,
             method_args=method_args,
             method_kwds=method_kwds,
-            oneway=oneway)
+            oneway_call=oneway_call)
 
-        if oneway:
+        if oneway_call:
             action_handle = None
 
         result = self.AsyncResult(
             self._action_manager, action_handle_data=action_handle)
 
-        if not async:
+        if not async_call:
             result = result.complete()
 
         end_time = time.time()
@@ -2776,7 +2772,7 @@ class _ScenarioTreeManagerClientPyroAdvanced(ScenarioTreeManagerClient,
                    worker_options,
                    worker_registered_name,
                    server_name=None,
-                   oneway=False):
+                   oneway_call=False):
 
         assert self._action_manager is not None
 
@@ -2818,7 +2814,7 @@ class _ScenarioTreeManagerClientPyroAdvanced(ScenarioTreeManagerClient,
             worker_name=worker_name,
             init_args=(worker_init,),
             init_kwds=worker_options,
-            generate_response=not oneway)
+            generate_response=not oneway_call)
 
         self._pyro_server_workers_map[server_name].append(worker_name)
         self._pyro_worker_server_map[worker_name] = server_name
@@ -2950,7 +2946,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
                         self.get_worker_for_bundle(bundle.name),
                         "_collect_scenario_tree_data_for_client",
                         method_args=(object_names,),
-                        async=True)
+                        async_call=True)
 
                 for node_name in object_names['nodes']:
                     need_node_data[node_name] = False
@@ -2972,7 +2968,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
                         self.get_worker_for_scenario(scenario.name),
                         "_collect_scenario_tree_data_for_client",
                         method_args=(object_names,),
-                        async=True)
+                        async_call=True)
 
                 for node_name in object_names['nodes']:
                     need_node_data[node_name] = False
@@ -3311,7 +3307,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
             self.invoke_method(
                 "assign_data",
                 method_args=("_aggregate_user_data", self._aggregate_user_data,),
-                oneway=True)
+                oneway_call=True)
 
         # run the user script to initialize variable bounds
         if len(self._options.postinit_callback_location):
@@ -3339,7 +3335,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
                     callback_name,
                     self._callback_mapped_module_name[callback_module_key],
                     invocation_type=InvocationType.PerScenario,
-                    oneway=True)
+                    oneway_call=True)
 
         if unpause:
             self.unpause_transmit()
@@ -3386,9 +3382,9 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
             invocation_type=InvocationType.Single,
             function_args=(),
             function_kwds=None,
-            async=False,
-            oneway=False):
-        assert not (async and oneway)
+            async_call=False,
+            oneway_call=False):
+        assert not (async_call and oneway_call)
         assert self._action_manager is not None
         start_time = time.time()
 
@@ -3414,7 +3410,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
                     "a function name is given")
 
         if self._transmission_paused:
-            if (not async) and (not oneway):
+            if (not async_call) and (not oneway_call):
                 raise ValueError(
                     "Unable to perform external function invocations. "
                     "Pyro transmissions are currently paused, but the "
@@ -3440,7 +3436,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
                     invocation_type=invocation_type,
                     function_args=function_args,
                     function_kwds=function_kwds,
-                    oneway=oneway)] = worker_name
+                    oneway_call=oneway_call)] = worker_name
 
             if invocation_type != InvocationType.Single:
                 map_result = lambda ah_to_result: \
@@ -3460,7 +3456,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
                 invocation_type=invocation_type,
                 function_args=function_args,
                 function_kwds=function_kwds,
-                oneway=oneway)
+                oneway_call=oneway_call)
 
         elif (invocation_type == InvocationType.OnBundle):
 
@@ -3471,7 +3467,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
                 invocation_type=invocation_type,
                 function_args=function_args,
                 function_kwds=function_kwds,
-                oneway=oneway)
+                oneway_call=oneway_call)
 
         elif (invocation_type == InvocationType.OnScenarios) or \
              (invocation_type == InvocationType.OnBundles):
@@ -3503,7 +3499,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
                     invocation_type=_invocation_type(worker_map[worker_name]),
                     function_args=function_args,
                     function_kwds=function_kwds,
-                    oneway=oneway)] = worker_name
+                    oneway_call=oneway_call)] = worker_name
 
             map_result = lambda ah_to_result: \
                          dict((key, result[key])
@@ -3533,7 +3529,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
                         invocation_type=invocation_type,
                         function_args=result,
                         function_kwds=function_kwds,
-                        oneway=False)).complete()
+                        oneway_call=False)).complete()
                 if len(function_args) == 0:
                     result = ()
 
@@ -3544,7 +3540,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
                 invocation_type=invocation_type,
                 function_args=result,
                 function_kwds=function_kwds,
-                oneway=oneway)
+                oneway_call=oneway_call)
 
         elif (invocation_type == InvocationType.OnScenariosChained) or \
              (invocation_type == InvocationType.OnBundlesChained):
@@ -3588,7 +3584,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
                         invocation_type=_invocation_type(object_names_for_worker),
                         function_args=result,
                         function_kwds=function_kwds,
-                        oneway=False)
+                        oneway_call=False)
                     if len(object_names) != 0:
                         result = self.AsyncResult(
                             self._action_manager,
@@ -3603,7 +3599,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
                              % (invocation_type,
                                 [str(v) for v in InvocationType._values]))
 
-        if oneway:
+        if oneway_call:
             action_handle_data = None
             map_result = None
 
@@ -3612,7 +3608,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
             action_handle_data=action_handle_data,
             map_result=map_result)
 
-        if not async:
+        if not async_call:
             result = result.complete()
 
         end_time = time.time()
@@ -3629,9 +3625,9 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
             method_name,
             method_args=(),
             method_kwds=None,
-            async=False,
-            oneway=False):
-        assert not (async and oneway)
+            async_call=False,
+            oneway_call=False):
+        assert not (async_call and oneway_call)
         assert self._action_manager is not None
         start_time = time.time()
 
@@ -3640,7 +3636,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
                   "to scenario tree workers")
 
         if self._transmission_paused:
-            if (not async) and (not oneway):
+            if (not async_call) and (not oneway_call):
                 raise ValueError(
                     "Unable to perform method invocations. "
                     "Pyro transmissions are currently paused, but the "
@@ -3658,21 +3654,21 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
                 queue_name=self.get_server_for_worker(worker_name),
                 worker_name=worker_name,
                 action=method_name,
-                generate_response=not oneway,
+                generate_response=not oneway_call,
                 args=method_args,
                 kwds=method_kwds),
              worker_name) for worker_name in self._pyro_worker_list)
         if not was_paused:
             self.unpause_transmit()
 
-        if oneway:
+        if oneway_call:
             action_handle_data = None
 
         result = self.AsyncResult(
             self._action_manager,
             action_handle_data=action_handle_data)
 
-        if not async:
+        if not async_call:
             result = result.complete()
 
         end_time = time.time()
@@ -3806,7 +3802,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
                     worker_name,
                     "_update_fixed_variables_for_client",
                     method_args=(worker_map[worker_name],),
-                    oneway=False))
+                    oneway_call=False))
             self.unpause_transmit()
             self._action_manager.wait_all(action_handles)
 

--- a/pyomo/pysp/scenariotree/manager_solver.py
+++ b/pyomo/pysp/scenariotree/manager_solver.py
@@ -109,7 +109,7 @@ class ScenarioTreeManagerSolver(PySPConfiguredObject):
                        ephemeral_solver_options,
                        disable_warmstart,
                        check_status,
-                       async):
+                       async_call):
 
         assert object_type in ('bundles', 'scenarios')
 
@@ -125,7 +125,7 @@ class ScenarioTreeManagerSolver(PySPConfiguredObject):
                 object_type,
                 _async_solve_result.complete(),
                 check_status))
-        if not async:
+        if not async_call:
             result = result.complete()
         return result
 
@@ -179,7 +179,7 @@ class ScenarioTreeManagerSolver(PySPConfiguredObject):
                 users catch errors early on and should be
                 set to :const:`False` in situations where
                 more advanced status handling is necessary.
-            async (bool): When set to :const:`True`, an
+            async_call (bool): When set to :const:`True`, an
                 async results object is returned that allows
                 the solves to be completed
                 asynchronously. Default is
@@ -192,7 +192,7 @@ class ScenarioTreeManagerSolver(PySPConfiguredObject):
         Returns:
             A :class:`ScenarioTreeSolveResults` object storing \
             basic status information for each subproblem. If \
-            the :attr:`async` keyword is set to :const:`True` \
+            the :attr:`async_call` keyword is set to :const:`True` \
             then an :class:`AsyncResult` object is returned.
 
         Examples:
@@ -207,7 +207,7 @@ class ScenarioTreeManagerSolver(PySPConfiguredObject):
             The following lines do the same by first
             initiating an asynchronous solve request.
 
-            >>> job = sp.solve_subproblems(async=True)
+            >>> job = sp.solve_subproblems(async_call=True)
             >>> # ... do other things ... #
             >>> results = job.complete()
             >>> results.pprint()
@@ -231,7 +231,7 @@ class ScenarioTreeManagerSolver(PySPConfiguredObject):
                         ephemeral_solver_options=None,
                         disable_warmstart=False,
                         check_status=True,
-                        async=False):
+                        async_call=False):
         """Solve scenarios (ignoring bundles even if they exists).
 
         Args:
@@ -253,7 +253,7 @@ class ScenarioTreeManagerSolver(PySPConfiguredObject):
                 users catch errors early on and should be
                 set to :const:`False` in situations where
                 more advanced status handling is necessary.
-            async (bool): When set to :const:`True`, an
+            async_call (bool): When set to :const:`True`, an
                 async results object is returned that allows
                 the solves to be completed
                 asynchronously. Default is
@@ -266,7 +266,7 @@ class ScenarioTreeManagerSolver(PySPConfiguredObject):
         Returns:
             A :class:`ScenarioTreeSolveResults` object storing \
             basic status information for each subproblem. If \
-            the :attr:`async` keyword is set to :const:`True` \
+            the :attr:`async_call` keyword is set to :const:`True` \
             then an :class:`AsyncResult` object is returned.
 
         Examples:
@@ -281,7 +281,7 @@ class ScenarioTreeManagerSolver(PySPConfiguredObject):
             The following lines do the same by first
             initiating an asynchronous solve request.
 
-            >>> job = sp.solve_scenarios(async=True)
+            >>> job = sp.solve_scenarios(async_call=True)
             >>> # ... do other things ... #
             >>> results = job.complete()
             >>> results.pprint()
@@ -296,14 +296,14 @@ class ScenarioTreeManagerSolver(PySPConfiguredObject):
                                    ephemeral_solver_options,
                                    disable_warmstart,
                                    check_status,
-                                   async)
+                                   async_call)
 
     def solve_bundles(self,
                       bundles=None,
                       ephemeral_solver_options=None,
                       disable_warmstart=False,
                       check_status=True,
-                      async=False):
+                      async_call=False):
         """Solve bundles (they must exists).
 
         Args:
@@ -325,7 +325,7 @@ class ScenarioTreeManagerSolver(PySPConfiguredObject):
                 users catch errors early on and should be
                 set to :const:`False` in situations where
                 more advanced status handling is necessary.
-            async (bool): When set to :const:`True`, an
+            async_call (bool): When set to :const:`True`, an
                 async results object is returned that allows
                 the solves to be completed
                 asynchronously. Default is
@@ -338,7 +338,7 @@ class ScenarioTreeManagerSolver(PySPConfiguredObject):
         Returns:
             A :class:`ScenarioTreeSolveResults` object storing \
             basic status information for each subproblem. If \
-            the :attr:`async` keyword is set to :const:`True` \
+            the :attr:`async_call` keyword is set to :const:`True` \
             then an :class:`AsyncResult` object is returned.
 
         Examples:
@@ -353,7 +353,7 @@ class ScenarioTreeManagerSolver(PySPConfiguredObject):
             The following lines do the same by first
             initiating an asynchronous solve request.
 
-            >>> job = sp.solve_bundles(async=True)
+            >>> job = sp.solve_bundles(async_call=True)
             >>> # ... do other things ... #
             >>> results = job.complete()
             >>> results.pprint()
@@ -373,7 +373,7 @@ class ScenarioTreeManagerSolver(PySPConfiguredObject):
                                    ephemeral_solver_options,
                                    disable_warmstart,
                                    check_status,
-                                   async)
+                                   async_call)
 
     def _process_solve_results(self,
                                object_type,
@@ -987,7 +987,7 @@ def ScenarioTreeManagerSolverFactory(sp, *args, **kwds):
         results are undefined.
 
         >>> with ScenarioTreeManagerSolverFactory(sp) as manager:
-        >>>    job = manager.solve_subproblems(async=True)
+        >>>    job = manager.solve_subproblems(async_call=True)
         >>>    reuslts = job.complete()
         >>> results.pprint()
     """

--- a/pyomo/pysp/scenariotree/manager_worker_pyro.py
+++ b/pyomo/pysp/scenariotree/manager_worker_pyro.py
@@ -336,9 +336,9 @@ class ScenarioTreeManagerWorkerPyro(_ScenarioTreeManagerWorker,
     # on ScenarioTreeManager
     # ** NOTE **: These version are meant to be invoked locally.
     #             The client-side will always invoke the *_impl
-    #             methods, which do not accept the async or
-    #             oneway keywords. When invoked here, the
-    #             async and oneway keywords behave like they
+    #             methods, which do not accept the async_call or
+    #             oneway_call keywords. When invoked here, the
+    #             async_call and oneway_call keywords behave like they
     #             do for the Serial solver manager (they are
     #             a dummy interface)
     #
@@ -349,14 +349,14 @@ class ScenarioTreeManagerWorkerPyro(_ScenarioTreeManagerWorker,
                         invocation_type=InvocationType.Single,
                         function_args=(),
                         function_kwds=None,
-                        async=False,
-                        oneway=False):
+                        async_call=False,
+                        oneway_call=False):
         """This function is an override of that on the
         ScenarioTreeManager interface. It should not be invoked by a
         client, but only locally (e.g., inside a local function
         invocation transmitted by the client).
         """
-        if async and oneway:
+        if async_call and oneway_call:
             raise ValueError("async oneway calls do not make sense")
         invocation_type = _map_deprecated_invocation_type(invocation_type)
 
@@ -377,10 +377,10 @@ class ScenarioTreeManagerWorkerPyro(_ScenarioTreeManagerWorker,
                                    function_args=function_args,
                                    function_kwds=function_kwds)
 
-        if not oneway:
+        if not oneway_call:
             if invocation_type == InvocationType.Single:
                 result = {self._worker_name: result}
-        if async:
+        if async_call:
             result = self.AsyncResult(None, result=result)
 
         return result
@@ -389,24 +389,24 @@ class ScenarioTreeManagerWorkerPyro(_ScenarioTreeManagerWorker,
                       method_name,
                       method_args=(),
                       method_kwds=None,
-                      async=False,
-                      oneway=False):
+                      async_call=False,
+                      oneway_call=False):
         """This function is an override of that on the
         ScenarioTreeManager interface. It should not be invoked by a
         client, but only locally (e.g., inside a local function
         invocation transmitted by the client).
 
         """
-        if async and oneway:
+        if async_call and oneway_call:
             raise ValueError("async oneway calls do not make sense")
 
         if method_kwds is None:
             method_kwds = {}
         result = getattr(self, method_name)(*method_args, **method_kwds)
 
-        if not oneway:
+        if not oneway_call:
             result = {self._worker_name: result}
-        if async:
+        if async_call:
             result = self.AsyncResult(None, result=result)
 
         return result

--- a/pyomo/pysp/solvers/admm.py
+++ b/pyomo/pysp/solvers/admm.py
@@ -466,7 +466,7 @@ class ADMMAlgorithm(PySPConfiguredObject):
             "EXTERNAL_initialize_for_admm",
             thisfile,
             invocation_type=InvocationType.PerScenario,
-            oneway=True)
+            oneway_call=True)
 
     def cleanup_subproblems(self):
         if self.get_option("verbose"):
@@ -475,49 +475,49 @@ class ADMMAlgorithm(PySPConfiguredObject):
             "EXTERNAL_cleanup_for_admm",
             thisfile,
             invocation_type=InvocationType.PerScenario,
-            oneway=True)
+            oneway_call=True)
 
     def activate_lagrangian_term(self):
         self._manager.invoke_function(
             "EXTERNAL_activate_lagrangian_term",
             thisfile,
             invocation_type=InvocationType.PerScenario,
-            oneway=True)
+            oneway_call=True)
 
     def deactivate_lagrangian_term(self):
         self._manager.invoke_function(
             "EXTERNAL_deactivate_lagrangian_term",
             thisfile,
             invocation_type=InvocationType.PerScenario,
-            oneway=True)
+            oneway_call=True)
 
     def activate_penalty_term(self):
         self._manager.invoke_function(
             "EXTERNAL_activate_penalty_term",
             thisfile,
             invocation_type=InvocationType.PerScenario,
-            oneway=True)
+            oneway_call=True)
 
     def deactivate_penalty_term(self):
         self._manager.invoke_function(
             "EXTERNAL_deactivate_penalty_term",
             thisfile,
             invocation_type=InvocationType.PerScenario,
-            oneway=True)
+            oneway_call=True)
 
     def activate_probability_weighted_cost_term(self):
         self._manager.invoke_function(
             "EXTERNAL_activate_probability_weighted_cost_term",
             thisfile,
             invocation_type=InvocationType.PerScenario,
-            oneway=True)
+            oneway_call=True)
 
     def deactivate_probability_weighted_cost_term(self):
         self._manager.invoke_function(
             "EXTERNAL_deactivate_probability_weighted_cost_term",
             thisfile,
             invocation_type=InvocationType.PerScenario,
-            oneway=True)
+            oneway_call=True)
 
     def run_x_update(self, x, y, z, rho):
         self._manager.invoke_function(
@@ -525,20 +525,20 @@ class ADMMAlgorithm(PySPConfiguredObject):
             thisfile,
             invocation_type=InvocationType.PerScenario,
             function_args=(rho,),
-            oneway=True)
+            oneway_call=True)
         for scenario in self._manager.scenario_tree.scenarios:
             self._manager.invoke_function(
                 "EXTERNAL_update_y",
                 thisfile,
                 invocation_type=InvocationType.OnScenario(scenario.name),
                 function_args=(y[scenario.name],),
-                oneway=True)
+                oneway_call=True)
         self._manager.invoke_function(
             "EXTERNAL_update_z",
             thisfile,
             invocation_type=InvocationType.PerScenario,
             function_args=(z,),
-            oneway=True)
+            oneway_call=True)
 
         self._manager_solver.solve_scenarios()
 

--- a/pyomo/pysp/solvers/benders.py
+++ b/pyomo/pysp/solvers/benders.py
@@ -681,28 +681,28 @@ class BendersAlgorithm(PySPConfiguredObject):
             "EXTERNAL_deactivate_rootnode_costs",
             thisfile,
             invocation_type=InvocationType.PerScenario,
-            oneway=True)
+            oneway_call=True)
 
     def activate_rootnode_costs(self):
         self._manager.invoke_function(
             "EXTERNAL_activate_rootnode_costs",
             thisfile,
             invocation_type=InvocationType.PerScenario,
-            oneway=True)
+            oneway_call=True)
 
     def activate_fix_constraints(self):
         self._manager.invoke_function(
             "EXTERNAL_activate_fix_constraints",
             thisfile,
             invocation_type=InvocationType.PerScenario,
-            oneway=True)
+            oneway_call=True)
 
     def deactivate_fix_constraints(self):
         self._manager.invoke_function(
             "EXTERNAL_deactivate_fix_constraints",
             thisfile,
             invocation_type=InvocationType.PerScenario,
-            oneway=True)
+            oneway_call=True)
 
     def update_fix_constraints(self, fix_values):
         self._manager.invoke_function(
@@ -710,14 +710,14 @@ class BendersAlgorithm(PySPConfiguredObject):
             thisfile,
             invocation_type=InvocationType.PerScenario,
             function_args=(fix_values,),
-            oneway=True)
+            oneway_call=True)
 
-    def collect_cut_data(self, async=False):
+    def collect_cut_data(self, async_call=False):
         return self._manager.invoke_function(
             "EXTERNAL_collect_cut_data",
             thisfile,
             invocation_type=InvocationType.PerScenario,
-            async=async)
+            async_call=async_call)
 
     def initialize_subproblems(self):
         if self.get_option("verbose"):
@@ -726,7 +726,7 @@ class BendersAlgorithm(PySPConfiguredObject):
             "EXTERNAL_initialize_for_benders",
             thisfile,
             invocation_type=InvocationType.PerScenario,
-            oneway=True)
+            oneway_call=True)
 
     def cleanup_subproblems(self):
         if self.get_option("verbose"):
@@ -735,7 +735,7 @@ class BendersAlgorithm(PySPConfiguredObject):
             "EXTERNAL_cleanup_from_benders",
             thisfile,
             invocation_type=InvocationType.PerScenario,
-            oneway=True)
+            oneway_call=True)
 
     def generate_cut(self,
                      xhat,

--- a/pyomo/pysp/solvers/ddsip.py
+++ b/pyomo/pysp/solvers/ddsip.py
@@ -345,7 +345,7 @@ class DDSIPSolver(SPSolverShellCommand, PySPConfiguredObject):
         #        thisfile,
         #        invocation_type=InvocationType.OnScenario(scenario.name),
         #        function_args=(solution_filename, scenario_id),
-        #        async=True))
+        #        async_call=True))
 
         xhat, results = self._read_solution(sp,
                                             input_files["symbols"],

--- a/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanager.py
+++ b/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanager.py
@@ -184,13 +184,13 @@ class _ScenarioTreeManagerTesterBase(object):
         options.scenario_tree_random_seed = 1
 
     @unittest.nottest
-    def _run_function_tests(self, manager, async=False, oneway=False, delay=False):
-        assert not (async and oneway)
+    def _run_function_tests(self, manager, async_call=False, oneway_call=False, delay=False):
+        assert not (async_call and oneway_call)
         class_name, test_name = self.id().split('.')[-2:]
         print("Running function tests on %s.%s" % (class_name, test_name))
         data = []
-        init = manager.initialize(async=async)
-        if async:
+        init = manager.initialize(async_call=async_call)
+        if async_call:
             init = init.complete()
         self.assertEqual(all(_v is True for _v in init.values()), True)
         self.assertEqual(sorted(init.keys()), sorted(manager.worker_names))
@@ -219,27 +219,27 @@ class _ScenarioTreeManagerTesterBase(object):
                 "_Single",
                 module_name=None,
                 invocation_type=InvocationType.Single,
-                oneway=oneway,
-                async=async)
+                oneway_call=oneway_call,
+                async_call=async_call)
         # bad invocation type
         with self.assertRaises(ValueError):
             manager.invoke_function(
                 "_Single",
                 module_name=thisfile,
                 invocation_type="_not_an_invocation_type_",
-                oneway=oneway,
-                async=async)
-        # bad oneway and async combo
+                oneway_call=oneway_call,
+                async_call=async_call)
+        # bad oneway_call and async_call combo
         with self.assertRaises(ValueError):
             manager.invoke_function(
                 "_Single",
                 module_name=thisfile,
                 invocation_type=InvocationType.Single,
-                oneway=True,
-                async=True)
+                oneway_call=True,
+                async_call=True)
         # bad paused state
         if isinstance(manager, ScenarioTreeManagerClientPyro) and \
-           (not async) and (not oneway) and (not delay):
+           (not async_call) and (not oneway_call) and (not delay):
             self.assertEqual(manager._transmission_paused, False)
             manager.pause_transmit()
             self.assertEqual(manager._transmission_paused, True)
@@ -248,8 +248,8 @@ class _ScenarioTreeManagerTesterBase(object):
                     "_Single",
                     module_name=thisfile,
                     invocation_type=InvocationType.Single,
-                    oneway=oneway,
-                    async=async)
+                    oneway_call=oneway_call,
+                    async_call=async_call)
             manager.unpause_transmit()
             self.assertEqual(manager._transmission_paused, False)
         if dill_available or \
@@ -259,10 +259,10 @@ class _ScenarioTreeManagerTesterBase(object):
             results = manager.invoke_function(
                 _Single,
                 invocation_type=InvocationType.Single,
-                oneway=oneway,
-                async=async)
+                oneway_call=oneway_call,
+                async_call=async_call)
             if not delay:
-                if async:
+                if async_call:
                     results = results.complete()
             data.append(('_Single', results))
             if isinstance(manager, ScenarioTreeManagerClientPyro):
@@ -272,8 +272,8 @@ class _ScenarioTreeManagerTesterBase(object):
                         _Single,
                         module_name=thisfile,
                         invocation_type=InvocationType.Single,
-                        oneway=oneway,
-                        async=async)
+                        oneway_call=oneway_call,
+                        async_call=async_call)
 
         elif isinstance(manager, ScenarioTreeManagerClientPyro):
             # requires dill
@@ -281,18 +281,18 @@ class _ScenarioTreeManagerTesterBase(object):
                 manager.invoke_function(
                     _Single,
                     invocation_type=InvocationType.Single,
-                    oneway=oneway,
-                    async=async)
+                    oneway_call=oneway_call,
+                    async_call=async_call)
         print("")
         print("Running InvocationType.Single...")
         results = manager.invoke_function(
             "_Single",
             module_name=thisfile,
             invocation_type=InvocationType.Single,
-            oneway=oneway,
-            async=async)
+            oneway_call=oneway_call,
+            async_call=async_call)
         if not delay:
-            if async:
+            if async_call:
                 results = results.complete()
         data.append(('_Single', results))
         print("Running InvocationType.PerScenario...")
@@ -300,10 +300,10 @@ class _ScenarioTreeManagerTesterBase(object):
             "_PerScenario",
             module_name=thisfile,
             invocation_type=InvocationType.PerScenario,
-            oneway=oneway,
-            async=async)
+            oneway_call=oneway_call,
+            async_call=async_call)
         if not delay:
-            if async:
+            if async_call:
                 results = results.complete()
         data.append(('_PerScenario', results))
         print("Running InvocationType.PerScenarioChained...")
@@ -312,10 +312,10 @@ class _ScenarioTreeManagerTesterBase(object):
             module_name=thisfile,
             function_args=(None,),
             invocation_type=InvocationType.PerScenarioChained,
-            oneway=oneway,
-            async=async)
+            oneway_call=oneway_call,
+            async_call=async_call)
         if not delay:
-            if async:
+            if async_call:
                 results = results.complete()
         data.append(('_PerScenarioChained', results))
         print("Running InvocationType.PerScenarioChained (no args)...")
@@ -323,10 +323,10 @@ class _ScenarioTreeManagerTesterBase(object):
             "_PerScenarioChained_noargs",
             module_name=thisfile,
             invocation_type=InvocationType.PerScenarioChained,
-            oneway=oneway,
-            async=async)
+            oneway_call=oneway_call,
+            async_call=async_call)
         if not delay:
-            if async:
+            if async_call:
                 results = results.complete()
         data.append(('_PerScenarioChained_noargs', results))
 
@@ -342,8 +342,8 @@ class _ScenarioTreeManagerTesterBase(object):
                     module_name=thisfile,
                     function_args=(None,),
                     invocation_type=InvocationType.PerScenarioChained,
-                    oneway=oneway,
-                    async=async)
+                    oneway_call=oneway_call,
+                    async_call=async_call)
             manager.unpause_transmit()
             self.assertEqual(manager._transmission_paused, False)
 
@@ -352,10 +352,10 @@ class _ScenarioTreeManagerTesterBase(object):
             "_PerScenario",
             module_name=thisfile,
             invocation_type=InvocationType.OnScenario('Scenario1'),
-            oneway=oneway,
-            async=async)
+            oneway_call=oneway_call,
+            async_call=async_call)
         if not delay:
-            if async:
+            if async_call:
                 results = results.complete()
         data.append(('_OnScenario', results))
         print("Running InvocationType.OnScenarios...")
@@ -363,10 +363,10 @@ class _ScenarioTreeManagerTesterBase(object):
             "_PerScenario",
             module_name=thisfile,
             invocation_type=InvocationType.OnScenarios(['Scenario1', 'Scenario3']),
-            oneway=oneway,
-            async=async)
+            oneway_call=oneway_call,
+            async_call=async_call)
         if not delay:
-            if async:
+            if async_call:
                 results = results.complete()
         data.append(('_OnScenarios', results))
         print("Running InvocationType.OnScenariosChained...")
@@ -375,10 +375,10 @@ class _ScenarioTreeManagerTesterBase(object):
             module_name=thisfile,
             function_args=(None,),
             invocation_type=InvocationType.OnScenariosChained(['Scenario1', 'Scenario3']),
-            oneway=oneway,
-            async=async)
+            oneway_call=oneway_call,
+            async_call=async_call)
         if not delay:
-            if async:
+            if async_call:
                 results = results.complete()
         data.append(('_OnScenariosChained', results))
         print("Running InvocationType.OnScenariosChained (no args)...")
@@ -386,10 +386,10 @@ class _ScenarioTreeManagerTesterBase(object):
             "_PerScenarioChained_noargs",
             module_name=thisfile,
             invocation_type=InvocationType.OnScenariosChained(['Scenario3', 'Scenario2']),
-            oneway=oneway,
-            async=async)
+            oneway_call=oneway_call,
+            async_call=async_call)
         if not delay:
-            if async:
+            if async_call:
                 results = results.complete()
         data.append(('_OnScenariosChained_noargs', results))
 
@@ -405,8 +405,8 @@ class _ScenarioTreeManagerTesterBase(object):
                     module_name=thisfile,
                     function_args=(None,),
                     invocation_type=InvocationType.OnScenariosChained(['Scenario1', 'Scenario3']),
-                    oneway=oneway,
-                    async=async)
+                    oneway_call=oneway_call,
+                    async_call=async_call)
             manager.unpause_transmit()
             self.assertEqual(manager._transmission_paused, False)
 
@@ -416,10 +416,10 @@ class _ScenarioTreeManagerTesterBase(object):
                 "_PerBundle",
                 module_name=thisfile,
                 invocation_type=InvocationType.PerBundle,
-                oneway=oneway,
-                async=async)
+                oneway_call=oneway_call,
+                async_call=async_call)
             if not delay:
-                if async:
+                if async_call:
                     results = results.complete()
             data.append(('_PerBundle', results))
             print("Running InvocationType.PerBundleChained...")
@@ -428,10 +428,10 @@ class _ScenarioTreeManagerTesterBase(object):
                 module_name=thisfile,
                 function_args=(None,),
                 invocation_type=InvocationType.PerBundleChained,
-                oneway=oneway,
-                async=async)
+                oneway_call=oneway_call,
+                async_call=async_call)
             if not delay:
-                if async:
+                if async_call:
                     results = results.complete()
             data.append(('_PerBundleChained', results))
             print("Running InvocationType.PerBundleChained (no args)...")
@@ -439,10 +439,10 @@ class _ScenarioTreeManagerTesterBase(object):
                 "_PerBundleChained_noargs",
                 module_name=thisfile,
                 invocation_type=InvocationType.PerBundleChained,
-                oneway=oneway,
-                async=async)
+                oneway_call=oneway_call,
+                async_call=async_call)
             if not delay:
-                if async:
+                if async_call:
                     results = results.complete()
             data.append(('_PerBundleChained_noargs', results))
 
@@ -451,10 +451,10 @@ class _ScenarioTreeManagerTesterBase(object):
                 "_PerBundle",
                 module_name=thisfile,
                 invocation_type=InvocationType.OnBundle('Bundle1'),
-                oneway=oneway,
-                async=async)
+                oneway_call=oneway_call,
+                async_call=async_call)
             if not delay:
-                if async:
+                if async_call:
                     results = results.complete()
             data.append(('_OnBundle', results))
             print("Running InvocationType.OnBundles...")
@@ -466,10 +466,10 @@ class _ScenarioTreeManagerTesterBase(object):
                 "_PerBundle",
                 module_name=thisfile,
                 invocation_type=InvocationType.OnBundles([b.name for b in manager.scenario_tree.bundles]),
-                oneway=oneway,
-                async=async)
+                oneway_call=oneway_call,
+                async_call=async_call)
             if not delay:
-                if async:
+                if async_call:
                     results = results.complete()
             data.append(('_OnBundles', results))
             print("Running InvocationType.OnBundlesChained...")
@@ -478,10 +478,10 @@ class _ScenarioTreeManagerTesterBase(object):
                 module_name=thisfile,
                 function_args=(None,),
                 invocation_type=InvocationType.OnBundlesChained(_bundle_names),
-                oneway=oneway,
-                async=async)
+                oneway_call=oneway_call,
+                async_call=async_call)
             if not delay:
-                if async:
+                if async_call:
                     results = results.complete()
             data.append(('_OnBundlesChained', results))
             print("Running InvocationType.OnBundlesChained (no args)...")
@@ -489,10 +489,10 @@ class _ScenarioTreeManagerTesterBase(object):
                 "_PerBundleChained_noargs",
                 module_name=thisfile,
                 invocation_type=InvocationType.OnBundlesChained(_bundle_names),
-                oneway=oneway,
-                async=async)
+                oneway_call=oneway_call,
+                async_call=async_call)
             if not delay:
-                if async:
+                if async_call:
                     results = results.complete()
             data.append(('_OnBundlesChained_noargs', results))
         else:
@@ -501,44 +501,44 @@ class _ScenarioTreeManagerTesterBase(object):
                     "_PerBundle",
                     module_name=thisfile,
                     invocation_type=InvocationType.PerBundle,
-                    oneway=oneway,
-                    async=async)
+                    oneway_call=oneway_call,
+                    async_call=async_call)
             with self.assertRaises(ValueError):
                 manager.invoke_function(
                     "_PerBundleChained",
                     module_name=thisfile,
                     function_args=(None,),
                     invocation_type=InvocationType.PerBundleChained,
-                    oneway=oneway,
-                    async=async)
+                    oneway_call=oneway_call,
+                    async_call=async_call)
             with self.assertRaises(ValueError):
                 manager.invoke_function(
                     "_PerBundle",
                     module_name=thisfile,
                     invocation_type=InvocationType.OnBundle('Bundle1'),
-                    oneway=oneway,
-                    async=async)
+                    oneway_call=oneway_call,
+                    async_call=async_call)
             with self.assertRaises(ValueError):
                 manager.invoke_function(
                     "_PerBundle",
                     module_name=thisfile,
                     invocation_type=InvocationType.OnBundles(['B1','B2']),
-                    oneway=oneway,
-                    async=async)
+                    oneway_call=oneway_call,
+                    async_call=async_call)
             with self.assertRaises(ValueError):
                 manager.invoke_function(
                     "_PerBundleChained",
                     module_name=thisfile,
                     function_args=(None,),
                     invocation_type=InvocationType.OnBundlesChained(['B1','B2']),
-                    oneway=oneway,
-                    async=async)
+                    oneway_call=oneway_call,
+                    async_call=async_call)
 
         for name, results in data:
             if delay:
-                if async:
+                if async_call:
                     results = results.complete()
-            if oneway:
+            if oneway_call:
                 self.assertEqual(id(results), id(None))
             else:
                 if name == "_Single":
@@ -654,15 +654,15 @@ class _ScenarioTreeManagerTesterBase(object):
         data['_Single'] = {}
         for worker_name in manager.worker_names:
 
-            # bad oneway and async combo
+            # bad oneway_call and async_call combo
             with self.assertRaises(ValueError):
                 manager.invoke_function_on_worker(
                     worker_name,
                     "_Single",
                     module_name=thisfile,
                     invocation_type=InvocationType.Single,
-                    oneway=True,
-                    async=True)
+                    oneway_call=True,
+                    async_call=True)
 
             if dill_available or \
                isinstance(manager, ScenarioTreeManagerClientPyro):
@@ -672,8 +672,8 @@ class _ScenarioTreeManagerTesterBase(object):
                     worker_name,
                     _Single,
                     invocation_type=InvocationType.Single,
-                    oneway=oneway,
-                    async=async)
+                    oneway_call=oneway_call,
+                    async_call=async_call)
                 if isinstance(manager, ScenarioTreeManagerClientPyro):
                     # module name must be None
                     with self.assertRaises(ValueError):
@@ -682,8 +682,8 @@ class _ScenarioTreeManagerTesterBase(object):
                             "_Single",
                             module_name=None,
                             invocation_type=InvocationType.Single,
-                            oneway=oneway,
-                            async=async)
+                            oneway_call=oneway_call,
+                            async_call=async_call)
 
             else:
                 if isinstance(manager, ScenarioTreeManagerClientPyro):
@@ -693,18 +693,18 @@ class _ScenarioTreeManagerTesterBase(object):
                             worker_name,
                             _Single,
                             invocation_type=InvocationType.Single,
-                            oneway=oneway,
-                            async=async)
+                            oneway_call=oneway_call,
+                            async_call=async_call)
                 results = manager.invoke_function_on_worker(
                     worker_name,
                     "_Single",
                     module_name=thisfile,
                     invocation_type=InvocationType.Single,
-                    oneway=oneway,
-                    async=async)
+                    oneway_call=oneway_call,
+                    async_call=async_call)
 
             if not delay:
-                if async:
+                if async_call:
                     results = results.complete()
             data['_Single'][worker_name] = results
 
@@ -716,10 +716,10 @@ class _ScenarioTreeManagerTesterBase(object):
                 "_PerScenario",
                 module_name=thisfile,
                 invocation_type=InvocationType.PerScenario,
-                oneway=oneway,
-                async=async)
+                oneway_call=oneway_call,
+                async_call=async_call)
             if not delay:
-                if async:
+                if async_call:
                     results = results.complete()
             data['_PerScenario'][worker_name] = results
         print("Running InvocationType.PerScenarioChained on individual workers...")
@@ -732,8 +732,8 @@ class _ScenarioTreeManagerTesterBase(object):
                 module_name=thisfile,
                 function_args=results,
                 invocation_type=InvocationType.PerScenarioChained,
-                async=async)
-            if async:
+                async_call=async_call)
+            if async_call:
                 results = results.complete()
         data['_PerScenarioChained'] = results
         print("Running InvocationType.PerScenarioChained (no args) on individual workers...")
@@ -744,9 +744,9 @@ class _ScenarioTreeManagerTesterBase(object):
                 "_PerScenarioChained_noargs",
                 module_name=thisfile,
                 invocation_type=InvocationType.PerScenarioChained,
-                async=async)
+                async_call=async_call)
             if not delay:
-                if async:
+                if async_call:
                     results = results.complete()
             data['_PerScenarioChained_noargs'][worker_name] = results
 
@@ -759,10 +759,10 @@ class _ScenarioTreeManagerTesterBase(object):
                 "_PerScenario",
                 module_name=thisfile,
                 invocation_type=InvocationType.OnScenario(manager.get_scenarios_for_worker(worker_name)[0]),
-                oneway=oneway,
-                async=async)
+                oneway_call=oneway_call,
+                async_call=async_call)
             if not delay:
-                if async:
+                if async_call:
                     results = results.complete()
             data['_OnScenario'][worker_name] = results
         print("Running InvocationType.OnScenarios on individual workers...")
@@ -774,10 +774,10 @@ class _ScenarioTreeManagerTesterBase(object):
                 "_PerScenario",
                 module_name=thisfile,
                 invocation_type=InvocationType.OnScenarios(manager.get_scenarios_for_worker(worker_name)),
-                oneway=oneway,
-                async=async)
+                oneway_call=oneway_call,
+                async_call=async_call)
             if not delay:
-                if async:
+                if async_call:
                     results = results.complete()
             data['_OnScenarios'][worker_name] = results
         print("Running InvocationType.OnScenariosChained on individual workers...")
@@ -791,9 +791,9 @@ class _ScenarioTreeManagerTesterBase(object):
                 module_name=thisfile,
                 function_args=results,
                 invocation_type=InvocationType.OnScenariosChained(manager.get_scenarios_for_worker(worker_name)),
-                oneway=oneway,
-                async=async)
-            if async:
+                oneway_call=oneway_call,
+                async_call=async_call)
+            if async_call:
                 results = results.complete()
         data['_OnScenariosChained'] = results
         print("Running InvocationType.OnScenariosChained (no args) on individual workers...")
@@ -805,10 +805,10 @@ class _ScenarioTreeManagerTesterBase(object):
                 "_PerScenarioChained_noargs",
                 module_name=thisfile,
                 invocation_type=InvocationType.OnScenariosChained(manager.get_scenarios_for_worker(worker_name)),
-                oneway=oneway,
-                async=async)
+                oneway_call=oneway_call,
+                async_call=async_call)
             if not delay:
-                if async:
+                if async_call:
                     results = results.complete()
             data['_OnScenariosChained_noargs'][worker_name] = results
 
@@ -821,10 +821,10 @@ class _ScenarioTreeManagerTesterBase(object):
                     "_PerBundle",
                     module_name=thisfile,
                     invocation_type=InvocationType.PerBundle,
-                    oneway=oneway,
-                    async=async)
+                    oneway_call=oneway_call,
+                    async_call=async_call)
                 if not delay:
-                    if async:
+                    if async_call:
                         results = results.complete()
                 data['_PerBundle'][worker_name] = results
             print("Running InvocationType.PerBundleChained on individual workers...")
@@ -837,8 +837,8 @@ class _ScenarioTreeManagerTesterBase(object):
                     module_name=thisfile,
                     function_args=results,
                     invocation_type=InvocationType.PerBundleChained,
-                    async=async)
-                if async:
+                    async_call=async_call)
+                if async_call:
                     results = results.complete()
             data['_PerBundleChained'] = results
             print("Running InvocationType.PerBundleChained (no args) on individual workers...")
@@ -849,9 +849,9 @@ class _ScenarioTreeManagerTesterBase(object):
                     "_PerBundleChained_noargs",
                     module_name=thisfile,
                     invocation_type=InvocationType.PerBundleChained,
-                    async=async)
+                    async_call=async_call)
                 if not delay:
-                    if async:
+                    if async_call:
                         results = results.complete()
                 data['_PerBundleChained_noargs'][worker_name] = results
 
@@ -864,10 +864,10 @@ class _ScenarioTreeManagerTesterBase(object):
                     "_PerBundle",
                     module_name=thisfile,
                     invocation_type=InvocationType.OnBundle(manager.get_bundles_for_worker(worker_name)[0]),
-                    oneway=oneway,
-                    async=async)
+                    oneway_call=oneway_call,
+                    async_call=async_call)
                 if not delay:
-                    if async:
+                    if async_call:
                         results = results.complete()
                 data['_OnBundle'][worker_name] = results
             print("Running InvocationType.OnBundles on individual workers...")
@@ -879,10 +879,10 @@ class _ScenarioTreeManagerTesterBase(object):
                     "_PerBundle",
                     module_name=thisfile,
                     invocation_type=InvocationType.OnBundles(manager.get_bundles_for_worker(worker_name)),
-                    oneway=oneway,
-                    async=async)
+                    oneway_call=oneway_call,
+                    async_call=async_call)
                 if not delay:
-                    if async:
+                    if async_call:
                         results = results.complete()
                 data['_OnBundles'][worker_name] = results
             print("Running InvocationType.OnBundlesChained on individual workers...")
@@ -895,8 +895,8 @@ class _ScenarioTreeManagerTesterBase(object):
                     module_name=thisfile,
                     function_args=results,
                     invocation_type=InvocationType.OnBundlesChained(manager.get_bundles_for_worker(worker_name)),
-                    async=async)
-                if async:
+                    async_call=async_call)
+                if async_call:
                     results = results.complete()
             data['_OnBundlesChained'] = results
             print("Running InvocationType.OnBundlesChained (no args) on individual workers...")
@@ -907,9 +907,9 @@ class _ScenarioTreeManagerTesterBase(object):
                     "_PerBundleChained_noargs",
                     module_name=thisfile,
                     invocation_type=InvocationType.OnBundlesChained(manager.get_bundles_for_worker(worker_name)),
-                    async=async)
+                    async_call=async_call)
                 if not delay:
-                    if async:
+                    if async_call:
                         results = results.complete()
                 data['_OnBundlesChained_noargs'][worker_name] = results
 
@@ -921,10 +921,10 @@ class _ScenarioTreeManagerTesterBase(object):
                (name != '_OnScenariosChained') and \
                (name != '_OnBundlesChained'):
                 if delay:
-                    if async:
+                    if async_call:
                         for worker_name in results:
                             results[worker_name] = results[worker_name].complete()
-            if oneway:
+            if oneway_call:
                 if (name != '_PerScenarioChained') and \
                    (name != '_PerBundleChained') and \
                    (name != '_OnScenariosChained') and \
@@ -1059,17 +1059,17 @@ class _ScenarioTreeManagerTesterBase(object):
         # Test invoke_method
         #
 
-        # bad oneway and async combo
+        # bad oneway_call and async_call combo
         with self.assertRaises(ValueError):
             manager.invoke_method(
                 "junk",
                 method_args=(None,),
                 method_kwds={'a': None},
-                oneway=True,
-                async=True)
+                oneway_call=True,
+                async_call=True)
         # bad paused state
         if isinstance(manager, ScenarioTreeManagerClientPyro) and \
-           (not async) and (not oneway) and (not delay):
+           (not async_call) and (not oneway_call) and (not delay):
             self.assertEqual(manager._transmission_paused, False)
             manager.pause_transmit()
             self.assertEqual(manager._transmission_paused, True)
@@ -1078,8 +1078,8 @@ class _ScenarioTreeManagerTesterBase(object):
                     "junk",
                     method_args=(None,),
                     method_kwds={'a': None},
-                    oneway=oneway,
-                    async=async)
+                    oneway_call=oneway_call,
+                    async_call=async_call)
             manager.unpause_transmit()
             self.assertEqual(manager._transmission_paused, False)
 
@@ -1087,11 +1087,11 @@ class _ScenarioTreeManagerTesterBase(object):
             "junk",
             method_args=(None,),
             method_kwds={'a': None},
-            oneway=oneway,
-            async=async)
-        if async:
+            oneway_call=oneway_call,
+            async_call=async_call)
+        if async_call:
             result = result.complete()
-        if oneway:
+        if oneway_call:
             self.assertEqual(id(result), id(None))
         else:
             self.assertEqual(sorted(result.keys()),
@@ -1107,26 +1107,26 @@ class _ScenarioTreeManagerTesterBase(object):
 
         results = {}
         for worker_name in manager.worker_names:
-            # bad oneway and async combo
+            # bad oneway_call and async_call combo
             with self.assertRaises(ValueError):
                 manager.invoke_method_on_worker(worker_name,
                                                 "junk",
                                                 method_args=(None,),
                                                 method_kwds={'a': None},
-                                                oneway=True,
-                                                async=True)
+                                                oneway_call=True,
+                                                async_call=True)
             results[worker_name] = \
                 manager.invoke_method_on_worker(worker_name,
                                                 "junk",
                                                 method_args=(None,),
                                                 method_kwds={'a': None},
-                                                oneway=oneway,
-                                                async=async)
-        if async:
+                                                oneway_call=oneway_call,
+                                                async_call=async_call)
+        if async_call:
             results = dict((worker_name, results[worker_name].complete())
                            for worker_name in results)
 
-        if oneway:
+        if oneway_call:
             for worker_name in results:
                 self.assertEqual(id(results[worker_name]), id(None))
         else:
@@ -1137,116 +1137,116 @@ class _ScenarioTreeManagerTesterBase(object):
 
     @unittest.nottest
     def _scenarios_test(self,
-                        async=False,
-                        oneway=False,
+                        async_call=False,
+                        oneway_call=False,
                         delay=False):
         self._setup(self.options)
         with self.cls(self.options, **_init_kwds) as manager:
             self._run_function_tests(manager,
-                                     async=async,
-                                     oneway=oneway,
+                                     async_call=async_call,
+                                     oneway_call=oneway_call,
                                      delay=delay)
             self.assertEqual(manager._scenario_tree.contains_bundles(), False)
         self.assertEqual(list(self.options.unused_user_values()), [])
 
     @unittest.nottest
     def _bundles1_test(self,
-                       async=False,
-                       oneway=False,
+                       async_call=False,
+                       oneway_call=False,
                        delay=False):
         options = PySPConfigBlock()
         self._setup(self.options)
         self.options.scenario_bundle_specification = self._bundle_dict1
         with self.cls(self.options, **_init_kwds) as manager:
             self._run_function_tests(manager,
-                                     async=async,
-                                     oneway=oneway,
+                                     async_call=async_call,
+                                     oneway_call=oneway_call,
                                      delay=delay)
             self.assertEqual(manager._scenario_tree.contains_bundles(), True)
         self.assertEqual(list(self.options.unused_user_values()), [])
 
     @unittest.nottest
     def _bundles2_test(self,
-                       async=False,
-                       oneway=False,
+                       async_call=False,
+                       oneway_call=False,
                        delay=False):
         options = PySPConfigBlock()
         self._setup(self.options)
         self.options.scenario_bundle_specification = self._bundle_dict2
         with self.cls(self.options, **_init_kwds) as manager:
             self._run_function_tests(manager,
-                                     async=async,
-                                     oneway=oneway,
+                                     async_call=async_call,
+                                     oneway_call=oneway_call,
                                      delay=delay)
             self.assertEqual(manager._scenario_tree.contains_bundles(), True)
         self.assertEqual(list(self.options.unused_user_values()), [])
 
     @unittest.nottest
     def _bundles3_test(self,
-                       async=False,
-                       oneway=False,
+                       async_call=False,
+                       oneway_call=False,
                        delay=False):
         options = PySPConfigBlock()
         self._setup(self.options)
         self.options.scenario_bundle_specification = self._bundle_dict3
         with self.cls(self.options, **_init_kwds) as manager:
             self._run_function_tests(manager,
-                                     async=async,
-                                     oneway=oneway,
+                                     async_call=async_call,
+                                     oneway_call=oneway_call,
                                      delay=delay)
             self.assertEqual(manager._scenario_tree.contains_bundles(), True)
         self.assertEqual(list(self.options.unused_user_values()), [])
 
     def test_scenarios(self):
-        self._scenarios_test(async=False,
-                             oneway=False,
+        self._scenarios_test(async_call=False,
+                             oneway_call=False,
                              delay=False)
-    def test_scenarios_async(self):
-        self._scenarios_test(async=True,
-                             oneway=False,
+    def test_scenarios_async_call(self):
+        self._scenarios_test(async_call=True,
+                             oneway_call=False,
                              delay=False)
-    def test_scenarios_async_delay(self):
-        self._scenarios_test(async=True,
-                             oneway=False,
+    def test_scenarios_async_call_delay(self):
+        self._scenarios_test(async_call=True,
+                             oneway_call=False,
                              delay=True)
 
     def test_bundles1(self):
-        self._bundles1_test(async=False,
-                            oneway=False,
+        self._bundles1_test(async_call=False,
+                            oneway_call=False,
                             delay=False)
-    def test_bundles1_async(self):
-        self._bundles1_test(async=True,
-                            oneway=False,
+    def test_bundles1_async_call(self):
+        self._bundles1_test(async_call=True,
+                            oneway_call=False,
                             delay=False)
-    def test_bundles1_async_delay(self):
-        self._bundles1_test(async=True,
-                            oneway=False,
+    def test_bundles1_async_call_delay(self):
+        self._bundles1_test(async_call=True,
+                            oneway_call=False,
                             delay=True)
 
     def test_bundles2(self):
-        self._bundles2_test(async=False,
-                            oneway=False,
+        self._bundles2_test(async_call=False,
+                            oneway_call=False,
                             delay=False)
-    def test_bundles2_async(self):
-        self._bundles2_test(async=True,
-                            oneway=False,
+    def test_bundles2_async_call(self):
+        self._bundles2_test(async_call=True,
+                            oneway_call=False,
                             delay=False)
-    def test_bundles2_async_delay(self):
-        self._bundles2_test(async=True,
-                            oneway=False,
+    def test_bundles2_async_call_delay(self):
+        self._bundles2_test(async_call=True,
+                            oneway_call=False,
                             delay=True)
 
     def test_bundles3(self):
-        self._bundles3_test(async=False,
-                            oneway=False,
+        self._bundles3_test(async_call=False,
+                            oneway_call=False,
                             delay=False)
-    def test_bundles3_async(self):
-        self._bundles3_test(async=True,
-                            oneway=False,
+    def test_bundles3_async_call(self):
+        self._bundles3_test(async_call=True,
+                            oneway_call=False,
                             delay=False)
-    def test_bundles3_async_delay(self):
-        self._bundles3_test(async=True,
-                            oneway=False,
+    def test_bundles3_async_call_delay(self):
+        self._bundles3_test(async_call=True,
+                            oneway_call=False,
                             delay=True)
 
     def test_random_bundles(self):
@@ -1271,8 +1271,8 @@ class TestScenarioTreeManagerClientSerial(
 
     def setUp(self):
         self.options = PySPConfigBlock()
-        self.async = False
-        self.oneway = False
+        self.async_call = False
+        self.oneway_call = False
         self.delay = False
         ScenarioTreeManagerClientSerial.register_options(self.options)
 
@@ -1366,107 +1366,107 @@ class _ScenarioTreeManagerClientPyroTesterBase(_ScenarioTreeManagerTesterBase):
 
     @unittest.nottest
     def _scenarios_1server_test(self,
-                                async=False,
-                                oneway=False,
+                                async_call=False,
+                                oneway_call=False,
                                 delay=False):
         self._setup(self.options, servers=1)
         with self.cls(self.options, **_init_kwds) as manager:
             self._run_function_tests(manager,
-                                     async=async,
-                                     oneway=oneway,
+                                     async_call=async_call,
+                                     oneway_call=oneway_call,
                                      delay=delay)
             self.assertEqual(manager._scenario_tree.contains_bundles(), False)
         self.assertEqual(list(self.options.unused_user_values()), [])
 
     @unittest.nottest
     def _bundles1_1server_test(self,
-                               async=False,
-                               oneway=False,
+                               async_call=False,
+                               oneway_call=False,
                                delay=False):
         self._setup(self.options, servers=1)
         self.options.scenario_bundle_specification = self._bundle_dict1
         with self.cls(self.options, **_init_kwds) as manager:
             self._run_function_tests(manager,
-                                     async=async,
-                                     oneway=oneway,
+                                     async_call=async_call,
+                                     oneway_call=oneway_call,
                                      delay=delay)
             self.assertEqual(manager._scenario_tree.contains_bundles(), True)
         self.assertEqual(list(self.options.unused_user_values()), [])
 
     @unittest.nottest
     def _bundles2_1server_test(self,
-                               async=False,
-                               oneway=False,
+                               async_call=False,
+                               oneway_call=False,
                                delay=False):
         self._setup(self.options, servers=1)
         self.options.scenario_bundle_specification = self._bundle_dict2
         with self.cls(self.options, **_init_kwds) as manager:
-            self._run_function_tests(manager, async=async, oneway=oneway, delay=delay)
+            self._run_function_tests(manager, async_call=async_call, oneway_call=oneway_call, delay=delay)
             self.assertEqual(manager._scenario_tree.contains_bundles(), True)
         self.assertEqual(list(self.options.unused_user_values()), [])
 
     @unittest.nottest
     def _bundles3_1server_test(self,
-                               async=False,
-                               oneway=False,
+                               async_call=False,
+                               oneway_call=False,
                                delay=False):
         self._setup(self.options, servers=1)
         self.options.scenario_bundle_specification = self._bundle_dict3
         with self.cls(self.options, **_init_kwds) as manager:
-            self._run_function_tests(manager, async=async, oneway=oneway, delay=delay)
+            self._run_function_tests(manager, async_call=async_call, oneway_call=oneway_call, delay=delay)
             self.assertEqual(manager._scenario_tree.contains_bundles(), True)
         self.assertEqual(list(self.options.unused_user_values()), [])
 
     def test_scenarios_1server(self):
-        self._scenarios_1server_test(async=False,
-                                     oneway=False,
+        self._scenarios_1server_test(async_call=False,
+                                     oneway_call=False,
                                      delay=False)
-    def test_scenarios_1server_async(self):
-        self._scenarios_1server_test(async=True,
-                                     oneway=False,
+    def test_scenarios_1server_async_call(self):
+        self._scenarios_1server_test(async_call=True,
+                                     oneway_call=False,
                                      delay=False)
-    def test_scenarios_1server_async_delay(self):
-        self._scenarios_1server_test(async=True,
-                                     oneway=False,
+    def test_scenarios_1server_async_call_delay(self):
+        self._scenarios_1server_test(async_call=True,
+                                     oneway_call=False,
                                      delay=True)
 
     def test_bundles1_1server(self):
-        self._bundles1_1server_test(async=False,
-                                    oneway=False,
+        self._bundles1_1server_test(async_call=False,
+                                    oneway_call=False,
                                     delay=False)
-    def test_bundles1_1server_async(self):
-        self._bundles1_1server_test(async=True,
-                                    oneway=False,
+    def test_bundles1_1server_async_call(self):
+        self._bundles1_1server_test(async_call=True,
+                                    oneway_call=False,
                                     delay=False)
-    def test_bundles1_1server_async_delay(self):
-        self._bundles1_1server_test(async=True,
-                                    oneway=False,
+    def test_bundles1_1server_async_call_delay(self):
+        self._bundles1_1server_test(async_call=True,
+                                    oneway_call=False,
                                     delay=True)
 
     def test_bundles2_1server(self):
-        self._bundles2_1server_test(async=False,
-                                    oneway=False,
+        self._bundles2_1server_test(async_call=False,
+                                    oneway_call=False,
                                     delay=False)
-    def test_bundles2_1server_async(self):
-        self._bundles2_1server_test(async=True,
-                                    oneway=False,
+    def test_bundles2_1server_async_call(self):
+        self._bundles2_1server_test(async_call=True,
+                                    oneway_call=False,
                                     delay=False)
-    def test_bundles2_1server_async_delay(self):
-        self._bundles2_1server_test(async=True,
-                                    oneway=False,
+    def test_bundles2_1server_async_call_delay(self):
+        self._bundles2_1server_test(async_call=True,
+                                    oneway_call=False,
                                     delay=True)
 
     def test_bundles3_1server(self):
-        self._bundles3_1server_test(async=False,
-                                    oneway=False,
+        self._bundles3_1server_test(async_call=False,
+                                    oneway_call=False,
                                     delay=False)
-    def test_bundles3_1server_async(self):
-        self._bundles3_1server_test(async=True,
-                                    oneway=False,
+    def test_bundles3_1server_async_call(self):
+        self._bundles3_1server_test(async_call=True,
+                                    oneway_call=False,
                                     delay=False)
-    def test_bundles3_1server_async_delay(self):
-        self._bundles3_1server_test(async=True,
-                                    oneway=False,
+    def test_bundles3_1server_async_call_delay(self):
+        self._bundles3_1server_test(async_call=True,
+                                    oneway_call=False,
                                     delay=True)
 
     def test_random_bundles_1server(self):

--- a/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanagersolver.py
+++ b/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanagersolver.py
@@ -579,14 +579,14 @@ class _ScenarioTreeManagerSolverTesterBase(object):
                 problem.validate_solve(self, sp, results, names=names)
             with self._init(problem.get_factory()) as sp:
                 with ScenarioTreeManagerSolverFactory(sp, _default_test_options) as manager:
-                    job = manager.solve_scenarios(async=True,
+                    job = manager.solve_scenarios(async_call=True,
                                                   check_status=True,
                                                   scenarios=names)
                     results = job.complete()
                 problem.validate_solve(self, sp, results, names=names)
             with self._init(problem.get_factory()) as sp:
                 with ScenarioTreeManagerSolverFactory(sp, _default_test_options) as manager:
-                    job = manager.solve_scenarios(async=True,
+                    job = manager.solve_scenarios(async_call=True,
                                                   check_status=False,
                                                   scenarios=names)
                     results = job.complete()
@@ -608,13 +608,13 @@ class _ScenarioTreeManagerSolverTesterBase(object):
                     manager.solve_scenarios(check_status=True)
         with self._init(problem.get_factory()) as sp:
             with ScenarioTreeManagerSolverFactory(sp, _default_test_options) as manager:
-                job = manager.solve_scenarios(async=True,
+                job = manager.solve_scenarios(async_call=True,
                                               check_status=True)
                 with self.assertRaises(PySPFailedSolveStatus):
                     job.complete()
         with self._init(problem.get_factory()) as sp:
             with ScenarioTreeManagerSolverFactory(sp, _default_test_options) as manager:
-                job = manager.solve_scenarios(async=True,
+                job = manager.solve_scenarios(async_call=True,
                                               check_status=False)
                 results = job.complete()
             problem.validate_solve(self, sp, results)
@@ -634,7 +634,7 @@ class _ScenarioTreeManagerSolverTesterBase(object):
                 problem.validate_solve(self, sp, results, names=names)
             with self._init(problem.get_factory()) as sp:
                 with ScenarioTreeManagerSolverFactory(sp, _default_test_options) as manager:
-                    job = manager.solve_scenarios(async=True,
+                    job = manager.solve_scenarios(async_call=True,
                                                   check_status=False,
                                                   scenarios=names)
                     results = job.complete()
@@ -663,14 +663,14 @@ class _ScenarioTreeManagerSolverTesterBase(object):
                 problem.validate_solve(self, sp, results, names=names)
             with self._init(problem.get_factory()) as sp:
                 with ScenarioTreeManagerSolverFactory(sp, _default_test_options) as manager:
-                    job = manager.solve_bundles(async=True,
+                    job = manager.solve_bundles(async_call=True,
                                                 check_status=True,
                                                 bundles=names)
                     results = job.complete()
                 problem.validate_solve(self, sp, results, names=names)
             with self._init(problem.get_factory()) as sp:
                 with ScenarioTreeManagerSolverFactory(sp, _default_test_options) as manager:
-                    job = manager.solve_bundles(async=True,
+                    job = manager.solve_bundles(async_call=True,
                                                 check_status=False,
                                                 bundles=names)
                     results = job.complete()
@@ -688,13 +688,13 @@ class _ScenarioTreeManagerSolverTesterBase(object):
                     manager.solve_bundles(check_status=True)
         with self._init(problem.get_factory()) as sp:
             with ScenarioTreeManagerSolverFactory(sp, _default_test_options) as manager:
-                job = manager.solve_bundles(async=True,
+                job = manager.solve_bundles(async_call=True,
                                             check_status=True)
                 with self.assertRaises(PySPFailedSolveStatus):
                     job.complete()
         with self._init(problem.get_factory()) as sp:
             with ScenarioTreeManagerSolverFactory(sp, _default_test_options) as manager:
-                job = manager.solve_bundles(async=True,
+                job = manager.solve_bundles(async_call=True,
                                             check_status=False)
                 results = job.complete()
             problem.validate_solve(self, sp, results)
@@ -714,7 +714,7 @@ class _ScenarioTreeManagerSolverTesterBase(object):
                 problem.validate_solve(self, sp, results, names=names)
             with self._init(problem.get_factory()) as sp:
                 with ScenarioTreeManagerSolverFactory(sp, _default_test_options) as manager:
-                    job = manager.solve_bundles(async=True,
+                    job = manager.solve_bundles(async_call=True,
                                                 check_status=False,
                                                 bundles=names)
                     results = job.complete()


### PR DESCRIPTION
In Python-3.7, `async` becomes a directive, so it can not be used as a variable name.

 - In phinit.py, the --async argparse option will now store its result into `async_mode`
 - In the `ScenarioTreeManager` class, the `async` keyword used in various methods has been renamed `async_call`.
 - For consistency with the above change, in the same methods, the `oneway` keyword has been renamed to `oneway_call`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
