### PR TITLE
Adding Python 3.8 to Travis test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - COVERAGE_PROCESS_START=${TRAVIS_BUILD_DIR}/coveragerc
   - DOCKERENV="-e TAG -e COVERAGE_PROCESS_START -e PYOMO_CONFIG_DIR"
   matrix:
+  - TAG=python_3.8    CATEGORY="nightly"
   - TAG=python_3.7    CATEGORY="nightly"
   - TAG=python_3.7    CATEGORY="nightly" SLIM=1
   - TAG=python_3.7    CATEGORY="smoke"   SETUP_OPTIONS="--with-cython"


### PR DESCRIPTION
## Fixes #N/A .

## Summary/Motivation:
This adds a Python 3.8 test suite to the Travis builds

## Changes proposed in this PR:
- Add python 3.8 build

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
