### PR TITLE
Fixing symbolic labels for BARON and GAMS

### DIFF
--- a/pyomo/core/base/label.py
+++ b/pyomo/core/base/label.py
@@ -12,6 +12,7 @@ __all__ = ['CounterLabeler', 'NumericLabeler', 'CNameLabeler', 'TextLabeler',
            'AlphaNumericTextLabeler','NameLabeler', 'CuidLabeler',
            'ShortNameLabeler']
 
+import re
 import six
 if six.PY3:
     _translate = str.translate
@@ -154,7 +155,7 @@ class NameLabeler(object):
 
 class ShortNameLabeler(object):
     def __init__(self, limit, suffix, start=0, labeler=None,
-                 prefix="", caseInsensitive=False):
+                 prefix="", caseInsensitive=False, legalRegex=None):
         self.id = start
         self.prefix = prefix
         self.suffix = suffix
@@ -164,6 +165,10 @@ class ShortNameLabeler(object):
         else:
             self.labeler = AlphaNumericTextLabeler()
         self.known_labels = set() if caseInsensitive else None
+        if isinstance(legalRegex, six.string_types):
+            self.legalRegex = re.compile(legalRegex)
+        else:
+            self.legalRegex = legalRegex
 
     def __call__(self, obj=None):
         lbl = self.labeler(obj)
@@ -175,6 +180,8 @@ class ShortNameLabeler(object):
              and lbl.endswith(self.suffix):
             shorten = True
         elif self.known_labels is not None and lbl.upper() in self.known_labels:
+            shorten = True
+        elif self.legalRegex and not self.legalRegex.match(lbl):
             shorten = True
         if shorten:
             self.id += 1

--- a/pyomo/core/base/label.py
+++ b/pyomo/core/base/label.py
@@ -154,7 +154,7 @@ class NameLabeler(object):
 
 class ShortNameLabeler(object):
     def __init__(self, limit, suffix, start=0, labeler=None,
-                 prefix="", caseInsensitive=True):
+                 prefix="", caseInsensitive=False):
         self.id = start
         self.prefix = prefix
         self.suffix = suffix

--- a/pyomo/core/base/label.py
+++ b/pyomo/core/base/label.py
@@ -153,20 +153,39 @@ class NameLabeler(object):
         return obj.getname(True, self.name_buffer)
 
 class ShortNameLabeler(object):
-    def __init__(self, limit, prefix, start=0, labeler=None):
+    def __init__(self, limit, suffix, start=0, labeler=None,
+                 prefix="", caseInsensitive=True):
         self.id = start
         self.prefix = prefix
+        self.suffix = suffix
         self.limit = limit
         if labeler is not None:
             self.labeler = labeler
         else:
             self.labeler = AlphaNumericTextLabeler()
+        self.known_labels = set() if caseInsensitive else None
 
     def __call__(self, obj=None):
         lbl = self.labeler(obj)
-        if (len(lbl) < self.limit) or ((len(lbl) == self.limit) and (lbl[-len(self.prefix):] != self.prefix)):
-            return lbl
-        else:
+        lbl_len = len(lbl)
+        shorten = False
+        if lbl_len > self.limit:
+            shorten = True
+        elif lbl_len == self.limit and lbl.startswith(self.prefix) \
+             and lbl.endswith(self.suffix):
+            shorten = True
+        elif self.known_labels is not None and lbl.upper() in self.known_labels:
+            shorten = True
+        if shorten:
             self.id += 1
-            suffix = self.prefix + str(self.id) + self.prefix
-            return lbl[-self.limit + len(suffix):] + suffix
+            suffix = "%s%d%s" % (self.suffix, self.id, self.suffix)
+            tail = -self.limit + len(suffix) + len(self.prefix)
+            if tail >= 0:
+                raise RuntimeError(
+                    "Too many identifiers.\n\t"
+                    "The ShortNameLabeler cannot generate a guaranteed unique "
+                    "label limited to %d characters" % (self.limit,)) 
+            lbl = self.prefix + lbl[tail:] + suffix
+        if self.known_labels is not None:
+            self.known_labels.add(lbl.upper())
+        return lbl

