### PR TITLE
Improve testing and coverage reporting for MPI tests

### DIFF
--- a/.github/workflows/mpi_matrix_test.yml
+++ b/.github/workflows/mpi_matrix_test.yml
@@ -17,6 +17,7 @@ jobs:
         include:
         - os: ubuntu-latest
           TARGET: linux
+
     steps:
     - uses: actions/checkout@v2
     - name: setup conda
@@ -27,11 +28,79 @@ jobs:
         conda-channels: anaconda, conda-forge
     - name: Install dependencies
       run: |
+        echo "Upgrade pip..."
         python -m pip install --upgrade pip
-        pip install numpy scipy nose
-        pip install --quiet git+https://github.com/PyUtilib/pyutilib
+        echo ""
+        echo "Install Pyomo dependencies..."
+        echo ""
+        pip install cython numpy scipy ipython openpyxl sympy pyyaml \
+            pyodbc networkx xlrd pandas matplotlib dill seaborn pymysql \
+            pyro4 pint pathos coverage
+        echo ""
+        echo "Install CPLEX Community Edition..."
+        echo ""
+        pip install cplex || echo "CPLEX Community Edition is not available for ${{ matrix.python-version }}"
+        echo ""
+        echo "Install GAMS..."
+        echo ""
+        if hash brew; then
+            wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0/macosx/osx_x64_64_sfx.exe -O gams_installer.exe
+        else
+            wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0/linux/linux_x64_64_sfx.exe -O gams_installer.exe
+        fi
+        chmod +x gams_installer.exe
+        ./gams_installer.exe -q -d gams
+        cd gams/*/apifiles/Python/
+        py_ver=$(python -c 'import sys;print("%s%s" % sys.version_info[:2])')
+        gams_ver=api
+        for ver in api_*; do
+            if test ${ver:4} -le $py_ver; then
+                gams_ver=$ver
+            fi
+        done
+        cd $gams_ver
+        python setup.py -q install -noCheck
+        echo ""
+        echo "Install conda packages"
+        echo ""
         conda install mpi4py
-        python setup.py develop
-    - name: Test with nose
+    - name: Install Pyomo and extensions
       run: |
-        mpirun -np 3 nosetests -v pyomo.contrib.pynumero.sparse.tests.test_mpi_block_vector.py pyomo.contrib.pynumero.sparse.tests.test_mpi_block_matrix.py
+        echo "Clone Pyomo-model-libraries..."
+        git clone --quiet https://github.com/Pyomo/pyomo-model-libraries.git
+        echo ""
+        echo "Install PyUtilib..."
+        echo ""
+        pip install --quiet git+https://github.com/PyUtilib/pyutilib
+        echo ""
+        echo "Install Pyomo..."
+        echo ""
+        python setup.py develop
+    - name: Set up coverage tracking
+      run: |
+        WORKSPACE=`pwd`
+        COVERAGE_PROCESS_START=${WORKSPACE}/coveragerc
+        cp ${WORKSPACE}/.coveragerc ${COVERAGE_PROCESS_START}
+        echo "data_file=${WORKSPACE}/.coverage" >> ${COVERAGE_PROCESS_START}
+        SITE_PACKAGES=`python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`
+        if [ -z "$DISABLE_COVERAGE" ]; then
+            echo 'import coverage; coverage.process_startup()' > ${SITE_PACKAGES}/run_coverage_at_startup.pth
+        fi
+    - name: Download and install extensions
+      run: |
+        pyomo download-extensions
+        pyomo build-extensions
+    - name: Run MPI tests with test.pyomo
+      run: |
+        echo "Run test.pyomo..."
+        GAMS_DIR=`ls -d1 $(pwd)/gams/*/ | head -1`
+        export PATH=$PATH:$GAMS_DIR
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GAMS_DIR
+        export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GAMS_DIR
+        pip install nose
+        mpirun -np 3 nosetests -v --eval-attr="mpi and (not fragile)" pyomo `pwd`/pyomo-model-libraries
+    - name: Upload coverage to codecov
+      run: |
+        find . -maxdepth 10 -name ".cov*"
+        coverage combine
+        bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/mpi_matrix_test.yml
+++ b/.github/workflows/mpi_matrix_test.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: setup conda
+    - name: Setup conda environment
       uses: s-weigand/setup-conda@v1
       with:
         update-conda: true
@@ -36,7 +36,7 @@ jobs:
         echo ""
         pip install cython numpy scipy ipython openpyxl sympy pyyaml \
             pyodbc networkx xlrd pandas matplotlib dill seaborn pymysql \
-            pyro4 pint pathos coverage
+            pyro4 pint pathos coverage nose
         echo ""
         echo "Install CPLEX Community Edition..."
         echo ""
@@ -98,7 +98,7 @@ jobs:
         export PATH=$PATH:$GAMS_DIR
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GAMS_DIR
         export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GAMS_DIR
-        pip install nose
+        python -c 'import pyomo.environ'        
         mpirun -np 3 nosetests -v --eval-attr="mpi and (not fragile)" pyomo `pwd`/pyomo-model-libraries
     - name: Upload coverage to codecov
       run: |

--- a/.github/workflows/mpi_matrix_test.yml
+++ b/.github/workflows/mpi_matrix_test.yml
@@ -107,4 +107,4 @@ jobs:
       run: |
         find . -maxdepth 10 -name ".cov*"
         coverage combine
-        bash <(curl -s https://codecov.io/bash)
+        bash <(curl -s https://codecov.io/bash) -X gcov

--- a/.github/workflows/mpi_matrix_test.yml
+++ b/.github/workflows/mpi_matrix_test.yml
@@ -29,7 +29,13 @@ jobs:
         conda-channels: anaconda, conda-forge
     - name: Install dependencies
       run: |
+        echo ""
+        echo "Install conda packages"
+        echo ""
+        conda install mpi4py
+        echo ""
         echo "Upgrade pip..."
+        echo ""
         python -m pip install --upgrade pip
         echo ""
         echo "Install Pyomo dependencies..."
@@ -61,10 +67,6 @@ jobs:
         done
         cd $gams_ver
         python setup.py -q install -noCheck
-        echo ""
-        echo "Install conda packages"
-        echo ""
-        conda install mpi4py
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."
@@ -81,6 +83,7 @@ jobs:
       run: |
         WORKSPACE=`pwd`
         COVERAGE_PROCESS_START=${WORKSPACE}/coveragerc
+        echo "::set-env name=COVERAGE_PROCESS_START::$COVERAGE_PROCESS_START"
         cp ${WORKSPACE}/.coveragerc ${COVERAGE_PROCESS_START}
         echo "data_file=${WORKSPACE}/.coverage" >> ${COVERAGE_PROCESS_START}
         SITE_PACKAGES=`python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`

--- a/.github/workflows/mpi_matrix_test.yml
+++ b/.github/workflows/mpi_matrix_test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+  push
 
 jobs:
   build:

--- a/.github/workflows/mpi_matrix_test.yml
+++ b/.github/workflows/mpi_matrix_test.yml
@@ -1,12 +1,10 @@
 name: continuous-integration/github/pr
 
 on:
+  push:
   pull_request:
     branches:
       - master
-  push:
-    branches:
-      - *
 
 jobs:
   build:

--- a/.github/workflows/mpi_matrix_test.yml
+++ b/.github/workflows/mpi_matrix_test.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     branches:
       - master
-  push
+  push:
+    branches:
+      - *
 
 jobs:
   build:

--- a/.github/workflows/mpi_matrix_test.yml
+++ b/.github/workflows/mpi_matrix_test.yml
@@ -2,6 +2,8 @@ name: continuous-integration/github/pr
 
 on:
   push:
+    branches:
+      - master
   pull_request:
     branches:
       - master
@@ -27,6 +29,7 @@ jobs:
         update-conda: true
         python-version: ${{ matrix.python-version }}
         conda-channels: anaconda, conda-forge
+
     - name: Install dependencies
       run: |
         echo ""
@@ -57,6 +60,10 @@ jobs:
         fi
         chmod +x gams_installer.exe
         ./gams_installer.exe -q -d gams
+        GAMS_DIR=`ls -d1 $(pwd)/gams/*/ | head -1`
+        export PATH=$PATH:$GAMS_DIR
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GAMS_DIR
+        export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GAMS_DIR
         cd gams/*/apifiles/Python/
         py_ver=$(python -c 'import sys;print("%s%s" % sys.version_info[:2])')
         gams_ver=api
