### PR TITLE
Add missing import for ftoa

### DIFF
--- a/pyomo/repn/tests/test_util.py
+++ b/pyomo/repn/tests/test_util.py
@@ -1,0 +1,25 @@
+import logging
+
+import pyutilib.th as unittest
+from six import StringIO
+
+from pyomo.common.log import LoggingIntercept
+from pyomo.repn.util import ftoa
+
+
+class TestRepnUtils(unittest.TestCase):
+    def test_ftoa(self):
+        warning_output = StringIO()
+        with LoggingIntercept(warning_output, 'pyomo.core', logging.WARNING):
+            x1 = 1.123456789012345678
+            x1str = ftoa(x1)
+            self.assertEqual(x1str, '1.1234567890123457')
+            # self.assertIn("to string resulted in loss of precision", warning_output.getvalue())
+            # Not sure how to construct a case that hits that part of the code, but it should be done.
+        x2 = 1.0 + 1E-15
+        x2str = ftoa(x2)
+        self.assertEqual(x2str, str(x2))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyomo/repn/tests/test_util.py
+++ b/pyomo/repn/tests/test_util.py
@@ -6,20 +6,31 @@ from six import StringIO
 from pyomo.common.log import LoggingIntercept
 from pyomo.repn.util import ftoa
 
+try:
+    import numpy as np
+    numpy_available = True
+except:
+    numpy_available = False
 
 class TestRepnUtils(unittest.TestCase):
     def test_ftoa(self):
-        warning_output = StringIO()
-        with LoggingIntercept(warning_output, 'pyomo.core', logging.WARNING):
-            x1 = 1.123456789012345678
-            x1str = ftoa(x1)
-            self.assertEqual(x1str, '1.1234567890123457')
-            # self.assertIn("to string resulted in loss of precision", warning_output.getvalue())
-            # Not sure how to construct a case that hits that part of the code, but it should be done.
-        x2 = 1.0 + 1E-15
-        x2str = ftoa(x2)
-        self.assertEqual(x2str, str(x2))
+        # Test that trailing zeros are removed
+        f = 1.0
+        a = ftoa(f)
+        self.assertEqual(a, '1')
 
+    @unittest.skipIf(not numpy_available, "NumPy is not available")
+    def test_ftoa_precision(self):
+        log = StringIO()
+        with LoggingIntercept(log, 'pyomo.core', logging.WARNING):
+            f = np.longdouble('1.1234567890123456789')
+            a = ftoa(f)
+        self.assertNotEqual(f, float(a))
+        self.assertEqual(a, '1.1234567890123457')
+        self.assertRegexpMatches(
+            log.getvalue(),
+            '.*Converting 1.1234567890123456789 to string '
+            'resulted in loss of precision')
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/repn/tests/test_util.py
+++ b/pyomo/repn/tests/test_util.py
@@ -25,12 +25,16 @@ class TestRepnUtils(unittest.TestCase):
         with LoggingIntercept(log, 'pyomo.core', logging.WARNING):
             f = np.longdouble('1.1234567890123456789')
             a = ftoa(f)
-        self.assertNotEqual(f, float(a))
         self.assertEqual(a, '1.1234567890123457')
-        self.assertRegexpMatches(
-            log.getvalue(),
-            '.*Converting 1.1234567890123456789 to string '
-            'resulted in loss of precision')
+        # Depending on the platform, np.longdouble may or may not have
+        # higher precision than float:
+        if f == float(f):
+            test = self.assertNotRegexpMatches
+        else:
+            test = self.assertRegexpMatches
+        test( log.getvalue(),
+              '.*Converting 1.1234567890123456789 to string '
+              'resulted in loss of precision' )
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/repn/util.py
+++ b/pyomo/repn/util.py
@@ -11,12 +11,14 @@
 from pyomo.core.base import Var, Param, Expression, Objective, Block, \
     Constraint, Suffix
 from pyomo.core.expr.numvalue import native_numeric_types, is_fixed, value
+import logging
+
+logger = logging.getLogger('pyomo.core')
 
 valid_expr_ctypes_minlp = {Var, Param, Expression, Objective}
 valid_active_ctypes_minlp = {Block, Constraint, Objective, Suffix}
 
-
-#Copied from cpxlp.py:
+# Copied from cpxlp.py:
 # Keven Hunter made a nice point about using %.16g in his attachment
 # to ticket #4319. I am adjusting this to %.17g as this mocks the
 # behavior of using %r (i.e., float('%r'%<number>) == <number>) with
@@ -29,6 +31,7 @@ valid_active_ctypes_minlp = {Block, Constraint, Objective, Suffix}
 #               and you will need to go add extra logic to output
 #               the number's sign.
 _ftoa_precision_str = '%.17g'
+
 
 def ftoa(val):
     if val is None:


### PR DESCRIPTION
# Summary/Motivation:
Fixes a missing import in `pyomo.repn.util` and attempts to add a test for it.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
