### PR TITLE
Coverage reporting updates

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,5 +15,5 @@ coverage:
 codecov:
   notify:
     # GHA: 18, Travis: 13, Jenkins: 6
-    after_n_builds: 35
+    after_n_builds: 33
     wait_for_ci: yes

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -393,7 +393,7 @@ jobs:
         i=0
         while : ; do
             curl --retry 8 -L https://codecov.io/bash -o codecov.sh
-            bash codecov.sh -X gcov -f coverage.xml | tee .cover.upload
+            bash codecov.sh -Z -X gcov -f coverage.xml | tee .cover.upload
             if test $? == 0; then
                 break
             elif test $i -ge 3; then

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -391,7 +391,7 @@ jobs:
         coverage report -i
         coverage xml -i
         i=0
-        while /bin/true; do
+        while : ; do
             curl --retry 8 -L https://codecov.io/bash -o codecov.sh
             bash codecov.sh -X gcov -f coverage.xml | tee .cover.upload
             if test $? == 0; then

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -396,10 +396,10 @@ jobs:
             bash codecov.sh -Z -X gcov -f coverage.xml | tee .cover.upload
             if test $? == 0; then
                 break
-            elif test $i -ge 3; then
+            elif test $i -ge 4; then
                 exit 1
             fi
-            DELAY=$(( RANDOM % 30 + 15))
+            DELAY=$(( RANDOM % 30 + 30))
             echo "Pausing $DELAY seconds before re-attempting upload"
             sleep $DELAY
         done

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -395,10 +395,10 @@ jobs:
             bash codecov.sh -Z -X gcov -f coverage.xml | tee .cover.upload
             if test $? == 0; then
                 break
-            elif test $i -ge 3; then
+            elif test $i -ge 4; then
                 exit 1
             fi
-            DELAY=$(( RANDOM % 30 + 15))
+            DELAY=$(( RANDOM % 30 + 30))
             echo "Pausing $DELAY seconds before re-attempting upload"
             sleep $DELAY
         done

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -390,7 +390,7 @@ jobs:
         coverage report -i
         coverage xml -i
         i=0
-        while /bin/true; do
+        while : ; do
             curl --retry 8 -L https://codecov.io/bash -o codecov.sh
             bash codecov.sh -X gcov -f coverage.xml | tee .cover.upload
             if test $? == 0; then

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -392,7 +392,7 @@ jobs:
         i=0
         while : ; do
             curl --retry 8 -L https://codecov.io/bash -o codecov.sh
-            bash codecov.sh -X gcov -f coverage.xml | tee .cover.upload
+            bash codecov.sh -Z -X gcov -f coverage.xml | tee .cover.upload
             if test $? == 0; then
                 break
             elif test $i -ge 3; then

--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -193,7 +193,7 @@ if test -z "$MODE" -o "$MODE" == test; then
                     | tee .cover.upload
                 if test $? == 0 -a `grep -i error .cover.upload | wc -l` -eq 0; then
                     break
-                elif  test $i -ge 3; then
+                elif test $i -ge 4; then
                     exit 1
                 fi
                 DELAY=$(( RANDOM % 30 + 15))

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,9 +106,23 @@ after_success:
   - ${DOC} coverage combine
   - ${DOC} coverage report -i
   - ${DOC} coverage xml -i
-  - ${DOC} codecov --env TAG -X gcov -X s3
-    # Trigger PyomoGallery build, but only when building the master branch
-    # Note: this is disabled unless a token is injected through an
-    # environment variable
+  - |
+    i=0
+    while : ; do
+        i=$[$i+1]
+        echo "Uploading coverage to codecov (attempt $i)"
+        ${DOC} codecov --env TAG -X gcov -X s3
+        if test $? == 0; then
+            break
+        elif test $i -ge 4; then
+            exit 1
+        fi
+        DELAY=$(( RANDOM % 30 + 30))
+        echo "Pausing $DELAY seconds before re-attempting upload"
+        sleep $DELAY
+    done
+  # Trigger PyomoGallery build, but only when building the master branch
+  # Note: this is disabled unless a token is injected through an
+  # environment variable
   - "if [ -n \"${SECRET_TRAVIS_TOKEN}\" -a -n \"${KEY_JOB}\" -a \"${TRAVIS_PULL_REQUEST}\" == false ]; then curl -s -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -H 'Travis-API-Version: 3' -H 'Authorization: token ${SECRET_TRAVIS_TOKEN}' -d '{\"request\": {\"branch\": \"master\"}}' https://api.travis-ci.org/repo/Pyomo%2FPyomoGallery/requests; fi"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ after_success:
   - ${DOC} coverage combine
   - ${DOC} coverage report -i
   - ${DOC} coverage xml -i
-  - ${DOC} codecov --env TAG -X gcov
+  - ${DOC} codecov --env TAG -X gcov -X s3
     # Trigger PyomoGallery build, but only when building the master branch
     # Note: this is disabled unless a token is injected through an
     # environment variable


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
A number of changes were necessary to improve the reliability of code coverage  reporting.  The S3 uploader through the codecov package is not currently working.  This PR disables S3 uploads so that we get coverage reports from Travis.  This also resolves an issue on OSX in GHA, and increases the number of upload retry attempts.

## Changes proposed in this PR:
- Disable S3 codecov uploader in Travis driver
- Add upload retry attempts to Travis
- Increase upload retry attempts with longer delays in between
- Fix a compatibility issue with OSX

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
