### PR TITLE
Add MatrixConstraint to AML interface.

### DIFF
--- a/pyomo/core/base/matrix_constraint.py
+++ b/pyomo/core/base/matrix_constraint.py
@@ -60,7 +60,7 @@ class _MatrixConstraintData(_ConstraintData):
         _index          The row index into the main coefficient matrix
     """
 
-    __slots__ = ('_index')
+    __slots__ = ('_index',)
 
     # the super secret flag that makes the writers
     # handle _MatrixConstraintData objects more efficiently

--- a/pyomo/core/base/matrix_constraint.py
+++ b/pyomo/core/base/matrix_constraint.py
@@ -1,0 +1,360 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+
+import logging
+import weakref
+
+import pyutilib.misc
+from pyomo.core.base.set_types import Any
+from pyomo.core.expr.numvalue import value
+from pyomo.core.expr.numeric_expr import LinearExpression
+from pyomo.core.base.plugin import ModelComponentFactory
+from pyomo.repn.standard_repn import StandardRepn
+from pyomo.core.base.constraint import (IndexedConstraint,
+                                        _ConstraintData)
+
+import six
+from six.moves import xrange
+
+if six.PY3:
+    from collections.abc import Mapping as collections_Mapping
+else:
+    from collections import Mapping as collections_Mapping
+
+
+logger = logging.getLogger('pyomo.core')
+
+class _MatrixConstraintData(_ConstraintData):
+    """
+    This class defines the data for a single linear constraint
+        derived from a canonical form Ax=b constraint.
+
+    Constructor arguments:
+        index           The index of this component within the container.
+        component       The Constraint object that owns this data.
+
+    Public class attributes:
+        active          A boolean that is true if this constraint is
+                            active in the model.
+        body            The Pyomo expression for this constraint
+        lower           The Pyomo expression for the lower bound
+        upper           The Pyomo expression for the upper bound
+        equality        A boolean that indicates whether this is an
+                            equality constraint
+        strict_lower    A boolean that indicates whether this
+                            constraint uses a strict lower bound
+        strict_upper    A boolean that indicates whether this
+                            constraint uses a strict upper bound
+
+    Private class attributes:
+        _component      The objective component.
+        _active         A boolean that indicates whether this data is active
+        _index          The row index into the main coefficient matrix
+    """
+
+    __slots__ = ('_index')
+
+    # the super secret flag that makes the writers
+    # handle _MatrixConstraintData objects more efficiently
+    _linear_canonical_form = True
+
+    #
+    # Define methods that writers expect when the
+    # _linear_canonical_form flag is True
+    #
+
+    def canonical_form(self, compute_values=True):
+        """Build a canonical representation of the body of
+        this constraints"""
+        comp = self.parent_component()
+        index = self._index
+        data = comp._A_data
+        indices = comp._A_indices
+        indptr = comp._A_indptr
+        x = comp._x
+
+        variables = []
+        coefficients = []
+        constant = 0
+        for p in xrange(indptr[index],
+                        indptr[index+1]):
+            v = x[indices[p]]
+            c = data[p]
+            if not v.fixed:
+                variables.append(v)
+                if compute_values:
+                    coefficients.append(value(c))
+                else:
+                    coefficients.append(c)
+            else:
+                if compute_values:
+                    constant += value(c) * v.value
+                else:
+                    constant += c * v
+        repn = StandardRepn()
+        repn.linear_vars = tuple(variables)
+        repn.linear_coefs = tuple(coefficients)
+        repn.constant = constant
+        return repn
+
+    def __init__(self, index, component_ref):
+        #
+        # These lines represent in-lining of the
+        # following constructors:
+        #   - _ConstraintData,
+        #   - ActiveComponentData
+        #   - ComponentData
+        self._component = component_ref
+        self._active = True
+
+        # row index into the sparse matrix stored on the parent
+        assert index >= 0
+        self._index = index
+
+    def __getstate__(self):
+        """
+        This method must be defined because this class uses slots.
+        """
+        result = super(_MatrixConstraintData, self).__getstate__()
+        result['_index'] = self._index
+        return result
+
+    # Since this class requires no special processing of the state
+    # dictionary, it does not need to implement __setstate__()
+
+    #
+    # Override the default interface methods to
+    # avoid generating the body expression where
+    # possible
+    #
+
+    def __call__(self, exception=True):
+        """Compute the value of the body of this constraint."""
+        comp = self.parent_component()
+        index = self._index
+        data = comp._A_data
+        indices = comp._A_indices
+        indptr = comp._A_indptr
+        x = comp._x
+        ptrs = xrange(indptr[index],
+                      indptr[index+1])
+        try:
+            return sum(x[indices[p]].value * data[p]
+                       for p in ptrs)
+        except (ValueError, TypeError):
+            if exception:
+                raise
+            return None
+
+    def has_lb(self):
+        """Returns :const:`False` when the lower bound is
+        :const:`None` or negative infinity"""
+        lb = self.lower
+        return (lb is not None) and \
+            (lb != float('-inf'))
+
+    def has_ub(self):
+        """Returns :const:`False` when the upper bound is
+        :const:`None` or positive infinity"""
+        ub = self.upper
+        return (ub is not None) and \
+            (ub != float('inf'))
+
+    def lslack(self):
+        """Lower slack (body - lb). Returns :const:`None` if
+        a value for the body can not be computed."""
+        # this method is written so that constraint
+        # types that build the body expression on the
+        # fly do not have to here
+        body = self(exception=False)
+        if body is None:
+            return None
+        lb = self.lower
+        if lb is None:
+            lb = -float('inf')
+        else:
+            lb = value(lb)
+        return body - lb
+
+    def uslack(self):
+        """Upper slack (ub - body). Returns :const:`None` if
+        a value for the body can not be computed."""
+        # this method is written so that constraint
+        # types that build the body expression on the
+        # fly do not have to here
+        body = self(exception=False)
+        if body is None:
+            return None
+        ub = self.upper
+        if ub is None:
+            ub = float('inf')
+        else:
+            ub = value(ub)
+        return ub - body
+
+    def slack(self):
+        """min(lslack, uslack). Returns :const:`None` if a
+        value for the body can not be computed."""
+        # this method is written so that constraint
+        # types that build the body expression on the
+        # fly do not have to here
+        body = self(exception=False)
+        if body is None:
+            return None
+        return min(self.lslack(), self.uslack())
+
+    #
+    # Override some default implementations on ComponentData
+    #
+
+    def index(self):
+        return self._index
+
+    #
+    # Abstract Interface (_ConstraintData)
+    #
+
+    @property
+    def body(self):
+        """Access the body of a constraint expression."""
+        comp = self.parent_component()
+        index = self._index
+        data = comp._A_data
+        indices = comp._A_indices
+        indptr = comp._A_indptr
+        x = comp._x
+        ptrs = xrange(indptr[index],
+                      indptr[index+1])
+        return LinearExpression(
+            linear_vars=[x[indices[p]] for p in ptrs],
+            linear_coefs=[data[p] for p in ptrs],
+            constant=0
+        )
+
+    @property
+    def lower(self):
+        """Access the lower bound of a constraint
+        expression."""
+        comp = self.parent_component()
+        index = self._index
+        return comp._lower[index]
+
+    @property
+    def upper(self):
+        """Access the upper bound of a constraint
+        expression."""
+        comp = self.parent_component()
+        index = self._index
+        return comp._upper[index]
+
+    @property
+    def equality(self):
+        """A boolean indicating whether this is an equality
+        constraint."""
+        comp = self.parent_component()
+        index = self._index
+        if (comp._lower[index] is None) or \
+           (comp._upper[index] is None):
+            return False
+        return comp._lower[index] == comp._upper[index]
+
+    @property
+    def strict_lower(self):
+        """A boolean indicating whether this constraint has
+        a strict lower bound."""
+        return False
+
+    @property
+    def strict_upper(self):
+        """A boolean indicating whether this constraint has
+        a strict upper bound."""
+        return False
+
+    def set_value(self, expr):
+        """Set the expression on this constraint."""
+        raise NotImplementedError(
+            "MatrixConstraint row elements can not be updated"
+        )
+
+@ModelComponentFactory.register(
+                   "A set of constraint expressions in Ax=b form.")
+class MatrixConstraint(collections_Mapping,
+                       IndexedConstraint):
+    """
+    Parameters
+    ----------
+    A_data : list
+        The values of the CSR format sparse matrix
+    A_indices : list
+        The column indices of the CSR format sparse matrix
+    A_indptr : list
+        The row start-stop pointers of the CSR format sparse matrix
+    lb : list
+        The list of constraint lower bounds
+    ub : list
+        The list of constraint upper bounds
+    x : list
+        The list of pyomo variables mapped to their appropriate column
+    """
+
+    def __init__(self, A_data, A_indices, A_indptr, lb, ub, x):
+
+        m = len(lb)
+        n = len(x)
+        nnz = len(A_data)
+        assert len(A_indices) == nnz
+        assert len(A_indptr) == m + 1
+        assert len(ub) == m
+        IndexedConstraint.__init__(self, Any)
+
+        self._A_data = A_data
+        self._A_indices = A_indices
+        self._A_indptr = A_indptr
+        self._lower = lb
+        self._upper = ub
+        self._x = tuple(x)
+
+    def construct(self, data=None):
+        """Construct the expression(s) for this constraint."""
+        if __debug__ and logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Constructing constraint %s"
+                         % (self.name))
+        if self._constructed:
+            return
+        self._constructed = True
+
+        ref = weakref.ref(self)
+        with pyutilib.misc.PauseGC():
+            self._data = tuple(_MatrixConstraintData(i, ref)
+                               for i in xrange(len(self._lower)))
+
+    #
+    # Override some IndexedComponent methods
+    #
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __len__(self):
+        return self._data.__len__()
+
+    def __iter__(self):
+        return iter(i for i in xrange(len(self)))
+
+    #
+    # Remove methods that allow modifying this constraint
+    #
+
+    def add(self, index, expr):
+        raise NotImplementedError
+
+    def __delitem__(self):
+        raise NotImplementedError

--- a/pyomo/core/base/matrix_constraint.py
+++ b/pyomo/core/base/matrix_constraint.py
@@ -284,11 +284,24 @@ class _MatrixConstraintData(_ConstraintData):
             "MatrixConstraint row elements can not be updated"
         )
 
+
 @ModelComponentFactory.register(
                    "A set of constraint expressions in Ax=b form.")
 class MatrixConstraint(collections_Mapping,
                        IndexedConstraint):
     """
