### PR TITLE
Fix to solver tempfiles

### DIFF
--- a/pyomo/contrib/trustregion/PyomoInterface.py
+++ b/pyomo/contrib/trustregion/PyomoInterface.py
@@ -1,7 +1,6 @@
 import os
 import numpy as np
 from pyutilib.math import infinity
-from pyutilib.services import TempfileManager
 from pyomo.common.modeling import randint, unique_component_name
 from pyomo.core import Block, Var, Param, Set, VarList, ConstraintList, Constraint, Objective, RangeSet, value, ConcreteModel, Reals, sqrt, minimize, maximize
 from pyomo.core.expr import current as EXPR
@@ -13,7 +12,6 @@ from pyomo.opt import SolverFactory, SolverStatus, TerminationCondition
 from pyomo.contrib.trustregion.GeometryGenerator import (
     generate_quadratic_rom_geometry
 )
-from pyomo.contrib.trustregion.readgjh import *
 from pyomo.contrib.trustregion.helper import *
 
 class ROMType:
@@ -96,7 +94,6 @@ class PyomoInterface:
 
     '''
 
-    TempfileManager.tempdir = "."
     solver = 'ipopt'
     solver_io = 'nl'
     stream_solver = False # True prints solver output to screen
@@ -474,12 +471,9 @@ class PyomoInterface:
         self.deactiveExtraConObj()
         self.activateRomCons(x, rom_params)
 
-        optGJH = SolverFactory('gjh', solver_io='nl')
-
-        optGJH.solve(
-            model, keepfiles=True, tee=False, symbolic_solver_labels=True)
-
-        g, J, varlist, conlist = readgjh()
+        optGJH = SolverFactory('contrib.gjh')
+        optGJH.solve(model, tee=False, symbolic_solver_labels=True)
+        g, J, varlist, conlist = model._gjh_info
 
         l = ConcreteModel()
         l.v = Var(varlist, domain=Reals)

--- a/pyomo/contrib/trustregion/plugins.py
+++ b/pyomo/contrib/trustregion/plugins.py
@@ -1,6 +1,13 @@
+
+from pyutilib.services import TempfileManager
+from pyutilib.services import register_executable
+
 from pyomo.common import plugin
 from pyomo.opt.base import IOptSolver
+from pyomo.solvers.plugins.solvers.ASL import ASL
+
 from pyomo.contrib.trustregion.TRF import TRF
+from pyomo.contrib.trustregion.readgjh import readgjh
 import pyomo.contrib.trustregion.param as param
 
 def load():
@@ -42,3 +49,35 @@ class TrustRegionSolver(plugin.Plugin):
         assert not kwds
         #config = param.CONFIG(kwds)
         return TRF(model, eflist)#, config)
+
+class GJHSolver(ASL):
+    """An interface to the AMPL GJH "solver" for evaluating a model at a
+    point."""
+
+    plugin.implements(IOptSolver)
+    plugin.alias(
+        'contrib.gjh', doc='Interface to the AMPL GJH "solver"')
+
+    def __init__(self, **kwds):
+        kwds['type'] = 'gjh'
+        super(GJHSolver, self).__init__(**kwds)
+        self.options.solver = 'gjh'
+        self._metasolver = False
+
+    # A hackish way to hold on to the model so that we can parse the
+    # results.
+    def _initialize_callbacks(self, model):
+        print "SETUP", self._keepfiles, type(model)
+        self._model = model
+        self._model._gjh_info = None
+        super(GJHSolver, self)._initialize_callbacks(model)
+
+    def _presolve(self, *args, **kwds):
+        super(GJHSolver, self)._presolve(*args, **kwds)
+        self._gjh_file = self._soln_file[:-3]+'gjh'
+        TempfileManager.add_tempfile(self._gjh_file, exists=False)
+
+    def _postsolve(self):
+        self._model._gjh_info = readgjh(self._gjh_file)
+        self._model = None
+        return super(GJHSolver, self)._postsolve()

--- a/pyomo/contrib/trustregion/plugins.py
+++ b/pyomo/contrib/trustregion/plugins.py
@@ -78,6 +78,11 @@ class GJHSolver(ASL):
         TempfileManager.add_tempfile(self._gjh_file, exists=False)
 
     def _postsolve(self):
+        #
+        # TODO: We should return the information using a better data
+        # structure (ComponentMap? so that the GJH solver does not need
+        # to be called with symbolic_solver_labels=True
+        #
         self._model._gjh_info = readgjh(self._gjh_file)
         self._model = None
         return super(GJHSolver, self)._postsolve()

--- a/pyomo/contrib/trustregion/plugins.py
+++ b/pyomo/contrib/trustregion/plugins.py
@@ -67,7 +67,6 @@ class GJHSolver(ASL):
     # A hackish way to hold on to the model so that we can parse the
     # results.
     def _initialize_callbacks(self, model):
-        print "SETUP", self._keepfiles, type(model)
         self._model = model
         self._model._gjh_info = None
         super(GJHSolver, self)._initialize_callbacks(model)

--- a/pyomo/contrib/trustregion/plugins.py
+++ b/pyomo/contrib/trustregion/plugins.py
@@ -60,6 +60,7 @@ class GJHSolver(ASL):
 
     def __init__(self, **kwds):
         kwds['type'] = 'gjh'
+        kwds['symbolic_solver_labels'] = True
         super(GJHSolver, self).__init__(**kwds)
         self.options.solver = 'gjh'
         self._metasolver = False

--- a/pyomo/contrib/trustregion/readgjh.py
+++ b/pyomo/contrib/trustregion/readgjh.py
@@ -53,6 +53,9 @@ def readgjh(fname=None):
         data = f.readline()
     f.close()
 
+    #
+    # TODO: Parse the Hessian information
+    #
 
     f = open(fname[:-3]+'col',"r")
     data = f.read()

--- a/pyomo/contrib/trustregion/readgjh.py
+++ b/pyomo/contrib/trustregion/readgjh.py
@@ -9,88 +9,61 @@ import os, glob, six
 # to write the .row file and .col file to get variable mappings
 
 
-def readgjh():
-    flag = 0
-
-    for file in glob.glob("*.gjh"):
-
-        flag = flag+1
-        if flag > 1:
+def readgjh(fname=None):
+    print "FNAME", fname
+    if fname is None:
+        files = list(glob.glob("*.gjh"))
+        fname = files.pop(0)
+        if len(files) > 1:
             print("**** WARNING **** More than one gjh file in current directory")
+            print("  Processing: %s\nIgnoring: %s" % (
+                fname, '\n         '.join(files)))
 
-        f = open(file,"r")
+    f = open(fname,"r")
 
-        data = "dummy_str"
-        while data != "param g :=\n":
-            data = f.readline()
-
+    data = "dummy_str"
+    while data != "param g :=\n":
         data = f.readline()
-        g = []
-        while data[0] != ';':
-            # gradient entry (sparse)
-            entry = [int(data.split()[0]) - 1, float(data.split()[1])] # subtract 1 to index from 0
-            g.append(entry) # build obj gradient in sparse format
-            data = f.readline()
 
-
-        while data != "param J :=\n":
-            data = f.readline()
-
+    data = f.readline()
+    g = []
+    while data[0] != ';':
+        # gradient entry (sparse)
+        entry = [int(data.split()[0]) - 1, float(data.split()[1])] # subtract 1 to index from 0
+        g.append(entry) # build obj gradient in sparse format
         data = f.readline()
-        J = []
-        while data[0] != ';':
-            if data[0] == '[':
-                # Jacobian row index
-                #
-                # The following replaces int(filter(str.isdigit,data)),
-                # which only works in 2.x
-                data_as_int = int(''.join(six.moves.filter(str.isdigit, data)))
-                row = data_as_int - 1  # subtract 1 to index from 0
-                data = f.readline()
 
-            entry = [row, int(data.split()[0]) - 1, float(data.split()[1])]  # subtract 1 to index from 0
-            J.append(entry) # Jacobian entries, sparse format
+
+    while data != "param J :=\n":
+        data = f.readline()
+
+    data = f.readline()
+    J = []
+    while data[0] != ';':
+        if data[0] == '[':
+            # Jacobian row index
+            #
+            # The following replaces int(filter(str.isdigit,data)),
+            # which only works in 2.x
+            data_as_int = int(''.join(six.moves.filter(str.isdigit, data)))
+            row = data_as_int - 1  # subtract 1 to index from 0
             data = f.readline()
-        f.close()
+
+        entry = [row, int(data.split()[0]) - 1, float(data.split()[1])]  # subtract 1 to index from 0
+        J.append(entry) # Jacobian entries, sparse format
+        data = f.readline()
+    f.close()
 
 
+    f = open(fname[:-3]+'col',"r")
+    data = f.read()
+    varlist = data.split()
+    f.close()
 
-
-    flag = 0
-    for file in glob.glob("*.col"):
-
-        flag = flag +1
-        if flag > 1:
-            print("**** WARNING **** More than one .col file in current directory")
-
-        f = open(file,"r")
-        data = f.read()
-        varlist = data.split()
-        f.close()
-
-
-    flag = 0
-    for file in glob.glob("*.row"):
-
-        flag = flag +1
-        if flag > 1:
-            print("**** WARNING **** More than one .row file in current directory")
-
-        f = open(file,"r")
-        data = f.read()
-        conlist = data.split()
-        f.close()
-
-
-
-
-    # Cleanup
-    tmpfiles = ( glob.glob("tmp*.col") + glob.glob("tmp*.row") + glob.glob("tmp*.sol") +
-        glob.glob("tmp*.log") + glob.glob("tmp*.nl") + glob.glob("tmp*.gjh") )
-    for file in tmpfiles:
-         os.remove(file)
-
-
+    f = open(fname[:-3]+'row',"r")
+    data = f.read()
+    conlist = data.split()
+    f.close()
 
     return g,J,varlist,conlist
 

--- a/pyomo/contrib/trustregion/readgjh.py
+++ b/pyomo/contrib/trustregion/readgjh.py
@@ -10,7 +10,6 @@ import os, glob, six
 
 
 def readgjh(fname=None):
-    print "FNAME", fname
     if fname is None:
         files = list(glob.glob("*.gjh"))
         fname = files.pop(0)

--- a/pyomo/solvers/plugins/converter/model.py
+++ b/pyomo/solvers/plugins/converter/model.py
@@ -171,6 +171,13 @@ class PyomoMIPConverter(SingletonPlugin):
             if args[1] == ProblemFormat.nl:
                 problem_filename = pyutilib.services.TempfileManager.\
                                    create_tempfile(suffix = '.pyomo.nl')
+                if io_options.get("symbolic_solver_labels", False):
+                    pyutilib.services.TempfileManager.add_tempfile(
+                        problem_filename[:-3]+".row",
+                        exists=False)
+                    pyutilib.services.TempfileManager.add_tempfile(
+                        problem_filename[:-3]+".col",
+                        exists=False)
             else:
                 assert args[1] == ProblemFormat.mps
                 problem_filename = pyutilib.services.TempfileManager.\

--- a/pyomo/solvers/plugins/solvers/GUROBI.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI.py
@@ -27,7 +27,7 @@ from pyomo.core.kernel.component_block import IBlockStorage
 
 logger = logging.getLogger('pyomo.solvers')
 
-from six import iteritems
+from six import iteritems, StringIO
 
 try:
     unicode
@@ -262,17 +262,14 @@ class GUROBISHELL(ILMLicensedSystemCallSolver):
         solver_exec = self.executable()
         if solver_exec is None:
             return _extract_version('')
-        outname = pyutilib.services.TempfileManager.create_tempfile(suffix = '.gurobi.version')
-        with open(outname,'w') as f:
-            # **Note, adding a 'timelimit' keyword here results in empty output for some reason
-            results = pyutilib.subprocess.run([solver_exec],
-                                              stdin=('from gurobipy import *; '
-                                                     'print(gurobi.version()); exit()'),
-                                              ostream=f)
+        f = StringIO()
+        results = pyutilib.subprocess.run([solver_exec],
+                                          stdin=('from gurobipy import *; '
+                                                 'print(gurobi.version()); exit()'),
+                                          ostream=f)
         tmp = None
         try:
-            with open(outname,'r') as f:
-                tmp = tuple(eval(f.read().strip()))
+            tmp = tuple(eval(f.getvalue().strip()))
             while(len(tmp) < 4):
                 tmp += (0,)
         except SyntaxError:


### PR DESCRIPTION
Recently, I noticed that a massive amount of temporary .row and .col solver files were left around in the working directory after running solver tests. The cause of this was twofold:

 1. When an NL-file based solver was used, we were actually never adding the .row and .col files to the TempfileManager.
 2. The recently added `pyomo.contrib.trustregion.PyomoInterface.PyomoInterface` class definition (which gets imported with `pyomo.environ`) includes the line `TempfileManager.tempdir = "."` at the class scope. As a result, the default tempdir for anyone who imports `pyomo.environ` is now `.`.

Issue (1) has existed since the beginning of time, and issue (2) made it easily observable.

This PR fixes (1) and also include a small improvement to GUROBI.py that avoids creating a file to extract the solver version, which was also not being cleaned up in most cases.

I think someone should commit a fix for (2) as part of this PR.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
