### PR TITLE
PyNumero support on Windows

### DIFF
--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install Pyomo dependencies
       shell: pwsh
       run: |
         $env:PYTHONWARNINGS="ignore::UserWarning"
@@ -44,26 +44,36 @@ jobs:
         $env:MINICONDA_EXTRAS=""
         $env:MINICONDA_EXTRAS="numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill seaborn "
         $env:ADDITIONAL_CF_PKGS=$env:ADDITIONAL_CF_PKGS + "pymysql pyro4 pint pathos " + $env:MINICONDA_EXTRAS
-        $env:ADDITIONAL_CF_PKGS=$env:ADDITIONAL_CF_PKGS + " glpk ipopt pynumero_libraries"
-        Write-Host ("")
-        Write-Host ("Installing Conda packages... ")
-        Write-Host ("")
+        $env:ADDITIONAL_CF_PKGS=$env:ADDITIONAL_CF_PKGS + " glpk ipopt"
         $env:EXP = $env:CONDAFORGE + $env:ADDITIONAL_CF_PKGS
         Invoke-Expression $env:EXP
+        $env:PYNUMERO = $env:CONDAFORGE + " pynumero_libraries"
         Write-Host ("")
-        Write-Host ("Setting up pynumero_libraries... ")
+        Write-Host ("Try to install Pynumero_libraries...")
         Write-Host ("")
-        $env:PYNUMERO = $env:CONDA_INSTALL + " -c conda-forge pynumero_libraries"
-        $env:EXP = $env:CONDAFORGE + $env:PYNUMERO
-        try {Invoke-Expression $env:PYNUMERO} catch {Write-Host ("Pynumero_libraries is not available for Python ${{matrix.python-version}}") }
+        try
+        {
+            Invoke-Expression $env:PYNUMERO
+        }
+        catch
+        {
+            Write-Host ("####################################################")
+            Write-Host ("WARNING: Pynumero_libraries is not available for Python ${{matrix.python-version}}")
+            Write-Host ("####################################################")
+        }
         Write-Host ("")
-        Write-Host ("Installing GAMS")
+        Write-Host ("Install GAMS...")
         Write-Host ("")
         Invoke-WebRequest -Uri 'https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/windows/windows_x64_64.exe' -OutFile 'windows_x64_64.exe'
         Start-Process -FilePath 'windows_x64_64.exe' -ArgumentList '/SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS'
         $env:PATH += $(Get-Location).Path + "\gams"
+        Write-Host ("")
         Write-Host ("New Shell Environment: ")
         gci env: | Sort Name
+    - name: Install Pyomo and extensions
+      shell: pwsh
+      run: |
+        $env:PYTHONWARNINGS="ignore::UserWarning"
         Write-Host ("")
         Write-Host ("Clone model library and install PyUtilib...")
         Write-Host ("")
@@ -76,16 +86,10 @@ jobs:
         Write-Host ("Install Pyomo...")
         Write-Host ("")
         python setup.py develop
-    - name: Install extensions
-      shell: pwsh
-      run: |
-        $env:PYTHONWARNINGS="ignore::UserWarning"
+        Write-Host ("")
         Write-Host "Pyomo download-extensions"
+        Write-Host ("")
         Invoke-Expression "pyomo download-extensions"
-        Invoke-Expression "pyomo build-extensions"
-        Write-Host "Calling solvers"
-        Invoke-Expression "glpsol -v"
-        Invoke-Expression "ipopt -v"
     - name: Run nightly tests with test.pyomo
       shell: pwsh
       run: |

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -39,7 +39,7 @@ jobs:
         $env:MINICONDA_EXTRAS=""
         $env:MINICONDA_EXTRAS="numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill seaborn "
         $env:ADDITIONAL_CF_PKGS=$env:ADDITIONAL_CF_PKGS + "pymysql pyro4 pint pathos " + $env:MINICONDA_EXTRAS
-        $env:ADDITIONAL_CF_PKGS=$env:ADDITIONAL_CF_PKGS + " glpk ipopt"
+        $env:ADDITIONAL_CF_PKGS=$env:ADDITIONAL_CF_PKGS + " glpk ipopt pynumero_libraries"
         $env:EXP = $env:CONDAFORGE + $env:ADDITIONAL_CF_PKGS
         Invoke-Expression $env:EXP
         Write-Host ("Installing GAMS")

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -29,6 +29,11 @@ jobs:
         Write-Host ("Current Enviroment variables: ")
         gci env: | Sort Name
         Write-Host ("")
+        Write-Host ("Update conda, then force it to NOT update itself again...")
+        Write-Host ("")
+        Invoke-Expression "conda config --set always_yes yes"
+        Invoke-Expression "conda config --set auto_update_conda false"
+        Write-Host ("")
         Write-Host ("Setting Conda Env Vars... ")
         Write-Host ("")
         $env:CONDA_INSTALL = "conda install -q -y "
