### PR TITLE
Shorten GAMS ShortNameLabeler symbols

### DIFF
--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -414,7 +414,7 @@ class ProblemWriter_gams(AbstractProblemWriter):
             # to start with a letter.  We will (randomly) choose "s_"
             # (for 'shortened')
             var_labeler = con_labeler = ShortNameLabeler(
-                63, prefix='s_', suffix='_', caseInsensitive=True,
+                60, prefix='s_', suffix='_', caseInsensitive=True,
                 legalRegex='^[a-zA-Z]')
         elif labeler is None:
             var_labeler = NumericLabeler('x')


### PR DESCRIPTION
## Summary/Motivation:
The GAMS writer currently shortens symbols to 63 characters for `symbolic_solver_labels=True`. However, we later append `_ub` or `_lb` to the constraint names for inequality constraints.

This change revises the shortened names to 60 characters to allow space for appending these suffixes.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
