### PR TITLE
Add flatten_dae_variables() utility

### DIFF
--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -13,6 +13,12 @@ from pyomo.core.base.sets import _SetProduct
 from pyomo.core.base.indexed_component_slice import _IndexedComponent_slice
 
 def identify_member_sets(index):
+    """
+    Identify all of the individual subsets in an indexing set. When the
+    Set rewrite is finished this function should no longer be needed,
+    the `subsets` method will provide this functionality.
+    """
+
     if index is None:
         return []
     queue = [index]
@@ -81,13 +87,13 @@ def generate_time_only_slices(obj, time):
 
 def generate_time_indexed_block_slices(block, time):
     # TODO: We should probably do a sanity check that time does not
-    # appeat in any sub-block / var indices.
+    # appear in any sub-block / var indices.
     queue = list( generate_time_only_slices(block, time) )
     while queue:
         _slice = queue.pop(0)
         # Pick a random block from this slice (i.e. TIME == TIME.first())
         #
-        # TODO: we should probably sometime check that the OTHER blocks
+        # TODO: we should probably check that the OTHER blocks
         # in the time set have the same variables.
         b = next(iter(_slice))
         # Any sub-blocks must be put on the queue to descend into and
@@ -104,6 +110,27 @@ def generate_time_indexed_block_slices(block, time):
         
 
 def flatten_dae_variables(model, time):
+    """
+    This function takes in a (hierarchical, block-structured) Pyomo
+    model and a `ContinuousSet` and returns two lists of "flattened"
+    variables. The first is a list of all `_VarData` that are not
+    indexed by the `ContinuousSet` and the second is a list of
+    `Reference` components such that each reference is indexed only by
+    the specified `ContinuousSet`. This function is convenient for
+    identifying variables that are implicitly indexed by the
+    `ContinuousSet`, for example, a singleton `Var` living on a `Block`
+    that is indexed by the `ContinuousSet`.
+
+    Parameters
+    ----------
+    model : Concrete Pyomo model
+
+    time : ``pyomo.dae.ContinuousSet``
+
+    Returns
+    -------
+    Two lists
+    """
     assert time.model() is model.model()
 
     block_queue = [model]

