### PR TITLE
Remove use of _implicit_subsets in Pyomo.DAE (requires #1195)

### DIFF
--- a/pyomo/dae/diffvar.py
+++ b/pyomo/dae/diffvar.py
@@ -99,7 +99,7 @@ class DerivativeVar(Var):
                 if sidx_sets.type() is ContinuousSet:
                     sVar._contset[sidx_sets] = 0
             else:
-                sidx_sets = sVar._implicit_subsets
+                sidx_sets = sVar.index_set().set_tuple
                 loc = 0
                 for i, s in enumerate(sidx_sets):
                     if s.type() is ContinuousSet:
@@ -161,12 +161,8 @@ class DerivativeVar(Var):
 
         kwds.setdefault('ctype', DerivativeVar)
 
-        if sVar._implicit_subsets is None:
-            arg = (sVar.index_set(),)
-        else:
-            arg = tuple(sVar._implicit_subsets)
+        Var.__init__(self,sVar.index_set(),**kwds)
 
-        Var.__init__(self,*arg,**kwds)
 
     def get_continuousset_list(self):
         """ Return the a list of :py:class:`ContinuousSet` components the

--- a/pyomo/dae/integral.py
+++ b/pyomo/dae/integral.py
@@ -167,7 +167,7 @@ class IndexedIntegral(IndexedExpression, Integral):
         if self.dim() == 1:
             setlist = [self.index_set(), ]
         else:
-            setlist = self._implicit_subsets
+            setlist = self.index_set().set_tuple
 
         for i in setlist:
             if i.type() is ContinuousSet:

--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -482,7 +482,7 @@ def get_index_information(var, ds):
         indCount = 0
         for index in var._implicit_subsets:
             if isinstance(index, ContinuousSet):
-                if index == ds:
+                if index is ds:
                     dsindex = indCount
                 else:
                     # If var is indexed by multiple ContinuousSets treat

--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -221,10 +221,11 @@ def update_contset_indexed_component(comp, expansion_map):
 
     # Extract the indexing sets. Must treat components with a single
     # index separately from components with multiple indexing sets.
-    if comp._implicit_subsets is None:
-        indexset = [comp._index]
+    temp = comp.index_set()
+    if hasattr(temp, 'set_tuple'):
+        indexset = comp.index_set().set_tuple
     else:
-        indexset = comp._implicit_subsets
+        indexset = [temp,]
 
     for s in indexset:
         if s.type() == ContinuousSet and s.get_changed():
@@ -406,10 +407,10 @@ def add_discretization_equations(block, d):
 
     if d.dim() == 1:
         block.add_component(d.local_name + '_disc_eq',
-                            Constraint(d._index, rule=_disc_eq))
+                            Constraint(d.index_set(), rule=_disc_eq))
     else:
         block.add_component(d.local_name + '_disc_eq',
-                            Constraint(*d._implicit_subsets, rule=_disc_eq))
+                            Constraint(*d.index_set().set_tuple, rule=_disc_eq))
 
 
 def add_continuity_equations(block, d, i, loc):
@@ -446,9 +447,9 @@ def add_continuity_equations(block, d, i, loc):
             return Constraint.Skip
 
     if d.dim() == 1:
-        block.add_component(nme, Constraint(d._index, rule=_cont_eq))
+        block.add_component(nme, Constraint(d.index_set(), rule=_cont_eq))
     else:
-        block.add_component(nme, Constraint(*d._implicit_subsets,
+        block.add_component(nme, Constraint(*d.index_set().set_tuple,
                                             rule=_cont_eq))
 
 
@@ -480,7 +481,7 @@ def get_index_information(var, ds):
 
     if var.dim() != 1:
         indCount = 0
-        for index in var._implicit_subsets:
+        for index in var.index_set().set_tuple:
             if isinstance(index, ContinuousSet):
                 if index is ds:
                     dsindex = indCount

--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -405,12 +405,8 @@ def add_discretization_equations(block, d):
         except IndexError:
             return Constraint.Skip
 
-    if d.dim() == 1:
-        block.add_component(d.local_name + '_disc_eq',
-                            Constraint(d.index_set(), rule=_disc_eq))
-    else:
-        block.add_component(d.local_name + '_disc_eq',
-                            Constraint(*d.index_set().set_tuple, rule=_disc_eq))
+    block.add_component(d.local_name + '_disc_eq',
+                        Constraint(d.index_set(), rule=_disc_eq))
 
 
 def add_continuity_equations(block, d, i, loc):
@@ -446,11 +442,8 @@ def add_continuity_equations(block, d, i, loc):
         except IndexError:
             return Constraint.Skip
 
-    if d.dim() == 1:
-        block.add_component(nme, Constraint(d.index_set(), rule=_cont_eq))
-    else:
-        block.add_component(nme, Constraint(*d.index_set().set_tuple,
-                                            rule=_cont_eq))
+    block.add_component(nme, Constraint(d.index_set(),
+                                        rule=_cont_eq))
 
 
 def block_fully_discretized(b):

--- a/pyomo/dae/plugins/colloc.py
+++ b/pyomo/dae/plugins/colloc.py
@@ -604,11 +604,12 @@ class Collocation_Discretization_Transformation(Transformation):
         if var.dim() == 0:
             raise IndexError("ContinuousSet '%s' is not an indexing set of"
                              " the variable '%s'" % (ds.name, var.name))
-        elif var.dim() == 1:
-            if ds not in var._index:
+        varidx = var.index_set()
+        if not hasattr(varidx, 'set_tuple'):
+            if ds is not varidx:
                 raise IndexError("ContinuousSet '%s' is not an indexing set of"
                                  " the variable '%s'" % (ds.name, var.name))
-        elif ds not in var._implicit_subsets:
+        elif ds not in varidx.set_tuple:
             raise IndexError("ContinuousSet '%s' is not an indexing set of the"
                              " variable '%s'" % (ds.name, var.name))
 

--- a/pyomo/dae/simulator.py
+++ b/pyomo/dae/simulator.py
@@ -462,15 +462,17 @@ class Simulator:
             # determine its order in the indexing sets
             if con.dim() == 0:
                 continue
-            elif con._implicit_subsets is None:
+                
+            conindex = con.index_set()
+            if not hasattr(conindex, 'set_tuple'):
                 # Check if the continuous set is the indexing set
-                if con._index is not contset:
+                if conindex is not contset:
                     continue
                 else:
                     csidx = 0
                     noncsidx = (None,)
             else:
-                temp = con._implicit_subsets
+                temp = conindex.set_tuple
                 dimsum = 0
                 csidx = -1
                 noncsidx = None

--- a/pyomo/dae/tests/test_diffvar.py
+++ b/pyomo/dae/tests/test_diffvar.py
@@ -62,8 +62,8 @@ class TestDerivativeVar(unittest.TestCase):
         self.assertTrue(m.dv._sVar is m.v)
         self.assertTrue(m.v._derivative[('t',)]() is m.dv)
         self.assertTrue(m.dv.type() is DerivativeVar)
-        self.assertTrue(m.t in m.dv._implicit_subsets)
-        self.assertTrue(m.s in m.dv._implicit_subsets)
+        self.assertTrue(m.t in m.dv.index_set().set_tuple)
+        self.assertTrue(m.s in m.dv.index_set().set_tuple)
         self.assertTrue(m.dv2._wrt[0] is m.t)
         self.assertTrue(m.dv2._wrt[1] is m.t)
         self.assertTrue(m.v._derivative[('t', 't')]() is m.dv2)
@@ -71,8 +71,6 @@ class TestDerivativeVar(unittest.TestCase):
         del m.dv2
         del m.v
         del m.v_index
-        del m.dv_index
-        del m.dv2_index
 
         m.v = Var(m.x, m.t)
         m.dv = DerivativeVar(m.v, wrt=m.x)
@@ -88,8 +86,8 @@ class TestDerivativeVar(unittest.TestCase):
         self.assertTrue(m.v._derivative[('t', 'x')]() is m.dv3)
         self.assertTrue(m.v._derivative[('t', 't')]() is m.dv4)
         self.assertTrue(m.dv.type() is DerivativeVar)
-        self.assertTrue(m.x in m.dv._implicit_subsets)
-        self.assertTrue(m.t in m.dv._implicit_subsets)
+        self.assertTrue(m.x in m.dv.index_set().set_tuple)
+        self.assertTrue(m.t in m.dv.index_set().set_tuple)
         self.assertTrue(m.dv3._wrt[0] is m.t)
         self.assertTrue(m.dv3._wrt[1] is m.x)
         self.assertTrue(m.dv4._wrt[0] is m.t)

--- a/pyomo/dae/tests/test_misc.py
+++ b/pyomo/dae/tests/test_misc.py
@@ -994,8 +994,8 @@ class TestDaeMisc(unittest.TestCase):
         index_getter = info['index function']
         
         self.assertEqual(len(nts), 33)
-        self.assertTrue(m.x in nts._implicit_subsets)
-        self.assertTrue(m.s in nts._implicit_subsets)
+        self.assertTrue(m.x in nts.set_tuple)
+        self.assertTrue(m.s in nts.set_tuple)
         self.assertEqual(index_getter((8.0,'a'),1,0),(2.0,8.0,'a'))
 
         info = get_index_information(m.v2, m.t)

--- a/pyomo/dae/tests/test_misc.py
+++ b/pyomo/dae/tests/test_misc.py
@@ -996,6 +996,7 @@ class TestDaeMisc(unittest.TestCase):
         self.assertEqual(len(nts), 33)
         self.assertTrue(m.x in nts._implicit_subsets)
         self.assertTrue(m.s in nts._implicit_subsets)
+        self.assertEqual(index_getter((8.0,'a'),1,0),(2.0,8.0,'a'))
 
         info = get_index_information(m.v2, m.t)
         nts = info['non_ds']
@@ -1003,6 +1004,7 @@ class TestDaeMisc(unittest.TestCase):
         
         self.assertEqual(len(nts), 3)
         self.assertTrue(m.s is nts)
+        self.assertEqual(index_getter('a',1,0),(2.0,'a'))
 
 
     

--- a/pyomo/dae/tests/test_misc.py
+++ b/pyomo/dae/tests/test_misc.py
@@ -952,9 +952,9 @@ class TestDaeMisc(unittest.TestCase):
         generate_finite_elements(m.b.t, 5)
         expand_components(m)
 
-        self.assertTrue(len(m.b.c.d), 6)
-        self.assertTrue(len(m.b.con), 6)
-        self.assertTrue(len(m.b.y), 6)
+        self.assertEqual(len(m.b.c.d), 6)
+        self.assertEqual(len(m.b.con), 6)
+        self.assertEqual(len(m.b.y), 6)
 
     def test_external_function(self):
         m = ConcreteModel()
@@ -974,8 +974,36 @@ class TestDaeMisc(unittest.TestCase):
         generate_finite_elements(m.t, 5)
         expand_components(m)
 
-        self.assertTrue(len(m.y), 6)
-        self.assertTrue(len(m.con), 6)
+        self.assertEqual(len(m.y), 6)
+        self.assertEqual(len(m.con), 6)
+
+    def test_get_index_information(self):
+        m = ConcreteModel()
+        m.t = ContinuousSet(bounds=(0,10))
+        m.x = ContinuousSet(bounds=(0,10))
+        m.s = Set(initialize=['a','b','c'])
+        m.v = Var(m.t, m.x, m.s, initialize=1)
+        m.v2 = Var(m.t, m.s, initialize=1)
+
+        disc = TransformationFactory('dae.collocation')
+        disc.apply_to(m, wrt=m.t, nfe=5, ncp=2, scheme='LAGRANGE-RADAU')
+        disc.apply_to(m, wrt=m.x, nfe=5, ncp=2, scheme='LAGRANGE-RADAU')
+
+        info = get_index_information(m.v, m.t)
+        nts = info['non_ds']
+        index_getter = info['index function']
+        
+        self.assertEqual(len(nts), 33)
+        self.assertTrue(m.x in nts._implicit_subsets)
+        self.assertTrue(m.s in nts._implicit_subsets)
+
+        info = get_index_information(m.v2, m.t)
+        nts = info['non_ds']
+        index_getter = info['index function']
+        
+        self.assertEqual(len(nts), 3)
+        self.assertTrue(m.s is nts)
+
 
     
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary/Motivation:
This PR removes all uses of the private `_implicit_subsets` attribute in Pyomo.DAE. @robbybp pointed out that the same functionality could be obtained by using `index_set().set_tuple` instead and that this approach is more robust for Reference components. 

## Changes proposed in this PR:
- Remove use of `_implicit_subsets` in Pyomo.DAE

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
