### PR TITLE
Fix Constraint Tightener `TransformationFactory`

### DIFF
--- a/pyomo/contrib/preprocessing/plugins/constraint_tightener.py
+++ b/pyomo/contrib/preprocessing/plugins/constraint_tightener.py
@@ -1,5 +1,6 @@
 import logging
-import textwrap
+
+from six.moves import zip
 
 from pyomo.core import Constraint, value, TransformationFactory
 from pyomo.core.plugins.transform.hierarchy import IsomorphicTransformation
@@ -31,27 +32,28 @@ class TightenContraintFromVars(IsomorphicTransformation):
             LB = UB = 0
             if repn.constant:
                 LB = UB = repn.constant
+
             # loop through each coefficent and variable pair
-            for i, coef in enumerate(repn.linear_coefs):
+            for var, coef in zip(repn.linear_vars, repn.linear_coefs):
                 # TODO: Rounding issues
                 # Calculate bounds using interval arithmetic
                 if coef >= 0:
-                    if repn.linear_vars[i].has_ub():
-                        UB = UB + coef * value(repn.linear_vars[i].ub)
+                    if var.has_ub():
+                        UB = UB + coef * value(var.ub)
                     else:
                         UB = float('Inf')
-                    if repn.linear_vars[i].has_lb():
-                        LB = LB + coef * value(repn.linear_vars[i].lb)
+                    if var.has_lb():
+                        LB = LB + coef * value(var.lb)
                     else:
                         LB = float('-Inf')
                 else:
                     # coef is negative, so signs switch
-                    if repn.linear_vars[i].has_lb():
-                        UB = UB + coef * value(repn.linear_vars[i].lb)
+                    if var.has_lb():
+                        UB = UB + coef * value(var.lb)
                     else:
                         UB = float('Inf')
-                    if repn.linear_vars[i].has_ub():
-                        LB = LB + coef * value(repn.linear_vars[i].ub)
+                    if var.has_ub():
+                        LB = LB + coef * value(var.ub)
                     else:
                         LB = float('-Inf')
 

--- a/pyomo/contrib/preprocessing/plugins/constraint_tightener.py
+++ b/pyomo/contrib/preprocessing/plugins/constraint_tightener.py
@@ -49,11 +49,11 @@ class TightenContraintFromVars(IsomorphicTransformation):
                     if repn.linear_vars[i].has_lb():
                         UB = UB + coef * value(repn.linear_vars[i].lb)
                     else:
-                        LB = float('-Inf')
+                        UB = float('Inf')
                     if repn.linear_vars[i].has_ub():
                         LB = LB + coef * value(repn.linear_vars[i].ub)
                     else:
-                        UB = float('Inf')
+                        LB = float('-Inf')
 
             # if inferred bound is tighter, replace bound
             new_ub = min(value(constr.upper), UB) if constr.has_ub() else UB

--- a/pyomo/contrib/preprocessing/tests/test_constraint_tightener.py
+++ b/pyomo/contrib/preprocessing/tests/test_constraint_tightener.py
@@ -80,6 +80,22 @@ class TestIntervalTightener(unittest.TestCase):
         self.assertEqual(value(m.c1.upper), -1)
         self.assertFalse(m.c1.has_lb())
 
+    def test_negative_coeff(self):
+        """Unbounded in one direction with negative coefficient"""
+        m = ConcreteModel()
+        m.v1 = Var(initialize=7, bounds=(1, float('inf')))
+        m.v2 = Var(initialize=2, bounds=(2, 5))
+        m.v3 = Var(initialize=6, bounds=(6, 9))
+        m.v4 = Var(initialize=1, bounds=(1, 1))
+        m.c1 = Constraint(expr=2 * m.v2 + m.v3 + m.v4 - m.v1 <= 50)
+
+        self.assertEqual(value(m.c1.upper), 50)
+        self.assertTrue(m.c1.has_ub())
+        self.assertFalse(m.c1.has_lb())
+        TransformationFactory('core.tighten_constraints_from_vars').apply_to(m)
+        self.assertEqual(value(m.c1.upper), 19)
+        self.assertFalse(m.c1.has_lb())
+
     def test_ignore_nonlinear(self):
         m = ConcreteModel()
         m.v1 = Var()


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
- The Constraint Tightener is untested for negative coefficients.
- In light of this, I believe I've found an issue with the bounds being applied (see 
f85a5bf)


## Changes proposed in this PR:
- The logic is being reversed twice; `has_lb()` and `has_ub()` have swapped as well as the setting of `LB` and `UB`. This is corrected to the best of my knowledge of this `TransformationFactory`
- Add `rounding_ndigits` functionality for rounding off the bounds being applied
- Some other general cleanup / refactoring

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
