### PR TITLE
Remove 'extras' for Python3.6 on Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,7 +44,9 @@ environment:
     - PYTHON_VERSION: 3.6
       PYTHON: "C:\\Miniconda36"
       CATEGORY: "nightly"
-      EXTRAS: YES
+      # [200316]: disable extras because of installation dependency 
+      # issues on appveyor
+      #EXTRAS: YES
 
     - PYTHON_VERSION: 3.7
       PYTHON: "C:\\Miniconda37"


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Due to conda-forge dependency issues, we will quit attempting to test Pyomo with "EXTRAS" on Python 3.6

## Changes proposed in this PR:
- Remove "EXTRAS" in Python 3.6 on Appveyor

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
