### PR TITLE
Cause Jenkins to delete any coverage info from previous builds

### DIFF
--- a/admin/driver.py
+++ b/admin/driver.py
@@ -192,7 +192,7 @@ def perform_tests(package, coverage=False, omit=None, cat='nightly'):
         cmd = [os.path.join( os.environ['WORKSPACE'],'python','bin','test.'+package ), '--cat', cat]
     cmd.append('-v')
     if coverage:
-        cmd.append('--coverage')
+        cmd.extend(['--coverage','--cover-erase'])
     if 'TEST_PACKAGES' in os.environ:
         cmd = cmd + re.split('[ \t]+', os.environ['TEST_PACKAGES'].strip())
     sys.stdout.write( "Running Command: %s\n" % " ".join(cmd) )


### PR DESCRIPTION
## Summary/Motivation:
Have the Jenkins test driver delete any previously-collected coverage information.  This continues work started in #627.

## Changes proposed in this PR:
- include the `--cover-erase` flag to `test.pyomo`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
