### PR TITLE
define the variable opt before use in the first example

### DIFF
--- a/doc/OnlineDocs/working_models.rst
+++ b/doc/OnlineDocs/working_models.rst
@@ -32,7 +32,8 @@ Repeated Solves
    ...    return pyo.summation(model.x)
    >>> model.o = pyo.Objective(rule=o_rule)
    >>> model.c = pyo.ConstraintList()
-   >>> SolverFactory('glpk').solve(model) # doctest: +SKIP
+   >>> opt = SolverFactory('glpk')
+   >>> opt.solve(model) # doctest: +SKIP
 
    Iterate to eliminate the previously found solution
    >>> for i in range(5):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
In the first iterative scripting example, the variable opt was used before
it is given a value. This probably passed doctest because opt is used
a lot in our examples, so it was probably defined in some earlier example.

## Changes proposed in this PR:
SolverFactory('glpk').solve(model) 
is now
opt = SolverFactory('glpk')
opt.solve(model) 

because opt is used  in the loop below. 


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
