### PR TITLE
Adding methods to IndexedVar to set bounds

### DIFF
--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -919,6 +919,20 @@ class SimpleVar(_GeneralVarData, Var):
 class IndexedVar(Var):
     """An array of variables."""
 
+    def setlb(self, val):
+        """
+        Set the lower bound for this variable.
+        """
+        for vardata in itervalues(self):
+            vardata.setlb(val)
+
+    def setub(self, val):
+        """
+        Set the upper bound for this variable.
+        """
+        for vardata in itervalues(self):
+            vardata.setub(val)
+
     def fix(self, *val):
         """
         Set the fixed indicator to True. Value argument is optional,

--- a/pyomo/core/tests/unit/test_var.py
+++ b/pyomo/core/tests/unit/test_var.py
@@ -114,6 +114,38 @@ class TestSimpleVar(PyomoModel):
         model.x.setub(model.p**2)
         model.x.setub(1.0)
 
+    def test_setlb_indexed(self):
+        """Test setlb variables method"""
+        self.model.B = RangeSet(4)
+        self.model.y = Var(self.model.B, dense=True)
+
+        self.instance = self.model.create_instance()
+        self.assertEqual(len(self.instance.y) > 0, True)
+        for a in self.instance.y:
+            self.assertEqual(self.instance.y[a].lb, None)
+        self.instance.y.setlb(1)
+        for a in self.instance.y:
+            self.assertEqual(self.instance.y[a].lb, 1)
+        self.instance.y.setlb(None)
+        for a in self.instance.y:
+            self.assertEqual(self.instance.y[a].lb, None)
+
+    def test_setub_indexed(self):
+        """Test setub variables method"""
+        self.model.B = RangeSet(4)
+        self.model.y = Var(self.model.B, dense=True)
+
+        self.instance = self.model.create_instance()
+        self.assertEqual(len(self.instance.y) > 0, True)
+        for a in self.instance.y:
+            self.assertEqual(self.instance.y[a].ub, None)
+        self.instance.y.setub(1)
+        for a in self.instance.y:
+            self.assertEqual(self.instance.y[a].ub, 1)
+        self.instance.y.setub(None)
+        for a in self.instance.y:
+            self.assertEqual(self.instance.y[a].ub, None)
+
     def test_fix_all(self):
         """Test fix all variables method"""
         self.model.B = RangeSet(4)


### PR DESCRIPTION
## Fixes NA.

## Summary/Motivation:
`setlb` and `setub` have not been implemented for `IndexedVars` requiring these to be set for each element individually.

## Changes proposed in this PR:
- Implement `setlb` and `setub` methods for `IndexedVars` with basic tests.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
