### PR TITLE
Fixing logic in NEOS

### DIFF
--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -86,7 +86,7 @@ else: # Python 3.x
             self.proxy = urlparse(host)
             if not self.proxy.hostname:
                 # User omitted scheme from the proxy; assume http
-                self.proxy = urlparse('http://'+proxy)
+                self.proxy = urlparse('http://'+host)
 
         def make_connection(self, host):
             scheme = urlparse(host).scheme

--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -82,8 +82,8 @@ else: # Python 3.x
     # ProxiedTransport from Python 3.x documentation
     # (https://docs.python.org/3/library/xmlrpc.client.html)
     class ProxiedTransport(xmlrpclib.Transport):
-        def set_proxy(self, host):
-            self.proxy = urlparse(host)
+        def set_proxy(self, proxy):
+            self.proxy = urlparse(proxy)
             if not self.proxy.hostname:
                 # User omitted scheme from the proxy; assume http
                 self.proxy = urlparse('http://'+proxy)

--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -82,8 +82,8 @@ else: # Python 3.x
     # ProxiedTransport from Python 3.x documentation
     # (https://docs.python.org/3/library/xmlrpc.client.html)
     class ProxiedTransport(xmlrpclib.Transport):
-        def set_proxy(self, proxy):
-            self.proxy = urlparse(proxy)
+        def set_proxy(self, host):
+            self.proxy = urlparse(host)
             if not self.proxy.hostname:
                 # User omitted scheme from the proxy; assume http
                 self.proxy = urlparse('http://'+proxy)


### PR DESCRIPTION
New code for Python 3.x had clear errors.  The name of a function argument changed between the 2.x and 3.x
versions.

## Fixes N/A

## Summary/Motivation:
This PR is a simple fix to an obvious error in new Python 3.x logic in NEOS.

## Changes proposed in this PR:
- Simple changes.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
