### PR TITLE
Fix `pyomo install-extras` for old versions of pip

### DIFF
--- a/pyomo/scripting/plugins/extras.py
+++ b/pyomo/scripting/plugins/extras.py
@@ -8,7 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import logging
 import six
 from pyomo.scripting.pyomo_parser import add_subparser, CustomHelpFormatter
 
@@ -77,7 +76,11 @@ def install_extras(args=[], quiet=False):
             results[package] = True
         except:
             results[package] = False
-        pip.logger.consumers = []
+        try:
+            pip.logger.consumers = []
+        except AttributeError:
+            # old pip versions (prior to 6.0~104^2)
+            pip.log.consumers = []
 
     if not quiet:
         print(' ')


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
This fixes a compatibility issue with old versions of PIP that we were encountering on some build servers when running `pyomo install-extras`

## Changes proposed in this PR:
-Fall back to the old pip log location if the current one raises an exception

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
