### PR TITLE
[WIP] Units convert_value PR-1

### DIFF
--- a/pyomo/common/importer.py
+++ b/pyomo/common/importer.py
@@ -1,0 +1,81 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import importlib
+
+class DeferredImportError(ImportError):
+    pass
+
+class ModuleUnavailable(object):
+    """Dummy object that raises a DeferredImportError upon attribute access
+
+    This object is returned by attempt_import() in liu of the module in
+    the case that the module import fails.  Any attempts to access
+    attributes on this object will raise a DeferredImportError
+    exception.
+
+    Parameters
+    ----------
+    message: str
+        The string message to return in the raised exception
+    """
+    def __init__(self, message):
+        self._error_message_ = message
+
+    def __getattr__(self, attr):
+        raise DeferredImportError(self._error_message_)
+
+def attempt_import(name, error_message=None, only_catch_importerror=True):
+    """Attempt to import the specified module.
+
+    This will attempt to import the specified module, returning a
+    (module, available) tuple.  If the import was successful, `module`
+    will be the imported module and `available` will be True.  If the
+    import results in an exception, then `module` will be an instance of
+    :py:class:`ModuleUnavailable` and `available` will be False
+
+    The following is equivalent to ``import numpy as np``:
+
+    .. doctest::
+
+       >>> from pyomo.common import attempt_import
+       >>> np, numpy_available = attempt_import('numpy')
+
+    Parameters
+    ----------
+    name: `str`
+        The name of the module to import
+
+    error_message: `str`, optional
+        The message for the exception raised by ModuleUnavailable
+
+    only_catch_importerror: `bool`, optional
+        If True, exceptions other than ImportError raised during module
+        import will be reraised.  If False, any exception will result in
+        returning a ModuleUnavailable object.
+
+    Returns
+    -------
+    : module
+        the imported module or an instance of :py:class:`ModuleUnavailable`
+    : bool
+        Boolean indicating if the module import succeeded
+    """
+    try:
+        return importlib.import_module(name), True
+    except ImportError:
+        pass
+    except:
+        if only_catch_importerror:
+            raise
+
+    if not error_message:
+        error_message = "The %s module failed to import" % (name,)
+    return ModuleUnavailable(error_message), False

--- a/pyomo/common/tests/test_importer.py
+++ b/pyomo/common/tests/test_importer.py
@@ -1,0 +1,27 @@
+"""Testing for deprecated function."""
+import pyutilib.th as unittest
+from pyomo.common.importer import attempt_import, DeferredImportError
+
+from six import StringIO
+
+import logging
+logger = logging.getLogger('pyomo.common')
+
+
+class TestImporter(unittest.TestCase):
+    """Tests for deprecated function decorator."""
+
+    def test_import_error(self):
+        module_obj, module_available = attempt_import('__there_is_no_module_named_this__', 'Testing import of a non-existant module')
+        self.assertFalse(module_available)
+        with self.assertRaises(DeferredImportError):
+            module_obj.try_to_call_a_method()
+                
+    def test_import_success(self):
+        module_obj, module_available = attempt_import('pyutilib','Testing import of PyUtilib')
+        self.assertTrue(module_available)
+        import pyutilib
+        self.assertTrue(module_obj is pyutilib)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -125,6 +125,9 @@ class _ParamData(ComponentData, NumericValue):
         """Set the value for this variable."""
         self.set_value(val)
 
+    def get_units(self):
+        """Return the units for this ParamData"""
+        return self.parent_component()._units
 
     def is_fixed(self):
         """
@@ -197,6 +200,8 @@ class Param(IndexedComponent):
         initialize  
             A dictionary or rule for setting up this parameter with existing 
             model data
+        unit: pyomo unit expression                                                                                            
+            An expression containing the units for the parameter
     """
 
     DefaultMutable = False
@@ -218,6 +223,9 @@ class Param(IndexedComponent):
         self._mutable       = kwd.pop('mutable', Param.DefaultMutable )
         self._default_val   = kwd.pop('default', _NotValid )
         self._dense_initialize = kwd.pop('initialize_as_dense', False)
