### PR TITLE
Update gdpopt.rst

### DIFF
--- a/doc/OnlineDocs/contributed_packages/gdpopt.rst
+++ b/doc/OnlineDocs/contributed_packages/gdpopt.rst
@@ -48,7 +48,7 @@ An example which includes the modeling approach may be found below.
   >>> model.objective = Objective(expr=model.x, sense=minimize)
 
   Solve the model using GDPopt
-  >>> SolverFactory('gdpopt').solve(model, mip_solver='glpk') # doctest: +SKIP
+  >>> SolverFactory('gdpopt').solve(model, mip='glpk') # doctest: +SKIP
 
 The solution may then be displayed by using the commands
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
keyword for the mip_solver is I believe changed to 'mip' in contrib.gdpopt.GDPopt. With the original sample code, 'mip_solver' is ignored and for 'mip' the default value of 'gurobi' is used, causing a 'ApplicationError: No executable found for solver 'gurobi''.

## Changes proposed in this PR:
- change the keyword from 'mip_solver' to 'mip' in sample code for using gdpopt.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
