### PR TITLE
Adding a TEST_SUITES environment variable to the Jenkins driver

### DIFF
--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -32,7 +32,7 @@ if test -z "$CATEGORY"; then
     export CATEGORY=nightly
 fi
 if test -z "$TEST_SUITES"; then
-    export TEST_SUITES="pyomo '$WORKSPACE/pyomo-model-libraries'"
+    export TEST_SUITES="pyomo ${WORKSPACE}/pyomo-model-libraries"
 fi
 if test -z "$SLIM"; then
     export VENV_SYSTEM_PACKAGES='--system-site-packages'

--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -11,6 +11,9 @@
 #
 # CATEGORY: the category to pass to test.pyomo (defaults to nightly)
 #
+# TEST_SUITES: Paths (module or directory) to be passed to nosetests to
+#     run. (defaults to "pyomo '$WORKSPACE/pyomo-model-libraries'")
+#
 # SLIM: If nonempty, then the virtualenv will only have pip, setuptools,
 #     and wheel installed.  Otherwise the virtualenv will inherit the
 #     system site-packages.
@@ -27,6 +30,9 @@ if test -z "$WORKSPACE"; then
 fi
 if test -z "$CATEGORY"; then
     export CATEGORY=nightly
+fi
+if test -z "$TEST_SUITES"; then
+    export TEST_SUITES="pyomo '$WORKSPACE/pyomo-model-libraries'"
 fi
 if test -z "$SLIM"; then
     export VENV_SYSTEM_PACKAGES='--system-site-packages'
@@ -143,7 +149,7 @@ if test -z "$MODE" -o "$MODE" == test; then
     echo "#"
     echo "# Running Pyomo tests"
     echo "#"
-    test.pyomo -v --cat=$CATEGORY pyomo "$WORKSPACE/pyomo-model-libraries"
+    test.pyomo -v --cat=$CATEGORY $TEST_SUITES
 
     # Combine the coverage results and upload
     if test -z "$DISABLE_COVERAGE"; then


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
Adding a TEST_SUITES environment variable to the Jenkins driver.  This will allow us to move the Jenkins Book tests over to the new driver.

## Changes proposed in this PR:
- Adding a `TEST_SUITES` environment variable that can override the tests run by `test.pyomo`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
