### PR TITLE
Appveyor MKL Fix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -69,6 +69,9 @@ install:
   - conda config --set always_yes yes
   - conda update -q -y conda
   - conda config --set auto_update_conda false
+  - conda --version
+  - conda update anaconda
+  - CRASH HERE
   #
   - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme"
   - python -m pip install codecov

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -69,8 +69,8 @@ install:
   - conda config --set always_yes yes
   - conda update -q -y conda
   - conda config --set auto_update_conda false
-  - conda --version
-  - conda update anaconda
+  - conda install anaconda
+  - anaconda --version
   - CRASH HERE
   #
   - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,10 +41,10 @@ environment:
     #  CATEGORY: "nightly"
     #  EXTRAS: YES
 
-    #- PYTHON_VERSION: 3.6
-    #  PYTHON: "C:\\Miniconda36-x64"
-    #  CATEGORY: "nightly"
-    #  EXTRAS: YES
+    - PYTHON_VERSION: 3.6
+      PYTHON: "C:\\Miniconda36-x64"
+      CATEGORY: "nightly"
+      EXTRAS: YES
 
 
 install:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -81,7 +81,8 @@ install:
   #
   # Install pyomo.extras
   #
-  - "IF DEFINED EXTRAS (%CONDAFORGE% nomkl numpy scipy ipython openpyxl sympy pymysql pyodbc pyro4 pyyaml networkx xlrd pandas matplotlib dill)"
+  - "IF DEFINED EXTRAS (%CONDAFORGE% numpy scipy ipython openpyxl sympy pymysql pyodbc pyro4 pyyaml networkx xlrd pandas matplotlib dill)"
+  - "IF DEFINED EXTRAS (%CONDAFORGE% mkl)"
   #
   - "%CONDAFORGE% glpk"
   - "glpsol -v"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,10 +36,10 @@ environment:
     #  CATEGORY: "nightly"
     #  EXTRAS: YES
 
-    #- PYTHON_VERSION: 3.5
-    #  PYTHON: "C:\\Miniconda35-x64"
-    #  CATEGORY: "nightly"
-    #  EXTRAS: YES
+    - PYTHON_VERSION: 3.5
+      PYTHON: "C:\\Miniconda35-x64"
+      CATEGORY: "nightly"
+      EXTRAS: YES
 
     - PYTHON_VERSION: 3.6
       PYTHON: "C:\\Miniconda36-x64"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,10 +26,10 @@ environment:
     #  PYTHON: "C:\\Miniconda36-x64"
     #  CATEGORY: "nightly"
 
-    #- PYTHON_VERSION: 2.7
-    #  PYTHON: "C:\\Miniconda-x64"
-    #  CATEGORY: "nightly"
-    #  EXTRAS: YES
+    - PYTHON_VERSION: 2.7
+      PYTHON: "C:\\Miniconda-x64"
+      CATEGORY: "nightly"
+      EXTRAS: YES
 
     - PYTHON_VERSION: 3.4
       PYTHON: "C:\\Miniconda34-x64"
@@ -41,10 +41,10 @@ environment:
     #  CATEGORY: "nightly"
     #  EXTRAS: YES
 
-    #- PYTHON_VERSION: 3.6
-    #  PYTHON: "C:\\Miniconda36-x64"
-    #  CATEGORY: "nightly"
-    #  EXTRAS: YES
+    - PYTHON_VERSION: 3.6
+      PYTHON: "C:\\Miniconda36-x64"
+      CATEGORY: "nightly"
+      EXTRAS: YES
 
 
 install:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -82,8 +82,9 @@ install:
   #
   # Install pyomo.extras
   #
