### PR TITLE
Pint test fix

### DIFF
--- a/pyomo/common/getGSL.py
+++ b/pyomo/common/getGSL.py
@@ -20,10 +20,10 @@ logger = logging.getLogger('pyomo.common')
 # These URLs were retrieved from
 #     https://ampl.com/resources/extended-function-library/
 urlmap = {
-    'linux':   'https://www.ampl.com/NEW/amplgsl/amplgsl.linux-intel%s.zip',
-    'windows': 'https://www.ampl.com/NEW/amplgsl/amplgsl.mswin%s.zip',
-    'cygwin':  'https://www.ampl.com/NEW/amplgsl/amplgsl.mswin%s.zip',
-    'darwin':  'https://www.ampl.com/NEW/amplgsl/amplgsl.macosx%s.zip'
+    'linux':   'https://ampl.com/NEW/amplgsl/amplgsl.linux-intel%s.zip',
+    'windows': 'https://ampl.com/NEW/amplgsl/amplgsl.mswin%s.zip',
+    'cygwin':  'https://ampl.com/NEW/amplgsl/amplgsl.mswin%s.zip',
+    'darwin':  'https://ampl.com/NEW/amplgsl/amplgsl.macosx%s.zip'
 }
 
 def find_GSL():

--- a/pyomo/core/tests/unit/test_units.py
+++ b/pyomo/core/tests/unit/test_units.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #  ___________________________________________________________________________
 #
 #  Pyomo: Python Optimization Modeling Objects
@@ -422,7 +423,13 @@ class TestPyomoUnit(unittest.TestCase):
         delta_degF = uc.delta_degF
         R = uc.rankine
 
-        self._get_check_units_ok(2.0*R + 3.0*R, uc, 'rankine', expr.NPV_SumExpression)
+        # In some recent versions of pint, rankine can be either
+        # 'rankine' or '°R' (note UTF-8 encoding, which requires the
+        # "coding: utf-8" comment flag at the top of this file).
+        R_str = R.getname()
+        #self.assertIn(R_str, ['rankine', '°R'])
+
+        self._get_check_units_ok(2.0*R + 3.0*R, uc, R_str, expr.NPV_SumExpression)
         self._get_check_units_ok(2.0*K + 3.0*K, uc, 'K', expr.NPV_SumExpression)
 
         ex = 2.0*delta_degC + 3.0*delta_degC + 1.0*delta_degC


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
Pint 0.10 changed the string representation of Rainkine from `rankine` to `°R` (a unicode string) for Python 3.x.  This change ducks the issue by just checking that the Units that the unit manager verified match whatever string pint is currently using for Rankine.

This PR depends on (includes the patch from) #1245 

## Changes proposed in this PR:
- update test to not hard-code the expected string for Rankine units.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
