### PR TITLE
Standardize preliminary time limit support across MindtPy and GDPopt

### DIFF
--- a/pyomo/contrib/gdpopt/GDPopt.py
+++ b/pyomo/contrib/gdpopt/GDPopt.py
@@ -65,7 +65,7 @@ class GDPoptSolver(object):
         description="Iteration limit."
     ))
     CONFIG.declare("time_limit", ConfigValue(
-        default=10,
+        default=600,
         domain=PositiveInt,
         description="Time limit (seconds)",
         doc="Seconds allowed until terminated"

--- a/pyomo/contrib/gdpopt/GDPopt.py
+++ b/pyomo/contrib/gdpopt/GDPopt.py
@@ -68,9 +68,9 @@ class GDPoptSolver(object):
         default=600,
         domain=PositiveInt,
         description="Time limit (seconds)",
-        doc="Seconds allowed until terminated. Note that currently only the"
-            "master problem can be checked and terminated, so you might need"
-            "to set a subsolver timelimit too."
+        doc="Seconds allowed until terminated. Note that the time limit can"
+            "currently only be enforced between subsolver invocations. You may"
+            "need to set subsolver time limits as well."
     ))
     CONFIG.declare("strategy", ConfigValue(
         default="LOA", domain=In(["LOA", "GLOA"]),

--- a/pyomo/contrib/gdpopt/GDPopt.py
+++ b/pyomo/contrib/gdpopt/GDPopt.py
@@ -68,7 +68,9 @@ class GDPoptSolver(object):
         default=600,
         domain=PositiveInt,
         description="Time limit (seconds)",
-        doc="Seconds allowed until terminated"
+        doc="Seconds allowed until terminated. Note that currently only the"
+            "master problem can be checked and terminated, so you might need"
+            "to set a subsolver timelimit too."
     ))
     CONFIG.declare("strategy", ConfigValue(
         default="LOA", domain=In(["LOA", "GLOA"]),

--- a/pyomo/contrib/gdpopt/GDPopt.py
+++ b/pyomo/contrib/gdpopt/GDPopt.py
@@ -245,7 +245,7 @@ class GDPoptSolver(object):
         solve_data.timing = Container()
 
         old_logger_level = config.logger.getEffectiveLevel()
-        with time_code(solve_data.timing, 'total'), \
+        with time_code(solve_data.timing, 'total', is_main_timer=True), \
                 restore_logger_level(config.logger), \
                 create_utility_block(model, 'GDPopt_utils', solve_data):
             if config.tee and old_logger_level > logging.INFO:
@@ -351,8 +351,8 @@ If you use this software, you may cite the following:
             solve_data.results.problem.upper_bound = solve_data.UB
 
         solve_data.results.solver.timing = solve_data.timing
-        solve_data.results.solver.user_time = solve_data.timing.total.elapsed
-        solve_data.results.solver.wallclock_time = solve_data.timing.total.elapsed
+        solve_data.results.solver.user_time = solve_data.timing.total
+        solve_data.results.solver.wallclock_time = solve_data.timing.total
 
         solve_data.results.solver.iterations = solve_data.master_iteration
 

--- a/pyomo/contrib/gdpopt/GDPopt.py
+++ b/pyomo/contrib/gdpopt/GDPopt.py
@@ -64,7 +64,7 @@ class GDPoptSolver(object):
         default=30, domain=NonNegativeInt,
         description="Iteration limit."
     ))