--- a/pyomo/core/tests/unit/test_labelers.py
+++ b/pyomo/core/tests/unit/test_labelers.py
@@ -205,5 +205,17 @@ class LabelerTests(unittest.TestCase):
         with self.assertRaisesRegexp(RuntimeError, "Too many identifiers"):
             lbl(m.mycomp)
 
+    def test_shortnamelabeler_legal_regex(self):
+        m = ConcreteModel()
+        lbl = ShortNameLabeler(
+            60, suffix='_', prefix='s_', legalRegex='^[a-zA-Z]')
+
+        m.legal_var = Var()
+        self.assertEqual(lbl(m.legal_var), 'legal_var')
+
+        m._illegal_var = Var()
+        self.assertEqual(lbl(m._illegal_var), 's__illegal_var_1_')
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/core/tests/unit/test_labelers.py
+++ b/pyomo/core/tests/unit/test_labelers.py
@@ -18,6 +18,7 @@ class LabelerTests(unittest.TestCase):
     def setUp(self):
         m = ConcreteModel()
         m.mycomp = Var()
+        m.MyComp = Var()
         m.that = Var()
         self.long1 = m.myverylongcomponentname = Var()
         self.long2 = m.myverylongcomponentnamerighthere = Var()
@@ -133,10 +134,9 @@ class LabelerTests(unittest.TestCase):
         self.assertEqual(lbl(m.ind[10]), ComponentUID(m.ind[10]))
         self.assertEqual(lbl(m.ind[1]), ComponentUID(m.ind[1]))
 
-    def test_shortnamelabeler(self):
+    def test_case_insensitive_shortnamelabeler(self):
         m = self.m
-        lbl = ShortNameLabeler(20, '_')
-        self.assertEqual(lbl(m.mycomp), 'mycomp')
+        lbl = ShortNameLabeler(20, '_', caseInsensitive=True)
         self.assertEqual(lbl(m.mycomp), 'mycomp')
         self.assertEqual(lbl(m.that), 'that')
         self.assertEqual(lbl(self.long1), 'longcomponentname_1_')
@@ -146,11 +146,64 @@ class LabelerTests(unittest.TestCase):
         self.assertEqual(lbl(self.long5), 'gcomponentname_1__5_')
         self.assertEqual(lbl(m.myblock), 'myblock')
         self.assertEqual(lbl(m.myblock.mystreet), 'myblock_mystreet')
-        self.assertEqual(lbl(self.thecopy), 'myblock_mystreet')
         self.assertEqual(lbl(m.ind[3]), 'ind_3_')
         self.assertEqual(lbl(m.ind[10]), 'ind_10_')
         self.assertEqual(lbl(m.ind[1]), 'ind_1_')
 
