### PR TITLE
Fixing typo that caused cython build failures

### DIFF
--- a/pyomo/repn/plugins/baron_writer.py
+++ b/pyomo/repn/plugins/baron_writer.py
@@ -46,6 +46,20 @@ from pyomo.repn.util import valid_expr_ctypes_minlp, \
 logger = logging.getLogger('pyomo.core')
 
 
+#Copied from cpxlp.py:
+# Keven Hunter made a nice point about using %.16g in his attachment
+# to ticket #4319. I am adjusting this to %.17g as this mocks the
+# behavior of using %r (i.e., float('%r'%<number>) == <number>) with
+# the added benefit of outputting (+/-). The only case where this
+# fails to mock the behavior of %r is for large (long) integers (L),
+# which is a rare case to run into and is probably indicative of
+# other issues with the model.
+# *** NOTE ***: If you use 'r' or 's' here, it will break code that
+#               relies on using '%+' before the formatting character
+#               and you will need to go add extra logic to output
+#               the number's sign.
+_ftoa_precision_str = '%.17g'
+
 def _ftoa(val):
     if val is None:
         return val
@@ -55,7 +69,7 @@ def _ftoa(val):
         else:
             raise ValueError("non-fixed bound or weight: " + str(exp))
 
-    a = _ftoa.precision_str % val
+    a = _ftoa_precision_str % val
     i = len(a)
     while i > 1:
         try:
@@ -71,20 +85,6 @@ def _ftoa(val):
     #if a.startswith('1.57'):
     #    raise RuntimeError("wtf %s %s, %s" % ( val, a, i))
     return a[:i]
-
-#Copied from cpxlp.py:
-# Keven Hunter made a nice point about using %.16g in his attachment
-# to ticket #4319. I am adjusting this to %.17g as this mocks the
-# behavior of using %r (i.e., float('%r'%<number>) == <number>) with
-# the added benefit of outputting (+/-). The only case where this
-# fails to mock the behavior of %r is for large (long) integers (L),
-# which is a rare case to run into and is probably indicative of
-# other issues with the model.
-# *** NOTE ***: If you use 'r' or 's' here, it will break code that
-#               relies on using '%+' before the formatting character
-#               and you will need to go add extra logic to output
-#               the number's sign.
-_ftoa.precision_str = '%.17g'
 
 
 #

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -36,6 +36,7 @@ import logging
 
 logger = logging.getLogger('pyomo.core')
 
+_ftoa_precision_str = '%.17g'
 def _ftoa(val):
     if val is None:
         return val
@@ -45,7 +46,7 @@ def _ftoa(val):
         else:
             raise ValueError("non-fixed bound or weight: " + str(val))
 
-    a = _ftoa.precision_str % val
+    a = _ftoa_precision_str % val
     i = len(a)
     while i > 1:
         try:
@@ -61,7 +62,6 @@ def _ftoa(val):
     #if a.startswith('1.57'):
     #    raise RuntimeError("wtf %s %s, %s" % ( val, a, i))
     return a[:i]
-_ftoa.precision_str = '%.17g'
 
 _legal_unary_functions = {
     'ceil','floor','exp','log','log10','sqrt',

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -43,7 +43,7 @@ def _ftoa(val):
         if is_fixed(val):
             val = value(val)
         else:
-            raise ValueError("non-fixed bound or weight: " + str(exp))
+            raise ValueError("non-fixed bound or weight: " + str(val))
 
     a = _ftoa.precision_str % val
     i = len(a)


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Fixing typo introduced in PR #989 that caused Cython builds to fail.

## Changes proposed in this PR:
- fixing typo

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
