### PR TITLE
Simplify the fix_disjuncts transformation

### DIFF
--- a/pyomo/gdp/plugins/fix_disjuncts.py
+++ b/pyomo/gdp/plugins/fix_disjuncts.py
@@ -1,119 +1,68 @@
 # -*- coding: UTF-8 -*-
-"""Transformation to fix disjuncts.
-
-This transformation looks for active disjunctions in the passed model instance
-and fixes the participating disjuncts based on their current indicator_var
-values. Active disjuncts are transformed to Block and inactive disjuncts
-(indicator_var = 0) are transformed to Block with all of their constituent
-constraints and disjunctions deactivated.
-
-"""
+"""Transformation to fix and enforce disjunct True/False status."""
 
 import logging
-import textwrap
 from math import fabs
-
-from six import itervalues
 
 from pyomo.common.config import ConfigBlock, ConfigValue, NonNegativeFloat
 from pyomo.core.base import Transformation, TransformationFactory
-from pyomo.core.base.component import _ComponentBase
-from pyomo.core.base.block import Block, _BlockData
-from pyomo.core.base.constraint import Constraint
+from pyomo.core.base.block import Block
 from pyomo.core.expr.numvalue import value
-from pyomo.core.kernel.component_set import ComponentSet
 from pyomo.gdp import GDP_Error
-from pyomo.gdp.disjunct import (Disjunct, Disjunction, _DisjunctData,
-                                _DisjunctionData)
+from pyomo.gdp.disjunct import Disjunct, Disjunction
 
 logger = logging.getLogger('pyomo.gdp.fix_disjuncts')
 
 
