### PR TITLE
Remove 'nightly' tests from the 'expensive' suite

### DIFF
--- a/pyomo/core/tests/diet/test_diet.py
+++ b/pyomo/core/tests/diet/test_diet.py
@@ -76,14 +76,14 @@ class Test(unittest.TestCase):
         baseline_file = os.path.join(currdir, 'baselines', 'diet1_pyomo_dat.jsn')
         self.assertMatchesJsonBaseline(results_file, baseline_file)
 
-    @unittest.category('nightly', 'expensive')
+    @unittest.category('nightly')
     @unittest.skipUnless(pyodbc_available, "Requires PyODBC")
     def test_pyomo_mdb(self):
         results_file = self.run_pyomo(os.path.join(exdir, 'diet1.py'), os.path.join(exdir, 'diet1.db.dat'), outputpath=os.path.join(currdir, 'pyomo_mdb.jsn'))
         baseline_file = os.path.join(currdir, 'baselines', 'diet1_pyomo_mdb.jsn')
         self.assertMatchesJsonBaseline(results_file, baseline_file)
 
-    @unittest.category('nightly', 'expensive')
+    @unittest.category('nightly')
     @unittest.skipUnless(pyodbc_available, "Requires PyODBC")
     def test_mdb_equality(self):
         dat_results_file = self.run_pyomo(os.path.join(exdir, 'diet1.py'), os.path.join(exdir, 'diet.dat'), outputpath=os.path.join(currdir, 'dat_results.jsn'))

--- a/pyomo/core/tests/examples/test_kernel_examples.py
+++ b/pyomo/core/tests/examples/test_kernel_examples.py
@@ -79,7 +79,6 @@ def create_test_method(example):
         self.assertEqual(rc, 0, msg=log)
     return testmethod
 
-@unittest.category("smoke", "nightly", "expensive")
 class TestKernelExamples(unittest.TestCase):
     pass
 for filename in examples:

--- a/pyomo/core/tests/transform/test_transform.py
+++ b/pyomo/core/tests/transform/test_transform.py
@@ -483,7 +483,7 @@ class Test(unittest.TestCase):
             transformed_sol["Solution"][0]["Objective"]['obj']["value"]
             )
 
-    @unittest.category('nightly', 'expensive')
+    @unittest.category('nightly')
     @unittest.skipIf(not 'glpk' in solvers, "glpk solver is not available")
     @unittest.expectedFailure
     def test_standard_form_transform_1(self):
@@ -568,7 +568,7 @@ class Test(unittest.TestCase):
             transformed_sol["Solution"][0]["Objective"]['obj']["value"]
             )
 
-    @unittest.category('nightly', 'expensive')
+    @unittest.category('nightly')
     @unittest.skipIf(not 'glpk' in solvers, "glpk solver is not available")
     @unittest.expectedFailure
     def test_standard_form_transform_2(self):

--- a/pyomo/pysp/tests/convert/test_ddsip.py
+++ b/pyomo/pysp/tests/convert/test_ddsip.py
@@ -33,7 +33,7 @@ pysp_examples_dir = \
 
 _run_verbose = True
 
-@unittest.category('nightly','expensive')
+@unittest.category('nightly')
 class TestConvertDDSIPSimple(unittest.TestCase):
 
     @unittest.nottest
@@ -412,7 +412,7 @@ create_test_classes('farmer',
                     'farmer',
                     farmer_model_dir,
                     farmer_data_dir,
-                    ('nightly','expensive'))
+                    ('nightly',))
 
 piecewise_model = join(thisdir, "piecewise_model.py")
 piecewise_scenario_tree = join(thisdir, "piecewise_scenario_tree.py")
@@ -420,14 +420,14 @@ create_test_classes('piecewise',
                     'piecewise',
                     piecewise_model,
                     piecewise_scenario_tree,
-                    ('nightly','expensive'))
+                    ('nightly',))
 
 piecewise_model = join(thisdir, "piecewise_model_alt.py")
 create_test_classes('piecewise_alt',
                     'piecewise',
                     piecewise_model,
                     piecewise_scenario_tree,
-                    ('nightly','expensive'))
+                    ('nightly',))
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/pysp/tests/convert/test_smps.py
+++ b/pyomo/pysp/tests/convert/test_smps.py
@@ -35,7 +35,7 @@ pysp_examples_dir = \
 
 _run_verbose = True
 
-@unittest.category('nightly','expensive')
+@unittest.category('nightly')
 class TestConvertSMPSSimple(unittest.TestCase):
 
     @unittest.nottest
@@ -586,7 +586,7 @@ create_test_classes('farmer',
                     'farmer',
                     farmer_model_dir,
                     farmer_data_dir,
-                    ('nightly','expensive'))
+                    ('nightly',))
 
 piecewise_model = join(thisdir, "piecewise_model.py")
 piecewise_scenario_tree = join(thisdir, "piecewise_scenario_tree.py")
