### PR TITLE
Prevent exception for transformations missing doc string

### DIFF
--- a/pyomo/scripting/driver_help.py
+++ b/pyomo/scripting/driver_help.py
@@ -259,7 +259,19 @@ def help_transformations():
     print("---------------------------")
     for xform in sorted(TransformationFactory):
         print("  "+xform)
-        print(wrapper.fill(TransformationFactory.doc(xform)))
+        _doc = TransformationFactory.doc(xform) or ""
+        # Ideally, the Factory would ensure that the doc string
+        # indicated deprecation, but as @deprecated() is Pyomo
+        # functionality and the Factory comes directly from PyUtilib,
+        # PyUtilib probably shouldn't contain Pyomo-specific processing.
+        # The next best thing is to ensure that the deprecation status
+        # is indicated here.
+        _init_doc = TransformationFactory.get_class(xform).__init__.__doc__ \
+                    or ""
+        if _init_doc.startswith('DEPRECATION') and 'DEPRECAT' not in _doc:
+            _doc = ' '.join(('[DEPRECATED]', _doc))
+        if _doc:
+            print(wrapper.fill(_doc))
 
 def help_solvers():
     import pyomo.environ

--- a/pyomo/scripting/tests/test_cmds.py
+++ b/pyomo/scripting/tests/test_cmds.py
@@ -13,7 +13,7 @@ import pyutilib.th as unittest
 from pyutilib.misc.redirect_io import capture_output
 
 from pyomo.environ import SolverFactory
-from pyomo.scripting.driver_help import help_solvers
+from pyomo.scripting.driver_help import help_solvers, help_transformations
 
 
 class Test(unittest.TestCase):
@@ -35,6 +35,15 @@ class Test(unittest.TestCase):
                 self.assertTrue(re.search("%s +\* [a-zA-Z]" % solver, OUT))
             else:
                 self.assertTrue(re.search("%s +[a-zA-Z]" % solver, OUT))
+
+    def test_help_transformations(self):
+        with capture_output() as OUT:
+            help_transformations()
+        OUT = OUT.getvalue()
+        self.assertTrue(re.search('Pyomo Model Transformations', OUT))
+        self.assertTrue(re.search('core.relax_integer_vars', OUT))
+        # test a transformation that we know is deprecated
+        self.assertTrue(re.search('duality.linear_dual\s+\[DEPRECATED\]', OUT))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fixes #N/A
(but was motivated by #1453)

## Summary/Motivation:
Transformations that fail to define a doc string should not cause `pyomo help --transformations` to generate an exception.  This also adds a basic test that help_transformations() runs and generates reasonable output.

## Changes proposed in this PR:
- Prevent generating an exception when running `pyomo help --transformations` for transformations that do not register a `doc` string.
- Ensure that the documentation outputted by `help_transformations` includes the string `[DEPRECATED]` if the transformation's `__init__()` was deprecated using `@deprecated`.
- Add a test that exercises `help_transformations()`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
