### PR TITLE
Correct typo in relax_integrality deprecation warning

### DIFF
--- a/pyomo/core/plugins/transform/relax_integrality.py
+++ b/pyomo/core/plugins/transform/relax_integrality.py
@@ -23,7 +23,7 @@ class RelaxIntegrality(RelaxIntegerVars):
     """
 
     @deprecated(
-        "core.relax_integrality is deprecated.  Use core.relax_integers",
+        "core.relax_integrality is deprecated.  Use core.relax_integer_vars",
         version='TBD')
     def __init__(self, **kwds):
         super(RelaxIntegrality, self).__init__(**kwds)


### PR DESCRIPTION
## Fixes #1383

## Summary/Motivation:
This corrects the deprecation warning for the `core.relax_integrality` transformation to refer to the correct transformation.

## Changes proposed in this PR:
- Update deprecation message

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
