### PR TITLE
Narrowing the check for a valid baron license.

### DIFF
--- a/pyomo/solvers/plugins/solvers/BARON.py
+++ b/pyomo/solvers/plugins/solvers/BARON.py
@@ -125,13 +125,11 @@ class BARONSHELL(SystemCallSolver):
 
     @staticmethod
     def license_is_valid(executable='baron'):
-        """
-        Runs a check for a valid Baron license using the
+        """Runs a check for a valid Baron license using the
         given executable (default is 'baron'). All output is
         hidden. If the test fails for any reason (including
         the executable being invalid), then this function
-        will return False.
-        """
+        will return False."""
         fnames= BARONSHELL._get_dummy_input_files(check_license=True)
         try:
             process = subprocess.Popen([executable, fnames[0]],
@@ -144,10 +142,8 @@ class BARONSHELL(SystemCallSolver):
                 rc = 1
             else:
                 stdout = stdout.decode()
-                for line in stdout.splitlines():
-                    if ("License file" in line) and ("not valid" in line):
-                        rc = 1
-                        break
+                if "Continuing in demo mode" in stdout:
+                    rc = 1
         except OSError:
             rc = 1
         finally:


### PR DESCRIPTION
The original check returned false when a license file existed that was expired or invalid. The check now returns false if baron attempts to run in demo mode for any reason. This will avoid failures in pyomo/solvers/tests/checks when a free version of Baron is installed. A few of the test models used there are slightly larger than Baron's demo mode will allow.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
