### PR TITLE
fixing _linear_canonical_form flag on linear_constraint

### DIFF
--- a/pyomo/core/kernel/component_constraint.py
+++ b/pyomo/core/kernel/component_constraint.py
@@ -675,7 +675,7 @@ class linear_constraint(_MutableBoundsConstraintMixin,
     # To avoid a circular import, for the time being, this
     # property will be set externally
     _ctype = None
-    _linear_canonical_form = False
+    _linear_canonical_form = True
     __slots__ = ("_parent",
                  "_storage_key",
                  "_active",

--- a/pyomo/core/tests/unit/test_component_constraint.py
+++ b/pyomo/core/tests/unit/test_component_constraint.py
@@ -2021,6 +2021,7 @@ class Test_linear_constraint(unittest.TestCase):
         p = parameter(value=1)
 
         c = linear_constraint()
+        self.assertEqual(c._linear_canonical_form, True)
 
         #
         # compute_values = True

--- a/pyomo/core/tests/unit/test_component_matrix_constraint.py
+++ b/pyomo/core/tests/unit/test_component_matrix_constraint.py
@@ -1067,6 +1067,8 @@ class Test_matrix_constraint(unittest.TestCase):
         vlist = create_variable_list(2)
         ctuple = matrix_constraint(A, x=vlist)
         self.assertEqual(ctuple.sparse, True)
+        for c in ctuple:
+            self.assertEqual(c._linear_canonical_form, True)
         terms = list(ctuple[0].terms)
         vs,cs = zip(*terms)
         self.assertEqual(len(terms), 1)
@@ -1099,6 +1101,8 @@ class Test_matrix_constraint(unittest.TestCase):
         ctuple = matrix_constraint(A, x=vlist,
                                    sparse=False)
         self.assertEqual(ctuple.sparse, False)
+        for c in ctuple:
+            self.assertEqual(c._linear_canonical_form, True)
         terms = list(ctuple[0].terms)
         vs,cs = zip(*terms)
         self.assertEqual(len(terms), 2)


### PR DESCRIPTION
For some reason the `_linear_canonical_form` flag on the kernel `linear_constraint` class was set to False in the Pyomo5 expression merge. This disabled performance optimizations built into the solver interfaces that made model I/O ~2x faster for problems with a large core of linear constraints.

This PR sets that flag back to True and modifies unit tests to make sure it is not changed again.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
