### PR TITLE
Implementation of the scaling transformation

### DIFF
--- a/examples/pyomo/transform/scaling_ex.py
+++ b/examples/pyomo/transform/scaling_ex.py
@@ -1,0 +1,94 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import pyomo.environ as pe
+
+###
+# create the original unscaled model
+###
+model = pe.ConcreteModel()
+model.x = pe.Var([1,2,3], bounds=(-10,10), initialize=5.0)
+model.z = pe.Var(bounds=(10,20))
+model.obj = pe.Objective(expr=model.z + model.x[1])
+
+# demonstrate scaling of duals as well
+model.dual = pe.Suffix(direction=pe.Suffix.IMPORT)
+model.rc = pe.Suffix(direction=pe.Suffix.IMPORT)
+        
+def con_rule(m, i):
+    if i == 1:
+        return m.x[1] + 2*m.x[2] + 1*m.x[3] == 4.0
+    if i == 2:
+        return m.x[1] + 2*m.x[2] + 2*m.x[3] == 5.0
+    if i == 3:
+        return m.x[1] + 3.0*m.x[2] + 1*m.x[3] == 5.0
+model.con = pe.Constraint([1,2,3], rule=con_rule)
+model.zcon = pe.Constraint(expr=model.z >= model.x[2])
+
+###
+# set the scaling parameters
+###
+model.scaling_factor = pe.Suffix(direction=pe.Suffix.EXPORT)
+model.scaling_factor[model.obj] = 2.0
+model.scaling_factor[model.x] = 0.5
+model.scaling_factor[model.z] = -10.0
+model.scaling_factor[model.con[1]] = 0.5 
+model.scaling_factor[model.con[2]] = 2.0
+model.scaling_factor[model.con[3]] = -5.0
+model.scaling_factor[model.zcon] = -3.0
+
+###
+# build and solve the scaled model
+###
+scaled_model = pe.TransformationFactory('core.scale_model').create_using(model)
+pe.SolverFactory('glpk').solve(scaled_model)
+
+
+###
+# propagate the solution back to the original model
+###
+pe.TransformationFactory('core.scale_model').propagate_solution(scaled_model, model)
+
+# print the scaled model
+scaled_model.pprint()
+
+# print the solution on the original model after backmapping
+model.pprint()
+
+compare_solutions = True
+if compare_solutions:
+    # compare the solution of the original model with a clone of the
+    # original that has a backmapped solution from the scaled model
+    
+    # solve the original (unscaled) model
+    original_model = model.clone()
+    pe.SolverFactory('glpk').solve(original_model)
+
+    # create and solve the scaled model
+    scaling_tx = pe.TransformationFactory('core.scale_model')
+    scaled_model = scaling_tx.create_using(model)
+    pe.SolverFactory('glpk').solve(scaled_model)
+
+    # propagate the solution from the scaled model back to a clone of the original model
+    backmapped_unscaled_model = model.clone()
+    scaling_tx.propagate_solution(scaled_model, backmapped_unscaled_model)
+
+    # compare the variable values
+    print('\n\n')
+    print('%s\t%12s           %18s' % ('Var', 'Orig.', 'Scaled -> Backmapped'))
+    print('=====================================================')
+    for v in original_model.component_data_objects(ctype=pe.Var, descend_into=True):
+        cuid = pe.ComponentUID(v)
+        bv = cuid.find_component_on(backmapped_unscaled_model)
+        print('%s\t%.16f\t%.16f' % (v.local_name, pe.value(v), pe.value(bv)))
+    print('=====================================================')
+
+
+

--- a/pyomo/core/plugins/transform/__init__.py
+++ b/pyomo/core/plugins/transform/__init__.py
@@ -18,3 +18,4 @@ import pyomo.core.plugins.transform.radix_linearization
 import pyomo.core.plugins.transform.discrete_vars
 # import pyomo.core.plugins.transform.util
 import pyomo.core.plugins.transform.add_slack_vars
+import pyomo.core.plugins.transform.scaling

