### PR TITLE
Fix compilation with Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ if using_cython:
             "pyomo/core/expr/numvalue.pyx",
             "pyomo/core/expr/numeric_expr.pyx",
             "pyomo/core/expr/logical_expr.pyx",
+            #"pyomo/core/expr/visitor.pyx",
             "pyomo/core/util.pyx",
             "pyomo/repn/standard_repn.pyx",
             "pyomo/repn/plugins/cpxlp.pyx",

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,8 @@ if using_cython:
         ]
         for f in files:
             shutil.copyfile(f[:-1], f)
-        ext_modules = cythonize(files)
+        ext_modules = cythonize(files, compiler_directives={
+            "language_level": 3 if sys.version_info >= (3, ) else 2})
     except:
         if using_cython == CYTHON_REQUIRED:
             print("""

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,6 @@ if using_cython:
             "pyomo/core/expr/numvalue.pyx",
             "pyomo/core/expr/numeric_expr.pyx",
             "pyomo/core/expr/logical_expr.pyx",
-            "pyomo/core/expr/visitor_expr.pyx",
             "pyomo/core/util.pyx",
             "pyomo/repn/standard_repn.pyx",
             "pyomo/repn/plugins/cpxlp.pyx",


### PR DESCRIPTION
## Fixes 
#1008 

## Summary/Motivation:
This re-enabled Cython compilation using latest master. But also the latest PyPI version is broken.

## Changes proposed in this PR:
- Remove the file-to-Cythonize that does not exist.
- Silence warnings about language version.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
