### PR TITLE
Model Viewer, fix bug in sorting residuals

### DIFF
--- a/pyomo/contrib/viewer/README.md
+++ b/pyomo/contrib/viewer/README.md
@@ -58,9 +58,11 @@ The viewer will start with an empty Pyomo ConcreteModel called ```model```. The
 advantage of the stand-alone viewer is that it will automatically set up the
 environment and start the UI, saving typing a few lines of code. In the kernel,
 ``pyomo.environ`` is imported as ```pyo```. An empty ConcreteModel is available
-as ```model``` and linked to the viewer. The main user interface window is
-available as ```ui```.  This provides a useful ability to script UI actions.
-You can link the model viewer to other models.
+as ```model``` and linked to the viewer. To launch the model viewer select
+"Show/Start Model Viewer" fro the "View" menu in the qtconsole window.
+After launching the model viewer it is available as ```ui```.  This provides
+a useful ability to script UI actions. You can link the model viewer to other
+models.
 
 ### Setting the Model
 

--- a/pyomo/contrib/viewer/README.md
+++ b/pyomo/contrib/viewer/README.md
@@ -56,13 +56,13 @@ viewer is based on the example code at
 https://github.com/jupyter/qtconsole/blob/master/examples/embed_qtconsole.py.
 The viewer will start with an empty Pyomo ConcreteModel called ```model```. The
 advantage of the stand-alone viewer is that it will automatically set up the
-environment and start the UI, saving typing a few lines of code. In the kernel,
-``pyomo.environ`` is imported as ```pyo```. An empty ConcreteModel is available
-as ```model``` and linked to the viewer. To launch the model viewer select
-"Show/Start Model Viewer" fro the "View" menu in the qtconsole window.
-After launching the model viewer it is available as ```ui```.  This provides
-a useful ability to script UI actions. You can link the model viewer to other
-models.
+environment and start the UI, saving typing a few lines of code. It also has a
+few menu items to help do common tasks. In the kernel, ``pyomo.environ`` is
+imported as ```pyo```. An empty ConcreteModel is available as ```model``` and
+linked to the viewer. To launch the model viewer select "Show/Start Model Viewer"
+from the "View" menu in the qtconsole window. After launching the model viewer
+it is available as ```ui```.  This provides a useful ability to script UI
+actions. You can link the model viewer to other models.
 
 ### Setting the Model
 

--- a/pyomo/contrib/viewer/main.ui
+++ b/pyomo/contrib/viewer/main.ui
@@ -29,19 +29,11 @@
      <height>38</height>
     </rect>
    </property>
-   <widget class="QMenu" name="menu_File">
-    <property name="title">
-     <string>&amp;File</string>
-    </property>
-    <addaction name="actionSet_Working_Directory"/>
-    <addaction name="actionModel_Selector"/>
-    <addaction name="separator"/>
-    <addaction name="action_Exit"/>
-   </widget>
    <widget class="QMenu" name="menu_View">
     <property name="title">
      <string>&amp;View</string>
     </property>
+    <addaction name="actionModel_Selector"/>
     <addaction name="actionRestart_Variable_View"/>
     <addaction name="actionRestart_Constraint_View"/>
     <addaction name="actionRestart_Parameter_View"/>
@@ -66,7 +58,6 @@
     </property>
     <addaction name="actionInformation"/>
    </widget>
-   <addaction name="menu_File"/>
    <addaction name="menu_View"/>
    <addaction name="menuCalculate"/>
    <addaction name="menuModel"/>
@@ -110,7 +101,7 @@
   </action>
   <action name="action_Exit">
    <property name="text">
-    <string>E&amp;xit</string>
+    <string>C&amp;lose Window</string>
    </property>
   </action>
   <action name="action_toggle_expressions">
@@ -275,7 +266,7 @@
   </action>
   <action name="actionModel_Selector">
    <property name="text">
-    <string>Model &amp;Selector</string>
+    <string>Model Sele&amp;ctor ...</string>
    </property>
   </action>
   <action name="actionRestart_Residual_Table">
@@ -285,7 +276,12 @@
   </action>
   <action name="actionSet_Working_Directory">
    <property name="text">
