### PR TITLE
Allow Handling for RangeSet in BigM and cHull transformations

### DIFF
--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -15,8 +15,8 @@ import textwrap
 
 from pyomo.core import (
     Block, Connector, Constraint, Param, Set, Suffix, Var,
-    Expression, SortComponents, TraversalStrategy, Any, value
-)
+    Expression, SortComponents, TraversalStrategy, Any, value,
+    RangeSet)
 from pyomo.core.base import Transformation, TransformationFactory
 from pyomo.core.base.component import ComponentUID, ActiveComponent
 from pyomo.core.kernel.component_map import ComponentMap
@@ -129,6 +129,7 @@ class BigM_Transformation(Transformation):
             Suffix:      False,
             Param:       False,
             Set:         False,
+            RangeSet:    False,
             Disjunction: self._warn_for_active_disjunction,
             Disjunct:    self._warn_for_active_disjunct,
             Block:       self._transform_block_on_disjunct,

--- a/pyomo/gdp/plugins/chull.py
+++ b/pyomo/gdp/plugins/chull.py
@@ -28,7 +28,7 @@ from pyomo.core.base import Transformation, TransformationFactory
 from pyomo.core import (
     Block, Connector, Constraint, Param, Set, Suffix, Var,
     Expression, SortComponents, TraversalStrategy,
-    Any, Reals, value
+    Any, RangeSet, Reals, value
 )
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 from pyomo.gdp.util import clone_without_expression_components, target_list
@@ -170,6 +170,7 @@ class ConvexHull_Transformation(Transformation):
             Expression : False,
             Param :      False,
             Set :        False,
+            RangeSet:    False,
             Suffix :     False,
             Disjunction: self._warn_for_active_disjunction,
             Disjunct:    self._warn_for_active_disjunct,

--- a/pyomo/gdp/plugins/chull.py
+++ b/pyomo/gdp/plugins/chull.py
@@ -8,19 +8,12 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import weakref
 import logging
-import textwrap
 
 import pyomo.common.config as cfg
 from pyomo.common.modeling import unique_component_name
-from pyomo.core.expr.numvalue import native_numeric_types, ZeroConstant
-from pyomo.core.expr import current as EXPR
-from pyomo.core import *
-from pyomo.core.base.block import SortComponents
-from pyomo.core.base.component import ComponentUID, ActiveComponent
-from pyomo.core.base import _ExpressionData
-from pyomo.core.base.var import _VarData
+from pyomo.core.expr.numvalue import ZeroConstant
+from pyomo.core.base.component import ActiveComponent
 from pyomo.core.kernel.component_map import ComponentMap
 from pyomo.core.kernel.component_set import ComponentSet
 import pyomo.core.expr.current as EXPR
@@ -36,8 +29,6 @@ from pyomo.gdp.plugins.gdp_var_mover import HACK_GDP_Disjunct_Reclassifier
 
 from six import iteritems, iterkeys
 
-# DEBUG
-from nose.tools import set_trace
 
 logger = logging.getLogger('pyomo.gdp.chull')
 

--- a/pyomo/gdp/tests/models.py
+++ b/pyomo/gdp/tests/models.py
@@ -1,5 +1,5 @@
 from pyomo.core import (Block, ConcreteModel, Constraint, Objective, Param,
-                        Set, Var, inequality)
+                        Set, Var, inequality, RangeSet)
 from pyomo.gdp import Disjunct, Disjunction
 
 
@@ -425,4 +425,15 @@ def makeDuplicatedNestedDisjunction():
     m.outerdisjunct = Disjunct([0, 1], rule=outerdisj_rule)
     m.disjunction = Disjunction(expr=[m.outerdisjunct[0],
                                       m.outerdisjunct[1]])
+    return m
+
+
+def makeDisjunctWithRangeSet():
+    m = ConcreteModel()
+    m.x = Var(bounds=(0, 1))
+    m.d1 = Disjunct()
+    m.d1.s = RangeSet(1)
+    m.d1.c = Constraint(rule=lambda _: m.x == 1)
+    m.d2 = Disjunct()
+    m.disj = Disjunction(expr=[m.d1, m.d2])
     return m

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -2205,5 +2205,12 @@ class InnerDisjunctionSharedDisjuncts(unittest.TestCase):
                      ComponentUID(m.disjunction)])
 
 
+class RangeSetOnDisjunct(unittest.TestCase):
+    def test_RangeSet(self):
+        m = models.makeDisjunctWithRangeSet()
+        TransformationFactory('gdp.bigm').apply_to(m)
+        self.assertIsInstance(m.d1.s, RangeSet)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/pyomo/gdp/tests/test_chull.py
+++ b/pyomo/gdp/tests/test_chull.py
@@ -765,6 +765,13 @@ class TestSpecialCases(unittest.TestCase):
         self.assertEqual(rd.z_bounds['ub'].body(), 9)
 
 
+class RangeSetOnDisjunct(unittest.TestCase):
+    def test_RangeSet(self):
+        m = models.makeDisjunctWithRangeSet()
+        TransformationFactory('gdp.chull').apply_to(m)
+        self.assertIsInstance(m.d1.s, RangeSet)
+
+
 # TODO (based on coverage):
 
 # test targets of all flavors


### PR DESCRIPTION
## Fixes #802  .

## Summary/Motivation:
Handler does nothing, because like a normal set, a RangeSet in a disjunct can be safely ignored.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