+        # Test name collision
+        self.assertEqual(lbl(m.mycomp), 'mycomp_6_')
+        self.assertEqual(lbl(self.thecopy), 'myblock_mystreet_7_')
+        self.assertEqual(lbl(m.MyComp), 'MyComp_8_')
+
+    def test_shortnamelabeler_prefix(self):
+        m = self.m
+        lbl = ShortNameLabeler(20, '_', prefix='s_', caseInsensitive=True)
+        self.assertEqual(lbl(m.mycomp), 'mycomp')
+        self.assertEqual(lbl(m.that), 'that')
+        self.assertEqual(lbl(self.long1), 's_ngcomponentname_1_')
+        self.assertEqual(lbl(self.long2), 's_ntnamerighthere_2_')
+        self.assertEqual(lbl(self.long3), 's_onebutdifferent_3_')
+        self.assertEqual(lbl(self.long4), 's_ngcomponentname_4_')
+        self.assertEqual(lbl(self.long5), 'longcomponentname_1_')
+        self.assertEqual(lbl(m.myblock), 'myblock')
+        self.assertEqual(lbl(m.myblock.mystreet), 'myblock_mystreet')
+        self.assertEqual(lbl(m.ind[3]), 'ind_3_')
+        self.assertEqual(lbl(m.ind[10]), 'ind_10_')
+        self.assertEqual(lbl(m.ind[1]), 'ind_1_')
+
+        # Test name collision
+        self.assertEqual(lbl(m.mycomp), 's_mycomp_5_')
+        self.assertEqual(lbl(self.thecopy), 's_yblock_mystreet_6_')
+        self.assertEqual(lbl(m.MyComp), 's_MyComp_7_')
+
+    def test_case_sensitive_shortnamelabeler(self):
+        m = self.m
+        lbl = ShortNameLabeler(20, '_')
+        self.assertEqual(lbl(m.mycomp), 'mycomp')
+        self.assertEqual(lbl(m.that), 'that')
+        self.assertEqual(lbl(self.long1), 'longcomponentname_1_')
+        self.assertEqual(lbl(self.long2), 'nentnamerighthere_2_')
+        self.assertEqual(lbl(self.long3), 'ngonebutdifferent_3_')
+        self.assertEqual(lbl(self.long4), 'longcomponentname_4_')
+        self.assertEqual(lbl(self.long5), 'gcomponentname_1__5_')
+        self.assertEqual(lbl(m.myblock), 'myblock')
+        self.assertEqual(lbl(m.myblock.mystreet), 'myblock_mystreet')
+        self.assertEqual(lbl(m.ind[3]), 'ind_3_')
+        self.assertEqual(lbl(m.ind[10]), 'ind_10_')
+        self.assertEqual(lbl(m.ind[1]), 'ind_1_')
+
+        # Test name collision
+        self.assertEqual(lbl(m.mycomp), 'mycomp')
+        self.assertEqual(lbl(self.thecopy), 'myblock_mystreet')
+        self.assertEqual(lbl(m.MyComp), 'MyComp')
+
+    def test_case_shortnamelabeler_overflow(self):
+        m = self.m
+        lbl = ShortNameLabeler(4, '_', caseInsensitive=True)
+        for i in range(9):
+            self.assertEqual(lbl(m.mycomp), 'p_%d_' % (i+1))
+        with self.assertRaisesRegexp(RuntimeError, "Too many identifiers"):
+            lbl(m.mycomp)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/repn/plugins/baron_writer.py
+++ b/pyomo/repn/plugins/baron_writer.py
@@ -654,6 +654,8 @@ class ProblemWriter_bar(AbstractProblemWriter):
         elif labeler is None:
             v_labeler = NumericLabeler('x')
             c_labeler = NumericLabeler('c')
+        else:
+            v_labeler = c_labeler = labeler
 
         symbol_map = SymbolMap()
         symbol_map.default_labeler = v_labeler

--- a/pyomo/repn/plugins/baron_writer.py
+++ b/pyomo/repn/plugins/baron_writer.py
@@ -650,7 +650,8 @@ class ProblemWriter_bar(AbstractProblemWriter):
             # to start with a letter.  We will (randomly) choose "s_"
             # (for 'shortened')
             v_labeler = c_labeler = ShortNameLabeler(
-                15, prefix='s_', suffix='_', caseInsensitive=True)
+                15, prefix='s_', suffix='_', caseInsensitive=True,
+                legalRegex='^[a-zA-Z]')
         elif labeler is None:
             v_labeler = NumericLabeler('x')
             c_labeler = NumericLabeler('c')

