### PR TITLE
Updating GAMS version in Appveyor to 29.1.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -132,8 +132,26 @@ install:
   #
   # Install GAMS
   #
-  - ps: Start-FileDownload 'https://d37drm4t2jghv5.cloudfront.net/distributions/24.8.5/windows/windows_x64_64.exe'
+  - ps: Start-FileDownload 'https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0/windows/windows_x64_64.exe'
   - windows_x64_64.exe /SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS
+  - "cd gams\apifiles\Python\"
+  - ps: >-
+    if($env:PYTHON_VERSION -eq 2.7) {
+          cd api
+          python setup.py -q install
+    }elseif($env:PYTHON_VERSION -eq 3.6) {
+          Write-Host ("PYTHON ${{matrix.python-version}}")
+          cd api_36
+          python setup.py -q install
+    }elseif($env:PYTHON_VERSION -eq 3.7) {
+          Write-Host ("PYTHON ${{matrix.python-version}}")
+          cd api_37
+          python setup.py -q install -noCheck
+    }else {
+          Write-Host ("########################################################################")
+          Write-Host ("WARNING: Python ${{matrix.python-version}}: GAMS Bindings not supported.")
+          Write-Host ("########################################################################")
+    }
   - "SET PATH=%cd%\\gams;%PATH%"
   #
   # Clone but don't install pyomo-model-libraries

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -134,24 +134,15 @@ install:
   #
   - ps: Start-FileDownload 'https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0/windows/windows_x64_64.exe'
   - windows_x64_64.exe /SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS
-  - "cd gams\apifiles\Python\"
-  - ps: >-
-    if($env:PYTHON_VERSION -eq 2.7) {
-          cd api
-          python setup.py -q install
-    }elseif($env:PYTHON_VERSION -eq 3.6) {
-          Write-Host ("PYTHON ${{matrix.python-version}}")
-          cd api_36
-          python setup.py -q install
-    }elseif($env:PYTHON_VERSION -eq 3.7) {
-          Write-Host ("PYTHON ${{matrix.python-version}}")
-          cd api_37
-          python setup.py -q install -noCheck
-    }else {
-          Write-Host ("########################################################################")
-          Write-Host ("WARNING: Python ${{matrix.python-version}}: GAMS Bindings not supported.")
-          Write-Host ("########################################################################")
-    }
+  - "SET cwd=%cd%"
+  - "cd gams\\apifiles\\Python"
+  - IF PYTHON_VERSION equ 2.7 (cd api \ python setup.py install )
+  - IF PYTHON_VERSION equ 3.6 (cd api_36 \ python setup.py install )
+  - IF PYTHON_VERSION equ 3.7 (cd api_37 \ python setup.py install )
+  - "cd %cwd%"
+  #
+  # Add GAMS to PATH
+  #
   - "SET PATH=%cd%\\gams;%PATH%"
   #
   # Clone but don't install pyomo-model-libraries


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
Github Actions is testing the newer GAMS version. To promote consistency, the Appveyor version needs to be updated.

## Changes proposed in this PR:
- Update to GAMS 29.1
- Install Python bindings

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
