### PR TITLE
Model viewer fix for editing numbers in tree views

### DIFF
--- a/pyomo/contrib/viewer/model_browser.py
+++ b/pyomo/contrib/viewer/model_browser.py
@@ -43,7 +43,10 @@ except:
         pass
     class _ModelBrowser(object):
         pass
-
+    class QItemEditorCreatorBase(object):
+        pass
+    class QItemDelegate(object):
+        pass
 
 class LineEditCreator(QItemEditorCreatorBase):
     """

--- a/pyomo/contrib/viewer/model_browser.py
+++ b/pyomo/contrib/viewer/model_browser.py
@@ -45,6 +45,45 @@ except:
         pass
 
 
+class LineEditCreator(QItemEditorCreatorBase):
+    """
+    Class to create editor widget for int and floats in a model view type object
+    """
+    def createWidget(self, parent):
+        return QLineEdit(parent=parent)
+
+
+class NumberDelegate(QItemDelegate):
+    """
+    Tree view item delegate. This is used here to change how items are edited.
+    """
+    def __init__(self, parent):
+        super(QItemDelegate, self).__init__(parent=parent)
+        factory = QItemEditorFactory()
+        factory.registerEditor(QtCore.QVariant.Int, LineEditCreator())
+        factory.registerEditor(QtCore.QVariant.Double, LineEditCreator())
+        self.setItemEditorFactory(factory)
+
+    def setModelData(self, editor, model, index):
+        if isinstance(editor, QComboBox):
+            value = editor.currentText()
+        else:
+            value = editor.text()
+        a = model.column[index.column()]
+        isinstance(index.internalPointer().get(a), bool)
+        try: # Recognize ints and floats.
+            if value == "False" or value == "false":
+                index.internalPointer().set(a, False)
+            elif value == "True" or value == "true":
+                index.internalPointer().set(a, True)
+            elif "." in value or "e" in value or "E" in value:
+                index.internalPointer().set(a, float(value))
+            else:
+                index.internalPointer().set(a, int(value))
+        except: # If not a valid number ignore
+            pass
+
+
 class ModelBrowser(_ModelBrowser, _ModelBrowserUI):
     def __init__(self, ui_data, parent=None, standard="Var"):
         """
@@ -58,8 +97,12 @@ class ModelBrowser(_ModelBrowser, _ModelBrowserUI):
         """
         super(ModelBrowser, self).__init__(parent=parent)
         self.setupUi(self)
+        # The default int and double spin boxes are not good for this
+        # application.  So just use regular line edits.
+        number_delegate = NumberDelegate(self)
         self.ui_data = ui_data
         self.ui_data.updated.connect(self.update_model)
+        self.treeView.setItemDelegate(number_delegate)
         if standard == "Var":
             # This if block sets up standard views
             components = Var
@@ -213,27 +256,27 @@ class ComponentDataItem(object):
     def _set_value_callback(self, val):
         if isinstance(self.data, _VarData):
             try:
-                self.data.value = float(val)
+                self.data.value = val
             except:
                 return
         elif isinstance(self.data, _ParamData):
             if not self.data._mutable: return
             try:
-                self.data.value = float(val)
+                self.data.value = val
             except:
                 return
 
     def _set_lb_callback(self, val):
         if isinstance(self.data, _VarData):
             try:
-                self.data.setlb(float(val))
+                self.data.setlb(val)
             except:
                 return
 
     def _set_ub_callback(self, val):
         if isinstance(self.data, _VarData):
             try:
-                self.data.setub(float(val))
+                self.data.setub(val)
             except:
                 return
 
@@ -436,13 +479,6 @@ class ComponentDataModel(QAbstractItemModel):
                 return QtCore.QVariant(QColor(QtCore.Qt.blue));
         else:
             return
-
-    def setData(self, index, value, role=QtCore.Qt.EditRole):
-        if role==QtCore.Qt.EditRole:
-            a = self.column[index.column()]
-            if a in self._col_editable:
-                index.internalPointer().set(a, value)
-        return 1
 
     def headerData(self, i, orientation, role=QtCore.Qt.DisplayRole):
         """

--- a/pyomo/contrib/viewer/qt.py
+++ b/pyomo/contrib/viewer/qt.py
@@ -63,8 +63,11 @@ except:
             from PyQt4.QtGui import (QAbstractItemView, QFileDialog, QMainWindow,
                                      QMessageBox, QMdiArea, QApplication,
                                      QTableWidgetItem, QColor, QAction,
-                                     QStatusBar)
-            from PyQt4.QtCore import QAbstractItemModel, QAbstractTableModel
+                                     QStatusBar, QLineEdit, QItemEditorFactory,
+                                     QItemEditorCreatorBase, QStyledItemDelegate,
+                                     QItemDelegate, QComboBox)
+            from PyQt4.QtCore import (QAbstractItemModel, QAbstractTableModel,
+                                      QVariant)
             import PyQt4.QtCore as QtCore
             from PyQt4 import uic
             qt_available = True
@@ -74,9 +77,13 @@ else:
     try:
         from PyQt5.QtWidgets import (QAbstractItemView, QFileDialog, QMainWindow,
                                      QMessageBox, QMdiArea, QApplication,
-                                     QTableWidgetItem, QAction, QStatusBar)
+                                     QTableWidgetItem, QAction, QStatusBar,
+                                     QLineEdit, QItemEditorFactory,
+                                     QItemEditorCreatorBase, QStyledItemDelegate,
+                                     QItemDelegate, QComboBox)
         from PyQt5.QtGui import QColor
-        from PyQt5.QtCore import QAbstractItemModel, QAbstractTableModel
+        from PyQt5.QtCore import (QAbstractItemModel, QAbstractTableModel,
+                                  QVariant)
         import PyQt5.QtCore as QtCore
         from PyQt5 import uic
         qt_available = True


### PR DESCRIPTION
## Fixes 

Model viewer problems editing numbers in the tree views for newer versions of Qt.

## Summary/Motivation:

By default in newer versions of Qt the editor widget for ints and floats is a spin box.  This can limit the number of decimal places and prevents truning an int into a float or a float to an int.  Trying to edit numbers in the tree view could be frustrating.  This changes adds a new item delegate to handle all the editing.  This brings all the editing stuff together and in the future it will be easier to expand and add validation for different things.  For now the main fix is that you can type any int or float you like in the tree view.

## Changes proposed in this PR:
- Add tree view item delegate
- Change number editor from a spin box to plain line edit.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
