### PR TITLE
Skipping kernel test for old scipy versions

### DIFF
--- a/pyomo/core/tests/unit/kernel/test_matrix_constraint.py
+++ b/pyomo/core/tests/unit/kernel/test_matrix_constraint.py
@@ -42,8 +42,10 @@ except:
 try:
     import scipy
     has_scipy = True
+    _scipy_ver = tuple(int(_) for _ in scipy.version.version.split('.')[:2])
 except:
     has_scipy = False
+    _scipy_ver = (0,0)
 
 def _create_variable_list(size, **kwds):
     assert size > 0
@@ -247,9 +249,8 @@ class Test_matrix_constraint(unittest.TestCase):
         for i, c in enumerate(ctuple):
             self.assertEqual(c.index, i)
 
-    @unittest.skipIf(
-        tuple(int(_) for _ in scipy.version.version.split('.')[:2]) < (1,1),
-        "csr_matrix.reshape only available in scipy >= 1.1")
+    @unittest.skipIf(_scipy_ver < (1,1),
+                     "csr_matrix.reshape only available in scipy >= 1.1")
     def test_A(self):
         A = numpy.ones((4,5))
 

--- a/pyomo/core/tests/unit/kernel/test_matrix_constraint.py
+++ b/pyomo/core/tests/unit/kernel/test_matrix_constraint.py
@@ -247,6 +247,9 @@ class Test_matrix_constraint(unittest.TestCase):
         for i, c in enumerate(ctuple):
             self.assertEqual(c.index, i)
 
+    @unittest.skipIf(
+        tuple(int(_) for _ in scipy.version.version.split('.')[:2]) < (1,1),
+        "csr_matrix.reshape only available in scipy >= 1.1")
     def test_A(self):
         A = numpy.ones((4,5))
 


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
This fixes a test failure that crept in with #1011 on platforms with old versions of scipy.

## Changes proposed in this PR:
- Skip a rest requiring `csr_matrix.reshape` when scipy < 1.1

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
