### PR TITLE
Make component slice objects picklable/deepcopyable

### DIFF
--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -202,10 +202,14 @@ class _ComponentBase(object):
                             'paranoid' mode by adding '__paranoid__' ==
                             True to the memo before calling
                             copy.deepcopy.""")
+                    if self.model() is self:
+                        what = 'Model'
+                    else:
+                        what = 'Component'
                     logger.error(
                         "Unable to clone Pyomo component attribute.\n"
-                        "Component '%s' contains an uncopyable field '%s' (%s)"
-                        % ( self.name, k, type(v) ))
+                        "%s '%s' contains an uncopyable field '%s' (%s)"
+                        % ( what, self.name, k, type(v) ))
         ans.__setstate__(new_state)
         return ans
 

--- a/pyomo/core/base/indexed_component_slice.py
+++ b/pyomo/core/base/indexed_component_slice.py
@@ -48,15 +48,24 @@ class _IndexedComponent_slice(object):
         set_attr('attribute_errors_generate_exceptions', True)
 
     def __getstate__(self):
+        """Serialize this object.
+
+        In general, we would not need to implement this (the object does
+        not leverage ``__slots__``).  However, because we have a
+        "blanket" implementation of :py:meth:`__getattr__`, we need to
+        explicitly implement these to avoid "accidentally" extending or
+        evaluating this slice."""
         return dict(
             (k,getattr(self,k)) for k in self.__dict__)
 
     def __setstate__(self, state):
+        """Deserialize the state into this object. """
         set_attr = super(_IndexedComponent_slice, self).__setattr__
         for k,v in iteritems(state):
             set_attr(k,v)
 
     def __deepcopy__(self, memo):
+        """Deepcopy this object (leveraging :py:meth:`__getstate__`)"""
         ans = memo[id(self)] = self.__class__.__new__(self.__class__)
         ans.__setstate__(copy.deepcopy(self.__getstate__(), memo))
         return ans

--- a/pyomo/core/base/indexed_component_slice.py
+++ b/pyomo/core/base/indexed_component_slice.py
@@ -7,7 +7,7 @@
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
-
+import copy
 from six import PY3, iteritems, advance_iterator
 from pyomo.common import DeveloperError
 
@@ -46,6 +46,20 @@ class _IndexedComponent_slice(object):
         set_attr('call_errors_generate_exceptions', True)
         set_attr('key_errors_generate_exceptions', True)
         set_attr('attribute_errors_generate_exceptions', True)
+
+    def __getstate__(self):
+        return dict(
+            (k,getattr(self,k)) for k in self.__dict__)
+
+    def __setstate__(self, state):
+        set_attr = super(_IndexedComponent_slice, self).__setattr__
+        for k,v in iteritems(state):
+            set_attr(k,v)
+
+    def __deepcopy__(self, memo):
+        ans = memo[id(self)] = self.__class__.__new__(self.__class__)
+        ans.__setstate__(copy.deepcopy(self.__getstate__(), memo))
+        return ans
 
     def __iter__(self):
         """Return an iterator over this slice"""


### PR DESCRIPTION
## Fixes #912 .

## Summary/Motivation:
This resolves #912, which pointed out that models containing References could not be cloned.  The root cause is that when deepcopy (called by clone) hit an `_IndexedComponent_slice` object (held by a `_ReferenceDict` in an indexed component returned by `Reference()`), it would extend and then evaluate the slice instead of serializing it. This change adds proper support for serializing / deepcopying the `_IndexedComponent_slice` object by defining `__getstate__`, `__setstate__`, and `__deepcopy__`.

## Changes proposed in this PR:
- Add explicit methods for handling serialization and deepcopying _IndexedComponent_slice objects
- Add tests to verify pickle / model.clone()

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
