### PR TITLE
add description of load_solutions=False

### DIFF
--- a/doc/OnlineDocs/working_models.rst
+++ b/doc/OnlineDocs/working_models.rst
@@ -71,14 +71,6 @@ computer to solve the problem or even to iterate over solutions. This
 example is provided just to illustrate some elementary aspects of
 scripting.
 
-.. note::
-
-   The built-in code for printing solutions prints only non-zero
-   variable values. So if you run this code, no variable values will be
-   output for the first solution found because all of the variables are
-   zero. However, other information about the solution, such as the
-   objective value, will be displayed.
-
 .. literalinclude:: script_spy_files/iterative1.spy
    :language: python
 
@@ -190,6 +182,20 @@ The final lines in the outer for loop find a solution and display it:
 
 .. literalinclude:: script_spy_files/iterative1_Find_and_display_solution.spy
    :language: python
+
+.. note::
+   
+   The assignment of the solve output to a results object is somewhat
+   anachronistic. Many scripts just use
+
+   >>> opt.solve(instance) # doctest: +SKIP
+
+   since the results are moved to the instance by default, leaving
+   the results object with little of interest. If, for some reason,
+   you want the results to stay in the results object and *not* be
+   moved to the instance, you would use
+
+   >>> results = opt.solve(instance, load_solutions=False) # doctest: +SKIP
 
 Changing the Model or Data and Re-solving
 -----------------------------------------

--- a/doc/OnlineDocs/working_models.rst
+++ b/doc/OnlineDocs/working_models.rst
@@ -200,9 +200,9 @@ The final lines in the outer for loop find a solution and display it:
    This approach can be usefull if there is a concern that the solver
    did not terminate with an optimal solution. For example,
    
-   >>> results = opt.solve(instance, load_solutions=False) #doctest: +SKIP
-   >>> if results.solver.termination_condition == TerminationCondition.optimal:
-   >>>     instance.solutions.load_from(results)
+   >>> results = opt.solve(instance, load_solutions=False) # doctest: +SKIP
+   >>> if results.solver.termination_condition == TerminationCondition.optimal: # doctest: +SKIP
+   >>>     instance.solutions.load_from(results) # doctest: +SKIP
 
 Changing the Model or Data and Re-solving
 -----------------------------------------

--- a/doc/OnlineDocs/working_models.rst
+++ b/doc/OnlineDocs/working_models.rst
@@ -196,6 +196,13 @@ The final lines in the outer for loop find a solution and display it:
    moved to the instance, you would use
 
    >>> results = opt.solve(instance, load_solutions=False) # doctest: +SKIP
+   
+   This approach can be usefull if there is a concern that the solver
+   did not terminate with an optimal solution. For example,
+   
+   >>> results = opt.solve(instance, load_solutions=False) #doctest: +SKIP
+   >>> if results.solver.termination_condition == TerminationCondition.optimal:
+   >>>     instance.solutions.load_from(results)
 
 Changing the Model or Data and Re-solving
 -----------------------------------------


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Document  opt.solve(..., load_solutions=False)

## Changes proposed in this PR:
I added a note below the iterative1.py example (that is untested, old-fashioned spy) with
two more untested lines to explain that
 results = opt.solve(instance)
leaves the results object in a bad state. If users want to look at the results object, they should
use
 results = opt.solve(instance, load_solutions=False)

Adding two more untested lines is bad, but they would be easy to test as soon as someone has time
to move iterative1.py inline. On the other hand, we got one question on the forum today and I got
 private question from a new developer about trying to print the results object and getting
bad stuff.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
