### PR TITLE
Add support for square root UnaryFunctionExpression in pyomo calculus

### DIFF
--- a/pyomo/core/expr/calculus/diff_with_pyomo.py
+++ b/pyomo/core/expr/calculus/diff_with_pyomo.py
@@ -220,6 +220,21 @@ def _diff_atan(node, val_dict, der_dict):
     der = der_dict[node]
     der_dict[arg] += der / (1 + val_dict[arg]**2)
 
+def _diff_sqrt(node, val_dict, der_dict):
+    """
+    Reverse automatic differentiation on the square root function.
+    Implementation copied from power function, with fixed exponent.
+
+    Parameters
+    ----------
+    node: pyomo.core.expr.numeric_expr.UnaryFunctionExpression
+    val_dict: ComponentMap
+    der_dict: ComponentMap
+    """
+    assert len(node.args) == 1
+    arg = node.args[0]
+    der = der_dict[node]
+    der_dict[arg] += der * 0.5 * val_dict[arg]**(-0.5)
 
 _unary_map = dict()
 _unary_map['exp'] = _diff_exp
@@ -230,6 +245,7 @@ _unary_map['tan'] = _diff_tan
 _unary_map['asin'] = _diff_asin
 _unary_map['acos'] = _diff_acos
 _unary_map['atan'] = _diff_atan
+_unary_map['sqrt'] = _diff_sqrt
 
 
 def _diff_UnaryFunctionExpression(node, val_dict, der_dict):

--- a/pyomo/core/tests/unit/test_derivs.py
+++ b/pyomo/core/tests/unit/test_derivs.py
@@ -73,7 +73,7 @@ class TestDerivs(unittest.TestCase):
         m = pe.ConcreteModel()
         m.x = pe.Var(initialize=2.0)
         m.y = pe.Var(initialize=3.0)
-        e = m.x ** 0.5
+        e = pe.sqrt(m.x)
         derivs = reverse_ad(e)
         symbolic = reverse_sd(e)
         self.assertAlmostEqual(derivs[m.x], pe.value(symbolic[m.x]), tol+3)

--- a/pyomo/core/tests/unit/test_derivs.py
+++ b/pyomo/core/tests/unit/test_derivs.py
@@ -69,6 +69,16 @@ class TestDerivs(unittest.TestCase):
         self.assertAlmostEqual(derivs[m.x], approx_deriv(e, m.x), tol)
         self.assertAlmostEqual(derivs[m.y], approx_deriv(e, m.y), tol)
 
+    def test_sqrt(self):
+        m = pe.ConcreteModel()
+        m.x = pe.Var(initialize=2.0)
+        m.y = pe.Var(initialize=3.0)
+        e = m.x ** 0.5
+        derivs = reverse_ad(e)
+        symbolic = reverse_sd(e)
+        self.assertAlmostEqual(derivs[m.x], pe.value(symbolic[m.x]), tol+3)
+        self.assertAlmostEqual(derivs[m.x], approx_deriv(e, m.x), tol)
+
     def test_exp(self):
         m = pe.ConcreteModel()
         m.x = pe.Var(initialize=2.0)


### PR DESCRIPTION
## Summary/Motivation:
Adds support for the square root function.
Let's please stop forgetting the humble square root function. I put in this same pull request for the sympy interface (#642).

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