-    CONFIG.declare("timelimit", ConfigValue(
+    CONFIG.declare("time_limit", ConfigValue(
         default=10,
         domain=PositiveInt,
         description="Time limit (seconds)",

--- a/pyomo/contrib/gdpopt/GDPopt.py
+++ b/pyomo/contrib/gdpopt/GDPopt.py
@@ -67,7 +67,7 @@ class GDPoptSolver(object):
     CONFIG.declare("time_limit", ConfigValue(
         default=600,
         domain=PositiveInt,
-        description="Time limit (seconds)",
+        description="Time limit (seconds, default=600)",
         doc="Seconds allowed until terminated. Note that the time limit can"
             "currently only be enforced between subsolver invocations. You may"
             "need to set subsolver time limits as well."

--- a/pyomo/contrib/gdpopt/GDPopt.py
+++ b/pyomo/contrib/gdpopt/GDPopt.py
@@ -6,7 +6,7 @@ import logging
 
 from pyomo.common.config import (
     ConfigBlock, ConfigList, ConfigValue, In, NonNegativeFloat, NonNegativeInt,
-    add_docstring_list
+    add_docstring_list, PositiveInt
 )
 from pyomo.contrib.gdpopt.data_class import GDPoptSolveData
 from pyomo.contrib.gdpopt.iterate import GDPopt_iteration_loop
@@ -63,6 +63,12 @@ class GDPoptSolver(object):
     CONFIG.declare("iterlim", ConfigValue(
         default=30, domain=NonNegativeInt,
         description="Iteration limit."
+    ))
+    CONFIG.declare("timelimit", ConfigValue(
+        default=10,
+        domain=PositiveInt,
+        description="Time limit (seconds)",
+        doc="Seconds allowed until terminated"
     ))
     CONFIG.declare("strategy", ConfigValue(
         default="LOA", domain=In(["LOA", "GLOA"]),
@@ -345,8 +351,8 @@ If you use this software, you may cite the following:
             solve_data.results.problem.upper_bound = solve_data.UB
 
         solve_data.results.solver.timing = solve_data.timing
-        solve_data.results.solver.user_time = solve_data.timing.total
-        solve_data.results.solver.wallclock_time = solve_data.timing.total
+        solve_data.results.solver.user_time = solve_data.timing.total.elapsed
+        solve_data.results.solver.wallclock_time = solve_data.timing.total.elapsed
 
         solve_data.results.solver.iterations = solve_data.master_iteration
 

--- a/pyomo/contrib/gdpopt/iterate.py
+++ b/pyomo/contrib/gdpopt/iterate.py
@@ -1,6 +1,7 @@
 """Iteration code."""
 from __future__ import division
 
+from timeit import default_timer
 from pyomo.contrib.gdpopt.cut_generation import (add_integer_cut,
                                                  add_outer_approximation_cuts,
                                                  add_affine_cuts)
@@ -87,6 +88,18 @@ def algorithm_should_terminate(solve_data, config):
             'Final bound values: LB: {:.10g}  UB: {:.10g}'.format(
                 solve_data.LB, solve_data.UB))
         solve_data.results.solver.termination_condition = tc.maxIterations
+        return True
+
+    # Check time limit
+    total_time_elapsed = default_timer() - solve_data.timing.total.start
+    if total_time_elapsed > config.timelimit:
+        config.logger.info(
+            'MindtPy unable to converge bounds '
+            'after {} seconds.'.format(total_time_elapsed))
+        config.logger.info(
+            'Final bound values: LB: {}  UB: {}'.
+            format(solve_data.LB, solve_data.UB))
+        solve_data.results.solver.termination_condition = tc.maxTimeLimit
         return True
 
     if not algorithm_is_making_progress(solve_data, config):

--- a/pyomo/contrib/gdpopt/iterate.py
+++ b/pyomo/contrib/gdpopt/iterate.py
@@ -92,7 +92,7 @@ def algorithm_should_terminate(solve_data, config):
 
     # Check time limit
     total_time_elapsed = default_timer() - solve_data.timing.total.start
-    if total_time_elapsed > config.timelimit:
+    if total_time_elapsed > config.time_limit:
         config.logger.info(
             'MindtPy unable to converge bounds '
             'after {} seconds.'.format(total_time_elapsed))

--- a/pyomo/contrib/gdpopt/iterate.py
+++ b/pyomo/contrib/gdpopt/iterate.py
@@ -7,7 +7,7 @@ from pyomo.contrib.gdpopt.cut_generation import (add_integer_cut,
 from pyomo.contrib.gdpopt.mip_solve import solve_LOA_master
 from pyomo.contrib.gdpopt.nlp_solve import (solve_global_subproblem, solve_local_subproblem)
 from pyomo.opt import TerminationCondition as tc
-from pyomo.contrib.gdpopt.util import time_code, get_total_time_elapsed
+from pyomo.contrib.gdpopt.util import time_code, get_main_elapsed_time
 
 
 def GDPopt_iteration_loop(solve_data, config):
@@ -92,8 +92,9 @@ def algorithm_should_terminate(solve_data, config):
     # Check time limit
     if get_main_elapsed_time(solve_data.timing) > config.time_limit:
         config.logger.info(
-            'MindtPy unable to converge bounds '
-            'after {} seconds.'.format(total_time_elapsed))
+            'GDPopt unable to converge bounds '
+            'after time limit of {} seconds.'
+            .format(get_main_elapsed_time(solve_data.timing)))
         config.logger.info(
             'Final bound values: LB: {}  UB: {}'.
             format(solve_data.LB, solve_data.UB))

--- a/pyomo/contrib/gdpopt/iterate.py
+++ b/pyomo/contrib/gdpopt/iterate.py
@@ -1,14 +1,13 @@
 """Iteration code."""
 from __future__ import division
 
-from timeit import default_timer
 from pyomo.contrib.gdpopt.cut_generation import (add_integer_cut,
                                                  add_outer_approximation_cuts,
                                                  add_affine_cuts)
 from pyomo.contrib.gdpopt.mip_solve import solve_LOA_master
 from pyomo.contrib.gdpopt.nlp_solve import (solve_global_subproblem, solve_local_subproblem)
 from pyomo.opt import TerminationCondition as tc
-from pyomo.contrib.gdpopt.util import time_code
+from pyomo.contrib.gdpopt.util import time_code, get_total_time_elapsed
 
 
 def GDPopt_iteration_loop(solve_data, config):
@@ -91,8 +90,7 @@ def algorithm_should_terminate(solve_data, config):
         return True
 
     # Check time limit
-    total_time_elapsed = default_timer() - solve_data.timing.total.start
-    if total_time_elapsed > config.time_limit:
+    if get_main_elapsed_time(solve_data.timing) > config.time_limit:
         config.logger.info(
             'MindtPy unable to converge bounds '
             'after {} seconds.'.format(total_time_elapsed))

--- a/pyomo/contrib/gdpopt/iterate.py
+++ b/pyomo/contrib/gdpopt/iterate.py
@@ -93,8 +93,9 @@ def algorithm_should_terminate(solve_data, config):
     if get_main_elapsed_time(solve_data.timing) > config.time_limit:
         config.logger.info(
             'GDPopt unable to converge bounds '
-            'after time limit of {} seconds.'
-            .format(get_main_elapsed_time(solve_data.timing)))
+            'before time limit of {} seconds. '
+            'Elapsed: {} seconds'
+            .format(config.time_limit, get_main_elapsed_time(solve_data.timing)))
         config.logger.info(
             'Final bound values: LB: {}  UB: {}'.
             format(solve_data.LB, solve_data.UB))

--- a/pyomo/contrib/gdpopt/util.py
+++ b/pyomo/contrib/gdpopt/util.py
@@ -2,6 +2,8 @@
 from __future__ import division
 
 import logging
+
+import six
 from math import fabs, floor, log
 
 from pyomo.contrib.mcpp.pyomo_mcpp import mcpp_available, McCormick
@@ -352,8 +354,8 @@ def time_code(timing_data_obj, code_block_name, is_main_timer=False):
     """Starts timer at entry, stores elapsed time at exit
 
     If `is_main_timer=True`, the start time is stored in the timing_data_obj,
-    allowing to calculate the total elapsed time 'on the fly' (i.e. to abort
-    the calculation after a specified time
+    allowing calculation of total elapsed time 'on the fly' (e.g. to enforce
+    a time limit) using `get_main_elapsed_time(timing_data_obj)`.
     """
     start_time = timeit.default_timer()
     if is_main_timer:
@@ -370,8 +372,10 @@ def get_main_elapsed_time(timing_data_obj):
     try:
         return current_time - timing_data_obj.main_timer_start_time
     except AttributeError as e:
-        raise AttributeError("{}.\nYou need to be in a 'time_code' context to" \
-                             "get the main elapsed time".format(str(e)))
+        if 'main_timer_start_time' in str(e):
+            six.raise_from(e, AttributeError(
+                "You need to be in a 'time_code' context to use `get_main_elapsed_time()`."
+            ))
 
 
 @contextmanager

--- a/pyomo/contrib/gdpopt/util.py
+++ b/pyomo/contrib/gdpopt/util.py
@@ -349,17 +349,23 @@ def constraints_in_True_disjuncts(model, config):
 
 
 @contextmanager
-def time_code(timing_data_obj, code_block_name):
-    if timing_data_obj[code_block_name] is None:
-        timing_data_obj[code_block_name] = Container()
+def time_code(timing_data_obj, code_block_name, is_main_timer = False):
     start_time = timeit.default_timer()
-    timing_data_obj[code_block_name].start = start_time
+    if is_main_timer:
+        timing_data_obj.main_timer_start_time = start_time
     yield
-    end_time = timeit.default_timer()
-    timing_data_obj[code_block_name].end = end_time
-    elapsed_time = end_time - start_time
-    prev_time = timing_data_obj[code_block_name].get('elapsed', 0)
-    timing_data_obj[code_block_name].elapsed = prev_time + elapsed_time
+    elapsed_time = timeit.default_timer() - start_time
+    prev_time = timing_data_obj.get(code_block_name, 0)
+    timing_data_obj[code_block_name] = prev_time + elapsed_time
+
+
+def get_main_elapsed_time(timing_data_obj):
+    current_time = timeit.default_timer()
+    try:
+        return current_time - timing_data_obj.main_timer_start_time
+    except AttributeError as e:
+        raise AttributeError("{}.\nYou need to be in a 'time_code' context to" \
+                             "get the main elapsed time".format(str(e)))
 
 
 @contextmanager

--- a/pyomo/contrib/gdpopt/util.py
+++ b/pyomo/contrib/gdpopt/util.py
@@ -17,7 +17,6 @@ from pyomo.common.log import LoggingIntercept
 import timeit
 from contextlib import contextmanager
 from pyomo.util.model_size import build_model_size_report
-from pyutilib.misc import Container
 
 
 class _DoNothing(object):
@@ -349,7 +348,13 @@ def constraints_in_True_disjuncts(model, config):
 
 
 @contextmanager
-def time_code(timing_data_obj, code_block_name, is_main_timer = False):
+def time_code(timing_data_obj, code_block_name, is_main_timer=False):
+    """Starts timer at entry, stores elapsed time at exit
+
+    If `is_main_timer=True`, the start time is stored in the timing_data_obj,
+    allowing to calculate the total elapsed time 'on the fly' (i.e. to abort
+    the calculation after a specified time
+    """
     start_time = timeit.default_timer()
     if is_main_timer:
         timing_data_obj.main_timer_start_time = start_time
@@ -360,6 +365,7 @@ def time_code(timing_data_obj, code_block_name, is_main_timer = False):
 
 
 def get_main_elapsed_time(timing_data_obj):
+    """Returns the time since entering the main `time_code` context"""
     current_time = timeit.default_timer()
     try:
         return current_time - timing_data_obj.main_timer_start_time

--- a/pyomo/contrib/gdpopt/util.py
+++ b/pyomo/contrib/gdpopt/util.py
@@ -17,6 +17,7 @@ from pyomo.common.log import LoggingIntercept
 import timeit
 from contextlib import contextmanager
 from pyomo.util.model_size import build_model_size_report
+from pyutilib.misc import Container
 
 
 class _DoNothing(object):
@@ -349,11 +350,16 @@ def constraints_in_True_disjuncts(model, config):
 
 @contextmanager
 def time_code(timing_data_obj, code_block_name):
+    if timing_data_obj[code_block_name] is None:
+        timing_data_obj[code_block_name] = Container()
     start_time = timeit.default_timer()
+    timing_data_obj[code_block_name].start = start_time
     yield
-    elapsed_time = timeit.default_timer() - start_time
-    prev_time = timing_data_obj.get(code_block_name, 0)
-    timing_data_obj[code_block_name] = prev_time + elapsed_time
+    end_time = timeit.default_timer()
+    timing_data_obj[code_block_name].end = end_time
+    elapsed_time = end_time - start_time
+    prev_time = timing_data_obj[code_block_name].get('elapsed', 0)
+    timing_data_obj[code_block_name].elapsed = prev_time + elapsed_time
 
 
 @contextmanager

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -66,7 +66,7 @@ class MindtPySolver(object):
         description="Iteration limit",
         doc="Number of maximum iterations in the decomposition methods"
     ))
-    CONFIG.declare("timelimit", ConfigValue(
+    CONFIG.declare("time_limit", ConfigValue(
         default=10,
         domain=PositiveInt,
         description="Time limit (seconds)",

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -376,7 +376,7 @@ class MindtPySolver(object):
         solve_data.results.solver.user_time = solve_data.timing.total
         solve_data.results.solver.wallclock_time = solve_data.timing.total
 
-        solve_data.results.solver.iterations = solve_data.mip_iter  # TODO @David this makes sense right?
+        solve_data.results.solver.iterations = solve_data.mip_iter
 
         return solve_data.results
 

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -66,6 +66,12 @@ class MindtPySolver(object):
         description="Iteration limit",
         doc="Number of maximum iterations in the decomposition methods"
     ))
+    CONFIG.declare("timelimit", ConfigValue(
+        default=10,
+        domain=PositiveInt,
+        description="Time limit (seconds)",
+        doc="Seconds allowed until terminated"
+    ))
     CONFIG.declare("strategy", ConfigValue(
         default="OA",
         domain=In(["OA", "GBD", "ECP", "PSC"]),
@@ -362,6 +368,14 @@ class MindtPySolver(object):
 
             solve_data.results.problem.lower_bound = solve_data.LB
             solve_data.results.problem.upper_bound = solve_data.UB
+
+        solve_data.results.solver.timing = solve_data.timing
+        solve_data.results.solver.user_time = solve_data.timing.total.elapsed
+        solve_data.results.solver.wallclock_time = solve_data.timing.total.elapsed
+
+        solve_data.results.solver.iterations = solve_data.mip_iter  # TODO @David this makes sense right?
+
+        return solve_data.results
 
     #
     # Support "with" statements.

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -71,9 +71,9 @@ class MindtPySolver(object):
         default=600,
         domain=PositiveInt,
         description="Time limit (seconds)",
-        doc="Seconds allowed until terminated. Note that currently only the"
-            "master problem can be checked and terminated, so you might need"
-            "to set a subsolver timelimit too."
+        doc="Seconds allowed until terminated. Note that the time limit can"
+            "currently only be enforced between subsolver invocations. You may"
+            "need to set subsolver time limits as well."
     ))
     CONFIG.declare("strategy", ConfigValue(
         default="OA",

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -71,7 +71,9 @@ class MindtPySolver(object):
         default=600,
         domain=PositiveInt,
         description="Time limit (seconds)",
-        doc="Seconds allowed until terminated"
+        doc="Seconds allowed until terminated. Note that currently only the"
+            "master problem can be checked and terminated, so you might need"
+            "to set a subsolver timelimit too."
     ))
     CONFIG.declare("strategy", ConfigValue(
         default="OA",

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -41,6 +41,7 @@ from pyomo.core import (
 from pyomo.opt import SolverFactory, SolverResults
 from pyutilib.misc import Container
 
+
 logger = logging.getLogger('pyomo.contrib.mindtpy')
 
 __version__ = (0, 1, 0)
@@ -237,7 +238,7 @@ class MindtPySolver(object):
         solve_data.timing = Container()
 
         old_logger_level = config.logger.getEffectiveLevel()
-        with time_code(solve_data.timing, 'total'), \
+        with time_code(solve_data.timing, 'total', is_main_timer=True), \
              restore_logger_level(config.logger), \
              create_utility_block(model, 'MindtPy_utils', solve_data):
             if config.tee and old_logger_level > logging.INFO:
@@ -370,8 +371,8 @@ class MindtPySolver(object):
             solve_data.results.problem.upper_bound = solve_data.UB
 
         solve_data.results.solver.timing = solve_data.timing
-        solve_data.results.solver.user_time = solve_data.timing.total.elapsed
-        solve_data.results.solver.wallclock_time = solve_data.timing.total.elapsed
+        solve_data.results.solver.user_time = solve_data.timing.total
+        solve_data.results.solver.wallclock_time = solve_data.timing.total
 
         solve_data.results.solver.iterations = solve_data.mip_iter  # TODO @David this makes sense right?
 

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -67,7 +67,7 @@ class MindtPySolver(object):
         doc="Number of maximum iterations in the decomposition methods"
     ))
     CONFIG.declare("time_limit", ConfigValue(
-        default=10,
+        default=600,
         domain=PositiveInt,
         description="Time limit (seconds)",
         doc="Seconds allowed until terminated"

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -70,7 +70,7 @@ class MindtPySolver(object):
     CONFIG.declare("time_limit", ConfigValue(
         default=600,
         domain=PositiveInt,
-        description="Time limit (seconds)",
+        description="Time limit (seconds, default=600)",
         doc="Seconds allowed until terminated. Note that the time limit can"
             "currently only be enforced between subsolver invocations. You may"
             "need to set subsolver time limits as well."

--- a/pyomo/contrib/mindtpy/iterate.py
+++ b/pyomo/contrib/mindtpy/iterate.py
@@ -95,7 +95,7 @@ def algorithm_should_terminate(solve_data, config):
 
     # Check time limit
     total_time_elapsed = default_timer() - solve_data.timing.total.start
-    if total_time_elapsed > config.timelimit:
+    if total_time_elapsed > config.time_limit:
         config.logger.info(
             'MindtPy unable to converge bounds '
             'after {} seconds.'.format(total_time_elapsed))

--- a/pyomo/contrib/mindtpy/iterate.py
+++ b/pyomo/contrib/mindtpy/iterate.py
@@ -97,7 +97,8 @@ def algorithm_should_terminate(solve_data, config):
     if get_main_elapsed_time(solve_data.timing) > config.time_limit:
         config.logger.info(
             'MindtPy unable to converge bounds '
-            'after {} seconds.'.format(total_time_elapsed))
+            'after time limit of {} seconds.'
+            .format(get_main_elapsed_time(solve_data.timing)))
         config.logger.info(
             'Final bound values: LB: {}  UB: {}'.
             format(solve_data.LB, solve_data.UB))

--- a/pyomo/contrib/mindtpy/iterate.py
+++ b/pyomo/contrib/mindtpy/iterate.py
@@ -1,11 +1,11 @@
 """Iteration loop for MindtPy."""
 from __future__ import division
 
-from timeit import default_timer
 from pyomo.contrib.mindtpy.mip_solve import (solve_OA_master)
 from pyomo.contrib.mindtpy.nlp_solve import solve_NLP_subproblem
 from pyomo.core import minimize, Objective
 from pyomo.opt import TerminationCondition as tc
+from pyomo.contrib.gdpopt.util import get_main_elapsed_time
 
 
 def MindtPy_iteration_loop(solve_data, config):
@@ -94,8 +94,7 @@ def algorithm_should_terminate(solve_data, config):
         return True
 
     # Check time limit
-    total_time_elapsed = default_timer() - solve_data.timing.total.start
-    if total_time_elapsed > config.time_limit:
+    if get_main_elapsed_time(solve_data.timing) > config.time_limit:
         config.logger.info(
             'MindtPy unable to converge bounds '
             'after {} seconds.'.format(total_time_elapsed))

--- a/pyomo/contrib/mindtpy/iterate.py
+++ b/pyomo/contrib/mindtpy/iterate.py
@@ -97,8 +97,9 @@ def algorithm_should_terminate(solve_data, config):
     if get_main_elapsed_time(solve_data.timing) > config.time_limit:
         config.logger.info(
             'MindtPy unable to converge bounds '
-            'after time limit of {} seconds.'
-            .format(get_main_elapsed_time(solve_data.timing)))
+            'before time limit of {} seconds. '
+            'Elapsed: {} seconds'
+            .format(config.time_limit, get_main_elapsed_time(solve_data.timing)))
         config.logger.info(
             'Final bound values: LB: {}  UB: {}'.
             format(solve_data.LB, solve_data.UB))

--- a/pyomo/contrib/mindtpy/nlp_solve.py
+++ b/pyomo/contrib/mindtpy/nlp_solve.py
@@ -182,6 +182,6 @@ def solve_NLP_feas(solve_data, config):
 
     if value(MindtPy.MindtPy_feas_obj.expr) == 0:
         raise ValueError(
-            'Problem is not infeasible, check NLP solver')
+            'Problem is not feasible, check NLP solver')
 
     return var_values, duals


### PR DESCRIPTION
When solving models, now a `time_limit=[secs]` argument can be passed to
the solve method, signaling that the algorithm should terminate after that time.

## Fixes
No issue assigned

## Summary/Motivation:
Most solvers support a time limit. This was missing so far from the **mindtpy** and **gdpopt** solvers, although timing capability was already implemented. This PR adds a new config block `time_limit` and an appropriate abort condition in the existing methods `algorithm_should_terminate` that already look for an iteration limit. ~Note that the name `timelimit` was chosen in accordance to other solvers.~

## Changes proposed in this PR:
- modify `time_code` method (in gdpopt util) to store start time
- add `time_limit` block to **MindtPy** and **gdpopt**
- add abort condition for time right after abort condition for iterations

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
