### PR TITLE
calculate_variable_from_constraint: catching expression evaluation errors

### DIFF
--- a/pyomo/core/expr/expr_pyomo5.py
+++ b/pyomo/core/expr/expr_pyomo5.py
@@ -1178,6 +1178,13 @@ def evaluate_expression(exp, exception=True, constant=False):
             raise
         return None
 
+    except TypeError:
+        # This can be raised in Python3 when evaluating a operation
+        # returns a complex number (e.g., sqrt(-1))
+        if exception:
+            raise
+        return None
+
 
 # =====================================================
 #  identify_components

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -171,7 +171,11 @@ class Test_calc_var(unittest.TestCase):
         m.x.set_value(600)
         output = six.StringIO()
         with LoggingIntercept(output, 'pyomo', logging.WARNING):
-            with self.assertRaises(ValueError):
+            if six.PY2:
+                expectedException = ValueError
+            else:
+                expectedException = TypeError
+            with self.assertRaises(expectedException):
                 calculate_variable_from_constraint(m.x, m.f, linesearch=False)
         self.assertIn('Encountered an error evaluating the expression '
                       'at the initial guess', output.getvalue())
@@ -188,7 +192,11 @@ class Test_calc_var(unittest.TestCase):
         m.x = .1
         output = six.StringIO()
         with LoggingIntercept(output, 'pyomo', logging.WARNING):
-            with self.assertRaises(ValueError):
+            if six.PY2:
+                expectedException = ValueError
+            else:
+                expectedException = TypeError
+            with self.assertRaises(expectedException):
                 calculate_variable_from_constraint(m.x, m.c, linesearch=False)
         self.assertIn("Newton's method encountered an error evaluating "
                       "the expression.", output.getvalue())

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -8,8 +8,11 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import logging
+import six
 import pyutilib.th as unittest
 
+from pyomo.common.log import LoggingIntercept
 from pyomo.environ import ConcreteModel, Var, Constraint, value, exp
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 from pyomo.core.base.symbolic import _sympy_available
@@ -114,20 +117,91 @@ class Test_calc_var(unittest.TestCase):
         m.e = Constraint(expr=(m.x - 2.0)**2 - 1 == 0)
         m.x.set_value(3.1)
         calculate_variable_from_constraint(m.x, m.e, linesearch=False)
+        self.assertAlmostEqual(value(m.x), 3)
 
         m.x.set_value(3.1)
         calculate_variable_from_constraint(m.x, m.e, linesearch=True)
+        self.assertAlmostEqual(value(m.x), 3)
 
 
         # we expect this to succeed with the linesearch
-        m.e = Constraint(expr=1.0/(1.0+exp(-m.x))-0.5 == 0)
+        m.f = Constraint(expr=1.0/(1.0+exp(-m.x))-0.5 == 0)
         m.x.set_value(3.0)
-        calculate_variable_from_constraint(m.x, m.e, linesearch=True)
+        calculate_variable_from_constraint(m.x, m.f, linesearch=True)
+        self.assertAlmostEqual(value(m.x), 0)
 
         # we expect this to fail without a linesearch
         m.x.set_value(3.0)
         with self.assertRaisesRegexp(
                 RuntimeError, "Newton's method encountered a derivative "
                 "that was too close to zero"):
-            calculate_variable_from_constraint(m.x, m.e, linesearch=False)
+            calculate_variable_from_constraint(m.x, m.f, linesearch=False)
 
