### PR TITLE
Fix setup.py: SystemExit.message doesn't exist in Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ ERROR: Cython was explicitly requested with --with-cython, but cythonization
 ERROR: setup() failed:
     %s
 Re-running setup() without the Cython modules
-""" % (e_info.message,))
+""" % (str(e_info),))
         ext_modules = []
         run_setup()
         print("""
@@ -213,4 +213,4 @@ WARNING: Installation completed successfully, but the attempt to cythonize
          optimizations and is not required for any Pyomo functionality.
          Cython returned the following error:
    "%s"
-""" % (e_info.message,))
+""" % (str(e_info),))


### PR DESCRIPTION
## Fixes #808, fixes #1118

## Summary/Motivation:
This resolves a Python 3 compatibility issue in `setup.py` (generally only encountered by Windows users installing without a fully-functional compiler)

## Changes proposed in this PR:
- Do not assume `SystemExit` has a `message` attribute

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
