### PR TITLE
Add read-only view of kernel matrix_constraint.A

### DIFF
--- a/pyomo/core/kernel/matrix_constraint.py
+++ b/pyomo/core/kernel/matrix_constraint.py
@@ -278,11 +278,15 @@ class matrix_constraint(constraint_tuple):
             self._A = scipy.sparse.csr_matrix(A,
                                               dtype=float,
                                               copy=True)
+            self._A.data.setflags(write=False)
+            self._A.indices.setflags(write=False)
+            self._A.indptr.setflags(write=False)
         else:
             self._sparse = False
             self._A = numpy.array(A,
                                   dtype=float,
                                   copy=True)
+            self._A.setflags(write=False)
         self._lb = numpy.ndarray(m, dtype=float)
         self._ub = numpy.ndarray(m, dtype=float)
         self._equality = numpy.ndarray(m, dtype=bool)
@@ -307,6 +311,15 @@ class matrix_constraint(constraint_tuple):
         """Boolean indicating whether or not the underlying
         matrix uses sparse storage"""
         return self._sparse
+
+    @property
+    def A(self):
+        """A read-only view of the constraint matrix"""
+        if self._sparse:
+            return scipy.sparse.csr_matrix(self._A,
+                                           copy=False)
+        else:
+            return self._A.view()
 
     @property
     def x(self):

--- a/pyomo/core/tests/unit/kernel/test_matrix_constraint.py
+++ b/pyomo/core/tests/unit/kernel/test_matrix_constraint.py
@@ -247,6 +247,37 @@ class Test_matrix_constraint(unittest.TestCase):
         for i, c in enumerate(ctuple):
             self.assertEqual(c.index, i)
 
+    def test_A(self):
+        A = numpy.ones((4,5))
+
+        # sparse
+        c = matrix_constraint(A)
+        self.assertEqual(c.A.shape, A.shape)
+        self.assertTrue((c.A == A).all())
+        self.assertEqual(c.sparse, True)
+        with self.assertRaises(ValueError):
+            c.A.data[0] = 2
+        with self.assertRaises(ValueError):
+            c.A.indices[0] = 2
+        with self.assertRaises(ValueError):
+            c.A.indptr[0] = 2
+        cA = c.A
+        cA.shape = (5,4)
+        # the shape of c.A should not be changed
+        self.assertEqual(c.A.shape, (4,5))
+
+        # dense
+        c = matrix_constraint(A, sparse=False)
+        self.assertEqual(c.A.shape, A.shape)
+        self.assertTrue((c.A == A).all())
+        self.assertEqual(c.sparse, False)
+        with self.assertRaises(ValueError):
+            c.A[0,0] = 2
+        cA = c.A
+        cA.shape = (5,4)
+        # the shape of c.A should not be changed
+        self.assertEqual(c.A.shape, (4,5))
+
     def test_x(self):
         A = numpy.ones((4,5))
         ctuple = matrix_constraint(A)


### PR DESCRIPTION
Adds an `A` property method to kernel matrix constraint, along with unit tests.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
