### PR TITLE
Adding the pathos library to the appveyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -102,7 +102,7 @@ install:
   - SET MINICONDA_EXTRAS=""
   - IF DEFINED USING_MINICONDA (SET MINICONDA_EXTRAS=numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill seaborn)
   #
-  - "IF DEFINED EXTRAS (SET ADDITIONAL_CF_PKGS=%ADDITIONAL_CF_PKGS% pymysql pyro4 pint %MINICONDA_EXTRAS%)"
+  - "IF DEFINED EXTRAS (SET ADDITIONAL_CF_PKGS=%ADDITIONAL_CF_PKGS% pymysql pyro4 pint pathos %MINICONDA_EXTRAS%)"
   #- "IF DEFINED EXTRAS (%CONDAFORGE% mkl)"
   #
   # Finally, add any solvers we want to the list


### PR DESCRIPTION
## Fixes #1122

## Summary/Motivation:
Adding pathos to the Appveyor build harness, an optional dependency required by the contributed multisolve solver (#963)

## Changes proposed in this PR:
- Adding pathos to the Appveyor build harness

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
