### PR TITLE
Initial stab at resolving #31

### DIFF
--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -609,11 +609,11 @@ use the AbstractModel or ConcreteModel class instead.""")
         self.statistics.number_of_objectives = 0
         for block in self.block_data_objects(active=active):
             for data in self.component_map(Var, active=active).itervalues():
-                self.statistics.number_of_variables += len(data)
+                self.statistics.number_of_variables += len(data) if data.is_indexed() else 1
             for data in self.component_map(Objective, active=active).itervalues():
-                self.statistics.number_of_objectives += len(data)
+                self.statistics.number_of_objectives += len(data._data)
             for data in self.component_map(Constraint, active=active).itervalues():
-                self.statistics.number_of_constraints += len(data)
+                self.statistics.number_of_constraints += len(data._data)
 
     def nvariables(self):
         self.compute_statistics()

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1233,7 +1233,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
             if comp.is_indexed():
                 _items = comp.iteritems()
             # This is a hack (see _NOTE_ above).
-            elif len(comp) or not hasattr(comp, '_data'):
+            elif not hasattr(comp, '_data') or len(comp._data):
                 _items = ((None, comp),)
             else:
                 _items = tuple()
@@ -1828,11 +1828,11 @@ class Block(ActiveIndexedComponent):
             super(Block, self).pprint(ostream=ostream, verbose=verbose,
                                       prefix=prefix)
 
-        if not len(self):
-            return
         if not self.is_indexed():
             _BlockData.pprint(self, ostream=ostream, verbose=verbose,
                               prefix=prefix+'    ' if subblock else prefix)
+            return
+        if not len(self):
             return
 
         # Note: all indexed blocks must be sub-blocks (if they aren't
@@ -1847,7 +1847,7 @@ class Block(ActiveIndexedComponent):
                               prefix=prefix + '    ' if subblock else prefix)
 
     def _pprint(self):
-        return [("Size", len(self)),
+        return [("Size", len(self) if self.is_indexed() else 1),
                 ("Index", self._index if self.is_indexed() else None),
                 ('Active', self.active),
                 ], ().__iter__(), (), ()

--- a/pyomo/core/base/connector.py
+++ b/pyomo/core/base/connector.py
@@ -210,12 +210,12 @@ class Connector(IndexedComponent):
                     _len = '-'
                 elif _k in v.aggregators:
                     _len = '*'
-                elif hasattr(_v,'__len__'):
-                    _len = len(_v)
+                elif hasattr(_v,'_data'):
+                    _len = len(_v._data)
                 else:
                     _len = 1
                 yield _k, _len, str(_v)
-        return ( [("Size", len(self)),
+        return ( [("Size", len(self._data)),
                   ("Index", self._index if self.is_indexed() else None),
                   ],
                  iteritems(self._data),
@@ -236,7 +236,7 @@ class Connector(IndexedComponent):
             ostream = sys.stdout
         tab="    "
         ostream.write(prefix+self.local_name+" : ")
-        ostream.write("Size="+str(len(self)))
+        ostream.write("Size="+str(len(self._data)))
 
         ostream.write("\n")
         def _line_generator(k,v):

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -782,7 +782,7 @@ class Constraint(ActiveIndexedComponent):
         Return data that will be printed for this component.
         """
         return (
-            [("Size", len(self)),
+            [("Size", len(self._data)),
              ("Index", self._index if self.is_indexed() else None),
              ("Active", self.active),
              ],
@@ -807,7 +807,7 @@ class Constraint(ActiveIndexedComponent):
             ostream = sys.stdout
         tab="    "
         ostream.write(prefix+self.local_name+" : ")
-        ostream.write("Size="+str(len(self)))
+        ostream.write("Size="+str(len(self._data)))
 
         ostream.write("\n")
         tabular_writer( ostream, prefix+tab,

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -288,7 +288,7 @@ class Expression(IndexedComponent):
 
     def _pprint(self):
         return (
-            [('Size', len(self)),
+            [('Size', len(self._data)),
              ('Index', None if (not self.is_indexed())
                   else self._index)
              ],
@@ -306,7 +306,7 @@ class Expression(IndexedComponent):
             ostream = sys.stdout
         tab="    "
         ostream.write(prefix+self.local_name+" : ")
-        ostream.write("Size="+str(len(self)))
+        ostream.write("Size="+str(len(self._data)))
 
         ostream.write("\n")
         tabular_writer(

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -417,11 +417,16 @@ class IndexedComponent(Component):
             return 0
         return getattr(self._index, 'dimen', 0)
 
+    def __bool__(self):
+        return self._index is UnindexedComponent_set or len(self) > 0
+
     def __len__(self):
         """
         Return the number of component data objects stored by this
         component.
         """
+        if self._index is UnindexedComponent_set:
+            raise TypeError("Cannot compute the length of type '%s'" % self.__class__)
         return len(self._data)
 
     def __contains__(self, idx):

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -381,7 +381,7 @@ class Objective(ActiveIndexedComponent):
         Return data that will be printed for this component.
         """
         return (
-            [("Size", len(self)),
+            [("Size", len(self._data)),
              ("Index", self._index if self.is_indexed() else None),
              ("Active", self.active)
              ],
@@ -402,7 +402,7 @@ class Objective(ActiveIndexedComponent):
             ostream = sys.stdout
         ostream.write(prefix+self.local_name+" : ")
         ostream.write(", ".join("%s=%s" % (k,v) for k,v in [
-                    ("Size", len(self)),
+                    ("Size", len(self._data)),
                     ("Index", self._index if self.is_indexed() else None),
                     ("Active", self.active),
                     ] ))

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -750,7 +750,7 @@ class Var(IndexedComponent):
 
     def _pprint(self):
         """Print component information."""
-        return ( [("Size", len(self)),
+        return ( [("Size", len(self) if self.is_indexed() else 1),
                   ("Index", self._index if self.is_indexed() else None),
                   ],
                  iteritems(self._data),

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -2112,7 +2112,7 @@ class TestBlock(unittest.TestCase):
 
         self.assertTrue(hasattr(model, 'scalar_constraint'))
         self.assertIs(model.scalar_constraint._type, Constraint)
-        self.assertEqual(len(model.scalar_constraint), 1)
+        self.assertRaises(TypeError, len, model.scalar_constraint)
 
         @model.Constraint(model.I)
         def vector_constraint(m, i):

--- a/pyomo/core/tests/unit/test_block_model.py
+++ b/pyomo/core/tests/unit/test_block_model.py
@@ -122,9 +122,9 @@ class Test(unittest.TestCase):
 
         # TODO: I think the correct answer should be zero before
         # construction
-        self.assertEqual(len(model.b), 1)
+        self.assertEqual(len(model.b._data), 1)
         inst = model.create_instance()
-        self.assertEqual(len(inst.b), 1)
+        self.assertEqual(len(inst.b._data), 1)
 
     def test_none_key(self):
 

--- a/pyomo/core/tests/unit/test_con.py
+++ b/pyomo/core/tests/unit/test_con.py
@@ -721,7 +721,7 @@ class TestSimpleCon(unittest.TestCase):
         model = ConcreteModel()
         model.c = Constraint()
 
-        self.assertEqual(len(model.c), 0)
+        self.assertEqual(len(model.c._data), 0)
 
     def test_None_key(self):
         """Test keys method"""
@@ -736,23 +736,24 @@ class TestSimpleCon(unittest.TestCase):
         model = AbstractModel()
         model.x = Var()
         model.c = Constraint(rule=lambda m: m.x == 1)
-        self.assertEqual(len(model.c),0)
+        self.assertEqual(len(model.c._data),0)
         inst = model.create_instance()
-        self.assertEqual(len(inst.c),1)
+        self.assertEqual(len(inst.c._data),1)
+        self.assertRaises(TypeError, len, inst.c)
 
     def test_setitem(self):
         m = ConcreteModel()
         m.x = Var()
         m.c = Constraint()
-        self.assertEqual(len(m.c), 0)
+        self.assertEqual(len(m.c._data), 0)
 
         m.c = m.x**2 <= 4
-        self.assertEqual(len(m.c), 1)
+        self.assertEqual(len(m.c._data), 1)
         self.assertEqual(list(m.c.keys()), [None])
         self.assertEqual(m.c.upper, 4)
 
         m.c = Constraint.Skip
-        self.assertEqual(len(m.c), 0)
+        self.assertEqual(len(m.c._data), 0)
 
 class TestArrayCon(unittest.TestCase):
 
@@ -886,13 +887,13 @@ class TestArrayCon(unittest.TestCase):
         model.x = Var(model.B, initialize=2)
         model.c = Constraint(rule=f)
 
-        self.assertEqual(len(model.c),1)
+        self.assertEqual(len(model.c._data),1)
 
     def test_setitem(self):
         m = ConcreteModel()
         m.x = Var()
         m.c = Constraint(range(5))
-        self.assertEqual(len(m.c), 0)
+        self.assertEqual(len(m.c._data), 0)
 
         m.c[2] = m.x**2 <= 4
         self.assertEqual(len(m.c), 1)
@@ -901,7 +902,7 @@ class TestArrayCon(unittest.TestCase):
         self.assertEqual(m.c[2].upper, 4)
 
         m.c[3] = Constraint.Skip
-        self.assertEqual(len(m.c), 1)
+        self.assertEqual(len(m.c._data), 1)
         self.assertRaisesRegexp( KeyError, "3", m.c.__getitem__, 3)
 
         self.assertRaisesRegexp( ValueError, "'c\[3\]': rule returned None",
@@ -1116,7 +1117,7 @@ class Test2DArrayCon(unittest.TestCase):
         model.x = Var(model.B, initialize=2)
         model.c = Constraint(rule=f)
 
-        self.assertEqual(len(model.c),1)
+        self.assertEqual(len(model.c._data),1)
 
 class MiscConTests(unittest.TestCase):
 
@@ -1169,7 +1170,7 @@ class MiscConTests(unittest.TestCase):
         # something to the constraint.
         #
         self.assertEqual(a._constructed, True)
-        self.assertEqual(len(a), 0)
+        self.assertEqual(len(a._data), 0)
         try:
             a()
             self.fail("Component is empty")
@@ -1208,7 +1209,7 @@ class MiscConTests(unittest.TestCase):
         x = Var(initialize=1.0)
         x.construct()
         a.set_value((0, x, 2))
-        self.assertEqual(len(a), 1)
+        self.assertEqual(len(a._data), 1)
         self.assertEqual(a(), 1)
         self.assertEqual(a.body(), 1)
         self.assertEqual(a.lower(), 0)
@@ -1220,7 +1221,7 @@ class MiscConTests(unittest.TestCase):
     def test_unconstructed_singleton(self):
         a = Constraint()
         self.assertEqual(a._constructed, False)
-        self.assertEqual(len(a), 0)
+        self.assertEqual(len(a._data), 0)
         try:
             a()
             self.fail("Component is unconstructed")
@@ -1260,7 +1261,7 @@ class MiscConTests(unittest.TestCase):
         x.construct()
         a.construct()
         a.set_value((0, x, 2))
-        self.assertEqual(len(a), 1)
+        self.assertEqual(len(a._data), 1)
         self.assertEqual(a(), 1)
         self.assertEqual(a.body(), 1)
         self.assertEqual(a.lower(), 0)

--- a/pyomo/core/tests/unit/test_connector.py
+++ b/pyomo/core/tests/unit/test_connector.py
@@ -28,12 +28,12 @@ class TestConnector(unittest.TestCase):
     def test_default_scalar_constructor(self):
         model = ConcreteModel()
         model.c = Connector()
-        self.assertEqual(len(model.c), 1)
+        self.assertEqual(len(model.c._data), 1)
         self.assertEqual(len(model.c.vars), 0)
 
         model = AbstractModel()
         model.c = Connector()
-        self.assertEqual(len(model.c), 0)
+        self.assertEqual(len(model.c._data), 0)
         # FIXME: Not sure I like this behavior: but since this is
         # (currently) an attribute, there is no way to check for
         # construction withough converting it to a property.
@@ -43,7 +43,7 @@ class TestConnector(unittest.TestCase):
         self.assertEqual(len(model.c.vars), 0)
 
         inst = model.create_instance()
-        self.assertEqual(len(inst.c), 1)
+        self.assertEqual(len(inst.c._data), 1)
         self.assertEqual(len(inst.c.vars), 0)
 
     def test_default_indexed_constructor(self):
@@ -70,14 +70,14 @@ class TestConnector(unittest.TestCase):
         pipe.OUT = Connector()
         pipe.OUT.add(pipe.flow, "flow")
         pipe.OUT.add(pipe.pOut, "pressure")
-        self.assertEqual(len(pipe.OUT), 1)
+        self.assertEqual(len(pipe.OUT._data), 1)
         self.assertEqual(len(pipe.OUT.vars), 2)
         self.assertFalse(pipe.OUT.vars['flow'].is_expression_type())
 
         pipe.IN = Connector()
         pipe.IN.add(-pipe.flow, "flow")
         pipe.IN.add(pipe.pIn, "pressure")
-        self.assertEqual(len(pipe.IN), 1)
+        self.assertEqual(len(pipe.IN._data), 1)
         self.assertEqual(len(pipe.IN.vars), 2)
         self.assertTrue(pipe.IN.vars['flow'].is_expression_type())
         
@@ -93,7 +93,7 @@ class TestConnector(unittest.TestCase):
         pipe.OUT.add(pipe.composition, "composition")
         pipe.OUT.add(pipe.pIn, "pressure")
 
-        self.assertEqual(len(pipe.OUT), 1)
+        self.assertEqual(len(pipe.OUT._data), 1)
         self.assertEqual(len(pipe.OUT.vars), 3)
 
 

--- a/pyomo/core/tests/unit/test_expression.py
+++ b/pyomo/core/tests/unit/test_expression.py
@@ -294,7 +294,7 @@ class TestExpression(unittest.TestCase):
     def test_unconstructed_singleton(self):
         a = Expression()
         self.assertEqual(a._constructed, False)
-        self.assertEqual(len(a), 0)
+        self.assertEqual(len(a._data), 0)
         try:
             a()
             self.fail("Component is unconstructed")
@@ -321,16 +321,17 @@ class TestExpression(unittest.TestCase):
         except ValueError:
             pass
         a.construct()
-        self.assertEqual(len(a), 1)
+        self.assertEqual(len(a._data), 1)
         self.assertEqual(a(), None)
         self.assertEqual(a.expr, None)
         self.assertEqual(a.is_constant(), False)
         a.set_value(5)
-        self.assertEqual(len(a), 1)
+        self.assertEqual(len(a._data), 1)
         self.assertEqual(a(), 5)
         self.assertEqual(a.expr(), 5)
         self.assertEqual(a.is_constant(), False)
         self.assertEqual(a.is_fixed(), True)
+        self.assertRaises(TypeError, len, a)
 
 
     def test_bad_init_wrong_type(self):
@@ -841,9 +842,9 @@ E : Size=2, Index=E_index
         model = AbstractModel()
         model.e = Expression()
 
-        self.assertEqual(len(model.e), 0)
+        self.assertEqual(len(model.e._data), 0)
         inst = model.create_instance()
-        self.assertEqual(len(inst.e), 1)
+        self.assertEqual(len(inst.e._data), 1)
 
     def test_None_key(self):
         model = AbstractModel()
@@ -854,7 +855,7 @@ E : Size=2, Index=E_index
     def test_singleton_get_set(self):
         model = ConcreteModel()
         model.e = Expression()
-        self.assertEqual(len(model.e), 1)
+        self.assertEqual(len(model.e._data), 1)
         self.assertEqual(model.e.expr, None)
         model.e.expr = 1
         self.assertEqual(model.e.expr(), 1)
@@ -864,7 +865,7 @@ E : Size=2, Index=E_index
     def test_singleton_get_set_value(self):
         model = ConcreteModel()
         model.e = Expression()
-        self.assertEqual(len(model.e), 1)
+        self.assertEqual(len(model.e._data), 1)
         self.assertEqual(model.e.expr, None)
         model.e.expr = 1
         self.assertEqual(model.e.expr(), 1)

--- a/pyomo/core/tests/unit/test_obj.py
+++ b/pyomo/core/tests/unit/test_obj.py
@@ -27,7 +27,7 @@ class TestSimpleObj(unittest.TestCase):
     def test_singleton_get_set(self):
         model = ConcreteModel()
         model.o = Objective(expr=1)
-        self.assertEqual(len(model.o), 1)
+        self.assertEqual(len(model.o._data), 1)
         self.assertEqual(model.o.expr, 1)
         model.o.expr = 2
         self.assertEqual(model.o.expr(), 2)
@@ -37,7 +37,7 @@ class TestSimpleObj(unittest.TestCase):
     def test_singleton_get_set_value(self):
         model = ConcreteModel()
         model.o = Objective(expr=1)
-        self.assertEqual(len(model.o), 1)
+        self.assertEqual(len(model.o._data), 1)
         self.assertEqual(model.o.expr, 1)
         model.o.expr = 2
         self.assertEqual(model.o.expr(), 2)
@@ -55,7 +55,7 @@ class TestSimpleObj(unittest.TestCase):
         # something to the objective.
         #
         self.assertEqual(a._constructed, True)
-        self.assertEqual(len(a), 0)
+        self.assertEqual(len(a._data), 0)
         try:
             a()
             self.fail("Component is empty")
@@ -74,7 +74,7 @@ class TestSimpleObj(unittest.TestCase):
         x = Var(initialize=1.0)
         x.construct()
         a.set_value(x + 1)
-        self.assertEqual(len(a), 1)
+        self.assertEqual(len(a._data), 1)
         self.assertEqual(a(), 2)
         self.assertEqual(a.expr(), 2)
         self.assertEqual(a.sense, minimize)
@@ -82,7 +82,7 @@ class TestSimpleObj(unittest.TestCase):
     def test_unconstructed_singleton(self):
         a = Objective()
         self.assertEqual(a._constructed, False)
-        self.assertEqual(len(a), 0)
+        self.assertEqual(len(a._data), 0)
         try:
             a()
             self.fail("Component is unconstructed")
@@ -100,12 +100,12 @@ class TestSimpleObj(unittest.TestCase):
             pass
         a.construct()
         a.set_sense(minimize)
-        self.assertEqual(len(a), 1)
+        self.assertEqual(len(a._data), 1)
         self.assertEqual(a(), None)
         self.assertEqual(a.expr, None)
         self.assertEqual(a.sense, minimize)
         a.sense = maximize
-        self.assertEqual(len(a), 1)
+        self.assertEqual(len(a._data), 1)
         self.assertEqual(a(), None)
         self.assertEqual(a.expr, None)
         self.assertEqual(a.sense, maximize)
@@ -234,9 +234,9 @@ class TestSimpleObj(unittest.TestCase):
         def rule(model):
             return 1.0
         model.obj = Objective(rule=rule)
-        self.assertEqual(len(model.obj),0)
+        self.assertEqual(len(model.obj._data),0)
         inst = model.create_instance()
-        self.assertEqual(len(inst.obj),1)
+        self.assertEqual(len(inst.obj._data),1)
 
         model = AbstractModel()
         """Test rule option"""
@@ -249,9 +249,9 @@ class TestSimpleObj(unittest.TestCase):
         model.x = Var(RangeSet(1,4),initialize=2)
         model.obj = Objective(rule=f)
 
-        self.assertEqual(len(model.obj),0)
+        self.assertEqual(len(model.obj._data),0)
         inst = model.create_instance()
-        self.assertEqual(len(inst.obj),1)
+        self.assertEqual(len(inst.obj._data),1)
 
     def test_keys_empty(self):
         """Test keys method"""
@@ -264,7 +264,7 @@ class TestSimpleObj(unittest.TestCase):
         """Test len method"""
         model = ConcreteModel()
         model.o = Objective()
-        self.assertEqual(len(model.o), 0)
+        self.assertEqual(len(model.o._data), 0)
 
 
 class TestArrayObj(unittest.TestCase):
@@ -468,7 +468,7 @@ class TestArrayObj(unittest.TestCase):
         model.x = Var(RangeSet(1,4),initialize=2)
         model.obj = Objective(rule=f)
 
-        self.assertEqual(len(model.obj),1)
+        self.assertEqual(len(model.obj._data),1)
 
 
 class Test2DArrayObj(unittest.TestCase):
@@ -559,7 +559,7 @@ class Test2DArrayObj(unittest.TestCase):
         model.x = Var(RangeSet(1,4),initialize=2)
         model.obj = Objective(rule=f)
 
-        self.assertEqual(len(model.obj),1)
+        self.assertEqual(len(model.obj._data),1)
 
 
 class TestObjList(unittest.TestCase):

--- a/pyomo/core/tests/unit/test_piecewise.py
+++ b/pyomo/core/tests/unit/test_piecewise.py
@@ -438,9 +438,10 @@ class TestInvalidPiecewise(unittest.TestCase):
                     'pw_constr_type':'EQ',\
                     'f_rule':lambda model,x: x**2}
         model.con = Piecewise(*args,**keywords)
-        self.assertEqual(len(model.con), 0)
+        self.assertEqual(len(model.con._data), 0)
         instance = model.create_instance()
-        self.assertEqual(len(instance.con), 1)
+        self.assertEqual(len(instance.con._data), 1)
+        self.assertRaises(TypeError, len, instance.con)
 
     def test_None_key(self):
         model = ConcreteModel()

--- a/pyomo/core/tests/unit/test_var.py
+++ b/pyomo/core/tests/unit/test_var.py
@@ -390,9 +390,9 @@ class TestSimpleVar(PyomoModel):
     def test_len(self):
         """Test len method"""
         self.model.x = Var()
-        self.assertEqual(len(self.model.x),0)
+        self.assertRaises(TypeError, len, self.model.x)
         self.instance = self.model.create_instance()
-        self.assertEqual(len(self.instance.x),1)
+        self.assertRaises(TypeError, len, self.model.x)
 
     def test_value(self):
         """Check the value of the variable"""

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -388,7 +388,7 @@ class Disjunction(ActiveIndexedComponent):
         Return data that will be printed for this component.
         """
         return (
-            [("Size", len(self)),
+            [("Size", len(self._data)),
              ("Index", self._index if self.is_indexed() else None),
              ("Active", self.active),
              ],

--- a/pyomo/gdp/tests/test_chull.py
+++ b/pyomo/gdp/tests/test_chull.py
@@ -270,7 +270,7 @@ class TwoTermDisj(unittest.TestCase):
 
         xorC = m._gdp_chull_relaxation_disjunction_xor
         self.assertIsInstance(xorC, Constraint)
-        self.assertEqual(len(xorC), 1)
+        self.assertEqual(len(xorC._data), 1)
 
         repn = generate_standard_repn(xorC.body)
         self.assertTrue(repn.is_linear())

--- a/pyomo/gdp/tests/test_disjunct.py
+++ b/pyomo/gdp/tests/test_disjunct.py
@@ -22,17 +22,17 @@ class TestDisjunction(unittest.TestCase):
         m.e = Disjunct()
 
         m.x1 = Disjunction()
-        self.assertEqual(len(m.x1), 0)
+        self.assertEqual(len(m.x1._data), 0)
 
         m.x1 = [m.d, m.e]
-        self.assertEqual(len(m.x1), 1)
+        self.assertEqual(len(m.x1._data), 1)
         self.assertEqual(m.x1.disjuncts, [m.d, m.e])
 
         m.x2 = Disjunction([1,2,3,4])
-        self.assertEqual(len(m.x2), 0)
+        self.assertEqual(len(m.x2._data), 0)
 
         m.x2[2] = [m.d, m.e]
-        self.assertEqual(len(m.x2), 1)
+        self.assertEqual(len(m.x2._data), 1)
         self.assertEqual(m.x2[2].disjuncts, [m.d, m.e])
 
     def test_construct_implicit_disjuncts(self):

--- a/pyomo/mpec/complementarity.py
+++ b/pyomo/mpec/complementarity.py
@@ -260,7 +260,7 @@ Error thrown for Complementarity "%s"
         Return data that will be printed for this component.
         """
         return (
-            [("Size", len(self)),
+            [("Size", len(self._data)),
              ("Index", self._index if self.is_indexed() else None),
              ("Active", self.active),
              ],

--- a/pyomo/repn/beta/matrix.py
+++ b/pyomo/repn/beta/matrix.py
@@ -147,7 +147,7 @@ def compile_block_linear_constraints(parent_block,
 
             assert not isinstance(constraint, MatrixConstraint)
 
-            if len(constraint) == 0:
+            if len(constraint._data) == 0:
 
                 empty_constraint_containers_to_remove.append((block, constraint))
 


### PR DESCRIPTION
## Fixes #31  .

## Summary/Motivation:
Removing the use of len() for non-indexed components.

## Changes proposed in this PR:
- Adding tests for the use of numpy data in expressions
- Various changes because len(component) returns TypeError unless the component is indexed.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
