### PR TITLE
Remove Python 2.7 from Linux/Mac Github Actions

### DIFF
--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -1,4 +1,4 @@
-name: Mac no Py27
+name: Mac no Python 2.7
 
 on:
   push:

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -32,24 +32,32 @@ jobs:
         brew install unixodbc
         brew install freetds # Now install Python modules
         python -m pip install --upgrade pip
+        echo ""
         echo "Install Pyomo dependencies..."
+        echo ""
         pip install cython numpy scipy ipython openpyxl sympy pyyaml pyodbc networkx xlrd pandas matplotlib dill seaborn pymysql pyro4 pint pathos
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."
         python -m pip install --upgrade pip
         git clone --quiet https://github.com/Pyomo/pyomo-model-libraries.git
+        echo ""
         echo "Install PyUtilib..."
+        echo ""
         pip install --quiet git+https://github.com/PyUtilib/pyutilib
+        echo ""
         echo "Install Pyomo..."
+        echo ""
         python setup.py develop # Install Pyomo
+        echo ""
         echo "Install extensions..."
+        echo ""
         pyomo download-extensions # Get Pyomo extensions
         pyomo build-extensions
     - name: Run nightly, not fragile tests with test.pyomo
       run: |
+        echo "Run test.pyomo..."
         python -m pip install --upgrade pip
         pip install nose
-        echo "Run test.pyomo..."
         KEY_JOB=1
         test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries # Run nightly, stable tests

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -1,9 +1,9 @@
-name: Mac no Python 2.7
+name: continuous-integration/github/pr/osx
 
 on:
-  push:
+  pull_request:
     branches:
-      - remove_py27_ga
+      - master
       # Can add additional branches if desired
 
 jobs:

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: macos-latest
     strategy:
       fail-fast: false
-      max-parallel: 4
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8] # All available Python versions
 
@@ -39,7 +38,6 @@ jobs:
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."
-        python -m pip install --upgrade pip
         git clone --quiet https://github.com/Pyomo/pyomo-model-libraries.git
         echo ""
         echo "Install PyUtilib..."
@@ -57,7 +55,6 @@ jobs:
     - name: Run nightly, not fragile tests with test.pyomo
       run: |
         echo "Run test.pyomo..."
-        python -m pip install --upgrade pip
         pip install nose
         KEY_JOB=1
         test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries # Run nightly, stable tests

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -1,9 +1,9 @@
-name: continuous-integration/github/pr/osx
+name: Mac no Py27
 
 on:
-  pull_request:
+  push:
     branches:
-      - master
+      - remove_py27_ga
       # Can add additional branches if desired
 
 jobs:
@@ -12,9 +12,9 @@ jobs:
     runs-on: macos-latest
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 4
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8] # All available Python versions
+        python-version: [3.5, 3.6, 3.7, 3.8] # All available Python versions
 
     steps:
     - uses: actions/checkout@v1 # Checkout branch(es)
@@ -24,27 +24,32 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Pyomo dependencies
       run: |
-        python -m pip install --upgrade pip
-        git clone --quiet https://github.com/Pyomo/pyomo-model-libraries.git
-        pip install --quiet git+https://github.com/PyUtilib/pyutilib
-        python setup.py develop # Install Pyomo
-
-    - name: Install Python modules and Pyomo extensions
-      run: |
-
+        echo "Install pre-dependencies for pyodbc..."
         brew update # Install pre-dependencies for pyodbc
         brew install bash gcc
         brew link --overwrite gcc
         brew install pkg-config
         brew install unixodbc
         brew install freetds # Now install Python modules
-
+        python -m pip install --upgrade pip
+        echo "Install Pyomo dependencies..."
         pip install cython numpy scipy ipython openpyxl sympy pyyaml pyodbc networkx xlrd pandas matplotlib dill seaborn pymysql pyro4 pint pathos
-
+    - name: Install Pyomo and extensions
+      run: |
+        echo "Clone Pyomo-model-libraries..."
+        python -m pip install --upgrade pip
+        git clone --quiet https://github.com/Pyomo/pyomo-model-libraries.git
+        echo "Install PyUtilib..."
+        pip install --quiet git+https://github.com/PyUtilib/pyutilib
+        echo "Install Pyomo..."
+        python setup.py develop # Install Pyomo
+        echo "Install extensions..."
         pyomo download-extensions # Get Pyomo extensions
         pyomo build-extensions
     - name: Run nightly, not fragile tests with test.pyomo
       run: |
+        python -m pip install --upgrade pip
         pip install nose
+        echo "Run test.pyomo..."
         KEY_JOB=1
         test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries # Run nightly, stable tests

