### PR TITLE
CPLEXDirect performance improvements

### DIFF
--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -48,7 +48,7 @@ class _CplexExpr(object):
     ):
         self.variables = variables
         self.coefficients = coefficients
-        self.offset = offset or 0.
+        self.offset = offset or 0.0
         self.q_variables1 = q_variables1 or []
         self.q_variables2 = q_variables2 or []
         self.q_coefficients = q_coefficients or []

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -442,7 +442,6 @@ class CPLEXDirect(DirectSolver):
             self._objective = None
 
         self._solver_model.objective.set_linear([(i, 0.0) for i in range(len(self._pyomo_var_to_solver_var_map.values()))])
-        self._solver_model.objective.set_quadratic([[[0], [0]] for i in self._pyomo_var_to_solver_var_map.keys()])
 
         if obj.active is False:
             raise ValueError('Cannot add inactive objective to solver.')

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -51,7 +51,7 @@ class _CplexExpr(object):
         self.offset = offset or 0.0
         self.q_variables1 = q_variables1 or []
         self.q_variables2 = q_variables2 or []
-        self.q_coefficients = q_coefficients or []
+        self.q_coefficients = [float(coef) for coef in q_coefficients or []]
 
 
 def _is_numeric(x):
@@ -573,7 +573,7 @@ class CPLEXDirect(DirectSolver):
                 self._solver_model.objective.set_linear(list(zip(cplex_expr.variables, cplex_expr.coefficients)))
 
         if quadratic_objective_already_exists or contains_quadratic_terms:
-            self._solver_model.objective.set_quadratic([0] * num_cols)
+            self._solver_model.objective.set_quadratic([0.0] * num_cols)
 
             if contains_quadratic_terms:
                 self._solver_model.objective.set_quadratic_coefficients(

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -114,6 +114,8 @@ class _LinearConstraintData(object):
         )
 
 
