### PR TITLE
Fixing precision warning from ftoa()

### DIFF
--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -30,38 +30,11 @@ from pyomo.core.kernel.base import ICategorizedObject
 from pyomo.opt import ProblemFormat
 from pyomo.opt.base import AbstractProblemWriter, WriterFactory
 from pyomo.repn.util import valid_expr_ctypes_minlp, \
-    valid_active_ctypes_minlp
+    valid_active_ctypes_minlp, ftoa
 
 import logging
 
 logger = logging.getLogger('pyomo.core')
-
-_ftoa_precision_str = '%.17g'
-def _ftoa(val):
-    if val is None:
-        return val
-    if type(val) not in native_numeric_types:
-        if is_fixed(val):
-            val = value(val)
-        else:
-            raise ValueError("non-fixed bound or weight: " + str(val))
-
-    a = _ftoa_precision_str % val
-    i = len(a)
-    while i > 1:
-        try:
-            if float(a[:i-1]) == val:
-                i -= 1
-            else:
-                break
-        except:
-            break
-    if i == len(a):
-        logger.warning(
-            "converting %s to string resulted in loss of precision" % val)
-    #if a.startswith('1.57'):
-    #    raise RuntimeError("wtf %s %s, %s" % ( val, a, i))
-    return a[:i]
 
 _legal_unary_functions = {
     'ceil','floor','exp','log','log10','sqrt',
@@ -114,7 +87,7 @@ class ToGamsVisitor(EXPR.ExpressionValueVisitor):
                     tmp.append(val)
 
         if node.__class__ in EXPR.NPV_expression_types:
-            return _ftoa(value(node))
+            return ftoa(value(node))
 
         if node.__class__ is EXPR.PowExpression:
             # If the exponent is a positive integer, use the power() function.
@@ -152,7 +125,7 @@ class ToGamsVisitor(EXPR.ExpressionValueVisitor):
             return True, None
 
         if node.__class__ in native_types:
-            return True, _ftoa(node)
+            return True, ftoa(node)
 
         if node.is_expression_type():
             # we will descend into this, so type checking will happen later
@@ -176,12 +149,12 @@ class ToGamsVisitor(EXPR.ExpressionValueVisitor):
 
         if node.is_variable_type():
             if node.fixed:
-                return True, _ftoa(value(node))
+                return True, ftoa(value(node))
             else:
                 label = self.smap.getSymbol(node)
                 return True, label
 
-        return True, _ftoa(value(node))
+        return True, ftoa(value(node))
 
     def ctype(self, comp):
         if isinstance(comp, ICategorizedObject):
@@ -568,14 +541,14 @@ class ProblemWriter_gams(AbstractProblemWriter):
                 ConstraintIO.write('%s.. %s =e= %s ;\n' % (
                     constraint_names[-1],
                     con_body_str,
-                    _ftoa(con.upper)
+                    ftoa(con.upper)
                 ))
             else:
                 if con.has_lb():
                     constraint_names.append('%s_lo' % cName)
                     ConstraintIO.write('%s.. %s =l= %s ;\n' % (
                         constraint_names[-1],
-                        _ftoa(con.lower),
+                        ftoa(con.lower),
                         con_body_str,
                     ))
                 if con.has_ub():
@@ -583,7 +556,7 @@ class ProblemWriter_gams(AbstractProblemWriter):
                     ConstraintIO.write('%s.. %s =l= %s ;\n' % (
                         constraint_names[-1],
                         con_body_str,
-                        _ftoa(con.upper)
+                        ftoa(con.upper)
                     ))
 
         obj = list(model.component_data_objects(Objective,
@@ -643,7 +616,7 @@ class ProblemWriter_gams(AbstractProblemWriter):
             if category == 'positive':
                 if var.has_ub():
                     output_file.write("%s.up = %s;\n" %
-                                      (var_name, _ftoa(var.ub)))
+                                      (var_name, ftoa(var.ub)))
             elif category == 'ints':
                 if not var.has_lb():
                     warn_int_bounds = True
@@ -653,7 +626,7 @@ class ProblemWriter_gams(AbstractProblemWriter):
                     output_file.write("%s.lo = -1.0E+100;\n" % (var_name))
                 elif value(var.lb) != 0:
                     output_file.write("%s.lo = %s;\n" %
-                                      (var_name, _ftoa(var.lb)))
+                                      (var_name, ftoa(var.lb)))
                 if not var.has_ub():
                     warn_int_bounds = True
                     # GAMS has an option value called IntVarUp that is the
@@ -665,26 +638,26 @@ class ProblemWriter_gams(AbstractProblemWriter):
                     output_file.write("%s.up = +1.0E+100;\n" % (var_name))
                 else:
                     output_file.write("%s.up = %s;\n" %
-                                      (var_name, _ftoa(var.ub)))
+                                      (var_name, ftoa(var.ub)))
             elif category == 'binary':
                 if var.has_lb() and value(var.lb) != 0:
                     output_file.write("%s.lo = %s;\n" %
-                                      (var_name, _ftoa(var.lb)))
+                                      (var_name, ftoa(var.lb)))
                 if var.has_ub() and value(var.ub) != 1:
                     output_file.write("%s.up = %s;\n" %
-                                      (var_name, _ftoa(var.ub)))
+                                      (var_name, ftoa(var.ub)))
             elif category == 'reals':
                 if var.has_lb():
                     output_file.write("%s.lo = %s;\n" %
-                                      (var_name, _ftoa(var.lb)))
+                                      (var_name, ftoa(var.lb)))
                 if var.has_ub():
                     output_file.write("%s.up = %s;\n" %
-                                      (var_name, _ftoa(var.ub)))
+                                      (var_name, ftoa(var.ub)))
             else:
                 raise KeyError('Category %s not supported' % category)
             if warmstart and var.value is not None:
                 output_file.write("%s.l = %s;\n" %
-                                  (var_name, _ftoa(var.value)))
+                                  (var_name, ftoa(var.value)))
 
         if warn_int_bounds:
             logger.warning(

--- a/pyomo/repn/util.py
+++ b/pyomo/repn/util.py
@@ -33,6 +33,8 @@ _ftoa_precision_str = '%.17g'
 def ftoa(val):
     if val is None:
         return val
+    #
+    # Basic checking, including conversion of *fixed* Pyomo types to floats
     if type(val) in native_numeric_types:
         _val = val
     else:
@@ -41,18 +43,29 @@ def ftoa(val):
         else:
             raise ValueError(
                 "Converting non-fixed bound or value to string: %s" (val,))
-
+    #
+    # Convert to string
     a = _ftoa_precision_str % _val
+    #
+    # Remove unnecessary least significant digits.  While not strictly
+    # necessary, this helps keep the emitted string consistent between
+    # python versions by simplifying things like "1.0000000000001" to
+    # "1".
     i = len(a)
-    while i > 1:
-        try:
+    try:
+        while i > 1:
             if float(a[:i-1]) == _val:
                 i -= 1
             else:
                 break
-        except:
-            break
+    except:
+        pass
+    #
+    # It is important to issue a warning if the conversion loses
+    # precision (as the emitted model is not exactly what the user
+    # specified)
     if i == len(a) and float(a) != _val:
         logger.warning(
             "Converting %s to string resulted in loss of precision" % val)
+    #
     return a[:i]

--- a/pyomo/repn/util.py
+++ b/pyomo/repn/util.py
@@ -10,6 +10,49 @@
 
 from pyomo.core.base import Var, Param, Expression, Objective, Block, \
     Constraint, Suffix
+from pyomo.core.expr.numvalue import native_numeric_types, is_fixed, value
 
 valid_expr_ctypes_minlp = {Var, Param, Expression, Objective}
 valid_active_ctypes_minlp = {Block, Constraint, Objective, Suffix}
+
+
+#Copied from cpxlp.py:
+# Keven Hunter made a nice point about using %.16g in his attachment
+# to ticket #4319. I am adjusting this to %.17g as this mocks the
+# behavior of using %r (i.e., float('%r'%<number>) == <number>) with
+# the added benefit of outputting (+/-). The only case where this
+# fails to mock the behavior of %r is for large (long) integers (L),
+# which is a rare case to run into and is probably indicative of
+# other issues with the model.
+# *** NOTE ***: If you use 'r' or 's' here, it will break code that
+#               relies on using '%+' before the formatting character
+#               and you will need to go add extra logic to output
+#               the number's sign.
+_ftoa_precision_str = '%.17g'
+
+def ftoa(val):
+    if val is None:
+        return val
+    if type(val) in native_numeric_types:
+        _val = val
+    else:
+        if is_fixed(val):
+            _val = value(val)
+        else:
+            raise ValueError(
+                "Converting non-fixed bound or value to string: %s" (val,))
+
+    a = _ftoa_precision_str % _val
+    i = len(a)
+    while i > 1:
+        try:
+            if float(a[:i-1]) == _val:
+                i -= 1
+            else:
+                break
+        except:
+            break
+    if i == len(a) and float(a) != _val:
+        logger.warning(
+            "Converting %s to string resulted in loss of precision" % val)
+    return a[:i]


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
The GAMS and BARON writers were generating large numbers of (incorrect) warnings about loss of precision (identified by @mrmundt). 

## Changes proposed in this PR:
- remove duplicate implementations of `_ftoa` from BARON and GAMS writers and putting it into `pyomo.repn.util.ftoa()`.
- check that `ftoa` is actually losing precision before emitting warning.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
