### PR TITLE
Adds a missing import to core.base.symbolic

### DIFF
--- a/pyomo/core/base/symbolic.py
+++ b/pyomo/core/base/symbolic.py
@@ -14,6 +14,7 @@ from pyomo import core
 from pyomo.core.expr import current as EXPR
 from pyomo.core.expr import native_types
 from pyomo.common import DeveloperError
+from pyomo.core.expr.numvalue import value
 
 _sympy_available = True
 try:


### PR DESCRIPTION
## Summary/Motivation:
Adds a missing import. Without it, this line doesn't work: https://github.com/qtothec/pyomo/blob/f19bb51225d8a0597ac93d177a33a581d48ca063/pyomo/core/base/symbolic.py#L200

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
