### PR TITLE
Bugfix: overriding set values (setitem) for IndexedSets in Python2.7

### DIFF
--- a/pyomo/core/base/sets.py
+++ b/pyomo/core/base/sets.py
@@ -1682,7 +1682,7 @@ class IndexedSet(Set):
         # Create a _SetData object if one doesn't already exist
         #
         if key in self._data:
-            self._data[key].value.clear()
+            self._data[key].clear()
         else:
             self._data[key] = self._SetData(self, self._bounds)
         #

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -1094,6 +1094,20 @@ class ArraySet(PyomoModel):
             self.fail("fail test_mul")
 
 
+    def test_override_values(self):
+        m = ConcreteModel()
+        m.I = Set([1,2,3])
+        m.I[1] = [1,2,3]
+        self.assertEqual(sorted(m.I[1]), [1,2,3])
+        m.I[1] = [4,5,6]
+        self.assertEqual(sorted(m.I[1]), [4,5,6])
+
+        m.J = Set([1,2,3], ordered=True)
+        m.J[1] = [1,3,2]
+        self.assertEqual(list(m.J[1]), [1,3,2])
+        m.J[1] = [5,4,6]
+        self.assertEqual(list(m.J[1]), [5,4,6])
+
 class ArraySet2(PyomoModel):
 
     def setUp(self):


### PR DESCRIPTION
## Fixes (N/A)

## Summary/Motivation:
@DLWoodruff found a (longstanding) problem with IndexedSet.

This fixes a problem where overriding values for IndexedSet sets doesn't
work in Python 2.7 (for unordered sets, the old values were not removed,
and for ordered sets an exception is raised).

## Changes proposed in this PR:
- 6-charcter fix for IndexedSet
- Tests that verify this functionality works (and fail without this fix)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
