### PR TITLE
Modified documentation of MC++ to point to the actual website

### DIFF
--- a/doc/OnlineDocs/contributed_packages/mcpp.rst
+++ b/doc/OnlineDocs/contributed_packages/mcpp.rst
@@ -5,7 +5,7 @@ The Pyomo-MC++ interface allows for bounding of factorable functions using the M
 the OMEGA research group at Imperial College London.
 Documentation for MC++ may be found on the `MC++ website`_.
 
-.. _MC++ website: https://dx.doi.org/10.1016/0098-1354(95)00219-7
+.. _MC++ website: https://omega-icl.github.io/mcpp/
 
 Installation
 ------------


### PR DESCRIPTION
## Fixes # .
Corrected the website pointing to the documentation of MC++ to the actual one (https://omega-icl.github.io/mcpp/)

## Summary/Motivation:
See above.

## Changes proposed in this PR:
- Just a change in documentation.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
