### PR TITLE
Use Graph.nodes instead of .node

### DIFF
--- a/pyomo/core/base/indexed_component_slice.py
+++ b/pyomo/core/base/indexed_component_slice.py
@@ -161,6 +161,14 @@ class _IndexedComponent_slice(object):
         the slice and call the item.  This allows "vector-like" operations
         like: `m.x[:,1].fix(0)`.
         """
+        # There is a weird case in pypy3.6-7.2.0 where __name__ gets
+        # called after retrieving an attribute that will be called.  I
+        # don't know why that happens, but we will trap it here and
+        # remove the getattr(__name__) from the call stack.
+        if self._call_stack[-1][0] == _IndexedComponent_slice.get_attribute \
+           and self._call_stack[-1][1] == '__name__':
+            self._call_stack.pop()
+
         self._call_stack.append( (
             _IndexedComponent_slice.call, idx, kwds ) )
         if self._call_stack[-2][1] == 'component':

--- a/pyomo/core/base/util.py
+++ b/pyomo/core/base/util.py
@@ -54,7 +54,7 @@ def _disable_method(fcn, msg=None):
     # Python 3.4.  For backwards compatability with Python 2.x, we will
     # create a temporary (lambda) function using eval that matches the
     # function signature passed in and calls the generic impl() function
-    args = inspect.formatargspec(*inspect.getargspec(fcn))
+    args = inspect.formatargspec(*getargspec(fcn))
     impl_args = eval('lambda %s: impl%s' % (args[1:-1], args), {'impl': impl})
     return functools.wraps(fcn)(impl_args)
 

--- a/pyomo/pysp/scenariotree/tree_structure_model.py
+++ b/pyomo/pysp/scenariotree/tree_structure_model.py
@@ -16,7 +16,8 @@ import six
 
 try:
     import networkx
-    has_networkx = True
+    # The code below conforms to the networkx>=2.0 API
+    has_networkx = int(networkx.__version__.split('.')[0]) >= 2
 except ImportError:                               #pragma:nocover
     has_networkx = False
 
@@ -232,7 +233,7 @@ def ScenarioTreeModelFromNetworkX(
 
     if not has_networkx:                          #pragma:nocover
         raise ValueError(
-            "networkx module is not available")
+            "networkx>=2.0 module is not available")
 
     if not networkx.is_tree(tree):
         raise TypeError(

--- a/pyomo/pysp/scenariotree/tree_structure_model.py
+++ b/pyomo/pysp/scenariotree/tree_structure_model.py
@@ -281,12 +281,12 @@ def ScenarioTreeModelFromNetworkX(
     scenario_bundle = {}
     def _setup(u, succ):
         if node_name_attribute is not None:
-            if node_name_attribute not in tree.node[u]:
+            if node_name_attribute not in tree.nodes[u]:
                 raise KeyError(
                     "node '%s' missing node name "
                     "attribute: '%s'"
                     % (u, node_name_attribute))
-            node_name = tree.node[u][node_name_attribute]
+            node_name = tree.nodes[u][node_name_attribute]
         else:
             node_name = u
         node_to_name[u] = node_name
@@ -297,18 +297,18 @@ def ScenarioTreeModelFromNetworkX(
         else:
             # a leaf node
             if scenario_name_attribute is not None:
-                if scenario_name_attribute not in tree.node[u]:
+                if scenario_name_attribute not in tree.nodes[u]:
                     raise KeyError(
                         "node '%s' missing scenario name "
                         "attribute: '%s'"
                         % (u, scenario_name_attribute))
-                scenario_name = tree.node[u][scenario_name_attribute]
+                scenario_name = tree.nodes[u][scenario_name_attribute]
             else:
                 scenario_name = u
             node_to_scenario[u] = scenario_name
             m.Scenarios.add(scenario_name)
             scenario_bundle[scenario_name] = \
-                tree.node[u].get('bundle', None)
+                tree.nodes[u].get('bundle', None)
     _setup(root,
            networkx.dfs_successors(tree, root))
     m = m.create_instance()
@@ -336,19 +336,19 @@ def ScenarioTreeModelFromNetworkX(
                 probability = 1.0/len(succ[pred[u]])
             m.ConditionalProbability[node_name] = probability
         # get node variables
-        if "variables" in tree.node[u]:
-            node_variables = tree.node[u]["variables"]
+        if "variables" in tree.nodes[u]:
+            node_variables = tree.nodes[u]["variables"]
             assert type(node_variables) in [tuple, list]
             for varstring in node_variables:
                 m.NodeVariables[node_name].add(varstring)
-        if "derived_variables" in tree.node[u]:
-            node_derived_variables = tree.node[u]["derived_variables"]
+        if "derived_variables" in tree.nodes[u]:
+            node_derived_variables = tree.nodes[u]["derived_variables"]
             assert type(node_derived_variables) in [tuple, list]
             for varstring in node_derived_variables:
                 m.NodeDerivedVariables[node_name].add(varstring)
-        if "cost" in tree.node[u]:
-            assert isinstance(tree.node[u]["cost"], six.string_types)
-            m.NodeCost[node_name].value = tree.node[u]["cost"]
+        if "cost" in tree.nodes[u]:
+            assert isinstance(tree.nodes[u]["cost"], six.string_types)
+            m.NodeCost[node_name].value = tree.nodes[u]["cost"]
         if u in succ:
             child_names = []
             for v in succ[u]:

--- a/pyomo/pysp/tests/unit/test_instancefactory.py
+++ b/pyomo/pysp/tests/unit/test_instancefactory.py
@@ -568,21 +568,21 @@ class Test(unittest.TestCase):
             self.assertEqual(scenario_tree.contains_bundles(), False)
             # check that we can modify the networkx tree to redefine
             # bundles
-            nx_tree.node["s1"]["bundle"] = 0
-            nx_tree.node["s2"]["bundle"] = 0
-            nx_tree.node["s3"]["bundle"] = 0
+            nx_tree.nodes["s1"]["bundle"] = 0
+            nx_tree.nodes["s2"]["bundle"] = 0
+            nx_tree.nodes["s3"]["bundle"] = 0
             scenario_tree = factory.generate_scenario_tree()
             self.assertEqual(scenario_tree.contains_bundles(), True)
             self.assertEqual(len(scenario_tree.bundles), 1)
-            nx_tree.node["s1"]["bundle"] = 0
-            nx_tree.node["s2"]["bundle"] = 1
-            nx_tree.node["s3"]["bundle"] = 2
+            nx_tree.nodes["s1"]["bundle"] = 0
+            nx_tree.nodes["s2"]["bundle"] = 1
+            nx_tree.nodes["s3"]["bundle"] = 2
             scenario_tree = factory.generate_scenario_tree()
             self.assertEqual(scenario_tree.contains_bundles(), True)
             self.assertEqual(len(scenario_tree.bundles), 3)
-            nx_tree.node["s1"]["bundle"] = None
-            nx_tree.node["s2"]["bundle"] = None
-            nx_tree.node["s3"]["bundle"] = None
+            nx_tree.nodes["s1"]["bundle"] = None
+            nx_tree.nodes["s2"]["bundle"] = None
+            nx_tree.nodes["s3"]["bundle"] = None
             scenario_tree = factory.generate_scenario_tree()
             self.assertEqual(scenario_tree.contains_bundles(), False)
 

--- a/pyomo/pysp/tests/unit/test_scenariotree.py
+++ b/pyomo/pysp/tests/unit/test_scenariotree.py
@@ -787,12 +787,12 @@ class TestScenarioTreeFromNetworkX(unittest.TestCase):
         self.assertEqual(list(model.Bundles), ["B"])
         self.assertEqual(list(model.BundleScenarios["B"]),
                          ["u"+str(i) for i in range(4)])
-        G.node["u0"]["bundle"] = None
+        G.nodes["u0"]["bundle"] = None
         with self.assertRaises(ValueError):
             ScenarioTreeModelFromNetworkX(
                 G,
                 edge_probability_attribute=None)
-        del G.node["u0"]["bundle"]
+        del G.nodes["u0"]["bundle"]
         with self.assertRaises(ValueError):
             ScenarioTreeModelFromNetworkX(
                 G,


### PR DESCRIPTION
## Fixes #1138.

## Summary/Motivation:
The .node attribute was deprecated in networkx 2.1 and removed in 2.4.

## Changes proposed in this PR:
- Replace usage of `Graph.node[]` with `Graph.nodes[]`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
