### PR TITLE
Adding guards to skip specific pynumero tests in old Numpy versions

### DIFF
--- a/pyomo/contrib/pynumero/__init__.py
+++ b/pyomo/contrib/pynumero/__init__.py
@@ -9,9 +9,26 @@
 #  ___________________________________________________________________________
 try:
     import numpy as np
-    numpy_available = True
+    # Note: sparse.BlockVector leverages the __array__ufunc__ interface
+    # released in numpy 1.13
+    numpy_available = np.lib.NumpyVersion(np.__version__) >= '1.13.0'
+    if not numpy_available:
+        import pyomo.common  # ...to set up the logger
+        import logging
+        logging.getLogger('pyomo.contrib.pynumero').warn(
+            "Pynumero requires numpy>=1.13.0; found %s" % (np.__version__,))
 except ImportError:
     numpy_available = False
+
+try:
+    import scipy
+    scipy_available = True
+except ImportError:
+    scipy_available = False
+    import pyomo.common  # ...to set up the logger
+    import logging
+    logging.getLogger('pyomo.contrib.pynumero').warn(
+        "Scipy not available. Install scipy before using pynumero")
 
 if numpy_available:
     from .sparse.intrinsic import *
@@ -22,11 +39,7 @@ else:
     # plugins, so pyomo.environ ignores it.  When we start implementing
     # general solvers in pynumero we will want to remove / move this
     # warning somewhere deeper in the code.
+    import pyomo.common  # ...to set up the logger
     import logging
     logging.getLogger('pyomo.contrib.pynumero').warn(
-        "Numpy not available. Install numpy before using pynumero")
-
-
-
-
-
+        "Numpy not available. Install numpy>=1.13.0 before using pynumero")

--- a/pyomo/contrib/pynumero/algorithms/__init__.py
+++ b/pyomo/contrib/pynumero/algorithms/__init__.py
@@ -8,9 +8,5 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-try:
-    import numpy as np
-    numpy_available = True
-except ImportError:
-    numpy_available = False
+from .. import numpy_available
 

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_cyipopt_solver.py
@@ -11,11 +11,12 @@
 import pyutilib.th as unittest
 import pyomo.environ as aml
 
-try:
-    import scipy.sparse as spa
-    import numpy as np
-except ImportError:
+from ... import numpy_available, scipy_available
+if not (numpy_available and scipy_available):
     raise unittest.SkipTest("Pynumero needs scipy and numpy to run NLP tests")
+
+import scipy.sparse as spa
+import numpy as np
 
 from pyomo.contrib.pynumero.extensions.asl import AmplInterface
 if not AmplInterface.available():

--- a/pyomo/contrib/pynumero/interfaces/__init__.py
+++ b/pyomo/contrib/pynumero/interfaces/__init__.py
@@ -8,16 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-try:
-    import numpy as np
-    numpy_available = True
-except ImportError:
-    numpy_available = False
-try:
-    import scipy
-    scipy_available = True
-except ImportError:
-    scipy_available = False
+from .. import numpy_available, scipy_available
 
 if numpy_available and scipy_available:
     from .nlp import AmplNLP, PyomoNLP

--- a/pyomo/contrib/pynumero/interfaces/tests/test_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_nlp.py
@@ -10,11 +10,12 @@
 import pyutilib.th as unittest
 import os
 
-try:
-    import scipy.sparse as spa
-    import numpy as np
-except ImportError:
+from .. import numpy_available, scipy_available
+if not (numpy_available and scipy_available):
     raise unittest.SkipTest("Pynumero needs scipy and numpy to run NLP tests")
+
+import scipy.sparse as spa
+import numpy as np
 
 from pyomo.contrib.pynumero.extensions.asl import AmplInterface
 if not AmplInterface.available():

--- a/pyomo/contrib/pynumero/interfaces/tests/test_nlp_compositions.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_nlp_compositions.py
@@ -11,11 +11,12 @@ import pyutilib.th as unittest
 import pyomo.environ as aml
 import os
 
-try:
-    import scipy.sparse as spa
-    import numpy as np
-except ImportError:
+from .. import numpy_available, scipy_available
+if not (numpy_available and scipy_available):
     raise unittest.SkipTest("Pynumero needs scipy and numpy to run NLP tests")
+
+import scipy.sparse as spa
+import numpy as np
 
 from pyomo.contrib.pynumero.extensions.asl import AmplInterface
 if not AmplInterface.available():

