### PR TITLE
Adding support for log10 in differentiation

### DIFF
--- a/pyomo/core/expr/calculus/diff_with_pyomo.py
+++ b/pyomo/core/expr/calculus/diff_with_pyomo.py
@@ -3,6 +3,7 @@ from pyomo.core.expr import current as _expr
 from pyomo.core.expr.visitor import ExpressionValueVisitor, nonpyomo_leaf_types
 from pyomo.core.expr.numvalue import value
 from pyomo.core.expr.current import exp, log, sin, cos, tan, asin, acos, atan
+import math
 
 
 """
@@ -148,6 +149,21 @@ def _diff_log(node, val_dict, der_dict):
     der_dict[arg] += der / val_dict[arg]
 
 
+def _diff_log10(node, val_dict, der_dict):
+    """
+
+    Parameters
+    ----------
+    node: pyomo.core.expr.numeric_expr.UnaryFunctionExpression
+    val_dict: ComponentMap
+    der_dict: ComponentMap
+    """
+    assert len(node.args) == 1
+    arg = node.args[0]
+    der = der_dict[node]
+    der_dict[arg] += der * math.log10(math.exp(1)) / val_dict[arg]
+
+
 def _diff_sin(node, val_dict, der_dict):
     """
 
@@ -237,6 +253,7 @@ def _diff_atan(node, val_dict, der_dict):
     der = der_dict[node]
     der_dict[arg] += der / (1 + val_dict[arg]**2)
 
+
 def _diff_sqrt(node, val_dict, der_dict):
     """
     Reverse automatic differentiation on the square root function.
@@ -253,9 +270,11 @@ def _diff_sqrt(node, val_dict, der_dict):
     der = der_dict[node]
     der_dict[arg] += der * 0.5 * val_dict[arg]**(-0.5)
 
+
 _unary_map = dict()
 _unary_map['exp'] = _diff_exp
 _unary_map['log'] = _diff_log
+_unary_map['log10'] = _diff_log10
 _unary_map['sin'] = _diff_sin
 _unary_map['cos'] = _diff_cos
 _unary_map['tan'] = _diff_tan

--- a/pyomo/core/tests/unit/test_derivs.py
+++ b/pyomo/core/tests/unit/test_derivs.py
@@ -97,6 +97,15 @@ class TestDerivs(unittest.TestCase):
         self.assertAlmostEqual(derivs[m.x], pe.value(symbolic[m.x]), tol+3)
         self.assertAlmostEqual(derivs[m.x], approx_deriv(e, m.x), tol)
 
+    def test_log10(self):
+        m = pe.ConcreteModel()
+        m.x = pe.Var(initialize=2.0)
+        e = pe.log10(m.x)
+        derivs = reverse_ad(e)
+        symbolic = reverse_sd(e)
+        self.assertAlmostEqual(derivs[m.x], pe.value(symbolic[m.x]), tol+3)
+        self.assertAlmostEqual(derivs[m.x], approx_deriv(e, m.x), tol)
+
     def test_sin(self):
         m = pe.ConcreteModel()
         m.x = pe.Var(initialize=2.0)


### PR DESCRIPTION
## Summary/Motivation:
This PR adds support for differentiation of log10 with native pyomo expressions.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
