### PR TITLE
Fix case where a single-term sum output a n-ary operator

### DIFF
--- a/pyomo/repn/plugins/ampl/ampl_.py
+++ b/pyomo/repn/plugins/ampl/ampl_.py
@@ -459,7 +459,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
                     if coef != 1:
                         OUTPUT.write(coef_term_str % (coef))
                     self._print_nonlinear_terms_NL(child_exp)
-            else:
+            else: # n == 1 or 2
                 for i in xrange(0,n):
                     assert(exp[i].__class__ is tuple)
                     coef = exp[i][0]
@@ -502,6 +502,8 @@ class ProblemWriter_nl(AbstractProblemWriter):
                     OUTPUT.write(binary_sum_str)
                     self._print_nonlinear_terms_NL(vargs[0])
                     self._print_nonlinear_terms_NL(vargs[1])
+                elif n == 1:
+                    self._print_nonlinear_terms_NL(vargs[0])
                 else:
                     OUTPUT.write(nary_sum_str % (n))
                     for child_exp in vargs:


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
This fixes a case where a SumExpression that has only a single term was being outputted as a nary sum.  The bug was uncovered in IDAES/idaes-dev#281.  I have not yet found a way to actually test this.

## Changes proposed in this PR:
- Trap an edge case where SumExpression has a single term

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