--- a/pyomo/contrib/pynumero/interfaces/tests/test_nlp_transformations.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_nlp_transformations.py
@@ -12,11 +12,12 @@ from pyomo.common.plugin import alias
 import pyomo.environ as aml
 import os
 
-try:
-    import scipy.sparse as spa
-    import numpy as np
-except ImportError:
+from .. import numpy_available, scipy_available
+if not (numpy_available and scipy_available):
     raise unittest.SkipTest("Pynumero needs scipy and numpy to run NLP tests")
+
+import scipy.sparse as spa
+import numpy as np
 
 from pyomo.contrib.pynumero.extensions.asl import AmplInterface
 

--- a/pyomo/contrib/pynumero/linalg/__init__.py
+++ b/pyomo/contrib/pynumero/linalg/__init__.py
@@ -7,20 +7,8 @@
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
-try:
-    import numpy as np
-    numpy_available = True
-except ImportError:
-    numpy_available = False
-try:
-    import scipy
-    scipy_available = True
-except ImportError:
-    scipy_available = False
+
+from .. import numpy_available, scipy_available
 
 if numpy_available and scipy_available:
     from .intrinsics import *
-else:
-    import logging
-    logging.getLogger('pyomo.contrib.pynumero.linalg').warn(
-        "Numpy not available. Install numpy before using pynumero")

--- a/pyomo/contrib/pynumero/sparse/__init__.py
+++ b/pyomo/contrib/pynumero/sparse/__init__.py
@@ -8,28 +8,9 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-try:
-    import numpy as np
-    numpy_available = True
-except ImportError:
-    numpy_available = False
+from .. import numpy_available, scipy_available
 
-try:
-    import scipy 
-    scipy_available = True
-except ImportError:
-    scipy_available = False
-    
 if numpy_available and scipy_available:
     from .coo import empty_matrix, diagonal_matrix
     from .block_vector import BlockVector
     from .block_matrix import BlockMatrix, BlockSymMatrix
-else:
-    import logging
-    _logger = logging.getLogger('pyomo.contrib.pynumero.sparse')
-    if not numpy_available:
-        #raise ImportError("Install numpy")
-        _logger.warn("Install numpy to use pynumero")
-    if not scipy_available:
-        #raise ImportError("Install scipy")
-        _logger.warn("Install scipy to use pynumero")

--- a/pyomo/contrib/pynumero/sparse/tests/test_block_matrix.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_block_matrix.py
@@ -8,12 +8,13 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 import pyutilib.th as unittest
-try:
-    from scipy.sparse import coo_matrix, bmat
-    import numpy as np
-except ImportError:
-    raise unittest.SkipTest(
-        "Pynumero needs scipy and numpy to run block matrix tests")
+
+from .. import numpy_available, scipy_available
+if not (numpy_available and scipy_available):
+    raise unittest.SkipTest("Pynumero needs scipy and numpy to run NLP tests")
+
+from scipy.sparse import coo_matrix, bmat
+import numpy as np
 
 from pyomo.contrib.pynumero.sparse import (BlockMatrix,
                                            BlockSymMatrix,

--- a/pyomo/contrib/pynumero/sparse/tests/test_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_block_vector.py
@@ -959,9 +959,11 @@ class TestBlockVector(unittest.TestCase):
                        np.fabs, np.sqrt, np.log, np.log2,
                        np.absolute, np.isfinite, np.isinf, np.isnan,
                        np.log1p, np.logical_not, np.exp2, np.expm1,
-                       np.sign, np.rint, np.square, np.positive,
+                       np.sign, np.rint, np.square,
                        np.negative, np.rad2deg, np.deg2rad,
                        np.conjugate, np.reciprocal]
+        if np.lib.NumpyVersion(np.__version__) >= '1.13.0':
+            unary_funcs.append(np.positive)
 
         for fun in unary_funcs:
             v2[0] = fun(v[0])
@@ -1019,7 +1021,9 @@ class TestBlockVector(unittest.TestCase):
                          np.maximum, np.minimum,
                          np.fmax, np.fmin, np.equal,
                          np.logaddexp, np.logaddexp2, np.remainder,
-                         np.heaviside, np.hypot]
+                         np.hypot]
+        if np.lib.NumpyVersion(np.__version__) >= '1.13.0':
+            binary_ufuncs.append(np.heaviside)
 
         for fun in binary_ufuncs:
             flat_res = fun(v.flatten(), v2.flatten())

--- a/pyomo/contrib/pynumero/sparse/tests/test_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_block_vector.py
@@ -9,11 +9,12 @@
 #  ___________________________________________________________________________
 import sys
 import pyutilib.th as unittest