+# `nullcontext()` is part of the standard library as of Py3.7
+# This is verbatim from `cpython/Lib/contextlib.py`
 class nullcontext(object):
     """Context manager that does no additional processing.
     Used as a stand-in for a normal context manager, when a particular

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -37,13 +37,22 @@ class DegreeError(ValueError):
 
 
 class _CplexExpr(object):
-    def __init__(self):
-        self.variables = []
-        self.coefficients = []
-        self.offset = 0
-        self.q_variables1 = []
-        self.q_variables2 = []
-        self.q_coefficients = []
+    def __init__(
+        self,
+        variables,
+        coefficients,
+        offset=None,
+        q_variables1=None,
+        q_variables2=None,
+        q_coefficients=None,
+    ):
+        self.variables = variables
+        self.coefficients = coefficients
+        self.offset = offset or 0.
+        self.q_variables1 = q_variables1 or []
+        self.q_variables2 = q_variables2 or []
+        self.q_coefficients = q_coefficients or []
+
 
 def _is_numeric(x):
     try:
@@ -193,29 +202,36 @@ class CPLEXDirect(DirectSolver):
         return Bunch(rc=None, log=None)
 
     def _get_expr_from_pyomo_repn(self, repn, max_degree=2):
-        referenced_vars = ComponentSet()
-
         degree = repn.polynomial_degree()
-        if (degree is None) or (degree > max_degree):
-            raise DegreeError('CPLEXDirect does not support expressions of degree {0}.'.format(degree))
+        if degree is None or degree > max_degree:
+            raise DegreeError(
+                "CPLEXDirect does not support expressions of degree {0}.".format(degree)
+            )
 
-        new_expr = _CplexExpr()
-        if len(repn.linear_vars) > 0:
-            referenced_vars.update(repn.linear_vars)
-            new_expr.variables.extend(self._pyomo_var_to_ndx_map[i] for i in repn.linear_vars)
-            new_expr.coefficients.extend(repn.linear_coefs)
+        referenced_vars = ComponentSet(repn.linear_vars)
 
+        q_coefficients = []
+        q_variables1 = []
+        q_variables2 = []
         for i, v in enumerate(repn.quadratic_vars):
             x, y = v
-            new_expr.q_coefficients.append(repn.quadratic_coefs[i])
-            new_expr.q_variables1.append(self._pyomo_var_to_ndx_map[x])
-            new_expr.q_variables2.append(self._pyomo_var_to_ndx_map[y])
+            q_coefficients.append(repn.quadratic_coefs[i])
+            q_variables1.append(self._pyomo_var_to_ndx_map[x])
+            q_variables2.append(self._pyomo_var_to_ndx_map[y])
             referenced_vars.add(x)
             referenced_vars.add(y)
 
-        new_expr.offset = repn.constant
-
-        return new_expr, referenced_vars
+        return (
+            _CplexExpr(
+                variables=[self._pyomo_var_to_ndx_map[var] for var in repn.linear_vars],
+                coefficients=repn.linear_coefs,
+                offset=repn.constant,
+                q_variables1=q_variables1,
+                q_variables2=q_variables2,
+                q_coefficients=q_coefficients,
+            ),
+            referenced_vars,
+        )
 
     def _get_expr_from_pyomo_expr(self, expr, max_degree=2):
         if max_degree == 2:

--- a/pyomo/solvers/tests/checks/test_CPLEXDirect.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXDirect.py
@@ -310,5 +310,108 @@ class TestDataContainers(unittest.TestCase):
         self.assertEqual(solver_model.linear_constraints.get_num(), 4)
 
 
+@unittest.skipIf(not unittest.mock_available, "'mock' is not available")
+@unittest.skipIf(not cplexpy_available, "The 'cplex' python bindings are not available")
+class TestAddVar(unittest.TestCase):
+    def test_add_single_variable(self):
+        """ Test that the variable is added correctly to `solver_model`. """
+        model = ConcreteModel()
+
+        opt = SolverFactory("cplex", solver_io="python")
+        opt._set_instance(model)
+
+        self.assertEqual(opt._solver_model.variables.get_num(), 0)
+        self.assertEqual(opt._solver_model.variables.get_num_binary(), 0)
+
+        model.X = Var(within=Binary)
+
+        var_interface = opt._solver_model.variables
+        with unittest.mock.patch.object(
+            var_interface, "add", wraps=var_interface.add
+        ) as wrapped_add_call, unittest.mock.patch.object(
+            var_interface, "set_lower_bounds", wraps=var_interface.set_lower_bounds
+        ) as wrapped_lb_call, unittest.mock.patch.object(
+            var_interface, "set_upper_bounds", wraps=var_interface.set_upper_bounds
+        ) as wrapped_ub_call:
+            opt._add_var(model.X)
+
+            self.assertEqual(wrapped_add_call.call_count, 1)
+            self.assertEqual(
+                wrapped_add_call.call_args,
+                ({"lb": [0], "names": ["x1"], "types": ["B"], "ub": [1]},),
+            )
+
+            self.assertFalse(wrapped_lb_call.called)
+            self.assertFalse(wrapped_ub_call.called)
+
+        self.assertEqual(opt._solver_model.variables.get_num(), 1)
+        self.assertEqual(opt._solver_model.variables.get_num_binary(), 1)
+
+    def test_add_block_containing_single_variable(self):
+        """ Test that the variable is added correctly to `solver_model`. """
+        model = ConcreteModel()
+
+        opt = SolverFactory("cplex", solver_io="python")
+        opt._set_instance(model)
+
+        self.assertEqual(opt._solver_model.variables.get_num(), 0)
+        self.assertEqual(opt._solver_model.variables.get_num_binary(), 0)
+
+        model.X = Var(within=Binary)
+
+        with unittest.mock.patch.object(
+            opt._solver_model.variables, "add", wraps=opt._solver_model.variables.add
+        ) as wrapped_add_call:
+            opt._add_block(model)
+
+            self.assertEqual(wrapped_add_call.call_count, 1)
+            self.assertEqual(
+                wrapped_add_call.call_args,
+                ({"lb": [0], "names": ["x1"], "types": ["B"], "ub": [1]},),
+            )
+
+        self.assertEqual(opt._solver_model.variables.get_num(), 1)
+        self.assertEqual(opt._solver_model.variables.get_num_binary(), 1)
+
+    def test_add_block_containing_multiple_variables(self):
+        """ Test that:
+            - The variable is added correctly to `solver_model`
+            - The CPLEX `variables` interface is called only once
+            - Fixed variable bounds are set correctly
+        """
+        model = ConcreteModel()
+
+        opt = SolverFactory("cplex", solver_io="python")
+        opt._set_instance(model)
+
+        self.assertEqual(opt._solver_model.variables.get_num(), 0)
+
+        model.X1 = Var(within=Binary)
+        model.X2 = Var(within=NonNegativeReals)
+        model.X3 = Var(within=NonNegativeIntegers)
+
+        model.X3.fix(5)
+
+        with unittest.mock.patch.object(
+            opt._solver_model.variables, "add", wraps=opt._solver_model.variables.add
+        ) as wrapped_add_call:
+            opt._add_block(model)
+
+            self.assertEqual(wrapped_add_call.call_count, 1)
+            self.assertEqual(
+                wrapped_add_call.call_args,
+                (
+                    {
+                        "lb": [0, 0, 5],
+                        "names": ["x1", "x2", "x3"],
+                        "types": ["B", "C", "I"],
+                        "ub": [1, cplex.infinity, 5],
+                    },
+                ),
+            )
+
+        self.assertEqual(opt._solver_model.variables.get_num(), 3)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/solvers/tests/checks/test_CPLEXDirect.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXDirect.py
@@ -413,5 +413,112 @@ class TestAddVar(unittest.TestCase):
         self.assertEqual(opt._solver_model.variables.get_num(), 3)
 
 
+@unittest.skipIf(not unittest.mock_available, "'mock' is not available")
+@unittest.skipIf(not cplexpy_available, "The 'cplex' python bindings are not available")
+class TestAddCon(unittest.TestCase):
+    def test_add_single_constraint(self):
+        model = ConcreteModel()
+        model.X = Var(within=Binary)
+
+        opt = SolverFactory("cplex", solver_io="python")
+        opt._set_instance(model)
+
+        self.assertEqual(opt._solver_model.linear_constraints.get_num(), 0)
+
+        model.C = Constraint(expr=model.X == 1)
+
+        con_interface = opt._solver_model.linear_constraints
+        with unittest.mock.patch.object(
+            con_interface, "add", wraps=con_interface.add
+        ) as wrapped_add_call:
+            opt._add_constraint(model.C)
+
+            self.assertEqual(wrapped_add_call.call_count, 1)
+            self.assertEqual(
+                wrapped_add_call.call_args,
+                (
+                    {
+                        "lin_expr": [[[0], (1,)]],
+                        "names": ["x2"],
+                        "range_values": [0.0],
+                        "rhs": [1.0],
+                        "senses": ["E"],
+                    },
+                ),
+            )
+
+        self.assertEqual(opt._solver_model.linear_constraints.get_num(), 1)
+
+    def test_add_block_containing_single_constraint(self):
+        model = ConcreteModel()
+        model.X = Var(within=Binary)
+
+        opt = SolverFactory("cplex", solver_io="python")
+        opt._set_instance(model)
+
+        self.assertEqual(opt._solver_model.linear_constraints.get_num(), 0)
+
+        model.B = Block()
+        model.B.C = Constraint(expr=model.X == 1)
+
+        con_interface = opt._solver_model.linear_constraints
+        with unittest.mock.patch.object(
+            con_interface, "add", wraps=con_interface.add
+        ) as wrapped_add_call:
+            opt._add_block(model.B)
+
+            self.assertEqual(wrapped_add_call.call_count, 1)
+            self.assertEqual(
+                wrapped_add_call.call_args,
+                (
+                    {
+                        "lin_expr": [[[0], (1,)]],
+                        "names": ["x2"],
+                        "range_values": [0.0],
+                        "rhs": [1.0],
+                        "senses": ["E"],
+                    },
+                ),
+            )
+
+        self.assertEqual(opt._solver_model.linear_constraints.get_num(), 1)
+
+    def test_add_block_containing_multiple_constraints(self):
+        model = ConcreteModel()
+        model.X = Var(within=Binary)
+
+        opt = SolverFactory("cplex", solver_io="python")
+        opt._set_instance(model)
+
+        self.assertEqual(opt._solver_model.linear_constraints.get_num(), 0)
+
+        model.B = Block()
+        model.B.C1 = Constraint(expr=model.X == 1)
+        model.B.C2 = Constraint(expr=model.X <= 1)
+        model.B.C3 = Constraint(expr=model.X >= 1)
+
+        con_interface = opt._solver_model.linear_constraints
+        with unittest.mock.patch.object(
+            con_interface, "add", wraps=con_interface.add
+        ) as wrapped_add_call:
+            opt._add_block(model.B)
+
+            self.assertEqual(wrapped_add_call.call_count, 1)
+            self.assertEqual(
+                wrapped_add_call.call_args,
+                (
+                    {
+                        "lin_expr": [[[0], (1,)], [[0], (1,)], [[0], (1,)]],
+                        "names": ["x2", "x3", "x4"],
+                        "range_values": [0.0, 0.0, 0.0],
+                        "rhs": [1.0, 1.0, 1.0],
+                        "senses": ["E", "L", "G"],
+                    },
+                ),
+            )
+
+        self.assertEqual(opt._solver_model.linear_constraints.get_num(), 3)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/solvers/tests/checks/test_CPLEXDirect.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXDirect.py
@@ -520,5 +520,82 @@ class TestAddCon(unittest.TestCase):
         self.assertEqual(opt._solver_model.linear_constraints.get_num(), 3)
 
 
+@unittest.skipIf(not unittest.mock_available, "'mock' is not available")
+@unittest.skipIf(not cplexpy_available, "The 'cplex' python bindings are not available")
+class TestLoadVars(unittest.TestCase):
+    def setUp(self):
+        opt = SolverFactory("cplex", solver_io="python")
+        model = ConcreteModel()
+        model.X = Var(within=NonNegativeReals, initialize=0)
+        model.Y = Var(within=NonNegativeReals, initialize=0)
+
+        model.C1 = Constraint(expr=2 * model.X + model.Y >= 8)
+        model.C2 = Constraint(expr=model.X + 3 * model.Y >= 6)
+
+        model.O = Objective(expr=model.X + model.Y)
+
+        opt.solve(model, load_solutions=False, save_results=False)
+
+        self._model = model
+        self._opt = opt
+
+    def test_all_vars_are_loaded(self):
+        self.assertTrue(self._model.X.stale)
+        self.assertTrue(self._model.Y.stale)
+        self.assertEqual(value(self._model.X), 0)
+        self.assertEqual(value(self._model.Y), 0)
+
+        with unittest.mock.patch.object(
+            self._opt._solver_model.solution,
+            "get_values",
+            wraps=self._opt._solver_model.solution.get_values,
+        ) as wrapped_values_call:
+            self._opt.load_vars()
+
+            self.assertEqual(wrapped_values_call.call_count, 1)
+            self.assertEqual(wrapped_values_call.call_args, tuple())
+
+        self.assertFalse(self._model.X.stale)
+        self.assertFalse(self._model.Y.stale)
+        self.assertAlmostEqual(value(self._model.X), 3.6)
+        self.assertAlmostEqual(value(self._model.Y), 0.8)
+
+    def test_only_specified_vars_are_loaded(self):
+        self.assertTrue(self._model.X.stale)
+        self.assertTrue(self._model.Y.stale)
+        self.assertEqual(value(self._model.X), 0)
+        self.assertEqual(value(self._model.Y), 0)
+
+        with unittest.mock.patch.object(
+            self._opt._solver_model.solution,
+            "get_values",
+            wraps=self._opt._solver_model.solution.get_values,
+        ) as wrapped_values_call:
+            self._opt.load_vars([self._model.X])
+
+            self.assertEqual(wrapped_values_call.call_count, 1)
+            self.assertEqual(wrapped_values_call.call_args, (([0],), {}))
+
+        self.assertFalse(self._model.X.stale)
+        self.assertTrue(self._model.Y.stale)
+        self.assertAlmostEqual(value(self._model.X), 3.6)
+        self.assertEqual(value(self._model.Y), 0)
+
+        with unittest.mock.patch.object(
+            self._opt._solver_model.solution,
+            "get_values",
+            wraps=self._opt._solver_model.solution.get_values,
+        ) as wrapped_values_call:
+            self._opt.load_vars([self._model.Y])
+
+            self.assertEqual(wrapped_values_call.call_count, 1)
+            self.assertEqual(wrapped_values_call.call_args, (([1],), {}))
+
+        self.assertFalse(self._model.X.stale)
+        self.assertFalse(self._model.Y.stale)
+        self.assertAlmostEqual(value(self._model.X), 3.6)
+        self.assertAlmostEqual(value(self._model.Y), 0.8)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/solvers/tests/checks/test_CPLEXDirect.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXDirect.py
@@ -8,12 +8,15 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pyutilib.th as unittest
-from pyomo.opt import *
-from pyomo.environ import *
 import sys
 
-from pyomo.solvers.plugins.solvers.cplex_direct import nullcontext, _VariableData, _LinearConstraintData, _CplexExpr
+import pyutilib.th as unittest
+
+from pyomo.environ import *
+from pyomo.opt import *
+from pyomo.solvers.plugins.solvers.cplex_direct import (_CplexExpr,
+                                                        _LinearConstraintData,
+                                                        _VariableData)
 
 try:
     import cplex
@@ -229,37 +232,23 @@ class TestIsFixedCallCount(unittest.TestCase):
             self.assertEqual(mock_is_fixed.call_count, 1)
 
 
-# `nullcontext()` is part of the standard library as of Py3.7
-# This is verbatim from `cpython/Lib/test/test_contextlib.py`
-class NullcontextTestCase(unittest.TestCase):
-    def test_nullcontext(self):
-        class C:
-            pass
-
-        c = C()
-        with nullcontext(c) as c_in:
-            self.assertIs(c_in, c)
-
-
 @unittest.skipIf(not cplexpy_available, "The 'cplex' python bindings are not available")
 class TestDataContainers(unittest.TestCase):
     def test_variable_data(self):
         solver_model = cplex.Cplex()
-        with _VariableData(solver_model) as var_data:
-            var_data.add(
-                lb=0, ub=1, type_=solver_model.variables.type.binary, name="var1"
-            )
-            var_data.add(
-                lb=0, ub=10, type_=solver_model.variables.type.integer, name="var2"
-            )
-            var_data.add(
-                lb=-cplex.infinity,
-                ub=cplex.infinity,
-                type_=solver_model.variables.type.continuous,
-                name="var3",
-            )
-
-            self.assertEqual(solver_model.variables.get_num(), 0)
+        var_data = _VariableData(solver_model)
+        var_data.add(lb=0, ub=1, type_=solver_model.variables.type.binary, name="var1")
+        var_data.add(
+            lb=0, ub=10, type_=solver_model.variables.type.integer, name="var2"
+        )
+        var_data.add(
+            lb=-cplex.infinity,
+            ub=cplex.infinity,
+            type_=solver_model.variables.type.continuous,
+            name="var3",
+        )
+        self.assertEqual(solver_model.variables.get_num(), 0)
+        var_data.store_in_cplex()
         self.assertEqual(solver_model.variables.get_num(), 3)
 
     def test_constraint_data(self):
@@ -275,38 +264,38 @@ class TestDataContainers(unittest.TestCase):
             ],
             names=["var1", "var2", "var3"],
         )
+        con_data = _LinearConstraintData(solver_model)
+        con_data.add(
+            cplex_expr=_CplexExpr(variables=[0, 1], coefficients=[10, 100]),
+            sense="L",
+            rhs=0,
+            range_values=0,
+            name="c1",
+        )
+        con_data.add(
+            cplex_expr=_CplexExpr(variables=[0], coefficients=[-30]),
+            sense="G",
+            rhs=1,
+            range_values=0,
+            name="c2",
+        )
+        con_data.add(
+            cplex_expr=_CplexExpr(variables=[1], coefficients=[80]),
+            sense="E",
+            rhs=2,
+            range_values=0,
+            name="c3",
+        )
+        con_data.add(
+            cplex_expr=_CplexExpr(variables=[2], coefficients=[50]),
+            sense="R",
+            rhs=3,
+            range_values=10,
+            name="c4",
+        )
 
-        with _LinearConstraintData(solver_model) as con_data:
-            con_data.add(
-                cplex_expr=_CplexExpr(variables=[0, 1], coefficients=[10, 100]),
-                sense="L",
-                rhs=0,
-                range_values=0,
-                name="c1",
-            )
-            con_data.add(
-                cplex_expr=_CplexExpr(variables=[0], coefficients=[-30]),
-                sense="G",
-                rhs=1,
-                range_values=0,
-                name="c2",
-            )
-            con_data.add(
-                cplex_expr=_CplexExpr(variables=[1], coefficients=[80]),
-                sense="E",
-                rhs=2,
-                range_values=0,
-                name="c3",
-            )
-            con_data.add(
-                cplex_expr=_CplexExpr(variables=[2], coefficients=[50]),
-                sense="R",
-                rhs=3,
-                range_values=10,
-                name="c4",
-            )
-
-            self.assertEqual(solver_model.linear_constraints.get_num(), 0)
+        self.assertEqual(solver_model.linear_constraints.get_num(), 0)
+        con_data.store_in_cplex()
         self.assertEqual(solver_model.linear_constraints.get_num(), 4)
 
 

--- a/pyomo/solvers/tests/checks/test_CPLEXDirect.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXDirect.py
@@ -13,7 +13,7 @@ from pyomo.opt import *
 from pyomo.environ import *
 import sys
 
-from pyomo.solvers.plugins.solvers.cplex_direct import nullcontext
+from pyomo.solvers.plugins.solvers.cplex_direct import nullcontext, _VariableData, _LinearConstraintData, _CplexExpr
 
 try:
     import cplex
@@ -239,6 +239,75 @@ class NullcontextTestCase(unittest.TestCase):
         c = C()
         with nullcontext(c) as c_in:
             self.assertIs(c_in, c)
+
+
+@unittest.skipIf(not cplexpy_available, "The 'cplex' python bindings are not available")
+class TestDataContainers(unittest.TestCase):
+    def test_variable_data(self):
+        solver_model = cplex.Cplex()
+        with _VariableData(solver_model) as var_data:
+            var_data.add(
+                lb=0, ub=1, type_=solver_model.variables.type.binary, name="var1"
+            )
+            var_data.add(
+                lb=0, ub=10, type_=solver_model.variables.type.integer, name="var2"
+            )
+            var_data.add(
+                lb=-cplex.infinity,
+                ub=cplex.infinity,
+                type_=solver_model.variables.type.continuous,
+                name="var3",
+            )
+
+            self.assertEqual(solver_model.variables.get_num(), 0)
+        self.assertEqual(solver_model.variables.get_num(), 3)
+
+    def test_constraint_data(self):
+        solver_model = cplex.Cplex()
+
+        solver_model.variables.add(
+            lb=[-cplex.infinity, -cplex.infinity, -cplex.infinity],
+            ub=[cplex.infinity, cplex.infinity, cplex.infinity],
+            types=[
+                solver_model.variables.type.continuous,
+                solver_model.variables.type.continuous,
+                solver_model.variables.type.continuous,
+            ],
+            names=["var1", "var2", "var3"],
+        )
+
+        with _LinearConstraintData(solver_model) as con_data:
+            con_data.add(
+                cplex_expr=_CplexExpr(variables=[0, 1], coefficients=[10, 100]),
+                sense="L",
+                rhs=0,
+                range_values=0,
+                name="c1",
+            )
+            con_data.add(
+                cplex_expr=_CplexExpr(variables=[0], coefficients=[-30]),
+                sense="G",
+                rhs=1,
+                range_values=0,
+                name="c2",
+            )
+            con_data.add(
+                cplex_expr=_CplexExpr(variables=[1], coefficients=[80]),
+                sense="E",
+                rhs=2,
+                range_values=0,
+                name="c3",
+            )
+            con_data.add(
+                cplex_expr=_CplexExpr(variables=[2], coefficients=[50]),
+                sense="R",
+                rhs=3,
+                range_values=10,
+                name="c4",
+            )
+
+            self.assertEqual(solver_model.linear_constraints.get_num(), 0)
+        self.assertEqual(solver_model.linear_constraints.get_num(), 4)
 
 
 if __name__ == "__main__":

--- a/pyomo/solvers/tests/checks/test_CPLEXDirect.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXDirect.py
@@ -13,6 +13,8 @@ from pyomo.opt import *
 from pyomo.environ import *
 import sys
 
+from pyomo.solvers.plugins.solvers.cplex_direct import nullcontext
+
 try:
     import cplex
     cplexpy_available = True
@@ -225,6 +227,18 @@ class TestIsFixedCallCount(unittest.TestCase):
             self.assertEqual(mock_is_fixed.call_count, 0)
             self._opt.add_constraint(self._model.c2)
             self.assertEqual(mock_is_fixed.call_count, 1)
+
+
+# `nullcontext()` is part of the standard library as of Py3.7
+# This is verbatim from `cpython/Lib/test/test_contextlib.py`
+class NullcontextTestCase(unittest.TestCase):
+    def test_nullcontext(self):
+        class C:
+            pass
+
+        c = C()
+        with nullcontext(c) as c_in:
+            self.assertIs(c_in, c)
 
 
 if __name__ == "__main__":

--- a/pyomo/solvers/tests/checks/test_CPLEXDirect.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXDirect.py
@@ -153,6 +153,7 @@ class CPLEXDirectTests(unittest.TestCase):
 @unittest.skipIf(not cplexpy_available, "The 'cplex' python bindings are not available")
 class TestIsFixedCallCount(unittest.TestCase):
     """ Tests for PR#1402 (669e7b2b) """