-    <string>Set &amp;Working Directory</string>
+    <string>Set &amp;Working Directory ...</string>
+   </property>
+  </action>
+  <action name="action_Run_Script">
+   <property name="text">
+    <string>&amp;Run Script ...</string>
    </property>
   </action>
  </widget>

--- a/pyomo/contrib/viewer/pyomo_viewer.py
+++ b/pyomo/contrib/viewer/pyomo_viewer.py
@@ -14,8 +14,10 @@
 
 from __future__ import print_function
 
+import os
 import sys
 import time
+
 
 from pyomo.scripting.pyomo_parser import add_subparser
 from pyomo.contrib.viewer.qt import *
@@ -36,7 +38,9 @@ if qtconsole_available:
         kc = km.client()
         kc.start_channels()
         kc.execute("%gui qt", silent=True)
-        time.sleep(1.5)
+        # make sure there is no possible way the user can start the model
+        # viewer before the Qt Application in the kernel finishes starting
+        time.sleep(1.0)
         return km, kc
 
     class MainWindow(QMainWindow):
@@ -47,12 +51,113 @@ if qtconsole_available:
             self.jupyter_widget.kernel_manager = kernel_manager
             self.jupyter_widget.kernel_client = kernel_client
             kernel_client.hb_channel.kernel_died.connect(self.close)
+            kernel_client.iopub_channel.message_received.connect(self.mrcv)
+            menubar = self.menuBar()
+            run_script_act = QAction("&Run Script...", self)
+            wdir_set_act = QAction("Set &Working Directory...", self)
+            exit_act = QAction("&Exit", self)
+            show_ui_act = QAction("&Start/Show Model Viewer", self)
+            hide_ui_act = QAction("&Hide Model Viewer", self)
+            exit_act.triggered.connect(self.close)
+            show_ui_act.triggered.connect(self.show_ui)
+            hide_ui_act.triggered.connect(self.hide_ui)
+            wdir_set_act.triggered.connect(self.wdir_select)
+            run_script_act.triggered.connect(self.run_script)
+            file_menu = menubar.addMenu('&File')
+            view_menu = menubar.addMenu('&View')
+            file_menu.addAction(wdir_set_act)
+            file_menu.addAction(run_script_act)
+            file_menu.addAction(exit_act)
+            view_menu.addAction(show_ui_act)
+            view_menu.addAction(hide_ui_act)
+            self.status_bar = QStatusBar()
+            self.setStatusBar(self.status_bar)
+            self.status_bar.show()
             self.setCentralWidget(self.jupyter_widget)
+            self._ui_created = False
+
+        def wdir_select(self, checked=False, wdir=None):
+            """
+            Change the current working directory.
+
+            Args:
+                wdir (str): if None show a dialog to select, otherwise try to
+                    change to this path
+                checked (bool): triggered signal sends this, but it is not used
+            Returns:
+                (str): new working directory path
+            """
+            if wdir is None:
+                # Show a dialog box for user to select working directory
+                wd = QFileDialog(self, 'Working Directory', os.getcwd())
+                wd.setFileMode(QFileDialog.DirectoryOnly)
+            if wd.exec_() == QFileDialog.Accepted:
+                wdir = wd.selectedFiles()[0]
+            else:
+                wdir = None
+            # Change directory if one was selected
+            if wdir is not None:
+                os.chdir(wdir)
+                self.jupyter_widget.kernel_client.execute(
+                    "%cd {}".format(wdir))
+            return wdir
+
+        def run_script(self, checked=False, filename=None):
+            """
+            Change the current working directory.
+
+            Args:
+                filename (str): if None show a dialog to select, otherwise try
+                    to change run filename script
+                checked (bool): triggered signal sends this, but it is not used
+            Returns:
+                (str): selected script file
+            """
+            if filename is None:
+                # Show a dialog box for user to select working directory
+                filename = QFileDialog.getOpenFileName(
+                    self,
+                    'Run Script',
+                    os.getcwd(),
+                    "py (*.py);;text (*.txt);;all (*)")
+                if filename[0]: # returns a tuple of file and filter or ("","")
+                    filename = filename[0]
+                else:
+                    filename = None
+            # Run script if one was selected
+            if filename is not None:
+                self.jupyter_widget.kernel_client.execute(
+                    "%run {}".format(filename))
+            return filename
+
+        def hide_ui(self):
+            if self._ui_created:
+                self.jupyter_widget.kernel_client.execute(
+                    "ui.hide()", silent=True)
+
+        def show_ui(self):
+            kc = self.jupyter_widget.kernel_client
+            if self._ui_created:
+                kc.execute("ui.show()", silent=True)
+            else:
+                self._ui_created = True
+                kc.execute("""
+from pyomo.contrib.viewer.ui import get_mainwindow
+import pyomo.environ as pyo
+ui, model = get_mainwindow()""", silent=True)
 
         def shutdown_kernel(self):
             print('Shutting down kernel...')
             self.jupyter_widget.kernel_client.stop_channels()
             self.jupyter_widget.kernel_manager.shutdown_kernel()
