### PR TITLE
Identify squared linear sums as quadratic with generate_standard_repn

### DIFF
--- a/pyomo/repn/standard_repn.py
+++ b/pyomo/repn/standard_repn.py
@@ -734,26 +734,18 @@ def _collect_pow(exp, multiplier, idMap, compute_values, verbose, quadratic):
             elif compute_values and len(res.linear) == 0:
                 return Results(constant=multiplier*res.constant**exponent)
             #
-            # If there is one linear term, then we compute the quadratic expression for it.
+            # If the base is linear, then we compute the quadratic expression for it.
             #
-            # elif len(res.linear) == 1:
-            #     key, coef = res.linear.popitem()
-            #     var = idMap[key]
-            #     ans = Results()
-            #     if not (res.constant.__class__ in native_numeric_types and res.constant == 0):
-            #         ans.constant = multiplier*res.constant*res.constant
-            #         ans.linear[key] = 2*multiplier*coef*res.constant
-            #     ans.quadratic[key,key] = multiplier*coef*coef
-            #     return ans
             else:
                 ans = Results()
-                has_cons = (res.constant.__class__ not in native_numeric_types
-                         or res.constant != 0)
-                if has_cons:
+                has_constant = (res.constant.__class__
+                                not in native_numeric_types
+                                or res.constant != 0)
+                if has_constant:
                     ans.constant = multiplier*res.constant*res.constant
                 while len(res.linear) > 0:
                     key1, coef1 = res.linear.popitem()
-                    if has_cons:
+                    if has_constant:
                         ans.linear[key1] = 2*multiplier*coef1*res.constant
                     ans.quadratic[key1,key1] = multiplier*coef1*coef1
                     for key2, coef2 in res.linear.items():

--- a/pyomo/repn/standard_repn.py
+++ b/pyomo/repn/standard_repn.py
@@ -736,14 +736,28 @@ def _collect_pow(exp, multiplier, idMap, compute_values, verbose, quadratic):
             #
             # If there is one linear term, then we compute the quadratic expression for it.
             #
-            elif len(res.linear) == 1:
-                key, coef = res.linear.popitem()
-                var = idMap[key]
+            # elif len(res.linear) == 1:
+            #     key, coef = res.linear.popitem()
+            #     var = idMap[key]
+            #     ans = Results()
+            #     if not (res.constant.__class__ in native_numeric_types and res.constant == 0):
+            #         ans.constant = multiplier*res.constant*res.constant
+            #         ans.linear[key] = 2*multiplier*coef*res.constant
+            #     ans.quadratic[key,key] = multiplier*coef*coef
+            #     return ans
+            else:
                 ans = Results()
-                if not (res.constant.__class__ in native_numeric_types and res.constant == 0):
+                has_cons = (res.constant.__class__ not in native_numeric_types
+                         or res.constant != 0)
+                if has_cons:
                     ans.constant = multiplier*res.constant*res.constant
-                    ans.linear[key] = 2*multiplier*coef*res.constant
-                ans.quadratic[key,key] = multiplier*coef*coef
+                while len(res.linear) > 0:
+                    key1, coef1 = res.linear.popitem()
+                    if has_cons:
+                        ans.linear[key1] = 2*multiplier*coef1*res.constant
+                    ans.quadratic[key1,key1] = multiplier*coef1*coef1
+                    for key2, coef2 in res.linear.items():
+                        ans.quadratic[key1,key2] = 2*multiplier*coef1*coef2
                 return ans
 
     #

--- a/pyomo/repn/tests/test_standard.py
+++ b/pyomo/repn/tests/test_standard.py
@@ -3260,6 +3260,51 @@ class Test(unittest.TestCase):
         baseline = { None:8 }
         self.assertEqual(baseline, repn_to_dict(rep))
 
