### PR TITLE
Minor Fixes to Avoid Deprecation Warnings

### DIFF
--- a/pyomo/common/_task.py
+++ b/pyomo/common/_task.py
@@ -236,17 +236,28 @@ def pyomo_api(fn=None, implements=None, outputs=None, namespace=None):
 
         if six.PY2:
             argspec = inspect.getargspec(fn)
+            if argspec.keywords is not None:
+                logger.error("Attempting to declare Pyomo task with function "
+                             "'%s' that contains variable keyword arguments" % _alias)
+                return                                      #pragma:nocover
         else:
             argspec = inspect.getfullargspec(fn)
-        if not argspec.varargs is None:
+            if argspec.varkw is not None:
+                logger.error("Attempting to declare Pyomo task with function "
+                             "'%s' that contains variable keyword arguments" % _alias)
+                return                                     #pragma:nocover
+            # Not supporting new keyword-only definitions until someone
+            # who maintains this code decides the code that uses argspec below here
+            # is worth updating. Note that this attribute is an empty list when
+            # there are not keyword-only arguments.
+            if argspec.kwonlyargs:
+                logger.error("Attempting to declare Pyomo task with function "
+                             "'%s' that contains keyword-only arguments" % _alias)
+                return                                      #pragma:nocover
+        if argspec.varargs is not None:
             logger.error("Attempting to declare Pyomo task with function "
                          "'%s' that contains variable arguments" % _alias)
             return                                      #pragma:nocover
-        if not argspec.keywords is None:
-            logger.error("Attempting to declare Pyomo task with function "
-                         "'%s' that contains variable keyword arguments" % _alias)
-            return                                      #pragma:nocover
-
         if _alias in PyomoAPIFactory.services():
             logger.error("Cannot define API %s, since this API name is already defined" % _alias)
             return                                      #pragma:nocover

--- a/pyomo/common/_task.py
+++ b/pyomo/common/_task.py
@@ -16,6 +16,7 @@ __all__ = ['pyomo_api', 'IPyomoTask', 'PyomoAPIFactory', 'PyomoAPIData']
 
 import inspect
 import logging
+import six
 from six import iteritems, with_metaclass
 
 import pyutilib.workflow
@@ -233,7 +234,10 @@ def pyomo_api(fn=None, implements=None, outputs=None, namespace=None):
             _alias =  namespace+'.'+fn.__name__
         _name = _alias.replace('_', '.')
 
-        argspec = inspect.getargspec(fn)
+        if six.PY2:
+            argspec = inspect.getargspec(fn)
+        else:
+            argspec = inspect.getfullargspec(fn)
         if not argspec.varargs is None:
             logger.error("Attempting to declare Pyomo task with function "
                          "'%s' that contains variable arguments" % _alias)

--- a/pyomo/common/_task.py
+++ b/pyomo/common/_task.py
@@ -129,7 +129,7 @@ class PyomoTask(PyomoTaskPlugin):
         # Process data
         #
         data = self._kwds.get('data', None)
-        if not data is None and type(data) is dict:
+        if (data is not None) and (type(data) is dict):
             _data = PyomoAPIData()
             _data.update(data)
             self._kwds['data'] = _data
@@ -140,7 +140,7 @@ class PyomoTask(PyomoTaskPlugin):
         def nested_lookup(kwds, lookup):
             lookups = lookup.split('.')
             obj = kwds[lookups[0]]
-            if not data is None and lookups[0] == 'data':
+            if (data is not None) and (lookups[0] == 'data'):
                 data.declare(lookups[1])
             for key in lookups[1:]:
                 #print key, obj
@@ -166,7 +166,7 @@ class PyomoTask(PyomoTaskPlugin):
         #
         # Process retval
         #
-        if retval is None or id(data) == id(retval):
+        if (retval is None) or (id(data) == id(retval)):
             self._retval = PyomoAPIData(data=data)
         elif isinstance(retval, PyomoAPIData):
             if not id(data) == id(retval):
@@ -264,7 +264,7 @@ def pyomo_api(fn=None, implements=None, outputs=None, namespace=None):
             def __init__(self, *args, **kwargs):
                 kwargs['fn'] = fn
                 PyomoTask.__init__(self, *args, **kwargs)
