### PR TITLE
Compdata references

### DIFF
--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -12,6 +12,9 @@ from pyutilib.misc import flatten_tuple
 from pyomo.common import DeveloperError
 from pyomo.core.base.sets import SetOf, _SetProduct, _SetDataBase
 from pyomo.core.base.component import Component, ComponentData
+from pyomo.core.base.var import SimpleVar, _GeneralVarData
+from pyomo.core.base.constraint import SimpleConstraint, _GeneralConstraintData
+from pyomo.core.base.block import SimpleBlock, _BlockData
 from pyomo.core.base.indexed_component import (
     IndexedComponent, UnindexedComponent_set
 )
@@ -518,10 +521,26 @@ def Reference(reference, ctype=_NotSpecified):
         pass
     elif isinstance(reference, Component):
         reference = reference[...]
+    elif isinstance(reference, _GeneralVarData):
+        obj = SimpleVar()
+        obj._costructed = True
+        obj.domain = reference.domain
+        obj._data = {None: reference}
+        return obj
+    elif isinstance(reference, _GeneralConstraintData):
+        obj = SimpleConstraint()
+        obj._costructed = True
+        obj._data = {None: reference}
+        return obj
+    elif isinstance(reference, _BlockData):
+        obj = SimpleBlock()
+        obj._costructed = True
+        obj._data = {None: reference}
+        return obj
     else:
         raise TypeError(
             "First argument to Reference constructors must be a "
-            "component or component slice (received %s)"
+            "component, component slice, or component data (received %s)"
             % (type(reference).__name__,))
 
     _data = _ReferenceDict(reference)

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -523,18 +523,18 @@ def Reference(reference, ctype=_NotSpecified):
         reference = reference[...]
     elif isinstance(reference, _GeneralVarData):
         obj = SimpleVar()
-        obj._costructed = True
+        obj._constructed = True
         obj.domain = reference.domain
         obj._data = {None: reference}
         return obj
     elif isinstance(reference, _GeneralConstraintData):
         obj = SimpleConstraint()
-        obj._costructed = True
+        obj._constructed = True
         obj._data = {None: reference}
         return obj
     elif isinstance(reference, _BlockData):
         obj = SimpleBlock()
-        obj._costructed = True
+        obj._constructed = True
         obj._data = {None: reference}
         return obj
     else:

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -24,7 +24,6 @@ from pyomo.core.base.indexed_component_slice import (
 
 import six
 from six import iteritems, advance_iterator
-import pdb
 
 if six.PY3:
     from collections.abc import MutableMapping as collections_MutableMapping

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -12,9 +12,6 @@ from pyutilib.misc import flatten_tuple
 from pyomo.common import DeveloperError
 from pyomo.core.base.sets import SetOf, _SetProduct, _SetDataBase
 from pyomo.core.base.component import Component, ComponentData
-from pyomo.core.base.var import SimpleVar, _GeneralVarData
-from pyomo.core.base.constraint import SimpleConstraint, _GeneralConstraintData
-from pyomo.core.base.block import SimpleBlock, _BlockData
 from pyomo.core.base.indexed_component import (
     IndexedComponent, UnindexedComponent_set
 )
@@ -533,7 +530,6 @@ def Reference(reference, ctype=_NotSpecified):
             % (type(reference).__name__,))
 
     _data = _ReferenceDict(reference)
-
     _iter = iter(reference)
     if ctype is _NotSpecified:
         ctypes = set()

--- a/pyomo/core/tests/unit/test_reference.py
+++ b/pyomo/core/tests/unit/test_reference.py
@@ -29,7 +29,6 @@ from pyomo.core.base.reference import (
 )
 
 
-
 class TestReferenceDict(unittest.TestCase):
     def setUp(self):
         self.m = m = ConcreteModel()

--- a/pyomo/core/tests/unit/test_reference.py
+++ b/pyomo/core/tests/unit/test_reference.py
@@ -734,10 +734,10 @@ class TestReference(unittest.TestCase):
         self.assertEqual(len(m.r1), 1)
         self.assertEqual(len(m.r2), 1)
 
