### PR TITLE
DAE model flattener bug fix

### DIFF
--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -47,7 +47,7 @@ def generate_time_only_slices(obj, time):
             idx += 1
         elif s.dimen is not None:
             for sub_idx in range(s.dimen):
-                regular_idx.append(idx)
+                regular_idx.append(idx+sub_idx)
             idx += s.dimen
         elif ellipsis_idx is None:
             ellipsis_idx = idx
@@ -74,7 +74,8 @@ def generate_time_only_slices(obj, time):
     )
     # For each combination of regular indices, we can generate a single
     # slice over the time index
-    time_sliced = {time_idx: time.first()}
+#    time_sliced = {time_idx: time.first()}
+    time_sliced = {time_idx: slice(None)}
     for key in _slice.wildcard_keys():
         if type(key) is not tuple:
             key = (key,)

--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -74,7 +74,6 @@ def generate_time_only_slices(obj, time):
     )
     # For each combination of regular indices, we can generate a single
     # slice over the time index
-#    time_sliced = {time_idx: time.first()}
     time_sliced = {time_idx: slice(None)}
     for key in _slice.wildcard_keys():
         if type(key) is not tuple:

--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -74,7 +74,7 @@ def generate_time_only_slices(obj, time):
     )
     # For each combination of regular indices, we can generate a single
     # slice over the time index
-    time_sliced = {time_idx: slice(None)}
+    time_sliced = [time_idx]
     for key in _slice.wildcard_keys():
         if type(key) is not tuple:
             key = (key,)

--- a/pyomo/dae/tests/test_flatten.py
+++ b/pyomo/dae/tests/test_flatten.py
@@ -109,6 +109,23 @@ class TestCategorize(unittest.TestCase):
         for ref in time:
             self.assertIn(self._hashRef(ref), ref_data)
 
+
+    def test_2dim_set(self):
+        m = ConcreteModel()
+        m.time = ContinuousSet(bounds=(0,1))
+
+        m.v = Var(m.time, [('a',1), ('b',2)])
+
+        scalar, dae = flatten_dae_variables(m, m.time)
+        self.assertEqual(len(scalar), 0)
+        ref_data = {
+                self._hashRef(Reference(m.v[:,'a',1])),
+                self._hashRef(Reference(m.v[:,'b',2])),
+                }
+        self.assertEqual(len(dae), len(ref_data))
+        for ref in dae:
+            self.assertIn(self._hashRef(ref), ref_data)
+
     # TODO: Add tests for Sets with dimen==None
 
 


### PR DESCRIPTION
## Summary/Motivation:
Omitted addition caused `flatten_dae_variables` to not work with (non-time) sets of dimension > 1. 

## Changes proposed in this PR:
- Fix omission so flattener works with sets of dimension > 1
- Add test on model with a 2-dimensional non-time set
- Change `time_sliced` dict to map to `slice(None)` instead of `time.first()`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
