### PR TITLE
Import from collections.abc in Python 3

### DIFF
--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -10,8 +10,6 @@
 
 __all__ = ['IndexedComponent', 'ActiveIndexedComponent']
 
-from collections import Sequence
-
 import pyutilib.misc
 
 from pyomo.core.expr.expr_errors import TemplateExpressionError
@@ -22,6 +20,12 @@ from pyomo.core.base.config import PyomoOptions
 from pyomo.common import DeveloperError
 
 from six import PY3, itervalues, iteritems, string_types
+
+if PY3:
+    from collections.abc import Sequence as collections_Sequence
+else:
+    from collections import Sequence as collections_Sequence
+
 
 UnindexedComponent_set = set([None])
 
@@ -47,7 +51,7 @@ def normalize_index(x):
         # Note that casting a tuple to a tuple is cheap (no copy, no
         # new object)
         x = tuple(x)
-    elif hasattr(x, '__iter__') and isinstance(x, Sequence):
+    elif hasattr(x, '__iter__') and isinstance(x, collections_Sequence):
         if isinstance(x, string_types):
             # This is very difficult to get to: it would require a user
             # creating a custom derived string type
@@ -69,7 +73,7 @@ def normalize_index(x):
             # Note that casting a tuple to a tuple is cheap (no copy, no
             # new object)
             x = x[:i] + tuple(x[i]) + x[i + 1:]
-        elif _xi_class is not tuple and isinstance(_xi, Sequence):
+        elif _xi_class is not tuple and isinstance(_xi, collections_Sequence):
             if isinstance(_xi, string_types):
                 # This is very difficult to get to: it would require a
                 # user creating a custom derived string type

--- a/pyomo/core/base/range.py
+++ b/pyomo/core/base/range.py
@@ -8,11 +8,15 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import collections
 import math
 
-from six import iteritems
+from six import iteritems, PY3
 from six.moves import xrange
+
+if PY3:
+    from collections.abc import Sequence as collections_Sequence
+else:
+    from collections import Sequence as collections_Sequence
 
 try:
     from math import remainder
@@ -893,7 +897,7 @@ class RangeProduct(object):
         return not self.__eq__(other)
 
     def __contains__(self, value):
-        if not isinstance(value, collections.Sequence):
+        if not isinstance(value, collections_Sequence):
             return False
         if len(value) != len(self.range_lists):
             return False

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -8,7 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import collections
 import inspect
 import itertools
 import logging
@@ -41,6 +40,12 @@ from pyomo.core.base.indexed_component import (
     IndexedComponent, UnindexedComponent_set, normalize_index,
 )
 from pyomo.core.base.misc import sorted_robust
+
+if six.PY3:
+    from collections.abc import Sequence as collections_Sequence
+else:
+    from collections import Sequence as collections_Sequence
+
 
 logger = logging.getLogger('pyomo.core')
 
@@ -208,7 +213,7 @@ class RangeSetInitializer(InitializerBase):
 
     def __call__(self, parent, idx):
         val = self._init(parent, idx)
-        if not isinstance(val, collections.Sequence):
+        if not isinstance(val, collections_Sequence):
             val = (1, val, self.default_step)
         if len(val) < 3:
             val = tuple(val) + (self.default_step,)

--- a/pyomo/core/base/util.py
+++ b/pyomo/core/base/util.py
@@ -20,10 +20,15 @@ from six import iteritems
 
 if six.PY2:
     getargspec = inspect.getargspec
+    from collections import Sequence as collections_Sequence
+    from collections import Mapping as collections_Mapping
 else:
     # For our needs, getfullargspec is a drop-in replacement for
     # getargspec (which was removed in Python 3.x)
     getargspec = inspect.getfullargspec
