### PR TITLE
Add deprecation wrapper for the old StreamBasedExpressionVisitor API

### DIFF
--- a/pyomo/core/expr/visitor.py
+++ b/pyomo/core/expr/visitor.py
@@ -10,9 +10,18 @@
 
 from __future__ import division
 
+import inspect
 import logging
+import six
 from copy import deepcopy
 from collections import deque
+
+if six.PY2:
+    getargspec = inspect.getargspec
+else:
+    # For our needs, getfullargspec is a drop-in replacement for
+    # getargspec (which was removed in Python 3.x)
+    getargspec = inspect.getfullargspec
 
 logger = logging.getLogger('pyomo.core')
 
@@ -22,6 +31,7 @@ from pyutilib.math.util import isclose
 from .symbol_map import SymbolMap
 from . import expr_common as common
 from .expr_errors import TemplateExpressionError
+from pyomo.common.deprecation import deprecation_warning
 from pyomo.core.expr.numvalue import (
     nonpyomo_leaf_types,
     native_numeric_types,
@@ -159,6 +169,25 @@ class StreamBasedExpressionVisitor(object):
                 setattr(self, field, None)
         if kwds:
             raise RuntimeError("Unrecognized keyword arguments: %s" % (kwds,))
+
+        # Handle deprecated APIs
+        _fcns = (('beforeChild',2), ('acceptChildResult',3), ('afterChild',2))
+        for name, nargs in _fcns:
+            fcn = getattr(self, name)
+            if fcn is None:
+                continue
+            _args = getargspec(fcn)
+            if len(_args.args) == nargs and _args.varargs is None:
+                deprecation_warning(
+                    "Note that the API for the StreamBasedExpressionVisitor "
+                    "has changed to include the argument index for the %s() "
+                    "method.  Please update your walker callbacks." % (name,))
+                def wrap(fcn, nargs):
+                    def wrapper(*args):
+                        return fcn(*args[:nargs])
+                    return wrapper
+                setattr(self, name, wrap(fcn, nargs))
+
 
     def walk_expression(self, expr):
         """Walk an expression, calling registered callbacks.

--- a/pyomo/core/expr/visitor.py
+++ b/pyomo/core/expr/visitor.py
@@ -177,7 +177,8 @@ class StreamBasedExpressionVisitor(object):
             if fcn is None:
                 continue
             _args = getargspec(fcn)
-            if len(_args.args) == nargs and _args.varargs is None:
+            _self_arg = 1 if inspect.ismethod(fcn) else 0
+            if len(_args.args) == nargs + _self_arg and _args.varargs is None:
                 deprecation_warning(
                     "Note that the API for the StreamBasedExpressionVisitor "
                     "has changed to include the argument index for the %s() "

--- a/pyomo/core/expr/visitor.py
+++ b/pyomo/core/expr/visitor.py
@@ -181,7 +181,7 @@ class StreamBasedExpressionVisitor(object):
             if len(_args.args) == nargs + _self_arg and _args.varargs is None:
                 deprecation_warning(
                     "Note that the API for the StreamBasedExpressionVisitor "
-                    "has changed to include the argument index for the %s() "
+                    "has changed to include the child index for the %s() "
                     "method.  Please update your walker callbacks." % (name,))
                 def wrap(fcn, nargs):
                     def wrapper(*args):

--- a/pyomo/core/tests/unit/test_visitor.py
+++ b/pyomo/core/tests/unit/test_visitor.py
@@ -763,7 +763,7 @@ class TestStreamBasedExpressionVisitor(unittest.TestCase):
             walker = StreamBasedExpressionVisitor(beforeChild=before)
         self.assertIn(
             "Note that the API for the StreamBasedExpressionVisitor "
-            "has changed to include the argument index for the beforeChild() "
+            "has changed to include the child index for the beforeChild() "
             "method", os.getvalue().replace('\n',' '))
 
         ans = walker.walk_expression(self.e)
@@ -944,15 +944,15 @@ class TestStreamBasedExpressionVisitor(unittest.TestCase):
                 beforeChild=before, acceptChildResult=accept, afterChild=after)
         self.assertIn(
             "Note that the API for the StreamBasedExpressionVisitor "
-            "has changed to include the argument index for the "
+            "has changed to include the child index for the "
             "beforeChild() method", os.getvalue().replace('\n',' '))
         self.assertIn(
             "Note that the API for the StreamBasedExpressionVisitor "
-            "has changed to include the argument index for the "
+            "has changed to include the child index for the "
             "acceptChildResult() method", os.getvalue().replace('\n',' '))
         self.assertIn(
             "Note that the API for the StreamBasedExpressionVisitor "
-            "has changed to include the argument index for the "
+            "has changed to include the child index for the "
             "afterChild() method", os.getvalue().replace('\n',' '))
 
         ans = walker.walk_expression(self.e)
@@ -1175,15 +1175,15 @@ Finalize""")
             walker = all_callbacks()
         self.assertIn(
             "Note that the API for the StreamBasedExpressionVisitor "
-            "has changed to include the argument index for the "
+            "has changed to include the child index for the "
             "beforeChild() method", os.getvalue().replace('\n',' '))
         self.assertIn(
             "Note that the API for the StreamBasedExpressionVisitor "
-            "has changed to include the argument index for the "
+            "has changed to include the child index for the "
             "acceptChildResult() method", os.getvalue().replace('\n',' '))
         self.assertIn(
             "Note that the API for the StreamBasedExpressionVisitor "
-            "has changed to include the argument index for the "
+            "has changed to include the child index for the "
             "afterChild() method", os.getvalue().replace('\n',' '))
 
         self.assertIsNone( walker.walk_expression(self.e) )


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
#1433 changed the API for three methods in the `StreamBasedExpressionVisitor`.  This PR implements deprecation logic so that clients still using the old API will receive a deprecation warning instead of an exception.

This issue was originally reported by @andrewlee94.

## Changes proposed in this PR:
- Add deprecation wrappers so that the old `StreamBasedExpressionVisitor` API is still supported.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
