### PR TITLE
BARON.py missing pyutilib import

### DIFF
--- a/pyomo/solvers/plugins/solvers/BARON.py
+++ b/pyomo/solvers/plugins/solvers/BARON.py
@@ -16,6 +16,7 @@ import re
 import tempfile
 
 import pyomo.common
+import pyutilib
 from pyutilib.misc import Options
 
 from pyomo.opt.base import *


### PR DESCRIPTION
This was causing a failure when checking the solver version.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