+    Defines a set of linear constraints of the form:
+
+       lb <= Ax <= ub
+
+    where A is specified in the standard compressed sparse
+    row (CSR) format. Variables must be provided as a list,
+    whose ordering maps the variables to their column index
+    in the associated coefficient matrix. This modeling
+    component allows for fast construction of large linear
+    constraint sets as it bypasses Pyomo's expression
+    system.
+
     Parameters
     ----------
     A_data : list
@@ -303,6 +316,22 @@ class MatrixConstraint(collections_Mapping,
         The list of constraint upper bounds
     x : list
         The list of pyomo variables mapped to their appropriate column
+
+    Example
+    -------
+    >>> from pyomo.environ import *
+    >>> from pyomo.core.base.matrix_constraint import MatrixConstraint
+    >>> model = ConcreteModel()
+    >>>
+    >>> # x_{i} <= x_{i+1}   (for i in {1,2})
+    >>> model.v = Var(RangeSet(0,2))
+    >>> data    = [1.0, -1.0, 1.0, -1.0]
+    >>> indices = [  0,    1,   1,    2]
+    >>> indptr  = [0, 2, 4]
+    >>> lb      = [None, None]
+    >>> ub      = [ 0.0,  0.0]
+    >>> x       = [model.v[0], model.v[1], model.v[2]]
+    >>> model.c = MatrixConstraint(data, indices, indptr, lb, ub, x)
     """
 
     def __init__(self, A_data, A_indices, A_indptr, lb, ub, x):
@@ -353,8 +382,11 @@ class MatrixConstraint(collections_Mapping,
     # Remove methods that allow modifying this constraint
     #
 
-    def add(self, index, expr):
+    def add(self, index, expr):  # pragma:nocover
         raise NotImplementedError
 
-    def __delitem__(self):
+    def __delitem__(self):  # pragma:nocover
+        raise NotImplementedError
+
+    def __setitem__(self, key, value):  # pragma:nocover
         raise NotImplementedError

--- a/pyomo/core/tests/unit/test_matrix_constraint.py
+++ b/pyomo/core/tests/unit/test_matrix_constraint.py
@@ -1,0 +1,93 @@
+import pickle
+
+import pyutilib.th as unittest
+import pyomo.environ as aml
+
+from pyomo.core.base.matrix_constraint import MatrixConstraint
+from pyomo.core.kernel.set_types import (RealSet,
+                                         IntegerSet)
+
+def _create_variable_list(size, **kwds):
+    assert size > 0
+    return aml.Var(aml.RangeSet(0,size-1), **kwds)
+
+def _get_csr(m, n, value):
+    data = [value] * (m * n)
+    indices = [j for j in range(n) for i in range(m)]
+    indptr = [0]
+    for i in range(m):
+        indptr.append(indptr[-1] + n)
+    return data, indices, indptr
+
+class TestMatrixConstraint(unittest.TestCase):
+
+    def test_init(self):
+        m = aml.ConcreteModel()
+        m.v = _create_variable_list(3, initialize=1.0)
+        data, indices, indptr = _get_csr(3,3,0.0)
+        lb = [None] * 3
+        ub = [None] * 3
+        m.c = MatrixConstraint(data, indices, indptr,
+                               lb, ub,
+                               x=list(m.v.values()))
+        self.assertEqual(len(m.c), 3)
+        for k, c in m.c.items():
+            with self.assertRaises(NotImplementedError):
+                c.set_value(m.v[k] == 1)
+            self.assertEqual(c.index(), k)
+            self.assertEqual(c.strict_upper, False)
+            self.assertEqual(c.strict_lower, False)
+            self.assertEqual(c.lower, None)
+            self.assertEqual(c.upper, None)
+            self.assertEqual(c.equality, False)
+            self.assertEqual(c.body(), 0)
+            self.assertEqual(c(), 0)
+            self.assertEqual(c.slack(), float('inf'))
+            self.assertEqual(c.lslack(), float('inf'))
+            self.assertEqual(c.uslack(), float('inf'))
+            self.assertEqual(c.has_lb(), False)
+            self.assertEqual(c.has_ub(), False)
+
+        m = aml.ConcreteModel()
+        m.v = _create_variable_list(3, initialize=3)
+        data, indices, indptr = _get_csr(2,3,1.0)
+        m.c = MatrixConstraint(data, indices, indptr,
+                               lb=[0]*2,
+                               ub=[2]*2,
+                               x=list(m.v.values()))
+        self.assertEqual(len(m.c), 2)
+        for k, c in m.c.items():
+            with self.assertRaises(NotImplementedError):
+                c.set_value(m.v[k] == 1)
+            self.assertEqual(c.index(), k)
+            self.assertEqual(c.strict_upper, False)
+            self.assertEqual(c.strict_lower, False)
+            self.assertEqual(c.lower, 0)
+            self.assertEqual(c.body(), 9)
+            self.assertEqual(c(), 9)
+            self.assertEqual(c.upper, 2)
+            self.assertEqual(c.equality, False)
+
+
+        m = aml.ConcreteModel()
+        m.v = _create_variable_list(3, initialize=3)
+        data, indices, indptr = _get_csr(2,3,1.0)
+        m.c = MatrixConstraint(data, indices, indptr,
+                               lb=[1]*2,
+                               ub=[1]*2,
+                               x=list(m.v.values()))
+        self.assertEqual(len(m.c), 2)
+        for k, c in m.c.items():
+            with self.assertRaises(NotImplementedError):
+                c.set_value(m.v[k] == 1)
+            self.assertEqual(c.index(), k)
+            self.assertEqual(c.strict_upper, False)
+            self.assertEqual(c.strict_lower, False)
+            self.assertEqual(c.lower, 1)
+            self.assertEqual(c.body(), 9)
+            self.assertEqual(c(), 9)
+            self.assertEqual(c.upper, 1)
+            self.assertEqual(c.equality, True)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a basic implementation of `pyomo.kernel.matrix_constraint` inrito the AML interface as `pyomo.core.base.matrix_constraint.MatrixConstraint`. Includes some minimal unit tests.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
