### PR TITLE
Ensure block rules are always called

### DIFF
--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1901,7 +1901,7 @@ class Block(ActiveIndexedComponent):
         try:
             if self.is_indexed():
                 # We can only populate Blocks with finite indexing sets
-                if self.index_set().isfinite():
+                if self._rule is not None and self.index_set().isfinite():
                     for _idx in self.index_set():
                         # Trigger population & call the rule
                         self._getitem_when_not_present(_idx)

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1051,8 +1051,10 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
             # NB: we don't have to construct the temporary / implicit
             # sets here: if necessary, that happens when
             # _add_implicit_sets() calls add_component().
-            if id(self) in _BlockConstruction.data:
-                data = _BlockConstruction.data[id(self)].get(name, None)
+            if _BlockConstruction.data:
+                data = _BlockConstruction.data.get(id(self), None)
+                if data is not None:
+                    data = data.get(name, None)
             else:
                 data = None
             if __debug__ and logger.isEnabledFor(logging.DEBUG):
@@ -1834,7 +1836,35 @@ class Block(ActiveIndexedComponent):
             self.construct()
 
     def _getitem_when_not_present(self, idx):
-        return self._setitem_when_not_present(idx)
+        _block = self._setitem_when_not_present(idx)
+        if self._rule is None:
+            return _block
+
+        if _BlockConstruction.data:
+            data = _BlockConstruction.data.get(id(self), None)
+            if data is not None:
+                data = data.get(idx, None)
+            if data is not None:
+                _BlockConstruction.data[id(_block)] = data
+        else:
+            data = None
+
+        try:
+            obj = apply_indexed_rule(
+                self, self._rule, _block, idx, self._options)
+        finally:
+            if data is not None:
+                del _BlockConstruction.data[id(_block)]
+
+        if obj is not _block and isinstance(obj, _BlockData):
+            # If the user returns a block, transfer over everything
+            # they defined into the empty one we created.
+            _block.transfer_attributes_from(obj)
+
+        # TBD: Should we allow skipping Blocks???
+        # if obj is Block.Skip and idx is not None:
+        #   del self._data[idx]
+        return _block
 
     def find_component(self, label_or_component):
         """
@@ -1854,54 +1884,57 @@ class Block(ActiveIndexedComponent):
         timer = ConstructionTimer(self)
         self._constructed = True
 
-        # We must check that any pre-existing components are
-        # constructed.  This catches the case where someone is building
-        # a Concrete model by building (potentially pseudo-abstract)
-        # sub-blocks and then adding them to a Concrete model block.
-        for idx in self._data:
-            _block = self[idx]
-            for name, obj in iteritems(_block.component_map()):
-                if not obj._constructed:
-                    if data is None:
-                        _data = None
-                    else:
-                        _data = data.get(name, None)
-                    obj.construct(_data)
+        # Constructing blocks is tricky.  Scalar blocks are already
+        # partially constructed (they have _data[None] == self) in order
+        # to support Abstract blocks.  The block may therefore already
+        # have components declared on it.  In order to preserve
+        # decl_order, we must construct those components *first* before
+        # firing any rule.  Indexed blocks should be empty, so we only
+        # need to fire the rule in order.
+        #
+        #  Since the rule does not pass any "data" on, we build a scalar
+        #  "stack" of pointers to block data (_BlockConstruction.data)
+        #  that the individual blocks' add_component() can refer back to
+        #  to handle component construction.
+        if data is not None:
+            _BlockConstruction.data[id(self)] = data
+        try:
+            if self.is_indexed():
+                # We can only populate Blocks with finite indexing sets
+                if self.index_set().isfinite():
+                    for _idx in self.index_set():
+                        # Trigger population & call the rule
+                        self._getitem_when_not_present(_idx)
+            else:
+                # We must check that any pre-existing components are
+                # constructed.  This catches the case where someone is
+                # building a Concrete model by building (potentially
+                # pseudo-abstract) sub-blocks and then adding them to a
+                # Concrete model block.
+                _idx = next(iter(UnindexedComponent_set))
+                _block = self[_idx]
+                for name, obj in iteritems(_block.component_map()):
+                    if not obj._constructed:
+                        if data is None:
+                            _data = None
+                        else:
+                            _data = data.get(name, None)
+                        obj.construct(_data)
+                if self._rule is not None:
+                    obj = apply_indexed_rule(
+                        self, self._rule, _block, _idx, self._options)
+                    if obj is not _block and isinstance(obj, _BlockData):
+                        # If the user returns a block, transfer over
+                        # everything they defined into the empty one we
+                        # created.
+                        _block.transfer_attributes_from(obj)
 
-        if self._rule is None:
-            # Ensure the _data dictionary is populated for singleton
-            # blocks
-            if not self.is_indexed():
-                self[None]
-            timer.report()
-            return
-        # If we have a rule, fire the rule for all indices.
-        # Notes:
-        #  - Since this block is now concrete, any components added to
-        #    it will be immediately constructed by
-        #    block.add_component().
-        #  - Since the rule does not pass any "data" on, we build a
-        #    scalar "stack" of pointers to block data
-        #    (_BlockConstruction.data) that the individual blocks'
-        #    add_component() can refer back to to handle component
-        #    construction.
-        for idx in self._index:
-            _block = self[idx]
-            if data is not None and idx in data:
-                _BlockConstruction.data[id(_block)] = data[idx]
-            obj = apply_indexed_rule(
-                self, self._rule, _block, idx, self._options)
-            if id(_block) in _BlockConstruction.data:
-                del _BlockConstruction.data[id(_block)]
-
-            if obj is not _block and isinstance(obj, _BlockData):
-                # If the user returns a block, transfer over everything
-                # they defined into the empty one we created.
-                _block.transfer_attributes_from(obj)
-
-            # TBD: Should we allow skipping Blocks???
-            # if obj is Block.Skip and idx is not None:
-            #   del self._data[idx]
+        finally:
+            # We must check if data is still in the dictionary, as
+            # scalar blocks will have already removed the entry (as
+            # the _data and the component are the same object)
+            if data is not None and id(self) in _BlockConstruction.data:
+                del _BlockConstruction.data[id(self)]
         timer.report()
 
     def _pprint_callback(self, ostream, idx, data):
@@ -1945,6 +1978,10 @@ class SimpleBlock(_BlockData, Block):
     def __init__(self, *args, **kwds):
         _BlockData.__init__(self, component=self)
         Block.__init__(self, *args, **kwds)
+        # Iniitalize the data dict so that (abstract) attribute
+        # assignment will work.  Note that we do not trigger
+        # get/setitem_when_not_present so that we do not (implicitly)
+        # trigger the Block rule
         self._data[None] = self
 
     def display(self, filename=None, ostream=None, prefix=""):

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -2427,6 +2427,58 @@ class TestBlock(unittest.TestCase):
         b.pprint(ostream=stream)
         self.assertEqual(correct_s, stream.getvalue())
 
+    def test_block_rules(self):
+        m = ConcreteModel()
+        m.I = Set()
+        _rule_ = []
+        def _block_rule(b,i):
+            _rule_.append(i)
+            b.x = Var(range(i))
+        m.b = Block(m.I, rule=_block_rule)
+        # I is empty: no rules called
+        self.assertEqual(_rule_, [])
+        m.I.update([1,3,5])
+        # Fetching a new block will call the rule
+        _b = m.b[3]
+        self.assertEqual(len(m.b), 1)
+        self.assertEqual(_rule_, [3])
+        self.assertIn('x', _b.component_map())
+        self.assertIn('x', m.b[3].component_map())
+
+        # If you transfer the attributes directly, the rule will still
+        # be called.
+        _tmp = Block()
+        _tmp.y = Var(range(3))
+        m.b[5].transfer_attributes_from(_tmp)
+        self.assertEqual(len(m.b), 2)
+        self.assertEqual(_rule_, [3,5])
+        self.assertIn('x', m.b[5].component_map())
+        self.assertIn('y', m.b[5].component_map())
+
+        # We do not support block assignment (and the rule will NOT be
+        # called)
+        _tmp = Block()
+        _tmp.y = Var(range(3))
+        with self.assertRaisesRegex(
+                RuntimeError, "Block components do not support "
+                "assignment or set_value"):
+            m.b[1] = _tmp
+        self.assertEqual(len(m.b), 2)
+        self.assertEqual(_rule_, [3,5])
+
+        # Blocks with non-finite indexing sets cannot be automatically
+        # populated (even if they have a rule!)
+        def _bb_rule(b, i, j):
+            _rule_.append((i,j))
+            b.x = Var(RangeSet(i))
+            b.y = Var(RangeSet(j))
+        m.bb = Block(m.I, NonNegativeIntegers, rule=_bb_rule)
+        self.assertEqual(_rule_, [3,5])
+        _b = m.bb[3,5]
+        self.assertEqual(_rule_, [3,5,(3,5)])
+        self.assertEqual(len(m.bb), 1)
+        self.assertEqual(len(_b.x), 3)
+        self.assertEqual(len(_b.y), 5)
 
 
 if __name__ == "__main__":

--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -333,23 +333,10 @@ def _update_block(blk):
                 'function on Block-derived components that override '
                 'construct()' % blk.name)
 
-    # Code taken from the construct() method of Block
     missing_idx = getattr(blk, '_dae_missing_idx', set([]))
     for idx in list(missing_idx):
-        _block = blk[idx]
-        obj = apply_indexed_rule(
-            blk, blk._rule, _block, idx, blk._options)
- 
-        if isinstance(obj, _BlockData) and obj is not _block:
-            # If the user returns a block, use their block instead
-            # of the empty one we just created.
-            for c in list(obj.component_objects(descend_into=False)):
-                obj.del_component(c)
-                _block.add_component(c.local_name, c)
-                # transfer over any other attributes that are not components
-            for name, val in iteritems(obj.__dict__):
-                if not hasattr(_block, name) and not hasattr(blk, name):
-                    super(_BlockData, _block).__setattr__(name, val)
+        # Trigger block creation (including calling the Block's rule)
+        blk[idx]
 
     # Remove book-keeping data after Block is discretized
     if hasattr(blk, '_dae_missing_idx'):

--- a/pyomo/mpec/complementarity.py
+++ b/pyomo/mpec/complementarity.py
@@ -21,6 +21,9 @@ from pyomo.core.base.plugin import ModelComponentFactory
 from pyomo.core.base.numvalue import ZeroConstant, _sub
 from pyomo.core.base.misc import apply_indexed_rule, tabular_writer
 from pyomo.core.base.block import _BlockData
+from pyomo.core.base.util import (
+    disable_methods, Initializer, IndexedCallInitializer, CountedCallInitializer
+)
 
 import logging
 logger = logging.getLogger('pyomo.core')
@@ -132,84 +135,7 @@ class _ComplementarityData(_BlockData):
             self.v = Var(bounds=(0, None))
             self.ve = Constraint(expr=self.v == _e1[2] - _e1[1])
 
-
-@ModelComponentFactory.register("Complementarity conditions.")
-class Complementarity(Block):
-
-    Skip = (1000,)
-
-    def __new__(cls, *args, **kwds):
-        if cls != Complementarity:
-            return super(Complementarity, cls).__new__(cls)
-        if args == ():
-            return SimpleComplementarity.__new__(SimpleComplementarity)
-        else:
-            return IndexedComplementarity.__new__(IndexedComplementarity)
-
-    def __init__(self, *args, **kwargs):
-        self._expr = kwargs.pop('expr', None )
-        #
-        kwargs.setdefault('ctype', Complementarity)
-        #
-        # The attribute _rule is initialized here.
-        #
-        Block.__init__(self, *args, **kwargs)
-
-    def construct(self, data=None):
-        if __debug__ and logger.isEnabledFor(logging.DEBUG):        #pragma:nocover
-            logger.debug("Constructing %s '%s', from data=%s",
-                         self.__class__.__name__, self.name, str(data))
-        if self._constructed:                                       #pragma:nocover
-            return
-        timer = ConstructionTimer(self)
-
-        #
-        _self_rule = self._rule
-        self._rule = None
-        super(Complementarity, self).construct()
-        self._rule = _self_rule
-        #
-        if _self_rule is None and self._expr is None:
-            # No construction rule or expression specified.
-            return
-        #
-        if not self.is_indexed():
-            #
-            # Scalar component
-            #
-            if _self_rule is None:
-                self.add(None, self._expr)
-            else:
-                try:
-                    tmp = _self_rule(self.parent_block())
-                    self.add(None, tmp)
-                except Exception:
-                    err = sys.exc_info()[1]
-                    logger.error(
-                        "Rule failed when generating expression for "
-                        "complementarity %s:\n%s: %s"
-                        % ( self.name, type(err).__name__, err ) )
-                    raise
-        else:
-            if not self._expr is None:
-                raise IndexError(
-                    "Cannot initialize multiple indices of a Complementarity "
-                    "component with a single expression")
-            _self_parent = self._parent()
-            for idx in self._index:
-                try:
-                    tmp = apply_indexed_rule( self, _self_rule, _self_parent, idx )
-                    self.add(idx, tmp)
-                except Exception:
-                    err = sys.exc_info()[1]
-                    logger.error(
-                        "Rule failed when generating expression for "
-                        "complementarity %s with index %s:\n%s: %s"
-                        % ( self.name, idx, type(err).__name__, err ) )
-                    raise
-        timer.report()
-
-    def add(self, index, cc):
+    def set_value(self, cc):
         """
         Add a complementarity condition with a specified index.
         """
@@ -218,37 +144,98 @@ class Complementarity(Block):
             # The ComplementarityTuple has a fixed length, so we initialize
             # the _args component and return
             #
-            self[index]._args = ( as_numeric(cc.arg0), as_numeric(cc.arg1) )
-            return self[index]
+            self._args = ( as_numeric(cc.arg0), as_numeric(cc.arg1) )
         #
-        if cc.__class__ is tuple:
+        elif cc.__class__ is tuple:
             if cc is Complementarity.Skip:
-                return
+                del self.parent_component()[self.index()]
             elif len(cc) != 2:
                 raise ValueError(
                     "Invalid tuple for Complementarity %s (expected 2-tuple):"
                     "\n\t%s" % (self.name, cc) )
+            else:
+                self._args = tuple( as_numeric(x) for x in cc )
         elif cc.__class__ is list:
             #
-            # Call add() recursively to apply the error same error
+            # Call set_value() recursively to apply the error same error
             # checks.
             #
-            return self.add(index, tuple(cc))
-        elif cc is None:
-                raise ValueError("""
+            return self.set_value(tuple(cc))
+        else:
+            raise ValueError(
+                "Unexpected value for Complementarity %s:\n\t%s"
+                % (self.name, cc) )
+
+
+@ModelComponentFactory.register("Complementarity conditions.")
+class Complementarity(Block):
+
+    Skip = (1000,)
+    _ComponentDataClass = _ComplementarityData
+
+    def __new__(cls, *args, **kwds):
+        if cls != Complementarity:
+            return super(Complementarity, cls).__new__(cls)
+        if args == ():
+            return super(Complementarity, cls).__new__(AbstractSimpleComplementarity)
+        else:
+            return super(Complementarity, cls).__new__(IndexedComplementarity)
+
+    @staticmethod
+    def _complementarity_rule(b, *idx):
+        _rule = b.parent_component()._init_rule
+        if _rule is None:
+            return
+        cc = _rule(b.parent_block(), idx)
+        if cc is None:
+            raise ValueError("""
 Invalid complementarity condition.  The complementarity condition
 is None instead of a 2-tuple.  Please modify your rule to return
 Complementarity.Skip instead of None.
 
-Error thrown for Complementarity "%s"
-""" % ( self.name, ) )
-        else:
+Error thrown for Complementarity "%s".""" % ( b.name, ) )
+        b.set_value(cc)
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('ctype', Complementarity)
+        _init = tuple( _arg for _arg in (
+            kwargs.pop('initialize', None),
+            kwargs.pop('rule', None),
+            kwargs.pop('expr', None) ) if _arg is not None )
+        if len(_init) > 1:
             raise ValueError(
-                "Unexpected argument declaring Complementarity %s:\n\t%s"
-                % (self.name, cc) )
-        #
-        self[index]._args = tuple( as_numeric(x) for x in cc )
-        return self[index]
+                "Duplicate initialization: Complementarity() only accepts "
+                "one of 'initialize=', 'rule=', and 'expr='")
+        elif _init:
+            _init = _init[0]
+        else:
+            _init = None
+
+        self._init_rule = Initializer(
+            _init, treat_sequences_as_mappings=False, allow_generators=True
+        )
+
+        if self._init_rule is not None:
+            kwargs['rule'] = Complementarity._complementarity_rule
+        Block.__init__(self, *args, **kwargs)
+
+        # HACK to make the "counted call" syntax work.  We wait until
+        # after the base class is set up so that is_indexed() is
+        # reliable.
+        if self._init_rule is not None \
+           and self._init_rule.__class__ is IndexedCallInitializer:
+            self._init_rule = CountedCallInitializer(self, self._init_rule)
+
+
+    def add(self, index, cc):
+        """
+        Add a complementarity condition with a specified index.
+        """
+        if cc is Complementarity.Skip:
+            return
+        _block = self[index]
+        _block.set_value(cc)
+        return _block
 
     def _pprint(self):
         """
