### PR TITLE
Allow ":" in cplex file names.

### DIFF
--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -62,7 +62,7 @@ def _validate_file_name(cplex, filename, description):
                 "CPLEX or remove the space from the %s path."
                 % (description, filename, description))
     return filename
-_validate_file_name.allowed_characters = r"a-zA-Z0-9 \.\-_\%s" % (os.path.sep,)
+_validate_file_name.allowed_characters = r"a-zA-Z0-9 :\.\-_\%s" % (os.path.sep,)
 _validate_file_name.illegal_characters = re.compile(
     '[^%s]' % (_validate_file_name.allowed_characters,))
 


### PR DESCRIPTION
## Fixes #809.

## Summary/Motivation:
The CPLEX file name validator (introduced in #586) was excessively restrictive.  This PR adds "`:`" to the list of valid characters. 

## Changes proposed in this PR:
- Allow "`:`" characters (e.g., after drive letters) in cplex file names.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