@@ -40,19 +45,25 @@ jobs:
         $env:MINICONDA_EXTRAS="numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill seaborn "
         $env:ADDITIONAL_CF_PKGS=$env:ADDITIONAL_CF_PKGS + "pymysql pyro4 pint pathos " + $env:MINICONDA_EXTRAS
         $env:ADDITIONAL_CF_PKGS=$env:ADDITIONAL_CF_PKGS + " glpk ipopt pynumero_libraries"
+        Write-Host ("")
+        Write-Host ("Installing Conda packages... ")
+        Write-Host ("")
         $env:EXP = $env:CONDAFORGE + $env:ADDITIONAL_CF_PKGS
         Invoke-Expression $env:EXP
+        Write-Host ("")
+        Write-Host ("Setting up pynumero_libraries... ")
+        Write-Host ("")
+        $env:PYNUMERO = $env:CONDA_INSTALL + " -c conda-forge pynumero_libraries"
+        $env:EXP = $env:CONDAFORGE + $env:PYNUMERO
+        try {Invoke-Expression $env:PYNUMERO} catch {Write-Host ("Pynumero_libraries is not available for Python ${{matrix.python-version}}") }
+        Write-Host ("")
         Write-Host ("Installing GAMS")
+        Write-Host ("")
         Invoke-WebRequest -Uri 'https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/windows/windows_x64_64.exe' -OutFile 'windows_x64_64.exe'
         Start-Process -FilePath 'windows_x64_64.exe' -ArgumentList '/SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS'
         $env:PATH += $(Get-Location).Path + "\gams"
         Write-Host ("New Shell Environment: ")
         gci env: | Sort Name
-        Write-Host ("")
-        Write-Host ("Update conda, then force it to NOT update itself again...")
-        Write-Host ("")
-        Invoke-Expression "conda config --set always_yes yes"
-        Invoke-Expression "conda config --set auto_update_conda false"
         Write-Host ("")
         Write-Host ("Clone model library and install PyUtilib...")
         Write-Host ("")

--- a/pyomo/contrib/pynumero/extensions/utils.py
+++ b/pyomo/contrib/pynumero/extensions/utils.py
@@ -17,6 +17,11 @@ def find_pynumero_library(library_name):
     asl_path = find_library(library_name)
     if asl_path is not None:
         return asl_path
+
+    # On windows the library is prefixed with 'lib'
+    asl_path = find_library('lib'+library_name)
+    if asl_path is not None:
+        return asl_path
     else:
         # try looking into extensions directory now
         file_path = os.path.abspath(__file__)

--- a/pyomo/contrib/pynumero/interfaces/tests/test_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_nlp.py
@@ -345,7 +345,7 @@ def execute_extended_nlp_interface(self, anlp):
     expected_hess = np.asarray(expected_hess, dtype=np.float64)
     self.assertTrue(np.array_equal(dense_hess, expected_hess))
 
-@unittest.skipIf(os.name in ['nt', 'dos'], "Do not test on windows")
+
 class TestAslNLP(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/pyomo/contrib/pynumero/interfaces/tests/test_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_nlp.py
@@ -363,7 +363,6 @@ class TestAslNLP(unittest.TestCase):
         anlp = AslNLP(self.filename)
         execute_extended_nlp_interface(self, anlp)
         
-@unittest.skipIf(os.name in ['nt', 'dos'], "Do not test on windows")
 class TestAmplNLP(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -441,7 +440,6 @@ class TestAmplNLP(unittest.TestCase):
         self.assertEqual(sum(ineq_constraint_idxs), 3)
 
 
-@unittest.skipIf(os.name in ['nt', 'dos'], "Do not test on windows")
 class TestPyomoNLP(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -550,7 +548,6 @@ class TestPyomoNLP(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             nlp = PyomoNLP(m)
 
-@unittest.skipIf(os.name in ['nt', 'dos'], "Do not test on windows")
 class TestUtils(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/pyomo/contrib/pynumero/sparse/tests/test_coomatrix.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_coomatrix.py
@@ -21,7 +21,6 @@ except ImportError:
 from pyomo.contrib.pynumero.sparse.coo import (diagonal_matrix,
                                                empty_matrix)
 
-@unittest.skipIf(os.name in ['nt', 'dos'], "Do not test on windows")
 class TestEmptyMatrix(unittest.TestCase):
 
     def test_constructor(self):


### PR DESCRIPTION
## Fixes #1261 

## Summary/Motivation:
@santiagoropb updated the `pynumero_libraries` conda package to support Windows. This PR makes a small change in PyNumero to get things working and enables all of the tests that were disabled by default on Windows. Technically this only adds Windows support for Anaconda users but I think that is enough to close #1261. 

@mrmundt could you help me add the `pynumero_libraries` package from conda-forge to the Windows Github Actions build? 

I also need to double check which PyNumero tests are being skipped on our other testing platforms and figure out how to update/install the PyNumero libraries when we're not using conda.

## Changes proposed in this PR:
- Change to the library finder in PyNumero to support Windows library names
- Enable all PyNumero tests on Windows

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
