### PR TITLE
NFC: Updating links to Pyomo tutorials and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Pyomo is currently tested with the following Python implementations:
 
     conda install -c conda-forge pyomo
 
+### Tutorials and Examples
+
+* [Pyomo Workshop Slides](https://software.sandia.gov/downloads/pub/pyomo/Pyomo-Workshop-Summer-2018.pdf)
+* [Prof. Jeffrey Kantor's Pyomo Cookbook](https://jckantor.github.io/ND-Pyomo-Cookbook/)
+* [Pyomo Gallery](https://github.com/Pyomo/PyomoGallery)
+
 ### Getting Help
 
 * [Ask a Pyomo Question on StackExchange](https://stackoverflow.com/questions/ask?tags=pyomo)

--- a/doc/OnlineDocs/tutorial_examples.rst
+++ b/doc/OnlineDocs/tutorial_examples.rst
@@ -3,7 +3,7 @@ Pyomo Tutorial Examples
 
 Additional Pyomo tutorials and examples can be found at the following links:
 
-`Prof. Jeffrey Kantor's Pyomo Cookbooks
+`Prof. Jeffrey Kantor's Pyomo Cookbook
 <https://jckantor.github.io/ND-Pyomo-Cookbook/>`_
 
 `Pyomo Gallery

--- a/doc/OnlineDocs/tutorial_examples.rst
+++ b/doc/OnlineDocs/tutorial_examples.rst
@@ -4,7 +4,7 @@ Pyomo Tutorial Examples
 Additional Pyomo tutorials and examples can be found at the following links:
 
 `Prof. Jeffrey Kantor's Pyomo Cookbooks
-<https://github.com/jckantor/ND-Pyomo-Cookbook>`_
+<https://jckantor.github.io/ND-Pyomo-Cookbook/>`_
 
 `Pyomo Gallery
 <https://github.com/Pyomo/PyomoGallery>`_


### PR DESCRIPTION
## Fixes #1027  .

## Summary/Motivation:
This PR is the implementation of PEP #1027. It adds a section to the main README with links to tutorials and examples and updates the link to Prof. Kantor's Pyomo Cookbook in readthedocs. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
