### PR TITLE
Remove an unneeded 'tee' of the codecov output

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -393,7 +393,7 @@ jobs:
         i=0
         while : ; do
             curl --retry 8 -L https://codecov.io/bash -o codecov.sh
-            bash codecov.sh -Z -X gcov -f coverage.xml | tee .cover.upload
+            bash codecov.sh -Z -X gcov -f coverage.xml
             if test $? == 0; then
                 break
             elif test $i -ge 4; then

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -392,7 +392,7 @@ jobs:
         i=0
         while : ; do
             curl --retry 8 -L https://codecov.io/bash -o codecov.sh
-            bash codecov.sh -Z -X gcov -f coverage.xml | tee .cover.upload
+            bash codecov.sh -Z -X gcov -f coverage.xml
             if test $? == 0; then
                 break
             elif test $i -ge 4; then


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This removes an unneeded 'tee' of the codecov output.  Removing this should avoid masking `$?`, so that the logic to re-attempt failed codecov uploads will work.

## Changes proposed in this PR:
- remove unneeded 'tee'/pipeline in codecov upload

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
