### PR TITLE
Replace code-block with doctest in pyomo network

### DIFF
--- a/doc/OnlineDocs/modeling_extensions/network.rst
+++ b/doc/OnlineDocs/modeling_extensions/network.rst
@@ -294,7 +294,8 @@ The following code demonstrates basic usage of the
 :py:class:`SequentialDecomposition <pyomo.network.SequentialDecomposition>`
 class:
 
-.. code-block:: python
+.. doctest::
+    :skipif: not __import__("pyomo.network").network.decomposition.imports_available
 
     >>> from pyomo.environ import *
     >>> from pyomo.network import *


### PR DESCRIPTION
## Summary/Motivation:
When we merged the pyomo network docs, I had to change the doctest to a code block since there was no way to skip the test if the optional dependencies (networkx and numpy) were not installed. The `skipif` feature of sphinx was under development at the time, but appears to have since been implemented and released.

## Changes proposed in this PR:
- Change one code-block in the network docs to a doctest with a conditional skipif

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
