### PR TITLE
Fix errors in Jenkins driver when files are moved/renamed

### DIFF
--- a/admin/driver.py
+++ b/admin/driver.py
@@ -114,6 +114,20 @@ def perform_install(package, config=None, user='hudson', dest='python', virtuale
             os.path.join(os.environ['WORKSPACE'], 'build', 'bin'),
             os.environ['PATH'] )
 
+    # We must cleanup old PYC files for the case that sources were
+    # renamed/deleted (coverage will fail if it finds PYC files
+    # without corresponding PY files).
+    sys.stdout.write("\n")
+    for dirpath, dnames, fnames in os.walk(
+        os.path.join(os.environ['WORKSPACE'],'src')):
+        for fname in fnames:
+            if not fname.endswith(('.pyc','.PYC')):
+                continue
+            if fname[:-1] not in fnames:
+                sys.stdout.write("Removing dangling PYC file: %s\n"
+                                 % os.path.join(dirpath, fname))
+                os.remove(os.path.join(dirpath, fname))
+
     python=os.environ.get('PYTHON','')
     if python == '':
         python = sys.executable

--- a/admin/jenkins.py
+++ b/admin/jenkins.py
@@ -22,6 +22,12 @@ hname = hname.split('.')[0]
 print("\nStarting jenkins.py")
 print("Configuration=%s" % config)
 
+if os.environ.get('WORKSPACE', None) is None:
+    sys.stdout.write(
+        "\n(INFO) WORKSPACE environment vatiable not found."
+        "\n       Assuming WORKSPACE==%s\n\n" % (os.getcwd(),) )
+    os.environ['WORKSPACE'] = os.getcwd()
+
 os.environ['CONFIGFILE'] = os.environ['WORKSPACE']+'/src/pyomo/admin/config.ini'
 #
 # Is the following even needed?

--- a/admin/jenkins.py
+++ b/admin/jenkins.py
@@ -132,3 +132,5 @@ elif config == "booktests" or config == "book":
 elif config == "perf":
     os.environ['NOSE_PROCESS_TIMEOUT'] = '1800'
     driver.perform_build('pyomo', cat='performance')
+else:
+    raise RuntimeError("Unknown Jenkins configuration: '%s'" % (config,))


### PR DESCRIPTION
## Summary/Motivation:
The Jenkins jobs fail whenever a file is renamed/moved/deleted until ad admin goes in and wipes the workspace.  This is due to the coverage analysis failing when there are PYC files that lack corresponding PY files.  This PR adds logic to search for and remove these problematic PYC files.

## Changes proposed in this PR:
- Remove lingering PYC files that lack corresponding PY files before beginning build/install

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
