### PR TITLE
Resolve DAT tokenizer bugs

### DIFF
--- a/pyomo/dataportal/parse_datacmds.py
+++ b/pyomo/dataportal/parse_datacmds.py
@@ -127,6 +127,7 @@ def t_WORD(t):
 
 def t_STRING(t):
     r'[a-zA-Z0-9_\.+\-\\\/]+'
+    # Note: RE guarantees the string has no embedded quotation characters
     t.value = '"'+t.value+'"'
     return t
 
@@ -139,6 +140,9 @@ def t_data_BRACKETEDSTRING(t):
 
 def t_QUOTEDSTRING(t):
     r'"(?:[^"]|"")*"'   '|'   r"'(?:[^']|'')*'"
+    # Normalize the quotes to use '"', and replace doubled ("escaped")
+    # quotation characters with a single character
+    t.value = '"' + t.value[1:-1].replace(2*t.value[0], t.value[0]) + '"'
     return t
 
 #t_NONWORD   = r"[^\.A-Za-z0-9,;:=<>\*\(\)\#{}\[\] \n\t\r]+"

--- a/pyomo/dataportal/parse_datacmds.py
+++ b/pyomo/dataportal/parse_datacmds.py
@@ -93,8 +93,10 @@ t_ASTERISK  = r"\*"
 #
 
 # Discard comments
+_re_singleline_comment = r'(?:\#[^\n]*)'
+_re_multiline_comment = r'(?:/\*(?:[\n]|.)*?\*/)'
+@lex.TOKEN('|'.join([_re_singleline_comment, _re_multiline_comment]))
 def t_COMMENT(t):
-    r'(?:\#[^\n]*)'   '|'   r'(?:/\*(?:[\n]|.)*?\*/)'
     # Single-line and multi-line strings
 
 def t_COLONEQ(t):
@@ -142,8 +144,9 @@ def t_data_BRACKETEDSTRING(t):
     # [1,*,'foo bar']
     return t
 
+_re_quoted_str = r'"(?:[^"]|"")*"'
+@lex.TOKEN("|".join([_re_quoted_str, _re_quoted_str.replace('"',"'")]))
 def t_QUOTEDSTRING(t):
-    r'"(?:[^"]|"")*"'   '|'   r"'(?:[^']|'')*'"
     # Normalize the quotes to use '"', and replace doubled ("escaped")
     # quotation characters with a single character
     t.value = '"' + t.value[1:-1].replace(2*t.value[0], t.value[0]) + '"'
@@ -152,8 +155,9 @@ def t_QUOTEDSTRING(t):
 #t_NONWORD   = r"[^\.A-Za-z0-9,;:=<>\*\(\)\#{}\[\] \n\t\r]+"
 
 # Error handling rule
-def t_error(t):             #pragma:nocover
-    raise IOError("ERROR: Token %s Value %s Line %s Column %s" % (t.type, t.value, t.lineno, t.lexpos))
+def t_error(t):
+    raise IOError("ERROR: Token %s Value %s Line %s Column %s"
+                  % (t.type, t.value, t.lineno, t.lexpos))
     t.lexer.skip(1)
 
 ## DEBUGGING: uncomment to get tokenization information

--- a/pyomo/dataportal/parse_datacmds.py
+++ b/pyomo/dataportal/parse_datacmds.py
@@ -22,6 +22,8 @@ from pyutilib.misc import flatten_list
 from pyutilib.ply import t_newline, t_ignore, _find_column, p_error, ply_init
         
 
+_re_number = r'[-+]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][-+]?[0-9]+)?'
+
 ## -----------------------------------------------------------
 ##
 ## Lexer definitions for tokenizing the input
@@ -105,8 +107,10 @@ def t_SEMICOLON(t):
     t.lexer.begin('INITIAL')
     return t
 
+# Numbers must be followed by a delimiter token (EOF is not a concern,
+# as valid DAT files always end with a ';').
+@lex.TOKEN(_re_number + r'(?=[\s()\[\]{}:;,])')
 def t_NUM_VAL(t):
-    r'[-+]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][-+]?[0-9]+)?(?=[\s()\[\]{}:;,])'
     _num = float(t.value)
     if '.' in t.value:
         t.value = _num

--- a/pyomo/dataportal/parse_datacmds.py
+++ b/pyomo/dataportal/parse_datacmds.py
@@ -87,7 +87,8 @@ t_ASTERISK  = r"\*"
 
 # Discard comments
 def t_COMMENT(t):
-    r'(\#[^\n]*)|(/\*(.*?).?(\*/))'
+    r'(?:\#[^\n]*)'   '|'   r'(?:/\*(?:[\n]|.)*?\*/)'
+    # Single-line and multi-line strings
 
 def t_COLONEQ(t):
     r':='

