### PR TITLE
Bugfix: constructing empty sets with dimen>1

### DIFF
--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -416,6 +416,8 @@ class TuplizeValuesInitializer(InitializerBase):
 
         if not isinstance(_val, collections_Sequence):
             _val = tuple(_val)
+        if len(_val) == 0:
+            return _val
         if isinstance(_val[0], tuple):
             return _val
         return self._tuplize(_val, parent, index)

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -5877,4 +5877,4 @@ c : Size=3, Index=CHOICES, Active=True
         m.a = Set(initialize=a_rule, dimen=1)
         self.assertEqual(len(m.a), 0)
         m.b = Set(initialize=b_rule, dimen=2)
-        self.assertEqual(len(m.a), 0)
+        self.assertEqual(len(m.b), 0)

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -5862,3 +5862,19 @@ c : Size=3, Index=CHOICES, Active=True
 
         finally:
             normalize_index.flatten = _oldFlatten
+
+    def test_issue_1375(self):
+        def a_rule(m):
+            for i in range(0):
+                yield i
+
+        def b_rule(m):
+            for i in range(3):
+                for j in range(0):
+                    yield i, j
+
+        m = ConcreteModel()
+        m.a = Set(initialize=a_rule, dimen=1)
+        self.assertEqual(len(m.a), 0)
+        m.b = Set(initialize=b_rule, dimen=2)
+        self.assertEqual(len(m.a), 0)


### PR DESCRIPTION
## Fixes #1375

## Summary/Motivation:
This fixes a logic bug in `TuplizeValuesInitializer` when the incoming data is an empty list.

## Changes proposed in this PR:
- Catch initialization of multi-dimensional Sets from an empty list

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
