### PR TITLE
Bugfix in get_index_information function of Pyomo.DAE

### DIFF
--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -482,7 +482,7 @@ def get_index_information(var, ds):
         indCount = 0
         for index in var._implicit_subsets:
             if isinstance(index, ContinuousSet):
-                if index == ds:
+                if index is ds:
                     dsindex = indCount
                 else:
                     # If var is indexed by multiple ContinuousSets treat

--- a/pyomo/dae/tests/test_misc.py
+++ b/pyomo/dae/tests/test_misc.py
@@ -996,6 +996,7 @@ class TestDaeMisc(unittest.TestCase):
         self.assertEqual(len(nts), 33)
         self.assertTrue(m.x in nts._implicit_subsets)
         self.assertTrue(m.s in nts._implicit_subsets)
+        self.assertEqual(index_getter((8.0,'a'),1,0),(2.0,8.0,'a'))
 
         info = get_index_information(m.v2, m.t)
         nts = info['non_ds']
@@ -1003,6 +1004,7 @@ class TestDaeMisc(unittest.TestCase):
         
         self.assertEqual(len(nts), 3)
         self.assertTrue(m.s is nts)
+        self.assertEqual(index_getter('a',1,0),(2.0,'a'))
 
 
     

--- a/pyomo/dae/tests/test_misc.py
+++ b/pyomo/dae/tests/test_misc.py
@@ -952,9 +952,9 @@ class TestDaeMisc(unittest.TestCase):
         generate_finite_elements(m.b.t, 5)
         expand_components(m)
 
-        self.assertTrue(len(m.b.c.d), 6)
-        self.assertTrue(len(m.b.con), 6)
-        self.assertTrue(len(m.b.y), 6)
+        self.assertEqual(len(m.b.c.d), 6)
+        self.assertEqual(len(m.b.con), 6)
+        self.assertEqual(len(m.b.y), 6)
 
     def test_external_function(self):
         m = ConcreteModel()
@@ -974,8 +974,36 @@ class TestDaeMisc(unittest.TestCase):
         generate_finite_elements(m.t, 5)
         expand_components(m)
 
-        self.assertTrue(len(m.y), 6)
-        self.assertTrue(len(m.con), 6)
+        self.assertEqual(len(m.y), 6)
+        self.assertEqual(len(m.con), 6)
+
+    def test_get_index_information(self):
+        m = ConcreteModel()
+        m.t = ContinuousSet(bounds=(0,10))
+        m.x = ContinuousSet(bounds=(0,10))
+        m.s = Set(initialize=['a','b','c'])
+        m.v = Var(m.t, m.x, m.s, initialize=1)
+        m.v2 = Var(m.t, m.s, initialize=1)
+
+        disc = TransformationFactory('dae.collocation')
+        disc.apply_to(m, wrt=m.t, nfe=5, ncp=2, scheme='LAGRANGE-RADAU')
+        disc.apply_to(m, wrt=m.x, nfe=5, ncp=2, scheme='LAGRANGE-RADAU')
+
+        info = get_index_information(m.v, m.t)
+        nts = info['non_ds']
+        index_getter = info['index function']
+        
+        self.assertEqual(len(nts), 33)
+        self.assertTrue(m.x in nts._implicit_subsets)
+        self.assertTrue(m.s in nts._implicit_subsets)
+
+        info = get_index_information(m.v2, m.t)
+        nts = info['non_ds']
+        index_getter = info['index function']
+        
+        self.assertEqual(len(nts), 3)
+        self.assertTrue(m.s is nts)
+
 
     
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary/Motivation:
This PR fixes a small bug in the `get_index_information` function in `pyomo.dae.misc` where `==` was used instead of `is`. This bug was discovered by @robbybp. I also added a few tests after discovering that this function wasn't being tested.

## Changes proposed in this PR:
- Bugfix in `get_index_information` function

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
