### PR TITLE
Fixing a bug in the collocation discretization

### DIFF
--- a/pyomo/dae/plugins/colloc.py
+++ b/pyomo/dae/plugins/colloc.py
@@ -213,7 +213,7 @@ def calc_adot(cp, order=1):
         pder = numpy.polyder(p, order)
         arow = []
         for j in range(len(cp)):
-            arow.append(numpy.polyval(pder, cp[j]))
+            arow.append(float(numpy.polyval(pder, cp[j])))
         a.append(arow)
     return a
 

--- a/pyomo/dae/tests/test_colloc.py
+++ b/pyomo/dae/tests/test_colloc.py
@@ -142,6 +142,19 @@ class TestCollocation(unittest.TestCase):
         repn_gen = repn_to_rounded_dict(repn, 5)
         self.assertEqual(repn_baseline, repn_gen)
 
+    # test second order derivative with single collocation point
+    def test_disc_second_order_1cp(self):
+        m = ConcreteModel()
+        m.t = ContinuousSet(bounds=(0,1))
+        m.t2 = ContinuousSet(bounds=(0,10))
+        m.v = Var(m.t, m.t2)
+        m.dv = DerivativeVar(m.v, wrt=(m.t, m.t2))
+        TransformationFactory('dae.collocation').apply_to(m, nfe=2, ncp=1)
+
+        self.assertTrue(hasattr(m, 'dv_disc_eq'))
+        self.assertTrue(len(m.dv_disc_eq) == 4)
+        self.assertTrue(len(m.v) == 9)                        
+
     # test collocation discretization with legendre points 
     # on var indexed by single ContinuousSet
     def test_disc_single_index_legendre(self):


### PR DESCRIPTION
## Fixes #972  .

## Summary/Motivation:
Fixing a bug in the collocation discretization pointed out by @ghackebeil in #972 

## Changes proposed in this PR:
- Wrap a numpy function call in `float` to avoid buggy behavior when discretizing a second order derivative with 1 collocation point

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
