### PR TITLE
Performance: only compute `is_fixed()` when necessary

### DIFF
--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -291,9 +291,8 @@ class CPLEXDirect(DirectSolver):
         if not con.active:
             return None
 
-        if is_fixed(con.body):
-            if self._skip_trivial_constraints:
-                return None
+        if self._skip_trivial_constraints and is_fixed(con.body):
+            return None
 
         conname = self._symbol_map.getSymbol(con, self._labeler)
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
- `is_fixed()` is a very expensive operation for large constraint expressions
- The default of `skip_trivial_constraint` is False so it isn't even being used
- Therefore don't compute it if we don't need it

## Changes proposed in this PR:
- Use Python's shortcircuting to ignore `is_fixed()` computation
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
