### PR TITLE
Use dict comprehension for constructing dictionaries

### DIFF
--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -1050,7 +1050,7 @@ class ComponentUID(object):
         return a
 
     def __getstate__(self):
-        return dict((x,getattr(self,x)) for x in ComponentUID.__slots__)
+        return {x:getattr(self, x) for x in ComponentUID.__slots__}
 
     def __setstate__(self, state):
         for key, val in iteritems(state):

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -329,8 +329,8 @@ class Expression(IndexedComponent):
     # expensive to extract the contents of an expression.
     #
     def extract_values(self):
-        return dict((key, expression_data.expr) \
-                    for key, expression_data in iteritems(self))
+        return {key:expression_data.expr
+                for key, expression_data in iteritems(self)}
 
     #
     # takes as input a (index, value) dictionary for updating this

--- a/pyomo/core/base/indexed_component_slice.py
+++ b/pyomo/core/base/indexed_component_slice.py
@@ -55,8 +55,7 @@ class _IndexedComponent_slice(object):
         "blanket" implementation of :py:meth:`__getattr__`, we need to
         explicitly implement these to avoid "accidentally" extending or
         evaluating this slice."""
-        return dict(
-            (k,getattr(self,k)) for k in self.__dict__)
+        return {k:getattr(self,k) for k in self.__dict__}
 
     def __setstate__(self, state):
         """Deserialize the state into this object. """

--- a/pyomo/core/base/label.py
+++ b/pyomo/core/base/label.py
@@ -39,9 +39,8 @@ class _CharMapper(object):
            other: the character to return for all characters not in
                   preserve or translate
         """
-        self.table = dict(
-            (k if isinstance(k, int) else ord(k), v)
-            for k,v in six.iteritems(dict(translate)) )
+        self.table = {k if isinstance(k, int) else ord(k): v
+            for k,v in six.iteritems(dict(translate)) }
         for c in preserve:
             _c = ord(c)
             if _c in self.table and self.table[_c] != c:

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -305,10 +305,7 @@ class Param(IndexedComponent):
             # Thus, we need to create a temporary dictionary that contains the
             # values from the ParamData objects.
             #
-            ans = {}
-            for key, param_value in self.iteritems():
-                ans[key] = param_value()
-            return ans
+            return {key:param_value() for key,param_value in self.iteritems()}
         elif not self.is_indexed():
             #
             # The parameter is a scalar, so we need to create a temporary

--- a/pyomo/core/base/piecewise.py
+++ b/pyomo/core/base/piecewise.py
@@ -580,14 +580,14 @@ class _LOGPiecewise(object):
         S = range(1,n+1)
         # turn the GrayCode into a dictionary indexed
         # starting at 1
-        G = dict(enumerate(_GrayCode(n),start=1))
+        G = {k:v for k,v in enumerate(_GrayCode(n),start=1)}
 
-        L = dict((s,[k+1 for k in xrange(BIGL+1) \
+        L = {s:[k+1 for k in xrange(BIGL+1) \
                          if ((k == 0) or (G[k][s-1] == 1)) \
-                         and ((k == BIGL) or (G[k+1][s-1] == 1))]) for s in S)
-        R = dict((s,[k+1 for k in xrange(BIGL+1) \
+                         and ((k == BIGL) or (G[k+1][s-1] == 1))] for s in S}
+        R = {s:[k+1 for k in xrange(BIGL+1) \
                          if ((k == 0) or (G[k][s-1] == 0)) \
-                         and ((k == BIGL) or (G[k+1][s-1] == 0))]) for s in S)
+                         and ((k == BIGL) or (G[k+1][s-1] == 0))] for s in S}
 
         return S,L,R
 
@@ -662,9 +662,9 @@ class _MCPiecewise(object):
         polytopes = range(1,len_x_pts)
 
         # create constants (using future division)
-        SLOPE = dict((p,(y_pts[p]-y_pts[p-1])/(x_pts[p]-x_pts[p-1])) \
-                         for p in polytopes)
-        INTERSEPT = dict((p,y_pts[p-1] - (SLOPE[p]*x_pts[p-1])) for p in polytopes)
+        SLOPE = {p:(y_pts[p]-y_pts[p-1])/(x_pts[p]-x_pts[p-1])
+                 for p in polytopes}
+        INTERSEPT = {p:y_pts[p-1] - (SLOPE[p]*x_pts[p-1]) for p in polytopes}
 
         # create vars
         pblock.MC_poly_x = Var(polytopes)

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -1365,8 +1365,7 @@ class _SortedSetData(_SortedSetMixin, _OrderedSetData):
     def _sort(self):
         self._ordered_values = list(self.parent_component()._sort_fcn(
             self._ordered_values))
