### PR TITLE
Add attempt_import(), standardize yaml imports

### DIFF
--- a/pyomo/__init__.py
+++ b/pyomo/__init__.py
@@ -7,3 +7,5 @@
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
+
+from . import common

--- a/pyomo/bilevel/plugins/solver2.py
+++ b/pyomo/bilevel/plugins/solver2.py
@@ -11,7 +11,6 @@
 import time
 import pyutilib.misc
 import pyomo.opt
-import pyomo.common
 from pyomo.core import TransformationFactory, Var, Set
 
 

--- a/pyomo/bilevel/plugins/solver3.py
+++ b/pyomo/bilevel/plugins/solver3.py
@@ -12,7 +12,6 @@ import time
 import pyutilib.misc
 import pyomo.opt
 #from pyomo.bilevel.components import SubModel
-import pyomo.common
 from pyomo.core import TransformationFactory, Var, Set
 
 

--- a/pyomo/bilevel/plugins/solver4.py
+++ b/pyomo/bilevel/plugins/solver4.py
@@ -11,7 +11,6 @@
 import time
 import pyutilib.misc
 import pyomo.opt
-import pyomo.common
 from pyomo.core import TransformationFactory, Var, Set
 
 

--- a/pyomo/bilevel/tests/test_blp.py
+++ b/pyomo/bilevel/tests/test_blp.py
@@ -21,18 +21,13 @@ exdir = normpath(join(currdir,'..','..','..','examples','bilevel'))
 import pyutilib.th as unittest
 import pyutilib.misc
 
+from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 import pyomo.opt
 import pyomo.scripting.pyomo_main as pyomo_main
 from pyomo.scripting.util import cleanup
 from pyomo.environ import *
 
 from six import iteritems
-
-try:
-    import yaml
-    yaml_available=True
-except ImportError:
-    yaml_available=False
 
 solvers = pyomo.opt.check_available_solvers('cplex', 'glpk', 'ipopt')
 
@@ -93,7 +88,7 @@ class CommonTests:
 
     def getObjective(self, fname):
         FILE = open(fname,'r')
-        data = yaml.load(FILE)
+        data = yaml.load(FILE, **yaml_load_args)
         FILE.close()
         solutions = data.get('Solution', [])
         ans = []

--- a/pyomo/bilevel/tests/test_linear_dual.py
+++ b/pyomo/bilevel/tests/test_linear_dual.py
@@ -19,18 +19,13 @@ exdir = normpath(join(currdir,'..','..','..','examples','bilevel'))
 
 import pyutilib.th as unittest
 
+from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 import pyomo.opt
 import pyomo.scripting.pyomo_main as pyomo_main
 from pyomo.scripting.util import cleanup
 from pyomo.environ import *
 
 from six import iteritems
-
-try:
-    import yaml
-    yaml_available=True
-except ImportError:
-    yaml_available=False
 
 solvers = pyomo.opt.check_available_solvers('cplex', 'glpk')
 
@@ -93,7 +88,7 @@ class CommonTests:
 
     def getObjective(self, fname):
         FILE = open(fname)
-        data = yaml.load(FILE)
+        data = yaml.load(FILE, **yaml_load_args)
         FILE.close()
         solutions = data.get('Solution', [])
         ans = []

--- a/pyomo/checker/tests/test_examples.py
+++ b/pyomo/checker/tests/test_examples.py
@@ -10,17 +10,13 @@
 
 import sys
 import os
-try:
-    import yaml
-    yaml_available=True
-except ImportError:
-    yaml_available=False
 
 import pyutilib.th as unittest
 
 from pyomo.checker import *
 from pyomo.checker.plugins.checker import PyomoModelChecker
 
+from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 
 currdir = os.path.dirname(os.path.abspath(__file__))
 exdir = os.path.join(currdir, "examples")
@@ -44,7 +40,8 @@ def createTestMethod(defs, package, checkerName, key):
 
 
 def assignTests(cls):
-    defs = yaml.load(open(os.path.join(currdir, 'examples.yml'), 'r'))
+    defs = yaml.load(open(os.path.join(currdir, 'examples.yml'), 'r'),
+                     **yaml_load_args)
     
     for package in defs:
         for checkerName in defs[package]:

--- a/pyomo/common/__init__.py
+++ b/pyomo/common/__init__.py
@@ -21,7 +21,7 @@ from .fileutils import (
     # The following will be deprecated soon
     register_executable, registered_executable, unregister_executable
 )
