### PR TITLE
Adding import check to dataportal test

### DIFF
--- a/pyomo/core/tests/examples/test_tutorials.py
+++ b/pyomo/core/tests/examples/test_tutorials.py
@@ -27,6 +27,17 @@ try:
     _win32com=True
 except:
     _win32com=False #pragma:nocover
+
+if _win32com:
+    from pyutilib.excel.spreadsheet_win32com import ExcelSpreadsheet_win32com
+    tmp = ExcelSpreadsheet_win32com()
+    try:
+        tmp._excel_dispatch()
+        tmp._excel_quit()
+        _excel_available = True
+    except:
+        _excel_available = False
+
 try:
     import xlrd
     _xlrd=True
@@ -37,11 +48,7 @@ try:
     _openpyxl=True
 except:
     _openpyxl=False
-try:
-    import pyodbc
-    _pyodbc=True
-except:
-    _pyodbc=False
+
 
 class PyomoTutorials(unittest.TestCase):
 
@@ -55,7 +62,7 @@ class PyomoTutorials(unittest.TestCase):
         pyutilib.misc.run_file(tutorial_dir+"data.py", logfile=currdir+"data.log", execdir=tutorial_dir)
         self.assertFileEqualsBaseline(currdir+"data.log", tutorial_dir+"data.out")
 
-    @unittest.skipIf(not (_win32com or _xlrd or _openpyxl or _pyodbc), "Cannot read excel file.")
+    @unittest.skipIf(not ((_win32com and _excel_available) or _xlrd or _openpyxl), "Cannot read excel file.")
     def test_excel(self):
         pyutilib.misc.run_file(tutorial_dir+"excel.py", logfile=currdir+"excel.log", execdir=tutorial_dir)
         self.assertFileEqualsBaseline(currdir+"excel.log", tutorial_dir+"excel.out")

--- a/pyomo/core/tests/examples/test_tutorials.py
+++ b/pyomo/core/tests/examples/test_tutorials.py
@@ -55,7 +55,7 @@ class PyomoTutorials(unittest.TestCase):
         pyutilib.misc.run_file(tutorial_dir+"data.py", logfile=currdir+"data.log", execdir=tutorial_dir)
         self.assertFileEqualsBaseline(currdir+"data.log", tutorial_dir+"data.out")
 
-    @unittest.skipIf(not (_win32com or _xlrd or _openpyxl or _pyodbc), "Cannot real excel file.")
+    @unittest.skipIf(not (_win32com or _xlrd or _openpyxl or _pyodbc), "Cannot read excel file.")
     def test_excel(self):
         pyutilib.misc.run_file(tutorial_dir+"excel.py", logfile=currdir+"excel.log", execdir=tutorial_dir)
         self.assertFileEqualsBaseline(currdir+"excel.log", tutorial_dir+"excel.out")

--- a/pyomo/core/tests/examples/test_tutorials.py
+++ b/pyomo/core/tests/examples/test_tutorials.py
@@ -37,6 +37,11 @@ try:
     _openpyxl=True
 except:
     _openpyxl=False
+try:
+    import pyodbc
+    _pyodbc=True
+except:
+    _pyodbc=False
 
 class PyomoTutorials(unittest.TestCase):
 
@@ -50,7 +55,7 @@ class PyomoTutorials(unittest.TestCase):
         pyutilib.misc.run_file(tutorial_dir+"data.py", logfile=currdir+"data.log", execdir=tutorial_dir)
         self.assertFileEqualsBaseline(currdir+"data.log", tutorial_dir+"data.out")
 
-    @unittest.skipIf(not (_win32com or _xlrd or _openpyxl), "Cannot real excel file.")
+    @unittest.skipIf(not (_win32com or _xlrd or _openpyxl or _pyodbc), "Cannot real excel file.")
     def test_excel(self):
         pyutilib.misc.run_file(tutorial_dir+"excel.py", logfile=currdir+"excel.log", execdir=tutorial_dir)
         self.assertFileEqualsBaseline(currdir+"excel.log", tutorial_dir+"excel.out")


### PR DESCRIPTION
This adds an import check to a dataportal test that has been failing intermittently on Appveyor due to `pyodbc` not being installed.

## Changes proposed in this PR:
- Skip one of the dataportal tests if pyodbc is unavailable

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