+
+        def mrcv(self, m):
+            try:
+                stat = m['content']['execution_state']
+                if stat:
+                    self.status_bar.showMessage("Kernel Status: {}".format(stat))
+            except:
+                pass
 
 def main(*args):
     if not qtconsole_available:
@@ -62,21 +167,6 @@ def main(*args):
     app = QApplication(sys.argv)
     window = MainWindow(kernel_manager=km, kernel_client=kc)
     window.show()
-    kc = window.jupyter_widget.kernel_client
-    time.sleep(2.5) # can't find any other good way to ensure Qt finished
-                    # startup. Just making sure the cell execution finishes
-                    # does not seems to be enough, and trying to check
-                    # QtAppliction() != None before moving on also does not
-                    # seem to work. 4 seconds may be too long, but I'm being
-                    # careful. I split the time between waiting for the console
-                    # window to show and waiting to start the model viewer so it
-                    # may not seem to take so long to the user.
-                    # May be related to:
-                    # https://github.com/ipython/ipython/issues/5629
-    kc.execute("""
-from pyomo.contrib.viewer.ui import get_mainwindow
-import pyomo.environ as pyo
-ui, model = get_mainwindow()""", silent=True)
     app.aboutToQuit.connect(window.shutdown_kernel)
     app.exec_()
 

--- a/pyomo/contrib/viewer/pyomo_viewer.py
+++ b/pyomo/contrib/viewer/pyomo_viewer.py
@@ -41,6 +41,14 @@ if qtconsole_available:
         # make sure there is no possible way the user can start the model
         # viewer before the Qt Application in the kernel finishes starting
         time.sleep(1.0)
+        # Now just do the standard imports of things you want to be available
+        # and whatever we may want to do to set up the environment just create
+        # an empty model, so you can start the model viewer right away.  You
+        # can add to the model if you want to use it, or create a new one.
+        kc.execute("""
+from pyomo.contrib.viewer.ui import get_mainwindow
+import pyomo.environ as pyo
+model = pyo.ConcreteModel("Default Model")""", silent=True)
         return km, kc
 
     class MainWindow(QMainWindow):
@@ -141,10 +149,8 @@ if qtconsole_available:
                 kc.execute("ui.show()", silent=True)
             else:
                 self._ui_created = True
-                kc.execute("""
-from pyomo.contrib.viewer.ui import get_mainwindow
-import pyomo.environ as pyo
-ui, model = get_mainwindow()""", silent=True)
+                kc.execute("ui, model = get_mainwindow(model=model)",
+                           silent=True)
 
         def shutdown_kernel(self):
             print('Shutting down kernel...')

--- a/pyomo/contrib/viewer/qt.py
+++ b/pyomo/contrib/viewer/qt.py
@@ -62,7 +62,8 @@ except:
         try:
             from PyQt4.QtGui import (QAbstractItemView, QFileDialog, QMainWindow,
                                      QMessageBox, QMdiArea, QApplication,
-                                     QTableWidgetItem, QColor)
+                                     QTableWidgetItem, QColor, QAction,
+                                     QStatusBar)
             from PyQt4.QtCore import QAbstractItemModel, QAbstractTableModel
             import PyQt4.QtCore as QtCore
             from PyQt4 import uic
