### PR TITLE
[NFC] RangeSet docstring type hint

### DIFF
--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -2527,7 +2527,7 @@ class RangeSet(Component):
 
     Parameters
     ----------
-    *args: tuple | int | None
+    *args: int | float | None
         The range defined by ([start=1], end, [step=1]).  If only a
         single positional parameter, `end` is supplied, then the
         RangeSet will be the integers starting at 1 up through and

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -2527,7 +2527,7 @@ class RangeSet(Component):
 
     Parameters
     ----------
-    *args: tuple, optional
+    *args: tuple | int | None
         The range defined by ([start=1], end, [step=1]).  If only a
         single positional parameter, `end` is supplied, then the
         RangeSet will be the integers starting at 1 up through and


### PR DESCRIPTION
## Summary/Motivation:
Pycharm was telling me that I was using RangeSet wrong because of the type hint.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
