### PR TITLE
Documentation: indexed components in persistent interfaces

### DIFF
--- a/doc/OnlineDocs/advanced_topics/persistent_solvers.rst
+++ b/doc/OnlineDocs/advanced_topics/persistent_solvers.rst
@@ -125,6 +125,34 @@ be modified and then updated with with solver:
 >>> m.x.setlb(1.0)  # doctest: +SKIP
 >>> opt.update_var(m.x)  # doctest: +SKIP
 
+Working with Indexed Variables and Constraints
+----------------------------------------------
+
+The examples above all used simple variables and constraints; in order to use
+indexed variables and/or constraints, the code must be slightly adapted:
+
+>>> for v in indexed_var.values():  # doctest: +SKIP
+...     opt.add_var(v)              # doctest: +SKIP
+... for c in indexed_con.values():  # doctest: +SKIP
+...     opt.add_constraint(v)       # doctest: +SKIP
+
+This must be done when removing variables/constraints, too. Not doing this would
+result in AttributeError exceptions, for example:
+
+>>> opt.add_var(v)   # doctest: +SKIP
+>>> # ERROR: AttributeError: 'IndexedVar' object has no attribute 'is_binary'
+>>> opt.add_constraint(c)   # doctest: +SKIP
+>>> # ERROR: AttributeError: 'IndexedConstraint' object has no attribute 'body'
+
+The method "is_indexed" can be used to automate the process, for example:
+
+>>> def add_variable(opt, variable):     # doctest: +SKIP
+...     if var.is_indexed():             # doctest: +SKIP
+...         for v in variable.values():  # doctest: +SKIP
+...             opt.add_var(v)           # doctest: +SKIP
+...     else:                            # doctest: +SKIP
+...         opt.add_var(v)               # doctest: +SKIP
+
 Persistent Solver Performance
 -----------------------------
 In order to get the best performance out of the persistent solvers, use the

--- a/doc/OnlineDocs/advanced_topics/persistent_solvers.rst
+++ b/doc/OnlineDocs/advanced_topics/persistent_solvers.rst
@@ -133,15 +133,15 @@ indexed variables and/or constraints, the code must be slightly adapted:
 
 >>> for v in indexed_var.values():  # doctest: +SKIP
 ...     opt.add_var(v)
-... for c in indexed_con.values():
+>>> for v in indexed_con.values():
 ...     opt.add_constraint(v)
 
 This must be done when removing variables/constraints, too. Not doing this would
 result in AttributeError exceptions, for example:
 
->>> opt.add_var(v)          # doctest: +SKIP
+>>> opt.add_var(indexed_var)          # doctest: +SKIP
 >>> # ERROR: AttributeError: 'IndexedVar' object has no attribute 'is_binary'
->>> opt.add_constraint(c)   # doctest: +SKIP
+>>> opt.add_constraint(indexed_con)   # doctest: +SKIP
 >>> # ERROR: AttributeError: 'IndexedConstraint' object has no attribute 'body'
 
 The method "is_indexed" can be used to automate the process, for example:

--- a/doc/OnlineDocs/advanced_topics/persistent_solvers.rst
+++ b/doc/OnlineDocs/advanced_topics/persistent_solvers.rst
@@ -133,7 +133,7 @@ indexed variables and/or constraints, the code must be slightly adapted:
 
 >>> for v in indexed_var.values():  # doctest: +SKIP
 ...     opt.add_var(v)
->>> for v in indexed_con.values():
+>>> for v in indexed_con.values():  # doctest: +SKIP
 ...     opt.add_constraint(v)
 
 This must be done when removing variables/constraints, too. Not doing this would

--- a/doc/OnlineDocs/advanced_topics/persistent_solvers.rst
+++ b/doc/OnlineDocs/advanced_topics/persistent_solvers.rst
@@ -132,14 +132,14 @@ The examples above all used simple variables and constraints; in order to use
 indexed variables and/or constraints, the code must be slightly adapted:
 
 >>> for v in indexed_var.values():  # doctest: +SKIP
-...     opt.add_var(v)              # doctest: +SKIP
-... for c in indexed_con.values():  # doctest: +SKIP
-...     opt.add_constraint(v)       # doctest: +SKIP
+...     opt.add_var(v)
+... for c in indexed_con.values():
+...     opt.add_constraint(v)
 
 This must be done when removing variables/constraints, too. Not doing this would
 result in AttributeError exceptions, for example:
 
->>> opt.add_var(v)   # doctest: +SKIP
+>>> opt.add_var(v)          # doctest: +SKIP
 >>> # ERROR: AttributeError: 'IndexedVar' object has no attribute 'is_binary'
 >>> opt.add_constraint(c)   # doctest: +SKIP
 >>> # ERROR: AttributeError: 'IndexedConstraint' object has no attribute 'body'
@@ -147,11 +147,11 @@ result in AttributeError exceptions, for example:
 The method "is_indexed" can be used to automate the process, for example:
 
 >>> def add_variable(opt, variable):     # doctest: +SKIP
-...     if var.is_indexed():             # doctest: +SKIP
-...         for v in variable.values():  # doctest: +SKIP
-...             opt.add_var(v)           # doctest: +SKIP
-...     else:                            # doctest: +SKIP
-...         opt.add_var(v)               # doctest: +SKIP
+...     if variable.is_indexed():
+...         for v in variable.values():
+...             opt.add_var(v)
+...     else:
+...         opt.add_var(v)
 
 Persistent Solver Performance
 -----------------------------


### PR DESCRIPTION
## Fixes # N/A

## Summary/Motivation:
The documentation for the persistent solvers does not explain how to use indexed variables/constraints.

## Changes proposed in this PR:
- Added a new section in the documentation

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
