### PR TITLE
[WIP] Switch TransformationFactory to return an "UnknownTransformation" object

### DIFF
--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -47,7 +47,9 @@ from pyomo.core.base.numvalue import *
 from pyomo.core.base.block import SimpleBlock
 from pyomo.core.base.set import Set, UnknownSetDimen
 from pyomo.core.base.component import Component, ComponentUID
-from pyomo.core.base.plugin import ModelComponentFactory, TransformationFactory
+from pyomo.core.base.plugin import (
+    ModelComponentFactory, TransformationFactory, UnknownTransformation,
+)
 from pyomo.core.base.label import CNameLabeler, CuidLabeler
 
 import pyomo.opt
@@ -933,7 +935,7 @@ TransformationFactory('%s').apply_to(model) to directly apply the
 transformation to the model instance.""" % (name,name,) )
 
         xfrm = TransformationFactory(name)
-        if xfrm is None:
+        if type(xfrm) is UnknownTransformation:
             raise ValueError("Unknown model transformation '%s'" % name)
         return xfrm.apply_to(self, **kwds)
 

--- a/pyomo/core/tests/unit/test_transformation.py
+++ b/pyomo/core/tests/unit/test_transformation.py
@@ -1,0 +1,47 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import pyutilib.th as unittest
+
+from pyomo.core.base.plugin import UnknownTransformation
+from pyomo.core.plugins.transform.discrete_vars import RelaxIntegerVars
+from pyomo.environ import TransformationFactory, ConcreteModel
+
+class TestTransformationFactory(unittest.TestCase):
+    def test_existing_solver(self):
+        xfrm = TransformationFactory('core.relax_integer_vars')
+        self.assertIs(type(xfrm), RelaxIntegerVars)
+
+    def test_unknown_solver(self):
+        m = ConcreteModel()
+        xfrm = TransformationFactory('core.__bad_transform')
+        self.assertIs(type(xfrm), UnknownTransformation)
+        with self.assertRaisesRegex(
+                RuntimeError,
+                '(?s)Attempting to use an unavailable transformation'
+                '.*unable to create "core.__bad_transform"'
+                '.*by calling method "apply".*{}'):
+            xfrm.apply(m)
+
+        with self.assertRaisesRegex(
+                RuntimeError,
+                '(?s)Attempting to use an unavailable transformation'
+                '.*unable to create "core.__bad_transform"'
+                '.*by calling method "apply_to".*{}'):
+            xfrm.apply_to(m)
+
+        xfrm = TransformationFactory('core.__bad_transform', mykwd='a val')
+        with self.assertRaisesRegex(
+                RuntimeError,
+                '(?s)Attempting to use an unavailable transformation'
+                '.*unable to create "core.__bad_transform"'
+                '.*by calling method "create_using"'
+                ".*mykwd: 'a val'"):
+            xfrm.create_using(m)


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
In #1383 @qtothec asked if we could return a more helpful return value from `TransformationFactory()` when the requested transformation was not found.  Currently, the Factory returns `None` for unknown transformations, and it is the responsibility of the user to check that before attempting to apply the transformation.  As users typically do not bother with the check, they end up getting less informative errors like:
```
AttributeError: 'NoneType' object has no attribute 'apply_to'
```

This changes the behavior of the TransformationFactory singleton to follow the pattern established by the `SolverFactory` and return an `UnknownTransformation` object instead of `None` when the factory doesn't have a registered matching transformation.  The `UnknownTransformation` instance implements the Transformation API, with public methods that raise errors like:
```
Attempting to use an unavailable transformation.

The TransformationFactory was unable to create "core._bad_transformation"
and returned an UnknownTransformation object.  This error is raised at
the point where the UnknownTransformation object was used as if it were
valid (by calling method "apply_to").

The original transformation was created with the following arguments:
        {}
```

Open design questions
- Should the Transformation API implement an `available()` method so that users can query if the transformation object returned by the factory is available / valid to use (right know, users need to know to import the `UnknownTransformation` clsas and compare types)?
- Should we extend *both* the Transformation and Solver APIs to incluse a `valid()` method to help distinguish between valid, but unavailable solvers/transformations (e.g., the solver is not installed), and invalid solvers/transformations (i.e., nothing is registered under that name)?
- Should the Factories (solver and transformation) raise exceptions for unregistered names?  Users who want to avoid the exception should either use try-except blocks or else check the name first, e.g.:
   ```python
   if name in TransformationFactory:
      TransformationFactory(name).apply_to(model)
   ```

## Changes proposed in this PR:
- return `UnknownTransformation` instance from `TransformationFactory` when the requested name is not registered.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
