### PR TITLE
show how to extend an objective function

### DIFF
--- a/doc/OnlineDocs/working_models.rst
+++ b/doc/OnlineDocs/working_models.rst
@@ -265,6 +265,39 @@ Note that ``instance.x.fix(2)`` is equivalent to
 
 and ``instance.x.fix()`` is equivalent to ``instance.x.fixed = True``
 
+Extending the Objective Function
+--------------------------------
+
+One can add terms to an objective function of a ``ConcreteModel`` (or
+and instantiated ``AbstractModel``) using the ``expr`` attribute
+of the objective function object. Here is a simple example:
+
+.. doctest::
+
+   >>> import pyomo.environ as pyo
+   >>> from pyomo.opt import SolverFactory
+
+   >>> model = pyo.ConcreteModel()
+
+   >>> model.x = pyo.Var(within=pyo.PositiveReals)
+   >>> model.y = pyo.Var(within=pyo.PositiveReals)
+
+   >>> model.sillybound = pyo.Constraint(expr = model.x + model.y <= 2)
+
+   >>> model.obj = pyo.Objective(expr = 20 * model.x)
+
+   >>> opt = SolverFactory('glpk') # doctest: +SKIP
+   >>> opt.solve(model) # doctest: +SKIP
+
+   >>> model.pprint() # doctest: +SKIP
+
+   >>> print ("------------- extend obj --------------") # doctest: +SKIP
+   >>> model.obj.expr += 10 * model.y
+
+   >>> opt = SolverFactory('cplex') # doctest: +SKIP
+   >>> opt.solve(model) # doctest: +SKIP
+   >>> model.pprint() # doctest: +SKIP
+
 Activating and Deactivating Objectives
 --------------------------------------
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Add documentation for extending the objective function using .expr +=

## Changes proposed in this PR:
Add documentation for extending the objective function using .expr +=
NOTE: When I run doctests locally, an unrelated failure occurs. If that happens when this PR is tested, will try to fix the unrelated error (that happens to be in PySP)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
