### PR TITLE
Add GAMS to MacOS

### DIFF
--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -42,20 +42,18 @@ jobs:
         chmod +x osx_x64_64_sfx.exe
         ./osx_x64_64_sfx.exe -q -d gams
         cd gams/gams29.1_osx_x64_64_sfx/apifiles/Python/
-        py_ver="$(python --version)"
-        if [[ "$py_ver" == *"2.7"* ]]; then
-          cd api
-          python setup.py -q install
-        elif [[ "$py_ver" == *'3.6'* ]]; then
-          cd api_36
-          python setup.py -q install
-        elif [[ "$py_ver" == *'3.7'* || "$py_ver" == *'3.8'* ]]; then
-          cd api_37
-          python setup.py -q install -noCheck
-        else 
-          cd api_34
-          python setup.py -q install -noCheck
-        fi
+        py_ver=$(python -c 'import sys;print("%s%s" % sys.version_info[:2])')
+        echo $py_ver
+        gams_ver=api
+        for ver in api_*; do
+            echo $ver
+            if test ${ver:4} -le $py_ver; then
+                gams_ver=$ver
+            fi  
+        done
+        echo $gams_ver
+        cd $gams_ver
+        python setup.py -q install -noCheck
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -1,9 +1,9 @@
 name: continuous-integration/github/pr/osx
 
 on:
-  pull_request:
+  push:
     branches:
-      - master
+      - mac_gams
       # Can add additional branches if desired
 
 jobs:
@@ -35,6 +35,13 @@ jobs:
         echo "Install Pyomo dependencies..."
         echo ""
         pip install cython numpy scipy ipython openpyxl sympy pyyaml pyodbc networkx xlrd pandas matplotlib dill seaborn pymysql pyro4 pint pathos
+        echo ""
+        echo "Install GAMS..."
+        echo ""
+        wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/30.1.0/macosx/osx_x64_64_sfx.exe
+        chmod +x osx_x64_64_sfx.exe
+        ./osx_x64_64_sfx.exe -q -d gams
+        PATH=$PATH:/gams/gams30.1_osx_x64_64
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -41,7 +41,7 @@ jobs:
         wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0/macosx/osx_x64_64_sfx.exe
         chmod +x osx_x64_64_sfx.exe
         ./osx_x64_64_sfx.exe -q -d gams
-        python gams/gams29.1_osx_x64_64_sfx/apifiles/Python/api/setup.py install -noCheck
+        python gams/gams29.1_osx_x64_64_sfx/apifiles/Python/api/setup.py install 
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -41,6 +41,7 @@ jobs:
         wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0/macosx/osx_x64_64_sfx.exe
         chmod +x osx_x64_64_sfx.exe
         ./osx_x64_64_sfx.exe -q -d gams
+        python /gams/gams29.1_osx_x64_64_sfx/apifiles/Python/api/setup.py install -noCheck
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -41,7 +41,8 @@ jobs:
         wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/30.1.0/macosx/osx_x64_64_sfx.exe
         chmod +x osx_x64_64_sfx.exe
         ./osx_x64_64_sfx.exe -q -d gams
-        PATH=$PATH:/gams/gams30.1_osx_x64_64
+        PATH=$PATH:gams/gams30.1_osx_x64_64/
+        export PATH # Need license: https://www.gams.com/latest/docs/UG_License.html
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -1,9 +1,9 @@
 name: continuous-integration/github/pr/osx
 
 on:
-  pull_request:
+  push:
     branches:
-      - master
+      - mac_gams
       # Can add additional branches if desired
 
 jobs:
@@ -41,8 +41,6 @@ jobs:
         wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/30.1.0/macosx/osx_x64_64_sfx.exe
         chmod +x osx_x64_64_sfx.exe
         ./osx_x64_64_sfx.exe -q -d gams
-        PATH=$PATH:gams/gams30.1_osx_x64_64/
-        export PATH # Need license: https://www.gams.com/latest/docs/UG_License.html
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."
@@ -63,6 +61,9 @@ jobs:
     - name: Run nightly, not fragile tests with test.pyomo
       run: |
         echo "Run test.pyomo..."
