### PR TITLE
Add support for sqrt function in differentiate()

### DIFF
--- a/pyomo/core/base/symbolic.py
+++ b/pyomo/core/base/symbolic.py
@@ -54,6 +54,7 @@ try:
         sympy.atanh: lambda x: core.atanh(x),
         sympy.ceiling: lambda x: core.ceil(x),
         sympy.floor: lambda x: core.floor(x),
+        sympy.sqrt: lambda x: core.sqrt(x),
         sympy.Derivative: _nondifferentiable,
     }
 
@@ -75,6 +76,7 @@ try:
         'atanh': sympy.atanh,
         'ceil': sympy.ceiling,
         'floor': sympy.floor,
+        'sqrt': sympy.sqrt,
     }
 except ImportError: #pragma:nocover
     _sympy_available = False

--- a/pyomo/core/tests/unit/test_symbolic.py
+++ b/pyomo/core/tests/unit/test_symbolic.py
@@ -237,6 +237,15 @@ class SymbolicDerivatives(unittest.TestCase):
         self.assertEqual(s(e), s(m.x**-1.0 * 1.0/log(10) * log(m.x)**-1.0))
 
 
+    def test_sqrt_function(self):
+        m = ConcreteModel()
+        m.x = Var()
+
+        e = differentiate(sqrt(m.x), wrt=m.x)
+        self.assertTrue(e.is_expression_type())
+        self.assertEqual(s(e), s(0.5 * m.x**-0.5))
+
+
     def test_nondifferentiable(self):
         m = ConcreteModel()
         m.x = Var()

--- a/pyomo/core/tests/unit/test_symbolic.py
+++ b/pyomo/core/tests/unit/test_symbolic.py
@@ -236,7 +236,6 @@ class SymbolicDerivatives(unittest.TestCase):
         self.assertTrue(e.is_expression_type())
         self.assertEqual(s(e), s(m.x**-1.0 * 1.0/log(10) * log(m.x)**-1.0))
 
-
     def test_sqrt_function(self):
         m = ConcreteModel()
         m.x = Var()
@@ -244,7 +243,6 @@ class SymbolicDerivatives(unittest.TestCase):
         e = differentiate(sqrt(m.x), wrt=m.x)
         self.assertTrue(e.is_expression_type())
         self.assertEqual(s(e), s(0.5 * m.x**-0.5))
-
 
     def test_nondifferentiable(self):
         m = ConcreteModel()


### PR DESCRIPTION
## Summary/Motivation:
Adds two lines and a test to enable `sqrt` support for `differentiate()`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
