### PR TITLE
fix block matrix transpose

### DIFF
--- a/pyomo/contrib/pynumero/sparse/block_matrix.py
+++ b/pyomo/contrib/pynumero/sparse/block_matrix.py
@@ -525,7 +525,13 @@ class BlockMatrix(BaseBlockMatrix):
             raise ValueError('BlockMatrix only supports transpose with copy=True')
 
         m, n = self.bshape
+        row_sizes = self.row_block_sizes()
+        col_sizes = self.col_block_sizes()
         mat = BlockMatrix(n, m)
+        for _ndx, _size in enumerate(row_sizes):
+            mat.set_col_size(_ndx, _size)
+        for _ndx, _size in enumerate(col_sizes):
+            mat.set_row_size(_ndx, _size)
         for i in range(m):
             for j in range(n):
                 if not self.is_empty_block(i, j):


### PR DESCRIPTION
## Summary/Motivation:
The transpose method on pynumero block matrices did not set the dimensions for empty rows/cols.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
