### PR TITLE
Bug fix in interior point/MUMPS memory reallocation logic

### DIFF
--- a/pyomo/contrib/interior_point/linalg/tests/test_realloc.py
+++ b/pyomo/contrib/interior_point/linalg/tests/test_realloc.py
@@ -51,7 +51,7 @@ class TestReallocation(unittest.TestCase):
         self.assertEqual(res.status, ip.linalg.LinearSolverStatus.successful)
 
         # Expected memory allocation (MB)
-        self.assertEqual(linear_solver._prev_allocation, 6)
+        self.assertEqual(linear_solver._prev_allocation, 2*predicted)
 
         actual = linear_solver.get_infog(18)
 

--- a/pyomo/contrib/interior_point/tests/test_realloc.py
+++ b/pyomo/contrib/interior_point/tests/test_realloc.py
@@ -7,6 +7,11 @@ np, numpy_available = attempt_import('numpy', 'Interior point requires numpy',
         minimum_version='1.13.0')
 scipy, scipy_available = attempt_import('scipy', 'Interior point requires scipy')
 mumps, mumps_available = attempt_import('mumps', 'Interior point requires mumps')
+if mumps_available:
+    mumps_version = mumps._dmumps.__version__
+else:
+    mumps_version = None
+
 if not (numpy_available and scipy_available):
     raise unittest.SkipTest('Interior point tests require numpy and scipy')
 
@@ -48,6 +53,8 @@ class TestReallocation(unittest.TestCase):
 
         return ip_solver
 
+    @unittest.skipIf(mumps_version != '5.3.1', 
+            'This test is calibrated for Mumps version 5.3.1')
     @unittest.skipIf(not mumps_available, 'Mumps is not available')
     def test_mumps(self):
         n = 20000

--- a/pyomo/contrib/interior_point/tests/test_realloc.py
+++ b/pyomo/contrib/interior_point/tests/test_realloc.py
@@ -48,6 +48,7 @@ class TestReallocation(unittest.TestCase):
 
         return ip_solver
 
+    @unittest.skipIf(not mumps_available, 'Mumps is not available')
     def test_mumps(self):
         n = 20000
         m = make_model_tri(n, small_val=1e-7)

--- a/pyomo/contrib/interior_point/tests/test_realloc.py
+++ b/pyomo/contrib/interior_point/tests/test_realloc.py
@@ -7,10 +7,6 @@ np, numpy_available = attempt_import('numpy', 'Interior point requires numpy',
         minimum_version='1.13.0')
 scipy, scipy_available = attempt_import('scipy', 'Interior point requires scipy')
 mumps, mumps_available = attempt_import('mumps', 'Interior point requires mumps')
-if mumps_available:
-    mumps_version = mumps._dmumps.__version__
-else:
-    mumps_version = None
 
 if not (numpy_available and scipy_available):
     raise unittest.SkipTest('Interior point tests require numpy and scipy')
@@ -53,8 +49,6 @@ class TestReallocation(unittest.TestCase):
 
         return ip_solver
 
-    @unittest.skipIf(mumps_version != '5.3.1', 
-            'This test is calibrated for Mumps version 5.3.1')
     @unittest.skipIf(not mumps_available, 'Mumps is not available')
     def test_mumps(self):
         n = 20000
@@ -70,8 +64,9 @@ class TestReallocation(unittest.TestCase):
         self._test_ip_with_reallocation(linear_solver, interface)
         actual = linear_solver.get_icntl(23)
 
-        self.assertEqual(predicted, 12)
-        self.assertEqual(actual, 14)
+        self.assertTrue(predicted == 12 or predicted == 11)
+        self.assertTrue(actual > predicted+1)
+        #self.assertEqual(actual, 14)
 
 
 if __name__ == '__main__':

--- a/pyomo/contrib/interior_point/tests/test_realloc.py
+++ b/pyomo/contrib/interior_point/tests/test_realloc.py
@@ -15,9 +15,9 @@ from pyomo.contrib.pynumero.asl import AmplInterface
 asl_available = AmplInterface.available()
 if not asl_available:
     raise unittest.SkipTest('Regularization tests require ASL')
-import pyomo.contrib.interior_point as ip
-from pyomo.contrib.pynumero.linalg.ma27 import MA27Interface
-ma27_available = MA27Interface.available()
+from pyomo.contrib.interior_point.interface import InteriorPointInterface
+from pyomo.contrib.interior_point.interior_point import InteriorPointSolver
+from pyomo.contrib.interior_point.linalg.mumps_interface import MumpsInterface
 
 
 def make_model_tri(n, small_val=1e-7, big_val=1e2):
@@ -35,7 +35,7 @@ def make_model_tri(n, small_val=1e-7, big_val=1e2):
 
 class TestReallocation(unittest.TestCase):
     def _test_ip_with_reallocation(self, linear_solver, interface):
