### PR TITLE
Fix the "pyomo install-extras" command

### DIFF
--- a/pyomo/scripting/driver_help.py
+++ b/pyomo/scripting/driver_help.py
@@ -25,48 +25,6 @@ import pyomo.scripting.pyomo_parser
 
 logger = logging.getLogger('pyomo.solvers')
 
-
-#--------------------------------------------------
-# install-extras
-#   -v
-#--------------------------------------------------
-
-def setup_install_extras_parser(parser):
-    parser.add_argument("--pip-args", dest="arg", nargs="*", help="Arguments that are passed to the 'pip' command when installing packages")
-    parser.add_argument("-q", dest="tee", action="store_false", default=True, help="Suppress the default verbose output")
-
-def install_extras_exec(options):
-    cmddir = os.path.dirname(os.path.abspath(sys.executable))+os.sep
-    if options.arg is None:
-        command = [cmddir+'get_pyomo_extras']
-    else:
-        command = [cmddir+'get_pyomo_extras'] + options.arg
-    if not options.tee:
-        command.append('-q')
-    pyutilib.subprocess.run(command, tee=True)
-
-#
-# Add a subparser for the pyomo install-extras subcommand
-#
-setup_install_extras_parser(
-    pyomo.scripting.pyomo_parser.add_subparser('install-extras',
-        func=install_extras_exec,
-        help='Install "extra" packages that Pyomo can leverage.',
-        description="""
-This pyomo subcommand is used to install packages that Pyomo could
-leverage.  The installation of some packages may fail, but this
-subcommand ignore these failures and provides a summary describing
-which packages were installed.
-""",
-        epilog="""
-Since pip options begin with a dash, the --pip-args option can only
-be used with the equals syntax.  For example:\n\n
-    pyomo install-extras --pip-args="--upgrade"
-""",
-        formatter_class=pyomo.scripting.pyomo_parser.CustomHelpFormatter
-        ))
-
-
 #--------------------------------------------------
 # run
 #   --list

--- a/pyomo/scripting/plugins/__init__.py
+++ b/pyomo/scripting/plugins/__init__.py
@@ -14,3 +14,4 @@ def load():
     import pyomo.scripting.plugins.solve
     import pyomo.scripting.plugins.download
     import pyomo.scripting.plugins.build_ext
+    import pyomo.scripting.plugins.extras

--- a/pyomo/scripting/plugins/extras.py
+++ b/pyomo/scripting/plugins/extras.py
@@ -1,0 +1,134 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import logging
+import six
+from pyomo.scripting.pyomo_parser import add_subparser, CustomHelpFormatter
+
+def get_packages():
+    packages = [
+        'sympy', 
+        'xlrd', 
+        'openpyxl', 
+        #('suds-jurko', 'suds'),
+        ('PyYAML', 'yaml'),
+        'pypyodbc', 
+        'pymysql', 
+        #'openopt', 
+        #'FuncDesigner', 
+        #'DerApproximator', 
+        ('ipython[notebook]', 'IPython'),
+        ('pyro4', 'Pyro4'),
+    ]
+    if six.PY2:
+        packages.append(('pyro','Pyro'))
+    return packages
+
+def install_extras(args=[], quiet=False):
+    #
+    # Verify that pip is installed
+    #
+    try:
+        import pip
+        pip_version = pip.__version__.split('.')
+        for i,s in enumerate(pip_version):
+            try:
+                pip_version[i] = int(s)
+            except:
+                pass
+        pip_version = tuple(pip_version)
+    except ImportError:
+        print("You must have 'pip' installed to run this script.")
+        raise SystemExit
+
+    cmd = ['--disable-pip-version-check', 'install','--upgrade']
+    # Disable the PIP download cache
+    if pip_version[0] >= 6:
+        cmd.append('--no-cache-dir')
+    else:
+        cmd.append('--download-cache')
+        cmd.append('')
+
+    if not quiet:
+        print(' ')
+        print('-'*60)
+        print("Installation Output Logs")
+        print("  (A summary will be printed below)")
+        print('-'*60)
+        print(' ')
+
+    results = {}
+    for package in get_packages():
+        if type(package) is tuple:
+            package, pkg_import = package
+        else:
+            pkg_import = package
+        try:
+            # Allow the user to provide extra options
+            #pip.main(cmd + args + [package])
+            print(cmd + args + [package])
+            __import__(pkg_import)
+            results[package] = True
+        except:
+            results[package] = False
+        pip.logger.consumers = []
+
+    if not quiet:
+        print(' ')
+        print(' ')
+    print('-'*60)
+    print("Installation Summary")
+    print('-'*60)
+    print(' ')
+    for package, result in sorted(six.iteritems(results)):
+        if result:
+            print("YES %s" % package)
+        else:
+            print("NO  %s" % package)
+
+
+def pyomo_subcommand(options):
+    return install_extras(options.args, quiet=options.quiet)
+
+
+_parser = add_subparser(
+    'install-extras',
+    func=pyomo_subcommand,
+    help='Install "extra" packages that Pyomo can leverage.',
+    description="""
+This pyomo subcommand uses PIP to install optional third-party Python
+packages that Pyomo could leverage from PyPI.  The installation of some
+packages may fail, but this subcommand ignore these failures and
+provides a summary describing which packages were installed.
+""",
+    epilog="""
+Since pip options begin with a dash, the --pip-args option can only be
+used with the equals syntax.  --pip-args may appear multiple times on
+the command line.  For example:\n\n
+    pyomo install-extras --pip-args="--upgrade"
+""",
+    formatter_class=CustomHelpFormatter,
+)
+
+_parser.add_argument(
+    '-q', '--quiet',
+    action='store_true',
+    dest='quiet',
+    default=False,
+    help="Suppress some terminal output",
+)
+_parser.add_argument(
+    "--pip-args",
+    dest="args",
+    action="append",
+    help=("Arguments that are passed to the 'pip' command when "
+          "installing packages"),
+)
+

