### PR TITLE
FileDownloader, find_library updates

### DIFF
--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -49,7 +49,8 @@ class FileDownloader(object):
                     % (self.cacert,))
 
 
-    def get_sysinfo(self):
+    @classmethod
+    def get_sysinfo(cls):
         """Return a tuple (platform_name, bits) for the current system
 
         Returns
@@ -65,7 +66,8 @@ class FileDownloader(object):
         bits = 64 if sys.maxsize > 2**32 else 32
         return system, bits
 
-    def _get_distver_from_os_release(self):
+    @classmethod
+    def _get_distver_from_os_release(cls):
         dist = ''
         ver = ''
         with open('/etc/os-release', 'rt') as FILE:
@@ -81,9 +83,10 @@ class FileDownloader(object):
                         ver = val[1:-1]
                     else:
                         ver = val
-        return self._map_dist(dist), ver
+        return cls._map_dist(dist), ver
 
-    def _get_distver_from_redhat_release(self):
+    @classmethod
+    def _get_distver_from_redhat_release(cls):
         # RHEL6 did not include /etc/os-release
         with open('/etc/redhat-release', 'rt') as FILE:
             dist = FILE.readline().lower().strip()
@@ -92,17 +95,20 @@ class FileDownloader(object):
                 if re.match('^[0-9\.]+', word):
                     ver = word
                     break
-        return self._map_dist(dist), ver
+        return cls._map_dist(dist), ver
 
-    def _get_distver_from_lsb_release(self):
+    @classmethod
+    def _get_distver_from_lsb_release(cls):
         rc, dist = run(['lsb_release', '-si'])
         rc, ver = run(['lsb_release', '-sr'])
-        return self._map_dist(dist.lower().strip()), ver.strip()
+        return cls._map_dist(dist.lower().strip()), ver.strip()
 
-    def _get_distver_from_distro(self):
+    @classmethod
+    def _get_distver_from_distro(cls):
         return distro.id(), distro.version(best=True)
 
-    def _map_dist(self, dist):
+    @classmethod
+    def _map_dist(cls, dist):
         dist = dist.lower()
         _map = {
             'centos': 'centos',
@@ -117,19 +123,20 @@ class FileDownloader(object):
                 return _map[key]
         return dist
 
-    def _get_os_version(self):
-        _os = self.get_sysinfo()[0]
+    @classmethod
+    def _get_os_version(cls):
+        _os = cls.get_sysinfo()[0]
         if _os == 'linux':
             if distro_available:
-                dist, ver = self._get_distver_from_distro()
+                dist, ver = cls._get_distver_from_distro()
             elif os.path.exists('/etc/redhat-release'):
-                dist, ver = self._get_distver_from_redhat_release()
+                dist, ver = cls._get_distver_from_redhat_release()
             elif run(['lsb_release'])[0] == 0:
-                dist, ver = self._get_distver_from_lsb_release()
+                dist, ver = cls._get_distver_from_lsb_release()
             elif os.path.exists('/etc/os-release'):
                 # Note that (at least on centos), os_release is an
                 # imprecise version string
-                dist, ver = self._get_distver_from_os_release()
+                dist, ver = cls._get_distver_from_os_release()
             else:
                 dist, ver = '',''
             return dist, ver
@@ -140,7 +147,8 @@ class FileDownloader(object):
         else:
             return '', ''
 
-    def get_os_version(self, normalize=True):
+    @classmethod
+    def get_os_version(cls, normalize=True):
         """Return a standardized representation of the OS version
 
         This method was designed to help identify compatible binaries,
