### PR TITLE
Test `is_fixed()` call count with `skip_trivial_constraints`

### DIFF
--- a/pyomo/solvers/tests/checks/test_CPLEXDirect.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXDirect.py
@@ -143,5 +143,88 @@ class CPLEXDirectTests(unittest.TestCase):
             self.assertEqual(results.solution.status,
                              SolutionStatus.optimal)
 
+
+@unittest.skipIf(not unittest.mock_available, "'mock' is not available")
+@unittest.skipIf(not cplexpy_available, "The 'cplex' python bindings are not available")
+class TestIsFixedCallCount(unittest.TestCase):
+    def setup(self, skip_trivial_constraints):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var()
+        m.c1 = Constraint(expr=m.x + m.y == 1)
+        m.c2 = Constraint(expr=m.x <= 1)
+        self.assertFalse(m.c2.has_lb())
+        self.assertTrue(m.c2.has_ub())
+        self._model = m
+
+        self._opt = SolverFactory("cplex_persistent")
+        self._opt.set_instance(
+            self._model, skip_trivial_constraints=skip_trivial_constraints
+        )
+
+    def test_skip_trivial_and_call_count_for_fixed_con_is_one(self):
+        self.setup(skip_trivial_constraints=True)
+        self._model.x.fix(1)
+        self.assertTrue(self._opt._skip_trivial_constraints)
+        self.assertTrue(self._model.c2.body.is_fixed())
+
+        with unittest.mock.patch(
+            "pyomo.solvers.plugins.solvers.cplex_direct.is_fixed", wraps=is_fixed
+        ) as mock_is_fixed:
+            mock_is_fixed.assert_not_called()
+            self._opt.add_constraint(self._model.c2)
+            mock_is_fixed.assert_called_once()
+
+    def test_skip_trivial_and_call_count_for_unfixed_con_is_two(self):
+        self.setup(skip_trivial_constraints=True)
+        self.assertTrue(self._opt._skip_trivial_constraints)
+        self.assertFalse(self._model.c2.body.is_fixed())
+
+        with unittest.mock.patch(
+            "pyomo.solvers.plugins.solvers.cplex_direct.is_fixed", wraps=is_fixed
+        ) as mock_is_fixed:
+            mock_is_fixed.assert_not_called()
+            self._opt.add_constraint(self._model.c2)
+            self.assertEqual(mock_is_fixed.call_count, 2)
+
+    def test_skip_trivial_and_call_count_for_unfixed_equality_con_is_three(self):
+        self.setup(skip_trivial_constraints=True)
+        self._model.c2 = Constraint(expr=self._model.x == 1)
+        self.assertTrue(self._opt._skip_trivial_constraints)
+        self.assertFalse(self._model.c2.body.is_fixed())
+
+        with unittest.mock.patch(
+            "pyomo.solvers.plugins.solvers.cplex_direct.is_fixed", wraps=is_fixed
+        ) as mock_is_fixed:
+            mock_is_fixed.assert_not_called()
+            self._opt.add_constraint(self._model.c2)
+            self.assertEqual(mock_is_fixed.call_count, 3)
+
+    def test_dont_skip_trivial_and_call_count_for_fixed_con_is_one(self):
+        self.setup(skip_trivial_constraints=False)
+        self._model.x.fix(1)
+        self.assertFalse(self._opt._skip_trivial_constraints)
+        self.assertTrue(self._model.c2.body.is_fixed())
+
+        with unittest.mock.patch(
+            "pyomo.solvers.plugins.solvers.cplex_direct.is_fixed", wraps=is_fixed
+        ) as mock_is_fixed:
+            mock_is_fixed.assert_not_called()
+            self._opt.add_constraint(self._model.c2)
+            mock_is_fixed.assert_called_once()
+
+    def test_dont_skip_trivial_and_call_count_for_unfixed_con_is_one(self):
+        self.setup(skip_trivial_constraints=False)
+        self.assertFalse(self._opt._skip_trivial_constraints)
+        self.assertFalse(self._model.c2.body.is_fixed())
+
+        with unittest.mock.patch(
+            "pyomo.solvers.plugins.solvers.cplex_direct.is_fixed", wraps=is_fixed
+        ) as mock_is_fixed:
+            mock_is_fixed.assert_not_called()
+            self._opt.add_constraint(self._model.c2)
+            mock_is_fixed.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/solvers/tests/checks/test_CPLEXDirect.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXDirect.py
@@ -172,9 +172,9 @@ class TestIsFixedCallCount(unittest.TestCase):
         with unittest.mock.patch(
             "pyomo.solvers.plugins.solvers.cplex_direct.is_fixed", wraps=is_fixed
         ) as mock_is_fixed:
