### PR TITLE
Change the default use_signal_handling from True to None

### DIFF
--- a/pyomo/opt/solver/shellcmd.py
+++ b/pyomo/opt/solver/shellcmd.py
@@ -46,7 +46,7 @@ class SystemCallSolver(OptSolver):
         # broadly useful for reporting, and in cases where
         # a solver plugin may not report execution time.
         self._last_solve_time = None
-        self._define_signal_handlers = True
+        self._define_signal_handlers = None
 
         if executable is not None:
             self.set_executable(name=executable, validate=validate)
@@ -193,7 +193,7 @@ class SystemCallSolver(OptSolver):
         TempfileManager.push()
 
         self._keepfiles = kwds.pop("keepfiles", False)
-        self._define_signal_handlers = kwds.pop('use_signal_handling',True)
+        self._define_signal_handlers = kwds.pop('use_signal_handling',None)
 
         OptSolver._presolve(self, *args, **kwds)
 


### PR DESCRIPTION
## Fixes #1010 

## Summary/Motivation:
This changes the default value of `use_signal_handling` for the system call solver's `solve()` to defer to the PyUtilib global `DEFINE_SIGNAL_HANDLERS_DEFAULT` value.

As was pointed out in #1010, the propagation of the signal handling control into Pyomo by #856 was somewhat fragile.  The current implementation explicitly overrides the pyutilib default to always enable signal handling unless the caller explicitly provides that argument, so setting `DEFINE_SIGNAL_HANDLERS_DEFAULT=False` is insufficient to disable signal handling across all of Pyomo.  Pyomo also launches many subprocesses, often without the direct request of the driving script / application (e.g., to check solver availability), so just providing `use_signal_handling=False` was insufficient to disable all signal handling.  In fact, some system calls happen "in the background" long before the user calls `solve()`, and in a way that is almost impossible for a user to intervene and to override if the signal handlers are set up.  This PR changes the implementation of the Pyomo `use_signal_handling` argument so that instead of defaulting to True, it will default to None, thereby allowing `pyutilib.subprocess` defer to the `DEFINE_SIGNAL_HANDLERS_DEFAULT` value.

This patch does not affect the use / fragility of the `use_signal_handling` flag in Pyomo (the flag is still there and will still behave the same way if set).

I would recommend users that want to disable all signal handling only set:
```
pyutilib.subprocess.GlobalData.DEFINE_SIGNAL_HANDLERS_DEFAULT = False
```


## Changes proposed in this PR:
- Change the default value for `use_signal_handling` to None so that pyutilib will pick up the global default unless a user explicitly sets the `use_signal_handling` argument to `solve()`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
