### PR TITLE
Rename Component.type() to Component.ctype

### DIFF
--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -49,7 +49,7 @@ class ConstructionTimer(object):
         except AttributeError:
             name = '(unknown)'
         try:
-            _type = self.obj.ctype().__name__
+            _type = self.obj.ctype.__name__
         except AttributeError:
             _type = type(self.obj).__name__
         try:

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -49,7 +49,7 @@ class ConstructionTimer(object):
         except AttributeError:
             name = '(unknown)'
         try:
-            _type = self.obj.type().__name__
+            _type = self.obj.ctype().__name__
         except AttributeError:
             _type = type(self.obj).__name__
         try:

--- a/pyomo/contrib/fbbt/fbbt.py
+++ b/pyomo/contrib/fbbt/fbbt.py
@@ -1404,14 +1404,14 @@ def fbbt(comp, deactivate_satisfied_constraints=False, integer_tol=1e-5, feasibi
         region is removed due to floating point arithmetic and to prevent math domain errors (a larger value
         is more conservative).
     max_iter: int
-        Used for Blocks only (i.e., comp.ctype() == Block). When performing FBBT on a Block, we first perform FBBT on
+        Used for Blocks only (i.e., comp.ctype == Block). When performing FBBT on a Block, we first perform FBBT on
         every constraint in the Block. We then attempt to identify which constraints to repeat FBBT on based on the
         improvement in variable bounds. If the bounds on a variable improve by more than improvement_tol, then FBBT
         is performed on the constraints using that Var. However, this algorithm is not guaranteed to converge, so
         max_iter limits the total number of times FBBT is performed to max_iter times the number of constraints
         in the Block.
     improvement_tol: float
-        Used for Blocks only (i.e., comp.ctype() == Block). When performing FBBT on a Block, we first perform FBBT on
+        Used for Blocks only (i.e., comp.ctype == Block). When performing FBBT on a Block, we first perform FBBT on
         every constraint in the Block. We then attempt to identify which constraints to repeat FBBT on based on the
         improvement in variable bounds. If the bounds on a variable improve by more than improvement_tol, then FBBT
         is performed on the constraints using that Var.
@@ -1435,7 +1435,7 @@ def fbbt(comp, deactivate_satisfied_constraints=False, integer_tol=1e-5, feasibi
     config.declare('improvement_tol', improvement_tol_config)
 
     new_var_bounds = ComponentMap()
-    if comp.ctype() == Constraint:
+    if comp.ctype == Constraint:
         if comp.is_indexed():
             for _c in comp.values():
                 _new_var_bounds = _fbbt_con(comp, config)
@@ -1443,7 +1443,7 @@ def fbbt(comp, deactivate_satisfied_constraints=False, integer_tol=1e-5, feasibi
         else:
             _new_var_bounds = _fbbt_con(comp, config)
             new_var_bounds.update(_new_var_bounds)
-    elif comp.ctype() in {Block, Disjunct}:
+    elif comp.ctype in {Block, Disjunct}:
         _new_var_bounds = _fbbt_block(comp, config)
         new_var_bounds.update(_new_var_bounds)
     else:
@@ -1482,7 +1482,7 @@ class BoundsManager(object):
         self._vars = ComponentSet()
         self._saved_bounds = list()
 
-        if comp.ctype() == Constraint:
+        if comp.ctype == Constraint:
             if comp.is_indexed():
                 for c in comp.values():
                     self._vars.update(identify_variables(c.body))

--- a/pyomo/contrib/fbbt/fbbt.py
+++ b/pyomo/contrib/fbbt/fbbt.py
@@ -1404,14 +1404,14 @@ def fbbt(comp, deactivate_satisfied_constraints=False, integer_tol=1e-5, feasibi
         region is removed due to floating point arithmetic and to prevent math domain errors (a larger value
         is more conservative).
     max_iter: int
-        Used for Blocks only (i.e., comp.type() == Block). When performing FBBT on a Block, we first perform FBBT on
+        Used for Blocks only (i.e., comp.ctype() == Block). When performing FBBT on a Block, we first perform FBBT on
         every constraint in the Block. We then attempt to identify which constraints to repeat FBBT on based on the
         improvement in variable bounds. If the bounds on a variable improve by more than improvement_tol, then FBBT
         is performed on the constraints using that Var. However, this algorithm is not guaranteed to converge, so
         max_iter limits the total number of times FBBT is performed to max_iter times the number of constraints
         in the Block.
     improvement_tol: float
-        Used for Blocks only (i.e., comp.type() == Block). When performing FBBT on a Block, we first perform FBBT on
+        Used for Blocks only (i.e., comp.ctype() == Block). When performing FBBT on a Block, we first perform FBBT on
         every constraint in the Block. We then attempt to identify which constraints to repeat FBBT on based on the
         improvement in variable bounds. If the bounds on a variable improve by more than improvement_tol, then FBBT
         is performed on the constraints using that Var.
@@ -1435,7 +1435,7 @@ def fbbt(comp, deactivate_satisfied_constraints=False, integer_tol=1e-5, feasibi
     config.declare('improvement_tol', improvement_tol_config)
 
     new_var_bounds = ComponentMap()
-    if comp.type() == Constraint:
+    if comp.ctype() == Constraint:
         if comp.is_indexed():
             for _c in comp.values():
                 _new_var_bounds = _fbbt_con(comp, config)
@@ -1443,7 +1443,7 @@ def fbbt(comp, deactivate_satisfied_constraints=False, integer_tol=1e-5, feasibi
         else:
             _new_var_bounds = _fbbt_con(comp, config)
             new_var_bounds.update(_new_var_bounds)
-    elif comp.type() in {Block, Disjunct}:
+    elif comp.ctype() in {Block, Disjunct}:
         _new_var_bounds = _fbbt_block(comp, config)
         new_var_bounds.update(_new_var_bounds)
     else:
@@ -1482,7 +1482,7 @@ class BoundsManager(object):
         self._vars = ComponentSet()
         self._saved_bounds = list()
 
-        if comp.type() == Constraint:
+        if comp.ctype() == Constraint:
             if comp.is_indexed():
                 for c in comp.values():
                     self._vars.update(identify_variables(c.body))

--- a/pyomo/contrib/gdp_bounds/compute_bounds.py
+++ b/pyomo/contrib/gdp_bounds/compute_bounds.py
@@ -30,7 +30,7 @@ def disjunctive_obbt(model, solver):
     model._disjuncts_to_process = list(model.component_data_objects(
         ctype=Disjunct, active=True, descend_into=(Block, Disjunct),
         descent_order=TraversalStrategy.BreadthFirstSearch))
-    if model.ctype() == Disjunct:
+    if model.ctype == Disjunct:
         model._disjuncts_to_process.insert(0, model)
 
     linear_var_set = ComponentSet()
@@ -145,7 +145,7 @@ def fbbt_disjunct(disj, parent_bounds):
     try:
         new_bnds = fbbt(disj)
     except InfeasibleConstraintException as e:
-        if disj.ctype() == Disjunct:
+        if disj.ctype == Disjunct:
             disj.deactivate()  # simply prune the disjunct
         new_bnds = parent_bounds
     bnds_manager.pop_bounds()

--- a/pyomo/contrib/gdp_bounds/compute_bounds.py
+++ b/pyomo/contrib/gdp_bounds/compute_bounds.py
@@ -30,7 +30,7 @@ def disjunctive_obbt(model, solver):
     model._disjuncts_to_process = list(model.component_data_objects(
         ctype=Disjunct, active=True, descend_into=(Block, Disjunct),
         descent_order=TraversalStrategy.BreadthFirstSearch))
-    if model.type() == Disjunct:
+    if model.ctype() == Disjunct:
         model._disjuncts_to_process.insert(0, model)
 
     linear_var_set = ComponentSet()
@@ -145,7 +145,7 @@ def fbbt_disjunct(disj, parent_bounds):
     try:
         new_bnds = fbbt(disj)
     except InfeasibleConstraintException as e:
-        if disj.type() == Disjunct:
+        if disj.ctype() == Disjunct:
             disj.deactivate()  # simply prune the disjunct
         new_bnds = parent_bounds
     bnds_manager.pop_bounds()

--- a/pyomo/contrib/preprocessing/plugins/induced_linearity.py
+++ b/pyomo/contrib/preprocessing/plugins/induced_linearity.py
@@ -88,7 +88,7 @@ def _process_container(blk, config):
     if not hasattr(blk, '_induced_linearity_info'):
         blk._induced_linearity_info = Block()
     else:
-        assert blk._induced_linearity_info.type() == Block
+        assert blk._induced_linearity_info.ctype() == Block
     eff_discr_vars = detect_effectively_discrete_vars(
         blk, config.equality_tolerance)
     # TODO will need to go through this for each disjunct, since it does
@@ -185,7 +185,7 @@ def prune_possible_values(block_scope, possible_values, config):
             Constraint, active=True, descend_into=(Block, Disjunct)):
         if constr.body.polynomial_degree() not in (1, 0):
             constr.deactivate()
-    if block_scope.type() == Disjunct:
+    if block_scope.ctype() == Disjunct:
         disj = tmp_clone_blk._tmp_block_scope[0]
         disj.indicator_var.fix(1)
         TransformationFactory('gdp.bigm').apply_to(model)

--- a/pyomo/contrib/preprocessing/plugins/induced_linearity.py
+++ b/pyomo/contrib/preprocessing/plugins/induced_linearity.py
@@ -88,7 +88,7 @@ def _process_container(blk, config):
     if not hasattr(blk, '_induced_linearity_info'):
         blk._induced_linearity_info = Block()
     else:
-        assert blk._induced_linearity_info.ctype() == Block
+        assert blk._induced_linearity_info.ctype == Block
     eff_discr_vars = detect_effectively_discrete_vars(
         blk, config.equality_tolerance)
     # TODO will need to go through this for each disjunct, since it does
@@ -185,7 +185,7 @@ def prune_possible_values(block_scope, possible_values, config):
             Constraint, active=True, descend_into=(Block, Disjunct)):
         if constr.body.polynomial_degree() not in (1, 0):
             constr.deactivate()
-    if block_scope.ctype() == Disjunct:
+    if block_scope.ctype == Disjunct:
         disj = tmp_clone_blk._tmp_block_scope[0]
         disj.indicator_var.fix(1)
         TransformationFactory('gdp.bigm').apply_to(model)

--- a/pyomo/contrib/sensitivity_toolbox/sens.py
+++ b/pyomo/contrib/sensitivity_toolbox/sens.py
@@ -74,7 +74,7 @@ def sipopt(instance,paramSubList,perturbList,cloneModel=True,
                         "length of perturbList")
 
     for pp in paramSubList:
-        if pp.ctype() is not Param:
+        if pp.ctype is not Param:
             raise ValueError("paramSubList argument is expecting a list of Params")
 
     for pp in paramSubList:
@@ -83,7 +83,7 @@ def sipopt(instance,paramSubList,perturbList,cloneModel=True,
 
         
     for pp in perturbList:
-        if pp.ctype() is not Param:
+        if pp.ctype is not Param:
             raise ValueError("perturbList argument is expecting a list of Params")
     #Add model block to compartmentalize all sipopt data
     b=Block()

--- a/pyomo/contrib/sensitivity_toolbox/sens.py
+++ b/pyomo/contrib/sensitivity_toolbox/sens.py
@@ -74,7 +74,7 @@ def sipopt(instance,paramSubList,perturbList,cloneModel=True,
                         "length of perturbList")
 
     for pp in paramSubList:
-        if pp.type() is not Param:
+        if pp.ctype() is not Param:
             raise ValueError("paramSubList argument is expecting a list of Params")
 
     for pp in paramSubList:
@@ -83,7 +83,7 @@ def sipopt(instance,paramSubList,perturbList,cloneModel=True,
 
         
     for pp in perturbList:
-        if pp.type() is not Param:
+        if pp.ctype() is not Param:
             raise ValueError("perturbList argument is expecting a list of Params")
     #Add model block to compartmentalize all sipopt data
     b=Block()

--- a/pyomo/contrib/sensitivity_toolbox/tests/test_sens.py
+++ b/pyomo/contrib/sensitivity_toolbox/tests/test_sens.py
@@ -97,56 +97,56 @@ class TestSensitivityToolbox(unittest.TestCase):
         self.assertFalse(m_sipopt == m_orig)
 
         self.assertTrue(hasattr(m_sipopt,'_sipopt_data') and
-                        m_sipopt._sipopt_data.type() is Block)
+                        m_sipopt._sipopt_data.ctype() is Block)
 
         self.assertFalse(hasattr(m_orig,'_sipopt_data'))
         self.assertFalse(hasattr(m_orig,'b'))
 
         #verify variable declaration
         self.assertTrue(hasattr(m_sipopt._sipopt_data,'a') and 
-                        m_sipopt._sipopt_data.a.type() is Var)
+                        m_sipopt._sipopt_data.a.ctype() is Var)
         self.assertTrue(hasattr(m_sipopt._sipopt_data,'H') and 
-                        m_sipopt._sipopt_data.H.type() is Var)
+                        m_sipopt._sipopt_data.H.ctype() is Var)
    
         #verify suffixes
         self.assertTrue(hasattr(m_sipopt,'sens_state_0') and
-                        m_sipopt.sens_state_0.type() is Suffix and
+                        m_sipopt.sens_state_0.ctype() is Suffix and
                         m_sipopt.sens_state_0[m_sipopt._sipopt_data.H]==2 and
                         m_sipopt.sens_state_0[m_sipopt._sipopt_data.a]==1)
   
         self.assertTrue(hasattr(m_sipopt,'sens_state_1') and
-                        m_sipopt.sens_state_1.type() is Suffix and
+                        m_sipopt.sens_state_1.ctype() is Suffix and
                         m_sipopt.sens_state_1[m_sipopt._sipopt_data.H]==2 and
                         m_sipopt.sens_state_1[m_sipopt._sipopt_data.a]==1)  
 
         self.assertTrue(hasattr(m_sipopt,'sens_state_value_1') and
-                        m_sipopt.sens_state_value_1.type() is Suffix and
+                        m_sipopt.sens_state_value_1.ctype() is Suffix and
                         m_sipopt.sens_state_value_1[
                                         m_sipopt._sipopt_data.H]==0.55 and
                         m_sipopt.sens_state_value_1[
                                         m_sipopt._sipopt_data.a]==-0.25)
   
         self.assertTrue(hasattr(m_sipopt,'sens_init_constr') and
-                        m_sipopt.sens_init_constr.type() is Suffix and
+                        m_sipopt.sens_init_constr.ctype() is Suffix and
                         m_sipopt.sens_init_constr[
                                      m_sipopt._sipopt_data.paramConst[1]]==1 and
                         m_sipopt.sens_init_constr[
                                      m_sipopt._sipopt_data.paramConst[2]]==2)
 
         self.assertTrue(hasattr(m_sipopt,'sens_sol_state_1') and
-                        m_sipopt.sens_sol_state_1.type() is Suffix)
+                        m_sipopt.sens_sol_state_1.ctype() is Suffix)
         self.assertAlmostEqual(
                         m_sipopt.sens_sol_state_1[
                            m_sipopt.F[15]],-0.00102016765,8)
 
         self.assertTrue(hasattr(m_sipopt,'sens_sol_state_1_z_L') and
-                        m_sipopt.sens_sol_state_1_z_L.type() is Suffix)
+                        m_sipopt.sens_sol_state_1_z_L.ctype() is Suffix)
         self.assertAlmostEqual(
                         m_sipopt.sens_sol_state_1_z_L[
                            m_sipopt.u[15]],-2.181712e-09,13)
 
         self.assertTrue(hasattr(m_sipopt,'sens_sol_state_1_z_U') and
-                        m_sipopt.sens_sol_state_1_z_U.type() is Suffix)
+                        m_sipopt.sens_sol_state_1_z_U.ctype() is Suffix)
         self.assertAlmostEqual(
                         m_sipopt.sens_sol_state_1_z_U[
                            m_sipopt.u[15]],6.580899e-09,13)
