### PR TITLE
Adding sphinx version to readthedocs requirements

### DIFF
--- a/.readthedocs_requirements.txt
+++ b/.readthedocs_requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/PyUtilib/pyutilib
-
+sphinx>=1.8.0


### PR DESCRIPTION
## Fixes #741.

## Summary/Motivation:
Adding a Sphinx version requirement to the readthedocs requirements file. Currently, readthedocs is automatically pinned to Sphinx version 1.7.9 and we need features introduced in 1.8 to render the pyomo.network documentation correctly.

## Changes proposed in this PR:
- Add a sphinx version requirement for readthedocs

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
