### PR TITLE
Fixing doctests for Pyomo.Network

### DIFF
--- a/.readthedocs_requirements.txt
+++ b/.readthedocs_requirements.txt
@@ -1,2 +1,4 @@
 git+https://github.com/PyUtilib/pyutilib
 sphinx>=1.8.0
+numpy
+networkx

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,9 +84,15 @@ script:
   - ${DOC} bash -c 'echo GJH_ASL_JSON_VERSION="$GJH_ASL_JSON_VERSION"'
   - ${DOC} pip list
   - ${DOC} test.pyomo -v --cat=$CATEGORY pyomo `pwd`/pyomo-model-libraries
+ 
  # Run documentation tests
-  - if [[ "$IMAGE_NAME" != "test-builds:python_3.7" ]]; then ${DOC} make -C doc/OnlineDocs doctest -d; fi
-
+  - |
+    if [ -z "$SLIM" ]; then
+      # As of July 2018, Sphinx wasn't completely Python 3.7 compatible
+      if [[ "$IMAGE_NAME" != "test-builds:python_3.7" ]]; then
+         ${DOC} make -C doc/OnlineDocs doctest -d
+      fi
+    fi
 after_script:
  # Kill the docker container
   - docker kill ${DOC_ID}


### PR DESCRIPTION
Fixes #741 

This is the missing piece to resolve #741 which was only partially fixed in #708 and #745. The problem is that the new ":skipif:" doctest option will cause the entire code snippet to be excluded from the documentation when the skip clause is false. The doctest using this in pyomo.network checks that numpy and networkx are installed. These packages are not available in the readthedocs build environment so the code snippet is not rendered in the documentation. 

This PR adds numpy and networkx to the readthedocs requirements and also updates the travis.yml file to skip doctests during "slim" builds when extra packages like numpy are not installed.

## Changes proposed in this PR:
- Add numpy and networkx to the readthedocs requirements
- Skip doctests in "slim" travis builds

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
