### PR TITLE
Fixing NumPy MKL issues in Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,6 +62,12 @@ install:
   - "SET ANACONDA=%CONDA_INSTALL% -c anaconda"
   - "SET CONDAFORGE=%CONDA_INSTALL% -c conda-forge --no-update-dependencies"
   #
+  # Determine if we will use Appveyor's Miniconda or install Anaconda
+  # (intermittently one or the other suffers from NumPy failing to load the
+  # MKL DLL; See #542, #577
+  #
+  - SET USING_MINICONDA=1
+  #
   # Update conda, then force it to NOT update itself again
   #
   # Somehow, the update from anaconda stalls for Python 3.4. So we're not specifying the channel here.
@@ -69,7 +75,11 @@ install:
   - conda config --set always_yes yes
   - conda update -q -y conda
   - conda config --set auto_update_conda false
-  - conda install anaconda
+  #
+  # If we are using full Anaconda instead of Appveyor's MiniConda,
+  # install it
+  #
+  - IF NOT DEFINED USING_MINICONDA (conda install anaconda)
   #
   - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme"
   - python -m pip install codecov
@@ -82,7 +92,13 @@ install:
   #
   # Install pyomo.extras
   #
-  - "IF DEFINED EXTRAS (%CONDAFORGE% pymysql pyro4)"
+  # If we are using Miniconda, we need to install additional packages
+  that usually come with the full Anaconda distribution
+  #
+  - SET MINICONDA_EXTRAS=""
+  - IF DEFINED USING_MINICONDA (SET MINICONDA_EXTRAS=numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill)
+  #
+  - "IF DEFINED EXTRAS (%CONDAFORGE% pymysql pyro4 %MINICONDA_EXTRAS%)"
   #- "IF DEFINED EXTRAS (%CONDAFORGE% numpy scipy ipython openpyxl sympy pymysql pyodbc pyro4 pyyaml networkx xlrd pandas matplotlib dill)"
   #- "IF DEFINED EXTRAS (%CONDAFORGE% mkl)"
   #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -88,9 +88,9 @@ install:
   #
   # Create a virtual environment for this build
   #
-  - conda create -n pyomo_test_env python=%PYTHON_VERSION%
-  - activate pyomo_test_env
-  - "SET CONDAENV=%PYTHON%\\envs\\pyomo_test_env"
+  #- conda create -n pyomo_test_env python=%PYTHON_VERSION%
+  #- activate pyomo_test_env
+  #- "SET CONDAENV=%PYTHON%\\envs\\pyomo_test_env"
   - "echo %PATH%"
   #
   - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme codecov"
@@ -102,10 +102,10 @@ install:
   - dir %PYTHON%\Library\bin
   - dir %PYTHON%\lib\site-packages
   - dir %PYTHON%\envs\pyomo_test_env
-  - dir %CONDAENV%\Scripts
-  - dir %CONDAENV%\site-packages
-  - dir %CONDAENV%\Lib\site-packages
-  - dir %CONDAENV%\libs\site-packages
+  #- dir %CONDAENV%\Scripts
+  #- dir %CONDAENV%\site-packages
+  #- dir %CONDAENV%\Lib\site-packages
+  #- dir %CONDAENV%\libs\site-packages
   - python -m codecov
   ## TESTING
   #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -95,9 +95,11 @@ install:
   #- python -m pip install codecov
   ## TESTING
   - dir
+  - dir scripts
   - dir %PYTHON%\Scripts
   - dir %PYTHON%\Library\bin
   - dir %PYTHON%\lib\site-packages
+  - dir %PYTHON%\envs\pyomo_test_env
   - python -m codecov
   ## TESTING
   #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,14 +66,14 @@ install:
   # (intermittently one or the other suffers from NumPy failing to load the
   # MKL DLL; See #542, #577
   #
-  - SET USING_MINICONDA=1
+  #- SET USING_MINICONDA=1
   #
   # Update conda, then force it to NOT update itself again
   #
   # Somehow, the update from anaconda stalls for Python 3.4. So we're not specifying the channel here.
   #
   - conda config --set always_yes yes
