### PR TITLE
Add support for Expression objects in derivative contrib package

### DIFF
--- a/pyomo/contrib/derivatives/differentiate.py
+++ b/pyomo/contrib/derivatives/differentiate.py
@@ -1,3 +1,4 @@
+from pyomo.core.base.expression import SimpleExpression, _GeneralExpressionData
 from pyomo.core.kernel.component_map import ComponentMap
 import pyomo.core.expr.expr_pyomo5 as _expr
 from pyomo.core.expr.expr_pyomo5 import ExpressionValueVisitor, nonpyomo_leaf_types, value
@@ -246,6 +247,11 @@ def _diff_UnaryFunctionExpression(node, val_dict, der_dict):
         raise DifferentiationException('Unsupported expression type for differentiation: {0}'.format(type(node)))
 
 
+def _diff_SimpleExpression(node, val_dict, der_dict):
+    der = der_dict[node]
+    der_dict[node.expr] += der
+
+
 _diff_map = dict()
 _diff_map[_expr.ProductExpression] = _diff_ProductExpression
 _diff_map[_expr.ReciprocalExpression] = _diff_ReciprocalExpression
@@ -254,6 +260,8 @@ _diff_map[_expr.SumExpression] = _diff_SumExpression
 _diff_map[_expr.MonomialTermExpression] = _diff_ProductExpression
 _diff_map[_expr.NegationExpression] = _diff_NegationExpression
 _diff_map[_expr.UnaryFunctionExpression] = _diff_UnaryFunctionExpression
+_diff_map[SimpleExpression] = _diff_SimpleExpression
+_diff_map[_GeneralExpressionData] = _diff_SimpleExpression
 
 
 class _ReverseADVisitorLeafToRoot(ExpressionValueVisitor):

--- a/pyomo/contrib/derivatives/tests/test_derivs.py
+++ b/pyomo/contrib/derivatives/tests/test_derivs.py
@@ -155,3 +155,19 @@ class TestDerivs(unittest.TestCase):
         self.assertAlmostEqual(derivs[m.x], approx_deriv(e, m.x), tol)
         self.assertAlmostEqual(derivs[m.y], approx_deriv(e, m.y), tol)
         self.assertAlmostEqual(derivs[m.p], approx_deriv(e, m.p), tol)
+
+    def test_expressiondata(self):
+        m = pe.ConcreteModel()
+        m.x = pe.Var(initialize=3)
+        m.e = pe.Expression(expr=m.x * 2)
+
+        @m.Expression([1, 2])
+        def e2(m, i):
+            if i == 1:
+                return m.x + 4
+            else:
+                return m.x ** 2
+        m.o = pe.Objective(expr=m.e + 1 + m.e2[1] + m.e2[2])
+        derivs = reverse_ad(m.o.expr)
+        symbolic = reverse_sd(m.o.expr)
+        self.assertAlmostEqual(derivs[m.x], pe.value(symbolic[m.x]), tol)


### PR DESCRIPTION
## Summary/Motivation:
Allow use of Expression objects in contrib.derivatives.
Adds test.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