@@ -67,6 +74,13 @@ jobs:
         done
         cd $gams_ver
         python setup.py -q install -noCheck
+        echo ""
+        echo "Pass key environment variables to subsequent steps"
+        echo ""
+        echo "::set-env name=PATH::$PATH"
+        echo "::set-env name=LD_LIBRARY_PATH::$LD_LIBRARY_PATH"
+        echo "::set-env name=DYLD_LIBRARY_PATH::$DYLD_LIBRARY_PATH"
+
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."
@@ -79,6 +93,7 @@ jobs:
         echo "Install Pyomo..."
         echo ""
         python setup.py develop
+
     - name: Set up coverage tracking
       run: |
         WORKSPACE=`pwd`
@@ -88,21 +103,24 @@ jobs:
         echo "data_file=${WORKSPACE}/.coverage" >> ${COVERAGE_PROCESS_START}
         SITE_PACKAGES=`python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`
         if [ -z "$DISABLE_COVERAGE" ]; then
-            echo 'import coverage; coverage.process_startup()' > ${SITE_PACKAGES}/run_coverage_at_startup.pth
+            echo 'import coverage; coverage.process_startup()' \
+                > ${SITE_PACKAGES}/run_coverage_at_startup.pth
         fi
+
     - name: Download and install extensions
       run: |
         pyomo download-extensions
         pyomo build-extensions
