### PR TITLE
Return meaningful errors when an Expression is treated as a Var

### DIFF
--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -222,6 +222,29 @@ class _GeneralExpressionDataImpl(_ExpressionData):
         """A boolean indicating whether this expression is fixed."""
         return self._expr.is_fixed()
 
+    # Define methods for common activities on Vars in case user mistakes
+    # an Expression for a Var
+    def setlb(self, val):
+        raise TypeError(
+            "Expressions cannot have bounds: %s"
+            % (self.name))
+
+    def setub(self, val):
+        raise TypeError(
+            "Expressions cannot have bounds: %s"
+            % (self.name))
+
+    def fix(self, val):
+        raise TypeError(
+            "Expressions cannot be fixed: %s"
+            % (self.name))
+
+    def unfix(self):
+        raise TypeError(
+            "Expressions cannot be fixed: %s"
+            % (self.name))
+
+
 class _GeneralExpressionData(_GeneralExpressionDataImpl,
                              ComponentData):
     """
@@ -526,3 +549,24 @@ class IndexedExpression(Expression):
         self._data[index] = cdata
         return cdata
 
+    # Define methods for common activities on Vars in case user mistakes
+    # an Expression for a Var
+    def setlb(self, val):
+        raise TypeError(
+            "Expressions cannot have bounds: %s"
+            % (self.name))
+
+    def setub(self, val):
+        raise TypeError(
+            "Expressions cannot have bounds: %s"
+            % (self.name))
+
+    def fix(self, val):
+        raise TypeError(
+            "Expressions cannot be fixed: %s"
+            % (self.name))
+
+    def unfix(self):
+        raise TypeError(
+            "Expressions cannot be fixed: %s"
+            % (self.name))

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -226,22 +226,22 @@ class _GeneralExpressionDataImpl(_ExpressionData):
     # an Expression for a Var
     def setlb(self, val):
         raise TypeError(
-            "Expressions cannot have bounds: %s"
+            "Component is an Expression and can not have bounds: %s"
             % (self.name))
 
     def setub(self, val):
         raise TypeError(
-            "Expressions cannot have bounds: %s"
+            "Component is an Expression and can not have bounds: %s"
             % (self.name))
 
     def fix(self, val):
         raise TypeError(
-            "Expressions cannot be fixed: %s"
+            "Component is an Expression and can not be fixed: %s"
             % (self.name))
 
     def unfix(self):
         raise TypeError(
-            "Expressions cannot be fixed: %s"
+            "Component is an Expression and can not be unfixed: %s"
             % (self.name))
 
 
@@ -553,20 +553,20 @@ class IndexedExpression(Expression):
     # an Expression for a Var
     def setlb(self, val):
         raise TypeError(
-            "Expressions cannot have bounds: %s"
+            "Component is an Expression and can not have bounds: %s"
             % (self.name))
 
     def setub(self, val):
         raise TypeError(
-            "Expressions cannot have bounds: %s"
+            "Component is an Expression and can not have bounds: %s"
             % (self.name))
 
     def fix(self, val):
         raise TypeError(
-            "Expressions cannot be fixed: %s"
+            "Component is an Expression and can not be fixed: %s"
             % (self.name))
 
     def unfix(self):
         raise TypeError(
-            "Expressions cannot be fixed: %s"
+            "Component is an Expression and can not be unfixed: %s"
             % (self.name))

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -224,24 +224,28 @@ class _GeneralExpressionDataImpl(_ExpressionData):
 
     # Define methods for common activities on Vars in case user mistakes
     # an Expression for a Var
-    def setlb(self, val):
+    def setlb(self, val=None):
         raise TypeError(
-            "Component is an Expression and can not have bounds: %s"
+            "Component is an Expression and can not have bounds: %s. "
+            "Use an inequality Constraint instead."
             % (self.name))
 
-    def setub(self, val):
+    def setub(self, val=None):
         raise TypeError(
-            "Component is an Expression and can not have bounds: %s"
+            "Component is an Expression and can not have bounds: %s. "
+            "Use an inequality Constraint instead."
             % (self.name))
 
-    def fix(self, val):
+    def fix(self, val=None):
         raise TypeError(
-            "Component is an Expression and can not be fixed: %s"
+            "Component is an Expression and can not be fixed: %s. "
+            "Use an equality Constraint instead."
             % (self.name))
 
     def unfix(self):
         raise TypeError(
-            "Component is an Expression and can not be unfixed: %s"
+            "Component is an Expression and can not be unfixed: %s. "
+            "Use an equality Constraint instead."
             % (self.name))
 
 
@@ -551,22 +555,26 @@ class IndexedExpression(Expression):
 
     # Define methods for common activities on Vars in case user mistakes
     # an Expression for a Var
-    def setlb(self, val):
+    def setlb(self, val=None):
         raise TypeError(
-            "Component is an Expression and can not have bounds: %s"
+            "Component is an Expression and can not have bounds: %s. "
+            "Use inequality Constraints instead."
             % (self.name))
 
-    def setub(self, val):
+    def setub(self, val=None):
         raise TypeError(
-            "Component is an Expression and can not have bounds: %s"
+            "Component is an Expression and can not have bounds: %s. "
+            "Use inequality Constraints instead."
             % (self.name))
 
-    def fix(self, val):
+    def fix(self, val=None):
         raise TypeError(
-            "Component is an Expression and can not be fixed: %s"
+            "Component is an Expression and can not be fixed: %s. "
+            "Use equality Constraints instead."
             % (self.name))
 
     def unfix(self):
         raise TypeError(
-            "Component is an Expression and can not be unfixed: %s"
+            "Component is an Expression and can not be unfixed: %s. "
+            "Use equality Constraints instead."
             % (self.name))


### PR DESCRIPTION
## Fixes #1091 .

## Summary/Motivation:
Within IDAES we have had cases where a user of a model has mistaken an `Expression` for a `Var` and tried to use `fix` to set its value. The returns an error saying the `_GeneralExpressionData` has not implemented a `fix` method, which is not meaningful to many users.

## Changes proposed in this PR:
- Implement methods for `setlb`, `setub`, `fix` and `unfix` in `_GeneralExpressionData` and `IndexedEpression` which raise `TypeErrors` telling the user that this action cannot be applied to an `Expression`.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
