### PR TITLE
Adding the Set.get_interval() method

### DIFF
--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -346,8 +346,11 @@ class _SetData(_SetDataBase):
                              "implement ranges" % (type(self).__name__,))
 
     def bounds(self):
-        _bnds = list((r.start, r.end) if r.step >= 0 else (r.end, r.start)
-                     for r in self.ranges())
+        try:
+            _bnds = list((r.start, r.end) if r.step >= 0 else (r.end, r.start)
+                         for r in self.ranges())
+        except AttributeError:
+            return None, None
         if not _bnds:
             return None, None
 
@@ -371,7 +374,7 @@ class _SetData(_SetDataBase):
 
     def get_interval(self):
         if self.dimen != 1:
-            return None
+            return self.bounds() + (None,)
         if self.isdiscrete():
             return self._get_discrete_interval()
         else:
@@ -399,11 +402,11 @@ class _SetData(_SetDataBase):
             step = vals[1]-vals[0]
             for i in xrange(2, len(vals)):
                 if step != vals[i] - vals[i-1]:
-                    return None
+                    return self.bounds() + (None,)
             return (vals[0], vals[-1], step)
         except AttributeError:
             # Catching Any, NonNumericRange, RangeProduct, etc...
-            return None
+            return self.bounds() + (None,)
 
         nRanges = len(ranges)
         r = ranges.pop()
@@ -414,13 +417,13 @@ class _SetData(_SetDataBase):
         else:
             end, start = r.start, r.end
         if r.step % step:
-            return None
+            return self.bounds() + (None,)
         # Catch misaligned ranges
         for r in ranges:
             if ( r.start - ref ) % step:
-                return None
+                return self.bounds() + (None,)
             if r.step % step:
-                return None
+                return self.bounds() + (None,)
 
         # This loop terminates when we have a complete pass that doesn't
         # remove any ranges from the ranges list.
@@ -463,7 +466,7 @@ class _SetData(_SetDataBase):
             ranges = list(_ for _ in ranges if _ is not None)
             _rlen = len(ranges)
         if ranges:
-            return None
+            return self.bounds() + (None,)
         return (start, end, step)
 
 
@@ -542,12 +545,12 @@ class _SetData(_SetDataBase):
             _rlen = len(ranges)
         if ranges:
             # The continuous ranges are disjoint
-            return None
+            return self.bounds() + (None,)
         for r in discrete:
             if not r.issubset(interval):
                 # The discrete range extends outside the continuous
                 # interval
-                return None
+                return self.bounds() + (None,)
         return (interval.start, interval.end, interval.step)
 
     @property

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -373,6 +373,16 @@ class _SetData(_SetDataBase):
         return lb, ub
 
     def get_interval(self):
+        """Return the interval for this Set as (start, end, step)
+
+        Returns the effective interval for this Set as a (start, end,
+        step) tuple.  Start and End are the same as returned by
+        `bounds()`.  Step is 0 for continuous ranges, a positive value
+        for regular discrete sets (e.g., 1 for Integers), or `None` for
+        Sets that do not have a regular interval (e.g., semicontinuous
+        sets, mixed type sets, sets with dimen != 1, etc).
+
+        """
         if self.dimen != 1:
             return self.bounds() + (None,)
         if self.isdiscrete():

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -4348,18 +4348,18 @@ class TestSetUtils(unittest.TestCase):
         self.assertEqual(a.get_interval(), (None, None, 0))
 
         a = NegativeReals | PositiveReals
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (None, None, None))
         a = NegativeReals | PositiveReals | [0]
-        self.assertEqual(a.get_interval(), (None,None,0))
+        self.assertEqual(a.get_interval(), (None, None, 0))
         a = NegativeReals | PositiveReals | RangeSet(0,5)
-        self.assertEqual(a.get_interval(), (None,None,0))
+        self.assertEqual(a.get_interval(), (None, None, 0))
 
         a = NegativeReals | RangeSet(-3, 3)
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (None, 3, None))
         a = NegativeReals | Binary
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (None, 1, None))
         a = PositiveReals | Binary
-        self.assertEqual(a.get_interval(), (0,None,0))
+        self.assertEqual(a.get_interval(), (0, None, 0))
 
         a = RangeSet(1,10,0) | RangeSet(5,15,0)
         self.assertEqual(a.get_interval(), (1,15,0))