-    - name: Run MPI tests with test.pyomo
+
+    - name: Run Pyomo tests
       run: |
-        echo "Run test.pyomo..."
-        GAMS_DIR=`ls -d1 $(pwd)/gams/*/ | head -1`
-        export PATH=$PATH:$GAMS_DIR
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GAMS_DIR
-        export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GAMS_DIR
+        echo "Run Pyomo tests..."
+        # Import pyomo.environ to ensure that things like the dat parser
+        # are fully set up
         python -c 'import pyomo.environ'        
-        mpirun -np 3 nosetests -v --eval-attr="mpi and (not fragile)" pyomo `pwd`/pyomo-model-libraries
+        mpirun -np 3 nosetests -v --eval-attr="mpi and (not fragile)" \
+            pyomo `pwd`/pyomo-model-libraries
+
     - name: Upload coverage to codecov
       run: |
         find . -maxdepth 10 -name ".cov*"

--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_matrix.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_matrix.py
@@ -12,12 +12,13 @@ import warnings
 import pyutilib.th as unittest
 
 SKIPTESTS=[]
-import pyomo.contrib.pynumero as pn
-if not (pn.sparse.numpy_available and pn.sparse.scipy_available):
+try:
+    import numpy as np
+    from scipy.sparse import coo_matrix, bmat
+except ImportError:
     SKIPTESTS.append("Pynumero needs scipy and numpy to run BlockMatrix tests")
-
-from scipy.sparse import coo_matrix, bmat
-import numpy as np
+else:
+    from pyomo.contrib.pynumero.sparse import BlockVector, BlockMatrix
 
 try:
     from mpi4py import MPI
@@ -26,14 +27,14 @@ try:
         SKIPTESTS.append(
             "Pynumero needs at least 3 processes to run BlockMatrix MPI tests"
         )
+except ImportError:
+    SKIPTESTS.append("Pynumero needs mpi4py to run BlockMatrix MPI tests")
+else:
     from pyomo.contrib.pynumero.sparse.mpi_block_vector import MPIBlockVector
     from pyomo.contrib.pynumero.sparse.mpi_block_matrix import (
         MPIBlockMatrix, NotFullyDefinedBlockMatrixError
     )
-except ImportError:
-    SKIPTESTS.append("Pynumero needs mpi4py to run BlockMatrix MPI tests")
 
-from pyomo.contrib.pynumero.sparse import BlockVector, BlockMatrix
 
 @unittest.category("mpi")
 class TestMPIBlockMatrix(unittest.TestCase):

--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_matrix.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_matrix.py
@@ -29,7 +29,8 @@ try:
         )
 except ImportError:
     SKIPTESTS.append("Pynumero needs mpi4py to run BlockMatrix MPI tests")