--- a/pyomo/core/plugins/transform/scaling.py
+++ b/pyomo/core/plugins/transform/scaling.py
@@ -1,0 +1,255 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+from pyomo.core.base import Var, Constraint, Objective, _ConstraintData, _ObjectiveData, Suffix, value
+from pyomo.core.plugins.transform.hierarchy import Transformation
+from pyomo.core.kernel.component_map import ComponentMap
+from pyomo.util.components import rename_components
+from pyomo.core.base import TransformationFactory
+from pyomo.core.expr.current import replace_expressions
+
+
+@TransformationFactory.register('core.scale_model',
+                                doc="Scale model variables, constraints, and objectives.")
+class ScaleModel(Transformation):
+    """
+    Transformation to scale a model.
+
+    This plugin performs variable, constraint, and objective scaling on
+    a model based on the scaling factors in the suffix 'scaling_parameter'
+    set for the variables, constraints, and/or objective. This is typically 
+    done to scale the problem for improved numerical properties.
+
+    Supported transformation methods:
+        * :py:meth:`apply_to <pyomo.core.plugins.transform.scaling.ScaleModel.apply_to>`
+        * :py:meth:`create_using <pyomo.core.plugins.transform.scaling.ScaleModel.create_using>`
+        * :py:meth:`propagate_solution <pyomo.core.plugins.transform.scaling.ScaleModel.propagate_solution>`
+
+
+    Examples:
+        >>> from pyomo.environ import *
+        >>> # create the model
+        >>> model = ConcreteModel()
+        >>> model.x = Var(bounds=(-5, 5), initialize=1.0)
+        >>> model.y = Var(bounds=(0, 1), initialize=1.0) 
+        >>> model.obj = Objective(expr=1e8*model.x + 1e6*model.y)
+        >>> model.con = Constraint(expr=model.x + model.y == 1.0)
+        >>> # create the scaling factors
+        >>> model.scaling_factor = Suffix(direction=Suffix.EXPORT)
+        >>> model.scaling_factor[model.obj] = 1e-6 # scale the objective
+        >>> model.scaling_factor[model.con] = 2.0  # scale the constraint
+        >>> model.scaling_factor[model.x] = 0.2    # scale the x variable
+        >>> # transform the model 
+        >>> scaled_model = TransformationFactory('core.scale_model').create_using(model)
+        >>> # print the value of the objective function to show scaling has occurred
+        >>> print(value(model.scaled_x))
+        1.0
+        >>> print(value(scaled_model.scaled_x))
+        0.2
+        >>> print(value(scaled_model.scaled_x.lb))
+        -1.0
+        >>> print(value(model.scaled_obj))
+        101000000.0
+        >>> print(value(scaled_model.scaled_obj))
+        101.0
+
+    ToDo
+    ====
+    - implement an option to change the variables names or not
+
+    """
+
+    def __init__(self, **kwds):
+        kwds['name'] = "scale_model"
+        self._scaling_method = kwds.pop('scaling_method', 'user')
+        super(ScaleModel, self).__init__(**kwds)
+
+    def _create_using(self, original_model, **kwds):
+        scaled_model = original_model.clone()
+        self._apply_to(scaled_model, **kwds)
+        return scaled_model
+
+    def _get_float_scaling_factor(self, instance, component_data):
+        scaling_factor = None
+        if component_data in instance.scaling_factor:
+            scaling_factor = instance.scaling_factor[component_data]
+        elif component_data.parent_component() in instance.scaling_factor:
+            scaling_factor = instance.scaling_factor[component_data.parent_component()]
+
+        if scaling_factor is None:
+            return 1.0
+
+        try:
+            scaling_factor = float(scaling_factor)
+        except ValueError:
+            raise ValueError(
+                "Suffix 'scaling_factor' has a value %s for component %s that cannot be converted to a float. "
+                "Floating point values are required for this suffix in the ScaleModel transformation."
+                % (scaling_factor, component_data))
+        return scaling_factor
+
+    def _apply_to(self, model, **kwds):
+        # create a map of component to scaling factor
+        component_scaling_factor_map = ComponentMap()
+
+        # if the scaling_method is 'user', get the scaling parameters from the suffixes
+        if self._scaling_method == 'user':
+            # perform some checks to make sure we have the necessary suffixes
+            if type(model.component('scaling_factor')) is not Suffix:
+                raise ValueError("ScaleModel transformation called with scaling_method='user'"
+                                 ", but cannot find the suffix 'scaling_factor' on the model")
+
+            # get the scaling factors
+            for c in model.component_data_objects(ctype=(Var, Constraint, Objective), descend_into=True):
+                component_scaling_factor_map[c] = self._get_float_scaling_factor(model, c)
+        else:
+            raise ValueError("ScaleModel transformation: unknown scaling_method found"
+                             "-- supported values: 'user' ")
+
+        # rename all the Vars, Constraints, and Objectives from foo to scaled_foo
+        scaled_component_to_original_name_map = \
+            rename_components(model=model,
+                              component_list=list(model.component_objects(ctype=[Var, Constraint, Objective])),
+                              prefix='scaled_')
+
+        # scale the variable bounds and values and build the variable substitution map
+        # for scaling vars in constraints
+        variable_substitution_map = ComponentMap()
+        for variable in [var for var in model.component_objects(ctype=Var, descend_into=True)]:
+            # set the bounds/value for the scaled variable
+            for k in variable:
+                v = variable[k]
+                scaling_factor = component_scaling_factor_map[v]
+                variable_substitution_map[v] = v / scaling_factor
+
+                if v.lb is not None:
+                    v.setlb(v.lb * scaling_factor)
+                if v.ub is not None:
+                    v.setub(v.ub * scaling_factor)
+                if scaling_factor < 0:
+                    temp = v.lb
+                    v.setlb(v.ub)
+                    v.setub(temp)
+
+                if v.value is not None:
+                    v.value = value(v) * scaling_factor
+
+        # scale the objectives/constraints and perform the scaled variable substitution
+        scale_constraint_dual = False
+        if type(model.component('dual')) is Suffix:
+            scale_constraint_dual = True
+
+        # translate the variable_substitution_map (ComponentMap)
+        # to variable_substition_dict (key: id() of component)
+        # ToDo: We should change replace_expressions to accept a ComponentMap as well
+        variable_substitution_dict = dict()
+        for k in variable_substitution_map:
+            variable_substitution_dict[id(k)] = variable_substitution_map[k]
+
+        for component in model.component_objects(ctype=(Constraint, Objective), descend_into=True):
+            for k in component:
+                c = component[k]
+                # perform the constraint/objective scaling and variable sub
+                scaling_factor = component_scaling_factor_map[c]
+                if isinstance(c, _ConstraintData):
+                    body = scaling_factor * \
+                           replace_expressions(expr=c.body,
+                                               substitution_map=variable_substitution_dict,
+                                               descend_into_named_expressions=True,
+                                               remove_named_expressions=True)
+
+                    # scale the rhs
+                    if c._lower is not None:
+                        c._lower = c._lower * scaling_factor
+                    if c._upper is not None:
+                        c._upper = c._upper * scaling_factor
+
+                    if scaling_factor < 0:
+                        c._lower, c._upper = c._upper, c._lower
+
+                    if scale_constraint_dual and c in model.dual:
+                        dual_value = model.dual[c]
+                        if dual_value is not None:
+                            model.dual[c] = dual_value / scaling_factor
+
+                    c.set_value((c._lower, body, c._upper))
+
+                elif isinstance(c, _ObjectiveData):
+                    c.expr = scaling_factor * \
+                             replace_expressions(expr=c.expr,
+                                                 substitution_map=variable_substitution_dict,
+                                                 descend_into_named_expressions=True,
+                                                 remove_named_expressions=True)
+                else:
+                    raise NotImplementedError(
+                        'Unknown object type found when applying scaling factors in ScaleModel transformation - Internal Error')
+
+        model.component_scaling_factor_map = component_scaling_factor_map
+        model.scaled_component_to_original_name_map = scaled_component_to_original_name_map
+
+        return model
+
+    def propagate_solution(self, scaled_model, original_model):
+        """
+        This method takes the solution in scaled_model and maps it back to the original model.
+
+        It will also transform duals and reduced costs if the suffixes 'dual' and/or 'rc' are present.
+        The :code:`scaled_model` argument must be a model that was already scaled using this transformation
+        as it expects data from the transformation to perform the back mapping.
+
+        Parameters
+        ----------
+        scaled_model : Pyomo Model
+           The model that was previously scaled with this transformation
+        original_model : Pyomo Model
+           The original unscaled source model
+
+        """
+        if not hasattr(scaled_model, 'component_scaling_factor_map'):
+            raise AttributeError('ScaleModel:propagate_solution called with scaled_model that does not '
+                                 'have a component_scaling_factor_map. It is possible this method was called '
+                                 'using a model that was not scaled with the ScaleModel transformation')
+        if not hasattr(scaled_model, 'scaled_component_to_original_name_map'):
+            raise AttributeError('ScaleModel:propagate_solution called with scaled_model that does not '
+                                 'have a scaled_component_to_original_name_map. It is possible this method was called '
+                                 'using a model that was not scaled with the ScaleModel transformation')
+
+        component_scaling_factor_map = scaled_model.component_scaling_factor_map
+        scaled_component_to_original_name_map = scaled_model.scaled_component_to_original_name_map
+
+        # get the objective scaling factor
+        scaled_objectives = list(scaled_model.component_data_objects(ctype=Objective, active=True, descend_into=True))
+        if len(scaled_objectives) != 1:
+            raise NotImplementedError(
+                'ScaleModel.propagate_solution requires a single active objective function, but %d objectives found.' % (
+                    len(objectives)))
+        objective_scaling_factor = component_scaling_factor_map[scaled_objectives[0]]
+
+        # transfer the variable values and reduced costs
+        check_reduced_costs = type(scaled_model.component('rc')) is Suffix
+        for scaled_v in scaled_model.component_objects(ctype=Var, descend_into=True):
+            # get the unscaled_v from the original model
+            original_v_path = scaled_component_to_original_name_map[scaled_v]
+            original_v = original_model.find_component(original_v_path)
+
+            for k in scaled_v:
+                original_v[k].value = value(scaled_v[k]) / component_scaling_factor_map[scaled_v[k]]
+                if check_reduced_costs and scaled_v[k] in scaled_model.rc:
+                    original_model.rc[original_v[k]] = scaled_model.rc[scaled_v[k]] * component_scaling_factor_map[
+                        scaled_v[k]] / objective_scaling_factor
+
+        # transfer the duals
+        if type(scaled_model.component('dual')) is Suffix and type(original_model.component('dual')) is Suffix:
+            for scaled_c in scaled_model.component_objects(ctype=Constraint, descend_into=True):
+                original_c = original_model.find_component(scaled_component_to_original_name_map[scaled_c])
+
+                for k in scaled_c:
+                    original_model.dual[original_c[k]] = scaled_model.dual[scaled_c[k]] * component_scaling_factor_map[
+                        scaled_c[k]] / objective_scaling_factor

