### PR TITLE
Get text file

### DIFF
--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -58,7 +58,26 @@ class FileDownloader(object):
         return system, bits
 
 
+    @deprecated("get_url() is deprecated. Use get_platform_url()",
+                version='TBD')
     def get_url(self, urlmap):
+        return self.get_platform_url(urlmap)
+
+
+    def get_platform_url(self, urlmap):
+        """Select the url for this platform
+
+        Given a `urlmap` dict that maps the platform name (from
+        `FileDownloader.get_sysinfo()`) to a platform-specific URL,
+        return the URL that matches the current platform.
+
+        Parameters
+        ----------
+        urlmap: dict
+            Map of platform name (e.g., `linux`, `windows`, `cygwin`,
+            `darwin`) to URL
+
+        """
         system, bits = self.get_sysinfo()
         url = urlmap.get(system, None)
         if url is None:

--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -21,6 +21,7 @@ import zipfile
 from six.moves.urllib.request import urlopen
 
 from .config import PYOMO_CONFIG_DIR
+from .deprecation import deprecated
 from .errors import DeveloperError
 import pyomo.common
 

--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -163,14 +163,24 @@ class FileDownloader(object):
         return ans
 
 
-    def get_binary_file(self, url):
+    def get_file(self, url, mode):
         if self._fname is None:
             raise DeveloperError("target file name has not been initialized "
                                  "with set_destination_filename")
-        with open(self._fname, 'wb') as FILE:
+        with open(self._fname, mode) as FILE:
             raw_file = self.retrieve_url(url)
             FILE.write(raw_file)
             logger.info("  ...wrote %s bytes" % (len(raw_file),))
+
+
+    def get_binary_file(self, url):
+        """Retrieve the specified url and write as a binary file"""
+        return self.get_file(url, mode='wb')
+
+
+    def get_text_file(self, url):
+        """Retrieve the specified url and write as a text file"""
+        return self.get_file(url, mode='wt')
 
 
     def get_binary_file_from_zip_archive(self, url, srcname):

--- a/pyomo/common/getGSL.py
+++ b/pyomo/common/getGSL.py
@@ -34,7 +34,7 @@ def find_GSL():
 
 def get_gsl(downloader):
     system, bits = downloader.get_sysinfo()
-    url = downloader.get_url(urlmap) % (bits,)
+    url = downloader.get_platform_url(urlmap) % (bits,)
 
     downloader.set_destination_filename(os.path.join('lib', 'amplgsl.dll'))
 

--- a/pyomo/common/tests/test_download.py
+++ b/pyomo/common/tests/test_download.py
@@ -137,15 +137,15 @@ class Test_FileDownloader(unittest.TestCase):
         self.assertFalse(any(c in ans[0] for c in '.-_'))
         self.assertIn(ans[1], (32,64))
 
-    def test_get_url(self):
+    def test_get_platform_url(self):
         f = FileDownloader()
         urlmap = {'bogus_sys': 'bogus'}
         with self.assertRaisesRegexp(
                 RuntimeError, "cannot infer the correct url for platform '.*'"):
-            f.get_url(urlmap)
+            f.get_platform_url(urlmap)
 
         urlmap[f.get_sysinfo()[0]] = 'correct'
-        self.assertEqual(f.get_url(urlmap), 'correct')
+        self.assertEqual(f.get_platform_url(urlmap), 'correct')
 
 
     def test_get_files_requires_set_destination(self):

--- a/pyomo/common/tests/test_download.py
+++ b/pyomo/common/tests/test_download.py
@@ -8,8 +8,10 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import io
 import os
 import platform
+import six
 import shutil
 import tempfile
 
@@ -166,14 +168,21 @@ class Test_FileDownloader(unittest.TestCase):
         tmpdir = tempfile.mkdtemp()
         try:
             f = FileDownloader()
+
             # Mock retrieve_url so network connections are not necessary
-            f.retrieve_url = lambda url: "\n"
+            if six.PY3:
+                f.retrieve_url = lambda url: bytes("\n", encoding='utf-8')
+            else:
+                f.retrieve_url = lambda url: bytes("\n")
 
             # Binary files will preserve line endings
             target = os.path.join(tmpdir, 'bin.txt')
             f.set_destination_filename(target)
             f.get_binary_file(None)
             self.assertEqual(os.path.getsize(target), 1)
+
+            # Mock retrieve_url so network connections are not necessary
+            f.retrieve_url = lambda url: "\n"
 
             # Text files will convert line endings to the local platform
             target = os.path.join(tmpdir, 'txt.txt')

--- a/pyomo/common/tests/test_download.py
+++ b/pyomo/common/tests/test_download.py
@@ -161,3 +161,24 @@ class Test_FileDownloader(unittest.TestCase):
         with self.assertRaisesRegexp(
                 DeveloperError, 'target file name has not been initialized'):
             f.get_gzipped_binary_file('bogus')
+
+    def test_get_test_binary_file(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            f = FileDownloader()
+            # Mock retrieve_url so network connections are not necessary
+            f.retrieve_url = lambda url: "\n"
+
+            # Binary files will preserve line endings
+            target = os.path.join(tmpdir, 'bin.txt')
+            f.set_destination_filename(target)
+            f.get_binary_file(None)
+            self.assertEqual(os.path.getsize(target), 1)
+
+            # Text files will convert line endings to the local platform
+            target = os.path.join(tmpdir, 'txt.txt')
+            f.set_destination_filename(target)
+            f.get_text_file(None)
+            self.assertEqual(os.path.getsize(target), len(os.linesep))
+        finally:
+            shutil.rmtree(tmpdir)

--- a/pyomo/contrib/trustregion/getGJH.py
+++ b/pyomo/contrib/trustregion/getGJH.py
@@ -33,7 +33,7 @@ exemap = {
 
 def get_gjh(downloader):
     system, bits = downloader.get_sysinfo()
-    url = downloader.get_url(urlmap)
+    url = downloader.get_platform_url(urlmap)
 
     downloader.set_destination_filename(
         os.path.join('bin', 'gjh'+exemap[system]))


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Add a `get_text_file()` method to the FileDownloader (for CORAMIN).  Also, rename `get_url` to `get_platform_url` to make the API more clear (since the method doesn't actually retrieve the url).

## Changes proposed in this PR:
- add `FileDownloader.get_text_file()`
- rename `FileDownloader.get_url()` to  `FileDownloader.get_platform_url()`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
