### PR TITLE
[IDEA] Adding files that define pyomo.ext

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -97,6 +97,8 @@ install:
   - "git clone https://github.com/Pyomo/pyomo-model-libraries.git"
   - "python -m pip install git+https://github.com/PyUtilib/pyutilib"
   - "python setup.py develop"
+  - "python -m pip install git+https://github.com/Pyomo/pyomocontrib_simplemodel"
+  - "python setup.py develop"
   #
   # Fetch additional solvers
   #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -98,7 +98,6 @@ install:
   - "python -m pip install git+https://github.com/PyUtilib/pyutilib"
   - "python setup.py develop"
   - "python -m pip install git+https://github.com/Pyomo/pyomocontrib_simplemodel"
-  - "python setup.py develop"
   #
   # Fetch additional solvers
   #

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,8 +62,6 @@ install:
   - ${DOC} python setup.py develop
  # Install simplemodel (master branch)
   - ${DOC} pip install --quiet git+https://github.com/Pyomo/pyomocontrib_simplemodel
- # Install this package
-  - ${DOC} python setup.py develop
  # Finish setting up coverage tracking for subprocesses
   - DOCKER_SITE_PACKAGES=`${DOC} python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,10 @@ install:
   - ${DOC} pip install --quiet git+https://github.com/PyUtilib/pyutilib
  # Install this package
   - ${DOC} python setup.py develop
+ # Install simplemodel (master branch)
+  - ${DOC} pip install --quiet git+https://github.com/Pyomo/pyomocontrib_simplemodel
+ # Install this package
+  - ${DOC} python setup.py develop
  # Finish setting up coverage tracking for subprocesses
   - DOCKER_SITE_PACKAGES=`${DOC} python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`
   - |

--- a/pyomo/__init__.py
+++ b/pyomo/__init__.py
@@ -23,7 +23,13 @@ from pyomo.common.ext import _ImportRedirect
 #
 # can map to the 'bar' package by having foo->bar in the dictionary.
 #
-_nonstandard_extension_packages = {'simplemodel': 'pyomocontrib_simplemodel'}
+_nonstandard_extension_packages = {
+    'bilevel': 'pyomo.bilevel',
+    'dae': 'pyomo.dae',
+    'gdp': 'pyomo.gdp',
+    'mpec': 'pyomo.mpec',
+    'pysp': 'pyomo.pysp',
+    'simplemodel': 'pyomocontrib_simplemodel'}
 
 
 ext = _ImportRedirect('pyomo.ext' if __name__ == '__main__' else __name__ + ".ext", 

--- a/pyomo/__init__.py
+++ b/pyomo/__init__.py
@@ -7,3 +7,27 @@
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
+
+from pyomo.common.ext import _ImportRedirect
+
+#
+# A dictionary that defines pyomo extension packages with nonstandard names.
+# When a user imports
+#
+#    import pyomo.ext.foo
+#
+# the default behavior is to import the package 'pyomoext_foo'.  However, this 
+# dictionary can specify an arbitrary package mapping.  Thus, 
+#
+#    import pyomo.ext.foo
+#
+# can map to the 'bar' package by having foo->bar in the dictionary.
+#
+_nonstandard_extension_packages = {'simplemodel': 'pyomocontrib_simplemodel'}
+
+
+ext = _ImportRedirect('pyomo.ext' if __name__ == '__main__' else __name__ + ".ext", 
+            'pyomoext_%s', 
+            __file__, 
+            _nonstandard_extension_packages).module
+

--- a/pyomo/common/ext.py
+++ b/pyomo/common/ext.py
@@ -1,0 +1,85 @@
+#  ___________________________________________________________________________
+# 
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import sys
+import imp
+
+
+class _ImportRedirect(object):
+    """
+    This class redirects imports.
+
+    This is adapted from the _ImportRedirect class defined in the Bottle
+    software (see https://github.com/bottlepy/bottle).
+    """
+
+    def __init__(self, name, impmask, modulefile, alternates):
+        """ Create a virtual package that redirects imports (see PEP 302). """
+        self.name = name
+        self.impmask = impmask
+        self.module = sys.modules.setdefault(name, imp.new_module(name))
+        self.module.__dict__.update({
+            '__file__': modulefile,
+            '__path__': [],
+            '__all__': [],
+            '__loader__': self,
+            '__package__': self.module.__name__
+        })
+        sys.meta_path.append(self)
+        self.alternates = alternates
+
+    def find_module(self, fullname, path=None):
+        if '.' not in fullname: return
+        packname = fullname.rsplit('.', 1)[0]
+        if packname != self.name: return
+        return self
+
+    def load_module(self, fullname):
+        if fullname in sys.modules: return sys.modules[fullname]
+        modname = fullname.rsplit('.', 1)[1]
+        if modname in self.alternates:
+            realname = self.alternates[modname]
+        else:
+            realname = self.impmask % modname
+        try:
+            __import__(realname)
+        except ModuleNotFoundError as err:
+            print("ERROR importing package '%s'" % fullname)
+            print("  Failed to import Pyomo extension package '%s'" % realname)
+            print("")
+            raise err
+        module = sys.modules[fullname] = sys.modules[realname]
+        setattr(self.module, modname, module)
+        module.__loader__ = self
+        return module
+
+
+"""
+Copyright (c) 2017, Marcel Hellkamp.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+

--- a/pyomo/common/ext.py
+++ b/pyomo/common/ext.py
@@ -50,7 +50,7 @@ class _ImportRedirect(object):
             realname = self.impmask % modname
         try:
             __import__(realname)
-        except ModuleNotFoundError as err:
+        except ImportError as err:
             print("ERROR importing package '%s'" % fullname)
             print("  Failed to import Pyomo extension package '%s'" % realname)
             print("")

--- a/pyomo/common/tests/test_ext.py
+++ b/pyomo/common/tests/test_ext.py
@@ -54,6 +54,13 @@ class Test(unittest.TestCase):
         else:
             self.skipTest("Skipping test of pyomo.ext.simplemodel")
 
+    def test_error1(self):
+        try:
+            import pyomo.ext.foobar
+            self.fail("ERROR: pyomo.ext.foobar imported without error")
+        except ModuleNotFoundError:
+            pass
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyomo/common/tests/test_ext.py
+++ b/pyomo/common/tests/test_ext.py
@@ -58,7 +58,7 @@ class Test(unittest.TestCase):
         try:
             import pyomo.ext.foobar
             self.fail("ERROR: pyomo.ext.foobar imported without error")
-        except ModuleNotFoundError:
+        except ImportError:
             pass
 
 

--- a/pyomo/common/tests/test_ext.py
+++ b/pyomo/common/tests/test_ext.py
@@ -1,0 +1,59 @@
+"""Testing for deprecated function."""
+import pyutilib.th as unittest
+
+import logging
+logger = logging.getLogger('pyomo.common')
+
+
+class Test(unittest.TestCase):
+
+    def test_bilevel(self):
+        try:
+            import pyomo.ext.bilevel
+        except:
+            self.fail("Error importing pyomo.ext.bilevel")
+        self.assertTrue('SubModel' in dir(pyomo.ext.bilevel))
+
+    def test_dae(self):
+        try:
+            import pyomo.ext.dae
+        except:
+            self.fail("Error importing pyomo.ext.dae")
+        self.assertTrue('ContinuousSet' in dir(pyomo.ext.dae))
+
+    def test_gdp(self):
+        try:
+            import pyomo.ext.gdp
+        except:
+            self.fail("Error importing pyomo.ext.gdp")
+        self.assertTrue('Disjunct' in dir(pyomo.ext.gdp))
+
+    def test_mpec(self):
+        try:
+            import pyomo.ext.mpec
+        except:
+            self.fail("Error importing pyomo.ext.mpec")
+        self.assertTrue('Complementarity' in dir(pyomo.ext.mpec))
+
+    def test_pysp(self):
+        try:
+            import pyomo.ext.pysp
+        except:
+            self.fail("Error importing pyomo.ext.pysp")
+        self.assertTrue('ph' in dir(pyomo.ext.pysp))
+
+    def test_simplemodel(self):
+        available=False
+        try:
+            import pyomo.ext.simplemodel
+            available=False
+        except:
+            pass
+        if available:
+            self.assertTrue('SimpleModel' in dir(pyomo.ext.simplemodel))
+        else:
+            self.skipTest("Skipping test of pyomo.ext.simplemodel")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Fixes NA.

## Summary/Motivation:

### Overview

This PR is a proof-of-concept for creating a dynamic pyomo.ext module.  The idea is that when a user/developer executes
```
import pyomo.ext.foo
```
then the symbols from the package "pyomoext_foo" are imported below "ext".  If pyomo.ext had an __init__.py file, then this would be equivalent to the following line being added to the that file:
```
import pyomoext_foo as foo
```

This is similar to pyomo.contrib, in that users/developers can pull-in external packages that look like they are part of pyomo.  The key difference is that the pyomo.ext module does this dynamically.  Thus, no previous registration is required.  All packages that begin with "pyomoext_" can be imported dynamically.

Additionally, the pyomo/__init__.py defines a dictionary that is used to initialize pyomo.ext, which can specify additional extension packages that do not follow this naming convention.  This allows Pyomo to optionally standardize the use of external packages through pyomo.ext.

### Motivation

While Pyomo has been developed as a monolithic package, increasingly developers have made the distinction between (1) the "core" packages that define key elements of Pyomo's modeling environment and (2) "extension" packages that build on these "core" capabilities.  For example, Pyomo's expression system and file writers are core elements, which the GDP/PYSP/DAE modeling packages extend to represent different classes of optimization applications.

Further, developers are increasingly developing extensions of Pyomo that require a separate development repository.  For example, Pyomo extensions are being developed in private repositories to support and protect unpublished research activities.  Similarly, Pyomo extensions are being developed in separate repositories for low-TRL research activities;  such projects are often ill-suited for direct inclusion in Pyomo since they involve immature, unstable code.  (FUrther, I'd argue that Pyomo's peer-review development process is ill-suited for such projects.)

While Pyomo development can proceed without coordination amongst such activities, this PR supports the definition of a common namespace that allows Pyomo and related packages to develop capabilities in a synergistic manner.  For example, if John is developing package foo, and he has a cool new function bar(), then my package can reliably import:
```
from pyomo.ext.foo import bar
```
Sure, I don't need to do that, since
```
from foo import bar
```
also works.  But the pyomo.ext module defines a namespace that minimizes the logical overhead for users/developers.  We can all act like we're working within a namespace, even if packages have different names.  Additionally, the pyomo.ext module can pull-in subpackage from Pyomo.  I've configured it to pull-in gdp, dae, bilevel, pysp and mpec.  This provides a semantic grouping of these packages, and it simplifies transitions when we move extension subpackages into or out of  Pyomo.

### Notes

- We probably could extend this logic to identify several canonical external package naming scemes.
- I'm not particularly wed to pyomoext_* as the canonical naming scheme.  Perhaps pyomo_* ???

## Changes proposed in this PR:
- This PR creates the pyomo.ext object, which is a module that dynamically translates the name of the package being imported.
- The module object is created using the _ImportRedirect class, which defined in pyomo.common.ext.py

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
