### PR TITLE
Adding SimpleBlock to pyomo.core namespace

### DIFF
--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -10,7 +10,7 @@
 
 __all__ = ['Block', 'TraversalStrategy', 'SortComponents',
            'active_components', 'components', 'active_components_data',
-           'components_data']
+           'components_data', 'SimpleBlock']
 
 import copy
 import sys


### PR DESCRIPTION
## Fixes NA.

## Summary/Motivation:
. Add SimpleBlock to the pyomo.core namespace

## Changes proposed in this PR:
- We expose SimpleVar and related objects to simplify the
API for pyomo.core users. This change adds SimpleBlock to be
consistent.
- This allows Pyomo extension packages to import SimpleBlock from pyomo.core, instead of from a module in pyomo.core.  This enhances the stability of Pyomo extension packages, since Pyomo can change its internal organization without impacting extension packages that pull symbols from pyomo.core.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