--- a/pyomo/repn/plugins/baron_writer.py
+++ b/pyomo/repn/plugins/baron_writer.py
@@ -27,7 +27,7 @@ from pyomo.core.expr.numvalue import (
 from pyomo.core.expr import current as EXPR
 from pyomo.core.base import (SortComponents,
                              SymbolMap,
-                             AlphaNumericTextLabeler,
+                             ShortNameLabeler,
                              NumericLabeler,
                              BooleanSet, Constraint,
                              IntegerSet, Objective,
@@ -643,8 +643,14 @@ class ProblemWriter_bar(AbstractProblemWriter):
         output_file.write("}\n\n")
 
         if symbolic_solver_labels:
-            v_labeler = AlphaNumericTextLabeler()
-            c_labeler = AlphaNumericTextLabeler()
+            # Note that the Var and Constraint labelers must use the
+            # same labeler, so that we can correctly detect name
+            # collisions (which can arise when we truncate the labels to
+            # the max allowable length.  BARON requires all identifiers
+            # to start with a letter.  We will (randomly) choose "s_"
+            # (for 'shortened')
+            v_labeler = c_labeler = ShortNameLabeler(
+                15, prefix='s_', suffix='_', caseInsensitive=True)
         elif labeler is None:
             v_labeler = NumericLabeler('x')
             c_labeler = NumericLabeler('c')

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -391,7 +391,14 @@ class ProblemWriter_gams(AbstractProblemWriter):
                              "I/O options is forbidden")
 
         if symbolic_solver_labels:
-            var_labeler = con_labeler = ShortNameLabeler(63, '_')
+            # Note that the Var and Constraint labelers must use the
+            # same labeler, so that we can correctly detect name
+            # collisions (which can arise when we truncate the labels to
+            # the max allowable length.  GAMS requires all identifiers
+            # to start with a letter.  We will (randomly) choose "s_"
+            # (for 'shortened')
+            var_labeler = con_labeler = ShortNameLabeler(
+                63, prefix='s_', suffix='_', caseInsensitive=True)
         elif labeler is None:
             var_labeler = NumericLabeler('x')
             con_labeler = NumericLabeler('c')

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -398,7 +398,8 @@ class ProblemWriter_gams(AbstractProblemWriter):
             # to start with a letter.  We will (randomly) choose "s_"
             # (for 'shortened')
             var_labeler = con_labeler = ShortNameLabeler(
-                63, prefix='s_', suffix='_', caseInsensitive=True)
+                63, prefix='s_', suffix='_', caseInsensitive=True,
+                legalRegex='^[a-zA-Z]')
         elif labeler is None:
             var_labeler = NumericLabeler('x')
             con_labeler = NumericLabeler('c')

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -36,6 +36,13 @@ import logging
 
 logger = logging.getLogger('pyomo.core')
 
+_legal_unary_functions = {
+    'ceil','floor','exp','log','log10','sqrt',
+    'sin','cos','tan','asin','acos','atan','sinh','cosh','tanh',
+}
+_arc_functions = {'acos','asin','atan'}
+_dnlp_functions = {'ceil','floor','abs'}
+
 #
 # A visitor pattern that creates a string for an expression
 # that is compatible with the GAMS syntax.
@@ -46,6 +53,7 @@ class ToGamsVisitor(EXPR.ExpressionValueVisitor):
         super(ToGamsVisitor, self).__init__()
         self.smap = smap
         self.treechecker = treechecker
+        self.is_discontinuous = False
 
     def visit(self, node, values):
         """ Visit nodes that have been expanded """
@@ -87,6 +95,20 @@ class ToGamsVisitor(EXPR.ExpressionValueVisitor):
                 return "power({0}, {1})".format(tmp[0], tmp[1])
             else:
                 return "{0} ** {1}".format(tmp[0], tmp[1])
+        elif node.__class__ is EXPR.UnaryFunctionExpression:
+            if node.name not in _legal_unary_functions:
+                raise RuntimeError(
+                    "GAMS files cannot represent the unary function %s"
+                    % ( node.name, ))
+            if node.name in _dnlp_functions:
+                self.is_discontinuous = True
+            if node.name in _arc_functions:
+                return "arc{0}({1})".format(node.name[1:], tmp[0])
+            else:
+                return node._to_string(tmp, None, self.smap, True)
+        elif node.__class__ is EXPR.AbsExpression:
+            self.is_discontinuous = True
+            return node._to_string(tmp, None, self.smap, True)
         else:
             return node._to_string(tmp, None, self.smap, True)
 
