### PR TITLE
NFC: add additional patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,12 @@ doc/OnlineDocs/_build
 # Running pyomo / tests / solvers occasionally leaves extra files
 *.out
 pyomo/core/data/parse_table_datacmds.py
+pyomo/dataportal/parse_table_datacmds.py
 gurobi.log
 
 # Results from nosetests --with-coverage
 .coverage
 *.cover
+
+# Jupyterhub/Jupyterlab checkpoints
+.ipynb_checkpoints

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ doc/OnlineDocs/_build
 
 # Running pyomo / tests / solvers occasionally leaves extra files
 *.out
-pyomo/core/data/parse_table_datacmds.py
 pyomo/dataportal/parse_table_datacmds.py
 gurobi.log
 


### PR DESCRIPTION
## Summary/Motivation:
Ignore Jupyterhub checkpoint files and additional extra leftover files (`parse_table_datacmds.py`) from runs.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