@@ -73,7 +74,7 @@ else:
     try:
         from PyQt5.QtWidgets import (QAbstractItemView, QFileDialog, QMainWindow,
                                      QMessageBox, QMdiArea, QApplication,
-                                     QTableWidgetItem)
+                                     QTableWidgetItem, QAction, QStatusBar)
         from PyQt5.QtGui import QColor
         from PyQt5.QtCore import QAbstractItemModel, QAbstractTableModel
         import PyQt5.QtCore as QtCore

--- a/pyomo/contrib/viewer/residual_table.py
+++ b/pyomo/contrib/viewer/residual_table.py
@@ -80,7 +80,7 @@ class ResidualDataModel(QAbstractTableModel):
         self._items.sort(key=
             lambda o: (o is None, get_residual(self.ui_data, o)
                                   if get_residual(self.ui_data, o) is not None
-                                  else float("inf")), reverse=True)
+                                  else -float("inf")), reverse=True)
 
     def rowCount(self, parent=QtCore.QModelIndex()):
         return len(self._items)

--- a/pyomo/contrib/viewer/residual_table.py
+++ b/pyomo/contrib/viewer/residual_table.py
@@ -64,16 +64,23 @@ class ResidualDataModel(QAbstractTableModel):
         super(ResidualDataModel, self).__init__(parent)
         self.column = ["name", "residual", "value", "ub", "lb", "active"]
         self.ui_data = ui_data
+        self.include_inactive = True
         self.update_model()
         self.sort()
 
     def update_model(self):
+        if self.include_inactive:
+            ac = None
+        else:
+            ac = True
         self._items = list(self.ui_data.model.component_data_objects(
-            pyo.Constraint, active=True))
+            pyo.Constraint, active=ac))
 
     def sort(self):
         self._items.sort(key=
-            lambda o: (o is None, get_residual(self.ui_data, o)), reverse=True)
+            lambda o: (o is None, get_residual(self.ui_data, o)
+                                  if get_residual(self.ui_data, o) is not None
+                                  else float("inf")), reverse=True)
 
     def rowCount(self, parent=QtCore.QModelIndex()):
         return len(self._items)

--- a/pyomo/contrib/viewer/tests/pytest_qt.py
+++ b/pyomo/contrib/viewer/tests/pytest_qt.py
@@ -67,14 +67,7 @@ def get_button(w, label):
 def test_get_mainwindow(qtbot):
     m = get_model()
     mw, m = get_mainwindow(model=m, testing=True)
-    qtbot.addWidget(mw)
-    mw._dialog_test_button = QMessageBox.No
-    assert(hasattr(mw, "menu_File"))
     assert(hasattr(mw, "menuBar"))
-    qtbot.keyClick(mw.menuBar(), "f", modifier=QtCore.Qt.AltModifier)
-    qtbot.keyClick(mw.menu_File, "x")
-    # should have actiavted exit dialog
-    assert(isinstance(mw._dialog, QMessageBox))
     assert(isinstance(mw.variables, ModelBrowser))
     assert(isinstance(mw.constraints, ModelBrowser))
     assert(isinstance(mw.expressions, ModelBrowser))
@@ -94,3 +87,9 @@ def test_model_information(qtbot):
     assert(text[1].startswith("7")) # Active equalities
     assert(text[2].startswith("7")) # Free vars in active equalities
     assert(text[3].startswith("0")) # degrees of feedom
+    # Main window has parts it is supposed to 
+    assert(hasattr(mw, "menuBar"))
+    assert(isinstance(mw.variables, ModelBrowser))
+    assert(isinstance(mw.constraints, ModelBrowser))
+    assert(isinstance(mw.expressions, ModelBrowser))
+    assert(isinstance(mw.parameters, ModelBrowser))

--- a/pyomo/contrib/viewer/tests/test_qt.py
+++ b/pyomo/contrib/viewer/tests/test_qt.py
@@ -39,9 +39,5 @@ def run_subproc_pytest(test_file, test_func, freq=1, timeout=10.0):
     assert(p.poll()==0)
 
 @unittest.skipIf(skip_qt_tests, "Required packages not available")
