### PR TITLE
Updating Travis badge (migration from org to com)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<!--[![Travis Status](https://travis-ci.org/Pyomo/pyomo.svg?branch=master)](https://travis-ci.org/Pyomo/pyomo)-->
-[![Travis Status](https://img.shields.io/travis/Pyomo/pyomo.svg?logo=travis)](https://travis-ci.org/Pyomo/pyomo)
+<!--[![Travis Status](https://travis-ci.com/Pyomo/pyomo.svg?branch=master)](https://travis-ci.com/Pyomo/pyomo)-->
+[![Travis Status](https://img.shields.io/travis/com/Pyomo/pyomo/master?logo=travis)](https://travis-ci.com/Pyomo/pyomo)
 [![Appveyor Status](https://ci.appveyor.com/api/projects/status/km08tbkv05ik14n9/branch/master?svg=true)](https://ci.appveyor.com/project/WilliamHart/pyomo/branch/master)
 [![Jenkins Status](https://img.shields.io/jenkins/s/https/software.sandia.gov/downloads/pub/pyomo/jenkins/Pyomo_trunk.svg?logo=jenkins&logoColor=white)](https://jenkins-srn.sandia.gov/job/Pyomo_trunk)
 [![codecov](https://codecov.io/gh/Pyomo/pyomo/branch/master/graph/badge.svg)](https://codecov.io/gh/Pyomo/pyomo)


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This updates the build badge for Travis-CI to reflect the move of Pyomo from travis-ci.org to travis-ci.com

## Changes proposed in this PR:
- update travis badge and link

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
