### PR TITLE
setup.py: Python3 fix for the Cython error trap on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -194,7 +194,7 @@ except SystemExit as e_info:
     # environment is missing / has an incorrect Microsoft compiler.
     # Since Cython is not strictly required, we will disable Cython and
     # try re-running setup(), but only for this very specific situation.
-    if 'Microsoft Visual C++' not in e_info.message:
+    if 'Microsoft Visual C++' not in str(e_info):
         raise
     elif using_cython == CYTHON_REQUIRED:
         print("""


### PR DESCRIPTION
## Fixes #822 

## Summary/Motivation:
This fixes a Python3 incompatibility when catching a SystemExit exception during setup()

## Changes proposed in this PR:
- Retrieve the message through `str()` instead of the `.message` attribute.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
