### PR TITLE
Allow MC++ to handle _ExpressionData objects in the expression tree

### DIFF
--- a/pyomo/contrib/mcpp/pyomo_mcpp.py
+++ b/pyomo/contrib/mcpp/pyomo_mcpp.py
@@ -7,6 +7,7 @@ import ctypes
 import logging
 import os
 
+from pyomo.core.base.expression import _ExpressionData
 from pyomo.core import value, Expression
 from pyomo.core.base.block import SubclassOf
 from pyomo.core.expr.numvalue import nonpyomo_leaf_types
@@ -210,7 +211,7 @@ class MCPP_visitor(StreamBasedExpressionVisitor):
             ans = self.mcpp.new_createConstant(node)
         elif not node.is_expression_type():
             ans = self.register_num(node)
-        elif type(node) in SubclassOf(Expression):
+        elif type(node) in SubclassOf(Expression) or isinstance(node, _ExpressionData):
             ans = data[0]
         else:
             raise RuntimeError("Unhandled expression type: %s" % (type(node)))


### PR DESCRIPTION
## Summary/Motivation:
For whatever reason, `type(node) in SubclassOf(Expression)` does not work as it should. This uses an `isinstance()` test to see if the node is an `_ExpressionData`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