--- a/pyomo/dataportal/parse_datacmds.py
+++ b/pyomo/dataportal/parse_datacmds.py
@@ -116,19 +116,18 @@ def t_NUM_VAL(t):
     return t
 
 def t_WORDWITHLBRACKET(t):
-    r'[a-zA-Z0-9_][a-zA-Z0-9_\.\-]*\['
-    if t.value in reserved:
-        t.type = reserved[t.value]    # Check for reserved words
+    r'[a-zA-Z_][a-zA-Z0-9_\.\-]*\['
     return t
 
 def t_WORD(t):
-    r'[a-zA-Z_0-9][a-zA-Z_0-9\.+\-]*'
+    r'[a-zA-Z_][a-zA-Z_0-9\.+\-]*'
     if t.value in reserved:
         t.type = reserved[t.value]    # Check for reserved words
     return t
 
 def t_STRING(t):
     r'[a-zA-Z0-9_\.+\-\\\/]+'
+    t.value = '"'+t.value+'"'
     return t
 
 def t_data_BRACKETEDSTRING(t):
@@ -136,14 +135,10 @@ def t_data_BRACKETEDSTRING(t):
     # NO SPACES
     # a[1,_df,'foo bar']
     # [1,*,'foo bar']
-    if t.value in reserved:
-        t.type = reserved[t.value]    # Check for reserved words
     return t
 
 def t_QUOTEDSTRING(t):
-    r'"([^"]|\"\")*"|\'([^\']|\'\')*\''
-    if t.value in reserved:
-        t.type = reserved[t.value]    # Check for reserved words
+    r'"(?:[^"]|"")*"'   '|'   r"'(?:[^']|'')*'"
     return t
 
 #t_NONWORD   = r"[^\.A-Za-z0-9,;:=<>\*\(\)\#{}\[\] \n\t\r]+"
@@ -153,6 +148,17 @@ def t_error(t):             #pragma:nocover
     raise IOError("ERROR: Token %s Value %s Line %s Column %s" % (t.type, t.value, t.lineno, t.lexpos))
     t.lexer.skip(1)
 
+## DEBUGGING: uncomment to get tokenization information
+# def _wrap(_name, _fcn):
+#     def _wrapper(t):
+#         print(_name + ": %s" % (t.value,))
+#         return _fcn(t)
+#     _wrapper.__doc__ = _fcn.__doc__
+#     return _wrapper
+# import inspect
+# for _name in list(globals()):
+#     if _name.startswith('t_') and inspect.isfunction(globals()[_name]):
+#         globals()[_name] = _wrap(_name, globals()[_name])
 
 ## -----------------------------------------------------------
 ##
@@ -278,8 +284,8 @@ def p_data(p):
         tmp = p[1]
     else:
         tmp = p[2]
-    if type(tmp) is str and tmp[0] == '"' and tmp[-1] == '"' and len(tmp) > 2 and not ' ' in tmp:
-        tmp = tmp[1:-1]
+    #if type(tmp) is str and tmp[0] == '"' and tmp[-1] == '"' and len(tmp) > 2 and not ' ' in tmp:
+    #    tmp = tmp[1:-1]
 
     # Grow items list according to parsed item length
     if single_item:

--- a/pyomo/dataportal/process_data.py
+++ b/pyomo/dataportal/process_data.py
@@ -19,7 +19,7 @@ import pyutilib.common
 from pyutilib.misc import flatten
 
 from pyomo.dataportal.parse_datacmds import (
-    parse_data_commands, t_NUM_VAL
+    parse_data_commands, _re_number
 )
 from pyomo.dataportal.factory import DataManagerFactory, UnknownDataManager
 
@@ -44,13 +44,13 @@ logger = logging.getLogger('pyomo.core')
 global Lineno
 global Filename
 
-_num_pattern = re.compile("^("+t_NUM_VAL.__doc__+")$")
+_num_pattern = re.compile("^("+_re_number+")$")
 _str_false_values = {'False','false','FALSE'}
 _str_bool_values = {'True','true','TRUE'}
 _str_bool_values.update(_str_false_values)
 
 def _process_token(token):
-    #print("TOKEN:",token)
+    #print("TOKEN:", token, type(token))
     if type(token) is tuple:
         return tuple(_process_token(i) for i in token)
     elif type(token) in numlist:

--- a/pyomo/dataportal/process_data.py
+++ b/pyomo/dataportal/process_data.py
@@ -18,7 +18,9 @@ from pyutilib.misc import quote_split, Options
 import pyutilib.common
 from pyutilib.misc import flatten
 
