### PR TITLE
SequentialDecomposition: cast fixed values back to float

### DIFF
--- a/pyomo/network/decomposition.py
+++ b/pyomo/network/decomposition.py
@@ -31,7 +31,6 @@ imports_available = networkx_available & numpy_available
 
 logger = logging.getLogger('pyomo.network')
 
-
 class SequentialDecomposition(FOQUSGraph):
     """
     A sequential decomposition tool for Pyomo Network models
@@ -470,7 +469,9 @@ class SequentialDecomposition(FOQUSGraph):
                     evars = [(evar, None)]
                 for evar, idx in evars:
                     fixed_inputs[dest_unit].add(evar)
-                    evar.fix(value(mem[idx] if mem.is_indexed() else mem))
+                    val = value(mem[idx] if mem.is_indexed() else mem)
+                    # val are numpy.float64; coerce val back to float
+                    evar.fix(float(val))
 
         for con in eblock.component_data_objects(Constraint, active=True):
             # we expect to find equality constraints with one linear variable
@@ -501,7 +502,8 @@ class SequentialDecomposition(FOQUSGraph):
             val = (value(con.lower) - repn.constant) / repn.linear_coefs[0]
             var = repn.linear_vars[0]
             fixed_inputs[dest_unit].add(var)
-            var.fix(val)
+            # val are numpy.float64; coerce val back to float
+            var.fix(float(val))
 
     def pass_single_value(self, port, name, member, val, fixed):
         """
@@ -525,7 +527,8 @@ class SequentialDecomposition(FOQUSGraph):
                 fval = (0 - repn.constant) / repn.linear_coefs[0]
                 var = repn.linear_vars[0]
                 fixed.add(var)
-                var.fix(fval)
+                # val are numpy.float64; coerce val back to float
+                var.fix(float(fval))
             else:
                 raise RuntimeError(
                     "Member '%s' of port '%s' had more than "
@@ -534,7 +537,8 @@ class SequentialDecomposition(FOQUSGraph):
                     "to this port." % (name, port.name))
         else:
             fixed.add(member)
-            member.fix(val)
+            # val are numpy.float64; coerce val back to float
+            member.fix(float(val))
 
     def load_guesses(self, guesses, port, fixed):
         srcs = port.sources()
@@ -577,7 +581,7 @@ class SequentialDecomposition(FOQUSGraph):
                             # silently ignore vars already fixed
                             continue
                         fixed.add(evar)
-                        evar.fix(val)
+                        evar.fix(float(val))
                 if not has_evars:
                     # the only NumericValues in Pyomo that return True
                     # for is_fixed are expressions and variables
@@ -591,7 +595,7 @@ class SequentialDecomposition(FOQUSGraph):
                                 port.name))
                     else:
                         fixed.add(var)
-                        var.fix(entry)
+                        var.fix(float(entry))
 
     def load_values(self, port, default, fixed, use_guesses):
         sources = port.sources()
@@ -652,7 +656,7 @@ class SequentialDecomposition(FOQUSGraph):
                     "guess, " if use_guesses else ""))
 
         fixed.add(var)
-        var.fix(val)
+        var.fix(float(val))
 
     def combine_and_fix(self, port, name, obj, evars, fixed):
         """


### PR DESCRIPTION
## Fixes #1468

## Summary/Motivation:
The SequentialDecomposition algorithm in Pyomo Network uses numpy arrays internally.  The routine was setting Variable values to be scalar `numpy.float64` values, which caused errors when other routines attempted to generate expressions using the `value()` of the variable.

Until #31 is resolved, this PR casts all values back to `float` before storing them into the Variable.

## Changes proposed in this PR:
- Cast values to `float` before storing them into a variable.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
