### PR TITLE
Remove imports from pyomo.core.expr

### DIFF
--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -12,9 +12,9 @@ __all__ = ['IndexedComponent', 'ActiveIndexedComponent']
 
 import pyutilib.misc
 
+from pyomo.core.expr.current import TemplateExpressionError
 from pyomo.core.base.component import Component, ActiveComponent
 from pyomo.core.base.config import PyomoOptions
-from pyomo.core.base.template_expr import TemplateExpressionError
 from pyomo.common import DeveloperError
 
 from six import PY3, itervalues, iteritems, advance_iterator

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -139,6 +139,12 @@ class _ParamData(ComponentData, NumericValue):
         """
         return False
 
+    def is_parameter_type(self):
+        """
+        Returns True because this is a parameter object.
+        """
+        return True
+
     def is_variable_type(self):
         """
         Returns False because this is not a variable object.

--- a/pyomo/core/base/template_expr.py
+++ b/pyomo/core/base/template_expr.py
@@ -16,13 +16,6 @@ from pyomo.core.expr.numvalue import (
 import pyomo.core.base
 
 
-class TemplateExpressionError(ValueError):
-
-    def __init__(self, template, *args, **kwds):
-        self.template = template
-        super(TemplateExpressionError, self).__init__(*args, **kwds)
-
-
 class IndexTemplate(NumericValue):
     """A "placeholder" for an index value in template expressions.
 
@@ -81,7 +74,7 @@ class IndexTemplate(NumericValue):
         """
         if self._value is None:
             if exception:
-                raise TemplateExpressionError(self)
+                raise EXPR.TemplateExpressionError(self)
             return None
         else:
             return self._value
@@ -171,7 +164,7 @@ class _GetItemIndexer(object):
                 val = value(x)
                 self._args.append(val)
                 _hash.append(val)
-            except TemplateExpressionError as e:
+            except EXPR.TemplateExpressionError as e:
                 if x is not e.template:
                     raise TypeError(
                         "Cannot use the param substituter with expression "

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -136,6 +136,10 @@ class _VarData(ComponentData, NumericValue):
         """Returns False because this is not a constant in an expression."""
         return False
 
+    def is_parameter_type(self):
+        """Returns False because this is not a parameter object."""
+        return False
+
     def is_variable_type(self):
         """Returns True because this is a variable."""
         return True

--- a/pyomo/core/expr/expr_pyomo5.py
+++ b/pyomo/core/expr/expr_pyomo5.py
@@ -1101,7 +1101,7 @@ class _ToStringVisitor(ExpressionValueVisitor):
         return False, None
 
 
-def expression_to_string(expr, verbose=None, labeler=None, smap=None, compute_values=False, standardize=False):
+def expression_to_string(expr, verbose=None, labeler=None, smap=None, compute_values=False):
     """
     Return a string representation of an expression.
 
@@ -1117,48 +1117,11 @@ def expression_to_string(expr, verbose=None, labeler=None, smap=None, compute_va
         compute_values (bool): If :const:`True`, then
             parameters and fixed variables are evaluated before the
             expression string is generated.  Default is :const:`False`.
-        standardize (bool): If :const:`True` and :attr:`verbose` is :const:`False`, then the
-            expression form is standardized to pull out constant and linear terms.
-            Default is :const:`False`.
 
     Returns:
         A string representation for the expression.
     """
     verbose = common.TO_STRING_VERBOSE if verbose is None else verbose
-    #
-    # Standardize the output of expressions if requested (when verbose=False).
-    # This involves constructing a standard representation and then creating
-    # a string.
-    #
-    if standardize and not verbose:
-        from pyomo.repn import generate_standard_repn
-        try:
-            if expr.__class__ is EqualityExpression:
-                repn0 = generate_standard_repn(expr._args_[0], quadratic=True, compute_values=compute_values)
-                repn1 = generate_standard_repn(expr._args_[1], quadratic=True, compute_values=compute_values)
-                expr = EqualityExpression( (repn0.to_expression(), repn1.to_expression()) )
-            elif expr.__class__ is InequalityExpression:
-                repn0 = generate_standard_repn(expr._args_[0], quadratic=True, compute_values=compute_values)
-                repn1 = generate_standard_repn(expr._args_[1], quadratic=True, compute_values=compute_values)
-                expr = InequalityExpression( (repn0.to_expression(), repn1.to_expression()), strict=expr._strict )
-            elif expr.__class__ is RangedExpression:
-                repn0 = generate_standard_repn(expr._args_[0], quadratic=True, compute_values=compute_values)
-                repn1 = generate_standard_repn(expr._args_[1], quadratic=True, compute_values=compute_values)
-                repn2 = generate_standard_repn(expr._args_[2], quadratic=True, compute_values=compute_values)
-                expr = RangedExpression( (repn0.to_expression(), repn1.to_expression(), repn2.to_expression()), strict=expr._strict )
-            else:
-                repn = generate_standard_repn(expr, quadratic=True, compute_values=compute_values)
-                expr = repn.to_expression()
-        except:     #pragma: no cover
-            #
-            # Generation of the standard repn will fail if the
-            # expression is uninitialized.  Hence, we default to
-            # using the non-standardized form.
-            #
-            # It might be smarter to raise errors for specific issues (e.g. uninitialized parameters).
-            # Let's see if we start seeing errors that are masked here.
-            #
-            pass
     #
     # Setup the symbol map
     #
@@ -1299,7 +1262,7 @@ class ExpressionBase(NumericValue):
         Returns:
             A string.
         """
-        return expression_to_string(self, standardize=False)
+        return expression_to_string(self)
 
     def to_string(self, verbose=None, labeler=None, smap=None, compute_values=False):
         """

--- a/pyomo/core/expr/expr_pyomo5.py
+++ b/pyomo/core/expr/expr_pyomo5.py
@@ -149,8 +149,6 @@ else:                               #pragma: no cover
     _chainedInequality = None
 
 
-_ParamData = None
-SimpleParam = None
 TemplateExpressionError = None
 def initialize_expression_data():
     """
@@ -159,10 +157,7 @@ def initialize_expression_data():
     This function is necessary to avoid global imports.  It is executed
     when ``pyomo.environ`` is imported.
     """
-    global _ParamData
-    global SimpleParam
     global TemplateExpressionError
-    from pyomo.core.base.param import _ParamData, SimpleParam
     from pyomo.core.base.template_expr import TemplateExpressionError
 
 
@@ -2847,37 +2842,21 @@ def _decompose_linear_terms(expr, multiplier=1):
 
 
 def _process_arg(obj):
-    #if False and obj.__class__ is SumExpression or obj.__class__ is _MutableSumExpression:
-    #    if ignore_entangled_expressions.detangle[-1] and obj._is_owned:
-            #
-            # If the viewsum expression is owned, then we need to
-            # clone it to avoid creating an entangled expression.
-            #
-            # But we don't have to worry about entanglement amongst other immutable
-            # expression objects.
-            #
-    #        return clone_expression( obj, clone_leaves=False )
-    #    return obj
-
-    #if obj.is_expression_type():
-    #    return obj
-
     if obj.__class__ is NumericConstant:
         return value(obj)
 
-    if (obj.__class__ is _ParamData or obj.__class__ is SimpleParam) and not obj._component()._mutable:
-        if not obj._constructed:
-            return obj
-        return obj()
-
-    if obj.is_indexed():
-        raise TypeError(
-                "Argument for expression is an indexed numeric "
-                "value\nspecified without an index:\n\t%s\nIs this "
-                "value defined over an index that you did not specify?"
-                % (obj.name, ) )
-
-    return obj
+    try:
+        if obj.is_parameter_type() and not obj._component()._mutable and obj._constructed:
+            return obj()
+        return obj
+    except:
+        if obj.is_indexed():
+            raise TypeError(
+                    "Argument for expression is an indexed numeric "
+                    "value\nspecified without an index:\n\t%s\nIs this "
+                    "value defined over an index that you did not specify?"
+                    % (obj.name, ) )
+        raise
 
 
 #@profile

--- a/pyomo/core/expr/numvalue.py
+++ b/pyomo/core/expr/numvalue.py
@@ -444,6 +444,10 @@ class NumericValue(object):
         """Return True if this is a non-constant value that has been fixed"""
         return False
 
+    def is_parameter_type(self):
+        """Return False unless this class is a parameter object"""
+        return False
+
     def is_variable_type(self):
         """Return False unless this class is a variable object"""
         return False

--- a/pyomo/core/kernel/component_expression.py
+++ b/pyomo/core/kernel/component_expression.py
@@ -222,6 +222,10 @@ class IExpression(IComponent, IIdentityExpression):
         """A boolean indicating whether this expression is constant."""
         return False
 
+    def is_parameter_type(self):
+        """A boolean indicating whether this expression is a parameter object."""
+        return False
+
     def is_variable_type(self):
         """A boolean indicating whether this expression is a variable object."""
         return False

--- a/pyomo/core/kernel/component_parameter.py
+++ b/pyomo/core/kernel/component_parameter.py
@@ -49,7 +49,12 @@ class IParameter(IComponent, NumericValue):
 
     def is_parameter_type(self):
         """A boolean indicating that this is a parameter object."""
-        return True
+        #
+        # The semantics of ParamData and parameter are different.
+        # By default, ParamData are immutable.  Hence, we treat the
+        # parameter objects as non-parameter data ... for now.
+        #
+        return False
 
     def is_variable_type(self):
         """A boolean indicating that this is a variable object."""

--- a/pyomo/core/kernel/component_parameter.py
+++ b/pyomo/core/kernel/component_parameter.py
@@ -47,6 +47,10 @@ class IParameter(IComponent, NumericValue):
         """A boolean indicating that this parameter is constant."""
         return False
 
+    def is_parameter_type(self):
+        """A boolean indicating that this is a parameter object."""
+        return True
+
     def is_variable_type(self):
         """A boolean indicating that this is a variable object."""
         return False

--- a/pyomo/core/kernel/component_variable.py
+++ b/pyomo/core/kernel/component_variable.py
@@ -246,6 +246,11 @@ class IVariable(IComponent, NumericValue):
         constant in an expression."""
         return False
 
+    def is_parameter_type(self):
+        """Returns :const:`False` because this is not a
+        parameter object."""
+        return False
+
     def is_variable_type(self):
         """Returns :const:`True` because this is a
         variable object."""

--- a/pyomo/core/tests/unit/test_expr_pyomo5.py
+++ b/pyomo/core/tests/unit/test_expr_pyomo5.py
@@ -5898,6 +5898,7 @@ class TestNumValueDuckTyping(unittest.TestCase):
     def check_api(self, obj):
         self.assertTrue(hasattr(obj, 'is_fixed'))
         self.assertTrue(hasattr(obj, 'is_constant'))
+        self.assertTrue(hasattr(obj, 'is_parameter_type'))
         self.assertTrue(hasattr(obj, 'is_potentially_variable'))
         self.assertTrue(hasattr(obj, 'is_variable_type'))
         self.assertTrue(hasattr(obj, 'is_named_expression_type'))
@@ -5905,6 +5906,21 @@ class TestNumValueDuckTyping(unittest.TestCase):
         self.assertTrue(hasattr(obj, '_compute_polynomial_degree'))
         self.assertTrue(hasattr(obj, '__call__'))
         self.assertTrue(hasattr(obj, 'to_string'))
+
+    def test_Param(self):
+        M = ConcreteModel()
+        M.x = Param()
+        self.check_api(M.x)
+
+    def test_MutableParam(self):
+        M = ConcreteModel()
+        M.x = Param(mutable=True)
+        self.check_api(M.x)
+
+    def test_MutableParamIndex(self):
+        M = ConcreteModel()
+        M.x = Param([0], initialize=10, mutable=True)
+        self.check_api(M.x[0])
 
     def test_Var(self):
         M = ConcreteModel()

--- a/pyomo/environ/__init__.py
+++ b/pyomo/environ/__init__.py
@@ -98,9 +98,3 @@ from pyomo.opt import (
     SolverFactory, SolverManagerFactory, UnknownSolver,
     TerminationCondition, SolverStatus,
 )
-
-#
-# Initialize expression data
-#
-from pyomo.core.expr.expr_pyomo5 import initialize_expression_data
-initialize_expression_data()


### PR DESCRIPTION
## Fixes NA.

## Summary/Motivation:
Carl asked whether pyomo.core.expr was dependent on other parts of pyomo.core, which prompted a discussion about the imports used to recognize components.  I realized that I could extend the duck typing in pyomo.core.expr and have an expression system that is completely self-contained!

## Changes proposed in this PR:
- Removing imports from pyomo.core.base and pyomo.repn
- Removed initialization function used in pyomo.environ

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
