### PR TITLE
Update tests to use sys.executable to launch python subprocesses

### DIFF
--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -17,6 +17,7 @@ import os
 import shutil
 import glob
 import subprocess
+import sys
 from itertools import product
 
 import pyomo.contrib.parmest.parmest as parmest
@@ -152,10 +153,10 @@ class parmest_object_Tester_RB(unittest.TestCase):
                    "rooney_biegler" + os.sep + "rooney_biegler.py"
         rbpath = os.path.abspath(rbpath) # paranoia strikes deep...
         if sys.version_info >= (3,5):
-            ret = subprocess.run(["python", rbpath])
+            ret = subprocess.run([sys.executable, rbpath])
             retcode = ret.returncode
         else:
-            retcode = subprocess.call(["python", rbpath])
+            retcode = subprocess.call([sys.executable, rbpath])
         assert(retcode == 0)
         
     @unittest.skip("Presently having trouble with mpiexec on appveyor")
@@ -168,7 +169,7 @@ class parmest_object_Tester_RB(unittest.TestCase):
         rbpath = parmestpath + os.sep + "examples" + os.sep + \
                    "rooney_biegler" + os.sep + "rooney_biegler_parmest.py"
         rbpath = os.path.abspath(rbpath) # paranoia strikes deep...
-        rlist = ["mpiexec", "--allow-run-as-root", "-n", "2", "python", rbpath]
+        rlist = ["mpiexec", "--allow-run-as-root", "-n", "2", sys.executable, rbpath]
         if sys.version_info >= (3,5):
             ret = subprocess.run(rlist)
             retcode = ret.returncode

--- a/pyomo/core/tests/examples/test_kernel_examples.py
+++ b/pyomo/core/tests/examples/test_kernel_examples.py
@@ -14,6 +14,7 @@
 
 import os
 import glob
+import sys
 from os.path import basename, dirname, abspath, join
 
 import pyutilib.subprocess
@@ -75,7 +76,7 @@ def create_test_method(example):
             if (not testing_solvers['ipopt','nl']) or \
                (not testing_solvers['mosek','python']):
                 self.skipTest("Ipopt or Mosek is not available")
-        rc, log = pyutilib.subprocess.run(['python',example])
+        rc, log = pyutilib.subprocess.run([sys.executable,example])
         self.assertEqual(rc, 0, msg=log)
     return testmethod
 

--- a/pyomo/pysp/tests/convert/test_ddsip.py
+++ b/pyomo/pysp/tests/convert/test_ddsip.py
@@ -15,6 +15,7 @@ import difflib
 import filecmp
 import shutil
 import subprocess
+import sys
 import pyutilib.subprocess
 import pyutilib.th as unittest
 from pyutilib.pyro import using_pyro3, using_pyro4
@@ -70,7 +71,7 @@ class TestConvertDDSIPSimple(unittest.TestCase):
             shutil.rmtree(options['--output-directory'],
                           ignore_errors=True)
 
-        cmd = ['python','-m','pyomo.pysp.convert.ddsip']
+        cmd = [sys.executable,'-m','pyomo.pysp.convert.ddsip']
         for name, val in options.items():
             cmd.append(name)
             if val is not None:
@@ -214,7 +215,7 @@ class _DDSIPTesterBase(object):
             shutil.rmtree(options['--output-directory'], ignore_errors=True)
 
     def _get_cmd(self):
-        cmd = ['python','-m','pyomo.pysp.convert.ddsip']
+        cmd = [sys.executable,'-m','pyomo.pysp.convert.ddsip']
         for name, val in self.options.items():
             cmd.append(name)
             if val is not None:

--- a/pyomo/pysp/tests/convert/test_schuripopt.py
+++ b/pyomo/pysp/tests/convert/test_schuripopt.py
@@ -15,6 +15,7 @@ import difflib
 import filecmp
 import shutil
 import subprocess
