### PR TITLE
Suppress QT import errors until the UI class is created

### DIFF
--- a/pyomo/contrib/viewer/pyomo_viewer.py
+++ b/pyomo/contrib/viewer/pyomo_viewer.py
@@ -42,7 +42,7 @@ if qtconsole_available:
     class MainWindow(QMainWindow):
         """A window that contains a single Qt console."""
         def __init__(self, kernel_manager, kernel_client):
-            super().__init__()
+            super(MainWindow, self).__init__()
             self.jupyter_widget = RichJupyterWidget()
             self.jupyter_widget.kernel_manager = kernel_manager
             self.jupyter_widget.kernel_client = kernel_client

--- a/pyomo/contrib/viewer/qt.py
+++ b/pyomo/contrib/viewer/qt.py
@@ -40,18 +40,24 @@ class DummyQAbstractItemModel(object):
     def __init__(*args, **kwargs):
         pass
 
+class DummyQAbstractTableModel(object):
+    """
+    A dummy QAbstractTableModel class to allow some testing without PyQt
+    """
+    def __init__(*args, **kwargs):
+        pass
+
 qt_available = False
+qt_import_errors = []
 
 try:
     from PyQt5 import QtCore
 except:
-    _log.exception("Cannot import PyQt5.QtCore")
+    qt_import_errors.append("Cannot import PyQt5.QtCore")
     try:
         from PyQt4 import QtCore
     except:
-        _log.exception("Cannot import PyQt4.QtCore")
-        QAbstractItemModel = DummyQAbstractItemModel
-        QtCore = DummyQtCore
+        qt_import_errors.append("Cannot import PyQt4.QtCore")
     else:
         try:
             from PyQt4.QtGui import (QAbstractItemView, QFileDialog, QMainWindow,
@@ -62,9 +68,7 @@ except:
             from PyQt4 import uic
             qt_available = True
         except:
-            _log.exception("Cannot import PyQt4")
-            QAbstractItemModel = DummyQAbstractItemModel
-            QtCore = DummyQtCore
+            qt_import_errors.append("Cannot import PyQt4")
 else:
     try:
         from PyQt5.QtWidgets import (QAbstractItemView, QFileDialog, QMainWindow,
@@ -76,6 +80,9 @@ else:
         from PyQt5 import uic
         qt_available = True
     except:
-        _log.exception("Cannot import PyQt5")
-        QAbstractItemModel = DummyQAbstractItemModel
-        QtCore = DummyQtCore
+        qt_import_errors.append("Cannot import PyQt5")
+
+if not qt_available:
+    QAbstractItemModel = DummyQAbstractItemModel
+    QAbstractTableModel = DummyQAbstractTableModel
+    QtCore = DummyQtCore

--- a/pyomo/contrib/viewer/ui.py
+++ b/pyomo/contrib/viewer/ui.py
@@ -53,6 +53,8 @@ except:
         pass
 
 if not qt_available:
+    for _err in qt_import_errors:
+        _log.error(_err)
     _log.error("Qt is not available. Cannot create UI classes.")
     raise ImportError("Could not import PyQt4 or PyQt5")
 


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
This resolves diffs that have appeared in the Book tests.

## Changes proposed in this PR:
- Cache Qt import error messages identified during module import
- Log cached import error messages when attempting to instantiate the UI
- Add an additional dummy class so that more modules can be imported without PyQt

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