-def target_list(x):
-    if isinstance(x, _ComponentBase):
-        return [x]
-    elif hasattr(x, '__iter__'):
-        ans = []
-        for i in x:
-            if isinstance(i, _ComponentBase):
-                ans.append(i)
-            else:
-                raise ValueError(
-                    "Expected Component or list of Components."
-                    "\n\tReceived %s" % (type(i),)
-                )
-
-
-
-@TransformationFactory.register('gdp.fix_disjuncts',
-          doc="Fix disjuncts to their current logical values.")
+@TransformationFactory.register(
+    'gdp.fix_disjuncts',
+    doc="Fix disjuncts to their current logical values.")
 class GDP_Disjunct_Fixer(Transformation):
     """Fix disjuncts to their current logical values.
 
-    This reclassifies all disjuncts as ctype Block and deactivates the
+    This reclassifies all disjuncts in the passed model instance as ctype Block and deactivates the
     constraints and disjunctions within inactive disjuncts.
 
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         # TODO This uses an integer tolerance. At some point, these should be
         # standardized.
-        super(GDP_Disjunct_Fixer, self).__init__(*args, **kwargs)
-        self._transformedDisjuncts = ComponentSet()
+        super(GDP_Disjunct_Fixer, self).__init__(**kwargs)
 
     CONFIG = ConfigBlock("gdp.fix_disjuncts")
-    CONFIG.declare('targets', ConfigValue(
-        default=None,
-        domain=target_list,
-        description="target or list of targets that will be fixed",
-    ))
     CONFIG.declare('integer_tolerance', ConfigValue(
         default=1E-6,
         domain=NonNegativeFloat,
         description="tolerance on binary variable 0, 1 values"
     ))
 
-    def _apply_to(self, instance, **kwds):
-        """Apply the transformation on the targets in the given instance.
-
-        The instance is expected to be Block-like.
-
-        The target ctype is expected to be Block, Disjunct, or Disjunction.
-        For a Block or Disjunct, the transformation will fix all disjuncts
-        found in disjunctions within the container. If no target is specified,
-        the whole instance is transformed.
-
-        """
+    def _apply_to(self, model, **kwds):
+        """Fix all disjuncts in the given model and reclassify them to Blocks."""
         config = self.config = self.CONFIG(kwds.pop('options', {}))
         config.set_value(kwds)
 
-        targets = config.targets if config.targets is not None else (instance,)
-        for t in targets:
-            if not t.active:
-                return  # do nothing for inactive containers
+        self._transformContainer(model)
 
-            # screen for allowable instance types
-            if (type(t) not in (_DisjunctData, _BlockData, _DisjunctionData)
-                    and t.type() not in (Disjunct, Block, Disjunction)):
-                raise GDP_Error(
-                    "Target %s was not a Block, Disjunct, or Disjunction. "
-                    "It was of type %s and can't be transformed."
-                    % (t.name, type(t)))
+        # Reclassify all disjuncts
+        for disjunct_object in model.component_objects(Disjunct, descend_into=(Block, Disjunct)):
+            disjunct_object.parent_block().reclassify_component_type(disjunct_object, Block)
 
-            # if the object is indexed, transform all of its _ComponentData
-            if t.is_indexed():
-                for obj in itervalues(t):
-                    self._transformObject(obj)
+    def _transformContainer(self, obj):
+        """Find all disjuncts in the container and transform them."""
+        for disjunct in obj.component_data_objects(ctype=Disjunct, active=True, descend_into=True):
+            if fabs(value(disjunct.indicator_var) - 1) <= self.config.integer_tolerance:
+                disjunct.indicator_var.fix(1)
+                self._transformContainer(disjunct)
+            elif fabs(value(disjunct.indicator_var)) <= self.config.integer_tolerance:
+                disjunct.deactivate()
             else:
-                self._transformObject(t)
+                raise ValueError(
+                    'Non-binary indicator variable value %s for disjunct %s'
+                    % (disjunct.name, value(disjunct.indicator_var)))
 
-    def _transformObject(self, obj):
-        # If the object is a disjunction, transform it.
-        if obj.type() == Disjunction and not obj.is_indexed():
-            self._transformDisjunctionData(obj)
-        # Otherwise, treat it like a container and transform its contents.
-        else:
-            self._transformContainer(obj)
+        for disjunction in obj.component_data_objects(ctype=Disjunction, active=True, descend_into=True):
+            self._transformDisjunctionData(disjunction)
 
     def _transformDisjunctionData(self, disjunction):
         # the sum of all the indicator variable values of disjuncts in the
@@ -139,42 +88,3 @@ class GDP_Disjunct_Fixer(Transformation):
         else:
             # disjunction is in feasible realization. Deactivate it.
             disjunction.deactivate()
-
-        # Process the disjuncts associated with the disjunction that have not
-        # already been transformed.
-        for disj in (ComponentSet(disjunction.disjuncts)
-                     - self._transformedDisjuncts):
-            self._transformDisjunctData(disj)
-        # Update the set of transformed disjuncts with those from this
-        # disjunction
-        self._transformedDisjuncts.update(disjunction.disjuncts)
-
-    def _transformDisjunctData(self, obj):
-        """Fix the disjunct either to a Block or a deactivated Block."""
-        if fabs(value(obj.indicator_var) - 1) <= self.config.integer_tolerance:
-            # Disjunct is active. Convert to Block.
-            obj.parent_block().reclassify_component_type(obj, Block)
-            obj.indicator_var.fix(1)
-            # Process the components attached to this disjunct.
-            self._transformContainer(obj)
-        elif fabs(value(obj.indicator_var)) <= self.config.integer_tolerance:
-            obj.parent_block().reclassify_component_type(obj, Block)
-            obj.indicator_var.fix(0)
-            # Deactivate all constituent constraints and disjunctions
-            # HACK I do not deactivate the whole block because some writers
-            # do not look for variables in deactivated blocks.
-            for constr in obj.component_objects(
-                    ctype=(Constraint, Disjunction),
-                    active=True, descend_into=True):
-                constr.deactivate()
-        else:
-            raise ValueError(
-                'Non-binary indicator variable value %s for disjunct %s'
-                % (obj.name, value(obj.indicator_var)))
-
-    def _transformContainer(self, obj):
-        """Find all disjunctions in the container and transform them."""
-        for disjunction in obj.component_data_objects(
-                ctype=Disjunction, active=True,
-                descend_into=Block):
-            self._transformDisjunctionData(disjunction)

--- a/pyomo/gdp/tests/test_fix_disjuncts.py
+++ b/pyomo/gdp/tests/test_fix_disjuncts.py
@@ -24,45 +24,10 @@ class TestFixDisjuncts(unittest.TestCase):
         self.assertTrue(m.d1.indicator_var.fixed)
         self.assertTrue(m.d1.active)
         self.assertTrue(m.d2.indicator_var.fixed)
-        self.assertTrue(m.d2.active)  # HACK for vars in deactivated blocks
+        self.assertFalse(m.d2.active)
         self.assertEqual(m.d1.type(), Block)
         self.assertEqual(m.d2.type(), Block)
-        self.assertFalse(m.d2.c.active)
-
-    def test_unallowable_type(self):
-        m = ConcreteModel()
-        m.c = Constraint()
-        with self.assertRaises(GDP_Error):
-            TransformationFactory('gdp.fix_disjuncts').apply_to(m, targets=m.c)
-
-    def test_inactive_target(self):
-        m = ConcreteModel()
-        m.b = Block()
-        m.b.deactivate()
-        TransformationFactory('gdp.fix_disjuncts').apply_to(m, targets=m.b)
-
-    def test_indexed_target(self):
-        m = ConcreteModel()
-        m.s = RangeSet(2)
-        m.b = Block(m.s)
-        m.b[1].bb = Block()
-        TransformationFactory('gdp.fix_disjuncts').apply_to(m, targets=m.b)
-
-    def test_disjunction_target(self):
-        m = ConcreteModel()
-        m.d1 = Disjunct()
-        m.d2 = Disjunct()
-        m.d = Disjunction(expr=[m.d1, m.d2])
-        m.d1.indicator_var.set_value(1)
-        m.d2.indicator_var.set_value(0)
-
-        TransformationFactory('gdp.fix_disjuncts').apply_to(m, targets=m.d)
-        self.assertTrue(m.d1.indicator_var.fixed)
-        self.assertTrue(m.d1.active)
-        self.assertTrue(m.d2.indicator_var.fixed)
-        self.assertTrue(m.d2.active)  # HACK for vars in deactivated blocks
-        self.assertEqual(m.d1.type(), Block)
-        self.assertEqual(m.d2.type(), Block)
+        self.assertTrue(m.d2.c.active)
 
     def test_xor_not_sum_to_1(self):
         m = ConcreteModel()


### PR DESCRIPTION
## Summary/Motivation:
The inability to have ComponentData-level granularity in reclassification makes effective use of specifying targets for this transformation difficult. As a result, use cases for this have not meaningfully materialized.
This PR simplifies the transformation to no longer accept the `targets` flag.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
