### PR TITLE
Enable publication of coverage results from Jenkins

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -102,16 +102,16 @@ install:
   - SET MINICONDA_EXTRAS=""
   - IF DEFINED USING_MINICONDA (SET MINICONDA_EXTRAS=numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill seaborn)
   #
-  - "IF DEFINED EXTRAS (SET ADDITIONAL_CF_PKGS=%ADDTIONAL_CF_PKGS% pymysql pyro4 %MINICONDA_EXTRAS%)"
+  - "IF DEFINED EXTRAS (SET ADDITIONAL_CF_PKGS=%ADDITIONAL_CF_PKGS% pymysql pyro4 %MINICONDA_EXTRAS%)"
   #- "IF DEFINED EXTRAS (%CONDAFORGE% mkl)"
   #
   # Finally, add any solvers we want to the list
   #
-  - "SET ADDITIONAL_CF_PKGS=%ADDTIONAL_CF_PKGS% glpk ipopt"
+  - "SET ADDITIONAL_CF_PKGS=%ADDITIONAL_CF_PKGS% glpk ipopt"
   #
   # ...and install everything from conda-force in one go
   #
-  - "%CONDAFORGE% %ADDTIONAL_CF_PKGS%"
+  - "%CONDAFORGE% %ADDITIONAL_CF_PKGS%"
   #
   # While we would like to install codecov using conda (for
   # consistency), there are cases (most recently, in Python 3.5) where

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,7 +53,6 @@ environment:
 
 
 install:
-  # We need wheel installed to build wheels
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON%\\Library\\bin;%PATH%"
   - python --version
   #
@@ -93,7 +92,26 @@ install:
   #- "SET CONDAENV=%PYTHON%\\envs\\pyomo_test_env"
   - "echo %PATH%"
   #
-  - "%CONDAFORGE% setuptools pip coverage sphinx_rtd_theme"
+  - "SET ADDITIONAL_CF_PKGS=setuptools pip coverage sphinx_rtd_theme"
+  #
+  # Install extra packages (formerly pyomo.extras)
+  #
+  #   If we are using Miniconda, we need to install additional packages
+  #   that usually come with the full Anaconda distribution
+  #
+  - SET MINICONDA_EXTRAS=""
+  - IF DEFINED USING_MINICONDA (SET MINICONDA_EXTRAS=numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill seaborn)
+  #
+  - "IF DEFINED EXTRAS (SET ADDITIONAL_CF_PKGS=%ADDTIONAL_CF_PKGS% pymysql pyro4 %MINICONDA_EXTRAS%)"
+  #- "IF DEFINED EXTRAS (%CONDAFORGE% mkl)"
+  #
+  # Finally, add any solvers we want to the list
+  #
+  - "SET ADDITIONAL_CF_PKGS=%ADDTIONAL_CF_PKGS% glpk ipopt"
+  #
+  # ...and install everything from conda-force in one go
+  #
+  - "%CONDAFORGE% %ADDTIONAL_CF_PKGS%"
   #
   # While we would like to install codecov using conda (for
   # consistency), there are cases (most recently, in Python 3.5) where
@@ -108,39 +126,33 @@ install:
   - windows_x64_64.exe /SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS
   - "SET PATH=%cd%\\gams;%PATH%"
   #
-  # Install pyomo.extras
-  #
-  # If we are using Miniconda, we need to install additional packages
-  # that usually come with the full Anaconda distribution
-  #
-  - SET MINICONDA_EXTRAS=""
-  - IF DEFINED USING_MINICONDA (SET MINICONDA_EXTRAS=numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill seaborn)
-  #
-  - "IF DEFINED EXTRAS (%CONDAFORGE% pymysql pyro4 %MINICONDA_EXTRAS%)"
-  #- "IF DEFINED EXTRAS (%CONDAFORGE% numpy scipy ipython openpyxl sympy pymysql pyodbc pyro4 pyyaml networkx xlrd pandas matplotlib dill)"
-  #- "IF DEFINED EXTRAS (%CONDAFORGE% mkl)"
-  #
-  - "%CONDAFORGE% glpk"
-  - "glpsol -v"
-  # NOTE: conda-forge doesn't build ipopt for Windows....
-  - "%CONDAFORGE% ipopt"
-  - "ipopt -v"
-  #
   # Clone but don't install pyomo-model-libraries
   #
   - "git clone https://github.com/Pyomo/pyomo-model-libraries.git"
   - "python -m pip install git+https://github.com/PyUtilib/pyutilib"
   - "python setup.py develop"