--- a/pyomo/scripting/plugins/extras.py
+++ b/pyomo/scripting/plugins/extras.py
@@ -72,8 +72,7 @@ def install_extras(args=[], quiet=False):
             pkg_import = package
         try:
             # Allow the user to provide extra options
-            #pip.main(cmd + args + [package])
-            print(cmd + args + [package])
+            pip.main(cmd + args + [package])
             __import__(pkg_import)
             results[package] = True
         except:

--- a/scripts/get_pyomo_extras.py
+++ b/scripts/get_pyomo_extras.py
@@ -31,5 +31,4 @@ if __name__ == '__main__':
         extras = __import__('extras')
         extras.install_extras()
     except:
-        raise
         print("Error running get-pyomo-extras.py")

--- a/scripts/get_pyomo_extras.py
+++ b/scripts/get_pyomo_extras.py
@@ -11,105 +11,25 @@
 # A script to optionally install packages that Pyomo could leverage.
 #
 
+import inspect
+import os
 import sys
 
-package_list = [
-'sympy', 
-'xlrd', 
-'openpyxl', 
-#'suds-jurko', 
-'PyYAML', 
-'pypyodbc', 
-'pymysql', 
-#'openopt', 
-#'FuncDesigner', 
-#'DerApproximator', 
-'ipython[notebook]', 
-'pyro', 
-'pyro4']
+from os.path import dirname, abspath
 
-packages = {
-'sympy':None, 
-'xlrd':None, 
-'openpyxl':None, 
-#'suds-jurko':'suds', 
-'PyYAML':'yaml', 
-'pypyodbc':None, 
-'pymysql':None, 
-#'openopt':None, 
-#'FuncDesigner':None, 
-#'DerApproximator':None, 
-'ipython[notebook]':'IPython'
-}
-if sys.version_info[0] < 3:
-    packages['pyro'] = 'Pyro'
-else:
-    packages['pyro4'] = 'Pyro4'
-
-def main():
-    #
-    # Verify that pip is installed
-    #
-    import sys
-    try:
-        import pip
-        pip_version = pip.__version__.split('.')
-        for i,s in enumerate(pip_version):
-            try:
-                pip_version[i] = int(s)
-            except:
-                pass
-        pip_version = tuple(pip_version)
-    except ImportError:
-        print("You must have 'pip' installed to run this script.")
-        raise SystemExit
-
-    cmd = ['--disable-pip-version-check', 'install','--upgrade']
-    # Disable the PIP download cache
-    if pip_version[0] >= 6:
-        cmd.append('--no-cache-dir')
-    else:
-        cmd.append('--download-cache')
-        cmd.append('')
-
-    if not '-q' in sys.argv:
-        print(' ')
-        print('-'*60)
-        print("Installation Output Logs")
-        print("  (A summary will be printed below)")
-        print('-'*60)
-        print(' ')
-
-    results = {}
-    for package in package_list:
-        try:
-            # Allow the user to provide extra options
-            pip.main(cmd + sys.argv[1:] + [package])
-            if packages[package]:
-                __import__(packages[package])
-            else:
-                __import__(package)
-            results[package] = True
-        except:
-            results[package] = False
-        pip.logger.consumers = []
-
-    if not '-q' in sys.argv:
-        print(' ')
-        print(' ')
-    print('-'*60)
-    print("Installation Summary")
-    print('-'*60)
-    print(' ')
-    for package in sorted(packages):
-        if results[package]:
-            print("YES %s" % package)
-        else:
-            print("NO  %s" % package)
-
+#
+# THIS SCRIPT IS DEPRECATED.  Please use "pyomo install-extras"
+#
 
 if __name__ == '__main__':
     try:
-        main()
+        callerFrame = inspect.stack()[0]
+        _dir = os.path.join(
+            dirname(dirname(abspath(inspect.getfile(callerFrame[0])))),
+            'pyomo','scripting','plugins')
+        sys.path.insert(0, _dir)
+        extras = __import__('extras')
+        extras.install_extras()
     except:
+        raise
         print("Error running get-pyomo-extras.py")

--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,6 @@ def run_setup():
         OSSolverService = pyomo.scripting.commands:OSSolverService
         pyomo_python = pyomo.scripting.commands:pyomo_python
         pyomo_old=pyomo.scripting.pyomo_command:main
-        get_pyomo_extras = scripts.get_pyomo_extras:main
 
         [pyomo.command]
         pyomo.runbenders=pyomo.pysp.benders


### PR DESCRIPTION
## Fixes #243, Fixes #601, and Fixes #740

## Summary/Motivation:
`pyomo install-extras` has never worked outside of a development installation of Pyomo because the command relied on the `scripts/get_pyomo_extras.py` file that did not reside within the pyomo package (and thus was not distributed).  This moves the logic into `pyomo/scripting/plugins/extras.py` so that the subcommand works.  It also cleans out `scripts/get_pyomo_extras.py` so that it loads / calls `pyomo/scripting/plugins/extras.py`.  Finally, it removes the `get_pyomo_extras` console script (this script was not documented anywhere)

This does not address #435 (deprecate `pyomo install-extras`)

## Changes proposed in this PR:
- Move logic for `pyomo install-extras` into the pyomo module
- Remove the `get_pyomo_extras` console script

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
