### PR TITLE
Allow user, password and database to be passed as options for pymysql

### DIFF
--- a/pyomo/dataportal/plugins/db_table.py
+++ b/pyomo/dataportal/plugins/db_table.py
@@ -167,6 +167,8 @@ or that there is a bug in the ODBC connector.
                 args.append(options.user)
             if not options.password is None:
                 args.append(options.password)
+            if not options.database is None:
+                args.append(options.database)
             return mod.connect(*args, **kwds)
         except ImportError:
             return None

--- a/pyomo/dataportal/process_data.py
+++ b/pyomo/dataportal/process_data.py
@@ -2,8 +2,8 @@
 #
 #  Pyomo: Python Optimization Modeling Objects
 #  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
-#  Under the terms of Contract DE-NA0003525 with National Technology and 
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
@@ -132,8 +132,8 @@ def _preprocess_data(cmd):
                 state = 0
             else:
                 tpl.append(_process_token(token))
-   
-        elif state == 2: 
+
+        elif state == 2:
             # After a '{'
             if type(token) in numlist:
                 tpl.append(token)
@@ -148,7 +148,7 @@ def _preprocess_data(cmd):
             else:
                 tpl.append(_process_token(token))
 
-        elif state == 3: 
+        elif state == 3:
             # After a '['
             if type(token) in numlist:
                 tpl.append(token)
@@ -814,7 +814,7 @@ def _process_load(cmd, _model, _data, _default, options=None):
 
     options = Options(**_options)
     for key in options:
-        if not key in ['range','filename','format','using','driver','query','table','user','password']:
+        if not key in ['range','filename','format','using','driver','query','table','user','password','database']:
             raise ValueError("Unknown load option '%s'" % key)
 
     global Filename
@@ -891,7 +891,7 @@ def _process_load(cmd, _model, _data, _default, options=None):
 
     #print "SELECT", _param, _select
     #
-    data.initialize(model=options.model, filename=options.filename, index=_index, index_name=index_name, param_name=symb_map, set=_set, param=_param, format=options.format, range=options.range, query=options.query, using=options.using, table=options.table, select=_select)
+    data.initialize(model=options.model, filename=options.filename, index=_index, index_name=index_name, param_name=symb_map, set=_set, param=_param, format=options.format, range=options.range, query=options.query, using=options.using, table=options.table, select=_select,user=options.user,password=options.password,database=options.database)
     #
     data.open()
     try:


### PR DESCRIPTION
## Fixes # 
## Summary/Motivation:
`user` and `password` options were not being passed to `db_table` objects and are thus unavailable to  create a connection with pymysql. Also, added the option field database to specify database in MySQL server (as opposed to overloading any other keyword)

## Changes proposed in this PR:
- Added the keyword `database` to the list of options processed by the `_process_load` module
- included `user`. `password` and `database` to the options loaded into the data structure during intialization of that data
- append database to the list of arguments to launch a connection in the `connect()` method of the `db_Table` class

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
