### PR TITLE
Avoid cplex_direct "No Solution Exists" Messages

### DIFF
--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -535,33 +535,17 @@ class CPLEXDirect(DirectSolver):
 
         self.results.problem.upper_bound = None
         self.results.problem.lower_bound = None
-        if (cpxprob.variables.get_num_binary() + cpxprob.variables.get_num_integer()) == 0:
-            try:
+        if cpxprob.solution.get_solution_type() != cpxprob.solution.type.none:
+            if (cpxprob.variables.get_num_binary() + cpxprob.variables.get_num_integer()) == 0:
                 self.results.problem.upper_bound = cpxprob.solution.get_objective_value()
                 self.results.problem.lower_bound = cpxprob.solution.get_objective_value()
-            except self._cplex.exceptions.CplexError:
-                pass
-        elif cpxprob.objective.get_sense() == cpxprob.objective.sense.minimize:
-            try:
+            elif cpxprob.objective.get_sense() == cpxprob.objective.sense.minimize:
                 self.results.problem.upper_bound = cpxprob.solution.get_objective_value()
-            except self._cplex.exceptions.CplexError:
-                pass
-            try:
                 self.results.problem.lower_bound = cpxprob.solution.MIP.get_best_objective()
-            except self._cplex.exceptions.CplexError:
-                pass
-        elif cpxprob.objective.get_sense() == cpxprob.objective.sense.maximize:
-            try:
+            else:
+                assert cpxprob.objective.get_sense() == cpxprob.objective.sense.maximize
                 self.results.problem.upper_bound = cpxprob.solution.MIP.get_best_objective()
-            except self._cplex.exceptions.CplexError:
-                pass
-            try:
                 self.results.problem.lower_bound = cpxprob.solution.get_objective_value()
-            except self._cplex.exceptions.CplexError:
-                pass
-        else:
-            raise RuntimeError('Unrecognized cplex objective sense: {0}'.\
-                               format(cpxprob.objective.get_sense()))
 
         try:
             soln.gap = self.results.problem.upper_bound - self.results.problem.lower_bound


### PR DESCRIPTION
Check that CPLEX is storing a solution before trying to extract the lower and upper bound. This avoids CPLEX logging an error message about no solution existing when handling an infeasible problem, which may be important for applications that want to control output.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