@@ -191,53 +191,53 @@ class TestSensitivityToolbox(unittest.TestCase):
 
         #test _sipopt_data block exists
         self.assertTrue(hasattr(m_orig,'_sipopt_data') and
-                        m_orig._sipopt_data.type() is Block)
+                        m_orig._sipopt_data.ctype() is Block)
         
         #test variable declaration
         self.assertTrue(hasattr(m_sipopt._sipopt_data,'a') and 
-                        m_sipopt._sipopt_data.a.type() is Var)
+                        m_sipopt._sipopt_data.a.ctype() is Var)
         self.assertTrue(hasattr(m_sipopt._sipopt_data,'H') and 
-                        m_sipopt._sipopt_data.H.type() is Var)
+                        m_sipopt._sipopt_data.H.ctype() is Var)
 
         #test for suffixes
         self.assertTrue(hasattr(m_sipopt,'sens_state_0') and
-                        m_sipopt.sens_state_0.type() is Suffix and
+                        m_sipopt.sens_state_0.ctype() is Suffix and
                         m_sipopt.sens_state_0[m_sipopt._sipopt_data.H]==2 and  
                         m_sipopt.sens_state_0[m_sipopt._sipopt_data.a]==1)
   
         self.assertTrue(hasattr(m_sipopt,'sens_state_1') and
-                        m_sipopt.sens_state_1.type() is Suffix and
+                        m_sipopt.sens_state_1.ctype() is Suffix and
                         m_sipopt.sens_state_1[m_sipopt._sipopt_data.H]==2 and
                         m_sipopt.sens_state_1[m_sipopt._sipopt_data.a]==1)  
 
         self.assertTrue(hasattr(m_sipopt,'sens_state_value_1') and
-                        m_sipopt.sens_state_value_1.type() is Suffix and
+                        m_sipopt.sens_state_value_1.ctype() is Suffix and
                         m_sipopt.sens_state_value_1[
                                         m_sipopt._sipopt_data.H]==0.55 and
                         m_sipopt.sens_state_value_1[
                                         m_sipopt._sipopt_data.a]==-0.25)
   
         self.assertTrue(hasattr(m_sipopt,'sens_init_constr') and
-                        m_sipopt.sens_init_constr.type() is Suffix and
+                        m_sipopt.sens_init_constr.ctype() is Suffix and
                         m_sipopt.sens_init_constr[
                                      m_sipopt._sipopt_data.paramConst[1]]==1 and
                         m_sipopt.sens_init_constr[
                                      m_sipopt._sipopt_data.paramConst[2]]==2)
 
         self.assertTrue(hasattr(m_sipopt,'sens_sol_state_1') and
-                        m_sipopt.sens_sol_state_1.type() is Suffix)
+                        m_sipopt.sens_sol_state_1.ctype() is Suffix)
         self.assertAlmostEqual(
                         m_sipopt.sens_sol_state_1[
                            m_sipopt.F[15]],-0.00102016765,8)
 
         self.assertTrue(hasattr(m_sipopt,'sens_sol_state_1_z_L') and
-                        m_sipopt.sens_sol_state_1_z_L.type() is Suffix)
+                        m_sipopt.sens_sol_state_1_z_L.ctype() is Suffix)
         self.assertAlmostEqual(
                         m_sipopt.sens_sol_state_1_z_L[
                            m_sipopt.u[15]],-2.181712e-09,13)
 
         self.assertTrue(hasattr(m_sipopt,'sens_sol_state_1_z_U') and
-                        m_sipopt.sens_sol_state_1_z_U.type() is Suffix)
+                        m_sipopt.sens_sol_state_1_z_U.ctype() is Suffix)
         self.assertAlmostEqual(
                         m_sipopt.sens_sol_state_1_z_U[
                            m_sipopt.u[15]],6.580899e-09,13)
@@ -317,8 +317,8 @@ class TestSensitivityToolbox(unittest.TestCase):
         m_sipopt = sipopt(m,[m.a,m.b], [m.pert_a,m.pert_b])
 
         #verify substitutions in equality constraint
-        self.assertTrue(m_sipopt.C_equal.lower.type() is Param and
-                        m_sipopt.C_equal.upper.type() is Param)
+        self.assertTrue(m_sipopt.C_equal.lower.ctype() is Param and
+                        m_sipopt.C_equal.upper.ctype() is Param)
         self.assertFalse(m_sipopt.C_equal.active)
 
         self.assertTrue(m_sipopt._sipopt_data.constList[3].lower == 0.0 and
@@ -328,7 +328,7 @@ class TestSensitivityToolbox(unittest.TestCase):
 
         #verify substitutions in one-sided bounded constraint
         self.assertTrue(m_sipopt.C_singleBnd.lower is None and
-                        m_sipopt.C_singleBnd.upper.type() is Param)
+                        m_sipopt.C_singleBnd.upper.ctype() is Param)
         self.assertFalse(m_sipopt.C_singleBnd.active)
 
         self.assertTrue(m_sipopt._sipopt_data.constList[4].lower is None and
@@ -337,8 +337,8 @@ class TestSensitivityToolbox(unittest.TestCase):
                                  m_sipopt._sipopt_data.constList[4].body))) == 2)
        
         #verify substitutions in ranged inequality constraint
-        self.assertTrue(m_sipopt.C_rangedIn.lower.type() is Param and
-                        m_sipopt.C_rangedIn.upper.type() is Param)
+        self.assertTrue(m_sipopt.C_rangedIn.lower.ctype() is Param and
+                        m_sipopt.C_rangedIn.upper.ctype() is Param)
         self.assertFalse(m_sipopt.C_rangedIn.active)
 
         self.assertTrue(m_sipopt._sipopt_data.constList[1].lower is None and

--- a/pyomo/contrib/sensitivity_toolbox/tests/test_sens.py
+++ b/pyomo/contrib/sensitivity_toolbox/tests/test_sens.py
@@ -97,56 +97,56 @@ class TestSensitivityToolbox(unittest.TestCase):
         self.assertFalse(m_sipopt == m_orig)
 
         self.assertTrue(hasattr(m_sipopt,'_sipopt_data') and
-                        m_sipopt._sipopt_data.ctype() is Block)
+                        m_sipopt._sipopt_data.ctype is Block)
 
         self.assertFalse(hasattr(m_orig,'_sipopt_data'))
         self.assertFalse(hasattr(m_orig,'b'))
 
         #verify variable declaration
         self.assertTrue(hasattr(m_sipopt._sipopt_data,'a') and 
-                        m_sipopt._sipopt_data.a.ctype() is Var)
+                        m_sipopt._sipopt_data.a.ctype is Var)
         self.assertTrue(hasattr(m_sipopt._sipopt_data,'H') and 
-                        m_sipopt._sipopt_data.H.ctype() is Var)
+                        m_sipopt._sipopt_data.H.ctype is Var)
    
         #verify suffixes
         self.assertTrue(hasattr(m_sipopt,'sens_state_0') and
-                        m_sipopt.sens_state_0.ctype() is Suffix and
+                        m_sipopt.sens_state_0.ctype is Suffix and
                         m_sipopt.sens_state_0[m_sipopt._sipopt_data.H]==2 and
                         m_sipopt.sens_state_0[m_sipopt._sipopt_data.a]==1)
   
         self.assertTrue(hasattr(m_sipopt,'sens_state_1') and
-                        m_sipopt.sens_state_1.ctype() is Suffix and
+                        m_sipopt.sens_state_1.ctype is Suffix and
                         m_sipopt.sens_state_1[m_sipopt._sipopt_data.H]==2 and
                         m_sipopt.sens_state_1[m_sipopt._sipopt_data.a]==1)  
 
         self.assertTrue(hasattr(m_sipopt,'sens_state_value_1') and
-                        m_sipopt.sens_state_value_1.ctype() is Suffix and
+                        m_sipopt.sens_state_value_1.ctype is Suffix and
                         m_sipopt.sens_state_value_1[
                                         m_sipopt._sipopt_data.H]==0.55 and
                         m_sipopt.sens_state_value_1[
                                         m_sipopt._sipopt_data.a]==-0.25)
   
         self.assertTrue(hasattr(m_sipopt,'sens_init_constr') and
-                        m_sipopt.sens_init_constr.ctype() is Suffix and
+                        m_sipopt.sens_init_constr.ctype is Suffix and
                         m_sipopt.sens_init_constr[
                                      m_sipopt._sipopt_data.paramConst[1]]==1 and
                         m_sipopt.sens_init_constr[
                                      m_sipopt._sipopt_data.paramConst[2]]==2)
 
         self.assertTrue(hasattr(m_sipopt,'sens_sol_state_1') and
-                        m_sipopt.sens_sol_state_1.ctype() is Suffix)
+                        m_sipopt.sens_sol_state_1.ctype is Suffix)
         self.assertAlmostEqual(
                         m_sipopt.sens_sol_state_1[
                            m_sipopt.F[15]],-0.00102016765,8)
 
         self.assertTrue(hasattr(m_sipopt,'sens_sol_state_1_z_L') and
-                        m_sipopt.sens_sol_state_1_z_L.ctype() is Suffix)
+                        m_sipopt.sens_sol_state_1_z_L.ctype is Suffix)
         self.assertAlmostEqual(
                         m_sipopt.sens_sol_state_1_z_L[
                            m_sipopt.u[15]],-2.181712e-09,13)
 
         self.assertTrue(hasattr(m_sipopt,'sens_sol_state_1_z_U') and
-                        m_sipopt.sens_sol_state_1_z_U.ctype() is Suffix)
+                        m_sipopt.sens_sol_state_1_z_U.ctype is Suffix)
         self.assertAlmostEqual(
                         m_sipopt.sens_sol_state_1_z_U[
                            m_sipopt.u[15]],6.580899e-09,13)
@@ -191,53 +191,53 @@ class TestSensitivityToolbox(unittest.TestCase):
 
         #test _sipopt_data block exists
         self.assertTrue(hasattr(m_orig,'_sipopt_data') and
-                        m_orig._sipopt_data.ctype() is Block)
+                        m_orig._sipopt_data.ctype is Block)
         
         #test variable declaration
         self.assertTrue(hasattr(m_sipopt._sipopt_data,'a') and 
-                        m_sipopt._sipopt_data.a.ctype() is Var)
+                        m_sipopt._sipopt_data.a.ctype is Var)
         self.assertTrue(hasattr(m_sipopt._sipopt_data,'H') and 
-                        m_sipopt._sipopt_data.H.ctype() is Var)
+                        m_sipopt._sipopt_data.H.ctype is Var)
 
         #test for suffixes
         self.assertTrue(hasattr(m_sipopt,'sens_state_0') and
-                        m_sipopt.sens_state_0.ctype() is Suffix and
+                        m_sipopt.sens_state_0.ctype is Suffix and
                         m_sipopt.sens_state_0[m_sipopt._sipopt_data.H]==2 and  
                         m_sipopt.sens_state_0[m_sipopt._sipopt_data.a]==1)
   
         self.assertTrue(hasattr(m_sipopt,'sens_state_1') and
-                        m_sipopt.sens_state_1.ctype() is Suffix and
+                        m_sipopt.sens_state_1.ctype is Suffix and
                         m_sipopt.sens_state_1[m_sipopt._sipopt_data.H]==2 and
                         m_sipopt.sens_state_1[m_sipopt._sipopt_data.a]==1)  
 
         self.assertTrue(hasattr(m_sipopt,'sens_state_value_1') and
-                        m_sipopt.sens_state_value_1.ctype() is Suffix and
+                        m_sipopt.sens_state_value_1.ctype is Suffix and
                         m_sipopt.sens_state_value_1[
                                         m_sipopt._sipopt_data.H]==0.55 and
                         m_sipopt.sens_state_value_1[
                                         m_sipopt._sipopt_data.a]==-0.25)
   
         self.assertTrue(hasattr(m_sipopt,'sens_init_constr') and
-                        m_sipopt.sens_init_constr.ctype() is Suffix and
+                        m_sipopt.sens_init_constr.ctype is Suffix and
                         m_sipopt.sens_init_constr[
                                      m_sipopt._sipopt_data.paramConst[1]]==1 and
                         m_sipopt.sens_init_constr[
                                      m_sipopt._sipopt_data.paramConst[2]]==2)
 
         self.assertTrue(hasattr(m_sipopt,'sens_sol_state_1') and
-                        m_sipopt.sens_sol_state_1.ctype() is Suffix)
+                        m_sipopt.sens_sol_state_1.ctype is Suffix)
         self.assertAlmostEqual(
                         m_sipopt.sens_sol_state_1[
                            m_sipopt.F[15]],-0.00102016765,8)
 
         self.assertTrue(hasattr(m_sipopt,'sens_sol_state_1_z_L') and
-                        m_sipopt.sens_sol_state_1_z_L.ctype() is Suffix)
+                        m_sipopt.sens_sol_state_1_z_L.ctype is Suffix)
         self.assertAlmostEqual(
                         m_sipopt.sens_sol_state_1_z_L[
                            m_sipopt.u[15]],-2.181712e-09,13)
 
         self.assertTrue(hasattr(m_sipopt,'sens_sol_state_1_z_U') and
-                        m_sipopt.sens_sol_state_1_z_U.ctype() is Suffix)
+                        m_sipopt.sens_sol_state_1_z_U.ctype is Suffix)
         self.assertAlmostEqual(
                         m_sipopt.sens_sol_state_1_z_U[
                            m_sipopt.u[15]],6.580899e-09,13)
@@ -317,8 +317,8 @@ class TestSensitivityToolbox(unittest.TestCase):
         m_sipopt = sipopt(m,[m.a,m.b], [m.pert_a,m.pert_b])
 
         #verify substitutions in equality constraint
-        self.assertTrue(m_sipopt.C_equal.lower.ctype() is Param and
-                        m_sipopt.C_equal.upper.ctype() is Param)
+        self.assertTrue(m_sipopt.C_equal.lower.ctype is Param and
+                        m_sipopt.C_equal.upper.ctype is Param)
         self.assertFalse(m_sipopt.C_equal.active)
 
         self.assertTrue(m_sipopt._sipopt_data.constList[3].lower == 0.0 and
@@ -328,7 +328,7 @@ class TestSensitivityToolbox(unittest.TestCase):
 
         #verify substitutions in one-sided bounded constraint
         self.assertTrue(m_sipopt.C_singleBnd.lower is None and
-                        m_sipopt.C_singleBnd.upper.ctype() is Param)
+                        m_sipopt.C_singleBnd.upper.ctype is Param)
         self.assertFalse(m_sipopt.C_singleBnd.active)
 
         self.assertTrue(m_sipopt._sipopt_data.constList[4].lower is None and
@@ -337,8 +337,8 @@ class TestSensitivityToolbox(unittest.TestCase):
                                  m_sipopt._sipopt_data.constList[4].body))) == 2)
        
         #verify substitutions in ranged inequality constraint
-        self.assertTrue(m_sipopt.C_rangedIn.lower.ctype() is Param and
-                        m_sipopt.C_rangedIn.upper.ctype() is Param)
+        self.assertTrue(m_sipopt.C_rangedIn.lower.ctype is Param and
+                        m_sipopt.C_rangedIn.upper.ctype is Param)
         self.assertFalse(m_sipopt.C_rangedIn.active)
 
         self.assertTrue(m_sipopt._sipopt_data.constList[1].lower is None and

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -828,7 +828,7 @@ from solvers are immediately loaded into the original model instance.""")
 
             for component_name, component in iteritems(self.component_map()):
 
-                if component.ctype() is Model:
+                if component.ctype is Model:
                     continue
 
                 self._initialize_component(modeldata, namespaces, component_name, profile_memory)
@@ -865,7 +865,7 @@ from solvers are immediately loaded into the original model instance.""")
         declaration = self.component(component_name)
 
         if component_name in modeldata._default:
-            if declaration.ctype() is not Set:
+            if declaration.ctype is not Set:
                 declaration.set_default(modeldata._default[component_name])
         data = None
 

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -828,7 +828,7 @@ from solvers are immediately loaded into the original model instance.""")
 
             for component_name, component in iteritems(self.component_map()):
 
-                if component.type() is Model:
+                if component.ctype() is Model:
                     continue
 
                 self._initialize_component(modeldata, namespaces, component_name, profile_memory)
@@ -865,7 +865,7 @@ from solvers are immediately loaded into the original model instance.""")
         declaration = self.component(component_name)
 
         if component_name in modeldata._default:
