### PR TITLE
Multiplying sets should not alter the arguments

### DIFF
--- a/examples/pyomo/tutorials/data.out
+++ b/examples/pyomo/tutorials/data.out
@@ -13,7 +13,7 @@
         [('A1', 1, 'A1'), ('A1', 1, 'A2'), ('A2', 2, 'A2'), ('A2', 2, 'A3'), ('A3', 3, 'A1'), ('A3', 3, 'A3')]
     E_domain : Dim=0, Dimen=3, Size=27, Domain=None, Ordered=False, Bounds=None
         Virtual
-    E_domain_index_0 : Dim=0, Dimen=2, Size=27, Domain=None, Ordered=False, Bounds=None
+    E_domain_index_0 : Dim=0, Dimen=2, Size=9, Domain=None, Ordered=False, Bounds=None
         Virtual
     F : Dim=1, Dimen=1, Size=9, Domain=None, ArraySize=3, Ordered=False, Bounds=None
         Key : Members

--- a/examples/pyomo/tutorials/excel.out
+++ b/examples/pyomo/tutorials/excel.out
@@ -13,7 +13,7 @@
         [('A1', 1.0, 'A1'), ('A1', 1.0, 'A2'), ('A2', 2.0, 'A2'), ('A2', 2.0, 'A3'), ('A3', 3.0, 'A1'), ('A3', 3.0, 'A3')]
     E_domain : Dim=0, Dimen=3, Size=27, Domain=None, Ordered=False, Bounds=None
         Virtual
-    E_domain_index_0 : Dim=0, Dimen=2, Size=27, Domain=None, Ordered=False, Bounds=None
+    E_domain_index_0 : Dim=0, Dimen=2, Size=9, Domain=None, Ordered=False, Bounds=None
         Virtual
     F : Dim=1, Dimen=1, Size=0, Domain=None, ArraySize=0, Ordered=False, Bounds=None
         Key : Members

--- a/examples/pyomo/tutorials/table.out
+++ b/examples/pyomo/tutorials/table.out
@@ -13,7 +13,7 @@
         [('A1', 1, 'A1'), ('A1', 1, 'A2'), ('A2', 2, 'A2'), ('A2', 2, 'A3'), ('A3', 3, 'A1'), ('A3', 3, 'A3')]
     E_domain : Dim=0, Dimen=3, Size=27, Domain=None, Ordered=False, Bounds=None
         Virtual
-    E_domain_index_0 : Dim=0, Dimen=2, Size=27, Domain=None, Ordered=False, Bounds=None
+    E_domain_index_0 : Dim=0, Dimen=2, Size=9, Domain=None, Ordered=False, Bounds=None
         Virtual
     F : Dim=1, Dimen=1, Size=0, Domain=None, ArraySize=0, Ordered=False, Bounds=None
         Key : Members

--- a/pyomo/core/base/sets.py
+++ b/pyomo/core/base/sets.py
@@ -1544,7 +1544,7 @@ class _SetProduct(_SetOperator):
         _SetOperator.__init__(self, *args, **kwd)
         # the individual index sets definining the product set.
         if isinstance(self._setA,_SetProduct):
-            self.set_tuple = self._setA.set_tuple
+            self.set_tuple = list(self._setA.set_tuple)
         else:
             self.set_tuple = [self._setA]
         if isinstance(self._setB,_SetProduct):


### PR DESCRIPTION
## Fixes #134 

## Summary/Motivation:
Multiplying a `_SetProduct` by another Set would change the original `_SetProduct` argument.  This resolves that issue by duplicating the underlying set_tuple list.

Supersedes #1101.

## Changes proposed in this PR:
- Duplicate the argument list when forming a `_SetProduct` from another `_SetProduct`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
