### PR TITLE
Fix component_data_objects for scalar components with no len()

### DIFF
--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -61,6 +61,7 @@ class TestGenerators(unittest.TestCase):
         model = ConcreteModel()
         model.q = Set(initialize=[1,2])
         model.Q = Set(model.q,initialize=[1,2])
+        model.qq = NonNegativeIntegers*model.q
         model.x = Var(initialize=-1)
         model.X = Var(model.q,initialize=-1)
         model.e = Expression(initialize=-1)
@@ -152,8 +153,8 @@ class TestGenerators(unittest.TestCase):
 
         model.component_lists = {}
         model.component_data_lists = {}
-        model.component_lists[Set] = [model.q, model.Q]
-        model.component_data_lists[Set] = [model.q, model.Q[1], model.Q[2]]
+        model.component_lists[Set] = [model.q, model.Q, model.qq]
+        model.component_data_lists[Set] = [model.q, model.Q[1], model.Q[2], model.qq]
         model.component_lists[Var] = [model.x, model.X]
         model.component_data_lists[Var] = [model.x, model.X[1], model.X[2]]
         model.component_lists[Expression] = [model.e, model.E]
@@ -186,7 +187,8 @@ class TestGenerators(unittest.TestCase):
                 generator = list(block.component_objects(ctype, active=True, descend_into=False))
             except:
                 if issubclass(ctype, Component):
-                    self.fail("component_objects(active=True) failed with ctype %s" % ctype)
+                    print("component_objects(active=True) failed with ctype %s" % ctype)
+                    raise
             else:
                 if not issubclass(ctype, Component):
                     self.fail("component_objects(active=True) should have failed with ctype %s" % ctype)
@@ -205,7 +207,8 @@ class TestGenerators(unittest.TestCase):
                 generator = list(block.component_objects(ctype, descend_into=False))
             except:
                 if issubclass(ctype, Component):
-                    self.fail("components failed with ctype %s" % ctype)
+                    print("components failed with ctype %s" % ctype)
+                    raise
             else:
                 if not issubclass(ctype, Component):
                     self.fail("components should have failed with ctype %s" % ctype)
@@ -224,7 +227,8 @@ class TestGenerators(unittest.TestCase):
                 generator = list(block.component_data_iterindex(ctype, active=True, sort=False, descend_into=False))
             except:
                 if issubclass(ctype, Component):
-                    self.fail("component_data_objects(active=True, sort_by_keys=False) failed with ctype %s" % ctype)
+                    print("component_data_objects(active=True, sort_by_keys=False) failed with ctype %s" % ctype)
+                    raise
             else:
                 if not issubclass(ctype, Component):
                     self.fail("component_data_objects(active=True, sort_by_keys=False) should have failed with ctype %s" % ctype)
@@ -243,7 +247,8 @@ class TestGenerators(unittest.TestCase):
                 generator = list(block.component_data_iterindex(ctype, active=True, sort=True, descend_into=False))
             except:
                 if issubclass(ctype, Component):
-                    self.fail("component_data_objects(active=True, sort=True) failed with ctype %s" % ctype)
+                    print("component_data_objects(active=True, sort=True) failed with ctype %s" % ctype)
+                    raise
             else:
                 if not issubclass(ctype, Component):
                     self.fail("component_data_objects(active=True, sort=True) should have failed with ctype %s" % ctype)
@@ -262,7 +267,8 @@ class TestGenerators(unittest.TestCase):
                 generator = list(block.component_data_iterindex(ctype, sort=False, descend_into=False))
             except:
                 if issubclass(ctype, Component):
-                    self.fail("components_data(sort_by_keys=True) failed with ctype %s" % ctype)
+                    print("components_data(sort_by_keys=True) failed with ctype %s" % ctype)
+                    raise
             else:
                 if not issubclass(ctype, Component):
                     self.fail("components_data(sort_by_keys=True) should have failed with ctype %s" % ctype)
@@ -281,7 +287,8 @@ class TestGenerators(unittest.TestCase):
                 generator = list(block.component_data_iterindex(ctype, sort=True, descend_into=False))
             except:
                 if issubclass(ctype, Component):
-                    self.fail("components_data(sort_by_keys=False) failed with ctype %s" % ctype)
+                    print("components_data(sort_by_keys=False) failed with ctype %s" % ctype)
+                    raise
             else:
                 if not issubclass(ctype, Component):
                     self.fail("components_data(sort_by_keys=False) should have failed with ctype %s" % ctype)


### PR DESCRIPTION
## Fixes #1435.

## Summary/Motivation:
This fixes an edge case where `component_data_objects()` failed when the model contained scalar components with no `len()` (i.e., non-finite Sets).

## Changes proposed in this PR:
- Correct logic when iterating over component datas
- Update tests to include a non-finite Set.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
