### PR TITLE
Reference "component" improvements

### DIFF
--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1580,18 +1580,20 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         # that expected by a user.
         #
         import pyomo.core.base.component_order
-        items = pyomo.core.base.component_order.items + [Block]
+        items = list(pyomo.core.base.component_order.items)
+        items_set = set(items)
+        items_set.add(Block)
         #
         # Collect other model components that are registered
         # with the IModelComponent extension point.  These are appended
         # to the end of the list of the list.
         #
         dynamic_items = set()
-        #for item in [ModelComponentFactory.get_class(name).component for name in ModelComponentFactory]:
-        for item in [ModelComponentFactory.get_class(name) for name in ModelComponentFactory]:
-            if not item in items:
+        for item in self._ctypes:
+            if not item in items_set:
                 dynamic_items.add(item)
         # extra items get added alphabetically (so output is consistent)
+        items.append(Block)
         items.extend(sorted(dynamic_items, key=lambda x: x.__name__))
 
         for item in items:

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -684,6 +684,16 @@ value() function.""" % ( self.name, i ))
                 "for scalar instances."
                 % (self.__class__.__name__,))
 
+    def _pprint(self):
+        """Print component information."""
+        return ( [("Size", len(self)),
+                  ("Index", self._index if self.is_indexed() else None),
+                  ],
+                 iteritems(self._data),
+                 ( "Object",),
+                 lambda k, v: [ type(v) ]
+                 )
+
     def id_index_map(self):
         """
         Return an dictionary id->index for

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -331,13 +331,15 @@ You can silence this warning by one of three ways:
             from pyomo.core.expr import current as EXPR
             if index.__class__ is EXPR.GetItemExpression:
                 return index
-            index = self._validate_index(index)
-            # _processUnhashableIndex could have found a slice, or
-            # _validate could have found an Ellipsis and returned a
-            # slicer
-            if index.__class__ is _IndexedComponent_slice:
-                return index
-            obj = self._data.get(index, _NotFound)
+            validated_index = self._validate_index(index)
+            if validated_index is not index:
+                index = validated_index
+                # _processUnhashableIndex could have found a slice, or
+                # _validate could have found an Ellipsis and returned a
+                # slicer
+                if index.__class__ is _IndexedComponent_slice:
+                    return index
+                obj = self._data.get(index, _NotFound)
             #
             # Call the _getitem_when_not_present helper to retrieve/return
             # the default value
@@ -466,11 +468,13 @@ You can silence this warning by one of three ways:
             # indices will be already be normalized, so we defer the
             # "automatic" call to normalize_index until now for the
             # sake of efficiency.
-            idx = normalize_index(idx)
-            if idx in self._data:
-                return idx
-            if idx in self._index:
-                return idx
+            normalized_idx = normalize_index(idx)
+            if normalized_idx is not idx:
+                idx = normalized_idx
+                if idx in self._data:
+                    return idx
+                if idx in self._index:
+                    return idx
         # There is the chance that the index contains an Ellipsis,
         # so we should generate a slicer
         if idx is Ellipsis or idx.__class__ is tuple and Ellipsis in idx:

--- a/pyomo/core/base/indexed_component_slice.py
+++ b/pyomo/core/base/indexed_component_slice.py
@@ -67,7 +67,7 @@ class _IndexedComponent_slice(object):
         This supports notation similar to:
 
             del model.b[:].c.x = 5