--- a/.github/workflows/ubuntu_python_matrix_test.yml
+++ b/.github/workflows/ubuntu_python_matrix_test.yml
@@ -1,9 +1,9 @@
-name: continuous-integration/github/pr/linux
+name: Ubuntu no Py27
 
 on:
-  pull_request:
+  push:
     branches:
-      - master
+      - remove_py27_ga
 
 jobs:
   pyomo-linux-tests:
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 4
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -22,34 +22,32 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        export PYTHONWARNINGS="ignore::UserWarning"
         echo "Upgrade pip..."
         python -m pip install --upgrade pip
         echo "Install extras..."
         pip install numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd matplotlib dill
         pip install pandas # Pandas needs to be installed after its dependencies to work correctly for Python 2.7 
         pip install seaborn pymysql pyro4 pint pathos 
-        echo "Installing GAMS..."
+        echo "Install GAMS..."
         wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/linux/linux_x64_64_sfx.exe
         chmod +x linux_x64_64_sfx.exe
         ./linux_x64_64_sfx.exe -q -d gams
         PATH=$PATH:/gams/gams24.3_linux_x64_64_sfx
-        echo "Cloning Pyomo-model-libraries..."
+        echo "Clone Pyomo-model-libraries..."
         git clone --quiet https://github.com/Pyomo/pyomo-model-libraries.git
-        echo "Installing PyUtilib..."
+        echo "Install PyUtilib..."
         pip install --quiet git+https://github.com/PyUtilib/pyutilib
-        echo "Installing Pyomo..."
+        echo "Install Pyomo..."
         python setup.py develop
     - name: Install extensions
       run: |
-        export PYTHONWARNINGS="ignore::UserWarning"
         echo "Download and install extensions..."
         pyomo download-extensions
         pyomo build-extensions
     - name: Run nightly tests with test.pyomo
       run: |
-        export PYTHONWARNINGS="ignore::UserWarning"
         echo "Run test.pyomo..."
+        python -m pip install --upgrade pip
         pip install nose
         KEY_JOB=1
         test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries

--- a/.github/workflows/ubuntu_python_matrix_test.yml
+++ b/.github/workflows/ubuntu_python_matrix_test.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
-      max-parallel: 4
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
     steps:
@@ -55,7 +54,6 @@ jobs:
     - name: Run nightly tests with test.pyomo
       run: |
         echo "Run test.pyomo..."
-        python -m pip install --upgrade pip
         pip install nose
         KEY_JOB=1
         test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries

--- a/.github/workflows/ubuntu_python_matrix_test.yml
+++ b/.github/workflows/ubuntu_python_matrix_test.yml
@@ -1,9 +1,9 @@
-name: Ubuntu no Python 2.7
+name: continuous-integration/github/pr/linux
 
 on:
-  push:
+  pull_request:
     branches:
-      - remove_py27_ga
+      - master
 
 jobs:
   pyomo-linux-tests:

--- a/.github/workflows/ubuntu_python_matrix_test.yml
+++ b/.github/workflows/ubuntu_python_matrix_test.yml
@@ -1,4 +1,4 @@
-name: Ubuntu no Py27
+name: Ubuntu no Python 2.7
 
 on:
   push:

--- a/.github/workflows/ubuntu_python_matrix_test.yml
+++ b/.github/workflows/ubuntu_python_matrix_test.yml
@@ -20,28 +20,36 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install Pyomo dependencies
       run: |
         echo "Upgrade pip..."
         python -m pip install --upgrade pip
+        echo ""
         echo "Install extras..."
-        pip install numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd matplotlib dill
-        pip install pandas # Pandas needs to be installed after its dependencies to work correctly for Python 2.7 
-        pip install seaborn pymysql pyro4 pint pathos 
+        echo ""
+        pip install numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd matplotlib dill pandas seaborn pymysql pyro4 pint pathos 
+        echo ""
         echo "Install GAMS..."
+        echo ""
         wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/linux/linux_x64_64_sfx.exe
         chmod +x linux_x64_64_sfx.exe
         ./linux_x64_64_sfx.exe -q -d gams
         PATH=$PATH:/gams/gams24.3_linux_x64_64_sfx
+    - name: Install Pyomo and extensions
+      run: |
         echo "Clone Pyomo-model-libraries..."
         git clone --quiet https://github.com/Pyomo/pyomo-model-libraries.git
+        echo ""
         echo "Install PyUtilib..."
+        echo ""
         pip install --quiet git+https://github.com/PyUtilib/pyutilib
+        echo ""
         echo "Install Pyomo..."
+        echo ""
         python setup.py develop
-    - name: Install extensions
-      run: |
+        echo ""
         echo "Download and install extensions..."