-            mock_is_fixed.assert_not_called()
+            self.assertEqual(mock_is_fixed.call_count, 0)
             self._opt.add_constraint(self._model.c2)
-            mock_is_fixed.assert_called_once()
+            self.assertEqual(mock_is_fixed.call_count, 1)
 
     def test_skip_trivial_and_call_count_for_unfixed_con_is_two(self):
         self.setup(skip_trivial_constraints=True)
@@ -184,7 +184,7 @@ class TestIsFixedCallCount(unittest.TestCase):
         with unittest.mock.patch(
             "pyomo.solvers.plugins.solvers.cplex_direct.is_fixed", wraps=is_fixed
         ) as mock_is_fixed:
-            mock_is_fixed.assert_not_called()
+            self.assertEqual(mock_is_fixed.call_count, 0)
             self._opt.add_constraint(self._model.c2)
             self.assertEqual(mock_is_fixed.call_count, 2)
 
@@ -197,7 +197,7 @@ class TestIsFixedCallCount(unittest.TestCase):
         with unittest.mock.patch(
             "pyomo.solvers.plugins.solvers.cplex_direct.is_fixed", wraps=is_fixed
         ) as mock_is_fixed:
-            mock_is_fixed.assert_not_called()
+            self.assertEqual(mock_is_fixed.call_count, 0)
             self._opt.add_constraint(self._model.c2)
             self.assertEqual(mock_is_fixed.call_count, 3)
 
@@ -210,9 +210,9 @@ class TestIsFixedCallCount(unittest.TestCase):
         with unittest.mock.patch(
             "pyomo.solvers.plugins.solvers.cplex_direct.is_fixed", wraps=is_fixed
         ) as mock_is_fixed:
-            mock_is_fixed.assert_not_called()
+            self.assertEqual(mock_is_fixed.call_count, 0)
             self._opt.add_constraint(self._model.c2)
-            mock_is_fixed.assert_called_once()
+            self.assertEqual(mock_is_fixed.call_count, 1)
 
     def test_dont_skip_trivial_and_call_count_for_unfixed_con_is_one(self):
         self.setup(skip_trivial_constraints=False)
@@ -222,9 +222,9 @@ class TestIsFixedCallCount(unittest.TestCase):
         with unittest.mock.patch(
             "pyomo.solvers.plugins.solvers.cplex_direct.is_fixed", wraps=is_fixed
         ) as mock_is_fixed:
-            mock_is_fixed.assert_not_called()
+            self.assertEqual(mock_is_fixed.call_count, 0)
             self._opt.add_constraint(self._model.c2)
-            mock_is_fixed.assert_called_once()
+            self.assertEqual(mock_is_fixed.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/pyomo/solvers/tests/checks/test_CPLEXDirect.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXDirect.py
@@ -147,6 +147,7 @@ class CPLEXDirectTests(unittest.TestCase):
 @unittest.skipIf(not unittest.mock_available, "'mock' is not available")
 @unittest.skipIf(not cplexpy_available, "The 'cplex' python bindings are not available")
 class TestIsFixedCallCount(unittest.TestCase):
+    """ Tests for PR#1402 (669e7b2b) """
     def setup(self, skip_trivial_constraints):
         m = ConcreteModel()
         m.x = Var()


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:


## Changes proposed in this PR:
- Tests for #1402 

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