+
+  # Set up python's coverage for covering subprocesses (important to do
+  # here because we want coverage of the download scripts below)
   #
+  - "SET BUILD_DIR=%cd%"
+  - "SET COVERAGE_PROCESS_START=%BUILD_DIR%\\coveragerc"
+  - "copy %BUILD_DIR%\\.coveragerc %COVERAGE_PROCESS_START%"
+  - "echo data_file=%BUILD_DIR%\\.coverage >> %COVERAGE_PROCESS_START%"
+  - python -c "from distutils.sysconfig import get_python_lib; import os; FILE=open(os.path.join(get_python_lib(),'run_coverage_at_startup.pth'), 'w'); FILE.write('import coverage; coverage.process_startup()'); FILE.close()"
+
   # Fetch additional solvers
   #
   - "mkdir %cd%\\bin"
   - "SET PATH=%cd%\\bin;%PATH%"
-  - "python pyomo\\contrib\\trustregion\\getGJH.py %cd%\\bin"
-  - "gjh -v"
   - "python pyomo\\common\\getGSL.py %cd%\\bin"
+  - "python pyomo\\contrib\\trustregion\\getGJH.py %cd%\\bin"
+
+  # Report relevant package versions
   #
-  # Verify the python version
+  - "gjh -v"
+  - "glpsol -v"
+  - "ipopt -v"
   - python --version
 
 build: off
@@ -159,9 +171,6 @@ test_script:
   # subprocesses launched by tests
   - "SET BUILD_DIR=%cd%"
   - "SET COVERAGE_PROCESS_START=%BUILD_DIR%\\coveragerc"
-  - "copy %BUILD_DIR%\\.coveragerc %COVERAGE_PROCESS_START%"
-  - "echo data_file=%BUILD_DIR%\\.coverage >> %COVERAGE_PROCESS_START%"
-  - python -c "from distutils.sysconfig import get_python_lib; import os; FILE=open(os.path.join(get_python_lib(),'run_coverage_at_startup.pth'), 'w'); FILE.write('import coverage; coverage.process_startup()'); FILE.close()"
 
   # Run Pyomo tests
   - "test.pyomo -v --cat=%CATEGORY% pyomo %BUILD_DIR%\\pyomo-model-libraries"

--- a/admin/driver.py
+++ b/admin/driver.py
@@ -192,6 +192,20 @@ def perform_tests(package, coverage=False, omit=None, cat='nightly'):
         cmd = [os.path.join( os.environ['WORKSPACE'],'python','bin','test.'+package ), '--cat', cat]
     cmd.append('-v')
     if coverage:
+        sitedir = os.path.join(
+            os.path.abspath(dest),'lib',
+            'python'+'.'.join(map(str,sys.version_info[:2])),'site-packages')
+        pthfile = os.path.join(sitedir, 'run_coverage_at_startup.pth')
+        with open(pthfile, 'w') as FILE:
+            FILE.write('import coverage; coverage.process_startup()\n')
+        srcdir = os.path.join(os.environ['WORKSPACE'],'src','pyomo')
+        with open(os.path.join(srcdir, '.coveragerc'), 'r') as FILE:
+            coveragerc = FILE.readlines()
+        coveragerc.append("data_file=%s%s.coverage\n" % (srcdir, os.path.sep))
+        coveragerc_file = os.path.join(srcdir, 'coveragerc')
+        with open(coveragerc_file, 'w') as FILE:
+            FILE.write(''.join(coveragerc))
+        os.environ['COVERAGE_PROCESS_START'] = coveragerc_file
         cmd.extend(['--coverage','--cover-erase'])
     if 'TEST_PACKAGES' in os.environ:
         cmd = cmd + re.split('[ \t]+', os.environ['TEST_PACKAGES'].strip())
