### PR TITLE
Check that the disjunction_data is active before processing it.

### DIFF
--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -314,6 +314,8 @@ class BigM_Transformation(Transformation):
         obj.deactivate()
 
     def _transformDisjunctionData(self, obj, transBlock, bigM, index):
+        if not obj.active:
+            return  # Do not process a deactivated disjunction
         parent_component = obj.parent_component()
         transBlock.disjContainers.add(parent_component)
         orConstraint = self._getXorConstraint(parent_component)


### PR DESCRIPTION
## Fixes #489  .

## Summary/Motivation:
Big-M was enforcing XOR for deactivated elements of an IndexedDisjunction

## Changes proposed in this PR:
- Add a check to _transformDisjunctionData for an inactive disjunction data

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
