### PR TITLE
[WIP] Enhance coverage of parmest tests

### DIFF
--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -40,6 +40,7 @@ import pyomo.environ as pyo
 
 from pyomo.opt import SolverFactory
 ipopt_available = SolverFactory('ipopt').available()
+k_aug_available = SolverFactory('k_aug').available()
 
 testdir = os.path.dirname(os.path.abspath(__file__))
 
@@ -198,7 +199,7 @@ class parmest_object_Tester_RB(unittest.TestCase):
             retcode = subprocess.call(rlist)
         assert(retcode == 0)
 
-    @unittest.skip("Most folks don't have k_aug installed")
+    @unittest.skipIf(not k_aug_available,"k_aug is not available")
     def test_theta_k_aug_for_Hessian(self):
         # this will fail if k_aug is not installed
         objval, thetavals, Hessian = self.pest.theta_est(solver="k_aug")


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
- See discussion in #1474 about need for more robust tests

## Changes proposed in this PR:
- [x] Make test for using k_aug conditional on if the solver is install
- [ ] Update Rooney-Biegler test to use the correct data
- [ ] Test the examples, not just copy them to the test suit
- [ ] Verify k_aug and Pynumero report the same reduced Hessian
- [ ] Verify test for k_aug is skipped if it is not available

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