@@ -594,7 +594,7 @@ create_test_classes('piecewise',
                     'piecewise',
                     piecewise_model,
                     piecewise_scenario_tree,
-                    ('nightly','expensive'))
+                    ('nightly',))
 
 # uses the same baselines as 'piecewise',
 # except annotations are declared differently
@@ -603,7 +603,7 @@ create_test_classes('piecewise_alt',
                     'piecewise',
                     piecewise_model,
                     piecewise_scenario_tree,
-                    ('nightly','expensive'))
+                    ('nightly',))
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/pysp/tests/convert/test_smps_embedded.py
+++ b/pyomo/pysp/tests/convert/test_smps_embedded.py
@@ -64,7 +64,7 @@ def tearDownModule():
         del sys.modules["piecewise_model_embedded"]
     piecewise_model_embedded = None
 
-@unittest.category('nightly','expensive')
+@unittest.category('nightly')
 class TestSMPSEmbeddedBad(unittest.TestCase):
 
     @classmethod
@@ -372,7 +372,7 @@ class TestSMPSEmbeddedBad(unittest.TestCase):
              "only supports discrete table distributions of type "
              "pyomo.pysp.embeddedsp.TableDistribution."))
 
-@unittest.category('nightly','expensive')
+@unittest.category('nightly')
 class TestSMPSEmbedded(unittest.TestCase):
 
     def _diff(self, baselinedir, outputdir, dc=None):

--- a/pyomo/pysp/tests/examples/test_examples.py
+++ b/pyomo/pysp/tests/examples/test_examples.py
@@ -54,7 +54,7 @@ examples_dir = join(pysp_examples_dir, "scripting")
 
 solvers = check_available_solvers('cplex', 'glpk')
 
-@unittest.category('nightly','expensive')
+@unittest.category('nightly')
 class TestExamples(unittest.TestCase):
 
     def setUp(self):

--- a/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanager.py
+++ b/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanager.py
@@ -1268,7 +1268,6 @@ class _ScenarioTreeManagerTesterBase(object):
 # create the actual testing classes
 #
 
-@unittest.category('smoke','nightly','expensive')
 class TestScenarioTreeManagerClientSerial(
         unittest.TestCase,
         _ScenarioTreeManagerTesterBase):

--- a/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanagersolver.py
+++ b/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanagersolver.py
@@ -722,7 +722,6 @@ class _ScenarioTreeManagerSolverTesterBase(object):
 @unittest.skipIf(not has_networkx, "Networkx is not available")
 @unittest.skipIf(not has_networkx, "Networkx is not available")
 @unittest.skipIf(not has_dill, "Dill is not available")
-@unittest.category('smoke','nightly','expensive')
 class TestScenarioTreeManagerSolverSerial(
         unittest.TestCase,
         _ScenarioTreeManagerSolverTesterBase):

--- a/pyomo/pysp/tests/unit/test_annotations.py
+++ b/pyomo/pysp/tests/unit/test_annotations.py
@@ -28,7 +28,6 @@ from pyomo.pysp.annotations import (locate_annotations,
                                     PySP_StochasticObjectiveAnnotation,
                                     StochasticVariableBoundsAnnotation)
 
-@unittest.category('smoke','nightly','expensive')
 class TestAnnotations(unittest.TestCase):
 
     def test_deprecated(self):

--- a/pyomo/pysp/tests/unit/test_embeddedsp.py
+++ b/pyomo/pysp/tests/unit/test_embeddedsp.py
@@ -550,7 +550,6 @@ class TestEmbeddedSP(unittest.TestCase):
         d = BetaDistribution(1,1)
         d.sample()
 
-TestEmbeddedSP = unittest.category('smoke','nightly','expensive')(TestEmbeddedSP)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/pysp/tests/unit/test_instancefactory.py
+++ b/pyomo/pysp/tests/unit/test_instancefactory.py
@@ -46,7 +46,6 @@ def setUpModule():
         join(testdatadir, "reference_test_model.py"))[0].model
 
 
-@unittest.category('smoke','nightly','expensive')
 class Test(unittest.TestCase):
 
     @classmethod

--- a/pyomo/pysp/tests/unit/test_scenariotree.py
+++ b/pyomo/pysp/tests/unit/test_scenariotree.py
@@ -798,8 +798,6 @@ class TestScenarioTreeFromNetworkX(unittest.TestCase):
                 G,
                 edge_probability_attribute=None)
 
-TestScenarioTree = unittest.category('smoke','nightly','expensive')(TestScenarioTree)
-TestScenarioTreeFromNetworkX = unittest.category('smoke','nightly','expensive')(TestScenarioTreeFromNetworkX)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/pysp/tests/unit/test_util.py
+++ b/pyomo/pysp/tests/unit/test_util.py
@@ -33,7 +33,6 @@ from pyomo.pysp.scenariotree.util import \
      scenario_tree_id_to_puint64,
      scenario_tree_id_to_nzuint64)
 