+        echo ""
         pyomo download-extensions
         pyomo build-extensions
     - name: Run nightly tests with test.pyomo

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -1,9 +1,9 @@
-name: Windows reconfigure
+name: continuous-integration/github/pr/win
 
 on:
-  push:
+  pull_request:
     branches:
-      - remove_py27_ga
+      - master
 
 jobs:
   pyomo-tests:

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -73,7 +73,7 @@ jobs:
         Write-Host "Pyomo download-extensions"
         Write-Host ("")
         Invoke-Expression "pyomo download-extensions"
-        Invoke-Expression "pyomo build-extensions"
+        try {Invoke-Expression "pyomo build-extensions"}
     - name: Run nightly tests with test.pyomo
       shell: pwsh
       run: |

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -47,10 +47,13 @@ jobs:
         $env:ADDITIONAL_CF_PKGS=$env:ADDITIONAL_CF_PKGS + " glpk ipopt"
         $env:EXP = $env:CONDAFORGE + $env:ADDITIONAL_CF_PKGS
         Invoke-Expression $env:EXP
+        Write-Host ("")
         Write-Host ("Installing GAMS")
+        Write-Host ("")
         Invoke-WebRequest -Uri 'https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/windows/windows_x64_64.exe' -OutFile 'windows_x64_64.exe'
         Start-Process -FilePath 'windows_x64_64.exe' -ArgumentList '/SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS'
         $env:PATH += $(Get-Location).Path + "\gams"
+        Write-Host ("")
         Write-Host ("New Shell Environment: ")
         gci env: | Sort Name
     - name: Install Pyomo and extensions
@@ -73,7 +76,7 @@ jobs:
         Write-Host "Pyomo download-extensions"
         Write-Host ("")
         Invoke-Expression "pyomo download-extensions"
-        try {Invoke-Expression "pyomo build-extensions"}
+        
     - name: Run nightly tests with test.pyomo
       shell: pwsh
       run: |

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -1,9 +1,9 @@
-name: continuous-integration/github/pr/win
+name: Windows reconfigure
 
 on:
-  pull_request:
+  push:
     branches:
-      - master
+      - remove_py27_ga
 
 jobs:
   pyomo-tests:
@@ -22,12 +22,17 @@ jobs:
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install Pyomo dependencies
       shell: pwsh
       run: |
         $env:PYTHONWARNINGS="ignore::UserWarning"
         Write-Host ("Current Enviroment variables: ")
         gci env: | Sort Name
+        Write-Host ("")
+        Write-Host ("Update conda, then force it to NOT update itself again...")
+        Write-Host ("")
+        Invoke-Expression "conda config --set always_yes yes"
+        Invoke-Expression "conda config --set auto_update_conda false"
         Write-Host ("")
         Write-Host ("Setting Conda Env Vars... ")
         Write-Host ("")
@@ -48,11 +53,10 @@ jobs:
         $env:PATH += $(Get-Location).Path + "\gams"
         Write-Host ("New Shell Environment: ")
         gci env: | Sort Name
-        Write-Host ("")
-        Write-Host ("Update conda, then force it to NOT update itself again...")
-        Write-Host ("")
-        Invoke-Expression "conda config --set always_yes yes"
-        Invoke-Expression "conda config --set auto_update_conda false"
+    - name: Install Pyomo and extensions
+      shell: pwsh
+      run: |
+        $env:PYTHONWARNINGS="ignore::UserWarning"
         Write-Host ("")
         Write-Host ("Clone model library and install PyUtilib...")
         Write-Host ("")
@@ -65,16 +69,11 @@ jobs:
         Write-Host ("Install Pyomo...")
         Write-Host ("")
         python setup.py develop
-    - name: Install extensions
-      shell: pwsh
-      run: |
-        $env:PYTHONWARNINGS="ignore::UserWarning"
+        Write-Host ("")
         Write-Host "Pyomo download-extensions"
+        Write-Host ("")
         Invoke-Expression "pyomo download-extensions"
         Invoke-Expression "pyomo build-extensions"
-        Write-Host "Calling solvers"
-        Invoke-Expression "glpsol -v"
-        Invoke-Expression "ipopt -v"
     - name: Run nightly tests with test.pyomo
       shell: pwsh
       run: |

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false # This flag causes all of the matrix to continue to run, even if one matrix option fails
-      max-parallel: 5
       matrix:
         os: ['windows-latest']
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8] 


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
We want to remove Python 2.7 tests from Mac and Linux Github Actions workflows. Because the Github runners are frequently changing, these tests are too unstable, and in the case of Linux, the tests are covered by regular Jenkins jobs as well.

## Changes proposed in this PR:
- Remove Python 2.7 Tests for Mac/Linux
- Reorganize the Workflows to all have the same format/printout messages for consistency

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
