### PR TITLE
Fix bug looking up a IndexedComponent member using a nonhashable object.

### DIFF
--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -322,7 +322,7 @@ You can silence this warning by one of three ways:
             if new_index.__class__ is _IndexedComponent_slice:
                 return new_index
             # The index could have contained constant but nonhashable
-            # objects (e.g., scalae immutable Params).
+            # objects (e.g., scalar immutable Params).
             # _processUnhashableIndex will evaluate those constants, so
             # if it made any changes to the index, we need to re-check
             # the _data dict for menbership.

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -318,17 +318,18 @@ You can silence this warning by one of three ways:
         try:
             obj = self._data.get(index, _NotFound)
         except TypeError:
-            new_index = self._processUnhashableIndex(index)
-            if new_index.__class__ is _IndexedComponent_slice:
-                return new_index
+            index = self._processUnhashableIndex(index)
+            if index.__class__ is _IndexedComponent_slice:
+                return index
             # The index could have contained constant but nonhashable
             # objects (e.g., scalar immutable Params).
             # _processUnhashableIndex will evaluate those constants, so
             # if it made any changes to the index, we need to re-check
             # the _data dict for membership.
-            if new_index is not index:
-                index = new_index
+            try:
                 obj = self._data.get(index, _NotFound)
+            except TypeError:
+                obj = _NotFound
 
         if obj is _NotFound:
             # Not good: we have to defer this import to now

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -325,7 +325,7 @@ You can silence this warning by one of three ways:
             # objects (e.g., scalar immutable Params).
             # _processUnhashableIndex will evaluate those constants, so
             # if it made any changes to the index, we need to re-check
-            # the _data dict for menbership.
+            # the _data dict for membership.
             if new_index is not index:
                 index = new_index
                 obj = self._data.get(index, _NotFound)

--- a/pyomo/core/tests/unit/test_indexed.py
+++ b/pyomo/core/tests/unit/test_indexed.py
@@ -100,6 +100,7 @@ class TestIndexedComponent(unittest.TestCase):
         m.x = Var([1,2,3], initialize=lambda m,x: 2*x)
         self.assertEqual(m.x[2], 4)
         self.assertEqual(m.x[m.i], 4)
+        self.assertIs(m.x[2], m.x[m.i])
 
     def test_index_by_multiple_constant_simpleComponent(self):
         m = ConcreteModel()
@@ -110,6 +111,9 @@ class TestIndexedComponent(unittest.TestCase):
         self.assertEqual(m.x[m.i,3], 12)
         self.assertEqual(m.x[m.i,m.j], 12)
         self.assertEqual(m.x[2,m.j], 12)
+        self.assertIs(m.x[2,3], m.x[m.i,3])
+        self.assertIs(m.x[2,3], m.x[m.i,m.j])
+        self.assertIs(m.x[2,3], m.x[2,m.j])
 
     def test_index_by_fixed_simpleComponent(self):
         m = ConcreteModel()


### PR DESCRIPTION
## Fixes #1003

## Summary/Motivation:
This fixes a bug where looking up a IndexedComponent member (i.e., with __getitem__) using an index that contains an unhashable object (like an immutable scalar Param) would return a new ComponentData and overwrite the original one. 

## Changes proposed in this PR:
- Fix for `IndexedComponent.__getitem__`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
