### PR TITLE
Stickies example minor update

### DIFF
--- a/examples/gdp/stickies.py
+++ b/examples/gdp/stickies.py
@@ -1,3 +1,5 @@
+import os
+
 from pyomo.environ import *
 from pyomo.gdp import *
 
@@ -486,7 +488,7 @@ def build_model():
     # model.accept_or_reject4 = Constraint(model.ScreenNodePairs,
     #                                      rule=accept_or_reject_rule4)
 
-    instance = model.create_instance(DATFILE)
+    instance = model.create_instance(os.path.join(os.path.dirname(__file__), DATFILE))
 
     # fix the variables they fix in GAMS
     for s in instance.Screens:

--- a/examples/gdp/stickies.py
+++ b/examples/gdp/stickies.py
@@ -1,5 +1,6 @@
 import os
 
+from pyomo.common.fileutils import this_file_dir
 from pyomo.environ import *
 from pyomo.gdp import *
 
@@ -488,7 +489,7 @@ def build_model():
     # model.accept_or_reject4 = Constraint(model.ScreenNodePairs,
     #                                      rule=accept_or_reject_rule4)
 
-    instance = model.create_instance(os.path.join(os.path.dirname(__file__), DATFILE))
+    instance = model.create_instance(os.path.join(this_file_dir(), DATFILE))
 
     # fix the variables they fix in GAMS
     for s in instance.Screens:


### PR DESCRIPTION
## Summary/Motivation:
Makes stickies.dat a relative file path from the stickies.py file so that `create_instance` works properly when stickies.py is imported from a different location.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
