### PR TITLE
Updating TravisCI to use python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ script:
   - ${DOC} pip list
   - ${DOC} test.pyomo -v --cat=$CATEGORY pyomo `pwd`/pyomo-model-libraries
  # Run documentation tests
-  - if [[ "$IMAGE_NAME" != "test-builds:python_3.7-rc" ]]; then ${DOC} make -C doc/OnlineDocs doctest -d; fi
+  - if [[ "$IMAGE_NAME" != "test-builds:python_3.7" ]]; then ${DOC} make -C doc/OnlineDocs doctest -d; fi
 
 after_script:
  # Kill the docker container

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   global:
   - DOCKERHUB_USERNAME=qkjqvazeqfjqftchxlgw
   matrix:
-  - IMAGE_NAME=test-builds:python_3.7-rc CATEGORY="nightly"
+  - IMAGE_NAME=test-builds:python_3.7    CATEGORY="nightly"
   - IMAGE_NAME=test-builds:python_3.6    CATEGORY="nightly"
   - IMAGE_NAME=test-builds:python_3.6    CATEGORY="nightly" SLIM=1
   - IMAGE_NAME=test-builds:python_3.5    CATEGORY="nightly"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pyomo is available under the BSD License.
 
 Pyomo is currently tested with the following Python implementations:
 
-* CPython: 2.7, 3.4, 3.5, 3.6
+* CPython: 2.7, 3.4, 3.5, 3.6, 3.7
 * PyPy: 2, 3
 
 ### Installation

--- a/pyomo/pysp/ef_writer_script.py
+++ b/pyomo/pysp/ef_writer_script.py
@@ -15,11 +15,6 @@ import time
 import itertools
 import math
 
-try:
-    from collections import OrderedDict
-except ImportError:                         #pragma:nocover
-    from ordereddict import OrderedDict
-
 import pyutilib.misc
 from pyutilib.pyro import shutdown_pyro_components
 

--- a/pyomo/pysp/solvers/ef.py
+++ b/pyomo/pysp/solvers/ef.py
@@ -14,11 +14,6 @@ import time
 import itertools
 import math
 
-try:
-    from collections import OrderedDict
-except ImportError:                         #pragma:nocover
-    from ordereddict import OrderedDict
-
 import pyutilib.misc
 from pyutilib.pyro import shutdown_pyro_components
 

--- a/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanager.py
+++ b/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanager.py
@@ -13,6 +13,7 @@ import os
 import time
 import subprocess
 import sys
+import collections
 if sys.version_info[:2] >= (3,6):
     _ordered_dict_ = dict
 else:

--- a/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanager.py
+++ b/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanager.py
@@ -12,10 +12,15 @@
 import os
 import time
 import subprocess
-try:
-    from collections import OrderedDict
-except ImportError:                         #pragma:nocover
-    from ordereddict import OrderedDict
+import sys
+if sys.version_info[:2] >= (3,6):
+    _ordered_dict_ = dict
+else:
+    try:
+        _ordered_dict_ = collections.OrderedDict
+    except ImportError:                         #pragma:nocover
+        import ordereddict
+        _ordered_dict_ = ordereddict.OrderedDict
 
 from pyutilib.pyro import using_pyro3, using_pyro4
 from pyomo.pysp.util.misc import (_get_test_nameserver,
@@ -153,16 +158,16 @@ def _PerBundleChained_noargs(worker, bundle):
 
 class _ScenarioTreeManagerTesterBase(object):
 
-    _bundle_dict3 = OrderedDict()
+    _bundle_dict3 = _ordered_dict_()
     _bundle_dict3['Bundle1'] = ['Scenario1']
     _bundle_dict3['Bundle2'] = ['Scenario2']
     _bundle_dict3['Bundle3'] = ['Scenario3']
 
-    _bundle_dict2 = OrderedDict()
+    _bundle_dict2 = _ordered_dict_()
     _bundle_dict2['Bundle1'] = ['Scenario1', 'Scenario2']
     _bundle_dict2['Bundle2'] = ['Scenario3']
 
-    _bundle_dict1 = OrderedDict()
+    _bundle_dict1 = _ordered_dict_()
     _bundle_dict1['Bundle1'] = ['Scenario1','Scenario2','Scenario3']
 
     @unittest.nottest

--- a/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanagersolver.py
+++ b/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanagersolver.py
@@ -12,10 +12,6 @@
 import os
 import time
 import subprocess
-try:
-    from collections import OrderedDict
-except ImportError:                         #pragma:nocover
-    from ordereddict import OrderedDict
 
 from pyutilib.pyro import using_pyro3, using_pyro4
 from pyomo.pysp.util.misc import (_get_test_nameserver,


### PR DESCRIPTION
We can merge this branch when a docker image is available.

## Fixes NA.

## Summary/Motivation:
Now that Python 3.7 has been released, we need to update our nightly tests to use the latest release.

## Changes proposed in this PR:
- Updates to Travis docker

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