@@ -298,10 +285,13 @@ class SimpleComplementarity(_ComplementarityData, Complementarity):
         self._data[None] = self
 
 
-class IndexedComplementarity(Complementarity):
+@disable_methods({'add', 'set_value', 'to_standard_form'})
+class AbstractSimpleComplementarity(SimpleComplementarity):
+    pass
 
-    def _getitem_when_not_present(self, idx):
-        return self._data.setdefault(idx, _ComplementarityData(self))
+
+class IndexedComplementarity(Complementarity):
+    pass
 
 
 @ModelComponentFactory.register("A list of complementarity conditions.")
@@ -319,6 +309,10 @@ class ComplementarityList(IndexedComplementarity):
         args = (Set(),)
         self._nconditions = 0
         Complementarity.__init__(self, *args, **kwargs)
+        # disable the implicit rule; construct will exhause the
+        # user-provided rule, and then subsequent attempts to add a CC
+        # will bypass the rule
+        self._rule = None
 
     def add(self, expr):
         """
@@ -333,41 +327,21 @@ class ComplementarityList(IndexedComplementarity):
         Construct the expression(s) for this complementarity condition.
         """
         generate_debug_messages = __debug__ and logger.isEnabledFor(logging.DEBUG)
-        if generate_debug_messages:         #pragma:nocover
+        if generate_debug_messages:
             logger.debug("Constructing complementarity list %s", self.name)