-  - "IF DEFINED EXTRAS (%CONDAFORGE% numpy scipy ipython openpyxl sympy pymysql pyodbc pyro4 pyyaml networkx xlrd pandas matplotlib dill)"
-  - "IF DEFINED EXTRAS (%CONDAFORGE% mkl)"
+  - "IF DEFINED EXTRAS (%CONDAFORGE% pymysql pyro4)"
+  #- "IF DEFINED EXTRAS (%CONDAFORGE% numpy scipy ipython openpyxl sympy pymysql pyodbc pyro4 pyyaml networkx xlrd pandas matplotlib dill)"
+  #- "IF DEFINED EXTRAS (%CONDAFORGE% mkl)"
   #
   - "%CONDAFORGE% glpk"
   - "glpsol -v"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,10 +26,10 @@ environment:
     #  PYTHON: "C:\\Miniconda36-x64"
     #  CATEGORY: "nightly"
 
-    - PYTHON_VERSION: 2.7
-      PYTHON: "C:\\Miniconda-x64"
-      CATEGORY: "nightly"
-      EXTRAS: YES
+    #- PYTHON_VERSION: 2.7
+    #  PYTHON: "C:\\Miniconda-x64"
+    #  CATEGORY: "nightly"
+    #  EXTRAS: YES
 
     - PYTHON_VERSION: 3.4
       PYTHON: "C:\\Miniconda34-x64"
@@ -41,10 +41,10 @@ environment:
     #  CATEGORY: "nightly"
     #  EXTRAS: YES
 
-    - PYTHON_VERSION: 3.6
-      PYTHON: "C:\\Miniconda36-x64"
-      CATEGORY: "nightly"
-      EXTRAS: YES
+    #- PYTHON_VERSION: 3.6
+    #  PYTHON: "C:\\Miniconda36-x64"
+    #  CATEGORY: "nightly"
+    #  EXTRAS: YES
 
 
 install:
@@ -81,7 +81,7 @@ install:
   #
   # Install pyomo.extras
   #
-  - "IF DEFINED EXTRAS (%CONDAFORGE% mkl numpy scipy ipython openpyxl sympy pymysql pyodbc pyro4 pyyaml networkx xlrd pandas matplotlib dill)"
+  - "IF DEFINED EXTRAS (%CONDAFORGE% nomkl numpy scipy ipython openpyxl sympy pymysql pyodbc pyro4 pyyaml networkx xlrd pandas matplotlib dill)"
   #
   - "%CONDAFORGE% glpk"
   - "glpsol -v"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,20 +31,20 @@ environment:
       CATEGORY: "nightly"
       EXTRAS: YES
 
-    - PYTHON_VERSION: 3.4
-      PYTHON: "C:\\Miniconda34-x64"
-      CATEGORY: "nightly"
-      EXTRAS: YES
+    #- PYTHON_VERSION: 3.4
+    #  PYTHON: "C:\\Miniconda34-x64"
+    #  CATEGORY: "nightly"
+    #  EXTRAS: YES
 
     #- PYTHON_VERSION: 3.5
     #  PYTHON: "C:\\Miniconda35-x64"
     #  CATEGORY: "nightly"
     #  EXTRAS: YES
 
-    - PYTHON_VERSION: 3.6
-      PYTHON: "C:\\Miniconda36-x64"
-      CATEGORY: "nightly"
-      EXTRAS: YES
+    #- PYTHON_VERSION: 3.6
+    #  PYTHON: "C:\\Miniconda36-x64"
+    #  CATEGORY: "nightly"
+    #  EXTRAS: YES
 
 
 install:
@@ -70,8 +70,6 @@ install:
   - conda update -q -y conda
   - conda config --set auto_update_conda false
   - conda install anaconda
-  - anaconda --version
-  - CRASH HERE
   #
   - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme"
   - python -m pip install codecov


### PR DESCRIPTION
## Fixes # .
- AppVeyor build failures

## Summary/Motivation:
Appveyor builds failing which doesn't allow test results on new PRs

## Changes proposed in this PR:
- For now, installing anaconda (instead of using AppVeyor's miniconda) seems to fix this.
- Only added back in 2.7, 3.5, and 3.6 (since anaconda install takes so long).
- ToDo: this is likely related to our use of conda-forge for all the numpy installs. A future PR should shift back to miniconda (remove the conda install anaconda line), and experiment with use of standard channel for extra packages instead of the conda-forge channel. This will allow us to remove the anaconda install and speed things up again.
(I will look at this later this week, but booked for the next couple of days.)


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
