### PR TITLE
Updating `pyomo download-extensions` to log a summary.

### DIFF
--- a/pyomo/scripting/plugins/build_ext.py
+++ b/pyomo/scripting/plugins/build_ext.py
@@ -21,22 +21,24 @@ class ExtensionBuilder(object):
     def call(self, args, unparsed):
         logger = logging.getLogger('pyomo.common')
         logger.setLevel(logging.INFO)
-        results = {}
+        results = []
+        result_fmt = "[%s]  %s"
         returncode = 0
         for target in ExtensionBuilderFactory:
             try:
                 ExtensionBuilderFactory(target)
-                results[target] = ' OK '
+                result = ' OK '
             except SystemExit:
-                results[target] = 'FAIL'
+                result = 'FAIL'
                 returncode = 1
             except:
-                results[target] = 'FAIL'
+                result = 'FAIL'
                 returncode = 1
+            results.append(result_fmt % (result, target))
         logger.info("Finished building Pyomo extensions.")
         logger.info(
             "The following extensions were built:\n    " +
-            "\n    ".join(["[%s]  %s" % (v,k) for k,v in iteritems(results)]))
+            "\n    ".join(results))
         return returncode
 
 #

--- a/pyomo/scripting/plugins/download.py
+++ b/pyomo/scripting/plugins/download.py
@@ -20,11 +20,29 @@ class GroupDownloader(object):
         return self.downloader.create_parser(parser)
 
     def call(self, args, unparsed):
-        logging.getLogger('pyomo.common').setLevel(logging.INFO)
+        logger = logging.getLogger('pyomo.common')
+        logger.setLevel(logging.INFO)
+        results = []
+        result_fmt = "[%s]  %s"
+        returncode = 0
         self.downloader.cacert = args.cacert
         self.downloader.insecure = args.insecure
         for target in DownloadFactory:
-            DownloadFactory(target, downloader=self.downloader)
+            try:
+                DownloadFactory(target, downloader=self.downloader)
+                result = ' OK '
+            except SystemExit:
+                result = 'FAIL'
+                returncode = 1
+            except:
+                result = 'FAIL'
+                returncode = 1
+            results.append(result_fmt % (result, target))
+        logger.info("Finished downloading Pyomo extensions.")
+        logger.info(
+            "The following extensions were downloaded:\n    " +
+            "\n    ".join(results))
+        return returncode
 
 
 #


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
This updates the download-extensions command to match the build-extensions command to attempt all downloads, even if one fails and produce a summary of the overall success at the end.  Updating both commands to output the summary in the order in which the extensions were called.

## Changes proposed in this PR:
- Updating `pyomo download-extensions` to match `pyomo build-extensions`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
