### PR TITLE
Raise error on failed Param validation

### DIFF
--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -601,6 +601,7 @@ class Param(IndexedComponent):
                 return value
         except:
             del self._data[index]
+            raise
 
 
     def _validate_value(self, index, value, validate_domain=True):

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -1169,6 +1169,58 @@ class MiscParamTests(unittest.TestCase):
             return 0.0
         model.p = Param(model.A, initialize=rule)
 
+    def test_param_validate(self):
+        """Test Param `validate` and `within` throw ValueError when not valid.
+
+        The `within` argument will catch the ValueError, log extra information
+        with of an "ERROR" message, and reraise the ValueError.
+
+        1. Immutable Param (unindexed)
+        2. Immutable Param (indexed)
+        3. Immutable Param (arbitrary validation rule)
+        4. Mutable Param (unindexed)
+        5. Mutable Param (indexed)
+        6. Mutable Param (arbitrary validation rule)
+        """
+        def validation_rule(model, value):
+            """Arbitrary validation rule that always returns False."""
+            return False
+
+        # 1. Immutable Param (unindexed)
+        with self.assertRaisesRegex(ValueError, "Value not in parameter domain"):
+            m = ConcreteModel()
+            m.p1 = Param(initialize=-3, within=NonNegativeReals)
+
+        # 2. Immutable Param (indexed)
+        with self.assertRaisesRegex(ValueError, "Value not in parameter domain"):
+            m = ConcreteModel()
+            m.A = RangeSet(1, 2)
+            m.p2 = Param(m.A, initialize=-3, within=NonNegativeReals)
+
+        # 3. Immutable Param (arbitrary validation rule)
+        with self.assertRaisesRegex(ValueError, "Invalid parameter value"):
+            m = ConcreteModel()
+            m.p5 = Param(initialize=1, validate=validation_rule)
+
+        # 4. Mutable Param (unindexed)
+        with self.assertRaisesRegex(ValueError, "Value not in parameter domain"):
+            m = ConcreteModel()
+            m.p3 = Param(within=NonNegativeReals, mutable=True)
+            m.p3 = -3
+
+        # 5. Mutable Param (indexed)
+        with self.assertRaisesRegex(ValueError, "Value not in parameter domain"):
+            m = ConcreteModel()
+            m.A = RangeSet(1, 2)
+            m.p4 = Param(m.A, within=NonNegativeReals, mutable=True)
+            m.p4[1] = -3
+
+        # 6. Mutable Param (arbitrary validation rule)
+        with self.assertRaisesRegex(ValueError, "Invalid parameter value"):
+            m = ConcreteModel()
+            m.p6 = Param(mutable=True, validate=validation_rule)
+            m.p6 = 1
+
     def test_get_uninitialized(self):
         model=AbstractModel()
         model.a = Param()


### PR DESCRIPTION
## Fixes #930

## Summary/Motivation:
As noted in #930, the `validate` option for Params does not raise an error when the validation function returns False (i.e., the functionality described in [the documentation](https://pyomo.readthedocs.io/en/stable/pyomo_modeling_components/Parameters.html) does not work as described). 

## Changes proposed in this PR:
- Raise the error that was caught in the `try/except` block. This proposed fix is modeled after the pattern used for the methods with the same name (`_setitem_when_not_present`) in for [IndexedComponent](https://github.com/goroderickgo/pyomo/blob/69b2e7bf9b4422750fba108a04d0d3216be02805/pyomo/core/base/indexed_component.py#L715-L736) and [Var](https://github.com/goroderickgo/pyomo/blob/69b2e7bf9b4422750fba108a04d0d3216be02805/pyomo/core/base/var.py#L629-L641).

I'm not very familiar with adding tests, so I would gladly take guidance if I need to add any.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
