### PR TITLE
Verbose options for infeasibility testing

### DIFF
--- a/pyomo/util/infeasible.py
+++ b/pyomo/util/infeasible.py
@@ -26,13 +26,6 @@ def log_infeasible_constraints(
         log_variables (bool): If true, prints the constraint variable names and values
 
     """
-    log_template = "CONSTR {name}: {lhs_value} {operation} {rhs_value}"
-    if log_expression:
-        log_template += "\n  {lhs_expr} {operation} {rhs_expr}"
-    if log_variables:
-        log_template += "\n{var_printout}"
-    vars_template = "  VAR {name}: {value}"
-
     # Iterate through all active constraints on the model
     for constr in m.component_data_objects(
             ctype=Constraint, active=True, descend_into=True):

--- a/pyomo/util/tests/test_infeasible.py
+++ b/pyomo/util/tests/test_infeasible.py
@@ -32,9 +32,9 @@ class TestInfeasible(unittest.TestCase):
         with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
             log_infeasible_constraints(m)
         expected_output = [
-            "CONSTR c: 1 < 2.0",
-            "CONSTR c2: 1 != 4.0",
-            "CONSTR c3: 1 > 0.0"]
+            "CONSTR c: 2.0 </= 1",
+            "CONSTR c2: 1 =/= 4.0",
+            "CONSTR c3: 1 </= 0.0"]
         self.assertEqual(output.getvalue().splitlines(), expected_output)
 
     def test_log_infeasible_bounds(self):
@@ -69,6 +69,30 @@ class TestInfeasible(unittest.TestCase):
             log_close_to_bounds(m)
         expected_output = ["y near UB of 2",
                            "c4 near LB"]
+        self.assertEqual(output.getvalue().splitlines(), expected_output)
+
+    def test_log_infeasible_constraints_verbose_expressions(self):
+        """Test for logging of infeasible constraints."""
+        m = self.build_model()
+        output = StringIO()
+        with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
+            log_infeasible_constraints(m, log_expression=True)
+        expected_output = [
+            "CONSTR c: 2.0 </= 1", "  2.0 </= x",
+            "CONSTR c2: 1 =/= 4.0", "  x =/= 4.0",
+            "CONSTR c3: 1 </= 0.0", "  x </= 0.0"]
+        self.assertEqual(output.getvalue().splitlines(), expected_output)
+
+    def test_log_infeasible_constraints_verbose_variables(self):
+        """Test for logging of infeasible constraints."""
+        m = self.build_model()
+        output = StringIO()
+        with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
+            log_infeasible_constraints(m, log_variables=True)
+        expected_output = [
+            "CONSTR c: 2.0 </= 1", "  VAR x: 1",
+            "CONSTR c2: 1 =/= 4.0", "  VAR x: 1",
+            "CONSTR c3: 1 </= 0.0", "  VAR x: 1"]
         self.assertEqual(output.getvalue().splitlines(), expected_output)
 
 

--- a/pyomo/util/tests/test_infeasible.py
+++ b/pyomo/util/tests/test_infeasible.py
@@ -23,6 +23,8 @@ class TestInfeasible(unittest.TestCase):
         m.c3 = Constraint(expr=m.x <= 0)
         m.y = Var(bounds=(0, 2), initialize=1.9999999)
         m.c4 = Constraint(expr=m.y >= m.y.value)
+        m.z = Var(bounds=(0, 6))
+        m.c5 = Constraint(expr=m.z >= 5)
         return m
 
     def test_log_infeasible_constraints(self):
@@ -34,8 +36,9 @@ class TestInfeasible(unittest.TestCase):
         expected_output = [
             "CONSTR c: 2.0 </= 1",
             "CONSTR c2: 1 =/= 4.0",
-            "CONSTR c3: 1 </= 0.0"]
-        self.assertEqual(output.getvalue().splitlines(), expected_output)
+            "CONSTR c3: 1 </= 0.0",
+            "CONSTR c5: missing variable value."]
+        self.assertEqual(expected_output, output.getvalue().splitlines())
 
     def test_log_infeasible_bounds(self):
         """Test for logging of infeasible variable bounds."""
@@ -47,7 +50,7 @@ class TestInfeasible(unittest.TestCase):
             log_infeasible_bounds(m)
         expected_output = ["VAR x: 1 < LB 2",
                            "VAR x: 1 > UB 0"]
-        self.assertEqual(output.getvalue().splitlines(), expected_output)
+        self.assertEqual(expected_output, output.getvalue().splitlines())
 
     def test_log_active_constraints(self):
         """Test for logging of active constraints."""
@@ -58,8 +61,9 @@ class TestInfeasible(unittest.TestCase):
         expected_output = ["c active",
                            "c2 active",
                            "c3 active",
-                           "c4 active"]
-        self.assertEqual(output.getvalue().splitlines(), expected_output)
+                           "c4 active",
+                           "c5 active"]
+        self.assertEqual(expected_output, output.getvalue().splitlines())
 
     def test_log_close_to_bounds(self):
         """Test logging of variables and constraints near bounds."""
@@ -68,8 +72,9 @@ class TestInfeasible(unittest.TestCase):
         with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
             log_close_to_bounds(m)
         expected_output = ["y near UB of 2",
-                           "c4 near LB"]
-        self.assertEqual(output.getvalue().splitlines(), expected_output)
+                           "c4 near LB",
+                           "Skipping CONSTR c5: missing variable value."]
+        self.assertEqual(expected_output, output.getvalue().splitlines())
 
     def test_log_infeasible_constraints_verbose_expressions(self):
         """Test for logging of infeasible constraints."""
@@ -80,8 +85,9 @@ class TestInfeasible(unittest.TestCase):
         expected_output = [
             "CONSTR c: 2.0 </= 1", "  2.0 </= x",
             "CONSTR c2: 1 =/= 4.0", "  x =/= 4.0",
-            "CONSTR c3: 1 </= 0.0", "  x </= 0.0"]
-        self.assertEqual(output.getvalue().splitlines(), expected_output)
+            "CONSTR c3: 1 </= 0.0", "  x </= 0.0",
+            "CONSTR c5: missing variable value."]
+        self.assertEqual(expected_output, output.getvalue().splitlines())
 
     def test_log_infeasible_constraints_verbose_variables(self):
         """Test for logging of infeasible constraints."""
@@ -92,8 +98,9 @@ class TestInfeasible(unittest.TestCase):
         expected_output = [
             "CONSTR c: 2.0 </= 1", "  VAR x: 1",
             "CONSTR c2: 1 =/= 4.0", "  VAR x: 1",
-            "CONSTR c3: 1 </= 0.0", "  VAR x: 1"]
-        self.assertEqual(output.getvalue().splitlines(), expected_output)
+            "CONSTR c3: 1 </= 0.0", "  VAR x: 1",
+            "CONSTR c5: missing variable value.", "  VAR z: None"]
+        self.assertEqual(expected_output, output.getvalue().splitlines())
 
 
 if __name__ == '__main__':

--- a/pyomo/util/tests/test_infeasible.py
+++ b/pyomo/util/tests/test_infeasible.py
@@ -37,7 +37,7 @@ class TestInfeasible(unittest.TestCase):
             "CONSTR c: 2.0 </= 1",
             "CONSTR c2: 1 =/= 4.0",
             "CONSTR c3: 1 </= 0.0",
-            "CONSTR c5: missing variable value."]
+            "CONSTR c5: 5.0 <?= missing variable value"]
         self.assertEqual(expected_output, output.getvalue().splitlines())
 
     def test_log_infeasible_bounds(self):
@@ -86,7 +86,7 @@ class TestInfeasible(unittest.TestCase):
             "CONSTR c: 2.0 </= 1", "  2.0 </= x",
             "CONSTR c2: 1 =/= 4.0", "  x =/= 4.0",
             "CONSTR c3: 1 </= 0.0", "  x </= 0.0",
-            "CONSTR c5: missing variable value."]
+            "CONSTR c5: 5.0 <?= missing variable value", "  5.0 <?= z"]
         self.assertEqual(expected_output, output.getvalue().splitlines())
 
     def test_log_infeasible_constraints_verbose_variables(self):
@@ -99,7 +99,7 @@ class TestInfeasible(unittest.TestCase):
             "CONSTR c: 2.0 </= 1", "  VAR x: 1",
             "CONSTR c2: 1 =/= 4.0", "  VAR x: 1",
             "CONSTR c3: 1 </= 0.0", "  VAR x: 1",
-            "CONSTR c5: missing variable value.", "  VAR z: None"]
+            "CONSTR c5: 5.0 <?= missing variable value", "  VAR z: None"]
         self.assertEqual(expected_output, output.getvalue().splitlines())
 
 


### PR DESCRIPTION
## Summary/Motivation:
Adds new verbose logging options to the model infeasibility testing utility: `log_expression` and `log_variables`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
