### PR TITLE
Check for consistent dimensions when slicing

### DIFF
--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -666,7 +666,15 @@ value() function.""" % ( self.name, i ))
                 fixed[i - len(idx)] = val
 
         if sliced or ellipsis is not None:
-            if (not normalize_index.flatten and 
+            if self.dim() == 0 and idx == (slice(None),):
+                # If dim == 0 and idx is slice(None), the component was
+                # a scalar passed a single slice. Since scalar components
+                # can be accessed with a "1-dimensional" index of None,
+                # this behavior is allowed.
+                #
+                # NOTE: dim will still be 0 if nomalize_index.flatten is False
+                pass
+            elif (not normalize_index.flatten and 
                 ellipsis is None and 
                 len(idx) != len(self._implicit_subsets)):
                 # dim will be None. Absent an ellipsis, the number of indices
@@ -686,12 +694,6 @@ value() function.""" % ( self.name, i ))
             elif self.dim() is None:
                 # Assume that the right thing to do here is return
                 # an IndexedComponent_slice
-                pass
-            elif self.dim() == 0 and idx == (slice(None),):
-                # If dim == 0 and idx is slice(None), the component was
-                # a scalar passed a single slice. Since scalar components
-                # can be accessed with a "1-dimensional" index of None,
-                # this behavior is allowed.
                 pass
             elif ellipsis is None and len(idx) != self.dim():
                 # If there is no ellipse and the index doesn't match the 

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -666,7 +666,24 @@ value() function.""" % ( self.name, i ))
                 fixed[i - len(idx)] = val
 
         if sliced or ellipsis is not None:
-            if self.dim() is None:
+            if (not normalize_index.flatten and 
+                ellipsis is None and 
+                len(idx) != len(self._implicit_subsets)):
+                # dim will be None. Absent an ellipsis, the number of indices
+                # passed in should be the length of _implicit_subsets.
+                raise IndexError(
+                    "Index %s contains an invalid number of entries for "
+                    "component %s. Expected %s, got %s." 
+                    % (idx, self.name, len(self._implicit_subsets), len(idx)))
+            elif (not normalize_index.flatten and 
+                len(fixed) + len(sliced) > len(self._implicit_subsets)):
+                # dim is still None. Raise an error if the number of fixed
+                # and sliced indices exceeds the length of _implicit_subsets.
+                raise IndexError(
+                    "Index %s contains an invalid number of entries for "
+                    "component %s. Expected no more than %s, got %s." 
+                    % (idx, self.name, len(self._implicit_subsets), len(idx)))
+            elif self.dim() is None:
                 # Assume that the right thing to do here is return
                 # an IndexedComponent_slice
                 pass

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -666,6 +666,27 @@ value() function.""" % ( self.name, i ))
                 fixed[i - len(idx)] = val
 
         if sliced or ellipsis is not None:
+            if self.dim() is None:
+                # Assume that the right thing to do here is return
+                # an IndexedComponent_slice
+                pass
+            elif self.dim() == 0 and idx == (slice(None),):
+                # If dim == 0 and idx is slice(None), the component was
+                # a scalar passed a single slice. Since scalar components
+                # can be accessed with a "1-dimensional" index of None,
+                # this behavior is allowed.
+                pass
+            elif ((ellipsis is None and len(idx) != self.dim()) or 
+                # If there is no ellipse and the index doesn't match the 
+                # component's dimension, raise an error.
+                # NOTE: Should this do something different for unflattened 
+                # indices?
+                (len(fixed) + len(sliced) > self.dim())):
+                # If an ellipsis is present and the index exceeds the dimension
+                # of the component, raise an error.
+                raise IndexError(
+                    "Index %s contains an invalid number of entries for "
+                    "component %s." % (idx, self.name))
             return IndexedComponent_slice(self, fixed, sliced, ellipsis)
         elif _found_numeric:
             if len(idx) == 1:

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -676,17 +676,22 @@ value() function.""" % ( self.name, i ))
                 # can be accessed with a "1-dimensional" index of None,
                 # this behavior is allowed.
                 pass
-            elif ((ellipsis is None and len(idx) != self.dim()) or 
+            elif ellipsis is None and len(idx) != self.dim():
                 # If there is no ellipse and the index doesn't match the 
                 # component's dimension, raise an error.
                 # NOTE: Should this do something different for unflattened 
                 # indices?
-                (len(fixed) + len(sliced) > self.dim())):
+                raise IndexError(
+                    "Index %s contains an invalid number of entries for "
+                    "component %s. Expected %s, got %s." 
+                    % (idx, self.name, self.dim(), len(idx)))
+            elif len(fixed) + len(sliced) > self.dim():
                 # If an ellipsis is present and the index exceeds the dimension
                 # of the component, raise an error.
                 raise IndexError(
                     "Index %s contains an invalid number of entries for "
-                    "component %s." % (idx, self.name))
+                    "component %s. Expected no more than %s, got %s." 
+                    % (idx, self.name, self.dim(), len(idx)))
             return IndexedComponent_slice(self, fixed, sliced, ellipsis)
         elif _found_numeric:
             if len(idx) == 1:

--- a/pyomo/core/tests/unit/test_indexed_slice.py
+++ b/pyomo/core/tests/unit/test_indexed_slice.py
@@ -600,6 +600,7 @@ class TestComponentSlices(unittest.TestCase):
 
         m.a = Var(m.I, m.J, m.K)
         m.b = Var(m.IJ, m.K)
+        m.c = Var()
         
         with self.assertRaisesRegexp(
             IndexError, 'Index .* contains an invalid number of '
@@ -633,6 +634,9 @@ class TestComponentSlices(unittest.TestCase):
 
         _slicer = m.b[0,...]
         self.assertEqual([], [var.name for var in _slicer])
+
+        _slicer = m.c[:]
+        self.assertEqual(['c'], [var.name for var in _slicer])
 
         normalize_index.flatten = True
 

--- a/pyomo/core/tests/unit/test_indexed_slice.py
+++ b/pyomo/core/tests/unit/test_indexed_slice.py
@@ -580,15 +580,13 @@ class TestComponentSlices(unittest.TestCase):
             _slicer = m.b[2, :].c[:,:,:].x
             # Error not raised immediately because accessing c is deferred
             # until iteration.
-            for var in _slicer:
-                pass
+            list(_slicer)
 
         with self.assertRaisesRegexp(
             IndexError, 'Index .* contains an invalid number of '
             'entries for component .*'):
             _slicer = m.b[2, :].c[:].x
-            for var in _slicer:
-                pass
+            list(_slicer)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fixes # .
Addresses part of #379 

## Summary/Motivation:
Slices silently "fail" in several scenarios, some of which are when too many or not enough `slice` objects are provided in the index. While the tests in test_indexed_slice.py indicated that this behavior was expected, I don't think it should be. 

## Changes proposed in this PR:
- Raise an error if the dimension of the index provided does not match the dimension of the `IndexedComponent`
- Change and add tests to expect this error

I'm not sure how these consistency checks might need to be altered if `normalize_index.flatten is False`. It seems like in this case I should relax the requirements I impose for dimension consistency, i.e. allow
```
len(fixed) + len(sliced) < self.dim()
```
as each item of `fixed` or `sliced` could correspond to a set of dimension greater than one. I don't know the context in which this flag is False, so there many be more implications I haven't realized. Suggestions on how to address are appreciated.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