-  - conda update -q -y conda
+  #- conda update -q -y conda
   - conda config --set auto_update_conda false
   #
   # If we are using full Anaconda instead of Appveyor's MiniConda,

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,7 @@ environment:
     #  CATEGORY: "nightly"
 
     - PYTHON_VERSION: 2.7
-      PYTHON: "C:\\Miniconda-x64"
+      PYTHON: "C:\\Miniconda"
       CATEGORY: "nightly"
       EXTRAS: YES
 
@@ -37,12 +37,12 @@ environment:
     #  EXTRAS: YES
 
     - PYTHON_VERSION: 3.5
-      PYTHON: "C:\\Miniconda35-x64"
+      PYTHON: "C:\\Miniconda35"
       CATEGORY: "nightly"
       EXTRAS: YES
 
     - PYTHON_VERSION: 3.6
-      PYTHON: "C:\\Miniconda36-x64"
+      PYTHON: "C:\\Miniconda36"
       CATEGORY: "nightly"
       EXTRAS: YES
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -83,8 +83,8 @@ install:
   #
   # Create a virtual environment for this build
   #
-  conda create -n pyomo_test_env python=%PYTHON_VERSION%
-  activate pyomo_test_env
+  - conda create -n pyomo_test_env python=%PYTHON_VERSION%
+  - activate pyomo_test_env
   #
   - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme codecov"
   #- python -m pip install codecov

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -93,8 +93,8 @@ install:
   #- "SET CONDAENV=%PYTHON%\\envs\\pyomo_test_env"
   - "echo %PATH%"
   #
-  - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme codecov"
-  #- python -m pip install codecov
+  - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme"
+  - python -m pip install codecov
   ## TESTING
   - dir
   - dir scripts

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -101,7 +101,7 @@ install:
   - dir %PYTHON%\Scripts
   - dir %PYTHON%\Library\bin
   - dir %PYTHON%\lib\site-packages
-  - dir %PYTHON%\envs\pyomo_test_env
+  #- dir %PYTHON%\envs\pyomo_test_env
   #- dir %CONDAENV%\Scripts
   #- dir %CONDAENV%\site-packages
   #- dir %CONDAENV%\Lib\site-packages

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -81,6 +81,11 @@ install:
   #
   - IF NOT DEFINED USING_MINICONDA (conda install anaconda)
   #
+  # Create a virtual environment for this build
+  #
+  conda create -n pyomo_test_env python=%PYTHON_VERSION%
+  activate pyomo_test_env
+  #
   - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme codecov"
   #- python -m pip install codecov
   #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -179,4 +179,6 @@ on_success:
   - "cd %BUILD_DIR%"
   - dir .cov*
   - "coverage combine %BUILD_DIR%"
-  - codecov -X gcov
+  # On some appveyor platforms, the codecov script does not appear to be
+  # in the PATH.  We will directly import the module (installed above)
+  - python -m codecov -X gcov

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -81,8 +81,8 @@ install:
   #
   - IF NOT DEFINED USING_MINICONDA (conda install anaconda)
   #
-  - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme"
-  - python -m pip install codecov
+  - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme codecov"
+  #- python -m pip install codecov
   #
   # Install GAMS
   #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,10 +26,10 @@ environment:
     #  PYTHON: "C:\\Miniconda36-x64"
     #  CATEGORY: "nightly"
 
-    ##- PYTHON_VERSION: 2.7
-    ##  PYTHON: "C:\\Miniconda"
-    ##  CATEGORY: "nightly"
-    ##  EXTRAS: YES
+    - PYTHON_VERSION: 2.7
+      PYTHON: "C:\\Miniconda"
+      CATEGORY: "nightly"
+      EXTRAS: YES
 
     #- PYTHON_VERSION: 3.4
     #  PYTHON: "C:\\Miniconda34-x64"
@@ -41,15 +41,15 @@ environment:
       CATEGORY: "nightly"
       EXTRAS: YES
 
-    ##- PYTHON_VERSION: 3.6
-    ##  PYTHON: "C:\\Miniconda36"
-    ##  CATEGORY: "nightly"
-    ##  EXTRAS: YES
+    - PYTHON_VERSION: 3.6
+      PYTHON: "C:\\Miniconda36"
+      CATEGORY: "nightly"
+      EXTRAS: YES
 
