### PR TITLE
Fix pyomo.network decomposition when ports contain References

### DIFF
--- a/pyomo/network/decomposition.py
+++ b/pyomo/network/decomposition.py
@@ -598,7 +598,7 @@ class SequentialDecomposition(FOQUSGraph):
 
     def load_values(self, port, default, fixed, use_guesses):
         sources = port.sources()
-        for name, obj in port.iter_vars(fixed=False, names=True):
+        for name, index, obj in port.iter_vars(fixed=False, names=True):
             evars = None
             if port.is_extensive(name):
                 # collect evars if there are any
@@ -610,9 +610,8 @@ class SequentialDecomposition(FOQUSGraph):
                     try:
                         # index into them if necessary, now that
                         # we know they are not None
-                        i = obj.index()
                         for j in range(len(evars)):
-                            evars[j] = evars[j][i]
+                            evars[j] = evars[j][index]
                     except AttributeError:
                         pass
             if evars is not None:
@@ -827,16 +826,12 @@ class SequentialDecomposition(FOQUSGraph):
             arc = G.edges[edge_list[tear]]["arc"]
             src, dest = arc.src, arc.dest
             sf = arc.expanded_block.component("splitfrac")
-            for name, mem in src.iter_vars(names=True):
+            for name, index, mem in src.iter_vars(names=True):
                 if src.is_extensive(name) and sf is not None:
                     # TODO: same as above, what if there's no splitfrac
                     svals.append(value(mem * sf))
                 else:
                     svals.append(value(mem))
-                try:
-                    index = mem.index()
-                except AttributeError:
-                    index = None
                 dvals.append(value(self.source_dest_peer(arc, name, index)))
         svals = numpy.array(svals)
         dvals = numpy.array(dvals)
@@ -889,11 +884,7 @@ class SequentialDecomposition(FOQUSGraph):
             if dest_unit not in fixed_inputs:
                 fixed_inputs[dest_unit] = ComponentSet()
 
-            for name, mem in src.iter_vars(names=True):
-                try:
-                    index = mem.index()
-                except AttributeError:
-                    index = None
+            for name, index, mem in src.iter_vars(names=True):
                 peer = self.source_dest_peer(arc, name, index)
                 self.pass_single_value(dest, name, peer, x[i],
                     fixed_inputs[dest_unit])
@@ -906,7 +897,7 @@ class SequentialDecomposition(FOQUSGraph):
             arc = G.edges[edge_list[tear]]["arc"]
             src = arc.src
             sf = arc.expanded_block.component("splitfrac")
-            for name, mem in src.iter_vars(names=True):
+            for name, index, mem in src.iter_vars(names=True):
                 if src.is_extensive(name) and sf is not None:
                     # TODO: same as above, what if there's no splitfrac
                     gofx.append(value(mem * sf))
@@ -920,11 +911,7 @@ class SequentialDecomposition(FOQUSGraph):
         x = []
         for tear in tears:
             arc = G.edges[edge_list[tear]]["arc"]
-            for name, mem in arc.src.iter_vars(names=True):
-                try:
-                    index = mem.index()
-                except AttributeError:
-                    index = None
+            for name, index, mem in arc.src.iter_vars(names=True):
                 peer = self.source_dest_peer(arc, name, index)
                 x.append(value(peer))
         x = numpy.array(x)

--- a/pyomo/network/port.py
+++ b/pyomo/network/port.py
@@ -235,14 +235,14 @@ class _PortData(ComponentData):
             fixed: `bool`
                 Only include variables/expressions with this type of fixed
             names: `bool`
-                If True, yield (name, var/expr) pairs
+                If True, yield (name, index, var/expr) tuples
         """
         for name, mem in iteritems(self.vars):
             if not mem.is_indexed():
-                itr = (mem,)
+                itr = {None: mem}
             else:
-                itr = itervalues(mem)
-            for v in itr:
+                itr = mem
+            for idx, v in iteritems(itr):
                 if fixed is not None and v.is_fixed() != fixed:
                     continue
                 if expr_vars and v.is_expression_type():
@@ -250,12 +250,12 @@ class _PortData(ComponentData):
                         if fixed is not None and var.is_fixed() != fixed:
                             continue
                         if names:
-                            yield name, var
+                            yield name, idx, var
                         else:
                             yield var
                 else:
                     if names:
-                        yield name, v
+                        yield name, idx, v
                     else:
                         yield v
 

--- a/pyomo/network/tests/test_decomposition.py
+++ b/pyomo/network/tests/test_decomposition.py
@@ -250,7 +250,9 @@ class TestSequentialDecomposition(unittest.TestCase):
         # Splitter
         m.splitter = Block()
 
-        m.splitter.flow_in = Var(m.comps)
+        @m.splitter.Block(m.comps)
+        def flow_in(b, i):
+            b.flow = Var()
         m.splitter.temperature_in = Var()
         m.splitter.pressure_in = Var()
 
@@ -288,7 +290,7 @@ class TestSequentialDecomposition(unittest.TestCase):
 
         @m.splitter.Port()
         def inlet(b):
-            return dict(flow=b.flow_in,
+            return dict(flow=Reference(b.flow_in[:].flow),
                 temperature=b.temperature_in,
                 pressure=b.pressure_in,
                 expr_idx=b.expr_idx_in,
@@ -314,8 +316,10 @@ class TestSequentialDecomposition(unittest.TestCase):
             recycle = 0.1
             prod = 1 - recycle
             for i in self.flow_in:
-                self.flow_out_side_1[i].value = prod * value(self.flow_in[i])
-                self.flow_out_side_2[i].value = recycle * value(self.flow_in[i])
+                self.flow_out_side_1[i].value \
+                    = prod * value(self.flow_in[i].flow)
+                self.flow_out_side_2[i].value \
+                    = recycle * value(self.flow_in[i].flow)
             for i in self.expr_var_idx_in:
                 self.expr_var_idx_out_side_1[i].value = \
                     prod * value(self.expr_var_idx_in[i])

--- a/pyomo/network/tests/test_port.py
+++ b/pyomo/network/tests/test_port.py
@@ -446,10 +446,10 @@ class TestPort(unittest.TestCase):
 
         v = list(p.iter_vars(expr_vars=True, names=True))
         self.assertEqual(len(v), 10)
-        self.assertEqual(len(v[0]), 2)
+        self.assertEqual(len(v[0]), 3)
         for t in v:
             if t[0] == 'x':
-                self.assertIs(t[1], m.x)
+                self.assertIs(t[2], m.x)
                 break
 
     def test_pprint(self):


### PR DESCRIPTION
## Fixes #974 

## Summary/Motivation:
This fixes a bug in pyomo.network when resolving sorce/destination variables when the variables are defined using references.  The root cause was that `_VarData.index()` returns the index from the point of view of the `_VarData` and not the reference in the Port.

## Changes proposed in this PR:
- Change how ports iterate over members and use the index defined by the indexed component in the Port (potentially a Reference)
- Update one of the decomposition tests to include a Port member defined by a Reference to exercise this functionality.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
