### PR TITLE
Resolving scaling issue with Pyomo expressions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Current Development
 - Adding TerminationCondition and SolverStatus to pyomo.environ (#429)
 - Resolved problems with ExternalFunctions with fixed arguments (#442)
 - Adding the Pyomo5 expression system, which supports PyPy (#272)
+- Resolving scaling issue with Pyomo expressions (#475)
 
 -------------------------------------------------------------------------------
 Pyomo 5.5

--- a/pyomo/repn/standard_repn.py
+++ b/pyomo/repn/standard_repn.py
@@ -783,20 +783,23 @@ def _collect_nonl(exp, multiplier, idMap, compute_values, verbose, quadratic):
 def _collect_negation(exp, multiplier, idMap, compute_values, verbose, quadratic):
     return _collect_standard_repn(exp._args_[0], -1*multiplier, idMap, compute_values, verbose, quadratic)
 
+#
+# TODO - Verify if code is used
+#
 def _collect_const(exp, multiplier, idMap, compute_values, verbose, quadratic):
     if compute_values:
-        return Results(constant=value(exp))
+        return Results(constant=multiplier*value(exp))
     else:
-        return Results(constant=exp)
+        return Results(constant=multiplier*exp)
 
 def _collect_identity(exp, multiplier, idMap, compute_values, verbose, quadratic):
     if exp._args_[0].__class__ in native_numeric_types:
-        return Results(constant=exp._args_[0])
+        return Results(constant=multiplier*exp._args_[0])
     if not exp._args_[0].is_potentially_variable():
         if compute_values:
-            return Results(constant=value(exp._args_[0]))
+            return Results(constant=multiplier*value(exp._args_[0]))
         else:
-            return Results(constant=exp._args_[0])
+            return Results(constant=multiplier*exp._args_[0])
     return _collect_standard_repn(exp.expr, multiplier, idMap, compute_values, verbose, quadratic)
 
 def _collect_linear(exp, multiplier, idMap, compute_values, verbose, quadratic):

--- a/pyomo/repn/tests/test_standard.py
+++ b/pyomo/repn/tests/test_standard.py
@@ -24,6 +24,7 @@ from pyomo.core.expr import expr_common, current as EXPR
 from pyomo.repn import *
 from pyomo.environ import *
 from pyomo.core.base.numvalue import native_numeric_types
+from pyomo.core.kernel import expression
 
 from six import iteritems
 from six.moves import range
@@ -56,7 +57,7 @@ def repn_to_dict(repn):
     return result
 
 
-class TestSimple(unittest.TestCase):
+class Test(unittest.TestCase):
 
     def test_number(self):
         # 1.0
@@ -3242,6 +3243,122 @@ class TestSimple(unittest.TestCase):
         s = pickle.dumps(rep)
         rep = pickle.loads(s)
         baseline = { id(rep.linear_vars[0]):1 }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+    def test_expr_identity1(self):
+        m = ConcreteModel()
+        m.p = Param(mutable=True, initialize=2)
+        m.e = Expression(expr=m.p)
+
+        e = 1000*m.e
+
+        rep = generate_standard_repn(e, compute_values=True)
+        #
+        self.assertTrue( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), 0 )
+        self.assertTrue( rep.is_constant() )
+        self.assertTrue( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertFalse( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertTrue(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 0)
+        baseline = { None:2000 }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+        rep = generate_standard_repn(e, compute_values=False)
+        #
+        self.assertTrue( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), 0 )
+        self.assertTrue( rep.is_constant() )
+        self.assertTrue( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertFalse( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertTrue(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 0)
+        baseline = { None:2000 }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+    def test_expr_identity2(self):
+        o = expression()
+        o.expr = 2
+
+        e = 1000*o
+
+        rep = generate_standard_repn(e)
+        #
+        self.assertTrue( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), 0 )
+        self.assertTrue( rep.is_constant() )
+        self.assertTrue( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertFalse( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertTrue(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 0)
+        baseline = { None:2000 }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+    def test_expr_identity3(self):
+        m = ConcreteModel()
+        m.v = Var(initialize=2)
+        m.e = Expression(expr=m.v)
+
+        e = 1000*m.e
+
+        rep = generate_standard_repn(e)
+        #
+        self.assertFalse( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), 1 )
+        self.assertFalse( rep.is_constant() )
+        self.assertTrue( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertFalse( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 1)
+        self.assertTrue(len(rep.linear_coefs) == 1)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertTrue(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 0)
+        baseline = { id(m.v):1000 }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+    def test_expr_const1(self):
+        o = expression()
+        o.expr = as_numeric(2)
+
+        e = 1000*o
+
+        rep = generate_standard_repn(e, compute_values=True)
+        #
+        self.assertTrue( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), 0 )
+        self.assertTrue( rep.is_constant() )
+        self.assertTrue( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertFalse( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertTrue(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 0)
+        baseline = { None:2000 }
         self.assertEqual(baseline, repn_to_dict(rep))
 
 


### PR DESCRIPTION
## Fixes #465  .

## Summary/Motivation:
Scaling differences were reported when using IDAES

## Changes proposed in this PR:
- Various fixes to generation of standard repn.
- Adding tests so we have near complete coverage of standard repn.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