+
     def setup(self, skip_trivial_constraints):
         m = ConcreteModel()
         m.x = Var()

--- a/pyomo/solvers/tests/checks/test_CPLEXPersistent.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXPersistent.py
@@ -1,0 +1,35 @@
+import pyutilib.th as unittest
+
+from pyomo.environ import *
+from pyomo.opt import *
+
+try:
+    import cplex
+
+    cplexpy_available = True
+except ImportError:
+    cplexpy_available = False
+
+
+@unittest.skipIf(not cplexpy_available, "The 'cplex' python bindings are not available")
+class TestQuadraticObjective(unittest.TestCase):
+    def test_quadratic_objective_is_set(self):
+        model = ConcreteModel()
+        model.X = Var(bounds=(-2, 2))
+        model.Y = Var(bounds=(-2, 2))
+        model.O = Objective(expr=model.X ** 2 + model.Y ** 2)
+        model.C1 = Constraint(expr=model.Y >= 2 * model.X - 1)
+        model.C2 = Constraint(expr=model.Y >= -model.X + 2)
+        opt = SolverFactory("cplex_persistent")
+        opt.set_instance(model)
+        opt.solve()
+
+        self.assertAlmostEqual(model.X.value, 1, places=3)
+        self.assertAlmostEqual(model.Y.value, 1, places=3)
+
+        del model.O
+        model.O = Objective(expr=model.X ** 2)
+        opt.set_objective(model.O)
+        opt.solve()
+        self.assertAlmostEqual(model.X.value, 0, places=3)
+        self.assertAlmostEqual(model.Y.value, 2, places=3)