@@ -146,7 +168,8 @@ def expression_to_string(expr, treechecker, labeler=None, smap=None):
             smap = SymbolMap()
         smap.default_labeler = labeler
     visitor = ToGamsVisitor(smap, treechecker)
-    return visitor.dfs_postorder_stack(expr)
+    expr_str = visitor.dfs_postorder_stack(expr)
+    return expr_str, visitor.is_discontinuous
 
 
 class Categorizer(object):
@@ -479,6 +502,7 @@ class ProblemWriter_gams(AbstractProblemWriter):
         ConstraintIO = StringIO()
         linear = True
         linear_degree = set([0,1])
+        dnlp = False
 
         # Make sure there are no strange ActiveComponents. The expression
         # walker will handle strange things in constraints later.
@@ -516,11 +540,14 @@ class ProblemWriter_gams(AbstractProblemWriter):
                     linear = False
 
             cName = symbolMap.getSymbol(con, con_labeler)
+            con_body_str, con_discontinuous = expression_to_string(
+                con_body, tc, smap=symbolMap)
+            dnlp |= con_discontinuous
             if con.equality:
                 constraint_names.append('%s' % cName)
                 ConstraintIO.write('%s.. %s =e= %s ;\n' % (
                     constraint_names[-1],
-                    expression_to_string(con_body, tc, smap=symbolMap),
+                    con_body_str,
                     _get_bound(con.upper)
                 ))
             else:
@@ -529,13 +556,13 @@ class ProblemWriter_gams(AbstractProblemWriter):
                     ConstraintIO.write('%s.. %s =l= %s ;\n' % (
                         constraint_names[-1],
                         _get_bound(con.lower),
-                        expression_to_string(con_body, tc, smap=symbolMap)
+                        con_body_str,
                     ))
                 if con.has_ub():
                     constraint_names.append('%s_hi' % cName)
                     ConstraintIO.write('%s.. %s =l= %s ;\n' % (
                         constraint_names[-1],
-                        expression_to_string(con_body, tc, smap=symbolMap),
+                        con_body_str,
                         _get_bound(con.upper)
                     ))
 
@@ -550,11 +577,14 @@ class ProblemWriter_gams(AbstractProblemWriter):
         if linear:
             if obj.expr.polynomial_degree() not in linear_degree:
                 linear = False
+        obj_expr_str, obj_discontinuous = expression_to_string(
+            obj.expr, tc, smap=symbolMap)
+        dnlp |= obj_discontinuous
         oName = symbolMap.getSymbol(obj, con_labeler)
         constraint_names.append(oName)
         ConstraintIO.write('%s.. GAMS_OBJECTIVE =e= %s ;\n' % (
             oName,
-            expression_to_string(obj.expr, tc, smap=symbolMap)
+            obj_expr_str,
         ))
 
         # Categorize the variables that we found
@@ -651,6 +681,8 @@ class ProblemWriter_gams(AbstractProblemWriter):
                 (0 if linear else 1) +
                 (2 if (categorized_vars.binary or categorized_vars.ints)
                  else 0)]
+            if mtype == 'nlp' and dnlp:
+                mtype = 'dnlp'
 
         if solver is not None:
             if mtype.upper() not in valid_solvers[solver.upper()]:

--- a/pyomo/repn/tests/gams/small14a.pyomo.gms
+++ b/pyomo/repn/tests/gams/small14a.pyomo.gms
@@ -17,10 +17,7 @@ EQUATIONS
 	c14
 	c15
 	c16
-	c17
-	c18
-	c19
-	c20;
+	c17;
 
 VARIABLES
 	GAMS_OBJECTIVE
@@ -35,24 +32,21 @@ c5.. tan(x2) =e= 0.0 ;
 c6.. sinh(x2) =e= 0.0 ;
 c7.. cosh(x2) =e= 1.0 ;
 c8.. tanh(x2) =e= 0.0 ;