-try:
-    import numpy as np
-except ImportError:
+
+import pyomo.contrib.pynumero as pn
+if not (pn.sparse.numpy_available and pn.sparse.scipy_available):
     raise unittest.SkipTest("Pynumero needs scipy and numpy to run NLP tests")
 
+import numpy as np
 from pyomo.contrib.pynumero.sparse.block_vector import BlockVector
 
 
@@ -959,11 +960,9 @@ class TestBlockVector(unittest.TestCase):
                        np.fabs, np.sqrt, np.log, np.log2,
                        np.absolute, np.isfinite, np.isinf, np.isnan,
                        np.log1p, np.logical_not, np.exp2, np.expm1,
-                       np.sign, np.rint, np.square,
+                       np.sign, np.rint, np.square, np.positive,
                        np.negative, np.rad2deg, np.deg2rad,
                        np.conjugate, np.reciprocal]
-        if np.lib.NumpyVersion(np.__version__) >= '1.13.0':
-            unary_funcs.append(np.positive)
 
         for fun in unary_funcs:
             v2[0] = fun(v[0])
@@ -1021,9 +1020,7 @@ class TestBlockVector(unittest.TestCase):
                          np.maximum, np.minimum,
                          np.fmax, np.fmin, np.equal,
                          np.logaddexp, np.logaddexp2, np.remainder,
-                         np.hypot]
-        if np.lib.NumpyVersion(np.__version__) >= '1.13.0':
-            binary_ufuncs.append(np.heaviside)
+                         np.heaviside, np.hypot]
 
         for fun in binary_ufuncs:
             flat_res = fun(v.flatten(), v2.flatten())

--- a/pyomo/contrib/pynumero/sparse/tests/test_intrinsics.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_intrinsics.py
@@ -9,12 +9,12 @@
 #  ___________________________________________________________________________
 import sys
 import pyutilib.th as unittest
-try:
-    import numpy as np
-    import scipy
-except ImportError:
+
+from .. import numpy_available, scipy_available
+if not (numpy_available and scipy_available):
     raise unittest.SkipTest("Pynumero needs scipy and numpy to run NLP tests")
 
+import numpy as np
 from pyomo.contrib.pynumero.sparse import BlockVector
 import pyomo.contrib.pynumero as pn
 
@@ -72,8 +72,6 @@ class TestSparseIntrinsics(unittest.TestCase):
         res_flat = pn.where(flat_condition, np.ones(bv.size) * 2.0, np.ones(bv.size))
         self.assertTrue(np.allclose(res.flatten(), res_flat))
 
-    @unittest.skipIf(np.lib.NumpyVersion(np.__version__) < '1.13.0',
-                     "numpy>=1.13.0 required to test isin")
     def test_isin(self):
 
         bv = self.bv

--- a/pyomo/contrib/pynumero/sparse/tests/test_intrinsics.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_intrinsics.py
@@ -72,6 +72,8 @@ class TestSparseIntrinsics(unittest.TestCase):
         res_flat = pn.where(flat_condition, np.ones(bv.size) * 2.0, np.ones(bv.size))
         self.assertTrue(np.allclose(res.flatten(), res_flat))
 
+    @unittest.skipIf(np.lib.NumpyVersion(np.__version__) < '1.13.0',
+                     "numpy>=1.13.0 required to test isin")
     def test_isin(self):
 
         bv = self.bv

--- a/pyomo/contrib/pynumero/sparse/tests/test_sparse_utils.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_sparse_utils.py
@@ -8,12 +8,13 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 import pyutilib.th as unittest
-try:
-    from scipy.sparse import coo_matrix, bmat
-    import numpy as np
-except ImportError:
-    raise unittest.SkipTest(
-        "Pynumero needs scipy and numpy to run block matrix tests")
+
+from .. import numpy_available, scipy_available
+if not (numpy_available and scipy_available):
+    raise unittest.SkipTest("Pynumero needs scipy and numpy to run NLP tests")
+
+from scipy.sparse import coo_matrix, bmat
+import numpy as np
 
 from pyomo.contrib.pynumero.sparse import BlockSymMatrix
 from pyomo.contrib.pynumero.sparse.utils import is_symmetric_dense, is_symmetric_sparse


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
Some pynumero tests fail (with exception) on with versions of NumPy older than 1.13.0.  This PR adds guards to skip those specific tests.  This was motivated by Appveyor, which periodically gets set up with an older numpy version (1.11.0)

## Changes proposed in this PR:
- Skip tests that exercise numpy features not available in the installed version of numpy.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
