### PR TITLE
Fix a typo in MOSEK problem status handling.

### DIFF
--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -548,7 +548,7 @@ class MosekDirect(DirectSolver):
             msk.prosta.dual_feas: 'd_feas',
             msk.prosta.prim_infeas: 'p_infeas',
             msk.prosta.dual_infeas: 'd_infeas',
-            msk.prosta.prim_and_dual_feas: 'pd_infeas',
+            msk.prosta.prim_and_dual_infeas: 'pd_infeas',
             msk.prosta.ill_posed: 'illposed',
             msk.prosta.prim_infeas_or_unbounded: 'p_inf_unb'
         }


### PR DESCRIPTION
## Fixes # .

A typo in MOSEK to Pyomo problem status translation. The same problem status appeared in the dictionary twice.

## Changes proposed in this PR:

Because of the typo the termination message could be incorrect for continuous problems.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
