### PR TITLE
Fix polynomial degree and `_is_fixed()` of linear expressions

### DIFF
--- a/pyomo/core/expr/numeric_expr.py
+++ b/pyomo/core/expr/numeric_expr.py
@@ -1366,7 +1366,7 @@ class LinearExpression(ExpressionBase):
         return 'sum'
 
     def _compute_polynomial_degree(self, result):
-        return 1 if len(self.linear_vars) > 0 else 0
+        return 1 if not self.is_fixed() else 0
 
     def is_constant(self):
         return len(self.linear_vars) == 0

--- a/pyomo/core/expr/numeric_expr.py
+++ b/pyomo/core/expr/numeric_expr.py
@@ -1371,13 +1371,16 @@ class LinearExpression(ExpressionBase):
     def is_constant(self):
         return len(self.linear_vars) == 0
 
-    def is_fixed(self):
+    def _is_fixed(self, values=None):
         if len(self.linear_vars) == 0:
             return True
         for v in self.linear_vars:
             if not v.fixed:
                 return False
         return True
+
+    def is_fixed(self):
+        return self._is_fixed()
 
     def _to_string(self, values, verbose, smap, compute_values):
         tmp = []

--- a/pyomo/core/expr/numeric_expr.py
+++ b/pyomo/core/expr/numeric_expr.py
@@ -1372,12 +1372,7 @@ class LinearExpression(ExpressionBase):
         return len(self.linear_vars) == 0
 
     def _is_fixed(self, values=None):
-        if len(self.linear_vars) == 0:
-            return True
-        for v in self.linear_vars:
-            if not v.fixed:
-                return False
-        return True
+        return all(v.fixed for v in self.linear_vars)
 
     def is_fixed(self):
         return self._is_fixed()

--- a/pyomo/core/tests/unit/test_numeric_expr.py
+++ b/pyomo/core/tests/unit/test_numeric_expr.py
@@ -16,6 +16,8 @@ import pickle
 import math
 import os
 import re
+from collections import defaultdict
+
 import six
 import sys
 from os.path import abspath, dirname
@@ -5211,6 +5213,26 @@ class TestDirect_LinearExpression(unittest.TestCase):
         self.assertAlmostEqual(repn.constant, 1.0)
         self.assertTrue(len(repn.linear_coefs) == N)
         self.assertTrue(len(repn.linear_vars) == N)
+
+    def test_LinearExpression_polynomial_degree(self):
+        m = ConcreteModel()
+        m.S = RangeSet(2)
+        m.var_1 = Var(initialize=0)
+        m.var_2 = Var(initialize=0)
+        m.var_3 = Var(m.S, initialize=0)
+
+        def con_rule(model):
+            return model.var_1 - (model.var_2 + sum_product(defaultdict(lambda: 1/6), model.var_3)) <= 0
+
+        m.c1 = Constraint(rule=con_rule)
+
+        m.var_1.fix(1)
+        m.var_2.fix(1)
+        m.var_3.fix(1)
+
+        self.assertTrue(is_fixed(m.c1.body))
+        self.assertEqual(polynomial_degree(m.c1.body), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/core/tests/unit/test_numeric_expr.py
+++ b/pyomo/core/tests/unit/test_numeric_expr.py
@@ -5233,6 +5233,25 @@ class TestDirect_LinearExpression(unittest.TestCase):
         self.assertTrue(is_fixed(m.c1.body))
         self.assertEqual(polynomial_degree(m.c1.body), 0)
 
+    def test_LinearExpression_is_fixed(self):
+        m = ConcreteModel()
+        m.S = RangeSet(2)
+        m.var_1 = Var(initialize=0)
+        m.var_2 = Var(initialize=0)
+        m.var_3 = Var(m.S, initialize=0)
+
+        def con_rule(model):
+            from collections import defaultdict
+            return model.var_1 - (model.var_2 + sum_product(defaultdict(lambda: 1 / 6), model.var_3)) <= 0
+
+        m.c1 = Constraint(rule=con_rule)
+
+        m.var_1.fix(1)
+        m.var_2.fix(1)
+
+        self.assertFalse(is_fixed(m.c1.body))
+        self.assertEqual(polynomial_degree(m.c1.body), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/core/tests/unit/test_numeric_expr.py
+++ b/pyomo/core/tests/unit/test_numeric_expr.py
@@ -5222,7 +5222,7 @@ class TestDirect_LinearExpression(unittest.TestCase):
         m.var_3 = Var(m.S, initialize=0)
 
         def con_rule(model):
-            return model.var_1 - (model.var_2 + sum_product(defaultdict(lambda: 1 / 6), model.var_3)) <= 0
+            return model.var_1 - (model.var_2 + sum_product(defaultdict(lambda: 6), model.var_3)) <= 0
 
         m.c1 = Constraint(rule=con_rule)
 
@@ -5241,7 +5241,7 @@ class TestDirect_LinearExpression(unittest.TestCase):
         m.var_3 = Var(m.S, initialize=0)
 
         def con_rule(model):
-            return model.var_1 - (model.var_2 + sum_product(defaultdict(lambda: 1 / 6), model.var_3)) <= 0
+            return model.var_1 - (model.var_2 + sum_product(defaultdict(lambda: 6), model.var_3)) <= 0
 
         m.c1 = Constraint(rule=con_rule)
 

--- a/pyomo/core/tests/unit/test_numeric_expr.py
+++ b/pyomo/core/tests/unit/test_numeric_expr.py
@@ -5222,7 +5222,7 @@ class TestDirect_LinearExpression(unittest.TestCase):
         m.var_3 = Var(m.S, initialize=0)
 
         def con_rule(model):
-            return model.var_1 - (model.var_2 + sum_product(defaultdict(lambda: 1/6), model.var_3)) <= 0
+            return model.var_1 - (model.var_2 + sum_product(defaultdict(lambda: 1 / 6), model.var_3)) <= 0
 
         m.c1 = Constraint(rule=con_rule)
 
@@ -5241,7 +5241,6 @@ class TestDirect_LinearExpression(unittest.TestCase):
         m.var_3 = Var(m.S, initialize=0)
 
         def con_rule(model):
-            from collections import defaultdict
             return model.var_1 - (model.var_2 + sum_product(defaultdict(lambda: 1 / 6), model.var_3)) <= 0
 
         m.c1 = Constraint(rule=con_rule)


### PR DESCRIPTION
## Fixes #1362

## Summary/Motivation:
### Polynomial Degree
- `LinearExpression` causes trivial constraints to remain in the model
- This is because their polynomial degree evaluates to 1 even when all vars are fixed
- It should instead evaluate to 0

### Is Fixed
- Conversely, `LinearExpression` causes non-trivial constraints to be removed from the model
- This is because when it is part of another expression, `LinearExpression._is_fixed()` evaluates to `True` because `values` (ie its children) is empty and `all([]) is True`
- It should instead evaluate to the same as `LinearExpression.is_fixed()`

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
