### PR TITLE
Add FileDownloader.get_os_version()

### DIFF
--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -86,8 +86,7 @@ class FileDownloader(object):
     def _get_distver_from_redhat_release(self):
         # RHEL6 did not include /etc/os-release
         with open('/etc/redhat-release', 'rt') as FILE:
-            dist = FILE.readline().lower()
-            print(dist)
+            dist = FILE.readline().lower().strip()
             ver = ''
             for word in dist.split():
                 if re.match('^[0-9\.]+', word):
@@ -98,7 +97,7 @@ class FileDownloader(object):
     def _get_distver_from_lsb_release(self):
         rc, dist = run(['lsb_release', '-si'])
         rc, ver = run(['lsb_release', '-sr'])
-        return self._map_dist(dist.lower()), ver.strip()
+        return self._map_dist(dist.lower().strip()), ver.strip()
 
     def _get_distver_from_distro(self):
         return distro.id(), distro.version(best=True)
@@ -108,6 +107,7 @@ class FileDownloader(object):
         _map = {
             'centos': 'centos',
             'redhat': 'rhel',
+            'red hat': 'rhel', # RHEL6 reports 'red hat enterprise'
             'fedora': 'fedora',
             'debian': 'debian',
             'ubuntu': 'ubuntu',

--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -14,9 +14,12 @@ import io
 import logging
 import os
 import platform
+import re
 import ssl
 import sys
 import zipfile
+
+from pyutilib.subprocess import run
 
 from .config import PYOMO_CONFIG_DIR
 from .deprecation import deprecated
@@ -25,12 +28,15 @@ import pyomo.common
 from pyomo.common.dependencies import attempt_import
 
 request = attempt_import('six.moves.urllib.request')[0]
+distro, distro_available = attempt_import('distro')
 
 logger = logging.getLogger('pyomo.common.download')
 
 DownloadFactory = pyomo.common.Factory('library downloaders')
 
 class FileDownloader(object):
+    _os_version = None
+
     def __init__(self, insecure=False, cacert=None):
         self._fname = None
         self.target = None
@@ -59,6 +65,117 @@ class FileDownloader(object):
         bits = 64 if sys.maxsize > 2**32 else 32
         return system, bits
 
+    def _get_distver_from_os_release(self):
+        dist = ''
+        ver = ''
+        with open('/etc/os-release', 'rt') as FILE:
+            for line in FILE:
+                line = line.strip()
+                if not line:
+                    continue
+                key,val = line.lower().split('=')
+                if key == 'id':
+                    dist = val
+                elif key == 'version_id':
+                    if val[0] == val[-1] and val[0] in '"\'':
+                        ver = val[1:-1]
+                    else:
+                        ver = val
+        return self._map_dist(dist), ver
+
+    def _get_distver_from_redhat_release(self):
+        # RHEL6 did not include /etc/os-release
+        with open('/etc/redhat-release', 'rt') as FILE:
+            dist = FILE.readline().lower()
+            print(dist)
+            ver = ''
+            for word in dist.split():
+                if re.match('^[0-9\.]+', word):
+                    ver = word
+                    break
+        return self._map_dist(dist), ver
+
+    def _get_distver_from_lsb_release(self):
+        rc, dist = run(['lsb_release', '-si'])
+        rc, ver = run(['lsb_release', '-sr'])
+        return self._map_dist(dist.lower()), ver.strip()
+
+    def _get_distver_from_distro(self):
+        return distro.id(), distro.version(best=True)
+
+    def _map_dist(self, dist):
+        dist = dist.lower()
+        _map = {
+            'centos': 'centos',
+            'redhat': 'rhel',
+            'fedora': 'fedora',
+            'debian': 'debian',
+            'ubuntu': 'ubuntu',
+        }
+        for key in _map:
+            if key in dist:
+                return _map[key]
+        return dist
+
+    def _get_os_version(self):
+        _os = self.get_sysinfo()[0]
+        if _os == 'linux':
+            if distro_available:
+                dist, ver = self._get_distver_from_distro()
+            elif os.path.exists('/etc/redhat-release'):
+                dist, ver = self._get_distver_from_redhat_release()
+            elif run(['lsb_release'])[0] == 0:
+                dist, ver = self._get_distver_from_lsb_release()
+            elif os.path.exists('/etc/os-release'):
+                # Note that (at least on centos), os_release is an
+                # imprecise version string
+                dist, ver = self._get_distver_from_os_release()
+            else:
+                dist, ver = '',''
+            return dist, ver
+        elif _os == 'darwin':
+            return 'macos', platform.mac_ver()[0]
+        elif _os == 'windows':
+            return 'win', platform.win32_ver()[0]
+        else:
+            return '', ''
+
+    def get_os_version(self, normalize=True):
+        """Return a standardized representation of the OS version
+
+        This method was designed to help identify compatible binaries,
+        and will return strings similar to:
+          - rhel6
+          - fedora24
+          - ubuntu18.04
+          - macos10.13
+          - win10
+
+        Parameters
+        ----------
+        normalize : bool, optional
+            If True (the default) returns a simplified normalized string
+            (e.g., `'rhel7'`) instead of the raw (os, version) tuple
+            (e.g., `('centos', '7.7.1908')`)
+
+        """
+        if FileDownloader._os_version is None:
+            FileDownloader._os_version = self._get_os_version()
+
+        if not normalize:
+            return FileDownloader._os_version
+
+        _os, _ver = FileDownloader._os_version
+        _map = {
+            'centos': 'rhel',
+        }
+        if _os in _map:
+            _os = _map[_os]
+
+        if _os in {'ubuntu','macos'}:
+            return _os + ''.join(_ver.split('.')[:2])
+        else:
+            return _os + _ver.split('.')[0]
 
     @deprecated("get_url() is deprecated. Use get_platform_url()",
                 version='5.6.9')

--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -172,7 +172,7 @@ class FileDownloader(object):
         if _os in _map:
             _os = _map[_os]
 
-        if _os in {'ubuntu','macos'}:
+        if _os in {'ubuntu','macos','win'}:
             return _os + ''.join(_ver.split('.')[:2])
         else:
             return _os + _ver.split('.')[0]

--- a/pyomo/common/tests/test_download.py
+++ b/pyomo/common/tests/test_download.py
@@ -11,17 +11,19 @@
 import io
 import os
 import platform
+import re
 import six
 import shutil
 import tempfile
 
 import pyutilib.th as unittest
 from pyutilib.misc import capture_output
+from pyutilib.subprocess import run
 
 from pyomo.common import DeveloperError
 from pyomo.common.config import PYOMO_CONFIG_DIR
 from pyomo.common.fileutils import this_file
-from pyomo.common.download import FileDownloader
+from pyomo.common.download import FileDownloader, distro_available
 
 class Test_FileDownloader(unittest.TestCase):
     def setUp(self):
@@ -138,6 +140,69 @@ class Test_FileDownloader(unittest.TestCase):
         self.assertTrue(platform.system().lower().startswith(ans[0]))
         self.assertFalse(any(c in ans[0] for c in '.-_'))
         self.assertIn(ans[1], (32,64))
+
+    def test_get_os_version(self):
+        f = FileDownloader()
+        _os, _ver = f.get_os_version(normalize=False)
+        _norm = f.get_os_version(normalize=True)
+        _sys = f.get_sysinfo()[0]
+        if _sys == 'linux':
+            dist, dist_ver = re.match('^([^0-9]+)(.*)', _norm).groups()
+            self.assertNotIn('.', dist_ver)
+            self.assertGreater(int(dist_ver), 0)
+            if dist == 'ubuntu':
+                self.assertEqual(dist_ver, ''.join(_ver.split('.')[:2]))
+            else:
+                self.assertEqual(dist_ver, _ver.split('.')[0])
+
+            if distro_available:
+                d, v = f._get_distver_from_distro()
+                self.assertEqual(_os, d)
+                self.assertEqual(_ver, v)
+                self.assertTrue(v.startswith(dist_ver))
+
+            if os.path.exists('/etc/redhat-release'):
+                d, v = f._get_distver_from_redhat_release()
+                self.assertEqual(_os, d)
+                self.assertEqual(_ver, v)
+                self.assertTrue(v.startswith(dist_ver))
+
+            if run(['lsb_release'])[0] == 0:
+                d, v = f._get_distver_from_lsb_release()
+                self.assertEqual(_os, d)
+                self.assertEqual(_ver, v)
+                self.assertTrue(v.startswith(dist_ver))
+
+            if os.path.exists('/etc/os-release'):
+                d, v = f._get_distver_from_os_release()
+                self.assertEqual(_os, d)
+                # Note that (at least on centos), os_release is an
+                # imprecise version string
+                self.assertTrue(_ver.startswith(v))
+                self.assertTrue(v.startswith(dist_ver))
+
+        elif _sys == 'darwin':
+            dist, ver = re.match('^([^0-9]+)(.*)', _norm).groups()
+            self.assertEqual(_os, 'macos')
+            self.assertEqual(dist, 'macos')
+            self.assertIn('.', ver)
+            self.assertGreater(int(ver.split('.')[0]), 0)
+        elif _sys == 'windows':
+            self.assertEqual(_os, 'win')
+            self.assertEqual(_norm, _os+_ver)
+        else:
+            self.assertEqual(ans, '')
+
+        self.assertEqual((_os, _ver), FileDownloader._os_version)
+        # Exercise the fetch from CACHE
+        try:
+            FileDownloader._os_version, tmp \
+                = ("test", '2'), FileDownloader._os_version
+            self.assertEqual(f.get_os_version(False), ("test","2"))
+            self.assertEqual(f.get_os_version(), "test2")
+        finally:
+            FileDownloader._os_version = tmp
+
 
     def test_get_platform_url(self):
         f = FileDownloader()

--- a/pyomo/common/tests/test_download.py
+++ b/pyomo/common/tests/test_download.py
@@ -195,7 +195,7 @@ class Test_FileDownloader(unittest.TestCase):
             self.assertEqual(_norm, _os+''.join(_ver.split('.')[:2]))
         elif _sys == 'windows':
             self.assertEqual(_os, 'win')
-            self.assertEqual(_norm, _os+_ver.split('.')[:2])
+            self.assertEqual(_norm, _os+''.join(_ver.split('.')[:2]))
         else:
             self.assertEqual(ans, '')
 

--- a/pyomo/common/tests/test_download.py
+++ b/pyomo/common/tests/test_download.py
@@ -195,7 +195,7 @@ class Test_FileDownloader(unittest.TestCase):
             self.assertEqual(_norm, _os+''.join(_ver.split('.')[:2]))
         elif _sys == 'windows':
             self.assertEqual(_os, 'win')
-            self.assertEqual(_norm, _os+_ver.split('.')[0])
+            self.assertEqual(_norm, _os+_ver.split('.')[:2])
         else:
             self.assertEqual(ans, '')
 

--- a/pyomo/common/tests/test_download.py
+++ b/pyomo/common/tests/test_download.py
@@ -145,7 +145,7 @@ class Test_FileDownloader(unittest.TestCase):
         f = FileDownloader()
         _os, _ver = f.get_os_version(normalize=False)
         _norm = f.get_os_version(normalize=True)
-        print(_os,_ver,_norm)
+        #print(_os,_ver,_norm)
         _sys = f.get_sysinfo()[0]
         if _sys == 'linux':
             dist, dist_ver = re.match('^([^0-9]+)(.*)', _norm).groups()
@@ -158,33 +158,33 @@ class Test_FileDownloader(unittest.TestCase):
 
             if distro_available:
                 d, v = f._get_distver_from_distro()
-                print(d,v)
+                #print(d,v)
                 self.assertEqual(_os, d)
                 self.assertEqual(_ver, v)
-                self.assertTrue(v.startswith(dist_ver))
+                self.assertTrue(v.startswith(dist_ver.replace('.','')))
 
             if os.path.exists('/etc/redhat-release'):
                 d, v = f._get_distver_from_redhat_release()
-                print(d,v)
+                #print(d,v)
                 self.assertEqual(_os, d)
                 self.assertEqual(_ver, v)
-                self.assertTrue(v.startswith(dist_ver))
+                self.assertTrue(v.startswith(dist_ver.replace('.','')))
 
             if run(['lsb_release'])[0] == 0:
                 d, v = f._get_distver_from_lsb_release()
-                print(d,v)
+                #print(d,v)
                 self.assertEqual(_os, d)
                 self.assertEqual(_ver, v)
-                self.assertTrue(v.startswith(dist_ver))
+                self.assertTrue(v.startswith(dist_ver.replace('.','')))
 
             if os.path.exists('/etc/os-release'):
                 d, v = f._get_distver_from_os_release()
-                print(d,v)
+                #print(d,v)
                 self.assertEqual(_os, d)
                 # Note that (at least on centos), os_release is an
                 # imprecise version string
-                self.assertTrue(_ver.startswith(v))
-                self.assertTrue(v.startswith(dist_ver))
+                self.assertTrue(_ver.replace('.','').startswith(v))
+                self.assertTrue(v.startswith(dist_ver.replace('.','')))
 
         elif _sys == 'darwin':
             dist, dist_ver = re.match('^([^0-9]+)(.*)', _norm).groups()

--- a/pyomo/common/tests/test_download.py
+++ b/pyomo/common/tests/test_download.py
@@ -161,21 +161,21 @@ class Test_FileDownloader(unittest.TestCase):
                 #print(d,v)
                 self.assertEqual(_os, d)
                 self.assertEqual(_ver, v)
-                self.assertTrue(v.startswith(dist_ver.replace('.','')))
+                self.assertTrue(v.replace('.','').startswith(dist_ver))
 
             if os.path.exists('/etc/redhat-release'):
                 d, v = f._get_distver_from_redhat_release()
                 #print(d,v)
                 self.assertEqual(_os, d)
                 self.assertEqual(_ver, v)
-                self.assertTrue(v.startswith(dist_ver.replace('.','')))
+                self.assertTrue(v.replace('.','').startswith(dist_ver))
 
             if run(['lsb_release'])[0] == 0:
                 d, v = f._get_distver_from_lsb_release()
                 #print(d,v)
                 self.assertEqual(_os, d)
                 self.assertEqual(_ver, v)
-                self.assertTrue(v.startswith(dist_ver.replace('.','')))
+                self.assertTrue(v.replace('.','').startswith(dist_ver))
 
             if os.path.exists('/etc/os-release'):
                 d, v = f._get_distver_from_os_release()
@@ -183,8 +183,8 @@ class Test_FileDownloader(unittest.TestCase):
                 self.assertEqual(_os, d)
                 # Note that (at least on centos), os_release is an
                 # imprecise version string
-                self.assertTrue(_ver.replace('.','').startswith(v))
-                self.assertTrue(v.startswith(dist_ver.replace('.','')))
+                self.assertTrue(_ver.startswith(v))
+                self.assertTrue(v.replace('.','').startswith(dist_ver))
 
         elif _sys == 'darwin':
             dist, dist_ver = re.match('^([^0-9]+)(.*)', _norm).groups()

--- a/pyomo/common/tests/test_download.py
+++ b/pyomo/common/tests/test_download.py
@@ -195,7 +195,7 @@ class Test_FileDownloader(unittest.TestCase):
             self.assertEqual(_norm, _os+''.join(_ver.split('.')[:2]))
         elif _sys == 'windows':
             self.assertEqual(_os, 'win')
-            self.assertEqual(_norm, _os+_ver)
+            self.assertEqual(_norm, _os+_ver.split('.')[0])
         else:
             self.assertEqual(ans, '')
 

--- a/pyomo/common/tests/test_download.py
+++ b/pyomo/common/tests/test_download.py
@@ -145,6 +145,7 @@ class Test_FileDownloader(unittest.TestCase):
         f = FileDownloader()
         _os, _ver = f.get_os_version(normalize=False)
         _norm = f.get_os_version(normalize=True)
+        print(_os,_ver,_norm)
         _sys = f.get_sysinfo()[0]
         if _sys == 'linux':
             dist, dist_ver = re.match('^([^0-9]+)(.*)', _norm).groups()
@@ -157,24 +158,28 @@ class Test_FileDownloader(unittest.TestCase):
 
             if distro_available:
                 d, v = f._get_distver_from_distro()
+                print(d,v)
                 self.assertEqual(_os, d)
                 self.assertEqual(_ver, v)
                 self.assertTrue(v.startswith(dist_ver))
 
             if os.path.exists('/etc/redhat-release'):
                 d, v = f._get_distver_from_redhat_release()
+                print(d,v)
                 self.assertEqual(_os, d)
                 self.assertEqual(_ver, v)
                 self.assertTrue(v.startswith(dist_ver))
 
             if run(['lsb_release'])[0] == 0:
                 d, v = f._get_distver_from_lsb_release()
+                print(d,v)
                 self.assertEqual(_os, d)
                 self.assertEqual(_ver, v)
                 self.assertTrue(v.startswith(dist_ver))
 
             if os.path.exists('/etc/os-release'):
                 d, v = f._get_distver_from_os_release()
+                print(d,v)
                 self.assertEqual(_os, d)
                 # Note that (at least on centos), os_release is an
                 # imprecise version string
@@ -182,11 +187,12 @@ class Test_FileDownloader(unittest.TestCase):
                 self.assertTrue(v.startswith(dist_ver))
 
         elif _sys == 'darwin':
-            dist, ver = re.match('^([^0-9]+)(.*)', _norm).groups()
+            dist, dist_ver = re.match('^([^0-9]+)(.*)', _norm).groups()
             self.assertEqual(_os, 'macos')
             self.assertEqual(dist, 'macos')
-            self.assertIn('.', ver)
-            self.assertGreater(int(ver.split('.')[0]), 0)
+            self.assertNotIn('.', dist_ver)
+            self.assertGreater(int(dist_ver), 0)
+            self.assertEqual(_norm, _os+''.join(_ver.split('.')[:2]))
         elif _sys == 'windows':
             self.assertEqual(_os, 'win')
             self.assertEqual(_norm, _os+_ver)


### PR DESCRIPTION
## Fixes #N/A .

## Summary/Motivation:
This adds a utility method that makes a best effort to determine the os platform, for use when determining appropriate binary images to download (requested as part of IDAES/idaes-dev#788).

## Changes proposed in this PR:
- Add `FileDownloader.get_os_version()`
- Add tests verifying output

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