-            if declaration.type() is not Set:
+            if declaration.ctype() is not Set:
                 declaration.set_default(modeldata._default[component_name])
         data = None
 

--- a/pyomo/core/base/alias.py
+++ b/pyomo/core/base/alias.py
@@ -56,12 +56,12 @@ class Alias(Component):
             self._aliased_object = weakref.ref(obj)
         ctype = Alias
         if isinstance(obj, Component):
-            ctype = obj.type()
+            ctype = obj.ctype()
         else:
             if not isinstance(obj, ComponentData):
                 raise TypeError("Aliased object must be an "
                                 "instance of Component or ComponentData")
-            ctype = obj.parent_component().type()
+            ctype = obj.parent_component().ctype()
         Component.__init__(self, ctype=ctype)
 
     @property

--- a/pyomo/core/base/alias.py
+++ b/pyomo/core/base/alias.py
@@ -56,12 +56,12 @@ class Alias(Component):
             self._aliased_object = weakref.ref(obj)
         ctype = Alias
         if isinstance(obj, Component):
-            ctype = obj.ctype()
+            ctype = obj.ctype
         else:
             if not isinstance(obj, ComponentData):
                 raise TypeError("Aliased object must be an "
                                 "instance of Component or ComponentData")
-            ctype = obj.parent_component().ctype()
+            ctype = obj.parent_component().ctype
         Component.__init__(self, ctype=ctype)
 
     @property

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -264,7 +264,7 @@ class PseudoMap(object):
         """
         if key in self._block._decl:
             x = self._block._decl_order[self._block._decl[key]]
-            if self._ctypes is None or x[0].ctype() in self._ctypes:
+            if self._ctypes is None or x[0].ctype in self._ctypes:
                 if self._active is None or x[0].active == self._active:
                     return x[0]
         msg = ""
@@ -332,7 +332,7 @@ class PseudoMap(object):
         # component matches those flags
         if key in self._block._decl:
             x = self._block._decl_order[self._block._decl[key]]
-            if self._ctypes is None or x[0].ctype() in self._ctypes:
+            if self._ctypes is None or x[0].ctype in self._ctypes:
                 return self._active is None or x[0].active == self._active
         return False
 
@@ -925,7 +925,7 @@ class _BlockData(ActiveComponentData):
         # component type that is suppressed.
         #
         _component = self.parent_component()
-        _type = val.ctype()
+        _type = val.ctype
         if _type in _component._suppress_ctypes:
             return
         #
@@ -1115,10 +1115,10 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         self._decl_order[idx] = (None, self._decl_order[idx][1])
 
         # Update the ctype linked lists
-        ctype_info = self._ctypes[obj.ctype()]
+        ctype_info = self._ctypes[obj.ctype]
         ctype_info[2] -= 1
         if ctype_info[2] == 0:
-            del self._ctypes[obj.ctype()]
+            del self._ctypes[obj.ctype]
 
         # Clear the _parent attribute
         obj._parent = None
@@ -1143,7 +1143,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         if obj is None:
             return
 
-        if obj.ctype() is new_ctype:
+        if obj.ctype is new_ctype:
             return
 
         name = obj.local_name
@@ -1159,15 +1159,15 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         idx = self._decl[name]
 
         # Update the ctype linked lists
-        ctype_info = self._ctypes[obj.ctype()]
+        ctype_info = self._ctypes[obj.ctype]
         ctype_info[2] -= 1
         if ctype_info[2] == 0:
-            del self._ctypes[obj.ctype()]
+            del self._ctypes[obj.ctype]
         elif ctype_info[0] == idx:
             ctype_info[0] = self._decl_order[idx][1]
         else:
             prev = None
-            tmp = self._ctypes[obj.ctype()][0]
+            tmp = self._ctypes[obj.ctype][0]
             while tmp < idx:
                 prev = tmp
                 tmp = self._decl_order[tmp][1]
@@ -1510,7 +1510,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         # "descend_into" argument in public calling functions: callers
         # expect that the called thing will be iterated over.
         #
-        # if self.parent_component().ctype() not in ctype:
+        # if self.parent_component().ctype not in ctype:
         #    return ().__iter__()
 
         if traversal is None or \

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -264,7 +264,7 @@ class PseudoMap(object):
         """
         if key in self._block._decl:
             x = self._block._decl_order[self._block._decl[key]]
-            if self._ctypes is None or x[0].type() in self._ctypes:
+            if self._ctypes is None or x[0].ctype() in self._ctypes:
                 if self._active is None or x[0].active == self._active:
                     return x[0]
         msg = ""
@@ -332,7 +332,7 @@ class PseudoMap(object):
         # component matches those flags
         if key in self._block._decl:
             x = self._block._decl_order[self._block._decl[key]]
-            if self._ctypes is None or x[0].type() in self._ctypes:
+            if self._ctypes is None or x[0].ctype() in self._ctypes:
                 return self._active is None or x[0].active == self._active
         return False
 
@@ -925,7 +925,7 @@ class _BlockData(ActiveComponentData):
         # component type that is suppressed.
         #
         _component = self.parent_component()
-        _type = val.type()
+        _type = val.ctype()
         if _type in _component._suppress_ctypes:
             return
         #
@@ -1115,10 +1115,10 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         self._decl_order[idx] = (None, self._decl_order[idx][1])
 
         # Update the ctype linked lists
-        ctype_info = self._ctypes[obj.type()]
+        ctype_info = self._ctypes[obj.ctype()]
         ctype_info[2] -= 1
         if ctype_info[2] == 0:
-            del self._ctypes[obj.type()]
+            del self._ctypes[obj.ctype()]
 
         # Clear the _parent attribute
         obj._parent = None
@@ -1143,7 +1143,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         if obj is None:
             return
 
-        if obj._type is new_ctype:
+        if obj.ctype() is new_ctype:
             return
 
         name = obj.local_name
@@ -1152,22 +1152,22 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
             # easiest (and fastest) thing to do is just delete it and
             # re-add it.
             self.del_component(name)
-            obj._type = new_ctype
+            obj._ctype = new_ctype
             self.add_component(name, obj)
             return
 
         idx = self._decl[name]
 
         # Update the ctype linked lists
-        ctype_info = self._ctypes[obj.type()]
+        ctype_info = self._ctypes[obj.ctype()]
         ctype_info[2] -= 1
         if ctype_info[2] == 0:
-            del self._ctypes[obj.type()]
+            del self._ctypes[obj.ctype()]
         elif ctype_info[0] == idx:
             ctype_info[0] = self._decl_order[idx][1]
         else:
             prev = None
-            tmp = self._ctypes[obj.type()][0]
+            tmp = self._ctypes[obj.ctype()][0]
             while tmp < idx:
                 prev = tmp
                 tmp = self._decl_order[tmp][1]
@@ -1177,7 +1177,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
             if ctype_info[1] == idx:
                 ctype_info[1] = prev
 
-        obj._type = new_ctype
+        obj._ctype = new_ctype
 
         # Insert into the new ctype list
         if new_ctype not in self._ctypes:
@@ -1510,7 +1510,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         # "descend_into" argument in public calling functions: callers
         # expect that the called thing will be iterated over.
         #
-        # if self.parent_component().type() not in ctype:
+        # if self.parent_component().ctype() not in ctype:
         #    return ().__iter__()
 
         if traversal is None or \

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -465,7 +465,7 @@ class Component(_ComponentBase):
         """Return the class type for this component"""
         return self._ctype
 
