### PR TITLE
Parse `noSolution` status from CPLEXShell and CPLEXDirect solvers correctly

### DIFF
--- a/pyomo/opt/base/problem.py
+++ b/pyomo/opt/base/problem.py
@@ -8,7 +8,13 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = [ 'AbstractProblemWriter', 'WriterFactory', 'ProblemConfigFactory', 'BaseProblemConfig' ]
+__all__ = [
+    "AbstractProblemWriter",
+    "WriterFactory",
+    "ProblemConfigFactory",
+    "BaseProblemConfig",
+    "BranchDirection",
+]
 
 from pyomo.common import Factory
 
@@ -44,3 +50,12 @@ class AbstractProblemWriter(object):
     def __exit__(self, t, v, traceback):
         pass
 
+
+class BranchDirection(object):
+    """ Allowed values for MIP variable branching directions in the `direction` Suffix of a model. """
+
+    default = 0
+    down = -1
+    up = 1
+
+    ALL = {default, down, up}

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -510,7 +510,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
 
         for line in output.split("\n"):
             tokens = re.split('[ \t]+',line.strip())
-            if len(tokens) > 3 and tokens[0] == "CPLEX" and tokens[1] == "Error":
+            if len(tokens) > 3 and ("CPLEX", "Error") in {tuple(tokens[0:2]), tuple(tokens[1:3])}:
             # IMPT: See below - cplex can generate an error line and then terminate fine, e.g., in CPLEX 12.1.
             #       To handle these cases, we should be specifying some kind of termination criterion always
             #       in the course of parsing a log file (we aren't doing so currently - just in some conditions).
@@ -518,6 +518,8 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 results.solver.error = " ".join(tokens)
             elif len(tokens) >= 3 and tokens[0] == "ILOG" and tokens[1] == "CPLEX":
                 cplex_version = tokens[2].rstrip(',')
+            elif len(tokens) >= 3 and tokens[1] == "Version":
+                cplex_version = tokens[3]
             elif len(tokens) >= 3 and tokens[0] == "Variables":
                 if results.problem.number_of_variables is None: # CPLEX 11.2 and subsequent versions have two Variables sections in the log file output.
                     results.problem.number_of_variables = int(tokens[2])
@@ -532,9 +534,9 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
             elif len(tokens) >= 3 and tokens[0] == "Nonzeros":
                 if results.problem.number_of_nonzeros is None: # CPLEX 11.2 and subsequent has two Nonzeros sections.
                     results.problem.number_of_nonzeros = int(tokens[2])
-            elif len(tokens) >= 5 and tokens[4] == "MINIMIZE":
+            elif (len(tokens) >= 5 and tokens[4] == "MINIMIZE") or (len(tokens) >= 4 and tokens[3] == 'Minimize'):
                 results.problem.sense = ProblemSense.minimize
-            elif len(tokens) >= 5 and tokens[4] == "MAXIMIZE":
+            elif (len(tokens) >= 5 and tokens[4] == "MAXIMIZE") or (len(tokens) >= 4 and tokens[3] == 'Maximize'):
                 results.problem.sense = ProblemSense.maximize
             elif len(tokens) >= 4 and tokens[0] == "Solution" and tokens[1] == "time" and tokens[2] == "=":
                 # technically, I'm not sure if this is CPLEX user time or user+system - CPLEX doesn't appear
@@ -565,6 +567,9 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 # handle processing when the time limit has been exceeded, and we have a feasible solution.
                 results.solver.status = SolverStatus.ok
                 results.solver.termination_condition = TerminationCondition.maxTimeLimit
+                results.solver.termination_message = ' '.join(tokens)
+            elif len(tokens) >= 6 and tokens[0] == "MIP" and tuple(tokens[5:]) == ('no', 'integer', 'solution.'):
+                results.solver.termination_condition = TerminationCondition.noSolution
                 results.solver.termination_message = ' '.join(tokens)
             elif len(tokens) >= 10 and tokens[0] == "Current" and tokens[1] == "MIP" and tokens[2] == "best" and tokens[3] == "bound":
                 self._best_bound = float(tokens[5])

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -23,6 +23,7 @@ from pyomo.opt.base.solvers import _extract_version
 from pyomo.opt.results import *
 from pyomo.opt.solver import *
 from pyomo.solvers.mockmip import MockMIP
