### PR TITLE
Add `SubclassOf` class to support finding components based on issubclass

### DIFF
--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -131,9 +131,10 @@ class SubclassOf(object):
 
         model.component_data_objects(Var, descend_into=SubclassOf(Block))
     """
-    def __init__(self, ctype):
+    def __init__(self, *ctype):
         self.ctype = ctype
-        self.__name__ = 'SubclassOf(%s)' % (ctype.__name__,)
+        self.__name__ = 'SubclassOf(%s)' % (
+            ','.join(x.__name__ for x in ctype),)
 
     def __contains__(self, item):
         return issubclass(item, self.ctype)

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -118,7 +118,34 @@ class _component_decorator(object):
             self._component, self._block, *args, **kwds)
 
 
+class SubclassOf(object):
+    """This mocks up a tuple-like interface based on subclass relationship.
+
+    Instances of this class present a somewhat tuple-like interface for
+    use in PseudoMap ctype / descend_into.  The constructor takes a
+    single ctype argument.  When used with PseudoMap (through Block APIs
+    like component_objects()), it will match any ctype that is a
+    subclass of the reference ctype.
+
+    This allows, for example:
+
+        model.component_data_objects(Var, descend_into=SubclassOf(Block))
+    """
+    def __init__(self, ctype):
+        self.ctype = ctype
+        self.__name__ = 'SubclassOf(%s)' % (ctype.__name__,)
+
+    def __contains__(self, item):
+        return issubclass(item, self.ctype)
+
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, item):
+        return self
+
 class SortComponents(object):
+
     """
     This class is a convenient wrapper for specifying various sort
     ordering.  We pass these objects to the "sort" argument to various
@@ -315,7 +342,8 @@ class _BlockData(ActiveComponentData):
                     return sum(x[2] for x in itervalues(self._block._ctypes))
                 else:
                     return sum(self._block._ctypes.get(x, (0, 0, 0))[2]
-                               for x in self._ctypes)
+                               for x in self._block._ctypes
+                               if x in self._ctypes)
             #
             # If _active is True or False, then we have to count by brute force.
             #
@@ -347,8 +375,8 @@ class _BlockData(ActiveComponentData):
             # at the end of the list.
             _decl_order = self._block._decl_order
             _idx_list = sorted((self._block._ctypes[x][0]
-                                for x in self._ctypes
-                                if x in self._block._ctypes),
+                                for x in self._block._ctypes
+                                if x in self._ctypes),
                                reverse=True)
             while _idx_list:
                 _idx = _idx_list.pop()

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -793,6 +793,12 @@ class TestBlock(unittest.TestCase):
             descend_into=SubclassOf(Block),
         )]
         self.assertEqual(HM.PrefixDFS_block_subclass, result)
+        result = [x.name for x in m.component_objects(
+            ctype=Block,
+            descent_order=TraversalStrategy.PrefixDepthFirstSearch,
+            descend_into=SubclassOf(Var,Block),
+        )]
+        self.assertEqual(HM.PrefixDFS_block_subclass, result)
 
     def test_iterate_mixed_hierarchy_PostfixDFS_block(self):
         HM = MixedHierarchicalModel()
@@ -824,6 +830,12 @@ class TestBlock(unittest.TestCase):
             descend_into=SubclassOf(Block),
         )]
         self.assertEqual(HM.PostfixDFS_block_subclass, result)
+        result = [x.name for x in m.component_objects(
+            ctype=Block,
+            descent_order=TraversalStrategy.PostfixDepthFirstSearch,
+            descend_into=SubclassOf(Var,Block),
+        )]
+        self.assertEqual(HM.PostfixDFS_block_subclass, result)
 
     def test_iterate_mixed_hierarchy_BFS_block(self):
         HM = MixedHierarchicalModel()
@@ -853,6 +865,12 @@ class TestBlock(unittest.TestCase):
             ctype=Block,
             descent_order=TraversalStrategy.BFS,
             descend_into=SubclassOf(Block),
+        )]
+        self.assertEqual(HM.BFS_block_subclass, result)
+        result = [x.name for x in m.component_objects(
+            ctype=Block,
+            descent_order=TraversalStrategy.BFS,
+            descend_into=SubclassOf(Var,Block),
         )]
         self.assertEqual(HM.BFS_block_subclass, result)
 
@@ -1339,7 +1357,17 @@ class TestBlock(unittest.TestCase):
         tester( m.component_map(SubclassOf(Var), active=True),
                 "active SubclassOf(Var) component 'a' not found in block foo" )
         tester( m.component_map(SubclassOf(Var), active=False),
-                "inactive SubclassOf(Var) component 'a' not found in block foo" )
+                "inactive SubclassOf(Var) component "
+                "'a' not found in block foo" )
+
+        tester( m.component_map(SubclassOf(Var,Block)),
+                "SubclassOf(Var,Block) component 'a' not found in block foo" )
+        tester( m.component_map(SubclassOf(Var,Block), active=True),
+                "active SubclassOf(Var,Block) component "
+                "'a' not found in block foo" )
+        tester( m.component_map(SubclassOf(Var,Block), active=False),
+                "inactive SubclassOf(Var,Block) component "
+                "'a' not found in block foo" )
 
         tester( m.component_map([Var,Param]),
                 "Param or Var component 'a' not found in block foo" )

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -27,7 +27,7 @@ import pyutilib.services
 
 from pyomo.environ import *
 from pyomo.common.log import LoggingIntercept
-from pyomo.core.base.block import SimpleBlock
+from pyomo.core.base.block import SimpleBlock, SubclassOf
 from pyomo.core.expr import current as EXPR
 from pyomo.opt import *
 
