### PR TITLE
[WIP] Switch back to miniconda with fixes for mkl errors in AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -82,7 +82,7 @@ install:
   #
   # Install pyomo.extras
   #
-  - "IF DEFINED EXTRAS (%ANACONDA% numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill)"
+  - "IF DEFINED EXTRAS (%ANACONDA% numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill mkl)"
   # These packages are not in anaconda, need to get them from conda-forge
   - "IF DEFINED EXTRAS (%CONDAFORGE% pymysql pyro4)"
   #- "IF DEFINED EXTRAS (%CONDAFORGE% numpy scipy ipython openpyxl sympy pymysql pyodbc pyro4 pyyaml networkx xlrd pandas matplotlib dill)"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,10 +36,10 @@ environment:
     #  CATEGORY: "nightly"
     #  EXTRAS: YES
 
-    - PYTHON_VERSION: 3.5
-      PYTHON: "C:\\Miniconda35-x64"
-      CATEGORY: "nightly"
-      EXTRAS: YES
+    #- PYTHON_VERSION: 3.5
+    #  PYTHON: "C:\\Miniconda35-x64"
+    #  CATEGORY: "nightly"
+    #  EXTRAS: YES
 
     - PYTHON_VERSION: 3.6
       PYTHON: "C:\\Miniconda36-x64"
@@ -69,7 +69,7 @@ install:
   - conda config --set always_yes yes
   - conda update -q -y conda
   - conda config --set auto_update_conda false
-  - conda install anaconda
+  # - conda install anaconda
   #
   - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme"
   - python -m pip install codecov
@@ -82,6 +82,8 @@ install:
   #
   # Install pyomo.extras
   #
+  - "IF DEFINED EXTRAS (%ANACONDA% numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill)"
+  # These packages are not in anaconda, need to get them from conda-forge
   - "IF DEFINED EXTRAS (%CONDAFORGE% pymysql pyro4)"
   #- "IF DEFINED EXTRAS (%CONDAFORGE% numpy scipy ipython openpyxl sympy pymysql pyodbc pyro4 pyyaml networkx xlrd pandas matplotlib dill)"
   #- "IF DEFINED EXTRAS (%CONDAFORGE% mkl)"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -82,7 +82,7 @@ install:
   #
   # Install pyomo.extras
   #
-  - "IF DEFINED EXTRAS (%ANACONDA% numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill mkl)"
+  - "IF DEFINED EXTRAS (%ANACONDA% numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill mkl=2017.0.3)"
   # These packages are not in anaconda, need to get them from conda-forge
   - "IF DEFINED EXTRAS (%CONDAFORGE% pymysql pyro4)"
   #- "IF DEFINED EXTRAS (%CONDAFORGE% numpy scipy ipython openpyxl sympy pymysql pyodbc pyro4 pyyaml networkx xlrd pandas matplotlib dill)"


### PR DESCRIPTION
We recently switched to anaconda instead of miniconda to get appveyor working again because of errors in mkl that may be associated with the conda-forge channel. This pull request will try to move us back to miniconda.

## Fixes # .
- AppVeyor failures due to mkl library error
- AppVeyor long run times due to installation of anaconda to fix above mkl error

## Summary/Motivation:
See above.

## Changes proposed in this PR:
- Remove anaconda installation (use standard miniconda from appveyor) to decrease appveyor build times
- Install scientific packages from anaconda channel instead of conda-forge channel to fix the mkl error

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
