### PR TITLE
Update codecov config to allow overall coverage to drop

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,14 @@
 coverage:
   range: "50...100"
+  status:
+    project:
+      default:
+        # Allow overall coverage to drop to avoid failures due to code
+        # cleanup or CI unavailability/lag
+        threshold: 5%
+    patch:
+      default:
+        # Force patches to be covered at the level of the codebase
+        threshold: 0%
 #  ci:
 #    - !ci.appveyor.com


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This allows overall coverage to drop (due to code cleanups, or CI provider lag / unavailability) without failing a PR.  PR patch coverage must still be at the level of the overall codebase.

## Changes proposed in this PR:
- allow overall coverage to drop by 5% without failing the PR check

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
