### PR TITLE
Coverage configuration updates

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,5 +10,8 @@ coverage:
       default:
         # Force patches to be covered at the level of the codebase
         threshold: 0%
+  notify:
+    # GHA: 18, Travis: 13, Jenkins: 6
+    after_n_builds: 37
 #  ci:
 #    - !ci.appveyor.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,8 @@ after_success:
     # Combine coverage reports over all subprocesses and upload
   - ${DOC} find . -maxdepth 10 -name ".cov*"
   - ${DOC} coverage combine
+  - ${DOC} coverage report -i
+  - ${DOC} coverage xml -i
   - ${DOC} codecov --env TAG -X gcov
     # Trigger PyomoGallery build, but only when building the master branch
     # Note: this is disabled unless a token is injected through an


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This prevents Codecov from reporting coverage results (and potentially failing the PR) until after all tests have completed.  This also adds a coverage report to the end of the Travis builds to make it more consistent with the GitHub Actions workflows.

## Changes proposed in this PR:
- Prevent Codecov notification until after all builds complete
- Add codecov report to the Travis jobs

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
