### PR TITLE
Comment out trustregion debugging accidentally merged into master

### DIFF
--- a/pyomo/contrib/trustregion/plugins.py
+++ b/pyomo/contrib/trustregion/plugins.py
@@ -15,9 +15,9 @@ from pyomo.contrib.trustregion.TRF import TRF
 from pyomo.contrib.trustregion.readgjh import readgjh
 
 logger = logging.getLogger('pyomo.contrib.trustregion')
-fh = logging.FileHandler('debug_vars.log')
-logger.setLevel(logging.DEBUG)
-logger.addHandler(fh)
+#fh = logging.FileHandler('debug_vars.log')
+#logger.setLevel(logging.DEBUG)
+#logger.addHandler(fh)
 
 def load():
     pass


### PR DESCRIPTION
## Fixes #784.

## Summary/Motivation:
This PR removes debugging code accidentally merged into master.

## Changes proposed in this PR:
- Remove the logging FileHandler that generated the `debug_vars.log` files.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
