### PR TITLE
bug in bigm transformation with set objects

### DIFF
--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -513,7 +513,7 @@ class BigM_Transformation(Transformation):
             try:
                 # The reason list(obj.index_set()) is used instead of just obj.index_set()
                 # is that the underlying index set for obj gets modified in this step
-                # if list() is not used. See PR #TBD
+                # if list() is not used. See PR #1101
                 newConstraint = Constraint(list(obj.index_set()), transBlock.lbub)
             except TypeError:
                 # The original constraint may have been indexed by a

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -511,7 +511,10 @@ class BigM_Transformation(Transformation):
 
         if obj.is_indexed():
             try:
-                newConstraint = Constraint(obj.index_set(), transBlock.lbub)
+                # The reason list(obj.index_set()) is used instead of just obj.index_set()
+                # is that the underlying index set for obj gets modified in this step
+                # if list() is not used. See PR #TBD
+                newConstraint = Constraint(list(obj.index_set()), transBlock.lbub)
             except TypeError:
                 # The original constraint may have been indexed by a
                 # non-concrete set (like an Any).  We will give up on


### PR DESCRIPTION
## Summary/Motivation:
When creating a constraint using the index set of another constraint combined with another set, the index set of the original constraint gets modified unintentionally. See the following example:

```
>>> import pyomo.environ as pe
>>> m = pe.ConcreteModel()
>>> m.a = pe.Set(initialize=[1,2,3])
>>> m.b = pe.Set(initialize=['a', 'b'])
>>> m.c = pe.Constraint(m.a, m.b)
>>> m.c.index_set().pprint()
c_index : Dim=0, Dimen=2, Size=6, Domain=None, Ordered=False, Bounds=None
    Virtual
>>> for i in m.c.index_set():
...     print(i)
...
(1, 'a')
(1, 'b')
(2, 'a')
(2, 'b')
(3, 'a')
(3, 'b')
>>> m.c2 = pe.Constraint(m.c.index_set(), m.b)
>>> m.c.index_set().pprint()
c_index : Dim=0, Dimen=2, Size=12, Domain=None, Ordered=False, Bounds=None
    Virtual
>>> for i in m.c.index_set():
...     print(i)
...
(1, 'a', 'a')
(1, 'a', 'b')
(1, 'b', 'a')
(1, 'b', 'b')
(2, 'a', 'a')
(2, 'a', 'b')
(2, 'b', 'a')
(2, 'b', 'b')
(3, 'a', 'a')
(3, 'a', 'b')
(3, 'b', 'a')
(3, 'b', 'b')
```

This creates a bug in the BigM transformation in ```pyomo.gdp```. This PR fixes this problem by wrapping the original index set in a ```list()``` when creating the new constraint. 

This is may not be the correct fix. We may need a fix in the Constraint constructor or somewhere in Sets. However, the new Set rewrite may fix this problem. @jsiirola What is your suggestion on how to proceed? Is this the correct fix until the set rewrite is complete or should I go ahead and try to fix the underlying problem?

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