-    ##- PYTHON_VERSION: 3.7
-    ##  PYTHON: "C:\\Miniconda37"
-    ##  CATEGORY: "nightly"
-    ##  EXTRAS: YES
+    - PYTHON_VERSION: 3.7
+      PYTHON: "C:\\Miniconda37"
+      CATEGORY: "nightly"
+      EXTRAS: YES
 
 
 install:
@@ -94,20 +94,13 @@ install:
   - "echo %PATH%"
   #
   - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme"
+  #
+  # While we would like to install codecov using conda (for
+  # consistency), there are cases (most recently, in Python 3.5) where
+  # the installation is not reliable and codecov is not available after
+  # being installed.
+  #
   - python -m pip install codecov
-  ## TESTING
-  - dir
-  - dir scripts
-  - dir %PYTHON%\Scripts
-  - dir %PYTHON%\Library\bin
-  - dir %PYTHON%\lib\site-packages
-  #- dir %PYTHON%\envs\pyomo_test_env
-  #- dir %CONDAENV%\Scripts
-  #- dir %CONDAENV%\site-packages
-  #- dir %CONDAENV%\Lib\site-packages
-  #- dir %CONDAENV%\libs\site-packages
-  - python -m codecov
-  ## TESTING
   #
   # Install GAMS
   #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,7 +66,7 @@ install:
   # (intermittently one or the other suffers from NumPy failing to load the
   # MKL DLL; See #542, #577
   #
-  #- SET USING_MINICONDA=1
+  - SET USING_MINICONDA=1
   #
   # Update conda, then force it to NOT update itself again
   #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,6 +90,8 @@ install:
   #
   - conda create -n pyomo_test_env python=%PYTHON_VERSION%
   - activate pyomo_test_env
+  - "SET CONDAENV=%PYTHON%\envs\pyomo_test_env"
+  - "echo %PATH%"
   #
   - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme codecov"
   #- python -m pip install codecov
@@ -100,6 +102,10 @@ install:
   - dir %PYTHON%\Library\bin
   - dir %PYTHON%\lib\site-packages
   - dir %PYTHON%\envs\pyomo_test_env
+  - dir %CONDAENV%\Scripts
+  - dir %CONDAENV%\site-packages
+  - dir %CONDAENV%\Lib\site-packages
+  - dir %CONDAENV%\libs\site-packages
   - python -m codecov
   ## TESTING
   #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,10 +26,10 @@ environment:
     #  PYTHON: "C:\\Miniconda36-x64"
     #  CATEGORY: "nightly"
 
-    - PYTHON_VERSION: 2.7
-      PYTHON: "C:\\Miniconda"
-      CATEGORY: "nightly"
-      EXTRAS: YES
+    ##- PYTHON_VERSION: 2.7
+    ##  PYTHON: "C:\\Miniconda"
+    ##  CATEGORY: "nightly"
+    ##  EXTRAS: YES
 
     #- PYTHON_VERSION: 3.4
     #  PYTHON: "C:\\Miniconda34-x64"
@@ -41,10 +41,15 @@ environment:
       CATEGORY: "nightly"
       EXTRAS: YES
 
-    - PYTHON_VERSION: 3.6
-      PYTHON: "C:\\Miniconda36"
-      CATEGORY: "nightly"
-      EXTRAS: YES
+    ##- PYTHON_VERSION: 3.6
+    ##  PYTHON: "C:\\Miniconda36"
+    ##  CATEGORY: "nightly"
+    ##  EXTRAS: YES
+
+    ##- PYTHON_VERSION: 3.7
+    ##  PYTHON: "C:\\Miniconda37"
+    ##  CATEGORY: "nightly"
+    ##  EXTRAS: YES
 
 
 install:
@@ -88,6 +93,13 @@ install:
   #
   - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme codecov"
   #- python -m pip install codecov
