### PR TITLE
Adjust output formatting for pyomo.util.infeasible

### DIFF
--- a/pyomo/util/infeasible.py
+++ b/pyomo/util/infeasible.py
@@ -61,12 +61,12 @@ def log_infeasible_constraints(
 
         log_template = "CONSTR {name}: {lb_value}{lb_operator}{body_value}{ub_operator}{ub_value}"
         if log_expression:
-            log_template += "\n  {lb_expr}{lb_operator}{body_expr}{ub_operator}{ub_expr}"
+            log_template += "\n  - EXPR: {lb_expr}{lb_operator}{body_expr}{ub_operator}{ub_expr}"
         if log_variables:
-            vars_template = "  VAR {name}: {value}"
-            log_template += "\n{var_printout}"
+            vars_template = "\n  - VAR {name}: {value}"
+            log_template += "{var_printout}"
             constraint_vars = identify_variables(constr.body, include_fixed=True)
-            output_dict['var_printout'] = '\n'.join(
+            output_dict['var_printout'] = ''.join(
                 vars_template.format(name=v.name, value=v.value) for v in constraint_vars)
 
         output_dict['body_value'] = "missing variable value" if constr_undefined else constr_body_value

--- a/pyomo/util/tests/test_infeasible.py
+++ b/pyomo/util/tests/test_infeasible.py
@@ -83,10 +83,10 @@ class TestInfeasible(unittest.TestCase):
         with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
             log_infeasible_constraints(m, log_expression=True)
         expected_output = [
-            "CONSTR c: 2.0 </= 1", "  2.0 </= x",
-            "CONSTR c2: 1 =/= 4.0", "  x =/= 4.0",
-            "CONSTR c3: 1 </= 0.0", "  x </= 0.0",
-            "CONSTR c5: 5.0 <?= missing variable value", "  5.0 <?= z"]
+            "CONSTR c: 2.0 </= 1", "  - EXPR: 2.0 </= x",
+            "CONSTR c2: 1 =/= 4.0", "  - EXPR: x =/= 4.0",
+            "CONSTR c3: 1 </= 0.0", "  - EXPR: x </= 0.0",
+            "CONSTR c5: 5.0 <?= missing variable value", "  - EXPR: 5.0 <?= z"]
         self.assertEqual(expected_output, output.getvalue().splitlines())
 
     def test_log_infeasible_constraints_verbose_variables(self):
@@ -96,10 +96,10 @@ class TestInfeasible(unittest.TestCase):
         with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
             log_infeasible_constraints(m, log_variables=True)
         expected_output = [
-            "CONSTR c: 2.0 </= 1", "  VAR x: 1",
-            "CONSTR c2: 1 =/= 4.0", "  VAR x: 1",
-            "CONSTR c3: 1 </= 0.0", "  VAR x: 1",
-            "CONSTR c5: 5.0 <?= missing variable value", "  VAR z: None"]
+            "CONSTR c: 2.0 </= 1", "  - VAR x: 1",
+            "CONSTR c2: 1 =/= 4.0", "  - VAR x: 1",
+            "CONSTR c3: 1 </= 0.0", "  - VAR x: 1",
+            "CONSTR c5: 5.0 <?= missing variable value", "  - VAR z: None"]
         self.assertEqual(expected_output, output.getvalue().splitlines())
 
 


### PR DESCRIPTION
## Summary/Motivation:
The logger sometimes unintentionally eats newlines. This changes the infeasible module formatting to avoid that.

Example output:
```
INFO: CONSTR c: 2.0 </= 1
      - EXPR: 2.0 </= x
      - VAR x: 1
INFO: CONSTR c2: 1 =/= 4.0
      - EXPR: x =/= 4.0
      - VAR x: 1
INFO: CONSTR c3: 1 </= 0.0
      - EXPR: x </= 0.0
      - VAR x: 1
INFO: CONSTR c5: 5.0 <?= missing variable value
      - EXPR: 5.0 <?= z
      - VAR z: None
```

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