-def test_get_mainwindow():
-    run_subproc_pytest(test_file, "test_get_mainwindow")
-
-@unittest.skipIf(skip_qt_tests, "Required packages not available")
 def test_model_information():
     run_subproc_pytest(test_file, "test_model_information")

--- a/pyomo/contrib/viewer/ui.py
+++ b/pyomo/contrib/viewer/ui.py
@@ -297,9 +297,8 @@ class MainWindow(_MainWindow, _MainWindowUI):
         self._dialog = msg
         msg.setIcon(QMessageBox.Question)
         msg.setText("Are you sure you want to close this window?"
-                    " You can reopen it with ui = get_mainwindow(model=model)"
-                    " function.")
-        msg.setWindowTitle("Exit?")
+                    " You can reopen it with ui.show().")
+        msg.setWindowTitle("Close?")
         msg.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
         if self.testing: # don't even show dialog just pretend button clicked
             result = self._dialog_test_button

--- a/pyomo/contrib/viewer/ui.py
+++ b/pyomo/contrib/viewer/ui.py
@@ -106,9 +106,7 @@ class MainWindow(_MainWindow, _MainWindowUI):
         self.ui_data.updated.connect(self.update_model)
         # Set menu actions (remember the menu items are defined in the ui file)
         # you can edit the menus in qt-designer
-        self.action_Exit.triggered.connect(self.exit_action)
         self.actionModel_Selector.triggered.connect(self.show_model_select)
-        self.actionSet_Working_Directory.triggered.connect(self.wdir_select)
         self.ui_data.exec_refresh.connect(self.refresh_on_execute)
         self.actionRestart_Variable_View.triggered.connect(
             self.variables_restart)
@@ -131,30 +129,6 @@ class MainWindow(_MainWindow, _MainWindowUI):
         self._dialog = None #dialog displayed so can access it easier for tests
         self._dialog_test_button = None # button clicked on dialog in test mode
         self.mdiArea.setViewMode(QMdiArea.TabbedView)
-
-    def wdir_select(self, checked=False, wdir=None):
-        """
-        Change the current working directory.
-
-        Args:
-            wdir (str): if None show a dialog to select, otherwise try to
-                change to this path
-            checked (bool): the triggered signal sends this, but it is not used
-        Returns:
-            (str): new working directory path
-        """
-        if wdir is None:
-            # Show a dialog box for user to select working directory
-            wd = QFileDialog(self, 'Working Directory', os.getcwd())
-            wd.setFileMode(QFileDialog.DirectoryOnly)
-        if wd.exec_() == QFileDialog.Accepted:
-            wdir = wd.selectedFiles()[0]
-        else:
-            wdir = None
-        # Change directory if one was selected
-        if wdir is not None:
-            os.chdir(wdir)
-        return wdir
 
     def toggle_tabs(self):
         # Could use not here, but this is a little more future proof
@@ -281,7 +255,6 @@ class MainWindow(_MainWindow, _MainWindowUI):
         model_select = ModelSelect(parent=self, ui_data=self.ui_data)
         model_select.update_models()
         model_select.show()
-
 
     def exit_action(self):
         """


### PR DESCRIPTION
## Summary/Motivation:

The main purpose of this PR is to fix a bug I came across in the residual table where if you calculate the constraints then add a new constraint to the model, the new constraint won't be calculated yet and the sort function will try to sort a list that contains floats and None, and fail.  I fixed this so if a residual value is None the sort treats it as -inf, making those constraints show up at the end.

Since I had to make some changes, I went ahead and made a few other minor improvements to the stand-alone model viewer.  I added a menu bar to the qtconsole window, and put menu items to run a script, change working directory, exit, show an hide the gui.  I also made only show the qtconsole window on start up.  You need to launch the model viewer by going to view and selecting show model viewer.  That fixed two problems 1) the model viewer no longer obscures the qtconsole window so people won't be confused about how to use it, and 2) I don't need to wait a few seconds to start the model browser UI in the jupyter kernel. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
