### PR TITLE
Fixes to setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[metadata]
+license_files = LICENSE.txt
+
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -16,25 +16,6 @@ import sys
 import os
 
 
-def _find_packages(path):
-    """
-    Generate a list of nested packages
-    """
-    pkg_list = []
-    if not os.path.exists(path):
-        return []
-    if not os.path.exists(path+os.sep+"__init__.py"):
-        return []
-    else:
-        pkg_list.append(path)
-    for root, dirs, files in os.walk(path, topdown=True):
-        if root in pkg_list and "__init__.py" in files:
-            for name in dirs:
-                if os.path.exists(root+os.sep+name+os.sep+"__init__.py"):
-                    pkg_list.append(root+os.sep+name)
-    return [pkg for pkg in map(lambda x:x.replace(os.sep, "."), pkg_list)]
-
-
 def read(*rnames):
     with open(os.path.join(os.path.dirname(__file__), *rnames)) as README:
         # Strip all leading badges up to, but not including the COIN-OR
@@ -120,8 +101,6 @@ ERROR: Cython was explicitly requested with --with-cython, but cythonization
             raise
         using_cython = False
 
-packages = _find_packages('pyomo')
-
 def run_setup():
    setup(name='Pyomo',
       #
@@ -159,8 +138,9 @@ def run_setup():
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Software Development :: Libraries :: Python Modules' ],
-      packages=find_packages('pyomo/pyomo/*'),
+      packages=find_packages(where='pyomo/*'),
       package_data={"pyomo.contrib.viewer":["*.ui"]},
+      data_files=[("",["LICENSE.txt"])],
       keywords=['optimization'],
       install_requires=requires,
       ext_modules = ext_modules,

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ def run_setup():
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Software Development :: Libraries :: Python Modules' ],
-      packages=find_packages(where='pyomo/*'),
+      packages=find_packages(exclude=("admin","scripts",)),
       package_data={"pyomo.contrib.viewer":["*.ui"]},
       keywords=['optimization'],
       install_requires=requires,

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,6 @@ def run_setup():
         'Topic :: Software Development :: Libraries :: Python Modules' ],
       packages=find_packages(where='pyomo/*'),
       package_data={"pyomo.contrib.viewer":["*.ui"]},
-      data_files=[("",["LICENSE.txt"])],
       keywords=['optimization'],
       install_requires=requires,
       ext_modules = ext_modules,

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ if sys.version_info < (2, 7):
     requires.append('unittest2')
     requires.append('ordereddict')
 
-from setuptools import setup
+from setuptools import setup, find_packages
 import sys
 
 CYTHON_REQUIRED = "required"
@@ -159,7 +159,7 @@ def run_setup():
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Software Development :: Libraries :: Python Modules' ],
-      packages=packages,
+      packages=find_packages('pyomo/pyomo/*'),
       package_data={"pyomo.contrib.viewer":["*.ui"]},
       keywords=['optimization'],
       install_requires=requires,


### PR DESCRIPTION
## Fixes # 
This PR removes an unnecessary _find_packages routine from the setup.py file.

## Summary/Motivation:
We want to use the built-in capabilities of setuptools for packaging Pyomo.

## Changes proposed in this PR:
- Remove _find_packages and replace with setuptools' find_packages
- Include License file in package (for Conda distribution)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
