### PR TITLE
Replace domain comparison by type(domain) comparison

### DIFF
--- a/pyomo/core/plugins/transform/discrete_vars.py
+++ b/pyomo/core/plugins/transform/discrete_vars.py
@@ -95,26 +95,29 @@ class RelaxDiscreteVars(Transformation):
 #
 # This transformation fixes known discrete domains to their current values
 #
-@TransformationFactory.register('core.fix_discrete', 
-           doc="Fix known discrete domains to continuous counterparts" )
+@TransformationFactory.register('core.fix_discrete',
+           doc="Fix known discrete domains to continuous counterparts")
 class FixDiscreteVars(Transformation):
 
     def __init__(self):
         super(FixDiscreteVars, self).__init__()
 
-    def _apply_to(self, model, **kwds): 
+    def _apply_to(self, model, **kwds):
         options = kwds.pop('options', {})
         if kwds.get('undo', options.get('undo', False)):
             for v in model._fixed_discrete_vars[None]:
                 v.unfix()
             model.del_component("_fixed_discrete_vars")
             return
-        
+
         fixed_vars = []
         _base_model_vars = model.component_data_objects(
-            Var, active=True, descend_into=True )
+            Var, active=True, descend_into=True)
         for var in _base_model_vars:
-            if any(type(var.domain) is type(domain) for domain in _discrete_relaxation_map) and not var.is_fixed():
+            # Instead of checking against `_discrete_relaxation_map.keys()` 
+            # we just check the item properties to fix #995 
+            # When #326 has been resolved, we can check against the dict-keys again
+            if not var.is_continuous() and not var.is_fixed():
                 fixed_vars.append(var)
                 var.fix()
         model._fixed_discrete_vars = Suffix(direction=Suffix.LOCAL)

--- a/pyomo/core/plugins/transform/discrete_vars.py
+++ b/pyomo/core/plugins/transform/discrete_vars.py
@@ -114,7 +114,7 @@ class FixDiscreteVars(Transformation):
         _base_model_vars = model.component_data_objects(
             Var, active=True, descend_into=True )
         for var in _base_model_vars:
-            if var.domain in _discrete_relaxation_map and not var.is_fixed():
+            if any(type(var.domain) is type(domain) for domain in _discrete_relaxation_map) and not var.is_fixed():
                 fixed_vars.append(var)
                 var.fix()
         model._fixed_discrete_vars = Suffix(direction=Suffix.LOCAL)

--- a/pyomo/core/tests/transform/test_transform.py
+++ b/pyomo/core/tests/transform/test_transform.py
@@ -167,6 +167,23 @@ class Test(unittest.TestCase):
         self.assertEqual(rinst.e.bounds, instance_cloned.e.bounds)
         self.assertEqual(rinst.f.bounds, instance_cloned.f.bounds)
 
+    def test_relax_integrality(self):
+        # Coverage of the _clear_attribute method
+        self.model.d = Var(within=Integers, bounds=(-2,3))
+        instance=self.model.create_instance()
+        instance_cloned = instance.clone()
+        xfrm = TransformationFactory('core.relax_integrality')
+        rinst = xfrm.create_using(instance_cloned)
+        self.assertEqual(type(rinst.d.domain), RealSet)
+
+    def test_relax_integrality_simple_cloned(self):
+        self.model.x = Var(within=Integers, bounds=(-2,3))
+        instance = self.model.create_instance()
+        instance_cloned = instance.clone()
+        xfrm = TransformationFactory('core.relax_discrete')
+        rinst = xfrm.create_using(instance_cloned)
+        self.assertNotEqual(type(rinst.x.domain), RealSet)
+
     def test_nonnegativity_transformation_1(self):
         self.model.a = Var()
         self.model.b = Var(within=NonNegativeIntegers)

--- a/pyomo/core/tests/transform/test_transform.py
+++ b/pyomo/core/tests/transform/test_transform.py
@@ -52,6 +52,45 @@ class Test(unittest.TestCase):
         model = AbstractModel()
         self.assertTrue(set(TransformationFactory) >= set(['core.relax_integrality']))
 