-@unittest.category('smoke','nightly','expensive')
 class TestScenarioTreeIDToInteger(unittest.TestCase):
 
     _name = "Root"

--- a/pyomo/repn/tests/ampl/test_ampl_comparison.py
+++ b/pyomo/repn/tests/ampl/test_ampl_comparison.py
@@ -37,7 +37,6 @@ class Tests(unittest.TestCase):
 class BaselineTests(Tests):
     def __init__(self, *args, **kwds):
         Tests.__init__(self, *args, **kwds)
-BaselineTests = unittest.category('smoke', 'nightly','expensive')(BaselineTests)
 
 #
 #The following test generates an nl file for the test case
@@ -63,7 +62,6 @@ class ASLTests(Tests):
 
     def __init__(self, *args, **kwds):
         Tests.__init__(self, *args, **kwds)
-ASLTests = unittest.category('smoke','nightly','expensive')(ASLTests)
 
 #
 # The following test calls the gjh_asl_json executable to

--- a/pyomo/repn/tests/baron/test_baron_comparison.py
+++ b/pyomo/repn/tests/baron/test_baron_comparison.py
@@ -34,7 +34,6 @@ class Tests(unittest.TestCase):
 class BaselineTests(Tests):
     def __init__(self, *args, **kwds):
         Tests.__init__(self, *args, **kwds)
-BaselineTests = unittest.category('smoke', 'nightly','expensive')(BaselineTests)
 
 #
 #The following test generates an BAR file for the test case
@@ -70,7 +69,6 @@ class ASLTests(Tests):
 
     def __init__(self, *args, **kwds):
         Tests.__init__(self, *args, **kwds)
-ASLTests = unittest.category('smoke','nightly','expensive')(ASLTests)
 
 
 # add test methods to classes

--- a/pyomo/repn/tests/gams/test_gams_comparison.py
+++ b/pyomo/repn/tests/gams/test_gams_comparison.py
@@ -34,7 +34,6 @@ class Tests(unittest.TestCase):
 class BaselineTests(Tests):
     def __init__(self, *args, **kwds):
         Tests.__init__(self, *args, **kwds)
-BaselineTests = unittest.category('smoke', 'nightly','expensive')(BaselineTests)
 
 #
 # The following test generates a GMS file for the test case

--- a/pyomo/solvers/tests/piecewise_linear/test_examples.py
+++ b/pyomo/solvers/tests/piecewise_linear/test_examples.py
@@ -25,7 +25,6 @@ import pyomo.scripting.convert as convert
 _NL_diff_tol = 1e-9
 _LP_diff_tol = 1e-9
 
-@unittest.category('smoke', 'nightly', 'expensive')
 class Test(unittest.TestCase):
 
     def run_convert2nl(self, name):

--- a/pyomo/solvers/tests/piecewise_linear/test_piecewise_linear.py
+++ b/pyomo/solvers/tests/piecewise_linear/test_piecewise_linear.py
@@ -118,13 +118,12 @@ def assignTests(cls, problem_list):
 @unittest.skipUnless(yaml_available, "PyYAML module is not available.")
 class PW_Tests(unittest.TestCase): pass
 
-@unittest.category('nightly', 'expensive')
-class PiecewiseLinearTest_Nightly(PW_Tests): pass
-assignTests(PiecewiseLinearTest_Nightly, nightly_problems)
-
-@unittest.category('smoke', 'nightly', 'expensive')
 class PiecewiseLinearTest_Smoke(PW_Tests): pass
 assignTests(PiecewiseLinearTest_Smoke, smoke_problems)
+
+@unittest.category('nightly')
+class PiecewiseLinearTest_Nightly(PW_Tests): pass
+assignTests(PiecewiseLinearTest_Nightly, nightly_problems)
 
 @unittest.category('expensive')
 class PiecewiseLinearTest_Expensive(PW_Tests): pass

--- a/pyomo/solvers/tests/piecewise_linear/test_piecewise_linear_kernel.py
+++ b/pyomo/solvers/tests/piecewise_linear/test_piecewise_linear_kernel.py
@@ -100,7 +100,6 @@ def assignTests(cls, problem_list):
                                     baseline_results = json.load(f)
                                     setattr(cls,PROBLEM+'_results',baseline_results)
 
-@unittest.category('smoke', 'nightly', 'expensive')
 class PiecewiseLinearKernelTest(unittest.TestCase):
     pass
 assignTests(PiecewiseLinearKernelTest, problems)


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
This removes all 'nightly' tests from the 'expensive' test suite.  The rationale is that the nightly tests are all run as part of PR testing and normal (immediate) master branch testing.  There is no utility in repeating those tests as part of the nightly "expensive" test suite (they have already been run on master long before the expensive suite is launched overnight).

## Changes proposed in this PR:
- remove all nightly tests from the expensive test suite

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
