### PR TITLE
Resolve Py3 issue in FileDownloader.get_text_file()

### DIFF
--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -165,24 +165,27 @@ class FileDownloader(object):
         return ans
 
 
-    def get_file(self, url, mode):
+    def get_file(self, url, binary):
         if self._fname is None:
             raise DeveloperError("target file name has not been initialized "
                                  "with set_destination_filename")
-        with open(self._fname, mode) as FILE:
+        with open(self._fname, 'wb' if binary else 'wt') as FILE:
             raw_file = self.retrieve_url(url)
-            FILE.write(raw_file)
+            if binary:
+                FILE.write(raw_file)
+            else:
+                FILE.write(raw_file.decode())
             logger.info("  ...wrote %s bytes" % (len(raw_file),))
 
 
     def get_binary_file(self, url):
         """Retrieve the specified url and write as a binary file"""
-        return self.get_file(url, mode='wb')
+        return self.get_file(url, binary=True)
 
 
     def get_text_file(self, url):
         """Retrieve the specified url and write as a text file"""
-        return self.get_file(url, mode='wt')
+        return self.get_file(url, binary=False)
 
 
     def get_binary_file_from_zip_archive(self, url, srcname):

--- a/pyomo/common/tests/test_download.py
+++ b/pyomo/common/tests/test_download.py
@@ -173,16 +173,13 @@ class Test_FileDownloader(unittest.TestCase):
             if six.PY3:
                 f.retrieve_url = lambda url: bytes("\n", encoding='utf-8')
             else:
-                f.retrieve_url = lambda url: bytes("\n")
+                f.retrieve_url = lambda url: str("\n")
 
             # Binary files will preserve line endings
             target = os.path.join(tmpdir, 'bin.txt')
             f.set_destination_filename(target)
             f.get_binary_file(None)
             self.assertEqual(os.path.getsize(target), 1)
-
-            # Mock retrieve_url so network connections are not necessary
-            f.retrieve_url = lambda url: "\n"
 
             # Text files will convert line endings to the local platform
             target = os.path.join(tmpdir, 'txt.txt')


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This resolves a type issue with the FileDownloader.get_text_file() under Python 3

## Changes proposed in this PR:
- Correct handling of bytes objects in Python 3
- Update test mock to generate the correct data types

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