-from . import config
+from . import config, timing
 from .deprecation import deprecated
 from .errors import DeveloperError
 from ._task import pyomo_api, PyomoAPIData, PyomoAPIFactory

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -117,7 +117,7 @@ def attempt_import(name, error_message=None, only_catch_importerror=True,
 #
 
 yaml, yaml_available = attempt_import('yaml')
-if hasattr(yaml, 'SafeLoader'):
+if yaml_available and hasattr(yaml, 'SafeLoader'):
     yaml_load_args = {'Loader': yaml.SafeLoader}
 else:
     yaml_load_args = {}

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -1,0 +1,126 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import importlib
+import logging
+
+class DeferredImportError(ImportError):
+    pass
+
+class ModuleUnavailable(object):
+    """Dummy object that raises a DeferredImportError upon attribute access
+
+    This object is returned by attempt_import() in liu of the module in
+    the case that the module import fails.  Any attempts to access
+    attributes on this object will raise a DeferredImportError
+    exception.
+
+    Parameters
+    ----------
+    message: str
+        The string message to return in the raised exception
+    """
+    def __init__(self, message):
+        self._error_message_ = message
+
+    def __getattr__(self, attr):
+        raise DeferredImportError(self._error_message_)
+
+    def generate_import_warning(self, logger='pyomo.common'):
+        logging.getLogger(logger).warning(
+            self._error_message_)
+
+try:
+    from packaging import version as _version
+    _parser = _version.parse
+except ImportError:
+    # pkg_resources is an order of magnitude slower to import than
+    # packaging.  Only use it if the preferred (but optional) packaging
+    # library is not present
+    from pkg_resources import parse_version as _parser
+
+def _check_version(module, min_version):
+    return _parser(min_version) <= _parser(module.__version__)
+    
+
+def attempt_import(name, error_message=None, only_catch_importerror=True,
+                   minimum_version=None):
+    """Attempt to import the specified module.
+
+    This will attempt to import the specified module, returning a
+    (module, available) tuple.  If the import was successful, `module`
+    will be the imported module and `available` will be True.  If the
+    import results in an exception, then `module` will be an instance of
+    :py:class:`ModuleUnavailable` and `available` will be False
+
+    The following is equivalent to ``import numpy as np``:
+
+    .. doctest::
+
+       >>> from pyomo.common.dependencies import attempt_import
+       >>> np, numpy_available = attempt_import('numpy')
+
+    Parameters
+    ----------
+    name: `str`
+        The name of the module to import
+
+    error_message: `str`, optional
+        The message for the exception raised by ModuleUnavailable
+
+    only_catch_importerror: `bool`, optional
+        If True, exceptions other than ImportError raised during module
+        import will be reraised.  If False, any exception will result in
+        returning a ModuleUnavailable object.
+
+    Returns
+    -------
+    : module
+        the imported module or an instance of :py:class:`ModuleUnavailable`
+    : bool
+        Boolean indicating if the module import succeeded
+    """
+    try:
+        module = importlib.import_module(name)
+        if minimum_version is None:
+            return module, True
+        elif _check_version(module, minimum_version):
+            return module, True
+        elif error_message:
+            error_message += " (version %s does not satisfy the minimum " \
+                             "version %s)" % (
+                                 module.__version__, minimum_version)
+        else:
+            error_message = "The %s module version %s does not satisfy " \
+                            "the minimum version %s" % (
+                                name, module.__version__.minimum_version)
+    except ImportError:
+        pass
+    except:
+        if only_catch_importerror:
+            raise
+
+    if not error_message:
+        error_message = "The %s module (an optional Pyomo dependency) " \
+                        "failed to import" % (name,)
+    return ModuleUnavailable(error_message), False
+
+#
+# Common optional dependencies used throughout Pyomo
+#
+
+yaml, yaml_available = attempt_import('yaml')
+if hasattr(yaml, 'SafeLoader'):
+    yaml_load_args = {'Loader': yaml.SafeLoader}
+else:
+    yaml_load_args = {}
+
+numpy, numpy_available = attempt_import('numpy')
+scipy, scipy_available = attempt_import('scipy')

--- a/pyomo/common/tests/test_task.py
+++ b/pyomo/common/tests/test_task.py
@@ -16,13 +16,6 @@ from pyomo.common.log import LoggingIntercept
 
 from six import StringIO
 
-try:
-    import yaml
-    yaml_available=True
-except ImportError:
-    yaml_available=False
-
-
 class TestData(unittest.TestCase):
 
     def test_print_PyomoAPIData_string(self):
@@ -46,7 +39,6 @@ c:
     y: 2""")
         self.assertEqual(len(data._dirty_), 0)
 
-    @unittest.skipIf(not yaml_available, "No YAML interface available")
     def test_print_PyomoAPIData_repr(self):
         #"""Print PyomoAPIData representation"""
         data = PyomoAPIData()

--- a/pyomo/contrib/pynumero/__init__.py
+++ b/pyomo/contrib/pynumero/__init__.py
@@ -7,39 +7,26 @@
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
-try:
-    import numpy as np
-    # Note: sparse.BlockVector leverages the __array__ufunc__ interface
-    # released in numpy 1.13
-    numpy_available = np.lib.NumpyVersion(np.__version__) >= '1.13.0'
-    if not numpy_available:
-        import pyomo.common  # ...to set up the logger
-        import logging
-        logging.getLogger('pyomo.contrib.pynumero').warn(
-            "Pynumero requires numpy>=1.13.0; found %s" % (np.__version__,))
-except ImportError:
-    numpy_available = False
 
-try:
-    import scipy
-    scipy_available = True
-except ImportError:
-    scipy_available = False
-    import pyomo.common  # ...to set up the logger
-    import logging
-    logging.getLogger('pyomo.contrib.pynumero').warn(
-        "Scipy not available. Install scipy before using pynumero")
+from pyomo.common.dependencies import attempt_import
 
-if numpy_available:
-    from .sparse.intrinsic import *
-else:
+scipy, scipy_available = attempt_import('scipy', 'Pynumero requires scipy')
+
+# Note: sparse.BlockVector leverages the __array__ufunc__ interface
+# released in numpy 1.13
+numpy, numpy_available = attempt_import('numpy', 'Pynumero requires numpy',
+                                        minimum_version='1.13.0')
+
+if not scipy_available:
     # In general, generating output in __init__.py is undesirable, as
     # many __init__.py get imported automatically by pyomo.environ.
     # Fortunately, at the moment, pynumero doesn't implement any
     # plugins, so pyomo.environ ignores it.  When we start implementing
     # general solvers in pynumero we will want to remove / move this
     # warning somewhere deeper in the code.
-    import pyomo.common  # ...to set up the logger
-    import logging
-    logging.getLogger('pyomo.contrib.pynumero').warn(
-        "Numpy not available. Install numpy>=1.13.0 before using pynumero")
+    scipy.generate_import_warning('pyomo.contrib.pynumero')
+
+if not numpy_available:
+    numpy.generate_import_warning('pyomo.contrib.pynumero')
+else:
+    from .sparse.intrinsic import *

--- a/pyomo/contrib/pynumero/extensions/asl.py
+++ b/pyomo/contrib/pynumero/extensions/asl.py
@@ -8,7 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 from pyomo.contrib.pynumero.extensions.utils import find_pynumero_library
-from pkg_resources import resource_filename
 import numpy.ctypeslib as npct
 import numpy as np
 import platform

--- a/pyomo/contrib/pynumero/sparse/block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/block_vector.py
@@ -20,9 +20,11 @@ where v_i are numpy arrays of dimension 1
 .. rubric:: Contents
 
 """
-from .base_block import BaseBlockVector
-import numpy as np
+
 import operator
+
+from pyomo.contrib.pynumero import numpy as np
+from .base_block import BaseBlockVector
 
 __all__ = ['BlockVector', 'NotFullyDefinedBlockVectorError']
 

--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_matrix.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_matrix.py
@@ -11,14 +11,17 @@
 import warnings
 import pyutilib.th as unittest
 
+from pyomo.contrib.pynumero import (
+    numpy_available, scipy_available, numpy as np
+)
+
 SKIPTESTS=[]
-from pyomo.contrib.pynumero import numpy_available, scipy_available
 if numpy_available and scipy_available:
-    import numpy as np
     from scipy.sparse import coo_matrix, bmat
-    from pyomo.contrib.pynumero.sparse import BlockVector, BlockMatrix
 else:
-    SKIPTESTS.append("Pynumero needs scipy and numpy>=1.13.0 to run BlockMatrix tests")
+    SKIPTESTS.append(
+        "Pynumero needs scipy and numpy>=1.13.0 to run BlockMatrix tests"
+    )
 
 try:
     from mpi4py import MPI
@@ -31,6 +34,7 @@ except ImportError:
     SKIPTESTS.append("Pynumero needs mpi4py to run BlockMatrix MPI tests")
 
 if not SKIPTESTS:
+    from pyomo.contrib.pynumero.sparse import BlockVector, BlockMatrix
     from pyomo.contrib.pynumero.sparse.mpi_block_vector import MPIBlockVector
     from pyomo.contrib.pynumero.sparse.mpi_block_matrix import (
         MPIBlockMatrix, NotFullyDefinedBlockMatrixError

--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
@@ -9,14 +9,17 @@
 #  ___________________________________________________________________________
 import pyutilib.th as unittest
 
+from pyomo.contrib.pynumero import (
+    numpy_available, scipy_available, numpy as np
+)
+
 SKIPTESTS=[]
-from pyomo.contrib.pynumero import numpy_available, scipy_available
 if numpy_available and scipy_available:
-    import numpy as np
     from scipy.sparse import coo_matrix, bmat
-    from pyomo.contrib.pynumero.sparse import BlockVector
 else:
-    SKIPTESTS.append("Pynumero needs scipy and numpy>=1.13.0 to run BlockMatrix tests")
+    SKIPTESTS.append(
+        "Pynumero needs scipy and numpy>=1.13.0 to run BlockMatrix tests"
+    )
 
 try:
     from mpi4py import MPI
@@ -29,6 +32,7 @@ except ImportError:
     SKIPTESTS.append("Pynumero needs mpi4py to run BlockVector MPI tests")
 
 if not SKIPTESTS:
+    from pyomo.contrib.pynumero.sparse import BlockVector
     from pyomo.contrib.pynumero.sparse.mpi_block_vector import MPIBlockVector
 
 

--- a/pyomo/contrib/trustregion/GeometryGenerator.py
+++ b/pyomo/contrib/trustregion/GeometryGenerator.py
@@ -3,7 +3,6 @@ import logging
 # This is an auto geometry generator for quadratic ROM
 import numpy as np
 from six import StringIO
-import pyomo.common
 from pyomo.contrib.trustregion.cache import GeometryCache
 
 logger = logging.getLogger('pyomo.contrib.trustregion')

--- a/pyomo/core/base/config.py
+++ b/pyomo/core/base/config.py
@@ -1,16 +1,12 @@
 import appdirs
 import os
 import json
-try:
-    import yaml
-    yaml_available = True
-except ImportError:
-    yaml_available = False
 
 from pyutilib.misc.config import ConfigBase
 from pyomo.common.config import (
     ConfigBlock, ConfigValue, ADVANCED_OPTION, PYOMO_CONFIG_DIR,
 )
+from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 import logging
 logger = logging.getLogger('pyomo.core')
 
@@ -21,16 +17,16 @@ class _PyomoOptions(object):
         self._options_stack = [ default_pyomo_config() ]
 
         # Load the user's configuration
-        sources = [(json.load, 'json')]
+        sources = [(json.load, 'json', {})]
         if yaml_available:
-            sources.append( (yaml.load, 'yml') )
-            sources.append( (yaml.load, 'yaml') )
-        for parser, suffix in sources:
+            sources.append( (yaml.load, 'yml', yaml_load_args) )
+            sources.append( (yaml.load, 'yaml', yaml_load_args) )
+        for parser, suffix, parser_args in sources:
             cfg_file = os.path.join( PYOMO_CONFIG_DIR, 'config.'+suffix)
             if os.path.exists(cfg_file):
                 fp = open(cfg_file)
                 try:
-                    data = parser(fp)
+                    data = parser(fp, **parser_args)
                 except:
                     logger.error("Error parsing the user's default "
                                  "configuration file\n\t%s." % (cfg_file,))

--- a/pyomo/core/tests/diet/test_diet.py
+++ b/pyomo/core/tests/diet/test_diet.py
@@ -12,8 +12,6 @@ import os
 from nose.tools import nottest
 
 import pyutilib.th as unittest
-from pyutilib.misc.pyyaml_util import *
-import pyutilib.common
 
 import pyomo.scripting.pyomo_main as main
 from pyomo.opt import check_available_solvers

--- a/pyomo/core/tests/examples/test_pyomo.py
+++ b/pyomo/core/tests/examples/test_pyomo.py
@@ -21,17 +21,12 @@ import pyutilib.subprocess
 import pyutilib.th as unittest
 from pyutilib.misc import setup_redirect, reset_redirect
 
+from pyomo.common.dependencies import yaml_available
 import pyomo.core
 import pyomo.scripting.pyomo_main as main
 from pyomo.opt import check_available_solvers
 
 from six import StringIO
-
-try:
-    import yaml
-    yaml_available=True
-except ImportError:
-    yaml_available=False
 
 if os.path.exists(sys.exec_prefix+os.sep+'bin'+os.sep+'coverage'):
     executable=sys.exec_prefix+os.sep+'bin'+os.sep+'coverage -x '

--- a/pyomo/core/tests/unit/test_model.py
+++ b/pyomo/core/tests/unit/test_model.py
@@ -18,22 +18,17 @@ import sys
 from os.path import abspath, dirname, join
 currdir = dirname(abspath(__file__))
 import pickle
+
 import pyutilib.th as unittest
 import pyutilib.services
-import pyomo.opt
-from pyomo.opt import SolutionStatus
-from pyomo.opt.parallel.local import SolverManager_Serial
-from pyomo.environ import *
+
+from pyomo.common.dependencies import yaml_available
 from pyomo.core.expr import current as EXPR
+from pyomo.environ import *
+from pyomo.opt import SolutionStatus, check_available_solvers
+from pyomo.opt.parallel.local import SolverManager_Serial
 
-solvers = pyomo.opt.check_available_solvers('glpk')
-
-try:
-    import yaml
-    yaml_available=True
-except ImportError:
-    yaml_available=False
-
+solvers = check_available_solvers('glpk')
 
 class Test(unittest.TestCase):
 

--- a/pyomo/dataportal/plugins/json_dict.py
+++ b/pyomo/dataportal/plugins/json_dict.py
@@ -11,14 +11,10 @@
 import os.path
 import json
 import six
-try:
-    import yaml
-    yaml_available = True
-except ImportError:
-    yaml_available = False
 
 from pyutilib.misc import Options
 
+from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 from pyomo.dataportal.factory import DataManagerFactory
 
 
@@ -227,7 +223,7 @@ class YamlDictionary(object):
         if not os.path.exists(self.filename):
             raise IOError("Cannot find file '%s'" % self.filename)
         INPUT = open(self.filename, 'r')
-        jdata = yaml.load(INPUT)
+        jdata = yaml.load(INPUT, **yaml_load_args)
         INPUT.close()
         if jdata is None:
             raise IOError("Empty YAML file")

--- a/pyomo/dataportal/tests/test_dataportal.py
+++ b/pyomo/dataportal/tests/test_dataportal.py
@@ -21,12 +21,6 @@ import pyutilib.th as unittest
 from pyomo.dataportal.factory import DataManagerFactory
 from pyomo.environ import *
 
-try:
-    import yaml
-    yaml_available=True
-except ImportError:
-    yaml_available=False
-
 currdir=dirname(abspath(__file__))+os.sep
 example_dir=pyomo_dir+os.sep+".."+os.sep+"examples"+os.sep+"pyomo"+os.sep+"tutorials"+os.sep+"tab"+os.sep
 tutorial_dir=pyomo_dir+os.sep+".."+os.sep+"examples"+os.sep+"pyomo"+os.sep+"tutorials"+os.sep
@@ -1033,7 +1027,7 @@ class TestJsonPortal(TestTextPortal):
         return {'filename':os.path.abspath(tutorial_dir+os.sep+'json'+os.sep+name+self.suffix)}
 
 
-@unittest.skipIf(not yaml_available, "YAML not available available")
+@unittest.skipIf(not yaml_interface, "YAML interface not available")
 class TestYamlPortal(TestTextPortal):
 
     suffix = '.yaml'

--- a/pyomo/duality/plugins.py
+++ b/pyomo/duality/plugins.py
@@ -11,7 +11,6 @@
 import logging
 from six import iteritems
 
-import pyomo.common
 from pyomo.common.deprecation import deprecated
 from pyomo.core.base import (Transformation,
                              TransformationFactory,

--- a/pyomo/duality/tests/test_linear_dual.py
+++ b/pyomo/duality/tests/test_linear_dual.py
@@ -19,6 +19,7 @@ exdir = normpath(join(currdir,'..','..','..','examples','pyomo','core'))
 
 import pyutilib.th as unittest
 
+from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 import pyomo.opt
 from pyomo.environ import *
 from pyomo.scripting.util import cleanup
@@ -26,12 +27,6 @@ import pyomo.scripting.pyomo_main as main
 
 
 from six import iteritems
-
-try:
-    import yaml
-    yaml_available=True
-except ImportError:
-    yaml_available=False
 
 solver = None
 class CommonTests(object):
@@ -82,7 +77,7 @@ class CommonTests(object):
 
     def getObjective(self, fname):
         FILE = open(fname)
-        data = yaml.load(FILE)
+        data = yaml.load(FILE, **yaml_load_args)
         FILE.close()
         solutions = data.get('Solution', [])
         ans = []

--- a/pyomo/gdp/tests/test_gdp.py
+++ b/pyomo/gdp/tests/test_gdp.py
@@ -26,18 +26,12 @@ except:
 
 import pyutilib.th as unittest
 
+from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 import pyomo.opt
 import pyomo.scripting.pyomo_main as main
 from pyomo.environ import *
 
 from six import iteritems
-
-
-try:
-    import yaml
-    yaml_available=True
-except ImportError:
-    yaml_available=False
 
 solvers = pyomo.opt.check_available_solvers('cplex', 'glpk','gurobi')
 
@@ -110,7 +104,7 @@ class CommonTests:
 
     def getObjective(self, fname):
         FILE = open(fname)
-        data = yaml.load(FILE)
+        data = yaml.load(FILE, **yaml_load_args)
         FILE.close()
         solutions = data.get('Solution', [])
         ans = []

--- a/pyomo/mpec/tests/test_minlp.py
+++ b/pyomo/mpec/tests/test_minlp.py
@@ -20,18 +20,13 @@ exdir = normpath(join(currdir,'..','..','..','examples','mpec'))
 
 import pyutilib.th as unittest
 
+from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 import pyomo.opt
 import pyomo.scripting.pyomo_main as pyomo_main
 from pyomo.scripting.util import cleanup
 from pyomo.environ import *
 
 from six import iteritems
-
-try:
-    import yaml
-    yaml_available=True
-except ImportError:
-    yaml_available=False
 
 solvers = pyomo.opt.check_available_solvers('cplex', 'glpk')
 
@@ -85,7 +80,7 @@ class CommonTests:
 
     def getObjective(self, fname):
         FILE = open(fname,'r')
-        data = yaml.load(FILE)
+        data = yaml.load(FILE, **yaml_load_args)
         FILE.close()
         solutions = data.get('Solution', [])
         ans = []

--- a/pyomo/mpec/tests/test_nlp.py
+++ b/pyomo/mpec/tests/test_nlp.py
@@ -20,18 +20,13 @@ exdir = normpath(join(currdir,'..','..','..','examples','mpec'))
 
 import pyutilib.th as unittest
 
+from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 import pyomo.opt
 import pyomo.scripting.pyomo_main as pyomo_main
 from pyomo.scripting.util import cleanup
 from pyomo.environ import *
 
 from six import iteritems
-
-try:
-    import yaml
-    yaml_available=True
-except ImportError:
-    yaml_available=False
 
 solvers = pyomo.opt.check_available_solvers('ipopt')
 
@@ -85,7 +80,7 @@ class CommonTests:
 
     def getObjective(self, fname):
         FILE = open(fname,'r')
-        data = yaml.load(FILE)
+        data = yaml.load(FILE, **yaml_load_args)
         FILE.close()
         solutions = data.get('Solution', [])
         ans = []

--- a/pyomo/mpec/tests/test_path.py
+++ b/pyomo/mpec/tests/test_path.py
@@ -20,18 +20,14 @@ exdir = normpath(join(currdir,'..','..','..','examples','mpec'))
 
 import six
 import pyutilib.th as unittest
+
+from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 import pyomo.opt
 import pyomo.scripting.pyomo_main as pyomo_main
 from pyomo.scripting.util import cleanup
 from pyomo.environ import *
 
 from six import iteritems
-
-try:
-    import yaml
-    yaml_available=True
-except ImportError:
-    yaml_available=False
 
 solvers = pyomo.opt.check_available_solvers('path')
 
@@ -80,7 +76,7 @@ class CommonTests:
 
     def getObjective(self, fname):
         FILE = open(fname,'r')
-        data = yaml.load(FILE)
+        data = yaml.load(FILE, **yaml_load_args)
         FILE.close()
         solutions = data.get('Solution', [])
         ans = []

--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -17,6 +17,7 @@ currdir = dirname(abspath(__file__))
 
 import pyutilib.th as unittest
 
+from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 import pyomo.scripting.pyomo_command as main
 from pyomo.scripting.util import cleanup
 from pyomo.neos.kestrel import kestrelAMPL
@@ -33,12 +34,6 @@ try:
         neos_available = True
 except:
     pass
-
-try:
-    import yaml
-    yaml_available=True
-except ImportError:
-    yaml_available=False
 
 
 #
@@ -67,7 +62,7 @@ class TestKestrel(unittest.TestCase):
             self.assertEqual(output.errorcode, 0)
 
             with open(results) as FILE:
-                data = yaml.load(FILE)
+                data = yaml.load(FILE, **yaml_load_args)
             self.assertEqual(
                 data['Solver'][0]['Status'], 'ok')
             self.assertAlmostEqual(

--- a/pyomo/opt/base/opt_config.py
+++ b/pyomo/opt/base/opt_config.py
@@ -8,4 +8,3 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pyomo.common

--- a/pyomo/opt/results/results_.py
+++ b/pyomo/opt/results/results_.py
@@ -15,6 +15,7 @@ import sys
 import copy
 import json
 
+from pyomo.common.dependencies import yaml, yaml_load_args
 import pyomo.opt
 from pyomo.opt.results.container import (undefined,
                                          ignore,
@@ -27,12 +28,6 @@ import pyomo.opt.results.solver
 
 from six import iteritems, StringIO
 from six.moves import xrange
-
-try:
-    import yaml
-    yaml_available=True
-except ImportError:
-    yaml_available=False
 
 
 class SolverResults(MapContainer):
@@ -182,9 +177,7 @@ class SolverResults(MapContainer):
             return
 
         if not 'format' in kwds or kwds['format'] == 'yaml':
-            if not yaml_available:
-                raise IOError("Aborting SolverResults.read() because PyYAML is not installed!")
-            repn = yaml.load(istream, Loader=yaml.SafeLoader)
+            repn = yaml.load(istream, **yaml_load_args)
         else:
             repn = json.load(istream)
         for i in xrange(len(self._order)):

--- a/pyomo/opt/testing/pyunit.py
+++ b/pyomo/opt/testing/pyunit.py
@@ -19,12 +19,6 @@ from inspect import getfile
 import pyutilib.th as unittest
 import pyutilib.subprocess
 
-try:
-    import yaml
-    using_yaml=True
-except ImportError:
-    using_yaml=False
-
 def _failIfPyomoResultsDiffer(self, cmd=None, baseline=None, cwd=None):
     if cwd is None:
         cwd = os.path.dirname(os.path.abspath(getfile(self.__class__)))
@@ -61,14 +55,10 @@ class TestCase(unittest.TestCase):
         unittest.TestCase.__init__(self, methodName)
 
     def failIfPyomoResultsDiffer(self, cmd, baseline, cwd=None):
-        if not using_yaml:
-            self.fail("Cannot compare Pyomo results because PyYaml is not installed")
         _failIfPyomoResultsDiffer(self, cmd=cmd, baseline=baseline, cwd=cwd)
 
     @unittest.nottest
     def add_pyomo_results_test(cls, name=None, cmd=None, fn=None, baseline=None, cwd=None):
-        if not using_yaml:
-            return
         if cmd is None and fn is None:
             print("ERROR: must specify either the 'cmd' or 'fn' option to define how the output file is generated")
             return

--- a/pyomo/opt/tests/base/test_soln.py
+++ b/pyomo/opt/tests/base/test_soln.py
@@ -21,15 +21,10 @@ import pyutilib.th as unittest
 import pyutilib.misc
 import pyutilib.services
 
+from pyomo.common.dependencies import yaml_available
 import pyomo.opt
 
 from six import iterkeys
-
-try:
-    import yaml
-    yaml_available=True
-except ImportError:
-    yaml_available=False
 
 old_tempdir = pyutilib.services.TempfileManager.tempdir
 

--- a/pyomo/pysp/ef_writer_script.py
+++ b/pyomo/pysp/ef_writer_script.py
@@ -19,6 +19,7 @@ import pyutilib.misc
 from pyutilib.pyro import shutdown_pyro_components
 
 import pyomo.solvers
+from pyomo.common.dependencies import yaml
 from pyomo.common import pyomo_command
 from pyomo.opt import (SolverFactory,
                        TerminationCondition,
@@ -773,7 +774,6 @@ def runef(options,
                         with open(options.output_scenario_costs, 'w') as f:
                             json.dump(result, f, indent=2, sort_keys=True)
                     elif options.output_scenario_costs.endswith('.yaml'):
-                        import yaml
                         result = {}
                         for scenario in manager.scenario_tree.scenarios:
                             result[str(scenario.name)] = scenario._cost

--- a/pyomo/pysp/evaluate_xhat.py
+++ b/pyomo/pysp/evaluate_xhat.py
@@ -13,6 +13,7 @@ import time
 import copy
 
 from pyomo.common import pyomo_command
+from pyomo.common.dependencies import yaml
 from pyomo.core import minimize
 from pyomo.pysp.util.config import (PySPConfigValue,
                                     PySPConfigBlock,
@@ -214,7 +215,6 @@ def run_evaluate_xhat(options,
                 with open(options.output_scenario_costs, 'w') as f:
                     json.dump(result, f, indent=2, sort_keys=True)
             elif options.output_scenario_costs.endswith('.yaml'):
-                import yaml
                 result = {}
                 for scenario in sp.scenario_tree.scenarios:
                     result[str(scenario.name)] = scenario._cost

--- a/pyomo/pysp/phinit.py
+++ b/pyomo/pysp/phinit.py
@@ -34,7 +34,7 @@ from pyutilib.pyro import shutdown_pyro_components
 from pyutilib.misc import import_file
 
 from pyomo.common import pyomo_command
-from pyomo.common.plugin import ExtensionPoint
+from pyomo.common.plugin import ExtensionPoint, SingletonPlugin
 from pyomo.core.base import maximize, minimize, Var, Suffix
 from pyomo.opt.base import SolverFactory
 from pyomo.opt.parallel import SolverManagerFactory
@@ -722,11 +722,10 @@ def PHAlgorithmBuilder(options, scenario_tree):
 
             for name, obj in inspect.getmembers(sys.modules[module_to_find],
                                                 inspect.isclass):
-                import pyomo.common
                 # the second condition gets around goofyness related
                 # to issubclass returning True when the obj is the
                 # same as the test class.
-                if issubclass(obj, pyomo.common.plugin.SingletonPlugin) and name != "SingletonPlugin":
+                if issubclass(obj, SingletonPlugin) and name != "SingletonPlugin":
                     for plugin in solution_writer_plugins(all=True):
                         if isinstance(plugin, obj):
                             plugin.enable()
@@ -835,11 +834,10 @@ def PHAlgorithmBuilder(options, scenario_tree):
 
             for name, obj in inspect.getmembers(sys.modules[module_to_find],
                                                 inspect.isclass):
-                import pyomo.common
                 # the second condition gets around goofyness related
                 # to issubclass returning True when the obj is the
                 # same as the test class.
-                if issubclass(obj, pyomo.common.plugin.SingletonPlugin) and name != "SingletonPlugin":
+                if issubclass(obj, SingletonPlugin) and name != "SingletonPlugin":
                     ph_extension_point = ExtensionPoint(IPHExtension)
                     for plugin in ph_extension_point(all=True):
                         if isinstance(plugin, obj):

--- a/pyomo/pysp/phsolverserver.py
+++ b/pyomo/pysp/phsolverserver.py
@@ -26,7 +26,7 @@ from pyutilib.pyro import (TaskWorker,
 from pyomo.core import *
 from pyomo.opt import UndefinedData
 from pyomo.common import pyomo_command
-from pyomo.common.plugin import ExtensionPoint
+from pyomo.common.plugin import ExtensionPoint, SingletonPlugin
 from pyomo.opt import (SolverFactory,
                        TerminationCondition,
                        SolutionStatus)
@@ -1362,10 +1362,9 @@ def exec_phsolverserver(options):
                 module_to_find = string.split(module_to_find,"/")[-1]
 
             for name, obj in inspect.getmembers(sys.modules[module_to_find], inspect.isclass):
-                import pyomo.common
                 # the second condition gets around goofyness related to issubclass returning
                 # True when the obj is the same as the test class.
-                if issubclass(obj, pyomo.common.plugin.SingletonPlugin) and name != "SingletonPlugin":
+                if issubclass(obj, SingletonPlugin) and name != "SingletonPlugin":
                     ph_extension_point = ExtensionPoint(IPHSolverServerExtension)
                     for plugin in ph_extension_point(all=True):
                         if isinstance(plugin, obj):

--- a/pyomo/pysp/plugins/wwphextension.py
+++ b/pyomo/pysp/plugins/wwphextension.py
@@ -14,6 +14,7 @@ import math
 import os
 import random
 
+from pyomo.common.dependencies import yaml, yaml_load_args
 import pyomo.common.plugin
 from pyomo.pysp import phextension
 from pyomo.pysp.phutils import *
@@ -30,14 +31,8 @@ from six.moves import xrange
 ###############
 def _parse_yaml_file(ph, filename):
 
-    try:
-        import yaml
-    except:
-        raise RuntimeError("***The PyYAML module is required "
-                           "to load file: "+filename)
-
     with open(filename) as f:
-        config_data = yaml.load(f)
+        config_data = yaml.load(f, **yaml_load_args)
 
     for node_or_stage_name, variable_dicts in iteritems(config_data):
 

--- a/pyomo/pysp/scenariotree/instance_factory.py
+++ b/pyomo/pysp/scenariotree/instance_factory.py
@@ -27,6 +27,7 @@ from pyomo.core import (Block,
                         IPyomoScriptModifyInstance,
                         AbstractModel)
 from pyomo.core.base.block import _BlockData
+from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 from pyomo.common.plugin import ExtensionPoint
 from pyomo.pysp.phutils import _OLD_OUTPUT
 from pyomo.pysp.util.misc import load_external_module
@@ -37,13 +38,6 @@ from pyomo.pysp.scenariotree.tree_structure import \
     ScenarioTree
 
 import six
-
-has_yaml = False
-try:
-    import yaml
-    has_yaml = True
-except:                #pragma:nocover
-    has_yaml = False
 
 has_networkx = False
 try:
@@ -639,7 +633,7 @@ class ScenarioTreeInstanceFactory(object):
                             scenario_data_filename + ".dat"
                         data = None
                     elif os.path.exists(scenario_data_filename+'.yaml'):
-                        if not has_yaml:
+                        if not yaml_available:
                             raise ValueError(
                                 "Found yaml data file for scenario '%s' "
                                 "but he PyYAML module is not available"
@@ -647,7 +641,7 @@ class ScenarioTreeInstanceFactory(object):
                         scenario_data_filename = \
                             scenario_data_filename+".yaml"
                         with open(scenario_data_filename) as f:
-                            data = yaml.load(f)
+                            data = yaml.load(f, **yaml_load_args)
                     else:
                         raise RuntimeError(
                             "Cannot find a data file for scenario '%s' "

--- a/pyomo/pysp/scenariotree/preprocessor.py
+++ b/pyomo/pysp/scenariotree/preprocessor.py
@@ -28,7 +28,6 @@ from pyomo.repn.standard_repn import (preprocess_block_objectives,
                                       preprocess_block_constraints,
                                       preprocess_constraint_data)
 
-import pyomo.common
 from pyomo.pysp.util.config import (PySPConfigBlock,
                                     safe_declare_common_option)
 from pyomo.pysp.util.configured_object import PySPConfiguredObject

--- a/pyomo/pysp/solvers/ef.py
+++ b/pyomo/pysp/solvers/ef.py
@@ -18,6 +18,7 @@ import pyutilib.misc
 from pyutilib.pyro import shutdown_pyro_components
 
 import pyomo.solvers
+from pyomo.common.dependencies import yaml
 from pyomo.core.base import ComponentUID
 from pyomo.opt import (SolverFactory,
                        TerminationCondition,
@@ -820,7 +821,6 @@ def runef(options,
                     with open(options.output_scenario_costs, 'w') as f:
                         json.dump(result, f, indent=2, sort_keys=True)
                 elif options.output_scenario_costs.endswith('.yaml'):
-                    import yaml
                     result = {}
                     for scenario in sp.scenario_tree.scenarios:
                         result[str(scenario.name)] = scenario._cost

--- a/pyomo/pysp/tests/examples/test_ph.py
+++ b/pyomo/pysp/tests/examples/test_ph.py
@@ -27,6 +27,7 @@ except:
 import pyutilib.th as unittest
 from pyutilib.misc.comparison import open_possibly_compressed_file
 import pyutilib.services
+from pyomo.common.dependencies import yaml_available
 from pyomo.pysp.util.misc import (_get_test_nameserver,
                                   _get_test_dispatcher,
                                   _poll,
@@ -34,12 +35,6 @@ from pyomo.pysp.util.misc import (_get_test_nameserver,
 from pyomo.pysp.tests.examples.ph_checker import main as validate_ph_main
 from pyutilib.pyro import using_pyro3, using_pyro4
 
-has_yaml = False
-try:
-    import yaml
-    has_yaml = True
-except ImportError:
-    has_yaml = False
 
 # Global test configuration options
 _test_name_wildcard_include = ["*"]
@@ -620,7 +615,7 @@ class FarmerTester(PHTester):
 
     # Test the wwphextension plugin (it's best if this test involves
     # variable fixing)
-    @unittest.skipIf(not has_yaml, "PyYAML module is not available")
+    @unittest.skipIf(not yaml_available, "PyYAML module is not available")
     def test6(self):
         self._baseline_test(options_string=("--enable-ww-extensions "
                                             "--ww-extension-cfgfile="
@@ -630,7 +625,7 @@ class FarmerTester(PHTester):
 
     # Test the wwphextension plugin (it's best if this test involves
     # variable fixing) and solve ef
-    @unittest.skipIf(not has_yaml, "PyYAML module is not available")
+    @unittest.skipIf(not yaml_available, "PyYAML module is not available")
     def test6_withef(self):
         self._withef_compare_baseline_test("test6",
                                            options_string=("--enable-ww-extensions "
@@ -641,7 +636,7 @@ class FarmerTester(PHTester):
 
     # Test the phboundextension plugin and that it does not effect ph
     # convergence
-    @unittest.skipIf(not has_yaml, "PyYAML module is not available")
+    @unittest.skipIf(not yaml_available, "PyYAML module is not available")
     def test7(self):
         def check_baseline_func(self, class_name, test_name):
             prefix = class_name+"."+test_name
@@ -668,7 +663,7 @@ class FarmerTester(PHTester):
 
     # Test the convexhullboundextension plugin (which does affect ph
     # convergence)
-    @unittest.skipIf(not has_yaml, "PyYAML module is not available")
+    @unittest.skipIf(not yaml_available, "PyYAML module is not available")
     def test8(self):
         self._convexhullboundextension_baseline_test()
 
@@ -676,7 +671,7 @@ class FarmerTester(PHTester):
     # (wwphextension), which involves variable fixing. These plugins
     # should not interact with each other so we additionally test
     # their output files against test6
-    @unittest.skipIf(not has_yaml, "PyYAML module is not available")
+    @unittest.skipIf(not yaml_available, "PyYAML module is not available")
     def test9(self):
         def check_baseline_func(self, class_name, test_name):
             prefix = class_name+"."+test_name
@@ -712,7 +707,7 @@ class FarmerTester(PHTester):
     # (wwphextension), which involves variable fixing. These plugins
     # likely interact with each other.  Not sure I can perform any
     # additional tests here.
-    @unittest.skipIf(not has_yaml, "PyYAML module is not available")
+    @unittest.skipIf(not yaml_available, "PyYAML module is not available")
     def test10(self):
         self._convexhullboundextension_baseline_test(
             options_string=("--enable-ww-extensions "
@@ -722,7 +717,7 @@ class FarmerTester(PHTester):
                             +join(farmer_config_dir,'wwph.suffixes')))
 
     # This is test9 with the --preprocess-fixed-variables flag
-    @unittest.skipIf(not has_yaml, "PyYAML module is not available")
+    @unittest.skipIf(not yaml_available, "PyYAML module is not available")
     def test11(self):
         def cleanup_func(self, class_name, test_name):
             prefix = class_name+"."+test_name
@@ -789,7 +784,7 @@ class FarmerTester(PHTester):
             check_baseline_func=check_baseline_func)
 
     # This is test10 with the --preprocess-fixed-variables flag
-    @unittest.skipIf(not has_yaml, "PyYAML module is not available")
+    @unittest.skipIf(not yaml_available, "PyYAML module is not available")
     def test12(self):
         def cleanup_func(self, class_name, test_name):
             prefix = class_name+"."+test_name
@@ -859,7 +854,7 @@ class FarmerTester(PHTester):
             check_baseline_func=check_baseline_func)
 
     # This is test6 with the --preprocess-fixed-variables flag
-    @unittest.skipIf(not has_yaml, "PyYAML module is not available")
+    @unittest.skipIf(not yaml_available, "PyYAML module is not available")
     def test13(self):
         def cleanup_func(self, class_name, test_name):
             prefix = class_name+"."+test_name
@@ -1116,7 +1111,7 @@ class NetworkFlowTester(PHTester):
         cls.solver_io = 'nl'
         PHTester._setUpClass(cls)
 
-    @unittest.skipIf(not has_yaml, "PyYAML module is not available")
+    @unittest.skipIf(not yaml_available, "PyYAML module is not available")
     def test1(self):
         self._baseline_test(
             options_string=("--max-iterations=0 --verbose "
@@ -1212,7 +1207,7 @@ class SizesTester(PHTester):
         cls.solver_io = 'nl'
         PHTester._setUpClass(cls)
 
-    @unittest.skipIf(not has_yaml, "PyYAML module is not available")
+    @unittest.skipIf(not yaml_available, "PyYAML module is not available")
     def test1(self):
         self._baseline_test(
             options_string=("--max-iterations=0 "
@@ -1264,7 +1259,7 @@ class ForestryTester(PHTester):
         cls.solver_io = 'nl'
         PHTester._setUpClass(cls)
 
-    @unittest.skipIf(not has_yaml, "PyYAML module is not available")
+    @unittest.skipIf(not yaml_available, "PyYAML module is not available")
     def test1(self):
         self._baseline_test(
             options_string=("--max-iterations=0 "

--- a/pyomo/pysp/tests/unit/test_instancefactory.py
+++ b/pyomo/pysp/tests/unit/test_instancefactory.py
@@ -28,13 +28,6 @@ try:
 except:
     has_networkx = False
 
-has_yaml = False
-try:
-    import yaml
-    has_yaml = True
-except:
-    has_yaml = False
-
 thisfile = abspath(__file__)
 thisdir = dirname(thisfile)
 testdatadir = join(thisdir, "testdata")
@@ -400,7 +393,7 @@ class Test(unittest.TestCase):
     # model: name of directory with ReferenceModel.py file with model
     # scenario_tree: name of .dat file
     # data: name of directory with yaml files
-    @unittest.skipIf(not has_yaml, "PyYAML is not available")
+    @unittest.skipIf(not yaml_available, "PyYAML is not available")
     def test_init10(self):
         with ScenarioTreeInstanceFactory(
                 model=testdatadir,

--- a/pyomo/pysp/tests/unit/test_instancefactory.py
+++ b/pyomo/pysp/tests/unit/test_instancefactory.py
@@ -14,6 +14,7 @@ from os.path import join, dirname, abspath, exists
 
 import pyutilib.th as unittest
 
+from pyomo.common.dependencies import yaml_available
 from pyomo.pysp.scenariotree.instance_factory import \
     ScenarioTreeInstanceFactory
 from pyomo.pysp.scenariotree.tree_structure_model import \

--- a/pyomo/pysp/tests/unit/test_ph.py
+++ b/pyomo/pysp/tests/unit/test_ph.py
@@ -53,13 +53,6 @@ import pyomo.pysp.ef_writer_script
 _diff_tolerance = 1e-5
 _diff_tolerance_relaxed = 1e-3
 
-has_yaml = False
-try:
-    import yaml
-    has_yaml = True
-except:
-    has_yaml = False
-
 def _remove(filename):
     try:
         os.remove(filename)
@@ -1388,7 +1381,7 @@ class TestPHExpensive(unittest.TestCase):
             os.remove(log_output_file)
 
     def test_quadratic_sizes3_cplex(self):
-        if (not solver['cplex','lp']) or (not has_yaml):
+        if (not solver['cplex','lp']) or (not yaml_available):
             self.skipTest("Either the 'cplex' executable is not "
                           "available or PyYAML is not available")
         sizes_example_dir = pysp_examples_dir + "sizes"
@@ -1430,7 +1423,7 @@ class TestPHExpensive(unittest.TestCase):
         os.remove(log_output_file)
 
     def test_quadratic_sizes3_cplex_direct(self):
-        if (not solver['cplex','python']) or (not has_yaml):
+        if (not solver['cplex','python']) or (not yaml_available):
             self.skipTest("The 'cplex' python solver is not "
                           "available or PyYAML is not available")
         sizes_example_dir = pysp_examples_dir + "sizes"
@@ -1472,7 +1465,7 @@ class TestPHExpensive(unittest.TestCase):
         os.remove(log_output_file)
 
     def test_quadratic_sizes3_gurobi(self):
-        if (not solver['gurobi','lp']) or (not has_yaml):
+        if (not solver['gurobi','lp']) or (not yaml_available):
             self.skipTest("Either the 'gurobi' executable is not "
                           "available or PyYAML is not available")
 
@@ -1768,7 +1761,7 @@ class TestPHExpensive(unittest.TestCase):
             os.remove(log_output_file)
 
     def test_linearized_forestry_cplex(self):
-        if (not solver['cplex','lp']) or (not has_yaml):
+        if (not solver['cplex','lp']) or (not yaml_available):
             self.skipTest("Either the 'cplex' executable is not "
                           "available or PyYAML is not available")
 
@@ -1813,7 +1806,7 @@ class TestPHExpensive(unittest.TestCase):
             os.remove(log_output_file)
 
     def test_linearized_forestry_gurobi(self):
-        if (not solver['gurobi','lp']) or (not has_yaml):
+        if (not solver['gurobi','lp']) or (not yaml_available):
             self.skipTest("Either the 'gurobi' executable is not "
                           "available or PyYAML is not available")
 
@@ -2070,7 +2063,7 @@ class TestPHParallel(unittest.TestCase):
 
     @unittest.category('fragile')
     def test_quadratic_sizes3_cplex_with_phpyro(self):
-        if (not solver['cplex','lp']) or (not has_yaml):
+        if (not solver['cplex','lp']) or (not yaml_available):
             self.skipTest("The 'cplex' executable is not available "
                           "or PyYAML is not available")
 
@@ -2131,7 +2124,7 @@ class TestPHParallel(unittest.TestCase):
 
     @unittest.category('fragile')
     def test_linearized_sizes3_cplex_with_phpyro(self):
-        if (not solver['cplex','lp']) or (not has_yaml):
+        if (not solver['cplex','lp']) or (not yaml_available):
             self.skipTest("The 'cplex' executable is not available "
                           "or PyYAML is not available")
 
@@ -2173,7 +2166,7 @@ class TestPHParallel(unittest.TestCase):
             os.remove(log_output_file)
 
     def test_quadratic_sizes3_gurobi_with_phpyro(self):
-        if (not solver['gurobi','lp']) or (not has_yaml):
+        if (not solver['gurobi','lp']) or (not yaml_available):
             self.skipTest("The 'gurobi' executable is not available "
                           "or PyYAML is not available")
 
@@ -2386,7 +2379,7 @@ class TestPHParallel(unittest.TestCase):
                 filter=filter_pyro)
 
     def test_linearized_networkflow1ef10_gurobi_with_phpyro(self):
-        if (not solver['gurobi','lp']) or (not has_yaml):
+        if (not solver['gurobi','lp']) or (not yaml_available):
             self.skipTest("The 'gurobi' executable is not available "
                           "or PyYAML is not available")
 
@@ -2504,7 +2497,7 @@ class TestPHParallel(unittest.TestCase):
 
     @unittest.category('fragile')
     def test_advanced_linearized_networkflow1ef10_cplex_with_phpyro(self):
-        if (not solver['cplex','lp']) or (not has_yaml):
+        if (not solver['cplex','lp']) or (not yaml_available):
             self.skipTest("The 'cplex' executable is not available "
                           "or PyYAML is not available")
 
@@ -2547,7 +2540,7 @@ class TestPHParallel(unittest.TestCase):
 
     @unittest.category('fragile')
     def test_linearized_networkflow1ef10_cplex_with_bundles_with_phpyro(self):
-        if (not solver['cplex','lp']) or (not has_yaml):
+        if (not solver['cplex','lp']) or (not yaml_available):
             self.skipTest("The 'cplex' executable is not available "
                           "or PyYAML is not available")
 

--- a/pyomo/repn/standard_repn.py
+++ b/pyomo/repn/standard_repn.py
@@ -22,7 +22,6 @@ from pyomo.core.base import (Constraint,
                              Objective,
                              ComponentMap)
 
-import pyomo.common
 from pyutilib.misc import Bunch
 from pyutilib.math.util import isclose as isclose_default
 

--- a/pyomo/scripting/driver_help.py
+++ b/pyomo/scripting/driver_help.py
@@ -20,7 +20,7 @@ import argparse
 import pyutilib.subprocess
 from pyutilib.misc import Options
 
-from pyomo.common import get_pyomo_commands
+import pyomo.common
 import pyomo.scripting.pyomo_parser
 
 logger = logging.getLogger('pyomo.solvers')
@@ -86,7 +86,7 @@ def help_commands():
     print("")
     print("The following commands are installed with Pyomo:")
     print("-"*75)
-    registry = get_pyomo_commands()
+    registry = pyomo.common.get_pyomo_commands()
     d = max(len(key) for key in registry)
     fmt = "%%-%ds  %%s" % d
     for key in sorted(registry.keys(), key=lambda v: v.upper()):
@@ -139,7 +139,6 @@ def help_datamanagers(options):
         print(wrapper.fill(DataManagerFactory.doc(xform)))
 
 def help_api(options):
-    import pyomo.common
     services = pyomo.common.PyomoAPIFactory.services()
     #
     f = {}

--- a/pyomo/scripting/util.py
+++ b/pyomo/scripting/util.py
@@ -22,11 +22,6 @@ from six.moves import xrange
 from pyomo.common import pyomo_api
 
 try:
-    import yaml
-    yaml_available=True
-except ImportError:
-    yaml_available=False
-try:
     import cProfile as profile
 except ImportError:
     import profile
@@ -58,10 +53,11 @@ except:
 memory_data = Options()
 
 import pyutilib.misc
-from pyomo.common.plugin import ExtensionPoint, Plugin, implements
 from pyutilib.misc import Container
 from pyutilib.services import TempfileManager
 
+from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
+from pyomo.common.plugin import ExtensionPoint, Plugin, implements
 from pyomo.opt import ProblemFormat
 from pyomo.opt.base import SolverFactory
 from pyomo.opt.parallel import SolverManagerFactory
@@ -407,13 +403,7 @@ def create_model(data):
                                                  profile_memory=data.options.runtime.profile_memory,
                                                  report_timing=data.options.runtime.report_timing)
             elif suffix == "yml" or suffix == 'yaml':
-                try:
-                    import yaml
-                except:
-                    msg = "Cannot apply load data from a YAML file: PyYaml is not installed"
-                    raise SystemExit(msg)
-
-                modeldata = yaml.load(open(data.options.data.files[0]))
+                modeldata = yaml.load(open(data.options.data.files[0]), **yaml_load_args)
                 instance = model.create_instance(modeldata,
                                                  namespaces=data.options.data.namespaces,
                                                  profile_memory=data.options.runtime.profile_memory,
@@ -1032,7 +1022,7 @@ def get_config_values(filename):
         if not yaml_available:
             raise ValueError("ERROR: yaml configuration file specified, but pyyaml is not installed!")
         INPUT = open(filename, 'r')
-        val = yaml.load(INPUT)
+        val = yaml.load(INPUT, **yaml_load_args)
         INPUT.close()
         return val
     elif filename.endswith('.jsn') or filename.endswith('.json'):

--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -11,7 +11,6 @@
 import logging
 import re
 import sys
-import pyomo.common
 from pyutilib.misc import Bunch
 from pyutilib.services import TempfileManager
 from pyomo.core.expr.numvalue import is_fixed

--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -11,7 +11,6 @@
 import logging
 import re
 import sys
-import pyomo.common
 from pyutilib.misc import Bunch
 from pyutilib.services import TempfileManager
 from pyomo.core.expr.numvalue import is_fixed

--- a/pyomo/solvers/tests/piecewise_linear/problems/tester.py
+++ b/pyomo/solvers/tests/piecewise_linear/problems/tester.py
@@ -13,8 +13,6 @@ from pyomo.opt import SolverFactory
 
 from six import itervalues
 
-#import yaml
-
 opt = SolverFactory('cplexamp',solve_io='nl')
 
 kwds = {'pw_constr_type':'UB','pw_repn':'DCC','sense':maximize,'force_pw':True}
@@ -54,6 +52,3 @@ for problem_name in problem_names:
                 if (name[:2] == 'Fx') or (name[:1] == 'x'):
                     res[name] = value(var)
     print(res)
-
-    #with open(problem_name+'_baseline_results.yml','w') as f:
-    #    yaml.dump(res,f)

--- a/pyomo/solvers/tests/piecewise_linear/test_piecewise_linear.py
+++ b/pyomo/solvers/tests/piecewise_linear/test_piecewise_linear.py
@@ -16,17 +16,11 @@ import pyutilib.th as unittest
 import pyutilib.misc
 
 import pyomo.opt
+from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 from pyomo.core.base import Var
 from pyomo.core.base.objective import minimize, maximize
 from pyomo.core.base.piecewise import Bound, PWRepn
 from pyomo.solvers.tests.solvers import test_solver_cases
-
-yaml_available=False
-try:
-    import yaml
-    yaml_available = True
-except:
-    pass
 
 smoke_problems = ['convex_var','step_var','step_vararray']
 
@@ -112,7 +106,7 @@ def assignTests(cls, problem_list):
                                 setattr(cls,attrName,createTestMethod(attrName,PROBLEM,solver,writer,kwds))
                                 if yaml_available:
                                     with open(join(thisDir,'baselines',PROBLEM+'_baseline_results.yml'),'r') as f:
-                                        baseline_results = yaml.load(f)
+                                        baseline_results = yaml.load(f, **yaml_load_args)
                                         setattr(cls,PROBLEM+'_results',baseline_results)
 
 @unittest.skipUnless(yaml_available, "PyYAML module is not available.")


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This adds an `attempt_import()` method for use with optional dependencies that will attempt to import a module, and if it fails, create a shim object that will generate DeferredImportErrors that are not raised until the module is actually used.  This propagates the use of this method to all imports of yaml, so that we can standardize some of the arguments to yaml.load and avoid deprecation warnings on newer versions of pyyaml.  Finally, this causes all imports of pyomo to automatically import pyomo.common.logging, so that all parts of pyomo can be ensured that the pyomo log handler has been set up.

## Changes proposed in this PR:
- add attempt_import() method
- standardize attempted import of yaml, numpy, and scipy
- ensure that the pyomo log handler is always set up
- clean up imports of pyomo.common

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
