### PR TITLE
Fixing logic for power expressions when generating standard repn

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Current Development
 - Adding TerminationCondition and SolverStatus to pyomo.environ (#429)
 - Resolved problems with ExternalFunctions with fixed arguments (#442)
 - Adding the Pyomo5 expression system, which supports PyPy (#272)
+- Bug fix processing exp() expressions in Pyomo5 (TODO)
 
 -------------------------------------------------------------------------------
 Pyomo 5.5

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,7 +12,7 @@ Current Development
 - Adding TerminationCondition and SolverStatus to pyomo.environ (#429)
 - Resolved problems with ExternalFunctions with fixed arguments (#442)
 - Adding the Pyomo5 expression system, which supports PyPy (#272)
-- Bug fix processing exp() expressions in Pyomo5 (TODO)
+- Bug fix processing exp() expressions in Pyomo5 (#471)
 
 -------------------------------------------------------------------------------
 Pyomo 5.5

--- a/pyomo/repn/tests/test_standard.py
+++ b/pyomo/repn/tests/test_standard.py
@@ -2919,9 +2919,344 @@ class TestSimple(unittest.TestCase):
         self.assertTrue(len(rep.quadratic_vars) == 0)
         self.assertTrue(len(rep.quadratic_coefs) == 0)
         self.assertTrue(rep.nonlinear_expr is None)
-        self.assertTrue(len(rep.nonlinear_vars) == 0)
-        baseline = { None:12 }
+
+    def test_pow3(self):
+        #       ^
+        #      / \
+        #     a   p
+        m = ConcreteModel()
+        m.a = Var(initialize=2)
+        m.p = Param(default=0, mutable=True)
+
+        e = m.a**m.p
+
+        rep = generate_standard_repn(e, compute_values=False, quadratic=False)
+        #
+        self.assertFalse( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), None )
+        self.assertFalse( rep.is_constant() )
+        self.assertFalse( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertTrue( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertFalse(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 1)
+        baseline = { }
         self.assertEqual(baseline, repn_to_dict(rep))
+
+        rep = generate_standard_repn(e, compute_values=True, quadratic=False)
+        #
+        self.assertTrue( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), 0 )
+        self.assertTrue( rep.is_constant() )
+        self.assertTrue( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertFalse( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertTrue(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 0)
+        baseline = { None:1 }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+        m.p.value = 1
+
+        rep = generate_standard_repn(e, compute_values=False, quadratic=False)
+        #
+        self.assertFalse( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), None )
+        self.assertFalse( rep.is_constant() )
+        self.assertFalse( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertTrue( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertFalse(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 1)
+        baseline = { }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+        rep = generate_standard_repn(e, compute_values=True, quadratic=False)
+        #
+        self.assertFalse( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), 1 )
+        self.assertFalse( rep.is_constant() )
+        self.assertTrue( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertFalse( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 1)
+        self.assertTrue(len(rep.linear_coefs) == 1)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertTrue(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 0)
+        baseline = { id(m.a):1 }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+    def test_pow4(self):
+        #       ^
+        #      / \
+        #     a   b
+        m = ConcreteModel()
+        m.a = Var(initialize=2)
+        m.b = Var(initialize=0)
+        m.a.fixed = True
+        m.b.fixed = True
+
+        e = m.a**m.b
+
+        rep = generate_standard_repn(e, compute_values=False, quadratic=False)
+        #
+        self.assertTrue( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), 0 )
+        self.assertTrue( rep.is_constant() )
+        self.assertTrue( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertFalse( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertTrue(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 0)
+        baseline = { None:1 }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+        rep = generate_standard_repn(e, compute_values=True, quadratic=False)
+        #
+        self.assertTrue( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), 0 )
+        self.assertTrue( rep.is_constant() )
+        self.assertTrue( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertFalse( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertTrue(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 0)
+        baseline = { None:1 }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+        m.b.fixed = False
+
+        rep = generate_standard_repn(e, compute_values=False, quadratic=False)
+        #
+        self.assertFalse( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), None )
+        self.assertFalse( rep.is_constant() )
+        self.assertFalse( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertTrue( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertFalse(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 1)
+        baseline = { }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+    def test_pow5(self):
+        m = ConcreteModel()
+        m.a = Var(initialize=2)
+        m.b = Var(initialize=2)
+
+        e = sin(m.a)**2
+
+        rep = generate_standard_repn(e, compute_values=False, quadratic=True)
+        #
+        self.assertFalse( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), None )
+        self.assertFalse( rep.is_constant() )
+        self.assertFalse( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertTrue( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertFalse(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 1)
+        baseline = { }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+        e = (m.a**2)**2
+
+        rep = generate_standard_repn(e, compute_values=False, quadratic=True)
+        #
+        self.assertFalse( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), None )
+        self.assertFalse( rep.is_constant() )
+        self.assertFalse( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertTrue( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertFalse(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 1)
+        baseline = { }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+        e = (m.a+m.b)**2
+
+        rep = generate_standard_repn(e, compute_values=False, quadratic=False)
+        #
+        self.assertFalse( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), None )
+        self.assertFalse( rep.is_constant() )
+        self.assertFalse( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertTrue( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertFalse(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 2)
+        baseline = { }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+        rep = generate_standard_repn(e, compute_values=False, quadratic=True)
+        #
+        self.assertFalse( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), None )
+        self.assertFalse( rep.is_constant() )
+        self.assertFalse( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertTrue( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertFalse(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 2)
+        baseline = { }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+        e = (m.a+3)**2
+
+        rep = generate_standard_repn(e, compute_values=False, quadratic=True)
+        #
+        self.assertFalse( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), 2 )
+        self.assertFalse( rep.is_constant() )
+        self.assertFalse( rep.is_linear() )
+        self.assertTrue( rep.is_quadratic() )
+        self.assertTrue( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 1)
+        self.assertTrue(len(rep.linear_coefs) == 1)
+        self.assertTrue(len(rep.quadratic_vars) == 1)
+        self.assertTrue(len(rep.quadratic_coefs) == 1)
+        self.assertTrue(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 0)
+        baseline = { None:9, id(m.a):6, (id(m.a),id(m.a)):1}
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+        rep = generate_standard_repn(e, compute_values=True, quadratic=True)
+        #
+        self.assertFalse( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), 2 )
+        self.assertFalse( rep.is_constant() )
+        self.assertFalse( rep.is_linear() )
+        self.assertTrue( rep.is_quadratic() )
+        self.assertTrue( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 1)
+        self.assertTrue(len(rep.linear_coefs) == 1)
+        self.assertTrue(len(rep.quadratic_vars) == 1)
+        self.assertTrue(len(rep.quadratic_coefs) == 1)
+        self.assertTrue(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 0)
+        baseline = { None:9, id(m.a):6, (id(m.a),id(m.a)):1 }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+        m.a.fixed = True
+
+        rep = generate_standard_repn(e, compute_values=True, quadratic=True)
+        #
+        self.assertTrue( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), 0 )
+        self.assertTrue( rep.is_constant() )
+        self.assertTrue( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertFalse( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertTrue(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 0)
+        baseline = { None:25 }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+    def test_pow6(self):
+        m = ConcreteModel()
+        m.a = Var(initialize=2)
+
+        e = m.a**3
+
+        rep = generate_standard_repn(e, compute_values=False, quadratic=False)
+        #
+        self.assertFalse( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), None )
+        self.assertFalse( rep.is_constant() )
+        self.assertFalse( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertTrue( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertFalse(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 1)
+        baseline = { }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+        m.a.fixed=True
+
+        rep = generate_standard_repn(e, compute_values=True, quadratic=False)
+        #
+        self.assertTrue( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), 0 )
+        self.assertTrue( rep.is_constant() )
+        self.assertTrue( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertFalse( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertTrue(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 0)
+        baseline = { None:8 }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
 
     def test_abs(self):
         #      abs


### PR DESCRIPTION
## Fixes #470.

## Summary/Motivation:
Resolving a bug found with IDAES.

## Changes proposed in this PR:
- Updating the logic for generating standard repn
- Adding tests that improve the coverage for power expressions

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
