### PR TITLE
Initialize dummy variable in the pyomo_ext_cyipopt interface

### DIFF
--- a/pyomo/contrib/pynumero/algorithms/solvers/pyomo_ext_cyipopt.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/pyomo_ext_cyipopt.py
@@ -13,7 +13,7 @@ import abc
 from pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver import CyIpoptProblemInterface
 from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP
 from pyomo.contrib.pynumero.sparse.block_vector import BlockVector
-from pyomo.environ import Var, Constraint
+from pyomo.environ import Var, Constraint, value
 from pyomo.core.base.var import _VarData
 from pyomo.common.modeling import unique_component_name
 
@@ -138,6 +138,16 @@ class PyomoExternalCyIpoptProblem(CyIpoptProblemInterface):
                sum(v for v in self._inputs) + sum(v for v in self._outputs)
             )
         setattr(self._pyomo_model, dummy_con_name, dummy_con)
+
+        # initialize the dummy var to the right hand side
+        dummy_var_value = 0
+        for v in self._inputs:
+            if v.value is not None:
+                dummy_var_value += value(v)
+        for v in self._outputs:
+            if v.value is not None:
+                dummy_var_value += value(v)
+        dummy_var.value = dummy_var_value
 
         # make an nlp interface from the pyomo model
         self._pyomo_nlp = PyomoNLP(self._pyomo_model)

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_pyomo_ext_cyipopt.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_pyomo_ext_cyipopt.py
@@ -94,10 +94,54 @@ class TestExternalInputOutputModel(unittest.TestCase):
                                         [m.P1, m.P2]
                                         )
 
+        # check that the dummy variable is initialized
+        expected_dummy_var_value = pyo.value(m.Pin) + pyo.value(m.c1) + pyo.value(m.c2) + pyo.value(m.F) \
+            + 0 + 0
+            # + pyo.value(m.P1) + pyo.value(m.P2) # not initialized - therefore should use zero
+        self.assertAlmostEqual(pyo.value(m._dummy_variable_CyIpoptPyomoExNLP), expected_dummy_var_value)
+
         # solve the problem
         solver = CyIpoptSolver(cyipopt_problem, {'hessian_approximation':'limited-memory'})
         x, info = solver.solve(tee=False)
         cyipopt_problem.load_x_into_pyomo(x)
         self.assertAlmostEqual(pyo.value(m.c1), 0.1, places=5)
         self.assertAlmostEqual(pyo.value(m.c2), 0.5, places=5)
-        
+
+    def test_pyomo_external_model_dummy_var_initialization(self):
+        m = pyo.ConcreteModel()
+        m.Pin = pyo.Var(initialize=100, bounds=(0,None))
+        m.c1 = pyo.Var(initialize=1.0, bounds=(0,None))
+        m.c2 = pyo.Var(initialize=1.0, bounds=(0,None))
+        m.F = pyo.Var(initialize=10, bounds=(0,None))
+
+        m.P1 = pyo.Var(initialize=75.0)
+        m.P2 = pyo.Var(initialize=50.0)
+
+        m.F_con = pyo.Constraint(expr = m.F == 10)
+        m.Pin_con = pyo.Constraint(expr = m.Pin == 100)
+
+        # simple parameter estimation test
+        m.obj = pyo.Objective(expr= (m.P1 - 90)**2 + (m.P2 - 40)**2)
+
+        cyipopt_problem = \
+            PyomoExternalCyIpoptProblem(m,
+                                        PressureDropModel(),
+                                        [m.Pin, m.c1, m.c2, m.F],
+                                        [m.P1, m.P2]
+                                        )
+
+        # check that the dummy variable is initialized
+        expected_dummy_var_value = pyo.value(m.Pin) + pyo.value(m.c1) + pyo.value(m.c2) + pyo.value(m.F) \
+            + pyo.value(m.P1) + pyo.value(m.P2)
+        self.assertAlmostEqual(pyo.value(m._dummy_variable_CyIpoptPyomoExNLP), expected_dummy_var_value)
+        # check that the dummy constraint is satisfied
+        self.assertAlmostEqual(pyo.value(m._dummy_constraint_CyIpoptPyomoExNLP.body),pyo.value(m._dummy_constraint_CyIpoptPyomoExNLP.lower))
+        self.assertAlmostEqual(pyo.value(m._dummy_constraint_CyIpoptPyomoExNLP.body),pyo.value(m._dummy_constraint_CyIpoptPyomoExNLP.upper))
+
+        # solve the problem
+        solver = CyIpoptSolver(cyipopt_problem, {'hessian_approximation':'limited-memory'})
+        x, info = solver.solve(tee=False)
+        cyipopt_problem.load_x_into_pyomo(x)
+        self.assertAlmostEqual(pyo.value(m.c1), 0.1, places=5)
+        self.assertAlmostEqual(pyo.value(m.c2), 0.5, places=5)
+


### PR DESCRIPTION
Added code the pyomo_ext_cyipopt interface to initialize the dummy variables so that it does not show an infeasibilty at the first iteration of the solve.

## Fixes # .

## Summary/Motivation:


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
