### PR TITLE
BigM estimation for nonlinear expressions

### DIFF
--- a/doc/OnlineDocs/modeling_extensions/gdp.rst
+++ b/doc/OnlineDocs/modeling_extensions/gdp.rst
@@ -73,10 +73,14 @@ If you are using a Python script, ``TransformationFactory`` accomplishes the sam
     - all variables that appear in disjuncts need upper and lower bounds for chull
 
     - for linear models, the BigM transform can estimate reasonably tight M
-      values for you if variables are bounded
+      values for you if variables are bounded.
+
+    - for nonlinear models where finite expression bounds may be inferred from
+      variable bounds, the BigM transformation may also be able to automatically
+      compute M values for you.
 
     - for all other models, you will need to provide the M values through a
-      “BigM” Suffix.
+      “BigM” Suffix. A ``GDP_Error`` will be raised for missing M values.
 
     - When you declare a Disjunct, it (at declaration time) will automatically
       have a variable “indicator_var” defined and attached to it.
@@ -92,7 +96,7 @@ Pyomo includes the contributed GDPopt solver, which can direct solve GDP models.
 Its documentation and usage is described at :doc:`/contributed_packages/gdpopt`.
 
 Examples
------
+--------
 
 The following models all work and are equivalent:
 

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -13,6 +13,7 @@
 import logging
 import textwrap
 
+from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
 from pyomo.core import (
     Block, Connector, Constraint, Param, Set, Suffix, Var,
     Expression, SortComponents, TraversalStrategy, Any, value,
@@ -694,8 +695,13 @@ class BigM_Transformation(Transformation):
                             "\n\t(found unbounded var %s while processing "
                             "constraint %s)" % (var.name, name))
         else:
-            raise GDP_Error("Cannot estimate M for nonlinear "
-                            "expressions.\n\t(found while processing "
-                            "constraint %s)" % name)
+            # expression is nonlinear. Try using `contrib.fbbt` to estimate.
+            expr_lb, expr_ub = compute_bounds_on_expr(expr)
+            if expr_lb is None or expr_ub is None:
+                raise GDP_Error("Cannot estimate M for nonlinear "
+                                "expressions.\n\t(found while processing "
+                                "constraint %s)" % name)
+            else:
+                M = (expr_lb, expr_ub)
 
         return tuple(M)

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -14,6 +14,7 @@ import logging
 import textwrap
 
 from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
+from pyomo.contrib.fbbt.interval import inf
 from pyomo.core import (
     Block, Connector, Constraint, Param, Set, Suffix, Var,
     Expression, SortComponents, TraversalStrategy, Any, value,
@@ -697,8 +698,8 @@ class BigM_Transformation(Transformation):
         else:
             # expression is nonlinear. Try using `contrib.fbbt` to estimate.
             expr_lb, expr_ub = compute_bounds_on_expr(expr)
-            if expr_lb is None or expr_ub is None:
-                raise GDP_Error("Cannot estimate M for nonlinear "
+            if expr_lb == -inf or expr_ub == inf:
+                raise GDP_Error("Cannot estimate M for unbounded nonlinear "
                                 "expressions.\n\t(found while processing "
                                 "constraint %s)" % name)
             else:

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -632,7 +632,7 @@ class TwoTermDisjNonlinear(unittest.TestCase, CommonTests):
         x = m.x = Var(bounds=(-4, 4))
         y = m.y = Var(bounds=(-10, 10))
         m.disj = Disjunction(expr=[
-            [x**2 + y**2 <= 2, x**3 + y**2 + x * y >= 1/2],
+            [x**2 + y**2 <= 2, x**3 + y**2 + x * y >= 1.0/2.0],
             [(x - 3)**2 + (y - 3)**2 <= 1]
         ])
         TransformationFactory('gdp.bigm').apply_to(m)

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -616,6 +616,17 @@ class TwoTermDisjNonlinear(unittest.TestCase, CommonTests):
         self.assertEqual(c['ub'].upper, m.d[0].c.upper)
         self.assertIsNone(c['ub'].lower)
 
+    def test_nonlinear_bigM_missing_var_bounds(self):
+        m = models.makeTwoTermDisj_Nonlinear()
+        m.y.setlb(None)
+        self.assertRaisesRegexp(
+            GDP_Error,
+            "Cannot estimate M for unbounded nonlinear "
+            "expressions.\n\t\(found while processing "
+            "constraint d\[0\].c\)",
+            TransformationFactory('gdp.bigm').apply_to,
+            m)
+
 
 class TwoTermIndexedDisj(unittest.TestCase, CommonTests):
     def setUp(self):


### PR DESCRIPTION
# Summary/Motivation:
This is scratching an itch that I have had for a while now. We have had nonlinear interval arithmetic through both MC++ and FBBT for a while now. This PR puts those capabilities to use for BigM estimation in Pyomo.GDP.

There is surprisingly little that needed to be updated in the code.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
