### PR TITLE
Change memo in clone_expression to substitute

### DIFF
--- a/pyomo/core/expr/expr_pyomo5.py
+++ b/pyomo/core/expr/expr_pyomo5.py
@@ -726,7 +726,7 @@ class ExpressionReplacementVisitor(object):
 #  clone_expression
 # =====================================================
 
-def clone_expression(expr, memo=None):
+def clone_expression(expr, substitute=None):
     """A function that is used to clone an expression.
 
     Cloning is equivalent to calling ``copy.deepcopy`` with no Block
@@ -735,9 +735,9 @@ def clone_expression(expr, memo=None):
 
     Args:
         expr: The expression that will be cloned.
-        memo (dict): A dictionary mapping object ids to
-            objects.  This dictionary has the same semantics as
-            the memo object used with ``copy.deepcopy``.  Defaults
+        substitute (dict): A dictionary mapping object ids to
+            objects. This dictionary has the same semantics as
+            the memo object used with ``copy.deepcopy``. Defaults
             to None, which indicates that no user-defined
             dictionary is used.
 
@@ -746,10 +746,9 @@ def clone_expression(expr, memo=None):
 
     """
     clone_counter._count += 1
-    if not memo:
-        memo = {}
-    if '__block_scope__' not in memo:
-        memo['__block_scope__'] = { id(None): False }
+    memo = {'__block_scope__': {id(None): False}}
+    if substitute:
+        memo.update(substitute)
     return deepcopy(expr, memo)
 
 
@@ -1397,7 +1396,7 @@ class ExpressionBase(NumericValue):
         Returns:
             A new expression tree.
         """
-        return clone_expression(self, memo=substitute)
+        return clone_expression(self, substitute=substitute)
 
     def create_node_with_local_data(self, args):
         """


### PR DESCRIPTION
Brings the API in line with pyomo4 and coopr3 expression systems.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
