### PR TITLE
Adding _associativity() to _ExpressionData

### DIFF
--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -80,6 +80,9 @@ class _ExpressionData(NumericValue):
     def _precedence(self):
         return 0
 
+    def _associativity(self):
+        return 0
+
     def _to_string(self, values, verbose, smap, compute_values):
         if verbose:
             return "%s{%s}" % (str(self), values[0])

--- a/pyomo/core/tests/unit/kernel/test_expression.py
+++ b/pyomo/core/tests/unit/kernel/test_expression.py
@@ -99,6 +99,10 @@ class Test_noclone(unittest.TestCase):
         # tests compatibility with _ToStringVisitor
         pyomo.kernel.pprint(noclone(v)+1)
         pyomo.kernel.pprint(noclone(v+1))
+        x = variable()
+        y = variable()
+        pyomo.kernel.pprint(y + x*noclone(noclone(x*y)))
+        pyomo.kernel.pprint(y + noclone(noclone(x*y))*x)
 
     def test_pickle(self):
         v = variable()
@@ -550,6 +554,12 @@ class Test_expression(_Test_expression_base,
                       unittest.TestCase):
     _ctype_factory = expression
 
+    def test_associativity(self):
+        x = variable()
+        y = variable()
+        pyomo.kernel.pprint(y + x*expression(expression(x*y)))
+        pyomo.kernel.pprint(y + expression(expression(x*y))*x)
+
     def test_ctype(self):
         e = expression()
         self.assertIs(e.ctype, IExpression)
@@ -612,6 +622,14 @@ class Test_data_expression(_Test_expression_base,
                            unittest.TestCase):
 
     _ctype_factory = data_expression
+
+    def test_associativity(self):
+        x = parameter()
+        y = parameter()
+        pyomo.kernel.pprint(
+            y + x*data_expression(data_expression(x*y)))
+        pyomo.kernel.pprint(
+            y + data_expression(data_expression(x*y))*x)
 
     def test_ctype(self):
         e = data_expression()

--- a/pyomo/core/tests/unit/test_visitor.py
+++ b/pyomo/core/tests/unit/test_visitor.py
@@ -398,10 +398,11 @@ class WalkerTests(unittest.TestCase):
         m.x = Var()
         m.y = Var()
         m.e = Expression(expr=m.x*m.y)
+        m.f = Expression(expr=m.e)
 
-        e = m.x + m.e*m.y
-        self.assertEqual("x + (x*y)*y", str(e))
-        self.assertEqual("x + (x*y)*y", expression_to_string(e))
+        e = m.x + m.f*m.y
+        self.assertEqual("x + ((x*y))*y", str(e))
+        self.assertEqual("x + ((x*y))*y", expression_to_string(e))
 #
 # Replace all variables with a product expression
 #

--- a/pyomo/core/tests/unit/test_visitor.py
+++ b/pyomo/core/tests/unit/test_visitor.py
@@ -393,6 +393,15 @@ class WalkerTests(unittest.TestCase):
         M.w.fixed = True
         self.assertEqual("sin(x) + x*2 + 3", expression_to_string(e, compute_values=True))
 
+    def test_expression_component_to_string(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var()
+        m.e = Expression(expr=m.x*m.y)
+
+        e = m.x + m.e*m.y
+        self.assertEqual("x + (x*y)*y", str(e))
+        self.assertEqual("x + (x*y)*y", expression_to_string(e))
 #
 # Replace all variables with a product expression
 #


### PR DESCRIPTION
## Fixes #1029 

## Summary/Motivation:
PR #966 added the `_associativity()` method to the Expression API. _ExpressionData duck-types the Expression API (instead of inheriting it).  This propagates that API change to _ExpressionData.

## Changes proposed in this PR:
- Declare _ExpressionData._associativity()

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
