### PR TITLE
fix one line used when k_aug is used (which cannot be tested on the C…

### DIFF
--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -58,10 +58,10 @@ def _object_from_string(instance, vstr):
 def _ef_ROOT_node_Object_from_string(efinstance, vstr):
     """
     Wrapper for _object_from_string for PySP extensive forms
-    but only for Vars at the node named ROOT.
-    DLW April 2018: needs work to generalized.
+    but only for Vars at the node named RootNode.
+    DLW April 2018: needs work to be generalized.
     """
-    efvstr = "MASTER_BLEND_VAR_Node_ROOT["+vstr+"]"
+    efvstr = "MASTER_BLEND_VAR_RootNode["+vstr+"]"
     return _object_from_string(efinstance, efvstr)
 
 #=============================================


### PR DESCRIPTION
…I systems)

## Fixes # .

## Summary/Motivation:
There is an option to use k_aug which is not tested (because k_aug is not on the test systems and
is hard to install). This fixes a bug in code that is needed when k_aug is used.

## Changes proposed in this PR:
- fixes a bug in how the root Vars are obtained when k_aug is used.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