-from pyomo.dataportal.parse_datacmds import parse_data_commands
+from pyomo.dataportal.parse_datacmds import (
+    parse_data_commands, t_NUM_VAL
+)
 from pyomo.dataportal.factory import DataManagerFactory, UnknownDataManager
 
 try:
@@ -33,57 +35,56 @@ except:
     unicode = str
 try:
     long
-    numlist = (bool, int, float, long)
+    numlist = {bool, int, float, long}
 except:
-    numlist = (bool, int, float)
+    numlist = {bool, int, float}
 
 logger = logging.getLogger('pyomo.core')
 
 global Lineno
 global Filename
 
+_num_pattern = re.compile("^("+t_NUM_VAL.__doc__+")$")
+_str_false_values = {'False','false','FALSE'}
+_str_bool_values = {'True','true','TRUE'}
+_str_bool_values.update(_str_false_values)
 
 def _process_token(token):
+    #print("TOKEN:",token)
     if type(token) is tuple:
         return tuple(_process_token(i) for i in token)
-    if type(token) in numlist:
+    elif type(token) in numlist:
         return token
-    if token in ('True','true','TRUE'):
-        return True
-    if token in ('False','false','FALSE'):
-        return False
-
-    if token[0] == '[' and token[-1] == ']':
+    elif token in _str_bool_values:
+        return token not in _str_false_values
+    elif token[0] == '"' and token[-1] == '"':
+        # Strip "flag" quotation characters
+        return token[1:-1]
+    elif token[0] == '[' and token[-1] == ']':
         vals = []
         token = token[1:-1]
         for item in token.split(","):
-            if item[0] == "'" or item[0] == '"':
+            if item[0] in '"\'' and item[0] == item[-1]:
                 vals.append( item[1:-1] )
-            try:
-                vals.append( int(item) )
-                continue
-            except:
-                pass
-            try:
-                vals.append( float(item) )
-                continue
-            except:
-                pass
-            vals.append( item )
+            elif _num_pattern.match(item):
+                _num = float(item)
+                if '.' in item:
+                    vals.append(_num)
+                else:
+                    _int = int(_num)
+                    vals.append(_int if _int == _num else _num)
+            else:
+                vals.append( item )
         return tuple(vals)
-
-    elif token[0] == "'" or token[0] == '"':
-        return token[1:-1]
-
-    try:
-        return int(token)
-    except:
-        pass
-    try:
-        return float(token)
-    except:
-        pass
-    return token
+    elif _num_pattern.match(token):
+        _num = float(token)
+        if '.' in token:
+            return _num
+        else:
+            _int = int(_num)
+            return _int if _int == _num else _num
+    else:
+        return token
 
 
 def _preprocess_data(cmd):

--- a/pyomo/dataportal/tester
+++ b/pyomo/dataportal/tester
@@ -3,7 +3,6 @@
 import sys
 import parse_datacmds
 
-parse_datacmds.debugging=True
 debug=int(sys.argv[2])
 print(parse_datacmds.parse_data_commands(filename=sys.argv[1], debug=debug))
 

--- a/pyomo/dataportal/tests/data_types.dat
+++ b/pyomo/dataportal/tests/data_types.dat
@@ -1,0 +1,111 @@
+param: I: p := 
+# simple integers
+ 501   2
+ 502  +2
+ 551  -2
+# scientific integers
+ 510   2E2
+ 511   2E+2
+ 512   2e2
+ 513   2e+2
+ 514  +2E2
+ 515  +2E+2
+ 516  +2e2
+ 517  +2e+2
+ 520  -2E2
+ 521  -2E+2
+ 522  -2e2
+ 523  -2e+2
+# scientific (non-integer)
+ 530   2E-2
+ 531   2e-2
+ 532  +2E-2
+ 533  +2e-2
+ 540  -2E-2
+ 541  -2e-2
+# basic floats
+ 100   1.0
+ 101   1. 
+ 102  +1.0
+ 103  +1.
+ 110  -1.0
+ 111  -1.
+ 120    .1
+ 121   +.1
+ 130   -.1
+ 140   1.1
+ 141  +1.1
+ 150  -1.1
+# scientific floats
+ 200   2.E2
+ 201   2.E+2
+ 202   2.e2
+ 203   2.e+2
+ 204  +2.E2
+ 205  +2.E+2
+ 206  +2.e2
+ 207  +2.e+2
+ 210  -2.E2
+ 211  -2.E+2
+ 212  -2.e2
+ 213  -2.e+2
+# scientific floats (negative exponents)
+ 220   2.E-2
+ 221   2.e-2
+ 222  +2.E-2
+ 223  +2.e-2
+ 230  -2.E-2
+ 231  -2.e-2
+# scientific floats (with fractional)
+ 300   2.1E2
+ 301   2.1E+2
+ 302   2.1e2
+ 303   2.1e+2
+ 304  +2.1E2
+ 305  +2.1E+2
+ 306  +2.1e2
+ 307  +2.1e+2
+ 310  -2.1E2
+ 311  -2.1E+2
+ 312  -2.1e2
+ 313  -2.1e+2
+# scientific floats (fractional, negative exponents)
+ 320   2.1E-2
+ 321   2.1e-2
+ 322  +2.1E-2
+ 323  +2.1e-2
+ 330  -2.1E-2
+ 331  -2.1e-2
+# scientific floats (with fractional)
+ 400   .1E2
+ 401   .1E+2
+ 402   .1e2
+ 403   .1e+2
+ 404  +.1E2
+ 405  +.1E+2
+ 406  +.1e2
+ 407  +.1e+2
+ 410  -.1E2
+ 411  -.1E+2
+ 412  -.1e2
+ 413  -.1e+2
+/* scientific floats (fractional, negative exponents) */
+ 420   .1E-2
+ 421   .1e-2
+ 422  +.1E-2
+ 423  +.1e-2
+ 430  -.1E-2
+ 431  -.1e-2
+/*Strings*/
+1000  a_string
+1001  "a_string"
+1002  'a_string'
+1003  "a "" string"
+1004  'a '' string'
+1005  1234_567
+1006  "123"
+/* and
+ a
+ multi-line
+ comment*/
+;

