### PR TITLE
Add IDAES' Ipopt to Github Actions

### DIFF
--- a/.github/workflows/mpi_matrix_test.yml
+++ b/.github/workflows/mpi_matrix_test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - idaes_ipopt
   pull_request:
     branches:
       - master

--- a/.github/workflows/mpi_matrix_test.yml
+++ b/.github/workflows/mpi_matrix_test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - idaes_ipopt
   pull_request:
     branches:
       - master
@@ -50,6 +51,15 @@ jobs:
         echo "Install CPLEX Community Edition..."
         echo ""
         pip install cplex || echo "CPLEX Community Edition is not available for ${{ matrix.python-version }}"
+        echo ""
+        echo "Install IDAES Ipopt..."
+        echo ""
+        sudo apt-get install libopenblas-dev gfortran liblapack-dev
+        mkdir ipopt && cd ipopt
+        wget -q https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-solvers-ubuntu1804-64.tar.gz -O ipopt.tar.gz
+        tar -xzf ipopt.tar.gz
+        cd ..
+        export PATH=$PATH:$(pwd)/ipopt
         echo ""
         echo "Install GAMS..."
         echo ""

--- a/.github/workflows/mpi_matrix_test.yml
+++ b/.github/workflows/mpi_matrix_test.yml
@@ -35,7 +35,7 @@ jobs:
         echo ""
         echo "Install conda packages"
         echo ""
-        conda install mpi4py ipopt
+        conda install mpi4py
         echo ""
         echo "Upgrade pip..."
         echo ""

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -28,17 +28,27 @@ jobs:
         echo ""
         echo "Install Pyomo dependencies..."
         echo ""
-        pip install cython numpy scipy ipython openpyxl sympy pyyaml pyodbc networkx xlrd pandas matplotlib dill seaborn pymysql pyro4 pint pathos
+        pip install cython numpy scipy ipython openpyxl sympy pyyaml pyodbc networkx xlrd pandas matplotlib dill seaborn pymysql pyro4 pint pathos nose
         echo ""
         echo "Install CPLEX Community Edition..."
         echo ""
         pip install cplex || echo "CPLEX Community Edition is not available for ${{ matrix.python-version }}"
+        echo ""
+        echo "Install IDAES Ipopt..."
+        echo ""
+        sudo apt-get install libopenblas-dev gfortran liblapack-dev
+        mkdir ipopt && cd ipopt
+        wget -q https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-solvers-ubuntu1804-64.tar.gz -O ipopt.tar.gz
+        tar -xzf ipopt.tar.gz
+        cd ..
+        export PATH=$PATH:$(pwd)/ipopt
         echo ""
         echo "Install GAMS..."
         echo ""
         wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0/linux/linux_x64_64_sfx.exe -O gams_installer.exe
         chmod +x gams_installer.exe
         ./gams_installer.exe -q -d gams
