### PR TITLE
Changed constructor of LinearExpression for easier user creation

### DIFF
--- a/pyomo/core/expr/numeric_expr.py
+++ b/pyomo/core/expr/numeric_expr.py
@@ -1281,7 +1281,8 @@ class LinearExpression(ExpressionBase):
         followed by the coefficients, followed by the variables.
         
         Alternatively, you can specify the constant, the list of linear_coeffs
-        and the list of linear_vars separately.
+        and the list of linear_vars separately. Note that these lists are NOT
+        copied.
         """
         # I am not sure why LinearExpression allows omitting args, but
         # it does.  If they are provided, they should be the constant
@@ -1292,15 +1293,9 @@ class LinearExpression(ExpressionBase):
             self.linear_coefs = args[1:n+1]
             self.linear_vars = args[n+1:]
         else:
-            self.constant = 0
-            if constant is not None:
-                self.constant = constant
-            self.linear_coefs = []
-            if linear_coefs is not None:
-                self.linear_coefs = linear_coefs
-            self.linear_vars = []
-            if linear_vars is not None:
-                self.linear_vars = linear_vars
+            self.constant = constant if constant is not None else 0
+            self.linear_coefs = linear_coefs if linear_coefs else []
+            self.linear_vars = linear_vars if linear_vars else []
             
         self._args_ = tuple()
 

--- a/pyomo/core/expr/numeric_expr.py
+++ b/pyomo/core/expr/numeric_expr.py
@@ -1271,7 +1271,18 @@ class LinearExpression(ExpressionBase):
 
     PRECEDENCE = 6
 
-    def __init__(self, args=None):
+    def __init__(self, args=None, constant=None, linear_coefs=None, linear_vars=None):
+        """ 
+        Build a linear expression object that stores the constant, as well as 
+        coefficients and variables to represent const + sum_i(c_i*x_i)
+        
+        You can specify args OR (constant, linear_coefs, and linear_vars)
+        If args is provided, it should be a list that contains the constant,
+        followed by the coefficients, followed by the variables.
+        
+        Alternatively, you can specify the constant, the list of linear_coeffs
+        and the list of linear_vars separately.
+        """
         # I am not sure why LinearExpression allows omitting args, but
         # it does.  If they are provided, they should be the constant
         # followed by the coefficients followed by the variables.
@@ -1282,8 +1293,15 @@ class LinearExpression(ExpressionBase):
             self.linear_vars = args[n+1:]
         else:
             self.constant = 0
+            if constant is not None:
+                self.constant = constant
             self.linear_coefs = []
+            if linear_coefs is not None:
+                self.linear_coefs = linear_coefs
             self.linear_vars = []
+            if linear_vars is not None:
+                self.linear_vars = linear_vars
+            
         self._args_ = tuple()
 
     def nargs(self):

--- a/pyomo/core/tests/unit/test_numeric_expr.py
+++ b/pyomo/core/tests/unit/test_numeric_expr.py
@@ -5201,11 +5201,11 @@ class TestDirect_LinearExpression(unittest.TestCase):
         N = 10
         S = list(range(1,N+1))
         m.x = Var(S, initialize=lambda m,i: 1.0/i)
-        m.P = Param(S, initialize=1.0, mutable=True)
+        m.P = Param(S, initialize=lambda m,i: i, mutable=True)
         m.obj = Objective(expr=LinearExpression(constant=1.0, linear_coefs=[i*m.P[i] for i in S], linear_vars=[m.x[i] for i in S]))
 
         # test that the expression evaluates correctly
-        self.assertAlmostEqual(value(m.obj), N+1)
+        self.assertAlmostEqual(value(m.obj), sum(i for i in S)+1)
 
         # test that the standard repn can be constructed
         repn = generate_standard_repn(m.obj.expr)

--- a/pyomo/core/tests/unit/test_numeric_expr.py
+++ b/pyomo/core/tests/unit/test_numeric_expr.py
@@ -58,6 +58,7 @@ from pyomo.core.base.label import *
 from pyomo.core.base.template_expr import IndexTemplate
 from pyomo.core.expr.expr_errors import TemplateExpressionError
 
+from pyomo.repn import generate_standard_repn
 
 class TestExpression_EvaluateNumericConstant(unittest.TestCase):
 
@@ -5143,6 +5144,74 @@ class TestNumValueDuckTyping(unittest.TestCase):
         x = pyomo.kernel.variable()
         self.check_api(x)
 
+class TestDirect_LinearExpression(unittest.TestCase):
+
+    def test_LinearExpression_Param(self):
+        m = ConcreteModel()
+        N = 10
+        S = list(range(1,N+1))
+        m.x = Var(S, initialize=lambda m,i: 1.0/i)
+        m.P = Param(S, initialize=lambda m,i: i)
+        m.obj = Objective(expr=LinearExpression(constant=1.0, linear_coefs=[m.P[i] for i in S], linear_vars=[m.x[i] for i in S]))
+
+        # test that the expression evaluates correctly
+        self.assertAlmostEqual(value(m.obj), N+1)
+
+        # test that the standard repn can be constructed
+        repn = generate_standard_repn(m.obj.expr)
+        self.assertAlmostEqual(repn.constant, 1.0)
+        self.assertTrue(len(repn.linear_coefs) == N)
+        self.assertTrue(len(repn.linear_vars) == N)
+
+    def test_LinearExpression_Number(self):
+        m = ConcreteModel()
+        N = 10
+        S = list(range(1,N+1))
+        m.x = Var(S, initialize=lambda m,i: 1.0/i)
+        m.obj = Objective(expr=LinearExpression(constant=1.0, linear_coefs=[i for i in S], linear_vars=[m.x[i] for i in S]))
+
+        # test that the expression evaluates correctly
+        self.assertAlmostEqual(value(m.obj), N+1)
+
+        # test that the standard repn can be constructed
+        repn = generate_standard_repn(m.obj.expr)
+        self.assertAlmostEqual(repn.constant, 1.0)
+        self.assertTrue(len(repn.linear_coefs) == N)
+        self.assertTrue(len(repn.linear_vars) == N)
+
+    def test_LinearExpression_MutableParam(self):
+        m = ConcreteModel()
+        N = 10
+        S = list(range(1,N+1))
+        m.x = Var(S, initialize=lambda m,i: 1.0/i)
+        m.P = Param(S, initialize=lambda m,i: i, mutable=True)
+        m.obj = Objective(expr=LinearExpression(constant=1.0, linear_coefs=[m.P[i] for i in S], linear_vars=[m.x[i] for i in S]))
+
+        # test that the expression evaluates correctly
+        self.assertAlmostEqual(value(m.obj), N+1)
+
+        # test that the standard repn can be constructed
+        repn = generate_standard_repn(m.obj.expr)
+        self.assertAlmostEqual(repn.constant, 1.0)
+        self.assertTrue(len(repn.linear_coefs) == N)
+        self.assertTrue(len(repn.linear_vars) == N)
+
+    def test_LinearExpression_expression(self):
+        m = ConcreteModel()
+        N = 10
+        S = list(range(1,N+1))
+        m.x = Var(S, initialize=lambda m,i: 1.0/i)
+        m.P = Param(S, initialize=1.0, mutable=True)
+        m.obj = Objective(expr=LinearExpression(constant=1.0, linear_coefs=[i*m.P[i] for i in S], linear_vars=[m.x[i] for i in S]))
+
+        # test that the expression evaluates correctly
+        self.assertAlmostEqual(value(m.obj), N+1)
+
+        # test that the standard repn can be constructed
+        repn = generate_standard_repn(m.obj.expr)
+        self.assertAlmostEqual(repn.constant, 1.0)
+        self.assertTrue(len(repn.linear_coefs) == N)
+        self.assertTrue(len(repn.linear_vars) == N)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

## Fixes # .

## Summary/Motivation:
It is possible to create a LinearExpression object directly in constraints. This might be desirable if this is faster than using sum() (which it appears it is - at least for dense constraints). This PR makes the constructor of LinearExpression a little easier to work with for users.

** still need to add a test - but I want to run Travis first.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