-        pip install nose
-        KEY_JOB=1
-        test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries # Run nightly, stable tests
+        PATH=$PATH:gams/gams30.1_osx_x64_64/
+        export PATH # Need license: https://www.gams.com/latest/docs/UG_License.html
+        gams
+        #pip install nose
+        #KEY_JOB=1
+        #test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries # Run nightly, stable tests

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -38,7 +38,7 @@ jobs:
         echo ""
         echo "Install GAMS..."
         echo ""
-        wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/30.1.0/macosx/osx_x64_64_sfx.exe
+        wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0/macosx/osx_x64_64_sfx.exe
         chmod +x osx_x64_64_sfx.exe
         ./osx_x64_64_sfx.exe -q -d gams
     - name: Install Pyomo and extensions
@@ -61,9 +61,8 @@ jobs:
     - name: Run nightly, not fragile tests with test.pyomo
       run: |
         echo "Run test.pyomo..."
-        PATH=$PATH:gams/gams30.1_osx_x64_64/
-        export PATH # Need license: https://www.gams.com/latest/docs/UG_License.html
-        gams
-        #pip install nose
-        #KEY_JOB=1
-        #test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries # Run nightly, stable tests
+        PATH=$PATH:$(pwd)/gams/gams29.1_osx_x64_64/
+        export PATH # Need license for 30.1.0: https://www.gams.com/latest/docs/UG_License.html
+        pip install nose
+        KEY_JOB=1
+        test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries # Run nightly, stable tests

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -41,7 +41,7 @@ jobs:
         wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0/macosx/osx_x64_64_sfx.exe
         chmod +x osx_x64_64_sfx.exe
         ./osx_x64_64_sfx.exe -q -d gams
-        python /gams/gams29.1_osx_x64_64_sfx/apifiles/Python/api/setup.py install -noCheck
+        python gams/gams29.1_osx_x64_64_sfx/apifiles/Python/api/setup.py install -noCheck
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -41,7 +41,8 @@ jobs:
         wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0/macosx/osx_x64_64_sfx.exe
         chmod +x osx_x64_64_sfx.exe
         ./osx_x64_64_sfx.exe -q -d gams
-        python gams/gams29.1_osx_x64_64_sfx/apifiles/Python/api/setup.py install 
+        cd gams/gams29.1_osx_x64_64_sfx/apifiles/Python/api/
+        python setup.py -q install -noCheck
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -1,9 +1,9 @@
 name: continuous-integration/github/pr/osx
 
 on:
-  push:
+  pull_request:
     branches:
-      - mac_gams
+      - master
       # Can add additional branches if desired
 
 jobs:

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -42,16 +42,13 @@ jobs:
         chmod +x osx_x64_64_sfx.exe
         ./osx_x64_64_sfx.exe -q -d gams
         cd gams/gams29.1_osx_x64_64_sfx/apifiles/Python/
-        py_ver=$(python -c 'import sys;print("%s%s" % sys.version_info[:2])')
-        echo $py_ver
+        y_ver=$(python -c 'import sys;print("%s%s" % sys.version_info[:2])')
         gams_ver=api
         for ver in api_*; do
-            echo $ver
             if test ${ver:4} -le $py_ver; then
                 gams_ver=$ver
             fi  
         done
-        echo $gams_ver
         cd $gams_ver
         python setup.py -q install -noCheck
     - name: Install Pyomo and extensions

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -1,9 +1,9 @@
 name: continuous-integration/github/pr/osx
 
 on:
-  push:
+  pull_request:
     branches:
-      - mac_gams
+      - master
       # Can add additional branches if desired
 
 jobs:
@@ -61,7 +61,7 @@ jobs:
     - name: Run nightly, not fragile tests with test.pyomo
       run: |
         echo "Run test.pyomo..."
-        PATH=$PATH:$(pwd)/gams/gams29.1_osx_x64_64/
+        PATH=$PATH:$(pwd)/gams/gams29.1_osx_x64_64_sfx/
         export PATH # Need license for 30.1.0: https://www.gams.com/latest/docs/UG_License.html
         pip install nose
         KEY_JOB=1

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -42,7 +42,7 @@ jobs:
         chmod +x osx_x64_64_sfx.exe
         ./osx_x64_64_sfx.exe -q -d gams
         cd gams/gams29.1_osx_x64_64_sfx/apifiles/Python/