-                if not fn is None:
+                if fn is not None:
                     if len(argspec.args) is 0:
                         nargs = 0
                     elif argspec.defaults is None:

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -8,7 +8,14 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import collections
+try:
+    # python3
+    from collections.abc import MutableMapping as collections_MutableMapping
+    from collections.abc import Set as collections_Set
+except:                                           #pragma:nocover
+    from collections import MutableMapping as collections_MutableMapping
+    from collections import Set as collections_Set
+
 from six import PY3, iteritems, advance_iterator
 
 from pyutilib.misc import flatten_tuple
@@ -105,7 +112,7 @@ class _fill_in_known_wildcards(object):
 class SliceEllipsisLookupError(Exception):
     pass
 
-class _ReferenceDict(collections.MutableMapping):
+class _ReferenceDict(collections_MutableMapping):
     def __init__(self, component_slice):
         self._slice = component_slice
 
@@ -234,7 +241,7 @@ if PY3:
     _ReferenceDict.items = _ReferenceDict.iteritems
     _ReferenceDict.values = _ReferenceDict.itervalues
 
-class _ReferenceSet(collections.Set):
+class _ReferenceSet(collections_Set):
     def __init__(self, ref_dict):
         self._ref = ref_dict
 

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -8,16 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-try:
-    # python3
-    from collections.abc import MutableMapping as collections_MutableMapping
-    from collections.abc import Set as collections_Set
-except:                                           #pragma:nocover
-    from collections import MutableMapping as collections_MutableMapping
-    from collections import Set as collections_Set
-
-from six import PY3, iteritems, advance_iterator
-
 from pyutilib.misc import flatten_tuple
 from pyomo.common import DeveloperError
 from pyomo.core.base.sets import SetOf, _SetProduct, _SetDataBase
