### PR TITLE
GDPopt-LBB set default BigM

### DIFF
--- a/pyomo/contrib/gdpopt/branch_and_bound.py
+++ b/pyomo/contrib/gdpopt/branch_and_bound.py
@@ -177,6 +177,8 @@ def _branch_on_node(node_data, node_model, solve_data):
         fixed_True_disjunct = child_unfixed_disjuncts[disjunct_index_to_fix_True]
         for constr in child_model.GDPopt_utils.disjunct_to_nonlinear_constraints.get(fixed_True_disjunct, ()):
             constr.activate()
+            # We set bigM arbitrarily to 1, but Y will be fixed to True (y=1), so the M value does not matter.
+            child_model.BigM[constr] = 1
 
         del child_model.GDPopt_utils.disjunction_to_unfixed_disjuncts[child_disjunction_to_branch]
         for child_disjunct in child_unfixed_disjuncts:


### PR DESCRIPTION
## Summary/Motivation:
Set a token Big M value for re-activated nonlinear constraints so that Big M transformation does not have to calculate an M (and also therefore does not complain when it is unable to do so).
It is fine to use M = 1 arbitrarily, because Y is fixed to True for these disjuncts. Hence, `g(x) <= M(1-y)` becomes `g(x) <= M(1-1)` = 0.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
