### PR TITLE
GAMS writer: start split lines with space

### DIFF
--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -244,7 +244,9 @@ def split_long_line(line):
                     "Found an 80,000+ character string with no spaces")
             i -= 1
         new_lines += line[:i] + '\n'
-        line = line[i + 1:]
+        # the space will be the first character in the next line,
+        # so that the line doesn't start with the comment character '*'
+        line = line[i:]
     new_lines += line
     return new_lines
 

--- a/pyomo/repn/tests/gams/test_gams.py
+++ b/pyomo/repn/tests/gams/test_gams.py
@@ -227,9 +227,15 @@ class Test(unittest.TestCase):
         pat = "var1 + log(var2 / 9) - "
         line = (pat * 10000) + "x"
         self.assertEqual(split_long_line(line),
-                         pat * 3478 + "var1 +\nlog(var2 / 9) - " +
-                         pat * 3477 + "var1 +\nlog(var2 / 9) - " +
+                         pat * 3478 + "var1 +\n log(var2 / 9) - " +
+                         pat * 3477 + "var1 +\n log(var2 / 9) - " +
                          pat * 3043 + "x")
+
+    def test_split_long_line_no_comment(self):
+        pat = "1000 * 2000 * "
+        line = pat * 5715 + "x"
+        self.assertEqual(split_long_line(line),
+            pat * 5714 + "1000\n * 2000 * x")
 
     def test_solver_arg(self):
         m = ConcreteModel()


### PR DESCRIPTION
## Fixes #796

## Summary/Motivation:
See issue. The problem arose when the first character in the next line was a `*`, since this is the GAMS comment character when it is the first character in a line. This fix puts a space at the front of every split line so that no line can start with a `*`.

## Changes proposed in this PR:
- Keep a space in front of the line for every split line

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
