### PR TITLE
Prevent crash when solver returns suffixes but not values for variables

### DIFF
--- a/pyomo/opt/plugins/sol.py
+++ b/pyomo/opt/plugins/sol.py
@@ -213,11 +213,10 @@ class ResultsReader_sol(results.AbstractResultsReader):
                     if kind == 0: # Var
                         for cnt in xrange(nvalues):
                             suf_line = fin.readline().split()
-                            # make sure an entry exists (solvers sometimes
-                            # return suffixes but not values)
-                            sol_var = soln_variable \
-                                .setdefault("v"+suf_line[0], {'Value': None})
-                            sol_var[suffix_name] = convert_function(suf_line[1])
+                            key = "v"+suf_line[0]
+                            if key not in soln_variable:
+                                soln_variable[key] = {}
+                            soln_variable[key] = convert_function(suf_line[1])
                     elif kind == 1: # Con
                         for cnt in xrange(nvalues):
                             suf_line = fin.readline().split()

--- a/pyomo/opt/plugins/sol.py
+++ b/pyomo/opt/plugins/sol.py
@@ -2,8 +2,8 @@
 #
 #  Pyomo: Python Optimization Modeling Objects
 #  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
-#  Under the terms of Contract DE-NA0003525 with National Technology and 
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
@@ -213,8 +213,11 @@ class ResultsReader_sol(results.AbstractResultsReader):
                     if kind == 0: # Var
                         for cnt in xrange(nvalues):
                             suf_line = fin.readline().split()
-                            soln_variable["v"+suf_line[0]][suffix_name] = \
-                                convert_function(suf_line[1])
+                            # make sure an entry exists (solvers sometimes
+                            # return suffixes but not values)
+                            sol_var = soln_variable \
+                                .setdefault("v"+suf_line[0], {'Value': None})
+                            sol_var[suffix_name] = convert_function(suf_line[1])
                     elif kind == 1: # Con
                         for cnt in xrange(nvalues):
                             suf_line = fin.readline().split()

--- a/pyomo/opt/plugins/sol.py
+++ b/pyomo/opt/plugins/sol.py
@@ -216,7 +216,8 @@ class ResultsReader_sol(results.AbstractResultsReader):
                             key = "v"+suf_line[0]
                             if key not in soln_variable:
                                 soln_variable[key] = {}
-                            soln_variable[key] = convert_function(suf_line[1])
+                            soln_variable[key][suffix_name] = \
+                                convert_function(suf_line[1])
                     elif kind == 1: # Con
                         for cnt in xrange(nvalues):
                             suf_line = fin.readline().split()

--- a/pyomo/opt/plugins/sol.py
+++ b/pyomo/opt/plugins/sol.py
@@ -215,7 +215,7 @@ class ResultsReader_sol(results.AbstractResultsReader):
                             suf_line = fin.readline().split()
                             key = "v"+suf_line[0]
                             if key not in soln_variable:
-                                soln_variable[key] = {"Value": None}
+                                soln_variable[key] = {}
                             soln_variable[key][suffix_name] = \
                                 convert_function(suf_line[1])
                     elif kind == 1: # Con

--- a/pyomo/opt/plugins/sol.py
+++ b/pyomo/opt/plugins/sol.py
@@ -224,9 +224,14 @@ class ResultsReader_sol(results.AbstractResultsReader):
                             key = "c"+suf_line[0]
                             if key not in soln_constraint:
                                 soln_constraint[key] = {}
-                            # convert the first letter of the suffix name to upper case,
-                            # mainly for pretty-print / output purposes. these are lower-cased
-                            # when loaded into real suffixes, so it is largely redundant.
+                            # GH: About the comment below: This makes for a
+                            # confusing results object and more confusing tests.
+                            # We should not muck with the names of suffixes
+                            # coming out of the sol file.
+                            #
+                            #   convert the first letter of the suffix name to upper case,
+                            #   mainly for pretty-print / output purposes. these are lower-cased
+                            #   when loaded into real suffixes, so it is largely redundant.
                             translated_suffix_name = suffix_name[0].upper() + suffix_name[1:]
                             soln_constraint[key][translated_suffix_name] = \
                                 convert_function(suf_line[1])

--- a/pyomo/opt/plugins/sol.py
+++ b/pyomo/opt/plugins/sol.py
@@ -215,7 +215,7 @@ class ResultsReader_sol(results.AbstractResultsReader):
                             suf_line = fin.readline().split()
                             key = "v"+suf_line[0]
                             if key not in soln_variable:
-                                soln_variable[key] = {}
+                                soln_variable[key] = {"Value": None}
                             soln_variable[key][suffix_name] = \
                                 convert_function(suf_line[1])
                     elif kind == 1: # Con

--- a/pyomo/opt/tests/base/iis_no_variable_values.sol
+++ b/pyomo/opt/tests/base/iis_no_variable_values.sol
@@ -1,0 +1,34 @@
+CPLEX 12.8.0.0: integer infeasible.
+0 MIP simplex iterations
+0 branch-and-bound nodes
+Returning an IIS of 2 variables and 1 constraints.
+No basis.
+
+Options
+3
+1
+1
+0
+1
+0
+2
+0
+objno 0 220
+suffix 0 2 4 181 11
+iis
+
+0	non	not in the iis
+1	low	at lower bound
+2	fix	fixed
+3	upp	at upper bound
+4	mem	member
+5	pmem	possible member
+6	plow	possibly at lower bound
+7	pupp	possibly at upper bound
+8	bug
+
+0 1
+1 1
+suffix 1 1 4 0 0
+iis
+0 4


### PR DESCRIPTION
## Fixes #597.

## Summary/Motivation:
When the user requests an irreducibly infeasible set of constraints (IIS) for an infeasible mixed-integer program, cplexamp sometimes returns the IIS but not values for the variables. This currently causes pyomo to crash. Specifically, `pyomo.opt.plugins.sol` only creates entries in `soln_variable` for variables whose values have been returned by the solver, but then it tries to attach the IIS suffix value to a non-existent item in `soln_variable`, causing an uncaught `KeyError()`.

There is already code in `pyomo.opt.plugins.sol` to prevent this problem with constraints. This pull request applies similar code to avoid this problem with variables.

The code below currently crashes Pyomo, but this error is fixed by the proposed changes:

    from pyomo.environ import *
    m = ConcreteModel()
    m.x1 = Var(within=NonNegativeReals)
    m.x2 = Var(within=NonNegativeIntegers)
    m.constraint = Constraint(rule=lambda m: m.x1 + m.x2 <= -1)
    m.objective = Objective(rule=lambda m: m.x1 + m.x2, sense=minimize)
    m.iis = Suffix(direction=Suffix.IMPORT)
    solver = SolverFactory('cplexamp')
    res = solver.solve(m, options_string='iisfind=1', tee=True)
    print("IIS:")
    print("\n".join(sorted(c.name for c in m.iis)))

## Changes proposed in this PR:
- add a dummy entry (`{'Value': None}`) to `soln_variable` if needed before applying the suffix. Note that this entry must include a `'Value'` key in order to prevent other errors later.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.