+  ## TESTING
+  - dir
+  - dir %PYTHON%\Scripts
+  - dir %PYTHON%\Library\bin
+  - dir %PYTHON%\lib\site-packages
+  - python -m codecov
+  ## TESTING
   #
   # Install GAMS
   #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,7 +90,7 @@ install:
   #
   - conda create -n pyomo_test_env python=%PYTHON_VERSION%
   - activate pyomo_test_env
-  - "SET CONDAENV=%PYTHON%\envs\pyomo_test_env"
+  - "SET CONDAENV=%PYTHON%\\envs\\pyomo_test_env"
   - "echo %PATH%"
   #
   - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme codecov"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -93,7 +93,7 @@ install:
   # Install pyomo.extras
   #
   # If we are using Miniconda, we need to install additional packages
-  that usually come with the full Anaconda distribution
+  # that usually come with the full Anaconda distribution
   #
   - SET MINICONDA_EXTRAS=""
   - IF DEFINED USING_MINICONDA (SET MINICONDA_EXTRAS=numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill)

--- a/pyomo/dataportal/plugins/db_table.py
+++ b/pyomo/dataportal/plugins/db_table.py
@@ -213,8 +213,11 @@ class pyodbc_db_Table(db_Table):
         except Exception:
             e = sys.exc_info()[1]
             code = e.args[0]
-            if code == 'IM002' or code == '08001':
+            if code == 'IM002' or code == '08001' and 'HOME' in os.environ:
                 # Need a DSN! Try to add it to $HOME/.odbc.ini ...
+                #
+                # Note: this only works on *nix platforms.  It appears
+                # that ODBC.INI is stored in the registry on windows
                 odbcIniPath = os.path.join(os.environ['HOME'], '.odbc.ini')
                 if os.path.exists(odbcIniPath):
                     shutil.copy(odbcIniPath, odbcIniPath + '.orig')

--- a/pyomo/dataportal/plugins/db_table.py
+++ b/pyomo/dataportal/plugins/db_table.py
@@ -213,7 +213,7 @@ class pyodbc_db_Table(db_Table):
         except Exception:
             e = sys.exc_info()[1]
             code = e.args[0]
-            if code == 'IM002' or code == '08001' and 'HOME' in os.environ:
+            if (code == 'IM002' or code == '08001') and 'HOME' in os.environ:
                 # Need a DSN! Try to add it to $HOME/.odbc.ini ...
                 #
                 # Note: this only works on *nix platforms.  It appears

--- a/pyomo/dataportal/plugins/db_table.py
+++ b/pyomo/dataportal/plugins/db_table.py
@@ -172,6 +172,12 @@ or that there is a bug in the ODBC connector.
         except ImportError:
             return None
 
+#
+# NOTE: The pyodbc interface currently doesn't work.  Notably, nothing
+# sets the "table" or "query" options, which causes db_table.read() to
+# fail.  This interface has been disabled by overriding pyodbc_available
+# in sheet.py
+#
 
 @DataManagerFactory.register('pyodbc', "%s database interface" % 'pyodbc')
 class pyodbc_db_Table(db_Table):

--- a/pyomo/dataportal/plugins/db_table.py
+++ b/pyomo/dataportal/plugins/db_table.py
@@ -334,6 +334,10 @@ class pyodbc_db_Table(db_Table):
         return connection
 
     def _get_driver(self, ctype):
+        # Given a list of possible drivers for this ctype, look to find
+        # a match in the pyodbc.drivvers() list.  If a match is found,
+        # return it.  Otherwise (arbitrarily) return the first one.  If
+        # the ctype is not known, return None.
         drivers = self._drivers.get(ctype,[])
         for driver in drivers:
             if driver in pyodbc.drivers():

--- a/pyomo/dataportal/plugins/db_table.py
+++ b/pyomo/dataportal/plugins/db_table.py
@@ -19,6 +19,7 @@ import re
 import sys
 import shutil
 from decimal import Decimal
+from six import iteritems
 
 try:
     import pyodbc
@@ -175,12 +176,16 @@ or that there is a bug in the ODBC connector.
 @DataManagerFactory.register('pyodbc', "%s database interface" % 'pyodbc')
 class pyodbc_db_Table(db_Table):
 
