### PR TITLE
Fixing bug in this_file_dir() of common/fileutils.py

### DIFF
--- a/pyomo/common/fileutils.py
+++ b/pyomo/common/fileutils.py
@@ -18,18 +18,18 @@ import six
 from .deprecation import deprecated
 from . import config
 
-def this_file():
+def this_file(stack_offset=1):
     """Returns the file name for the module that calls this function.
 
     This function is more reliable than __file__ on platforms like
-    WIndows and in situations where the program has called
+    Windows and in situations where the program has called
     os.chdir().
 
     """
     # __file__ fails if script is called in different ways on Windows
     # __file__ fails if someone does os.chdir() before
     # sys.argv[0] also fails because it does not always contains the path
-    callerFrame = inspect.stack()[1]
+    callerFrame = inspect.stack()[stack_offset]
     frameName = callerFrame[1]
     if frameName and frameName[0] == '<' and frameName[-1] == '>':
         return frameName
@@ -39,7 +39,7 @@ def this_file():
 def this_file_dir():
     """Returns the directory containing the module that calls this function.
     """
-    return os.path.dirname(this_file())
+    return os.path.dirname(this_file(stack_offset=2))
 
 
 PYOMO_ROOT_DIR = os.path.dirname(os.path.dirname(this_file_dir()))

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -24,11 +24,12 @@ from pyutilib.subprocess import run
 import pyomo.common.config as config
 from pyomo.common.log import LoggingIntercept
 from pyomo.common.fileutils import (
-    this_file, find_file, find_library, find_executable, ExecutableManager,
-    _system, _path, _exeExt, _libExt,
+    this_file, this_file_dir, find_file, find_library, find_executable, 
+    ExecutableManager, _system, _path, _exeExt, _libExt,
 )
 
 _this_file = this_file()
+_this_file_dir = this_file_dir()
 
 class TestFileUtils(unittest.TestCase):
     def setUp(self):
@@ -71,6 +72,10 @@ class TestFileUtils(unittest.TestCase):
             stdin='from pyomo.common.fileutils import this_file;'
             'print(this_file())'
         )[1].strip(), '<stdin>')
+
+    def test_this_file_dir(self):
+        print(_this_file_dir)
+        self.assertTrue(_this_file_dir.endswith('pyomo/common/tests'))
 
     def test_system(self):
         self.assertTrue(platform.system().lower().startswith(_system()))

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -74,7 +74,6 @@ class TestFileUtils(unittest.TestCase):
         )[1].strip(), '<stdin>')
 
     def test_this_file_dir(self):
-        print(_this_file_dir)
         expected_path = os.path.join('pyomo','common','tests')
         self.assertTrue(_this_file_dir.endswith(expected_path))
 

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -75,7 +75,8 @@ class TestFileUtils(unittest.TestCase):
 
     def test_this_file_dir(self):
         print(_this_file_dir)
-        self.assertTrue(_this_file_dir.endswith('pyomo/common/tests'))
+        expected_path = os.path.join('pyomo','common','tests')
+        self.assertTrue(_this_file_dir.endswith(expected_path))
 
     def test_system(self):
         self.assertTrue(platform.system().lower().startswith(_system()))


### PR DESCRIPTION
The function this_file_dir was returning location of "fileutils.py" instead of the location of the file that called this_file_dir (it was adding another call onto the stack which resulted in this_file using an incorrect stack entry). this_file now accepts a stack_offset which defaults to 1.

## Fixes # .

## Summary/Motivation:
- fixes a bug in this_file_dir (see description above).

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.