-        y_ver=$(python -c 'import sys;print("%s%s" % sys.version_info[:2])')
+        py_ver=$(python -c 'import sys;print("%s%s" % sys.version_info[:2])')
         gams_ver=api
         for ver in api_*; do
             if test ${ver:4} -le $py_ver; then

--- a/.github/workflows/mac_python_matrix_test.yml
+++ b/.github/workflows/mac_python_matrix_test.yml
@@ -41,8 +41,21 @@ jobs:
         wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0/macosx/osx_x64_64_sfx.exe
         chmod +x osx_x64_64_sfx.exe
         ./osx_x64_64_sfx.exe -q -d gams
-        cd gams/gams29.1_osx_x64_64_sfx/apifiles/Python/api/
-        python setup.py -q install -noCheck
+        cd gams/gams29.1_osx_x64_64_sfx/apifiles/Python/
+        py_ver="$(python --version)"
+        if [[ "$py_ver" == *"2.7"* ]]; then
+          cd api
+          python setup.py -q install
+        elif [[ "$py_ver" == *'3.6'* ]]; then
+          cd api_36
+          python setup.py -q install
+        elif [[ "$py_ver" == *'3.7'* || "$py_ver" == *'3.8'* ]]; then
+          cd api_37
+          python setup.py -q install -noCheck
+        else 
+          cd api_34
+          python setup.py -q install -noCheck
+        fi
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."
@@ -63,8 +76,8 @@ jobs:
     - name: Run nightly, not fragile tests with test.pyomo
       run: |
         echo "Run test.pyomo..."
-        PATH=$PATH:$(pwd)/gams/gams29.1_osx_x64_64_sfx/
-        export PATH # Need license for 30.1.0: https://www.gams.com/latest/docs/UG_License.html
+        export PATH=$PATH:$(pwd)/gams/gams29.1_osx_x64_64_sfx/ 
+        export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$(pwd)/gams/gams29.1_osx_x64_64_sfx/
         pip install nose
         KEY_JOB=1
         test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries # Run nightly, stable tests

--- a/.github/workflows/ubuntu_python_matrix_test.yml
+++ b/.github/workflows/ubuntu_python_matrix_test.yml
@@ -33,7 +33,7 @@ jobs:
         wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/linux/linux_x64_64_sfx.exe
         chmod +x linux_x64_64_sfx.exe
         ./linux_x64_64_sfx.exe -q -d gams
-        python /gams/gams24.8_linux_x64_64_sfx/apifiles/Python/api/setup.py install -noCheck
+        python gams/gams24.8_linux_x64_64_sfx/apifiles/Python/api/setup.py install -noCheck
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."

--- a/.github/workflows/ubuntu_python_matrix_test.yml
+++ b/.github/workflows/ubuntu_python_matrix_test.yml
@@ -33,6 +33,7 @@ jobs:
         wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/linux/linux_x64_64_sfx.exe
         chmod +x linux_x64_64_sfx.exe
         ./linux_x64_64_sfx.exe -q -d gams
+        python /gams/gams24.8_linux_x64_64_sfx/apifiles/Python/api/setup.py install -noCheck
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."

--- a/.github/workflows/ubuntu_python_matrix_test.yml
+++ b/.github/workflows/ubuntu_python_matrix_test.yml
@@ -53,9 +53,8 @@ jobs:
     - name: Run nightly tests with test.pyomo
       run: |
         echo "Run test.pyomo..."
-        PATH=$PATH:gams/gams24.3_linux_x64_64_sfx/
+        PATH=$PATH:$(pwd)/gams/gams24.8_linux_x64_64_sfx/
         export PATH
-        gams
-        #pip install nose
-        #KEY_JOB=1
-        #test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries
+        pip install nose
+        KEY_JOB=1
+        test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries

