### PR TITLE
Fix pyomo help -s

### DIFF
--- a/pyomo/contrib/gdpopt/GDPopt.py
+++ b/pyomo/contrib/gdpopt/GDPopt.py
@@ -57,6 +57,8 @@ class GDPoptSolver(pyomo.common.plugin.Plugin):
     pyomo.common.plugin.alias(
         'gdpopt', doc='The GDPopt decomposition-based GDP solver')
 
+    _metasolver = False
+
     CONFIG = ConfigBlock("GDPopt")
     CONFIG.declare("bound_tolerance", ConfigValue(
         default=1E-6, domain=NonNegativeFloat,

--- a/pyomo/scripting/driver_help.py
+++ b/pyomo/scripting/driver_help.py
@@ -339,7 +339,13 @@ def help_solvers():
         for s in solver_list:
             # Create a solver, and see if it is available
             with pyomo.opt.SolverFactory(s) as opt:
-                if s == 'py' or opt._metasolver:
+                try:
+                    # Not all solvers implement the private
+                    # "_metasolver" attribute
+                    _metasolver = opt._metasolver
+                except AttributeError:
+                    _metasolver = False
+                if s == 'py' or _metasolver:
                     msg = '    %-'+str(n)+'s   + %s'
                 elif opt.available(False):
                     msg = '    %-'+str(n)+'s   * %s'

--- a/pyomo/scripting/driver_help.py
+++ b/pyomo/scripting/driver_help.py
@@ -339,11 +339,13 @@ def help_solvers():
         for s in solver_list:
             # Create a solver, and see if it is available
             with pyomo.opt.SolverFactory(s) as opt:
-                try:
-                    # Not all solvers implement the private
-                    # "_metasolver" attribute
+                # Not all solvers implement the private "_metasolver"
+                # attribute, but solvers also raise a RuntimeError when
+                # attempting to get an unknown attribute if the solver
+                # is not available.
+                if hasattr(opt, '_metasolver'):
                     _metasolver = opt._metasolver
-                except AttributeError:
+                else:
                     _metasolver = False
                 if s == 'py' or _metasolver:
                     msg = '    %-'+str(n)+'s   + %s'

--- a/pyomo/scripting/driver_help.py
+++ b/pyomo/scripting/driver_help.py
@@ -339,15 +339,11 @@ def help_solvers():
         for s in solver_list:
             # Create a solver, and see if it is available
             with pyomo.opt.SolverFactory(s) as opt:
-                # Not all solvers implement the private "_metasolver"
-                # attribute, but solvers also raise a RuntimeError when
-                # attempting to get an unknown attribute if the solver
-                # is not available.
-                if hasattr(opt, '_metasolver'):
-                    _metasolver = opt._metasolver
-                else:
-                    _metasolver = False
-                if s == 'py' or _metasolver:
+                if s == 'py' or (hasattr(opt, "_metasolver") and opt._metasolver):
+                    # py is a metasolver, but since we don't specify a subsolver
+                    # for this test, opt is actually an UnknownSolver, so we
+                    # can't try to get the _metasolver attribute from it.
+                    # Also, default to False if the attribute isn't implemented
                     msg = '    %-'+str(n)+'s   + %s'
                 elif opt.available(False):
                     msg = '    %-'+str(n)+'s   * %s'

--- a/pyomo/scripting/driver_help.py
+++ b/pyomo/scripting/driver_help.py
@@ -335,7 +335,7 @@ def help_solvers():
     wrapper = textwrap.TextWrapper(subsequent_indent=' '*(n+9))
     try:
         # Disable warnings
-        logger.disable(logging.WARNING)
+        logging.disable(logging.WARNING)
         for s in solver_list:
             # Create a solver, and see if it is available
             with pyomo.opt.SolverFactory(s) as opt:
@@ -348,7 +348,7 @@ def help_solvers():
                 print(wrapper.fill(msg % (s, pyomo.opt.SolverFactory.doc(s))))
     finally:
         # Reset logging level
-        logger.disable(logging.NOTSET)
+        logging.disable(logging.NOTSET)
     print("")
     wrapper = textwrap.TextWrapper(subsequent_indent='')
     print(wrapper.fill("An asterisk indicates solvers that are currently available to be run from Pyomo with the serial solver manager. A plus indicates meta-solvers, that are always available."))

--- a/pyomo/scripting/tests/test_cmds.py
+++ b/pyomo/scripting/tests/test_cmds.py
@@ -29,7 +29,7 @@ class TestScriptingCommands(unittest.TestCase):
         self.assertTrue(re.search('ps +\*', OUT))
         for solver in ('ipopt','baron','cbc','glpk'):
             s = SolverFactory(solver)
-            if s.available:
+            if s.available():
                 self.assertTrue(re.search("%s +\* [a-zA-Z]" % solver, OUT))
             else:
                 self.assertTrue(re.search("%s +[a-zA-Z]" % solver, OUT))

--- a/pyomo/scripting/tests/test_cmds.py
+++ b/pyomo/scripting/tests/test_cmds.py
@@ -1,0 +1,35 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+import re
+import pyutilib.th as unittest
+from pyutilib.misc.redirect_io import capture_output
+
+from pyomo.environ import SolverFactory
+from pyomo.scripting.driver_help import help_solvers
+
+class TestScriptingCommands(unittest.TestCase):
+    def test_help_solvers(self):
+        with capture_output() as OUT:
+            help_solvers()
+        OUT = OUT.getvalue()
+        self.assertTrue(re.search('Pyomo Solvers and Solver Managers', OUT))
+        self.assertTrue(re.search('Serial Solver', OUT))
+        # Test known solvers and metasolver flags
+        # ASL is a metasolver
+        self.assertTrue(re.search('asl +\+', OUT))
+        # PS is bundles with Pyomo so should always be available
+        self.assertTrue(re.search('ps +\*', OUT))
+        for solver in ('ipopt','baron','cbc','glpk'):
+            s = SolverFactory(solver)
+            if s.available:
+                self.assertTrue(re.search("%s +\* [a-zA-Z]" % solver, OUT))
+            else:
+                self.assertTrue(re.search("%s +[a-zA-Z]" % solver, OUT))

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -74,11 +74,13 @@ class GAMSDirect(pyomo.common.plugin.Plugin):
     Visit Python API page on gams.com for installation help.
     """
     pyomo.common.plugin.implements(IOptSolver)
-    pyomo.common.plugin.alias('_gams_direct', doc='The GAMS modeling language')
+    pyomo.common.plugin.alias('_gams_direct',
+        doc='Direct python interface to the GAMS modeling language')
 
     def __init__(self, **kwds):
         self._version = None
         self._default_variable_value = None
+        self._metasolver = False
 
         self._capabilities = Options()
         self._capabilities.linear = True
@@ -524,11 +526,13 @@ class GAMSDirect(pyomo.common.plugin.Plugin):
 class GAMSShell(pyomo.common.plugin.Plugin):
     """A generic shell interface to GAMS solvers."""
     pyomo.common.plugin.implements(IOptSolver)
-    pyomo.common.plugin.alias('_gams_shell', doc='The GAMS modeling language')
+    pyomo.common.plugin.alias('_gams_shell',
+        doc='Shell interface to the GAMS modeling language')
 
     def __init__(self, **kwds):
         self._version = None
         self._default_variable_value = None
+        self._metasolver = False
 
         self._capabilities = Options()
         self._capabilities.linear = True


### PR DESCRIPTION
## Fixes #266 

## Summary/Motivation:
See issue. Simple fix so that the `pyomo help -s` command runs properly again.

Note that the GAMS solver breaks when you try to use the `pyomo solve model.py --solver=gams` command, because it doesn't have a `config_block` method, which it would if it inherited from `OptSolver`. I got confused quickly when I tried to understand how those worked for the solvers.

## Changes proposed in this PR:
- Add `_metasolver=False` attribute to GAMS and GDPopt solvers
- Fix `logging` vs `logger` typo causing a bug
- Make some of the doc strings longer

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
