### PR TITLE
Switch Pyomo Viewer to a Multiple Document Interface Instead of DockWidgets

### DIFF
--- a/pyomo/contrib/viewer/README.md
+++ b/pyomo/contrib/viewer/README.md
@@ -9,10 +9,7 @@ This is an interactive tree viewer for Pyomo models.  You can inspect and change
 
 The model viewer has a few additional Python package requirements beyond the standard Pyomo install.
 
-For using the model viewer from IPython or Jupyter notebook, **PyQt5** is required.  To use the stand-alone viewer, Jupyter **qtconsole** and **ipykernel** are also required.
-
-**Note:**
-At the time this the time this was written, a bug in the released version of ipykernel (5.1.0) requires a more recent development version to be installed from https://github.com/ipython/ipykernel.
+For using the model viewer from IPython or Jupyter notebook, **PyQt5** is required.  To use the stand-alone viewer, Jupyter **qtconsole** is required.
 
 ### Install
 
@@ -22,26 +19,30 @@ The Pyomo install also installs the viewer modules. To run the stand-alone viewe
 
 ### Opening from IPython
 
-This works with IPython and Jupyter Notebook.  This even works in IDEs and editors (e.g. Spyder) that provide and IPython console for running code.  The following example shows how to setup a model the the viewer.
+This works with IPython and Jupyter Notebook.  This also works in IDEs and editors (e.g. Spyder) that provide an IPython console for running code.  The following example shows how to setup a model the the viewer.
 
 ```python
-from pyomo.contrib.viewer.ui import get_mainwindow_nb
 %gui qt  #Enables Ipython's GUI event loop integration.
-from pyomo.environ import ConcreteModel, Var
+from pyomo.contrib.viewer.ui import get_mainwindow_nb
+import pyomo.environ as pyo
 
-model = ConcreteModel() # could import an existing model here
+model = pyo.ConcreteModel() # could import an existing model here
 ui = get_mainwindow_nb(model=model)
 
 # Do model things, the viewer will stay in sync with the Pyomo model
 ```
 