@@ -28,6 +18,16 @@ from pyomo.core.base.indexed_component import (
 from pyomo.core.base.indexed_component_slice import (
     _IndexedComponent_slice, _IndexedComponent_slice_iter
 )
+
+import six
+from six import iteritems, advance_iterator
+
+if six.PY3:
+    from collections.abc import MutableMapping as collections_MutableMapping
+    from collections.abc import Set as collections_Set
+else:
+    from collections import MutableMapping as collections_MutableMapping
+    from collections import Set as collections_Set
 
 _NotSpecified = object()
 
@@ -237,7 +237,7 @@ class _ReferenceDict(collections_MutableMapping):
         return _IndexedComponent_slice_iter(
             _slice, _fill_in_known_wildcards(flatten_tuple(key)))
 
-if PY3:
+if six.PY3:
     _ReferenceDict.items = _ReferenceDict.iteritems
     _ReferenceDict.values = _ReferenceDict.itervalues
 

--- a/pyomo/core/kernel/component_map.py
+++ b/pyomo/core/kernel/component_map.py
@@ -8,16 +8,15 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-try:
-    # python3
-    from collections.abc import MutableMapping as collections_MutableMapping
-    from collections.abc import Mapping as collections_Mapping
-except:                                           #pragma:nocover
-    from collections import MutableMapping as collections_MutableMapping
-    from collections import Mapping as collections_Mapping
-
 import six
 from six import itervalues
+
+if six.PY3:
+    from collections.abc import MutableMapping as collections_MutableMapping
+    from collections.abc import Mapping as collections_Mapping
+else:
+    from collections import MutableMapping as collections_MutableMapping
+    from collections import Mapping as collections_Mapping
 
 class ComponentMap(collections_MutableMapping):
     """

--- a/pyomo/core/kernel/component_map.py
+++ b/pyomo/core/kernel/component_map.py
@@ -9,17 +9,17 @@
 #  ___________________________________________________________________________
 
 try:
-    # python 3.7+
-    from collections.abc import MutableMapping as _MutableMapping
-    from collections.abc import Mapping as _Mapping
+    # python3
+    from collections.abc import MutableMapping as collections_MutableMapping
+    from collections.abc import Mapping as collections_Mapping
 except:                                           #pragma:nocover
-    from collections import MutableMapping as _MutableMapping
-    from collections import Mapping as _Mapping
+    from collections import MutableMapping as collections_MutableMapping
+    from collections import Mapping as collections_Mapping
 
 import six
 from six import itervalues
 
-class ComponentMap(_MutableMapping):
+class ComponentMap(collections_MutableMapping):
     """
     This class is a replacement for dict that allows Pyomo
     modeling components to be used as entry keys. The
@@ -132,7 +132,7 @@ class ComponentMap(_MutableMapping):
     # plain dictionary mapping key->(type(val), id(val)) and
     # compare that instead.
     def __eq__(self, other):
-        if not isinstance(other, _Mapping):
+        if not isinstance(other, collections_Mapping):
             return False
         return dict(((type(key), id(key)), val)
                     for key, val in self.items()) == \

--- a/pyomo/core/kernel/component_set.py
+++ b/pyomo/core/kernel/component_set.py
@@ -8,16 +8,15 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-try:
-    # python3
-    from collections.abc import MutableSet as collections_MutableSet
-    from collections.abc import Set as collections_Set
-except:                                           #pragma:nocover
-    from collections import MutableSet as collections_MutableSet
-    from collections import Set as collections_Set
-
 import six
 from six import itervalues, iteritems
+
+if six.PY3:
+    from collections.abc import MutableSet as collections_MutableSet
+    from collections.abc import Set as collections_Set
+else:
+    from collections import MutableSet as collections_MutableSet
+    from collections import Set as collections_Set
 
 class ComponentSet(collections_MutableSet):
     """

--- a/pyomo/core/kernel/component_set.py
+++ b/pyomo/core/kernel/component_set.py
@@ -9,17 +9,17 @@
 #  ___________________________________________________________________________
 
 try:
-    # python 3.7+
-    from collections.abc import MutableSet as _MutableSet
-    from collections.abc import Set as _Set
+    # python3
+    from collections.abc import MutableSet as collections_MutableSet
+    from collections.abc import Set as collections_Set
 except:                                           #pragma:nocover
-    from collections import MutableSet as _MutableSet
-    from collections import Set as _Set
+    from collections import MutableSet as collections_MutableSet
+    from collections import Set as collections_Set
 
 import six
 from six import itervalues, iteritems
 
-class ComponentSet(_MutableSet):
+class ComponentSet(collections_MutableSet):
     """
     This class is a replacement for set that allows Pyomo
     modeling components to be used as entries. The
@@ -110,7 +110,7 @@ class ComponentSet(_MutableSet):
     # plain dictionary mapping key->(type(val), id(val)) and
     # compare that instead.
     def __eq__(self, other):
-        if not isinstance(other, _Set):
+        if not isinstance(other, collections_Set):
             return False
         return set((type(val), id(val))
                    for val in self) == \

--- a/pyomo/core/kernel/dict_container.py
+++ b/pyomo/core/kernel/dict_container.py
@@ -21,12 +21,12 @@ else:
         import ordereddict
         _ordered_dict_ = ordereddict.OrderedDict
 try:
-    # python 3.7+
-    from collections.abc import MutableMapping as _MutableMapping
-    from collections.abc import Mapping as _Mapping
+    # python3
+    from collections.abc import MutableMapping as collections_MutableMapping
+    from collections.abc import Mapping as collections_Mapping
 except:                                           #pragma:nocover
-    from collections import MutableMapping as _MutableMapping
-    from collections import Mapping as _Mapping
+    from collections import MutableMapping as collections_MutableMapping
+    from collections import Mapping as collections_Mapping
 
 from pyomo.core.kernel.homogeneous_container import \
     IHomogeneousContainer
@@ -45,7 +45,7 @@ logger = logging.getLogger('pyomo.core')
 # closer to a Python 3-only world these types of objects are
 # not memory bottlenecks.
 class DictContainer(IHomogeneousContainer,
-                    _MutableMapping):
+                    collections_MutableMapping):
     """
     A partial implementation of the IHomogeneousContainer
     interface that provides dict-like storage functionality.
@@ -174,7 +174,7 @@ class DictContainer(IHomogeneousContainer,
     # plain dictionary mapping key->(type(val), id(val)) and
     # compare that instead.
     def __eq__(self, other):
-        if not isinstance(other, _Mapping):
+        if not isinstance(other, collections_Mapping):
             return False
         return dict((key, (type(val), id(val)))
                     for key, val in self.items()) == \

--- a/pyomo/core/kernel/dict_container.py
+++ b/pyomo/core/kernel/dict_container.py
@@ -20,19 +20,19 @@ else:
     except ImportError:                           #pragma:nocover
         import ordereddict
         _ordered_dict_ = ordereddict.OrderedDict
-try:
-    # python3
-    from collections.abc import MutableMapping as collections_MutableMapping
-    from collections.abc import Mapping as collections_Mapping
-except:                                           #pragma:nocover
-    from collections import MutableMapping as collections_MutableMapping
-    from collections import Mapping as collections_Mapping
 
 from pyomo.core.kernel.homogeneous_container import \
     IHomogeneousContainer
 
 import six
 from six import itervalues, iteritems
+
+if six.PY3:
+    from collections.abc import MutableMapping as collections_MutableMapping
+    from collections.abc import Mapping as collections_Mapping
+else:
+    from collections import MutableMapping as collections_MutableMapping
+    from collections import Mapping as collections_Mapping
 
 logger = logging.getLogger('pyomo.core')
 

--- a/pyomo/core/kernel/list_container.py
+++ b/pyomo/core/kernel/list_container.py
@@ -9,10 +9,10 @@
 #  ___________________________________________________________________________
 
 try:
-    # python 3.7+
-    from collections.abc import MutableSequence as _MutableSequence
+    # python3
+    from collections.abc import MutableSequence as collections_MutableSequence
 except:                                           #pragma:nocover
-    from collections import MutableSequence as _MutableSequence
+    from collections import MutableSequence as collections_MutableSequence
 import logging
 
 from pyomo.core.kernel.tuple_container import TupleContainer
@@ -22,7 +22,7 @@ from six.moves import xrange as range
 logger = logging.getLogger('pyomo.core')
 
 class ListContainer(TupleContainer,
-                    _MutableSequence):
+                    collections_MutableSequence):
     """
     A partial implementation of the IHomogeneousContainer
     interface that provides list-like storage functionality.

