### PR TITLE
Add deprecation warning for Set.value_list

### DIFF
--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -1149,6 +1149,13 @@ class _FiniteSetMixin(object):
     def value(self):
         return set(self)
 
+    @property
+    @deprecated("The 'value_list' attribute is deprecated.  Use "
+                ".ordered_data() to retrieve the values from a finite set "
+                "in a deterministic order.", version='TBD')
+    def value_list(self):
+        return list(self.ordered_data())
+
     def sorted_data(self):
         return tuple(sorted_robust(self.data()))
 

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -5449,10 +5449,24 @@ class TestDeprecation(unittest.TestCase):
         output = StringIO()
         with LoggingIntercept(output, 'pyomo.core'):
             tmp = m.J.value
+        self.assertIs(type(tmp), set)
         self.assertEqual(tmp, set([1,3,2]))
         self.assertRegexpMatches(
             output.getvalue(),
             "^DEPRECATED: The 'value' attribute is deprecated.  Use .data\(\)")
+
+    def test_value_list_attr(self):
+        m = ConcreteModel()
+        m.J = Set(ordered=True, initialize=[1,3,2])
+        output = StringIO()
+        with LoggingIntercept(output, 'pyomo.core'):
+            tmp = m.J.value_list
+        self.assertIs(type(tmp), list)
+        self.assertEqual(tmp, list([1,3,2]))
+        self.assertRegexpMatches(
+            output.getvalue().replace('\n',' '),
+            "^DEPRECATED: The 'value_list' attribute is deprecated.  "
+            "Use .ordered_data\(\)")
 
     def test_check_values(self):
         m = ConcreteModel()


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Adding a missing deprecation warning from the Set rewrite (reported as a comment on #936).

## Changes proposed in this PR:
- Add a `value_list` property to finite sets, with a deprecation warning
- Test the deprecation warning

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
