### PR TITLE
Clean up z3satsolver imports

### DIFF
--- a/pyomo/contrib/satsolver/satsolver.py
+++ b/pyomo/contrib/satsolver/satsolver.py
@@ -1,4 +1,4 @@
-from pyomo.core import value
+from pyomo.core import value, SymbolMap, NumericLabeler, Var, Constraint
 from pyomo.core.kernel.set_types import (RealSet,
                                          IntegerSet,
                                          BooleanSet)
@@ -14,7 +14,6 @@ from pyomo.core.expr.expr_pyomo5 import (EqualityExpression,
                                          UnaryFunctionExpression,
                                          nonpyomo_leaf_types,
                                          StreamBasedExpressionVisitor)
-from pyomo.environ import SymbolMap, NumericLabeler, Var, Constraint
 from pyomo.gdp import Disjunction
 import math
 


### PR DESCRIPTION
## Summary/Motivation:
z3 imports not working correctly when used in solvers

## Changes proposed in this PR:
- cleaned up imports

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
