### PR TITLE
Adding a license check for Mosek for solver tests

### DIFF
--- a/pyomo/opt/base/solvers.py
+++ b/pyomo/opt/base/solvers.py
@@ -192,6 +192,7 @@ SolverFactory = SolverFactoryClass('solver type')
 def check_available_solvers(*args):
     from pyomo.solvers.plugins.solvers.GUROBI import GUROBISHELL
     from pyomo.solvers.plugins.solvers.BARON import BARONSHELL
+    from pyomo.solvers.plugins.solvers.mosek_direct import MosekDirect
 
     logging.disable(logging.WARNING)
 
@@ -210,6 +211,9 @@ def check_available_solvers(*args):
             available = False
         elif (arg[0] == "baron") and \
            (not BARONSHELL.license_is_valid()):
+            available = False
+        elif (arg[0] == "mosek") and \
+           (not MosekDirect.license_is_valid()):
             available = False
         else:
             available = \

--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -95,6 +95,22 @@ class MosekDirect(DirectSolver):
         self._capabilities.sos1 = False
         self._capabilities.sos2 = False
 
+    @staticmethod
+    def license_is_valid():
+        """
+        Runs a check for a valid Mosek license. Returns False
+        if Mosek fails to run on a trivial test case.
+        """
+        try:
+            import mosek
+        except ImportError:
+            return False
+        try:
+            mosek.Env().Task(0,0).optimize()
+        except mosek.Error:
+            return False
+        return True
+
     def _apply_solver(self):
         if not self._save_results:
             for block in self._pyomo_model.block_data_objects(descend_into=True,

--- a/pyomo/solvers/tests/solvers.py
+++ b/pyomo/solvers/tests/solvers.py
@@ -21,7 +21,7 @@ from pyomo.opt.base.solvers import UnknownSolver
 import pyomo.environ
 from pyomo.solvers.plugins.solvers.GUROBI import GUROBISHELL
 from pyomo.solvers.plugins.solvers.BARON import BARONSHELL
-
+from pyomo.solvers.plugins.solvers.mosek_direct import MosekDirect
 
 # ----------------------------------------------------------------
 
@@ -51,6 +51,9 @@ def initialize(**kwds):
         obj.available = False
     elif (obj.name == "baron") and \
        (not BARONSHELL.license_is_valid()):
+        obj.available = False
+    elif (obj.name == "mosek") and \
+       (not MosekDirect.license_is_valid()):
         obj.available = False
     else:
         obj.available = \


### PR DESCRIPTION
This adds a `license_is_valid` method to the MosekDirect solver plugin. It also updates the general set of solver tests so that tests using Mosek will be skipped unless a valid license is present. Fixes #1005.


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
