### PR TITLE
NFC: Remove CBC from our installation documentation

### DIFF
--- a/doc/OnlineDocs/installation.rst
+++ b/doc/OnlineDocs/installation.rst
@@ -23,7 +23,7 @@ optimization solvers can be installed with conda as well:
 
 ::
 
-   conda install -c conda-forge ipopt coincbc glpk
+   conda install -c conda-forge ipopt glpk
 
 
 Using PIP


### PR DESCRIPTION
## Fixes #1302 

## Summary/Motivation:
This removes CBC from the list of solvers that we mention can be installed using conda in our installation documentation. @CatChenal pointed out that the conda package only works on Linux and OSX and @mrmundt pointed out that the newer version of CBC causes test failures (#1295). Rather than update the documentation with a bunch of caveats for a particular solver, I think the better approach is to remove it completely for now. We should probably add a section to the documentation that gives more guidance on installing different solvers but that is outside the scope of this PR.

## Changes proposed in this PR:
- Remove CBC from our conda installation documentation

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