-c9.. asin(x2) =e= 0.0 ;
-c10.. acos(x2) =e= 1.5707963267948966 ;
-c11.. atan(x2) =e= 0.0 ;
-c12.. asinh(x2) =e= 0.0 ;
-c13.. acosh((7.3890560989306495 + x1)*0.18393972058572117) =e= 0.0 ;
-c14.. atanh(x2) =e= 0.0 ;
-c15.. exp(x2) =e= 1.0 ;
-c16.. sqrt(x1) =e= 1.0 ;
-c17.. ceil(x1) =e= 1.0 ;
-c18.. floor(x1) =e= 1.0 ;
-c19.. abs(x1) =e= 1.0 ;
-c20.. GAMS_OBJECTIVE =e= x1 + x2 ;
+c9.. arcsin(x2) =e= 0.0 ;
+c10.. arccos(x2) =e= 1.5707963267948966 ;
+c11.. arctan(x2) =e= 0.0 ;
+c12.. exp(x2) =e= 1.0 ;
+c13.. sqrt(x1) =e= 1.0 ;
+c14.. ceil(x1) =e= 1.0 ;
+c15.. floor(x1) =e= 1.0 ;
+c16.. abs(x1) =e= 1.0 ;
+c17.. GAMS_OBJECTIVE =e= x1 + x2 ;
 
 x1.l = 1;
 x2.l = 0;
 
 MODEL GAMS_MODEL /all/ ;
-SOLVE GAMS_MODEL USING nlp minimizing GAMS_OBJECTIVE;
+SOLVE GAMS_MODEL USING dnlp minimizing GAMS_OBJECTIVE;
 
 Scalars MODELSTAT 'model status', SOLVESTAT 'solve status';
 MODELSTAT = GAMS_MODEL.modelstat;

--- a/pyomo/repn/tests/gams/small14a_testCase.py
+++ b/pyomo/repn/tests/gams/small14a_testCase.py
@@ -1,0 +1,46 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+from pyomo.environ import *
+from math import e, pi
+
+model = ConcreteModel()
+
+# pick a value in the domain of all of these functions
+model.ONE = Var(initialize=1)
+model.ZERO = Var(initialize=0)
+
+
+model.obj = Objective(expr=model.ONE+model.ZERO)
+
+model.c_log     = Constraint(expr=log(model.ONE) == 0)
+model.c_log10   = Constraint(expr=log10(model.ONE) == 0)
+
+model.c_sin     = Constraint(expr=sin(model.ZERO) == 0)
+model.c_cos     = Constraint(expr=cos(model.ZERO) == 1)
+model.c_tan     = Constraint(expr=tan(model.ZERO) == 0)
+
+model.c_sinh    = Constraint(expr=sinh(model.ZERO) == 0)
+model.c_cosh    = Constraint(expr=cosh(model.ZERO) == 1)
+model.c_tanh    = Constraint(expr=tanh(model.ZERO) == 0)
+
+model.c_asin    = Constraint(expr=asin(model.ZERO) == 0)
+model.c_acos    = Constraint(expr=acos(model.ZERO) == pi/2)
+model.c_atan    = Constraint(expr=atan(model.ZERO) == 0)
+
+#model.c_asinh   = Constraint(expr=asinh(model.ZERO) == 0)
+#model.c_acosh   = Constraint(expr=acosh((e**2 + model.ONE)/(2*e)) == 0)
+#model.c_atanh   = Constraint(expr=atanh(model.ZERO) == 0)
+
+model.c_exp     = Constraint(expr=exp(model.ZERO) == 1)
+model.c_sqrt    = Constraint(expr=sqrt(model.ONE) == 1)
+model.c_ceil    = Constraint(expr=ceil(model.ONE) == 1)
+model.c_floor   = Constraint(expr=floor(model.ONE) == 1)
+model.c_abs     = Constraint(expr=abs(model.ONE) == 1)

