### PR TITLE
Fixing the regex that calculates the short job name for codecov

### DIFF
--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -159,7 +159,7 @@ if test -z "$MODE" -o "$MODE" == test; then
         if test -z "$CODECOV_TOKEN"; then
             coverage xml
         else
-            CODECOV_JOB_NAME=`echo ${JOB_NAME} | sed -r 's/^(.*autotest_)?Pyomo_([^\/]+).*/\1/'`.$BUILD_NUMBER.$python
+            CODECOV_JOB_NAME=`echo ${JOB_NAME} | sed -r 's/^(.*autotest_)?Pyomo_([^\/]+).*/\2/'`.$BUILD_NUMBER.$python
             i=0
             while test $i -lt 3; do
                 i=$[$i+1]


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
This fixes the regex used to calculate the short job name when uploading coverage information from Jenkins to codecov.

## Changes proposed in this PR:
- fixing a typo in the regex

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
