### PR TITLE
Improve error reporting from GAMS solver

### DIFF
--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -177,6 +177,7 @@ if test -z "$MODE" -o "$MODE" == test; then
         # Note, that the PWD should still be $WORKSPACE/pyomo
         #
         coverage combine || exit 1
+        coverage report -i
         export OS=`uname`
         if test -z "$CODECOV_TOKEN"; then
             coverage xml

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -744,13 +744,18 @@ class GAMSShell(_GAMSSolver):
                 print("\nGAMS WORKING DIRECTORY: %s\n" % tmpdir)
 
             if rc == 1 or rc == 127:
-                raise RuntimeError("Command 'gams' was not recognized")
+                raise IOError("Command 'gams' was not recognized")
             elif rc != 0:
                 if rc == 3:
                     # Execution Error
                     # Run check_expr_evaluation, which errors if necessary
                     check_expr_evaluation(model, symbolMap, 'shell')
                 # If nothing was raised, or for all other cases, raise this
+                logger.error("GAMS encountered an error during solve. "
+                             "Check listing file for details.")
+                logger.error("GAMS OUTPUT:\n\n%s" % (_,))
+                with open(lst_filename, 'r') as FILE:
+                    logger.error("GAMS LISTING:\n\n%s" % (FILE.read(),))
                 raise RuntimeError("GAMS encountered an error during solve. "
                                    "Check listing file for details.")
 

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -738,7 +738,7 @@ class GAMSShell(_GAMSSolver):
             command.append("lf=" + str(logfile))
 
         try:
-            rc, _ = pyutilib.subprocess.run(command, tee=tee)
+            rc, txt = pyutilib.subprocess.run(command, tee=tee)
 
             if keepfiles:
                 print("\nGAMS WORKING DIRECTORY: %s\n" % tmpdir)
@@ -753,7 +753,7 @@ class GAMSShell(_GAMSSolver):
                 # If nothing was raised, or for all other cases, raise this
                 logger.error("GAMS encountered an error during solve. "
                              "Check listing file for details.")
-                logger.error(_)
+                logger.error(txt)
                 if os.path.exists(lst_filename):
                     with open(lst_filename, 'r') as FILE:
                         logger.error(

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -753,9 +753,11 @@ class GAMSShell(_GAMSSolver):
                 # If nothing was raised, or for all other cases, raise this
                 logger.error("GAMS encountered an error during solve. "
                              "Check listing file for details.")
-                logger.error("GAMS OUTPUT:\n\n%s" % (_,))
-                with open(lst_filename, 'r') as FILE:
-                    logger.error("GAMS LISTING:\n\n%s" % (FILE.read(),))
+                logger.error(_)
+                if os.path.exists(lst_filename):
+                    with open(lst_filename, 'r') as FILE:
+                        logger.error(
+                            "GAMS Listing file:\n\n%s" % (FILE.read(),))
                 raise RuntimeError("GAMS encountered an error during solve. "
                                    "Check listing file for details.")
 

--- a/pyomo/solvers/tests/checks/test_GAMS.py
+++ b/pyomo/solvers/tests/checks/test_GAMS.py
@@ -339,9 +339,11 @@ class GAMSLogfileTestBase(unittest.TestCase):
         self.assertTrue(os.path.exists(self.logfile))
         with open(self.logfile) as f:
             logfile_contents = f.read()
+            print("LOGFILE:\n%s" % (logfile_contents,))
         self.assertIn(self.characteristic_output_string, logfile_contents)
 
     def _check_stdout(self, output_string, exists=True):
+        print("STDOUT:\n%s" % (output_string,))
         if exists:
             # Starting Compilation is outputted by the solver itself which in this
             # case should be printed to stdout and captured

--- a/pyomo/solvers/tests/checks/test_GAMS.py
+++ b/pyomo/solvers/tests/checks/test_GAMS.py
@@ -339,11 +339,9 @@ class GAMSLogfileTestBase(unittest.TestCase):
         self.assertTrue(os.path.exists(self.logfile))
         with open(self.logfile) as f:
             logfile_contents = f.read()
-            print("LOGFILE:\n%s" % (logfile_contents,))
         self.assertIn(self.characteristic_output_string, logfile_contents)
 
     def _check_stdout(self, output_string, exists=True):
-        print("STDOUT:\n%s" % (output_string,))
         if exists:
             # Starting Compilation is outputted by the solver itself which in this
             # case should be printed to stdout and captured


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
When debugging problems with the GAMS 29.1.0 installation in the Travis docket images, I ran across cases where the GAMS solver was swallowing import error information from GAMS.  This PR passes that error information to the user through the Pyomo logger.

## Changes proposed in this PR:
- Pass error messages from GAMS on through the pyomo logger.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