--- a/.github/workflows/ubuntu_python_matrix_test.yml
+++ b/.github/workflows/ubuntu_python_matrix_test.yml
@@ -30,11 +30,24 @@ jobs:
         echo ""
         echo "Install GAMS..."
         echo ""
-        wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/linux/linux_x64_64_sfx.exe
+        wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0/linux/linux_x64_64_sfx.exe
         chmod +x linux_x64_64_sfx.exe
         ./linux_x64_64_sfx.exe -q -d gams
-        cd gams/gams24.8_linux_x64_64_sfx/apifiles/Python/api
-        python setup.py -q install 
+        cd gams/gams29.1_linux_x64_64_sfx/apifiles/Python/
+        py_ver="$(python --version)"
+        if [[ "$py_ver" == *"2.7"* ]]; then
+          cd api
+          python setup.py -q install
+        elif [[ "$py_ver" == *'3.6'* ]]; then
+          cd api_36
+          python setup.py -q install
+        elif [[ "$py_ver" == *'3.7'* || "$py_ver" == *'3.8'* ]]; then
+          cd api_37
+          python setup.py -q install -noCheck
+        else 
+          cd api_34
+          python setup.py -q install -noCheck
+        fi
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."
@@ -55,8 +68,8 @@ jobs:
     - name: Run nightly tests with test.pyomo
       run: |
         echo "Run test.pyomo..."
-        PATH=$PATH:$(pwd)/gams/gams24.8_linux_x64_64_sfx/
-        export PATH
+        export PATH=$PATH:$(pwd)/gams/gams29.1_linux_x64_64_sfx/
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/gams/gams29.1_linux_x64_64_sfx/
         pip install nose
         KEY_JOB=1
         test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries

--- a/.github/workflows/ubuntu_python_matrix_test.yml
+++ b/.github/workflows/ubuntu_python_matrix_test.yml
@@ -1,9 +1,9 @@
 name: continuous-integration/github/pr/linux
 
 on:
-  push:
+  pull_request:
     branches:
-      - mac_gams
+      - master
 
 jobs:
   pyomo-linux-tests:

--- a/.github/workflows/ubuntu_python_matrix_test.yml
+++ b/.github/workflows/ubuntu_python_matrix_test.yml
@@ -34,20 +34,18 @@ jobs:
         chmod +x linux_x64_64_sfx.exe
         ./linux_x64_64_sfx.exe -q -d gams
         cd gams/gams29.1_linux_x64_64_sfx/apifiles/Python/
-        py_ver="$(python --version)"
-        if [[ "$py_ver" == *"2.7"* ]]; then
-          cd api
-          python setup.py -q install
-        elif [[ "$py_ver" == *'3.6'* ]]; then
-          cd api_36
-          python setup.py -q install
-        elif [[ "$py_ver" == *'3.7'* || "$py_ver" == *'3.8'* ]]; then
-          cd api_37
-          python setup.py -q install -noCheck
-        else 
-          cd api_34
-          python setup.py -q install -noCheck
-        fi
+        py_ver=$(python -c 'import sys;print("%s%s" % sys.version_info[:2])')
+        echo $py_ver
+        gams_ver=api
+        for ver in api_*; do
+            echo $ver
+            if test ${ver:4} -le $py_ver; then
+                gams_ver=$ver
+            fi  
+        done
+        echo $gams_ver
+        cd $gams_ver
+        python setup.py -q install -noCheck
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."

--- a/.github/workflows/ubuntu_python_matrix_test.yml
+++ b/.github/workflows/ubuntu_python_matrix_test.yml
@@ -1,9 +1,9 @@
 name: continuous-integration/github/pr/linux
 
 on:
-  pull_request:
+  push:
     branches:
-      - master
+      - mac_gams
 
 jobs:
   pyomo-linux-tests:
@@ -33,7 +33,6 @@ jobs:
         wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/linux/linux_x64_64_sfx.exe
         chmod +x linux_x64_64_sfx.exe
         ./linux_x64_64_sfx.exe -q -d gams
-        PATH=$PATH:/gams/gams24.3_linux_x64_64_sfx
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."
@@ -54,6 +53,9 @@ jobs:
     - name: Run nightly tests with test.pyomo
       run: |
         echo "Run test.pyomo..."
