### PR TITLE
Add MC++ interface versioning

### DIFF
--- a/pyomo/contrib/mcpp/mcppInterface.cpp
+++ b/pyomo/contrib/mcpp/mcppInterface.cpp
@@ -20,6 +20,9 @@ std::string lastDisplay;
 
 extern "C"
 {
+    // Version number
+    const char* get_version() {return "19.11.12"}
+
     // Functions to build up an MC object
     void* newVar(double lb, double pt, double ub, int count, int index)
     {

--- a/pyomo/contrib/mcpp/mcppInterface.cpp
+++ b/pyomo/contrib/mcpp/mcppInterface.cpp
@@ -18,17 +18,14 @@ typedef mc::McCormick<I> MC;
 // Module-level variables as utilities to pass information back to Python
 std::string lastException;
 std::string lastDisplay;
-std::string version;
 
 extern "C"
 {
+    const char* version_string = "19.11.12";
 
     // Version number
     const char* get_version() {
-        std::ostringstream vStream;
-        vStream << "19.11.12" << std::flush;
-        version = vStream.str();
-        return version.c_str();
+        return version_string;
     }
 
     // Functions to build up an MC object

--- a/pyomo/contrib/mcpp/mcppInterface.cpp
+++ b/pyomo/contrib/mcpp/mcppInterface.cpp
@@ -17,11 +17,12 @@ typedef mc::McCormick<I> MC;
 // Module-level variables as utilities to pass information back to Python
 std::string lastException;
 std::string lastDisplay;
+std::string version = "19.11.12";
 
 extern "C"
 {
     // Version number
-    const char* get_version() {return "19.11.12";}
+    const char* get_version() {return version.c_str();}
 
     // Functions to build up an MC object
     void* newVar(double lb, double pt, double ub, int count, int index)

--- a/pyomo/contrib/mcpp/mcppInterface.cpp
+++ b/pyomo/contrib/mcpp/mcppInterface.cpp
@@ -21,7 +21,7 @@ std::string lastDisplay;
 extern "C"
 {
     // Version number
-    const char* get_version() {return "19.11.12"}
+    const char* get_version() {return "19.11.12";}
 
     // Functions to build up an MC object
     void* newVar(double lb, double pt, double ub, int count, int index)

--- a/pyomo/contrib/mcpp/mcppInterface.cpp
+++ b/pyomo/contrib/mcpp/mcppInterface.cpp
@@ -11,18 +11,25 @@
 #include "interval.hpp"
 #include "mccormick.hpp"
 #include <sstream>
+#include <string>
 typedef mc::Interval I;
 typedef mc::McCormick<I> MC;
 
 // Module-level variables as utilities to pass information back to Python
 std::string lastException;
 std::string lastDisplay;
-std::string version = "19.11.12";
+std::string version;
 
 extern "C"
 {
+
     // Version number
-    const char* get_version() {return version.c_str();}
+    const char* get_version() {
+        std::ostringstream vStream;
+        vStream << "19.11.12" << std::flush;
+        version = vStream.str();
+        return version.c_str();
+    }
 
     // Functions to build up an MC object
     void* newVar(double lb, double pt, double ub, int count, int index)

--- a/pyomo/contrib/mcpp/pyomo_mcpp.py
+++ b/pyomo/contrib/mcpp/pyomo_mcpp.py
@@ -64,12 +64,7 @@ def _MCPP_lib():
 
     # Version number
     mcpp.get_version.restype = ctypes.c_char_p
-    if not mcpp.get_version() == __version__:
-        raise MCPP_Error(
-            "Shared object file version %s is out of date with MC++ interface version %s. "
-            "Please rebuild the library." % (mcpp.get_version(), __version__)
-        )
-
+    
     mcpp.toString.argtypes = [ctypes.c_void_p]
     mcpp.toString.restype = ctypes.c_char_p
 
@@ -208,6 +203,14 @@ class MCPP_visitor(StreamBasedExpressionVisitor):
     def __init__(self, expression, improved_var_bounds=None):
         super(MCPP_visitor, self).__init__()
         self.mcpp = _MCPP_lib()
+        so_file_version = self.mcpp.get_version()
+        if six.PY3:
+            so_file_version = so_file_version.decode("utf-8")
+        if not so_file_version == __version__:
+            raise MCPP_Error(
+                "Shared object file version %s is out of date with MC++ interface version %s. "
+                "Please rebuild the library." % (so_file_version, __version__)
+            )
         self.missing_value_warnings = []
         self.expr = expression
         vars = list(identify_variables(expression, include_fixed=False))

--- a/pyomo/contrib/mcpp/pyomo_mcpp.py
+++ b/pyomo/contrib/mcpp/pyomo_mcpp.py
@@ -39,6 +39,8 @@ logger = logging.getLogger('pyomo.contrib.mcpp')
 
 path = os.path.dirname(__file__)
 
+__version__ = "19.11.12"
+
 
 def mcpp_available():
     """True if the MC++ shared object file exists. False otherwise."""
@@ -59,6 +61,14 @@ def _MCPP_lib():
         return _MCPP_lib._mcpp
 
     _MCPP_lib._mcpp = mcpp = ctypes.CDLL(Library('mcppInterface').path())
+
+    # Version number
+    mcpp.get_version.restype = ctypes.c_char_p
+    if not mcpp.get_version() == __version__:
+        raise MCPP_Error(
+            "Shared object file version %s is out of date with MC++ interface version %s. "
+            "Please rebuild the library." % (mcpp.get_version(), __version__)
+        )
 
     mcpp.toString.argtypes = [ctypes.c_void_p]
     mcpp.toString.restype = ctypes.c_char_p


### PR DESCRIPTION
## Fixes #1123 .

## Summary/Motivation:
Adds a version check to the MC++ library shared object file to make sure it does not fall out of date with the python code.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
