### PR TITLE
Allow variable identification for LinearExpression

### DIFF
--- a/pyomo/core/tests/unit/test_expr_pyomo5.py
+++ b/pyomo/core/tests/unit/test_expr_pyomo5.py
@@ -5149,6 +5149,12 @@ class TestExpressionUtilities(unittest.TestCase):
         #self.assertEqual( list(EXPR.identify_variables(m.a**m.a + m.a, allow_duplicates=True)),
         #                  [ m.a, m.a, m.a,  ] )
 
+    def test_identify_vars_linear_expression(self):
+        m = ConcreteModel()
+        m.x = Var()
+        expr = quicksum([m.x, m.x], linear=True)
+        self.assertEqual(list(EXPR.identify_variables(expr, include_fixed=False)), [m.x])
+
 
 class TestIdentifyParams(unittest.TestCase):
 


### PR DESCRIPTION
## Summary/Motivation:
`identify_vars()` sees `LinearExpression` as a leaf node and does not properly yield its constituent variables. These changes allow proper behavior for `identify_vars()` without making changes to `LinearExpression`.

Fixes #919 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
