### PR TITLE
Fix component decorator return value

### DIFF
--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -106,6 +106,7 @@ class _generic_component_decorator(object):
             rule.__name__,
             self._component(*self._args, rule=rule, **(self._kwds))
         )
+        return rule
 
 
 class _component_decorator(object):

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -14,6 +14,7 @@
 import os
 import sys
 import six
+import types
 
 from six import StringIO
 
@@ -2363,6 +2364,7 @@ class TestBlock(unittest.TestCase):
         self.assertTrue(hasattr(model, 'scalar_constraint'))
         self.assertIs(model.scalar_constraint._type, Constraint)
         self.assertEqual(len(model.scalar_constraint), 1)
+        self.assertIs(type(scalar_constraint), types.FunctionType)
 
         @model.Constraint(model.I)
         def vector_constraint(m, i):
@@ -2371,6 +2373,7 @@ class TestBlock(unittest.TestCase):
         self.assertTrue(hasattr(model, 'vector_constraint'))
         self.assertIs(model.vector_constraint._type, Constraint)
         self.assertEqual(len(model.vector_constraint), 3)
+        self.assertIs(type(vector_constraint), types.FunctionType)
 
     def test_reserved_words(self):
         m = ConcreteModel()


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Currently, the "`@model.Constraint()`" notation masks the decorated function:
```python
@model.Constraint()
def foo(m):
    return m.x >= 0
```
results in `foo` being declared in the local namespace, but `type(foo) is None`.  This PR fixes it so that `foo` is the original rule function.

## Changes proposed in this PR:
- Fix return value for component decorator

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
