### PR TITLE
Restrict the auto-build of PyomoGallery to only master branch builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,8 +103,8 @@ after_success:
   - ${DOC} find . -maxdepth 10 -name ".cov*"
   - ${DOC} coverage combine
   - ${DOC} codecov --env TAG -X gcov
-    # Trigger PyomoGallery build
-  - "if [ -n \"${KEY_JOB}\" ]; then curl -s -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -H 'Travis-API-Version: 3' -H 'Authorization: token 4DadIB521uUPyBXMtvQVOw' -d '{\"request\": {\"branch\": \"master\"}}' https://api.travis-ci.org/repo/Pyomo%2FPyomoGallery/requests; fi"
+    # Trigger PyomoGallery build, but only when building the master branch
+  - "if [ -n \"${KEY_JOB}\" -a \"${TRAVIS_PULL_REQUEST}\" == false ]; then curl -s -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -H 'Travis-API-Version: 3' -H 'Authorization: token 4DadIB521uUPyBXMtvQVOw' -d '{\"request\": {\"branch\": \"master\"}}' https://api.travis-ci.org/repo/Pyomo%2FPyomoGallery/requests; fi"
 
 deploy:
   - provider: pypi


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
Travis was causing the PyomoGallery Travis build to fire for every Pyomo PR, even though the PyomoGallery build only builds against Pyomo master.  This restricts the trigger for only firing when Travis is building the master branch (and not PRs).

## Changes proposed in this PR:
- Do not trigger PyomoGallery builds after Pyomo PR builds

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
