### PR TITLE
PySP is divorcing pyutilib.enum

### DIFF
--- a/pyomo/core/base/piecewise.py
+++ b/pyomo/core/base/piecewise.py
@@ -43,8 +43,8 @@ import math
 import itertools
 import operator
 import types
+import enum
 
-from pyutilib.enum import Enum
 from pyutilib.misc import flatten_tuple
 
 from pyomo.common.timing import ConstructionTimer
@@ -61,19 +61,21 @@ from six.moves import xrange, zip
 
 logger = logging.getLogger('pyomo.core')
 
-PWRepn = Enum('SOS2',
-              'BIGM_BIN',
-              'BIGM_SOS1',
-              'CC',
-              'DCC',
-              'DLOG',
-              'LOG',
-              'MC',
-              'INC')
+class PWRepn(str, enum.Enum):
+    SOS2 =      'SOS2'
+    BIGM_BIN =  'BIGM_BIN'
+    BIGM_SOS1 = 'BIGM_SOS1'
+    CC =        'CC'
+    DCC =       'DCC'
+    DLOG =      'DLOG'
+    LOG =       'LOG'
+    MC =        'MC'
+    INC =       'INC'
 
-Bound = Enum('Lower',
-             'Upper',
-             'Equal')
+class Bound(str, enum.Enum):
+    Lower = 'Lower'
+    Upper = 'Upper'
+    Equal = 'Equal'
 
 # BE SURE TO CHANGE THE PIECWISE DOCSTRING
 # IF THIS GETS CHANGED

--- a/pyomo/pysp/embeddedsp.py
+++ b/pyomo/pysp/embeddedsp.py
@@ -663,13 +663,17 @@ class EmbeddedSP(object):
     def _create_scenario_tree_model(self, size):
         assert size > 0
         stm = CreateAbstractScenarioTreeModel()
-        stm.Stages.add('t1')
-        stm.Stages.add('t2')
-        stm.Nodes.add('root')
+        _stages = ["t1", "t2"]
+        _nodes = ["root"]
+        _scenarios = []
         for i in xrange(1, size+1):
-            stm.Nodes.add('n'+str(i))
-            stm.Scenarios.add('s'+str(i))
-        stm = stm.create_instance()
+            _nodes.append('n'+str(i))
+            _scenarios.append('s'+str(i))
+        stm = stm.create_instance(
+            data={None: {"Stages": _stages,
+                         "Nodes": _nodes,
+                         "Scenarios": _scenarios}}
+        )
         stm.NodeStage['root'] = 't1'
         stm.ConditionalProbability['root'] = 1.0
         weight = 1.0/float(size)

--- a/pyomo/pysp/phsolverserverutils.py
+++ b/pyomo/pysp/phsolverserverutils.py
@@ -13,20 +13,21 @@
 
 import time
 import itertools
-
-from pyutilib.enum import Enum
+import enum
 
 from pyomo.core import *
 
 from six import iteritems, itervalues
 
-InvocationType = Enum('SingleInvocation',
-                      'PerBundleInvocation',
-                      'PerBundleChainedInvocation',
-                      'PerScenarioInvocation',
-                      'PerScenarioChainedInvocation',
-                      'PerNodeInvocation',
-                      'PerNodeChainedInvocation')
+
+class InvocationType(str, enum.Enum):
+    SingleInvocation =             'SingleInvocation'
+    PerBundleInvocation =          'PerBundleInvocation'
+    PerBundleChainedInvocation =   'PerBundleChainedInvocation'
+    PerScenarioInvocation =        'PerScenarioInvocation'
+    PerScenarioChainedInvocation = 'PerScenarioChainedInvocation'
+    PerNodeInvocation =            'PerNodeInvocation'
+    PerNodeChainedInvocation =     'PerNodeChainedInvocation'
 
 class TransmitType(object):
 
