### PR TITLE
Fix setup.py Windows installation failure when Cython is present

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,7 @@ def run_setup():
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: Jython',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ if using_cython:
         import platform
         if platform.python_implementation() != "CPython":
             # break out of this try-except (disable Cython)
-            raise RuntimeError("Cython is only supported uncer CPython")
+            raise RuntimeError("Cython is only supported under CPython")
         from Cython.Build import cythonize
         #
         # Note: The Cython developers recommend that you destribute C source

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,9 @@ else:
 if '--with-cython' in sys.argv:
     using_cython = True
     sys.argv.remove('--with-cython')
+if '--without-cython' in sys.argv:
+    using_cython = False
+    sys.argv.remove('--without-cython')
 
 ext_modules = []
 if using_cython:


### PR DESCRIPTION
## Fixes #808

## Summary/Motivation:
This resolves problems installing Pyomo through `setup.py` on Windows.  Specifically, if Cython was available (e.g. though Anaconda), but no valid (Microsoft) compiler was available, then Cython raised a `SystemExit` exception and killed the install.

## Changes proposed in this PR:
- Attempt to re-run `setup()` without Cython if the first attempt generates a `SystemExit` exception with a message about `Microsoft Visual C++`.
- Add a `--without-cython` option to `setup.py` to explicitly disable Cython
- Make `--with-cython` *require* successful cythonization of the target modules
- (Add Python 3.7 to the list of valid Python versions - an oversight from the 5.6 release)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
