### PR TITLE
Use tmpdir for gams subprocess files

### DIFF
--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -714,12 +714,15 @@ class GAMSShell(pyomo.common.plugin.Plugin):
             os.makedirs(tmpdir)
             newdir = True
 
-        output_filename = os.path.join(tmpdir, 'model.gms')
-        lst_filename = os.path.join(tmpdir, 'output.lst')
-        statresults_filename = os.path.join(tmpdir, 'resultsstat.dat')
+        output = "model.gms"
+        output_filename = os.path.join(tmpdir, output)
+        lst = "output.lst"
+        lst_filename = os.path.join(tmpdir, lst)
 
-        io_options['put_results'] = os.path.join(tmpdir, 'results')
-        results_filename = os.path.join(tmpdir, 'results.dat')
+        put_results = "results"
+        io_options["put_results"] = put_results
+        results_filename = os.path.join(tmpdir, put_results + ".dat")
+        statresults_filename = os.path.join(tmpdir, put_results + "stat.dat")
 
         if isinstance(model, IBlockStorage):
             # Kernel blocks have slightly different write method
@@ -744,7 +747,7 @@ class GAMSShell(pyomo.common.plugin.Plugin):
         ####################################################################
 
         exe = self.executable()
-        command = [exe, output_filename, 'o=' + lst_filename]
+        command = [exe, output, "o=" + lst, "curdir=" + tmpdir]
         if tee and not logfile:
             # default behaviour of gams is to print to console, for
             # compatability with windows and *nix we want to explicitly log to


### PR DESCRIPTION
## Fixes #359 

## Summary/Motivation:
See issue. I also checked the API solver too and it already stores those subprocess files in the `tmpdir` so it doesn't need any changing.

## Changes proposed in this PR:
- Use `curdir` command line argument to change the GAMS process working directory to `tmpdir` so that GAMS's scratch work is done within that directory.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