-        self._values = dict(
-            (j, i) for i, j in enumerate(self._ordered_values) )
+        self._values = {j:i for i, j in enumerate(self._ordered_values)}
         self._is_sorted = True
 
 

--- a/pyomo/core/base/sets.py
+++ b/pyomo/core/base/sets.py
@@ -337,7 +337,7 @@ class _OrderedSetData(_SetDataBase):
             self.value_list,
             key=None if _sorter is Set.SortedOrder else _sorter
         )
-        self.order_dict = dict((j,i) for i,j in enumerate(self.value_list))
+        self.order_dict = {j:i for i,j in enumerate(self.value_list)}
         self._is_sorted = 1
 
     def _clear(self):

--- a/pyomo/core/base/util.py
+++ b/pyomo/core/base/util.py
@@ -190,7 +190,7 @@ class InitializerBase(object):
     verified = False
 
     def __getstate__(self):
-        return dict((k, getattr(self,k)) for k in self.__slots__)
+        return {k:getattr(self,k) for k in self.__slots__}
 
     def __setstate__(self, state):
         for key, val in iteritems(state):

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -551,11 +551,10 @@ class Var(IndexedComponent):
         Return a dictionary of index-value pairs.
         """
         if include_fixed_values:
-            return dict((idx, vardata.value)
-                            for idx, vardata in iteritems(self._data))
-        return dict((idx, vardata.value)
+            return {idx:vardata.value for idx,vardata in iteritems(self._data)}
+        return {idx:vardata.value
                             for idx, vardata in iteritems(self._data)
-                                                if not vardata.fixed)
+                                                if not vardata.fixed}
 
     extract_values = get_values
 

--- a/pyomo/core/expr/calculus/diff_with_sympy.py
+++ b/pyomo/core/expr/calculus/diff_with_sympy.py
@@ -51,7 +51,7 @@ def differentiate(expr, wrt=None, wrt_list=None):
     # appear in the expression (so that we can detect wrt combinations
     # that are, by definition, 0)
     #
-    partial_derivs = dict((x,None) for x in objectMap.sympyVars())
+    partial_derivs = {x:None for x in objectMap.sympyVars()}
     #
     # Setup the WRT list
     #

--- a/pyomo/core/expr/symbol_map.py
+++ b/pyomo/core/expr/symbol_map.py
@@ -58,12 +58,9 @@ class SymbolMap(object):
         }
 
     def __setstate__(self, state):
-        self.byObject = dict(
-            (id(obj), key) for key, obj  in state['bySymbol'] )
-        self.bySymbol = dict(
-            (key, weakref_ref(obj)) for key, obj in state['bySymbol'] )
-        self.aliases = dict(
-            (key, weakref_ref(obj)) for key, obj in state['aliases'] )
+        self.byObject = {id(obj):key for key, obj  in state['bySymbol']}
+        self.bySymbol = {key:weakref_ref(obj) for key,obj in state['bySymbol']}
+        self.aliases = {key:weakref_ref(obj) for key, obj in state['aliases']}
 
     def addSymbol(self, obj, symb):
         """
