### PR TITLE
Fix typos in .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,8 +10,10 @@ coverage:
       default:
         # Force patches to be covered at the level of the codebase
         threshold: 0%
-  notify:
-    # GHA: 18, Travis: 13, Jenkins: 6
-    after_n_builds: 37
 #  ci:
 #    - !ci.appveyor.com
+codecov:
+  notify:
+    # GHA: 18, Travis: 13, Jenkins: 6
+    after_n_builds: 35
+    wait_for_ci: yes


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Fixing error from #1451.  The 'notify:' section needs to by under 'codecov:' and not 'coverage:'

## Changes proposed in this PR:
- Move the `notify:` section in the `.codecov.yml` configuration

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
