### PR TITLE
Appveyor fix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,7 +66,8 @@ install:
   - conda update -q -y conda
   - conda config --set auto_update_conda false
   #
-  - "%CONDAFORGE% setuptools pip coverage codecov sphinx_rtd_theme"
+  - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme"
+  - python -m pip install codecov
   #
   # Install GAMS
   #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,16 +66,7 @@ install:
   - conda update -q -y conda
   - conda config --set auto_update_conda false
   #
-  - "%CONDAFORGE% setuptools pip"
-  - python -m pip install coverage
-  - python -m pip install codecov
-  - IF DEFINED YAML (python -m pip install pyyaml)
-  - "IF DEFINED PYRO (python -m pip install %PYRO%)"
-  - python -m pip install xlrd
-  - python -m pip install openpyxl
-  - python -m pip install sphinx_rtd_theme
-  - "%ANACONDA% pandas networkx"
-  - "%ANACONDA% scipy"
+  - "%CONDAFORGE% setuptools pip coverage codecov sphinx_rtd_theme"
   #
   # Install GAMS
   #


### PR DESCRIPTION
## Fixes #538 

## Summary/Motivation:
Get appveyor builds functioning under Python 3.6.  A recent change somewhere caused an incompatibility between numpy and openpyxl.  This changes the Appveyor build to only pull packages from conda-forge to (hopefully) reduce the packages incompatibilities.

## Changes proposed in this PR:
- Only install packages from conda-forge (except for codecov, which needs to use pip for Python3.4 support)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
