### PR TITLE
unhide how to print the full ef solution.

### DIFF
--- a/doc/OnlineDocs/advanced_topics/pysp_rapper/demorapper.rst
+++ b/doc/OnlineDocs/advanced_topics/pysp_rapper/demorapper.rst
@@ -98,14 +98,14 @@ Emulate some aspects of `runef`
    >>> obj = stsolver.root_E_obj() # doctest: +SKIP
    >>> print ("Expecatation take over scenarios=", obj) # doctest: +SKIP
    
+   Also, `stsolver.scenario_tree` has the solution. The package
+   csvw is imported from PySP as shown above.
+   
+   >>> csvw.write_csv_soln(stsolver.scenario_tree, "testcref") # doctest: +SKIP
+
 .. testoutput::
    :hide:
    :options: +ELLIPSIS
-
-   Also, `stsolver.scenario_tree` has the solution (csvw is imported
-   from PySP and is not part of `rapper`.)
-   
-   >>> csvw.write_csv_soln(stsolver.scenario_tree, "testcref") # doctest: +SKIP
 
 Again, but with mip gap reported
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/OnlineDocs/advanced_topics/pysp_rapper/demorapper.rst
+++ b/doc/OnlineDocs/advanced_topics/pysp_rapper/demorapper.rst
@@ -103,10 +103,6 @@ Emulate some aspects of `runef`
    
    >>> csvw.write_csv_soln(stsolver.scenario_tree, "testcref") # doctest: +SKIP
 
-.. testoutput::
-   :hide:
-   :options: +ELLIPSIS
-
 Again, but with mip gap reported
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
A few lines of rapper documentation concerning print the full ef solution 
were not visible due to some test directives.


## Changes proposed in this PR:
- Moved a few rapper documentation lines above a test directive.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
