### PR TITLE
Deprecate Connector

### DIFF
--- a/pyomo/core/base/connector.py
+++ b/pyomo/core/base/connector.py
@@ -143,8 +143,6 @@ class Connector(IndexedComponent):
     def __new__(cls, *args, **kwds):
         if cls != Connector:
             return super(Connector, cls).__new__(cls)
-        logger.warning("DEPRECATED: The Connector component is deprecated. "
-            "It has been replaced by Port in the pyomo.network package.")
         if args == ():
             return SimpleConnector.__new__(SimpleConnector)
         else:
@@ -281,13 +279,13 @@ class IndexedConnector(Connector):
     pass
 
 
-@deprecated(
-    "Use of pyomo.connectors is deprecated. "
-    "Its functionality has been replaced by pyomo.network.",
-    version='TBD', remove_in='TBD',)
 class ConnectorExpander(Plugin):
     implements(IPyomoScriptModifyInstance)
 
+    @deprecated(
+        "Use of pyomo.connectors is deprecated. "
+        "Its functionality has been replaced by pyomo.network.",
+        version='TBD', remove_in='TBD', )
     def apply(self, **kwds):
         instance = kwds.pop('instance')
         xform = TransformationFactory('core.expand_connectors')

--- a/pyomo/core/base/connector.py
+++ b/pyomo/core/base/connector.py
@@ -16,6 +16,7 @@ from six import iteritems, itervalues, iterkeys
 from six.moves import xrange
 from weakref import ref as weakref_ref
 
+from pyomo.common import deprecated
 from pyomo.common.timing import ConstructionTimer
 from pyomo.common.plugin import Plugin, implements
 
@@ -117,7 +118,6 @@ class _ConnectorData(ComponentData, NumericValue):
                     yield v
 
 
-
 @ModelComponentFactory.register("A bundle of variables that can be manipilated together.")
 class Connector(IndexedComponent):
     """A collection of variables, which may be defined over a index
@@ -150,8 +150,11 @@ class Connector(IndexedComponent):
         else:
             return IndexedConnector.__new__(IndexedConnector)
 
-
     # TODO: default keyword is  not used?  Need to talk to Bill ...?
+    @deprecated(
+        "Use of pyomo.connectors is deprecated. "
+        "Its functionality has been replaced by pyomo.network.",
+        version='TBD', remove_in='TBD',)
     def __init__(self, *args, **kwd):
         kwd.setdefault('ctype', Connector)
         self._rule = kwd.pop('rule', None)
@@ -278,7 +281,10 @@ class IndexedConnector(Connector):
     pass
 
 
-
+@deprecated(
+    "Use of pyomo.connectors is deprecated. "
+    "Its functionality has been replaced by pyomo.network.",
+    version='TBD', remove_in='TBD',)
 class ConnectorExpander(Plugin):
     implements(IPyomoScriptModifyInstance)
 


### PR DESCRIPTION
## Summary/Motivation:
Use `pyomo.network` instead.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
