### PR TITLE
Add a guard in getname() for unattached ComponentData

### DIFF
--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -458,9 +458,12 @@ class Component(_ComponentBase):
             if relative_to is None:
                 relative_to = self.model()
             if pb is not None and pb is not relative_to:
-                ans = pb.getname(fully_qualified, name_buffer, relative_to) + "." + self._name
+                ans = pb.getname(fully_qualified, name_buffer, relative_to) \
+                      + "." + self._name
             elif pb is None and relative_to != self.model():
-                raise RuntimeError("The relative_to argument was specified but not found in the block hierarchy: %s" % str(relative_to))
+                raise RuntimeError(
+                    "The relative_to argument was specified but not found "
+                    "in the block hierarchy: %s" % str(relative_to))
             else:
                 ans = self._name
         else:
@@ -756,14 +759,29 @@ class ComponentData(_ComponentBase):
 
         c = self.parent_component()
         if c is self:
-            # This is a scalar component, so call the Component.getname() method
-            return super(ComponentData, self).getname(fully_qualified, name_buffer, relative_to)
-        #
-        # Get the name of the component
-        #
-        base = c.getname(fully_qualified, name_buffer, relative_to)
+            #
+            # This is a scalar component, so call the
+            # Component.getname() method
+            #
+            return super(ComponentData, self).getname(
+                fully_qualified, name_buffer, relative_to)
+        elif c is not None:
+            #
+            # Get the name of the parent component
+            #
+            base = c.getname(fully_qualified, name_buffer, relative_to)
+        else:
+            #
+            # Defensive: this is a ComponentData without a valid
+            # parent_component.  As this usually occurs when handling
+            # exceptions during model construction, we need to ensure
+            # that this method doesn't itself raise another exception.
+            #
+            return '[Unattached %s]' % (type(self).__name__,)
+
         if name_buffer is not None:
-            # Iterate through the dictionary and generate all names in the buffer
+            # Iterate through the dictionary and generate all names in
+            # the buffer
             for idx, obj in iteritems(c):
                 name_buffer[id(obj)] = base + _name_index_generator(idx)
             if id(self) in name_buffer:

--- a/pyomo/core/tests/unit/test_component.py
+++ b/pyomo/core/tests/unit/test_component.py
@@ -22,11 +22,67 @@ from pyomo.environ import *
 class TestComponent(unittest.TestCase):
 
     def test_construct_component_throws_exception(self):
-        try:
+        with self.assertRaisesRegexp(
+                DeveloperError,
+                "Must specify a component type for class Component"):
             Component()
-            self.fail("Expected DeveloperError")
-        except DeveloperError:
-            pass
+
+    def test_getname(self):
+        m = ConcreteModel()
+        m.b = Block([1,2])
+        m.b[2].c = Var([1,2],[3,4])
+
+        self.assertEqual(m.getname(fully_qualified=True), "unknown")
+        self.assertEqual(m.b.getname(fully_qualified=True), "b")
+        self.assertEqual(m.b[1].getname(fully_qualified=True), "b[1]")
+        self.assertEqual(m.b[2].c[2,4].getname(fully_qualified=True),
+                         "b[2].c[2,4]")
+        self.assertEqual(m.getname(fully_qualified=False), "unknown")
+        self.assertEqual(m.b.getname(fully_qualified=False), "b")
+        self.assertEqual(m.b[1].getname(fully_qualified=False), "b[1]")
+        self.assertEqual(m.b[2].c[2,4].getname(fully_qualified=False),
+                         "c[2,4]")
+
+        cache = {}
+        self.assertEqual(
+            m.b[2].c[2,4].getname(fully_qualified=True, name_buffer=cache),
+            "b[2].c[2,4]")
+        self.assertEqual(len(cache), 8)
+        self.assertIn(id(m.b[2].c[2,4]), cache)
+        self.assertIn(id(m.b[2].c[1,3]), cache)
+        self.assertIn(id(m.b[2].c), cache)
+        self.assertIn(id(m.b[2]), cache)
+        self.assertIn(id(m.b[1]), cache)
+        self.assertIn(id(m.b), cache)
+        self.assertNotIn(id(m), cache)
+        self.assertEqual(
+            m.b[2].c[1,3].getname(fully_qualified=True, name_buffer=cache),
+            "b[2].c[1,3]")
+
+        m.b[2]._component = None
+        self.assertEqual(m.b[2].getname(fully_qualified=True),
+                         "[Unattached _BlockData]")
+        # I think that getname() should do this:
+        #self.assertEqual(m.b[2].c[2,4].getname(fully_qualified=True),
+        #                 "[Unattached _BlockData].c[2,4]")
+        # but it doesn't match current behavior.  I will file a PEP to
+        # propose changing the behavior later and proceed to test
+        # current behavior.
+        self.assertEqual(m.b[2].c[2,4].getname(fully_qualified=True),
+                         "c[2,4]")
+
+        self.assertEqual(m.b[2].getname(fully_qualified=False),
+                         "[Unattached _BlockData]")
+        self.assertEqual(m.b[2].c[2,4].getname(fully_qualified=False),
+                         "c[2,4]")
+
+        # Cached names still work...
+        self.assertEqual(
+            m.b[2].getname(fully_qualified=True, name_buffer=cache),
+            "b[2]")
+        self.assertEqual(
+            m.b[2].c[1,3].getname(fully_qualified=True, name_buffer=cache),
+            "b[2].c[1,3]")
 
 
 class TestComponentUID(unittest.TestCase):


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
This PR adds a bit of defensive programming to `Component.getname()` to catch a situation where someone calls `getname()` on a `ComponentData` before the `ComponentData` was attached to a `Component` container.  I do not know how to test this through our public API, but @andrewlee94 was hitting it in some IDAES tests.

## Changes proposed in this PR:
- Guard for ComponentData with no parent component
- Adding tests
- PEP 8 reformatting

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