@@ -78,7 +75,7 @@ class SymbolMap(object):
 
         This method assumes that symbol names will not conflict.
         """
-        tuples = list((obj, symb) for obj,symb in obj_symbol_tuples)
+        tuples = [(obj, symb) for obj,symb in obj_symbol_tuples]
         self.byObject.update((id(obj_), symb_) for obj_,symb_ in tuples)
         self.bySymbol.update((symb_, weakref_ref(obj_)) for obj_,symb_ in tuples)
 

--- a/pyomo/core/kernel/block.py
+++ b/pyomo/core/kernel/block.py
@@ -369,8 +369,8 @@ class block(IBlock):
         # Generate the list of active import suffixes on
         # this top level model
         valid_import_suffixes = \
-            dict((obj.storage_key, obj)
-                 for obj in import_suffix_generator(self))
+            {obj.storage_key:obj
+                 for obj in import_suffix_generator(self)}
 
         # To ensure that import suffix data gets properly
         # overwritten (e.g., the case where nonzero dual

--- a/pyomo/core/kernel/component_map.py
+++ b/pyomo/core/kernel/component_map.py
@@ -65,8 +65,8 @@ class ComponentMap(collections_MutableMapping):
         # object id() may have changed after unpickling,
         # so we rebuild the dictionary keys
         self._dict = \
-            dict((id(obj), (obj,val)) \
-                 for obj, val in itervalues(state['_dict']))
+            {id(obj):(obj,val) \
+                 for obj, val in itervalues(state['_dict'])}
 
     def __getstate__(self):
         # *** Temporary hack to allow this class to be used
@@ -88,9 +88,7 @@ class ComponentMap(collections_MutableMapping):
 
     def __str__(self):
         """String representation of the mapping."""
-        tmp = dict()
-        for c,v in self.items():
-            tmp[str(c)+" (id="+str(id(c))+")"] = v
+        tmp = {str(c)+" (id="+str(id(c))+")":v for c,v in self.items()}
         return "ComponentMap("+str(tmp)+")"
 
     #
@@ -133,10 +131,10 @@ class ComponentMap(collections_MutableMapping):
     def __eq__(self, other):
         if not isinstance(other, collections_Mapping):
             return False
-        return dict(((type(key), id(key)), val)
-                    for key, val in self.items()) == \
-               dict(((type(key), id(key)), val)
-                    for key, val in other.items())
+        return {(type(key), id(key)):val
+                    for key, val in self.items()} == \
+               {(type(key), id(key)):val
+                    for key, val in other.items()}
 
     def __ne__(self, other):
         return not (self == other)

--- a/pyomo/core/kernel/component_set.py
+++ b/pyomo/core/kernel/component_set.py
@@ -72,8 +72,7 @@ class ComponentSet(collections_MutableSet):
         # object id() may have changed after unpickling,
         # so we rebuild the dictionary keys
         assert len(state) == 1
-        self._data = dict((id(obj), obj)
-                          for obj in state['_data'])
+        self._data = {id(obj):obj for obj in state['_data']}
 
     def __getstate__(self):
         return {'_data': tuple(self._data.values())}

--- a/pyomo/core/kernel/dict_container.py
+++ b/pyomo/core/kernel/dict_container.py
@@ -170,10 +170,10 @@ class DictContainer(IHomogeneousContainer,
     def __eq__(self, other):
         if not isinstance(other, collections_Mapping):
             return False
-        return dict((key, (type(val), id(val)))
-                    for key, val in self.items()) == \
-               dict((key, (type(val), id(val)))
-                    for key, val in other.items())
+        return {key:(type(val), id(val))
+                    for key, val in self.items()} == \
+               {key:(type(val), id(val))
+                    for key, val in other.items()}
 
     def __ne__(self, other):
         return not (self == other)

--- a/pyomo/core/kernel/piecewise_library/transforms.py
+++ b/pyomo/core/kernel/piecewise_library/transforms.py
@@ -268,8 +268,7 @@ class PiecewiseLinearFunction(object):
     def __getstate__(self):
         """Required for older versions of the pickle
         protocol since this class uses __slots__"""
-        return dict((key, getattr(self, key))
-                    for key in self.__slots__)
+        return {key:getattr(self, key) for key in self.__slots__}
 
     def __setstate__(self, state):
         """Required for older versions of the pickle

--- a/pyomo/core/kernel/piecewise_library/transforms_nd.py
+++ b/pyomo/core/kernel/piecewise_library/transforms_nd.py
@@ -166,8 +166,7 @@ class PiecewiseLinearFunctionND(object):
     def __getstate__(self):
         """Required for older versions of the pickle
         protocol since this class uses __slots__"""
