### PR TITLE
Fix bug in bigm transformation for nested indexed disjunctions

### DIFF
--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -535,8 +535,6 @@ class BigM_Transformation(Transformation):
 
         # delete everything we moved.
         for idx in to_delete:
-            # Note we have to do it by index because python scoping is
-            # obnoxious...
             del fromBlock.relaxedDisjuncts[idx]
 
         # Note that we could handle other components here if we ever needed

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -42,7 +42,6 @@ from functools import wraps
 from six import iterkeys, iteritems
 from weakref import ref as weakref_ref
 
-
 logger = logging.getLogger('pyomo.gdp.bigm')
 
 NAME_BUFFER = {}
@@ -521,6 +520,7 @@ class BigM_Transformation(Transformation):
         # to move those over. We know the XOR constraints are on the block, and
         # we need to leave those on the disjunct.
         disjunctList = toBlock.relaxedDisjuncts
+        to_delete = []
         for idx, disjunctBlock in iteritems(fromBlock.relaxedDisjuncts):
             newblock = disjunctList[len(disjunctList)]
             newblock.transfer_attributes_from(disjunctBlock)
@@ -530,8 +530,14 @@ class BigM_Transformation(Transformation):
             original._transformation_block = weakref_ref(newblock)
             newblock._srcDisjunct = weakref_ref(original)
 
-        # we delete this container because we just moved everything out
-        del fromBlock.relaxedDisjuncts
+            # save index of what we just moved so that we can delete it
+            to_delete.append(idx)
+
+        # delete everything we moved.
+        for idx in to_delete:
+            # Note we have to do it by index because python scoping is
+            # obnoxious...
+            del fromBlock.relaxedDisjuncts[idx]
 
         # Note that we could handle other components here if we ever needed
         # to, but we control what is on the transformation block and


### PR DESCRIPTION
## Fixes # NA

## Summary/Motivation:

With the recent rewrite, the following transformation would throw an AttributeError because the `relaxedDisjuncts` container was prematurely deleted when moving up information to transform the disjuncts in the first nested DisjunctionData, meaning we lost the transformation blocks for the disjuncts of the second DisjunctionData.
```
m = ConcreteModel()
m.d1 = Disjunct()
m.d1.indexedDisjunct1 = Disjunct([0,1])
m.d1.indexedDisjunct2 = Disjunct([0,1])
@m.d1.Disjunction([0,1])
def innerIndexed(d, i):
    return [d.indexedDisjunct1[i], d.indexedDisjunct2[i]]
m.d2 = Disjunct()
m.outer = Disjunction(expr=[m.d1, m.d2])

TransformationFactory('gdp.bigm').apply_to(m)
```

## Changes proposed in this PR:
- Fixes the above bug by only deleting BlockDatas from relaxedDisjuncts, never the whole container.
- Adds a test

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
