### PR TITLE
Jenkins build infrastructure improvements

### DIFF
--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -119,15 +119,18 @@ if test -z "$MODE" -o "$MODE" == setup; then
 
     # Use Pyomo to download & compile binary extensions
     i=0
-    while test $i -lt 3; do
+    while /bin/true; do
         i=$[$i+1]
         echo "Downloading pyomo extensions (attempt $i)"
         pyomo download-extensions $PYOMO_DOWNLOAD_ARGS
         if test $? == 0; then
             break
+        elif test $i -ge 3; then
+            exit 1
         fi
-        echo "Pausing 30 seconds before re-attempting download"
-        sleep 30
+        DELAY=$(( RANDOM % 30 + 15))
+        echo "Pausing $DELAY seconds before re-attempting download"
+        sleep $DELAY
     done
     pyomo build-extensions || exit 1
 
@@ -180,7 +183,7 @@ if test -z "$MODE" -o "$MODE" == test; then
         else
             CODECOV_JOB_NAME=`echo ${JOB_NAME} | sed -r 's/^(.*autotest_)?Pyomo_([^\/]+).*/\2/'`.$BUILD_NUMBER.$python
             i=0
-            while test $i -lt 3; do
+            while /bin/true; do
                 i=$[$i+1]
                 echo "Uploading coverage to codecov (attempt $i)"
                 codecov -X gcovcodecov -X gcov --no-color \
@@ -189,9 +192,12 @@ if test -z "$MODE" -o "$MODE" == test; then
                     | tee .cover.upload
                 if test $? == 0 -a `grep -i error .cover.upload | wc -l` -eq 0; then
                     break
+                elif  test $i -ge 3; then
+                    exit 1
                 fi
-                echo "Pausing 30 seconds before re-attempting upload"
-                sleep 30
+                DELAY=$(( RANDOM % 30 + 15))
+                echo "Pausing $DELAY seconds before re-attempting upload"
+                sleep $DELAY
             done
         fi
         rm .coverage

--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -118,7 +118,17 @@ if test -z "$MODE" -o "$MODE" == setup; then
     echo ""
 
     # Use Pyomo to download & compile binary extensions
-    pyomo download-extensions $PYOMO_DOWNLOAD_ARGS || exit 1
+    i=0
+    while test $i -lt 3; do
+        i=$[$i+1]
+        echo "Downloading pyomo extensions (attempt $i)"
+        pyomo download-extensions $PYOMO_DOWNLOAD_ARGS
+        if test $? == 0; then
+            break
+        fi
+        echo "Pausing 30 seconds before re-attempting download"
+        sleep 30
+    done
     pyomo build-extensions || exit 1
 
     # Print useful version information

--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -25,7 +25,7 @@
 #
 # DISABLE_COVERAGE: if nonempty, then coverage analysis is disabled
 #
-# PYOMO_DOWNLOAD_ARGS: passed to the 'pyomo download-extensions" commamd
+# PYOMO_DOWNLOAD_ARGS: passed to the 'pyomo download-extensions" command
 #     (e.g., to set up local SSL certificate authorities)
 #
 if test -z "$WORKSPACE"; then

--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -25,6 +25,9 @@
 #
 # DISABLE_COVERAGE: if nonempty, then coverage analysis is disabled
 #
+# PYOMO_DOWNLOAD_ARGS: passed to the 'pyomo download-extensions" commamd
+#     (e.g., to set up local SSL certificate authorities)
+#
 if test -z "$WORKSPACE"; then
     export WORKSPACE=`pwd`
 fi
@@ -115,7 +118,7 @@ if test -z "$MODE" -o "$MODE" == setup; then
     echo ""
 
     # Use Pyomo to download & compile binary extensions
-    pyomo download-extensions || exit 1
+    pyomo download-extensions $PYOMO_DOWNLOAD_ARGS || exit 1
     pyomo build-extensions || exit 1
 
     # Print useful version information
@@ -177,7 +180,7 @@ if test -z "$MODE" -o "$MODE" == test; then
                 if test $? == 0 -a `grep -i error .cover.upload | wc -l` -eq 0; then
                     break
                 fi
