### PR TITLE
Fix bug and add new configs in MindtPy

### DIFF
--- a/pyomo/contrib/gdpopt/util.py
+++ b/pyomo/contrib/gdpopt/util.py
@@ -206,9 +206,9 @@ def copy_var_list_values(from_list, to_list, config,
             rounded_val = int(round(var_val))
             # Check to see if this is just a tolerance issue
             if ignore_integrality \
-                    and not v_to.is_continuous():
+                    and v_to.is_integer():  # not v_to.is_continuous()
                 v_to.value = value(v_from, exception=False)
-            elif not v_to.is_continuous() and (fabs(var_val - rounded_val) <= config.integer_tolerance):
+            elif v_to.is_integer() and (fabs(var_val - rounded_val) <= config.integer_tolerance):  # not v_to.is_continuous()
                 v_to.set_value(rounded_val)
             elif 'is not in domain NonNegativeReals' in err_msg and (
                     fabs(var_val) <= config.zero_tolerance):

--- a/pyomo/contrib/gdpopt/util.py
+++ b/pyomo/contrib/gdpopt/util.py
@@ -135,7 +135,7 @@ def process_objective(solve_data, config, move_linear_objective=False, use_mcpp=
         raise ValueError('Model has multiple active objectives.')
     else:
         main_obj = active_objectives[0]
-    solve_data.results.problem.sense = main_obj.sense
+    solve_data.results.problem.sense = ProblemSense.minimize if main_obj.sense == 1 else ProblemSense.maximize
     solve_data.objective_sense = main_obj.sense
 
     # Move the objective to the constraints if it is nonlinear
@@ -161,11 +161,9 @@ def process_objective(solve_data, config, move_linear_objective=False, use_mcpp=
         if main_obj.sense == minimize:
             util_blk.objective_constr = Constraint(
                 expr=util_blk.objective_value >= main_obj.expr)
-            solve_data.results.problem.sense = ProblemSense.minimize
         else:
             util_blk.objective_constr = Constraint(
                 expr=util_blk.objective_value <= main_obj.expr)
-            solve_data.results.problem.sense = ProblemSense.maximize
         # Deactivate the original objective and add this new one.
         main_obj.deactivate()
         util_blk.objective = Objective(

--- a/pyomo/contrib/gdpopt/util.py
+++ b/pyomo/contrib/gdpopt/util.py
@@ -206,8 +206,7 @@ def copy_var_list_values(from_list, to_list, config,
             rounded_val = int(round(var_val))
             # Check to see if this is just a tolerance issue
             if ignore_integrality \
-                and ('is not in domain Binary' in err_msg
-                     or 'is not in domain Integers' in err_msg):
+                    and not v_to.is_continuous():
                 v_to.value = value(v_from, exception=False)
             elif 'is not in domain Binary' in err_msg and (
                     fabs(var_val - 1) <= config.integer_tolerance or

--- a/pyomo/contrib/gdpopt/util.py
+++ b/pyomo/contrib/gdpopt/util.py
@@ -224,7 +224,7 @@ def is_feasible(model, config):
     untransformed GDP models.
 
     """
-    disj=next(model.component_data_objects(
+    disj = next(model.component_data_objects(
         ctype=Disjunct, active=True), None)
     if disj is not None:
         raise NotImplementedError(
@@ -235,7 +235,7 @@ def is_feasible(model, config):
 
     config.logger.debug('Checking if model is feasible.')
     for constr in model.component_data_objects(
-            ctype = Constraint, active = True, descend_into = True):
+            ctype=Constraint, active=True, descend_into=True):
         # Check constraint lower bound
         if (constr.lower is not None and (
                 value(constr.lower) - value(constr.body)
@@ -252,7 +252,7 @@ def is_feasible(model, config):
             config.logger.info('%s: body %s > UB %s' % (
                 constr.name, value(constr.body), value(constr.upper)))
             return False
-    for var in model.component_data_objects(ctype = Var, descend_into = True):
+    for var in model.component_data_objects(ctype=Var, descend_into=True):
         # Check variable lower bound
         if (var.has_lb() and
                 value(var.lb) - value(var) >= config.variable_tolerance):
@@ -277,8 +277,8 @@ def build_ordered_component_lists(model, solve_data):
     forth.
 
     """
-    util_blk=getattr(model, solve_data.util_block_name)
-    var_set=ComponentSet()
+    util_blk = getattr(model, solve_data.util_block_name)
+    var_set = ComponentSet()
     setattr(
         util_blk, 'constraint_list', list(
             model.component_data_objects(
@@ -298,10 +298,10 @@ def build_ordered_component_lists(model, solve_data):
     # Identify the non-fixed variables in (potentially) active constraints and
     # objective functions
     for constr in getattr(util_blk, 'constraint_list'):
-        for v in identify_variables(constr.body, include_fixed = False):
+        for v in identify_variables(constr.body, include_fixed=False):
             var_set.add(v)
-    for obj in model.component_data_objects(ctype = Objective, active = True):
-        for v in identify_variables(obj.expr, include_fixed = False):
+    for obj in model.component_data_objects(ctype=Objective, active=True):
+        for v in identify_variables(obj.expr, include_fixed=False):
             var_set.add(v)
     # Disjunct indicator variables might not appear in active constraints. In
     # fact, if we consider them Logical variables, they should not appear in
@@ -312,7 +312,7 @@ def build_ordered_component_lists(model, solve_data):
 
     # We use component_data_objects rather than list(var_set) in order to
     # preserve a deterministic ordering.
-    var_list=list(
+    var_list = list(
         v for v in model.component_data_objects(
             ctype=Var, descend_into=(Block, Disjunct))
         if v in var_set)
@@ -322,27 +322,27 @@ def build_ordered_component_lists(model, solve_data):
 def setup_results_object(solve_data, config):
     """Record problem statistics for original model."""
     # Create the solver results object
-    res=solve_data.results
-    prob=res.problem
-    res.problem.name=solve_data.original_model.name
-    res.problem.number_of_nonzeros=None  # TODO
+    res = solve_data.results
+    prob = res.problem
+    res.problem.name = solve_data.original_model.name
+    res.problem.number_of_nonzeros = None  # TODO
     # TODO work on termination condition and message
-    res.solver.termination_condition=None
-    res.solver.message=None
-    res.solver.user_time=None
-    res.solver.system_time=None
-    res.solver.wallclock_time=None
-    res.solver.termination_message=None
+    res.solver.termination_condition = None
+    res.solver.message = None
+    res.solver.user_time = None
+    res.solver.system_time = None
+    res.solver.wallclock_time = None
+    res.solver.termination_message = None
 
-    num_of=build_model_size_report(solve_data.original_model)
+    num_of = build_model_size_report(solve_data.original_model)
 
     # Get count of constraints and variables
-    prob.number_of_constraints=num_of.activated.constraints
-    prob.number_of_disjunctions=num_of.activated.disjunctions
-    prob.number_of_variables=num_of.activated.variables
-    prob.number_of_binary_variables=num_of.activated.binary_variables
-    prob.number_of_continuous_variables=num_of.activated.continuous_variables
-    prob.number_of_integer_variables=num_of.activated.integer_variables
+    prob.number_of_constraints = num_of.activated.constraints
+    prob.number_of_disjunctions = num_of.activated.disjunctions
+    prob.number_of_variables = num_of.activated.variables
+    prob.number_of_binary_variables = num_of.activated.binary_variables
+    prob.number_of_continuous_variables = num_of.activated.continuous_variables
+    prob.number_of_integer_variables = num_of.activated.integer_variables
 
     config.logger.info(
         "Original model has %s constraints (%s nonlinear) "
@@ -382,7 +382,7 @@ def constraints_in_True_disjuncts(model, config):
     """Yield constraints in disjuncts where the indicator value is set or fixed to True."""
     for constr in model.component_data_objects(Constraint):
         yield constr
-    observed_disjuncts=ComponentSet()
+    observed_disjuncts = ComponentSet()
     for disjctn in model.component_data_objects(Disjunction):
         # get all the disjuncts in the disjunction. Check which ones are True.
         for disj in disjctn.disjuncts:
@@ -395,25 +395,25 @@ def constraints_in_True_disjuncts(model, config):
 
 
 @contextmanager
-def time_code(timing_data_obj, code_block_name, is_main_timer = False):
+def time_code(timing_data_obj, code_block_name, is_main_timer=False):
     """Starts timer at entry, stores elapsed time at exit
 
     If `is_main_timer=True`, the start time is stored in the timing_data_obj,
     allowing calculation of total elapsed time 'on the fly' (e.g. to enforce
     a time limit) using `get_main_elapsed_time(timing_data_obj)`.
     """
-    start_time=timeit.default_timer()
+    start_time = timeit.default_timer()
     if is_main_timer:
-        timing_data_obj.main_timer_start_time=start_time
+        timing_data_obj.main_timer_start_time = start_time
     yield
-    elapsed_time=timeit.default_timer() - start_time
-    prev_time=timing_data_obj.get(code_block_name, 0)
-    timing_data_obj[code_block_name]=prev_time + elapsed_time
+    elapsed_time = timeit.default_timer() - start_time
+    prev_time = timing_data_obj.get(code_block_name, 0)
+    timing_data_obj[code_block_name] = prev_time + elapsed_time
 
 
 def get_main_elapsed_time(timing_data_obj):
     """Returns the time since entering the main `time_code` context"""
-    current_time=timeit.default_timer()
+    current_time = timeit.default_timer()
     try:
         return current_time - timing_data_obj.main_timer_start_time
     except AttributeError as e:
@@ -426,18 +426,18 @@ def get_main_elapsed_time(timing_data_obj):
 @deprecated(
     "'restore_logger_level()' has been deprecated in favor of the more "
     "specific 'lower_logger_level_to()' function.",
-    version = '5.6.9')
+    version='5.6.9')
 @contextmanager
 def restore_logger_level(logger):
-    old_logger_level=logger.getEffectiveLevel()
+    old_logger_level = logger.getEffectiveLevel()
     yield
     logger.setLevel(old_logger_level)
 
 
 @contextmanager
-def lower_logger_level_to(logger, level = None):
+def lower_logger_level_to(logger, level=None):
     """Increases logger verbosity by lowering reporting level."""
-    old_logger_level=logger.getEffectiveLevel()
+    old_logger_level = logger.getEffectiveLevel()
     if level is not None and old_logger_level > level:
         # If logger level is higher (less verbose), decrease it
         logger.setLevel(level)
@@ -449,7 +449,7 @@ def lower_logger_level_to(logger, level = None):
 
 @contextmanager
 def create_utility_block(model, name, solve_data):
-    created_util_block=False
+    created_util_block = False
     # Create a model block on which to store GDPopt-specific utility
     # modeling objects.
     if hasattr(model, name):
@@ -458,10 +458,10 @@ def create_utility_block(model, name, solve_data):
             "on the model object, but an attribute with that name "
             "already exists." % name)
     else:
-        created_util_block=True
+        created_util_block = True
         setattr(model, name, Block(
             doc="Container for GDPopt solver utility modeling objects"))
-        solve_data.util_block_name=name
+        solve_data.util_block_name = name
 
         # Save ordered lists of main modeling components, so that data can
         # be easily transferred between future model clones.
@@ -473,44 +473,44 @@ def create_utility_block(model, name, solve_data):
 
 @contextmanager
 def setup_solver_environment(model, config):
-    solve_data=GDPoptSolveData()  # data object for storing solver state
-    solve_data.config=config
-    solve_data.results=SolverResults()
-    solve_data.timing=Container()
-    min_logging_level=logging.INFO if config.tee else None
-    with time_code(solve_data.timing, 'total', is_main_timer = True), \
+    solve_data = GDPoptSolveData()  # data object for storing solver state
+    solve_data.config = config
+    solve_data.results = SolverResults()
+    solve_data.timing = Container()
+    min_logging_level = logging.INFO if config.tee else None
+    with time_code(solve_data.timing, 'total', is_main_timer=True), \
             lower_logger_level_to(config.logger, min_logging_level), \
             create_utility_block(model, 'GDPopt_utils', solve_data):
 
         # Create a working copy of the original model
-        solve_data.original_model=model
-        solve_data.working_model=model.clone()
+        solve_data.original_model = model
+        solve_data.working_model = model.clone()
         setup_results_object(solve_data, config)
-        solve_data.active_strategy=config.strategy
-        util_block=solve_data.working_model.GDPopt_utils
+        solve_data.active_strategy = config.strategy
+        util_block = solve_data.working_model.GDPopt_utils
 
         # Save model initial values.
         # These can be used later to initialize NLP subproblems.
-        solve_data.initial_var_values=list(
+        solve_data.initial_var_values = list(
             v.value for v in util_block.variable_list)
-        solve_data.best_solution_found=None
+        solve_data.best_solution_found = None
 
         # Integer cuts exclude particular discrete decisions
-        util_block.integer_cuts=ConstraintList(doc = 'integer cuts')
+        util_block.integer_cuts = ConstraintList(doc='integer cuts')
 
         # Set up iteration counters
-        solve_data.master_iteration=0
-        solve_data.mip_iteration=0
-        solve_data.nlp_iteration=0
+        solve_data.master_iteration = 0
+        solve_data.mip_iteration = 0
+        solve_data.nlp_iteration = 0
 
         # set up bounds
-        solve_data.LB=float('-inf')
-        solve_data.UB=float('inf')
-        solve_data.iteration_log={}
+        solve_data.LB = float('-inf')
+        solve_data.UB = float('inf')
+        solve_data.iteration_log = {}
 
         # Flag indicating whether the solution improved in the past
         # iteration or not
-        solve_data.feasible_solution_improved=False
+        solve_data.feasible_solution_improved = False
 
         yield solve_data  # yield setup solver environment
 
@@ -518,17 +518,17 @@ def setup_solver_environment(model, config):
                 and solve_data.best_solution_found is not solve_data.original_model):
             # Update values on the original model
             copy_var_list_values(
-                from_list = solve_data.best_solution_found.GDPopt_utils.variable_list,
-                to_list = solve_data.original_model.GDPopt_utils.variable_list,
-                config = config)
+                from_list=solve_data.best_solution_found.GDPopt_utils.variable_list,
+                to_list=solve_data.original_model.GDPopt_utils.variable_list,
+                config=config)
 
     # Finalize results object
-    solve_data.results.problem.lower_bound=solve_data.LB
-    solve_data.results.problem.upper_bound=solve_data.UB
-    solve_data.results.solver.iterations=solve_data.master_iteration
-    solve_data.results.solver.timing=solve_data.timing
-    solve_data.results.solver.user_time=solve_data.timing.total
-    solve_data.results.solver.wallclock_time=solve_data.timing.total
+    solve_data.results.problem.lower_bound = solve_data.LB
+    solve_data.results.problem.upper_bound = solve_data.UB
+    solve_data.results.solver.iterations = solve_data.master_iteration
+    solve_data.results.solver.timing = solve_data.timing
+    solve_data.results.solver.user_time = solve_data.timing.total
+    solve_data.results.solver.wallclock_time = solve_data.timing.total
 
 
 def indent(text, prefix):

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -371,18 +371,13 @@ class MindtPySolver(object):
             # Set of MIP iterations for which cuts were generated in ECP
             lin.mip_iters = Set(dimen=1)
 
-            nonlinear_constraints = [c for c in MindtPy.constraint_list if
-                                     c.body.polynomial_degree() not in (1, 0)]
-            lin.nl_constraint_set = RangeSet(
-                len(nonlinear_constraints),
-                doc="Integer index set over the nonlinear constraints")
-
             if config.feasibility_norm == 'L1' or config.feasibility_norm == 'L2':
-                feas.constraint_set = RangeSet(
-                    len(MindtPy.constraint_list),
-                    doc="integer index set over the constraints")
+                feas.nl_constraint_set = Set(initialize=[i for i, constr in enumerate(MindtPy.constraint_list, 1) if
+                                                         constr.body.polynomial_degree() not in (1, 0)],
+                                             doc="Integer index set over the nonlinear constraints."
+                                             "The set corresponds to the index of nonlinear constraint in constraint_set")
                 # Create slack variables for feasibility problem
-                feas.slack_var = Var(feas.constraint_set,
+                feas.slack_var = Var(feas.nl_constraint_set,
                                      domain=NonNegativeReals, initialize=1)
             else:
                 feas.slack_var = Var(domain=NonNegativeReals, initialize=1)

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -256,6 +256,11 @@ class MindtPySolver(object):
         domain=In(["reverse_symbolic", "sympy"]),
         description="differentiate mode to calculate jacobian"
     ))
+    CONFIG.declare("linearize_inactive", ConfigValue(
+        default=False,
+        description="Add OA cuts for inactive constraints.",
+        domain=bool
+    ))
 
     def available(self, exception_flag=True):
         """Check if solver is available.

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -391,17 +391,7 @@ class MindtPySolver(object):
             else:
                 feas.slack_var = Var(domain=NonNegativeReals, initialize=1)
 
-                # # Mapping Constraint -> integer index
-                # MindtPy.feas_map = {}
-                # # Mapping integer index -> Constraint
-                # MindtPy.feas_inverse_map = {}
-                # # Generate the two maps. These maps may be helpful for later
-                # # interpreting indices on the slack variables or generated cuts.
-                # for c, n in zip(MindtPy.constraint_list, feas.constraint_set):
-                #     MindtPy.feas_map[c] = n
-                #     MindtPy.feas_inverse_map[n] = c
-
-                # Create slack variables for OA cuts
+            # Create slack variables for OA cuts
             if config.add_slack:
                 lin.slack_vars = VarList(
                     bounds=(0, config.max_slack), initialize=0, domain=NonNegativeReals)

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -247,7 +247,7 @@ class MindtPySolver(object):
         domain=bool
     ))
     CONFIG.declare("feasibility_norm", ConfigValue(
-        default="L1",
+        default="L_infinity",
         domain=In(["L1", "L2", "L_infinity"]),
         description="different forms of objective function in feasibility subproblem."
     ))

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -59,13 +59,13 @@ class MindtPySolver(object):
         default=1E-5,
         domain=PositiveFloat,
         description="Bound tolerance",
-        doc="Relative tolerance for bound feasibility checks"
+        doc="Relative tolerance for bound feasibility checks."
     ))
     CONFIG.declare("iteration_limit", ConfigValue(
         default=30,
         domain=PositiveInt,
         description="Iteration limit",
-        doc="Number of maximum iterations in the decomposition methods"
+        doc="Number of maximum iterations in the decomposition methods."
     ))
     CONFIG.declare("time_limit", ConfigValue(
         default=600,
@@ -82,7 +82,7 @@ class MindtPySolver(object):
         doc="MINLP Decomposition strategy to be applied to the method. "
             "Currently available Outer Approximation (OA), Extended Cutting "
             "Plane (ECP), Partial Surrogate Cuts (PSC), and Generalized "
-            "Benders Decomposition (GBD)"
+            "Benders Decomposition (GBD)."
     ))
     CONFIG.declare("init_strategy", ConfigValue(
         default="rNLP",
@@ -91,14 +91,14 @@ class MindtPySolver(object):
         doc="Initialization strategy used by any method. Currently the "
             "continuous relaxation of the MINLP (rNLP), solve a maximal "
             "covering problem (max_binary), and fix the initial value for "
-            "the integer variables (initial_binary)"
+            "the integer variables (initial_binary)."
     ))
     CONFIG.declare("max_slack", ConfigValue(
         default=1000.0,
         domain=PositiveFloat,
         description="Maximum slack variable",
         doc="Maximum slack variable value allowed for the Outer Approximation "
-            "cuts"
+            "cuts."
     ))
     CONFIG.declare("OA_penalty_factor", ConfigValue(
         default=1000.0,
@@ -106,7 +106,7 @@ class MindtPySolver(object):
         description="Outer Approximation slack penalty factor",
         doc="In the objective function of the Outer Approximation method, the "
             "slack variables corresponding to all the constraints get "
-            "multiplied by this number and added to the objective"
+            "multiplied by this number and added to the objective."
     ))
     CONFIG.declare("ECP_tolerance", ConfigValue(
         default=1E-4,
@@ -114,20 +114,20 @@ class MindtPySolver(object):
         description="ECP tolerance",
         doc="Feasibility tolerance used to determine the stopping criterion in"
             "the ECP method. As long as nonlinear constraint are violated for "
-            "more than this tolerance, the method will keep iterating"
+            "more than this tolerance, the method will keep iterating."
     ))
     CONFIG.declare("nlp_solver", ConfigValue(
         default="ipopt",
         domain=In(["ipopt", "gams"]),
         description="NLP subsolver name",
         doc="Which NLP subsolver is going to be used for solving the nonlinear"
-            "subproblems"
+            "subproblems."
     ))
     CONFIG.declare("nlp_solver_args", ConfigBlock(
         implicit=True,
         description="NLP subsolver options",
         doc="Which NLP subsolver options to be passed to the solver while "
-            "solving the nonlinear subproblems"
+            "solving the nonlinear subproblems."
     ))
     CONFIG.declare("mip_solver", ConfigValue(
         default="glpk",
@@ -135,13 +135,13 @@ class MindtPySolver(object):
                    "gurobi_persistent", "cplex_persistent"]),
         description="MIP subsolver name",
         doc="Which MIP subsolver is going to be used for solving the mixed-"
-            "integer master problems"
+            "integer master problems."
     ))
     CONFIG.declare("mip_solver_args", ConfigBlock(
         implicit=True,
         description="MIP subsolver options",
         doc="Which MIP subsolver options to be passed to the solver while "
-            "solving the mixed-integer master problems"
+            "solving the mixed-integer master problems."
     ))
     CONFIG.declare("call_after_master_solve", ConfigValue(
         default=_DoNothing(),
@@ -206,7 +206,7 @@ class MindtPySolver(object):
     ))
     CONFIG.declare("integer_to_binary", ConfigValue(
         default=False,
-        description="Convert integer variables to binaries (for integer cuts)",
+        description="Convert integer variables to binaries (for integer cuts).",
         domain=bool
     ))
     CONFIG.declare("add_integer_cuts", ConfigValue(
@@ -228,7 +228,7 @@ class MindtPySolver(object):
     CONFIG.declare("add_slack", ConfigValue(
         default=False,
         description="whether add slack variable here."
-                    "slack variables here are used to deal with nonconvex MINLP",
+                    "slack variables here are used to deal with nonconvex MINLP.",
         domain=bool
     ))
     CONFIG.declare("continuous_var_bound", ConfigValue(
@@ -249,12 +249,12 @@ class MindtPySolver(object):
     CONFIG.declare("feasibility_norm", ConfigValue(
         default="L1",
         domain=In(["L1", "L2", "L_infinity"]),
-        description="different forms of objective function in feasibility subproblem"
+        description="different forms of objective function in feasibility subproblem."
     ))
     CONFIG.declare("differentiate_mode", ConfigValue(
         default="reverse_symbolic",
         domain=In(["reverse_symbolic", "sympy"]),
-        description="differentiate mode to calculate jacobian"
+        description="differentiate mode to calculate jacobian."
     ))
     CONFIG.declare("linearize_inactive", ConfigValue(
         default=False,

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -249,8 +249,12 @@ class MindtPySolver(object):
     CONFIG.declare("feasibility_norm", ConfigValue(
         default="L1",
         domain=In(["L1", "L2", "L_infinity"]),
-        description="Initialization strategy",
-        doc="different forms of objective function in feasibility subproblem"
+        description="different forms of objective function in feasibility subproblem"
+    ))
+    CONFIG.declare("differentiate_mode", ConfigValue(
+        default="reverse_symbolic",
+        domain=In(["reverse_symbolic", "sympy"]),
+        description="differentiate mode to calculate jacobian"
     ))
 
     def available(self, exception_flag=True):

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -130,7 +130,7 @@ class MindtPySolver(object):
             "solving the nonlinear subproblems"
     ))
     CONFIG.declare("mip_solver", ConfigValue(
-        default="gurobi",
+        default="glpk",
         domain=In(["gurobi", "cplex", "cbc", "glpk", "gams",
                    "gurobi_persistent", "cplex_persistent"]),
         description="MIP subsolver name",

--- a/pyomo/contrib/mindtpy/cut_generation.py
+++ b/pyomo/contrib/mindtpy/cut_generation.py
@@ -36,8 +36,7 @@ def add_objective_linearization(solve_data, config):
 
 def add_oa_cuts(target_model, dual_values, solve_data, config,
                 linearize_active=True,
-                linearize_violated=True,
-                linearize_inactive=False):
+                linearize_violated=True):
     """Linearizes nonlinear constraints.
 
     For nonconvex problems, turn on 'config.add_slack'. Slack variables will
@@ -68,7 +67,7 @@ def add_oa_cuts(target_model, dual_values, solve_data, config,
             if constr.has_ub() \
                 and (linearize_active and abs(constr.uslack()) < config.zero_tolerance) \
                     or (linearize_violated and constr.uslack() < 0) \
-                    or (linearize_inactive and constr.uslack() > 0):
+                    or (config.linearize_inactive and constr.uslack() > 0):
                 if config.add_slack:
                     slack_var = target_model.MindtPy_utils.MindtPy_linear_cuts.slack_vars.add()
 
@@ -82,7 +81,7 @@ def add_oa_cuts(target_model, dual_values, solve_data, config,
             if constr.has_lb() \
                 and (linearize_active and abs(constr.lslack()) < config.zero_tolerance) \
                     or (linearize_violated and constr.lslack() < 0) \
-                    or (linearize_inactive and constr.lslack() > 0):
+                    or (config.linearize_inactive and constr.lslack() > 0):
                 if config.add_slack:
                     slack_var = target_model.MindtPy_utils.MindtPy_linear_cuts.slack_vars.add()
 

--- a/pyomo/contrib/mindtpy/cut_generation.py
+++ b/pyomo/contrib/mindtpy/cut_generation.py
@@ -34,7 +34,6 @@ def add_objective_linearization(solve_data, config):
         MindtPy.ECP_constr_map[obj, solve_data.mip_iter] = c
 
 
-'''
 def add_oa_cuts(target_model, dual_values, solve_data, config,
                 linearize_active=True,
                 linearize_violated=True,
@@ -95,9 +94,9 @@ def add_oa_cuts(target_model, dual_values, solve_data, config,
                           + (slack_var if config.add_slack else 0)
                           >= constr.lower)
                 )
+
+
 '''
-
-
 def add_oa_cuts(target_model, dual_values, solve_data, config,
                 linearize_active=True,
                 linearize_violated=True,
@@ -111,9 +110,6 @@ def add_oa_cuts(target_model, dual_values, solve_data, config,
                                     dual_values):
         if constr.body.polynomial_degree() in (0, 1):
             continue
-
-        # constr_vars = list(identify_variables(constr.body))
-        # jacs = solve_data.jacobians
 
         # Equality constraint (makes the problem nonconvex)
         if constr.has_ub() and constr.has_lb() and constr.upper == constr.lower:
@@ -156,7 +152,7 @@ def add_oa_cuts(target_model, dual_values, solve_data, config,
                         + (slack_var if config.add_slack else 0)
                         >= constr.lower)
                 )
-
+'''
 # def add_oa_equality_relaxation(var_values, duals, solve_data, config, ignore_integrality=False):
 #     """More general case for outer approximation
 

--- a/pyomo/contrib/mindtpy/cut_generation.py
+++ b/pyomo/contrib/mindtpy/cut_generation.py
@@ -93,64 +93,6 @@ def add_oa_cuts(target_model, dual_values, solve_data, config,
                           >= constr.lower)
                 )
 
-
-'''
-def add_oa_cuts(target_model, dual_values, solve_data, config,
-                linearize_active=True,
-                linearize_violated=True,
-                linearize_inactive=False):
-    """Linearizes nonlinear constraints.
-
-    For nonconvex problems, turn on 'config.add_slack'. Slack variables will
-    always be used for nonlinear equality constraints.
-    """
-    for (constr, dual_value) in zip(target_model.MindtPy_utils.constraint_list,
-                                    dual_values):
-        if constr.body.polynomial_degree() in (0, 1):
-            continue
-
-        # Equality constraint (makes the problem nonconvex)
-        if constr.has_ub() and constr.has_lb() and constr.upper == constr.lower:
-            sign_adjust = -1 if solve_data.objective_sense == minimize else 1
-            rhs = ((0 if constr.upper is None else constr.upper)
-                   + (0 if constr.lower is None else constr.lower))
-            rhs = constr.lower if constr.has_lb() and constr.has_ub() else rhs
-            if config.add_slack:
-                slack_var = target_model.MindtPy_utils.MindtPy_linear_cuts.slack_vars.add()
-            target_model.MindtPy_utils.MindtPy_linear_cuts.oa_cuts.add(
-                expr=copysign(1, sign_adjust * dual_value)
-                * (taylor_series_expansion(
-                    constr.body, diff_mode=differentiate.Modes.reverse_numeric, order=1) - rhs)
-                - (slack_var if config.add_slack else 0) <= 0)
-
-        else:  # Inequality constraint (possibly two-sided)
-            if constr.has_ub() \
-                and (linearize_active and abs(constr.uslack()) < config.zero_tolerance) \
-                    or (linearize_violated and constr.uslack() < 0) \
-                    or (linearize_inactive and constr.uslack() > 0):
-                if config.add_slack:
-                    slack_var = target_model.MindtPy_utils.MindtPy_linear_cuts.slack_vars.add()
-                target_model.MindtPy_utils.MindtPy_linear_cuts.oa_cuts.add(
-                    expr=(taylor_series_expansion(
-                        constr.body, diff_mode=differentiate.Modes.reverse_numeric, order=1)
-                        - (slack_var if config.add_slack else 0)
-                        <= constr.upper)
-                )
-
-            if constr.has_lb() \
-                and (linearize_active and abs(constr.lslack()) < config.zero_tolerance) \
-                    or (linearize_violated and constr.lslack() < 0) \
-                    or (linearize_inactive and constr.lslack() > 0):
-                if config.add_slack:
-                    slack_var = target_model.MindtPy_utils.MindtPy_linear_cuts.slack_vars.add()
-
-                target_model.MindtPy_utils.MindtPy_linear_cuts.oa_cuts.add(
-                    expr=(taylor_series_expansion(
-                        constr.body, diff_mode=differentiate.Modes.reverse_numeric, order=1)
-                        + (slack_var if config.add_slack else 0)
-                        >= constr.lower)
-                )
-'''
 # def add_oa_equality_relaxation(var_values, duals, solve_data, config, ignore_integrality=False):
 #     """More general case for outer approximation
 

--- a/pyomo/contrib/mindtpy/cut_generation.py
+++ b/pyomo/contrib/mindtpy/cut_generation.py
@@ -6,6 +6,8 @@ from math import copysign
 from pyomo.core import Constraint, minimize, value
 from pyomo.core.expr import current as EXPR
 from pyomo.contrib.gdpopt.util import copy_var_list_values, identify_variables
+from pyomo.core.expr.taylor_series import taylor_series_expansion
+from pyomo.core.expr import differentiate
 
 
 def add_objective_linearization(solve_data, config):
@@ -32,6 +34,7 @@ def add_objective_linearization(solve_data, config):
         MindtPy.ECP_constr_map[obj, solve_data.mip_iter] = c
 
 
+'''
 def add_oa_cuts(target_model, dual_values, solve_data, config,
                 linearize_active=True,
                 linearize_violated=True,
@@ -92,7 +95,67 @@ def add_oa_cuts(target_model, dual_values, solve_data, config,
                           + (slack_var if config.add_slack else 0)
                           >= constr.lower)
                 )
+'''
 
+
+def add_oa_cuts(target_model, dual_values, solve_data, config,
+                linearize_active=True,
+                linearize_violated=True,
+                linearize_inactive=False):
+    """Linearizes nonlinear constraints.
+
+    For nonconvex problems, turn on 'config.add_slack'. Slack variables will
+    always be used for nonlinear equality constraints.
+    """
+    for (constr, dual_value) in zip(target_model.MindtPy_utils.constraint_list,
+                                    dual_values):
+        if constr.body.polynomial_degree() in (0, 1):
+            continue
+
+        constr_vars = list(identify_variables(constr.body))
+        jacs = solve_data.jacobians
+
+        # Equality constraint (makes the problem nonconvex)
+        if constr.has_ub() and constr.has_lb() and constr.upper == constr.lower:
+            sign_adjust = -1 if solve_data.objective_sense == minimize else 1
+            rhs = ((0 if constr.upper is None else constr.upper)
+                   + (0 if constr.lower is None else constr.lower))
+            rhs = constr.lower if constr.has_lb() and constr.has_ub() else rhs
+            if config.add_slack:
+                slack_var = target_model.MindtPy_utils.MindtPy_linear_cuts.slack_vars.add()
+            target_model.MindtPy_utils.MindtPy_linear_cuts.oa_cuts.add(
+                expr=copysign(1, sign_adjust * dual_value)
+                * (taylor_series_expansion(
+                    constr.body, diff_mode=differentiate.Modes.reverse_numeric, order=1) - rhs)
+                - (slack_var if config.add_slack else 0) <= 0)
+
+        else:  # Inequality constraint (possibly two-sided)
+            if constr.has_ub() \
+                and (linearize_active and abs(constr.uslack()) < config.zero_tolerance) \
+                    or (linearize_violated and constr.uslack() < 0) \
+                    or (linearize_inactive and constr.uslack() > 0):
+                if config.add_slack:
+                    slack_var = target_model.MindtPy_utils.MindtPy_linear_cuts.slack_vars.add()
+                target_model.MindtPy_utils.MindtPy_linear_cuts.oa_cuts.add(
+                    expr=(taylor_series_expansion(
+                        constr.body, diff_mode=differentiate.Modes.reverse_numeric, order=1)
+                        - (slack_var if config.add_slack else 0)
+                        <= constr.upper)
+                )
+
+            if constr.has_lb() \
+                and (linearize_active and abs(constr.lslack()) < config.zero_tolerance) \
+                    or (linearize_violated and constr.lslack() < 0) \
+                    or (linearize_inactive and constr.lslack() > 0):
+                if config.add_slack:
+                    slack_var = target_model.MindtPy_utils.MindtPy_linear_cuts.slack_vars.add()
+
+                target_model.MindtPy_utils.MindtPy_linear_cuts.oa_cuts.add(
+                    expr=(taylor_series_expansion(
+                        constr.body, diff_mode=differentiate.Modes.reverse_numeric, order=1)
+                        + (slack_var if config.add_slack else 0)
+                        >= constr.lower)
+                )
 
 # def add_oa_equality_relaxation(var_values, duals, solve_data, config, ignore_integrality=False):
 #     """More general case for outer approximation

--- a/pyomo/contrib/mindtpy/cut_generation.py
+++ b/pyomo/contrib/mindtpy/cut_generation.py
@@ -54,8 +54,6 @@ def add_oa_cuts(target_model, dual_values, solve_data, config,
         # Equality constraint (makes the problem nonconvex)
         if constr.has_ub() and constr.has_lb() and constr.upper == constr.lower:
             sign_adjust = -1 if solve_data.objective_sense == minimize else 1
-            rhs = ((0 if constr.upper is None else constr.upper)
-                   + (0 if constr.lower is None else constr.lower))
             rhs = constr.lower if constr.has_lb() and constr.has_ub() else rhs
             if config.add_slack:
                 slack_var = target_model.MindtPy_utils.MindtPy_linear_cuts.slack_vars.add()

--- a/pyomo/contrib/mindtpy/cut_generation.py
+++ b/pyomo/contrib/mindtpy/cut_generation.py
@@ -112,8 +112,8 @@ def add_oa_cuts(target_model, dual_values, solve_data, config,
         if constr.body.polynomial_degree() in (0, 1):
             continue
 
-        constr_vars = list(identify_variables(constr.body))
-        jacs = solve_data.jacobians
+        # constr_vars = list(identify_variables(constr.body))
+        # jacs = solve_data.jacobians
 
         # Equality constraint (makes the problem nonconvex)
         if constr.has_ub() and constr.has_lb() and constr.upper == constr.lower:

--- a/pyomo/contrib/mindtpy/initialization.py
+++ b/pyomo/contrib/mindtpy/initialization.py
@@ -32,7 +32,7 @@ def MindtPy_initialize_master(solve_data, config):
     m.dual.deactivate()
 
     if config.strategy == 'OA':
-        # calc_jacobians(solve_data, config)  # preload jacobians
+        calc_jacobians(solve_data, config)  # preload jacobians
         MindtPy.MindtPy_linear_cuts.oa_cuts = ConstraintList(
             doc='Outer approximation cuts')
     # elif config.strategy == 'ECP':

--- a/pyomo/contrib/mindtpy/initialization.py
+++ b/pyomo/contrib/mindtpy/initialization.py
@@ -32,7 +32,7 @@ def MindtPy_initialize_master(solve_data, config):
     m.dual.deactivate()
 
     if config.strategy == 'OA':
-        calc_jacobians(solve_data, config)  # preload jacobians
+        # calc_jacobians(solve_data, config)  # preload jacobians
         MindtPy.MindtPy_linear_cuts.oa_cuts = ConstraintList(
             doc='Outer approximation cuts')
     # elif config.strategy == 'ECP':

--- a/pyomo/contrib/mindtpy/nlp_solve.py
+++ b/pyomo/contrib/mindtpy/nlp_solve.py
@@ -202,7 +202,7 @@ def solve_NLP_feas(solve_data, config):
     Returns: Result values and dual values
     """
     fixed_nlp = solve_data.working_model.clone()
-    add_feas_slacks(fixed_nlp)
+    add_feas_slacks(fixed_nlp, config)
     MindtPy = fixed_nlp.MindtPy_utils
     next(fixed_nlp.component_data_objects(Objective, active=True)).deactivate()
     for constr in fixed_nlp.component_data_objects(
@@ -211,9 +211,18 @@ def solve_NLP_feas(solve_data, config):
             constr.deactivate()
 
     MindtPy.MindtPy_feas.activate()
-    MindtPy.MindtPy_feas_obj = Objective(
-        expr=sum(s for s in MindtPy.MindtPy_feas.slack_var[...]),
-        sense=minimize)
+    if config.feasibility_norm == 'L1':
+        MindtPy.MindtPy_feas_obj = Objective(
+            expr=sum(s for s in MindtPy.MindtPy_feas.slack_var[...]),
+            sense=minimize)
+    elif config.feasibility_norm == 'L2':
+        MindtPy.MindtPy_feas_obj = Objective(
+            expr=sum(s*s for s in MindtPy.MindtPy_feas.slack_var[...]),
+            sense=minimize)
+    else:
+        MindtPy.MindtPy_feas_obj = Objective(
+            expr=MindtPy.MindtPy_feas.slack_var,
+            sense=minimize)
     TransformationFactory('core.fix_integer_vars').apply_to(fixed_nlp)
 
     with SuppressInfeasibleWarning():

--- a/pyomo/contrib/mindtpy/nlp_solve.py
+++ b/pyomo/contrib/mindtpy/nlp_solve.py
@@ -46,7 +46,7 @@ def solve_NLP_subproblem(solve_data, config):
     # | g(x) <= b  | -1    | g(x1) > b    | g(x1) - b            |
     # | g(x) >= b  | +1    | g(x1) >= b   | 0                    |
     # | g(x) >= b  | +1    | g(x1) < b    | b - g(x1)            |
-    flag = False
+    evaluation_error = False
     for c in fixed_nlp.component_data_objects(ctype=Constraint, active=True,
                                               descend_into=True):
         # We prefer to include the upper bound as the right hand side since we are
@@ -61,8 +61,8 @@ def solve_NLP_subproblem(solve_data, config):
                 0, c_geq*(rhs - value(c.body)))
         except (ValueError, OverflowError) as error:
             fixed_nlp.tmp_duals[c] = None
-            flag = True
-    if flag:
+            evaluation_error = True
+    if evaluation_error:
         for nlp_var, orig_val in zip(
                 MindtPy.variable_list,
                 solve_data.initial_var_values):

--- a/pyomo/contrib/mindtpy/single_tree.py
+++ b/pyomo/contrib/mindtpy/single_tree.py
@@ -72,8 +72,6 @@ class LazyOACallback_cplex(LazyConstraintCallback):
             # Equality constraint (makes the problem nonconvex)
             if constr.has_ub() and constr.has_lb() and constr.upper == constr.lower:
                 sign_adjust = -1 if solve_data.objective_sense == minimize else 1
-                rhs = ((0 if constr.upper is None else constr.upper)
-                       + (0 if constr.lower is None else constr.lower))
                 rhs = constr.lower if constr.has_lb() and constr.has_ub() else rhs
 
                 # since the cplex requires the lazy cuts in cplex type, we need to transform the pyomo expression into cplex expression
@@ -237,4 +235,3 @@ class LazyOACallback_cplex(LazyConstraintCallback):
         else:
             self.handle_lazy_NLP_subproblem_other_termination(fixed_nlp, fixed_nlp_result.solver.termination_condition,
                                                               solve_data, config)
-

--- a/pyomo/contrib/mindtpy/single_tree.py
+++ b/pyomo/contrib/mindtpy/single_tree.py
@@ -57,8 +57,7 @@ class LazyOACallback_cplex(LazyConstraintCallback):
 
     def add_lazy_oa_cuts(self, target_model, dual_values, solve_data, config, opt,
                          linearize_active=True,
-                         linearize_violated=True,
-                         linearize_inactive=False):
+                         linearize_violated=True):
         """Add oa_cuts through Cplex inherent function self.add()"""
 
         for (constr, dual_value) in zip(target_model.MindtPy_utils.constraint_list,
@@ -86,7 +85,7 @@ class LazyOACallback_cplex(LazyConstraintCallback):
                 if constr.has_ub() \
                     and (linearize_active and abs(constr.uslack()) < config.zero_tolerance) \
                         or (linearize_violated and constr.uslack() < 0) \
-                        or (linearize_inactive and constr.uslack() > 0):
+                        or (config.linearize_inactive and constr.uslack() > 0):
 
                     pyomo_expr = sum(
                         value(jacs[constr][var])*(var - var.value) for var in constr_vars) + value(constr.body)
@@ -98,7 +97,7 @@ class LazyOACallback_cplex(LazyConstraintCallback):
                 if constr.has_lb() \
                     and (linearize_active and abs(constr.lslack()) < config.zero_tolerance) \
                         or (linearize_violated and constr.lslack() < 0) \
-                        or (linearize_inactive and constr.lslack() > 0):
+                        or (config.linearize_inactive and constr.lslack() > 0):
                     pyomo_expr = sum(value(jacs[constr][var]) * (var - self.get_values(
                         opt._pyomo_var_to_solver_var_map[var])) for var in constr_vars) + value(constr.body)
                     cplex_rhs = -generate_standard_repn(pyomo_expr).constant

--- a/pyomo/contrib/mindtpy/tests/from_proposal.py
+++ b/pyomo/contrib/mindtpy/tests/from_proposal.py
@@ -17,8 +17,8 @@ class ProposalModel(ConcreteModel):
         m.x = Var(domain=Reals, bounds=(0, 20), initialize=4)
         m.y = Var(domain=Integers, bounds=(0, 20), initialize=2)
 
-        m.c1 = Constraint(expr=m.x**2/20 + m.y <= 20)
-        m.c2 = Constraint(expr=(m.x-1)**2/40 - m.y <= -4)
+        m.c1 = Constraint(expr=m.x**2/20.0 + m.y <= 20)
+        m.c2 = Constraint(expr=(m.x-1)**2/40.0 - m.y <= -4)
         m.c3 = Constraint(expr=m.y - 10*sqrt(m.x+0.1) <= 0)
         m.c4 = Constraint(expr=-m.x-m.y <= -5)
 

--- a/pyomo/contrib/mindtpy/tests/from_proposal.py
+++ b/pyomo/contrib/mindtpy/tests/from_proposal.py
@@ -2,7 +2,7 @@
 See David Bernal PhD proposal example.
 """
 
-
+from __future__ import division
 from pyomo.environ import (ConcreteModel, Constraint, Reals, Integers,
                            Objective, Var, sqrt, minimize)
 

--- a/pyomo/contrib/mindtpy/tests/test_mindtpy.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy.py
@@ -41,7 +41,7 @@ class TestMindtPy(unittest.TestCase):
             results = opt.solve(model, strategy='OA',
                                 init_strategy='rNLP',
                                 mip_solver=required_solvers[1],
-                                nlp_solver=required_solvers[0], feasibility_norm='L_infinity',
+                                nlp_solver=required_solvers[0],
                                 bound_tolerance=1E-5)
 
             self.assertIs(results.solver.termination_condition,
@@ -55,7 +55,7 @@ class TestMindtPy(unittest.TestCase):
             print('\n Solving 8PP problem with Outer Approximation(max_binary)')
             results = opt.solve(model, strategy='OA',
                                 init_strategy='max_binary',
-                                mip_solver=required_solvers[1], feasibility_norm='L_infinity',
+                                mip_solver=required_solvers[1],
                                 nlp_solver=required_solvers[0])
 
             self.assertIs(results.solver.termination_condition,
@@ -109,7 +109,7 @@ class TestMindtPy(unittest.TestCase):
             results = opt.solve(model, strategy='OA',
                                 init_strategy='initial_binary',
                                 mip_solver=required_solvers[1],
-                                nlp_solver=required_solvers[0], feasibility_norm='L_infinity',
+                                nlp_solver=required_solvers[0],
                                 obj_bound=10)
 
             self.assertIs(results.solver.termination_condition,
@@ -124,7 +124,7 @@ class TestMindtPy(unittest.TestCase):
             results = opt.solve(model, strategy='OA',
                                 init_strategy='initial_binary',
                                 mip_solver=required_solvers[1],
-                                nlp_solver=required_solvers[0], feasibility_norm='L_infinity',
+                                nlp_solver=required_solvers[0],
                                 obj_bound=10)
 
             self.assertIs(results.solver.termination_condition,
@@ -138,7 +138,7 @@ class TestMindtPy(unittest.TestCase):
             print('\n Solving MINLP3_simple problem with Outer Approximation')
             results = opt.solve(model, strategy='OA', init_strategy='initial_binary',
                                 mip_solver=required_solvers[1],
-                                nlp_solver=required_solvers[0], feasibility_norm='L_infinity',
+                                nlp_solver=required_solvers[0],
                                 obj_bound=10)
 
             self.assertIs(results.solver.termination_condition,
@@ -151,7 +151,7 @@ class TestMindtPy(unittest.TestCase):
             model = ProposalModel()
             print('\n Solving Proposal problem with Outer Approximation')
             results = opt.solve(model, strategy='OA',
-                                mip_solver=required_solvers[1], feasibility_norm='L_infinity',
+                                mip_solver=required_solvers[1],
                                 nlp_solver=required_solvers[0])
 
             self.assertIs(results.solver.termination_condition,
@@ -165,7 +165,7 @@ class TestMindtPy(unittest.TestCase):
             print('\n Solving Proposal problem with Outer Approximation(integer cuts)')
             results = opt.solve(model, strategy='OA',
                                 mip_solver=required_solvers[1],
-                                nlp_solver=required_solvers[0], feasibility_norm='L_infinity',
+                                nlp_solver=required_solvers[0],
                                 add_integer_cuts=True,
                                 integer_to_binary=True  # if we use lazy callback, we cannot set integer_to_binary True
                                 )
@@ -179,7 +179,7 @@ class TestMindtPy(unittest.TestCase):
             model = ConstraintQualificationExample()
             print('\n Solving Constraint Qualification Example with Outer Approximation')
             results = opt.solve(model, strategy='OA',
-                                mip_solver=required_solvers[1], feasibility_norm='L_infinity',
+                                mip_solver=required_solvers[1],
                                 nlp_solver=required_solvers[0]
                                 )
             self.assertIs(results.solver.termination_condition,
@@ -193,7 +193,7 @@ class TestMindtPy(unittest.TestCase):
                 '\n Solving Constraint Qualification Example with Outer Approximation(integer cut)')
             results = opt.solve(model, strategy='OA',
                                 mip_solver=required_solvers[1],
-                                nlp_solver=required_solvers[0], feasibility_norm='L_infinity',
+                                nlp_solver=required_solvers[0],
                                 add_integer_cuts=True
                                 )
             self.assertIs(results.solver.termination_condition,
@@ -205,7 +205,7 @@ class TestMindtPy(unittest.TestCase):
             model = OnlineDocExample()
             print('\n Solving Online Doc Example with Outer Approximation')
             results = opt.solve(model, strategy='OA',
-                                mip_solver=required_solvers[1], feasibility_norm='L_infinity',
+                                mip_solver=required_solvers[1],
                                 nlp_solver=required_solvers[0]
                                 )
             self.assertIs(results.solver.termination_condition,

--- a/pyomo/contrib/mindtpy/tests/test_mindtpy.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy.py
@@ -62,6 +62,34 @@ class TestMindtPy(unittest.TestCase):
                           TerminationCondition.optimal)
             self.assertAlmostEqual(value(model.cost.expr), 68, places=1)
 
+    def test_OA_8PP_L2_norm(self):
+        """Test the outer approximation decomposition algorithm."""
+        with SolverFactory('mindtpy') as opt:
+            model = EightProcessFlowsheet()
+            print('\n Solving 8PP problem with Outer Approximation(max_binary)')
+            results = opt.solve(model, strategy='OA',
+                                mip_solver=required_solvers[1],
+                                nlp_solver=required_solvers[0],
+                                feasibility_norm='L2')
+
+            self.assertIs(results.solver.termination_condition,
+                          TerminationCondition.optimal)
+            self.assertAlmostEqual(value(model.cost.expr), 68, places=1)
+
+    def test_OA_8PP_sympy(self):
+        """Test the outer approximation decomposition algorithm."""
+        with SolverFactory('mindtpy') as opt:
+            model = EightProcessFlowsheet()
+            print('\n Solving 8PP problem with Outer Approximation(max_binary)')
+            results = opt.solve(model, strategy='OA',
+                                mip_solver=required_solvers[1],
+                                nlp_solver=required_solvers[0],
+                                differentiate_mode='sympy')
+
+            self.assertIs(results.solver.termination_condition,
+                          TerminationCondition.optimal)
+            self.assertAlmostEqual(value(model.cost.expr), 68, places=1)
+
     # def test_PSC(self):
     #     """Test the partial surrogate cuts decomposition algorithm."""
     #     with SolverFactory('mindtpy') as opt:
@@ -207,6 +235,20 @@ class TestMindtPy(unittest.TestCase):
             results = opt.solve(model, strategy='OA',
                                 mip_solver=required_solvers[1],
                                 nlp_solver=required_solvers[0]
+                                )
+            self.assertIs(results.solver.termination_condition,
+                          TerminationCondition.optimal)
+            self.assertAlmostEqual(
+                value(model.objective.expr), 2.438447, places=2)
+
+    def test_OA_OnlineDocExample_L_infinity_norm(self):
+        with SolverFactory('mindtpy') as opt:
+            model = OnlineDocExample()
+            print('\n Solving Online Doc Example with Outer Approximation')
+            results = opt.solve(model, strategy='OA',
+                                mip_solver=required_solvers[1],
+                                nlp_solver=required_solvers[0],
+                                feasibility_norm="L_infinity"
                                 )
             self.assertIs(results.solver.termination_condition,
                           TerminationCondition.optimal)

--- a/pyomo/contrib/mindtpy/tests/test_mindtpy.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy.py
@@ -41,7 +41,7 @@ class TestMindtPy(unittest.TestCase):
             results = opt.solve(model, strategy='OA',
                                 init_strategy='rNLP',
                                 mip_solver=required_solvers[1],
-                                nlp_solver=required_solvers[0],
+                                nlp_solver=required_solvers[0], feasibility_norm='L_infinity',
                                 bound_tolerance=1E-5)
 
             self.assertIs(results.solver.termination_condition,
@@ -55,7 +55,7 @@ class TestMindtPy(unittest.TestCase):
             print('\n Solving 8PP problem with Outer Approximation(max_binary)')
             results = opt.solve(model, strategy='OA',
                                 init_strategy='max_binary',
-                                mip_solver=required_solvers[1],
+                                mip_solver=required_solvers[1], feasibility_norm='L_infinity',
                                 nlp_solver=required_solvers[0])
 
             self.assertIs(results.solver.termination_condition,
@@ -109,7 +109,7 @@ class TestMindtPy(unittest.TestCase):
             results = opt.solve(model, strategy='OA',
                                 init_strategy='initial_binary',
                                 mip_solver=required_solvers[1],
-                                nlp_solver=required_solvers[0],
+                                nlp_solver=required_solvers[0], feasibility_norm='L_infinity',
                                 obj_bound=10)
 
             self.assertIs(results.solver.termination_condition,
@@ -124,7 +124,7 @@ class TestMindtPy(unittest.TestCase):
             results = opt.solve(model, strategy='OA',
                                 init_strategy='initial_binary',
                                 mip_solver=required_solvers[1],
-                                nlp_solver=required_solvers[0],
+                                nlp_solver=required_solvers[0], feasibility_norm='L_infinity',
                                 obj_bound=10)
 
             self.assertIs(results.solver.termination_condition,
@@ -138,7 +138,7 @@ class TestMindtPy(unittest.TestCase):
             print('\n Solving MINLP3_simple problem with Outer Approximation')
             results = opt.solve(model, strategy='OA', init_strategy='initial_binary',
                                 mip_solver=required_solvers[1],
-                                nlp_solver=required_solvers[0],
+                                nlp_solver=required_solvers[0], feasibility_norm='L_infinity',
                                 obj_bound=10)
 
             self.assertIs(results.solver.termination_condition,
@@ -151,7 +151,7 @@ class TestMindtPy(unittest.TestCase):
             model = ProposalModel()
             print('\n Solving Proposal problem with Outer Approximation')
             results = opt.solve(model, strategy='OA',
-                                mip_solver=required_solvers[1],
+                                mip_solver=required_solvers[1], feasibility_norm='L_infinity',
                                 nlp_solver=required_solvers[0])
 
             self.assertIs(results.solver.termination_condition,
@@ -165,7 +165,7 @@ class TestMindtPy(unittest.TestCase):
             print('\n Solving Proposal problem with Outer Approximation(integer cuts)')
             results = opt.solve(model, strategy='OA',
                                 mip_solver=required_solvers[1],
-                                nlp_solver=required_solvers[0],
+                                nlp_solver=required_solvers[0], feasibility_norm='L_infinity',
                                 add_integer_cuts=True,
                                 integer_to_binary=True  # if we use lazy callback, we cannot set integer_to_binary True
                                 )
@@ -179,7 +179,7 @@ class TestMindtPy(unittest.TestCase):
             model = ConstraintQualificationExample()
             print('\n Solving Constraint Qualification Example with Outer Approximation')
             results = opt.solve(model, strategy='OA',
-                                mip_solver=required_solvers[1],
+                                mip_solver=required_solvers[1], feasibility_norm='L_infinity',
                                 nlp_solver=required_solvers[0]
                                 )
             self.assertIs(results.solver.termination_condition,
@@ -193,7 +193,7 @@ class TestMindtPy(unittest.TestCase):
                 '\n Solving Constraint Qualification Example with Outer Approximation(integer cut)')
             results = opt.solve(model, strategy='OA',
                                 mip_solver=required_solvers[1],
-                                nlp_solver=required_solvers[0],
+                                nlp_solver=required_solvers[0], feasibility_norm='L_infinity',
                                 add_integer_cuts=True
                                 )
             self.assertIs(results.solver.termination_condition,
@@ -205,7 +205,7 @@ class TestMindtPy(unittest.TestCase):
             model = OnlineDocExample()
             print('\n Solving Online Doc Example with Outer Approximation')
             results = opt.solve(model, strategy='OA',
-                                mip_solver=required_solvers[1],
+                                mip_solver=required_solvers[1], feasibility_norm='L_infinity',
                                 nlp_solver=required_solvers[0]
                                 )
             self.assertIs(results.solver.termination_condition,

--- a/pyomo/contrib/mindtpy/util.py
+++ b/pyomo/contrib/mindtpy/util.py
@@ -76,12 +76,16 @@ def calc_jacobians(solve_data, config):
     # Map nonlinear_constraint --> Map(
     #     variable --> jacobian of constraint wrt. variable)
     solve_data.jacobians = ComponentMap()
+    if config.differentiate_mode == "reverse_symbolic":
+        mode = differentiate.Modes.reverse_symbolic
+    elif config.differentiate_mode == "sympy":
+        mode = differentiate.Modes.sympy
     for c in solve_data.mip.MindtPy_utils.constraint_list:
         if c.body.polynomial_degree() in (1, 0):
             continue  # skip linear constraints
         vars_in_constr = list(EXPR.identify_variables(c.body))
         jac_list = differentiate(
-            c.body, wrt_list=vars_in_constr, mode=differentiate.Modes.reverse_symbolic)
+            c.body, wrt_list=vars_in_constr, mode=mode)
         solve_data.jacobians[c] = ComponentMap(
             (var, jac_wrt_var)
             for var, jac_wrt_var in zip(vars_in_constr, jac_list))

--- a/pyomo/contrib/mindtpy/util.py
+++ b/pyomo/contrib/mindtpy/util.py
@@ -80,12 +80,8 @@ def calc_jacobians(solve_data, config):
         if c.body.polynomial_degree() in (1, 0):
             continue  # skip linear constraints
         vars_in_constr = list(EXPR.identify_variables(c.body))
-        # if len(vars_in_constr) >= MAX_SYMBOLIC_DERIV_SIZE:
-        #     mode = differentiate.Modes.reverse_numeric
-        # else:
-        #     mode = differentiate.Modes.sympy
         jac_list = differentiate(
-            c.body, wrt_list=vars_in_constr, mode=differentiate.Modes.sympy)
+            c.body, wrt_list=vars_in_constr, mode=differentiate.Modes.reverse_symbolic)
         solve_data.jacobians[c] = ComponentMap(
             (var, jac_wrt_var)
             for var, jac_wrt_var in zip(vars_in_constr, jac_list))

--- a/pyomo/contrib/mindtpy/util.py
+++ b/pyomo/contrib/mindtpy/util.py
@@ -15,8 +15,6 @@ from pyomo.opt import SolverFactory
 from pyomo.opt.results import ProblemSense
 from pyomo.solvers.plugins.solvers.persistent_solver import PersistentSolver
 
-MAX_SYMBOLIC_DERIV_SIZE = 1000
-
 
 class MindtPySolveData(object):
     """Data container to hold solve-instance data.
@@ -94,7 +92,7 @@ def calc_jacobians(solve_data, config):
 def add_feas_slacks(m, config):
     MindtPy = m.MindtPy_utils
     # generate new constraints
-    if config.feasibility_norm == 'L1' or config.feasibility_norm == 'L2':
+    if config.feasibility_norm in {'L1', 'L2'}:
         for i, constr in enumerate(MindtPy.constraint_list, 1):
             if constr.body.polynomial_degree() not in [0, 1]:
                 rhs = constr.upper if constr.has_ub() else constr.lower

--- a/pyomo/contrib/mindtpy/util.py
+++ b/pyomo/contrib/mindtpy/util.py
@@ -92,17 +92,14 @@ def calc_jacobians(solve_data, config):
 def add_feas_slacks(m, config):
     MindtPy = m.MindtPy_utils
     # generate new constraints
-    if config.feasibility_norm in {'L1', 'L2'}:
-        for i, constr in enumerate(MindtPy.constraint_list, 1):
-            if constr.body.polynomial_degree() not in [0, 1]:
-                rhs = constr.upper if constr.has_ub() else constr.lower
+    for i, constr in enumerate(MindtPy.constraint_list, 1):
+        if constr.body.polynomial_degree() not in [0, 1]:
+            rhs = constr.upper if constr.has_ub() else constr.lower
+            if config.feasibility_norm in {'L1', 'L2'}:
                 c = MindtPy.MindtPy_feas.feas_constraints.add(
                     constr.body - rhs
                     <= MindtPy.MindtPy_feas.slack_var[i])
-    else:
-        for i, constr in enumerate(MindtPy.constraint_list, 1):
-            if constr.body.polynomial_degree() not in [0, 1]:
-                rhs = constr.upper if constr.has_ub() else constr.lower
+            else:
                 c = MindtPy.MindtPy_feas.feas_constraints.add(
                     constr.body - rhs
                     <= MindtPy.MindtPy_feas.slack_var)


### PR DESCRIPTION
## Fixes #1499.

## Changes proposed in this PR:
- Add config feasibility_norm which supports different forms (L1, L2, L-infinity) of the objective function in the feasibility subproblem.
- Add config differentiate_mode, which supports different differentiate_mode (`sympy` and `reverse_symbolic`) to calculate Jacobian.
- Add config linearize_inactive, whether to add OA cuts for inactive constraints.
- Add slack variable only for nonlinear constraints in the feasibility subproblem.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