--- a/pyomo/repn/tests/gams/test_gams.py
+++ b/pyomo/repn/tests/gams/test_gams.py
@@ -18,7 +18,8 @@ from six import StringIO
 import pyutilib.th as unittest
 from pyomo.core.base import NumericLabeler, SymbolMap
 from pyomo.environ import (Block, ConcreteModel, Connector, Constraint,
-                           Objective, TransformationFactory, Var, exp, log)
+                           Objective, TransformationFactory, Var, exp, log,
+                           ceil, floor, asin, acos, atan, asinh, acosh, atanh)
 from pyomo.repn.plugins.gams_writer import (StorageTreeChecker,
                                             expression_to_string,
                                             split_long_line)
@@ -129,32 +130,32 @@ class Test(unittest.TestCase):
         expr = M.abc**2.0
         self.assertEqual(str(expr), "abc**2.0")
         self.assertEqual(expression_to_string(
-            expr, tc, smap=smap), "power(abc, 2.0)")
+            expr, tc, smap=smap), ("power(abc, 2.0)", False))
 
         expr = log(M.abc**2.0)
         self.assertEqual(str(expr), "log(abc**2.0)")
         self.assertEqual(expression_to_string(
-            expr, tc, smap=smap), "log(power(abc, 2.0))")
+            expr, tc, smap=smap), ("log(power(abc, 2.0))", False))
 
         expr = log(M.abc**2.0) + 5
         self.assertEqual(str(expr), "log(abc**2.0) + 5")
         self.assertEqual(expression_to_string(
-            expr, tc, smap=smap), "log(power(abc, 2.0)) + 5")
+            expr, tc, smap=smap), ("log(power(abc, 2.0)) + 5", False))
 
         expr = exp(M.abc**2.0) + 5
         self.assertEqual(str(expr), "exp(abc**2.0) + 5")
         self.assertEqual(expression_to_string(
-            expr, tc, smap=smap), "exp(power(abc, 2.0)) + 5")
+            expr, tc, smap=smap), ("exp(power(abc, 2.0)) + 5", False))
 
         expr = log(M.abc**2.0)**4
         self.assertEqual(str(expr), "log(abc**2.0)**4")
         self.assertEqual(expression_to_string(
-            expr, tc, smap=smap), "power(log(power(abc, 2.0)), 4)")
+            expr, tc, smap=smap), ("power(log(power(abc, 2.0)), 4)", False))
 
         expr = log(M.abc**2.0)**4.5
         self.assertEqual(str(expr), "log(abc**2.0)**4.5")
         self.assertEqual(expression_to_string(
-            expr, tc, smap=smap), "log(power(abc, 2.0)) ** 4.5")
+            expr, tc, smap=smap), ("log(power(abc, 2.0)) ** 4.5", False))
 
     def test_power_function_to_string(self):
         m = ConcreteModel()
@@ -163,11 +164,11 @@ class Test(unittest.TestCase):
         smap = SymbolMap(lbl)
         tc = StorageTreeChecker(m)
         self.assertEqual(expression_to_string(
-            m.x ** -3, tc, lbl, smap=smap), "power(x1, (-3))")
+            m.x ** -3, tc, lbl, smap=smap), ("power(x1, (-3))", False))
         self.assertEqual(expression_to_string(
-            m.x ** 0.33, tc, smap=smap), "x1 ** 0.33")
+            m.x ** 0.33, tc, smap=smap), ("x1 ** 0.33", False))
         self.assertEqual(expression_to_string(
-            pow(m.x, 2), tc, smap=smap), "power(x1, 2)")
+            pow(m.x, 2), tc, smap=smap), ("power(x1, 2)", False))
 
     def test_fixed_var_to_string(self):
         m = ConcreteModel()
