### PR TITLE
Activate coverage for Anaconda Travis Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
   - TAG=python_2.7    CATEGORY="nightly" KEY_JOB=1
   - TAG=pypy_3        CATEGORY="nightly" DISABLE_COVERAGE=1
   - TAG=pypy_2        CATEGORY="nightly" DISABLE_COVERAGE=1
-  - TAG=anaconda_3    CATEGORY="nightly" DISABLE_COVERAGE=1
-  - TAG=anaconda_2    CATEGORY="nightly" DISABLE_COVERAGE=1
+  - TAG=anaconda_3    CATEGORY="nightly"
+  - TAG=anaconda_2    CATEGORY="nightly"
   - TAG=python_3.6    CATEGORY="parallel"
   - TAG=python_2.7    CATEGORY="parallel"
 


### PR DESCRIPTION
Extensions such as `pyomo.contrib.pynumero` rely on third-party software for testing that is only available on these builds.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