--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -1,0 +1,130 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+from pyomo.core.base import Block, Var, Reference
+from pyomo.core.base.block import SubclassOf
+from pyomo.core.base.sets import _SetProduct
+from pyomo.core.base.indexed_component_slice import _IndexedComponent_slice
+
+def identify_member_sets(index):
+    if index is None:
+        return []
+    queue = [index]
+    ans = []
+    while queue:
+        s = queue.pop(0)
+        if not isinstance(s, _SetProduct):
+            ans.append(s)
+        else:
+            queue.extend(s.set_tuple)
+    return ans
+
+
+def generate_time_only_slices(obj, time):
+    o_sets = identify_member_sets(obj.index_set())
+    # Given a potentially complex set, determine the index of the TIME
+    # set, as well as all other "fixed" indices.  We will even support a
+    # single Set with dimen==None (using ellipsis in the slice).
+    ellipsis_idx = None
+    time_idx = None
+    regular_idx = []
+    idx = 0
+    for s in o_sets:
+        if s is time:
+            time_idx = idx
+            idx += 1
+        elif s.dimen is not None:
+            for sub_idx in range(s.dimen):
+                regular_idx.append(idx)
+            idx += s.dimen
+        elif ellipsis_idx is None:
+            ellipsis_idx = idx
+            idx += 1
+        else:
+            raise RuntimeError(
+                "We can only handle a single Set with dimen=None")
+    # To support Sets with dimen==None (using ellipsis), we need to have
+    # all fixed/time indices be positive if they appear before the
+    # ellipsis and negative (counting from the end of the list) if they
+    # are after the ellipsis.
+    if ellipsis_idx:
+        if time_idx > ellipsis_idx:
+            time_idx = time_idx - idx
+        regular_idx = [ i - idx if i > ellipsis_idx else i
+                      for i in fixed_idx ]
+    # We now form a temporary slice that slices over all the regular
+    # indices for a fixed value of the time index.
+    tmp_sliced = {i: slice(None) for i in regular_idx}
+    tmp_fixed = {time_idx: time.first()}
+    tmp_ellipsis = ellipsis_idx
+    _slice = _IndexedComponent_slice(
+        obj, tmp_fixed, tmp_sliced, tmp_ellipsis
+    )
+    # For each combination of regular indices, we can generate a single
+    # slice over the time index
+    time_sliced = {time_idx: time.first()}
+    for key in _slice.wildcard_keys():
+        if type(key) is not tuple:
+            key = (key,)
+        time_fixed = dict(
+            (i, val) if i<time_idx else (i+1, val)
+            for i,val in enumerate(key)
+        )
+        yield _IndexedComponent_slice(obj, time_fixed, time_sliced, None)
+
+
+def generate_time_indexed_block_slices(block, time):
+    # TODO: We should probably do a sanity check that time does not
+    # appeat in any sub-block / var indices.
+    queue = list( generate_time_only_slices(block, time) )
+    while queue:
+        _slice = queue.pop(0)
+        # Pick a random block from this slice (i.e. TIME == TIME.first())
+        #
+        # TODO: we should probably sometime check that the OTHER blocks
+        # in the time set have the same variables.
+        b = next(iter(_slice))
+        # Any sub-blocks must be put on the queue to descend into and
+        # process
+        for sub_b in b.component_objects(Block, descend_into=False):
+            _name = sub_b.local_name
+            for idx in sub_b:
+                queue.append(_slice.duplicate().component(_name)[idx])
+        # Any Vars must be mapped to slices and returned
+        for v in b.component_objects(Var, descend_into=False):
+            _name = v.local_name
+            for idx in v:
+                yield _slice.duplicate().component(_name)[idx]
+        
+
+def flatten_dae_variables(model, time):
+    assert time.model() is model.model()
+
+    block_queue = [model]
+    regular_vars = []
+    time_indexed_vars = []
+    while block_queue:
+        b = block_queue.pop(0)
+        b_sets = identify_member_sets(b.index_set())
+        if time in b_sets:
+            for _slice in generate_time_indexed_block_slices(b, time):
+                time_indexed_vars.append(Reference(_slice))
+            continue
+        block_queue.extend(
+            list(b.component_objects(Block, descend_into=False))
+        )
+        for v in b.component_objects(SubclassOf(Var), descend_into=False):
+            v_sets = identify_member_sets(v.index_set())
+            if time in v_sets:
+                for _slice in generate_time_only_slices(v, time):
+                    time_indexed_vars.append(Reference(_slice))
+            else:
+                regular_vars.extend(list(v.values()))
+
+    return regular_vars, time_indexed_vars

