### PR TITLE
changing NoArgumentGiven to a class

### DIFF
--- a/pyomo/common/modeling.py
+++ b/pyomo/common/modeling.py
@@ -35,18 +35,14 @@ def unique_component_name(instance, name):
             name += str(randint(0,9))
 
 
-# Helper class for NoArgumentGiven object below.
-class _NoArgumentGiven(object):
-    def __str__(self):
-        return "<No argument specified>"
+class NoArgumentGiven(object):
+    """
+    Class to be used to indicate that an optional argument
+    was not specified, if `None` may be ambiguous. Usage:
 
+      >>> def foo(value=NoArgumentGiven):
+      >>>     if value is NoArgumentGiven:
+      >>>         pass  # no argument was provided to `value`
 
-"""
-Object to be used to indicate that an optional argument
-was not specified, if `None` may be ambiguous. Usage:
-
-  >>> def foo(value=NoArgumentGiven):
-  >>>     if value is NoArgumentGiven:
-  >>>         pass  # no argument was provided to `value`
-"""
-NoArgumentGiven = _NoArgumentGiven()
+    """
+    pass

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -15,6 +15,7 @@ import types
 import logging
 from weakref import ref as weakref_ref
 
+from pyomo.common.modeling import NoArgumentGiven
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base.plugin import ModelComponentFactory
 from pyomo.core.base.component import ComponentData
@@ -44,11 +45,6 @@ def _raise_modifying_immutable_error(obj, index):
 class _NotValid(object):
     """A dummy type that is pickle-safe that we can use as the default
     value for Params to indicate that no valid value is present."""
-    pass
-
-class _NoArgument(object):
-    """A dummy type that is pickle-safe that we can use as the default
-    value for optional arguments where we cannot just use None."""
     pass
 
 
@@ -98,9 +94,9 @@ class _ParamData(ComponentData, NumericValue):
     # operations like validation efficient.  As it stands now, if
     # set_value is called without specifying an index, this call
     # involves a linear scan of the _data dict.
-    def set_value(self, value, idx=_NoArgument):
+    def set_value(self, value, idx=NoArgumentGiven):
         self._value = value
-        if idx is _NoArgument:
+        if idx is NoArgumentGiven:
             idx = self.index()
         self.parent_component()._validate_value(idx, value)
 
@@ -980,8 +976,8 @@ class SimpleParam(_ParamData, Param):
                 "the Param has been constructed (there is currently no "
                 "value to return)." % (self.name,) )
 
-    def set_value(self, value, index=_NoArgument):
-        if index is _NoArgument:
+    def set_value(self, value, index=NoArgumentGiven):
+        if index is NoArgumentGiven:
             index = None
         if self._constructed and not self._mutable:
             _raise_modifying_immutable_error(self, index)


### PR DESCRIPTION
## Summary/Motivation:
Changing `NoArgumentGiven` to a class. Standardizing Param to use this.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