-        return dict((key, getattr(self, key))
-                    for key in self.__slots__)
+        return {key:getattr(self, key) for key in self.__slots__}
 
     def __setstate__(self, state):
         """Required for older versions of the pickle

--- a/pyomo/core/plugins/transform/scaling.py
+++ b/pyomo/core/plugins/transform/scaling.py
@@ -153,9 +153,8 @@ class ScaleModel(Transformation):
         # translate the variable_substitution_map (ComponentMap)
         # to variable_substition_dict (key: id() of component)
         # ToDo: We should change replace_expressions to accept a ComponentMap as well
-        variable_substitution_dict = dict()
-        for k in variable_substitution_map:
-            variable_substitution_dict[id(k)] = variable_substitution_map[k]
+        variable_substitution_dict = {id(k):variable_substitution_map[k]
+                                      for k in variable_substitution_map}
 
         for component in model.component_objects(ctype=(Constraint, Objective), descend_into=True):
             for k in component:

--- a/pyomo/core/tests/unit/kernel/test_dict_container.py
+++ b/pyomo/core/tests/unit/kernel/test_dict_container.py
@@ -280,8 +280,7 @@ class _TestDictContainerBase(object):
 
     def test_keys(self):
         index = ['a', 1, None, (1,), (1,2)]
-        raw_constraint_dict = dict((i, self._ctype_factory())
-                                   for i in index)
+        raw_constraint_dict = {i:self._ctype_factory() for i in index}
         c = self._container_type(raw_constraint_dict)
         self.assertEqual(sorted(list(raw_constraint_dict.keys()),
                                 key=str),
@@ -289,8 +288,7 @@ class _TestDictContainerBase(object):
 
     def test_values(self):
         index = ['a', 1, None, (1,), (1,2)]
-        raw_constraint_dict = dict((i, self._ctype_factory())
-                                   for i in index)
+        raw_constraint_dict = {i:self._ctype_factory() for i in index}
         c = self._container_type(raw_constraint_dict)
         self.assertEqual(
             sorted(list(id(_v)
@@ -302,8 +300,7 @@ class _TestDictContainerBase(object):
 
     def test_items(self):
         index = ['a', 1, None, (1,), (1,2)]
-        raw_constraint_dict = dict((i, self._ctype_factory())
-                                   for i in index)
+        raw_constraint_dict = {i:self._ctype_factory() for i in index}
         c = self._container_type(raw_constraint_dict)
         self.assertEqual(
             sorted(list((_i, id(_v))
@@ -315,8 +312,7 @@ class _TestDictContainerBase(object):
 
     def test_update(self):
         index = ['a', 1, None, (1,), (1,2)]
-        raw_constraint_dict = dict((i, self._ctype_factory())
-                                   for i in index)
+        raw_constraint_dict = {i:self._ctype_factory() for i in index}
         c = self._container_type()
         c.update(raw_constraint_dict)
         self.assertEqual(sorted(list(raw_constraint_dict.keys()),

--- a/pyomo/core/tests/unit/test_dict_objects.py
+++ b/pyomo/core/tests/unit/test_dict_objects.py
@@ -211,8 +211,7 @@ class _TestComponentDictBase(object):
     def test_keys(self):
         model = self.model
         index = ['a', 1, None, (1,), (1,2)]
-        raw_constraint_dict = dict((i, self._cdatatype(self._arg()))
-                                   for i in index)
+        raw_constraint_dict = {i:self._cdatatype(self._arg()) for i in index}
         model.c = self._ctype(raw_constraint_dict)
         self.assertEqual(sorted(list(raw_constraint_dict.keys()), key=str),
                          sorted(list(model.c.keys()), key=str))
@@ -220,8 +219,7 @@ class _TestComponentDictBase(object):
     def test_values(self):
         model = self.model
         index = ['a', 1, None, (1,), (1,2)]
-        raw_constraint_dict = dict((i, self._cdatatype(self._arg()))
-                                   for i in index)
+        raw_constraint_dict = {i:self._cdatatype(self._arg()) for i in index}
         model.c = self._ctype(raw_constraint_dict)
         self.assertEqual(
             sorted(list(id(_v)
@@ -234,8 +232,7 @@ class _TestComponentDictBase(object):
     def test_items(self):
         model = self.model
         index = ['a', 1, None, (1,), (1,2)]
-        raw_constraint_dict = dict((i, self._cdatatype(self._arg()))
-                                   for i in index)
+        raw_constraint_dict = {i:self._cdatatype(self._arg()) for i in index}
         model.c = self._ctype(raw_constraint_dict)
         self.assertEqual(
             sorted(list((_i, id(_v))
@@ -248,8 +245,7 @@ class _TestComponentDictBase(object):
     def test_update(self):
         model = self.model
         index = ['a', 1, None, (1,), (1,2)]
-        raw_constraint_dict = dict((i, self._cdatatype(self._arg()))
-                                   for i in index)
+        raw_constraint_dict = {i:self._cdatatype(self._arg()) for i in index}
         model.c = self._ctype()
         model.c.update(raw_constraint_dict)
         self.assertEqual(sorted(list(raw_constraint_dict.keys()), key=str),


### PR DESCRIPTION
## Summary/Motivation:
This PR replaces all the uses of the `dict()` constructor with dict comprehension (where it was straightforward to do so). This PR has minor performance implications as we discovered that dict comprehension is the fastest way to build dictionaries. I'm not sure how to quantify the impact this will have on performance as the minor improvement I saw on my VM was within the error margin for timing Python. 

I'm opening this PR to not lose track of work done during the Pyomo developer sprint and to ask for suggestions on quantifying the performance impact of these changes. 

## Changes proposed in this PR:
- Use dictionary comprehension to construct dictionaries

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