-else:
+
+if not SKIPTESTS:
     from pyomo.contrib.pynumero.sparse.mpi_block_vector import MPIBlockVector
     from pyomo.contrib.pynumero.sparse.mpi_block_matrix import (
         MPIBlockMatrix, NotFullyDefinedBlockMatrixError

--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
@@ -9,9 +9,10 @@
 #  ___________________________________________________________________________
 import pyutilib.th as unittest
 
+SKIPTESTS=[]
 import pyomo.contrib.pynumero as pn
 if not (pn.sparse.numpy_available and pn.sparse.scipy_available):
-    raise unittest.SkipTest("Pynumero needs scipy and numpy to run BlockVector tests")
+    SKIPTESTS.append("Pynumero needs scipy and numpy to run BlockVector tests")
 
 from scipy.sparse import coo_matrix, bmat
 import numpy as np
@@ -20,30 +21,27 @@ try:
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
     if comm.Get_size() < 3:
-        raise unittest.SkipTest(
-            "These tests need at least 3 processors")
-except ImportError:
-    raise unittest.SkipTest(
-        "Pynumero needs mpi4py to run mpi block vector tests")
-
-try:
+        SKIPTESTS.append(
+            "Pynumero needs at least 3 processes to run BlockVector MPI tests"
+        )
     from pyomo.contrib.pynumero.sparse.mpi_block_vector import MPIBlockVector
 except ImportError:
-    raise unittest.SkipTest(
-        "Pynumero needs mpi4py to run mpi block vector tests")
+    SKIPTESTS.append("Pynumero needs mpi4py to run BlockVector MPI tests")
 
 from pyomo.contrib.pynumero.sparse import BlockVector
 
 
-@unittest.skipIf(comm.Get_size() < 3, "Need at least 3 processors to run tests")
+@unittest.category("mpi")
 class TestMPIBlockVector(unittest.TestCase):
 
+    # Because the setUpClass is called before decorators around the
+    # class itself, we need to put the skipIf on the class setup and not
+    # the class.
+
     @classmethod
+    @unittest.skipIf(SKIPTESTS, SKIPTESTS)
     def setUpClass(cls):
         # test problem 1
-
-        if comm.Get_size() < 3:
-            raise unittest.SkipTest("Need at least 3 processors to run tests")
 
         v1 = MPIBlockVector(4, [0,1,0,1], comm)
 

--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
@@ -19,7 +19,6 @@ except ImportError:
 else:
     from pyomo.contrib.pynumero.sparse import BlockVector
 
-
 try:
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
@@ -29,7 +28,8 @@ try:
         )
 except ImportError:
     SKIPTESTS.append("Pynumero needs mpi4py to run BlockVector MPI tests")
-else:
+
+if not SKIPTESTS:
     from pyomo.contrib.pynumero.sparse.mpi_block_vector import MPIBlockVector
 
 

--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
@@ -10,12 +10,15 @@
 import pyutilib.th as unittest
 
 SKIPTESTS=[]
-import pyomo.contrib.pynumero as pn
-if not (pn.sparse.numpy_available and pn.sparse.scipy_available):
-    SKIPTESTS.append("Pynumero needs scipy and numpy to run BlockVector tests")
 
-from scipy.sparse import coo_matrix, bmat
-import numpy as np
+try:
+    import numpy as np
+    from scipy.sparse import coo_matrix, bmat
+except ImportError:
+    SKIPTESTS.append("Pynumero needs scipy and numpy to run BlockVector tests")
+else:
+    from pyomo.contrib.pynumero.sparse import BlockVector
+
 
 try:
     from mpi4py import MPI
@@ -24,11 +27,10 @@ try:
         SKIPTESTS.append(
             "Pynumero needs at least 3 processes to run BlockVector MPI tests"
         )
-    from pyomo.contrib.pynumero.sparse.mpi_block_vector import MPIBlockVector
 except ImportError:
     SKIPTESTS.append("Pynumero needs mpi4py to run BlockVector MPI tests")
-
-from pyomo.contrib.pynumero.sparse import BlockVector
+else:
+    from pyomo.contrib.pynumero.sparse.mpi_block_vector import MPIBlockVector
 
 
 @unittest.category("mpi")


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This PR overhauls the MPI workflow and pynumero MPI tests.  This brings the MPI workflow to closer match the unix workflow, simplifies the logic for skipping MPI tests in pynumero, and adds coverage support for the MPI tests.

If this is accepted, key parts of this workflow should be migrated back to the unix, windows, and push workflows.

## Changes proposed in this PR:
- migrate the Github Action workflow to closer match the unix workflow. 
- simplify the skip logic in the MPI tests
- adding codecov support

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