-        m.r1['a'].set_value(5)
-        m.r2['b'].set_value(10)
-        self.assertEqual(m.r1['a'].value, m.b[1].v1['a'].value)
-        self.assertEqual(m.r2['b'].value, m.v['b'].value)
+        m.r1[None].set_value(5)
+        m.r2[None].set_value(10)
+        self.assertEqual(m.r1[None].value, m.b[1].v1['a'].value)
+        self.assertEqual(m.r2[None].value, m.v['b'].value)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/core/tests/unit/test_reference.py
+++ b/pyomo/core/tests/unit/test_reference.py
@@ -28,6 +28,8 @@ from pyomo.core.base.reference import (
     _ReferenceDict, _ReferenceSet, Reference, _get_base_sets
 )
 
+import pdb
+
 
 class TestReferenceDict(unittest.TestCase):
     def setUp(self):
@@ -716,6 +718,27 @@ class TestReference(unittest.TestCase):
             m.xx.add((2,1))
         self.assertEqual(len(m.b), 2)
         self.assertEqual(len(list(m.b[2].component_objects())), 0)
+
+    def test_reference_to_data(self):
+        m = ConcreteModel()
+        m.s = Set(initialize=['a', 'b', 'c'])
+        m.t = Set(initialize=[1, 2, 3])
+        m.v = Var(m.s, initialize=1)
+
+        @m.Block(m.t)
+        def b(b, i):
+            b.v1 = Var(b.model().s, initialize=2)
+            return b
+
+        m.r1 = Reference(m.b[1].v1['a'])
+        m.r2 = Reference(m.v['b'])
+        self.assertEqual(len(m.r1), 1)
+        self.assertEqual(len(m.r2), 1)
+
+        m.r1['a'].set_value(5)
+        m.r2['b'].set_value(10)
+        self.assertEqual(m.r1['a'].value, m.b[1].v1['a'].value)
+        self.assertEqual(m.r2['b'].value, m.v['b'].value)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/core/tests/unit/test_reference.py
+++ b/pyomo/core/tests/unit/test_reference.py
@@ -28,7 +28,6 @@ from pyomo.core.base.reference import (
     _ReferenceDict, _ReferenceSet, Reference, _get_base_sets
 )
 
-import pdb
 
 
 class TestReferenceDict(unittest.TestCase):

--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -482,7 +482,7 @@ def get_index_information(var, ds):
         indCount = 0
         for index in var._implicit_subsets:
             if isinstance(index, ContinuousSet):
-                if id(index) == id(ds):
+                if index is ds:
                     dsindex = indCount
                 else:
                     # If var is indexed by multiple ContinuousSets treat

--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -482,7 +482,7 @@ def get_index_information(var, ds):
         indCount = 0
         for index in var._implicit_subsets:
             if isinstance(index, ContinuousSet):
-                if index == ds:
+                if id(index) == id(ds):
                     dsindex = indCount
                 else:
                     # If var is indexed by multiple ContinuousSets treat


### PR DESCRIPTION
## Summary/Motivation:
Would like to create references to data objects for an IDAES model DAE integrator. In particular, creating references at a particular time point to variables and constraints that are only indexed by time requires this. 
See: https://groups.google.com/d/topic/pyomo-forum/o_-RKlSlmvU/discussion

Note that this change would be unnecessary (for my purposes) if I could use start and stop values in a slice to create a reference to variables and constraints at time points within a finite element. 
See: https://groups.google.com/d/topic/pyomo-forum/xfS5fDCgm4U/discussion

## Changes proposed in this PR:
-Allow Reference function to be called with VarData, ConstraintData, and BlockData objects as arguments
-For these objects, return a SimpleComponent object whose _data dict maps None to the data object to be referenced. If this object is created as:

```
m.add_component(ref_name, Reference(data_object))
```

It must be accessed as ```m.ref_name[None]``` instead of just ```m.ref_name```, which may lead to some confusion as, for variables, ```m.ref_name.value``` is distinct from ```m.ref_name[None].value```. I am not sure what other problems this may cause, for instance when sending variables to a solver/.nl file, but it seems to work for the integrator as I have it written. 

Opening the PR for discussion/feedback.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
