### PR TITLE
Adding missing import, fixes #894

### DIFF
--- a/pyomo/neos/plugins/kestrel_plugin.py
+++ b/pyomo/neos/plugins/kestrel_plugin.py
@@ -16,6 +16,7 @@ import six
 from six.moves.xmlrpc_client import ProtocolError
 
 from pyomo.opt import SolverFactory, SolverManagerFactory, OptSolver
+from pyomo.opt.parallel.manager import ActionManagerError
 from pyomo.opt.parallel.async_solver import (
     AsynchronousSolverManager, ActionStatus
 )


### PR DESCRIPTION
## Fixes #894 

## Summary/Motivation:
Recent NEOS test failures exposed a missing import in `kestrel_plugin.py`. This is a 1 line change adding the missing import. I'm not sure how to test it.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