-        if self._constructed:               #pragma:nocover
+        if self._constructed:
             return
         timer = ConstructionTimer(self)
-        _self_rule = self._rule
         self._constructed=True
-        if _self_rule is None:
-            return
-        #
-        _generator = None
-        _self_parent = self._parent()
-        if inspect.isgeneratorfunction(_self_rule):
-            _generator = _self_rule(_self_parent)
-        elif inspect.isgenerator(_self_rule):
-            _generator = _self_rule
-        if _generator is None:
-            while True:
-                val = self._nconditions + 1
-                if generate_debug_messages:     #pragma:nocover
-                    logger.debug("   Constructing complementarity index "+str(val))
-                expr = apply_indexed_rule( self, _self_rule, _self_parent, val )
-                if expr is None:
-                    raise ValueError( "Complementarity rule returned None "
-                                      "instead of ComplementarityList.End" )
-                if (expr.__class__ is tuple and expr == ComplementarityList.End):
-                    return
-                self.add(expr)
-        else:
-            for expr in _generator:
-                if expr is None:
-                    raise ValueError( "Complementarity generator returned None "
-                                      "instead of ComplementarityList.End" )
-                if (expr.__class__ is tuple and expr == ComplementarityList.End):
-                    return
-                self.add(expr)
+
+        if self._init_rule is not None:
+            _init = self._init_rule(self.parent_block(), ())
+            for cc in iter(_init):
+                if cc is ComplementarityList.End:
+                    break
+                if cc is Complementarity.Skip:
+                    continue
+                self.add(cc)
+
         timer.report()
 

