### PR TITLE
correcting ipopt capabilities

### DIFF
--- a/pyomo/solvers/plugins/solvers/IPOPT.py
+++ b/pyomo/solvers/plugins/solvers/IPOPT.py
@@ -54,11 +54,11 @@ class IPOPT(SystemCallSolver):
         self._capabilities.linear = True
         # Should we set this to False? Doing so might cause
         # a headache for some folks.
-        self._capabilities.integer = True
+        self._capabilities.integer = False
         self._capabilities.quadratic_objective = True
         self._capabilities.quadratic_constraint = True
-        self._capabilities.sos1 = True
-        self._capabilities.sos2 = True
+        self._capabilities.sos1 = False
+        self._capabilities.sos2 = False
 
     def _default_results_format(self, prob_format):
         return ResultsFormat.sol

--- a/pyomo/solvers/plugins/solvers/IPOPT.py
+++ b/pyomo/solvers/plugins/solvers/IPOPT.py
@@ -52,8 +52,6 @@ class IPOPT(SystemCallSolver):
         # Note: Undefined capabilities default to 'None'
         self._capabilities = pyutilib.misc.Options()
         self._capabilities.linear = True
-        # Should we set this to False? Doing so might cause
-        # a headache for some folks.
         self._capabilities.integer = False
         self._capabilities.quadratic_objective = True
         self._capabilities.quadratic_constraint = True


### PR DESCRIPTION
## Fixes #572  .

## Summary/Motivation:
Ipopt ```has_capability('integer')``` return ```True```.

## Changes proposed in this PR:
- Correcting Ipopt capabilities
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
