### PR TITLE
Return the subcommand error code from the pyomo script

### DIFF
--- a/pyomo/core/tests/examples/test_pyomo.py
+++ b/pyomo/core/tests/examples/test_pyomo.py
@@ -65,12 +65,12 @@ class BaseTester(unittest.TestCase):
         setup_redirect(OUTPUT)
         os.chdir(currdir)
         if type(cmd) is list:
-            output = main.main(['solve', '--solver=glpk', '--results-format=json', '--save-results=%s' % results] + cmd, get_return=True)
+            output = main.main(['solve', '--solver=glpk', '--results-format=json', '--save-results=%s' % results] + cmd)
         elif cmd.endswith('json') or cmd.endswith('yaml'):
-            output = main.main(['solve', '--results-format=json', '--save-results=%s' % results] + [cmd], get_return=True)
+            output = main.main(['solve', '--results-format=json', '--save-results=%s' % results] + [cmd])
         else:
             args=re.split('[ ]+',cmd)
-            output = main.main(['solve', '--solver=glpk', '--results-format=json', '--save-results=%s' % results] + list(args), get_return=True)
+            output = main.main(['solve', '--solver=glpk', '--results-format=json', '--save-results=%s' % results] + list(args))
         reset_redirect()
         if not 'root' in kwds:
             return OUTPUT.getvalue()

--- a/pyomo/scripting/convert.py
+++ b/pyomo/scripting/convert.py
@@ -221,25 +221,25 @@ def pyomo2lp(args=None):
     if args is None:
         return main()
     else:
-        return main(['convert', '--format=lp']+args, get_return=True)
+        return main(['convert', '--format=lp']+args)
 
 def pyomo2nl(args=None):
     from pyomo.scripting.pyomo_main import main
     if args is None:
         return main()
     else:
-        return main(['convert', '--format=nl']+args, get_return=True)
+        return main(['convert', '--format=nl']+args)
 
 def pyomo2bar(args=None):
     from pyomo.scripting.pyomo_main import main
     if args is None:
         return main()
     else:
-        return main(['convert', '--format=bar']+args, get_return=True)
+        return main(['convert', '--format=bar']+args)
 
 def pyomo2dakota(args=None):
     from pyomo.scripting.pyomo_main import main
     if args is None:
         return main()
     else:
-        return main(['convert','--format=dakota']+args, get_return=True)
+        return main(['convert','--format=dakota']+args)

--- a/pyomo/scripting/driver_help.py
+++ b/pyomo/scripting/driver_help.py
@@ -91,11 +91,11 @@ def command_exec(options):
         return
     if len(options.command) == 0:
         print("  ERROR: no command specified")
-        return
+        return 1
     if not os.path.exists(cmddir+options.command[0]):
         print("  ERROR: the command '%s' does not exist" % (cmddir+options.command[0]))
-        return
-    pyutilib.subprocess.run(cmddir+' '.join(options.command), tee=True)
+        return 1
+    return pyutilib.subprocess.run(cmddir+' '.join(options.command), tee=True)[0]
 
 #
 # Add a subparser for the pyomo command

--- a/pyomo/scripting/pyomo_command.py
+++ b/pyomo/scripting/pyomo_command.py
@@ -383,5 +383,5 @@ def run(args=None):
     if args is None:
         return main()
     else:
-        return main(['solve']+args, get_return=True)
+        return main(['solve']+args)
 

--- a/pyomo/scripting/pyomo_main.py
+++ b/pyomo/scripting/pyomo_main.py
@@ -37,7 +37,7 @@ for entrypoint in pyomo_commands:
         raise ImportError(msg)
 
 
-def main(args=None, get_return=True):
+def main(args=None):
     #
     # Load subcommands
     #
@@ -82,5 +82,15 @@ def main(args=None, get_return=True):
         retval = _options.func(_options)
     else:
         retval = _options.func(_options, _unparsed)
-    if get_return:
-        return retval
+    return retval
+
+
+def main_console_script():
+    "This is the entry point for the main Pyomo script"
+    # Note that we eat the retval data structure and only return the
+    # process return code
+    ans = main()
+    try:
+        return ans.errorcode
+    except AttributeError:
+        return ans

--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,7 @@ def run_setup():
         results_schema=pyomo.scripting.commands:results_schema
         pyro_mip_server = pyomo.scripting.pyro_mip_server:main
         test.pyomo = pyomo.scripting.runtests:runPyomoTests
-        pyomo = pyomo.scripting.pyomo_main:main
+        pyomo = pyomo.scripting.pyomo_main:main_console_script
         pyomo_ns = pyomo.scripting.commands:pyomo_ns
         pyomo_nsc = pyomo.scripting.commands:pyomo_nsc
         kill_pyro_mip_servers = pyomo.scripting.commands:kill_pyro_mip_servers


### PR DESCRIPTION
## Summary/Motivation:
The `pyomo` script always returns a return code of 0 (indicating no failure), even if the underlying subcommand encountered an error.  This PR propagates the subcommand error code out to the calling shell so that those who script around pyomo can more easily detect if the pyomo script encountered an error.

## Changes proposed in this PR:
- Return the underlying subcommand `errorcode` value from the pyomo script to the calling process
- Eliminate the `get_result` flag from `pyomo_main.main()`.  

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