--- a/pyomo/core/kernel/list_container.py
+++ b/pyomo/core/kernel/list_container.py
@@ -8,16 +8,17 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-try:
-    # python3
-    from collections.abc import MutableSequence as collections_MutableSequence
-except:                                           #pragma:nocover
-    from collections import MutableSequence as collections_MutableSequence
 import logging
 
 from pyomo.core.kernel.tuple_container import TupleContainer
 
+import six
 from six.moves import xrange as range
+
+if six.PY3:
+    from collections.abc import MutableSequence as collections_MutableSequence
+else:
+    from collections import MutableSequence as collections_MutableSequence
 
 logger = logging.getLogger('pyomo.core')
 

--- a/pyomo/core/kernel/tuple_container.py
+++ b/pyomo/core/kernel/tuple_container.py
@@ -10,12 +10,12 @@
 
 import weakref
 try:
-    # python 3.7+
-    from collections.abc import Sequence as _Sequence
-    from collections.abc import Set as _Set
+    # python3
+    from collections.abc import Sequence as collections_Sequence
+    from collections.abc import Set as collections_Set
 except:                                           #pragma:nocover
-    from collections import Sequence as _Sequence
-    from collections import Set as _Set
+    from collections import Sequence as collections_Sequence
+    from collections import Set as collections_Set
 
 from pyomo.core.kernel.homogeneous_container import \
     IHomogeneousContainer
@@ -23,7 +23,7 @@ from pyomo.core.kernel.homogeneous_container import \
 from six.moves import xrange as range
 
 class TupleContainer(IHomogeneousContainer,
-                     _Sequence):
+                     collections_Sequence):
     """
     A partial implementation of the IHomogeneousContainer
     interface that provides tuple-like storage functionality.
@@ -124,7 +124,8 @@ class TupleContainer(IHomogeneousContainer,
     # Convert both objects to a plain tuple of (type(val),
     # id(val)) tuples and compare that instead.
     def __eq__(self, other):
-        if not isinstance(other, (_Set, _Sequence)):
+        if not isinstance(other, (collections_Set,
+                                  collections_Sequence)):
             return False
         return tuple((type(val), id(val))
                      for val in self) == \

--- a/pyomo/core/kernel/tuple_container.py
+++ b/pyomo/core/kernel/tuple_container.py
@@ -9,18 +9,19 @@
 #  ___________________________________________________________________________
 
 import weakref
-try:
-    # python3
-    from collections.abc import Sequence as collections_Sequence
-    from collections.abc import Set as collections_Set
-except:                                           #pragma:nocover
-    from collections import Sequence as collections_Sequence
-    from collections import Set as collections_Set
 
 from pyomo.core.kernel.homogeneous_container import \
     IHomogeneousContainer
 
+import six
 from six.moves import xrange as range
+
+if six.PY3:
+    from collections.abc import Sequence as collections_Sequence
+    from collections.abc import Set as collections_Set
+else:
+    from collections import Sequence as collections_Sequence
+    from collections import Set as collections_Set
 
 class TupleContainer(IHomogeneousContainer,
                      collections_Sequence):


### PR DESCRIPTION
## Fixes # .

- In Python 3+, use `inspect.getfullargspec` in place of `inspect.getargspec`.
- In Python 3+, import abstract base classes from `collections.abc` instead of `collections` 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