-        pip install nose
-        KEY_JOB=1
-        test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries
+        PATH=$PATH:gams/gams24.3_linux_x64_64_sfx/
+        export PATH
+        gams
+        #pip install nose
+        #KEY_JOB=1
+        #test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries

--- a/.github/workflows/ubuntu_python_matrix_test.yml
+++ b/.github/workflows/ubuntu_python_matrix_test.yml
@@ -33,7 +33,7 @@ jobs:
         wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/linux/linux_x64_64_sfx.exe
         chmod +x linux_x64_64_sfx.exe
         ./linux_x64_64_sfx.exe -q -d gams
-        python gams/gams24.8_linux_x64_64_sfx/apifiles/Python/api/setup.py install -noCheck
+        python gams/gams24.8_linux_x64_64_sfx/apifiles/Python/api/setup.py install 
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."

--- a/.github/workflows/ubuntu_python_matrix_test.yml
+++ b/.github/workflows/ubuntu_python_matrix_test.yml
@@ -34,16 +34,13 @@ jobs:
         chmod +x linux_x64_64_sfx.exe
         ./linux_x64_64_sfx.exe -q -d gams
         cd gams/gams29.1_linux_x64_64_sfx/apifiles/Python/
-        py_ver=$(python -c 'import sys;print("%s%s" % sys.version_info[:2])')
-        echo $py_ver
+        y_ver=$(python -c 'import sys;print("%s%s" % sys.version_info[:2])')
         gams_ver=api
         for ver in api_*; do
-            echo $ver
             if test ${ver:4} -le $py_ver; then
                 gams_ver=$ver
             fi  
         done
-        echo $gams_ver
         cd $gams_ver
         python setup.py -q install -noCheck
     - name: Install Pyomo and extensions

--- a/.github/workflows/ubuntu_python_matrix_test.yml
+++ b/.github/workflows/ubuntu_python_matrix_test.yml
@@ -33,7 +33,8 @@ jobs:
         wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/linux/linux_x64_64_sfx.exe
         chmod +x linux_x64_64_sfx.exe
         ./linux_x64_64_sfx.exe -q -d gams
-        python gams/gams24.8_linux_x64_64_sfx/apifiles/Python/api/setup.py install 
+        cd gams/gams24.8_linux_x64_64_sfx/apifiles/Python/api
+        python setup.py -q install 
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."

--- a/.github/workflows/ubuntu_python_matrix_test.yml
+++ b/.github/workflows/ubuntu_python_matrix_test.yml
@@ -34,7 +34,7 @@ jobs:
         chmod +x linux_x64_64_sfx.exe
         ./linux_x64_64_sfx.exe -q -d gams
         cd gams/gams29.1_linux_x64_64_sfx/apifiles/Python/
-        y_ver=$(python -c 'import sys;print("%s%s" % sys.version_info[:2])')
+        py_ver=$(python -c 'import sys;print("%s%s" % sys.version_info[:2])')
         gams_ver=api
         for ver in api_*; do
             if test ${ver:4} -le $py_ver; then

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -55,9 +55,9 @@ jobs:
         }
         catch
         {
-            Write-Host ("####################################################")
-            Write-Host ("WARNING: Pynumero_libraries is not available for Python ${{matrix.python-version}}")
-            Write-Host ("####################################################")
+            Write-Host ("##############################################################################")
+            Write-Host ("WARNING: Python ${{matrix.python-version}}: Pynumero_libraries not available. ")
+            Write-Host ("##############################################################################")
         }
         Write-Host ("")
         Write-Host ("Installing GAMS")
@@ -66,6 +66,7 @@ jobs:
         Start-Process -FilePath 'windows_x64_64.exe' -ArgumentList '/SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS' -Wait
         cd gams\apifiles\Python\
         $env:py_ver = (Get-Command python).FileVersionInfo.FileVersion
