### PR TITLE
Standardizing github actions naming

### DIFF
--- a/.github/workflows/mpi_matrix_test.yml
+++ b/.github/workflows/mpi_matrix_test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: parallel/${{ matrix.TARGET }}/py${{ matrix.python-version }}
+    name: mpi/${{ matrix.TARGET }}/py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 1

--- a/.github/workflows/mpi_matrix_test.yml
+++ b/.github/workflows/mpi_matrix_test.yml
@@ -18,7 +18,7 @@ jobs:
         - os: ubuntu-latest
           TARGET: linux
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: setup conda
       uses: s-weigand/setup-conda@v1
       with:

--- a/.github/workflows/parallel_tests.yml
+++ b/.github/workflows/parallel_tests.yml
@@ -1,4 +1,4 @@
-name: parallel_tests
+name: continuous-integration/github/pr
 
 on:
   pull_request:
@@ -7,11 +7,16 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: parallel/${{ matrix.TARGET }}/py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 1
       matrix:
+        os: [ubuntu-latest]
         python-version: [3.7]
+        include:
+        - os: ubuntu-latest
+          TARGET: linux
     steps:
     - uses: actions/checkout@v1
     - name: setup conda

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -1,15 +1,19 @@
-name: continuous-integration/github/push/linux
+name: continuous-integration/github/push
 
 on: push
 
 jobs:
-  pyomo-linux-master-test:
-    name: py${{ matrix.python-version }}
-    runs-on: ubuntu-18.04
+  pyomo-linux-branch-test:
+    name: ${{ matrix.TARGET }}/py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7] 
+        os: [ubuntu-18.04]
+        include:
+        - os: ubuntu-18.04
+          TARGET: linux
+        python-version: [3.7]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: [3.7]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: [3.5, 3.6, 3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  pyomo-mac-tests:
+  pyomo-unix-tests:
     name: ${{ matrix.TARGET }}/py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -1,4 +1,4 @@
-name: continuous-integration/github/pr/win
+name: continuous-integration/github/pr
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pyomo-tests:
-    name: py${{ matrix.python-version }}
+    name: win/py${{ matrix.python-version }}
     runs-on: windows-latest
     strategy:
       fail-fast: false # This flag causes all of the matrix to continue to run, even if one matrix option fails

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8] 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }} with Miniconda
       uses: goanpeca/setup-miniconda@v1 # Using an action created by user goanpeca to set up different Python Miniconda environments
       with:


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This standardizes the naming for the various GitHub Actions drivers.

## Changes proposed in this PR:
- standardize test names as `continuous-integration/github/{push,pr} / [mpi/]{linux,osx,win}/py{N}.{M}`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
