### PR TITLE
[MONITOR] Restore Python3.7 testing with extras

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,9 +49,7 @@ environment:
     - PYTHON_VERSION: 3.7
       PYTHON: "C:\\Miniconda37"
       CATEGORY: "nightly"
-      # [191115]: disable extras because of installation dependency 
-      # issues with Miniconda 3.7 on appveyor
-      #EXTRAS: YES
+      EXTRAS: YES
 
 
 install:


### PR DESCRIPTION
## Fixes #N/A .

## Summary/Motivation:
This reverts #1180 and restores EXTRAS testing with Python 3.7

## Changes proposed in this PR:
- test Python 3.7 with extras

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