@@ -4367,18 +4367,18 @@ class TestSetUtils(unittest.TestCase):
         self.assertEqual(a.get_interval(), (1,15,0))
 
         a = RangeSet(5,15,0) | RangeSet(1,4,0)
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (1, 15, None))
         a = RangeSet(1,4,0) | RangeSet(5,15,0)
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (1, 15, None))
 
         a = NegativeReals | Any
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (None, None, None))
         a = Any | NegativeReals
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (None, None, None))
         a = SetOf('abc') | NegativeReals
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (None, None, None))
         a = NegativeReals | SetOf('abc')
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (None, None, None))
 
     def test_get_discrete_interval(self):
         self.assertEqual(Integers.get_interval(), (None,None,1))
@@ -4387,16 +4387,16 @@ class TestSetUtils(unittest.TestCase):
         self.assertEqual(Binary.get_interval(), (0,1,1))
 
         a = PositiveIntegers | NegativeIntegers
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (None, None, None))
         a = NegativeIntegers | NonNegativeIntegers
-        self.assertEqual(a.get_interval(), (None,None,1))
+        self.assertEqual(a.get_interval(), (None, None, 1))
 
         a = SetOf([1,3,5,6,4,2])
         self.assertEqual(a.get_interval(), (1, 6, 1))
         a = SetOf([1,3,5,6,2])
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (1, 6, None))
         a = SetOf([1,3,5,6,4,2,'a'])
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (None, None, None))
         a = SetOf([3])
         self.assertEqual(a.get_interval(), (3,3,0))
 
@@ -4411,9 +4411,9 @@ class TestSetUtils(unittest.TestCase):
         self.assertEqual(a.get_interval(), (0, 10, 1))
 
         a = RangeSet(ranges=(NR(0,3,1), NR(5,10,1)))
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (0, 10, None))
         a = RangeSet(ranges=(NR(5,10,1), NR(0,3,1)))
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (0, 10, None))
 
         a = RangeSet(ranges=(NR(0,4,2), NR(6,10,2)))
         self.assertEqual(a.get_interval(), (0, 10, 2))
@@ -4421,14 +4421,14 @@ class TestSetUtils(unittest.TestCase):
         self.assertEqual(a.get_interval(), (0, 10, 2))
 
         a = RangeSet(ranges=(NR(0,4,2), NR(5,10,2)))
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (0, 9, None))
         a = RangeSet(ranges=(NR(5,10,2), NR(0,4,2)))
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (0, 9, None))
 
         a = RangeSet(ranges=(NR(0,10,2), NR(0,10,3)))
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (0, 10, None))
         a = RangeSet(ranges=(NR(0,10,3), NR(0,10,2)))
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (0, 10, None))
 
         a = RangeSet(ranges=(NR(2,10,2), NR(0,12,4)))
         self.assertEqual(a.get_interval(), (0,12,2))
@@ -4438,9 +4438,9 @@ class TestSetUtils(unittest.TestCase):
         # Even though the following are reasonable intervals, we
         # currently don't support resolving it:
         a = RangeSet(ranges=(NR(0,10,2), NR(1,10,2)))
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (0, 10, None))
         a = RangeSet(ranges=(NR(0,10,3), NR(1,10,3), NR(2,10,3)))
