### PR TITLE
Deprecating pyomo.contrib.simplemodel

### DIFF
--- a/pyomo/contrib/simplemodel/__init__.py
+++ b/pyomo/contrib/simplemodel/__init__.py
@@ -1,4 +1,7 @@
+from pyomo.common.deprecation import deprecation_warning
+
 try:
+    deprecation_warning("The use of pyomo.contrib.simple model is deprecated.  This capability is now supported in the pyomo_simplemodel package, which is included in the pyomo_community distribution.")
     from pyomocontrib_simplemodel import *
 except:
     # Only raise exception if nose is NOT running

--- a/pyomo/contrib/simplemodel/__init__.py
+++ b/pyomo/contrib/simplemodel/__init__.py
@@ -1,7 +1,11 @@
 from pyomo.common.deprecation import deprecation_warning
 
 try:
-    deprecation_warning("The use of pyomo.contrib.simple model is deprecated.  This capability is now supported in the pyomo_simplemodel package, which is included in the pyomo_community distribution.")
+    deprecation_warning("The use of pyomo.contrib.simple model is deprecated. "  
+                        "This capability is now supported in the "
+                        "pyomo_simplemodel package, which is included in the "
+                        "pyomo_community distribution.", version='TBD', 
+                        remove_in='TBD')
     from pyomocontrib_simplemodel import *
 except:
     # Only raise exception if nose is NOT running


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
Removing support for pyomo.contrib.simplemodel.  This package will be supported separately in pyomo_community

## Changes proposed in this PR:
- Adding a deprecation warning that pyomo.contrib.simplemodel is no longer supported.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
