### PR TITLE
Make Travis builds work with PRs from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ services:
 - docker
 env:
   global:
-  - secure: dC9Ihi6+5pLmJD3EtJNa/UMDRAUE+BK2QLOhD/igYvuCOVzA/blfDozDUXUKhBj4151pMRmT5HJW2tKoktAGvPMeV9N7kWEwSl5/tmOy+ATzAYcdQFylW2bYshPfyBRlK3CW4XrsF1/e0J4+L6FRIlvpAEFTtkPQQUDl/4cBE5ftR69gOKV1cEcbVzQ7zfA28TZN+J6DAR0rE11OaL1d0wRUzrxXbGVGNJ2W50R1LV+GZbRHu20qTwIGfLUVegriUXCa/xuq95upzN5/2mOIgDaLrwkpFEQDj6gUb60QDIPPi2GgNX05uaAszRWLnbroChCoK7niK2t616HvOgXRSvkcr+HRMQlwSCA1NAf3Qn5S1EMR5cekNTver9f13p8YbXzm0Hil/n8qCAAhMsKc9SAn1S6vDIdnMIUYaQ/eHPWJgGTqRkWGiaWzgb5/5QIHHE/WjJAleeV3p/pOD6myJeIqDByLCnLOhIgQeZ7fZ0d/S9+VavSoHTKfp5+ZBp/Xh7utl7wKDsSNak7Cw8miV7CntT8zTBtSiHVFWd0jvd6TEqHsFHw0AloUJu/0998kv3vk6Xj7yqpd/grZqL9DJSoBlJnHmuf/lqIYknGEUOX3ZczGnnmstc9c9TNwp8g6MD4f5cRXSLuqvW94BM7MoFh3eyx/mmCX1+uJTEpxHZs=
-  - secure: Sofev3DLx/rWCgAmNxprKOEue4AjPq6i6z8o7eHigPEx6SO3IMH36EENsuvEpE/HyNn+PHqGWudEz1ArkL+2pxiVo1FVRL94cUoo3FwachUMWMK7BnIJleJ7nW1pUwsANs0bWpw8qNkRMVRG3ycCY28MQzfx71U+/AQd+xS0EkVqDg3WWcbjVnVDRpmFH1pdm/syOHzW3jGVKTRsr1u5v9LJ+QKwEQHeKIrntP17mzyWQhZ+SbgqHcEQrK0o0sCSv4g3b/cJdazaR12H7nfxmtNjKETiLCx37OPIE0DnMKWYJVFlhbxeUfX+fPvGdjFkfu7rGnanZgsHEPy0eiXQAPfXLCwSsrJ8/RTL5RVUzQ7aK/bIQbkUr1fvqwCcS0UQOj/ajTHZYKLe19s17lgOhxtMA8CIIC8rY828uEb8hZKKSvfz37lx0yz4OePxDddZJAm1jNsfqNeofW333yjE2jQx4ASIcm29arAv+izv0S3+2RZTPSa5XdWnqw9/Ko2whgbb/Ccts/hhbCYCLqED0XjZ2OSb0cLDScd/qXJRfkW8YBraE6KMaJou10S3NCyXBYQVB9PCmT7mPH32f/pPO98JiBC0sW1Ghe285pYUJMxrhSCScw80b2Mb8847KyviH9aQt3yqtkwAl87W0YICZu0AH5hRUSO3kpaW0WbmaBA=
+  - DOCKERHUB_USERNAME=qkjqvazeqfjqftchxlgw
   matrix:
   - IMAGE_NAME=test-builds:python_3.7-rc CATEGORY="nightly"
   - IMAGE_NAME=test-builds:python_3.6    CATEGORY="nightly"
@@ -20,7 +19,6 @@ env:
   - IMAGE_NAME=test-builds:python_2.7    CATEGORY="parallel"
 
 before_install:
-  - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
   - docker pull ${DOCKERHUB_USERNAME}/${IMAGE_NAME}
  # (1) We are mounting the current directory onto the
  #     docker container and giving it a mount location with
@@ -38,7 +36,7 @@ before_install:
   - export COVERAGE_PROCESS_START=${TRAVIS_BUILD_DIR}/coveragerc
   - cp ${TRAVIS_BUILD_DIR}/.coveragerc ${COVERAGE_PROCESS_START}
   - echo "data_file=${TRAVIS_BUILD_DIR}/.coverage" >> ${COVERAGE_PROCESS_START}
- # commands prefixed by ${DOC_} will execute inside the
+ # commands prefixed by ${DOC} will execute inside the
  # running docker container
   - export DOC="docker exec ${CI_ENV} -e IMAGE_NAME -e COVERAGE_PROCESS_START ${DOC_ID}"
 


### PR DESCRIPTION
I've made the DockerHub repo that stores the test images for Travis public. They do not contain any commercial software at this time. If we want to include commercial software in the future, we can likely make another set of images that are private, use those by default, and fall back to the public test images for external PRs.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
