### PR TITLE
Allow '~' in CPLEX file names.

### DIFF
--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -62,7 +62,8 @@ def _validate_file_name(cplex, filename, description):
                 "CPLEX or remove the space from the %s path."
                 % (description, filename, description))
     return filename
-_validate_file_name.allowed_characters = r"a-zA-Z0-9 :\.\-_\%s" % (os.path.sep,)
+_validate_file_name.allowed_characters = r"a-zA-Z0-9 ~:\.\-_\%s" % (
+    os.path.sep,)
 _validate_file_name.illegal_characters = re.compile(
     '[^%s]' % (_validate_file_name.allowed_characters,))
 


### PR DESCRIPTION
## Fixes #923 

## Summary/Motivation:
This resolves an overly-restrictive set search pattern for valid file names in the CPLEX interface.  The tilda character (`~`) is legal in both *NIX file names and on Windows.  While uncommon on Linux, `~` is common on Windows, where it is used by the OS when constructing shortened (8.3) file names.

It is important to note that while we allow `~` *within* file names, we are still NOT performing "tilda expansion" on *NIX platforms (that is `~/tmpdir` will NOT be expanded to `$HOME/tmpdir`)

## Changes proposed in this PR:
- Add `~` to the list of allowable characters.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
