### PR TITLE
Resolve Book test failures

### DIFF
--- a/examples/doc/pyomobook/gdp-ch/verify_scont.py
+++ b/examples/doc/pyomobook/gdp-ch/verify_scont.py
@@ -7,7 +7,10 @@ def verify(obj, x, iv):
         assert iv[i,0] == (0 if x[i] else 1)
         assert iv[i,1] == (1 if x[i] else 0)
         assert sum(x.values()) >= 7
-    print("%s: OK: result validated" % (os.path.basename(__file__),))
+    fname = os.path.basename(__file__)
+    if fname.endswith('.pyc'):
+        fname = fname[:-1]
+    print("%s: OK: result validated" % (fname,))
 
 def verify_file(fname):
     import yaml

--- a/examples/doc/pyomobook/python-ch/pyomodivide.py2.txt
+++ b/examples/doc/pyomobook/python-ch/pyomodivide.py2.txt
@@ -12,11 +12,11 @@
 1 Objective Declarations
     MyObjective : Size=1, Index=None, Active=True
         Key  : Active : Sense    : Expression
-        None :   True : maximize : 4 * aVar
+        None :   True : maximize :     4*aVar
 
 1 Constraint Declarations
     MyConstraint : Size=1, Index=None, Active=True
-        Key  : Lower : Body        : Upper : Active
-        None :  -Inf : 0.25 * aVar :   0.8 :   True
+        Key  : Lower : Body      : Upper : Active
+        None :  -Inf : 0.25*aVar :   0.8 :   True
 
 5 Declarations: pParm wParm aVar MyConstraint MyObjective

--- a/examples/doc/pyomobook/test_book_examples.py
+++ b/examples/doc/pyomobook/test_book_examples.py
@@ -123,6 +123,20 @@ def check_skip(tfname_, name):
                     'are' if len(_missing) > 1 else 'is',)
     return False
 
+_DEPRECATION_MESSAGES = """
+WARNING: DEPRECATED: Chained inequalities are deprecated. Use the inequality()
+    function to express ranged inequality expressions.
+WARNING: DEPRECATED: Use of the pyomo.bilevel package is deprecated. There are
+    known bugs in pyomo.bilevel, and we do not recommend the use of this code.
+    Development of bilevel optimization capabilities has been shifted to the
+    Pyomo Adversarial Optimization (PAO) library. Please contact William Hart
+    for further details (wehart@sandia.gov). (deprecated in 5.6.2)
+WARNING: DEPRECATED: Use of the pyomo.duality package is deprecated. There are
+    known bugs in pyomo.duality, and we do not recommend the use of this code.
+    Development of dualization capabilities has been shifted to the Pyomo
+    Adversarial Optimization (PAO) library. Please contact William Hart for
+    further details (wehart@sandia.gov).  (deprecated in 5.6.2)
+""".strip()
 
 def filter(line):
     # Ignore certain text when comparing output with baseline
@@ -138,7 +152,7 @@ def filter(line):
                    'Job ',
                    'Importing module',
                    'Function',
-                   'File',):
+                   'File', ):
         if line.startswith(field):
             return True
     for field in ( 'Total CPU',
@@ -152,6 +166,10 @@ def filter(line):
                    'execution time=',
                    'Solver results file:' ):
         if field in line:
+            return True
+    for field in _DEPRECATION_MESSAGES.splitlines():
+        strip_field = field.strip()
+        if strip_field and strip_field in line:
             return True
     return False
 


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
We have been carrying several test failures in our Book regression test suite (dating back to Pyomo5 expressions).  This PR resolves those test failures.  All Book examples still run!

## Changes proposed in this PR:
- Update the test driver to ignore deprecation warnings in the diffs
- Update one test baseline due to white space changes in the pprint output (pprint does not appear in the Book)
- Update a test verifier to account for differences in recent Python 2 / 3 versions.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
