### PR TITLE
Fix construction of scalar derived blocks

### DIFF
--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1908,6 +1908,10 @@ class Block(ActiveIndexedComponent):
                 # Concrete model block.
                 _idx = next(iter(UnindexedComponent_set))
                 if _idx not in self._data:
+                    # Derived block classes may not follow the scalar
+                    # Block convention of initializing _data to point to
+                    # itself (i.e., they are not set up to support
+                    # Abstract models)
                     self._data[_idx] = self
                 _block = self
                 for name, obj in iteritems(_block.component_map()):

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1907,7 +1907,9 @@ class Block(ActiveIndexedComponent):
                 # pseudo-abstract) sub-blocks and then adding them to a
                 # Concrete model block.
                 _idx = next(iter(UnindexedComponent_set))
-                _block = self[_idx]
+                if _idx not in self._data:
+                    self._data[_idx] = self
+                _block = self
                 for name, obj in iteritems(_block.component_map()):
                     if not obj._constructed:
                         if data is None:
@@ -1923,14 +1925,13 @@ class Block(ActiveIndexedComponent):
                         # everything they defined into the empty one we
                         # created.
                         _block.transfer_attributes_from(obj)
-
         finally:
             # We must check if data is still in the dictionary, as
             # scalar blocks will have already removed the entry (as
             # the _data and the component are the same object)
             if data is not None and id(self) in _BlockConstruction.data:
                 del _BlockConstruction.data[id(self)]
-        timer.report()
+            timer.report()
 
     def _pprint_callback(self, ostream, idx, data):
         if not self.is_indexed():
@@ -1973,7 +1974,7 @@ class SimpleBlock(_BlockData, Block):
     def __init__(self, *args, **kwds):
         _BlockData.__init__(self, component=self)
         Block.__init__(self, *args, **kwds)
-        # Iniitalize the data dict so that (abstract) attribute
+        # Initialize the data dict so that (abstract) attribute
         # assignment will work.  Note that we do not trigger
         # get/setitem_when_not_present so that we do not (implicitly)
         # trigger the Block rule

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -2487,6 +2487,27 @@ class TestBlock(unittest.TestCase):
         self.assertEqual(len(_b.x), 3)
         self.assertEqual(len(_b.y), 5)
 
+    def test_derived_block_construction(self):
+        # This tests a case where a derived block doesn't follow the
+        # assumption that unconstructed scalar blocks initialize
+        # `_data[None] = self` (therefore doesn't fully support abstract
+        # models).  At one point, that was causing the block rule to
+        # fire twice during construction.
+        class ConcreteBlock(Block):
+            pass
+
+        class ScalarConcreteBlock(_BlockData, ConcreteBlock):
+            def __init__(self, *args, **kwds):
+                _BlockData.__init__(self, component=self)
+                ConcreteBlock.__init__(self, *args, **kwds)
+
+        _buf = []
+        def _rule(b):
+            _buf.append(1)
+
+        m = ConcreteModel()
+        m.b = ScalarConcreteBlock(rule=_rule)
+        self.assertEqual(_buf, [1])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
#1438 changed how Block rules were fired to ensure that the rule is always fired.  This led to a situation where a scalar derived Block class that did *not* initialize `self._data[None] = self` ended up getting its rule called twice.  The `_data` initialization is used to support "abstract" blocks, and derived classes may not intentionally support Abstract mode.

The bug was discovered by [IDAES](https://github.com/IDAES/idaes-pse).

## Changes proposed in this PR:
- improve Block construction for the case where a derived Block fails to initialize `self._data`
- add a test case verifying this condition.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