--- a/pyomo/core/tests/transform/test_scaling.py
+++ b/pyomo/core/tests/transform/test_scaling.py
@@ -1,0 +1,132 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+
+
+import pyutilib.th as unittest
+import pyomo.environ as pe
+from pyomo.opt.base.solvers import UnknownSolver
+
+class TestScaleModelTransformation(unittest.TestCase):
+
+    def test_linear_scaling(self):
+        model = pe.ConcreteModel()
+        model.x = pe.Var([1,2,3], bounds=(-10,10), initialize=5.0)
+        model.z = pe.Var(bounds=(10,20))
+        model.obj = pe.Objective(expr=model.z + model.x[1])
+
+        # test scaling of duals as well
+        model.dual = pe.Suffix(direction=pe.Suffix.IMPORT)
+        model.rc = pe.Suffix(direction=pe.Suffix.IMPORT)
+        
+        def con_rule(m, i):
+            if i == 1:
+                return m.x[1] + 2*m.x[2] + 1*m.x[3] == 4.0
+            if i == 2:
+                return m.x[1] + 2*m.x[2] + 2*m.x[3] == 5.0
+            if i == 3:
+                return m.x[1] + 3.0*m.x[2] + 1*m.x[3] == 5.0
+        model.con = pe.Constraint([1,2,3], rule=con_rule)
+        model.zcon = pe.Constraint(expr=model.z >= model.x[2])
+
+        x_scale = 0.5
+        obj_scale = 2.0
+        z_scale = -10.0
+        con_scale1 = 0.5
+        con_scale2 = 2.0
+        con_scale3 = -5.0
+        zcon_scale = -3.0
+        
+        unscaled_model = model.clone()
+        unscaled_model.scaling_factor = pe.Suffix(direction=pe.Suffix.EXPORT)
+        unscaled_model.scaling_factor[unscaled_model.obj] = obj_scale
+        unscaled_model.scaling_factor[unscaled_model.x] = x_scale
+        unscaled_model.scaling_factor[unscaled_model.z] = z_scale
+        unscaled_model.scaling_factor[unscaled_model.con[1]] = con_scale1 
+        unscaled_model.scaling_factor[unscaled_model.con[2]] = con_scale2
+        unscaled_model.scaling_factor[unscaled_model.con[3]] = con_scale3
+        unscaled_model.scaling_factor[unscaled_model.zcon] = zcon_scale
+                
+        scaled_model = pe.TransformationFactory('core.scale_model').create_using(unscaled_model)
+
+        # print('*** unscaled ***')
+        # unscaled_model.pprint()
+        # print('*** scaled ***')
+        # scaled_model.pprint()
+
+        glpk_solver =  pe.SolverFactory('glpk')
+        if isinstance(glpk_solver, UnknownSolver) or \
+           (not glpk_solver.available()):
+            raise unittest.SkipTest("glpk solver not available")
+
+        glpk_solver.solve(unscaled_model)
+        glpk_solver.solve(scaled_model)
+
+        # check vars
+        self.assertAlmostEqual(pe.value(unscaled_model.x[1]), pe.value(scaled_model.scaled_x[1])/x_scale, 4)
+        self.assertAlmostEqual(pe.value(unscaled_model.x[2]), pe.value(scaled_model.scaled_x[2])/x_scale, 4)
+        self.assertAlmostEqual(pe.value(unscaled_model.x[3]), pe.value(scaled_model.scaled_x[3])/x_scale, 4)
+        self.assertAlmostEqual(pe.value(unscaled_model.z), pe.value(scaled_model.scaled_z)/z_scale, 4)
+        # check var lb
+        self.assertAlmostEqual(pe.value(unscaled_model.x[1].lb), pe.value(scaled_model.scaled_x[1].lb)/x_scale, 4)
+        self.assertAlmostEqual(pe.value(unscaled_model.x[2].lb), pe.value(scaled_model.scaled_x[2].lb)/x_scale, 4)
+        self.assertAlmostEqual(pe.value(unscaled_model.x[3].lb), pe.value(scaled_model.scaled_x[3].lb)/x_scale, 4)
+        # note: z_scale is negative, therefore, the inequality directions swap
+        self.assertAlmostEqual(pe.value(unscaled_model.z.lb), pe.value(scaled_model.scaled_z.ub)/z_scale, 4)
+        # check var ub
+        self.assertAlmostEqual(pe.value(unscaled_model.x[1].ub), pe.value(scaled_model.scaled_x[1].ub)/x_scale, 4)
+        self.assertAlmostEqual(pe.value(unscaled_model.x[2].ub), pe.value(scaled_model.scaled_x[2].ub)/x_scale, 4)
+        self.assertAlmostEqual(pe.value(unscaled_model.x[3].ub), pe.value(scaled_model.scaled_x[3].ub)/x_scale, 4)
+        # note: z_scale is negative, therefore, the inequality directions swap
+        self.assertAlmostEqual(pe.value(unscaled_model.z.ub), pe.value(scaled_model.scaled_z.lb)/z_scale, 4)
+        # check var multipliers (rc)
+        self.assertAlmostEqual(pe.value(unscaled_model.rc[unscaled_model.x[1]]), pe.value(scaled_model.rc[scaled_model.scaled_x[1]])*x_scale/obj_scale, 4)
+        self.assertAlmostEqual(pe.value(unscaled_model.rc[unscaled_model.x[2]]), pe.value(scaled_model.rc[scaled_model.scaled_x[2]])*x_scale/obj_scale, 4)
+        self.assertAlmostEqual(pe.value(unscaled_model.rc[unscaled_model.x[3]]), pe.value(scaled_model.rc[scaled_model.scaled_x[3]])*x_scale/obj_scale, 4)
+        self.assertAlmostEqual(pe.value(unscaled_model.rc[unscaled_model.z]), pe.value(scaled_model.rc[scaled_model.scaled_z])*z_scale/obj_scale, 4)
+        # check constraint multipliers
+        self.assertAlmostEqual(pe.value(unscaled_model.dual[unscaled_model.con[1]]),pe.value(scaled_model.dual[scaled_model.scaled_con[1]])*con_scale1/obj_scale, 4)
+        self.assertAlmostEqual(pe.value(unscaled_model.dual[unscaled_model.con[2]]),pe.value(scaled_model.dual[scaled_model.scaled_con[2]])*con_scale2/obj_scale, 4)
+        self.assertAlmostEqual(pe.value(unscaled_model.dual[unscaled_model.con[3]]),pe.value(scaled_model.dual[scaled_model.scaled_con[3]])*con_scale3/obj_scale, 4)
+
+        # put the solution from the scaled back into the original
+        pe.TransformationFactory('core.scale_model').propagate_solution(scaled_model, model)
+
+        # compare var values and rc with the unscaled soln
+        for vm in model.component_objects(ctype=pe.Var, descend_into=True):
+            cuid = pe.ComponentUID(vm)
+            vum = cuid.find_component_on(unscaled_model)
+            self.assertEqual((vm in model.rc), (vum in unscaled_model.rc)) 
+            if vm in model.rc:
+                self.assertAlmostEqual(pe.value(model.rc[vm]), pe.value(unscaled_model.rc[vum]), 4)
+            for k in vm:
+                vmk = vm[k]
+                vumk = vum[k]
+                self.assertAlmostEqual(pe.value(vmk), pe.value(vumk), 4)
+                self.assertEqual((vmk in model.rc), (vumk in unscaled_model.rc)) 
+                if vmk in model.rc:
+                    self.assertAlmostEqual(pe.value(model.rc[vmk]), pe.value(unscaled_model.rc[vumk]), 4)
+
+        # compare constraint duals and value
+        for model_con in model.component_objects(ctype=pe.Constraint, descend_into=True):
+            cuid = pe.ComponentUID(model_con)
+            unscaled_model_con = cuid.find_component_on(unscaled_model)
+            self.assertEqual((model_con in model.rc), (unscaled_model_con in unscaled_model.rc)) 
+            if model_con in model.dual:
+                self.assertAlmostEqual(pe.value(model.dual[model_con]), pe.value(unscaled_model.dual[unscaled_model_con]), 4)
+            for k in model_con:
+                mk = model_con[k]
+                umk = unscaled_model_con[k]
+                self.assertEqual((mk in model.dual), (umk in unscaled_model.dual)) 
+                if mk in model.dual:
+                    self.assertAlmostEqual(pe.value(model.dual[mk]), pe.value(unscaled_model.dual[umk]), 4)
+        
+if __name__ == "__main__":
+    unittest.main()

