### PR TITLE
Fixing typos etc in sphinx documentation

### DIFF
--- a/doc/OnlineDocs/getting_started/Constraints.rst
+++ b/doc/OnlineDocs/getting_started/Constraints.rst
@@ -4,7 +4,7 @@ Constraints
 Most constraints are specified using equality or inequality expressions
 that are created using a rule, which is a Python function. For example, if the variable
 ``model.x`` has the indexes 'butter' and 'scones', then this constraint limits
-the sum for them to be exactly three:
+the sum over these indexes to be exactly three:
 
 .. literalinclude:: spyfiles/spy4Constraints_Constraint_example.spy
    :language: python

--- a/doc/OnlineDocs/getting_started/Disjunctions.rst
+++ b/doc/OnlineDocs/getting_started/Disjunctions.rst
@@ -36,7 +36,7 @@ condensed code snippet illustrates a ``Disjunct`` and a ``Disjunction``:
 >>>     return [model.d[0], model.d[1]]
 >>> model.c = Disjunction(rule=_c)
 
-Model.d is an indexed ``Disjunct`` that is indexed over an implicit set
+model.d is an indexed ``Disjunct`` that is indexed over an implicit set
 with members 0 and 1. Since it is an indexed thing, each member is
 initialized using a call to a rule, passing in the index value (just
 like any other pyomo component). However, just defining disjuncts is

--- a/doc/OnlineDocs/getting_started/Expressions.rst
+++ b/doc/OnlineDocs/getting_started/Expressions.rst
@@ -196,7 +196,7 @@ first index to be x squared.
 >>> model.x = Var(initialize=1.0)
 >>> def _e(m,i):
 >>>     return m.x*i
->>> model.e = Expression([1,2,3],initialize=_e)
+>>> model.e = Expression([1,2,3],rule=_e)
 >>>
 >>> instance = model.create_instance()
 >>>

--- a/doc/OnlineDocs/getting_started/Expressions.rst
+++ b/doc/OnlineDocs/getting_started/Expressions.rst
@@ -1,9 +1,9 @@
 Expressions
 ===========
 
-In this chapter, we use the word "expression" is two ways: first in the general
+In this chapter, we use the word "expression" in two ways: first in the general
 sense of the word and second to desribe a class of Pyomo objects that have
-the name ``Expression`` as described in the subsection on expression objects.
+the name ``Expression``, as described in the subsection on expression objects.
 
 Rules to Generate Expressions
 -----------------------------
@@ -14,8 +14,8 @@ expression. These are first-class functions that can access
 global data as well as data passed in, including the model object.
 
 Operations on model elements results in expressions, which seems
-natural in expression like the constraints we have seen so far. It is also
-possible to build up expressions. The following example illustrates this along
+natural in expressions like the constraints we have seen so far. It is also
+possible to build up expressions. The following example illustrates this, along
 with a reference to global Pyton data in the form of a Python variable called ``switch``:
 
 >>> switch = 3
@@ -81,13 +81,13 @@ Keywords:
 *********
 
 * pw_pts=\{\},[],()
