### PR TITLE
Pyomo.util.infeasible Bugfix

### DIFF
--- a/pyomo/util/infeasible.py
+++ b/pyomo/util/infeasible.py
@@ -122,10 +122,10 @@ def log_infeasible_bounds(m, tol=1E-6, logger=logger):
             logger.debug("Skipping VAR {} with no assigned value.")
             continue
         if var.has_lb() and value(var.lb - var) >= tol:
-            logger.info('VAR {}: {} < LB {}'.format(
+            logger.info('VAR {}: {} >/= LB {}'.format(
                 var.name, value(var), value(var.lb)))
         if var.has_ub() and value(var - var.ub) >= tol:
-            logger.info('VAR {}: {} > UB {}'.format(
+            logger.info('VAR {}: {} </= UB {}'.format(
                 var.name, value(var), value(var.ub)))
 
 

--- a/pyomo/util/infeasible.py
+++ b/pyomo/util/infeasible.py
@@ -48,9 +48,9 @@ def log_infeasible_constraints(
                 if fabs(constr_lb_value - constr_body_value) >= tol:
                     equality_violated = True
             else:
-                if constr.has_lb() and fabs(constr_lb_value - constr_body_value) >= tol:
+                if constr.has_lb() and constr_lb_value - constr_body_value >= tol:
                     lb_violated = True
-                if constr.has_ub() and fabs(constr_body_value - constr_ub_value) >= tol:
+                if constr.has_ub() and constr_body_value - constr_ub_value >= tol:
                     ub_violated = True
 
         if not any((constr_undefined, equality_violated, lb_violated, ub_violated)):

--- a/pyomo/util/tests/test_infeasible.py
+++ b/pyomo/util/tests/test_infeasible.py
@@ -6,7 +6,7 @@ from six import StringIO
 
 import pyutilib.th as unittest
 from pyomo.common.log import LoggingIntercept
-from pyomo.environ import ConcreteModel, Constraint, Var
+from pyomo.environ import ConcreteModel, Constraint, Var, inequality
 from pyomo.util.infeasible import (log_active_constraints, log_close_to_bounds,
                                    log_infeasible_bounds,
                                    log_infeasible_constraints)
@@ -18,14 +18,24 @@ class TestInfeasible(unittest.TestCase):
     def build_model(self):
         m = ConcreteModel()
         m.x = Var(initialize=1)
-        m.c = Constraint(expr=m.x >= 2)
+        m.c1 = Constraint(expr=m.x >= 2)
         m.c2 = Constraint(expr=m.x == 4)
         m.c3 = Constraint(expr=m.x <= 0)
         m.y = Var(bounds=(0, 2), initialize=1.9999999)
         m.c4 = Constraint(expr=m.y >= m.y.value)
         m.z = Var(bounds=(0, 6))
-        m.c5 = Constraint(expr=m.z >= 5)
-        m.feasible = Constraint(expr=m.x + m.y <= 6)
+        m.c5 = Constraint(expr=inequality(5, m.z, 10), doc="Range infeasible")
+        m.c6 = Constraint(expr=m.x + m.y <= 6, doc="Feasible")
+        m.c7 = Constraint(expr=m.z == 6, doc="Equality infeasible")
+        m.c8 = Constraint(expr=inequality(3, m.x, 6), doc="Range lb infeasible")
+        m.c9 = Constraint(expr=inequality(0, m.x, 0.5), doc="Range ub infeasible")
+        m.c10 = Constraint(expr=m.y >= 3, doc="Inactive")
+        m.c10.deactivate()
+        m.c11 = Constraint(expr=m.y <= m.y.value)
+        m.yy = Var(bounds=(0, 1), initialize=1E-7, doc="Close to lower bound")
+        m.y3 = Var(bounds=(0, 1E-7), initialize=0, doc="Bounds too close")
+        m.y4 = Var(bounds=(0, 1), initialize=2, doc="Fixed out of bounds.")
+        m.y4.fix()
         return m
 
     def test_log_infeasible_constraints(self):
@@ -35,10 +45,14 @@ class TestInfeasible(unittest.TestCase):
         with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
             log_infeasible_constraints(m)
         expected_output = [
-            "CONSTR c: 2.0 </= 1",
+            "CONSTR c1: 2.0 </= 1",
             "CONSTR c2: 1 =/= 4.0",
             "CONSTR c3: 1 </= 0.0",
-            "CONSTR c5: 5.0 <?= missing variable value"]
+            "CONSTR c5: 5.0 <?= missing variable value <?= 10.0",
+            "CONSTR c7: missing variable value =?= 6.0",
+            "CONSTR c8: 3.0 </= 1 <= 6.0",
+            "CONSTR c9: 0.0 <= 1 </= 0.5",
+        ]
         self.assertEqual(expected_output, output.getvalue().splitlines())
 
     def test_log_infeasible_bounds(self):
@@ -49,8 +63,9 @@ class TestInfeasible(unittest.TestCase):
         output = StringIO()
         with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
             log_infeasible_bounds(m)
-        expected_output = ["VAR x: 1 < LB 2",
-                           "VAR x: 1 > UB 0"]
+        expected_output = [
+            "VAR x: 1 >/= LB 2", "VAR x: 1 </= UB 0", "VAR y4: 2 </= UB 1",
+        ]
         self.assertEqual(expected_output, output.getvalue().splitlines())
 
     def test_log_active_constraints(self):
@@ -59,11 +74,11 @@ class TestInfeasible(unittest.TestCase):
         output = StringIO()
         with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
             log_active_constraints(m)
-        expected_output = ["c active",
-                           "c2 active",
-                           "c3 active",
-                           "c4 active",
-                           "c5 active"]
+        expected_output = [
+            "c1 active", "c2 active", "c3 active", "c4 active",
+            "c5 active", "c6 active", "c7 active", "c8 active",
+            "c9 active", "c11 active"
+        ]
         self.assertEqual(expected_output, output.getvalue().splitlines())
 
     def test_log_close_to_bounds(self):
@@ -72,9 +87,11 @@ class TestInfeasible(unittest.TestCase):
         output = StringIO()
         with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
             log_close_to_bounds(m)
-        expected_output = ["y near UB of 2",
-                           "c4 near LB",
-                           "Skipping CONSTR c5: missing variable value."]
+        expected_output = [
+            "y near UB of 2", "yy near LB of 0", "c4 near LB",
+            "Skipping CONSTR c5: missing variable value.",
+            "c11 near UB",
+        ]
         self.assertEqual(expected_output, output.getvalue().splitlines())
 
     def test_log_infeasible_constraints_verbose_expressions(self):
@@ -84,10 +101,14 @@ class TestInfeasible(unittest.TestCase):
         with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
             log_infeasible_constraints(m, log_expression=True)
         expected_output = [
-            "CONSTR c: 2.0 </= 1", "  2.0 </= x",
+            "CONSTR c1: 2.0 </= 1", "  2.0 </= x",
             "CONSTR c2: 1 =/= 4.0", "  x =/= 4.0",
             "CONSTR c3: 1 </= 0.0", "  x </= 0.0",
-            "CONSTR c5: 5.0 <?= missing variable value", "  5.0 <?= z"]
+            "CONSTR c5: 5.0 <?= missing variable value <?= 10.0", "  5.0 <?= z <?= 10.0",
+            "CONSTR c7: missing variable value =?= 6.0", "  z =?= 6.0",
+            "CONSTR c8: 3.0 </= 1 <= 6.0", "  3.0 </= x <= 6.0",
+            "CONSTR c9: 0.0 <= 1 </= 0.5", "  0.0 <= x </= 0.5",
+        ]
         self.assertEqual(expected_output, output.getvalue().splitlines())
 
     def test_log_infeasible_constraints_verbose_variables(self):
@@ -97,10 +118,14 @@ class TestInfeasible(unittest.TestCase):
         with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
             log_infeasible_constraints(m, log_variables=True)
         expected_output = [
-            "CONSTR c: 2.0 </= 1", "  VAR x: 1",
+            "CONSTR c1: 2.0 </= 1", "  VAR x: 1",
             "CONSTR c2: 1 =/= 4.0", "  VAR x: 1",
             "CONSTR c3: 1 </= 0.0", "  VAR x: 1",
-            "CONSTR c5: 5.0 <?= missing variable value", "  VAR z: None"]
+            "CONSTR c5: 5.0 <?= missing variable value <?= 10.0", "  VAR z: None",
+            "CONSTR c7: missing variable value =?= 6.0", "  VAR z: None",
+            "CONSTR c8: 3.0 </= 1 <= 6.0", "  VAR x: 1",
+            "CONSTR c9: 0.0 <= 1 </= 0.5", "  VAR x: 1",
+        ]
         self.assertEqual(expected_output, output.getvalue().splitlines())
 
 

--- a/pyomo/util/tests/test_infeasible.py
+++ b/pyomo/util/tests/test_infeasible.py
@@ -25,6 +25,7 @@ class TestInfeasible(unittest.TestCase):
         m.c4 = Constraint(expr=m.y >= m.y.value)
         m.z = Var(bounds=(0, 6))
         m.c5 = Constraint(expr=m.z >= 5)
+        m.feasible = Constraint(expr=m.x + m.y <= 6)
         return m
 
     def test_log_infeasible_constraints(self):


### PR DESCRIPTION
## Summary/Motivation:
Right now the constraint infeasibility detection will yell at you for `4.0 </= 6.0`, which is demonstratively not true. This is the bugfix and accompanying unit tests to cover the rest of the module.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