-        
+
         and immediately evaluates the slice.
         """
         # Don't overload any pre-existing attributes
@@ -97,7 +97,7 @@ class _IndexedComponent_slice(object):
         This supports notation similar to:
 
             del model.b[:].c.x[1,:] = 5
-        
+
         and immediately evaluates the slice.
         """
         self._call_stack.append( (
@@ -112,7 +112,7 @@ class _IndexedComponent_slice(object):
         This supports notation similar to:
 
             del model.b[:].c.x[1,:]
-        
+
         and immediately evaluates the slice.
         """
         self._call_stack.append( (
@@ -126,7 +126,7 @@ class _IndexedComponent_slice(object):
 
         Creating a slice of a component returns a _IndexedComponent_slice
         object.  Subsequent attempts to call items hit this method.  We
-        handle the __call__ method separately based on the item ( identifier
+        handle the __call__ method separately based on the item (identifier
         immediately before the "()") being called:
 
         - if the item was 'component', then we defer resolution of this call
@@ -223,6 +223,7 @@ class _slice_generator(object):
                 # derived class may implement a non-standard storage
                 # mechanism (e.g., Param)
                 return self.component[index]
+
 
 # Mock up a callable object with a "check_complete" method
 def _advance_iter(_iter):

--- a/pyomo/core/base/indexed_component_slice.py
+++ b/pyomo/core/base/indexed_component_slice.py
@@ -161,6 +161,10 @@ class _IndexedComponent_slice(object):
         _iter = self.__iter__()
         return (_iter.get_last_index_wildcards() for _ in _iter)
 
+    def wildcard_items(self):
+        _iter = self.__iter__()
+        return ((_iter.get_last_index_wildcards(), _) for _ in _iter)
+
     def expanded_keys(self):
         _iter = self.__iter__()
         return (_iter.get_last_index() for _ in _iter)
@@ -452,17 +456,25 @@ class _IndexedComponent_slice_iter(object):
                 return _comp
 
     def get_last_index(self):
-        return sum(
+        ans = sum(
             ( x.last_index for x in self._iter_stack if x is not None ),
             ()
         )
+        if len(ans) == 1:
+            return ans[0]
+        else:
+            return ans
 
     def get_last_index_wildcards(self):
-        return sum(
+        ans = sum(
             ( tuple( x.last_index[i]
                      for i in range(len(x.last_index))
                      if i not in x.fixed )
               for x in self._iter_stack if x is not None ),
             ()
         )
+        if len(ans) == 1:
+            return ans[0]
+        else:
+            return ans
 

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -135,7 +135,7 @@ class _ReferenceDict(collections.MutableMapping):
         elif op == _IndexedComponent_slice.slice_info:
             tmp._call_stack[-1] = (
                 _IndexedComponent_slice.set_item,
-                tmp,
+                tmp._call_stack[-1][1],
                 val )
         elif op == _IndexedComponent_slice.get_attribute:
             tmp._call_stack[-1] = (

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -171,12 +171,45 @@ class _ReferenceDict(collections.MutableMapping):
         except (AttributeError, KeyError):
             return False
 
+    def iteritems(self):
+        """Return the wildcard, value tuples for this ReferenceDict
+
+        This method is necessary because the default implementation
+        iterates over the keys and looks the values up in the
+        dictionary.  Unfortunately some slices have structures that make
+        looking up components by the wildcard keys very expensive
+        (linear time; e.g., the use of elipses with jagged sets).  By
+        implementing this method without using lookups, general methods
+        that iterate over everything (like component.pprint()) will
+        still be linear and not quadratic time.
+
+        """
+        return self._slice.wildcard_items()
+
+    def itervalues(self):
+        """Return the values for this ReferenceDict
+
+        This method is necessary because the default implementation
+        iterates over the keys and looks the values up in the
+        dictionary.  Unfortunately some slices have structures that make
+        looking up components by the wildcard keys very expensive
+        (linear time; e.g., the use of elipses with jagged sets).  By
+        implementing this method without using lookups, general methods
+        that iterate over everything (like component.pprint()) will
+        still be linear and not quadratic time.
+
+        """
+        return iter(self._slice)
+
     def _get_iter(self, _slice, key):
         if key.__class__ not in (tuple, list):
             key = (key,)
         return _IndexedComponent_slice_iter(
             _slice, _fill_in_known_wildcards(flatten_tuple(key)))
 
+if PY3:
+    _ReferenceDict.items = _ReferenceDict.iteritems
+    _ReferenceDict.values = _ReferenceDict.itervalues
 
 class _ReferenceSet(collections.Set):
     def __init__(self, ref_dict):

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -14,7 +14,7 @@ from six import PY3, iteritems, advance_iterator
 from pyutilib.misc import flatten_tuple
 from pyomo.common import DeveloperError
 from pyomo.core.base.sets import SetOf, _SetProduct, _SetDataBase
-from pyomo.core.base.component import Component
+from pyomo.core.base.component import Component, ComponentData
 from pyomo.core.base.indexed_component import (
     IndexedComponent, UnindexedComponent_set
 )
@@ -437,6 +437,15 @@ def Reference(reference, ctype=_NotSpecified):
     index = []
     for obj in _iter:
         ctypes.add(obj.type())
+        if not isinstance(obj, ComponentData):
+            # This object is not a ComponentData (likely it is a pure
+            # IndexedComponent container).  As the Reference will treat
+            # it as if it *were* a ComponentData, we will skip ctype
+            # identification and return a base IndexedComponent, thereby
+            # preventing strange exceptions in the writers and with
+            # things like pprint().  Of course, all of this logic is
+            # skipped if the User knows better and forced a ctype on us.
+            ctypes.add(0)
         if index is not None:
             index = _identify_wildcard_sets(_iter._iter_stack, index)
         # Note that we want to walk the entire slice, unless we can

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -377,9 +377,9 @@ def Reference(reference, ctype=_NotSpecified):
         >>> m.r2 = Reference(m.b[:,3].x)
         >>> m.r2.pprint()
         r2 : Size=2, Index=b_index_0
-            Key  : Lower : Value : Upper : Fixed : Stale : Domain
-            (1,) :     1 :  None :     3 : False :  True :  Reals
-            (2,) :     2 :  None :     3 : False :  True :  Reals
+            Key : Lower : Value : Upper : Fixed : Stale : Domain
+              1 :     1 :  None :     3 : False :  True :  Reals
+              2 :     2 :  None :     3 : False :  True :  Reals
 
     Reference components may have wildcards at multiple levels of the
     model hierarchy:

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -270,6 +270,10 @@ def _identify_wildcard_sets(iter_stack, index):
             offset = 0
             wildcard_sets = {}
             for j,s in enumerate(_get_base_sets(level.component.index_set())):
+                if s is UnindexedComponent_set:
+                    wildcard_sets[j] = s
+                    offset += 1
+                    continue
                 if s.dimen is None:
                     return None
                 wild = sum( 1 for k in range(s.dimen)
@@ -434,8 +438,12 @@ def Reference(reference, ctype=_NotSpecified):
         wildcards = sum((sorted(iteritems(lvl)) for lvl in index
                          if lvl is not None), [])
         index = wildcards[0][1]
-        for idx in wildcards[1:]:
-            index = index * idx[1]
+        if not isinstance(index, _SetDataBase):
+            index = SetOf(index)
+        for lvl, idx in wildcards[1:]:
+            if not isinstance(idx, _SetDataBase):
+                idx = SetOf(idx)
+            index = index * idx
     if ctype is _NotSpecified:
         if len(ctypes) == 1:
             ctype = ctypes.pop()

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -432,6 +432,11 @@ def Reference(reference, ctype=_NotSpecified):
     for obj in _iter:
         ctypes.add(obj.type())
         index = _identify_wildcard_sets(_iter._iter_stack, index)
+        # Note that we want to walk the entire slice, unless we can
+        # prove that BOTH there aren't common indexing sets AND there is
+        # more than one ctype.
+        if index is None and len(ctypes) > 1:
+            break
     if index is None:
         index = SetOf(_ReferenceSet(_data))
     else:

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -427,15 +427,22 @@ def Reference(reference, ctype=_NotSpecified):
 
     _data = _ReferenceDict(reference)
     _iter = iter(reference)
-    ctypes = set()
+    if ctype is _NotSpecified:
+        ctypes = set()
+    else:
+        # If the caller specified a ctype, then we will prepopulate the
+        # list to improve our chances of avoiding a scan of the entire
+        # Reference
+        ctypes = set((1,2))
     index = []
     for obj in _iter:
         ctypes.add(obj.type())
-        index = _identify_wildcard_sets(_iter._iter_stack, index)
+        if index is not None:
+            index = _identify_wildcard_sets(_iter._iter_stack, index)
         # Note that we want to walk the entire slice, unless we can
         # prove that BOTH there aren't common indexing sets AND there is
         # more than one ctype.
-        if index is None and len(ctypes) > 1:
+        elif len(ctypes) > 1:
             break
     if index is None:
         index = SetOf(_ReferenceSet(_data))

--- a/pyomo/core/tests/unit/test_reference.py
+++ b/pyomo/core/tests/unit/test_reference.py
@@ -527,8 +527,10 @@ class TestReference(unittest.TestCase):
         m.b = Block([1,2])
         m.b[1].x = Var(m.js)
         m.b[1].y = Var()
+        m.b[1].z = Var([1,2])
         m.b[2].x = Param(initialize=0)
         m.b[2].y = Var()
+        m.b[2].z = Var([1,2])
 
         m.x = Reference(m.b[:].x[...])
         self.assertIs(type(m.x), IndexedComponent)
@@ -539,6 +541,10 @@ class TestReference(unittest.TestCase):
         m.y1 = Reference(m.b[:].y[...], ctype=None)
         self.assertIs(type(m.y1), IndexedComponent)
         self.assertIs(m.y1.type(), IndexedComponent)
+
+        m.z = Reference(m.b[:].z)
+        self.assertIs(type(m.z), IndexedComponent)
+        self.assertIs(m.z.type(), IndexedComponent)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/core/tests/unit/test_reference.py
+++ b/pyomo/core/tests/unit/test_reference.py
@@ -16,7 +16,7 @@ from os.path import abspath, dirname
 currdir = dirname(abspath(__file__))+os.sep
 
 import pyutilib.th as unittest
-from six import itervalues
+from six import itervalues, StringIO
 
 from pyomo.environ import *
 from pyomo.core.base.var import IndexedVar
@@ -346,6 +346,19 @@ class TestReference(unittest.TestCase):
         self.assertIs(m.t[1], m.y[1])
         with self.assertRaises(KeyError):
             m.t[3]
+
+    def test_reference_indexedcomponent_pprint(self):
+        m = ConcreteModel()
+        m.x = Var([1,2], initialize={1:4,2:8})
+        m.r = Reference(m.x, ctype=IndexedComponent)
+        buf = StringIO()
+        m.r.pprint(ostream=buf)
+        self.assertEqual(buf.getvalue(),
+"""r : Size=2, Index=x_index
+    Key : Object
+      1 : <class 'pyomo.core.base.var._GeneralVarData'>
+      2 : <class 'pyomo.core.base.var._GeneralVarData'>
+""")
 
     def test_single_reference(self):
         m = ConcreteModel()


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This PR contains a number of improvements to the `Reference()` method, including better support for using ellipses when defining the slice, formal support for generating references to scalar components, minor efficiency improvements, and additional tests.

## Changes proposed in this PR:
- improved support for ellipsis (and identifying common underlying indexing sets)
- added support for references to scalar components
- fix Block's `pprint()` so that all components are printed out (see #690)
- Additional tests and defensive error traps (e.g., References to indexed components instead of ComponentData objects)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