@@ -463,6 +463,7 @@ class MixedHierarchicalModel(object):
         m.b.d = DerivedBlock()
         m.b.e = Block()
         m.b.e.f = DerivedBlock()
+        m.b.e.f.g = Block()
 
         self.PrefixDFS_block = [
             'unknown',
@@ -480,17 +481,37 @@ class MixedHierarchicalModel(object):
         self.PrefixDFS_both = [
             'unknown',
             'a', 'a.c',
-            'b', 'b.d', 'b.e', 'b.e.f',
+            'b', 'b.d', 'b.e', 'b.e.f', 'b.e.f.g',
         ]
         self.PostfixDFS_both = [
             'a.c', 'a',
-            'b.d', 'b.e.f', 'b.e', 'b',
+            'b.d', 'b.e.f.g', 'b.e.f', 'b.e', 'b',
             'unknown',
         ]
         self.BFS_both = [
             'unknown',
             'a', 'b',
-            'a.c', 'b.d', 'b.e', 'b.e.f',
+            'a.c', 'b.d', 'b.e', 'b.e.f', 'b.e.f.g',
+        ]
+
+        #
+        # References for component_objects tests (note: the model
+        # doesn't appear)
+        #
+        self.PrefixDFS_block_subclass = [
+            'a',
+            'b.e',
+            'b.e.f.g',
+        ]
+        self.PostfixDFS_block_subclass = [
+            'b.e.f.g',
+            'b.e',
+            'a',
+        ]
+        self.BFS_block_subclass = [
+            'a',
+            'b.e',
+            'b.e.f.g',
         ]
 
 class TestBlock(unittest.TestCase):
@@ -758,6 +779,20 @@ class TestBlock(unittest.TestCase):
             ctype=(Block,DerivedBlock),
         )]
         self.assertEqual(HM.PrefixDFS_both, result)
+    def test_iterate_mixed_hierarchy_PrefixDFS_SubclassOf(self):
+        HM = MixedHierarchicalModel()
+        m = HM.model
+        result = [x.name for x in m._tree_iterator(
+            traversal=TraversalStrategy.PrefixDepthFirstSearch,
+            ctype=SubclassOf(Block),
+        )]
+        self.assertEqual(HM.PrefixDFS_both, result)
+        result = [x.name for x in m.component_objects(
+            ctype=Block,
+            descent_order=TraversalStrategy.PrefixDepthFirstSearch,
+            descend_into=SubclassOf(Block),
+        )]
+        self.assertEqual(HM.PrefixDFS_block_subclass, result)
 
     def test_iterate_mixed_hierarchy_PostfixDFS_block(self):
         HM = MixedHierarchicalModel()
@@ -775,6 +810,20 @@ class TestBlock(unittest.TestCase):
             ctype=(Block,DerivedBlock),
         )]
         self.assertEqual(HM.PostfixDFS_both, result)
+    def test_iterate_mixed_hierarchy_PostfixDFS_SubclassOf(self):
+        HM = MixedHierarchicalModel()
+        m = HM.model
+        result = [x.name for x in m._tree_iterator(
+            traversal=TraversalStrategy.PostfixDepthFirstSearch,
+            ctype=SubclassOf(Block),
+        )]
+        self.assertEqual(HM.PostfixDFS_both, result)
+        result = [x.name for x in m.component_objects(
+            ctype=Block,
+            descent_order=TraversalStrategy.PostfixDepthFirstSearch,
+            descend_into=SubclassOf(Block),
+        )]
+        self.assertEqual(HM.PostfixDFS_block_subclass, result)
 
     def test_iterate_mixed_hierarchy_BFS_block(self):
         HM = MixedHierarchicalModel()
@@ -792,6 +841,20 @@ class TestBlock(unittest.TestCase):
             ctype=(Block,DerivedBlock),
         )]
         self.assertEqual(HM.BFS_both, result)
+    def test_iterate_mixed_hierarchy_BFS_SubclassOf(self):
+        HM = MixedHierarchicalModel()
+        m = HM.model
+        result = [x.name for x in m._tree_iterator(
+            traversal=TraversalStrategy.BFS,
+            ctype=SubclassOf(Block),
+        )]
+        self.assertEqual(HM.BFS_both, result)
+        result = [x.name for x in m.component_objects(
+            ctype=Block,
+            descent_order=TraversalStrategy.BFS,
+            descend_into=SubclassOf(Block),
+        )]
+        self.assertEqual(HM.BFS_block_subclass, result)
 
 
     def test_add_remove_component_byname(self):
@@ -1270,6 +1333,13 @@ class TestBlock(unittest.TestCase):
                 "active Var component 'a' not found in block foo" )
         tester( m.component_map(Var, active=False),
                 "inactive Var component 'a' not found in block foo" )
+
+        tester( m.component_map(SubclassOf(Var)),
+                "SubclassOf(Var) component 'a' not found in block foo" )
+        tester( m.component_map(SubclassOf(Var), active=True),
+                "active SubclassOf(Var) component 'a' not found in block foo" )
+        tester( m.component_map(SubclassOf(Var), active=False),
+                "inactive SubclassOf(Var) component 'a' not found in block foo" )
 
         tester( m.component_map([Var,Param]),
                 "Param or Var component 'a' not found in block foo" )


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
This allows users to iterate over model hierarchies based on `issubclass(obj.type(), ctype)` instead of just `obj.type() is ctype`.  This way, for example, users can get Var objects on any "Block-like" object in the model with:
```
model.component_data_objects(Var, descend_into=SubclassOf(Block))
```

## Changes proposed in this PR:
- Add `pyomo.core.base.block.SubclassOf` class
- Add tests

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
