### PR TITLE
Add version= and remove_in= to deprecation_warning()

### DIFF
--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -7,7 +7,26 @@ import textwrap
 
 from pyomo.common.errors import DeveloperError
 
-def deprecation_warning(msg, logger='pyomo.core'):
+def _default_msg(user_msg, version, remove_in, func=None):
+    if user_msg is None:
+        if inspect.isclass(func):
+            _obj = ' class'
+        elif inspect.isfunction(func):
+            _obj = ' function'
+        else:
+            _obj = ''
+        user_msg = 'This%s has been deprecated and may be removed in a ' \
+                   'future release.' % (_obj,)
+    comment = []
+    if version:
+        comment.append('deprecated in %s' % (version,))
+    if remove_in:
+        comment.append('will be removed in %s' % (remove_in))
+    if comment:
+        user_msg += "  (%s)" % (', '.join(comment))
+    return user_msg
+
+def deprecation_warning(msg, logger='pyomo.core', version=None, remove_in=None):
     """Standardized formatter for deprecation warnings
 
     This is a standardized routine for formatting deprecation warnings
@@ -16,6 +35,7 @@ def deprecation_warning(msg, logger='pyomo.core'):
     Args:
         msg (str): the deprecation message to format
     """
+    msg = _default_msg(msg, version, remove_in)
     logging.getLogger(logger).warning(
         textwrap.fill('DEPRECATED: %s' % (msg,), width=70) )
 
@@ -48,7 +68,7 @@ def deprecated( msg=None, logger='pyomo.core', version=None, remove_in=None ):
         raise DeveloperError("@deprecated missing initial version")
 
     def wrap(func):
-        message = _default_msg(msg, func)
+        message = _default_msg(msg, version, remove_in, func)
 
         @functools.wraps(func, assigned=('__module__', '__name__'))
         def wrapper(*args, **kwargs):
@@ -63,24 +83,5 @@ def deprecated( msg=None, logger='pyomo.core', version=None, remove_in=None ):
                 'DEPRECATION WARNING: %s' % (message,), width=70) + '\n\n' + \
                 textwrap.fill(textwrap.dedent(func.__doc__.strip()))
         return wrapper
-
-    def _default_msg(user_msg, func):
-        if user_msg is None:
-            if inspect.isclass(func):
-                _obj = ' class'
-            elif inspect.isfunction(func):
-                _obj = ' function'
-            else:
-                _obj = ''
-            user_msg = 'This%s has been deprecated and may be removed in a ' \
-                       'future release.' % (_obj,)
-        comment = []
-        if version:
-            comment.append('deprecated in %s' % (version,))
-        if remove_in:
-            comment.append('will be removed in %s' % (remove_in))
-        if comment:
-            user_msg += "  (%s)" % (','.join(comment))
-        return user_msg
 
     return wrap

--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -7,7 +7,12 @@ import textwrap
 
 from pyomo.common.errors import DeveloperError
 
+
 def _default_msg(user_msg, version, remove_in, func=None):
+    """Generate the default deprecation message.
+
+    See deprecated() function for argument details.
+    """
     if user_msg is None:
         if inspect.isclass(func):
             _obj = ' class'
@@ -26,6 +31,7 @@ def _default_msg(user_msg, version, remove_in, func=None):
         user_msg += "  (%s)" % (', '.join(comment))
     return user_msg
 
+
 def deprecation_warning(msg, logger='pyomo.core', version=None, remove_in=None):
     """Standardized formatter for deprecation warnings
 
@@ -39,7 +45,8 @@ def deprecation_warning(msg, logger='pyomo.core', version=None, remove_in=None):
     logging.getLogger(logger).warning(
         textwrap.fill('DEPRECATED: %s' % (msg,), width=70) )
 
-def deprecated( msg=None, logger='pyomo.core', version=None, remove_in=None ):
+
+def deprecated(msg=None, logger='pyomo.core', version=None, remove_in=None):
     """Indicate that a function, method or class is deprecated.
 
     This decorator will cause a warning to be logged when the wrapped

--- a/pyomo/common/tests/test_deprecated.py
+++ b/pyomo/common/tests/test_deprecated.py
@@ -1,7 +1,7 @@
 """Testing for deprecated function."""
 import pyutilib.th as unittest
 from pyomo.common import DeveloperError
-from pyomo.common.deprecation import deprecated
+from pyomo.common.deprecation import deprecated, deprecation_warning
 from pyomo.common.log import LoggingIntercept
 
 from six import StringIO
@@ -12,6 +12,26 @@ logger = logging.getLogger('pyomo.common')
 
 class TestDeprecated(unittest.TestCase):
     """Tests for deprecated function decorator."""
