### PR TITLE
Adding missing import guards

### DIFF
--- a/doc/OnlineDocs/contributed_packages/parmest/driver.rst
+++ b/doc/OnlineDocs/contributed_packages/parmest/driver.rst
@@ -34,17 +34,22 @@ the following code. A description of each argument is listed below.  Examples ar
 
 .. testsetup:: *
     
-    import pandas as pd
+    try:
+        import pandas as pd
+    except:
+        pd = None
     from pyomo.contrib.parmest.examples.rooney_biegler.rooney_biegler import rooney_biegler_model as model_function
-    data = pd.DataFrame(data=[[1,8.3],[2,10.3],[3,19.0],
-                                   [4,16.0],[5,15.6],[6,19.8]],
-                                   columns=['hour', 'y'])
-    theta_names = ['asymptote', 'rate_constant']
-    def objective_function(model, data):  
-        expr = sum((data.y[i] - model.response_function[data.hour[i]])**2 for i in data.index)
-        return expr
+    if pd is not None:
+        data = pd.DataFrame(data=[[1,8.3],[2,10.3],[3,19.0],
+                                  [4,16.0],[5,15.6],[6,19.8]],
+                            columns=['hour', 'y'])
+        theta_names = ['asymptote', 'rate_constant']
+        def objective_function(model, data):  
+            expr = sum((data.y[i] - model.response_function[data.hour[i]])**2 for i in data.index)
+            return expr
 
 .. doctest::
+    :skipif: pd is None
 
     >>> import pyomo.contrib.parmest.parmest as parmest
     >>> pest = parmest.Estimator(model_function, data, theta_names, objective_function)

--- a/doc/OnlineDocs/contributed_packages/parmest/driver.rst
+++ b/doc/OnlineDocs/contributed_packages/parmest/driver.rst
@@ -33,23 +33,20 @@ A :class:`~pyomo.contrib.parmest.parmest.Estimator` object can be created using
 the following code. A description of each argument is listed below.  Examples are provided in the :ref:`examplesection` Section.
 
 .. testsetup:: *
-    
-    try:
-        import pandas as pd
-    except:
-        pd = None
+    :skipif: not __import__('pyomo.contrib.parmest.parmest').contrib.parmest.parmest.parmest_available
+
+    import pandas as pd
     from pyomo.contrib.parmest.examples.rooney_biegler.rooney_biegler import rooney_biegler_model as model_function
-    if pd is not None:
-        data = pd.DataFrame(data=[[1,8.3],[2,10.3],[3,19.0],
-                                  [4,16.0],[5,15.6],[6,19.8]],
-                            columns=['hour', 'y'])
-        theta_names = ['asymptote', 'rate_constant']
-        def objective_function(model, data):  
-            expr = sum((data.y[i] - model.response_function[data.hour[i]])**2 for i in data.index)
-            return expr
+    data = pd.DataFrame(data=[[1,8.3],[2,10.3],[3,19.0],
+                              [4,16.0],[5,15.6],[6,19.8]],
+                        columns=['hour', 'y'])
+    theta_names = ['asymptote', 'rate_constant']
+    def objective_function(model, data):
+        expr = sum((data.y[i] - model.response_function[data.hour[i]])**2 for i in data.index)
+        return expr
 
 .. doctest::
-    :skipif: pd is None
+    :skipif: not __import__('pyomo.contrib.parmest.parmest').contrib.parmest.parmest.parmest_available
 
     >>> import pyomo.contrib.parmest.parmest as parmest
     >>> pest = parmest.Estimator(model_function, data, theta_names, objective_function)

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -6,8 +6,9 @@ try:
     import numpy as np
     import pandas as pd
     from scipy import stats
-except:
-    pass
+    parmest_available = True
+except ImportError:
+    parmest_available = False
 
 import pyomo.environ as pyo
 import pyomo.pysp.util.rapper as st

--- a/pyomo/contrib/pynumero/interfaces/__init__.py
+++ b/pyomo/contrib/pynumero/interfaces/__init__.py
@@ -13,7 +13,12 @@ try:
     numpy_available = True
 except ImportError:
     numpy_available = False
+try:
+    import scipy
+    scipy_available = True
+except ImportError:
+    scipy_available = False
 
-if numpy_available:
+if numpy_available and scipy_available:
     from .nlp import AmplNLP, PyomoNLP
     from .nlp_compositions import TwoStageStochasticNLP

--- a/pyomo/contrib/pynumero/linalg/__init__.py
+++ b/pyomo/contrib/pynumero/linalg/__init__.py
@@ -12,8 +12,13 @@ try:
     numpy_available = True
 except ImportError:
     numpy_available = False
+try:
+    import scipy
+    scipy_available = True
+except ImportError:
+    scipy_available = False
 
-if numpy_available:
+if numpy_available and scipy_available:
     from .intrinsics import *
 else:
     import logging

--- a/pyomo/contrib/pynumero/sparse/tests/test_intrinsics.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_intrinsics.py
@@ -11,6 +11,7 @@ import sys
 import pyutilib.th as unittest
 try:
     import numpy as np
+    import scipy
 except ImportError:
     raise unittest.SkipTest("Pynumero needs scipy and numpy to run NLP tests")
 


### PR DESCRIPTION
## Summary/Motivation:
This adds various missing import guards to contrib packages for the case where numpy is available, but pandas and scipy are not (as pointed out by a new set of Travis docker image builds).

## Changes proposed in this PR:
- Adding pandas import guards to parmest doctest
- Adding scipy import guards to pynumero

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