@@ -211,17 +225,32 @@ def perform_tests(package, coverage=False, omit=None, cat='nightly'):
     if not coverage:
         return
     os.chdir(os.path.join( os.environ['WORKSPACE'],'src','pyomo' ))
-    libdir = os.path.join( os.environ['WORKSPACE'],'python','lib','*' )
-    libdir = libdir + "," + os.path.join( libdir,'site-packages','*' )
-    if omit is not None:
-        omit = ","+omit
-    else:
-        omit = ""
-    covFName = os.path.join( os.environ['WORKSPACE'],'src','coverage.xml' )
+    cover_cmd=[os.path.join(os.environ['WORKSPACE'],'python','bin','coverage')]
     if platform == 'win':
-        cmd = [os.path.join( os.environ['WORKSPACE'],'python','bin','coverage.exe' ), 'xml', '--omit="%s%s"' % (libdir,omit), '-o', covFName ]
+        cover_cmd[0] += '.exe'
+    cmd = cover_cmd + ['combine']
+    sys.stdout.write( "Running Command: %s\n" % " ".join(cmd) )
+    sys.stdout.flush()
+    if platform == 'win':
+        sys.stdout.write( str(subprocess.call(['cmd','/c']+cmd)) + '\n' )
     else:
-        cmd = [os.path.join( os.environ['WORKSPACE'],'python','bin','coverage' ), 'xml', '--omit="%s%s"' % (libdir,omit), '-o', covFName ]
+        sys.stdout.write( str(subprocess.call(cmd)) + '\n' )
+
+    # site-packages and the python libraries are omitted by the
+    # coveragerc file.
+    #
+    #libdir = os.path.join( os.environ['WORKSPACE'],'python','lib','*' )
+    #libdir = libdir + "," + os.path.join( libdir,'site-packages','*' )
+    #if omit is not None:
+    #    omit = ","+omit
+    #else:
+    #    omit = ""
+
+    cmd = cover_cmd + ['xml']
+    if omit is not None:
+        cmd.append('--omit=%s' % (omit,))
+    covFName = os.path.join( os.environ['WORKSPACE'],'src','coverage.xml' )
+    cmd.extend(['-o', covFName])
     sys.stdout.write( "Running Command: %s\n" % " ".join(cmd) )
     sys.stdout.flush()
     if platform == 'win':
@@ -231,7 +260,9 @@ def perform_tests(package, coverage=False, omit=None, cat='nightly'):
         #sys.stdout.write( str(subprocess.call(['ls', '-la'])) + '\n')
         sys.stdout.write( str(subprocess.call(cmd)) + '\n' )
 
-    # NB: for Hudson source rendering to work correctly, the XML must include the relative path to the source filenames *from the project workspace*
+    # NB: for Hudson source rendering to work correctly, the XML must
+    # include the relative path to the source filenames *from the
+    # project workspace*
     try:
         keep(covFName, 'package', 'name', '.*\.tests', covFName)
         doc = xml.dom.minidom.parse(covFName)

--- a/admin/driver.py
+++ b/admin/driver.py
@@ -237,8 +237,10 @@ def perform_tests(package, coverage=False, omit=None, cat='nightly'):
     else:
         sys.stdout.write( str(subprocess.call(cmd)) + '\n' )
 
-    # site-packages and the python libraries are omitted by the
-    # coveragerc file.
+    # We used to hard-code the ommission of the site-packages and the
+    # python libraries here.  That directive is now managed by the
+    # coveragerc file.  The commented code below is maintained strictly
+    # for historical reference.
     #
     #libdir = os.path.join( os.environ['WORKSPACE'],'python','lib','*' )
     #libdir = libdir + "," + os.path.join( libdir,'site-packages','*' )

