### PR TITLE
Fixing the unicode handling in the Jenkins driver

### DIFF
--- a/admin/jenkins.py
+++ b/admin/jenkins.py
@@ -87,9 +87,12 @@ elif config == "core":
         _run_cmd("python/bin/pyomo install-extras", shell=True)
     elif _run_cmd is subprocess.check_output:
         output = _run_cmd("python/bin/pyomo install-extras", shell=True)
-        if hasattr(output, 'encode'):
-            output = output.encode('utf-8','replace')
-        print(output.decode('utf-8'))
+        try:
+            print(output)
+        except:
+            if hasattr(output, 'encode'):
+                output = output.encode('utf-8','replace')
+            print(output.decode('utf-8'))
     else:
         assert False
     # Test
@@ -124,9 +127,12 @@ elif config == "booktests" or config == "book":
         output = _run_cmd("python/bin/python src/pyomo/scripts/get_pyomo_extras.py -v", shell=True)
     elif _run_cmd is subprocess.check_output:
         output = _run_cmd("python/bin/python src/pyomo/scripts/get_pyomo_extras.py -v", shell=True)
-        if hasattr(output, 'encode'):
-            output = output.encode('utf-8','replace')
-        print(output.decode('utf-8'))
+        try:
+            print(output)
+        except:
+            if hasattr(output, 'encode'):
+                output = output.encode('utf-8','replace')
+            print(output.decode('utf-8'))
     else:
         assert False
     # Test

--- a/admin/jenkins.py
+++ b/admin/jenkins.py
@@ -136,6 +136,11 @@ elif config == "booktests" or config == "book":
     else:
         assert False
     # Test
+    book_examples = os.path.join(
+        os.environ['WORKSPACE'], 'src', 'pyomo', 'examples', 'doc', 'pyomobook')
+    if not os.path.isdir(book_examples):
+        raise RuntimeError("Cannot find the Book examples directory (%s)" % (book_examples,))
+    os.environ['TEST_PACKAGES'] = 'pyomo %s' % (book_examples,)
     os.environ['NOSE_PROCESS_TIMEOUT'] = '1800'
     driver.perform_tests('pyomo', cat='book')
 


### PR DESCRIPTION
## Summary/Motivation:
This should fix the setup for the Book tests in Jenkins to get the build running again.

## Changes proposed in this PR:
- change the way we handle subprocess output to run cleanly on all Pythons

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