+    def test_pow_of_lin_sum(self):
+        m = ConcreteModel()
+        m.x = Var(range(4))
+        e = sum(x for x in m.x.values())**2
+
+        rep = generate_standard_repn(e, compute_values=False, quadratic=False)
+        #
+        self.assertFalse( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), None )
+        self.assertFalse( rep.is_constant() )
+        self.assertFalse( rep.is_linear() )
+        self.assertFalse( rep.is_quadratic() )
+        self.assertTrue( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
+        self.assertFalse(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 4)
+        baseline = { }
+        self.assertEqual(baseline, repn_to_dict(rep))
+
+        rep = generate_standard_repn(e, compute_values=False, quadratic=True)
+        #
+        self.assertFalse( rep.is_fixed() )
+        self.assertEqual( rep.polynomial_degree(), 2 )
+        self.assertFalse( rep.is_constant() )
+        self.assertFalse( rep.is_linear() )
+        self.assertTrue( rep.is_quadratic() )
+        self.assertTrue( rep.is_nonlinear() )
+        #
+        self.assertTrue(len(rep.linear_vars) == 0)
+        self.assertTrue(len(rep.linear_coefs) == 0)
+        self.assertTrue(len(rep.quadratic_vars) == 10)
+        self.assertTrue(len(rep.quadratic_coefs) == 10)
+        self.assertTrue(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 0)
+        baseline = {(id(i), id(j)): 2
+                    for i in m.x.values()
+                    for j in m.x.values()
+                    if id(i) < id(j)}
+        baseline.update({(id(i), id(i)): 1 for i in m.x.values()})
+        self.assertEqual(baseline, repn_to_dict(rep))
+
     def test_fixed_exponent(self):
         m = ConcreteModel()
         m.x = Var()

--- a/pyomo/repn/tests/test_standard.py
+++ b/pyomo/repn/tests/test_standard.py
@@ -3141,19 +3141,21 @@ class Test(unittest.TestCase):
         rep = generate_standard_repn(e, compute_values=False, quadratic=True)
         #
         self.assertFalse( rep.is_fixed() )
-        self.assertEqual( rep.polynomial_degree(), None )
+        self.assertEqual( rep.polynomial_degree(), 2 )
         self.assertFalse( rep.is_constant() )
         self.assertFalse( rep.is_linear() )
-        self.assertFalse( rep.is_quadratic() )
+        self.assertTrue( rep.is_quadratic() )
         self.assertTrue( rep.is_nonlinear() )
         #
         self.assertTrue(len(rep.linear_vars) == 0)
         self.assertTrue(len(rep.linear_coefs) == 0)
-        self.assertTrue(len(rep.quadratic_vars) == 0)
-        self.assertTrue(len(rep.quadratic_coefs) == 0)
-        self.assertFalse(rep.nonlinear_expr is None)
-        self.assertTrue(len(rep.nonlinear_vars) == 2)
-        baseline = { }
+        self.assertTrue(len(rep.quadratic_vars) == 3)
+        self.assertTrue(len(rep.quadratic_coefs) == 3)
+        self.assertTrue(rep.nonlinear_expr is None)
+        self.assertTrue(len(rep.nonlinear_vars) == 0)
+        baseline = { (id(m.a), id(m.a)): 1,
+                     (id(m.a), id(m.b)): 2,
+                     (id(m.b), id(m.b)): 1 }
         self.assertEqual(baseline, repn_to_dict(rep))
 
         e = (m.a+3)**2

--- a/pyomo/repn/tests/test_standard.py
+++ b/pyomo/repn/tests/test_standard.py
@@ -3154,8 +3154,12 @@ class Test(unittest.TestCase):
         self.assertTrue(rep.nonlinear_expr is None)
         self.assertTrue(len(rep.nonlinear_vars) == 0)
         baseline = { (id(m.a), id(m.a)): 1,
-                     (id(m.a), id(m.b)): 2,
                      (id(m.b), id(m.b)): 1 }
+        if id(m.a) < id(m.b):
+            baseline[id(m.a), id(m.b)] = 2
+        else:
+            baseline[id(m.b), id(m.a)] = 2
+
         self.assertEqual(baseline, repn_to_dict(rep))
 
         e = (m.a+3)**2


### PR DESCRIPTION
## Fixes # .
#1287 
## Summary/Motivation:

`generate_standard_repn` should recognize the square of a linear sum `(x_1 + x_2 + ... + x_n)**2` as a quadratic when `quadratic=True`. It currently returns a nonlinear expression if the linear sum has more than one term. This leads, e.g., to issues when trying to solve a model with a quadratic constraint of this form with Gurobi. 

Note that there is a test case which asks for this behavior for expression `e = (m.a + m.b)**2`:
https://github.com/Pyomo/pyomo/blob/79205167333552a840d9e468a5ac188d4fa758c3/pyomo/repn/tests/test_standard.py#L3141-L3157
Am I missing a reason why this behavior might be wanted?

## Changes proposed in this PR:
- `_collect_pow` returns a quadratic expression for any `PowExpression` with linear base and exponent 2. The underlying logic is:
`(sum_i x_i)**2 = sum_i sum_j x_i*x_j = sum_i x_i**2 + 2*sum_i sum_{j<i} x_i*x_j`
- Modifies a test case for expression `(m.a + m.b)**2` which currently expects `generate_standard_repn` to return a nonlinear expression.
- Adds a test case for expression `(linear sum)**2` with more than two variables.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
