### PR TITLE
Fix for decoding unicode in Jenkins booktests driver

### DIFF
--- a/admin/jenkins.py
+++ b/admin/jenkins.py
@@ -122,7 +122,7 @@ elif config == "booktests" or config == "book":
         output = _run_cmd("python/bin/python src/pyomo/scripts/get_pyomo_extras.py -v", shell=True)
     elif _run_cmd is subprocess.check_output:
         output = _run_cmd("python/bin/python src/pyomo/scripts/get_pyomo_extras.py -v", shell=True)
-        print(output.decode('ascii'))
+        print(output.decode('utf-8'))
     else:
         assert False
     # Test


### PR DESCRIPTION
## Summary/Motivation:
Switch unicode decoding from ascii to utf-8 to resolve booktests failures.

## Changes proposed in this PR:

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
