### PR TITLE
Change mul order in taylor series to avoid numpy compatibility issues

### DIFF
--- a/pyomo/core/expr/taylor_series.py
+++ b/pyomo/core/expr/taylor_series.py
@@ -48,7 +48,7 @@ def taylor_series_expansion(expr, diff_mode=differentiate.Modes.reverse_numeric,
     res = value(expr)
     if order >= 1:
         derivs = differentiate(expr=expr, wrt_list=e_vars, mode=diff_mode)
-        res += sum(value(derivs[i]) * (e_vars[i] - e_vars[i].value) for i in range(len(e_vars)))
+        res += sum((e_vars[i] - e_vars[i].value) * value(derivs[i]) for i in range(len(e_vars)))
 
     """
     This last bit of code is just for higher order taylor series expansions.
@@ -68,6 +68,6 @@ def taylor_series_expansion(expr, diff_mode=differentiate.Modes.reverse_numeric,
                 tmp = coef
                 for ndx in ndx_list:
                     tmp *= (e_vars[ndx] - e_vars[ndx].value)
-                res += tmp * sum(value(_derivs[i]) * (e_vars[i] - e_vars[i].value) for i in range(len(e_vars)))
+                res += tmp * sum((e_vars[i] - e_vars[i].value) * value(_derivs[i]) for i in range(len(e_vars)))
 
     return res


### PR DESCRIPTION
## Summary/Motivation:

After setting a variable value to a `numpy.float64` object, `taylor_series_expansion` throws the following exception: 

```
  File "Coramin/coramin/relaxations/relaxations_base.py", line 357, in add_cut
    cut_expr = self.get_aux_var() >= taylor_series_expansion(self.get_rhs_expr())
  File "/pyomo/pyomo/core/expr/taylor_series.py", line 51, in taylor_series_expansion
    res += sum(value(derivs[i]) * (e_vars[i] - e_vars[i].value) for i in range(len(e_vars)))
  File "/pyomo/pyomo/core/expr/taylor_series.py", line 51, in <genexpr>
    res += sum(value(derivs[i]) * (e_vars[i] - e_vars[i].value) for i in range(len(e_vars)))
  File "/pyomo/pyomo/core/base/indexed_component.py", line 407, in __getitem__
    validated_index = self._validate_index(index)
  File "/pyomo/pyomo/core/base/indexed_component.py", line 561, in _validate_index
    "as an indexed component" % ( self.name, ))
KeyError: "Cannot treat the scalar component 'i2'as an indexed component"
```

My and @michaelbynum guess is that numpy tries to index the simple var as if it was an array.
By moving the floating point values to the right hand side, we ensure Pyomo handles the arithmetic operation.
 

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