@@ -798,7 +799,7 @@ def transmit_external_function_invocation_to_worker(
     action_handle = ph._solver_manager.queue(action="invoke_external_function",
                                              queue_name=ph._phpyro_job_worker_map[worker_name],
                                              name=worker_name,
-                                             invocation_type=invocation_type.key,
+                                             invocation_type=invocation_type.value,
                                              generateResponse=generate_response,
                                              module_name=module_name,
                                              function_name=function_name,
@@ -839,7 +840,7 @@ def transmit_external_function_invocation(
                     action="invoke_external_function",
                     queue_name=ph._phpyro_job_worker_map[bundle.name],
                     name=bundle.name,
-                    invocation_type=invocation_type.key,
+                    invocation_type=invocation_type.value,
                     generateResponse=generate_responses,
                     module_name=module_name,
                     function_name=function_name,
@@ -855,7 +856,7 @@ def transmit_external_function_invocation(
                     action="invoke_external_function",
                     queue_name=ph._phpyro_job_worker_map[scenario.name],
                     name=scenario.name,
-                    invocation_type=invocation_type.key,
+                    invocation_type=invocation_type.value,
                     generateResponse=generate_responses,
                     module_name=module_name,
                     function_name=function_name,

--- a/pyomo/pysp/phsolverserverutils.py
+++ b/pyomo/pysp/phsolverserverutils.py
@@ -2,8 +2,8 @@
 #
 #  Pyomo: Python Optimization Modeling Objects
 #  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
-#  Under the terms of Contract DE-NA0003525 with National Technology and 
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
@@ -89,7 +89,7 @@ def collect_full_results(ph, var_config):
         print("Waiting for results extraction")
 
     num_results_so_far = 0
-    
+
     while (num_results_so_far < len(ph._scenario_tree.subproblems)):
 
         action_handle = ph._solver_manager.wait_any()
@@ -146,7 +146,7 @@ def warmstart_scenario_instances(ph):
     action_handle_scenario_map = {} # maps action handles to scenario names
 
     ph._solver_manager.begin_bulk()
-    
+
     if ph._scenario_tree.contains_bundles():
 
         for bundle in ph._scenario_tree._scenario_bundles:
@@ -174,7 +174,7 @@ def warmstart_scenario_instances(ph):
 
             scenario_action_handle_map[scenario.name] = new_action_handle
             action_handle_scenario_map[new_action_handle] = scenario.name
-            
+
     ph._solver_manager.end_bulk()
 
     if ph._verbose:
@@ -231,7 +231,7 @@ def transmit_weights(ph):
     generate_responses = ph._handshake_with_phpyro
 
     ph._solver_manager.begin_bulk()
-    
+
     if ph._scenario_tree.contains_bundles():
 
         for bundle in ph._scenario_tree._scenario_bundles:
@@ -266,7 +266,7 @@ def transmit_weights(ph):
                 generateResponse=generate_responses,
                 name=scenario.name,
                 new_weights=scenario._w) )
-            
+
     ph._solver_manager.end_bulk()
 
     if generate_responses:
@@ -294,7 +294,7 @@ def transmit_xbars(ph):
     generate_responses = ph._handshake_with_phpyro
 
     ph._solver_manager.begin_bulk()
-    
+
     if ph._scenario_tree.contains_bundles():
 
         for bundle in ph._scenario_tree._scenario_bundles:
@@ -333,7 +333,7 @@ def transmit_xbars(ph):
                 generateResponse=generate_responses,
                 name=scenario.name,
                 new_xbars=xbars_to_transmit) )
-            
+
     ph._solver_manager.end_bulk()
 
     if generate_responses:
@@ -382,14 +382,14 @@ def release_phsolverservers(ph):
         print("Revoking PHPyroWorker job assignments")
 
     ph._solver_manager.begin_bulk()
-    
+
     for job, worker in iteritems(ph._phpyro_job_worker_map):
         ph._solver_manager.queue(action="release",
                                  queue_name=ph._phpyro_job_worker_map[job],
                                  name=worker,
                                  object_name=job,
                                  generateResponse=False)
-        
+
     ph._solver_manager.end_bulk()
 
     ph._phpyro_worker_jobs_map = {}
@@ -583,7 +583,7 @@ def activate_ph_objective_weight_terms(ph):
     generate_responses = ph._handshake_with_phpyro
 
     ph._solver_manager.begin_bulk()