+
+    def test_deprecation_warning(self):
+        DEP_OUT = StringIO()
+        with LoggingIntercept(DEP_OUT, 'pyomo.core'):
+            deprecation_warning(None, version='1.2', remove_in='3.4')
+
+        self.assertIn('DEPRECATED: This has been deprecated',
+                      DEP_OUT.getvalue())
+        self.assertIn('(deprecated in 1.2, will be removed in 3.4)',
+                      DEP_OUT.getvalue().replace('\n',' '))
+
+        DEP_OUT = StringIO()
+        with LoggingIntercept(DEP_OUT, 'pyomo.core'):
+            deprecation_warning("custom message here", version='1.2', remove_in='3.4')
+
+        self.assertIn('DEPRECATED: custom message here',
+                      DEP_OUT.getvalue())
+        self.assertIn('(deprecated in 1.2, will be removed in 3.4)',
+                      DEP_OUT.getvalue().replace('\n',' '))
+
 
     def test_no_version_exception(self):
         with self.assertRaises(DeveloperError):

--- a/pyomo/common/tests/test_deprecated.py
+++ b/pyomo/common/tests/test_deprecated.py
@@ -231,6 +231,34 @@ class TestDeprecated(unittest.TestCase):
         self.assertIn('DEPRECATED: This function has been deprecated',
                       DEP_OUT.getvalue())
 
+    def test_with_remove_in(self):
+        class foo(object):
+            def __init__(self):
+                pass
+            @deprecated(version='1.2', remove_in='3.4')
+            def bar(self):
+                logger.warn('yeah')
+
+        self.assertIn('DEPRECATION WARNING: This function has been deprecated',
+                      foo.bar.__doc__)
+        self.assertIn('(deprecated in 1.2, will be removed in 3.4)',
+                      foo.bar.__doc__.replace('\n',' '))
+
+        # Test the default argument
+        DEP_OUT = StringIO()
+        FCN_OUT = StringIO()
+        with LoggingIntercept(DEP_OUT, 'pyomo.core'):
+            with LoggingIntercept(FCN_OUT, 'pyomo.common'):
+                foo().bar()
+        # Test that the function produces output
+        self.assertIn('yeah', FCN_OUT.getvalue())
+        self.assertNotIn('DEPRECATED', FCN_OUT.getvalue())
+        # Test that the deprecation warning was logged
+        self.assertIn('DEPRECATED: This function has been deprecated',
+                      DEP_OUT.getvalue())
+        self.assertIn('(deprecated in 1.2, will be removed in 3.4)',
+                      DEP_OUT.getvalue())
+
 
 
 if __name__ == '__main__':

--- a/pyomo/common/tests/test_deprecated.py
+++ b/pyomo/common/tests/test_deprecated.py
@@ -45,7 +45,7 @@ class TestDeprecated(unittest.TestCase):
         #"""Test for deprecated function decorator."""
         @deprecated(version='')
         def foo(bar='yeah'):
-            logger.warn(bar)
+            logger.warning(bar)
 
         self.assertIn('DEPRECATION WARNING: This function has been deprecated',
                       foo.__doc__)
@@ -86,7 +86,7 @@ class TestDeprecated(unittest.TestCase):
             Because I document my public functions.
 
             """
-            logger.warn(bar)
+            logger.warning(bar)
 
         self.assertIn('DEPRECATION WARNING: This function has been deprecated',
                       foo.__doc__)
@@ -128,7 +128,7 @@ class TestDeprecated(unittest.TestCase):
             Because I document my public functions.
 
             """
-            logger.warn(bar)
+            logger.warning(bar)
 
         self.assertIn('DEPRECATION WARNING: This is a custom message',
                       foo.__doc__)
@@ -170,7 +170,7 @@ class TestDeprecated(unittest.TestCase):
             Because I document my public functions.
 
             """
-            logger.warn(bar)
+            logger.warning(bar)
 
         self.assertIn('DEPRECATION WARNING: This is a custom message',
                       foo.__doc__)
@@ -208,7 +208,7 @@ class TestDeprecated(unittest.TestCase):
         @deprecated(version='')
         class foo(object):
             def __init__(self):
-                logger.warn('yeah')
+                logger.warning('yeah')
 
         self.assertIn('DEPRECATION WARNING: This class has been deprecated',
                       foo.__doc__)
@@ -233,7 +233,7 @@ class TestDeprecated(unittest.TestCase):
                 pass
             @deprecated(version='')
             def bar(self):
-                logger.warn('yeah')
+                logger.warning('yeah')
 
         self.assertIn('DEPRECATION WARNING: This function has been deprecated',
                       foo.bar.__doc__)
@@ -257,7 +257,7 @@ class TestDeprecated(unittest.TestCase):
                 pass
             @deprecated(version='1.2', remove_in='3.4')
             def bar(self):
-                logger.warn('yeah')
+                logger.warning('yeah')
 
         self.assertIn('DEPRECATION WARNING: This function has been deprecated',
                       foo.bar.__doc__)


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
This adds `version` and `remove_in` arguments to `deprecation_warning()` to match the `@deprecated` decorator.

## Changes proposed in this PR:
- Adding `version` and `remove_in` arguments to `deprecation_warning()` , plus tests

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