-        ip_solver = ip.InteriorPointSolver(linear_solver,
+        ip_solver = InteriorPointSolver(linear_solver,
                 max_reallocation_iterations=3,
                 reallocation_factor=1.1,
                 # The small factor is to ensure that multiple iterations of
@@ -53,8 +53,8 @@ class TestReallocation(unittest.TestCase):
     def test_mumps(self):
         n = 20000
         m = make_model_tri(n, small_val=1e-7)
-        interface = ip.InteriorPointInterface(m)
-        linear_solver = ip.linalg.MumpsInterface()
+        interface = InteriorPointInterface(m)
+        linear_solver = MumpsInterface()
         # Default memory "buffer" factor: 20
         linear_solver.set_icntl(14, 20)
 

--- a/pyomo/contrib/interior_point/tests/test_realloc.py
+++ b/pyomo/contrib/interior_point/tests/test_realloc.py
@@ -55,7 +55,8 @@ class TestReallocation(unittest.TestCase):
         m = make_model_tri(n, small_val=1e-7)
         interface = ip.InteriorPointInterface(m)
         linear_solver = ip.linalg.MumpsInterface()
-        linear_solver.set_icntl(14, 20) # Default memory "buffer" factor: 20
+        # Default memory "buffer" factor: 20
+        linear_solver.set_icntl(14, 20)
 
         kkt = interface.evaluate_primal_dual_kkt_matrix()
         res = linear_solver.do_symbolic_factorization(kkt)
@@ -65,8 +66,11 @@ class TestReallocation(unittest.TestCase):
         actual = linear_solver.get_icntl(23)
 
         self.assertTrue(predicted == 12 or predicted == 11)
-        self.assertTrue(actual > predicted+1)
+        self.assertTrue(actual > predicted)
         #self.assertEqual(actual, 14)
+        # NOTE: This test will break if Mumps (or your Mumps version)
+        # gets more conservative at estimating memory requirement,
+        # or if the numeric factorization gets more efficient.
 
 
 if __name__ == '__main__':

--- a/pyomo/contrib/interior_point/tests/test_realloc.py
+++ b/pyomo/contrib/interior_point/tests/test_realloc.py
@@ -1,0 +1,71 @@
+import pyutilib.th as unittest
+import pyomo.environ as pe
+from pyomo.core.base import ConcreteModel, Var, Constraint, Objective
+from pyomo.common.dependencies import attempt_import
+
+np, numpy_available = attempt_import('numpy', 'Interior point requires numpy',
+        minimum_version='1.13.0')
+scipy, scipy_available = attempt_import('scipy', 'Interior point requires scipy')
+mumps, mumps_available = attempt_import('mumps', 'Interior point requires mumps')
+if not (numpy_available and scipy_available):
+    raise unittest.SkipTest('Interior point tests require numpy and scipy')
+
+from pyomo.contrib.pynumero.asl import AmplInterface
+asl_available = AmplInterface.available()
+if not asl_available:
+    raise unittest.SkipTest('Regularization tests require ASL')
+import pyomo.contrib.interior_point as ip
+from pyomo.contrib.pynumero.linalg.ma27 import MA27Interface
+ma27_available = MA27Interface.available()
+
+
+def make_model_tri(n, small_val=1e-7, big_val=1e2):
+    m = ConcreteModel()
+    m.x = Var(range(n), initialize=0.5)
+
+    def c_rule(m, i):
+        return big_val*m.x[i-1] + small_val*m.x[i] + big_val*m.x[i+1] == 1
+    
+    m.c = Constraint(range(1,n-1), rule=c_rule)
+
+    m.obj = Objective(expr=small_val*sum((m.x[i]-1)**2 for i in range(n)))
+
+    return m
+
+class TestReallocation(unittest.TestCase):
+    def _test_ip_with_reallocation(self, linear_solver, interface):
+        ip_solver = ip.InteriorPointSolver(linear_solver,
+                max_reallocation_iterations=3,
+                reallocation_factor=1.1,
+                # The small factor is to ensure that multiple iterations of
+                # reallocation are performed. The bug in the previous
+                # implementation only occurred if 2+ reallocation iterations
+                # were needed (max_reallocation_iterations >= 3).
+                max_iter=1)
+        ip_solver.set_interface(interface)
+
+        ip_solver.solve(interface)
+
+        return ip_solver
+
+    def test_mumps(self):
+        n = 20000
+        m = make_model_tri(n, small_val=1e-7)
+        interface = ip.InteriorPointInterface(m)
+        linear_solver = ip.linalg.MumpsInterface()
+        linear_solver.set_icntl(14, 20) # Default memory "buffer" factor: 20
+
+        kkt = interface.evaluate_primal_dual_kkt_matrix()
+        res = linear_solver.do_symbolic_factorization(kkt)
+        predicted = linear_solver.get_infog(16)
+
+        self._test_ip_with_reallocation(linear_solver, interface)
+        actual = linear_solver.get_icntl(23)
+
+        self.assertEqual(predicted, 12)
+        self.assertEqual(actual, 14)
+
+
+if __name__ == '__main__':
+    #
+    unittest.main()


### PR DESCRIPTION
## Fixes 
Fixes a bug in the Interior Point/MUMPS memory reallocation logic, where `_prev_allocation` was not being updated correctly after a symbolic factorization. This was only a problem because symbolic factorization is being performed for every numeric factorization attempt, and would only become apparent if multiple reallocations were necessary.

## Changes proposed in this PR:
- Fix bug by updating `_prev_allocation` to be the max of ICNTL(23) and INFOG(16) after symbolic factorization
- Cast `_prev_allocation` as an int to accurately represent the info sent to MUMPS in ICNTL(23).
- Test to catch the erroneous behavior.

The test to catch this bug is very slow, about 3s. This is because the bug only became a problem if 2 or more reallocation iterations were necessary, so I needed to find an NLP for which this was the case. This is complicated by the fact that memory allocations via ICNTL(23) are rounded to the nearest MB, so I needed a KKT matrix whose actual memory requirement was at least 2 MB greater than the prediction. The NLP in the test file is the smallest/fastest I could find with this property.

I could switch to a test that only requires one iteration of reallocation, which could be made much faster, but would not cover the specific bug I encountered. Also up for debate whether this is more of a "MUMPS test" or an "Interior Point test." It's located in the latter's directory because that's how I encountered it. Suggestions appreciated on both of these counts, or on a smaller KKT matrix that requires 2 MB of reallocation.  

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
