### PR TITLE
Fix Multistart Solver Objective Reference

### DIFF
--- a/pyomo/contrib/multistart/multi.py
+++ b/pyomo/contrib/multistart/multi.py
@@ -175,7 +175,7 @@ class MultiStart(object):
                 if (result.solver.status is SolverStatus.ok and
                         result.solver.termination_condition is tc.optimal):
                     model_objectives = m.component_data_objects(Objective, active=True)
-                    mobj = next(model_objectives, None)
+                    mobj = next(model_objectives)
                     obj_val = value(mobj.expr)
                     objectives.append(obj_val)
                     if obj_val * obj_sign < obj_sign * best_objective:

--- a/pyomo/contrib/multistart/multi.py
+++ b/pyomo/contrib/multistart/multi.py
@@ -118,12 +118,16 @@ class MultiStart(object):
         # Model sense
         objectives = model.component_data_objects(Objective, active=True)
         obj = next(objectives, None)
+        #Check model validity
         if next(objectives, None) is not None:
             raise RuntimeError(
                 "Multistart solver is unable to handle model with multiple active objectives.")
         if obj is None:
             raise RuntimeError(
                 "Multistart solver is unable to handle model with no active objective.")
+        if obj.polynomial_degree()==0:
+            raise RuntimeError(
+                "Multistart solver received model with constant objective")
 
         # store objective values and objective/result information for best
         # solution obtained

--- a/pyomo/contrib/multistart/multi.py
+++ b/pyomo/contrib/multistart/multi.py
@@ -143,7 +143,7 @@ class MultiStart(object):
             best_result = result = solver.solve(model, **config.solver_args)
             if (result.solver.status is SolverStatus.ok and
                     result.solver.termination_condition is tc.optimal):
-                obj_val = value(model.obj.expr)
+                obj_val = value(obj.expr)
                 best_objective = obj_val
                 objectives.append(obj_val)
             num_iter = 0
@@ -170,7 +170,9 @@ class MultiStart(object):
                 result = solver.solve(m, **config.solver_args)
                 if (result.solver.status is SolverStatus.ok and
                         result.solver.termination_condition is tc.optimal):
-                    obj_val = value(m.obj.expr)
+                    model_objectives = m.component_data_objects(Objective, active=True)
+                    mobj = next(model_objectives, None)
+                    obj_val = value(mobj.expr)
                     objectives.append(obj_val)
                     if obj_val * obj_sign < obj_sign * best_objective:
                         # objective has improved

--- a/pyomo/contrib/multistart/test_multi.py
+++ b/pyomo/contrib/multistart/test_multi.py
@@ -31,7 +31,11 @@ class MultistartTests(unittest.TestCase):
         for i in range(10):
             m2 = build_model()
             SolverFactory('multistart').solve(m2, iterations=10)
-            self.assertTrue((value(m2.obj.expr)) >= (value(m.obj.expr) - .001))
+            m_objectives = m.component_data_objects(Objective, active=True)
+            m_obj = next(m_objectives, None)
+            m2_objectives = m2.component_data_objects(Objective, active=True)
+            m2_obj = next(m2_objectives,None)
+            self.assertTrue((value(m2_obj.expr)) >= (value(m_obj.expr) - .001))
             del m2
 
     def test_as_good_with_iteration_other_strategies(self):
@@ -45,19 +49,31 @@ class MultistartTests(unittest.TestCase):
             m2 = build_model()
             SolverFactory('multistart').solve(
                 m2, iterations=10, strategy='rand_distributed')
-            self.assertTrue((value(m2.obj.expr)) >= (value(m.obj.expr) - .001))
+            m_objectives = m.component_data_objects(Objective, active=True)
+            m_obj = next(m_objectives, None)
+            m2_objectives = m2.component_data_objects(Objective, active=True)
+            m2_obj = next(m2_objectives,None)
+            self.assertTrue((value(m2_obj.expr)) >= (value(m_obj.expr) - .001))
             del m2
         for i in range(10):
             m2 = build_model()
             SolverFactory('multistart').solve(
                 m2, iterations=10, strategy='midpoint_guess_and_bound')
-            self.assertTrue((value(m2.obj.expr)) >= (value(m.obj.expr) - .001))
+            m_objectives = m.component_data_objects(Objective, active=True)
+            m_obj = next(m_objectives, None)
+            m2_objectives = m2.component_data_objects(Objective, active=True)
+            m2_obj = next(m2_objectives,None)
+            self.assertTrue((value(m2_obj.expr)) >= (value(m_obj.expr) - .001))
             del m2
         for i in range(10):
             m2 = build_model()
             SolverFactory('multistart').solve(
                 m2, iterations=10, strategy='rand_guess_and_bound')
-            self.assertTrue((value(m2.obj.expr)) >= (value(m.obj.expr) - .001))
+            m_objectives = m.component_data_objects(Objective, active=True)
+            m_obj = next(m_objectives, None)
+            m2_objectives = m2.component_data_objects(Objective, active=True)
+            m2_obj = next(m2_objectives,None)
+            self.assertTrue((value(m2_obj.expr)) >= (value(m_obj.expr) - .001))
             del m2
 
     def test_as_good_with_HCS_rule(self):