+    from collections.abc import Sequence as collections_Sequence
+    from collections.abc import Mapping as collections_Mapping
+
 
 from pyomo.common import DeveloperError
 from pyomo.core.expr.numvalue import (
@@ -143,9 +148,9 @@ def Initializer(init,
             return ScalarCallInitializer(init)
         else:
             return IndexedCallInitializer(init)
-    elif isinstance(init, collections.Mapping):
+    elif isinstance(init, collections_Mapping):
         return ItemInitializer(init)
-    elif isinstance(init, collections.Sequence) \
+    elif isinstance(init, collections_Sequence) \
             and not isinstance(init, six.string_types):
         if treat_sequences_as_mappings:
             return ItemInitializer(init)

--- a/pyomo/core/tests/unit/kernel/test_component_map.py
+++ b/pyomo/core/tests/unit/kernel/test_component_map.py
@@ -9,7 +9,6 @@
 #  ___________________________________________________________________________
 
 import pickle
-import collections
 
 import pyutilib.th as unittest
 from pyomo.core.kernel.component_map import ComponentMap
@@ -29,6 +28,16 @@ from pyomo.core.kernel.block import (block,
                                      block_dict,
                                      block_list)
 from pyomo.core.kernel.suffix import suffix
+
+import six
+
+if six.PY3:
+    from collections.abc import Mapping as collections_Mapping
+    from collections.abc import MutableMapping as collections_MutableMapping
+else:
+    from collections import Mapping as collections_Mapping
+    from collections import MutableMapping as collections_MutableMapping
+
 
 class TestComponentMap(unittest.TestCase):
 
@@ -105,10 +114,10 @@ class TestComponentMap(unittest.TestCase):
 
     def test_type(self):
         cmap = ComponentMap()
-        self.assertTrue(isinstance(cmap, collections.Mapping))
-        self.assertTrue(isinstance(cmap, collections.MutableMapping))
-        self.assertTrue(issubclass(type(cmap), collections.Mapping))
-        self.assertTrue(issubclass(type(cmap), collections.MutableMapping))
+        self.assertTrue(isinstance(cmap, collections_Mapping))
+        self.assertTrue(isinstance(cmap, collections_MutableMapping))
+        self.assertTrue(issubclass(type(cmap), collections_Mapping))
+        self.assertTrue(issubclass(type(cmap), collections_MutableMapping))
 
     def test_str(self):
         cmap = ComponentMap()

--- a/pyomo/core/tests/unit/kernel/test_component_set.py
+++ b/pyomo/core/tests/unit/kernel/test_component_set.py
@@ -9,7 +9,6 @@
 #  ___________________________________________________________________________
 
 import pickle
-import collections
 
 import pyutilib.th as unittest
 from pyomo.core.kernel.component_set import ComponentSet
@@ -31,6 +30,14 @@ from pyomo.core.kernel.block import (block,
 from pyomo.core.kernel.suffix import suffix
 
 import six
+
+if six.PY3:
+    from collections.abc import Set as collections_Set
+    from collections.abc import MutableSet as collections_MutableSet
+else:
+    from collections import Set as collections_Set
+    from collections import MutableSet as collections_MutableSet
+
 
 class TestComponentSet(unittest.TestCase):
 
@@ -108,10 +115,10 @@ class TestComponentSet(unittest.TestCase):
 
     def test_type(self):
         cset = ComponentSet()
-        self.assertTrue(isinstance(cset, collections.Set))
-        self.assertTrue(isinstance(cset, collections.MutableSet))
-        self.assertTrue(issubclass(type(cset), collections.Set))
-        self.assertTrue(issubclass(type(cset), collections.MutableSet))
+        self.assertTrue(isinstance(cset, collections_Set))
+        self.assertTrue(isinstance(cset, collections_MutableSet))
+        self.assertTrue(issubclass(type(cset), collections_Set))
+        self.assertTrue(issubclass(type(cset), collections_MutableSet))
 
     def test_str(self):
         cset = ComponentSet()

--- a/pyomo/core/tests/unit/kernel/test_dict_container.py
+++ b/pyomo/core/tests/unit/kernel/test_dict_container.py
@@ -9,7 +9,6 @@
 #  ___________________________________________________________________________
 
 import pickle
-import collections
 
 import pyutilib.th as unittest
 import pyomo.kernel as pmo
@@ -26,6 +25,13 @@ from pyomo.core.kernel.block import (IBlock,
 
 import six
 from six import StringIO
+
+if six.PY3:
+    from collections.abc import Mapping as collections_Mapping
+    from collections.abc import MutableMapping as collections_MutableMapping
+else:
+    from collections import Mapping as collections_Mapping
+    from collections import MutableMapping as collections_MutableMapping
 
 #
 # There are no fully implemented test suites in this
@@ -132,10 +138,10 @@ class _TestDictContainerBase(object):
         self.assertTrue(isinstance(cdict, ICategorizedObjectContainer))
         self.assertTrue(isinstance(cdict, IHomogeneousContainer))
         self.assertTrue(isinstance(cdict, DictContainer))
-        self.assertTrue(isinstance(cdict, collections.Mapping))
-        self.assertTrue(isinstance(cdict, collections.MutableMapping))
-        self.assertTrue(issubclass(type(cdict), collections.Mapping))
-        self.assertTrue(issubclass(type(cdict), collections.MutableMapping))
+        self.assertTrue(isinstance(cdict, collections_Mapping))
+        self.assertTrue(isinstance(cdict, collections_MutableMapping))
+        self.assertTrue(issubclass(type(cdict), collections_Mapping))
+        self.assertTrue(issubclass(type(cdict), collections_MutableMapping))
 
     def test_len1(self):
         cdict = self._container_type()
@@ -602,8 +608,8 @@ class _TestActiveDictContainerBase(_TestDictContainerBase):
         self.assertTrue(isinstance(cdict, ICategorizedObjectContainer))
         self.assertTrue(isinstance(cdict, IHomogeneousContainer))
         self.assertTrue(isinstance(cdict, DictContainer))
-        self.assertTrue(isinstance(cdict, collections.Mapping))
-        self.assertTrue(isinstance(cdict, collections.MutableMapping))
+        self.assertTrue(isinstance(cdict, collections_Mapping))
+        self.assertTrue(isinstance(cdict, collections_MutableMapping))
 
     def test_active(self):
         children = {}

--- a/pyomo/core/tests/unit/kernel/test_list_container.py
+++ b/pyomo/core/tests/unit/kernel/test_list_container.py
@@ -9,7 +9,6 @@
 #  ___________________________________________________________________________
 
 import pickle
-import collections
 
 import pyutilib.th as unittest
 import pyomo.kernel as pmo
@@ -26,6 +25,13 @@ from pyomo.core.kernel.block import (IBlock,
 
 import six
 from six import StringIO
+
+if six.PY3:
+    from collections.abc import Sequence as collections_Sequence
+    from collections.abc import MutableSequence as collections_MutableSequence
+else:
+    from collections import Sequence as collections_Sequence
+    from collections import MutableSequence as collections_MutableSequence
 
 #
 # There are no fully implemented test suites in this
@@ -92,10 +98,10 @@ class _TestListContainerBase(object):
         self.assertTrue(isinstance(clist, ICategorizedObjectContainer))
         self.assertTrue(isinstance(clist, IHomogeneousContainer))
         self.assertTrue(isinstance(clist, ListContainer))
-        self.assertTrue(isinstance(clist, collections.Sequence))
-        self.assertTrue(issubclass(type(clist), collections.Sequence))
-        self.assertTrue(isinstance(clist, collections.MutableSequence))
-        self.assertTrue(issubclass(type(clist), collections.MutableSequence))
+        self.assertTrue(isinstance(clist, collections_Sequence))
+        self.assertTrue(issubclass(type(clist), collections_Sequence))
+        self.assertTrue(isinstance(clist, collections_MutableSequence))
+        self.assertTrue(issubclass(type(clist), collections_MutableSequence))
 
     def test_len1(self):
         c = self._container_type()
@@ -647,10 +653,10 @@ class _TestActiveListContainerBase(_TestListContainerBase):
         self.assertTrue(isinstance(clist, ICategorizedObjectContainer))
         self.assertTrue(isinstance(clist, IHomogeneousContainer))
         self.assertTrue(isinstance(clist, ListContainer))
-        self.assertTrue(isinstance(clist, collections.Sequence))
-        self.assertTrue(issubclass(type(clist), collections.Sequence))
-        self.assertTrue(isinstance(clist, collections.MutableSequence))
-        self.assertTrue(issubclass(type(clist), collections.MutableSequence))
+        self.assertTrue(isinstance(clist, collections_Sequence))
+        self.assertTrue(issubclass(type(clist), collections_Sequence))
+        self.assertTrue(isinstance(clist, collections_MutableSequence))
+        self.assertTrue(issubclass(type(clist), collections_MutableSequence))
 
     def test_active(self):
         index = list(range(4))

--- a/pyomo/core/tests/unit/kernel/test_suffix.py
+++ b/pyomo/core/tests/unit/kernel/test_suffix.py
@@ -1,5 +1,4 @@
 import sys
-import collections
 import pickle
 
 import pyutilib.th as unittest
@@ -25,6 +24,14 @@ from pyomo.core.kernel.set_types import (RealSet,
 
 import six
 from six import StringIO
+
+if six.PY3:
+    from collections.abc import Mapping as collections_Mapping
+    from collections.abc import MutableMapping as collections_MutableMapping
+else:
+    from collections import Mapping as collections_Mapping
+    from collections import MutableMapping as collections_MutableMapping
+
 
 class Test_suffix(unittest.TestCase):
 
@@ -102,10 +109,10 @@ class Test_suffix(unittest.TestCase):
     def test_type(self):
         s = suffix()
         self.assertTrue(isinstance(s, ICategorizedObject))
-        self.assertTrue(isinstance(s, collections.Mapping))
-        self.assertTrue(isinstance(s, collections.MutableMapping))
-        self.assertTrue(issubclass(type(s), collections.Mapping))
-        self.assertTrue(issubclass(type(s), collections.MutableMapping))
+        self.assertTrue(isinstance(s, collections_Mapping))
+        self.assertTrue(isinstance(s, collections_MutableMapping))
+        self.assertTrue(issubclass(type(s), collections_Mapping))
+        self.assertTrue(issubclass(type(s), collections_MutableMapping))
 
     def test_import_export_enabled(self):
         s = suffix()

--- a/pyomo/core/tests/unit/kernel/test_tuple_container.py
+++ b/pyomo/core/tests/unit/kernel/test_tuple_container.py
@@ -9,7 +9,6 @@
 #  ___________________________________________________________________________
 
 import pickle
-import collections
 
 import pyutilib.th as unittest
 import pyomo.kernel as pmo
@@ -24,6 +23,11 @@ from pyomo.core.kernel.block import (IBlock,
                                      block_list)
 
 import six
+
+if six.PY3:
+    from collections.abc import Sequence as collections_Sequence
+else:
+    from collections import Sequence as collections_Sequence
 
 #
 # There are no fully implemented test suites in this
@@ -71,8 +75,8 @@ class _TestTupleContainerBase(object):
         self.assertTrue(isinstance(ctuple, ICategorizedObjectContainer))
         self.assertTrue(isinstance(ctuple, IHomogeneousContainer))
         self.assertTrue(isinstance(ctuple, TupleContainer))
-        self.assertTrue(isinstance(ctuple, collections.Sequence))
-        self.assertTrue(issubclass(type(ctuple), collections.Sequence))
+        self.assertTrue(isinstance(ctuple, collections_Sequence))
+        self.assertTrue(issubclass(type(ctuple), collections_Sequence))
 
     def test_len1(self):
         c = self._container_type()
@@ -463,8 +467,8 @@ class _TestActiveTupleContainerBase(_TestTupleContainerBase):
         self.assertTrue(isinstance(ctuple, ICategorizedObjectContainer))
         self.assertTrue(isinstance(ctuple, IHomogeneousContainer))
         self.assertTrue(isinstance(ctuple, TupleContainer))
-        self.assertTrue(isinstance(ctuple, collections.Sequence))
-        self.assertTrue(issubclass(type(ctuple), collections.Sequence))
+        self.assertTrue(isinstance(ctuple, collections_Sequence))
+        self.assertTrue(issubclass(type(ctuple), collections_Sequence))
 
     def test_active(self):
         index = list(range(4))

--- a/pyomo/pysp/tests/examples/compare_histories.py
+++ b/pyomo/pysp/tests/examples/compare_histories.py
@@ -8,13 +8,20 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import collections
 import math
 import sys
 
 from pyutilib.misc import compare_repn
 
 from pyomo.pysp.plugins.phhistoryextension import load_history
+
+import six
+
+if six.PY3:
+    from collections.abc import MutableMapping as collections_MutableMapping
+else:
+    from collections import MutableMapping as collections_MutableMapping
+
 
 assert len(sys.argv) == 3
 
@@ -25,7 +32,7 @@ def flatten(d, parent_key=''):
     items = []
     for k, v in d.items():
         new_key = parent_key + '_' + k if parent_key else k
-        if v and isinstance(v, collections.MutableMapping):
+        if v and isinstance(v, collections_MutableMapping):
             items.extend(flatten(v, new_key).items())
         else:
             items.append((new_key, v))

--- a/pyomo/pysp/tests/examples/compare_solutions.py
+++ b/pyomo/pysp/tests/examples/compare_solutions.py
@@ -8,13 +8,20 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import collections
 import math
 import sys
 
 from pyutilib.misc import compare_repn
 
 from pyomo.pysp.plugins.phhistoryextension import load_solution
+
+import six
+
+if six.PY3:
+    from collections.abc import MutableMapping as collections_MutableMapping
+else:
+    from collections import MutableMapping as collections_MutableMapping
+
 
 assert len(sys.argv) == 3
 
@@ -25,7 +32,7 @@ def flatten(d, parent_key=''):
     items = []
     for k, v in d.items():
         new_key = parent_key + '_' + k if parent_key else k
-        if v and isinstance(v, collections.MutableMapping):
+        if v and isinstance(v, collections_MutableMapping):
             items.extend(flatten(v, new_key).items())
         else:
             items.append((new_key, v))

--- a/pyomo/repn/beta/matrix.py
+++ b/pyomo/repn/beta/matrix.py
@@ -14,7 +14,6 @@ __all__ = ("_LinearConstraintData", "MatrixConstraint",
 import time
 import logging
 import array
-import collections
 from weakref import ref as weakref_ref
 
 from pyomo.core.base.set_types import Any
@@ -32,8 +31,14 @@ from pyomo.core.base.constraint import (Constraint,
 from pyomo.core.expr.numvalue import native_numeric_types
 from pyomo.repn import generate_standard_repn
 
-from six import iteritems
+from six import iteritems, PY3
 from six.moves import xrange
+
+if PY3:
+    from collections.abc import Mapping as collections_Mapping
+else:
+    from collections import Mapping as collections_Mapping
+
 
 logger = logging.getLogger('pyomo.core')
 
@@ -621,7 +626,7 @@ class _LinearMatrixConstraintData(_LinearConstraintData):
 
 @ModelComponentFactory.register(
                    "A set of constraint expressions in Ax=b form.")
-class MatrixConstraint(collections.Mapping,
+class MatrixConstraint(collections_Mapping,
                        IndexedConstraint):
 
     #


### PR DESCRIPTION
## Summary/Motivation:

Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working

## Changes proposed in this PR:
- Import from collection.abc in Python 3

I tried to stick to code style so I copied the `collections_Mapping` naming from other files. The imports are not perfectly consistent (PY2 or PY3 first, PY3 or six.PY3) so I did what seemed the most sensible to me.


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
