### PR TITLE
MC++ variable bound guards

### DIFF
--- a/pyomo/contrib/mcpp/pyomo_mcpp.py
+++ b/pyomo/contrib/mcpp/pyomo_mcpp.py
@@ -320,6 +320,11 @@ class MCPP_visitor(StreamBasedExpressionVisitor):
         """Registers a new variable."""
         var_idx = self.var_to_idx[var]
         inf = float('inf')
+
+        # Guard against errant None values in lb and ub
+        lb = -inf if lb is None else lb
+        ub = inf if ub is None else ub
+
         lb = max(var.lb if var.has_lb() else -inf, lb)
         ub = min(var.ub if var.has_ub() else inf, ub)
         var_val = value(var, exception=False)


### PR DESCRIPTION
## Summary/Motivation:
Small change: adds a couple of lines to the MC++ variable declaration to guard against `None` values in the bounds.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
