### PR TITLE
Fixing python3 errors for Jenkins core,booktests targets

### DIFF
--- a/admin/jenkins.py
+++ b/admin/jenkins.py
@@ -87,7 +87,9 @@ elif config == "core":
         _run_cmd("python/bin/pyomo install-extras", shell=True)
     elif _run_cmd is subprocess.check_output:
         output = _run_cmd("python/bin/pyomo install-extras", shell=True)
-        print(output.encode('utf-8','replace').decode('utf-8'))
+        if hasattr(output, 'encode'):
+            output = output.encode('utf-8','replace')
+        print(output.decode('utf-8'))
     else:
         assert False
     # Test
@@ -122,7 +124,9 @@ elif config == "booktests" or config == "book":
         output = _run_cmd("python/bin/python src/pyomo/scripts/get_pyomo_extras.py -v", shell=True)
     elif _run_cmd is subprocess.check_output:
         output = _run_cmd("python/bin/python src/pyomo/scripts/get_pyomo_extras.py -v", shell=True)
-        print(output.encode('utf-8','replace').decode('utf-8'))
+        if hasattr(output, 'encode'):
+            output = output.encode('utf-8','replace')
+        print(output.decode('utf-8'))
     else:
         assert False
     # Test


### PR DESCRIPTION
## Summary/Motivation:

This fixes problems in the Jenkins test driver for the `core` and `booktests` targets when running in Python 3.x.

## Changes proposed in this PR:
- More careful decoding of output from `subprocess.check_output`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
