### PR TITLE
Only test master (and PRs)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - master
+
 environment:
 
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+  - master
 cache: false
 language: generic
 services:


### PR DESCRIPTION
## Fixes #532 

## Summary/Motivation:
See issue. We currently waste time building tests twice for branches with PRs.

## Changes proposed in this PR:
In the absence of further discussion, I chose to try out one of the options I mentioned in the issue to hopefully get closer to merging a fix. See the issue for the other options. Basically, my thinking was that the only choice for Travis is to skip branches altogether (except master), since unlike AppVeyor, it does not have an option to skip branches with an open PR. So I chose to implement the same choice for AppVeyor to keep consistency. This allows people who develop on the main repo's branches to selectively choose when they want to start continuous testing, by opening a PR.

- Limit Travis and AppVeyor to only test a branch if it is `master`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
