### PR TITLE
Fix if statement for solver arg in GAMS writer

### DIFF
--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -631,11 +631,11 @@ class ProblemWriter_gams(AbstractProblemWriter):
                 (2 if (categorized_vars.binary or categorized_vars.ints)
                  else 0)]
 
-        if (solver is not None and
-            mtype.upper() not in valid_solvers[solver.upper()]):
-            raise ValueError("GAMS writer passed solver (%s) "
-                             "unsuitable for model type (%s)"
-                             % (solver, mtype))
+        if solver is not None:
+            if mtype.upper() not in valid_solvers[solver.upper()]:
+                raise ValueError("GAMS writer passed solver (%s) "
+                                 "unsuitable for model type (%s)"
+                                 % (solver, mtype))
             output_file.write("option %s=%s;\n" % (mtype, solver))
 
         if add_options is not None:

--- a/pyomo/repn/tests/test_gams.py
+++ b/pyomo/repn/tests/test_gams.py
@@ -100,8 +100,8 @@ class GAMSTests(unittest.TestCase):
         m.c = Constraint(expr=m.x == 2)
         m.o = Objective(expr=m.x)
         os = StringIO()
-        m.write(os, format="gams", io_options=dict(solver="baron"))
-        self.assertIn("option lp=baron", os.getvalue())
+        m.write(os, format="gams", io_options=dict(solver="gurobi"))
+        self.assertIn("option lp=gurobi", os.getvalue())
 
 
 if __name__ == "__main__":

--- a/pyomo/repn/tests/test_gams.py
+++ b/pyomo/repn/tests/test_gams.py
@@ -94,6 +94,15 @@ class GAMSTests(unittest.TestCase):
             pat * 3477 + "var1 +\nlog(var2 / 9) - " +
             pat * 3043 + "x")
 
+    def test_solver_arg(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.c = Constraint(expr=m.x == 2)
+        m.o = Objective(expr=m.x)
+        os = StringIO()
+        m.write(os, format="gams", io_options=dict(solver="baron"))
+        self.assertIn("option lp=baron", os.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary/Motivation:
I created a small bug in the gams ctypes PR that started ignoring the `solver` argument to the writer. This is a quick fix for it.

## Changes proposed in this PR:
- Fix bug
- Add a test

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
