### PR TITLE
Skip certain trust region tests when Ipopt is not available

### DIFF
--- a/pyomo/contrib/trustregion/tests/TestTRConfig.py
+++ b/pyomo/contrib/trustregion/tests/TestTRConfig.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     numpy_available = False
 
-
+@unittest.skipIf(not SolverFactory('ipopt').available(False), "The IPOPT solver is not available")
 @unittest.skipIf(not SolverFactory('gjh').available(False), "The GJH solver is not available")
 @unittest.skipIf(not numpy_available, "Cannot test the trustregion solver without numpy")
 class TestTrustRegionConfigBlock(unittest.TestCase):


### PR DESCRIPTION
## Summary/Motivation:
The work on setting up GitHub actions (#1194) revealed that we had a few tests in the trust region code that implicitly require Ipopt. This PR adds unit test skipping if Ipopt is not available.

## Changes proposed in this PR:
- Skip certain trust region tests when Ipopt is not available

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