--- a/pyomo/core/tests/unit/test_expr_pyomo5.py
+++ b/pyomo/core/tests/unit/test_expr_pyomo5.py
@@ -6040,6 +6040,16 @@ class WalkerTests(unittest.TestCase):
         self.assertEqual("2*(z[0]*x[0] + z[1]*x[1] + z[2]*x[2])", str(e))
         self.assertEqual("2*(z[0]*w[4] + z[1]*w[5] + z[2]*w[6])", str(f))
 
+    def test_replace_expressions_with_monomial_term(self):
+        M = ConcreteModel()
+        M.x = Var()
+        e = 2.0*M.x
+        substitution_map = {id(M.x): 3.0*M.x}
+        new_e = EXPR.replace_expressions(e, substitution_map=substitution_map)
+        self.assertEqual('6.0*x', str(new_e))
+        # See comment about this test in ExpressionReplacementVisitor
+        # old code would print '2.0*3.0*x'
+
     def test_identify_components(self):
         M = ConcreteModel()
         M.x = Var()
@@ -6811,4 +6821,4 @@ class TestEvaluateExpression(unittest.TestCase):
         self.assertRaises(TemplateExpressionError, EXPR.evaluate_expression, e, constant=True)
 
 if __name__ == "__main__":
-    unittest.main()
+   unittest.main()