@@ -179,16 +180,56 @@ class Test(unittest.TestCase):
         smap = SymbolMap(lbl)
         tc = StorageTreeChecker(m)
         self.assertEqual(expression_to_string(
-            m.x + m.y - m.z, tc, lbl, smap=smap), "x1 + x2 - (-3)")
+            m.x + m.y - m.z, tc, lbl, smap=smap), ("x1 + x2 - (-3)", False))
         m.z.fix(-400)
         self.assertEqual(expression_to_string(
-            m.z + m.y - m.z, tc, smap=smap), "(-400) + x2 - (-400)")
+            m.z + m.y - m.z, tc, smap=smap), ("(-400) + x2 - (-400)", False))
         m.z.fix(8.8)
         self.assertEqual(expression_to_string(
-            m.x + m.z - m.y, tc, smap=smap), "x1 + 8.8 - x2")
+            m.x + m.z - m.y, tc, smap=smap), ("x1 + 8.8 - x2", False))
         m.z.fix(-8.8)
         self.assertEqual(expression_to_string(
-            m.x * m.z - m.y, tc, smap=smap), "x1*(-8.8) - x2")
+            m.x * m.z - m.y, tc, smap=smap), ("x1*(-8.8) - x2", False))
+
+    def test_dnlp_to_string(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var()
+        m.z = Var()
+        lbl = NumericLabeler('x')
+        smap = SymbolMap(lbl)
+        tc = StorageTreeChecker(m)
+        self.assertEqual(expression_to_string(
+            ceil(m.x), tc, lbl, smap=smap), ("ceil(x1)", True))
+        self.assertEqual(expression_to_string(
+            floor(m.x), tc, lbl, smap=smap), ("floor(x1)", True))
+        self.assertEqual(expression_to_string(
+            abs(m.x), tc, lbl, smap=smap), ("abs(x1)", True))
+
+    def test_arcfcn_to_string(self):
+        m = ConcreteModel()
+        m.x = Var()
+        lbl = NumericLabeler('x')
+        smap = SymbolMap(lbl)
+        tc = StorageTreeChecker(m)
+        self.assertEqual(expression_to_string(
+            asin(m.x), tc, lbl, smap=smap), ("arcsin(x1)", False))
+        self.assertEqual(expression_to_string(
+            acos(m.x), tc, lbl, smap=smap), ("arccos(x1)", False))
+        self.assertEqual(expression_to_string(
+            atan(m.x), tc, lbl, smap=smap), ("arctan(x1)", False))
+        with self.assertRaisesRegexp(
+                RuntimeError,
+                "GAMS files cannot represent the unary function asinh"):
+            expression_to_string(asinh(m.x), tc, lbl, smap=smap)
+        with self.assertRaisesRegexp(
+                RuntimeError,
+                "GAMS files cannot represent the unary function acosh"):
+            expression_to_string(acosh(m.x), tc, lbl, smap=smap)
+        with self.assertRaisesRegexp(
+                RuntimeError,
+                "GAMS files cannot represent the unary function atanh"):
+            expression_to_string(atanh(m.x), tc, lbl, smap=smap)
 
     def test_gams_connector_in_active_constraint(self):
         m = ConcreteModel()
@@ -260,9 +301,9 @@ class Test(unittest.TestCase):
         smap = SymbolMap(lbl)
         tc = StorageTreeChecker(m)
         self.assertEqual(expression_to_string(
-            m.c.body, tc, smap=smap), "4*(-7)*(-2)")
+            m.c.body, tc, smap=smap), ("4*(-7)*(-2)", False))
         self.assertEqual(expression_to_string(
-            m.c2.body, tc, smap=smap), "x1 ** (-1.5)")
+            m.c2.body, tc, smap=smap), ("x1 ** (-1.5)", False))
 
 
 class TestGams_writer(unittest.TestCase):


### PR DESCRIPTION
## Fixes #1041, fixes #832, fixes #683, fixes #1055

## Summary/Motivation:
This fixes issues with symbolic labels in GAMS and BARON writers.  Both interfaces have maximum variable lengths, are case insensitive, and require identifiers to start with a letter.

## Changes proposed in this PR:
- renames the `ShortNameLabeler` `prefix` flag to `suffix`
- adds a `caseInsensitive` flag to the `ShortNameLabeler`
- adds a `prefix` flag to the `ShortNameLabeler` that is prepended to the label
- checks labels for invalid initial characters
- mapping asin,acos,atan to arcsin,arccos,arctan (in GAMS)
- checking for invalid unary functions (in GAMS)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
