### PR TITLE
Disable extras on Appveyor/python3.7 build.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,7 +49,9 @@ environment:
     - PYTHON_VERSION: 3.7
       PYTHON: "C:\\Miniconda37"
       CATEGORY: "nightly"
-      EXTRAS: YES
+      # [191115]: disable extras because of installation dependency 
+      # issues with Miniconda 3.7 on appveyor
+      #EXTRAS: YES
 
 
 install:


### PR DESCRIPTION
## Fixes #N/A.

## Summary/Motivation:
There are currently dependency issues installing extras on Miniconda37, see, e.g., https://ci.appveyor.com/project/WilliamHart/pyomo/builds/28892891

## Changes proposed in this PR:
- disable EXTRAS for only the Python 3.7 build

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
