### PR TITLE
add formatting to docstring so newlines are preserved when needed

### DIFF
--- a/pyomo/pysp/util/rapper.py
+++ b/pyomo/pysp/util/rapper.py
@@ -77,9 +77,9 @@ class StochSolver:
       fsfile (str): is a path to the file that contains the scenario 
                     callback for concrete or the reference model for abstract.
       fsfct (str, or fct, or None): 
-         str   callback function name in the file
-         fct   callback function
-         None  it is a AbstractModel
+         |  str:   callback function name in the file
+         |  fct:   callback function (fsfile is ignored)
+         |  None:  it is a AbstractModel
       tree_model (concrete model, or networkx tree, or path): 
         gives the tree as a concrete model (which could be a fct)
         or a valid networkx scenario tree


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
The docstring for the constructor was confusing when rendered by Sphinx because lines were merged.

## Changes proposed in this PR:
- add some | in key places in the docstring for the constructor.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