--- a/pyomo/dataportal/tests/data_types.dat
+++ b/pyomo/dataportal/tests/data_types.dat
@@ -1,4 +1,4 @@
-param: I: p := 
+param: I: p :=
 # simple integers
  501   2
  502  +2
@@ -25,7 +25,7 @@ param: I: p :=
  541  -2e-2
 # basic floats
  100   1.0
- 101   1. 
+ 101   1.
  102  +1.0
  103  +1.
  110  -1.0

--- a/pyomo/dataportal/tests/test_dataportal.py
+++ b/pyomo/dataportal/tests/test_dataportal.py
@@ -428,6 +428,58 @@ class PyomoDataPortal(unittest.TestCase):
         except IOError:
             pass
 
+    def test_dat_type_conversion(self):
+        model = AbstractModel()
+        model.I = Set()
+        model.p = Param(model.I, domain=Any)
+        i = model.create_instance(currdir+"data_types.dat")
+        ref = {
+            50:  (int, 2),
+            55: (int, -2),
+            51:  (int, 200),
+            52: (int, -200),
+            53: (float, 0.02),
+            54: (float, -0.02),
+            10: (float, 1.),
+            11: (float, -1.),
+            12: (float, .1),
+            13: (float, -.1),
+            14: (float, 1.1),
+            15: (float, -1.1),
+            20: (float, 200.),
+            21: (float, -200.),
+            22: (float, .02),
+            23: (float, -.02),
+            30: (float, 210.),
+            31: (float, -210.),
+            32: (float, .021),
+            33: (float, -.021),
+            40: (float, 10.),
+            41: (float, -10.),
+            42: (float, .001),
+            43: (float, -.001),
+            1000: (str, "a_string"),
+            1001: (str, "a_string"),
+            1002: (str, 'a_string'),
+            1003: (str, 'a " string'),
+            1004: (str, "a ' string"),
+            1005: (str, '1234_567'),
+            1006: (str, '123'),
+        }
+        for k, v in i.p.items():
+            #print(k,v, type(v))
+            if k in ref:
+                err="index %s: (%s, %s) does not match ref %s" % (
+                    k, type(v), v, ref[k],)
+                self.assertIs(type(v), ref[k][0], err)
+                self.assertEqual(v, ref[k][1], err)
+            else:
+                n = k // 10
+                err="index %s: (%s, %s) does not match ref %s" % (
+                    k, type(v), v, ref[n],)
+                self.assertIs(type(v), ref[n][0], err)
+                self.assertEqual(v, ref[n][1], err)
+
     def test_data_namespace(self):
         model=AbstractModel()
         model.a=Param()


### PR DESCRIPTION
## Fixes #1121

## Summary/Motivation:
This resolves tokenization errors in the DAT parser:
- Python 3 introduces the feature that `int('123_456') == 123456`.  This PR updates how we tokenize DAT files to more explicitly look for numeric values so that `123_456` is recognized as a string
- quoted numbers (e.g., `"123"`) were not preserved as strings.  This resolved that error.

## Changes proposed in this PR:
- Improve regex for identifying numeric (float, int, long) values
- Preserve quoted numbers as strings
- reduce the number of global variables
- eliminate dependency on `pyutilib.ply`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
