### PR TITLE
Fix windows stdout issue in gams solver

### DIFF
--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -163,10 +163,9 @@ class GAMSDirect(_GAMSSolver):
             return _extract_version('')
         from gams import GamsWorkspace
         ws = GamsWorkspace()
-        version = tuple(int(i) for i in ws._version.split('.'))
+        version = tuple(int(i) for i in ws._version.split('.')[:4])
         while(len(version) < 4):
             version += (0,)
-        version = version[:4]
         return version
 
     def solve(self, *args, **kwds):
@@ -601,8 +600,12 @@ class GAMSShell(_GAMSSolver):
         if solver_exec is None:
             return _extract_version('')
         else:
-            results = pyutilib.subprocess.run([solver_exec])
-            return _extract_version(results[1])
+            # specify logging to stdout for windows compatibility
+            # technically this command makes gams complain because we're not
+            # providing a filename, but it will include the version name anyway
+            cmd = [solver_exec, "", "lo=3"]
+            _, txt = pyutilib.subprocess.run(cmd, tee=False)
+            return _extract_version(txt)
 
     def solve(self, *args, **kwds):
         """

--- a/pyomo/solvers/tests/checks/test_GAMS.py
+++ b/pyomo/solvers/tests/checks/test_GAMS.py
@@ -295,6 +295,18 @@ class GAMSTests(unittest.TestCase):
             opt.solve(m, load_solutions=True) # overwrite option
             self.assertEqual(m.x.value, 10)
 
+    @unittest.skipIf(not gamspy_available,
+                     "The 'gams' python bindings are not available")
+    def test_version_py(self):
+        with SolverFactory("gams", solver_io="python") as opt:
+            self.assertIsNotNone(opt.version())
+
+    @unittest.skipIf(not gamsgms_available,
+                     "The 'gams' executable is not available")
+    def test_version_gms(self):
+        with SolverFactory("gams", solver_io="gms") as opt:
+            self.assertIsNotNone(opt.version())
+
 class GAMSLogfileTestBase(unittest.TestCase):
     def setUp(self):
         """Set up model and temporary directory."""


### PR DESCRIPTION
## Summary/Motivation:
Windows has a compatibility issue when it comes to streaming to stdout vs the console (screen). We came across this in #302, but the GAMS shell solver's `version` method still made a call to `pyutilib.subprocess.run` without specifying `lo=3` to explicitly log to stdout instead of the console. This led to both:

- The `version` method did not work because the `run` call was expecting to capture output from stdout, not console
- The output of the gams call in the `version` method would show on the screen, and since `version` is called in the `solve` method, it would show during a solve as well

## Changes proposed in this PR:
- Explicitly log to stdout
- Add a test to make sure `version` does not return `None`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
