### PR TITLE
Function to compute bounds on an expression

### DIFF
--- a/pyomo/contrib/fbbt/fbbt.py
+++ b/pyomo/contrib/fbbt/fbbt.py
@@ -994,3 +994,23 @@ def fbbt(comp, deactivate_satisfied_constraints=False, update_variable_bounds=Tr
         raise FBBTException('Cannot perform FBBT on objects of type {0}'.format(type(comp)))
 
     return new_var_bounds
+
+
+def compute_bounds_on_expr(expr):
+    """
+    Compute bounds on an expression based on the bounds on the variables in the expression.
+
+    Parameters
+    ----------
+    expr: pyomo.core.expr.expr_pyomo5.ExpressionBase
+
+    Returns
+    -------
+    lb: float
+    ub: float
+    """
+    bnds_dict = ComponentMap()
+    visitor = _FBBTVisitorLeafToRoot(bnds_dict)
+    visitor.dfs_postorder_stack(expr)
+
+    return bnds_dict[expr]

--- a/pyomo/contrib/fbbt/tests/test_fbbt.py
+++ b/pyomo/contrib/fbbt/tests/test_fbbt.py
@@ -1,6 +1,6 @@
 import pyutilib.th as unittest
 import pyomo.environ as pe
-from pyomo.contrib.fbbt.fbbt import fbbt
+from pyomo.contrib.fbbt.fbbt import fbbt, compute_bounds_on_expr
 from pyomo.core.expr.expr_pyomo5 import ProductExpression, UnaryFunctionExpression
 import math
 import logging
@@ -481,3 +481,12 @@ class TestFBBT(unittest.TestCase):
         b = b.strip()
         self.assertTrue(b.startswith(a))
         logger.removeHandler(handler)
+
+    def test_compute_expr_bounds(self):
+        m = pe.ConcreteModel()
+        m.x = pe.Var(bounds=(-1,1))
+        m.y = pe.Var(bounds=(-1,1))
+        e = m.x + m.y
+        lb, ub = compute_bounds_on_expr(e)
+        self.assertAlmostEqual(lb, -2, 14)
+        self.assertAlmostEqual(ub, 2, 14)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:


## Changes proposed in this PR:
- Added a function to pyomo.contrib.fbbt to compute bounds on an expression from the bounds on the variables in the expression.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