+    def test_fix_discrete(self):
+        # Coverage of the _clear_attribute method
+        self.model.A = RangeSet(1,4)
+        self.model.a = Var()
+        self.model.b = Var(within=self.model.A)
+        self.model.c = Var(within=NonNegativeIntegers)
+        self.model.d = Var(within=Integers, bounds=(-2,3))
+        self.model.e = Var(within=Boolean)
+        self.model.f = Var(domain=Boolean)
+        instance=self.model.create_instance()
+        xfrm = TransformationFactory('core.fix_discrete')
+        rinst = xfrm.create_using(instance)
+        self.assertFalse(rinst.a.is_fixed())
+        self.assertTrue(rinst.b.is_fixed())
+        self.assertTrue(rinst.c.is_fixed())
+        self.assertTrue(rinst.d.is_fixed())
+        self.assertTrue(rinst.e.is_fixed())
+        self.assertTrue(rinst.f.is_fixed())
+
+    def test_fix_discrete_clone(self):
+        # Coverage of the _clear_attribute method
+        self.model.A = RangeSet(1,4)
+        self.model.a = Var()
+        self.model.b = Var(within=self.model.A)
+        self.model.c = Var(within=NonNegativeIntegers)
+        self.model.d = Var(within=Integers, bounds=(-2,3))
+        self.model.e = Var(within=Boolean)
+        self.model.f = Var(domain=Boolean)
+        instance=self.model.create_instance()
+        instance_clone = instance.clone()
+        xfrm = TransformationFactory('core.fix_discrete')
+        rinst = xfrm.create_using(instance_clone)
+        self.assertFalse(rinst.a.is_fixed())
+        self.assertTrue(rinst.b.is_fixed())
+        self.assertTrue(rinst.c.is_fixed())
+        self.assertTrue(rinst.d.is_fixed())
+        self.assertTrue(rinst.e.is_fixed())
+        self.assertTrue(rinst.f.is_fixed())
+
     def test_relax_integrality1(self):
         # Coverage of the _clear_attribute method
         self.model.A = RangeSet(1,4)
@@ -101,6 +140,32 @@ class Test(unittest.TestCase):
         self.assertEqual(rinst.d[1].bounds, instance.d[1].bounds)
         self.assertEqual(rinst.e[1].bounds, instance.e[1].bounds)
         self.assertEqual(rinst.f[1].bounds, instance.f[1].bounds)
+
+    def test_relax_integrality_cloned(self):
+        # Coverage of the _clear_attribute method
+        self.model.A = RangeSet(1,4)
+        self.model.a = Var()
+        self.model.b = Var(within=self.model.A)
+        self.model.c = Var(within=NonNegativeIntegers)
+        self.model.d = Var(within=Integers, bounds=(-2,3))
+        self.model.e = Var(within=Boolean)
+        self.model.f = Var(domain=Boolean)
+        instance=self.model.create_instance()
+        instance_cloned = instance.clone()
+        xfrm = TransformationFactory('core.relax_integrality')
+        rinst = xfrm.create_using(instance_cloned)
+        self.assertEqual(type(rinst.a.domain), RealSet)
+        self.assertEqual(type(rinst.b.domain), RealSet)
+        self.assertEqual(type(rinst.c.domain), RealSet)
+        self.assertEqual(type(rinst.d.domain), RealSet)
+        self.assertEqual(type(rinst.e.domain), RealSet)
+        self.assertEqual(type(rinst.f.domain), RealSet)
+        self.assertEqual(rinst.a.bounds, instance_cloned.a.bounds)
+        self.assertEqual(rinst.b.bounds, instance_cloned.b.bounds)
+        self.assertEqual(rinst.c.bounds, instance_cloned.c.bounds)
+        self.assertEqual(rinst.d.bounds, instance_cloned.d.bounds)
+        self.assertEqual(rinst.e.bounds, instance_cloned.e.bounds)
+        self.assertEqual(rinst.f.bounds, instance_cloned.f.bounds)
 
     def test_nonnegativity_transformation_1(self):
         self.model.a = Var()


### PR DESCRIPTION
Fixes #995
Note that this bug is blocking development for #983

## Fixes #995

## Summary/Motivation
Variables of a cloned models don't get fixed by the Transformation (due to an ID copy issue). See the assigned issue for more information.

## Changes proposed in this PR:
- change `domain` comparison to `type(domain)` comparison

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