+import sys
 import pyutilib.th as unittest
 from pyutilib.pyro import using_pyro3, using_pyro4
 from pyomo.pysp.util.misc import (_get_test_nameserver,
@@ -83,7 +84,7 @@ class _SchurIpoptTesterBase(object):
             shutil.rmtree(options['--output-directory'], ignore_errors=True)
 
     def _get_cmd(self):
-        cmd = ['python','-m','pyomo.pysp.convert.schuripopt']
+        cmd = [sys.executable,'-m','pyomo.pysp.convert.schuripopt']
         for name, val in self.options.items():
             cmd.append(name)
             if val is not None:

--- a/pyomo/pysp/tests/convert/test_smps.py
+++ b/pyomo/pysp/tests/convert/test_smps.py
@@ -16,6 +16,7 @@ import difflib
 import filecmp
 import shutil
 import subprocess
+import sys
 import pyutilib.subprocess
 import pyutilib.services
 import pyutilib.th as unittest
@@ -74,7 +75,7 @@ class TestConvertSMPSSimple(unittest.TestCase):
             shutil.rmtree(options['--output-directory'],
                           ignore_errors=True)
 
-        cmd = ['python','-m','pyomo.pysp.convert.smps']
+        cmd = [sys.executable,'-m','pyomo.pysp.convert.smps']
         for name, val in options.items():
             cmd.append(name)
             if val is not None:
@@ -247,7 +248,7 @@ class _SMPSTesterBase(object):
             shutil.rmtree(options['--output-directory'], ignore_errors=True)
 
     def _get_cmd(self):
-        cmd = ['python','-m','pyomo.pysp.convert.smps']
+        cmd = [sys.executable,'-m','pyomo.pysp.convert.smps']
         for name, val in self.options.items():
             cmd.append(name)
             if val is not None:

--- a/pyomo/pysp/tests/examples/test_examples.py
+++ b/pyomo/pysp/tests/examples/test_examples.py
@@ -16,6 +16,7 @@ import subprocess
 import difflib
 import filecmp
 import shutil
+import sys
 
 from pyutilib.pyro import using_pyro3, using_pyro4
 import pyutilib.services
@@ -84,14 +85,14 @@ class TestExamples(unittest.TestCase):
     @unittest.skipIf(not 'cplex' in solvers,
                      'cplex not available')
     def test_ef_duals(self):
-        cmd = ['python', join(examples_dir, 'ef_duals.py')]
+        cmd = [sys.executable, join(examples_dir, 'ef_duals.py')]
         self._run_cmd(cmd)
         self._cleanup()
 
     @unittest.skipIf(not 'cplex' in solvers,
                      'cplex not available')
     def test_benders_scripting(self):
-        cmd = ['python', join(examples_dir, 'benders_scripting.py')]
+        cmd = [sys.executable, join(examples_dir, 'benders_scripting.py')]
         self._run_cmd(cmd)
         self._cleanup()
 
@@ -102,7 +103,7 @@ class TestExamples(unittest.TestCase):
         tmpdir = os.path.join(thisdir, class_name+"_"+test_name)
         shutil.rmtree(tmpdir, ignore_errors=True)
         self.assertEqual(os.path.exists(tmpdir), False)
-        cmd = ['python', join(examples_dir, 'apps', 'compile_scenario_tree.py')]
+        cmd = [sys.executable, join(examples_dir, 'apps', 'compile_scenario_tree.py')]
         cmd.extend(["-m", join(pysp_examples_dir,
                                "networkx_scenariotree",
                                "ReferenceModel.py")])
@@ -122,7 +123,7 @@ class TestExamples(unittest.TestCase):
         tmpdir = os.path.join(thisdir, class_name+"_"+test_name)
         shutil.rmtree(tmpdir, ignore_errors=True)
         self.assertEqual(os.path.exists(tmpdir), False)
-        cmd = ['python', join(examples_dir, 'apps', 'generate_distributed_NL.py')]
+        cmd = [sys.executable, join(examples_dir, 'apps', 'generate_distributed_NL.py')]
         cmd.extend(["-m", join(pysp_examples_dir,
                                "networkx_scenariotree",
                                "ReferenceModel.py")])
@@ -145,7 +146,7 @@ class TestExamples(unittest.TestCase):
         except OSError:
             pass
         self.assertEqual(os.path.exists(tmpfname), False)
-        cmd = ['python', join(examples_dir, 'apps', 'scenario_tree_image.py')]
+        cmd = [sys.executable, join(examples_dir, 'apps', 'scenario_tree_image.py')]
         cmd.extend(["-m", join(pysp_examples_dir,
                                "networkx_scenariotree",
                                "ReferenceModel.py")])
@@ -256,7 +257,7 @@ class TestParallelExamples(unittest.TestCase):
                                          ["--pyro-port="+str(ns_port)],
                                          stdout=f,
                                          stderr=subprocess.STDOUT))
-            cmd = ['python', join(examples_dir, 'solve_distributed.py'), str(ns_port)]
+            cmd = [sys.executable, join(examples_dir, 'solve_distributed.py'), str(ns_port)]
             time.sleep(2)
             [_poll(proc) for proc in scenariotreeserver_processes]
             self._run_cmd(cmd)
@@ -278,7 +279,7 @@ class TestParallelExamples(unittest.TestCase):
         tmpdir = os.path.join(thisdir, class_name+"_"+test_name)
         shutil.rmtree(tmpdir, ignore_errors=True)
         self.assertEqual(os.path.exists(tmpdir), False)
-        cmd = ['python', join(examples_dir, 'apps', 'compile_scenario_tree.py')]
+        cmd = [sys.executable, join(examples_dir, 'apps', 'compile_scenario_tree.py')]
         cmd.extend(["-m", join(pysp_examples_dir,
                                "networkx_scenariotree",
                                "ReferenceModel.py")])
@@ -298,7 +299,7 @@ class TestParallelExamples(unittest.TestCase):
         tmpdir = os.path.join(thisdir, class_name+"_"+test_name)
         shutil.rmtree(tmpdir, ignore_errors=True)
         self.assertEqual(os.path.exists(tmpdir), False)
-        cmd = ['python', join(examples_dir, 'apps', 'generate_distributed_NL.py')]
+        cmd = [sys.executable, join(examples_dir, 'apps', 'generate_distributed_NL.py')]
         cmd.extend(["-m", join(pysp_examples_dir,
                                "networkx_scenariotree",
                                "ReferenceModel.py")])


### PR DESCRIPTION
## Fixes #N/A .

## Summary/Motivation:
Switch tests over to use `sys.executable` to specify the python interpreter to use when spawning python subprocesses for testing.  This enables testing with pypy, where the interpreter name is not "python".

## Changes proposed in this PR:
- use `sys.executable` instead of `'python'` when spawning python subprocesses

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
