### PR TITLE
Sympy fix for complex numbers

### DIFF
--- a/pyomo/core/expr/sympy_tools.py
+++ b/pyomo/core/expr/sympy_tools.py
@@ -62,6 +62,7 @@ try:
         sympy.ceiling: lambda x: current.ceil(x),
         sympy.floor: lambda x: current.floor(x),
         sympy.sqrt: lambda x: current.sqrt(x),
+        sympy.Abs: lambda x: abs(x),
         sympy.Derivative: _nondifferentiable,
         sympy.Tuple: lambda *x: x,
     }

--- a/pyomo/core/expr/sympy_tools.py
+++ b/pyomo/core/expr/sympy_tools.py
@@ -108,7 +108,10 @@ class PyomoSympyBimap(object):
     def getSympySymbol(self, pyomo_object):
         if pyomo_object in self.pyomo2sympy:
             return self.pyomo2sympy[pyomo_object]
-        sympy_obj = sympy.Symbol("x%d" % self.i)
+        # Pyomo currently ONLY supports Real variables (not complex
+        # variables).  If that ever changes, then we will need to
+        # revisit hard-coding the symbol type here
+        sympy_obj = sympy.Symbol("x%d" % self.i, real=True)
         self.i += 1
         self.pyomo2sympy[pyomo_object] = sympy_obj
         self.sympy2pyomo[sympy_obj] = pyomo_object

--- a/pyomo/core/tests/unit/test_symbolic.py
+++ b/pyomo/core/tests/unit/test_symbolic.py
@@ -243,6 +243,16 @@ class SymbolicDerivatives(unittest.TestCase):
         self.assertTrue(e.is_expression_type())
         self.assertEqual(s(e), s(0.5 * m.x**-0.5))
 
+    def test_abs_and_complex(self):
+        m = ConcreteModel()
+        m.x = Var()
+
+        # Unless we force sympy to know that X is real, it will return a
+        # complex expression.  This tests issue #1139.
+        e = differentiate(abs(m.x**2), wrt=m.x)
+        self.assertTrue(e.is_expression_type())
+        self.assertEqual(s(e), s(2 * m.x))
+
     def test_param(self):
         m = ConcreteModel()
         m.x = Var()


### PR DESCRIPTION
## Fixes #1139 

## Summary/Motivation:
In certain situations, sympy's `diff()` will return expressions with `re()` and `im()` nodes in the tree.  We will tell sympy that all variables are expected to be real variables, so that some situations can avoid the introduction of complex nodes.

## Changes proposed in this PR:
- inform sympy that all pyomo variables are expected to be real values
- add processing of the sympy.Abs expression node

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