+        Write-Host ("Received Python version: " + $env:py_ver)
         if(!$env:py_ver) {
           cd api
           python setup.py -q install
@@ -76,10 +77,13 @@ jobs:
           cd api_37
           python setup.py -q install -noCheck
         }else { 
-          Write-Host ("WARNING: GAMS Python API bindings not available for Python " + ${{matrix.python-version}})
-          cd api_34
-          python setup.py -q install -noCheck
+          Write-Host ("########################################################################")
+          Write-Host ("WARNING: Python ${{matrix.python-version}}: GAMS Bindings not supported.")
+          Write-Host ("########################################################################")
         }
+        Write-Host ("")
+        Write-Host ("New Shell Environment: ")
+        gci env: | Sort Name
     - name: Install Pyomo and extensions
       shell: pwsh
       run: |
@@ -100,11 +104,12 @@ jobs:
         Write-Host "Pyomo download-extensions"
         Write-Host ("")
         Invoke-Expression "pyomo download-extensions"
+
     - name: Run nightly tests with test.pyomo
       shell: pwsh
       run: |
         $env:PYTHONWARNINGS="ignore::UserWarning"
-        Write-Host "Setup and run nosetests..."
+        Write-Host "Setup and run nosetests"
         $env:BUILD_DIR = $(Get-Location).Path
         $env:PATH += ';' + $(Get-Location).Path + "\gams"
         $env:EXP = "test.pyomo -v --cat='nightly' pyomo " + $env:BUILD_DIR + "\pyomo-model-libraries"

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -1,9 +1,9 @@
 name: continuous-integration/github/pr/win
 
 on:
-  pull_request:
+  push:
     branches:
-      - master
+      - mac_gams
 
 jobs:
   pyomo-tests:
@@ -96,5 +96,7 @@ jobs:
         $env:PYTHONWARNINGS="ignore::UserWarning"
         Write-Host "Setup and run nosetests"
         $env:BUILD_DIR = $(Get-Location).Path
-        $env:EXP = "test.pyomo -v --cat='nightly' pyomo " + $env:BUILD_DIR + "\pyomo-model-libraries"
-        Invoke-Expression $env:EXP
+        $env:PATH += $(Get-Location).Path + "\gams"
+        gams
+        #$env:EXP = "test.pyomo -v --cat='nightly' pyomo " + $env:BUILD_DIR + "\pyomo-model-libraries"
+        #Invoke-Expression $env:EXP

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -64,7 +64,7 @@ jobs:
         Write-Host ("")
         Invoke-WebRequest -Uri 'https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/windows/windows_x64_64.exe' -OutFile 'windows_x64_64.exe'
         Start-Process -FilePath 'windows_x64_64.exe' -ArgumentList '/SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS' -Wait
-        python gams\apifiles\Python\api\setup.py install -noCheck
+        python gams\apifiles\Python\api\setup.py install 
         Write-Host ("")
         Write-Host ("New Shell Environment: ")
         gci env: | Sort Name

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -62,13 +62,24 @@ jobs:
         Write-Host ("")
         Write-Host ("Installing GAMS")
         Write-Host ("")
-        Invoke-WebRequest -Uri 'https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/windows/windows_x64_64.exe' -OutFile 'windows_x64_64.exe'
+        Invoke-WebRequest -Uri 'https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0/windows/windows_x64_64.exe' -OutFile 'windows_x64_64.exe'
         Start-Process -FilePath 'windows_x64_64.exe' -ArgumentList '/SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS' -Wait
-        cd gams\apifiles\Python\api\
-        python setup.py -q install 
-        Write-Host ("")
-        Write-Host ("New Shell Environment: ")
-        gci env: | Sort Name
+        cd gams\apifiles\Python\
+        $env:py_ver = (Get-Command python).FileVersionInfo.FileVersion
+        if(!$env:py_ver) {
+          cd api
+          python setup.py -q install
+        }elseif($env:py_ver -Match '3.6') {
+          cd api_36
+          python setup.py -q install
+        }elseif($env:py_ver -Match '3.7') {
+          cd api_37
+          python setup.py -q install -noCheck
+        }else { 
+          Write-Host ("WARNING: GAMS Python API bindings not available for Python " + ${{matrix.python-version}})
+          cd api_34
+          python setup.py -q install -noCheck
+        }
     - name: Install Pyomo and extensions
       shell: pwsh
       run: |
