### PR TITLE
add tempdir parameter for solver.solve

### DIFF
--- a/pyomo/opt/base/solvers.py
+++ b/pyomo/opt/base/solvers.py
@@ -282,6 +282,13 @@ class OptSolver(object):
         _raise_ephemeral_error('soln_file')
 
     @property
+    def temp_dir(self):
+        _raise_ephemeral_error('temp_dir')
+    @temp_dir.setter
+    def temp_dir(self, val):
+        _raise_ephemeral_error('temp_dir')
+
+    @property
     def log_file(self):
         _raise_ephemeral_error('log_file')
     @log_file.setter
@@ -361,6 +368,7 @@ class OptSolver(object):
         self._report_timing = False
         self._suffixes = []
         self._log_file = None
+        self._temp_dir = None
         self._soln_file = None
 
         # overridden by a solver plugin when it returns sparse results
@@ -653,6 +661,7 @@ class OptSolver(object):
     def _presolve(self, *args, **kwds):
 
         self._log_file                = kwds.pop("logfile", None)
+        self._temp_dir                = kwds.pop("tempdir", None)
         self._soln_file               = kwds.pop("solnfile", None)
         self._select_index            = kwds.pop("select", 0)
         self._load_solutions          = kwds.pop("load_solutions", True)
@@ -670,6 +679,7 @@ class OptSolver(object):
                 self._convert_problem(args,
                                       self._problem_format,
                                       self._valid_problem_formats,
+                                      temp_dir=self._temp_dir,
                                       **kwds)
             total_time = time.time() - write_start_time
             if self._report_timing:

--- a/pyomo/solvers/plugins/converter/model.py
+++ b/pyomo/solvers/plugins/converter/model.py
@@ -10,6 +10,7 @@
 
 
 import os
+from functools import partial
 from six import iteritems, PY3
 
 import pyutilib.services
@@ -49,6 +50,9 @@ class PyomoMIPConverter(object):
         import pyomo.scripting.convert
 
         capabilities = kwds.pop("capabilities", None)
+        temp_dir = kwds.pop("temp_dir", None)
+        create_tempfile = partial((pyutilib.services.TempfileManager
+                                           .create_tempfile), dir=temp_dir)
 
         # all non-consumed keywords are assumed to be options
         # that should be passed to the writer.
@@ -69,8 +73,8 @@ class PyomoMIPConverter(object):
             instance = args[2]
 
         if args[1] == ProblemFormat.cpxlp:
-            problem_filename = pyutilib.services.TempfileManager.\
-                               create_tempfile(suffix = '.pyomo.lp')
+            problem_filename = create_tempfile(suffix='.pyomo.lp')
+
             if instance is not None:
                 if isinstance(instance, IBlock):
                     symbol_map_id = instance.write(
@@ -115,8 +119,8 @@ class PyomoMIPConverter(object):
                 return (problem_filename,),symbol_map
 
         elif args[1] == ProblemFormat.bar:
-            problem_filename = pyutilib.services.TempfileManager.\
-                               create_tempfile(suffix = '.pyomo.bar')
+            problem_filename = create_tempfile(suffix='.pyomo.bar')
+
             if instance is not None:
                 if isinstance(instance, IBlock):
                     symbol_map_id = instance.write(
@@ -161,8 +165,8 @@ class PyomoMIPConverter(object):
 
         elif args[1] in [ProblemFormat.mps, ProblemFormat.nl]:
             if args[1] == ProblemFormat.nl:
-                problem_filename = pyutilib.services.TempfileManager.\
-                                   create_tempfile(suffix = '.pyomo.nl')
+                problem_filename = create_tempfile(suffix = '.pyomo.nl')
+
                 if io_options.get("symbolic_solver_labels", False):
                     pyutilib.services.TempfileManager.add_tempfile(
                         problem_filename[:-3]+".row",
@@ -172,8 +176,8 @@ class PyomoMIPConverter(object):
                         exists=False)
             else:
                 assert args[1] == ProblemFormat.mps
-                problem_filename = pyutilib.services.TempfileManager.\
-                                   create_tempfile(suffix = '.pyomo.mps')
+                problem_filename = create_tempfile(suffix = '.pyomo.mps')
+
             if instance is not None:
                 if isinstance(instance, IBlock):
                     symbol_map_id = instance.write(
@@ -235,8 +239,8 @@ class PyomoMIPConverter(object):
 
         elif args[1] == ProblemFormat.osil:
             if False:
-                problem_filename = pyutilib.services.TempfileManager.\
-                               create_tempfile(suffix='pyomo.osil')
+                problem_filename = create_tempfile(suffix='pyomo.osil')
+
                 if instance:
                     if isinstance(instance, IBlock):
                         symbol_map_id = instance.write(

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -232,7 +232,8 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
             if self._warm_start_file_name is None:
                 assert not user_warmstart
                 self._warm_start_file_name = pyutilib.services.TempfileManager.\
-                                             create_tempfile(suffix = '.cplex.mst')
+                                             create_tempfile(suffix='.cplex.mst',
+                                                             dir=self._temp_dir)
 
         # let the base class handle any remaining keywords/actions.
         ILMLicensedSystemCallSolver._presolve(self, *args, **kwds)
@@ -287,7 +288,8 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
         #
         if self._log_file is None:
             self._log_file = pyutilib.services.TempfileManager.\
-                            create_tempfile(suffix = '.cplex.log')
+                            create_tempfile(suffix = '.cplex.log',
+                                            dir=self._temp_dir)
         self._log_file = _validate_file_name(self, self._log_file, "log")
 
         #
@@ -296,7 +298,8 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
         #
         if self._soln_file is None:
             self._soln_file = pyutilib.services.TempfileManager.\
-                              create_tempfile(suffix = '.cplex.sol')
+                              create_tempfile(suffix = '.cplex.sol',
+                                              dir=self._temp_dir)
         self._soln_file = _validate_file_name(self, self._soln_file, "solution")
 
         #
@@ -340,7 +343,8 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
         # user if we're keeping files around.
         if self._keepfiles:
             script_fname = pyutilib.services.TempfileManager.\
-                           create_tempfile(suffix = '.cplex.script')
+                           create_tempfile(suffix = '.cplex.script',
+                                           dir=self._temp_dir)
             tmp = open(script_fname,'w')
             tmp.write(script)
             tmp.close()


### PR DESCRIPTION
## Summary/Motivation:
Adds a temp_dir parameter for all CPLEX temporary files. This allows to freely choose the temporary files' directory by running the solver like e.g. `solver.solve(tempdir='.')`. Motivation: For larger problems and `keepfiles=True` we don't necessarily want our default `/tmp/` dir to be filled up.

## Changes proposed in this PR:
- added `temp_dir` attrs/params in 3 files; in all cases, these are passed as the `dir` parameter to the `TempfileManager.create_tempfile` method
- Only tested for CPLEX; omitting the `tempdir` parameter in the `solver.solve` call defaults to the old behavior

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
