### PR TITLE
Minor GDP fixes

### DIFF
--- a/pyomo/gdp/basic_step.py
+++ b/pyomo/gdp/basic_step.py
@@ -48,7 +48,7 @@ def apply_basic_step(disjunctions_or_constraints):
     constraints = list(obj for obj in disjunctions_or_constraints
                        if obj.type() == Constraint)
     for d in disjunctions:
-        if not d.parent_component().xor:
+        if not d.xor:
             raise ValueError(
                 "Basic steps can only be applied to XOR'd disjunctions\n\t"
                 "(raised by disjunction %s)" % (d.name,))

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -308,7 +308,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         check_linear_coef(self, repn, model.a, 1)
         check_linear_coef(self, repn, model.d[0].indicator_var, cons1lb)
         self.assertEqual(repn.constant, -cons1lb)
-        self.assertIs(c['lb'].lower, model.d[0].c.lower)
+        self.assertEqual(c['lb'].lower, model.d[0].c.lower)
         self.assertIsNone(c['lb'].upper)
 
         # second constraint
@@ -321,7 +321,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         check_linear_coef(self, repn, model.a, 1)
         check_linear_coef(self, repn, model.d[1].indicator_var, cons2lb)
         self.assertEqual(repn.constant, -cons2lb)
-        self.assertIs(c['lb'].lower, model.d[1].c1.lower)
+        self.assertEqual(c['lb'].lower, model.d[1].c1.lower)
         self.assertIsNone(c['lb'].upper)
         self.assertTrue(c['ub'].active)
         repn = generate_standard_repn(c['ub'].body)
@@ -331,7 +331,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         check_linear_coef(self, repn, model.d[1].indicator_var, cons2ub)
         self.assertEqual(repn.constant, -cons2ub)
         self.assertIsNone(c['ub'].lower)
-        self.assertIs(c['ub'].upper, model.d[1].c1.upper)
+        self.assertEqual(c['ub'].upper, model.d[1].c1.upper)
 
         # third constraint
         c = disjBlock[1].component("d[1].c2")
@@ -344,7 +344,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         check_linear_coef(self, repn, model.d[1].indicator_var, cons3ub)
         self.assertEqual(repn.constant, -cons3ub)
         self.assertIsNone(c['ub'].lower)
-        self.assertIs(c['ub'].upper, model.d[1].c2.upper)
+        self.assertEqual(c['ub'].upper, model.d[1].c2.upper)
 
     def test_suffix_M_None(self):
         m = models.makeTwoTermDisj()


### PR DESCRIPTION
## Summary/Motivation:
This fixes two minor problems:
  - the basic steps function was looking in the wrong place for the `xor` flag (it got moved to the _DisjunctionData)
  - the BigM tests were fragile and failing in some situations under Jenkins

## Changes proposed in this PR:
- (minor bug fixes)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