@@ -89,12 +100,11 @@ jobs:
         Write-Host "Pyomo download-extensions"
         Write-Host ("")
         Invoke-Expression "pyomo download-extensions"
-
     - name: Run nightly tests with test.pyomo
       shell: pwsh
       run: |
         $env:PYTHONWARNINGS="ignore::UserWarning"
-        Write-Host "Setup and run nosetests"
+        Write-Host "Setup and run nosetests..."
         $env:BUILD_DIR = $(Get-Location).Path
         $env:PATH += ';' + $(Get-Location).Path + "\gams"
         $env:EXP = "test.pyomo -v --cat='nightly' pyomo " + $env:BUILD_DIR + "\pyomo-model-libraries"

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -64,6 +64,7 @@ jobs:
         Write-Host ("")
         Invoke-WebRequest -Uri 'https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/windows/windows_x64_64.exe' -OutFile 'windows_x64_64.exe'
         Start-Process -FilePath 'windows_x64_64.exe' -ArgumentList '/SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS' -Wait
+        python gams\apifiles\Python\api\setup.py install -noCheck
         Write-Host ("")
         Write-Host ("New Shell Environment: ")
         gci env: | Sort Name

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -65,7 +65,14 @@ jobs:
         Invoke-WebRequest -Uri 'https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0/windows/windows_x64_64.exe' -OutFile 'windows_x64_64.exe'
         Start-Process -FilePath 'windows_x64_64.exe' -ArgumentList '/SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS' -Wait
         cd gams\apifiles\Python\
-        $env:py_ver = (Get-Command python).FileVersionInfo.FileVersion
+        try
+        {
+            $env:py_ver = (Get-Command python3).FileVersionInfo.FileVersion
+        }
+        catch
+        {
+            $env:py_ver = (Get-Command python).FileVersionInfo.FileVersion
+        }
         Write-Host ("Received Python version: " + $env:py_ver)
         if(!$env:py_ver) {
           cd api
@@ -94,12 +101,26 @@ jobs:
         git clone --quiet https://github.com/Pyomo/pyomo-model-libraries.git
         git clone --quiet https://github.com/PyUtilib/pyutilib.git
         cd pyutilib
-        python setup.py develop
+        try
+        {
+            python3 setup.py develop
+        }
+        catch
+        {
+            python setup.py develop
+        }
         cd ..
         Write-Host ("")
         Write-Host ("Install Pyomo...")
         Write-Host ("")
-        python setup.py develop
+        try
+        {
+            python3 setup.py develop
+        }
+        catch
+        {
+            python setup.py develop
+        }
         Write-Host ("")
         Write-Host "Pyomo download-extensions"
         Write-Host ("")

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -25,12 +25,15 @@ jobs:
       run: |
         $env:PYTHONWARNINGS="ignore::UserWarning"
         Write-Host ("Current Enviroment variables: ")
-        gci env: | Sort Name
+        gci env:Path | Sort Name
         Write-Host ("")
         Write-Host ("Update conda, then force it to NOT update itself again...")
         Write-Host ("")
         Invoke-Expression "conda config --set always_yes yes"
         Invoke-Expression "conda config --set auto_update_conda false"
+        conda info
+        conda config --show-sources
+        conda list --show-channel-urls
         Write-Host ("")
         Write-Host ("Setting Conda Env Vars... ")
         Write-Host ("")
@@ -58,29 +61,25 @@ jobs:
             Write-Host ("##############################################################################")
             Write-Host ("WARNING: Python ${{matrix.python-version}}: Pynumero_libraries not available. ")
             Write-Host ("##############################################################################")
+            conda deactivate
+            conda activate test 
         }
+        conda list --show-channel-urls
         Write-Host ("")
         Write-Host ("Installing GAMS")
         Write-Host ("")
         Invoke-WebRequest -Uri 'https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0/windows/windows_x64_64.exe' -OutFile 'windows_x64_64.exe'
         Start-Process -FilePath 'windows_x64_64.exe' -ArgumentList '/SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS' -Wait
         cd gams\apifiles\Python\
