### PR TITLE
Ensure sympy configuration happens

### DIFF
--- a/pyomo/core/expr/sympy_tools.py
+++ b/pyomo/core/expr/sympy_tools.py
@@ -139,6 +139,7 @@ class PyomoSympyBimap(object):
 class Pyomo2SympyVisitor(EXPR.StreamBasedExpressionVisitor):
 
     def __init__(self, object_map):
+        sympy.Add  # this ensures _configure_sympy gets run
         super(Pyomo2SympyVisitor, self).__init__()
         self.object_map = object_map
 
@@ -175,6 +176,7 @@ class Pyomo2SympyVisitor(EXPR.StreamBasedExpressionVisitor):
 class Sympy2PyomoVisitor(EXPR.StreamBasedExpressionVisitor):
 
     def __init__(self, object_map):
+        sympy.Add  # this ensures _configure_sympy gets run
         super(Sympy2PyomoVisitor, self).__init__()
         self.object_map = object_map
 
@@ -214,8 +216,6 @@ def sympyify_expression(expr):
 
 
 def sympy2pyomo_expression(expr, object_map):
-    if not sympy_available:
-        raise ImportError('sympy is not available')
     visitor = Sympy2PyomoVisitor(object_map)
     is_expr, ans = visitor.beforeChild(None, expr)
     if not is_expr:

--- a/pyomo/core/expr/sympy_tools.py
+++ b/pyomo/core/expr/sympy_tools.py
@@ -214,6 +214,8 @@ def sympyify_expression(expr):
 
 
 def sympy2pyomo_expression(expr, object_map):
+    if not sympy_available:
+        raise ImportError('sympy is not available')
     visitor = Sympy2PyomoVisitor(object_map)
     is_expr, ans = visitor.beforeChild(None, expr)
     if not is_expr:


### PR DESCRIPTION
## Fixes
This PR fixes the error below.

```
from pyomo.core.expr.sympy_tools import PyomoSympyBimap, sympy2pyomo_expression, sympy_available
import sympy
import pyomo.environ as pe
x = sympy.Symbol('x')
y = sympy.Symbol('y')
e = x + y
m = pe.ConcreteModel()
m.x = pe.Var()
m.y = pe.Var()
obj_map = PyomoSympyBimap()
obj_map.sympy2pyomo[x] = m.x
obj_map.sympy2pyomo[y] = m.y
try:
    sympy2pyomo_expression(e, obj_map)
except Exception as err:
    print(err)
bool(sympy_available)
print(sympy2pyomo_expression(e, obj_map))
```

Output:
```
Internal Pyomo implementation error:
	"sympy expression type '<class 'sympy.core.add.Add'>' not found in the operator map"
	Please report this to the Pyomo Developers.
x + y
```

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