-**Note:** in a Jupyter Notebook the ```%gui qt``` cell must be executed on its own and execution must complete before running any other cells (you can't use "run all").  This may be a bug in Jupyter Notebook.
+**Note:** the ```%gui qt``` cell must be executed on its own and execution must complete before running any other cells (you can't use "run all").
 
-The model viewer adds an IPython callback after each cell executes to update the viewer in case components have been added or removed from the model. The model viewer should always display the current state of the model except for calculated items.  You must explicitly request that calculations be updated, since for very large models the time required may be significant.
+The model viewer adds a callback after each cell executes to update the viewer in case components have been added or removed from the model. The model viewer should always display the current state of the model except for calculated items.  You must explicitly request that calculations be updated, since for very large models the time required may be significant.
 
-### Stand-Alone with Embedded Jupyter QtConsole
+### Opening the Stand-Alone Version
 
-Run the "pyomo_viewer.py" script to get a stand alone model viewer with an embedded IPython console. The viewer will start with an empty Pyomo ConcreteModel called ```model```. To set the viewer to look at a new model run (the model does not need to be named model):
+Run the "pyomo_viewer.py" script to get a stand-alone model viewer.  The standalone viewer is based on the example code at https://github.com/jupyter/qtconsole/blob/master/examples/embed_qtconsole.py. The viewer will start with an empty Pyomo ConcreteModel called ```model```. The advantage of the stand-alone viewer is that it will automatically set up the environment and start the UI, saving typing a few lines of code. In the kernel ``pyomo.environ`` is imported as ```pyo```. An empty Concrete model is imported as ```model```. The main user interface window is imported as ```ui```.  This provides a useful ability to script ui actions.  
+
+### Setting the Model
+
+To set the viewer to look at a new model run (the model does not need to be named model):
 
 ```python
 ui.set_model(model)
@@ -49,9 +50,9 @@ ui.set_model(model)
 
 You could have multiple models in and switch the model viewer widgets between them using ```ui.set_model(model)```.
 
-**Note:** Some versions of ipykernel may have a bug where an error message "Execution Stopped" appears when trying to run commands after a command results in an exception. Versions of ipykernel > 5.1.0 should be okay.  Running exit in the IPython console may not work depending on the ipykernel version. Close the main UI window or select exit from the file menu to quit.
+# Controling the UI
 
-Inside the QtConsole ``pyomo.environ`` is imported as ```pyo```. An empty Concrete model is imported as ```model```. The main user interface window is imported as ```ui```.  This provides a useful ability to script ui actions.  You can even do things that are not yet possible through the graphical part of the user interface. For example to expand or collapse the tree view for variables:
+You can interact with the UI through code. For example (assuming the UI object is ```ui```) to expand or collapse the tree view for variables:
 
 ```python
 ui.variables.treeView.expandAll()

--- a/pyomo/contrib/viewer/main.ui
+++ b/pyomo/contrib/viewer/main.ui
@@ -6,23 +6,27 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>924</width>
-    <height>753</height>
+    <width>1531</width>
+    <height>1078</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>IDAES/Pyomo Model View</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QVBoxLayout" name="verticalLayout_3"/>
+   <layout class="QVBoxLayout" name="verticalLayout_3">
+    <item>
+     <widget class="QMdiArea" name="mdiArea"/>
+    </item>
+   </layout>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>924</width>
-     <height>20</height>
+     <width>1531</width>
+     <height>38</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -37,19 +41,15 @@
     <property name="title">
      <string>&amp;View</string>
     </property>
-    <addaction name="action_toggle_variables"/>
-    <addaction name="action_toggle_constraints"/>
-    <addaction name="action_toggle_parameters"/>
-    <addaction name="action_toggle_expressions"/>
+    <addaction name="actionRestart_Variable_View"/>
+    <addaction name="actionRestart_Constraint_View"/>
+    <addaction name="actionRestart_Parameter_View"/>
+    <addaction name="actionRestart_Expression_View"/>
     <addaction name="separator"/>
-    <addaction name="action_toggle_streams"/>
+    <addaction name="actionTile"/>
+    <addaction name="actionCascade"/>
     <addaction name="separator"/>
-    <addaction name="separator"/>
-   </widget>
-   <widget class="QMenu" name="menu_Help">
-    <property name="title">
-     <string>&amp;Help</string>
-    </property>
+    <addaction name="actionTabs"/>
    </widget>
    <widget class="QMenu" name="menuCalculate">
     <property name="title">
@@ -68,7 +68,6 @@
    <addaction name="menu_View"/>
    <addaction name="menuCalculate"/>
    <addaction name="menuModel"/>
-   <addaction name="menu_Help"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
   <action name="action_toggle_variables">
@@ -235,6 +234,41 @@
   <action name="actionSolve_2">
    <property name="text">
     <string>Solve</string>
+   </property>
+  </action>
+  <action name="actionRestart_Variable_View">
+   <property name="text">
+    <string>Restart Variable View</string>
+   </property>
+  </action>
+  <action name="actionRestart_Constraint_View">
+   <property name="text">
+    <string>Restart Constraint View</string>
+   </property>
+  </action>
+  <action name="actionRestart_Parameter_View">
+   <property name="text">
+    <string>Restart Parameter View</string>
+   </property>
+  </action>
+  <action name="actionRestart_Expression_View">
+   <property name="text">
+    <string>Restart Expression View</string>
+   </property>
+  </action>
+  <action name="actionTile">
+   <property name="text">
+    <string>Tile</string>
+   </property>
+  </action>
+  <action name="actionCascade">
+   <property name="text">
+    <string>Cascade</string>
+   </property>
+  </action>
+  <action name="actionTabs">
+   <property name="text">
+    <string>Toggle Tabs</string>
    </property>
   </action>
  </widget>

--- a/pyomo/contrib/viewer/model_browser.py
+++ b/pyomo/contrib/viewer/model_browser.py
@@ -81,7 +81,7 @@ class ModelBrowser(_ModelBrowser, _ModelBrowserUI):
             editable = []
             self.setWindowTitle("Expressions")
         else:
-            raise Exception("Not a valid view type")
+            raise ValueError("{} is not a valid view type".format(standard))
         # Create a data model.  This is what translates the Pyomo model into
         # a tree view.
         datmodel = ComponentDataModel(self, ui_setup=ui_setup,
@@ -99,12 +99,6 @@ class ModelBrowser(_ModelBrowser, _ModelBrowserUI):
     def refresh(self):
         added = self.datmodel._update_tree()
         self.datmodel.layoutChanged.emit()
-
-    def toggle(self):
-        if self.isVisible():
-            self.hide()
-        else:
-            self.show()
 
     def update_model(self):
         self.datmodel.update_model()

--- a/pyomo/contrib/viewer/model_browser.ui
+++ b/pyomo/contrib/viewer/model_browser.ui
@@ -1,31 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>DockWidget</class>
- <widget class="QDockWidget" name="DockWidget">
+ <class>ModelView</class>
+ <widget class="QWidget" name="ModelView">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>1413</width>
+    <height>608</height>
    </rect>
   </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
-  </property>
   <property name="windowTitle">
-   <string>DockWidget</string>
+   <string>Form</string>
   </property>
-  <widget class="QWidget" name="dockWidgetContents">
-   <layout class="QHBoxLayout" name="horizontalLayout">
-    <item>
-     <widget class="QTreeView" name="treeView"/>
-    </item>
-   </layout>
-  </widget>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTreeView" name="treeView"/>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/pyomo/contrib/viewer/pyomo_viewer.py
+++ b/pyomo/contrib/viewer/pyomo_viewer.py
@@ -8,65 +8,52 @@
 #
 # This software is distributed under the 3-clause BSD License.
 ##############################################################################
-"""
-Run a Pyomo model viewer with embeded Jupyter QtConsole
-"""
+
+# based on the example code at:
+#  https://github.com/jupyter/qtconsole/blob/master/examples/embed_qtconsole.py
+
+from __future__ import print_function
 
 import sys
-import logging
-import traceback
-_log = logging.getLogger(__name__)
-from pyomo.contrib.viewer.ui import *
-import pyomo.environ as pyo
+import time
 
-ui = None
+from pyomo.contrib.viewer.pyqt_4or5 import *
+from qtconsole.rich_jupyter_widget import RichJupyterWidget
+from qtconsole.manager import QtKernelManager
 
-def log_unhandled_exception(etype, evalue, etrace):
-    """
-    This will log an exception and show a message box about what went wrong, but
-    let the application keep running.  It could be frustrating if an unhandled
-    exception caused the program to immediatly terminate.
-    """
-    if etype == KeyboardInterrupt:
-        if ui is not None:
-            ui.close()
-            return
-        else:
-            sys.exit()
-    try:
-        _log.critical("unhandled exception", exc_info=(etype, evalue, etrace))
-        msgBox = QMessageBox()
-        msgBox.setWindowTitle("Error")
-        msgBox.setText("Unhandled Exception: Please report this error to the "
-                       "developers. Save and exit as soon as possible.")
-        msgBox.setInformativeText(
-            ''.join(traceback.format_exception(etype, evalue, etrace)))
-        msgBox.exec_()
-    except Exception:
-        _log.exception("problem logging unhandled exception")
+def make_jupyter_widget_with_kernel():
 
-def main():
-    global ui
-    if not can_containt_qtconsole or not qt_available:
-        _log.error("Cannot import qtconsole")
-        sys.exit(1)
-    # The code below is based on the example
-    # https://github.com/ipython/ipykernel/blob/master/examples/embedding/inprocess_qtconsole.py
-    app = guisupport.get_app_qt4() # qt4 is okay even though its Qt5!
-    kernel_manager = QtInProcessKernelManager()
-    kernel_manager.start_kernel()
-    kernel = kernel_manager.kernel
-    kernel.gui = 'qt'
-    kernel_client = kernel_manager.client()
-    kernel_client.start_channels()
-    ui, model = get_mainwindow_nb(main=True)
-    ui._qtconsole.kernel_manager = kernel_manager
-    ui._qtconsole.kernel_client = kernel_client
-    # push the ui, model, and pyomo.environ module as pyo to ipy env
-    kernel.shell.push({"ui":ui, "model":model, "pyo":pyo})
-    # catch any exception that falls through to prevent abrupt termination
-    sys.excepthook = log_unhandled_exception
-    guisupport.start_event_loop_qt4(app)
+    return jupyter_widget
+
+class MainWindow(QMainWindow):
+    """A window that contains a single Qt console."""
+    def __init__(self):
+        super().__init__()
+        km = QtKernelManager(autorestart=False)
+        km.start_kernel()
+        kc = km.client()
+        kc.start_channels()
+        self.jupyter_widget = RichJupyterWidget()
+        self.jupyter_widget.kernel_manager = km
+        self.jupyter_widget.kernel_client = kc
+        self.setCentralWidget(self.jupyter_widget)
+        kc.execute("%gui qt", silent=True)
+        time.sleep(3) # I need something better here, but I need to make sure
+                      # the QApplication in the kernel has started before
+                      # attempting to start the UI or it won't start
+        kc.execute(
+            "from pyomo.contrib.viewer.ui import get_mainwindow", silent=True)
+        kc.execute("import pyomo.environ as pyo", silent=True)
+        kc.execute("ui, model = get_mainwindow()", silent=True)
+
+    def shutdown_kernel(self):
+        print('Shutting down kernel...')
+        self.jupyter_widget.kernel_client.stop_channels()
+        self.jupyter_widget.kernel_manager.shutdown_kernel()
 
 if __name__ == "__main__":
-    main()
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    app.aboutToQuit.connect(window.shutdown_kernel)
+sys.exit(app.exec_())

--- a/pyomo/contrib/viewer/pyqt_4or5.py
+++ b/pyomo/contrib/viewer/pyqt_4or5.py
@@ -54,8 +54,9 @@ except:
         QtCore = DummyQtCore
     else:
         try:
-            from PyQt4.QtGui import QAbstractItemView, QFileDialog, QMessageBox
-            from PyQt4.QtCore import QAbstractItemModel
+            from PyQt4.QtGui import (QAbstractItemView, QFileDialog, QMainWindow,
+                                     QMessageBox, QMdiArea, QApplication)
+            from PyQt4.QtCore import QAbstractItemModel, QTimer
             from PyQt4 import uic
             qt_available = True
         except:
@@ -64,19 +65,12 @@ except:
             QtCore = DummyQtCore
 else:
     try:
-        from PyQt5.QtWidgets import QAbstractItemView, QFileDialog, QMessageBox
-        from PyQt5.QtCore import QAbstractItemModel
+        from PyQt5.QtWidgets import (QAbstractItemView, QFileDialog, QMainWindow,
+                                     QMessageBox, QMdiArea, QApplication)
+        from PyQt5.QtCore import QAbstractItemModel, QTimer
         from PyQt5 import uic
         qt_available = True
     except:
         _log.exception("Cannot import PyQt5")
         QAbstractItemModel = DummyQAbstractItemModel
         QtCore = DummyQtCore
-
-try:
-    from qtconsole.rich_jupyter_widget import RichIPythonWidget
-    from qtconsole.inprocess import QtInProcessKernelManager
-    can_containt_qtconsole = True
-except:
-    _log.exception("Cannot import modules requied for qtconsole")
-    can_containt_qtconsole = False

--- a/pyomo/contrib/viewer/ui.py
+++ b/pyomo/contrib/viewer/ui.py
@@ -49,9 +49,6 @@ if not qt_available:
     _log.error("Qt is not available. Cannot create UI classes.")
     raise ImportError("Could not import PyQt4 or PyQt5")
 
-def get_environ_file():
-    return os.join(os.path.dirname(__file__), "pyomo_viewer_envorion.ipy")
-
 def get_mainwindow(model=None, show=True):
     """
     Create a UI MainWindow.
@@ -118,7 +115,7 @@ class UISetup(QtCore.QObject):
     def model(self, value):
         self._model = value
         self.emit_update()
-        
+
 
 class MainWindow(_MainWindow, _MainWindowUI):
     def __init__(self, *args, **kwargs):

--- a/pyomo/contrib/viewer/ui.py
+++ b/pyomo/contrib/viewer/ui.py
@@ -24,7 +24,6 @@ import datetime
 import json
 import sys
 from IPython import get_ipython
-from IPython.lib import guisupport
 import pyomo.contrib.viewer.report as rpt
 import pyomo.environ as pe
 
@@ -50,21 +49,29 @@ if not qt_available:
     _log.error("Qt is not available. Cannot create UI classes.")
     raise ImportError("Could not import PyQt4 or PyQt5")
 
-def get_mainwindow_nb(model=None, show=True, main=False):
+def get_environ_file():
+    return os.join(os.path.dirname(__file__), "pyomo_viewer_envorion.ipy")
+
+def get_mainwindow(model=None, show=True):
     """
     Create a UI MainWindow.
 
     Args:
         model: A Pyomo model to work with
         show: show the window after it is created
-        main: if true add a qtconsole to make this the main application
+    Returns:
+        (ui, model): ui is the MainWindow widget, and model is the linked Pyomo
+            model.  If no model is provided a new ConcreteModel is created
     """
     if model is None:
         model = pe.ConcreteModel()
-    ui = MainWindow(model=model, main=main)
+    ui = MainWindow(model=model)
     get_ipython().events.register('post_execute', ui.refresh_on_execute)
     if show: ui.show()
     return ui, model
+
+def get_mainwindow_nb(model=None, show=True):
+    return get_mainwindow(model=model, show=show)
 
 
 class UISetup(QtCore.QObject):
@@ -91,14 +98,14 @@ class UISetup(QtCore.QObject):
         """
         self._begin_update = True
 
-    def end_update(self, noemit=False):
+    def end_update(self, emit=True):
         """
         Start automatically emitting update signal again when properties are
         changed and emit update for changes made between begin_update and
         end_update
         """
         self._begin_update = False
-        if not noemit: self.emit_update()
+        if emit: self.emit_update()
 
     def emit_update(self):
         if not self._begin_update: self.updated.emit()
@@ -111,6 +118,7 @@ class UISetup(QtCore.QObject):
     def model(self, value):
         self._model = value
         self.emit_update()
+        
 
 class MainWindow(_MainWindow, _MainWindowUI):
     def __init__(self, *args, **kwargs):
@@ -121,45 +129,81 @@ class MainWindow(_MainWindow, _MainWindowUI):
             kwargs[flags] = flags | QtCore.Qt.WindowStaysOnTopHint
         self.ui_setup = UISetup(model=model)
         self.ui_setup.updated.connect(self.update_model)
-
         super(MainWindow, self).__init__(*args, **kwargs)
         self.setupUi(self)
-        if main and can_containt_qtconsole:
-            self._qtconsole = RichIPythonWidget(parent=self)
-            self.setCentralWidget(self._qtconsole)
-        elif main and not can_containt_qtconsole:
-            _log.error("Cannot create qtconsole widget")
-            sys.exit(1)
-        self._main = main
+        self.setCentralWidget(self.mdiArea)
 
-        # Create model browsers these are dock widgets
-        uis = self.ui_setup
-        self.variables = ModelBrowser(parent=self, standard="Var", ui_setup=uis)
-        self.constraints = ModelBrowser(parent=self, standard="Constraint", ui_setup=uis)
-        self.parameters = ModelBrowser(parent=self, standard="Param", ui_setup=uis)
-        self.expressions = ModelBrowser(parent=self, standard="Expression", ui_setup=uis)
+        self._refresh_list = []
+        self.variables = None
+        self.constraints = None
+        self.expressions = None
+        self.parameters = None
 
-        # Dock the widgets along the bottom and tabify them
-        self.addDockWidget(QtCore.Qt.BottomDockWidgetArea, self.variables)
-        self.addDockWidget(QtCore.Qt.BottomDockWidgetArea, self.constraints)
-        self.addDockWidget(QtCore.Qt.BottomDockWidgetArea, self.parameters)
-        self.addDockWidget(QtCore.Qt.BottomDockWidgetArea, self.expressions)
-        self.tabifyDockWidget(self.variables, self.parameters)
-        self.tabifyDockWidget(self.variables, self.expressions)
-        self.tabifyDockWidget(self.variables, self.constraints)
-        self.variables.raise_()
+        self.variables_restart()
+        self.expressions_restart()
+        self.constraints_restart()
+        self.parameters_restart()
+
+
+        self.mdiArea.tileSubWindows()
 
         # Set menu actions (remember the menu items are defined in the ui file)
         # you can edit the menus in qt-designer
         self.action_Exit.triggered.connect(self.exit_action)
-        self.action_toggle_variables.triggered.connect(self.variables.toggle)
-        self.action_toggle_constraints.triggered.connect(self.constraints.toggle)
-        self.action_toggle_parameters.triggered.connect(self.parameters.toggle)
-        self.action_toggle_expressions.triggered.connect(self.expressions.toggle)
-        self.actionToggle_Always_on_Top.triggered.connect(self.toggle_always_on_top)
+        self.actionRestart_Variable_View.triggered.connect(
+            self.variables_restart)
+        self.actionRestart_Constraint_View.triggered.connect(
+            self.constraints_restart)
+        self.actionRestart_Parameter_View.triggered.connect(
+            self.parameters_restart)
+        self.actionRestart_Expression_View.triggered.connect(
+            self.expressions_restart)
         self.actionInformation.triggered.connect(self.model_information)
-        self.actionCalculateConstraints.triggered.connect(self.calculate_constraints)
-        self.actionCalculateExpressions.triggered.connect(self.calculate_expressions)
+        self.actionCalculateConstraints.triggered.connect(
+            self.calculate_constraints)
+        self.actionCalculateExpressions.triggered.connect(
+            self.calculate_expressions)
+        self.actionTile.triggered.connect(self.mdiArea.tileSubWindows)
+        self.actionCascade.triggered.connect(self.mdiArea.cascadeSubWindows)
+        self.actionTabs.triggered.connect(self.toggle_tabs)
+
+    def toggle_tabs(self):
+        self.mdiArea.setViewMode(not self.mdiArea.viewMode())
+
+    def _tree_restart(self, w, standard):
+        """
+        Start/Restart the variables window
+        """
+        try:
+            self._refresh_list.remove(w)
+        except ValueError: # not in list? that's okay
+            pass
+        try:
+            try:
+                self.mdiArea.removeSubWindow(w.parent())
+            except RuntimeError: # user closed with "X" button
+                pass
+            del w
+            w = None
+        except AttributeError:
+            pass
+        w = ModelBrowser(standard=standard, ui_setup=self.ui_setup)
+        self.mdiArea.addSubWindow(w)
+        w.parent().show() # parent is now a MdiAreaSubWindow
+        self._refresh_list.append(w)
+        return w
+
+    def variables_restart(self):
+        self.variables = self._tree_restart(self.variables, "Var")
+
+    def expressions_restart(self):
+        self.expressions = self._tree_restart(self.expressions, "Expression")
+
+    def parameters_restart(self):
+        self.parameters = self._tree_restart(self.parameters, "Param")
+
+    def constraints_restart(self):
+        self.constraints = self._tree_restart(self.constraints, "Constraint")
 
     def calculate_constraints(self):
         self.constraints.calculate_all()
@@ -173,7 +217,13 @@ class MainWindow(_MainWindow, _MainWindowUI):
         self.ui_setup.model = model
 
     def update_model(self):
-        pass
+        """
+        Play it safe by restarting all the tree view widgets when the model updates
+        """
+        self.variables_restart()
+        self.expressions_restart()
+        self.constraints_restart()
+        self.parameters_restart()
 
     def model_information(self):
         """
@@ -209,23 +259,17 @@ class MainWindow(_MainWindow, _MainWindowUI):
             "{}  -- {} of freedom\n"\
             .format(active_eq, free_vars, dof, doftext))
 
-    def toggle_always_on_top(self):
-        """
-        This toggles the always on top hint.  Whether this has any effect after
-        the main window is created probably depends on the system.
-        """
-        self.setWindowFlags(window.windowFlags() ^ QtCore.Qt.WindowStaysOnTopHint)
-
     def refresh_on_execute(self):
         """
         This is the call back function that happens when code is executed in the
         ipython kernel.  The main purpose of this right now it to refresh the
         UI display so that it matches the current state of the model.
         """
-        self.variables.refresh()
-        self.constraints.refresh()
-        self.expressions.refresh()
-        self.parameters.refresh()
+        for w in self._refresh_list:
+            try:
+                w.refresh()
+            except RuntimeError: # window closed by user pushing "X" button
+                pass
 
     def exit_action(self):
         """
@@ -242,10 +286,6 @@ class MainWindow(_MainWindow, _MainWindowUI):
             "Are you sure you want to exit ?",
             QMessageBox.Yes| QMessageBox.No)
         if result == QMessageBox.Yes:
-            if self._main:
-                self._qtconsole.kernel_client.stop_channels()
-                self._qtconsole.kernel_manager.shutdown_kernel()
-                guisupport.get_app_qt4().exit()
             event.accept()
         else:
             event.ignore()


### PR DESCRIPTION
It looks like there are some problems with the ipython inprocess kernel, so I've given up hope on embedding a jupyter console in the model viewer, and accepted that the console and model viewer will have to be in to separate processes.  So I stopped holding on to the main area in the viewer, and switched from dock widgets to a multiple document interface.

The standalone app no longer uses the inprocess kernel, it just starts a kernel,attaches a qtconsole, and  sets up the UI in the kernel.  It dosen't do much, but it's nice not to have to put in a few lines of boilerplate every time.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
