### PR TITLE
Add ConfigEnum class

### DIFF
--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -11,6 +11,7 @@
 import os
 import platform
 
+import enum
 import six
 from pyutilib.misc.config import ConfigBlock, ConfigList, ConfigValue
 
@@ -157,3 +158,14 @@ def add_docstring_list(docstring, configblock, indent_by=4):
             indent_spacing=0,
             width=256
         ).splitlines(True))
+
+
+class ConfigEnum(enum.Enum):
+    @classmethod
+    def from_enum_or_string(cls, arg):
+        if type(arg) is str:
+            return cls[arg]
+        else:
+            # Handles enum or integer inputs
+            return cls(arg)
+

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -168,4 +168,3 @@ class ConfigEnum(enum.Enum):
         else:
             # Handles enum or integer inputs
             return cls(arg)
-

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -15,7 +15,7 @@ from pyomo.common.config import (
     ConfigBlock, ConfigList, ConfigValue,
     PositiveInt, NegativeInt, NonPositiveInt, NonNegativeInt,
     PositiveFloat, NegativeFloat, NonPositiveFloat, NonNegativeFloat,
-    In, Path, PathList
+    In, Path, PathList, ConfigEnum
 )
 
 class TestConfig(unittest.TestCase):
@@ -338,3 +338,17 @@ class TestConfig(unittest.TestCase):
         c.a = ()
         self.assertEqual(len(c.a), 0)
         self.assertIs(type(c.a), list)
+
+    def test_ConfigEnum(self):
+        class TestEnum(ConfigEnum):
+            ITEM_ONE = 1
+            ITEM_TWO = 2
+
+        self.assertEqual(TestEnum.from_enum_or_string(1),
+                TestEnum.ITEM_ONE)
+        self.assertEqual(TestEnum.from_enum_or_string(
+            TestEnum.ITEM_TWO), TestEnum.ITEM_TWO)
+        self.assertEqual(TestEnum.from_enum_or_string('ITEM_ONE'),
+                TestEnum.ITEM_ONE)
+
+

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -350,5 +350,3 @@ class TestConfig(unittest.TestCase):
             TestEnum.ITEM_TWO), TestEnum.ITEM_TWO)
         self.assertEqual(TestEnum.from_enum_or_string('ITEM_ONE'),
                 TestEnum.ITEM_ONE)
-
-

--- a/setup.py
+++ b/setup.py
@@ -36,13 +36,6 @@ def get_version():
         exec(_FILE.read(), _verInfo)
     return _verInfo['__version__']
 
-requires = [
-    'PyUtilib>=5.8.1.dev0',
-    'appdirs',
-    'ply',
-    'six>=1.4',
-    ]
-
 from setuptools import setup, find_packages
 
 CYTHON_REQUIRED = "required"
@@ -109,6 +102,7 @@ def run_setup():
       description='Pyomo: Python Optimization Modeling Objects',
       long_description=read('README.md'),
       long_description_content_type='text/markdown',
+      keywords=['optimization'],
       classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: End Users/Desktop',
@@ -132,12 +126,17 @@ def run_setup():
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Software Development :: Libraries :: Python Modules' ],
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+      install_requires=[
+          'PyUtilib>=5.8.1.dev0',
+          'appdirs',
+          'enum34;python_version<"3.4"',
+          'ply',
+          'six>=1.4',
+      ],
       packages=find_packages(exclude=("scripts",)),
       package_data={"pyomo.contrib.viewer":["*.ui"]},
-      keywords=['optimization'],
-      install_requires=requires,
       ext_modules = ext_modules,
-      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       entry_points="""
         [console_scripts]
         runbenders=pyomo.pysp.benders:Benders_main


### PR DESCRIPTION
## Summary/Motivation:
Sometimes would like to accept user input in form of an Enum, int, or string, each of which is translated to the corresponding Enum value.

## Changes proposed in this PR:
- Add ConfigEnum class, which implements the from_enum_or_string method, intended for use as a domain in a ConfigValue
- Test

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
