### PR TITLE
Adding logic to control signals in shellcmd solvers

### DIFF
--- a/pyomo/opt/solver/shellcmd.py
+++ b/pyomo/opt/solver/shellcmd.py
@@ -45,6 +45,8 @@ class SystemCallSolver(OptSolver):
         # broadly useful for reporting, and in cases where
         # a solver plugin may not report execution time.
         self._last_solve_time = None
+        self._last_solve_time = None
+        self._define_signal_handlers = True
 
         if executable is not None:
             self.set_executable(name=executable, validate=validate)
@@ -196,6 +198,7 @@ class SystemCallSolver(OptSolver):
         TempfileManager.push()
 
         self._keepfiles = kwds.pop("keepfiles", False)
+        self._define_signal_handlers = kwds.pop('use_signal_handling',True)
 
         OptSolver._presolve(self, *args, **kwds)
 
@@ -306,7 +309,8 @@ class SystemCallSolver(OptSolver):
                 stdin = _input,
                 timelimit = self._timelimit if self._timelimit is None else self._timelimit + max(1, 0.01*self._timelimit),
                 env   = command.env,
-                tee   = self._tee
+                tee   = self._tee,
+                define_signal_handlers = self._define_signal_handlers
              )
         except WindowsError:
             err = sys.exc_info()[1]

--- a/pyomo/opt/solver/shellcmd.py
+++ b/pyomo/opt/solver/shellcmd.py
@@ -45,7 +45,6 @@ class SystemCallSolver(OptSolver):
         # broadly useful for reporting, and in cases where
         # a solver plugin may not report execution time.
         self._last_solve_time = None
-        self._last_solve_time = None
         self._define_signal_handlers = True
 
         if executable is not None:


### PR DESCRIPTION
By default, Pyomo calls PyUtilib to launch solvers using signals.
This causes problems in some multithreaded applications, where Pyomo
is not running in the main thread.  We added control of signal
management to PyUtilib last year, and this branch propagates this
change to Pyomo, using the flag 'use_signal_handling' (which defaults
to True).

## Fixes NA

## Summary/Motivation:

This adds a 'use_signal_handling' flag, which is passed to the shellcmd solver.


## Changes proposed in this PR:
- See above.
- NOTE:  No tests are added with this change.  This change adds the ability to remove error checks from Pyomo solver execution.  It's not clear how to test this, without having tests that fail.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
