### PR TITLE
Fixing syntax warnings in Python 3.8

### DIFF
--- a/pyomo/common/_task.py
+++ b/pyomo/common/_task.py
@@ -276,7 +276,7 @@ def pyomo_api(fn=None, implements=None, outputs=None, namespace=None):
                 kwargs['fn'] = fn
                 PyomoTask.__init__(self, *args, **kwargs)
                 if fn is not None:
-                    if len(argspec.args) is 0:
+                    if len(argspec.args) == 0:
                         nargs = 0
                     elif argspec.defaults is None:
                         nargs = len(argspec.args)

--- a/pyomo/core/base/plugin.py
+++ b/pyomo/core/base/plugin.py
@@ -280,7 +280,7 @@ TransformationFactory = Factory('transformation type')
 
 @deprecated(version='4.3.11323')
 def apply_transformation(*args, **kwds):
-    if len(args) is 0:
+    if len(args) == 0:
         return list(TransformationFactory)
     xfrm = TransformationFactory(args[0])
     if len(args) == 1 or xfrm is None:

--- a/pyomo/dae/simulator.py
+++ b/pyomo/dae/simulator.py
@@ -590,7 +590,7 @@ class Simulator:
                         "DerivativeVar %s" % str(dvkey))
             
                 derivlist.append(dvkey)
-                if self._intpackage is 'casadi':
+                if self._intpackage == 'casadi':
                     rhsdict[dvkey] = substitute_pyomo2casadi(RHS, templatemap)
                 else:
                     rhsdict[dvkey] = convert_pyomo2scipy(RHS, templatemap)
@@ -759,7 +759,7 @@ class Simulator:
             valid_integrators = ['vode', 'zvode', 'lsoda', 'dopri5', 'dop853']
             if integrator is None:
                 integrator = 'lsoda'
-            elif integrator is 'odeint':
+            elif integrator == 'odeint':
                 integrator = 'lsoda'
         else:
             # Specify the casadi integrator to use for simulation.
@@ -823,7 +823,7 @@ class Simulator:
                 else:
                     self._simalgvars.append(alg)
 
-            if self._intpackage is 'scipy' and len(self._simalgvars) != 0:
+            if self._intpackage == 'scipy' and len(self._simalgvars) != 0:
                 raise DAE_Error("When simulating with Scipy you must "
                                 "provide values for all parameters "
                                 "and algebraic variables that are indexed "
@@ -876,7 +876,7 @@ class Simulator:
                 initcon.append(value(v._base[vidx]))
 
         # Call the integrator
-        if self._intpackage is 'scipy':
+        if self._intpackage == 'scipy':
             if not scipy_available:
                 raise ValueError("The scipy module is not available. "
                                   "Cannot simulate the model.")

--- a/pyomo/opt/base/solvers.py
+++ b/pyomo/opt/base/solvers.py
@@ -405,7 +405,7 @@ class OptSolver(object):
         tokens = pyutilib.misc.quote_split('[ ]+',istr)
         for token in tokens:
             index = token.find('=')
-            if index is -1:
+            if index == -1:
                 raise ValueError(
                     "Solver options must have the form option=value: '%s'" % istr)
             try:

--- a/pyomo/pysp/plugins/wwphextension.py
+++ b/pyomo/pysp/plugins/wwphextension.py
@@ -1023,7 +1023,7 @@ class wwphextension(pyomo.common.plugin.SingletonPlugin):
 
             if (self.CheckWeightOscillationAfterIter > 0) and \
                (ph._current_iteration >= self.CheckWeightOscillationAfterIter):
-                if (last_flip_iter is 0) or \
+                if (last_flip_iter == 0) or \
                    (flip_duration >= self.FixIfWeightOscillationCycleLessThan):
                     pass
                 else:

--- a/pyomo/pysp/scenariotree/tree_structure.py
+++ b/pyomo/pysp/scenariotree/tree_structure.py
@@ -1622,7 +1622,7 @@ class ScenarioTree(object):
                 scenario_leaf_node_name = value(scenario_leaf_ids[scenario_name])
                 if scenario_leaf_node_name not in self._tree_node_map:
                     raise ValueError("Uknown tree node=%s specified as leaf "
-                                     "of scenario=%s"
+                                     "of scenario=%s" %
                                      (scenario_leaf_node_name, scenario_name))
                 else:
                     new_scenario._leaf_node = \

--- a/pyomo/repn/standard_repn.py
+++ b/pyomo/repn/standard_repn.py
@@ -490,7 +490,7 @@ def _collect_sum(exp, multiplier, idMap, compute_values, verbose, quadratic):
             # Add returned from recursion
             #
             ans.constant += res_.constant
-            if not (res_.nonl is 0 or res_.nonl.__class__ in native_numeric_types and res_.nonl == 0):
+            if not (res_.nonl.__class__ in native_numeric_types and res_.nonl == 0):
                 nonl.append(res_.nonl)
             for i in res_.linear:
                 ans.linear[i] = ans.linear.get(i,0) + res_.linear[i]

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -83,7 +83,7 @@ class _GAMSSolver(object):
         tokens = quote_split('[ ]+',istr)
         for token in tokens:
             index = token.find('=')
-            if index is -1:
+            if index == -1:
                 raise ValueError(
                     "Solver options must have the form option=value: '%s'" % istr)
             try:

--- a/pyomo/solvers/plugins/solvers/GLPK_old.py
+++ b/pyomo/solvers/plugins/solvers/GLPK_old.py
@@ -960,7 +960,7 @@ class GLPKSHELL_old(SystemCallSolver):
         elif soln.status is SolutionStatus.stoppedByLimit:
             soln.gap = "Infinity"  # until proven otherwise
             if "lower_bound" in dir(results.problem):
-                if results.problem.lower_bound is "-Infinity":
+                if results.problem.lower_bound == "-Infinity":
                     soln.gap = "Infinity"
                 elif not results.problem.lower_bound is None:
                     if "upper_bound" not in dir(results.problem):
@@ -971,7 +971,7 @@ class GLPKSHELL_old(SystemCallSolver):
                         soln.gap = eval(soln.objective(0)) - \
                                    eval(results.problem.lower_bound)
             elif "upper_bound" in dir(results.problem):
-                if results.problem.upper_bound is "Infinity":
+                if results.problem.upper_bound == "Infinity":
                     soln.gap = "Infinity"
                 elif not results.problem.upper_bound is None:
                     soln.gap = eval(results.problem.upper_bound) - \


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Fixing syntax warnings issued by Python 3.8

## Changes proposed in this PR:
- removing comparison to literal using `is`
- Adding a missing `%` operator in an exception message

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
