### PR TITLE
Improve Baron warning for ResName/TimName options

### DIFF
--- a/pyomo/solvers/plugins/solvers/BARON.py
+++ b/pyomo/solvers/plugins/solvers/BARON.py
@@ -238,11 +238,16 @@ class BARONSHELL(SystemCallSolver):
         for key in self.options:
             lower_key = key.lower()
             if lower_key == 'resname':
-                logger.warning('The ResName option is set to %s'
-                               % self._soln_file)
+                logger.warning(
+                    'Ignoring user-specified option "%s=%s".  This '
+                    'option is set to %s, and can be overridden using '
+                    'the "solnfile" argument to the solve() method.'
+                    % (key, self.options[key], self._soln_file))
             elif lower_key == 'timname':
-                logger.warning('The TimName option is set to %s'
-                               % self._tim_file)
+                logger.warning(
+                    'Ignoring user-specified option "%s=%s".  This '
+                    'option is set to %s.'
+                    % (key, self.options[key], self._tim_file))
             else:
                 solver_options[key] = self.options[key]
 


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Improve / clarify the warning that we emit when a user attempts to set `ResName` and `TimName` through the `options` dictionary for the Baron solver interface.  This was brought up by a Baron user through Yash Puranik at the Optimization Firm.

## Changes proposed in this PR:
- Improve warning message
- Add test that the warning is actually emitted

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
