### PR TITLE
Adding a Travis job to test Cython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ env:
   - DOCKERENV="-e TAG -e COVERAGE_PROCESS_START -e PYOMO_CONFIG_DIR"
   matrix:
   - TAG=python_3.7    CATEGORY="nightly"
+  - TAG=python_3.7    CATEGORY="nightly" SLIM=1
+  - TAG=python_3.7    CATEGORY="smoke"   SETUP_OPTIONS="--with-cython"
   - TAG=python_3.6    CATEGORY="nightly"
-  - TAG=python_3.6    CATEGORY="nightly" SLIM=1
   - TAG=python_3.5    CATEGORY="nightly"
   - TAG=python_2.7    CATEGORY="nightly" KEY_JOB=1
   - TAG=pypy_3        CATEGORY="nightly" DISABLE_COVERAGE=1
@@ -71,7 +72,7 @@ install:
     # Install PyUtilib (master branch)
   - ${DOC} pip install --quiet git+https://github.com/PyUtilib/pyutilib
     # Install this package
-  - ${DOC} python setup.py develop
+  - ${DOC} python setup.py develop ${SETUP_OPTIONS}
     # Finish setting up coverage tracking for subprocesses
   - DOCKER_SITE_PACKAGES=`${DOC} python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`
   - |


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
This adds an additional Travis build to test the cythonization (on Linux).  It also moves the SLIM build from 3.6 to 3.7 (with the logic that 3.7 is the new standard production python version)

## Changes proposed in this PR:
- Add a `--with-cython` build
- Move the SLIM build from python3.6 to python3.7

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
