### PR TITLE
GDPOpt fix use of numeric derivatives

### DIFF
--- a/pyomo/contrib/gdpopt/cut_generation.py
+++ b/pyomo/contrib/gdpopt/cut_generation.py
@@ -3,6 +3,7 @@ from __future__ import division
 
 from collections import namedtuple
 from math import copysign, fabs
+from six import iteritems
 from pyomo.contrib.gdp_bounds.info import disjunctive_bounds
 from pyomo.contrib.gdpopt.util import time_code, constraints_in_True_disjuncts
 from pyomo.contrib.mcpp.pyomo_mcpp import McCormick as mc, MCPP_Error
@@ -109,7 +110,7 @@ def add_outer_approximation_cuts(nlp_result, solve_data, config):
                     copysign(1, sign_adjust * dual_value) * (
                         value(constr.body) - rhs + sum(
                             value(jac) * (var - value(var))
-                            for var, jac in iteritems(jacobian.jac)))
+                            for var, jac in iteritems(jacobian.jac))
                         ) - slack_var <= 0)
                 if new_oa_cut.polynomial_degree() not in (1, 0):
                     for var, jac in iteritems(jacobian.jac):

--- a/pyomo/contrib/gdpopt/cut_generation.py
+++ b/pyomo/contrib/gdpopt/cut_generation.py
@@ -1,6 +1,7 @@
 """This module provides functions for cut generation."""
 from __future__ import division
 
+from collections import namedtuple
 from math import copysign, fabs
 from pyomo.contrib.gdp_bounds.info import disjunctive_bounds
 from pyomo.contrib.gdpopt.util import time_code, constraints_in_True_disjuncts
@@ -13,6 +14,8 @@ from pyomo.core.kernel.component_map import ComponentMap
 from pyomo.core.kernel.component_set import ComponentSet
 from pyomo.gdp import Disjunct
 
+MAX_SYMBOLIC_DERIV_SIZE = 1000
+JacInfo = namedtuple('JacInfo', ['mode','vars','jac'])
 
 def add_subproblem_cuts(subprob_result, solve_data, config):
     if config.strategy == "LOA":
@@ -60,19 +63,32 @@ def add_outer_approximation_cuts(nlp_result, solve_data, config):
                 "Adding OA cut for %s with dual value %s"
                 % (constr.name, dual_value))
 
-            # Cache jacobians
-            jacobians = GDPopt.jacobians.get(constr, None)
-            if jacobians is None:
-                constr_vars = list(identify_variables(constr.body, include_fixed=False))
-                if len(constr_vars) >= 1000:
+            # Cache jacobian
+            jacobian = GDPopt.jacobians.get(constr, None)
+            if jacobian is None:
+                constr_vars = list(identify_variables(
+                    constr.body, include_fixed=False))
+                if len(constr_vars) >= MAX_SYMBOLIC_DERIV_SIZE:
                     mode = differentiate.Modes.reverse_numeric
                 else:
                     mode = differentiate.Modes.sympy
 
+                try:
+                    jac_list = differentiate(
+                        constr.body, wrt_list=constr_vars, mode=mode)
+                    jac_map = ComponentMap(zip(constr_vars, jac_list))
+                except:
+                    if mode is differentiate.Modes.reverse_numeric:
+                        raise
+                    mode = differentiate.Modes.reverse_numeric
+                    jac_map = ComponentMap()
+                jacobian = JacInfo(mode=mode, vars=constr_vars, jac=jac_map)
+                GDPopt.jacobians[constr] = jacobian
+            # Recompute numeric derivatives
+            if not jacobian.jac:
                 jac_list = differentiate(
-                    constr.body, wrt_list=constr_vars, mode=mode)
-                jacobians = ComponentMap(zip(constr_vars, jac_list))
-                GDPopt.jacobians[constr] = jacobians
+                    constr.body, wrt_list=jacobian.vars, mode=jacobian.mode)
+                jacobian.jac.update(zip(jacobian.vars, jac_list))
 
             # Create a block on which to put outer approximation cuts.
             oa_utils = parent_block.component('GDPopt_OA')
@@ -92,11 +108,12 @@ def add_outer_approximation_cuts(nlp_result, solve_data, config):
                 new_oa_cut = (
                     copysign(1, sign_adjust * dual_value) * (
                         value(constr.body) - rhs + sum(
-                            value(jacobians[var]) * (var - value(var))
-                            for var in jacobians)) - slack_var <= 0)
+                            value(jac) * (var - value(var))
+                            for var, jac in iteritems(jacobian.jac)))
+                        ) - slack_var <= 0)
                 if new_oa_cut.polynomial_degree() not in (1, 0):
-                    for var in jacobians:
-                        print(var.name, value(jacobians[var]))
+                    for var, jac in iteritems(jacobian.jac):
+                        print(var.name, value(jac))
                 oa_cuts.add(expr=new_oa_cut)
                 counter += 1
             except ZeroDivisionError:
@@ -106,6 +123,9 @@ def add_outer_approximation_cuts(nlp_result, solve_data, config):
                     % (constr.name,)
                 )
                 # Simply continue on to the next constraint.
+            # Clear out the numeric Jacobian values
+            if jacobian.mode is differentiate.Modes.reverse_numeric:
+                jacobian.jac.clear()
 
         config.logger.info('Added %s OA cuts' % counter)
 

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -5,7 +5,6 @@ from os.path import abspath, dirname, join, normpath
 
 from six import StringIO
 
-import pyomo.core.base.symbolic
 import pyutilib.th as unittest
 from pyomo.common.log import LoggingIntercept
 from pyomo.contrib.gdpopt.GDPopt import GDPoptSolver
@@ -148,8 +147,6 @@ class TestGDPoptUnit(unittest.TestCase):
 @unittest.skipIf(not LOA_solvers_available,
                  "Required subsolvers %s are not available"
                  % (LOA_solvers,))
-@unittest.skipIf(not pyomo.core.base.symbolic.differentiate_available,
-                 "Symbolic differentiation is not available")
 class TestGDPopt(unittest.TestCase):
     """Tests for the GDPopt solver plugin."""
 


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
GDPOpt currently caches symbolic derivatives for small constraints between iterations, making iterative cut generation more efficient.  However, if the derivatives are obtained numerically, the cached derivative values are incorrect.  This PR clears out numeric derivative values after the cut is generated.  It also adds a fallback option: if generation of symbolic derivatives fails, then it will automatically fall back on the generation of numeric derivatives (this is in preparation for the support of external functions in the numeric differentiation code).

Tests of the fallback routine will be added once efternal functions are supported by the numeric differentiation code.

## Changes proposed in this PR:
- clear (do not cache) numeric derivative values after the cut is generated
- add fallback to numeric derivatives if symbolic derivative generation fails.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
