### PR TITLE
Adding IDAES' ipopt to Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -185,6 +185,10 @@ install:
   - "ipopt -v"
   - python --version
 
+
+  # Debugging Appveyor
+  - nosetests -v --nocapture pyomo.core.tests.unit.test_external
+
 build: off
 
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -115,7 +115,7 @@ install:
   #
   # Finally, add any solvers we want to the list
   #
-  - "SET ADDITIONAL_CF_PKGS=%ADDITIONAL_CF_PKGS% glpk ipopt"
+  - "SET ADDITIONAL_CF_PKGS=%ADDITIONAL_CF_PKGS% glpk "
   #
   # ...and install everything from conda-force in one go
   #
@@ -129,6 +129,17 @@ install:
   - "python -m pip install --upgrade pip"
   - "%PIP% --version"
   - "%PIP% install codecov"
+  #
+  # Install IDAES' Ipopt
+  #
+  - MKDIR idaes_ipopt
+  - cd idaes_ipopt
+  - ps: Start-FileDownload 'https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-solvers-windows-64.tar.gz'
+  - "tar -xzf idaes-solvers-windows-64.tar.gz"
+  - ps: Start-FileDownload 'https://github.com/IDAES/idaes-ext/releases/download/2.0.0/idaes-lib-windows-64.tar.gz'
+  - "tar -xzf idaes-lib-windows-64.tar.gz"
+  - cd ..
+  - "SET PATH=%cd%\\idaes_ipopt;%PATH%"
   #
   # Install GAMS
   #

--- a/pyomo/core/tests/unit/test_external.py
+++ b/pyomo/core/tests/unit/test_external.py
@@ -127,6 +127,7 @@ class TestAMPLExternalFunction(unittest.TestCase):
         DLL = find_GSL()
         if not DLL:
             self.skipTest("Could not find the amplgsl.dll library")
+        print(DLL)
         model = ConcreteModel()
         model.z_func = ExternalFunction(library=DLL, function="gsl_sf_gamma")
         model.x = Var(initialize=3, bounds=(1e-5,None))


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
This replaces the current version of Ipopt on Appveyor with IDAES' Ipopt. This addresses an issue with #1363 .

## Changes proposed in this PR:
- Replace generic Ipopt with IDAES' Ipopt

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
