### PR TITLE
Update GSL URL to track change in AMPL SSL certificate.

### DIFF
--- a/pyomo/common/getGSL.py
+++ b/pyomo/common/getGSL.py
@@ -20,10 +20,10 @@ logger = logging.getLogger('pyomo.common')
 # These URLs were retrieved from
 #     https://ampl.com/resources/extended-function-library/
 urlmap = {
-    'linux':   'https://www.ampl.com/NEW/amplgsl/amplgsl.linux-intel%s.zip',
-    'windows': 'https://www.ampl.com/NEW/amplgsl/amplgsl.mswin%s.zip',
-    'cygwin':  'https://www.ampl.com/NEW/amplgsl/amplgsl.mswin%s.zip',
-    'darwin':  'https://www.ampl.com/NEW/amplgsl/amplgsl.macosx%s.zip'
+    'linux':   'https://ampl.com/NEW/amplgsl/amplgsl.linux-intel%s.zip',
+    'windows': 'https://ampl.com/NEW/amplgsl/amplgsl.mswin%s.zip',
+    'cygwin':  'https://ampl.com/NEW/amplgsl/amplgsl.mswin%s.zip',
+    'darwin':  'https://ampl.com/NEW/amplgsl/amplgsl.macosx%s.zip'
 }
 
 def find_GSL():


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
The AMPL SSL certificate was recently updated and is only valid for the domain "ampl.com" and not "www.ampl.com".  This is causing the downloader to fail (and all our tests).  I believe that changing our URL to only use `ampl.com` is appropriate, as `https://www.ampl.com` redirects automatically to `https://ampl.com`, which indicates that AMPL is moving to `ampl.com` as the canonical domain.

## Changes proposed in this PR:
- change GSL URL from `www.ampl.com` to `ampl.com`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
