### PR TITLE
Correctly sizing the hes buffer, per AMPL documentation

### DIFF
--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -129,9 +129,10 @@ class AMPLExternalFunction(ExternalFunction):
         if fixed is None:
             fixed = tuple( arg.__class__ in native_types or arg.is_fixed()
                            for arg in args )
+        N = len(args)
         f, arglist = self._evaluate(args, 2, fixed)
-        g = [arglist.derivs[i] for i in range(len(args))]
-        h = [arglist.hes[i] for i in range(len(args)**2)]
+        g = [arglist.derivs[i] for i in range(N)]
+        h = [arglist.hes[i] for i in range((N+N**2)//2)]
         return f, g, h
 
     def load_library(self):
@@ -274,7 +275,7 @@ class _ARGLIST(Structure):
         if fgh > 0:
             self.derivs = (c_double*N)(0.)
         if fgh > 1:
-            self.hes = (c_double*(N*N))(0.)
+            self.hes = (c_double*((N+N*N)//2))(0.)
 
         for i,v in enumerate(args):
             self.at[i] = i

--- a/pyomo/core/tests/unit/test_external.py
+++ b/pyomo/core/tests/unit/test_external.py
@@ -109,7 +109,6 @@ class TestAMPLExternalFunction(unittest.TestCase):
         f,g,h = model.bessel.evaluate_fgh((2.5, 2.0,), fixed=[1,0])
         self.assertAlmostEqual(f, 0.223924531469, 7)
         self.assertAlmostEqual(g, [0.0, 0.21138811435101745], 7)
-        print h
         self.assertAlmostEqual(h, [0.0, 0.0, 0.02026349177575621], 7)
 
     @unittest.skipIf(not check_available_solvers('ipopt'),

--- a/pyomo/core/tests/unit/test_external.py
+++ b/pyomo/core/tests/unit/test_external.py
@@ -109,7 +109,8 @@ class TestAMPLExternalFunction(unittest.TestCase):
         f,g,h = model.bessel.evaluate_fgh((2.5, 2.0,), fixed=[1,0])
         self.assertAlmostEqual(f, 0.223924531469, 7)
         self.assertAlmostEqual(g, [0.0, 0.21138811435101745], 7)
-        self.assertAlmostEqual(h, [0.0, 0.0, 0.02026349177575621, 0.0], 7)
+        print h
+        self.assertAlmostEqual(h, [0.0, 0.0, 0.02026349177575621], 7)
 
     @unittest.skipIf(not check_available_solvers('ipopt'),
                      "The 'ipopt' solver is not available")


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
This is a followup on #666 / #664. @eslickj noted that AMPL only requires the upper triangle of the matrix.

## Changes proposed in this PR:
- Reduce the size of the `hes` buffer to (N+N**2)//2

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
