### PR TITLE
Obtain column names from `cursor.description()` in sql query

### DIFF
--- a/pyomo/core/data/TableData.py
+++ b/pyomo/core/data/TableData.py
@@ -2,8 +2,8 @@
 #
 #  Pyomo: Python Optimization Modeling Objects
 #  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
-#  Under the terms of Contract DE-NA0003525 with National Technology and 
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
@@ -120,7 +120,10 @@ class TableData(Plugin):
                 header_index.append(i)
         else:
             for i in self.options.select:
-                header_index.append(headers.index(str(i)))
+                try:
+                    header_index.append(headers.index(str(i)))
+                except ValueError as e:
+                    raise Exception("Model declaration '%s' not found in returned query columns" %str(i)) from e
         self.options.ncolumns = len(headers)
 
         if not self.options.param is None:
@@ -268,4 +271,3 @@ class TableData(Plugin):
                     cols.append(param)
                 tmp = [cols] + tmp
         return tmp
-

--- a/pyomo/core/data/TableData.py
+++ b/pyomo/core/data/TableData.py
@@ -122,8 +122,8 @@ class TableData(Plugin):
             for i in self.options.select:
                 try:
                     header_index.append(headers.index(str(i)))
-                except ValueError as e:
-                    raise Exception("Model declaration '%s' not found in returned query columns" %str(i)) from e
+                except:
+                    print("Model declaration '%s' not found in returned query columns" %str(i))
         self.options.ncolumns = len(headers)
 
         if not self.options.param is None:

--- a/pyomo/core/data/TableData.py
+++ b/pyomo/core/data/TableData.py
@@ -124,6 +124,7 @@ class TableData(Plugin):
                     header_index.append(headers.index(str(i)))
                 except:
                     print("Model declaration '%s' not found in returned query columns" %str(i))
+                    raise
         self.options.ncolumns = len(headers)
 
         if not self.options.param is None:


### PR DESCRIPTION
## Fixes #537 .

## Summary/Motivation:
To implement legacy request  [#4480](https://software.sandia.gov/trac/pyomo/ticket/4480) which proposes to obtain column names in an SQL query from `cursor.description()` as opposed to parsing the query request from the .dat file. This enables the use of alias names for columns in databases whose names cannot match model declarations.

## Changes proposed in this PR:
- Eliminate the parsing of column names from query in `pyomo.core.data.db_table.read`
- Execute the query inside an existing try statement to catch SQL malform expressions non-silently
- If successful, obtain returned column names from `cursor.description` and use subsequently to populate model
- Raise an explicit exception in `pyomo.core.data.TableData._set_data` method to catch when returned column names do not match model declarations (e.g. when an alias is required)

## Alias example
For example: a query to obtain the value of a parameter `P` that is indexed over 3 sets `A`. `B` and `C` would read:
```sql
SELECT database_column_name1 as A, database_column_name2 as B, 
database_column_name3 as C,database_column_name4 as P
FROM dabatase_table
WHERE /*more sql code here*/
```


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