-    @deprecated("The Component .type() attribute has been renamed .ctype()."
+    @deprecated("The Component .type() attribute has been renamed .ctype().",
                 version='TBD')
     def type(self):
         """Return the class type for this component"""
@@ -778,7 +778,7 @@ class ComponentData(_ComponentBase):
             return _parent
         return _parent._ctype
 
-    @deprecated("The Component .type() attribute has been renamed .ctype()."
+    @deprecated("The Component .type() attribute has been renamed .ctype().",
                 version='TBD')
     def type(self):
         """Return the class type for this component"""

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -382,15 +382,15 @@ class Component(_ComponentBase):
         _constructed    A boolean that is true if this component has been
                             constructed
         _parent         A weakref to the parent block that owns this component
-        _type           The class type for the derived subclass
+        _ctype          The class type for the derived subclass
     """
 
     def __init__ (self, **kwds):
         #
         # Get arguments
         #
-        self._type = kwds.pop('ctype', None)
-        self.doc   = kwds.pop('doc', None)
+        self._ctype = kwds.pop('ctype', None)
+        self.doc    = kwds.pop('doc', None)
         self._name  = kwds.pop('name', str(type(self).__name__))
         if kwds:
             raise ValueError(
@@ -399,7 +399,7 @@ class Component(_ComponentBase):
         #
         # Verify that ctype has been specified.
         #
-        if self._type is None:
+        if self._ctype is None:
             raise pyomo.common.DeveloperError(
                 "Must specify a component type for class %s!"
                 % ( type(self).__name__, ) )
@@ -461,9 +461,15 @@ class Component(_ComponentBase):
                 # of setting self.__dict__[key] = val.
                 object.__setattr__(self, key, val)
 
+    def ctype(self):
+        """Return the class type for this component"""
+        return self._ctype
+
+    @deprecated("The Component .type() attribute has been renamed .ctype()."
+                version='TBD')
     def type(self):
         """Return the class type for this component"""
-        return self._type
+        return self.ctype()
 
     def construct(self, data=None):                     #pragma:nocover
         """API definition for constructing components"""
@@ -765,12 +771,18 @@ class ComponentData(_ComponentBase):
                 # of setting self.__dict__[key] = val.
                 object.__setattr__(self, key, val)
 
-    def type(self):
+    def ctype(self):
         """Return the class type for this component"""
         _parent = self.parent_component()
         if _parent is None:
             return _parent
-        return _parent._type
+        return _parent._ctype
+
+    @deprecated("The Component .type() attribute has been renamed .ctype()."
+                version='TBD')
+    def type(self):
+        """Return the class type for this component"""
+        return self.ctype()
 
     def parent_component(self):
         """Returns the component associated with this object."""

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -242,13 +242,12 @@ class _ComponentBase(object):
         ans.__setstate__(new_state)
         return ans
 
+    @deprecated("""The cname() method has been renamed to getname().
+    The preferred method of obtaining a component name is to use the
+    .name property, which returns the fully qualified component name.
+    The .local_name property will return the component name only within
+    the context of the immediate parent container.""", version='5.0')
     def cname(self, *args, **kwds):
-        logger.warning(
-            """DEPRECATED: The cname() method has been renamed to getname().
-The preferred method of obtaining a component name is to use the .name
-property, which returns the fully qualified component name.  The
-.local_name property will return the component name only within the
-context of the immediate parent container.""")
         return self.getname(*args, **kwds)
 
     def pprint(self, ostream=None, verbose=False, prefix=""):
@@ -461,15 +460,16 @@ class Component(_ComponentBase):
                 # of setting self.__dict__[key] = val.
                 object.__setattr__(self, key, val)
 
+    @property
     def ctype(self):
         """Return the class type for this component"""
         return self._ctype
 
-    @deprecated("The Component .type() attribute has been renamed .ctype().",
-                version='TBD')
+    @deprecated("Component.type() method has been replaced by the "
+                ".ctype property.", version='TBD')
     def type(self):
         """Return the class type for this component"""
-        return self.ctype()
+        return self.ctype
 
     def construct(self, data=None):                     #pragma:nocover
         """API definition for constructing components"""
@@ -771,18 +771,19 @@ class ComponentData(_ComponentBase):
                 # of setting self.__dict__[key] = val.
                 object.__setattr__(self, key, val)
 
+    @property
     def ctype(self):
         """Return the class type for this component"""
         _parent = self.parent_component()
         if _parent is None:
-            return _parent
+            return None
         return _parent._ctype
 
-    @deprecated("The Component .type() attribute has been renamed .ctype().",
-                version='TBD')
+    @deprecated("Component.type() method has been replaced by the "
+                ".ctype property.", version='TBD')
     def type(self):
         """Return the class type for this component"""
-        return self.ctype()
+        return self.ctype
 
     def parent_component(self):
         """Returns the component associated with this object."""

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -527,7 +527,7 @@ def Reference(reference, ctype=_NotSpecified):
         ctypes = set((1,2))
     index = []
     for obj in _iter:
-        ctypes.add(obj.type())
+        ctypes.add(obj.ctype())
         if not isinstance(obj, ComponentData):
             # This object is not a ComponentData (likely it is a pure
             # IndexedComponent container).  As the Reference will treat

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -527,7 +527,7 @@ def Reference(reference, ctype=_NotSpecified):
         ctypes = set((1,2))
     index = []
     for obj in _iter:
-        ctypes.add(obj.ctype())
+        ctypes.add(obj.ctype)
         if not isinstance(obj, ComponentData):
             # This object is not a ComponentData (likely it is a pure
             # IndexedComponent container).  As the Reference will treat

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -117,7 +117,7 @@ def process_setarg(arg):
     elif isinstance(arg, IndexedComponent):
         raise TypeError("Cannot apply a Set operator to an "
                         "indexed %s component (%s)"
-                        % (arg.ctype().__name__, arg.name,))
+                        % (arg.ctype.__name__, arg.name,))
     elif isinstance(arg, Component):
         raise TypeError("Cannot apply a Set operator to a non-Set "
                         "%s component (%s)"

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -117,7 +117,7 @@ def process_setarg(arg):
     elif isinstance(arg, IndexedComponent):
         raise TypeError("Cannot apply a Set operator to an "
                         "indexed %s component (%s)"
-                        % (arg.type().__name__, arg.name,))
+                        % (arg.ctype().__name__, arg.name,))
     elif isinstance(arg, Component):
         raise TypeError("Cannot apply a Set operator to a non-Set "
                         "%s component (%s)"

--- a/pyomo/core/base/util.py
+++ b/pyomo/core/base/util.py
@@ -364,7 +364,7 @@ class CountedCallInitializer(InitializerBase):
         self._fcn = _indexed_init._fcn
         self._is_counted_rule = None
         self._scalar = not obj.is_indexed()
-        self._ctype = obj.ctype()
+        self._ctype = obj.ctype
         if self._scalar:
             self._is_counted_rule = True
 

--- a/pyomo/core/base/util.py
+++ b/pyomo/core/base/util.py
@@ -364,7 +364,7 @@ class CountedCallInitializer(InitializerBase):
         self._fcn = _indexed_init._fcn
         self._is_counted_rule = None
         self._scalar = not obj.is_indexed()
-        self._ctype = obj.type()
+        self._ctype = obj.ctype()
         if self._scalar:
             self._is_counted_rule = True
 

--- a/pyomo/core/tests/unit/kernel/test_kernel.py
+++ b/pyomo/core/tests/unit/kernel/test_kernel.py
@@ -193,7 +193,7 @@ class Test_kernel(unittest.TestCase):
                     pmo.block()]:
             ctype = obj.ctype
             self.assertIs(obj.__class__._ctype, ctype)
-            self.assertIs(obj.type(), ctype)
+            self.assertIs(obj.ctype(), ctype)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/core/tests/unit/kernel/test_kernel.py
+++ b/pyomo/core/tests/unit/kernel/test_kernel.py
@@ -182,18 +182,6 @@ class Test_kernel(unittest.TestCase):
         self.assertEqual(
             [str(obj) for obj in model.block_data_objects()],
             [str(model)]+[str(obj) for obj in model.components(ctype=IBlock)])
-    def test_type_hack(self):
-        for obj in [pmo.variable(),
-                    pmo.constraint(),
-                    pmo.objective(),
-                    pmo.expression(),
-                    pmo.parameter(),
-                    pmo.suffix(),
-                    pmo.sos([]),
-                    pmo.block()]:
-            ctype = obj.ctype
-            self.assertIs(obj.__class__._ctype, ctype)
-            self.assertIs(obj.ctype(), ctype)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -2361,7 +2361,7 @@ class TestBlock(unittest.TestCase):
             return m.x[1]**2 <= 0
 
         self.assertTrue(hasattr(model, 'scalar_constraint'))
-        self.assertIs(model.scalar_constraint._type, Constraint)
+        self.assertIs(model.scalar_constraint.ctype(), Constraint)
         self.assertEqual(len(model.scalar_constraint), 1)
         self.assertIs(type(scalar_constraint), types.FunctionType)
 
@@ -2370,7 +2370,7 @@ class TestBlock(unittest.TestCase):
             return m.x[i]**2 <= 0
 
         self.assertTrue(hasattr(model, 'vector_constraint'))
-        self.assertIs(model.vector_constraint._type, Constraint)
+        self.assertIs(model.vector_constraint.ctype(), Constraint)
         self.assertEqual(len(model.vector_constraint), 3)
         self.assertIs(type(vector_constraint), types.FunctionType)
 

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -2361,7 +2361,7 @@ class TestBlock(unittest.TestCase):
             return m.x[1]**2 <= 0
 
         self.assertTrue(hasattr(model, 'scalar_constraint'))
-        self.assertIs(model.scalar_constraint.ctype(), Constraint)
+        self.assertIs(model.scalar_constraint.ctype, Constraint)
         self.assertEqual(len(model.scalar_constraint), 1)
         self.assertIs(type(scalar_constraint), types.FunctionType)
 
@@ -2370,7 +2370,7 @@ class TestBlock(unittest.TestCase):
             return m.x[i]**2 <= 0
 
         self.assertTrue(hasattr(model, 'vector_constraint'))
-        self.assertIs(model.vector_constraint.ctype(), Constraint)
+        self.assertIs(model.vector_constraint.ctype, Constraint)
         self.assertEqual(len(model.vector_constraint), 3)
         self.assertIs(type(vector_constraint), types.FunctionType)
 

--- a/pyomo/core/tests/unit/test_reference.py
+++ b/pyomo/core/tests/unit/test_reference.py
@@ -384,7 +384,7 @@ class TestReference(unittest.TestCase):
         m.x = Var()
         m.r = Reference(m.x)
 
-        self.assertIs(m.r.type(), Var)
+        self.assertIs(m.r.ctype(), Var)
         self.assertIsNot(m.r.index_set(), m.x.index_set())
         self.assertIs(m.x.index_set(), UnindexedComponent_set)
         self.assertIs(type(m.r.index_set()), UnorderedSetOf)
@@ -398,7 +398,7 @@ class TestReference(unittest.TestCase):
 
         m.s = Reference(m.x[:])
 
-        self.assertIs(m.s.type(), Var)
+        self.assertIs(m.s.ctype(), Var)
         self.assertIsNot(m.s.index_set(), m.x.index_set())
         self.assertIs(m.x.index_set(), UnindexedComponent_set)
         self.assertIs(type(m.s.index_set()), UnorderedSetOf)
@@ -413,7 +413,7 @@ class TestReference(unittest.TestCase):
         m.y = Var([1,2])
         m.t = Reference(m.y)
 
-        self.assertIs(m.t.type(), Var)
+        self.assertIs(m.t.ctype(), Var)
         self.assertIs(m.t.index_set(), m.y.index_set())
         self.assertEqual(len(m.t), 2)
         self.assertTrue(m.t.is_indexed())
@@ -444,7 +444,7 @@ class TestReference(unittest.TestCase):
         m.b[2].x = Var(bounds=(2,None))
         m.r = Reference(m.b[:].x)
 
-        self.assertIs(m.r.type(), Var)
+        self.assertIs(m.r.ctype(), Var)
         self.assertIs(m.r.index_set(), m.b.index_set())
         self.assertEqual(len(m.r), 2)
         self.assertEqual(m.r[1].lb, 1)
@@ -465,7 +465,7 @@ class TestReference(unittest.TestCase):
 
         m.r = Reference(m.b[:].x[:])
 
-        self.assertIs(m.r.type(), Var)
+        self.assertIs(m.r.ctype(), Var)
         self.assertIsInstance(m.r.index_set(), SetProduct)
         self.assertIs(m.r.index_set().set_tuple[0], m.I)
         self.assertIs(m.r.index_set().set_tuple[1], m.J)
@@ -490,7 +490,7 @@ class TestReference(unittest.TestCase):
 
         m.r = Reference(m.b[:].x[:,:])
 
-        self.assertIs(m.r.type(), Var)
+        self.assertIs(m.r.ctype(), Var)
         self.assertIsInstance(m.r.index_set(), SetProduct)
         self.assertIs(m.r.index_set().set_tuple[0], m.I)
         self.assertIs(m.r.index_set().set_tuple[1], m.J)
@@ -516,7 +516,7 @@ class TestReference(unittest.TestCase):
 
         m.r = Reference(m.b[:].x[3,:])
 
-        self.assertIs(m.r.type(), Var)
+        self.assertIs(m.r.ctype(), Var)
         self.assertIs(type(m.r.index_set()), UnorderedSetOf)
         self.assertEqual(len(m.r), 2*1)
         self.assertEqual(m.r[1,3].lb, 1)
@@ -539,7 +539,7 @@ class TestReference(unittest.TestCase):
 
         m.r = Reference(m.b[:].x[:])
 
-        self.assertIs(m.r.type(), Var)
+        self.assertIs(m.r.ctype(), Var)
         self.assertIs(type(m.r.index_set()), UnorderedSetOf)
         self.assertEqual(len(m.r), 2*2)
         self.assertEqual(m.r[1,3].lb, 1)
@@ -562,7 +562,7 @@ class TestReference(unittest.TestCase):
 
         m.r = Reference(m.b[:].x[:])
 
-        self.assertIs(m.r.type(), Var)
+        self.assertIs(m.r.ctype(), Var)
         self.assertIs(type(m.r.index_set()), UnorderedSetOf)
         self.assertEqual(len(m.r), 2*2)
         self.assertEqual(m.r[1,3].lb, 1)
@@ -585,7 +585,7 @@ class TestReference(unittest.TestCase):
 
         m.r = Reference(m.b[:].x[:,:])
 
-        self.assertIs(m.r.type(), Var)
+        self.assertIs(m.r.ctype(), Var)
         self.assertIs(type(m.r.index_set()), UnorderedSetOf)
         self.assertEqual(len(m.r), 2*2*2)
         self.assertEqual(m.r[1,3,3].lb, 1)
@@ -627,14 +627,14 @@ class TestReference(unittest.TestCase):
 
         m.y = Reference(m.b[:].y[...])
         self.assertIs(type(m.y), IndexedVar)
-        self.assertIs(m.y.type(), Var)
+        self.assertIs(m.y.ctype(), Var)
         m.y1 = Reference(m.b[:].y[...], ctype=None)
         self.assertIs(type(m.y1), IndexedComponent)
-        self.assertIs(m.y1.type(), IndexedComponent)
+        self.assertIs(m.y1.ctype(), IndexedComponent)
 
         m.z = Reference(m.b[:].z)
         self.assertIs(type(m.z), IndexedComponent)
-        self.assertIs(m.z.type(), IndexedComponent)
+        self.assertIs(m.z.ctype(), IndexedComponent)
 
     def test_reference_to_sparse(self):
         m = ConcreteModel()

--- a/pyomo/core/tests/unit/test_reference.py
+++ b/pyomo/core/tests/unit/test_reference.py
@@ -384,7 +384,7 @@ class TestReference(unittest.TestCase):
         m.x = Var()
         m.r = Reference(m.x)
 
-        self.assertIs(m.r.ctype(), Var)
+        self.assertIs(m.r.ctype, Var)
         self.assertIsNot(m.r.index_set(), m.x.index_set())
         self.assertIs(m.x.index_set(), UnindexedComponent_set)
         self.assertIs(type(m.r.index_set()), UnorderedSetOf)
@@ -398,7 +398,7 @@ class TestReference(unittest.TestCase):
 
         m.s = Reference(m.x[:])
 
-        self.assertIs(m.s.ctype(), Var)
+        self.assertIs(m.s.ctype, Var)
         self.assertIsNot(m.s.index_set(), m.x.index_set())
         self.assertIs(m.x.index_set(), UnindexedComponent_set)
         self.assertIs(type(m.s.index_set()), UnorderedSetOf)
@@ -413,7 +413,7 @@ class TestReference(unittest.TestCase):
         m.y = Var([1,2])
         m.t = Reference(m.y)
 
-        self.assertIs(m.t.ctype(), Var)
+        self.assertIs(m.t.ctype, Var)
         self.assertIs(m.t.index_set(), m.y.index_set())
         self.assertEqual(len(m.t), 2)
         self.assertTrue(m.t.is_indexed())
@@ -444,7 +444,7 @@ class TestReference(unittest.TestCase):
         m.b[2].x = Var(bounds=(2,None))
         m.r = Reference(m.b[:].x)
 
-        self.assertIs(m.r.ctype(), Var)
+        self.assertIs(m.r.ctype, Var)
         self.assertIs(m.r.index_set(), m.b.index_set())
         self.assertEqual(len(m.r), 2)
         self.assertEqual(m.r[1].lb, 1)
@@ -465,7 +465,7 @@ class TestReference(unittest.TestCase):
 
         m.r = Reference(m.b[:].x[:])
 
-        self.assertIs(m.r.ctype(), Var)
+        self.assertIs(m.r.ctype, Var)
         self.assertIsInstance(m.r.index_set(), SetProduct)
         self.assertIs(m.r.index_set().set_tuple[0], m.I)
         self.assertIs(m.r.index_set().set_tuple[1], m.J)
@@ -490,7 +490,7 @@ class TestReference(unittest.TestCase):
 
         m.r = Reference(m.b[:].x[:,:])
 
-        self.assertIs(m.r.ctype(), Var)
+        self.assertIs(m.r.ctype, Var)
         self.assertIsInstance(m.r.index_set(), SetProduct)
         self.assertIs(m.r.index_set().set_tuple[0], m.I)
         self.assertIs(m.r.index_set().set_tuple[1], m.J)
@@ -516,7 +516,7 @@ class TestReference(unittest.TestCase):
 
         m.r = Reference(m.b[:].x[3,:])
 
-        self.assertIs(m.r.ctype(), Var)
+        self.assertIs(m.r.ctype, Var)
         self.assertIs(type(m.r.index_set()), UnorderedSetOf)
         self.assertEqual(len(m.r), 2*1)
         self.assertEqual(m.r[1,3].lb, 1)
@@ -539,7 +539,7 @@ class TestReference(unittest.TestCase):
 
         m.r = Reference(m.b[:].x[:])
 
-        self.assertIs(m.r.ctype(), Var)
+        self.assertIs(m.r.ctype, Var)
         self.assertIs(type(m.r.index_set()), UnorderedSetOf)
         self.assertEqual(len(m.r), 2*2)
         self.assertEqual(m.r[1,3].lb, 1)
@@ -562,7 +562,7 @@ class TestReference(unittest.TestCase):
 
         m.r = Reference(m.b[:].x[:])
 
-        self.assertIs(m.r.ctype(), Var)
+        self.assertIs(m.r.ctype, Var)
         self.assertIs(type(m.r.index_set()), UnorderedSetOf)
         self.assertEqual(len(m.r), 2*2)
         self.assertEqual(m.r[1,3].lb, 1)
@@ -585,7 +585,7 @@ class TestReference(unittest.TestCase):
 
         m.r = Reference(m.b[:].x[:,:])
 
-        self.assertIs(m.r.ctype(), Var)
+        self.assertIs(m.r.ctype, Var)
         self.assertIs(type(m.r.index_set()), UnorderedSetOf)
         self.assertEqual(len(m.r), 2*2*2)
         self.assertEqual(m.r[1,3,3].lb, 1)
@@ -627,14 +627,14 @@ class TestReference(unittest.TestCase):
 
         m.y = Reference(m.b[:].y[...])
         self.assertIs(type(m.y), IndexedVar)
-        self.assertIs(m.y.ctype(), Var)
+        self.assertIs(m.y.ctype, Var)
         m.y1 = Reference(m.b[:].y[...], ctype=None)
         self.assertIs(type(m.y1), IndexedComponent)
-        self.assertIs(m.y1.ctype(), IndexedComponent)
+        self.assertIs(m.y1.ctype, IndexedComponent)
 
         m.z = Reference(m.b[:].z)
         self.assertIs(type(m.z), IndexedComponent)
-        self.assertIs(m.z.ctype(), IndexedComponent)
+        self.assertIs(m.z.ctype, IndexedComponent)
 
     def test_reference_to_sparse(self):
         m = ConcreteModel()

--- a/pyomo/dae/diffvar.py
+++ b/pyomo/dae/diffvar.py
@@ -100,7 +100,7 @@ class DerivativeVar(Var):
                 sidx_sets = list(sVar.index_set().subsets())
                 loc = 0
                 for i, s in enumerate(sidx_sets):
-                    if s.ctype() is ContinuousSet:
+                    if s.ctype is ContinuousSet:
                         sVar._contset[s] = loc
                     _dim = s.dimen
                     if _dim is None:

--- a/pyomo/dae/diffvar.py
+++ b/pyomo/dae/diffvar.py
@@ -100,7 +100,7 @@ class DerivativeVar(Var):
                 sidx_sets = list(sVar.index_set().subsets())
                 loc = 0
                 for i, s in enumerate(sidx_sets):
-                    if s.type() is ContinuousSet:
+                    if s.ctype() is ContinuousSet:
                         sVar._contset[s] = loc
                     _dim = s.dimen
                     if _dim is None:

--- a/pyomo/dae/integral.py
+++ b/pyomo/dae/integral.py
@@ -170,7 +170,7 @@ class IndexedIntegral(IndexedExpression, Integral):
             setlist = self.index_set().set_tuple
 
         for i in setlist:
-            if i.ctype() is ContinuousSet:
+            if i.ctype is ContinuousSet:
                 if 'scheme' not in i.get_discretization_info():
                     return False
         return True

--- a/pyomo/dae/integral.py
+++ b/pyomo/dae/integral.py
@@ -170,7 +170,7 @@ class IndexedIntegral(IndexedExpression, Integral):
             setlist = self.index_set().set_tuple
 
         for i in setlist:
-            if i.type() is ContinuousSet:
+            if i.ctype() is ContinuousSet:
                 if 'scheme' not in i.get_discretization_info():
                     return False
         return True

--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -188,7 +188,7 @@ def update_contset_indexed_component(comp, expansion_map):
     # you must initialize it with every index you would like to have
     # access to!
 
-    if comp.ctype() is Suffix:
+    if comp.ctype is Suffix:
         return
     
     # Params indexed by a ContinuousSet should include an initialize
@@ -196,13 +196,13 @@ def update_contset_indexed_component(comp, expansion_map):
     # parameter value at a new point in the ContinuousSet is
     # requested. Therefore, no special processing is required for
     # Params.
-    if comp.ctype() is Param:
+    if comp.ctype is Param:
         return
 
     # Integral components are handled after every ContinuousSet has been
     # discretized. Import is deferred to here due to circular references.
     from pyomo.dae import Integral
-    if comp.ctype() is Integral:
+    if comp.ctype is Integral:
         return
 
     # Skip components that do not have a 'dim' attribute. This assumes that
@@ -225,22 +225,22 @@ def update_contset_indexed_component(comp, expansion_map):
         indexset = [temp,]
 
     for s in indexset:
-        if s.ctype() == ContinuousSet and s.get_changed():
+        if s.ctype == ContinuousSet and s.get_changed():
             if isinstance(comp, Var):  # Don't use the type() method here
                 # because we want to catch DerivativeVar components as well
                 # as Var components
                 expansion_map[comp] = _update_var
                 _update_var(comp)
-            elif comp.ctype() == Constraint:
+            elif comp.ctype == Constraint:
                 expansion_map[comp] = _update_constraint
                 _update_constraint(comp)
-            elif comp.ctype() == Expression:
+            elif comp.ctype == Expression:
                 expansion_map[comp] = _update_expression
                 _update_expression(comp)
             elif isinstance(comp, Piecewise):
                 expansion_map[comp] =_update_piecewise
                 _update_piecewise(comp)
-            elif comp.ctype() == Block:
+            elif comp.ctype == Block:
                 expansion_map[comp] = _update_block
                 _update_block(comp)    
             else:
@@ -251,7 +251,7 @@ def update_contset_indexed_component(comp, expansion_map):
                     "discretization transformation in pyomo.dae. "
                     "Try adding the component to the model "
                     "after discretizing. Alert the pyomo developers "
-                    "for more assistance." % (str(comp), comp.ctype()))
+                    "for more assistance." % (str(comp), comp.ctype))
 
 
 def _update_var(v):

--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -188,7 +188,7 @@ def update_contset_indexed_component(comp, expansion_map):
     # you must initialize it with every index you would like to have
     # access to!
 
-    if comp.type() is Suffix:
+    if comp.ctype() is Suffix:
         return
     
     # Params indexed by a ContinuousSet should include an initialize
@@ -196,13 +196,13 @@ def update_contset_indexed_component(comp, expansion_map):
     # parameter value at a new point in the ContinuousSet is
     # requested. Therefore, no special processing is required for
     # Params.
-    if comp.type() is Param:
+    if comp.ctype() is Param:
         return
 
     # Integral components are handled after every ContinuousSet has been
     # discretized. Import is deferred to here due to circular references.
     from pyomo.dae import Integral
-    if comp.type() is Integral:
+    if comp.ctype() is Integral:
         return
 
     # Skip components that do not have a 'dim' attribute. This assumes that
@@ -225,22 +225,22 @@ def update_contset_indexed_component(comp, expansion_map):
         indexset = [temp,]
 
     for s in indexset:
-        if s.type() == ContinuousSet and s.get_changed():
+        if s.ctype() == ContinuousSet and s.get_changed():
             if isinstance(comp, Var):  # Don't use the type() method here
                 # because we want to catch DerivativeVar components as well
                 # as Var components
                 expansion_map[comp] = _update_var
                 _update_var(comp)
-            elif comp.type() == Constraint:
+            elif comp.ctype() == Constraint:
                 expansion_map[comp] = _update_constraint
                 _update_constraint(comp)
-            elif comp.type() == Expression:
+            elif comp.ctype() == Expression:
                 expansion_map[comp] = _update_expression
                 _update_expression(comp)
             elif isinstance(comp, Piecewise):
                 expansion_map[comp] =_update_piecewise
                 _update_piecewise(comp)
-            elif comp.type() == Block:
+            elif comp.ctype() == Block:
                 expansion_map[comp] = _update_block
                 _update_block(comp)    
             else:
@@ -251,7 +251,7 @@ def update_contset_indexed_component(comp, expansion_map):
                     "discretization transformation in pyomo.dae. "
                     "Try adding the component to the model "
                     "after discretizing. Alert the pyomo developers "
-                    "for more assistance." % (str(comp), comp.type()))
+                    "for more assistance." % (str(comp), comp.ctype()))
 
 
 def _update_var(v):

--- a/pyomo/dae/plugins/colloc.py
+++ b/pyomo/dae/plugins/colloc.py
@@ -374,7 +374,7 @@ class Collocation_Discretization_Transformation(Transformation):
         tmpds = config.wrt
 
         if tmpds is not None:
-            if tmpds.type() is not ContinuousSet:
+            if tmpds.ctype() is not ContinuousSet:
                 raise TypeError("The component specified using the 'wrt' "
                                 "keyword must be a continuous set")
             elif 'scheme' in tmpds.get_discretization_info():
@@ -558,7 +558,7 @@ class Collocation_Discretization_Transformation(Transformation):
         if contset is None:
             raise TypeError("A continuous set must be specified using the "
                             "keyword 'contset'")
-        if contset.type() is not ContinuousSet:
+        if contset.ctype() is not ContinuousSet:
             raise TypeError("The component specified using the 'contset' "
                             "keyword must be a ContinuousSet")
         ds = contset
@@ -578,7 +578,7 @@ class Collocation_Discretization_Transformation(Transformation):
 
         if var is None:
             raise TypeError("A variable must be specified")
-        if var.type() is not Var:
+        if var.ctype() is not Var:
             raise TypeError("The component specified using the 'var' keyword "
                             "must be a variable")
 

--- a/pyomo/dae/plugins/colloc.py
+++ b/pyomo/dae/plugins/colloc.py
@@ -374,7 +374,7 @@ class Collocation_Discretization_Transformation(Transformation):
         tmpds = config.wrt
 
         if tmpds is not None:
-            if tmpds.ctype() is not ContinuousSet:
+            if tmpds.ctype is not ContinuousSet:
                 raise TypeError("The component specified using the 'wrt' "
                                 "keyword must be a continuous set")
             elif 'scheme' in tmpds.get_discretization_info():
@@ -558,7 +558,7 @@ class Collocation_Discretization_Transformation(Transformation):
         if contset is None:
             raise TypeError("A continuous set must be specified using the "
                             "keyword 'contset'")
-        if contset.ctype() is not ContinuousSet:
+        if contset.ctype is not ContinuousSet:
             raise TypeError("The component specified using the 'contset' "
                             "keyword must be a ContinuousSet")
         ds = contset
@@ -578,7 +578,7 @@ class Collocation_Discretization_Transformation(Transformation):
 
         if var is None:
             raise TypeError("A variable must be specified")
-        if var.ctype() is not Var:
+        if var.ctype is not Var:
             raise TypeError("The component specified using the 'var' keyword "
                             "must be a variable")
 

--- a/pyomo/dae/plugins/finitedifference.py
+++ b/pyomo/dae/plugins/finitedifference.py
@@ -172,7 +172,7 @@ class Finite_Difference_Transformation(Transformation):
         tmpds = config.wrt
 
         if tmpds is not None:
-            if tmpds.ctype() is not ContinuousSet:
+            if tmpds.ctype is not ContinuousSet:
                 raise TypeError("The component specified using the 'wrt' "
                                 "keyword must be a continuous set")
             elif 'scheme' in tmpds.get_discretization_info():

--- a/pyomo/dae/plugins/finitedifference.py
+++ b/pyomo/dae/plugins/finitedifference.py
@@ -172,7 +172,7 @@ class Finite_Difference_Transformation(Transformation):
         tmpds = config.wrt
 
         if tmpds is not None:
-            if tmpds.type() is not ContinuousSet:
+            if tmpds.ctype() is not ContinuousSet:
                 raise TypeError("The component specified using the 'wrt' "
                                 "keyword must be a continuous set")
             elif 'scheme' in tmpds.get_discretization_info():

--- a/pyomo/dae/tests/test_diffvar.py
+++ b/pyomo/dae/tests/test_diffvar.py
@@ -42,7 +42,7 @@ class TestDerivativeVar(unittest.TestCase):
         self.assertTrue(m.dv._wrt[0] is m.t)
         self.assertTrue(m.dv._sVar is m.v)
         self.assertTrue(m.v._derivative[('t',)]() is m.dv)
-        self.assertTrue(m.dv.ctype() is DerivativeVar)
+        self.assertTrue(m.dv.ctype is DerivativeVar)
         self.assertTrue(m.dv._index is m.t)
         self.assertTrue(m.dv2._wrt[0] is m.t)
         self.assertTrue(m.dv2._wrt[1] is m.t)
@@ -61,7 +61,7 @@ class TestDerivativeVar(unittest.TestCase):
         self.assertTrue(m.dv._wrt[0] is m.t)
         self.assertTrue(m.dv._sVar is m.v)
         self.assertTrue(m.v._derivative[('t',)]() is m.dv)
-        self.assertTrue(m.dv.ctype() is DerivativeVar)
+        self.assertTrue(m.dv.ctype is DerivativeVar)
         self.assertTrue(m.t in m.dv.index_set().set_tuple)
         self.assertTrue(m.s in m.dv.index_set().set_tuple)
         self.assertTrue(m.dv2._wrt[0] is m.t)
@@ -85,7 +85,7 @@ class TestDerivativeVar(unittest.TestCase):
         self.assertTrue(m.v._derivative[('t',)]() is m.dv2)
         self.assertTrue(m.v._derivative[('t', 'x')]() is m.dv3)
         self.assertTrue(m.v._derivative[('t', 't')]() is m.dv4)
-        self.assertTrue(m.dv.ctype() is DerivativeVar)
+        self.assertTrue(m.dv.ctype is DerivativeVar)
         self.assertTrue(m.x in m.dv.index_set().set_tuple)
         self.assertTrue(m.t in m.dv.index_set().set_tuple)
         self.assertTrue(m.dv3._wrt[0] is m.t)
@@ -163,15 +163,15 @@ class TestDerivativeVar(unittest.TestCase):
 
         TransformationFactory('dae.finite_difference').apply_to(m, wrt=m.t)
 
-        self.assertTrue(m.dv.ctype() is Var)
-        self.assertTrue(m.dv2.ctype() is Var)
+        self.assertTrue(m.dv.ctype is Var)
+        self.assertTrue(m.dv2.ctype is Var)
         self.assertTrue(m.dv.is_fully_discretized())
         self.assertTrue(m.dv2.is_fully_discretized())
-        self.assertTrue(m.dv3.ctype() is DerivativeVar)
+        self.assertTrue(m.dv3.ctype is DerivativeVar)
         self.assertFalse(m.dv3.is_fully_discretized())
 
         TransformationFactory('dae.collocation').apply_to(m, wrt=m.x)
-        self.assertTrue(m.dv3.ctype() is Var)
+        self.assertTrue(m.dv3.ctype is Var)
         self.assertTrue(m.dv3.is_fully_discretized())
 
 

--- a/pyomo/dae/tests/test_diffvar.py
+++ b/pyomo/dae/tests/test_diffvar.py
@@ -42,7 +42,7 @@ class TestDerivativeVar(unittest.TestCase):
         self.assertTrue(m.dv._wrt[0] is m.t)
         self.assertTrue(m.dv._sVar is m.v)
         self.assertTrue(m.v._derivative[('t',)]() is m.dv)
-        self.assertTrue(m.dv.type() is DerivativeVar)
+        self.assertTrue(m.dv.ctype() is DerivativeVar)
         self.assertTrue(m.dv._index is m.t)
         self.assertTrue(m.dv2._wrt[0] is m.t)
         self.assertTrue(m.dv2._wrt[1] is m.t)
@@ -61,7 +61,7 @@ class TestDerivativeVar(unittest.TestCase):
         self.assertTrue(m.dv._wrt[0] is m.t)
         self.assertTrue(m.dv._sVar is m.v)
         self.assertTrue(m.v._derivative[('t',)]() is m.dv)
-        self.assertTrue(m.dv.type() is DerivativeVar)
+        self.assertTrue(m.dv.ctype() is DerivativeVar)
         self.assertTrue(m.t in m.dv.index_set().set_tuple)
         self.assertTrue(m.s in m.dv.index_set().set_tuple)
         self.assertTrue(m.dv2._wrt[0] is m.t)
@@ -85,7 +85,7 @@ class TestDerivativeVar(unittest.TestCase):
         self.assertTrue(m.v._derivative[('t',)]() is m.dv2)
         self.assertTrue(m.v._derivative[('t', 'x')]() is m.dv3)
         self.assertTrue(m.v._derivative[('t', 't')]() is m.dv4)
-        self.assertTrue(m.dv.type() is DerivativeVar)
+        self.assertTrue(m.dv.ctype() is DerivativeVar)
         self.assertTrue(m.x in m.dv.index_set().set_tuple)
         self.assertTrue(m.t in m.dv.index_set().set_tuple)
         self.assertTrue(m.dv3._wrt[0] is m.t)
@@ -163,15 +163,15 @@ class TestDerivativeVar(unittest.TestCase):
 
         TransformationFactory('dae.finite_difference').apply_to(m, wrt=m.t)
 
-        self.assertTrue(m.dv.type() is Var)
-        self.assertTrue(m.dv2.type() is Var)
+        self.assertTrue(m.dv.ctype() is Var)
+        self.assertTrue(m.dv2.ctype() is Var)
         self.assertTrue(m.dv.is_fully_discretized())
         self.assertTrue(m.dv2.is_fully_discretized())
-        self.assertTrue(m.dv3.type() is DerivativeVar)
+        self.assertTrue(m.dv3.ctype() is DerivativeVar)
         self.assertFalse(m.dv3.is_fully_discretized())
 
         TransformationFactory('dae.collocation').apply_to(m, wrt=m.x)
-        self.assertTrue(m.dv3.type() is Var)
+        self.assertTrue(m.dv3.ctype() is Var)
         self.assertTrue(m.dv3.is_fully_discretized())
 
 

--- a/pyomo/dae/tests/test_integral.py
+++ b/pyomo/dae/tests/test_integral.py
@@ -73,10 +73,10 @@ class TestIntegral(unittest.TestCase):
         self.assertEqual(len(m.int2), 3)
         self.assertEqual(len(m.int3), 2)
         self.assertEqual(len(m.int4), 1)
-        self.assertTrue(m.int1.type() is Integral)
-        self.assertTrue(m.int2.type() is Integral)
-        self.assertTrue(m.int3.type() is Integral)
-        self.assertTrue(m.int4.type() is Integral)
+        self.assertTrue(m.int1.ctype() is Integral)
+        self.assertTrue(m.int2.ctype() is Integral)
+        self.assertTrue(m.int3.ctype() is Integral)
+        self.assertTrue(m.int4.ctype() is Integral)
 
         repn = generate_standard_repn(m.int1.expr)
         self.assertEqual(repn.linear_coefs, (0.5, 0.5))
@@ -185,20 +185,20 @@ class TestIntegral(unittest.TestCase):
             self.assertFalse(m.int3.is_fully_discretized())
             self.assertFalse(m.int4.is_fully_discretized())
 
-            self.assertTrue(m.int1.type() is Integral)
-            self.assertTrue(m.int2.type() is Integral)
-            self.assertTrue(m.int3.type() is Integral)
-            self.assertTrue(m.int4.type() is Integral)
+            self.assertTrue(m.int1.ctype() is Integral)
+            self.assertTrue(m.int2.ctype() is Integral)
+            self.assertTrue(m.int3.ctype() is Integral)
+            self.assertTrue(m.int4.ctype() is Integral)
 
             TransformationFactory('dae.finite_difference').apply_to(m, wrt=m.x)
 
             self.assertTrue(m.int3.is_fully_discretized())
             self.assertTrue(m.int4.is_fully_discretized())
 
-            self.assertTrue(m.int1.type() is Expression)
-            self.assertTrue(m.int2.type() is Expression)
-            self.assertTrue(m.int3.type() is Expression)
-            self.assertTrue(m.int4.type() is Expression)
+            self.assertTrue(m.int1.ctype() is Expression)
+            self.assertTrue(m.int2.ctype() is Expression)
+            self.assertTrue(m.int3.ctype() is Expression)
+            self.assertTrue(m.int4.ctype() is Expression)
 
     # test DerivativeVar reclassification after discretization
     def test_reclassification_collocation(self):
@@ -242,20 +242,20 @@ class TestIntegral(unittest.TestCase):
         self.assertFalse(m.int3.is_fully_discretized())
         self.assertFalse(m.int4.is_fully_discretized())
 
-        self.assertTrue(m.int1.type() is Integral)
-        self.assertTrue(m.int2.type() is Integral)
-        self.assertTrue(m.int3.type() is Integral)
-        self.assertTrue(m.int4.type() is Integral)
+        self.assertTrue(m.int1.ctype() is Integral)
+        self.assertTrue(m.int2.ctype() is Integral)
+        self.assertTrue(m.int3.ctype() is Integral)
+        self.assertTrue(m.int4.ctype() is Integral)
 
         TransformationFactory('dae.collocation').apply_to(m, wrt=m.x)
 
         self.assertTrue(m.int3.is_fully_discretized())
         self.assertTrue(m.int4.is_fully_discretized())
 
-        self.assertTrue(m.int1.type() is Expression)
-        self.assertTrue(m.int2.type() is Expression)
-        self.assertTrue(m.int3.type() is Expression)
-        self.assertTrue(m.int4.type() is Expression)
+        self.assertTrue(m.int1.ctype() is Expression)
+        self.assertTrue(m.int2.ctype() is Expression)
+        self.assertTrue(m.int3.ctype() is Expression)
+        self.assertTrue(m.int4.ctype() is Expression)
 
 
 if __name__ == "__main__":

--- a/pyomo/dae/tests/test_integral.py
+++ b/pyomo/dae/tests/test_integral.py
@@ -73,10 +73,10 @@ class TestIntegral(unittest.TestCase):
         self.assertEqual(len(m.int2), 3)
         self.assertEqual(len(m.int3), 2)
         self.assertEqual(len(m.int4), 1)
-        self.assertTrue(m.int1.ctype() is Integral)
-        self.assertTrue(m.int2.ctype() is Integral)
-        self.assertTrue(m.int3.ctype() is Integral)
-        self.assertTrue(m.int4.ctype() is Integral)
+        self.assertTrue(m.int1.ctype is Integral)
+        self.assertTrue(m.int2.ctype is Integral)
+        self.assertTrue(m.int3.ctype is Integral)
+        self.assertTrue(m.int4.ctype is Integral)
 
         repn = generate_standard_repn(m.int1.expr)
         self.assertEqual(repn.linear_coefs, (0.5, 0.5))
@@ -185,20 +185,20 @@ class TestIntegral(unittest.TestCase):
             self.assertFalse(m.int3.is_fully_discretized())
             self.assertFalse(m.int4.is_fully_discretized())
 
-            self.assertTrue(m.int1.ctype() is Integral)
-            self.assertTrue(m.int2.ctype() is Integral)
-            self.assertTrue(m.int3.ctype() is Integral)
-            self.assertTrue(m.int4.ctype() is Integral)
+            self.assertTrue(m.int1.ctype is Integral)
+            self.assertTrue(m.int2.ctype is Integral)
+            self.assertTrue(m.int3.ctype is Integral)
+            self.assertTrue(m.int4.ctype is Integral)
 
             TransformationFactory('dae.finite_difference').apply_to(m, wrt=m.x)
 
             self.assertTrue(m.int3.is_fully_discretized())
             self.assertTrue(m.int4.is_fully_discretized())
 
-            self.assertTrue(m.int1.ctype() is Expression)
-            self.assertTrue(m.int2.ctype() is Expression)
-            self.assertTrue(m.int3.ctype() is Expression)
-            self.assertTrue(m.int4.ctype() is Expression)
+            self.assertTrue(m.int1.ctype is Expression)
+            self.assertTrue(m.int2.ctype is Expression)
+            self.assertTrue(m.int3.ctype is Expression)
+            self.assertTrue(m.int4.ctype is Expression)
 
     # test DerivativeVar reclassification after discretization
     def test_reclassification_collocation(self):
@@ -242,20 +242,20 @@ class TestIntegral(unittest.TestCase):
         self.assertFalse(m.int3.is_fully_discretized())
         self.assertFalse(m.int4.is_fully_discretized())
 
-        self.assertTrue(m.int1.ctype() is Integral)
-        self.assertTrue(m.int2.ctype() is Integral)
-        self.assertTrue(m.int3.ctype() is Integral)
-        self.assertTrue(m.int4.ctype() is Integral)
+        self.assertTrue(m.int1.ctype is Integral)
+        self.assertTrue(m.int2.ctype is Integral)
+        self.assertTrue(m.int3.ctype is Integral)
+        self.assertTrue(m.int4.ctype is Integral)
 
         TransformationFactory('dae.collocation').apply_to(m, wrt=m.x)
 
         self.assertTrue(m.int3.is_fully_discretized())
         self.assertTrue(m.int4.is_fully_discretized())
 
-        self.assertTrue(m.int1.ctype() is Expression)
-        self.assertTrue(m.int2.ctype() is Expression)
-        self.assertTrue(m.int3.ctype() is Expression)
-        self.assertTrue(m.int4.ctype() is Expression)
+        self.assertTrue(m.int1.ctype is Expression)
+        self.assertTrue(m.int2.ctype is Expression)
+        self.assertTrue(m.int3.ctype is Expression)
+        self.assertTrue(m.int4.ctype is Expression)
 
 
 if __name__ == "__main__":

--- a/pyomo/gdp/basic_step.py
+++ b/pyomo/gdp/basic_step.py
@@ -44,9 +44,9 @@ def apply_basic_step(disjunctions_or_constraints):
     # Basic steps only apply to XOR'd disjunctions
     #
     disjunctions = list(obj for obj in disjunctions_or_constraints
-                        if obj.type() == Disjunction)
+                        if obj.ctype() == Disjunction)
     constraints = list(obj for obj in disjunctions_or_constraints
-                       if obj.type() == Constraint)
+                       if obj.ctype() == Constraint)
     for d in disjunctions:
         if not d.xor:
             raise ValueError(

--- a/pyomo/gdp/basic_step.py
+++ b/pyomo/gdp/basic_step.py
@@ -44,9 +44,9 @@ def apply_basic_step(disjunctions_or_constraints):
     # Basic steps only apply to XOR'd disjunctions
     #
     disjunctions = list(obj for obj in disjunctions_or_constraints
-                        if obj.ctype() == Disjunction)
+                        if obj.ctype == Disjunction)
     constraints = list(obj for obj in disjunctions_or_constraints
-                       if obj.ctype() == Constraint)
+                       if obj.ctype == Constraint)
     for d in disjunctions:
         if not d.xor:
             raise ValueError(

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -221,7 +221,7 @@ class _DisjunctionData(ActiveComponentData):
             # the new Disjuncts are Blocks already. This catches them for who
             # they are anyway.
             if isinstance(e, _DisjunctData):
-            #if hasattr(e, 'type') and e.ctype() == Disjunct:
+            #if hasattr(e, 'type') and e.ctype == Disjunct:
                 self.disjuncts.append(e)
                 continue
             # The user was lazy and gave us a single constraint

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -221,7 +221,7 @@ class _DisjunctionData(ActiveComponentData):
             # the new Disjuncts are Blocks already. This catches them for who
             # they are anyway.
             if isinstance(e, _DisjunctData):
-            #if hasattr(e, 'type') and e.type() == Disjunct:
+            #if hasattr(e, 'type') and e.ctype() == Disjunct:
                 self.disjuncts.append(e)
                 continue
             # The user was lazy and gave us a single constraint

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -214,12 +214,12 @@ class BigM_Transformation(Transformation):
                                knownBlocks=knownBlocks):
                 raise GDP_Error("Target %s is not a component on instance %s!"
                                 % (t.name, instance.name))
-            elif t.type() is Disjunction:
+            elif t.ctype() is Disjunction:
                 if t.parent_component() is t:
                     self._transform_disjunction(t, bigM)
                 else:
                     self._transform_disjunctionData( t, bigM, t.index())
-            elif t.type() in (Block, Disjunct):
+            elif t.ctype() in (Block, Disjunct):
                 if t.parent_component() is t:
                     self._transform_block(t, bigM)
                 else:
@@ -475,7 +475,7 @@ class BigM_Transformation(Transformation):
         # that because we only iterate through active components, this means
         # non-ActiveComponent types cannot have handlers.)
         for obj in block.component_objects(active=True, descend_into=False):
-            handler = self.handlers.get(obj.type(), None)
+            handler = self.handlers.get(obj.ctype(), None)
             if not handler:
                 if handler is None:
                     raise GDP_Error(
@@ -483,7 +483,7 @@ class BigM_Transformation(Transformation):
                         "for modeling components of type %s. If your " 
                         "disjuncts contain non-GDP Pyomo components that "
                         "require transformation, please transform them first."
-                        % obj.type())
+                        % obj.ctype())
                 continue
             # obj is what we are transforming, we pass disjunct
             # through so that we will have access to the indicator

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -214,12 +214,12 @@ class BigM_Transformation(Transformation):
                                knownBlocks=knownBlocks):
                 raise GDP_Error("Target %s is not a component on instance %s!"
                                 % (t.name, instance.name))
-            elif t.ctype() is Disjunction:
+            elif t.ctype is Disjunction:
                 if t.parent_component() is t:
                     self._transform_disjunction(t, bigM)
                 else:
                     self._transform_disjunctionData( t, bigM, t.index())
-            elif t.ctype() in (Block, Disjunct):
+            elif t.ctype in (Block, Disjunct):
                 if t.parent_component() is t:
                     self._transform_block(t, bigM)
                 else:
@@ -475,7 +475,7 @@ class BigM_Transformation(Transformation):
         # that because we only iterate through active components, this means
         # non-ActiveComponent types cannot have handlers.)
         for obj in block.component_objects(active=True, descend_into=False):
-            handler = self.handlers.get(obj.ctype(), None)
+            handler = self.handlers.get(obj.ctype, None)
             if not handler:
                 if handler is None:
                     raise GDP_Error(
@@ -483,7 +483,7 @@ class BigM_Transformation(Transformation):
                         "for modeling components of type %s. If your " 
                         "disjuncts contain non-GDP Pyomo components that "
                         "require transformation, please transform them first."
-                        % obj.ctype())
+                        % obj.ctype)
                 continue
             # obj is what we are transforming, we pass disjunct
             # through so that we will have access to the indicator

--- a/pyomo/gdp/plugins/chull.py
+++ b/pyomo/gdp/plugins/chull.py
@@ -208,12 +208,12 @@ class ConvexHull_Transformation(Transformation):
                                knownBlocks=knownBlocks):
                 raise GDP_Error("Target %s is not a component on instance %s!"
                                 % (t.name, instance.name))
-            elif t.type() is Disjunction:
+            elif t.ctype() is Disjunction:
                 if t.parent_component() is t:
                     self._transformDisjunction(t, transBlock)
                 else:
                     self._transformDisjunctionData(t, transBlock, t.index())
-            elif t.type() in (Block, Disjunct):
+            elif t.ctype() in (Block, Disjunct):
                 if t.parent_component() is t:
                     self._transformBlock(t, transBlock)
                 else:
@@ -625,12 +625,12 @@ class ConvexHull_Transformation(Transformation):
         for name, obj in list(iteritems(block.component_map())):
             if hasattr(obj, 'active') and not obj.active:
                 continue
-            handler = self.handlers.get(obj.type(), None)
+            handler = self.handlers.get(obj.ctype(), None)
             if not handler:
                 if handler is None:
                     raise GDP_Error(
                         "No chull transformation handler registered "
-                        "for modeling components of type %s" % obj.type() )
+                        "for modeling components of type %s" % obj.ctype() )
                 continue
             # obj is what we are transforming, we pass disjunct
             # through so that we will have access to the indicator

--- a/pyomo/gdp/plugins/chull.py
+++ b/pyomo/gdp/plugins/chull.py
@@ -208,12 +208,12 @@ class ConvexHull_Transformation(Transformation):
                                knownBlocks=knownBlocks):
                 raise GDP_Error("Target %s is not a component on instance %s!"
                                 % (t.name, instance.name))
-            elif t.ctype() is Disjunction:
+            elif t.ctype is Disjunction:
                 if t.parent_component() is t:
                     self._transformDisjunction(t, transBlock)
                 else:
                     self._transformDisjunctionData(t, transBlock, t.index())
-            elif t.ctype() in (Block, Disjunct):
+            elif t.ctype in (Block, Disjunct):
                 if t.parent_component() is t:
                     self._transformBlock(t, transBlock)
                 else:
@@ -625,12 +625,12 @@ class ConvexHull_Transformation(Transformation):
         for name, obj in list(iteritems(block.component_map())):
             if hasattr(obj, 'active') and not obj.active:
                 continue
-            handler = self.handlers.get(obj.ctype(), None)
+            handler = self.handlers.get(obj.ctype, None)
             if not handler:
                 if handler is None:
                     raise GDP_Error(
                         "No chull transformation handler registered "
-                        "for modeling components of type %s" % obj.ctype() )
+                        "for modeling components of type %s" % obj.ctype )
                 continue
             # obj is what we are transforming, we pass disjunct
             # through so that we will have access to the indicator

--- a/pyomo/gdp/plugins/gdp_var_mover.py
+++ b/pyomo/gdp/plugins/gdp_var_mover.py
@@ -161,9 +161,9 @@ class HACK_GDP_Disjunct_Reclassifier(Transformation):
         # Disjunct, before raising a warning.
         parent_block = disjunct.parent_block()
         while parent_block is not None:
-            if parent_block.type() is Block and not parent_block.active:
+            if parent_block.ctype() is Block and not parent_block.active:
                 return False
-            elif (parent_block.type() is Disjunct and not parent_block.active
+            elif (parent_block.ctype() is Disjunct and not parent_block.active
                   and parent_block.indicator_var.value == 0
                   and parent_block.indicator_var.fixed):
                 return False

--- a/pyomo/gdp/plugins/gdp_var_mover.py
+++ b/pyomo/gdp/plugins/gdp_var_mover.py
@@ -161,9 +161,9 @@ class HACK_GDP_Disjunct_Reclassifier(Transformation):
         # Disjunct, before raising a warning.
         parent_block = disjunct.parent_block()
         while parent_block is not None:
-            if parent_block.ctype() is Block and not parent_block.active:
+            if parent_block.ctype is Block and not parent_block.active:
                 return False
-            elif (parent_block.ctype() is Disjunct and not parent_block.active
+            elif (parent_block.ctype is Disjunct and not parent_block.active
                   and parent_block.indicator_var.value == 0
                   and parent_block.indicator_var.fixed):
                 return False

--- a/pyomo/gdp/tests/test_fix_disjuncts.py
+++ b/pyomo/gdp/tests/test_fix_disjuncts.py
@@ -25,8 +25,8 @@ class TestFixDisjuncts(unittest.TestCase):
         self.assertTrue(m.d1.active)
         self.assertTrue(m.d2.indicator_var.fixed)
         self.assertFalse(m.d2.active)
-        self.assertEqual(m.d1.ctype(), Block)
-        self.assertEqual(m.d2.ctype(), Block)
+        self.assertEqual(m.d1.ctype, Block)
+        self.assertEqual(m.d2.ctype, Block)
         self.assertTrue(m.d2.c.active)
 
     def test_xor_not_sum_to_1(self):

--- a/pyomo/gdp/tests/test_fix_disjuncts.py
+++ b/pyomo/gdp/tests/test_fix_disjuncts.py
@@ -25,8 +25,8 @@ class TestFixDisjuncts(unittest.TestCase):
         self.assertTrue(m.d1.active)
         self.assertTrue(m.d2.indicator_var.fixed)
         self.assertFalse(m.d2.active)
-        self.assertEqual(m.d1.type(), Block)
-        self.assertEqual(m.d2.type(), Block)
+        self.assertEqual(m.d1.ctype(), Block)
+        self.assertEqual(m.d2.ctype(), Block)
         self.assertTrue(m.d2.c.active)
 
     def test_xor_not_sum_to_1(self):

--- a/pyomo/gdp/tests/test_reclassify.py
+++ b/pyomo/gdp/tests/test_reclassify.py
@@ -18,9 +18,9 @@ class TestDisjunctReclassify(unittest.TestCase):
         m.d1.disj = Disjunction(expr=[m.d1.sub1, m.d1.sub2])
         m.d1.deactivate()
         TransformationFactory('gdp.reclassify').apply_to(m)
-        self.assertIs(m.d1.ctype(), Block)
-        self.assertIs(m.d1.sub1.ctype(), Block)
-        self.assertIs(m.d1.sub2.ctype(), Block)
+        self.assertIs(m.d1.ctype, Block)
+        self.assertIs(m.d1.sub1.ctype, Block)
+        self.assertIs(m.d1.sub2.ctype, Block)
 
     def test_deactivated_parent_block(self):
         m = ConcreteModel()
@@ -30,9 +30,9 @@ class TestDisjunctReclassify(unittest.TestCase):
         m.d1.disj = Disjunction(expr=[m.d1.sub1, m.d1.sub2])
         m.d1.deactivate()
         TransformationFactory('gdp.reclassify').apply_to(m)
-        self.assertIs(m.d1.ctype(), Block)
-        self.assertIs(m.d1.sub1.ctype(), Block)
-        self.assertIs(m.d1.sub2.ctype(), Block)
+        self.assertIs(m.d1.ctype, Block)
+        self.assertIs(m.d1.sub1.ctype, Block)
+        self.assertIs(m.d1.sub2.ctype, Block)
 
     def test_active_parent_disjunct(self):
         m = ConcreteModel()
@@ -52,9 +52,9 @@ class TestDisjunctReclassify(unittest.TestCase):
         TransformationFactory('gdp.bigm').apply_to(m, targets=m.d1.disj)
         m.d1.indicator_var.fix(1)
         TransformationFactory('gdp.reclassify').apply_to(m)
-        self.assertIs(m.d1.ctype(), Block)
-        self.assertIs(m.d1.sub1.ctype(), Block)
-        self.assertIs(m.d1.sub2.ctype(), Block)
+        self.assertIs(m.d1.ctype, Block)
+        self.assertIs(m.d1.sub1.ctype, Block)
+        self.assertIs(m.d1.sub2.ctype, Block)
 
     def test_active_parent_block(self):
         m = ConcreteModel()

--- a/pyomo/gdp/tests/test_reclassify.py
+++ b/pyomo/gdp/tests/test_reclassify.py
@@ -18,9 +18,9 @@ class TestDisjunctReclassify(unittest.TestCase):
         m.d1.disj = Disjunction(expr=[m.d1.sub1, m.d1.sub2])
         m.d1.deactivate()
         TransformationFactory('gdp.reclassify').apply_to(m)
-        self.assertIs(m.d1.type(), Block)
-        self.assertIs(m.d1.sub1.type(), Block)
-        self.assertIs(m.d1.sub2.type(), Block)
+        self.assertIs(m.d1.ctype(), Block)
+        self.assertIs(m.d1.sub1.ctype(), Block)
+        self.assertIs(m.d1.sub2.ctype(), Block)
 
     def test_deactivated_parent_block(self):
         m = ConcreteModel()
@@ -30,9 +30,9 @@ class TestDisjunctReclassify(unittest.TestCase):
         m.d1.disj = Disjunction(expr=[m.d1.sub1, m.d1.sub2])
         m.d1.deactivate()
         TransformationFactory('gdp.reclassify').apply_to(m)
-        self.assertIs(m.d1.type(), Block)
-        self.assertIs(m.d1.sub1.type(), Block)
-        self.assertIs(m.d1.sub2.type(), Block)
+        self.assertIs(m.d1.ctype(), Block)
+        self.assertIs(m.d1.sub1.ctype(), Block)
+        self.assertIs(m.d1.sub2.ctype(), Block)
 
     def test_active_parent_disjunct(self):
         m = ConcreteModel()
@@ -52,9 +52,9 @@ class TestDisjunctReclassify(unittest.TestCase):
         TransformationFactory('gdp.bigm').apply_to(m, targets=m.d1.disj)
         m.d1.indicator_var.fix(1)
         TransformationFactory('gdp.reclassify').apply_to(m)
-        self.assertIs(m.d1.type(), Block)
-        self.assertIs(m.d1.sub1.type(), Block)
-        self.assertIs(m.d1.sub2.type(), Block)
+        self.assertIs(m.d1.ctype(), Block)
+        self.assertIs(m.d1.sub1.ctype(), Block)
+        self.assertIs(m.d1.sub2.ctype(), Block)
 
     def test_active_parent_block(self):
         m = ConcreteModel()

--- a/pyomo/kernel/__init__.py
+++ b/pyomo/kernel/__init__.py
@@ -228,12 +228,6 @@ def _valid_problem_types(self):
 block.valid_problem_types = _valid_problem_types
 del _valid_problem_types
 
-from pyomo.core.kernel.base import ICategorizedObject
-def _type(self):
-    return self._ctype
-ICategorizedObject.type = _type
-del ICategorizedObject
-
 # update the reserved block attributes now that
 # new hacked methods have been placed on blocks
 block._refresh_block_reserved_words()

--- a/pyomo/mpec/complementarity.py
+++ b/pyomo/mpec/complementarity.py
@@ -274,7 +274,7 @@ Error thrown for Complementarity "%s"
         # _pprint_callback if there are components (requires baseline
         # updates and a check that we do not break anything in the
         # Book).
-        _transformed = not issubclass(self.ctype(), Complementarity)
+        _transformed = not issubclass(self.ctype, Complementarity)
         def _conditional_block_printer(ostream, idx, data):
             if _transformed or len(data.component_map()):
                 self._pprint_callback(ostream, idx, data)

--- a/pyomo/mpec/complementarity.py
+++ b/pyomo/mpec/complementarity.py
@@ -109,13 +109,13 @@ class _ComplementarityData(_BlockData):
         #
         if _e2[0] is None and _e2[2] is None:
             self.c = Constraint(expr=(None, _e2[1], None))
-            self.c._complemtarity_type = 3
+            self.c._complementarity_type = 3
         elif _e2[2] is None:
             self.c = Constraint(expr=_e2[0] <= _e2[1])
-            self.c._complemtarity_type = 1
+            self.c._complementarity_type = 1
         elif _e2[0] is None:
             self.c = Constraint(expr=- _e2[2] <= - _e2[1])
-            self.c._complemtarity_type = 1
+            self.c._complementarity_type = 1
         #
         if not _e1[0] is None and not _e1[2] is None:
             if not (_e1[0].__class__ in native_numeric_types or _e1[0].is_constant()):

--- a/pyomo/mpec/complementarity.py
+++ b/pyomo/mpec/complementarity.py
@@ -109,13 +109,13 @@ class _ComplementarityData(_BlockData):
         #
         if _e2[0] is None and _e2[2] is None:
             self.c = Constraint(expr=(None, _e2[1], None))
-            self.c._type = 3
+            self.c._complemtarity_type = 3
         elif _e2[2] is None:
             self.c = Constraint(expr=_e2[0] <= _e2[1])
-            self.c._type = 1
+            self.c._complemtarity_type = 1
         elif _e2[0] is None:
             self.c = Constraint(expr=- _e2[2] <= - _e2[1])
-            self.c._type = 1
+            self.c._complemtarity_type = 1
         #
         if not _e1[0] is None and not _e1[2] is None:
             if not (_e1[0].__class__ in native_numeric_types or _e1[0].is_constant()):
@@ -274,7 +274,7 @@ Error thrown for Complementarity "%s"
         # _pprint_callback if there are components (requires baseline
         # updates and a check that we do not break anything in the
         # Book).
-        _transformed = not issubclass(self._type, Complementarity)
+        _transformed = not issubclass(self.ctype(), Complementarity)
         def _conditional_block_printer(ostream, idx, data):
             if _transformed or len(data.component_map()):
                 self._pprint_callback(ostream, idx, data)

--- a/pyomo/mpec/plugins/mpec1.py
+++ b/pyomo/mpec/plugins/mpec1.py
@@ -72,7 +72,7 @@ class MPEC1_Transformation(Transformation):
                     continue
                 _data.to_standard_form()
                 #
-                _type = getattr(_data.c, "_type", 0)
+                _type = getattr(_data.c, "_complemtarity_type", 0)
                 if _type == 1:
                     #
                     # Constraint expression is bounded below, so we can replace 
@@ -80,14 +80,14 @@ class MPEC1_Transformation(Transformation):
                     # constraint c is active or variable v is at its lower bound.
                     #
                     _data.ccon = Constraint(expr=(_data.c.body - _data.c.lower)*_data.v <= instance.mpec_bound)
-                    del _data.c._type
+                    del _data.c._complemtarity_type
                 elif _type == 3:
                     #
                     # Variable v is bounded above and below.  We can define
                     #
                     _data.ccon_l = Constraint(expr=(_data.v - _data.v.bounds[0])*_data.c.body <= instance.mpec_bound)
                     _data.ccon_u = Constraint(expr=(_data.v - _data.v.bounds[1])*_data.c.body <= instance.mpec_bound)
-                    del _data.c._type
+                    del _data.c._complemtarity_type
                 elif _type == 2:        #pragma:nocover
                     raise ValueError("to_standard_form does not generate _type 2 expressions")
             tdata.compl_cuids.append( ComponentUID(complementarity) )

--- a/pyomo/mpec/plugins/mpec1.py
+++ b/pyomo/mpec/plugins/mpec1.py
@@ -72,7 +72,7 @@ class MPEC1_Transformation(Transformation):
                     continue
                 _data.to_standard_form()
                 #
-                _type = getattr(_data.c, "_complemtarity_type", 0)
+                _type = getattr(_data.c, "_complementarity_type", 0)
                 if _type == 1:
                     #
                     # Constraint expression is bounded below, so we can replace 
@@ -80,14 +80,14 @@ class MPEC1_Transformation(Transformation):
                     # constraint c is active or variable v is at its lower bound.
                     #
                     _data.ccon = Constraint(expr=(_data.c.body - _data.c.lower)*_data.v <= instance.mpec_bound)
-                    del _data.c._complemtarity_type
+                    del _data.c._complementarity_type
                 elif _type == 3:
                     #
                     # Variable v is bounded above and below.  We can define
                     #
                     _data.ccon_l = Constraint(expr=(_data.v - _data.v.bounds[0])*_data.c.body <= instance.mpec_bound)
                     _data.ccon_u = Constraint(expr=(_data.v - _data.v.bounds[1])*_data.c.body <= instance.mpec_bound)
-                    del _data.c._complemtarity_type
+                    del _data.c._complementarity_type
                 elif _type == 2:        #pragma:nocover
                     raise ValueError("to_standard_form does not generate _type 2 expressions")
             tdata.compl_cuids.append( ComponentUID(complementarity) )

--- a/pyomo/network/arc.py
+++ b/pyomo/network/arc.py
@@ -211,7 +211,7 @@ class _ArcData(ActiveComponentData):
                     "containing exactly 2 Ports.")
             for p in ports:
                 try:
-                    if p.type() is not Port:
+                    if p.ctype() is not Port:
                         raise ValueError(msg +
                             "found object '%s' in 'ports' not "
                             "of type Port." % p.name)
@@ -230,7 +230,7 @@ class _ArcData(ActiveComponentData):
                     "for directed Arc.")
             for p, side in [(source, "source"), (destination, "destination")]:
                 try:
-                    if p.type() is not Port:
+                    if p.ctype() is not Port:
                         raise ValueError(msg +
                             "%s object '%s' not of type Port." % (p.name, side))
                     elif p.is_indexed():

--- a/pyomo/network/arc.py
+++ b/pyomo/network/arc.py
@@ -211,7 +211,7 @@ class _ArcData(ActiveComponentData):
                     "containing exactly 2 Ports.")
             for p in ports:
                 try:
-                    if p.ctype() is not Port:
+                    if p.ctype is not Port:
                         raise ValueError(msg +
                             "found object '%s' in 'ports' not "
                             "of type Port." % p.name)
@@ -230,7 +230,7 @@ class _ArcData(ActiveComponentData):
                     "for directed Arc.")
             for p, side in [(source, "source"), (destination, "destination")]:
                 try:
-                    if p.ctype() is not Port:
+                    if p.ctype is not Port:
                         raise ValueError(msg +
                             "%s object '%s' not of type Port." % (p.name, side))
                     elif p.is_indexed():

--- a/pyomo/network/tests/test_arc.py
+++ b/pyomo/network/tests/test_arc.py
@@ -48,17 +48,17 @@ class TestArc(unittest.TestCase):
         m = ConcreteModel()
         m.c1 = Arc([1, 2, 3])
         self.assertEqual(len(m.c1), 0)
-        self.assertIs(m.c1.type(), Arc)
+        self.assertIs(m.c1.ctype(), Arc)
 
         m = AbstractModel()
         m.c1 = Arc([1, 2, 3])
         self.assertEqual(len(m.c1), 0)
-        self.assertIs(m.c1.type(), Arc)
+        self.assertIs(m.c1.ctype(), Arc)
 
 
         inst = m.create_instance()
         self.assertEqual(len(m.c1), 0)
-        self.assertIs(m.c1.type(), Arc)
+        self.assertIs(m.c1.ctype(), Arc)
 
     def test_with_scalar_ports(self):
         def rule(m):
@@ -173,10 +173,10 @@ class TestArc(unittest.TestCase):
         m.prt2 = Port(m.s)
         m.c1 = Arc(m.s, rule=rule1)
         self.assertEqual(len(m.c1), 0)
-        self.assertIs(m.c1.type(), Arc)
+        self.assertIs(m.c1.ctype(), Arc)
         m.c2 = Arc(m.s, rule=rule2)
         self.assertEqual(len(m.c2), 0)
-        self.assertIs(m.c1.type(), Arc)
+        self.assertIs(m.c1.ctype(), Arc)
 
         inst = m.create_instance()
         self.assertEqual(len(inst.c1), 5)

--- a/pyomo/network/tests/test_arc.py
+++ b/pyomo/network/tests/test_arc.py
@@ -48,17 +48,17 @@ class TestArc(unittest.TestCase):
         m = ConcreteModel()
         m.c1 = Arc([1, 2, 3])
         self.assertEqual(len(m.c1), 0)
-        self.assertIs(m.c1.ctype(), Arc)
+        self.assertIs(m.c1.ctype, Arc)
 
         m = AbstractModel()
         m.c1 = Arc([1, 2, 3])
         self.assertEqual(len(m.c1), 0)
-        self.assertIs(m.c1.ctype(), Arc)
+        self.assertIs(m.c1.ctype, Arc)
 
 
         inst = m.create_instance()
         self.assertEqual(len(m.c1), 0)
-        self.assertIs(m.c1.ctype(), Arc)
+        self.assertIs(m.c1.ctype, Arc)
 
     def test_with_scalar_ports(self):
         def rule(m):
@@ -173,10 +173,10 @@ class TestArc(unittest.TestCase):
         m.prt2 = Port(m.s)
         m.c1 = Arc(m.s, rule=rule1)
         self.assertEqual(len(m.c1), 0)
-        self.assertIs(m.c1.ctype(), Arc)
+        self.assertIs(m.c1.ctype, Arc)
         m.c2 = Arc(m.s, rule=rule2)
         self.assertEqual(len(m.c2), 0)
-        self.assertIs(m.c1.ctype(), Arc)
+        self.assertIs(m.c1.ctype, Arc)
 
         inst = m.create_instance()
         self.assertEqual(len(inst.c1), 5)

--- a/pyomo/pysp/embeddedsp.py
+++ b/pyomo/pysp/embeddedsp.py
@@ -407,7 +407,7 @@ class EmbeddedSP(object):
         # remove the parent blocks from this map
         keys_to_delete = []
         for var in self.variable_symbols:
-            if var.parent_component().type() is not Var:
+            if var.parent_component().ctype() is not Var:
                 keys_to_delete.append(var)
         for key in keys_to_delete:
             del self.variable_symbols[key]

--- a/pyomo/pysp/embeddedsp.py
+++ b/pyomo/pysp/embeddedsp.py
@@ -407,7 +407,7 @@ class EmbeddedSP(object):
         # remove the parent blocks from this map
         keys_to_delete = []
         for var in self.variable_symbols:
-            if var.parent_component().ctype() is not Var:
+            if var.parent_component().ctype is not Var:
                 keys_to_delete.append(var)
         for key in keys_to_delete:
             del self.variable_symbols[key]

--- a/pyomo/pysp/plugins/ddextensionnew.py
+++ b/pyomo/pysp/plugins/ddextensionnew.py
@@ -620,7 +620,7 @@ class DDSIP_Input(object):
             stage_cost_component = \
                 self._reference_scenario_instance.\
                 find_component(cost_variable_name)
-            if stage_cost_component.ctype() is not Expression:
+            if stage_cost_component.ctype is not Expression:
                 LP_name = LP_byObject[id(stage_cost_component[cost_variable_index])]
                 assert LP_name not in self._FirstStageVars
                 if LP_name not in self._AllVars:
@@ -679,7 +679,7 @@ class DDSIP_Input(object):
                 stage_cost_component = \
                     self._reference_scenario_instance.\
                     find_component(cost_variable_name)
-                if stage_cost_component.ctype() is not Expression:
+                if stage_cost_component.ctype is not Expression:
                     cost_vars.add(stage_cost_component[cost_variable_index].name)
             print(("Number of Scenario Tree Cost Variables (found in ddsip LP file): "+str(len(cost_vars))))
             print ("writing cost_vars.dat")

--- a/pyomo/pysp/plugins/ddextensionnew.py
+++ b/pyomo/pysp/plugins/ddextensionnew.py
@@ -620,7 +620,7 @@ class DDSIP_Input(object):
             stage_cost_component = \
                 self._reference_scenario_instance.\
                 find_component(cost_variable_name)
-            if stage_cost_component.type() is not Expression:
+            if stage_cost_component.ctype() is not Expression:
                 LP_name = LP_byObject[id(stage_cost_component[cost_variable_index])]
                 assert LP_name not in self._FirstStageVars
                 if LP_name not in self._AllVars:
@@ -679,7 +679,7 @@ class DDSIP_Input(object):
                 stage_cost_component = \
                     self._reference_scenario_instance.\
                     find_component(cost_variable_name)
-                if stage_cost_component.type() is not Expression:
+                if stage_cost_component.ctype() is not Expression:
                     cost_vars.add(stage_cost_component[cost_variable_index].name)
             print(("Number of Scenario Tree Cost Variables (found in ddsip LP file): "+str(len(cost_vars))))
             print ("writing cost_vars.dat")

--- a/pyomo/pysp/plugins/ddextensionold.py
+++ b/pyomo/pysp/plugins/ddextensionold.py
@@ -277,7 +277,7 @@ class ddextension_base(object):
             stage_cost_component = \
                 self._reference_scenario_instance.\
                 find_component(cost_variable_name)
-            if stage_cost_component.ctype() is not Expression:
+            if stage_cost_component.ctype is not Expression:
                 LP_name = LP_byObject[id(stage_cost_component[cost_variable_index])]
                 assert LP_name not in self._FirstStageVars
                 if LP_name not in self._AllVars:
@@ -306,7 +306,7 @@ class ddextension_base(object):
                 stage_cost_component = \
                     self._reference_scenario_instance.\
                     find_component(cost_variable_name)
-                if stage_cost_component.ctype() is not Expression:
+                if stage_cost_component.ctype is not Expression:
                     cost_vars.add(stage_cost_component[cost_variable_index].name)
             print(("Number of Scenario Tree Variables (found ddsip LP file): "+str(len(tree_vars))))
             print(("Number of Scenario Tree Cost Variables (found ddsip LP file): "+str(len(cost_vars))))

--- a/pyomo/pysp/plugins/ddextensionold.py
+++ b/pyomo/pysp/plugins/ddextensionold.py
@@ -277,7 +277,7 @@ class ddextension_base(object):
             stage_cost_component = \
                 self._reference_scenario_instance.\
                 find_component(cost_variable_name)
-            if stage_cost_component.type() is not Expression:
+            if stage_cost_component.ctype() is not Expression:
                 LP_name = LP_byObject[id(stage_cost_component[cost_variable_index])]
                 assert LP_name not in self._FirstStageVars
                 if LP_name not in self._AllVars:
@@ -306,7 +306,7 @@ class ddextension_base(object):
                 stage_cost_component = \
                     self._reference_scenario_instance.\
                     find_component(cost_variable_name)
-                if stage_cost_component.type() is not Expression:
+                if stage_cost_component.ctype() is not Expression:
                     cost_vars.add(stage_cost_component[cost_variable_index].name)
             print(("Number of Scenario Tree Variables (found ddsip LP file): "+str(len(tree_vars))))
             print(("Number of Scenario Tree Cost Variables (found ddsip LP file): "+str(len(cost_vars))))

--- a/pyomo/pysp/scenariotree/tree_structure.py
+++ b/pyomo/pysp/scenariotree/tree_structure.py
@@ -283,8 +283,8 @@ class ScenarioTreeNode(object):
                        self._stage._name,
                        scenario_instance.name))
 
-            if component_object.type() is not Block:
-                isVar = (component_object.type() is Var)
+            if component_object.ctype() is not Block:
+                isVar = (component_object.ctype() is Var)
                 if not derived:
                     if not isVar:
                         raise RuntimeError("The component=%s "
@@ -297,8 +297,8 @@ class ScenarioTreeNode(object):
                                               type(component_object)))
                 else:
                     if (not isVar) and \
-                       (component_object.type() is not Expression) and \
-                       (component_object.type() is not Objective):
+                       (component_object.ctype() is not Expression) and \
+                       (component_object.ctype() is not Objective):
                         raise RuntimeError("The derived component=%s "
                                            "associated with stage=%s "
                                            "is present in instance=%s "
@@ -448,14 +448,14 @@ class ScenarioTreeNode(object):
                                  % (cost_variable_name,
                                     self._stage._name,
                                     scenario_instance.name))
-            if not cost_variable.type() in [Var,Expression,Objective]:
+            if not cost_variable.ctype() in [Var,Expression,Objective]:
                 raise RuntimeError("The component=%s associated with stage=%s "
                                    "is present in model=%s but is not a "
                                    "variable or expression - type=%s"
                                    % (cost_variable_name,
                                       self._stage._name,
                                       scenario_instance.name,
-                                      cost_variable.type()))
+                                      cost_variable.ctype()))
             if cost_variable_index not in cost_variable:
                 raise RuntimeError("The index %s is not defined for cost "
                                    "variable=%s on model=%s"

--- a/pyomo/pysp/scenariotree/tree_structure.py
+++ b/pyomo/pysp/scenariotree/tree_structure.py
@@ -283,8 +283,8 @@ class ScenarioTreeNode(object):
                        self._stage._name,
                        scenario_instance.name))
 
-            if component_object.ctype() is not Block:
-                isVar = (component_object.ctype() is Var)
+            if component_object.ctype is not Block:
+                isVar = (component_object.ctype is Var)
                 if not derived:
                     if not isVar:
                         raise RuntimeError("The component=%s "
@@ -297,8 +297,8 @@ class ScenarioTreeNode(object):
                                               type(component_object)))
                 else:
                     if (not isVar) and \
-                       (component_object.ctype() is not Expression) and \
-                       (component_object.ctype() is not Objective):
+                       (component_object.ctype is not Expression) and \
+                       (component_object.ctype is not Objective):
                         raise RuntimeError("The derived component=%s "
                                            "associated with stage=%s "
                                            "is present in instance=%s "
@@ -448,14 +448,14 @@ class ScenarioTreeNode(object):
                                  % (cost_variable_name,
                                     self._stage._name,
                                     scenario_instance.name))
-            if not cost_variable.ctype() in [Var,Expression,Objective]:
+            if not cost_variable.ctype in [Var,Expression,Objective]:
                 raise RuntimeError("The component=%s associated with stage=%s "
                                    "is present in model=%s but is not a "
                                    "variable or expression - type=%s"
                                    % (cost_variable_name,
                                       self._stage._name,
                                       scenario_instance.name,
-                                      cost_variable.ctype()))
+                                      cost_variable.ctype))
             if cost_variable_index not in cost_variable:
                 raise RuntimeError("The index %s is not defined for cost "
                                    "variable=%s on model=%s"

--- a/pyomo/repn/plugins/ampl/ampl_.py
+++ b/pyomo/repn/plugins/ampl/ampl_.py
@@ -1829,14 +1829,14 @@ class ProblemWriter_nl(AbstractProblemWriter):
             else:
                 _parent = v.parent_block()
                 while _parent is not None and _parent is not model:
-                    if _parent.ctype() is not model.type():
+                    if _parent.ctype is not model.type():
                         _errors.append(
                             "Variable '%s' exists within %s '%s', "
                             "but is used by an active "
                             "expression.  Currently variables "
                             "must be reachable through a tree "
                             "of active Blocks."
-                            % (v.name, _parent.ctype().__name__,
+                            % (v.name, _parent.ctype.__name__,
                                _parent.name))
                     if not _parent.active:
                         _errors.append(
@@ -1845,7 +1845,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
                             "an active expression.  Currently "
                             "variables must be reachable through "
                             "a tree of active Blocks."
-                            % (v.name, _parent.ctype().__name__,
+                            % (v.name, _parent.ctype.__name__,
                                _parent.name))
                     _parent = _parent.parent_block()
 

--- a/pyomo/repn/plugins/ampl/ampl_.py
+++ b/pyomo/repn/plugins/ampl/ampl_.py
@@ -1829,14 +1829,14 @@ class ProblemWriter_nl(AbstractProblemWriter):
             else:
                 _parent = v.parent_block()
                 while _parent is not None and _parent is not model:
-                    if _parent.type() is not model.type():
+                    if _parent.ctype() is not model.type():
                         _errors.append(
                             "Variable '%s' exists within %s '%s', "
                             "but is used by an active "
                             "expression.  Currently variables "
                             "must be reachable through a tree "
                             "of active Blocks."
-                            % (v.name, _parent.type().__name__,
+                            % (v.name, _parent.ctype().__name__,
                                _parent.name))
                     if not _parent.active:
                         _errors.append(
@@ -1845,7 +1845,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
                             "an active expression.  Currently "
                             "variables must be reachable through "
                             "a tree of active Blocks."
-                            % (v.name, _parent.type().__name__,
+                            % (v.name, _parent.ctype().__name__,
                                _parent.name))
                     _parent = _parent.parent_block()
 

--- a/pyomo/repn/plugins/baron_writer.py
+++ b/pyomo/repn/plugins/baron_writer.py
@@ -150,7 +150,7 @@ class ToBaronVisitor(EXPR.ExpressionValueVisitor):
             if isinstance(node, ICategorizedObject):
                 _ctype = node.ctype
             else:
-                _ctype = node.ctype()
+                _ctype = node.ctype
             if _ctype not in valid_expr_ctypes_minlp:
                 # Make sure all components in active constraints
                 # are basic ctypes we know how to deal with.

--- a/pyomo/repn/plugins/baron_writer.py
+++ b/pyomo/repn/plugins/baron_writer.py
@@ -147,10 +147,7 @@ class ToBaronVisitor(EXPR.ExpressionValueVisitor):
             return False, None
 
         if node.is_component_type():
-            if isinstance(node, ICategorizedObject):
-                _ctype = node.ctype
-            else:
-                _ctype = node.ctype
+            _ctype = node.ctype
             if _ctype not in valid_expr_ctypes_minlp:
                 # Make sure all components in active constraints
                 # are basic ctypes we know how to deal with.

--- a/pyomo/repn/plugins/baron_writer.py
+++ b/pyomo/repn/plugins/baron_writer.py
@@ -150,7 +150,7 @@ class ToBaronVisitor(EXPR.ExpressionValueVisitor):
             if isinstance(node, ICategorizedObject):
                 _ctype = node.ctype
             else:
-                _ctype = node.type()
+                _ctype = node.ctype()
             if _ctype not in valid_expr_ctypes_minlp:
                 # Make sure all components in active constraints
                 # are basic ctypes we know how to deal with.

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -160,7 +160,7 @@ class ToGamsVisitor(EXPR.ExpressionValueVisitor):
         if isinstance(comp, ICategorizedObject):
             return comp.ctype
         else:
-            return comp.ctype()
+            return comp.ctype
 
 
 def expression_to_string(expr, treechecker, labeler=None, smap=None):

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -134,15 +134,15 @@ class ToGamsVisitor(EXPR.ExpressionValueVisitor):
             return False, None
 
         if node.is_component_type():
-            if self.ctype(node) not in valid_expr_ctypes_minlp:
+            if node.ctype not in valid_expr_ctypes_minlp:
                 # Make sure all components in active constraints
                 # are basic ctypes we know how to deal with.
                 raise RuntimeError(
                     "Unallowable component '%s' of type %s found in an active "
                     "constraint or objective.\nThe GAMS writer cannot export "
                     "expressions with this component type."
-                    % (node.name, self.ctype(node).__name__))
-            if self.ctype(node) is not Var:
+                    % (node.name, node.ctype.__name__))
+            if node.ctype is not Var:
                 # For these, make sure it's on the right model. We can check
                 # Vars later since they don't disappear from the expressions
                 self.treechecker(node)
@@ -155,12 +155,6 @@ class ToGamsVisitor(EXPR.ExpressionValueVisitor):
                 return True, label
 
         return True, ftoa(value(node))
-
-    def ctype(self, comp):
-        if isinstance(comp, ICategorizedObject):
-            return comp.ctype
-        else:
-            return comp.ctype
 
 
 def expression_to_string(expr, treechecker, labeler=None, smap=None):

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -160,7 +160,7 @@ class ToGamsVisitor(EXPR.ExpressionValueVisitor):
         if isinstance(comp, ICategorizedObject):
             return comp.ctype
         else:
-            return comp.type()
+            return comp.ctype()
 
 
 def expression_to_string(expr, treechecker, labeler=None, smap=None):

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -466,9 +466,9 @@ class GAMSDirect(_GAMSSolver):
                 if obj.ctype is not IVariable:
                     continue
             else:
-                if obj.parent_component().type() is Objective:
+                if obj.parent_component().ctype() is Objective:
                     soln.objective[sym] = {'Value': objctvval}
-                if obj.parent_component().type() is not Var:
+                if obj.parent_component().ctype() is not Var:
                     continue
             rec = t1.out_db[sym].find_record()
             # obj.value = rec.level
@@ -939,9 +939,9 @@ class GAMSShell(_GAMSSolver):
                 if obj.ctype is not IVariable:
                     continue
             else:
-                if obj.parent_component().type() is Objective:
+                if obj.parent_component().ctype() is Objective:
                     soln.objective[sym] = {'Value': objctvval}
-                if obj.parent_component().type() is not Var:
+                if obj.parent_component().ctype() is not Var:
                     continue
             rec = model_soln[sym]
             # obj.value = float(rec[0])

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -466,9 +466,9 @@ class GAMSDirect(_GAMSSolver):
                 if obj.ctype is not IVariable:
                     continue
             else:
-                if obj.parent_component().ctype() is Objective:
+                if obj.parent_component().ctype is Objective:
                     soln.objective[sym] = {'Value': objctvval}
-                if obj.parent_component().ctype() is not Var:
+                if obj.parent_component().ctype is not Var:
                     continue
             rec = t1.out_db[sym].find_record()
             # obj.value = rec.level
@@ -939,9 +939,9 @@ class GAMSShell(_GAMSSolver):
                 if obj.ctype is not IVariable:
                     continue
             else:
-                if obj.parent_component().ctype() is Objective:
+                if obj.parent_component().ctype is Objective:
                     soln.objective[sym] = {'Value': objctvval}
-                if obj.parent_component().ctype() is not Var:
+                if obj.parent_component().ctype is not Var:
                     continue
             rec = model_soln[sym]
             # obj.value = float(rec[0])

--- a/pyomo/solvers/tests/core/test_component_perf.py
+++ b/pyomo/solvers/tests/core/test_component_perf.py
@@ -45,10 +45,10 @@ class ComponentPerformanceBase(object):
 
     def test_iteration(self):
         cnt = 0
-        for cdata in self.model.component_data_objects(self.model.test_component.ctype()):
+        for cdata in self.model.component_data_objects(self.model.test_component.ctype):
             cnt += 1
         self.assertTrue(cnt > 0)
-        if self.model.test_component.ctype() in (Set, Var):
+        if self.model.test_component.ctype in (Set, Var):
             self.assertEqual(cnt,
                              len(self.model.test_component) + 1)
         else:

--- a/pyomo/solvers/tests/core/test_component_perf.py
+++ b/pyomo/solvers/tests/core/test_component_perf.py
@@ -45,10 +45,10 @@ class ComponentPerformanceBase(object):
 
     def test_iteration(self):
         cnt = 0
-        for cdata in self.model.component_data_objects(self.model.test_component.type()):
+        for cdata in self.model.component_data_objects(self.model.test_component.ctype()):
             cnt += 1
         self.assertTrue(cnt > 0)
-        if self.model.test_component.type() in (Set, Var):
+        if self.model.test_component.ctype() in (Set, Var):
             self.assertEqual(cnt,
                              len(self.model.test_component) + 1)
         else:


### PR DESCRIPTION
## Fixes #613

## Summary/Motivation:
This renames the `Component.type()` method to be a `Component.ctype` property.  This change matches the development team's vernacular when describing that field, as well as its use in methods (like `component_data_objects()`).  The switch from method to property makes it consistent with the kernel implementation.

## Changes proposed in this PR:
- switch `Component.type()` (method) to `Component.ctype` (property)
- rename the internal `_type` attribute to `_ctype`
- remove the `type()` hack & test from kernel
- bugfix: rename Complementarity's use of `_type` to `_complementarity_type` for recording the standard form format
- (unrelated: switch a Component deprecation log message to use `pyomo.common.deprecation.deprecated`)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