-    _drivers = {  'mdb' : "Microsoft Access Driver (*.mdb)",
-                  'xls' : "Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)",
-                 'xlsx' : "Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)",
-                 'xlsm' : "Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)",
-                 'xlsb' : "Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)",
-                'mysql' : "MySQL" }
+    _drivers = {
+        'mdb': ["Microsoft Access Driver (*.mdb)"],
+        'xls': ["Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)","Microsoft Excel Driver (*.xls)"],
+        'xlsx': ["Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)"],
+        'xlsm': ["Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)"],
+        'xlsb': ["Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)"],
+        'mysql': ["MySQL"]
+    }
+    _drivers['access'] = _drivers['mdb']
+    _drivers['excel'] = _drivers['xls']
 
     def __init__(self):
         db_Table.__init__(self)
@@ -213,27 +218,45 @@ class pyodbc_db_Table(db_Table):
         except Exception:
             e = sys.exc_info()[1]
             code = e.args[0]
-            if (code == 'IM002' or code == '08001') and 'HOME' in os.environ:
-                # Need a DSN! Try to add it to $HOME/.odbc.ini ...
-                #
-                # Note: this only works on *nix platforms.  It appears
-                # that ODBC.INI is stored in the registry on windows
-                odbcIniPath = os.path.join(os.environ['HOME'], '.odbc.ini')
-                if os.path.exists(odbcIniPath):
-                    shutil.copy(odbcIniPath, odbcIniPath + '.orig')
-                    config = ODBCConfig(filename=odbcIniPath)
+            if code == 'IM002' or code == '08001':
+                if 'HOME' in os.environ:
+                    # Need a DSN! Try to add it to $HOME/.odbc.ini ...
+                    #
+                    # Note: this only works on *nix platforms.  It appears
+                    # that ODBC.INI is stored in the registry on windows
+                    #
+                    # [JDS, 8 Oct 18]: I am not convinced that writing a
+                    # .odbc.ini file is necessary; see the "else" branch
+                    # below.
+                    #
+                    odbcIniPath = os.path.join(os.environ['HOME'], '.odbc.ini')
+                    if os.path.exists(odbcIniPath):
+                        shutil.copy(odbcIniPath, odbcIniPath + '.orig')
+                        config = ODBCConfig(filename=odbcIniPath)
+                    else:
+                        config = ODBCConfig()
+
+                    dsninfo = self.create_dsn_dict(connection, config)
+                    dsnid = re.sub('[^A-Za-z0-9]', '', dsninfo['Database']) # Strip filenames of funny characters
+                    dsn = 'PYOMO{0}'.format(dsnid)
+
+                    config.add_source(dsn, dsninfo['Driver'])
+                    config.add_source_spec(dsn, dsninfo)
+                    config.write(odbcIniPath)
+
+                    connstr = "DRIVER={{{0}}};DSN={1}".format(dsninfo['Driver'], dsn)
                 else:
+                    # Attempt to re-generate the connection string with a Driver
                     config = ODBCConfig()
+                    dsninfo = self.create_dsn_dict(connection, config)
+                    connstr = []
+                    for k,v in iteritems(dsninfo):
+                        if ' ' in v and (v[0] != "{" or v[-1] != "}"):
+                            connstr.append("%s={%s}" % (k.upper(),v))
+                        else:
+                            connstr.append("%s=%s" % (k.upper(),v))
+                    connstr = ";".join(connstr)
 
-                dsninfo = self.create_dsn_dict(connection, config)
-                dsnid = re.sub('[^A-Za-z0-9]', '', dsninfo['Database']) # Strip filenames of funny characters
-                dsn = 'PYOMO{0}'.format(dsnid)
-
-                config.add_source(dsn, dsninfo['Driver'])
-                config.add_source_spec(dsn, dsninfo)
-                config.write(odbcIniPath)
-
-                connstr = "DRIVER={{{0}}};DSN={1}".format(dsninfo['Driver'], dsn)
                 conn = db_Table.connect(self, connstr, options, extras) # Will raise its own exception on failure
 
             # Propagate the exception
