### PR TITLE
GAMS: handle fixed variables in LinearExpressions

### DIFF
--- a/pyomo/repn/tests/gams/fixed_linear_expr.gams.baseline
+++ b/pyomo/repn/tests/gams/fixed_linear_expr.gams.baseline
@@ -1,0 +1,52 @@
+$offlisting
+$offdigit
+
+EQUATIONS
+	c1_lo
+	c2
+	obj;
+
+POSITIVE VARIABLES
+	x;
+
+VARIABLES
+	GAMS_OBJECTIVE
+	y;
+
+y.fx = 0;
+
+c1_lo.. 0 =l= y + y ;
+c2.. x + y =e= 1 ;
+obj.. GAMS_OBJECTIVE =e= x ;
+
+
+MODEL GAMS_MODEL /all/ ;
+option solprint=off;
+option limrow=0;
+option limcol=0;
+option solvelink=5;
+SOLVE GAMS_MODEL USING lp minimizing GAMS_OBJECTIVE;
+
+Scalars MODELSTAT 'model status', SOLVESTAT 'solve status';
+MODELSTAT = GAMS_MODEL.modelstat;
+SOLVESTAT = GAMS_MODEL.solvestat;
+
+Scalar OBJEST 'best objective', OBJVAL 'objective value';
+OBJEST = GAMS_MODEL.objest;
+OBJVAL = GAMS_MODEL.objval;
+
+Scalar NUMVAR 'number of variables';
+NUMVAR = GAMS_MODEL.numvar
+
+Scalar NUMEQU 'number of equations';
+NUMEQU = GAMS_MODEL.numequ
+
+Scalar NUMDVAR 'number of discrete variables';
+NUMDVAR = GAMS_MODEL.numdvar
+
+Scalar NUMNZ 'number of nonzeros';
+NUMNZ = GAMS_MODEL.numnz
+
+Scalar ETSOLVE 'time to execute solve statement';
+ETSOLVE = GAMS_MODEL.etsolve
+

--- a/pyomo/repn/tests/gams/test_gams.py
+++ b/pyomo/repn/tests/gams/test_gams.py
@@ -21,6 +21,7 @@ from pyomo.environ import (Block, ConcreteModel, Connector, Constraint,
                            Objective, TransformationFactory, Var, exp, log,
                            ceil, floor, asin, acos, atan, asinh, acosh, atanh,
                            Binary, quicksum)
+from pyomo.gdp import Disjunction
 from pyomo.repn.plugins.gams_writer import (StorageTreeChecker,
                                             expression_to_string,
                                             split_long_line)
@@ -130,6 +131,59 @@ class Test(unittest.TestCase):
         m.c2 = Constraint(expr=quicksum([m.x, m.y], linear=True) == 1)
         m.obj = Objective(expr=m.x)
         self._check_baseline(m)
+
+    def test_nested_GDP_with_deactivate(self):
+        m = ConcreteModel()
+        m.x = Var(bounds=(0, 1))
+
+        @m.Disjunct([0, 1])
+        def disj(disj, _):
+            @disj.Disjunct(['A', 'B'])
+            def nested(n_disj, _):
+                pass  # Blank nested disjunct
+
+            return disj
+
+        m.choice = Disjunction(expr=[m.disj[0], m.disj[1]])
+
+        m.c = Constraint(expr=m.x ** 2 + m.disj[1].nested['A'].indicator_var >= 1)
+
+        m.disj[0].indicator_var.fix(1)
+        m.disj[1].deactivate()
+        m.disj[0].nested['A'].indicator_var.fix(1)
+        m.disj[0].nested['B'].deactivate()
+        m.disj[1].nested['A'].indicator_var.set_value(1)
+        m.disj[1].nested['B'].deactivate()
+        m.o = Objective(expr=m.x)
+        TransformationFactory('gdp.fix_disjuncts').apply_to(m)
+
+        os = StringIO()
+        m.write(os, format='gams', io_options=dict(solver='dicopt'))
+        self.assertIn("USING minlp", os.getvalue())
+
+    def test_quicksum(self):
+        m = ConcreteModel()
+        m.y = Var(domain=Binary)
+        m.c = Constraint(expr=quicksum([m.y, m.y], linear=True) == 1)
+        m.y.fix(1)
+        lbl = NumericLabeler('x')
+        smap = SymbolMap(lbl)
+        tc = StorageTreeChecker(m)
+        self.assertEqual(("x1 + x1", False), expression_to_string(m.c.body, tc, smap=smap))
+        m.x = Var()
+        m.c2 = Constraint(expr=quicksum([m.x, m.y], linear=True) == 1)
+        self.assertEqual(("x2 + x1", False), expression_to_string(m.c2.body, tc, smap=smap))
+
+    def test_quicksum_integer_var_fixed(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var(domain=Binary)
+        m.c = Constraint(expr=quicksum([m.y, m.y], linear=True) == 1)
+        m.o = Objective(expr=m.x ** 2)
+        m.y.fix(1)
+        os = StringIO()
+        m.write(os, format='gams')
+        self.assertIn("USING nlp", os.getvalue())
 
     def test_expr_xfrm(self):
         from pyomo.repn.plugins.gams_writer import (


### PR DESCRIPTION
## Fixes #924

## Summary/Motivation:
Alternative implementation to #917: fixes the bug where fixed variables appearing in a Linear Expression are sent to GAMS as free variables.

This implementation adds extra processing to make sure that any fixed variables that are emitted by the expression walkers (e.g., in the case of LinearExpression) are marked as 'fixed' in the GAMS input.  An alternative implementation (#917) adds special processing for the LinearExpression node in the `ToGamsVisitor`.

The advantage of this implementation is that it should also correctly handle other (future) cases where a fixed variable could sneak through the visitor logic.  The advantage of the #917 implementation is that fixed variables are completely hidden from GAMS.

## Changes proposed in this PR:
- catch fixed variables in the variable categorization logic and output them to GAMS as fixed.
- add a test to the writer for this situation (with LinearExpression nodes)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