--- a/pyomo/util/components.py
+++ b/pyomo/util/components.py
@@ -1,0 +1,54 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+from pyomo.core.kernel.component_map import ComponentMap
+from pyomo.common.modeling import unique_component_name
+
+def rename_components(model, component_list, prefix):
+    """
+    Rename components in component_list using the prefix AND
+    unique_component_name
+
+    Parameters
+    ----------
+    model : Pyomo model (or Block)
+       The variables, constraints and objective will be renamed on this model
+    component_list : list
+       List of components to rename
+    prefix : str
+       The prefix to use when building the new names
+
+    Examples
+    --------
+    >>> c_list = list(model.component_objects(ctype=Var, descend_into=True))
+    >>> rename_components(model, component_list=c_list, prefix='special_')
+
+    Returns
+    -------
+    ComponentMap : maps the renamed Component objects
+       to a string that provides their old fully qualified names
+
+    ToDo
+    ----
+    - need to add a check to see if someone accidentally passes a generator since this can lead to an infinite loop
+
+    """
+    name_map = ComponentMap()
+    for c in component_list:
+        # get the parent block - we will use this to ensure new names are
+        # unique and to add the new "scaled" components
+        parent = c.parent_block()
+        old_name = c.name
+        new_name = unique_component_name(parent, prefix + c.local_name)
+        parent.del_component(c)
+        parent.add_component(new_name, c)
+        name_map[c] = old_name
+
+    return name_map