@@ -296,11 +319,23 @@ class pyodbc_db_Table(db_Table):
         return result
 
     def create_connection_string(self, ctype, connection, options):
-        if ctype in ['xls', 'xlsx', 'xlsm', 'xlsb', 'excel']:
-            return "DRIVER={Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)}; Dbq=%s;" % connection
-        if ctype in ['mdb', 'access']:
-            return "DRIVER={Microsoft Access Driver (*.mdb)}; Dbq=%s;" % connection
+        driver = self._get_driver(ctype)
+        if driver:
+            if ' ' in driver and (driver[0] != "{" or driver[-1] != "}"):
+                return "DRIVER={%s};Dbq=%s;" % (driver, connection)
+            else:
+                return "DRIVER=%s;Dbq=%s;" % (driver, connection)
         return connection
+
+    def _get_driver(self, ctype):
+        drivers = self._drivers.get(ctype,[])
+        for driver in drivers:
+            if driver in pyodbc.drivers():
+                return driver
+        if drivers:
+            return drivers[0]
+        else:
+            return None
 
 
 class ODBCError(Exception):

--- a/pyomo/dataportal/plugins/sheet.py
+++ b/pyomo/dataportal/plugins/sheet.py
@@ -97,6 +97,10 @@ if pyodbc_available or not pypyodbc_available:
 else:
     pyodbc_db_base = pypyodbc_db_Table
 
+#
+# FIXME: The pyodbc interface doesn't work right now.  We will disable it.
+#
+pyodbc_available = False
 
 if (win32com_available and _excel_available) or xlrd_available:
 
@@ -115,7 +119,7 @@ if (win32com_available and _excel_available) or xlrd_available:
         def requirements(self):
             return "win32com or xlrd"
 
-else:
+elif pypyodbc_available:
 
     @DataManagerFactory.register("xls", "Excel XLS file interface")
     class pyodbc_xls(pyodbc_db_base):
@@ -151,7 +155,10 @@ if (win32com_available and _excel_available) or openpyxl_available:
         def requirements(self):
             return "win32com or openpyxl"
 
-else:
+elif pyodbc_available:
+    #
+    # This class is OK, but the pyodbc interface doesn't work right now.
+    #
 
     @DataManagerFactory.register("xlsx", "Excel XLSX file interface")
     class SheetTable_xlsx(pyodbc_db_base):
@@ -170,10 +177,8 @@ else:
             return pyodbc_db_base.open(self)
 
 
-if 0:
-    #
-    # This class is OK, but the pyodbc interface doesn't work right now.
-    #
+if pyodbc_available:
+
     @DataManagerFactory.register("xlsb", "Excel XLSB file interface")
     class SheetTable_xlsb(pyodbc_db_base):
 
@@ -208,7 +213,7 @@ if (win32com_available and _excel_available) or openpyxl_available:
         def requirements(self):
             return "win32com or openpyxl"
 
-else:
+elif pyodbc_available:
 
     @DataManagerFactory.register("xlsm", "Excel XLSM file interface")
     class SheetTable_xlsm(pyodbc_db_base):

--- a/pyomo/dataportal/plugins/sheet.py
+++ b/pyomo/dataportal/plugins/sheet.py
@@ -119,7 +119,7 @@ if (win32com_available and _excel_available) or xlrd_available:
         def requirements(self):
             return "win32com or xlrd"
 
-elif pypyodbc_available:
+elif pyodbc_available:
 
     @DataManagerFactory.register("xls", "Excel XLS file interface")
     class pyodbc_xls(pyodbc_db_base):


### PR DESCRIPTION
## Summary/Motivation:
This is once again trying to fix NumPy / Intel MKL issues that result in
```
Intel MKL FATAL ERROR: Cannot load mkl_intel_thread.dll.
```

## Changes proposed in this PR:
- Switch back to using Appveyor's Miniconda
- Switch to using 32-bit Python
- Disabling the DataPortals Excel ODBC interface.  This class does not appear to work and was causing failures when `pyodbc` is present but not `xlrd` (which overrides the ODBC interface).
- add testing for Python 3.7
- switch `codecov` installation from `conda` back to `pip`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