@@ -73,7 +89,11 @@ class MultistartTests(unittest.TestCase):
             m2 = build_model()
             SolverFactory('multistart').solve(
                 m2, iterations=-1, stopping_mass=0.99, stopping_delta=0.99)
-            self.assertTrue((value(m2.obj.expr)) >= (value(m.obj.expr) - .001))
+            m_objectives = m.component_data_objects(Objective, active=True)
+            m_obj = next(m_objectives, None)
+            m2_objectives = m2.component_data_objects(Objective, active=True)
+            m2_obj = next(m2_objectives,None)
+            self.assertTrue((value(m2_obj.expr)) >= (value(m_obj.expr) - .001))
             del m2
 
     def test_missing_bounds(self):
@@ -138,7 +158,7 @@ def build_model():
     model.x1 = Var(initialize=1, bounds=(0, 100))
     model.x2 = Var(initialize=5, bounds=(5, 6))
     model.x2.fix(5)
-    model.obj = Objective(expr=model.x1 * sin(model.x1), sense=maximize)
+    model.objtv = Objective(expr=model.x1 * sin(model.x1), sense=maximize)
     return model
 
 

--- a/pyomo/contrib/multistart/test_multi.py
+++ b/pyomo/contrib/multistart/test_multi.py
@@ -17,7 +17,8 @@ class MultistartTests(unittest.TestCase):
     """
     Due to stochastic nature of the random restarts, these tests just
     demonstrate, that for a small sample, the test will not do worse than the
-    standard solver. this is non-exhaustive due to the randomness.
+    standard solver. this is non-exhaustive due to the randomness. Hence all
+    asserts are inequalities.
     """
 
     # test standard random restarts
@@ -53,6 +54,7 @@ class MultistartTests(unittest.TestCase):
             m_obj = next(m_objectives, None)
             m2_objectives = m2.component_data_objects(Objective, active=True)
             m2_obj = next(m2_objectives,None)
+            #Assert that multistart solver does no worse than standard solver
             self.assertTrue((value(m2_obj.expr)) >= (value(m_obj.expr) - .001))
             del m2
         for i in range(10):
@@ -63,6 +65,7 @@ class MultistartTests(unittest.TestCase):
             m_obj = next(m_objectives, None)
             m2_objectives = m2.component_data_objects(Objective, active=True)
             m2_obj = next(m2_objectives,None)
+            #Assert that multistart solver does no worse than standard solver
             self.assertTrue((value(m2_obj.expr)) >= (value(m_obj.expr) - .001))
             del m2
         for i in range(10):
@@ -71,8 +74,10 @@ class MultistartTests(unittest.TestCase):
                 m2, iterations=10, strategy='rand_guess_and_bound')
             m_objectives = m.component_data_objects(Objective, active=True)
             m_obj = next(m_objectives, None)
-            m2_objectives = m2.component_data_objects(Objective, active=True)
+            m2_objectives = m2.component_data
+            _objects(Objective, active=True)
             m2_obj = next(m2_objectives,None)
+            #Assert that multistart solver does no worse than standard solver
             self.assertTrue((value(m2_obj.expr)) >= (value(m_obj.expr) - .001))
             del m2
 
@@ -93,6 +98,7 @@ class MultistartTests(unittest.TestCase):
             m_obj = next(m_objectives, None)
             m2_objectives = m2.component_data_objects(Objective, active=True)
             m2_obj = next(m2_objectives,None)
+            #Assert that multistart solver does no worse than standard solver
             self.assertTrue((value(m2_obj.expr)) >= (value(m_obj.expr) - .001))
             del m2
 

--- a/pyomo/contrib/multistart/test_multi.py
+++ b/pyomo/contrib/multistart/test_multi.py
@@ -74,8 +74,7 @@ class MultistartTests(unittest.TestCase):
                 m2, iterations=10, strategy='rand_guess_and_bound')
             m_objectives = m.component_data_objects(Objective, active=True)
             m_obj = next(m_objectives, None)
-            m2_objectives = m2.component_data
-            _objects(Objective, active=True)
+            m2_objectives = m2.component_data_objects(Objective, active=True)
             m2_obj = next(m2_objectives,None)
             #Assert that multistart solver does no worse than standard solver
             self.assertTrue((value(m2_obj.expr)) >= (value(m_obj.expr) - .001))

--- a/pyomo/contrib/multistart/test_multi.py
+++ b/pyomo/contrib/multistart/test_multi.py
@@ -151,6 +151,12 @@ class MultistartTests(unittest.TestCase):
         with self.assertRaisesRegexp(RuntimeError, "no active objective"):
             SolverFactory('multistart').solve(m)
 
+    def test_const_obj(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.o = Objective(expr = 5)
+        with self.assertRaisesRegexp(RuntimeError, "constant objective"):
+            SolverFactory('multistart').solve(m)
 
 def build_model():
     """Simple non-convex model with many local minima"""


### PR DESCRIPTION
## Summary/Motivation:
Multistart Solver wrapper had a non-general reference to the model's objective function. Does not work for models without a specific name for the objective function. The testing file had a similar bug

## Changes proposed in this PR:
- Change objective reference to work for objective functions with any name.
- Also implement change in testing file.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