--- a/pyomo/util/tests/test_components.py
+++ b/pyomo/util/tests/test_components.py
@@ -1,0 +1,51 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import pyutilib.th as unittest
+import pyomo.environ as pe
+from pyomo.util.components import rename_components
+
+class TestUtilComponents(unittest.TestCase):
+
+    def test_rename_components(self):
+        model = pe.ConcreteModel()
+        model.x = pe.Var([1, 2, 3], bounds=(-10, 10), initialize=5.0)
+        model.z = pe.Var(bounds=(10, 20))
+        model.obj = pe.Objective(expr=model.z + model.x[1])
+
+        def con_rule(m, i):
+            return m.x[i] + m.z == i
+        model.con = pe.Constraint([1, 2, 3], rule=con_rule)
+        model.zcon = pe.Constraint(expr=model.z >= model.x[2])
+        model.b = pe.Block()
+        model.b.bx = pe.Var([1,2,3], initialize=42)
+        model.b.bz = pe.Var(initialize=42)
+
+        c_list = list(model.component_objects(ctype=[pe.Var,pe.Constraint,pe.Objective]))
+        name_map = rename_components(model=model,
+                                     component_list=c_list,
+                                     prefix='scaled_')
+
+        self.assertEquals(name_map[model.scaled_obj], 'obj')
+        self.assertEquals(name_map[model.scaled_x], 'x')
+        self.assertEquals(name_map[model.scaled_con], 'con')
+        self.assertEquals(name_map[model.scaled_zcon], 'zcon')
+        self.assertEquals(name_map[model.b.scaled_bz], 'b.bz')
+
+        self.assertEquals(model.scaled_obj.name, 'scaled_obj')
+        self.assertEquals(model.scaled_x.name, 'scaled_x')
+        self.assertEquals(model.scaled_con.name, 'scaled_con')
+        self.assertEquals(model.scaled_zcon.name, 'scaled_zcon')
+        self.assertEquals(model.b.name, 'b')
+        self.assertEquals(model.b.scaled_bz.name, 'b.scaled_bz')
+
+if __name__ == '__main__':
+    t = TestUtilComponents()
+    t.test_rename_components()


### PR DESCRIPTION
This is a scaling transformation that takes in user provided values for the variable, constraint, and objective scaling factors (as suffixes).

It supports creation of a scaled model and propagation of the solution back to the unscaled model.

- also added a helper function in util/components.py to rename components on a model

## Fixes # .
- fixes a bug in the ExpressionReplacementWalker when the rhs of a MonomialTerm was replaced with another MonomialTerm
- added a method replace_expressions that calls the ExpressionReplacementWalker

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
