### PR TITLE
Remove remaining < Python 2.7 references

### DIFF
--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -48,41 +48,6 @@ from pyomo.opt import WriterFactory
 logger = logging.getLogger('pyomo.core')
 
 
-# Monkey-patch for deepcopying weakrefs
-# Only required on Python <= 2.6
-#
-# TODO: can we verify that this is really needed? [JDS 7/8/14]
-if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
-    copy._copy_dispatch[weakref.ref] = copy._copy_immutable
-    copy._deepcopy_dispatch[weakref.ref] = copy._deepcopy_atomic
-    copy._deepcopy_dispatch[weakref.KeyedRef] = copy._deepcopy_atomic
-
-    def dcwvd(self, memo):
-        """Deepcopy implementation for WeakValueDictionary class"""
-        from copy import deepcopy
-        new = self.__class__()
-        for key, wr in self.data.items():
-            o = wr()
-            if o is not None:
-                new[deepcopy(key, memo)] = o
-        return new
-    weakref.WeakValueDictionary.__copy__ = \
-        weakref.WeakValueDictionary.copy
-    weakref.WeakValueDictionary.__deepcopy__ = dcwvd
-
-    def dcwkd(self, memo):
-        """Deepcopy implementation for WeakKeyDictionary class"""
-        from copy import deepcopy
-        new = self.__class__()
-        for key, value in self.data.items():
-            o = key()
-            if o is not none:
-                new[o] = deepcopy(value, memo)
-        return new
-    weakref.WeakKeyDictionary.__copy__ = weakref.WeakKeyDictionary.copy
-    weakref.WeakKeyDictionary.__deepcopy__ = dcwkd
-
-
 class _generic_component_decorator(object):
     """A generic decorator that wraps Block.__setattr__()
 

--- a/pyomo/core/tests/unit/test_pickle.py
+++ b/pyomo/core/tests/unit/test_pickle.py
@@ -290,7 +290,6 @@ class Test(unittest.TestCase):
 
     # verifies that the use of lambda expressions as rules yields model instances
     # that are not pickle'able.
-    @unittest.skipIf(sys.version_info[:2] < (2,6), "Skipping test because the sparse_dict repn is not supported")
     def test_pickle3(self):
         def rule1(model):
             return (1,model.x+model.y[1],2)

--- a/pyomo/scripting/pyomo_parser.py
+++ b/pyomo/scripting/pyomo_parser.py
@@ -65,18 +65,6 @@ def get_version():
             platform.release() )
 
 #
-# `BaseException.message` is deprecated as of Python 2.6, its usage triggers
-# a `DeprecationWarning`.  As `ArgumentError` derives indirectly from
-# `BaseException`, `ArgumentError.message` triggers this warning too
-#
-if sys.version_info[:2] == (2,6):
-    warnings.filterwarnings(
-        'ignore',
-        message='BaseException.message has been deprecated as of Python 2.6',
-        category=DeprecationWarning,
-        module='argparse')
-
-#
 # Create the argparse parser for Pyomo
 #
 doc="This is the main driver for the Pyomo optimization software."

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ Script to generate the installer for pyomo.
 import sys
 import os
 
-
 def read(*rnames):
     with open(os.path.join(os.path.dirname(__file__), *rnames)) as README:
         # Strip all leading badges up to, but not including the COIN-OR
@@ -43,13 +42,8 @@ requires = [
     'ply',
     'six>=1.4',
     ]
-if sys.version_info < (2, 7):
-    requires.append('argparse')
-    requires.append('unittest2')
-    requires.append('ordereddict')
 
 from setuptools import setup, find_packages
-import sys
 
 CYTHON_REQUIRED = "required"
 if 'develop' in sys.argv:


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
There are a few remaining checks/references for Python 2.6 (or lower). Seeing as the build requires Python 2.7+, these checks can be removed.

## Changes proposed in this PR:
- Remove any remaining code that checks/references too-old Python versions.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
