### PR TITLE
[WIP] With References check for equivalent sets instead of identical Set objects

### DIFF
--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -410,7 +410,7 @@ def _identify_wildcard_sets(iter_stack, index):
         if len(index[i]) != len(level):
             return None
         # if any subset differs
-        if any(index[i].get(j,None) is not _set for j,_set in iteritems(level)):
+        if any(index[i].get(j,None) != _set for j,_set in iteritems(level)):
             return None
     return index
 

--- a/pyomo/core/tests/unit/test_reference.py
+++ b/pyomo/core/tests/unit/test_reference.py
@@ -540,7 +540,7 @@ class TestReference(unittest.TestCase):
         m.r = Reference(m.b[:].x[:])
 
         self.assertIs(m.r.type(), Var)
-        self.assertIs(type(m.r.index_set()), SetOf)
+        self.assertIs(type(m.r.index_set()), _SetProduct)
         self.assertEqual(len(m.r), 2*2)
         self.assertEqual(m.r[1,3].lb, 1)
         self.assertEqual(m.r[2,4].lb, 2)


### PR DESCRIPTION
## Fixes #905 

## Summary/Motivation:
I think this will resolve an issue where for some types of models using both Pyomo.DAE and Pyomo.Network, the discretization and arc_expansion transformations had to be applied in a particular order. This makes a very small change in `reference.py` in how indexing sets are compared when iterating over the components in a slice. Instead of checking if the same Set objects are used this checks that **equivalent** sets are used. 

@andrewlee94 could you check if this change resolves the ordering problem for IDAES models?

## Changes proposed in this PR:
- check for equivalent sets when creating Reference objects

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