-        try
-        {
-            $env:py_ver = (Get-Command python3).FileVersionInfo.FileVersion
-        }
-        catch
-        {
-            $env:py_ver = (Get-Command python).FileVersionInfo.FileVersion
-        }
-        Write-Host ("Received Python version: " + $env:py_ver)
-        if(!$env:py_ver) {
+        if(${{matrix.python-version}} -eq 2.7) {
           cd api
           python setup.py -q install
-        }elseif($env:py_ver -Match '3.6') {
+        }elseif(${{matrix.python-version}} -eq 3.6) {
+          Write-Host ("PYTHON ${{matrix.python-version}}")
           cd api_36
           python setup.py -q install
-        }elseif($env:py_ver -Match '3.7') {
+        }elseif(${{matrix.python-version}} -eq 3.7) {
+          Write-Host ("PYTHON ${{matrix.python-version}}")
           cd api_37
           python setup.py -q install -noCheck
         }else { 

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -64,8 +64,7 @@ jobs:
         Write-Host ("Installing GAMS")
         Write-Host ("")
         Invoke-WebRequest -Uri 'https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/windows/windows_x64_64.exe' -OutFile 'windows_x64_64.exe'
-        Start-Process -FilePath 'windows_x64_64.exe' -ArgumentList '/SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS'
-        $env:PATH += $(Get-Location).Path + "\gams"
+        Start-Process -FilePath 'windows_x64_64.exe' -ArgumentList '/SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS' -Wait
         Write-Host ("")
         Write-Host ("New Shell Environment: ")
         gci env: | Sort Name
@@ -96,7 +95,7 @@ jobs:
         $env:PYTHONWARNINGS="ignore::UserWarning"
         Write-Host "Setup and run nosetests"
         $env:BUILD_DIR = $(Get-Location).Path
-        $env:PATH += $(Get-Location).Path + "\gams"
+        $env:PATH += ';' + $(Get-Location).Path + "\gams"
         gams
         #$env:EXP = "test.pyomo -v --cat='nightly' pyomo " + $env:BUILD_DIR + "\pyomo-model-libraries"
         #Invoke-Expression $env:EXP

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -64,7 +64,8 @@ jobs:
         Write-Host ("")
         Invoke-WebRequest -Uri 'https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/windows/windows_x64_64.exe' -OutFile 'windows_x64_64.exe'
         Start-Process -FilePath 'windows_x64_64.exe' -ArgumentList '/SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS' -Wait
-        python gams\apifiles\Python\api\setup.py install 
+        cd gams\apifiles\Python\api\
+        python setup.py -q install 
         Write-Host ("")
         Write-Host ("New Shell Environment: ")
         gci env: | Sort Name

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -1,18 +1,17 @@
 name: continuous-integration/github/pr/win
 
 on:
-  push:
+  pull_request:
     branches:
-      - mac_gams
+      - master
 
 jobs:
   pyomo-tests:
     name: py${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
     strategy:
       fail-fast: false # This flag causes all of the matrix to continue to run, even if one matrix option fails
       matrix:
-        os: ['windows-latest']
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8] 
     steps:
     - uses: actions/checkout@v1
@@ -96,6 +95,5 @@ jobs:
         Write-Host "Setup and run nosetests"
         $env:BUILD_DIR = $(Get-Location).Path
         $env:PATH += ';' + $(Get-Location).Path + "\gams"
-        gams
-        #$env:EXP = "test.pyomo -v --cat='nightly' pyomo " + $env:BUILD_DIR + "\pyomo-model-libraries"
-        #Invoke-Expression $env:EXP
+        $env:EXP = "test.pyomo -v --cat='nightly' pyomo " + $env:BUILD_DIR + "\pyomo-model-libraries"
+        Invoke-Expression $env:EXP


### PR DESCRIPTION
## Fixes #1279 

## Summary/Motivation:
GAMS is represented in Windows and Linux testing. We need to add it to MacOS.

## Changes proposed in this PR:
- Add GAMS installation to MacOS
- GAMS version 29.1.0 (older distributions do not install on Mac 10.15)
- Fix Windows/Linux path variables for GAMS solver

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