+        # Calculate the bubble point of Benzene.  THe first step
+        # computed by calculate_variable_from_constraint will make the
+        # second term become complex, and the evaluation will fail.
+        # This tests that the algorithm cleanly continues
+        m = ConcreteModel()
+        m.x = Var()
+        m.pc = 48.9e5
+        m.tc = 562.2
+        m.psc = {'A': -6.98273,
+                 'B': 1.33213,
+                 'C': -2.62863,
+                 'D': -3.33399,
+        }
+        m.p = 101325
+        @m.Constraint()
+        def f(m):
+            return m.pc * \
+                exp((m.psc['A'] * (1 - m.x / m.tc) +
+                     m.psc['B'] * (1 - m.x / m.tc)**1.5 +
+                     m.psc['C'] * (1 - m.x / m.tc)**3 +
+                     m.psc['D'] * (1 - m.x / m.tc)**6
+                 ) / (1 - (1 - m.x / m.tc))) - m.p == 0
+        m.x.set_value(298.15)
+        calculate_variable_from_constraint(m.x, m.f, linesearch=False)
+        self.assertAlmostEqual(value(m.x), 353.31855602)
+        m.x.set_value(298.15)
+        calculate_variable_from_constraint(m.x, m.f, linesearch=True)
+        self.assertAlmostEqual(value(m.x), 353.31855602)
+
+        # Starting with an invalid guess (above TC) should raise an
+        # exception
+        m.x.set_value(600)
+        output = six.StringIO()
+        with LoggingIntercept(output, 'pyomo', logging.WARNING):
+            with self.assertRaises(ValueError):
+                calculate_variable_from_constraint(m.x, m.f, linesearch=False)
+        self.assertIn('Encountered an error evaluating the expression '
+                      'at the initial guess', output.getvalue())
+
+        # This example triggers an expression evaluation error if the
+        # linesearch is turned off because the first step in Newton's
+        # method will cause the LHS to become complex
+        m = ConcreteModel()
+        m.x = Var()
+        m.c = Constraint(expr=(1/m.x**3)**0.5 == 100)
+        m.x = .1
+        calculate_variable_from_constraint(m.x, m.c, linesearch=True)
+        self.assertAlmostEqual(value(m.x), 0.046415888)
+        m.x = .1
+        output = six.StringIO()
+        with LoggingIntercept(output, 'pyomo', logging.WARNING):
+            with self.assertRaises(ValueError):
+                calculate_variable_from_constraint(m.x, m.c, linesearch=False)
+        self.assertIn("Newton's method encountered an error evaluating "
+                      "the expression.", output.getvalue())
+
+        # This is a completely contrived example where the linesearch
+        # hits the iteration limit before Newton's method ever finds a
+        # feasible step
+        m = ConcreteModel()
+        m.x = Var()
+        m.c = Constraint(expr=m.x**0.5 == -1e-8)
+        m.x = 1e-8#197.932807183
+        with self.assertRaisesRegexp(
+                RuntimeError, "Linesearch iteration limit reached; "
+                "remaining residual = {function evaluation error}"):
+            calculate_variable_from_constraint(m.x, m.c, linesearch=True,
+                                               alpha_min=.5)

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -192,11 +192,13 @@ class Test_calc_var(unittest.TestCase):
         m.x = .1
         output = six.StringIO()
         with LoggingIntercept(output, 'pyomo', logging.WARNING):
-            if six.PY2:
-                expectedException = ValueError
-            else:
-                expectedException = TypeError
-            with self.assertRaises(expectedException):
+            with self.assertRaises(ValueError):
+                # Note that the ValueError is different between Python 2
+                # and Python 3: in Python 2 it is a specific error
+                # "negative number cannot be raised to a fractional
+                # power", and We mock up that error in Python 3 by
+                # raising a generic ValueError in
+                # calculate_variable_from_constraint
                 calculate_variable_from_constraint(m.x, m.c, linesearch=False)
         self.assertIn("Newton's method encountered an error evaluating "
                       "the expression.", output.getvalue())


### PR DESCRIPTION
## Fixes IDAES/idaes-dev#80.

## Summary/Motivation:
When evaluating variable values, it is possible for the variable to move to a value where the expression cannot be evaluated (e.g., `sqrt(-1)`).  This traps and corrects for expression evaluation errors encountered when searching / performing Newton's method.

## Changes proposed in this PR:
- Catch (most) expression expressions errors

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