+        GAMS_DIR=`ls -d1 $(pwd)/gams/*/ | head -1`
         cd gams/*/apifiles/Python/
         py_ver=$(python -c 'import sys;print("%s%s" % sys.version_info[:2])')
         gams_ver=api
@@ -49,6 +59,14 @@ jobs:
         done
         cd $gams_ver
         python setup.py -q install -noCheck
+        export PATH=$PATH:$GAMS_DIR
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GAMS_DIR
+        echo ""
+        echo "Pass key environment variables to subsequent steps"
+        echo ""
+        echo "::set-env name=PATH::$PATH"
+        echo "::set-env name=LD_LIBRARY_PATH::$LD_LIBRARY_PATH"
+
     - name: Install Pyomo and extensions
       run: |
         echo "Clone Pyomo-model-libraries..."
@@ -69,8 +87,4 @@ jobs:
     - name: Run nightly tests with test.pyomo
       run: |
         echo "Run test.pyomo..."
-        GAMS_DIR=`ls -d1 $(pwd)/gams/*/ | head -1`
-        export PATH=$PATH:$GAMS_DIR
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GAMS_DIR
-        pip install nose
         test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -62,6 +62,7 @@ jobs:
         echo "Install IDAES Ipopt (Linux only)..."
         echo ""
         if [ ${{ matrix.TARGET }} == 'linux' ]; then
+            sudo apt-get install gfortran
             mkdir ipopt && cd ipopt
             wget -q https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-solvers-ubuntu1804-64.tar.gz -O ipopt.tar.gz
             tar -xzf ipopt.tar.gz

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -62,14 +62,13 @@ jobs:
         echo "Install IDAES Ipopt (Linux only)..."
         echo ""
         if [ ${{ matrix.TARGET }} == 'linux' ]; then
-            CWD=$(pwd)
+            sudo apt-get install libopenblas-dev gfortran liblapack-dev
             mkdir ipopt && cd ipopt
-            wget -q https://github.com/IDAES/idaes-ext/archive/2.0.0.tar.gz -O ipopt.tar.gz
-            tar -xzf ipopt.tar.gz && cd idaes-ext-2.0.0
-            bash scripts/compile_solvers.sh
-            bash scripts/compile_libs.sh
-            cd CWD
-            export PATH=$PATH:$(pwd)/ipopt/idaes-ext-2.0.0
+            wget -q https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-solvers-ubuntu1804-64.tar.gz -O ipopt.tar.gz
+            tar -xzf ipopt.tar.gz
+            cd ..
+            export PATH=$PATH:$(pwd)/ipopt
+            ipopt -v
         fi
         echo ""
         echo "Install GAMS..."

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -62,12 +62,14 @@ jobs:
         echo "Install IDAES Ipopt (Linux only)..."
         echo ""
         if [ ${{ matrix.TARGET }} == 'linux' ]; then
-            sudo apt-get install gfortran
+            CWD=$(pwd)
             mkdir ipopt && cd ipopt
-            wget -q https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-solvers-ubuntu1804-64.tar.gz -O ipopt.tar.gz
-            tar -xzf ipopt.tar.gz
-            cd ..
-            export PATH=$PATH:$(pwd)/ipopt
+            wget -q https://github.com/IDAES/idaes-ext/archive/2.0.0.tar.gz -O ipopt.tar.gz
+            tar -xzf ipopt.tar.gz && cd idaes-ext-2.0.0
+            bash scripts/compile_solvers.sh
+            bash scripts/compile_libs.sh
+            cd CWD
+            export PATH=$PATH:$(pwd)/ipopt/idaes-ext-2.0.0
         fi
         echo ""
         echo "Install GAMS..."

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - idaes_ipopt
   pull_request:
     branches:
       - master
@@ -57,6 +58,16 @@ jobs:
         echo "Install CPLEX Community Edition..."
         echo ""
         pip install cplex || echo "CPLEX Community Edition is not available for ${{ matrix.python-version }}"
+        echo ""
+        echo "Install IDAES Ipopt (Linux only)..."
+        echo ""
+        if [ ${{ matrix.TARGET }} == 'linux' ]; then
+            mkdir ipopt && cd ipopt
+            wget -q https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-solvers-ubuntu1804-64.tar.gz -O ipopt.tar.gz
+            tar -xzf ipopt.tar.gz
+            cd ..
+            export PATH=$PATH:$(pwd)/ipopt
+        fi
         echo ""
         echo "Install GAMS..."
         echo ""

--- a/.github/workflows/unix_python_matrix_test.yml
+++ b/.github/workflows/unix_python_matrix_test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - idaes_ipopt
   pull_request:
     branches:
       - master
@@ -68,7 +67,6 @@ jobs:
             tar -xzf ipopt.tar.gz
             cd ..
             export PATH=$PATH:$(pwd)/ipopt
-            ipopt -v
         fi
         echo ""
         echo "Install GAMS..."

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -87,8 +87,8 @@ jobs:
         Write-Host ("")
         Write-Host ("Installing IDAES Ipopt")
         Write-Host ("")
-        New-Item -Path . -Name "ipopt" -ItemType "directory"
-        cd ipopt
+        New-Item -Path . -Name "solver_dir" -ItemType "directory"
+        cd solver_dir
         Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-solvers-windows-64.tar.gz' -OutFile 'ipopt1.tar.gz'
         Invoke-Expression 'tar -xzf ipopt1.tar.gz'
         Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-lib-windows-64.tar.gz' -OutFile 'ipopt2.tar.gz'
@@ -148,6 +148,6 @@ jobs:
         Write-Host "Setup and run nosetests"
         $env:BUILD_DIR = $(Get-Location).Path
         $env:PATH += ';' + $(Get-Location).Path + "\gams"
-        $env:PATH += ';' + $(Get-Location).Path + "\ipopt"
+        $env:PATH += ';' + $(Get-Location).Path + "\solver_dir"
         $env:EXP = "test.pyomo -v --cat='nightly' pyomo " + $env:BUILD_DIR + "\pyomo-model-libraries"
         Invoke-Expression $env:EXP

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -1,9 +1,6 @@
 name: GitHub CI (win)
 
 on:
-  push:
-    branches:
-      - idaes_ipopt
   pull_request:
     branches:
       - master

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -149,6 +149,5 @@ jobs:
         $env:BUILD_DIR = $(Get-Location).Path
         $env:PATH += ';' + $(Get-Location).Path + "\gams"
         $env:PATH += ';' + $(Get-Location).Path + "\ipopt"
-        Invoke-Expression 'ipopt.exe -v'
-        #$env:EXP = "test.pyomo -v --cat='nightly' pyomo " + $env:BUILD_DIR + "\pyomo-model-libraries"
-        #Invoke-Expression $env:EXP
+        $env:EXP = "test.pyomo -v --cat='nightly' pyomo " + $env:BUILD_DIR + "\pyomo-model-libraries"
+        Invoke-Expression $env:EXP

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -1,6 +1,9 @@
 name: GitHub CI (win)
 
 on:
+  push:
+    branches:
+      - idaes_ipopt
   pull_request:
     branches:
       - master
@@ -45,8 +48,9 @@ jobs:
         $env:MINICONDA_EXTRAS=""
         $env:MINICONDA_EXTRAS="numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill seaborn "
         $env:ADDITIONAL_CF_PKGS=$env:ADDITIONAL_CF_PKGS + "pymysql pyro4 pint pathos " + $env:MINICONDA_EXTRAS
-        $env:ADDITIONAL_CF_PKGS=$env:ADDITIONAL_CF_PKGS + " glpk ipopt"
+        $env:ADDITIONAL_CF_PKGS=$env:ADDITIONAL_CF_PKGS + " glpk "
         $env:EXP = $env:CONDAFORGE + $env:ADDITIONAL_CF_PKGS
+        Invoke-Expression $env:EXP
         $env:CPLEX = $env:CONDAFORGE + "-c ibmdecisionoptimization cplex=12.10"
         Write-Host ("")
         Write-Host ("Try to install CPLEX...")
@@ -63,7 +67,6 @@ jobs:
             conda deactivate
             conda activate test
         }
-        Invoke-Expression $env:EXP
         $env:PYNUMERO = $env:CONDAFORGE + " pynumero_libraries"
         Write-Host ("")
         Write-Host ("Try to install Pynumero_libraries...")
@@ -81,6 +84,14 @@ jobs:
             conda activate test 
         }
         conda list --show-channel-urls
+        Write-Host ("")
+        Write-Host ("Installing IDAES Ipopt")
+        Write-Host ("")
+        New-Item -Path . -Name "ipopt" -ItemType "directory"
+        cd ipopt
+        Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-solvers-windows-64.tar.gz' -OutFile 'ipopt.tar.gz'
+        Invoke-Expression 'tar -xzf ipopt.tar.gz'
+        cd ..
         Write-Host ("")
         Write-Host ("Installing GAMS")
         Write-Host ("")
@@ -116,26 +127,12 @@ jobs:
         git clone --quiet https://github.com/Pyomo/pyomo-model-libraries.git
         git clone --quiet https://github.com/PyUtilib/pyutilib.git
         cd pyutilib
-        try
-        {
-            python3 setup.py develop
-        }
-        catch
-        {
-            python setup.py develop
-        }
+        python setup.py develop
         cd ..
         Write-Host ("")
         Write-Host ("Install Pyomo...")
         Write-Host ("")
-        try
-        {
-            python3 setup.py develop
-        }
-        catch
-        {
-            python setup.py develop
-        }
+        python setup.py develop
         Write-Host ("")
         Write-Host "Pyomo download-extensions"
         Write-Host ("")
@@ -148,5 +145,6 @@ jobs:
         Write-Host "Setup and run nosetests"
         $env:BUILD_DIR = $(Get-Location).Path
         $env:PATH += ';' + $(Get-Location).Path + "\gams"
+        $env:PATH += ';' + $(Get-Location).Path + "\ipopt"
         $env:EXP = "test.pyomo -v --cat='nightly' pyomo " + $env:BUILD_DIR + "\pyomo-model-libraries"
         Invoke-Expression $env:EXP

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -92,8 +92,8 @@ jobs:
         $env:CWD=$(pwd)
         cd .\ipopt\idaes-ext-2.0.0\scripts
         pwd
-        Invoke-Expression '.\compile_libs.sh'
-        Invoke-Expression '.\compile_solvers.sh'
+        bash compile_libs.sh
+        bash compile_solvers.sh
         ls
         cd $env:CWD
         Write-Host ("")

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -89,11 +89,10 @@ jobs:
         Write-Host ("")
         Write-Host ("Installing IDAES Ipopt")
         Write-Host ("")
-        New-Item -Path . -Name "ipopt" -ItemType "directory"
-        cd ipopt
-        Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-solvers-windows-64.tar.gz' -OutFile 'ipopt.tar.gz'
-        Invoke-Expression 'tar -xzf ipopt.tar.gz'
-        cd ..
+        Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/archive/2.0.0.zip' -OutFile 'ipopt.zip'
+        Expand-Archive 'ipopt.zip'
+        $env:PATH += ';' + $(Get-Location).Path + "\ipopt"
+        ipopt -v
         Write-Host ("")
         Write-Host ("Installing GAMS")
         Write-Host ("")

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -89,10 +89,13 @@ jobs:
         Write-Host ("")
         Write-Host ("Installing IDAES Ipopt")
         Write-Host ("")
-        Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/archive/2.0.0.zip' -OutFile 'ipopt.zip'
-        Expand-Archive 'ipopt.zip'
-        $env:PATH += ';' + $(Get-Location).Path + "\ipopt"
-        ipopt -v
+        New-Item -Path . -Name "ipopt" -ItemType "directory"
+        cd ipopt
+        Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-solvers-windows-64.tar.gz' -OutFile 'ipopt.tar.gz'
+        Invoke-Expression 'tar -xzf ipopt.tar.gz'
+        Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-lib-windows-64.tar.gz' -OutFile 'ipopt.tar.gz'
+        Invoke-Expression 'tar -xzf ipopt.tar.gz'
+        cd ..
         Write-Host ("")
         Write-Host ("Installing GAMS")
         Write-Host ("")

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -91,10 +91,10 @@ jobs:
         Write-Host ("")
         New-Item -Path . -Name "ipopt" -ItemType "directory"
         cd ipopt
-        Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-solvers-windows-64.tar.gz' -OutFile 'ipopt.tar.gz'
-        Invoke-Expression 'tar -xzf ipopt.tar.gz'
-        Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-lib-windows-64.tar.gz' -OutFile 'ipopt.tar.gz'
-        Invoke-Expression 'tar -xzf ipopt.tar.gz'
+        Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-solvers-windows-64.tar.gz' -OutFile 'ipopt1.tar.gz'
+        Invoke-Expression 'tar -xzf ipopt1.tar.gz'
+        Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-lib-windows-64.tar.gz' -OutFile 'ipopt2.tar.gz'
+        Invoke-Expression 'tar -xzf ipopt2.tar.gz'
         cd ..
         Write-Host ("")
         Write-Host ("Installing GAMS")

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -3,7 +3,7 @@ name: GitHub CI (win)
 on:
   push:
     branches:
-      - idaes_ipopts
+      - idaes_ipopt
   pull_request:
     branches:
       - master
@@ -46,11 +46,13 @@ jobs:
         $env:USING_MINICONDA = 1
         $env:ADDITIONAL_CF_PKGS="setuptools pip coverage sphinx_rtd_theme "
         $env:MINICONDA_EXTRAS=""
-        $env:MINICONDA_EXTRAS="numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill seaborn "
+        $env:MINICONDA_EXTRAS="numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill seaborn lapack blas "
         $env:ADDITIONAL_CF_PKGS=$env:ADDITIONAL_CF_PKGS + "pymysql pyro4 pint pathos " + $env:MINICONDA_EXTRAS
         $env:ADDITIONAL_CF_PKGS=$env:ADDITIONAL_CF_PKGS + " glpk "
         $env:EXP = $env:CONDAFORGE + $env:ADDITIONAL_CF_PKGS
         Invoke-Expression $env:EXP
+        $env:GFORT = $env:CONDAFORGE + "-c msys2 m2w64-gcc-fortran"
+        Invoke-Expression $env:GFORT
         $env:CPLEX = $env:CONDAFORGE + "-c ibmdecisionoptimization cplex=12.10"
         Write-Host ("")
         Write-Host ("Try to install CPLEX...")
@@ -87,15 +89,11 @@ jobs:
         Write-Host ("")
         Write-Host ("Installing IDAES Ipopt")
         Write-Host ("")
-        Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/archive/2.0.0.zip' -OutFile 'ipopt.zip'
-        Expand-Archive ipopt.zip
-        $env:CWD=$(pwd)
-        cd .\ipopt\idaes-ext-2.0.0\scripts
-        pwd
-        bash compile_libs.sh
-        bash compile_solvers.sh
-        ls
-        cd $env:CWD
+        New-Item -Path . -Name "ipopt" -ItemType "directory"
+        cd ipopt
+        Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-solvers-windows-64.tar.gz' -OutFile 'ipopt.tar.gz'
+        Invoke-Expression 'tar -xzf ipopt.tar.gz'
+        cd ..
         Write-Host ("")
         Write-Host ("Installing GAMS")
         Write-Host ("")

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -89,9 +89,13 @@ jobs:
         Write-Host ("")
         Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/archive/2.0.0.zip' -OutFile 'ipopt.zip'
         Expand-Archive ipopt.zip
+        $env:CWD=$(pwd)
         cd .\ipopt\idaes-ext-2.0.0\scripts
+        pwd
         Invoke-Expression '.\compile_libs.sh'
         Invoke-Expression '.\compile_solvers.sh'
+        ls
+        cd $env:CWD
         Write-Host ("")
         Write-Host ("Installing GAMS")
         Write-Host ("")
@@ -114,6 +118,7 @@ jobs:
           Write-Host ("WARNING: Python ${{matrix.python-version}}: GAMS Bindings not supported.")
           Write-Host ("########################################################################")
         }
+        cd $env:CWD
         Write-Host ("")
         Write-Host ("New Shell Environment: ")
         gci env: | Sort Name

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -87,11 +87,11 @@ jobs:
         Write-Host ("")
         Write-Host ("Installing IDAES Ipopt")
         Write-Host ("")
-        New-Item -Path . -Name "ipopt" -ItemType "directory"
-        cd ipopt
-        Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-solvers-windows-64.tar.gz' -OutFile 'ipopt.tar.gz'
-        Invoke-Expression 'tar -xzf ipopt.tar.gz'
-        cd ..
+        Invoke-WebRequest -Uri 'https://github.com/IDAES/idaes-ext/archive/2.0.0.zip' -OutFile 'ipopt.zip'
+        Expand-Archive ipopt.zip
+        cd .\ipopt\idaes-ext-2.0.0\scripts
+        Invoke-Expression '.\compile_libs.sh'
+        Invoke-Expression '.\compile_solvers.sh'
         Write-Host ("")
         Write-Host ("Installing GAMS")
         Write-Host ("")
@@ -146,5 +146,6 @@ jobs:
         $env:BUILD_DIR = $(Get-Location).Path
         $env:PATH += ';' + $(Get-Location).Path + "\gams"
         $env:PATH += ';' + $(Get-Location).Path + "\ipopt"
-        $env:EXP = "test.pyomo -v --cat='nightly' pyomo " + $env:BUILD_DIR + "\pyomo-model-libraries"
-        Invoke-Expression $env:EXP
+        Invoke-Expression 'ipopt.exe -v'
+        #$env:EXP = "test.pyomo -v --cat='nightly' pyomo " + $env:BUILD_DIR + "\pyomo-model-libraries"
+        #Invoke-Expression $env:EXP

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -46,13 +46,11 @@ jobs:
         $env:USING_MINICONDA = 1
         $env:ADDITIONAL_CF_PKGS="setuptools pip coverage sphinx_rtd_theme "
         $env:MINICONDA_EXTRAS=""
-        $env:MINICONDA_EXTRAS="numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill seaborn lapack blas "
+        $env:MINICONDA_EXTRAS="numpy scipy ipython openpyxl sympy pyodbc pyyaml networkx xlrd pandas matplotlib dill seaborn  "
         $env:ADDITIONAL_CF_PKGS=$env:ADDITIONAL_CF_PKGS + "pymysql pyro4 pint pathos " + $env:MINICONDA_EXTRAS
         $env:ADDITIONAL_CF_PKGS=$env:ADDITIONAL_CF_PKGS + " glpk "
         $env:EXP = $env:CONDAFORGE + $env:ADDITIONAL_CF_PKGS
         Invoke-Expression $env:EXP
-        $env:GFORT = $env:CONDAFORGE + "-c msys2 m2w64-gcc-fortran"
-        Invoke-Expression $env:GFORT
         $env:CPLEX = $env:CONDAFORGE + "-c ibmdecisionoptimization cplex=12.10"
         Write-Host ("")
         Write-Host ("Try to install CPLEX...")

--- a/.github/workflows/win_python_matrix_test.yml
+++ b/.github/workflows/win_python_matrix_test.yml
@@ -3,7 +3,7 @@ name: GitHub CI (win)
 on:
   push:
     branches:
-      - idaes_ipopt
+      - idaes_ipopts
   pull_request:
     branches:
       - master


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
IDAES' Ipopt is necessary to get tests passing for #1363 . Ipopt was not being represented in a majority of the Github Actions tests, so this is added to those that are missing and replaces those that already had it. (**NOTE**: There is no IDAES Ipopt for OSX)

## Changes proposed in this PR:
- Add IDAES Ipopt to Linux tests
- Change Windows from conda Ipopt to IDAES Ipopt 

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