### PR DESCRIPTION
This PR contains a number of performance improvements to the `CPLEXDirect` class, and by extension, the `CPLEXPersistent` class.

# Notes

There are just a couple of functions (if not lines) that are resulting in very large bottlenecks. On the whole, things are quite performant as-is.

## Batching "transactions" with CPLEX

The `cplex` package's Linear Constraints and Variable interfaces allow for batched transactions. I think an appropriate design is to generate all the necessary data and add these objects as one call to the `solver_model`. I've also removed unnecessary transactions such as resetting variable bounds immediately after adding that variable with an obsolete bound.

## Querying results from CPLEX

Asking the `cplex` solution for *specific* variables' values is extremely slow due to the conversion on `cplex`'s end to lookup the variables you've asked for. It is orders of magnitude faster to get the full solution vector. Even worse, using the "specific variable interface" to get the full solution vector. If we must get specific variables (ie. `_load_vars()`) then their index should be used instead of their name.

## Expected performance vs LP solvers

It would be interesting to benchmark specifically writing the LP file vs the total time spent interfacing with the CPLEX library in isolation. I think it's a fallacy to suggest that the Direct interfaces *should* be faster because "there's no file IO" as suggested in GitHub issues and on SO. Once the repn has been generated, writing a string to disk takes no time at all. If anything I would imagine interfacing with a third-party library should be expected to take *more* time. To me, the gains are realised when using the Persistent interfaces to apply incremental resolves of a model. The LP solver has to regen the entire model whereas the Persistent interface only has to generate the changes.
Not to mention that a slight decline in performance is a small price to pay for access to the full advanced functionality of the `cplex` package for those who need it.

# Benchmark

- Ran the "benchmark-ish" case in #51 ten times for each solver:

| **Solver** | `master`                      | This branch |
| ------------- | ------------- | ------------- |
| **LP**     | 10.74s to 11.06s. Mean 10.84s | 10.94s to 11.27s. Mean 11.08s |
| **Direct** | 32.48s to 34.00s. _Mean 33.14s_ | 11.67s to 12.23s. _Mean 12.00s_ |

- There was still a speedup when I set `n_steps = 10` so it's not as though we're optimising for very large models only
- The total time is now almost wholly taken up by (a) model build and (b) `generate_standard_repn()` which both of these interfaces have to do (and is therefore out-of-scope here).
- There are still a few inefficiencies but I didn't bother digging / fixing to shave part-seconds on a large test case. For example, generators are slower than list comprehension.
	There are many places where generators are used where the iterable is sufficiently small to consume into memory (eg. `ComponentSet.update()`)
- Clearly the LP solver appears to for whatever reason gotten worse as well. I reran it as a control and I don't really have an explanation for that... Might need the reviewer's help in case I've somehow inadvertently impacted that solver.

### TODO

- [x] Unit tests

## Related

- #51
- #331
- #1160
- #1169

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
