### PR TITLE
Pyomo Viewer, Improved error handling for Expression and Constraint calculation

### DIFF
--- a/pyomo/contrib/viewer/README.md
+++ b/pyomo/contrib/viewer/README.md
@@ -3,6 +3,21 @@
 ## Overview
 This is an interactive tree viewer for Pyomo models.  You can inspect and change values, bound, fixed, and active attributes of Pyomo components.  It also calculates and displays constraint and named expression values.
 
+## Installation
+
+### Requirements
+
+The model viewer has a few additional Python package requirements beyond the standard Pyomo install.
+
+For using the model viewer from IPython or Jupyter notebook, **PyQt5** is required.  To use the stand-alone viewer, Jupyter **qtconsole** and **ipykernel** are also required.
+
+**Note:**
+At the time this the time this was written, a bug in the released version of ipykernel (5.1.0) requires a more recent development version to be installed from https://github.com/ipython/ipykernel.
+
+### Install
+
+The Pyomo install also installs the viewer modules. To run the stand-alone viewer, just copy the pyomo_viewer.py script to a location that is convenient to run.   
+
 ## Using
 
 ### Opening from IPython
@@ -24,7 +39,7 @@ ui = get_mainwindow_nb(model=model)
 
 The model viewer adds an IPython callback after each cell executes to update the viewer in case components have been added or removed from the model. The model viewer should always display the current state of the model except for calculated items.  You must explicitly request that calculations be updated, since for very large models the time required may be significant.
 
-### Embedded Jupyter QtConsole
+### Stand-Alone with Embedded Jupyter QtConsole
 
 Run the "pyomo_viewer.py" script to get a stand alone model viewer with an embedded IPython console. The viewer will start with an empty Pyomo ConcreteModel called ```model```. To set the viewer to look at a new model run (the model does not need to be named model):
 
@@ -36,7 +51,7 @@ You could have multiple models in and switch the model viewer widgets between th
 
 **Note:** Some versions of ipykernel may have a bug where an error message "Execution Stopped" appears when trying to run commands after a command results in an exception. Versions of ipykernel > 5.1.0 should be okay.  Running exit in the IPython console may not work depending on the ipykernel version. Close the main UI window or select exit from the file menu to quit.
 
