### PR TITLE
Change deprecated 'warn' to 'warning'

### DIFF
--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -231,18 +231,20 @@ class ModelSolutions(object):
         # If there is a warning, then print a warning message.
         #
         if (results.solver.status == pyomo.opt.SolverStatus.warning):
-            logger.warn('Loading a SolverResults object with a '
-                        'warning status into model=%s;\n'
-                        '    message from solver=%s'
-                        % (instance.name, results.solver.Message))
+            logger.warning(
+                'Loading a SolverResults object with a '
+                'warning status into model=%s;\n'
+                '    message from solver=%s'
+                % (instance.name, results.solver.Message))
         #
         # If the solver status not one of either OK or Warning, then generate an error.
         #
         elif results.solver.status != pyomo.opt.SolverStatus.ok:
             if (results.solver.status == pyomo.opt.SolverStatus.aborted) and \
                (len(results.solution) > 0):
-                logger.warn("Loading a SolverResults object with "
-                            "an 'aborted' status, but containing a solution")
+                logger.warning(
+                    "Loading a SolverResults object with "
+                    "an 'aborted' status, but containing a solution")
             else:
                 raise ValueError("Cannot load a SolverResults object "
                                  "with bad status: %s"


### PR DESCRIPTION
## Summary/Motivation:
In Python 3.x, calling `logger.warn()` results in a deprecation warning.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
