### PR TITLE
Updating scaling and fixing an error in the DAE Jacobian calculation

### DIFF
--- a/pyomo/contrib/petsc/examples/dae_pyomo/example01.py
+++ b/pyomo/contrib/petsc/examples/dae_pyomo/example01.py
@@ -28,10 +28,10 @@ if __name__ == "__main__":
     #    (dy6/dt is not explicitly in the equations, so only 5 ydots)
     model.t = Var(initialize=0) #time, but not used anywhere could delete
                                 #using time explicilty in equations is possible
-    model.y = Var([1,2,3,4,5,6])  #
-    model.ydot = Var([1,2,3,4,5]) # dy/dt
-    model.r = Var([1,2,3,4,5])
-    model.Fin = Var()
+    model.y = Var([1,2,3,4,5,6], initialize=1.0)  #
+    model.ydot = Var([1,2,3,4,5], initialize=1.0) # dy/dt
+    model.r = Var([1,2,3,4,5], initialize=1.0)
+    model.Fin = Var(initialize=1.0)
 
     # Equations
     model.eq_ydot1 = Constraint(expr=model.ydot[1] == -2.0*model.r[1] +
@@ -64,8 +64,28 @@ if __name__ == "__main__":
     # variables (r and y6 well and the derivative vars too).
     y0 = {1:0.444, 2:0.00123, 3:0.0, 4:0.007, 5:0.0} #initial differntial vars
     for i in [1,2,3,4,5]: model.y[i].fix(y0[i])
-    print("Solving initial:")
-    res = opt.solve(model, tee=True, options={"-snes_monitor":""})
+
+    #---------------------------------------------------------------------------
+    # The scaling factor stuff here is just for testing and demonstration
+    # You don't need to supply scaling factors and if you do provide the
+    # scaling_factor suffix you don't need factors for each varibale and
+    # constaint.  These are used only for user scaling options
+    # "-scale_eqs 3" and "-scale_vars 1"
+    model.scaling_factor = Suffix(direction=Suffix.EXPORT, datatype=Suffix.FLOAT)
+    model.scaling_factor[model.Fin] = 0.5
+
+    model.scaling_factor[model.eq_Fin] = 100
+    #---------------------------------------------------------------------------
+
+    print("Solving initial conditions:")
+    res = opt.solve(
+        model,
+        tee=True,
+        options={
+            "-snes_monitor":"",
+            "-on_error_attach_debugger":"",
+            "-scale_vars":1})
+
     for i in [1,2,3,4,5]: model.y[i].unfix()
     model.display() # show the initial state
 
@@ -74,6 +94,7 @@ if __name__ == "__main__":
     # 3=time. dae_link associates differential variables to their derivatives
     model.dae_suffix = Suffix(direction=Suffix.EXPORT, datatype=Suffix.INT)
     model.dae_link = Suffix(direction=Suffix.EXPORT, datatype=Suffix.INT)
+
     # Label the vars.  Seems 0 is default if I don't attach a suffix so don't
     # need to explicitly label algebraic vars
     model.dae_suffix[model.t] = 3 # this labels t as the time variables
@@ -90,19 +111,23 @@ if __name__ == "__main__":
     # would want to specify a time step, or an adaptive time stepping method
     res = opt.solve(model, tee=True,
         options={
-            "-dae_solve":"",              #tell solver to expect dae problem
-            "-ts_monitor":"",             #show progess of TS solver
-            "-ts_max_snes_failures":10,   #max nonlin solve fails before give up
-            #"-ts_type":"sundials",       #ts solver
-            "-ts_type":"alpha",           #ts_solver
-            "-snes_monitor":"",           #show progress on nonlinear solves
-            "-pc_type":"lu",              #direct solve MUMPS default LU fact
-            "-ksp_type":"preonly",        #no ksp used direct solve preconditioner
-            "-scale_vars":"0",            #currently not compatable dae
-            "-scale_eqs":"0",             #should work, but prob don't need
-            "-snes_type":"newtonls",      # newton line search for nonliner solver
-            "-ts_adapt_type":"basic",       # there are a lot of adaptive step
-            "-ts_max_time":180,           # final time
+            "-dae_solve":"",             #tell solver to expect dae problem
+            "-ts_monitor":"",            #show progess of TS solver
+            "-ts_max_snes_failures":40,  #max nonlin solve fails before give up
+            "-ts_max_reject":20,         #max steps to reject
+            "-ts_type":"alpha",          #ts_solver
+            "-snes_monitor":"",          #show progress on nonlinear solves
+            "-pc_type":"lu",             #direct solve MUMPS default LU fact
+            "-ksp_type":"preonly",       #no ksp used direct solve preconditioner
+            "-scale_vars":1,             #variable scaling method
+            "-scale_eqs":3,              #equation scaling method
+            #"-scale_eq_jac_max":100,    #set max J element to 1 for eq scaling
+            #"-show_scale_factors":"",
+            #"-show_jac":"",
+            #"-show_initial":"",
+            "-snes_type":"newtonls",     # newton line search for nonliner solver
+            "-ts_adapt_type":"basic",
+            "-ts_max_time":180,          # final time
             "-ts_save_trajectory":1,
             "-ts_trajectory_type":"visualization",
             #"-ts_exact_final_time":"stepover",

--- a/pyomo/contrib/petsc/fg_dae.c
+++ b/pyomo/contrib/petsc/fg_dae.c
@@ -47,7 +47,7 @@ PetscErrorCode FormDAEJacobian(
   ierr = VecGetArrayRead(xdot, &xxdot); CHKERRQ(ierr);
   for(i=0;i<sol_ctx->n_var_state;++i){
     x_asl[sol_ctx->dae_map_x[i]] = xx[i];
-    if(sol_ctx->dae_map_xdot[i] >= 0) x_asl[sol_ctx->dae_map_xdot[i]] = xx[i];
+    if(sol_ctx->dae_map_xdot[i] >= 0) x_asl[sol_ctx->dae_map_xdot[i]] = xxdot[i];
   }
   ierr = VecRestoreArrayRead(x,&xx);CHKERRQ(ierr);
   ierr = VecRestoreArrayRead(xdot,&xxdot);CHKERRQ(ierr);
@@ -84,6 +84,7 @@ void dae_var_map(Solver_ctx *sol_ctx){
   for(i=0;i<n_var;++i){
     if(sol_ctx->dae_suffix_var->u.i[i]==2){ //a derivative var
       for(j=0;j<n_var;++j){
+        if(i == j) continue;
         if(sol_ctx->dae_link_var->u.i[i] == sol_ctx->dae_link_var->u.i[j]){
           sol_ctx->dae_link[i] = j;
           sol_ctx->dae_link[j] = i;

--- a/pyomo/contrib/petsc/help.h
+++ b/pyomo/contrib/petsc/help.h
@@ -8,12 +8,27 @@ in an AMPL nl file. Optimization solver support will be added soon.\n\n\
    Added Options: \n\
      [filename]: File name with or without extension (when -s is not specified) \n\
      -s <stub>: File name with or without extension\n\
-     -show_constraints: Show body, rhs upper and lower values at initial point\n\
+     -show_scale_factors: Show the calculated or user specified scale factors\n\
      -show_jac: Show non-zero jacobian values at initial point\n\
      -show_intial: Show the guess intial values \n\
+     -show_cl: Show the command line input and transformation from AMPL format\n\
      -perturb_test <factor>: Test using nl file where initial value is solution \n\
         This just multiplies the inital value by factor and resolves, then it \n\
         compares the new solution to the intial value and report differnces > \n\
         1e-6. It's a fairly crude test but it should ensure the Jacobian and \n\
         function are calculating right.\n\
-     -dae_solve: Run DAE solver, must provide appropriate suffixes\n";
+     -dae_solve: Run DAE solver, must provide appropriate suffixes\n\
+     -jac_explicit_diag: Create explicit Jacobian entries in diagonal\n\
+     -scale_eqs <method>: Equation scaling method:\n\
+        0 - None\n\
+        1 - Auto scale based on Jacobian values at initial point\n\
+        2 - (Not Implimented) Auto scale based on Jacobian values at\n\
+          multiple points selected randomly.\n\
+        3 - User defined scaling factors specified in 'scaling_factor' suffix\n\
+     -scale_vars <method>: \n\
+        0 - None\n\
+        1 - User defined scaling factors specified in 'scaling_factor' suffix\n\
+   Equation scaling options:\n\
+     -scale_eq_jac_max: Maximum Jacobian after scaling (default 100)\n\
+     -scale_eq_fac_min: Minimum equation scaling factor (default 1e-6)\n\
+    ";

--- a/pyomo/contrib/petsc/petsc.c
+++ b/pyomo/contrib/petsc/petsc.c
@@ -12,21 +12,24 @@ John Eslick
 #include<math.h>
 
 int main(int argc, char **argv){
-  PetscErrorCode ierr;         // Error code from PETSc functions
-  PetscInt       its;          // Number of solver iterations
-  ASL            *asl;         // ASL context
-  Solver_ctx     sol_ctx;      // solver context
-  int            err;          // Error code  from ASL fulctions
+  PetscErrorCode ierr;        // Error code from PETSc functions
+  PetscInt       its;         // Number of solver iterations
+  ASL            *asl;        // ASL context
+  Solver_ctx     sol_ctx;     // solver context
+  int            err;         // Error code  from ASL fulctions
   int            i=0;         // Loop counters
-  real           *R;           // ASL constraint body test
   PetscInt       temp_int;    // a temporary variable to store a option
-  int            argc_new;   // new number of arguments reformated for PETSc
-  char           **argv_new; // argv transformed to PETSc's format
+  PetscScalar    temp_scalar; // a temporary scalar for reading options
+  PetscBool      temp_bool;   // a temporart bool for reading options
+  int            argc_new;    // new number of arguments reformated for PETSc
+  char           **argv_new;  // argv transformed to PETSc's format
   static SufDecl suftab[] = { // suffixes to read in
     //doc for this at https://ampl.com/netlib/ampl/solvers/README.suf
-    {"dae_suffix", NULL, ASL_Sufkind_var, 1}, //var kinds for DAE solver
-    {"dae_suffix", NULL, ASL_Sufkind_con, 1},
-    {"dae_link",   NULL, ASL_Sufkind_var, 1}}; //link derivatives to vars
+    {"dae_suffix", NULL, ASL_Sufkind_var}, //var kinds for DAE solver
+    {"dae_link",   NULL, ASL_Sufkind_var}, //link derivatives to vars
+    {"scaling_factor", NULL, ASL_Sufkind_var|ASL_Sufkind_real}, //var scale factors
+    {"scaling_factor", NULL, ASL_Sufkind_con|ASL_Sufkind_real} //constraint scale factors
+  };
   Vec            x,r,xl,xu; // solution, residual, bound vectors
   Mat            J;            // Jacobian matrix
   TS             ts;           // DAE solver
@@ -50,13 +53,13 @@ int main(int argc, char **argv){
   ierr = MPI_Comm_size(PETSC_COMM_WORLD, &sol_ctx.opt.mpi_size);CHKERRQ(ierr);
   // Get added options
   PetscOptionsGetString(NULL, NULL, "-s", sol_ctx.opt.stub, PETSC_MAX_PATH_LEN-1, &sol_ctx.opt.got_stub);
-  PetscOptionsHasName(NULL, NULL, "-show_constraints", &sol_ctx.opt.show_con);
   PetscOptionsHasName(NULL, NULL, "-show_jac", &sol_ctx.opt.show_jac);
   PetscOptionsHasName(NULL, NULL, "-show_initial", &sol_ctx.opt.show_init);
+  PetscOptionsHasName(NULL, NULL, "-show_scale_factors", &sol_ctx.opt.show_scale_factors);
   PetscOptionsHasName(NULL, NULL, "-use_bounds", &sol_ctx.opt.use_bounds);
   PetscOptionsGetScalar(NULL, NULL, "-perturb_test",&sol_ctx.opt.ptest, &sol_ctx.opt.per_test);
   if(!sol_ctx.opt.per_test) sol_ctx.opt.ptest = 1.0;
-  PetscOptionsGetInt(NULL, NULL, "-scale_eqs",&temp_int, &sol_ctx.opt.scale_eq);
+  PetscOptionsGetInt(NULL, NULL, "-scale_eqs", &temp_int, &sol_ctx.opt.scale_eq);
   sol_ctx.opt.eq_scale_method = (EQSCALE_TYPE)temp_int;
   PetscOptionsGetInt(NULL, NULL, "-scale_vars", &temp_int, &sol_ctx.opt.scale_var);
   sol_ctx.opt.var_scale_method = (VARSCALE_TYPE)temp_int;
@@ -64,6 +67,13 @@ int main(int argc, char **argv){
   PetscOptionsHasName(NULL, NULL, "-jac_explicit_diag", &sol_ctx.opt.jac_explicit_diag);
   PetscOptionsHasName(NULL, NULL, "-dae_solve", &sol_ctx.opt.dae_solve);
   PetscOptionsHasName(NULL, NULL, "-show_cl", &sol_ctx.opt.show_cl);
+  PetscOptionsGetScalar(NULL, NULL, "-scale_eq_jac_max",&temp_scalar, &temp_bool);
+  if(temp_bool) sol_ctx.opt.scale_eq_jac_max = temp_scalar;
+  else sol_ctx.opt.scale_eq_jac_max = 100;
+  PetscOptionsGetScalar(NULL, NULL, "-scale_eq_fac_min",&temp_scalar, &temp_bool);
+  if(temp_bool) sol_ctx.opt.scale_eq_fac_min = temp_scalar;
+  else sol_ctx.opt.scale_eq_fac_min = 1e-6;
+
   // If show_cl otion, show the original and transformed command line
   if(sol_ctx.opt.show_cl){
     PetscPrintf(PETSC_COMM_SELF, "-----------------------------------------------------------------\n");
@@ -88,7 +98,6 @@ int main(int argc, char **argv){
   }
   // Allocated space for some ASL items and test calculations
   X0 = (real*)Malloc(n_var*sizeof(real));  /* Initial X values */
-  R = (real*)Malloc(n_con*sizeof(real));   /* Constraint body values */
   LUv = (real*)Malloc(n_var*sizeof(real)); /* Variable lower bounds */
   Uvx = (real*)Malloc(n_var*sizeof(real)); /* Variable upper bounds */
   LUrhs = (real*)Malloc(n_con*sizeof(real)); /* Lower constraint right side */
@@ -140,15 +149,10 @@ int main(int argc, char **argv){
   PetscPrintf(PETSC_COMM_SELF, "---------------------------------------------------\n");
 
   // Equation/variable scaling
-  ScaleEqs(sol_ctx.opt.eq_scale_method, sol_ctx.asl);
-  if(!sol_ctx.opt.dae_solve) ScaleVars(sol_ctx.opt.var_scale_method, sol_ctx.asl); //for now not compatable with dae
-  if(sol_ctx.opt.var_scale_method && !sol_ctx.opt.eq_scale_method){
-    PetscPrintf(PETSC_COMM_SELF, "Warning: scale equations if scaling vars\n");}
-  // Optionally print some stuff
-  if(sol_ctx.opt.show_init) print_x_asl(sol_ctx.asl);
-  if(sol_ctx.opt.show_jac) print_jac_asl(sol_ctx.asl, 101, 1e-3);
-  if(sol_ctx.opt.show_con) for(i=0; i<n_con; ++i){
-    PetscPrintf(PETSC_COMM_SELF, "c%d: %e <= %e <= %e\n", i, LUrhs[i], R[i], Urhsx[i]);}
+  sol_ctx.dae_suffix_var = suf_get("dae_suffix", ASL_Sufkind_var);
+  sol_ctx.dae_link_var = suf_get("dae_link", ASL_Sufkind_var);
+  sol_ctx.scaling_factor_var = suf_get("scaling_factor", ASL_Sufkind_var);
+  sol_ctx.scaling_factor_con = suf_get("scaling_factor", ASL_Sufkind_con);
 
   if(sol_ctx.opt.dae_solve){  //This block sets up DAE solve and solves
     ierr = TSCreate(PETSC_COMM_WORLD, &ts); CHKERRQ(ierr);
@@ -163,6 +167,10 @@ int main(int argc, char **argv){
         xx[sol_ctx.dae_map_back[i]] = X0[i];
       }
     }
+    // Equation/variable scaling
+    ScaleVars(&sol_ctx);
+    ScaleEqs(&sol_ctx);
+    print_init_diagnostic(&sol_ctx); //print initial diagnostic information
     ierr = VecRestoreArray(x, &xx);CHKERRQ(ierr);
     // Make Jacobian matrix (by default sparse AIJ)
     ierr = MatCreate(PETSC_COMM_WORLD,&J); CHKERRQ(ierr);
@@ -213,6 +221,11 @@ int main(int argc, char **argv){
     ierr = TSDestroy(&ts);
   } //end ts solve
   else{ // nonlinear solver setup and solve
+    // Equation/variable scaling
+    ScaleVars(&sol_ctx);
+    ScaleEqs(&sol_ctx);
+    // Print requested diagnostic info
+    print_init_diagnostic(&sol_ctx);
     /*Create nonlinear solver context*/
     ierr = SNESCreate(PETSC_COMM_WORLD, &snes); CHKERRQ(ierr);
     /*Create vectors for solution and nonlinear function*/
@@ -345,5 +358,5 @@ void sol_ctx_init(Solver_ctx *ctx){
   ctx->dof=0; //degrees of freedom
   ctx->opt.ptest=1.0; // method to scale equations
   ctx->opt.eq_scale_method=EQ_SCALE_MAX_GRAD; // method to scale equations
-  ctx->opt.var_scale_method=VAR_SCALE_GRAD; // method to scale variables
+  ctx->opt.var_scale_method=VAR_SCALE_NONE; // method to scale variables
 }

--- a/pyomo/contrib/petsc/petsc.h
+++ b/pyomo/contrib/petsc/petsc.h
@@ -30,16 +30,16 @@ John Eslick
 
 /* Variable scaling methods */
 typedef enum{
-    VAR_SCALE_NONE=0,
-    VAR_SCALE_GRAD=1,
-    VAR_SCALE_MULTIGRAD=2 //not ready yet
+    VAR_SCALE_NONE = 0,
+    VAR_SCALE_USER = 1
 }VARSCALE_TYPE;
 
 /* Equation scaling methods */
 typedef enum{
-    EQ_SCALE_NONE=0,
-    EQ_SCALE_MAX_GRAD=1,
-    EQ_SCALE_MAX_MULTIGRAD=2 //not ready yet
+    EQ_SCALE_NONE = 0,
+    EQ_SCALE_MAX_GRAD = 1,
+    EQ_SCALE_MAX_MULTIGRAD = 2, //not ready yet
+    EQ_SCALE_USER = 3
 }EQSCALE_TYPE;
 
 typedef enum{  //keep these under 50 and shouldn't confilict with PETSc codes
@@ -63,6 +63,9 @@ typedef struct{
   PetscBool      show_con;  // Option to show initial constraint values
   PetscBool      show_init; // show initial values for x vec
   PetscBool      show_jac;  // show jacobian at intial value
+  PetscBool      show_scale_factors;  // show jacobian at intial value
+  PetscScalar    scale_eq_jac_max; //Max jacobian entry for scaling
+  PetscScalar    scale_eq_fac_min; //Minimum scaling factor to use (overrides scale_eq_jac_max)
   PetscBool      ampl_opt;  // -AMPL specified I catch it but ignore
   PetscBool      per_test;  // perturb inital solved value and resolve  to test
   PetscBool      use_bounds; // give solver variable bounds
@@ -80,6 +83,8 @@ typedef struct{
   Solver_options opt; // command-line options
   SufDesc *dae_suffix_var; // DAE suffixes on variables
   SufDesc *dae_link_var; // DAE link derivatives to vars
+  SufDesc *scaling_factor_var; //user scale factors for vars
+  SufDesc *scaling_factor_con; //user scale factors for constraints
   int dae_map_t; // ASL index of time variable (-1 for none)
   int *dae_map_x; // PETSc index in x vec -> ASL index
   int *dae_map_xdot; // PETSc index in xdot vec -> ASL index
@@ -105,13 +110,17 @@ void get_dae_info(Solver_ctx *sol_ctx);
 void dae_var_map(Solver_ctx *sol_ctx);
 void sol_ctx_init(Solver_ctx *ctx);
 int get_snes_sol_message(char *msg, SNESConvergedReason term_reason, ASL *asl);
-int ScaleVars(VARSCALE_TYPE method, ASL *asl);
-int ScaleVarsGrad(ASL *asl);
-int ScaleEqs(EQSCALE_TYPE method, ASL *asl);
-int ScaleEqs_Largest_Grad(ASL *asl);
+int ScaleVars(Solver_ctx *sol_ctx);
+int ScaleVarsUser(Solver_ctx *sol_ctx);
+int ScaleEqs(Solver_ctx *sol_ctx);
+int ScaleEqs_Largest_Grad(Solver_ctx *sol_ctx);
+int ScaleEqsUser(Solver_ctx *sol_ctx);
 char **transform_args(int argc, char** argv, int *size);
 void print_commandline(const char* msg, int argc, char **argv);
 void print_x_asl(ASL *asl);
 void print_jac_asl(ASL *asl, real u, real l);
+void print_var_scale_factors_asl(ASL *asl);
+void print_con_scale_factors_asl(ASL *asl);
+void print_init_diagnostic(Solver_ctx *sol_ctx);
 
 #endif

--- a/pyomo/contrib/petsc/printing.c
+++ b/pyomo/contrib/petsc/printing.c
@@ -8,10 +8,23 @@ void print_commandline(const char* msg, int argc, char **argv){
   PetscPrintf(PETSC_COMM_SELF, "\n");
 }
 
+void print_init_diagnostic(Solver_ctx *sol_ctx){
+  if(sol_ctx->opt.show_jac){
+    print_jac_asl(sol_ctx->asl, 100, 1e-6);
+  }
+  if(sol_ctx->opt.show_init){
+    print_x_asl(sol_ctx->asl);
+  }
+  if(sol_ctx->opt.show_scale_factors){
+    print_var_scale_factors_asl(sol_ctx->asl);
+    print_con_scale_factors_asl(sol_ctx->asl);
+  }
+}
+
 void print_x_asl(ASL *asl){
   int i=0;
   char color_code[20];
-  PetscPrintf(PETSC_COMM_SELF, "Initial Guess Values (red is outside bounds)\n");
+  PetscPrintf(PETSC_COMM_SELF, "Initial Values (scaled)\n");
   for (i=0;i<n_var;++i){
      if(X0[i] > Uvx[i] || X0[i] < LUv[i]){
        memcpy(color_code, COLOR_RED, 15*sizeof(char));
@@ -20,6 +33,18 @@ void print_x_asl(ASL *asl){
      PetscPrintf(PETSC_COMM_SELF, "%sv%d: %e <= %e <= %e%s\n",
      color_code, i, LUv[i], X0[i], Uvx[i], COLOR_NORMAL);
   }
+}
+
+void print_var_scale_factors_asl(ASL *asl){
+  int i;
+  if(asl->i.vscale!=NULL){
+    for(i=0;i<n_var;++i) printf("scale Factor v%d: %f\n", i, asl->i.vscale[i]);}
+}
+
+void print_con_scale_factors_asl(ASL *asl){
+  int i;
+  if(asl->i.cscale!=NULL){
+    for(i=0;i<n_con;++i) printf("scale factor c%d: %f\n", i, asl->i.cscale[i]);}
 }
 
 void print_jac_asl(ASL *asl, real u, real l){


### PR DESCRIPTION

## Summary/Motivation:

This brings user scaling to the PETSc solver.  It should use the same suffixes as ipopt, so it should be compatible.  Both equation and variable scaling seem to work for DAE solver, but DAE solver needs more testing in general.   

## Changes proposed in this PR:
- Error in DAE Jacobian 
- Error in ASL to PETSc mapping, which was previously unused
- Removed and Added scaling code

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
