### PR TITLE
Repair damage from a bug in tree_structure that manifests itself only…

### DIFF
--- a/pyomo/pysp/plugins/csvsolutionwriter.py
+++ b/pyomo/pysp/plugins/csvsolutionwriter.py
@@ -66,9 +66,15 @@ def write_csv_soln(scenario_tree, output_file_prefix):
     cost_filename = output_file_prefix + "_StageCostDetail.csv"
     with open(cost_filename, "w") as f:
         for stage in scenario_tree.stages:
-            cost_name, cost_index = stage._cost_variable
+            # DLW March 2020 to pasting over a bug in handling
+            # of NetworkX by tree_structure.py
+            # (stage costs may be None but are OK at the node level)
+            scost = stage._cost_variable  # might be None
             for tree_node in sorted(stage.nodes,
                                     key=lambda x: x.name):
+                if scost is None:
+                    scost = tree_node._cost_variable
+                cost_name, cost_index = scost # moved into loop 3/2020 hack
                 for scenario in sorted(tree_node.scenarios,
                                        key=lambda x: x.name):
                     stage_cost = scenario._stage_costs[stage.name]

--- a/pyomo/pysp/scenariotree/tree_structure.py
+++ b/pyomo/pysp/scenariotree/tree_structure.py
@@ -1389,7 +1389,8 @@ class ScenarioTree(object):
                     new_stage._derived_variable_templates[variable_name].append(match_template)
 
             # de-reference is required to access the parameter value
-
+            # TBD March 2020: make it so the stages always know their cost names.
+            # dlw March 2020: when coming from NetworkX, we don't know these yet!!
             cost_variable_string = stage_cost_variable_names[stage_name].value
             if cost_variable_string is not None:
                 if isVariableNameIndexed(cost_variable_string):

--- a/pyomo/pysp/tests/rapper/rapper_tester.py
+++ b/pyomo/pysp/tests/rapper/rapper_tester.py
@@ -12,6 +12,11 @@ import pyomo.pysp.util.rapper as rapper
 from pyomo.pysp.scenariotree.tree_structure_model import CreateAbstractScenarioTreeModel
 import pyomo.pysp.plugins.csvsolutionwriter as csvw
 import pyomo as pyomoroot
+try:
+    import networkx
+    havenetx = True
+except:
+    havenetx = False
 
 __author__ = 'David L. Woodruff <DLWoodruff@UCDavis.edu>'
 __date__ = 'August 14, 2017'
@@ -161,8 +166,8 @@ class Testrapper(unittest.TestCase):
             pass
         assert(nodename == 'RootNode')
 
-    @unittest.skipIf(not solver_available,
-                     "%s solver is not available" % (solvername,))
+    @unittest.skipIf(not solver_available or not havenetx,
+                     "solver or NetworkX not available")
     def test_NetX_ef_csvwriter(self):
         """ solve the ef and report gap"""
         import NetXReferenceModel as ref

--- a/pyomo/pysp/tests/rapper/rapper_tester.py
+++ b/pyomo/pysp/tests/rapper/rapper_tester.py
@@ -15,7 +15,7 @@ import pyomo as pyomoroot
 
 __author__ = 'David L. Woodruff <DLWoodruff@UCDavis.edu>'
 __date__ = 'August 14, 2017'
-__version__ = 1.6
+__version__ = 1.7
 
 solvername = "ipopt" # could use almost any solver
 solver_available = pyo.SolverFactory(solvername).available(False)
@@ -53,7 +53,14 @@ class Testrapper(unittest.TestCase):
         shutil.copyfile(farmpath + os.sep +"scenariodata" + os.sep + "ScenarioStructure.dat",
                         self.tdir + os.sep + "ScenarioStructure.dat")
         self.farmer_concrete_tree = \
-                abstract_tree.create_instance("ScenarioStructure.dat")
+                        abstract_tree.create_instance("ScenarioStructure.dat")
+        # added networkx example March 2020
+        self.farmer_netx_file = farmpath + os.sep + \
+                                    "concreteNetX" + os.sep + "ReferenceModel.py"
+
+        shutil.copyfile(self.farmer_netx_file,
+                        self.tdir + os.sep + "NetXReferenceModel.py")
+        
 
     def tearDown(self):
         # from GH: This step is key, as Python keys off the name of the module, not the location.
@@ -153,6 +160,22 @@ class Testrapper(unittest.TestCase):
         for nodename, varname, varvalue in rapper.xhat_walker(xhat):
             pass
         assert(nodename == 'RootNode')
+
+    @unittest.skipIf(not solver_available,
+                     "%s solver is not available" % (solvername,))
+    def test_NetX_ef_csvwriter(self):
+        """ solve the ef and report gap"""
+        import NetXReferenceModel as ref
+        tree_model = ref.pysp_scenario_tree_model_callback()
+        stsolver = rapper.StochSolver("NetXReferenceModel.py",
+                                      fsfct="pysp_instance_creation_callback",
+                                      tree_model=tree_model)
+        res, gap = stsolver.solve_ef(solvername, tee=True, need_gap=True)
+        csvw.write_csv_soln(stsolver.scenario_tree, "testcref")
+        with open("testcref_StageCostDetail.csv", 'r') as f:
+            line = f.readline()
+            print("debug line={}".format(line))
+        assert(line.split(",")[0] == "Stage1")
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyomo/pysp/tests/rapper/rapper_tester.py
+++ b/pyomo/pysp/tests/rapper/rapper_tester.py
@@ -174,7 +174,6 @@ class Testrapper(unittest.TestCase):
         csvw.write_csv_soln(stsolver.scenario_tree, "testcref")
         with open("testcref_StageCostDetail.csv", 'r') as f:
             line = f.readline()
-            print("debug line={}".format(line))
         assert(line.split(",")[0] == "Stage1")
 
 if __name__ == '__main__':

--- a/pyomo/pysp/util/rapper.py
+++ b/pyomo/pysp/util/rapper.py
@@ -132,12 +132,7 @@ class StochSolver:
                 tree_maker = getattr(m, treecbname)
 
                 tree = tree_maker()
-                if isinstance(tree, Pyo.ConcreteModel):
-                    tree_model = tree
-                else:
-                    raise RuntimeError("The tree returned by",treecbname,
-                                       "must be a ConcreteModel") 
-                    
+
                 scenario_instance_factory = ScenarioTreeInstanceFactory(scen_function, tree_model)
 
             else: 


### PR DESCRIPTION
… in csvwriter

## Fixes # .

## Summary/Motivation:
csvwriter was not working correctly when NetworkX was used to specify the tree.

## Changes proposed in this PR:
- Add comments about the underlying problem in tree_structure.py, but this would take longer
to fix and is probably not worth the effort,
- so I fixed the only place it bites, which is in csvsolutionwriter and added a test.
(TMI: The problem is that when NetworkX is used to specify the tree, the stage cost names (which are private attributes) are set to None on the stage objects because they are not known at the time of stage creation; however, they are OK on the node and scenario objects. The only code that uses the private cost names on the stage objects is in csvsolutionwriter, so I edited that code to pick up names from the tree nodes if they are None on the stages.)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
