### PR TITLE
Changing conda --no-update-dependencies option to --no-update-deps.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,7 +65,7 @@ install:
   #
   - SET CONDA_INSTALL=conda install -q -y
   - "SET ANACONDA=%CONDA_INSTALL% -c anaconda"
-  - "SET CONDAFORGE=%CONDA_INSTALL% -c conda-forge --no-update-dependencies"
+  - "SET CONDAFORGE=%CONDA_INSTALL% -c conda-forge --no-update-deps"
   #
   # Determine if we will use Appveyor's Miniconda or install Anaconda
   # (intermittently one or the other suffers from NumPy failing to load the


### PR DESCRIPTION
## Fixes #829.

## Summary/Motivation:
This tracks a change in the conda CLI.

## Changes proposed in this PR:
- Changing conda `--no-update-dependencies` option to `--no-update-deps`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