-    
+
     for subproblem in ph._scenario_tree.subproblems:
         action_handles.append( ph._solver_manager.queue(
             action="activate_ph_objective_weight_terms",
@@ -612,7 +612,7 @@ def deactivate_ph_objective_weight_terms(ph):
     generate_responses = ph._handshake_with_phpyro
 
     ph._solver_manager.begin_bulk()
-    
+
     for subproblem in ph._scenario_tree.subproblems:
         action_handles.append( ph._solver_manager.queue(
             action="deactivate_ph_objective_weight_terms",
@@ -642,7 +642,7 @@ def activate_ph_objective_proximal_terms(ph):
     generate_responses = ph._handshake_with_phpyro
 
     ph._solver_manager.begin_bulk()
-    
+
     for subproblem in ph._scenario_tree.subproblems:
         action_handles.append( ph._solver_manager.queue(
             action="activate_ph_objective_proximal_terms",
@@ -678,7 +678,7 @@ def deactivate_ph_objective_proximal_terms(ph):
             queue_name=ph._phpyro_job_worker_map[subproblem.name],
             generateResponse=generate_responses,
             name=subproblem.name) )
-            
+
     ph._solver_manager.end_bulk()
 
     if generate_responses:
@@ -890,7 +890,7 @@ def define_import_suffix(ph, suffix_name):
     generate_responses = ph._handshake_with_phpyro
 
     ph._solver_manager.begin_bulk()
-    
+
     for subproblem in ph._scenario_tree.subproblems:
         action_handles.append( ph._solver_manager.queue(
             action="define_import_suffix",

--- a/pyomo/pysp/scenariotree/manager.py
+++ b/pyomo/pysp/scenariotree/manager.py
@@ -24,7 +24,6 @@ from collections import (defaultdict,
                          namedtuple)
 
 import pyutilib.misc
-import pyutilib.enum
 from pyutilib.pyro import (shutdown_pyro_components,
                            using_pyro4)
 from pyomo.common.dependencies import dill, dill_available
@@ -41,8 +40,7 @@ from pyomo.pysp.util.config import (PySPConfigValue,
                                     safe_register_common_option,
                                     _domain_must_be_str,
                                     _domain_tuple_of_str)
-from pyomo.pysp.util.misc import (load_external_module,
-                                  _EnumValueWithData)
+from pyomo.pysp.util.misc import load_external_module
 from pyomo.pysp.scenariotree.instance_factory import \
     ScenarioTreeInstanceFactory
 from pyomo.pysp.scenariotree.action_manager_pyro \
@@ -60,52 +58,18 @@ from six.moves import xrange
 
 logger = logging.getLogger('pyomo.pysp')
 
-_invocation_type_enum_list = []
-_invocation_type_enum_list.append(
-    pyutilib.enum.EnumValue('InvocationType', 0, 'Single'))
-_invocation_type_enum_list.append(
-    pyutilib.enum.EnumValue('InvocationType', 1, 'PerScenario'))
-_invocation_type_enum_list.append(
-    pyutilib.enum.EnumValue('InvocationType', 2, 'PerScenarioChained'))
-_invocation_type_enum_list.append(
-    pyutilib.enum.EnumValue('InvocationType', 3, 'PerBundle'))
-_invocation_type_enum_list.append(
-    pyutilib.enum.EnumValue('InvocationType', 4, 'PerBundleChained'))
+class _InvocationTypeMeta(type):
+    def __contains__(cls, obj):
+        return isinstance(obj, cls._value)
+    def __iter__(cls):
+        return iter(
+            sorted((obj for obj in cls.__dict__.values()
+                    if isinstance(obj, cls._value)),
+                   key=lambda _: _.index)
+        )
 
-##### These values are DEPRECATED
-_invocation_type_enum_list.append(
-    pyutilib.enum.EnumValue('InvocationType', 5, 'SingleInvocation'))
-_invocation_type_enum_list.append(
-    pyutilib.enum.EnumValue('InvocationType', 6, 'PerScenarioInvocation'))
-_invocation_type_enum_list.append(
-    pyutilib.enum.EnumValue('InvocationType', 7, 'PerScenarioChainedInvocation'))
-_invocation_type_enum_list.append(
-    pyutilib.enum.EnumValue('InvocationType', 8, 'PerBundleInvocation'))
-_invocation_type_enum_list.append(
-    pyutilib.enum.EnumValue('InvocationType', 9, 'PerBundleChainedInvocation'))
-#####
-
-# These are enum values that carry data with them
-_invocation_type_enum_list.append(
-    _EnumValueWithData(_domain_must_be_str,
-                       'InvocationType', 10, 'OnScenario'))
-_invocation_type_enum_list.append(
-    _EnumValueWithData(_domain_tuple_of_str,
-                       'InvocationType', 11, 'OnScenarios'))
-_invocation_type_enum_list.append(
-    _EnumValueWithData(_domain_must_be_str,
-                       'InvocationType', 12, 'OnBundle'))
-_invocation_type_enum_list.append(
-    _EnumValueWithData(_domain_tuple_of_str,
-                       'InvocationType', 13, 'OnBundles'))
-_invocation_type_enum_list.append(
-    _EnumValueWithData(_domain_tuple_of_str,
-                       'InvocationType', 14, 'OnScenariosChained'))
-_invocation_type_enum_list.append(
-    _EnumValueWithData(_domain_tuple_of_str,
-                       'InvocationType', 15, 'OnBundlesChained'))
-
-class _InvocationTypeDocumentedEnum(pyutilib.enum.Enum):
+@six.add_metaclass(_InvocationTypeMeta)
+class InvocationType(object):
     """Controls execution of function invocations with a scenario tree manager.
 
     In all cases, the function must accept the process-local scenario
@@ -220,8 +184,61 @@ class _InvocationTypeDocumentedEnum(pyutilib.enum.Enum):
             managed by the named scenario tree worker.
 
     """
-
-InvocationType = _InvocationTypeDocumentedEnum(*_invocation_type_enum_list)
+    class _value(object):
+        def __init__(self, key, index):
+            self._key = key
+            self._index = index
+        @property
+        def key(self):
+            return self._key
+        @property
+        def index(self):
+            return self._index
+        def __hash__(self):
+            return hash((self.key, self.index))
+        def __eq__(self, other):
+            return (self.__class__ is other.__class__) and \
+                (self.key == other.key) and (self.index == other.index)
+        def __ne__(self, other):
+            return not self.__eq__(other)
+        def __repr__(self):
+            return ("InvocationType.%s" % (self.key))
+    class _value_with_data(_value):
+        def __init__(self, key, id_, domain):
+            super(self.__class__, self).__init__(key, id_)
+            self._domain = domain
+            self._data = None
+        @property
+        def data(self):
+            return self._data
+        def __call__(self, data):
+            if self.data is not None:
+                raise ValueError("Must create from InvocationType class")
+            obj = self.__class__(self.key, self.index, self._domain)
+            assert obj.data is None
+            obj._data = self._domain(data)
+            assert obj.data is obj._data
+            return obj
+    Single =                       _value("Single", 0)
+    PerScenario =                  _value("PerScenario", 1)
+    PerScenarioChained =           _value("PerScenarioChained", 2)
+    PerBundle =                    _value("PerBundle", 3)
+    PerBundleChained =             _value("PerBundleChained", 4)
+    ### deprecated
+    SingleInvocation =             _value("SingleInvocation", 5)
+    PerScenarioInvocation =        _value("PerScenarioInvocation", 6)
+    PerScenarioChainedInvocation = _value("PerScenarioChainedInvocation", 7)
+    PerBundleInvocation =          _value("PerBundleInvocation", 8)
+    PerBundleChainedInvocation =   _value("PerBundleChainedInvocation", 9)
+    ###
+    OnScenario =                   _value_with_data("OnScenario", 10 ,_domain_must_be_str)
+    OnScenarios =                  _value_with_data("OnScenarios", 11, _domain_tuple_of_str)
+    OnBundle =                     _value_with_data("OnBundle", 12, _domain_must_be_str)
+    OnBundles =                    _value_with_data("OnBundles", 13, _domain_tuple_of_str)
+    OnScenariosChained =           _value_with_data("OnScenariosChained", 14, _domain_tuple_of_str)
+    OnBundlesChained =             _value_with_data("OnBundlesChained", 15, _domain_tuple_of_str)
+    def __init__(self, *args, **kwds):
+        raise NotImplementedError
 
 _deprecated_invocation_types = \
     {InvocationType.SingleInvocation: InvocationType.Single,
@@ -1753,7 +1770,7 @@ class _ScenarioTreeManagerWorker(PySPConfiguredObject):
             raise ValueError("Unexpected function invocation type '%s'. "
                              "Expected one of %s"
                              % (invocation_type,
-                                [str(v) for v in InvocationType._values]))
+                                [str(v) for v in InvocationType]))
 
         result = None
         if (invocation_type == InvocationType.Single):
@@ -3592,7 +3609,7 @@ class ScenarioTreeManagerClientPyro(_ScenarioTreeManagerClientPyroAdvanced,
             raise ValueError("Unexpected function invocation type '%s'. "
                              "Expected one of %s"
                              % (invocation_type,
-                                [str(v) for v in InvocationType._values]))
+                                [str(v) for v in InvocationType]))
 
         if oneway_call:
             action_handle_data = None

--- a/pyomo/pysp/scenariotree/manager_worker_pyro.py
+++ b/pyomo/pysp/scenariotree/manager_worker_pyro.py
@@ -13,7 +13,6 @@ __all__ = ("ScenarioTreeManagerWorkerPyro",)
 import time
 
 from pyomo.common.dependencies import dill, dill_available
-from pyomo.pysp.util.misc import _EnumValueWithData
 from pyomo.pysp.util.configured_object import PySPConfiguredObject
 from pyomo.pysp.util.config import (PySPConfigBlock,
                                     safe_declare_common_option)
@@ -270,16 +269,15 @@ class ScenarioTreeManagerWorkerPyro(_ScenarioTreeManagerWorker,
                 print("Received request to invoke anonymous "
                       "function serialized using the dill module")
 
-        # pyutilib.Enum can not be serialized depending on the
-        # serializer type used by Pyro, so we just transmit it
-        # as a (key, data) tuple in that case
+        # InvocationType is transmitted as (key, data) to
+        # avoid issues with Pyro, so this function accepts a
+        # tuple and converts back to InvocationType
         if type(invocation_type) is tuple:
             _invocation_type_key, _invocation_type_data = invocation_type
             assert isinstance(_invocation_type_key, string_types)
             invocation_type = getattr(InvocationType,
                                       _invocation_type_key)
             if _invocation_type_data is not None:
-                assert isinstance(invocation_type, _EnumValueWithData)
                 invocation_type = invocation_type(_invocation_type_data)
 
         # here we assume that if the module_name is None,

--- a/pyomo/pysp/solvers/spsolvershellcommand.py
+++ b/pyomo/pysp/solvers/spsolvershellcommand.py
@@ -15,6 +15,7 @@ import pprint
 
 import pyutilib.misc
 
+import pyomo.common
 from pyomo.pysp.solvers.spsolver import SPSolver
 
 logger = logging.getLogger('pyomo.pysp')

--- a/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanagersolver.py
+++ b/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanagersolver.py
@@ -25,8 +25,7 @@ from pyomo.pysp.util.misc import (_get_test_nameserver,
 from pyomo.pysp.util.config import PySPConfigBlock
 from pyomo.pysp.scenariotree.manager import \
     (ScenarioTreeManagerClientSerial,
-     ScenarioTreeManagerClientPyro,
-     InvocationType)
+     ScenarioTreeManagerClientPyro)
 from pyomo.pysp.scenariotree.instance_factory import \
     ScenarioTreeInstanceFactory
 from pyomo.pysp.scenariotree.manager_solver import \

--- a/pyomo/pysp/util/misc.py
+++ b/pyomo/pysp/util/misc.py
@@ -31,14 +31,13 @@ try:
 except ImportError:
     pstats_available=False
 
-from pyutilib.enum import EnumValue
 from pyutilib.misc import PauseGC, import_file
 from pyutilib.services import TempfileManager
 import pyutilib.common
 from pyomo.opt.base import ConverterError
 from pyomo.common.dependencies import attempt_import
 from pyomo.common.plugin import (ExtensionPoint,
-                               SingletonPlugin)
+                                 SingletonPlugin)
 from pyomo.pysp.util.config import PySPConfigBlock
 from pyomo.pysp.util.configured_object import PySPConfiguredObject
 
@@ -515,31 +514,3 @@ def _get_test_dispatcher(ns_host=None,
             dispatcher_port = None
             dispatcher_process = None
     return dispatcher_process, dispatcher_port
-
-class _EnumValueWithData(EnumValue):
-    """A subclass of pyutilib.enum.EnumValue that carries additional data.
-
-    The data carried by the _EnumValueWithData object does not affect
-    equality checks with other instances of the same enumerated value,
-    nor does it affect containment checks in the owning Enum
-    container.
-
-    """
-    def __init__(self, check_type, *args, **kwds):
-        super(_EnumValueWithData, self).__init__(*args, **kwds)
-        self._data = None
-        self._check_type = check_type
-    @property
-    def data(self):
-        return self._data
-    def __repr__(self):
-        return (super(_EnumValueWithData, self).__repr__() + \
-                ": %s" % (self.data))
-    def __call__(self, data):
-        self._check_type(data)
-        obj = self.__class__(self._check_type,
-                             self.enumtype,
-                             self.index,
-                             self.key)
-        obj._data = data
-        return obj


### PR DESCRIPTION
This eliminates the use of pyutilib.enum from pysp. It does the same for the AML piecewise module. Mostly just swaps out pyutilib.enum with the enum module, except for the _EnumValueWithData class. For this, I just implemented something from scratch that behaves close enough to an enum.

Also includes unrelated pysp fixes found during local testing. I suppose we are not really running these anywhere. 

![image](https://user-images.githubusercontent.com/2308454/82767982-bc500600-9df9-11ea-928d-bc0b20953fca.png)

Sorry I didn't do this through a fork. I just remembered we are supposed to be doing that.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