+from pyomo.core.base import Var, ComponentMap, Suffix, active_export_suffix_generator
 from pyomo.core.kernel.block import IBlock
 
 logger = logging.getLogger('pyomo.solvers')
@@ -112,6 +113,28 @@ class CPLEX(OptSolver):
         return opt
 
 
+class ORDFileSchema(object):
+    HEADER = "* ENCODING=ISO-8859-1\nNAME             Priority Order\n"
+    FOOTER = "ENDATA\n"
+
+    @classmethod
+    def ROW(cls, name, priority, branch_direction=None):
+        return " %s %s %s\n" % (
+            cls._direction_to_str(branch_direction),
+            name,
+            priority,
+        )
+
+    @staticmethod
+    def _direction_to_str(branch_direction):
+        try:
+            return {BranchDirection.down: "DN", BranchDirection.up: "UP"}[
+                branch_direction
+            ]
+        except KeyError:
+            return ""
+
+
 @SolverFactory.register('_cplex_shell', doc='Shell interface to the CPLEX LP/MIP solver')
 class CPLEXSHELL(ILMLicensedSystemCallSolver):
     """Shell interface to the CPLEX LP/MIP solver
@@ -162,9 +185,6 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
     # write a warm-start file in the CPLEX MST format.
     #
     def _warm_start(self, instance):
-
-        from pyomo.core.base import Var
-
         # for each variable in the symbol_map, add a child to the
         # variables element.  Both continuous and discrete are accepted
         # (and required, depending on other options), according to the
@@ -201,6 +221,76 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
             mst_file.write("</variables>\n")
             mst_file.write("</CPLEXSolution>\n")
 
+    # Expected names of `Suffix` components for branching priorities and directions respectively
+    SUFFIX_PRIORITY_NAME = "priority"
+    SUFFIX_DIRECTION_NAME = "direction"
+
+    def _write_priorities_file(self, instance):
+        """ Write a variable priorities file in the CPLEX ORD format. """
+        priorities, directions = self._get_suffixes(instance)
+        rows = self._convert_priorities_to_rows(instance, priorities, directions)
+        self._write_priority_rows(rows)
+
+    def _get_suffixes(self, instance):
+        if isinstance(instance, IBlock):
+            suffixes = pyomo.core.kernel.suffix.export_suffix_generator(
+                instance, datatype=Suffix.INT, active=True, descend_into=False
+            )
+        else:
+            suffixes = active_export_suffix_generator(instance, datatype=Suffix.INT)
+        suffixes = dict(suffixes)
+
+        if self.SUFFIX_PRIORITY_NAME not in suffixes:
+            raise ValueError(
+                "Cannot write branching priorities file as `model.%s` Suffix has not been declared."
+                % (self.SUFFIX_PRIORITY_NAME,)
+            )
+
+        return (
+            suffixes[self.SUFFIX_PRIORITY_NAME],
+            suffixes.get(self.SUFFIX_DIRECTION_NAME, ComponentMap()),
+        )
+
+    def _convert_priorities_to_rows(self, instance, priorities, directions):
+        if isinstance(instance, IBlock):
+            smap = getattr(instance, "._symbol_maps")[self._smap_id]
+        else:
+            smap = instance.solutions.symbol_map[self._smap_id]
+        byObject = smap.byObject
+
+        rows = []
+        for var, priority in priorities.items():
+            if priority is None or not var.active:
+                continue
+
+            if not (0 <= priority == int(priority)):
+                raise ValueError("`priority` must be a non-negative integer")
+
+            var_direction = directions.get(var, BranchDirection.default)
+
+            if not var.is_indexed():
+                if id(var) not in byObject:
+                    continue
+
+                rows.append((byObject[id(var)], priority, var_direction))
+                continue
+
+            for child_var in var.values():
+                if id(child_var) not in byObject:
+                    continue
+
+                child_var_direction = directions.get(child_var, var_direction)
+
+                rows.append((byObject[id(child_var)], priority, child_var_direction))
+        return rows
+
+    def _write_priority_rows(self, rows):
+        with open(self._priorities_file_name, "w") as ord_file:
+            ord_file.write(ORDFileSchema.HEADER)
+            for var_name, priority, direction in rows:
+                ord_file.write(ORDFileSchema.ROW(var_name, priority, direction))
+            ord_file.write(ORDFileSchema.FOOTER)
+
     # over-ride presolve to extract the warm-start keyword, if specified.
     def _presolve(self, *args, **kwds):
 
@@ -234,6 +324,21 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 self._warm_start_file_name = pyutilib.services.TempfileManager.\
                                              create_tempfile(suffix = '.cplex.mst')
 
+        self._priorities_solve = kwds.pop("priorities", False)
+        self._priorities_file_name = _validate_file_name(
+            self, kwds.pop("priorities_file", None), "branching priorities"
+        )
+        user_priorities = self._priorities_file_name is not None
+
+        if (
+            self._priorities_solve
+            and not isinstance(args[0], basestring)
+            and not user_priorities
+        ):
+            self._priorities_file_name = pyutilib.services.TempfileManager.create_tempfile(
+                suffix=".cplex.ord"
+            )
+
         # let the base class handle any remaining keywords/actions.
         ILMLicensedSystemCallSolver._presolve(self, *args, **kwds)
 
@@ -258,6 +363,16 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 if self._report_timing:
                     print("Warm start write time= %.2f seconds"
                           % (end_time-start_time))
+
+            if self._priorities_solve and (not user_priorities):
+                start_time = time.time()
+                self._write_priorities_file(args[0])
+                end_time = time.time()
+                if self._report_timing:
+                    print(
+                        "Branching priorities write time= %.2f seconds"
+                        % (end_time - start_time)
+                    )
 
     def _default_executable(self):
         executable = pyomo.common.Executable("cplex")
@@ -328,6 +443,9 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
            (self._warm_start_file_name is not None):
             script += 'read %s\n' % (self._warm_start_file_name,)
 
+        if self._priorities_solve and self._priorities_file_name is not None:
+            script += "read %s\n" % (self._priorities_file_name,)
+
         if 'relax_integrality' in self.options:
             script += 'change problem lp\n'
 
@@ -350,6 +468,9 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                (self._warm_start_file_name is not None):
                 print("Solver warm-start file="
                       +self._warm_start_file_name)
+
+            if self._priorities_solve and self._priorities_file_name is not None:
+                print("Solver priorities file=" + self._priorities_file_name)
 
         #
         # Define command line

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -9,9 +9,14 @@
 #  ___________________________________________________________________________
 
 import os
+
+import pyutilib
 import pyutilib.th as unittest
 
-from pyomo.solvers.plugins.solvers.CPLEX import _validate_file_name
+from pyomo.core import Binary, ConcreteModel, Constraint, Objective, Var, Integers, RangeSet, minimize, quicksum, Suffix
+from pyomo.opt import ProblemFormat, convert_problem, SolverFactory, BranchDirection
+from pyomo.solvers.plugins.solvers.CPLEX import CPLEXSHELL, MockCPLEX, _validate_file_name, ORDFileSchema
+
 
 class _mock_cplex_128(object):
     def version(self):
@@ -53,6 +58,197 @@ class CPLEX_utils(unittest.TestCase):
             _validate_file_name(_126, fname, 'xxx')
         with self.assertRaisesRegexp(ValueError, msg):
             _validate_file_name(_128, fname, 'xxx')
+
+
+class CPLEXShellWritePrioritiesFile(unittest.TestCase):
+    def setUp(self):
+        from pyomo.solvers.plugins.converter.model import PyomoMIPConverter  # register the `ProblemConverterFactory`
+        from pyomo.repn.plugins.cpxlp import ProblemWriter_cpxlp  # register the `WriterFactory`
+
+        self.mock_model = self.get_mock_model()
+        self.mock_cplex_shell = self.get_mock_cplex_shell(self.mock_model)
+        self.mock_cplex_shell._priorities_file_name = pyutilib.services.TempfileManager.create_tempfile(
+            suffix=".cplex.ord"
+        )
+
+    def tearDown(self):
+        pyutilib.services.TempfileManager.clear_tempfiles()
+
+    def get_mock_model(self):
+        model = ConcreteModel()
+        model.x = Var(within=Binary)
+        model.con = Constraint(expr=model.x >= 1)
+        model.obj = Objective(expr=model.x)
+        return model
+
+    def get_mock_cplex_shell(self, mock_model):
+        solver = MockCPLEX()
+        solver._problem_files, solver._problem_format, solver._smap_id = convert_problem(
+            (mock_model,),
+            ProblemFormat.cpxlp,
+            [ProblemFormat.cpxlp],
+            has_capability=lambda x: True,
+        )
+        return solver
+
+    def get_priorities_file_as_string(self, mock_cplex_shell):
+        with open(mock_cplex_shell._priorities_file_name, "r") as ord_file:
+            priorities_file = ord_file.read()
+        return priorities_file
+
+    def test_write_without_priority_suffix(self):
+        with self.assertRaises(ValueError):
+            CPLEXSHELL._write_priorities_file(self.mock_cplex_shell, self.mock_model)
+
+    def test_write_priority_to_priorities_file(self):
+        self.mock_model.priority = Suffix(direction=Suffix.EXPORT, datatype=Suffix.INT)
+        priority_val = 10
+        self.mock_model.priority.set_value(self.mock_model.x, priority_val)
+
+        CPLEXSHELL._write_priorities_file(self.mock_cplex_shell, self.mock_model)
+        priorities_file = self.get_priorities_file_as_string(self.mock_cplex_shell)
+
+        self.assertEqual(
+            priorities_file,
+            "* ENCODING=ISO-8859-1\nNAME             Priority Order\n  x1 %d\nENDATA\n"
+            % (priority_val,),
+        )
+
+    def test_write_priority_and_direction_to_priorities_file(self):
+        self.mock_model.priority = Suffix(direction=Suffix.EXPORT, datatype=Suffix.INT)
+        priority_val = 10
+        self.mock_model.priority.set_value(self.mock_model.x, priority_val)
+
+        self.mock_model.direction = Suffix(direction=Suffix.EXPORT, datatype=Suffix.INT)
+        direction_val = BranchDirection.down
+        self.mock_model.direction.set_value(self.mock_model.x, direction_val)
+
+        CPLEXSHELL._write_priorities_file(self.mock_cplex_shell, self.mock_model)
+        priorities_file = self.get_priorities_file_as_string(self.mock_cplex_shell)
+
+        self.assertEqual(
+            priorities_file,
+            "* ENCODING=ISO-8859-1\nNAME             Priority Order\n %s x1 %d\nENDATA\n"
+            % (ORDFileSchema._direction_to_str(direction_val), priority_val),
+        )
+
+    def test_raise_due_to_invalid_priority(self):
+        self.mock_model.priority = Suffix(direction=Suffix.EXPORT, datatype=Suffix.INT)
+        self.mock_model.priority.set_value(self.mock_model.x, -1)
+        with self.assertRaises(ValueError):
+            CPLEXSHELL._write_priorities_file(self.mock_cplex_shell, self.mock_model)
+
+        self.mock_model.priority.set_value(self.mock_model.x, 1.1)
+        with self.assertRaises(ValueError):
+            CPLEXSHELL._write_priorities_file(self.mock_cplex_shell, self.mock_model)
+
+    def test_use_default_due_to_invalid_direction(self):
+        self.mock_model.priority = Suffix(direction=Suffix.EXPORT, datatype=Suffix.INT)
+        priority_val = 10
+        self.mock_model.priority.set_value(self.mock_model.x, priority_val)
+
+        self.mock_model.direction = Suffix(direction=Suffix.EXPORT, datatype=Suffix.INT)
+        self.mock_model.direction.set_value(
+            self.mock_model.x, "invalid_branching_direction"
+        )
+
+        CPLEXSHELL._write_priorities_file(self.mock_cplex_shell, self.mock_model)
+        priorities_file = self.get_priorities_file_as_string(self.mock_cplex_shell)
+
+        self.assertEqual(
+            priorities_file,
+            "* ENCODING=ISO-8859-1\nNAME             Priority Order\n  x1 %d\nENDATA\n"
+            % (priority_val,),
+        )
+
+
+class CPLEXShellSolvePrioritiesFile(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def get_mock_model_with_priorities(self):
+        m = ConcreteModel()
+        m.x = Var(domain=Integers)
+        m.s = RangeSet(10)
+        m.y = Var(m.s, domain=Integers)
+        m.o = Objective(expr=m.x + sum(m.y), sense=minimize)
+        m.c = Constraint(expr=m.x >= 1)
+        m.c2 = Constraint(expr=quicksum(m.y[i] for i in m.s) >= 10)
+
+        m.priority = Suffix(direction=Suffix.EXPORT, datatype=Suffix.INT)
+        m.direction = Suffix(direction=Suffix.EXPORT, datatype=Suffix.INT)
+
+        m.priority.set_value(m.x, 1)
+
+        # Ensure tests work for both options of `expand`
+        m.priority.set_value(m.y, 2, expand=False)
+        m.direction.set_value(m.y, BranchDirection.down, expand=True)
+
+        m.direction.set_value(m.y[10], BranchDirection.up)
+        return m
+
+    def test_use_variable_priorities(self):
+        model = self.get_mock_model_with_priorities()
+        with SolverFactory("_mock_cplex") as opt:
+            opt._presolve(model, priorities=True, keepfiles=True)
+
+            with open(opt._priorities_file_name, "r") as ord_file:
+                priorities_file = ord_file.read()
+
+        assert priorities_file == (
+            "* ENCODING=ISO-8859-1\n"
+            "NAME             Priority Order\n"
+            "  x1 1\n"
+            " DN x2 2\n"
+            " DN x3 2\n"
+            " DN x4 2\n"
+            " DN x5 2\n"
+            " DN x6 2\n"
+            " DN x7 2\n"
+            " DN x8 2\n"
+            " DN x9 2\n"
+            " DN x10 2\n"
+            " UP x11 2\n"
+            "ENDATA\n"
+        )
+
+        assert "read %s\n" % (opt._priorities_file_name,) in opt._command.script
+
+    def test_ignore_variable_priorities(self):
+        model = self.get_mock_model_with_priorities()
+        with SolverFactory("_mock_cplex") as opt:
+            opt._presolve(model, priorities=False, keepfiles=True)
+
+            assert opt._priorities_file_name is None
+            assert ".ord" not in opt._command.script
+
+    def test_can_use_manual_priorities_file_with_lp_solve(self):
+        """ Test that we can pass an LP file (not a pyomo model) along with a priorities file to `.solve()` """
+        model = self.get_mock_model_with_priorities()
+
+        with SolverFactory("_mock_cplex") as pre_opt:
+            pre_opt._presolve(model, priorities=True, keepfiles=True)
+            lp_file = pre_opt._problem_files[0]
+            priorities_file_name = pre_opt._priorities_file_name
+
+            with open(priorities_file_name, "r") as ord_file:
+                provided_priorities_file = ord_file.read()
+
+        with SolverFactory("_mock_cplex") as opt:
+            opt._presolve(
+                lp_file,
+                priorities=True,
+                priorities_file=priorities_file_name,
+                keepfiles=True,
+            )
+
+            assert ".ord" in opt._command.script
+
+            with open(opt._priorities_file_name, "r") as ord_file:
+                priorities_file = ord_file.read()
+
+        assert priorities_file == provided_priorities_file
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Fixes

## Summary/Motivation:
Currently when CPLEX returns "No Solution", this isn't captured in any of the Pyomo solution or solver data objects. We can identify "No Solution" because when both of (1) max time limit is reached and (2) the model is infeasible occur.

## Changes proposed in this PR:

### `CPLEXDirect`
- Clean up the status codes in `_postsolve()` to use the actual CPLEX library constants
- Add new logic to handle `MIP_time_limit_infeasible` and `MIP_dettime_limit_infeasible` as indicating a solver `termination_condition` of `noSolution`
- Get the solver return code if possible from any `CplexSolverError`s (but don't add this to the returned `Bunch` due to downstream code raising `ApplicationError`s)
- Set `results.solver.return_code` and `results.solver.termination_message` using the available information

### `CPLEXSHELL`
- Fix `process_logfile()` for CPLEX 12.10 as it looks like IBM have updated the log file schema and is no longer being parsed correctly
- Add new logic to handle `'no integer solution.'` in the log file as indicating a solver `termination_condition` of `noSolution`
- Get the solver return code if possible from any `CPLEX Error` lines in the log file

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
