### PR TITLE
Update parmest test import checks.

### DIFF
--- a/pyomo/contrib/parmest/graphics.py
+++ b/pyomo/contrib/parmest/graphics.py
@@ -8,8 +8,9 @@ try:
     import matplotlib.pyplot as plt
     import matplotlib.tri as tri
     from matplotlib.lines import Line2D
-except:
-    pass
+    imports_available = True
+except ImportError:
+    imports_available = False
 
 
 def _get_variables(ax,columns):

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -20,6 +20,7 @@ import subprocess
 from itertools import product
 
 import pyomo.contrib.parmest.parmest as parmest
+import pyomo.contrib.parmest.graphics as graphics
 import pyomo.contrib.parmest as parmestbase
 import pyomo.environ as pyo
 
@@ -47,7 +48,8 @@ class Object_from_string_Tester(unittest.TestCase):
         self.assertEqual(fixstatus, False)
 
         
-@unittest.skipIf(imports_not_present, "Cannot test parmest: required dependencies are missing")
+@unittest.skipIf(not parmest.parmest_available,
+                 "Cannot test parmest: required dependencies are missing")
 @unittest.skipIf(not ipopt_available, "The 'ipopt' command is not available")
 class parmest_object_Tester_RB(unittest.TestCase):
     
@@ -71,7 +73,9 @@ class parmest_object_Tester_RB(unittest.TestCase):
         self.assertAlmostEqual(objval, 4.4675, places=2)
         self.assertAlmostEqual(thetavals['asymptote'], 19.2189, places=2) # 19.1426 from the paper
         self.assertAlmostEqual(thetavals['rate_constant'], 0.5312, places=2) # 0.5311 from the paper
-        
+
+    @unittest.skipIf(not graphics.imports_available,
+                     "parmest.graphics imports are unavailable")
     def test_bootstrap(self):
         objval, thetavals = self.pest.theta_est()
         
@@ -103,6 +107,8 @@ class parmest_object_Tester_RB(unittest.TestCase):
                                          filename=filename)
         #self.assertTrue(os.path.isfile(filename))
         
+    @unittest.skipIf(not graphics.imports_available,
+                     "parmest.graphics imports are unavailable")
     def test_likelihood_ratio(self):
         # tbd: write the plot file(s) to a temp dir and delete in cleanup
         objval, thetavals = self.pest.theta_est()


### PR DESCRIPTION
## Summary/Motivation:
This resolves test failures on systems where numpy/scipy/matplotlib are available, but seaborn is not.

## Changes proposed in this PR:
- adding a flag / test guards if the `contrib.parmest.graphics` module does not import all its dependencies.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