-          A dictionary of lists (keys are index set) or a single list (for
+          A dictionary of lists (where keys are the index set) or a single list (for
           the non-indexed case or when an identical set of breakpoints is
           used across all indices) defining the set of domain breakpoints for
           the piecewise linear function.
 
           NOTE: pw_pts is always required. These give the breakpoints for the piecewise function
-          and are expected to full span the bounds for the independent variable(s).
+          and are expected to fully span the bounds for the independent variable(s).
 
 * pw_repn=<Option>
           Indicates the type of piecewise representation to use. This can have
@@ -160,7 +160,7 @@ Keywords:
           domain variable. Default=False
 
           NOTE: This does not imply unbounded piecewise segments will be
-          constructed. The outermost piecwise breakpoints will bound the
+          constructed. The outermost piecewise breakpoints will bound the
           domain variable at each index. However, the Var attributes
           .lb and .ub will not be modified.
 

--- a/doc/OnlineDocs/getting_started/Parameters.rst
+++ b/doc/OnlineDocs/getting_started/Parameters.rst
@@ -44,7 +44,7 @@ In this example, the index set contained integers, but index sets need not be nu
 NOTE: Data specified in an input file will override the data specified by the initialize options.
 
 Parameter values can be checked by a validation function. In the following example, the parameter S indexed by ``model.A``
-and checked to be greater than 3.14159. If value is provided that is less than that, the model instantation would be terminated
+and is checked to be greater than 3.14159. If a value is provided that is less than that, the model instantation would be terminated
 and an error message issued. The function used to validate should be written so as to return ``True`` if the data is valid
 and ``False`` otherwise.
 

--- a/doc/OnlineDocs/getting_started/Sets.rst
+++ b/doc/OnlineDocs/getting_started/Sets.rst
@@ -92,18 +92,6 @@ illustrate the set operators union, intersection, difference, and exclusive-or:
 .. literalinclude:: spyfiles/Spy4Sets_Set_operators.spy
    :language: python
 
-The cross-product operator is the asterisk (*). For example, to assign
-a set the cross product of two other sets, one could use
-
-.. literalinclude:: spyfiles/Spy4Sets_Set_cross_product.spy
-   :language: python
-
-or to indicate the the members of a set are restricted to be
-in the cross product of two other sets, one could use
-
-.. literalinclude:: spyfiles/Spy4Sets_Restrict_to_crossproduct.spy
-   :language: python
-
 The cross-product operator is the asterisk (*).
 For example, to create a set that contains the cross-product
 of sets A and B, use
@@ -181,7 +169,7 @@ Consider the following simple version of minimum cost flow problem:
 	\begin{array}{lll}
 	\mbox{minimize} & \sum_{a \in \mathcal{A}} c_{a}x_{a} \\
 	\mbox{subject to:} & S_{n} + \sum_{(i,n) \in \mathcal{A}}x_{(i,n)} &  \\
-					& -D_{n} - \sum_{(n,j) \in \mathcal{A}}x_{(n,j)} & n \in \mathcal{N} \\
+					& -D_{n} - \sum_{(n,j) \in \mathcal{A}}x_{(n,j)} & n \in \mathcal{N} = 0 \\
 					& x_{a} \geq 0, &  a \in \mathcal{A}
 	\end{array}
 

--- a/doc/OnlineDocs/getting_started/Variables.rst
+++ b/doc/OnlineDocs/getting_started/Variables.rst
@@ -3,20 +3,20 @@ Variables
 
 Variables are intended to ultimately be given values by an optimization package. They are
 declared and optionally bounded, given initial values, and documented using the Pyomo ``Var`` function. If index sets are given as arguments to this function
-they are used to index the variable, other optional directives include:
+they are used to index the variable. Other optional directives include:
 
 * bounds = A function (or Python object) that gives a (lower,upper) bound pair for the variable
 * domain = A set that is a super-set of the values the variable can take on.
 * initialize = A function (or Python object) that gives a starting value for the variable; this is particularly important for non-linear models
 * within = (synonym for ``domain``)
 
-The following code snippet illustrates some aspects of these options by declaring a *singleton* (i.e. unindexed) variable named ``model.LumberJack``
+The following code snippet illustrates some aspects of these options by declaring a *singleton* (i.e., unindexed) variable named ``model.LumberJack``
 that will take on real values between zero and 6 and it initialized to be 1.5:
 
 .. literalinclude:: spyfiles/spy4Variables_Declare_singleton_variable.spy
    :language: python
 
-Instead of the ``initialize`` option, initialization is sometimes done with a Python assignment statement
+Instead of the ``initialize`` option, initialization is sometimes done with a Python assignment statement,
 as in
 
 .. literalinclude:: spyfiles/spy4Variables_Assign_value.spy

--- a/doc/OnlineDocs/getting_started/overview.rst
+++ b/doc/OnlineDocs/getting_started/overview.rst
@@ -465,7 +465,7 @@ has a special structure that makes it useful for post-processing. To see a summa
 
 ::
 
-pyomo solve abstract1.py abstract1.dat --solver=cplex --summary
+   pyomo solve abstract1.py abstract1.dat --solver=cplex --summary
 
 To see a list of Pyomo command line options, use:
 

--- a/doc/OnlineDocs/getting_started/overview.rst
+++ b/doc/OnlineDocs/getting_started/overview.rst
@@ -11,9 +11,9 @@ This chapter provides an introduction to Pyomo: Python Optimization Modeling Obj
 A more complete description is contained in the [PyomoBookII]_ book. Pyomo
 supports the formulation and analysis of mathematical models for complex
 optimization applications.  This capability is commonly associated with
-commerically available algebraic modeling languages (AMLs) such as AMPL [AMPL]_ AIMMS [AIMMS]_
+commerically available algebraic modeling languages (AMLs) such as AMPL [AMPL]_, AIMMS [AIMMS]_,
 and GAMS [GAMS]_.  Pyomo's modeling objects are embedded within Python, a
-full-featured high-level programming language that contains a rich set of
+full-featured, high-level programming language that contains a rich set of
 supporting libraries.
 
 Modeling is a fundamental process in many aspects of scientific research,
@@ -34,14 +34,13 @@ Pyomo can be used in a variety of ways:
 
 - *Analyze trade-offs* to support human decision makers.
 
-Mathematical models represent system knowledge with a formalized
-mathematical language.
+Mathematical models represent system knowledge with a formalized language.
 The following mathematical concepts are central to modern
 modeling activities:
 
 variables
 *********
-    Variables represent unknown or changing parts of a model (e.g. whether or not to make a decision, or the characteristic of a system outcome). The values taken by the variables are often referred to as a *solution* and are usually an output of the optimization process.
+    Variables represent unknown or changing parts of a model (e.g., whether or not to make a decision, or the characteristic of a system outcome). The values taken by the variables are often referred to as a *solution* and are usually an output of the optimization process.
 
 parameters
 **********
@@ -59,7 +58,7 @@ The widespread availability of computing resources has made the
 numerical analysis of mathematical models a commonplace activity.
 Without a modeling language, the process of setting up input files,
 executing a solver and extracting the final results from the solver
-output is tedious and error prone.  This difficulty is compounded
+output is tedious and error-prone.  This difficulty is compounded
 in complex, large-scale real-world applications which are difficult
 to debug when errors occur.  Additionally, there are many different
 formats used by optimization software packages, and few formats are
@@ -140,7 +139,7 @@ Abstract Versus Concrete Models
 
 A mathematical model can be defined using symbols that represent data values.
 For example, the following equations represent a linear program
-(LP) to find optimal values for the vector :math:`x` with parameters :math: `n` and :math:`b`, and parameter vectors :math:`a` and :math:`c`:
+(LP) to find optimal values for the vector :math:`x` with parameters :math:`n` and :math:`b`, and parameter vectors :math:`a` and :math:`c`:
 
 .. math::
    :nowrap:
@@ -159,7 +158,7 @@ The ``AbstractModel`` class provides a context for defining and initializing abs
 optimization models in Pyomo when the data values will be supplied at the time a solution
 is to be obtained.
 
-In many contexts a mathematical model can and should be directly defined
+In many contexts, a mathematical model can and should be directly defined
 with the data values supplied at the time of the model definition.
 We call these *concrete* mathematical models.
 For example, the following LP model is a concrete instance of the previous abstract model:
@@ -178,7 +177,7 @@ The ``ConcreteModel`` class is used to define concrete optimization models in Py
 NOTE: Python programmers will probably prefer to write concrete
 models, while users of some other algebraic modeling languages may
 tend to prefer to write abstract models.  The choice is largely a
-matter of taste, some applications may be a little more
+matter of taste; some applications may be a little more
 straightforward using one or the other.
 
 A Simple Abstract Pyomo Model
@@ -266,7 +265,7 @@ and will passed to the solver when data is provided and the model is solved. Spe
 
 In abstract models, Pyomo expressions are usually provided to objective function and constraint declarations via a function
 defined with a
-Python ``def`` statement. The +def+ statement establishes a name for a function along with its arguments. When
+Python ``def`` statement. The ``def`` statement establishes a name for a function along with its arguments. When
 Pyomo uses a function to get objective function or constraint expressions, it always passes in the model (i.e., itself) as the
 the first argument so the model is always the first formal argument when declaring such functions in Pyomo.
 Additional arguments, if needed, follow. Since summation is an extremely common part of optimization models,
@@ -460,11 +459,12 @@ This yields the following output on the screen:
    [    0.39] Applying Pyomo postprocessing actions
    [    0.39] Pyomo Finished
 
-The numbers is square brackets indicate how much time was required for each step. Results are written to the file named ``results.json``, which
+The numbers in square brackets indicate how much time was required for each step. Results are written to the file named ``results.json``, which
 has a special structure that makes it useful for post-processing. To see a summary of results written to the screen, use the
 ``--summary`` option:
 
 ::
+
 pyomo solve abstract1.py abstract1.dat --solver=cplex --summary
 
 To see a list of Pyomo command line options, use:

--- a/doc/OnlineDocs/getting_started/spyfiles/Spy4Sets_Declare_arcs_crossproduct.spy
+++ b/doc/OnlineDocs/getting_started/spyfiles/Spy4Sets_Declare_arcs_crossproduct.spy
@@ -1,1 +1,1 @@
->>> model.Arcs = Set(within=model.Nodes*model.Nodes)
+>>> model.Arcs = Set(model.Nodes*model.Nodes)


### PR DESCRIPTION
## Fixes # .
In Expressions example script, change initialize= to rule= for Expression creation
## Summary/Motivation:
Primarily fixing typos and wording errors.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