--- a/pyomo/mpec/complementarity.py
+++ b/pyomo/mpec/complementarity.py
@@ -309,7 +309,7 @@ class ComplementarityList(IndexedComplementarity):
         args = (Set(),)
         self._nconditions = 0
         Complementarity.__init__(self, *args, **kwargs)
-        # disable the implicit rule; construct will exhause the
+        # disable the implicit rule; construct will exhaust the
         # user-provided rule, and then subsequent attempts to add a CC
         # will bypass the rule
         self._rule = None

--- a/pyomo/mpec/tests/test_complementarity.py
+++ b/pyomo/mpec/tests/test_complementarity.py
@@ -208,11 +208,9 @@ class CCTests(object):
     def test_cov6(self):
         # Testing construction with indexing and an expression
         M = self._setup()
-        try:
+        with self.assertRaisesRegex(
+                ValueError, "Invalid tuple for Complementarity"):
             M.cc = Complementarity([0,1], expr=())
-            self.fail("Expected an IndexError")
-        except IndexError:
-            pass
 
     def test_cov7(self):
         # Testing error checking with return value
@@ -313,7 +311,10 @@ class CCTests(object):
 
     def test_list5(self):
         M = self._setup()
-        M.cc = ComplementarityList(rule=(complements(M.y + M.x3, M.x1 + 2*M.x2 == i) for i in range(3)))
+        M.cc = ComplementarityList(
+            rule=( complements(M.y + M.x3, M.x1 + 2*M.x2 == i)
+                   for i in range(3) )
+        )
         self._test("list5", M)
 
     def test_list6(self):


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This resolves an issue where Block rules were not being called for blocks created outside of `construct()`.  As the `rule` is the user's "initializer" for a Block, it was surprising (and problematic for DAE) that the rule was not being triggered automatically for Blocks that were created after `construct()` (e.g., when the underlying set was extended, or for Blocks indexed by non-finite Sets).

## Changes proposed in this PR:
- Ensure that the Block rule is always called, regardless of when the BlockData was created.
- Update tests to cover this behavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
