### PR TITLE
Minor documentation updates

### DIFF
--- a/doc/OnlineDocs/contributed_packages/index.rst
+++ b/doc/OnlineDocs/contributed_packages/index.rst
@@ -22,6 +22,7 @@ Contributed packages distributed with Pyomo:
    parmest/index.rst
    mcpp.rst
    mindtpy.rst
+   satsolver.rst
 
 Contributed packages distributed independently of Pyomo, but accessible
 through ``pyomo.contrib``:

--- a/doc/OnlineDocs/installation.rst
+++ b/doc/OnlineDocs/installation.rst
@@ -45,9 +45,10 @@ Extensions to Pyomo, and many of the contributions in `pyomo.contrib`,
 also have conditional dependencies on a variety of third-party Python
 packages including but not limited to: numpy, scipy, sympy, networkx,
 openpxl, pyodbc, xlrd, pandas, matplotlib, pymysql, pyro4, and
-pint. 
+pint. Pyomo extensions that require any of these packages will generate
+an error message for missing dependencies upon use.
 
-Many of these packages are already distributed with Anaconda. You can
-check which Python packages you already have installed using the command
-``conda list`` or ``pip list``. Additional Python packages may be installed
-as needed.
+Many of the conditional dependencies are already distributed with
+Anaconda. You can check which Python packages you already have installed
+using the command ``conda list`` or ``pip list``. Additional Python
+packages may be installed as needed.

--- a/doc/OnlineDocs/installation.rst
+++ b/doc/OnlineDocs/installation.rst
@@ -3,7 +3,8 @@ Installation
 
 Pyomo currently supports the following versions of Python:
 
-* CPython: 2.7, 3.4, 3.5, 3.6, 3.7
+* CPython: 2.7, 3.4, 3.5, 3.6, 3.7, 3.8
+* PyPy: 2, 3
 
 
 Using CONDA
@@ -16,13 +17,6 @@ Python installation by executing the following in a shell:
 ::
    
    conda install -c conda-forge pyomo
-
-Pyomo also has conditional dependencies on a variety of third-party
-Python packages.  These can also be installed with conda:
-
-::
-
-   conda install -c conda-forge pyomo.extras
 
 Optimization solvers are not installed with Pyomo, but some open source
 optimization solvers can be installed with conda as well:
@@ -42,3 +36,18 @@ the following in a shell:
 ::
 
    pip install pyomo
+
+
+Conditional Dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Extensions to Pyomo, and many of the contributions in `pyomo.contrib`,
+also have conditional dependencies on a variety of third-party Python
+packages including but not limited to: numpy, scipy, sympy, networkx,
+openpxl, pyodbc, xlrd, pandas, matplotlib, pymysql, pyro4, and
+pint. 
+
+Many of these packages are already distributed with Anaconda. You can
+check which Python packages you already have installed using the command
+``conda list`` or ``pip list``. Additional Python packages may be installed
+as needed.

--- a/pyomo/solvers/plugins/solvers/gurobi_persistent.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_persistent.py
@@ -149,7 +149,7 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
         """
         Set the value of an attribute on a gurobi linear constraint.
 
-        Paramaters
+        Parameters
         ----------
         con: pyomo.core.base.constraint._GeneralConstraintData
             The pyomo constraint for which the corresponding gurobi constraint attribute
@@ -177,7 +177,7 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
         """
         Set the value of an attribute on a gurobi variable.
 
-        Paramaters
+        Parameters
         ----------
         con: pyomo.core.base.var._GeneralVarData
             The pyomo var for which the corresponding gurobi var attribute
@@ -315,7 +315,7 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
         """
         Get the value of an attribute on a gurobi var.
 
-        Paramaters
+        Parameters
         ----------
         var: pyomo.core.base.var._GeneralVarData
             The pyomo var for which the corresponding gurobi var attribute
@@ -356,7 +356,7 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
         """
         Get the value of an attribute on a gurobi linear constraint.
 
-        Paramaters
+        Parameters
         ----------
         con: pyomo.core.base.constraint._GeneralConstraintData
             The pyomo constraint for which the corresponding gurobi constraint attribute
@@ -384,7 +384,7 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
         """
         Get the value of an attribute on a gurobi sos constraint.
 
-        Paramaters
+        Parameters
         ----------
         con: pyomo.core.base.sos._SOSConstraintData
             The pyomo SOS constraint for which the corresponding gurobi SOS constraint attribute
@@ -401,7 +401,7 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
         """
         Get the value of an attribute on a gurobi quadratic constraint.
 
-        Paramaters
+        Parameters
         ----------
         con: pyomo.core.base.constraint._GeneralConstraintData
             The pyomo constraint for which the corresponding gurobi constraint attribute


### PR DESCRIPTION
## Summary/Motivation:
Updates to the installation instructions on readthedocs to partially address #1183. @whart222 let me know if there is additional text you want added about `pyomo.solvers`.

While making those updates I also fixed a few other sphinx errors that cropped up since the last time I built the documentation locally. I added the z3 sat solver documentation that was never included in the table of contents and I fixed a few typos in docstrings of the Gurobi persistent interfaces.
 
## Changes proposed in this PR:
- Update installation instructions
- Add z3 sat solver documentation to readthedocs
- Fix typos in docstrings of the Gurobi persistent interface

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
