### PR TITLE
Add test coverage to linux/osx GitHub actions

### DIFF
--- a/.github/workflows/mpi_matrix_test.yml
+++ b/.github/workflows/mpi_matrix_test.yml
@@ -125,5 +125,5 @@ jobs:
       run: |
         find . -maxdepth 10 -name ".cov*"
         coverage combine
-        coverage report
+        coverage report -i
         bash <(curl -s https://codecov.io/bash) -X gcov

--- a/.github/workflows/mpi_matrix_test.yml
+++ b/.github/workflows/mpi_matrix_test.yml
@@ -1,4 +1,4 @@
-name: continuous-integration/github/pr
+name: GitHub CI
 
 on:
   push:

--- a/.github/workflows/mpi_matrix_test.yml
+++ b/.github/workflows/mpi_matrix_test.yml
@@ -1,4 +1,4 @@
-name: GitHub CI
+name: GitHub CI (mpi)
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: mpi/${{ matrix.TARGET }}/py${{ matrix.python-version }}
+    name: ${{ matrix.TARGET }}/py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 1
@@ -122,8 +122,10 @@ jobs:
             pyomo `pwd`/pyomo-model-libraries
 
     - name: Upload coverage to codecov
+      env:
+        GITHUB_JOB_NAME: mpi/${{ matrix.TARGET }}/py${{ matrix.python-version }}
       run: |
         find . -maxdepth 10 -name ".cov*"
         coverage combine
         coverage report -i
-        bash <(curl -s https://codecov.io/bash) -X gcov
+        bash <(curl -s https://codecov.io/bash) -X gcov -n "$GITHUB_JOB_NAME"

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -16,6 +16,8 @@ jobs:
         include:
         - os: macos-latest
           TARGET: osx
+        - os: ubuntu-latest
+          TARGET: linux
         - os: ubuntu-18.04
           TARGET: linux
         python-version: [3.5, 3.6, 3.7, 3.8]

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -1,9 +1,6 @@
 name: continuous-integration/github/pr
 
 on:
-  push:
-    branches:
-      - unix_coverage
   pull_request:
     branches:
       - master

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -128,5 +128,5 @@ jobs:
       run: |
         find . -maxdepth 10 -name ".cov*"
         coverage combine
-        coverage report
+        coverage report -i
         bash <(curl -s https://codecov.io/bash) -X gcov

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -33,12 +33,12 @@ jobs:
       run: |
         if hash brew; then
             echo "Install pre-dependencies for pyodbc..."
-            brew update 
+            brew update
             brew install bash gcc
             brew link --overwrite gcc
             brew install pkg-config
             brew install unixodbc
-            brew install freetds 
+            brew install freetds
         fi
         echo "Upgrade pip..."
         python -m pip install --upgrade pip

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -1,6 +1,9 @@
 name: continuous-integration/github/pr
 
 on:
+  push:
+    branches:
+      - unix_coverage
   pull_request:
     branches:
       - master
@@ -59,6 +62,10 @@ jobs:
         fi
         chmod +x gams_installer.exe
         ./gams_installer.exe -q -d gams
+        GAMS_DIR=`ls -d1 $(pwd)/gams/*/ | head -1`
+        export PATH=$PATH:$GAMS_DIR
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GAMS_DIR
+        export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GAMS_DIR
         cd gams/*/apifiles/Python/
         py_ver=$(python -c 'import sys;print("%s%s" % sys.version_info[:2])')
         gams_ver=api

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -1,6 +1,9 @@
 name: continuous-integration/github/pr
 
 on:
+  push:
+    branches:
+      - unix_coverage
   pull_request:
     branches:
       - master
@@ -30,21 +33,19 @@ jobs:
       run: |
         if hash brew; then
             echo "Install pre-dependencies for pyodbc..."
-            brew update
-            brew list bash || brew install bash
-            brew list gcc || brew install gcc
+            brew update 
+            brew install bash gcc
             brew link --overwrite gcc
-            brew list pkg-config || brew install pkg-config
-            brew list unixodbc || brew install unixodbc
-            brew list freetds || brew install freetds 
+            brew install pkg-config
+            brew install unixodbc
+            brew install freetds 
         fi
         echo "Upgrade pip..."
         python -m pip install --upgrade pip
         echo ""
         echo "Install Pyomo dependencies..."
         echo ""
-        # Note: pandas 1.0.3 causes gams 29.1.0 import to fail in python 3.8
-        pip install cython numpy scipy ipython openpyxl sympy pyyaml pyodbc networkx xlrd pandas matplotlib dill seaborn pymysql pyro4 pint pathos
+        pip install cython numpy scipy ipython openpyxl sympy pyyaml pyodbc networkx xlrd pandas matplotlib dill seaborn pymysql pyro4 pint pathos coverage nose
         echo ""
         echo "Install CPLEX Community Edition..."
         echo ""
@@ -59,6 +60,10 @@ jobs:
         fi
         chmod +x gams_installer.exe
         ./gams_installer.exe -q -d gams
+        GAMS_DIR=`ls -d1 $(pwd)/gams/*/ | head -1`
+        export PATH=$PATH:$GAMS_DIR
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GAMS_DIR
+        export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GAMS_DIR
         cd gams/*/apifiles/Python/
         py_ver=$(python -c 'import sys;print("%s%s" % sys.version_info[:2])')
         gams_ver=api
@@ -69,6 +74,12 @@ jobs:
         done
         cd $gams_ver
         python setup.py -q install -noCheck
+        echo ""
+        echo "Pass key environment variables to subsequent steps"
+        echo ""
+        echo "::set-env name=PATH::$PATH"
+        echo "::set-env name=LD_LIBRARY_PATH::$LD_LIBRARY_PATH"
+        echo "::set-env name=DYLD_LIBRARY_PATH::$DYLD_LIBRARY_PATH"
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."
@@ -81,17 +92,29 @@ jobs:
         echo "Install Pyomo..."
         echo ""
         python setup.py develop
-        echo ""
-        echo "Download and install extensions..."
-        echo ""
+    - name: Set up coverage tracking
+      run: |
+        WORKSPACE=`pwd`
+        COVERAGE_PROCESS_START=${WORKSPACE}/coveragerc
+        echo "::set-env name=COVERAGE_PROCESS_START::$COVERAGE_PROCESS_START"
+        cp ${WORKSPACE}/.coveragerc ${COVERAGE_PROCESS_START}
+        echo "data_file=${WORKSPACE}/.coverage" >> ${COVERAGE_PROCESS_START}
+        SITE_PACKAGES=`python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`
+        if [ -z "$DISABLE_COVERAGE" ]; then
+            echo 'import coverage; coverage.process_startup()' \
+                > ${SITE_PACKAGES}/run_coverage_at_startup.pth
+        fi
+    - name: Download and install extensions
+      run: |
         pyomo download-extensions
         pyomo build-extensions
     - name: Run nightly tests with test.pyomo
       run: |
         echo "Run test.pyomo..."
-        GAMS_DIR=`ls -d1 $(pwd)/gams/*/ | head -1`
-        export PATH=$PATH:$GAMS_DIR
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GAMS_DIR
-        export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GAMS_DIR
-        pip install nose
+        python -c 'import pyomo.environ'
         test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries
+    - name: Upload coverage to codecov
+      run: |
+        find . -maxdepth 10 -name ".cov*"
+        coverage combine
+        bash <(curl -s https://codecov.io/bash) -X gcov

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -1,4 +1,4 @@
-name: GitHub CI
+name: GitHub CI (unix)
 
 on:
   push:
@@ -125,8 +125,10 @@ jobs:
         test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries
 
     - name: Upload coverage to codecov
+      env:
+        GITHUB_JOB_NAME: unix/${{ matrix.TARGET }}/py${{ matrix.python-version }}
       run: |
         find . -maxdepth 10 -name ".cov*"
         coverage combine
         coverage report -i
-        bash <(curl -s https://codecov.io/bash) -X gcov
+        bash <(curl -s https://codecov.io/bash) -X gcov -n "$GITHUB_JOB_NAME"

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -1,6 +1,9 @@
 name: GitHub CI
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -1,4 +1,4 @@
-name: continuous-integration/github/pr
+name: GitHub CI
 
 on:
   pull_request:

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -34,17 +34,19 @@ jobs:
         if hash brew; then
             echo "Install pre-dependencies for pyodbc..."
             brew update
-            brew install bash gcc
+            brew list bash || brew install bash
+            brew list gcc || brew install gcc
             brew link --overwrite gcc
-            brew install pkg-config
-            brew install unixodbc
-            brew install freetds
+            brew list pkg-config || brew install pkg-config
+            brew list unixodbc || brew install unixodbc
+            brew list freetds || brew install freetds
         fi
         echo "Upgrade pip..."
         python -m pip install --upgrade pip
         echo ""
         echo "Install Pyomo dependencies..."
         echo ""
+        # Note: pandas 1.0.3 causes gams 29.1.0 import to fail in python 3.8
         pip install cython numpy scipy ipython openpyxl sympy pyyaml pyodbc networkx xlrd pandas matplotlib dill seaborn pymysql pyro4 pint pathos coverage nose
         echo ""
         echo "Install CPLEX Community Edition..."
@@ -60,10 +62,6 @@ jobs:
         fi
         chmod +x gams_installer.exe
         ./gams_installer.exe -q -d gams
-        GAMS_DIR=`ls -d1 $(pwd)/gams/*/ | head -1`
-        export PATH=$PATH:$GAMS_DIR
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GAMS_DIR
-        export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GAMS_DIR
         cd gams/*/apifiles/Python/
         py_ver=$(python -c 'import sys;print("%s%s" % sys.version_info[:2])')
         gams_ver=api

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-18.04]
+        os: [macos-latest, ubuntu-latest]
         include:
         - os: macos-latest
           TARGET: osx

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -21,8 +21,6 @@ jobs:
           TARGET: osx
         - os: ubuntu-latest
           TARGET: linux
-        - os: ubuntu-18.04
-          TARGET: linux
         python-version: [3.5, 3.6, 3.7, 3.8]
 
     steps:

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -1,4 +1,4 @@
-name: GitHub CI
+name: GitHub CI (win)
 
 on:
   pull_request:

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -1,4 +1,4 @@
-name: continuous-integration/github/pr
+name: GitHub CI
 
 on:
   pull_request:


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
The introduction of coverage reports into Github Actions get us one step closer to removing other external dependencies.

## Changes proposed in this PR:
- Add coverage report uploads to Unix workflow

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