-Inside the QtConsole ``pyomo.environ`` is imported as ```pyo```. An empty Concrete model is imported as ```model```. The main user interface windows is imported as ```ui```.  This provides a useful ability to script ui actions.  You can even do things that are not yet possible through the graphical part of the user interface. For example to expand or collapse the tree view for variables:
+Inside the QtConsole ``pyomo.environ`` is imported as ```pyo```. An empty Concrete model is imported as ```model```. The main user interface window is imported as ```ui```.  This provides a useful ability to script ui actions.  You can even do things that are not yet possible through the graphical part of the user interface. For example to expand or collapse the tree view for variables:
 
 ```python
 ui.variables.treeView.expandAll()

--- a/pyomo/contrib/viewer/model_browser.py
+++ b/pyomo/contrib/viewer/model_browser.py
@@ -179,10 +179,14 @@ class ComponentDataItem(object):
                 self._cache_value = value(self.data.body, exception=False)
             except ZeroDivisionError:
                 self._cache_value = "Divide_by_0"
-            # I think these are constants, so don't think I need try/except
-            self._cache_lb = value(self.data.lower, exception=False)
-            self._cache_ub = value(self.data.upper, exception=False)
-
+            try:
+                self._cache_lb = value(self.data.lower, exception=False)
+            except ZeroDivisionError:
+                self._cache_lb = "Divide_by_0"
+            try:
+                self._cache_ub = value(self.data.upper, exception=False)
+            except ZeroDivisionError:
+                self._cache_ub = "Divide_by_0"
 
     def get(self, a):
         """Get an attribute"""

--- a/pyomo/contrib/viewer/model_browser.py
+++ b/pyomo/contrib/viewer/model_browser.py
@@ -170,14 +170,19 @@ class ComponentDataItem(object):
     def calculate(self):
         """Calculate items, applies to expressions and constraints"""
         if isinstance(self.data, _ExpressionData):
-            self._cache_value = value(self.data)
+            try:
+                self._cache_value = value(self.data, exception=False)
+            except ZeroDivisionError:
+                self._cache_value = "Divide_by_0"
         if isinstance(self.data, _ConstraintData) and self.data.active:
             try:
                 self._cache_value = value(self.data.body, exception=False)
-                self._cache_lb = value(self.data.lower, exception=False)
-                self._cache_ub = value(self.data.upper, exception=False)
-            except:
-                pass
+            except ZeroDivisionError:
+                self._cache_value = "Divide_by_0"
+            # I think these are constants, so don't think I need try/except
+            self._cache_lb = value(self.data.lower, exception=False)
+            self._cache_ub = value(self.data.upper, exception=False)
+
 
     def get(self, a):
         """Get an attribute"""

--- a/pyomo/contrib/viewer/report.py
+++ b/pyomo/contrib/viewer/report.py
@@ -21,7 +21,13 @@ def active_equalities(blk):
         blk: a Pyomo block in which to look for variables.
     """
     for o in blk.component_data_objects(Constraint, active=True):
-        if o.upper == o.lower: yield o
+        try:
+            u = value(o.upper, exception=False)
+            l = value(o.lower, exception=False)
+            if u == l and l is not None:
+                yield o
+        except ZeroDivisionError:
+            pass
 
 def count_free_variables(blk):
     """

--- a/pyomo/contrib/viewer/tests/test_data_model_item.py
+++ b/pyomo/contrib/viewer/tests/test_data_model_item.py
@@ -57,52 +57,52 @@ class TestDataModelItem(unittest.TestCase):
     def test_expr_calc(self):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.b1.e1)
         cdi.calculate()
-        assert(abs(cdi.get("value")-3) < 0.0001)
+        self.assertAlmostEqual(cdi.get("value"), 3)
 
     def test_expr_calc_div0(self):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.b1.e2)
         cdi.calculate()
-        assert(cdi.get("value") == "Divide_by_0")
+        self.assertEqual(cdi.get("value"), "Divide_by_0")
 
     def test_expr_calc_log0(self):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.b1.e4)
         cdi.calculate()
-        assert(cdi.get("value") == None)
+        self.assertIsNone(cdi.get("value"))
 
     def test_expr_calc_log_neg(self):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.b1.e5)
         cdi.calculate()
-        assert(cdi.get("value") == None)
+        self.assertIsNone(cdi.get("value"))
 
     def test_expr_calc_value_None(self):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.b1.e3)
         cdi.calculate()
-        assert(cdi.get("value") == None)
+        self.assertIsNone(cdi.get("value"))
 
     def test_cons_calc(self):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.c3)
         cdi.calculate()
-        assert(abs(cdi.get("residual") - 2) < 0.0001)
+        self.assertAlmostEqual(cdi.get("residual"), 2)
 
     def test_cons_calc_div0(self):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.c4)
         cdi.calculate()
-        assert(cdi.get("value") == "Divide_by_0")
+        self.assertEqual(cdi.get("value"), "Divide_by_0")
 
     def test_cons_calc_log0(self):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.c5)
         cdi.calculate()
-        assert(cdi.get("value") == None)
+        self.assertIsNone(cdi.get("value"))
 
     def test_cons_calc_log_neg(self):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.c6)
         cdi.calculate()
-        assert(cdi.get("value") == None)
+        self.assertIsNone(cdi.get("value"))
 
     def test_cons_calc_value_None(self):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.c7)
         cdi.calculate()
-        assert(cdi.get("value") == None)
+        self.assertIsNone(cdi.get("value"))
 
     def test_cons_calc_upper_div0(self):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.c8)
@@ -112,35 +112,35 @@ class TestDataModelItem(unittest.TestCase):
         # constarints in the same view, but I split them up, so may want
         # to reconsider that choise in the future. This is to remind myself
         # why I'm getting "ub" and not "upper"
-        assert(cdi.get("ub") == "Divide_by_0")
+        self.assertEqual(cdi.get("ub"), "Divide_by_0")
 
     def test_var_get_value(self):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.x[1])
-        assert(abs(cdi.get("value") - 1) < 0.0001)
+        self.assertAlmostEqual(cdi.get("value"), 1)
 
     def test_var_get_bounds(self):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.x[1])
         self.m.x[1].setlb(0)
         self.m.x[1].setub(10)
-        assert(abs(cdi.get("lb") - 0) < 0.0001)
-        assert(abs(cdi.get("ub") - 10) < 0.0001)
+        self.assertAlmostEqual(cdi.get("lb"), 0)
+        self.assertAlmostEqual(cdi.get("ub"), 10)
 
     def test_var_set_bounds(self):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.x[1])
         cdi.set("lb", 2)
         cdi.set("ub", 8)
-        assert(abs(cdi.get("lb") - 2) < 0.0001)
-        assert(abs(cdi.get("ub") - 8) < 0.0001)
+        self.assertAlmostEqual(cdi.get("lb"), 2)
+        self.assertAlmostEqual(cdi.get("ub"), 8)
 
     def test_var_fixed_bounds(self):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.x[1])
         cdi.set("fixed", True)
-        assert(cdi.get("fixed"))
+        self.assertTrue(cdi.get("fixed"))
         cdi.set("fixed", False)
-        assert(not cdi.get("fixed"))
+        self.assertFalse(cdi.get("fixed"))
 
     def test_degrees_of_freedom(self):
         import pyomo.contrib.viewer.report as rpt
         # this should hit everything in report.  It only exists to calculate
         # degrees of freedom for display in the ui
-        assert(rpt.degrees_of_freedom(self.m)==0)
+        self.assertEqual(rpt.degrees_of_freedom(self.m),0)

--- a/pyomo/contrib/viewer/tests/test_data_model_item.py
+++ b/pyomo/contrib/viewer/tests/test_data_model_item.py
@@ -13,6 +13,7 @@ Test data model items for QTreeView. These tests should work even without PyQt.
 """
 
 import pyutilib.th as unittest
+
 from pyomo.environ import *
 from pyomo.contrib.viewer.model_browser import ComponentDataItem
 
@@ -48,6 +49,9 @@ class TestDataModelItem(unittest.TestCase):
         m.c5 = Constraint(expr=0 == log(m.x[2]))
         m.c6 = Constraint(expr=0 == log(m.x[2]-4))
         m.c7 = Constraint(expr=0 == log(m.x[3]))
+        m.p1 = Param(mutable=True, initialize=1)
+        m.c8 = Constraint(expr = m.x[1] <= 1/m.p1)
+        m.p1 = 0
         self.m = m.clone()
 
     def test_expr_calc(self):
@@ -99,6 +103,16 @@ class TestDataModelItem(unittest.TestCase):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.c7)
         cdi.calculate()
         assert(cdi.get("value") == None)
+
+    def test_cons_calc_upper_div0(self):
+        cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.c8)
+        cdi.calculate()
+        # the ui lists the upper and lower attributes as ub and lb
+        # this was originally so I could easily combine variables and
+        # constarints in the same view, but I split them up, so may want
+        # to reconsider that choise in the future. This is to remind myself
+        # why I'm getting "ub" and not "upper"
+        assert(cdi.get("ub") == "Divide_by_0")
 
     def test_var_get_value(self):
         cdi = ComponentDataItem(parent=None, ui_setup=None, o=self.m.x[1])


### PR DESCRIPTION
## Summary/Motivation:
There was a problem when calculation of expressions values ended in an error in the Pyomo Viewer.  I improved the error handling for both expression and constraint calculation and added a bunch of tests for different kinds of errors.  I use the ```exception=False``` arg for ```value()``` and so far the only error it doesn't seem to catch is division by zero.  I assume there is a good reason for that, so I catch division by zero myself.  Any error not handled by those two things will still fall through and  1) halt the calculations and 2) trigger the unhanded exception message.

I'm a little hesitant to just ignore all exceptions when doing calculations in case I make a coding mistake, so I'm just going to try to catch all the expected cases.

## Changes proposed in this PR:
- Improved error trapping when calculating constraint and expression values
- tests for above
- add information about installing (ok not installing exactly) to readme

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
