### PR TITLE
Updating symbolic differentiation to be compatible with sympy 1.3

### DIFF
--- a/pyomo/core/base/symbolic.py
+++ b/pyomo/core/base/symbolic.py
@@ -30,9 +30,15 @@ try:
         return sum(x_ for x_ in x)
 
     def _nondifferentiable(*x):
+        if type(x[1]) is tuple:
+            # sympy >= 1.3 returns tuples (var, order)
+            wrt = x[1][0]
+        else:
+            # early versions of sympy returned the bare var
+            wrt = x[1]
         raise NondifferentiableError(
             "The sub-expression '%s' is not differentiable with respect to %s"
-            % (x[0],x[1]) )
+            % (x[0], wrt) )
 
     _operatorMap = {
         sympy.Add: _sum,
@@ -56,6 +62,7 @@ try:
         sympy.floor: lambda x: core.floor(x),
         sympy.sqrt: lambda x: core.sqrt(x),
         sympy.Derivative: _nondifferentiable,
+        sympy.Tuple: lambda *x: x,
     }
 
     _functionMap = {

--- a/pyomo/core/tests/unit/test_symbolic.py
+++ b/pyomo/core/tests/unit/test_symbolic.py
@@ -246,17 +246,19 @@ class SymbolicDerivatives(unittest.TestCase):
 
     def test_nondifferentiable(self):
         m = ConcreteModel()
-        m.x = Var()
+        m.foo = Var()
 
         self.assertRaisesRegexp(
             NondifferentiableError,
-            "The sub-expression '.*' is not differentiable with respect to x",
-            differentiate, ceil(m.x), wrt=m.x)
+            "The sub-expression '.*' is not differentiable "
+            "with respect to .*foo",
+            differentiate, ceil(m.foo), wrt=m.foo)
 
         self.assertRaisesRegexp(
             NondifferentiableError,
-            "The sub-expression '.*' is not differentiable with respect to x",
-            differentiate, floor(m.x), wrt=m.x)
+            "The sub-expression '.*' is not differentiable "
+            "with respect to .*foo",
+            differentiate, floor(m.foo), wrt=m.foo)
 
     def test_errors(self):
         m = ConcreteModel()


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Starting around SymPy 1.3, the WRT for the Derivative node in sympy
expressions went from being a bare symbol to a Tuple(symbol, order).
This tracks that change and makes the nondifferentiable test more
robust.

## Changes proposed in this PR:
- Add `sympy.Tuple` tot he list of known expression nodes
- Update nondifferentiable test

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
