### PR TITLE
Appveyor fix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -77,7 +77,7 @@ install:
   #
   # Install pyomo.extras
   #
-  - "IF DEFINED EXTRAS (%CONDAFORGE% numpy scipy ipython openpyxl sympy pymysql pyodbc pyro4 pyyaml networkx xlrd pandas matplotlib dill)"
+  - "IF DEFINED EXTRAS (%CONDAFORGE% mkl numpy scipy ipython openpyxl sympy pymysql pyodbc pyro4 pyyaml networkx xlrd pandas matplotlib dill)"
   #
   - "%CONDAFORGE% glpk"
   - "glpsol -v"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,10 +32,10 @@ environment:
       CATEGORY: "nightly"
       EXTRAS: YES
 
-    - PYTHON_VERSION: 3.5
-      PYTHON: "C:\\Miniconda35-x64"
-      CATEGORY: "nightly"
-      EXTRAS: YES
+    #- PYTHON_VERSION: 3.5
+    #  PYTHON: "C:\\Miniconda35-x64"
+    #  CATEGORY: "nightly"
+    #  EXTRAS: YES
 
     - PYTHON_VERSION: 3.6
       PYTHON: "C:\\Miniconda36-x64"


### PR DESCRIPTION
## Summary/Motivation:
Temporarily disabling Python 3.5 on Appveyor (until the numpy build is updated to resolve MKL DLL issues). 

## Changes proposed in this PR:
- Remove the python 3.5 build

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