--- a/pyomo/dae/tests/test_flatten.py
+++ b/pyomo/dae/tests/test_flatten.py
@@ -1,0 +1,116 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+import pyutilib.th as unittest
+
+from pyomo.environ import ConcreteModel, Block, Var, Reference
+from pyomo.dae import ContinuousSet
+# This inport will have to change when we decide where this should go...
+from pyomo.dae.flatten import flatten_dae_variables
+
+class TestCategorize(unittest.TestCase):
+    def _hashRef(self, ref):
+        return tuple(sorted(id(_) for _ in ref.values()))
+
+    def test_flat_model(self):
+        m = ConcreteModel()
+        m.T = ContinuousSet(bounds=(0,1))
+        m.x = Var()
+        m.y = Var([1,2])
+        m.a = Var(m.T)
+        m.b = Var(m.T, [1,2])
+        m.c = Var([3,4], m.T)
+
+        regular, time = flatten_dae_variables(m, m.T)
+        regular_id = set(id(_) for _ in regular)
+        self.assertEqual(len(regular), 3)
+        self.assertIn(id(m.x), regular_id)
+        self.assertIn(id(m.y[1]), regular_id)
+        self.assertIn(id(m.y[2]), regular_id)
+        # Output for debugging
+        #for v in time:
+        #    v.pprint()
+        #    for _ in v.values():
+        #        print"     -> ", _.name
+        ref_data = {
+            self._hashRef(Reference(m.a[:])),
+            self._hashRef(Reference(m.b[:,1])),
+            self._hashRef(Reference(m.b[:,2])),
+            self._hashRef(Reference(m.c[3,:])),
+            self._hashRef(Reference(m.c[4,:])),
+        }
+        self.assertEqual(len(time), len(ref_data))
+        for ref in time:
+            self.assertIn(self._hashRef(ref), ref_data)
+
+    def test_1level_model(self):
+        m = ConcreteModel()
+        m.T = ContinuousSet(bounds=(0,1))
+        @m.Block([1,2],m.T)
+        def B(b, i, t):
+            b.x = Var(list(range(2*i, 2*i+2)))
+
+        regular, time = flatten_dae_variables(m, m.T)
+        self.assertEqual(len(regular), 0)
+        # Output for debugging
+        #for v in time:
+        #    v.pprint()
+        #    for _ in v.values():
+        #        print"     -> ", _.name
+        ref_data = {
+            self._hashRef(Reference(m.B[1,:].x[2])),
+            self._hashRef(Reference(m.B[1,:].x[3])),
+            self._hashRef(Reference(m.B[2,:].x[4])),
+            self._hashRef(Reference(m.B[2,:].x[5])),
+        }
+        self.assertEqual(len(time), len(ref_data))
+        for ref in time:
+            self.assertIn(self._hashRef(ref), ref_data)
+
+
+    def test_2level_model(self):
+        m = ConcreteModel()
+        m.T = ContinuousSet(bounds=(0,1))
+        @m.Block([1,2],m.T)
+        def B(b, i, t):
+            @b.Block(list(range(2*i, 2*i+2)))
+            def bb(bb, j):
+                bb.y = Var([10,11])
+            b.x = Var(list(range(2*i, 2*i+2)))
+
+        regular, time = flatten_dae_variables(m, m.T)
+        self.assertEqual(len(regular), 0)
+        # Output for debugging
+        #for v in time:
+        #    v.pprint()
+        #    for _ in v.values():
+        #        print"     -> ", _.name
+        ref_data = {
+            self._hashRef(Reference(m.B[1,:].x[2])),
+            self._hashRef(Reference(m.B[1,:].x[3])),
+            self._hashRef(Reference(m.B[2,:].x[4])),
+            self._hashRef(Reference(m.B[2,:].x[5])),
+            self._hashRef(Reference(m.B[1,:].bb[2].y[10])),
+            self._hashRef(Reference(m.B[1,:].bb[2].y[11])),
+            self._hashRef(Reference(m.B[1,:].bb[3].y[10])),
+            self._hashRef(Reference(m.B[1,:].bb[3].y[11])),
+            self._hashRef(Reference(m.B[2,:].bb[4].y[10])),
+            self._hashRef(Reference(m.B[2,:].bb[4].y[11])),
+            self._hashRef(Reference(m.B[2,:].bb[5].y[10])),
+            self._hashRef(Reference(m.B[2,:].bb[5].y[11])),
+        }
+        self.assertEqual(len(time), len(ref_data))
+        for ref in time:
+            self.assertIn(self._hashRef(ref), ref_data)
+
+    # TODO: Add tests for Sets with dimen==None
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This adds a `flatten_dae_variables()` utility that will take a model and a continuous set and return two lists of "flattened" variables (i.e., all the model block / set structure has been removed:
- the first is a list of all `_VarData` that are not indexed by the specified continuous set
- the second is a set of References such that each reference is indexed *only* by the specified continuous set.

## Changes proposed in this PR:
- adding `flatten_dae_variables()`
- adding tests for `flatten_dae_variables()`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