+        self._units         = kwd.pop('units', None)                                                                           
+        if self._units is not None:                                                                                            
+            self._mutable = True
         #
         if 'repn' in kwd:
             logger.error(
@@ -994,7 +1002,10 @@ class SimpleParam(_ParamData, Param):
         """
         return self._constructed and not self._mutable
 
-
+    def get_units(self):
+        """Return the units expression for this parameter"""
+        return self._units
+    
 class IndexedParam(Param):
 
     def __call__(self, exception=True):

--- a/pyomo/core/base/units_container.py
+++ b/pyomo/core/base/units_container.py
@@ -34,7 +34,7 @@ Examples:
        >>> model = ConcreteModel()
        >>> model.acc = Var()
        >>> model.obj = Objective(expr=(model.acc*un.m/un.s**2 - 9.81*un.m/un.s**2)**2)
-       >>> print(units.get_units(model.obj.expr))
+       >>> print(un.get_units(model.obj.expr))
        m ** 2 / s ** 4
 
 .. note:: This module has a module level instance of a PyomoUnitsContainer that you can access using
@@ -115,7 +115,7 @@ class InconsistentUnitsError(UnitsError):
     """
     An exception indicating that inconsistent units are present on an expression.
 
-    E.g., x == y, where x is in units of units.kg and y is in units of units.meter
+    E.g., x == y, where x is in units of kg and y is in units of meter
     """
     def __init__(self, exp1, exp2, msg):
         msg = '{}: {} not compatible with {}.'.format(str(msg), str(exp1), str(exp2))

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -408,6 +408,12 @@ class _GeneralVarData(_VarData):
     def ub(self, val):
         raise AttributeError("Assignment not allowed. Use the setub method")
 
+    def get_units(self):                                                                                                       
+        """Return the units for this variable entry."""                                                                        
+        # parent_component() returns self if this is scalar, or the owning                                                     
+        # component if not scalar                                                                                              
+        return self.parent_component()._units
+
     # fixed is an attribute
 
     # stale is an attribute
@@ -476,6 +482,8 @@ class Var(IndexedComponent):
             `index_set()` when constructing the Var (True) or just the
             variables returned by `initialize`/`rule` (False).  Defaults
             to True.
+        units (pyomo units expression, optional): Set the units corresponding                                                  
+            to the entries in this variable.
     """
 
     _ComponentDataClass = _GeneralVarData
@@ -498,7 +506,8 @@ class Var(IndexedComponent):
         domain = kwd.pop('domain', domain)
         bounds = kwd.pop('bounds', None)
         self._dense = kwd.pop('dense', True)
-
+        self._units = kwd.pop('units', None)
+        
         #
         # Initialize the base class
         #
@@ -568,6 +577,10 @@ class Var(IndexedComponent):
         """
         for index, new_value in iteritems(new_values):
             self[index].set_value(new_value, valid)
+
+    def get_units(self):                                                                                                       
+        """Return the units expression for this Var."""                                                                        
+        return self._units
 
     def construct(self, data=None):
         """Construct this component."""

--- a/pyomo/core/tests/unit/test_units.py
+++ b/pyomo/core/tests/unit/test_units.py
@@ -33,7 +33,7 @@ class TestPyomoUnit(unittest.TestCase):
 
     def test_PyomoUnit_NumericValueMethods(self):
         m = ConcreteModel()
-        uc = units()
+        uc = units
         kg = uc.kg
 
         self.assertEqual(kg.getname(), 'kg')
@@ -177,7 +177,7 @@ class TestPyomoUnit(unittest.TestCase):
         # therefore, if the expression system changes and we get a different expression type,
         # we will know we need to change these tests
 
-        uc = units()
+        uc = units
         kg = uc.kg
         m = uc.m
 
@@ -382,7 +382,7 @@ class TestPyomoUnit(unittest.TestCase):
 
     # @unittest.skip('Skipped testing LinearExpression since StreamBasedExpressionVisitor does not handle LinearExpressions')
     def test_linear_expression(self):
-        uc = units()
+        uc = units
         model = ConcreteModel()
         kg = uc.kg
         m = uc.m
@@ -399,7 +399,7 @@ class TestPyomoUnit(unittest.TestCase):
         self._get_check_units_fail(linex2, uc, expr.LinearExpression)
 
     def test_dimensionless(self):
-        uc = units()
+        uc = units
         kg = uc.kg
         dless = uc.dimensionless
         self._get_check_units_ok(2.0 == 2.0*dless, uc, None, expr.EqualityExpression)
@@ -408,7 +408,7 @@ class TestPyomoUnit(unittest.TestCase):
         self.assertEqual(None, uc.get_units(kg/kg))
 
     def test_temperatures(self):
-        uc = units()
+        uc = units
 
         # Pyomo units framework disallows "offset" units
         with self.assertRaises(UnitsError):
@@ -447,11 +447,11 @@ class TestPyomoUnit(unittest.TestCase):
         from pyomo.environ import ConcreteModel, Var, Objective, units
         model = ConcreteModel()
         model.acc = Var()
-        model.obj = Objective(expr=(model.acc*units().m/units().s**2 - 9.81*units().m/units().s**2)**2)
-        self.assertEqual('m ** 2 / s ** 4', str(units().get_units(model.obj.expr)))
+        model.obj = Objective(expr=(model.acc*units.m/units.s**2 - 9.81*units.m/units.s**2)**2)
+        self.assertEqual('m ** 2 / s ** 4', str(units.get_units(model.obj.expr)))
 
     def test_convert_value(self):
-        u = units()
+        u = units
         x = 0.4535923*u.kg
         expected_lb_value = 1.0
         actual_lb_value = u.convert_value(src=x, from_units=u.kg, to_units=u.lb)

--- a/pyomo/core/tests/unit/test_units.py
+++ b/pyomo/core/tests/unit/test_units.py
@@ -443,6 +443,14 @@ class TestPyomoUnit(unittest.TestCase):
         self._get_check_units_fail(2.0*K + 3.0*R, uc, expr.NPV_SumExpression)
         self._get_check_units_fail(2.0*delta_degC + 3.0*delta_degF, uc, expr.NPV_SumExpression)
 
+        self.assertAlmostEqual(uc.convert_temp_K_to_C(323.15), 50.0, places=5)
+        self.assertAlmostEqual(uc.convert_temp_C_to_K(50.0), 323.15, places=5)
+        self.assertAlmostEqual(uc.convert_temp_R_to_F(509.67), 50.0, places=5)
+        self.assertAlmostEqual(uc.convert_temp_F_to_R(50.0), 509.67, places=5)
+
+        with self.assertRaises(UnitsError):
+            uc.convert_temp_K_to_C(ex)
+
     def test_module_example(self):
         from pyomo.environ import ConcreteModel, Var, Objective, units
         model = ConcreteModel()
@@ -462,6 +470,48 @@ class TestPyomoUnit(unittest.TestCase):
         with self.assertRaises(UnitsError):
             actual_lb_value = u.convert_value(src=x, from_units=u.meters, to_units=u.lb)
 
+    def test_convert(self):
+        u = units
+        m = ConcreteModel()
+        m.sx = Var(units=u.m, initialize=10)
+        m.sy = Var(units=u.m, initialize=5)
+        m.vx = Var(units=u.m/u.s, initialize=5)
+        m.vy = Var(units=u.m/u.s, initialize=5)
+        m.t = Var(units=u.s, bounds=(0,100), initialize=10)
+        m.v = Var(units=u.m/u.s, initialize=10)
+        m.ay = Param(initialize=-9.8, units=u.m/u.s**2)
+        m.angle = Var(bounds=(0.05*3.14, 0.45*3.14), initialize=0.2*3.14, units=u.radians)
+
+        def x_dist_rule(m):
+            return  m.sx == m.vx*m.t
+        m.x_dist = Constraint(rule=x_dist_rule)
+
+        def y_dist_rule(m):
+            return m.sy == m.vy*m.t + 1/2*m.ay*m.t**2
+        m.y_dist = Constraint(rule=y_dist_rule)
+
+        def vx_angle_rule(m):
+            return  m.vx == m.v * cos(m.angle)
+        m.vx_angle = Constraint(rule=vx_angle_rule)
+
+        def vy_angle_rule(m):
+            return m.vy == m.v  * sin(m.angle)
+        m.vy_angle = Constraint(rule=vy_angle_rule)
+
+        m.sy.fix(0.0)
+        m.sx.fix(10.0)
+        #m.angle.fix(0.25*3.14)
+        #m.v.fix(10)
+        #m.t.fix(5)
+        
+        # lets solve for the v and angle that minimize time to impact
+        m.obj = Objective(expr=m.t)
+
+        #SolverFactory('ipopt').solve(m, tee=True)
+        #m.pprint()
+        #m.display()
+        #self.assertTrue(False)
+        
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/core/tests/unit/test_units.py
+++ b/pyomo/core/tests/unit/test_units.py
@@ -450,6 +450,18 @@ class TestPyomoUnit(unittest.TestCase):
         model.obj = Objective(expr=(model.acc*units().m/units().s**2 - 9.81*units().m/units().s**2)**2)
         self.assertEqual('m ** 2 / s ** 4', str(units().get_units(model.obj.expr)))
 
+    def test_convert_value(self):
+        u = units()
+        x = 0.4535923*u.kg
+        expected_lb_value = 1.0
+        actual_lb_value = u.convert_value(src=x, from_units=u.kg, to_units=u.lb)
+        self.assertAlmostEqual(expected_lb_value, actual_lb_value, places=5)
+        actual_lb_value = u.convert_value(src=x, to_units=u.lb)
+        self.assertAlmostEqual(expected_lb_value, actual_lb_value, places=5)
+
+        with self.assertRaises(UnitsError):
+            actual_lb_value = u.convert_value(src=x, from_units=u.meters, to_units=u.lb)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/core/tests/unit/test_units.py
+++ b/pyomo/core/tests/unit/test_units.py
@@ -33,7 +33,7 @@ class TestPyomoUnit(unittest.TestCase):
 
     def test_PyomoUnit_NumericValueMethods(self):
         m = ConcreteModel()
-        uc = units
+        uc = units()
         kg = uc.kg
 
         self.assertEqual(kg.getname(), 'kg')
@@ -177,7 +177,7 @@ class TestPyomoUnit(unittest.TestCase):
         # therefore, if the expression system changes and we get a different expression type,
         # we will know we need to change these tests
 
-        uc = units
+        uc = units()
         kg = uc.kg
         m = uc.m
 
@@ -382,7 +382,7 @@ class TestPyomoUnit(unittest.TestCase):
 
     # @unittest.skip('Skipped testing LinearExpression since StreamBasedExpressionVisitor does not handle LinearExpressions')
     def test_linear_expression(self):
-        uc = units
+        uc = units()
         model = ConcreteModel()
         kg = uc.kg
         m = uc.m
@@ -399,7 +399,7 @@ class TestPyomoUnit(unittest.TestCase):
         self._get_check_units_fail(linex2, uc, expr.LinearExpression)
 
     def test_dimensionless(self):
-        uc = units
+        uc = units()
         kg = uc.kg
         dless = uc.dimensionless
         self._get_check_units_ok(2.0 == 2.0*dless, uc, None, expr.EqualityExpression)
@@ -408,7 +408,7 @@ class TestPyomoUnit(unittest.TestCase):
         self.assertEqual(None, uc.get_units(kg/kg))
 
     def test_temperatures(self):
-        uc = units
+        uc = units()
 
         # Pyomo units framework disallows "offset" units
         with self.assertRaises(UnitsError):
@@ -444,11 +444,11 @@ class TestPyomoUnit(unittest.TestCase):
         self._get_check_units_fail(2.0*delta_degC + 3.0*delta_degF, uc, expr.NPV_SumExpression)
 
     def test_module_example(self):
-        from pyomo.environ import ConcreteModel, Var, Objective, units # import components and 'units' instance
+        from pyomo.environ import ConcreteModel, Var, Objective, units
         model = ConcreteModel()
         model.acc = Var()
-        model.obj = Objective(expr=(model.acc*units.m/units.s**2 - 9.81*units.m/units.s**2)**2)
-        self.assertEqual('m ** 2 / s ** 4', str(units.get_units(model.obj.expr)))
+        model.obj = Objective(expr=(model.acc*units().m/units().s**2 - 9.81*units().m/units().s**2)**2)
+        self.assertEqual('m ** 2 / s ** 4', str(units().get_units(model.obj.expr)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implemented the convert_value method to convert numerical values using Pyomo units objects.

## Summary/Motivation:
- need a convert value method for working with constants containing Pyomo units.

## Changes proposed in this PR:
- implemented the convert_value method on the PyomoUnitsContainer to allow
for conversion of numerical values based on Pyomo Units.
- Changed the singleton behavior to access the singleton units container through a module function.


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