-        self.assertEqual(a.get_interval(), None)
+        self.assertEqual(a.get_interval(), (0, 10, None))
 
 
 class TestDeprecation(unittest.TestCase):

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -36,6 +36,7 @@ from pyomo.core.base.set import (
     AnyRange, _AnySet, Any, Binary,
     Reals, NonNegativeReals, PositiveReals, NonPositiveReals, NegativeReals,
     Integers, PositiveIntegers, NegativeIntegers,
+    NonPositiveIntegers, NonNegativeIntegers,
     Set,
     SetOf, OrderedSetOf, UnorderedSetOf,
     RangeSet, _FiniteRangeSetData, _InfiniteRangeSetData,
@@ -282,6 +283,9 @@ class InfiniteSetTester(unittest.TestCase):
         self.assertNotIn('A', Reals)
         self.assertNotIn(None, Reals)
 
+        self.assertFalse(Reals.isdiscrete())
+        self.assertFalse(Reals.isfinite())
+
     def test_Integers(self):
         self.assertIn(0, Integers)
         self.assertNotIn(1.5, Integers)
@@ -290,6 +294,9 @@ class InfiniteSetTester(unittest.TestCase):
         self.assertNotIn('A', Integers)
         self.assertNotIn(None, Integers)
 
+        self.assertTrue(Integers.isdiscrete())
+        self.assertFalse(Integers.isfinite())
+
     def test_Any(self):
         self.assertIn(0, Any)
         self.assertIn(1.5, Any)
@@ -297,6 +304,9 @@ class InfiniteSetTester(unittest.TestCase):
         self.assertIn(-100, Any),
         self.assertIn('A', Any)
         self.assertIn(None, Any)
+
+        self.assertFalse(Any.isdiscrete())
+        self.assertFalse(Any.isfinite())
 
     @unittest.skipIf(not numpy_available, "NumPy required for these tests")
     def test_numpy_compatible(self):
@@ -822,28 +832,34 @@ class Test_SetOf_and_RangeSet(unittest.TestCase):
 
     def test_is_functions(self):
         i = SetOf({1,2,3})
+        self.assertTrue(i.isdiscrete())
         self.assertTrue(i.isfinite())
         self.assertFalse(i.isordered())
 
         i = SetOf([1,2,3])
+        self.assertTrue(i.isdiscrete())
         self.assertTrue(i.isfinite())
         self.assertTrue(i.isordered())
 
         i = SetOf((1,2,3))
+        self.assertTrue(i.isdiscrete())
         self.assertTrue(i.isfinite())
         self.assertTrue(i.isordered())
 
         i = RangeSet(3)
+        self.assertTrue(i.isdiscrete())
         self.assertTrue(i.isfinite())
         self.assertTrue(i.isordered())
         self.assertIsInstance(i, _FiniteRangeSetData)
 
         i = RangeSet(1,3)
+        self.assertTrue(i.isdiscrete())
         self.assertTrue(i.isfinite())
         self.assertTrue(i.isordered())
         self.assertIsInstance(i, _FiniteRangeSetData)
 
         i = RangeSet(1,3,0)
+        self.assertFalse(i.isdiscrete())
         self.assertFalse(i.isfinite())
         self.assertFalse(i.isordered())
         self.assertIsInstance(i, _InfiniteRangeSetData)
@@ -4316,6 +4332,115 @@ class TestAbstractSetAPI(unittest.TestCase):
 
         with self.assertRaises(DeveloperError):
             s.ord(0)
+
+
+class TestSetUtils(unittest.TestCase):
+    def test_get_continuous_interval(self):
+        self.assertEqual(Reals.get_interval(), (None,None,0))
+        self.assertEqual(PositiveReals.get_interval(), (0,None,0))
+        self.assertEqual(NonNegativeReals.get_interval(), (0,None,0))
+        self.assertEqual(NonPositiveReals.get_interval(), (None,0,0))
+        self.assertEqual(NegativeReals.get_interval(), (None,0,0))
+
+        a = NonNegativeReals | NonPositiveReals
+        self.assertEqual(a.get_interval(), (None, None, 0))
+        a = NonPositiveReals | NonNegativeReals
+        self.assertEqual(a.get_interval(), (None, None, 0))
+
+        a = NegativeReals | PositiveReals
+        self.assertEqual(a.get_interval(), None)
+        a = NegativeReals | PositiveReals | [0]
+        self.assertEqual(a.get_interval(), (None,None,0))
+        a = NegativeReals | PositiveReals | RangeSet(0,5)
+        self.assertEqual(a.get_interval(), (None,None,0))
+
+        a = NegativeReals | RangeSet(-3, 3)
+        self.assertEqual(a.get_interval(), None)
+        a = NegativeReals | Binary
+        self.assertEqual(a.get_interval(), None)
+        a = PositiveReals | Binary
+        self.assertEqual(a.get_interval(), (0,None,0))
+
+        a = RangeSet(1,10,0) | RangeSet(5,15,0)
+        self.assertEqual(a.get_interval(), (1,15,0))
+        a = RangeSet(5,15,0) | RangeSet(1,10,0)
+        self.assertEqual(a.get_interval(), (1,15,0))
+
+        a = RangeSet(5,15,0) | RangeSet(1,4,0)
+        self.assertEqual(a.get_interval(), None)
+        a = RangeSet(1,4,0) | RangeSet(5,15,0)
+        self.assertEqual(a.get_interval(), None)
+
+        a = NegativeReals | Any
+        self.assertEqual(a.get_interval(), None)
+        a = Any | NegativeReals
+        self.assertEqual(a.get_interval(), None)
+        a = SetOf('abc') | NegativeReals
+        self.assertEqual(a.get_interval(), None)
+        a = NegativeReals | SetOf('abc')
+        self.assertEqual(a.get_interval(), None)
+
+    def test_get_discrete_interval(self):
+        self.assertEqual(Integers.get_interval(), (None,None,1))
+        self.assertEqual(PositiveIntegers.get_interval(), (1,None,1))
+        self.assertEqual(NegativeIntegers.get_interval(), (None,-1,1))
+        self.assertEqual(Binary.get_interval(), (0,1,1))
+
+        a = PositiveIntegers | NegativeIntegers
+        self.assertEqual(a.get_interval(), None)
+        a = NegativeIntegers | NonNegativeIntegers
+        self.assertEqual(a.get_interval(), (None,None,1))
+
+        a = SetOf([1,3,5,6,4,2])
+        self.assertEqual(a.get_interval(), (1, 6, 1))
+        a = SetOf([1,3,5,6,2])
+        self.assertEqual(a.get_interval(), None)
+        a = SetOf([1,3,5,6,4,2,'a'])
+        self.assertEqual(a.get_interval(), None)
+        a = SetOf([3])
+        self.assertEqual(a.get_interval(), (3,3,0))
+
+        a = RangeSet(ranges=(NR(0,5,1), NR(5,10,1)))
+        self.assertEqual(a.get_interval(), (0, 10, 1))
+        a = RangeSet(ranges=(NR(5,10,1), NR(0,5,1)))
+        self.assertEqual(a.get_interval(), (0, 10, 1))
+
+        a = RangeSet(ranges=(NR(0,4,1), NR(5,10,1)))
+        self.assertEqual(a.get_interval(), (0, 10, 1))
+        a = RangeSet(ranges=(NR(5,10,1), NR(0,4,1)))
+        self.assertEqual(a.get_interval(), (0, 10, 1))
+
+        a = RangeSet(ranges=(NR(0,3,1), NR(5,10,1)))
+        self.assertEqual(a.get_interval(), None)
+        a = RangeSet(ranges=(NR(5,10,1), NR(0,3,1)))
+        self.assertEqual(a.get_interval(), None)
+
+        a = RangeSet(ranges=(NR(0,4,2), NR(6,10,2)))
+        self.assertEqual(a.get_interval(), (0, 10, 2))
+        a = RangeSet(ranges=(NR(6,10,2), NR(0,4,2)))
+        self.assertEqual(a.get_interval(), (0, 10, 2))
+
+        a = RangeSet(ranges=(NR(0,4,2), NR(5,10,2)))
+        self.assertEqual(a.get_interval(), None)
+        a = RangeSet(ranges=(NR(5,10,2), NR(0,4,2)))
+        self.assertEqual(a.get_interval(), None)
+
+        a = RangeSet(ranges=(NR(0,10,2), NR(0,10,3)))
+        self.assertEqual(a.get_interval(), None)
+        a = RangeSet(ranges=(NR(0,10,3), NR(0,10,2)))
+        self.assertEqual(a.get_interval(), None)
+
+        a = RangeSet(ranges=(NR(2,10,2), NR(0,12,4)))
+        self.assertEqual(a.get_interval(), (0,12,2))
+        a = RangeSet(ranges=(NR(0,12,4), NR(2,10,2)))
+        self.assertEqual(a.get_interval(), (0,12,2))
+
+        # Even though the following are reasonable intervals, we
+        # currently don't support resolving it:
+        a = RangeSet(ranges=(NR(0,10,2), NR(1,10,2)))
+        self.assertEqual(a.get_interval(), None)
+        a = RangeSet(ranges=(NR(0,10,3), NR(1,10,3), NR(2,10,3)))
+        self.assertEqual(a.get_interval(), None)
 
 
 class TestDeprecation(unittest.TestCase):


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
While working on integrating the new Set objects into Kernel, I realized that it would be useful to be able to ask a Set to return its "interval", that is, it's starting point, ending point, and step size -- or `None` if the set does not have a uniform step size.

## Changes proposed in this PR:
- Add the `get_interval()` method to Set clases
- Adding testing of the new method

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
