### PR TITLE
Fix report_timing for constructing objects without index_set()

### DIFF
--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -1,0 +1,56 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import pyutilib.th as unittest
+
+from six import StringIO
+
+from pyomo.common.log import LoggingIntercept
+from pyomo.common.timing import ConstructionTimer, report_timing
+from pyomo.environ import ConcreteModel, RangeSet, Var
+
+class TestTiming(unittest.TestCase):
+    def test_raw_construction_timer(self):
+        a = ConstructionTimer(None)
+        self.assertIn(
+            "ConstructionTimer object for NoneType (unknown); ",
+            str(a))
+
+    def test_report_timing(self):
+        # Create a set to ensure that the global sets have already been
+        # constructed (this is an issue until the new set system is
+        # merged in and the GlobalSet objects are not automatically
+        # created by pyomo.core
+        m = ConcreteModel()
+        m.x = Var([1,2])
+
+        ref = """
+           0 seconds to construct Block ConcreteModel; 1 index total
+           0 seconds to construct RangeSet r; 1 index total
+           0 seconds to construct Var x; 2 indicies total
+""".strip()
+
+        os = StringIO()
+        try:
+            report_timing(os)
+            m = ConcreteModel()
+            m.r = RangeSet(2)
+            m.x = Var(m.r)
+            self.assertEqual(os.getvalue().strip(), ref)
+        finally:
+            report_timing(False)
+        buf = StringIO()
+        with LoggingIntercept(buf, 'pyomo'):
+            m = ConcreteModel()
+            m.r = RangeSet(2)
+            m.x = Var(m.r)
+            self.assertEqual(os.getvalue().strip(), ref)
+            self.assertEqual(buf.getvalue().strip(), "")
+

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -35,7 +35,10 @@ class ConstructionTimer(object):
 
     def __str__(self):
         total_time = self.timer
-        idx = len(self.obj.index_set())
+        try:
+            idx = len(self.obj.index_set())
+        except AttributeError:
+            idx = 1
         try:
             name = self.obj.name
         except RuntimeError:
@@ -43,16 +46,22 @@ class ConstructionTimer(object):
                 name = self.obj.local_name
             except RuntimeError:
                 name = '(unknown)'
+        except AttributeError:
+            name = '(unknown)'
+        try:
+            _type = self.obj.type().__name__
+        except AttributeError:
+            _type = type(self.obj).__name__
         try:
             return self.fmt % ( 2 if total_time>=0.005 else 0,
-                                self.obj.type().__name__,
+                                _type,
                                 name,
                                 idx,
                                 'indicies' if idx > 1 else 'index',
                             ) % total_time
         except TypeError:
             return "ConstructionTimer object for %s %s; %s elapsed seconds" % (
-                self.obj.type().__name__,
+                _type,
                 name,
                 self.timer.toc("") )
 


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This fixes the exception being raised by `report_timing()` for non-indexed components (that do not implement the `index_set()` method.

## Changes proposed in this PR:
- fix exception raised when component is not an IndexedCOmponent
- add unit tests for the construction timer

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
