### PR TITLE
Units: Add support for ContinuousSet, clean handling of equality constraints

### DIFF
--- a/pyomo/util/check_units.py
+++ b/pyomo/util/check_units.py
@@ -111,17 +111,21 @@ def _assert_units_consistent_expression(expr):
     """
     pyomo_unit, pint_unit = units._get_units_tuple(expr)
 
-def _assert_units_complementarity(cdata):
-    """
-    Raise an exception if any units in either of the complementarity
-    expressions are inconsistent, and also check the standard block
-    methods.
-    """
-    if cdata._args[0] is not None:
-        pyomo_unit, pint_unit = units._get_units_tuple(cdata._args[0])
-    if cdata._args[1] is not None:
-        pyomo_unit, pint_unit = units._get_units_tuple(cdata._args[1])
-    _assert_units_consistent_block(cdata)
+# Complementarities that are not in standard form do not
+# current work with the checking code. The Units container
+# should be modified to allow sum and relationals with zero
+# terms (e.g., unitless). Then this code can be enabled.
+#def _assert_units_complementarity(cdata):
+#    """
+#    Raise an exception if any units in either of the complementarity
+#    expressions are inconsistent, and also check the standard block
+#    methods.
+#    """
+#    if cdata._args[0] is not None:
+#        pyomo_unit, pint_unit = units._get_units_tuple(cdata._args[0])
+#    if cdata._args[1] is not None:
+#        pyomo_unit, pint_unit = units._get_units_tuple(cdata._args[1])
+#    _assert_units_consistent_block(cdata)
 
 def _assert_units_consistent_block(obj):
     """

--- a/pyomo/util/check_units.py
+++ b/pyomo/util/check_units.py
@@ -16,7 +16,8 @@ module objects.
 from pyomo.core.base.units_container import units, UnitsError, UnitExtractionVisitor
 from pyomo.core.base import (Objective, Constraint, Var, Param,
                              Suffix, Set, RangeSet, Block,
-                             ExternalFunction, Expression)
+                             ExternalFunction, Expression,
+                             value)
 from pyomo.dae import ContinuousSet
 from pyomo.mpec import Complementarity
 from pyomo.gdp import Disjunct, Disjunction
@@ -82,12 +83,18 @@ def _assert_units_consistent_constraint_data(condata):
     # Therefore, if the lower and/or upper is 0, we allow it to be unitless
     # and check the consistency of the body only
     args = list()
-    if condata.lower != 0.0 and condata.lower is not None:
+    if condata.lower is not None and value(condata.lower) != 0.0:
         args.append(condata.lower)
+
     args.append(condata.body)
-    if condata.upper != 0.0 and condata.upper is not None:
+
+    if condata.upper is not None and value(condata.upper) != 0.0:
         args.append(condata.upper)
-    assert_units_equivalent(*args)
+
+    if len(args) == 1:
+        assert_units_consistent(*args)
+    else:
+        assert_units_equivalent(*args)
 
 def _assert_units_consistent_property_expr(obj):
     """

--- a/pyomo/util/tests/test_check_units.py
+++ b/pyomo/util/tests/test_check_units.py
@@ -154,22 +154,6 @@ class TestUnitsChecking(unittest.TestCase):
         assert_units_consistent(m.unitless_con[2]) # check unitless constraint data
 
     def test_assert_units_consistent_all_components(self):
-        """
-    Objective: _assert_units_consistent_property_expr,
-    Constraint:  _assert_units_consistent_constraint_data,
-    Var: _assert_units_consistent_expression,
-    Expression: _assert_units_consistent_property_expr,
-    Suffix: None,
-    Param: _assert_units_consistent_expression,
-    Set: None,
-    RangeSet: None,
-    Disjunct:_assert_units_consistent_block,
-    Disjunction: None,
-    Block: _assert_units_consistent_block,
-    ExternalFunction: None,
-    ContinuousSet: None, # ToDo: change this when continuous sets have units assigned
-    Complementarity: _assert_units_complementarity
-    """
         # test all scalar components consistent
         u = units
         m = self._create_model_and_vars()


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
- Adds support for checking units when a model contains a ContinuousSet

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