--- a/admin/driver.py
+++ b/admin/driver.py
@@ -193,7 +193,7 @@ def perform_tests(package, coverage=False, omit=None, cat='nightly'):
     cmd.append('-v')
     if coverage:
         sitedir = os.path.join(
-            os.path.abspath(dest),'lib',
+            os.path.join( os.environ['WORKSPACE'],'python','lib',
             'python'+'.'.join(map(str,sys.version_info[:2])),'site-packages')
         pthfile = os.path.join(sitedir, 'run_coverage_at_startup.pth')
         with open(pthfile, 'w') as FILE:

--- a/admin/driver.py
+++ b/admin/driver.py
@@ -193,7 +193,7 @@ def perform_tests(package, coverage=False, omit=None, cat='nightly'):
     cmd.append('-v')
     if coverage:
         sitedir = os.path.join(
-            os.path.join( os.environ['WORKSPACE'],'python','lib',
+            os.environ['WORKSPACE'],'python','lib',
             'python'+'.'.join(map(str,sys.version_info[:2])),'site-packages')
         pthfile = os.path.join(sitedir, 'run_coverage_at_startup.pth')
         with open(pthfile, 'w') as FILE:

--- a/admin/driver.py
+++ b/admin/driver.py
@@ -206,7 +206,8 @@ def perform_tests(package, coverage=False, omit=None, cat='nightly'):
         with open(coveragerc_file, 'w') as FILE:
             FILE.write(''.join(coveragerc))
         os.environ['COVERAGE_PROCESS_START'] = coveragerc_file
-        cmd.extend(['--coverage','--cover-erase'])
+        # The above supersedes the need for --coverage
+        #cmd.extend(['--coverage','--cover-erase'])
     if 'TEST_PACKAGES' in os.environ:
         cmd = cmd + re.split('[ \t]+', os.environ['TEST_PACKAGES'].strip())
     sys.stdout.write( "Running Command: %s\n" % " ".join(cmd) )

--- a/admin/jenkins.py
+++ b/admin/jenkins.py
@@ -55,12 +55,13 @@ print("\nPython version: %s" % sys.version)
 print("\nSystem PATH:\n\t%s" % os.environ['PATH'])
 print("\nPython path:\n\t%s" % sys.path)
 
-coverage_omit=','.join([
-    os.sep.join([os.environ['WORKSPACE'], 'src', 'pyomo', 'pyomo', '*', 'tests']),
-    'pyomo.*.tests',
-    os.sep.join([os.environ['WORKSPACE'], 'src', 'pyutilib.*']),
-    'pyutilib.*',
-])
+#coverage_omit=','.join([
+#    os.sep.join([os.environ['WORKSPACE'], 'src', 'pyomo', 'pyomo', '*', 'tests']),
+#    'pyomo.*.tests',
+#    os.sep.join([os.environ['WORKSPACE'], 'src', 'pyutilib.*']),
+#    'pyutilib.*',
+#])
+coverage_omit = None
 
 pyomo_packages = [
     'pyomo.%s' % os.path.basename(x) for x in

--- a/admin/jenkins.py
+++ b/admin/jenkins.py
@@ -55,6 +55,11 @@ print("\nPython version: %s" % sys.version)
 print("\nSystem PATH:\n\t%s" % os.environ['PATH'])
 print("\nPython path:\n\t%s" % sys.path)
 
+# We used to hard-code the ommission of tests and pyutilib here.  That
+# directive is now managed by the coveragerc file using slightly
+# different patterns.  The commented code below is maintained strictly
+# for historical reference.
+#
 #coverage_omit=','.join([
 #    os.sep.join([os.environ['WORKSPACE'], 'src', 'pyomo', 'pyomo', '*', 'tests']),
 #    'pyomo.*.tests',


### PR DESCRIPTION
## Fixes #46.

## Summary/Motivation:
This updates the Jenkins builds to use the same coverage approach/configuration as is used by Travis and Appveyor.  Separately, the Jenkins builds have been updated to push coverage results to Codecov.

Note that implementing this requires a patched version of codecov, see codecov/codecov-python#187.

## Changes proposed in this PR:
- Update Jenkins driver touse the .coveragerc file to configure coverage
- Update the Jenkins driver to enable collecting coverage statistics for subprocesses
- Update the Appveyor driver to get coverage for the pyomo downloaders
- Clean up the Appveyor driver to reduce the number of calls to "`conda install`"

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