-                echo "Pausing 30 seconds before re-appempting upload"
+                echo "Pausing 30 seconds before re-attempting upload"
                 sleep 30
             done
         fi

--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -129,7 +129,9 @@ class FileDownloader(object):
     def retrieve_url(self, url):
         """Return the contents of a URL as an io.BytesIO object"""
         try:
-            ctx = ssl.create_default_context(cafile=self.cacert)
+            ctx = ssl.create_default_context()
+            if self.cacert:
+                ctx.load_verify_locations(cafile=self.cacert)
             if self.insecure:
                 ctx.check_hostname = False
                 ctx.verify_mode = ssl.CERT_NONE

--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -86,6 +86,13 @@ class FileDownloader(object):
             help="Use CACERT as the file of certificate authorities "
             "to verify peers.",
         )
+        parser.add_argument(
+            '-v','--verbose',
+            action='store_true',
+            dest='verbose',
+            default=False,
+            help="Verbose output when download fails",
+        )
         return parser
 
     def parse_args(self, argv):

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -151,7 +151,7 @@ class parmest_object_Tester_RB(unittest.TestCase):
         rbpath = parmestpath + os.sep + "examples" + os.sep + \
                    "rooney_biegler" + os.sep + "rooney_biegler.py"
         rbpath = os.path.abspath(rbpath) # paranoia strikes deep...
-        if sys.version_info >= (3,0):
+        if sys.version_info >= (3,5):
             ret = subprocess.run(["python", rbpath])
             retcode = ret.returncode
         else:
@@ -169,7 +169,7 @@ class parmest_object_Tester_RB(unittest.TestCase):
                    "rooney_biegler" + os.sep + "rooney_biegler_parmest.py"
         rbpath = os.path.abspath(rbpath) # paranoia strikes deep...
         rlist = ["mpiexec", "--allow-run-as-root", "-n", "2", "python", rbpath]
-        if sys.version_info >= (3,0):
+        if sys.version_info >= (3,5):
             ret = subprocess.run(rlist)
             retcode = ret.returncode
         else:

--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -136,7 +136,7 @@ class kestrelAMPL:
         try:
             result = self.neos.ping()
             logger.info("OK.")
-        except socket.error:
+        except (socket.error, xmlrpclib.ProtocolError):
             e = sys.exc_info()[1]
             self.neos = None
             logger.info("Fail.")

--- a/pyomo/repn/util.py
+++ b/pyomo/repn/util.py
@@ -42,7 +42,7 @@ def ftoa(val):
             _val = value(val)
         else:
             raise ValueError(
-                "Converting non-fixed bound or value to string: %s" (val,))
+                "Converting non-fixed bound or value to string: %s" % (val,))
     #
     # Convert to string
     a = _ftoa_precision_str % _val

--- a/pyomo/scripting/plugins/download.py
+++ b/pyomo/scripting/plugins/download.py
@@ -9,6 +9,7 @@
 #  ___________________________________________________________________________
 
 import logging
+import traceback
 from pyomo.common.download import FileDownloader, DownloadFactory
 from pyomo.scripting.pyomo_parser import add_subparser
 
@@ -34,9 +35,13 @@ class GroupDownloader(object):
             except SystemExit:
                 result = 'FAIL'
                 returncode = 1
+                if args.verbose:
+                    traceback.print_exc()
             except:
                 result = 'FAIL'
                 returncode = 1
+                if args.verbose:
+                    traceback.print_exc()
             results.append(result_fmt % (result, target))
         logger.info("Finished downloading Pyomo extensions.")
         logger.info(


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This should get the Jenkins builds running for python 3.7 and 3.8.

## Changes proposed in this PR:
- Add additional arguments (for SSL cert chains) to '`pyomo download-extenstions`' in `.jenkins.sh`
- Add a `--verbose` option to `download-extensions` for diagnosing download failures
- Fix an (unrelated to downloading) syntax error that Python 3.8 points out

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
