### PR TITLE
avoiding math range errors in fbbt

### DIFF
--- a/pyomo/contrib/fbbt/interval.py
+++ b/pyomo/contrib/fbbt/interval.py
@@ -282,14 +282,14 @@ def _inverse_power2(zl, zu, xl, xu, feasiblity_tol):
 
 
 def exp(xl, xu):
-    if xl >= 100:
-        lb = math.inf
-    else:
+    try:
         lb = math.exp(xl)
-    if xu >= 100:
-        ub = math.inf
-    else:
+    except OverflowError:
+        lb = math.inf
+    try:
         ub = math.exp(xu)
+    except OverflowError:
+        ub = math.inf
     return lb, ub
 
 

--- a/pyomo/contrib/fbbt/interval.py
+++ b/pyomo/contrib/fbbt/interval.py
@@ -282,7 +282,15 @@ def _inverse_power2(zl, zu, xl, xu, feasiblity_tol):
 
 
 def exp(xl, xu):
-    return math.exp(xl), math.exp(xu)
+    if xl >= 100:
+        lb = math.inf
+    else:
+        lb = math.exp(xl)
+    if xu >= 100:
+        ub = math.inf
+    else:
+        ub = math.exp(xu)
+    return lb, ub
 
 
 def log(xl, xu):


### PR DESCRIPTION
## Summary/Motivation:
This PR updates the interval arithmetic for exp to avoid math range errors when performing FBBT. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