@@ -160,7 +168,7 @@ class FileDownloader(object):
 
         """
         if FileDownloader._os_version is None:
-            FileDownloader._os_version = self._get_os_version()
+            FileDownloader._os_version = cls._get_os_version()
 
         if not normalize:
             return FileDownloader._os_version

--- a/pyomo/common/fileutils.py
+++ b/pyomo/common/fileutils.py
@@ -8,6 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import ctypes.util
 import glob
 import inspect
 import logging
@@ -317,7 +318,7 @@ def find_library(libname, cwd=True, include_PATH=True, pathlist=None):
     if libname.startswith('lib'):
         libname = libname[3:]
     libname_base, ext = os.path.splitext(libname)
-    if ext.lower() in {'so','dll','dylib'}:
+    if ext.lower().startswith(('.so','.dll','.dylib')):
         return ctypes.util.find_library(libname_base)
     else:
         return ctypes.util.find_library(libname)

--- a/pyomo/common/fileutils.py
+++ b/pyomo/common/fileutils.py
@@ -320,12 +320,12 @@ def find_library(libname, cwd=True, include_PATH=True, pathlist=None):
     # Search 1: original filename (with extensions) in our paths
     lib = find_file(libname, cwd=cwd, ext=ext, pathlist=pathlist)
     if lib is None and not libname.startswith('lib'):
-        # Search 2: prpend 'lib' (with extensions) in our paths
+        # Search 2: prepend 'lib' (with extensions) in our paths
         lib = find_file('lib'+libname, cwd=cwd, ext=ext, pathlist=pathlist)
     if lib is not None:
         return lib
     # Search 3: use ctypes.util.find_library (which expects 'lib' and
-    # extension to be removed fro mthe name)
+    # extension to be removed from the name)
     if libname.startswith('lib') and _system() != 'windows':
         libname = libname[3:]
     libname_base, ext = os.path.splitext(os.path.basename(libname))

--- a/pyomo/common/fileutils.py
+++ b/pyomo/common/fileutils.py
@@ -311,7 +311,16 @@ def find_library(libname, cwd=True, include_PATH=True, pathlist=None):
     if include_PATH:
         pathlist.extend(_path())
     ext = _libExt.get(_system(), None)
-    return find_file(libname, cwd=cwd, ext=ext, pathlist=pathlist)
+    lib = find_file(libname, cwd=cwd, ext=ext, pathlist=pathlist)
+    if lib is not None:
+        return lib
+    if libname.startswith('lib'):
+        libname = libname[3:]
+    libname_base, ext = os.path.splitext(libname)
+    if ext.lower() in {'so','dll','dylib'}:
+        return ctypes.util.find_library(libname_base)
+    else:
+        return ctypes.util.find_library(libname)
 
 
 def find_executable(exename, cwd=True, include_PATH=True, pathlist=None):

--- a/pyomo/common/fileutils.py
+++ b/pyomo/common/fileutils.py
@@ -315,7 +315,7 @@ def find_library(libname, cwd=True, include_PATH=True, pathlist=None):
     lib = find_file(libname, cwd=cwd, ext=ext, pathlist=pathlist)
     if lib is not None:
         return lib
-    if libname.startswith('lib'):
+    if libname.startswith('lib') and _system() != 'windows':
         libname = libname[3:]
     libname_base, ext = os.path.splitext(libname)
     if ext.lower().startswith(('.so','.dll','.dylib')):

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -250,7 +250,7 @@ class TestFileUtils(unittest.TestCase):
                 find_library(f_in_path, include_PATH=False)
             )
         else:
-            # Note on windows, ctypes.util.find_library *always*
+            # Note that on Windows, ctypes.util.find_library *always*
             # searches the PATH
             self.assertIsNone(
                 find_library(f_in_path, include_PATH=False)
@@ -276,7 +276,7 @@ class TestFileUtils(unittest.TestCase):
         )
         # ... but only if include_PATH is true
         if _system == 'windows':
-            # Note on windows, ctypes.util.find_library *always*
+            # Note that on Windows, ctypes.util.find_library *always*
             # searches the PATH
             self._check_file(
                 os.path.join(config_bindir, f_in_configbin),

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -275,17 +275,9 @@ class TestFileUtils(unittest.TestCase):
             find_library(f_in_configbin)
         )
         # ... but only if include_PATH is true
-        if _system() == 'windows':
-            # Note that on Windows, ctypes.util.find_library *always*
-            # searches the PATH
-            self._check_file(
-                os.path.join(config_bindir, f_in_configbin),
-                find_library(f_in_configbin, include_PATH=False)
-            )
-        else:
-            self.assertIsNone(
-                find_library(f_in_configbin, include_PATH=False)
-            )
+        self.assertIsNone(
+            find_library(f_in_configbin, include_PATH=False)
+        )
         # And none of them if the pathlist is specified
         self.assertIsNone(
             find_library(f_in_configlib, pathlist=pathdir)

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -27,6 +27,7 @@ from pyomo.common.fileutils import (
     this_file, this_file_dir, find_file, find_library, find_executable, 
     PathManager, _system, _path, _exeExt, _libExt, _ExecutableData,
 )
+from pyomo.common.download import FileDownloader
 
 try:
     samefile = os.path.samefile
@@ -275,6 +276,24 @@ class TestFileUtils(unittest.TestCase):
         self.assertIsNone(
             find_library(f_in_configbin, pathlist=pathdir)
         )
+
+        # Find a system library
+        if FileDownloader.get_sysinfo()[0] == 'windows':
+            a = find_library('ntdll')
+            self.assertIsNotNone(a)
+            self.assertTrue(os.path.exists(a))
+            b = find_library('ntdll.dll')
+            self.assertIsNotNone(b)
+            self.assertTrue(os.path.exists(b))
+            self.assertEqual(a,b)
+        else:
+            a = find_library('c')
+            self.assertIsNotNone(a)
+            self.assertTrue(os.path.exists(a))
+            b = find_library('libc.so')
+            self.assertIsNotNone(b)
+            self.assertTrue(os.path.exists(b))
+            self.assertEqual(a,b)
 
 
     def test_find_executable(self):

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -8,6 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import ctypes
 import logging
 import os
 import platform
@@ -278,22 +279,21 @@ class TestFileUtils(unittest.TestCase):
         )
 
         # Find a system library
+        _args = {'cwd':False, 'include_PATH':False, 'pathlist':[]}
         if FileDownloader.get_sysinfo()[0] == 'windows':
-            a = find_library('ntdll')
-            self.assertIsNotNone(a)
-            self.assertTrue(os.path.exists(a))
-            b = find_library('ntdll.dll')
-            self.assertIsNotNone(b)
-            self.assertTrue(os.path.exists(b))
-            self.assertEqual(a,b)
+            a = find_library('ntdll', **_args)
+            b = find_library('ntdll.dll', **_args)
         else:
-            a = find_library('c')
-            self.assertIsNotNone(a)
-            self.assertTrue(os.path.exists(a))
-            b = find_library('libc.so')
-            self.assertIsNotNone(b)
-            self.assertTrue(os.path.exists(b))
-            self.assertEqual(a,b)
+            a = find_library('c', **_args)
+            b = find_library('libc.so', **_args)
+        self.assertIsNotNone(a)
+        self.assertIsNotNone(b)
+        self.assertEqual(a,b)
+        # Verify that the library is loadable
+        a_lib = ctypes.cdll.LoadLibrary(a)
+        self.assertIsNotNone(a_lib)
+        b_lib = ctypes.cdll.LoadLibrary(b)
+        self.assertIsNotNone(b_lib)
 
 
     def test_find_executable(self):

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -244,7 +244,7 @@ class TestFileUtils(unittest.TestCase):
             os.path.join(pathdir, f_in_path),
             find_library(f_in_path)
         )
-        if _system == 'windows':
+        if _system() == 'windows':
             self._check_file(
                 os.path.join(pathdir, f_in_path),
                 find_library(f_in_path, include_PATH=False)
@@ -275,7 +275,7 @@ class TestFileUtils(unittest.TestCase):
             find_library(f_in_configbin)
         )
         # ... but only if include_PATH is true
-        if _system == 'windows':
+        if _system() == 'windows':
             # Note that on Windows, ctypes.util.find_library *always*
             # searches the PATH
             self._check_file(

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -194,6 +194,23 @@ class TestFileUtils(unittest.TestCase):
         self.tmpdir = os.path.abspath(tempfile.mkdtemp())
         os.chdir(self.tmpdir)
 
+        # Find a system library (before we muck with the PATH)
+        _args = {'cwd':False, 'include_PATH':False, 'pathlist':[]}
+        if FileDownloader.get_sysinfo()[0] == 'windows':
+            a = find_library('ntdll', **_args)
+            b = find_library('ntdll.dll', **_args)
+        else:
+            a = find_library('c', **_args)
+            b = find_library('libc.so', **_args)
+        self.assertIsNotNone(a)
+        self.assertIsNotNone(b)
+        self.assertEqual(a,b)
+        # Verify that the library is loadable
+        a_lib = ctypes.cdll.LoadLibrary(a)
+        self.assertIsNotNone(a_lib)
+        b_lib = ctypes.cdll.LoadLibrary(b)
+        self.assertIsNotNone(b_lib)
+
         config.PYOMO_CONFIG_DIR = self.tmpdir
         config_libdir = os.path.join(self.tmpdir, 'lib')
         os.mkdir(config_libdir)
@@ -285,23 +302,6 @@ class TestFileUtils(unittest.TestCase):
         self.assertIsNone(
             find_library(f_in_configbin, pathlist=pathdir)
         )
-
-        # Find a system library
-        _args = {'cwd':False, 'include_PATH':False, 'pathlist':[]}
-        if FileDownloader.get_sysinfo()[0] == 'windows':
-            a = find_library('ntdll', **_args)
-            b = find_library('ntdll.dll', **_args)
-        else:
-            a = find_library('c', **_args)
-            b = find_library('libc.so', **_args)
-        self.assertIsNotNone(a)
-        self.assertIsNotNone(b)
-        self.assertEqual(a,b)
-        # Verify that the library is loadable
-        a_lib = ctypes.cdll.LoadLibrary(a)
-        self.assertIsNotNone(a_lib)
-        b_lib = ctypes.cdll.LoadLibrary(b)
-        self.assertIsNotNone(b_lib)
 
 
     def test_find_executable(self):

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -199,17 +199,20 @@ class TestFileUtils(unittest.TestCase):
         if FileDownloader.get_sysinfo()[0] == 'windows':
             a = find_library('ntdll', **_args)
             b = find_library('ntdll.dll', **_args)
+            c = find_library('foo\\bar\\ntdll.dll', **_args)
         else:
             a = find_library('c', **_args)
             b = find_library('libc.so', **_args)
+            c = find_library('foo/bar/libc.so', **_args)
         self.assertIsNotNone(a)
         self.assertIsNotNone(b)
+        self.assertIsNotNone(c)
         self.assertEqual(a,b)
-        # Verify that the library is loadable
-        a_lib = ctypes.cdll.LoadLibrary(a)
-        self.assertIsNotNone(a_lib)
-        b_lib = ctypes.cdll.LoadLibrary(b)
-        self.assertIsNotNone(b_lib)
+        self.assertEqual(a,c)
+        # Verify that the library is loadable (they are all the same
+        # file, so only check one)
+        _lib = ctypes.cdll.LoadLibrary(a)
+        self.assertIsNotNone(_lib)
 
         config.PYOMO_CONFIG_DIR = self.tmpdir
         config_libdir = os.path.join(self.tmpdir, 'lib')

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -244,9 +244,17 @@ class TestFileUtils(unittest.TestCase):
             os.path.join(pathdir, f_in_path),
             find_library(f_in_path)
         )
-        self.assertIsNone(
-            find_library(f_in_path, include_PATH=False)
-        )
+        if _system == 'windows':
+            self._check_file(
+                os.path.join(pathdir, f_in_path),
+                find_library(f_in_path, include_PATH=False)
+            )
+        else:
+            # Note on windows, ctypes.util.find_library *always*
+            # searches the PATH
+            self.assertIsNone(
+                find_library(f_in_path, include_PATH=False)
+            )
         self._check_file(
             os.path.join(pathdir, f_in_path),
             find_library(f_in_path, pathlist=os.pathsep+pathdir+os.pathsep)
@@ -267,9 +275,17 @@ class TestFileUtils(unittest.TestCase):
             find_library(f_in_configbin)
         )
         # ... but only if include_PATH is true
-        self.assertIsNone(
-            find_library(f_in_configbin, include_PATH=False)
-        )
+        if _system == 'windows':
+            # Note on windows, ctypes.util.find_library *always*
+            # searches the PATH
+            self._check_file(
+                os.path.join(config_bindir, f_in_configbin),
+                find_library(f_in_configbin, include_PATH=False)
+            )
+        else:
+            self.assertIsNone(
+                find_library(f_in_configbin, include_PATH=False)
+            )
         # And none of them if the pathlist is specified
         self.assertIsNone(
             find_library(f_in_configlib, pathlist=pathdir)


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This converts the `FileDownloader.get_sysinfo()` and `FileDownloader.get_os_version()` to `@classmethod`s so that clients can easily access them without being forced to create a FileDownloader instance.  This also updates the `find_library()` method to search the system library locations (using `ctypes.util.find_library()`)

## Changes proposed in this PR:
- Switch  `FileDownloader.get_sysinfo()` and `FileDownloader.get_os_version()` to `@classmethod`s
- Add system paths to the locations searched by `find_library()`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
