### PR TITLE
Deprecate GDP Reclassify Transformation in Favor of Using References

### DIFF
--- a/pyomo/contrib/fme/fourier_motzkin_elimination.py
+++ b/pyomo/contrib/fme/fourier_motzkin_elimination.py
@@ -8,8 +8,9 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from pyomo.core import (Var, Block, Constraint, Param, Set, Suffix, Expression,
-                        Objective, SortComponents, value, ConstraintList)
+from pyomo.core import (Var, Block, Constraint, Param, Set, SetOf, Suffix,
+                        Expression, Objective, SortComponents, value,
+                        ConstraintList)
 from pyomo.core.base import TransformationFactory, _VarData
 from pyomo.core.base.block import _BlockData
 from pyomo.core.base.param import _ParamData
@@ -137,8 +138,8 @@ class Fourier_Motzkin_Elimination_Transformation(Transformation):
         # collect all of the constraints
         # NOTE that we are ignoring deactivated constraints
         constraints = []
-        ctypes_not_to_transform = set((Block, Param, Objective, Set, Expression,
-                                       Suffix))
+        ctypes_not_to_transform = set((Block, Param, Objective, Set, SetOf,
+                                       Expression, Suffix))
         for obj in instance.component_data_objects(
                 descend_into=Block,
                 sort=SortComponents.deterministic,
@@ -441,7 +442,6 @@ class Fourier_Motzkin_Elimination_Transformation(Transformation):
             obj = Objective(expr=constraints[i].body - constraints[i].lower)
             m.add_component(obj_name, obj)
             results = solver_factory.solve(m)
-            print(results.solver.termination_condition)
             if results.solver.termination_condition == \
                TerminationCondition.unbounded:
                 obj_val = -float('inf')

--- a/pyomo/contrib/fme/tests/test_fourier_motzkin_elimination.py
+++ b/pyomo/contrib/fme/tests/test_fourier_motzkin_elimination.py
@@ -504,18 +504,7 @@ class TestFourierMotzkinElimination(unittest.TestCase):
              hull.get_disaggregated_var(m.p[1], m.off),
              hull.get_disaggregated_var(m.p[2], m.off)
          ])
-                                          
-        # from nose.tools import set_trace
-        # set_trace()
-        # disaggregatedVars = ComponentSet([relaxationBlocks[0].component("p[1]"),
-        #                                   relaxationBlocks[1].component("p[1]"),
-        #                                   relaxationBlocks[2].component("p[1]"),
-        #                                   relaxationBlocks[2].component("p[2]"),
-        #                                   relaxationBlocks[3].component("p[1]"),
-        #                                   relaxationBlocks[3].component("p[2]"),
-        #                                   relaxationBlocks[4].component("p[1]"),
-        #                                   relaxationBlocks[4].component("p[2]")])
-
+        
         return m, disaggregatedVars
 
     def test_project_disaggregated_vars(self):
@@ -534,15 +523,16 @@ class TestFourierMotzkinElimination(unittest.TestCase):
         constraints = m._pyomo_contrib_fme_transformation.projected_constraints
         # we of course get tremendous amounts of garbage, but we make sure that
         # what should be here is:
-        self.check_hull_projected_constraints(m, constraints, [22, 20, 58, 61,
-                                                                56, 38, 32, 1, 2,
+        self.check_hull_projected_constraints(m, constraints, [21, 16, 57, 59,
+                                                                55, 33, 27, 1, 2,
                                                                 4, 5])
         # and when we filter, it's still there.
         constraints = filtered._pyomo_contrib_fme_transformation.\
                       projected_constraints
+        constraints.pprint()
         self.check_hull_projected_constraints(filtered, constraints, [6, 5, 16,
                                                                        17, 15,
-                                                                       11, 8, 1,
+                                                                       9, 8, 1,
                                                                        2, 3, 4])
     
     @unittest.skipIf(not 'glpk' in solvers, 'glpk not available')
@@ -559,7 +549,7 @@ class TestFourierMotzkinElimination(unittest.TestCase):
         # They should be the same as the above, but now these are *all* the
         # constraints
         self.check_hull_projected_constraints(m, constraints, [6, 5, 16, 17,
-                                                                15, 11, 8, 1, 2,
+                                                                15, 9, 8, 1, 2,
                                                                 3, 4])
 
         # and check that we didn't change the model

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -20,7 +20,7 @@ from pyomo.core import (
     Expression, SortComponents, TraversalStrategy, value,
     RangeSet, NonNegativeIntegers)
 from pyomo.core.base.external import ExternalFunction
-from pyomo.core.base import Transformation, TransformationFactory
+from pyomo.core.base import Transformation, TransformationFactory, Reference
 from pyomo.core.base.component import ComponentUID, ActiveComponent
 from pyomo.core.base.PyomoModel import ConcreteModel, AbstractModel
 from pyomo.core.kernel.component_map import ComponentMap
@@ -32,7 +32,6 @@ from pyomo.gdp.util import (target_list, is_child_of, get_src_disjunction,
                             _get_constraint_transBlock, get_src_disjunct,
                             _warn_for_active_disjunction,
                             _warn_for_active_disjunct)
-from pyomo.gdp.plugins.gdp_var_mover import HACK_GDP_Reference_Indicator_Vars
 from pyomo.repn import generate_standard_repn
 from pyomo.common.config import ConfigBlock, ConfigValue
 from pyomo.common.modeling import unique_component_name
@@ -233,9 +232,6 @@ class BigM_Transformation(Transformation):
         targets = config.targets
         if targets is None:
             targets = (instance, )
-            _HACK_transform_whole_instance = True
-        else:
-            _HACK_transform_whole_instance = False
         # We need to check that all the targets are in fact on instance. As we
         # do this, we will use the set below to cache components we know to be
         # in the tree rooted at instance.
@@ -278,21 +274,6 @@ class BigM_Transformation(Transformation):
                     else:
                         warning_msg += "\t%s\n" % component
                 logger.warn(warning_msg)
-
-        # HACK for backwards compatibility with the older GDP transformations
-        #
-        # Until the writers are updated to find variables on things other than
-        # active blocks, we will create references to the indicator variables on
-        # the transformation block of each Disjunct so that the writers will
-        # pick them up there.
-        if not instance.ctype is Block:
-            # instance could be a Disjunction, so just call this on its parent
-            # block if that's the case. We won't mess with untransformed stuff
-            # anyway.
-            instance = instance.parent_block()
-            _HACK_transform_whole_instance = False
-        HACK_GDP_Reference_Indicator_Vars().apply_to(
-            instance, check_model_algebraic=_HACK_transform_whole_instance)
             
     def _add_transformation_block(self, instance):
         # make a transformation block on instance to put transformed disjuncts
@@ -463,6 +444,7 @@ class BigM_Transformation(Transformation):
         # want it to move with the disjunct transformation blocks in the case of
         # nested constraints, to make it easier to query.
         relaxationBlock.bigm_src = {}
+        relaxationBlock.localVarReferences = Block()
         obj._transformation_block = weakref_ref(relaxationBlock)
         relaxationBlock._srcDisjunct = weakref_ref(obj)
 
@@ -482,10 +464,22 @@ class BigM_Transformation(Transformation):
 
     def _transform_block_components(self, block, disjunct, bigM, arg_list,
                                     suffix_list):
-        # We first need to find any transformed disjunctions that might be here
+        # Find all the variables declared here (including the indicator_var) and
+        # add a reference on the transformation block so these will be
+        # accessible when the Disjunct is deactivated. We don't descend into
+        # Disjuncts because we'll just reference the references which are
+        # already on their transformation blocks.
+        disjunctBlock = disjunct._transformation_block()
+        varRefBlock = disjunctBlock.localVarReferences
+        for v in block.component_objects(Var, descend_into=Block, active=None):
+            varRefBlock.add_component(unique_component_name( 
+                varRefBlock, v.getname(fully_qualified=True, 
+                                       name_buffer=NAME_BUFFER)), Reference(v))
+
+        # Now need to find any transformed disjunctions that might be here
         # because we need to move their transformation blocks up onto the parent
         # block before we transform anything else on this block
-        destinationBlock = disjunct._transformation_block().parent_block()
+        destinationBlock = disjunctBlock.parent_block()
         for obj in block.component_data_objects(
                 Disjunction,
                 sort=SortComponents.deterministic,

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -16,7 +16,7 @@ import textwrap
 from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
 from pyomo.contrib.fbbt.interval import inf
 from pyomo.core import (
-    Block, Connector, Constraint, Param, Set, Suffix, Var,
+    Block, Connector, Constraint, Param, Set, SetOf, Suffix, Var,
     Expression, SortComponents, TraversalStrategy, value,
     RangeSet, NonNegativeIntegers)
 from pyomo.core.base.external import ExternalFunction
@@ -158,6 +158,7 @@ class BigM_Transformation(Transformation):
             Suffix:      False,
             Param:       False,
             Set:         False,
+            SetOf:       False,
             RangeSet:    False,
             Disjunction: self._warn_for_active_disjunction,
             Disjunct:    self._warn_for_active_disjunct,

--- a/pyomo/gdp/plugins/cuttingplane.py
+++ b/pyomo/gdp/plugins/cuttingplane.py
@@ -90,12 +90,6 @@ class CuttingPlane_Transformation(Transformation):
         hullRelaxation = TransformationFactory('gdp.hull')
         relaxIntegrality = TransformationFactory('core.relax_integrality')
 
-        # HACK: for the current writers, we need to also apply gdp.reclassify so
-        # that the indicator variables stay where they are in the big M model
-        # (since that is what we are eventually going to solve after we add our
-        # cuts).
-        reclassify = TransformationFactory('gdp.reclassify')
-
         #
         # Generalte the Hull relaxation (used for the separation
         # problem to generate cutting planes
@@ -103,7 +97,6 @@ class CuttingPlane_Transformation(Transformation):
         instance_rHull = hullRelaxation.create_using(instance)
         # This relies on relaxIntegrality relaxing variables on deactivated
         # blocks, which should be fine.
-        reclassify.apply_to(instance_rHull)
         relaxIntegrality.apply_to(instance_rHull)
 
         #
@@ -111,7 +104,6 @@ class CuttingPlane_Transformation(Transformation):
         # be the final instance returned to the user)
         #
         bigMRelaxation.apply_to(instance, bigM=bigM)
-        reclassify.apply_to(instance)
 
         #
         # Generate the continuous relaxation of the BigM transformation

--- a/pyomo/gdp/plugins/gdp_var_mover.py
+++ b/pyomo/gdp/plugins/gdp_var_mover.py
@@ -23,7 +23,6 @@ from pyomo.core import TraversalStrategy, TransformationFactory
 from pyomo.core.base.indexed_component import ActiveIndexedComponent
 from pyomo.common.deprecation import deprecated
 from pyomo.common.modeling import unique_component_name
-from pyomo.common.config import ConfigBlock, ConfigValue
 
 from six import itervalues
 

--- a/pyomo/gdp/plugins/gdp_var_mover.py
+++ b/pyomo/gdp/plugins/gdp_var_mover.py
@@ -42,8 +42,8 @@ class HACK_GDP_Disjunct_Reclassifier(Transformation):
                 "variables local to each Disjunct during the transformation. "
                 "Validation that the model has been completely transformed "
                 "to an algebraic model has been moved to the "
-                "assert_model_algebraic function in gdp.util.",
-                version='5.6.10')
+                "check_model_algebraic function in gdp.util.",
+                version='TBD')
     def _apply_to(self, instance, **kwds):
         assert not kwds  # no keywords expected to the transformation
         disjunct_generator = instance.component_objects(

--- a/pyomo/gdp/plugins/gdp_var_mover.py
+++ b/pyomo/gdp/plugins/gdp_var_mover.py
@@ -17,44 +17,125 @@ detect variables inside of Disjuncts or deactivated Blocks.
 import logging
 import textwrap
 from pyomo.common.plugin import alias
-from pyomo.core.base import Transformation, Block, Constraint
+from pyomo.core.base import Transformation, Block, Constraint, Reference
 from pyomo.gdp import Disjunct, GDP_Error, Disjunction
-from pyomo.core import TraversalStrategy, TransformationFactory
+from pyomo.core import TraversalStrategy, TransformationFactory, SimpleVar
 from pyomo.core.base.indexed_component import ActiveIndexedComponent
 from pyomo.common.deprecation import deprecated
+from pyomo.common.config import ConfigBlock, ConfigValue
 
 from six import itervalues
 
 logger = logging.getLogger('pyomo.gdp')
 
 
-
-@TransformationFactory.register('gdp.varmover', doc="Move indicator vars to top block.")
-class HACK_GDP_Var_Mover(Transformation):
-    """Move indicator vars to top block.
-
-    HACK: this will move all indicator variables on the model to the top block
-    so the writers can find them.
-
+@TransformationFactory.register('gdp.reference_indicator_vars', 
+                                doc = "Create references to indicator_vars "
+                                "on the Disjunct's transformation block "
+                                "so that the writers will pick them up.")
+class HACK_GDP_Reference_Indicator_Vars(Transformation):
     """
+    Creates References for all indicator_vars on the transformation block of
+    all transformed Disjuncts. This means that the writers will pick up these
+    variables despite not looking for them on Disjuncts.
+    """
+    CONFIG = ConfigBlock("gdp.reference_indicator_vars")
+    CONFIG.declare('check_model_algebraic', ConfigValue(
+        default=False,
+        domain=bool,
+        description="Whether or not to check that the model is completely "
+        "algebraic.",
+        doc="""
+        This specifies whether or not we should do any error checking to see 
+        if the model is completely algebraic. Setting this to True provides
+        backwards compatibility with the deprecated HACK_GDP_DisjunctReclassifier
+        transformation because it will mean this transformation checks for 
+        untransformed Disjuncts. Set to False if this transformation is called after
+        using targets, when you do not expect the GDP model to be complete transformed
+        yet.
+        """
+    ))
 
-    @deprecated(msg="The gdp.varmover transformation has been deprecated in "
-                "favor of the gdp.reclassify transformation.",
-                version='5.5.1')
     def _apply_to(self, instance, **kwds):
-        assert not kwds
-        count = 0
-        disjunct_generator = instance.component_data_objects(
-            Disjunct, descend_into=(Block, Disjunct))
-        for disjunct in disjunct_generator:
-            count += 1
-            var = disjunct.indicator_var
-            var.doc = "%s(Moved from %s)" % (
-                var.doc + " " if var.doc else "", var.name, )
-            disjunct.del_component(var)
-            instance.add_component("_gdp_moved_IV_%s" % (count,), var)
+        config = self.CONFIG(kwds.pop('options', {}))
+        config.set_value(kwds)
+        check_algebraic = config.check_model_algebraic
 
+        # First, do a couple checks in order to give a more useful error
+        # message. (This is all for the check-for-algebraic hack
+        # below. Completely unncessary when the writers are fixed.)
+        disjunction_set = {i for i in instance.component_data_objects(
+            Disjunction, descend_into=(Block, Disjunct), active=None)}
+        active_disjunction_set = {i for i in instance.component_data_objects(
+            Disjunction, descend_into=(Block, Disjunct), active=True)}
+        disjuncts_in_disjunctions = set()
+        for i in disjunction_set:
+            disjuncts_in_disjunctions.update(i.disjuncts)
+        disjuncts_in_active_disjunctions = set()
+        for i in active_disjunction_set:
+            disjuncts_in_active_disjunctions.update(i.disjuncts)
+        
+        for disjunct in instance.component_data_objects(
+                Disjunct, descend_into=(Block, Disjunct),
+                descent_order=TraversalStrategy.PostfixDFS):
+            # check if it's relaxed
+            if disjunct.transformation_block is not None:
+                disjBlock = disjunct.transformation_block()
+                if disjBlock.component("indicator_var") is None:
+                    disjBlock.indicator_var = Reference(disjunct.indicator_var)
+            # It's not transformed, check if we should complain
+            elif check_algebraic and disjunct.active and \
+                 self._disjunct_not_fixed_true(disjunct) and \
+                 self._disjunct_on_active_block(disjunct):
+                # If someone thinks they've transformed the whole instance, but
+                # there is still an active Disjunct on the model, we will warn
+                # them. (Though this is a HACK becuase in the future this should
+                # be the writers' job.)
+                if disjunct not in disjuncts_in_disjunctions:
+                    raise GDP_Error('Disjunct "%s" is currently active, '
+                                    'but was not found in any Disjunctions. '
+                                    'This is generally an error as the model '
+                                    'has not been fully relaxed to a '
+                                    'pure algebraic form.' % (disjunct.name,))
+                elif disjunct not in disjuncts_in_active_disjunctions:
+                    raise GDP_Error('Disjunct "%s" is currently active. While '
+                                    'it participates in a Disjunction, '
+                                    'that Disjunction is currently deactivated. '
+                                    'This is generally an error as the '
+                                    'model has not been fully relaxed to a pure '
+                                    'algebraic form. Did you deactivate '
+                                    'the Disjunction without addressing the '
+                                    'individual Disjuncts?' % (disjunct.name,))
+                else:
+                    raise GDP_Error('Disjunct "%s" is currently active. It must be '
+                                    'transformed or deactivated before solving the '
+                                    'model.' % (disjunct.name,))
 
+    def _disjunct_not_fixed_true(self, disjunct):
+        # Return true if the disjunct indicator variable is not fixed to True
+        return not (disjunct.indicator_var.fixed and
+                    disjunct.indicator_var.value == 1)
+
+    def _disjunct_on_active_block(self, disjunct):
+        # Check first to make sure that the disjunct is not a
+        # descendent of an inactive Block or fixed and deactivated
+        # Disjunct, before raising a warning.
+        parent_block = disjunct.parent_block()
+        while parent_block is not None:
+            # deactivated Block
+            if parent_block.ctype is Block and not parent_block.active:
+                return False
+            # properly deactivated Disjunct
+            elif (parent_block.ctype is Disjunct and not parent_block.active
+                  and parent_block.indicator_var.value == 0
+                  and parent_block.indicator_var.fixed):
+                return False
+            else:
+                # Step up one level in the hierarchy
+                parent_block = parent_block.parent_block()
+                continue
+        return True
+                
 @TransformationFactory.register('gdp.reclassify',
           doc="Reclassify Disjuncts to Blocks.")
 class HACK_GDP_Disjunct_Reclassifier(Transformation):
@@ -64,7 +145,9 @@ class HACK_GDP_Disjunct_Reclassifier(Transformation):
     can find the variables
 
     """
-
+    @deprecated(msg="The gdp.reclasify transformation has been deprecated in "
+                "favor of the gdp.reference_indicator_vars transformation.",
+                version='5.6.10')
     def _apply_to(self, instance, **kwds):
         assert not kwds  # no keywords expected to the transformation
         disjunct_generator = instance.component_objects(
@@ -152,9 +235,8 @@ class HACK_GDP_Disjunct_Reclassifier(Transformation):
 
     def _disjunct_not_relaxed(self, disjunct):
         # Return True if the disjunct was not relaxed by a transformation.
-        return not getattr(
-            disjunct, '_gdp_transformation_info', {}).get('relaxed', False)
-
+        return disjunct.transformation_block is None
+        
     def _disjunct_on_active_block(self, disjunct):
         # Check first to make sure that the disjunct is not a
         # descendent of an inactive Block or fixed and deactivated

--- a/pyomo/gdp/plugins/gdp_var_mover.py
+++ b/pyomo/gdp/plugins/gdp_var_mover.py
@@ -17,9 +17,9 @@ detect variables inside of Disjuncts or deactivated Blocks.
 import logging
 import textwrap
 from pyomo.common.plugin import alias
-from pyomo.core.base import Transformation, Block, Constraint, Reference, Var
+from pyomo.core.base import Transformation, Block, Constraint
 from pyomo.gdp import Disjunct, GDP_Error, Disjunction
-from pyomo.core import TraversalStrategy, TransformationFactory, SimpleVar
+from pyomo.core import TraversalStrategy, TransformationFactory
 from pyomo.core.base.indexed_component import ActiveIndexedComponent
 from pyomo.common.deprecation import deprecated
 from pyomo.common.modeling import unique_component_name
@@ -39,7 +39,11 @@ class HACK_GDP_Disjunct_Reclassifier(Transformation):
 
     """
     @deprecated(msg="The gdp.reclasify transformation has been deprecated in "
-                "favor of the gdp.reference_indicator_vars transformation.",
+                "favor of the gdp transformations creating References to "
+                "variables local to each Disjunct during the transformation. "
+                "Validation that the model has been completely transformed "
+                "to an algebraic model has been moved to the "
+                "assert_model_algebraic function in gdp.util.",
                 version='5.6.10')
     def _apply_to(self, instance, **kwds):
         assert not kwds  # no keywords expected to the transformation

--- a/pyomo/gdp/plugins/gdp_var_mover.py
+++ b/pyomo/gdp/plugins/gdp_var_mover.py
@@ -17,124 +17,17 @@ detect variables inside of Disjuncts or deactivated Blocks.
 import logging
 import textwrap
 from pyomo.common.plugin import alias
-from pyomo.core.base import Transformation, Block, Constraint, Reference
+from pyomo.core.base import Transformation, Block, Constraint, Reference, Var
 from pyomo.gdp import Disjunct, GDP_Error, Disjunction
 from pyomo.core import TraversalStrategy, TransformationFactory, SimpleVar
 from pyomo.core.base.indexed_component import ActiveIndexedComponent
 from pyomo.common.deprecation import deprecated
+from pyomo.common.modeling import unique_component_name
 from pyomo.common.config import ConfigBlock, ConfigValue
 
 from six import itervalues
 
 logger = logging.getLogger('pyomo.gdp')
-
-
-@TransformationFactory.register('gdp.reference_indicator_vars', 
-                                doc = "Create references to indicator_vars "
-                                "on the Disjunct's transformation block "
-                                "so that the writers will pick them up.")
-class HACK_GDP_Reference_Indicator_Vars(Transformation):
-    """
-    Creates References for all indicator_vars on the transformation block of
-    all transformed Disjuncts. This means that the writers will pick up these
-    variables despite not looking for them on Disjuncts.
-    """
-    CONFIG = ConfigBlock("gdp.reference_indicator_vars")
-    CONFIG.declare('check_model_algebraic', ConfigValue(
-        default=False,
-        domain=bool,
-        description="Whether or not to check that the model is completely "
-        "algebraic.",
-        doc="""
-        This specifies whether or not we should do any error checking to see 
-        if the model is completely algebraic. Setting this to True provides
-        backwards compatibility with the deprecated HACK_GDP_DisjunctReclassifier
-        transformation because it will mean this transformation checks for 
-        untransformed Disjuncts. Set to False if this transformation is called after
-        using targets, when you do not expect the GDP model to be complete transformed
-        yet.
-        """
-    ))
-
-    def _apply_to(self, instance, **kwds):
-        config = self.CONFIG(kwds.pop('options', {}))
-        config.set_value(kwds)
-        check_algebraic = config.check_model_algebraic
-
-        # First, do a couple checks in order to give a more useful error
-        # message. (This is all for the check-for-algebraic hack
-        # below. Completely unncessary when the writers are fixed.)
-        disjunction_set = {i for i in instance.component_data_objects(
-            Disjunction, descend_into=(Block, Disjunct), active=None)}
-        active_disjunction_set = {i for i in instance.component_data_objects(
-            Disjunction, descend_into=(Block, Disjunct), active=True)}
-        disjuncts_in_disjunctions = set()
-        for i in disjunction_set:
-            disjuncts_in_disjunctions.update(i.disjuncts)
-        disjuncts_in_active_disjunctions = set()
-        for i in active_disjunction_set:
-            disjuncts_in_active_disjunctions.update(i.disjuncts)
-        
-        for disjunct in instance.component_data_objects(
-                Disjunct, descend_into=(Block, Disjunct),
-                descent_order=TraversalStrategy.PostfixDFS):
-            # check if it's relaxed
-            if disjunct.transformation_block is not None:
-                disjBlock = disjunct.transformation_block()
-                if disjBlock.component("indicator_var") is None:
-                    disjBlock.indicator_var = Reference(disjunct.indicator_var)
-            # It's not transformed, check if we should complain
-            elif check_algebraic and disjunct.active and \
-                 self._disjunct_not_fixed_true(disjunct) and \
-                 self._disjunct_on_active_block(disjunct):
-                # If someone thinks they've transformed the whole instance, but
-                # there is still an active Disjunct on the model, we will warn
-                # them. (Though this is a HACK becuase in the future this should
-                # be the writers' job.)
-                if disjunct not in disjuncts_in_disjunctions:
-                    raise GDP_Error('Disjunct "%s" is currently active, '
-                                    'but was not found in any Disjunctions. '
-                                    'This is generally an error as the model '
-                                    'has not been fully relaxed to a '
-                                    'pure algebraic form.' % (disjunct.name,))
-                elif disjunct not in disjuncts_in_active_disjunctions:
-                    raise GDP_Error('Disjunct "%s" is currently active. While '
-                                    'it participates in a Disjunction, '
-                                    'that Disjunction is currently deactivated. '
-                                    'This is generally an error as the '
-                                    'model has not been fully relaxed to a pure '
-                                    'algebraic form. Did you deactivate '
-                                    'the Disjunction without addressing the '
-                                    'individual Disjuncts?' % (disjunct.name,))
-                else:
-                    raise GDP_Error('Disjunct "%s" is currently active. It must be '
-                                    'transformed or deactivated before solving the '
-                                    'model.' % (disjunct.name,))
-
-    def _disjunct_not_fixed_true(self, disjunct):
-        # Return true if the disjunct indicator variable is not fixed to True
-        return not (disjunct.indicator_var.fixed and
-                    disjunct.indicator_var.value == 1)
-
-    def _disjunct_on_active_block(self, disjunct):
-        # Check first to make sure that the disjunct is not a
-        # descendent of an inactive Block or fixed and deactivated
-        # Disjunct, before raising a warning.
-        parent_block = disjunct.parent_block()
-        while parent_block is not None:
-            # deactivated Block
-            if parent_block.ctype is Block and not parent_block.active:
-                return False
-            # properly deactivated Disjunct
-            elif (parent_block.ctype is Disjunct and not parent_block.active
-                  and parent_block.indicator_var.value == 0
-                  and parent_block.indicator_var.fixed):
-                return False
-            else:
-                # Step up one level in the hierarchy
-                parent_block = parent_block.parent_block()
-                continue
-        return True
                 
 @TransformationFactory.register('gdp.reclassify',
           doc="Reclassify Disjuncts to Blocks.")

--- a/pyomo/gdp/tests/common_tests.py
+++ b/pyomo/gdp/tests/common_tests.py
@@ -495,7 +495,7 @@ def check_only_targets_get_transformed(self, transformation):
     self.assertIsNone(m.disjunct2[1].transformation_block)
 
 def check_targets_with_container_as_arg(self, transformation):
-    # check that we can giv a Disjunction as the argument to the transformation
+    # check that we can give a Disjunction as the argument to the transformation
     # and use targets to specify a DisjunctionData to transform
     m = models.makeTwoTermIndexedDisjunction()
     TransformationFactory('gdp.%s' % transformation).apply_to(
@@ -1375,7 +1375,8 @@ def check_mappings_between_disjunctions_and_xors(self, transformation):
     disjunctionPairs = [
         (m.disjunction, transBlock.disjunction_xor),
         (m.disjunct[1].innerdisjunction[0],
-         m.disjunct[1].component("_pyomo_gdp_%s_reformulation" % transformation).\
+         m.disjunct[1].component("_pyomo_gdp_%s_reformulation" 
+                                 % transformation).\
          component("disjunct[1].innerdisjunction_xor")[0]),
         (m.simpledisjunct.innerdisjunction,
          m.simpledisjunct.component(

--- a/pyomo/gdp/tests/jobshop_large_hull.lp
+++ b/pyomo/gdp/tests/jobshop_large_hull.lp
@@ -42,422 +42,422 @@ c_u_Feas(G)_:
 <= -17
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_B_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(B)
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_B_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(B)
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_C_1)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(C)
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_D_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars_t(D)
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_E_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars_t(E)
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_E_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars_t(E)
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_F_1)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars_t(F)
 +1 t(F)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_F_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars_t(F)
 +1 t(F)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_G_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars_t(G)
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_C_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars_t(C)
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_D_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars_t(D)
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_D_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars_t(D)
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_E_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars_t(E)
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_E_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars_t(E)
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_E_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars_t(E)
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_F_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars_t(F)
 +1 t(F)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_G_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars_t(G)
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_G_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars_t(G)
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_C_D_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars_t(D)
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_C_D_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars_t(D)
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_C_E_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars_t(E)
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_C_F_1)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars_t(F)
 +1 t(F)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_C_F_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars_t(F)
 +1 t(F)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_C_G_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars_t(G)
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_C_G_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars_t(G)
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_D_E_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars_t(E)
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_D_E_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars_t(E)
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_D_F_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars_t(F)
 +1 t(F)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_D_F_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars_t(F)
 +1 t(F)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_D_G_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars_t(G)
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_D_G_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars_t(G)
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_E_F_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars_t(F)
 +1 t(F)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_E_G_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars_t(G)
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_E_G_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars_t(G)
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_F_G_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars_t(G)
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_B_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(A)
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_B_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(A)
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_C_1)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(A)
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_D_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars_t(A)
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_E_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars_t(A)
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_E_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars_t(A)
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_F_1)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars_t(A)
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_F_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars_t(A)
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_G_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars_t(A)
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_C_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars_t(B)
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_D_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars_t(B)
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_D_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars_t(B)
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_E_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars_t(B)
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_E_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars_t(B)
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_E_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars_t(B)
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_F_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars_t(B)
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_G_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars_t(B)
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_G_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars_t(B)
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_C_D_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars_t(C)
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_C_D_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars_t(C)
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_C_E_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars_t(C)
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_C_F_1)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars_t(C)
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_C_F_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars_t(C)
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_C_G_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars_t(C)
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_C_G_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars_t(C)
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_D_E_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars_t(D)
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_D_E_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars_t(D)
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_D_F_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars_t(D)
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_D_F_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars_t(D)
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_D_G_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars_t(D)
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_D_G_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars_t(D)
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_E_F_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars_t(E)
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_E_G_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars_t(E)
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_E_G_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars_t(E)
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_F_G_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars_t(F)
 +1 t(F)
 = 0
 
@@ -638,1118 +638,1118 @@ c_e__pyomo_gdp_hull_reformulation_disj_xor(F_G_4)_:
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(B)_bounds(ub)_:
 -92 NoClash(A_B_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(A)_bounds(ub)_:
 -92 NoClash(A_B_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_NoClash(A_B_3_0)_c(ub)_:
 +4 NoClash(A_B_3_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(B)_bounds(ub)_:
 -92 NoClash(A_B_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(A)_bounds(ub)_:
 -92 NoClash(A_B_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_NoClash(A_B_3_1)_c(ub)_:
 +5 NoClash(A_B_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(B)_bounds(ub)_:
 -92 NoClash(A_B_5_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(A)_bounds(ub)_:
 -92 NoClash(A_B_5_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_NoClash(A_B_5_0)_c(ub)_:
 +2 NoClash(A_B_5_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(B)_bounds(ub)_:
 -92 NoClash(A_B_5_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(A)_bounds(ub)_:
 -92 NoClash(A_B_5_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_NoClash(A_B_5_1)_c(ub)_:
 +3 NoClash(A_B_5_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(C)_bounds(ub)_:
 -92 NoClash(A_C_1_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(A)_bounds(ub)_:
 -92 NoClash(A_C_1_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_NoClash(A_C_1_0)_c(ub)_:
 +6 NoClash(A_C_1_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(C)_bounds(ub)_:
 -92 NoClash(A_C_1_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(A)_bounds(ub)_:
 -92 NoClash(A_C_1_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_NoClash(A_C_1_1)_c(ub)_:
 +3 NoClash(A_C_1_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_t(D)_bounds(ub)_:
 -92 NoClash(A_D_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_t(A)_bounds(ub)_:
 -92 NoClash(A_D_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_NoClash(A_D_3_0)_c(ub)_:
 +10 NoClash(A_D_3_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_t(D)_bounds(ub)_:
 -92 NoClash(A_D_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_t(A)_bounds(ub)_:
 -92 NoClash(A_D_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_NoClash(A_D_3_1)_c(ub)_:
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_t(E)_bounds(ub)_:
 -92 NoClash(A_E_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_t(A)_bounds(ub)_:
 -92 NoClash(A_E_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_NoClash(A_E_3_0)_c(ub)_:
 +7 NoClash(A_E_3_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_t(E)_bounds(ub)_:
 -92 NoClash(A_E_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_t(A)_bounds(ub)_:
 -92 NoClash(A_E_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_NoClash(A_E_3_1)_c(ub)_:
 +4 NoClash(A_E_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_t(E)_bounds(ub)_:
 -92 NoClash(A_E_5_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_t(A)_bounds(ub)_:
 -92 NoClash(A_E_5_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_NoClash(A_E_5_0)_c(ub)_:
 +4 NoClash(A_E_5_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_t(E)_bounds(ub)_:
 -92 NoClash(A_E_5_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_t(A)_bounds(ub)_:
 -92 NoClash(A_E_5_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_NoClash(A_E_5_1)_c(ub)_:
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_t(F)_bounds(ub)_:
 -92 NoClash(A_F_1_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_t(A)_bounds(ub)_:
 -92 NoClash(A_F_1_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_NoClash(A_F_1_0)_c(ub)_:
 +2 NoClash(A_F_1_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_t(F)_bounds(ub)_:
 -92 NoClash(A_F_1_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_t(A)_bounds(ub)_:
 -92 NoClash(A_F_1_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_NoClash(A_F_1_1)_c(ub)_:
 +3 NoClash(A_F_1_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_t(F)_bounds(ub)_:
 -92 NoClash(A_F_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_t(A)_bounds(ub)_:
 -92 NoClash(A_F_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_NoClash(A_F_3_0)_c(ub)_:
 +4 NoClash(A_F_3_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_t(F)_bounds(ub)_:
 -92 NoClash(A_F_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_t(A)_bounds(ub)_:
 -92 NoClash(A_F_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_NoClash(A_F_3_1)_c(ub)_:
 +6 NoClash(A_F_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_t(G)_bounds(ub)_:
 -92 NoClash(A_G_5_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_t(A)_bounds(ub)_:
 -92 NoClash(A_G_5_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_NoClash(A_G_5_0)_c(ub)_:
 +9 NoClash(A_G_5_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_t(G)_bounds(ub)_:
 -92 NoClash(A_G_5_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_t(A)_bounds(ub)_:
 -92 NoClash(A_G_5_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_NoClash(A_G_5_1)_c(ub)_:
 -3 NoClash(A_G_5_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_t(C)_bounds(ub)_:
 -92 NoClash(B_C_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_t(B)_bounds(ub)_:
 -92 NoClash(B_C_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_NoClash(B_C_2_0)_c(ub)_:
 +9 NoClash(B_C_2_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_t(C)_bounds(ub)_:
 -92 NoClash(B_C_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_t(B)_bounds(ub)_:
 -92 NoClash(B_C_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_NoClash(B_C_2_1)_c(ub)_:
 -3 NoClash(B_C_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_t(D)_bounds(ub)_:
 -92 NoClash(B_D_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_t(B)_bounds(ub)_:
 -92 NoClash(B_D_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_NoClash(B_D_2_0)_c(ub)_:
 +8 NoClash(B_D_2_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_t(D)_bounds(ub)_:
 -92 NoClash(B_D_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_t(B)_bounds(ub)_:
 -92 NoClash(B_D_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_NoClash(B_D_2_1)_c(ub)_:
 +3 NoClash(B_D_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_t(D)_bounds(ub)_:
 -92 NoClash(B_D_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_t(B)_bounds(ub)_:
 -92 NoClash(B_D_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_NoClash(B_D_3_0)_c(ub)_:
 +10 NoClash(B_D_3_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_t(D)_bounds(ub)_:
 -92 NoClash(B_D_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_t(B)_bounds(ub)_:
 -92 NoClash(B_D_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_NoClash(B_D_3_1)_c(ub)_:
 -1 NoClash(B_D_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_t(E)_bounds(ub)_:
 -92 NoClash(B_E_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_t(B)_bounds(ub)_:
 -92 NoClash(B_E_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_NoClash(B_E_2_0)_c(ub)_:
 +4 NoClash(B_E_2_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_t(E)_bounds(ub)_:
 -92 NoClash(B_E_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_t(B)_bounds(ub)_:
 -92 NoClash(B_E_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_NoClash(B_E_2_1)_c(ub)_:
 +3 NoClash(B_E_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_t(E)_bounds(ub)_:
 -92 NoClash(B_E_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_t(B)_bounds(ub)_:
 -92 NoClash(B_E_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_NoClash(B_E_3_0)_c(ub)_:
 +7 NoClash(B_E_3_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_t(E)_bounds(ub)_:
 -92 NoClash(B_E_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_t(B)_bounds(ub)_:
 -92 NoClash(B_E_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_NoClash(B_E_3_1)_c(ub)_:
 +3 NoClash(B_E_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_t(E)_bounds(ub)_:
 -92 NoClash(B_E_5_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_t(B)_bounds(ub)_:
 -92 NoClash(B_E_5_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_NoClash(B_E_5_0)_c(ub)_:
 +5 NoClash(B_E_5_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_t(E)_bounds(ub)_:
 -92 NoClash(B_E_5_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_t(B)_bounds(ub)_:
 -92 NoClash(B_E_5_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_NoClash(B_E_5_1)_c(ub)_:
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_t(F)_bounds(ub)_:
 -92 NoClash(B_F_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_t(B)_bounds(ub)_:
 -92 NoClash(B_F_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_NoClash(B_F_3_0)_c(ub)_:
 +4 NoClash(B_F_3_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_t(F)_bounds(ub)_:
 -92 NoClash(B_F_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_t(B)_bounds(ub)_:
 -92 NoClash(B_F_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_NoClash(B_F_3_1)_c(ub)_:
 +5 NoClash(B_F_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_t(G)_bounds(ub)_:
 -92 NoClash(B_G_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_t(B)_bounds(ub)_:
 -92 NoClash(B_G_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_NoClash(B_G_2_0)_c(ub)_:
 +8 NoClash(B_G_2_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_t(G)_bounds(ub)_:
 -92 NoClash(B_G_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_t(B)_bounds(ub)_:
 -92 NoClash(B_G_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_NoClash(B_G_2_1)_c(ub)_:
 +3 NoClash(B_G_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_t(G)_bounds(ub)_:
 -92 NoClash(B_G_5_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_t(B)_bounds(ub)_:
 -92 NoClash(B_G_5_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_NoClash(B_G_5_0)_c(ub)_:
 +10 NoClash(B_G_5_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_t(G)_bounds(ub)_:
 -92 NoClash(B_G_5_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_t(B)_bounds(ub)_:
 -92 NoClash(B_G_5_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_NoClash(B_G_5_1)_c(ub)_:
 -3 NoClash(B_G_5_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_t(D)_bounds(ub)_:
 -92 NoClash(C_D_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_t(C)_bounds(ub)_:
 -92 NoClash(C_D_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_NoClash(C_D_2_0)_c(ub)_:
 +2 NoClash(C_D_2_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_t(C)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_t(D)_bounds(ub)_:
 -92 NoClash(C_D_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_t(C)_bounds(ub)_:
 -92 NoClash(C_D_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_NoClash(C_D_2_1)_c(ub)_:
 +9 NoClash(C_D_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_t(D)_bounds(ub)_:
 -92 NoClash(C_D_4_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_t(C)_bounds(ub)_:
 -92 NoClash(C_D_4_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_NoClash(C_D_4_0)_c(ub)_:
 +5 NoClash(C_D_4_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_t(C)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_t(D)_bounds(ub)_:
 -92 NoClash(C_D_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_t(C)_bounds(ub)_:
 -92 NoClash(C_D_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_NoClash(C_D_4_1)_c(ub)_:
 +2 NoClash(C_D_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_t(E)_bounds(ub)_:
 -92 NoClash(C_E_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_t(C)_bounds(ub)_:
 -92 NoClash(C_E_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_NoClash(C_E_2_0)_c(ub)_:
 -2 NoClash(C_E_2_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_t(C)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_t(E)_bounds(ub)_:
 -92 NoClash(C_E_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_t(C)_bounds(ub)_:
 -92 NoClash(C_E_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_NoClash(C_E_2_1)_c(ub)_:
 +9 NoClash(C_E_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_t(F)_bounds(ub)_:
 -92 NoClash(C_F_1_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_t(C)_bounds(ub)_:
 -92 NoClash(C_F_1_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_NoClash(C_F_1_0)_c(ub)_:
 +2 NoClash(C_F_1_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_t(C)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_t(F)_bounds(ub)_:
 -92 NoClash(C_F_1_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_t(C)_bounds(ub)_:
 -92 NoClash(C_F_1_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_NoClash(C_F_1_1)_c(ub)_:
 +6 NoClash(C_F_1_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_t(F)_bounds(ub)_:
 -92 NoClash(C_F_4_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_t(C)_bounds(ub)_:
 -92 NoClash(C_F_4_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_NoClash(C_F_4_0)_c(ub)_:
 +5 NoClash(C_F_4_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_t(C)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_t(F)_bounds(ub)_:
 -92 NoClash(C_F_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_t(C)_bounds(ub)_:
 -92 NoClash(C_F_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_NoClash(C_F_4_1)_c(ub)_:
 +8 NoClash(C_F_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_t(G)_bounds(ub)_:
 -92 NoClash(C_G_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_t(C)_bounds(ub)_:
 -92 NoClash(C_G_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_NoClash(C_G_2_0)_c(ub)_:
 +2 NoClash(C_G_2_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_t(C)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_t(G)_bounds(ub)_:
 -92 NoClash(C_G_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_t(C)_bounds(ub)_:
 -92 NoClash(C_G_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_NoClash(C_G_2_1)_c(ub)_:
 +9 NoClash(C_G_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_t(G)_bounds(ub)_:
 -92 NoClash(C_G_4_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_t(C)_bounds(ub)_:
 -92 NoClash(C_G_4_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_NoClash(C_G_4_0)_c(ub)_:
 +4 NoClash(C_G_4_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_t(C)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_t(G)_bounds(ub)_:
 -92 NoClash(C_G_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_t(C)_bounds(ub)_:
 -92 NoClash(C_G_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_NoClash(C_G_4_1)_c(ub)_:
 +7 NoClash(C_G_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_t(E)_bounds(ub)_:
 -92 NoClash(D_E_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_t(D)_bounds(ub)_:
 -92 NoClash(D_E_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_NoClash(D_E_2_0)_c(ub)_:
 +4 NoClash(D_E_2_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_t(D)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_t(E)_bounds(ub)_:
 -92 NoClash(D_E_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_t(D)_bounds(ub)_:
 -92 NoClash(D_E_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_NoClash(D_E_2_1)_c(ub)_:
 +8 NoClash(D_E_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_t(E)_bounds(ub)_:
 -92 NoClash(D_E_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_t(D)_bounds(ub)_:
 -92 NoClash(D_E_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_NoClash(D_E_3_0)_c(ub)_:
 +2 NoClash(D_E_3_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_t(D)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_t(E)_bounds(ub)_:
 -92 NoClash(D_E_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_t(D)_bounds(ub)_:
 -92 NoClash(D_E_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_NoClash(D_E_3_1)_c(ub)_:
 +9 NoClash(D_E_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_t(F)_bounds(ub)_:
 -92 NoClash(D_F_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_t(D)_bounds(ub)_:
 -92 NoClash(D_F_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_NoClash(D_F_3_0)_c(ub)_:
 -1 NoClash(D_F_3_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_t(D)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_t(F)_bounds(ub)_:
 -92 NoClash(D_F_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_t(D)_bounds(ub)_:
 -92 NoClash(D_F_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_NoClash(D_F_3_1)_c(ub)_:
 +11 NoClash(D_F_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_t(F)_bounds(ub)_:
 -92 NoClash(D_F_4_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_t(D)_bounds(ub)_:
 -92 NoClash(D_F_4_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_NoClash(D_F_4_0)_c(ub)_:
 +1 NoClash(D_F_4_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_t(D)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_t(F)_bounds(ub)_:
 -92 NoClash(D_F_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_t(D)_bounds(ub)_:
 -92 NoClash(D_F_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_NoClash(D_F_4_1)_c(ub)_:
 +7 NoClash(D_F_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_t(G)_bounds(ub)_:
 -92 NoClash(D_G_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_t(D)_bounds(ub)_:
 -92 NoClash(D_G_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_NoClash(D_G_2_0)_c(ub)_:
 +8 NoClash(D_G_2_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_t(D)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_t(G)_bounds(ub)_:
 -92 NoClash(D_G_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_t(D)_bounds(ub)_:
 -92 NoClash(D_G_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_NoClash(D_G_2_1)_c(ub)_:
 +8 NoClash(D_G_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_t(G)_bounds(ub)_:
 -92 NoClash(D_G_4_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_t(D)_bounds(ub)_:
 -92 NoClash(D_G_4_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_NoClash(D_G_4_0)_c(ub)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_t(D)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_t(G)_bounds(ub)_:
 -92 NoClash(D_G_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_t(D)_bounds(ub)_:
 -92 NoClash(D_G_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars_t(D)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_NoClash(D_G_4_1)_c(ub)_:
 +6 NoClash(D_G_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_t(F)_bounds(ub)_:
 -92 NoClash(E_F_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_t(E)_bounds(ub)_:
 -92 NoClash(E_F_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_NoClash(E_F_3_0)_c(ub)_:
 +3 NoClash(E_F_3_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_t(E)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_t(F)_bounds(ub)_:
 -92 NoClash(E_F_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_t(E)_bounds(ub)_:
 -92 NoClash(E_F_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_NoClash(E_F_3_1)_c(ub)_:
 +8 NoClash(E_F_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_t(G)_bounds(ub)_:
 -92 NoClash(E_G_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_t(E)_bounds(ub)_:
 -92 NoClash(E_G_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_NoClash(E_G_2_0)_c(ub)_:
 +8 NoClash(E_G_2_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_t(E)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_t(G)_bounds(ub)_:
 -92 NoClash(E_G_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_t(E)_bounds(ub)_:
 -92 NoClash(E_G_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_NoClash(E_G_2_1)_c(ub)_:
 +4 NoClash(E_G_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_t(G)_bounds(ub)_:
 -92 NoClash(E_G_5_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_t(E)_bounds(ub)_:
 -92 NoClash(E_G_5_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_NoClash(E_G_5_0)_c(ub)_:
 +7 NoClash(E_G_5_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_t(E)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_t(G)_bounds(ub)_:
 -92 NoClash(E_G_5_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_t(E)_bounds(ub)_:
 -92 NoClash(E_G_5_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars_t(E)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_NoClash(E_G_5_1)_c(ub)_:
 -1 NoClash(E_G_5_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_t(G)_bounds(ub)_:
 -92 NoClash(F_G_4_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_t(F)_bounds(ub)_:
 -92 NoClash(F_G_4_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_NoClash(F_G_4_0)_c(ub)_:
 +6 NoClash(F_G_4_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_t(F)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_t(G)_bounds(ub)_:
 -92 NoClash(F_G_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars_t(G)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_t(F)_bounds(ub)_:
 -92 NoClash(F_G_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars_t(F)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_NoClash(F_G_4_1)_c(ub)_:
 +6 NoClash(F_G_4_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars_t(G)
 <= 0
 
 c_e_ONE_VAR_CONSTANT: 
@@ -1765,215 +1765,215 @@ bounds
    0 <= t(F) <= 92
    0 <= t(G) <= 92
    0 <= NoClash(A_B_3_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_B_3_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_B_5_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_B_5_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_C_1_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_C_1_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_D_3_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_D_3_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_E_3_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_E_3_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_E_5_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_E_5_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_F_1_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_F_1_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_F_3_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_F_3_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_G_5_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(A_G_5_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars_t(A) <= 92
    0 <= NoClash(B_C_2_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_C_2_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_D_2_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_D_2_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_D_3_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_D_3_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_E_2_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_E_2_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_E_3_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_E_3_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_E_5_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_E_5_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_F_3_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_F_3_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_G_2_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_G_2_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_G_5_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(B_G_5_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars_t(B) <= 92
    0 <= NoClash(C_D_2_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars_t(C) <= 92
    0 <= NoClash(C_D_2_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars_t(C) <= 92
    0 <= NoClash(C_D_4_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars_t(C) <= 92
    0 <= NoClash(C_D_4_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars_t(C) <= 92
    0 <= NoClash(C_E_2_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars_t(C) <= 92
    0 <= NoClash(C_E_2_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars_t(C) <= 92
    0 <= NoClash(C_F_1_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars_t(C) <= 92
    0 <= NoClash(C_F_1_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars_t(C) <= 92
    0 <= NoClash(C_F_4_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars_t(C) <= 92
    0 <= NoClash(C_F_4_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars_t(C) <= 92
    0 <= NoClash(C_G_2_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars_t(C) <= 92
    0 <= NoClash(C_G_2_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars_t(C) <= 92
    0 <= NoClash(C_G_4_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars_t(C) <= 92
    0 <= NoClash(C_G_4_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars_t(C) <= 92
    0 <= NoClash(D_E_2_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars_t(D) <= 92
    0 <= NoClash(D_E_2_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars_t(D) <= 92
    0 <= NoClash(D_E_3_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars_t(D) <= 92
    0 <= NoClash(D_E_3_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars_t(D) <= 92
    0 <= NoClash(D_F_3_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars_t(D) <= 92
    0 <= NoClash(D_F_3_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars_t(D) <= 92
    0 <= NoClash(D_F_4_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars_t(D) <= 92
    0 <= NoClash(D_F_4_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars_t(D) <= 92
    0 <= NoClash(D_G_2_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars_t(D) <= 92
    0 <= NoClash(D_G_2_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars_t(D) <= 92
    0 <= NoClash(D_G_4_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars_t(D) <= 92
    0 <= NoClash(D_G_4_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars_t(D) <= 92
    0 <= NoClash(E_F_3_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars_t(E) <= 92
    0 <= NoClash(E_F_3_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars_t(E) <= 92
    0 <= NoClash(E_G_2_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars_t(E) <= 92
    0 <= NoClash(E_G_2_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars_t(E) <= 92
    0 <= NoClash(E_G_5_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars_t(E) <= 92
    0 <= NoClash(E_G_5_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars_t(E) <= 92
    0 <= NoClash(F_G_4_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars_t(F) <= 92
    0 <= NoClash(F_G_4_1)_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_t(A) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars_t(G) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars_t(F) <= 92
 binary
   NoClash(A_B_3_0)_indicator_var
   NoClash(A_B_3_1)_indicator_var

--- a/pyomo/gdp/tests/jobshop_small_hull.lp
+++ b/pyomo/gdp/tests/jobshop_small_hull.lp
@@ -22,38 +22,38 @@ c_u_Feas(C)_:
 <= -6
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_B_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(B)
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_C_1)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(C)
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_C_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(C)
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_B_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(A)
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_C_1)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(A)
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_C_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(B)
 +1 t(B)
 = 0
 
@@ -74,97 +74,97 @@ c_e__pyomo_gdp_hull_reformulation_disj_xor(B_C_2)_:
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(B)_bounds(ub)_:
 -19 NoClash(A_B_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(A)_bounds(ub)_:
 -19 NoClash(A_B_3_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_NoClash(A_B_3_0)_c(ub)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(B)_bounds(ub)_:
 -19 NoClash(A_B_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(A)_bounds(ub)_:
 -19 NoClash(A_B_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_NoClash(A_B_3_1)_c(ub)_:
 +5 NoClash(A_B_3_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(C)_bounds(ub)_:
 -19 NoClash(A_C_1_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(A)_bounds(ub)_:
 -19 NoClash(A_C_1_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_NoClash(A_C_1_0)_c(ub)_:
 +2 NoClash(A_C_1_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(C)_bounds(ub)_:
 -19 NoClash(A_C_1_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(A)_bounds(ub)_:
 -19 NoClash(A_C_1_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(A)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_NoClash(A_C_1_1)_c(ub)_:
 +5 NoClash(A_C_1_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(C)_bounds(ub)_:
 -19 NoClash(B_C_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(B)_bounds(ub)_:
 -19 NoClash(B_C_2_0)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_NoClash(B_C_2_0)_c(ub)_:
 +6 NoClash(B_C_2_0)_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(C)_bounds(ub)_:
 -19 NoClash(B_C_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(C)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(B)_bounds(ub)_:
 -19 NoClash(B_C_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(B)
 <= 0
 
 c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_NoClash(B_C_2_1)_c(ub)_:
 +1 NoClash(B_C_2_1)_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(C)
 <= 0
 
 c_e_ONE_VAR_CONSTANT: 
@@ -176,23 +176,23 @@ bounds
    0 <= t(B) <= 19
    0 <= t(C) <= 19
    0 <= NoClash(A_B_3_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(B) <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(A) <= 19
    0 <= NoClash(A_B_3_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(B) <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(A) <= 19
    0 <= NoClash(A_C_1_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(C) <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(A) <= 19
    0 <= NoClash(A_C_1_1)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(C) <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(A) <= 19
    0 <= NoClash(B_C_2_0)_indicator_var <= 1
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(C) <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(B) <= 19
    0 <= NoClash(B_C_2_1)_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(B) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(A) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(B) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(A) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(C) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(A) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(C) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(A) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(C) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(B) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(C) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(B) <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(C) <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(B) <= 19
 binary
   NoClash(A_B_3_0)_indicator_var
   NoClash(A_B_3_1)_indicator_var

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -1729,11 +1729,8 @@ class BlocksOnDisjuncts(unittest.TestCase):
 
         self.assertIsInstance(disjBlock, Block)
         self.assertEqual(len(disjBlock), 2)
-        # [ESJ 06/07/2020] This is the stuff we test below, plus indicator_var
-        # and indicator_var_index that get added by our hack of adding a
-        # Reference to get around the writers.
-        self.assertEqual(len(disjBlock[0].component_map()), 3)
-        self.assertEqual(len(disjBlock[1].component_map()), 6)
+        self.assertEqual(len(disjBlock[0].component_map()), 2)
+        self.assertEqual(len(disjBlock[1].component_map()), 5)
         self.assertIsInstance(disjBlock[0].component("evil[0].c"), Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].b.c"), Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].bb[1].c"),
@@ -1743,6 +1740,10 @@ class BlocksOnDisjuncts(unittest.TestCase):
         self.assertIsInstance(
             disjBlock[1].component("evil[1].b.anotherblock.c"),
                                                      Constraint)
+        self.assertIsInstance(disjBlock[0].component("localVarReferences"),
+                              Block)
+        self.assertIsInstance(disjBlock[1].component("localVarReferences"),
+                              Block)
 
     def test_do_not_transform_deactivated_constraint(self):
         m = models.makeTwoTermDisj_BlockOnDisj()
@@ -1755,17 +1756,18 @@ class BlocksOnDisjuncts(unittest.TestCase):
 
         self.assertIsInstance(disjBlock, Block)
         self.assertEqual(len(disjBlock), 2)
-        # [ESJ 06/07/2020] This is the stuff we test below, plus indicator_var
-        # and indicator_var_index that get added by our hack of adding a
-        # Reference to get around the writers.
-        self.assertEqual(len(disjBlock[0].component_map()), 3)
-        self.assertEqual(len(disjBlock[1].component_map()), 5)
+        self.assertEqual(len(disjBlock[0].component_map()), 2)
+        self.assertEqual(len(disjBlock[1].component_map()), 4)
         self.assertIsInstance(disjBlock[0].component("evil[0].c"), Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].b.c"), Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].bb[1].c"),
                               Constraint)
         self.assertIsInstance(
             disjBlock[1].component("evil[1].b.c_4"), Constraint)
+        self.assertIsInstance(disjBlock[0].component("localVarReferences"),
+                              Block)
+        self.assertIsInstance(disjBlock[1].component("localVarReferences"),
+                              Block)
 
     def test_do_not_transform_deactivated_block(self):
         m = models.makeTwoTermDisj_BlockOnDisj()
@@ -1778,17 +1780,18 @@ class BlocksOnDisjuncts(unittest.TestCase):
 
         self.assertIsInstance(disjBlock, Block)
         self.assertEqual(len(disjBlock), 2)
-        # [ESJ 06/07/2020] This is the stuff we test below, plus indicator_var
-        # and indicator_var_index that get added by our hack of adding a
-        # Reference to get around the writers.
-        self.assertEqual(len(disjBlock[0].component_map()), 3)
-        self.assertEqual(len(disjBlock[1].component_map()), 5)
+        self.assertEqual(len(disjBlock[0].component_map()), 2)
+        self.assertEqual(len(disjBlock[1].component_map()), 4)
         self.assertIsInstance(disjBlock[0].component("evil[0].c"), Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].b.c"), Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].bb[1].c"),
                               Constraint)
         self.assertIsInstance(
             disjBlock[1].component("evil[1].b.c_4"), Constraint)
+        self.assertIsInstance(disjBlock[0].component("localVarReferences"),
+                              Block)
+        self.assertIsInstance(disjBlock[1].component("localVarReferences"),
+                              Block)
 
     def test_pick_up_bigm_suffix_on_block(self):
         m = models.makeTwoTermDisj_BlockOnDisj()

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -447,16 +447,16 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
         # 2 blocks: the original Disjunct and the transformation block
         self.assertEqual(
-            len(list(m.component_objects(Block, descend_into=False))), 2)
+            len(list(m.component_objects(Block, descend_into=False))), 1)
         self.assertEqual(
-            len(list(m.component_objects(Disjunct))), 0)
+            len(list(m.component_objects(Disjunct))), 1)
 
-        # Each relaxed disjunct should have 0 vars, and i "d[i].c"
-        # Constraints
+        # Each relaxed disjunct should have 1 vars (the reference to the
+        # indicator var), and i "d[i].c" Constraints
         for i in [1,2,3]:
             relaxed = transBlock.relaxedDisjuncts[i-1]
-            self.assertEqual(len(list(relaxed.component_objects(Var))), 0)
-            self.assertEqual(len(list(relaxed.component_data_objects(Var))), 0)
+            self.assertEqual(len(list(relaxed.component_objects(Var))), 1)
+            self.assertEqual(len(list(relaxed.component_data_objects(Var))), 1)
             self.assertEqual(
                 len(list(relaxed.component_objects(Constraint))), 1)
             self.assertEqual(
@@ -480,16 +480,16 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
         # 2 blocks: the original Disjunct and the transformation block
         self.assertEqual(
-            len(list(m.component_objects(Block, descend_into=False))), 2)
+            len(list(m.component_objects(Block, descend_into=False))), 1)
         self.assertEqual(
-            len(list(m.component_objects(Disjunct))), 0)
+            len(list(m.component_objects(Disjunct))), 1)
 
-        # Each relaxed disjunct should have 0 vars, and i "d[i].c"
-        # Constraints
+        # Each relaxed disjunct should have 1 var (the reference to the
+        # indicator var), and i "d[i].c" Constraints
         for i in [1,2,3]:
             relaxed = transBlock.relaxedDisjuncts[i-1]
-            self.assertEqual(len(list(relaxed.component_objects(Var))), 0)
-            self.assertEqual(len(list(relaxed.component_data_objects(Var))), 0)
+            self.assertEqual(len(list(relaxed.component_objects(Var))), 1)
+            self.assertEqual(len(list(relaxed.component_data_objects(Var))), 1)
             self.assertEqual(
                 len(list(relaxed.component_objects(Constraint))), 1)
             self.assertEqual(
@@ -1729,8 +1729,11 @@ class BlocksOnDisjuncts(unittest.TestCase):
 
         self.assertIsInstance(disjBlock, Block)
         self.assertEqual(len(disjBlock), 2)
-        self.assertEqual(len(disjBlock[0].component_map()), 1)
-        self.assertEqual(len(disjBlock[1].component_map()), 4)
+        # [ESJ 06/07/2020] This is the stuff we test below, plus indicator_var
+        # and indicator_var_index that get added by our hack of adding a
+        # Reference to get around the writers.
+        self.assertEqual(len(disjBlock[0].component_map()), 3)
+        self.assertEqual(len(disjBlock[1].component_map()), 6)
         self.assertIsInstance(disjBlock[0].component("evil[0].c"), Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].b.c"), Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].bb[1].c"),
@@ -1752,8 +1755,11 @@ class BlocksOnDisjuncts(unittest.TestCase):
 
         self.assertIsInstance(disjBlock, Block)
         self.assertEqual(len(disjBlock), 2)
-        self.assertEqual(len(disjBlock[0].component_map()), 1)
-        self.assertEqual(len(disjBlock[1].component_map()), 3)
+        # [ESJ 06/07/2020] This is the stuff we test below, plus indicator_var
+        # and indicator_var_index that get added by our hack of adding a
+        # Reference to get around the writers.
+        self.assertEqual(len(disjBlock[0].component_map()), 3)
+        self.assertEqual(len(disjBlock[1].component_map()), 5)
         self.assertIsInstance(disjBlock[0].component("evil[0].c"), Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].b.c"), Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].bb[1].c"),
@@ -1772,8 +1778,11 @@ class BlocksOnDisjuncts(unittest.TestCase):
 
         self.assertIsInstance(disjBlock, Block)
         self.assertEqual(len(disjBlock), 2)
-        self.assertEqual(len(disjBlock[0].component_map()), 1)
-        self.assertEqual(len(disjBlock[1].component_map()), 3)
+        # [ESJ 06/07/2020] This is the stuff we test below, plus indicator_var
+        # and indicator_var_index that get added by our hack of adding a
+        # Reference to get around the writers.
+        self.assertEqual(len(disjBlock[0].component_map()), 3)
+        self.assertEqual(len(disjBlock[1].component_map()), 5)
         self.assertIsInstance(disjBlock[0].component("evil[0].c"), Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].b.c"), Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].bb[1].c"),

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -451,7 +451,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         self.assertEqual(
             len(list(m.component_objects(Disjunct))), 1)
 
-        # Each relaxed disjunct should have 1 vars (the reference to the
+        # Each relaxed disjunct should have 1 var (the reference to the
         # indicator var), and i "d[i].c" Constraints
         for i in [1,2,3]:
             relaxed = transBlock.relaxedDisjuncts[i-1]

--- a/pyomo/gdp/tests/test_gdp_reclassification_error.py
+++ b/pyomo/gdp/tests/test_gdp_reclassification_error.py
@@ -1,7 +1,7 @@
 import pyutilib.th as unittest
 import pyomo.environ as pe
 import pyomo.gdp as gdp
-from pyomo.gdp.util import assert_model_algebraic
+from pyomo.gdp.util import check_model_algebraic
 from pyomo.common.log import LoggingIntercept
 import logging
 from six import StringIO
@@ -18,7 +18,7 @@ class TestGDPReclassificationError(unittest.TestCase):
         pe.TransformationFactory('gdp.bigm').apply_to(m)
         log = StringIO()
         with LoggingIntercept(log, 'pyomo.gdp', logging.WARNING):
-            assert_model_algebraic(m)
+            check_model_algebraic(m)
         self.assertRegexpMatches( log.getvalue(), 
                                   '.*not found in any Disjunctions.*')
 
@@ -34,7 +34,7 @@ class TestGDPReclassificationError(unittest.TestCase):
         pe.TransformationFactory('gdp.bigm').apply_to(m)
         log = StringIO()
         with LoggingIntercept(log, 'pyomo.gdp', logging.WARNING):
-            assert_model_algebraic(m)
+            check_model_algebraic(m)
         self.assertRegexpMatches(log.getvalue(), 
                                  '.*While it participates in a Disjunction, '
                                  'that Disjunction is currently deactivated.*')

--- a/pyomo/gdp/tests/test_gdp_reclassification_error.py
+++ b/pyomo/gdp/tests/test_gdp_reclassification_error.py
@@ -1,6 +1,10 @@
 import pyutilib.th as unittest
 import pyomo.environ as pe
 import pyomo.gdp as gdp
+from pyomo.gdp.util import assert_model_algebraic
+from pyomo.common.log import LoggingIntercept
+import logging
+from six import StringIO
 
 
 class TestGDPReclassificationError(unittest.TestCase):
@@ -11,9 +15,12 @@ class TestGDPReclassificationError(unittest.TestCase):
         m.d1.c = pe.Constraint(expr=m.x == 1)
         m.d2 = gdp.Disjunct()
         m.d2.c = pe.Constraint(expr=m.x == 0)
-        with self.assertRaisesRegexp(
-                gdp.GDP_Error, '.*not found in any Disjunctions.*'):
-            pe.TransformationFactory('gdp.bigm').apply_to(m)
+        pe.TransformationFactory('gdp.bigm').apply_to(m)
+        log = StringIO()
+        with LoggingIntercept(log, 'pyomo.gdp', logging.WARNING):
+            assert_model_algebraic(m)
+        self.assertRegexpMatches( log.getvalue(), 
+                                  '.*not found in any Disjunctions.*')
 
     def test_disjunct_not_in_active_disjunction(self):
         m = pe.ConcreteModel()
@@ -24,7 +31,10 @@ class TestGDPReclassificationError(unittest.TestCase):
         m.d2.c = pe.Constraint(expr=m.x == 0)
         m.disjunction = gdp.Disjunction(expr=[m.d1, m.d2])
         m.disjunction.deactivate()
-        with self.assertRaisesRegexp(
-                gdp.GDP_Error, '.*While it participates in a Disjunction, '
-                'that Disjunction is currently deactivated.*'):
-            pe.TransformationFactory('gdp.bigm').apply_to(m)
+        pe.TransformationFactory('gdp.bigm').apply_to(m)
+        log = StringIO()
+        with LoggingIntercept(log, 'pyomo.gdp', logging.WARNING):
+            assert_model_algebraic(m)
+        self.assertRegexpMatches(log.getvalue(), 
+                                 '.*While it participates in a Disjunction, '
+                                 'that Disjunction is currently deactivated.*')

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -549,12 +549,15 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         self.assertEqual(
             len(list(m.component_objects(Disjunct))), 1)
 
-        # Each relaxed disjunct should have 3 vars + the indicator_var
-        # reference, but i "d[i].c" Constraints
+        # Each relaxed disjunct should have 3 disaggregated vars, but i "d[i].c"
+        # Constraints
         for i in [1,2,3]:
             relaxed = transBlock.relaxedDisjuncts[i-1]
-            self.assertEqual(len(list(relaxed.component_objects(Var))), 4)
-            self.assertEqual(len(list(relaxed.component_data_objects(Var))), 4)
+            self.assertEqual(
+                len(list(relaxed.disaggregatedVars.component_objects(Var))), 3)
+            self.assertEqual(
+                len(list(relaxed.disaggregatedVars.component_data_objects(Var))),
+                3)
             self.assertEqual(
                 len(list(relaxed.component_objects(Constraint))), 4)
             # Note: m.x LB == 0, so only 3 bounds constriants (not 6)
@@ -583,12 +586,15 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         self.assertEqual(
             len(list(m.component_objects(Disjunct))), 1)
 
-        # Each relaxed disjunct should have 3 vars + the indicator_var
-        # reference, but i "d[i].c" Constraints
+        # Each relaxed disjunct should have 3 disaggregated vars, but i "d[i].c"
+        # Constraints
         for i in [1,2,3]:
             relaxed = transBlock.relaxedDisjuncts[i-1]
-            self.assertEqual(len(list(relaxed.component_objects(Var))), 4)
-            self.assertEqual(len(list(relaxed.component_data_objects(Var))), 4)
+            self.assertEqual(
+                len(list(relaxed.disaggregatedVars.component_objects( Var))), 3)
+            self.assertEqual(
+                len(list(relaxed.disaggregatedVars.component_data_objects(
+                    Var))), 3)
             self.assertEqual(
                 len(list(relaxed.component_objects(Constraint))), 4)
             self.assertEqual(
@@ -1309,14 +1315,14 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         self.assertIs(disj1.disaggregatedVars.x, 
                       hull.get_disaggregated_var(m.x, m.d1))
         self.assertIs(m.x, hull.get_src_var(disj1.disaggregatedVars.x))
-        d3 = disj1.disaggregatedVars.component("indicator_var")
+        d3 = disj1.disaggregatedVars.component("d1.d3.indicator_var")
         self.assertEqual(d3.lb, 0)
         self.assertEqual(d3.ub, 1)
         self.assertIsInstance(d3, Var)
         self.assertIs(d3, hull.get_disaggregated_var(m.d1.d3.indicator_var,
                                                       m.d1))
         self.assertIs(m.d1.d3.indicator_var, hull.get_src_var(d3))
-        d4 = disj1.disaggregatedVars.component("indicator_var_4")
+        d4 = disj1.disaggregatedVars.component("d1.d4.indicator_var")
         self.assertIsInstance(d4, Var)
         self.assertEqual(d4.lb, 0)
         self.assertEqual(d4.ub, 1)
@@ -1345,12 +1351,14 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         self.check_bounds_constraint_ub(disj1.x_bounds, 2,
                                         disj1.disaggregatedVars.x,
                                         m.d1.indicator_var)
-        self.check_bounds_constraint_ub(disj1.indicator_var_bounds, 1,
-                                        disj1.disaggregatedVars.indicator_var,
-                                        m.d1.indicator_var)
-        self.check_bounds_constraint_ub(disj1.indicator_var_4_bounds, 1,
-                                        disj1.disaggregatedVars.indicator_var_4,
-                                        m.d1.indicator_var)
+        self.check_bounds_constraint_ub(
+            disj1.component("d1.d3.indicator_var_bounds"), 1, 
+            disj1.disaggregatedVars.component("d1.d3.indicator_var"), 
+            m.d1.indicator_var)
+        self.check_bounds_constraint_ub(
+            disj1.component("d1.d4.indicator_var_bounds"), 1,
+            disj1.disaggregatedVars.component("d1.d4.indicator_var"), 
+            m.d1.indicator_var)
 
         # check the transformed constraints
 
@@ -1366,10 +1374,12 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         self.assertTrue(repn.is_linear())
         self.assertEqual(repn.constant, 0)
         self.assertEqual(len(repn.linear_vars), 3)
-        ct.check_linear_coef(self, repn, disj1.disaggregatedVars.indicator_var,
-                             1)
-        ct.check_linear_coef(self, repn,
-                             disj1.disaggregatedVars.indicator_var_4, 1)
+        ct.check_linear_coef(
+            self, repn,
+            disj1.disaggregatedVars.component("d1.d3.indicator_var"), 1)
+        ct.check_linear_coef(
+            self, repn,
+            disj1.disaggregatedVars.component("d1.d4.indicator_var"), 1)
         ct.check_linear_coef(self, repn, m.d1.indicator_var, -1)
 
         # inner disjunction disaggregation constraint
@@ -1396,10 +1406,10 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
             "d1._pyomo_gdp_hull_reformulation.relaxedDisjuncts[0].x_bounds")
         original_cons = m.d1._pyomo_gdp_hull_reformulation.relaxedDisjuncts[0].\
                         x_bounds
-        self.check_inner_disaggregated_var_bounds(x3_bounds, x3,
-                                                  disj1.disaggregatedVars.\
-                                                  indicator_var,
-                                                  original_cons)
+        self.check_inner_disaggregated_var_bounds(
+            x3_bounds, x3, 
+            disj1.disaggregatedVars.component("d1.d3.indicator_var"),
+            original_cons)
 
 
         # disaggregated d4.x bounds constraints
@@ -1407,10 +1417,10 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
             "d1._pyomo_gdp_hull_reformulation.relaxedDisjuncts[1].x_bounds")
         original_cons = m.d1._pyomo_gdp_hull_reformulation.relaxedDisjuncts[1].\
                         x_bounds
-        self.check_inner_disaggregated_var_bounds(x4_bounds, x4,
-                                                  disj1.disaggregatedVars.\
-                                                  indicator_var_4,
-                                                  original_cons)
+        self.check_inner_disaggregated_var_bounds(
+            x4_bounds, x4,
+            disj1.disaggregatedVars.component("d1.d4.indicator_var"),
+            original_cons)
 
         # transformed x >= 1.2
         cons = disj1.component(
@@ -1418,10 +1428,10 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         first_transformed = m.d1._pyomo_gdp_hull_reformulation.\
                             relaxedDisjuncts[0].component("d1.d3.c")
         original = m.d1.d3.c
-        self.check_inner_transformed_constraint(cons, x3, 1.2,
-                                                disj1.disaggregatedVars.\
-                                                indicator_var,
-                                                first_transformed, original)
+        self.check_inner_transformed_constraint(
+            cons, x3, 1.2,
+            disj1.disaggregatedVars.component("d1.d3.indicator_var"),
+            first_transformed, original)
 
         # transformed x >= 1.3
         cons = disj1.component(
@@ -1429,10 +1439,10 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         first_transformed = m.d1._pyomo_gdp_hull_reformulation.\
                             relaxedDisjuncts[1].component("d1.d4.c")
         original = m.d1.d4.c
-        self.check_inner_transformed_constraint(cons, x4, 1.3,
-                                                disj1.disaggregatedVars.\
-                                                indicator_var_4,
-                                                first_transformed, original)
+        self.check_inner_transformed_constraint(
+            cons, x4, 1.3,
+            disj1.disaggregatedVars.component("d1.d4.indicator_var"),
+            first_transformed, original)
 
         # outer disjunction transformed constraint
         cons = disj1.component("d1.c")
@@ -1504,6 +1514,34 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
                       m.d1._pyomo_gdp_hull_reformulation.relaxedDisjuncts[1])
         self.assertIs(hull.get_src_disjunct(
             m.d1._pyomo_gdp_hull_reformulation.relaxedDisjuncts[1]), m.d1.d4)
+
+    @unittest.skipIf(not linear_solvers, "No linear solver available")
+    def test_solve_nested_model(self):
+        # This is really a test that our variable references have all been moved
+        # up correctly.
+        m = models.makeNestedDisjunctions_NestedDisjuncts()
+
+        hull = TransformationFactory('gdp.hull')
+        m_hull = hull.create_using(m)
+
+        SolverFactory(linear_solvers[0]).solve(m_hull)
+
+        # check solution
+        self.assertEqual(value(m_hull.d1.indicator_var), 0)
+        self.assertEqual(value(m_hull.d2.indicator_var), 1)
+        self.assertEqual(value(m_hull.x), 1.1)
+
+        # transform inner problem with bigm, outer with hull and make sure it
+        # still works
+        TransformationFactory('gdp.bigm').apply_to(m.d1.disj2)
+        hull.apply_to(m)
+
+        SolverFactory(linear_solvers[0]).solve(m)
+
+        # check solution
+        self.assertEqual(value(m.d1.indicator_var), 0)
+        self.assertEqual(value(m.d2.indicator_var), 1)
+        self.assertEqual(value(m.x), 1.1)
 
 class TestSpecialCases(unittest.TestCase):
     def test_local_vars(self):

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -67,9 +67,9 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         # same on both disjuncts
         for i in [0,1]:
             relaxationBlock = disjBlock[i]
-            w = relaxationBlock.w
-            x = relaxationBlock.x
-            y = relaxationBlock.y
+            w = relaxationBlock.disaggregatedVars.w
+            x = relaxationBlock.disaggregatedVars.x
+            y = relaxationBlock.disaggregatedVars.y
             # variables created
             self.assertIsInstance(w, Var)
             self.assertIsInstance(x, Var)
@@ -116,9 +116,11 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         self.assertEqual(
             str(cons.body),
             "(%s*d[0].indicator_var + %s)*("
-            "_pyomo_gdp_hull_reformulation.relaxedDisjuncts[0].x"
+            "_pyomo_gdp_hull_reformulation.relaxedDisjuncts[0]."
+            "disaggregatedVars.x"
             "/(%s*d[0].indicator_var + %s) + "
-            "(_pyomo_gdp_hull_reformulation.relaxedDisjuncts[0].y/"
+            "(_pyomo_gdp_hull_reformulation.relaxedDisjuncts[0]."
+            "disaggregatedVars.y/"
             "(%s*d[0].indicator_var + %s))**2) - "
             "%s*(0.0 + 0.0**2)*(1 - d[0].indicator_var) "
             "- 14.0*d[0].indicator_var"
@@ -140,11 +142,11 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         repn = generate_standard_repn(cons.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(len(repn.linear_vars), 2)
-        ct.check_linear_coef(self, repn, disjBlock[1].x, -1)
+        ct.check_linear_coef(self, repn, disjBlock[1].disaggregatedVars.x, -1)
         ct.check_linear_coef(self, repn, m.d[1].indicator_var, 2)
         self.assertEqual(repn.constant, 0)
-        self.assertEqual(disjBlock[1].x.lb, 0)
-        self.assertEqual(disjBlock[1].x.ub, 8)
+        self.assertEqual(disjBlock[1].disaggregatedVars.x.lb, 0)
+        self.assertEqual(disjBlock[1].disaggregatedVars.x.ub, 8)
 
         c2 = disjBlock[1].component("d[1].c2")
         # 'eq' is preserved
@@ -155,11 +157,11 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         repn = generate_standard_repn(cons.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(len(repn.linear_vars), 2)
-        ct.check_linear_coef(self, repn, disjBlock[1].w, 1)
+        ct.check_linear_coef(self, repn, disjBlock[1].disaggregatedVars.w, 1)
         ct.check_linear_coef(self, repn, m.d[1].indicator_var, -3)
         self.assertEqual(repn.constant, 0)
-        self.assertEqual(disjBlock[1].w.lb, 0)
-        self.assertEqual(disjBlock[1].w.ub, 7)
+        self.assertEqual(disjBlock[1].disaggregatedVars.w.lb, 0)
+        self.assertEqual(disjBlock[1].disaggregatedVars.w.ub, 7)
 
         c3 = disjBlock[1].component("d[1].c3")
         # bounded inequality is split
@@ -170,7 +172,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         repn = generate_standard_repn(cons.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(len(repn.linear_vars), 2)
-        ct.check_linear_coef(self, repn, disjBlock[1].x, -1)
+        ct.check_linear_coef(self, repn, disjBlock[1].disaggregatedVars.x, -1)
         ct.check_linear_coef(self, repn, m.d[1].indicator_var, 1)
         self.assertEqual(repn.constant, 0)
 
@@ -180,7 +182,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         repn = generate_standard_repn(cons.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(len(repn.linear_vars), 2)
-        ct.check_linear_coef(self, repn, disjBlock[1].x, 1)
+        ct.check_linear_coef(self, repn, disjBlock[1].disaggregatedVars.x, 1)
         ct.check_linear_coef(self, repn, m.d[1].indicator_var, -3)
         self.assertEqual(repn.constant, 0)
 
@@ -216,11 +218,14 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         for i in [0,1]:
             # check bounds constraints for each variable on each of the two
             # disjuncts.
-            self.check_bound_constraints(disjBlock[i].w_bounds, disjBlock[i].w,
+            self.check_bound_constraints(disjBlock[i].w_bounds,
+                                         disjBlock[i].disaggregatedVars.w,
                                          m.d[i].indicator_var, 2, 7)
-            self.check_bound_constraints(disjBlock[i].x_bounds, disjBlock[i].x,
+            self.check_bound_constraints(disjBlock[i].x_bounds,
+                                         disjBlock[i].disaggregatedVars.x,
                                          m.d[i].indicator_var, 1, 8)
-            self.check_bound_constraints(disjBlock[i].y_bounds, disjBlock[i].y,
+            self.check_bound_constraints(disjBlock[i].y_bounds,
+                                         disjBlock[i].disaggregatedVars.y,
                                          m.d[i].indicator_var, -10, -3)
 
     def test_error_for_or(self):
@@ -251,13 +256,13 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
         self.check_disaggregation_constraint(
             hull.get_disaggregation_constraint(m.w, m.disjunction), m.w,
-            disjBlock[0].w, disjBlock[1].w)
+            disjBlock[0].disaggregatedVars.w, disjBlock[1].disaggregatedVars.w)
         self.check_disaggregation_constraint(
             hull.get_disaggregation_constraint(m.x, m.disjunction), m.x,
-            disjBlock[0].x, disjBlock[1].x)
+            disjBlock[0].disaggregatedVars.x, disjBlock[1].disaggregatedVars.x)
         self.check_disaggregation_constraint(
             hull.get_disaggregation_constraint(m.y, m.disjunction), m.y,
-            disjBlock[0].y, disjBlock[1].y)
+            disjBlock[0].disaggregatedVars.y, disjBlock[1].disaggregatedVars.y)
 
     def test_xor_constraint_mapping(self):
         ct.check_xor_constraint_mapping(self, 'hull')
@@ -328,9 +333,9 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
         for i in [0,1]:
             mappings = ComponentMap()
-            mappings[m.w] = disjBlock[i].w
-            mappings[m.y] = disjBlock[i].y
-            mappings[m.x] = disjBlock[i].x
+            mappings[m.w] = disjBlock[i].disaggregatedVars.w
+            mappings[m.y] = disjBlock[i].disaggregatedVars.y
+            mappings[m.x] = disjBlock[i].disaggregatedVars.x
 
             for orig, disagg in iteritems(mappings):
                 self.assertIs(hull.get_src_var(disagg), orig)
@@ -349,9 +354,9 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
             # this *map* was useless before. It should be disaggregated variable
             # to the constraints, not the original variable? Why did this even
             # work??
-            mappings[disjBlock[i].w] = disjBlock[i].w_bounds
-            mappings[disjBlock[i].y] = disjBlock[i].y_bounds
-            mappings[disjBlock[i].x] = disjBlock[i].x_bounds
+            mappings[disjBlock[i].disaggregatedVars.w] = disjBlock[i].w_bounds
+            mappings[disjBlock[i].disaggregatedVars.y] = disjBlock[i].y_bounds
+            mappings[disjBlock[i].disaggregatedVars.x] = disjBlock[i].x_bounds
             for var, cons in iteritems(mappings):
                 self.assertIs(hull.get_var_bounds_constraint(var), cons)
 
@@ -371,7 +376,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
         # check that we used the bounds on the local variable as if they are
         # global. Which means checking the bounds constraints...
-        y_disagg = m.disj2.transformation_block().y
+        y_disagg = m.disj2.transformation_block().disaggregatedVars.y
         cons = hull.get_var_bounds_constraint(y_disagg)
         lb = cons['lb']
         self.assertIsNone(lb.lower)
@@ -398,8 +403,10 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         # two birds one stone: test the mappings too
         disj1y = hull.get_disaggregated_var(m.disj2.y, m.disj1)
         disj2y = hull.get_disaggregated_var(m.disj2.y, m.disj2)
-        self.assertIs(disj1y, m.disj1._transformation_block().y)
-        self.assertIs(disj2y, m.disj2._transformation_block().y)
+        self.assertIs(disj1y, 
+                      m.disj1._transformation_block().disaggregatedVars.y)
+        self.assertIs(disj2y,
+                      m.disj2._transformation_block().disaggregatedVars.y)
         self.assertIs(hull.get_src_var(disj1y), m.disj2.y)
         self.assertIs(hull.get_src_var(disj2y), m.disj2.y)
 
@@ -437,10 +444,11 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         # check that all the variables are disaggregated
         for disj in [m.disj1, m.disj2, m.disj3, m.disj4]:
             transBlock = disj.transformation_block()
+            varBlock = transBlock.disaggregatedVars
             self.assertEqual(len([v for v in
-                                  transBlock.component_data_objects(Var)]), 2)
-            x = transBlock.component("x")
-            y = transBlock.component("y")
+                                  varBlock.component_data_objects(Var)]), 2)
+            x = varBlock.component("x")
+            y = varBlock.component("y")
             self.assertIsInstance(x, Var)
             self.assertIsInstance(y, Var)
             self.assertIs(hull.get_disaggregated_var(m.disj1.x, disj), x)
@@ -451,10 +459,11 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
     def check_name_collision_disaggregated_vars(self, m, disj, name):
         hull = TransformationFactory('gdp.hull')
         transBlock = disj.transformation_block()
+        varBlock = transBlock.disaggregatedVars
         self.assertEqual(len([v for v in
-                              transBlock.component_data_objects(Var)]), 2)
-        x = transBlock.component("x")
-        x2 = transBlock.component(name)
+                              varBlock.component_data_objects(Var)]), 2)
+        x = varBlock.component("x")
+        x2 = varBlock.component(name)
         self.assertIsInstance(x, Var)
         self.assertIsInstance(x2, Var)
         self.assertIs(hull.get_disaggregated_var(m.disj1.x, disj), x)
@@ -536,16 +545,16 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
         # 2 blocks: the original Disjunct and the transformation block
         self.assertEqual(
-            len(list(m.component_objects(Block, descend_into=False))), 2)
+            len(list(m.component_objects(Block, descend_into=False))), 1)
         self.assertEqual(
-            len(list(m.component_objects(Disjunct))), 0)
+            len(list(m.component_objects(Disjunct))), 1)
 
-        # Each relaxed disjunct should have 3 vars, but i "d[i].c"
-        # Constraints
+        # Each relaxed disjunct should have 3 vars + the indicator_var
+        # reference, but i "d[i].c" Constraints
         for i in [1,2,3]:
             relaxed = transBlock.relaxedDisjuncts[i-1]
-            self.assertEqual(len(list(relaxed.component_objects(Var))), 3)
-            self.assertEqual(len(list(relaxed.component_data_objects(Var))), 3)
+            self.assertEqual(len(list(relaxed.component_objects(Var))), 4)
+            self.assertEqual(len(list(relaxed.component_data_objects(Var))), 4)
             self.assertEqual(
                 len(list(relaxed.component_objects(Constraint))), 4)
             # Note: m.x LB == 0, so only 3 bounds constriants (not 6)
@@ -570,16 +579,16 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
         # 2 blocks: the original Disjunct and the transformation block
         self.assertEqual(
-            len(list(m.component_objects(Block, descend_into=False))), 2)
+            len(list(m.component_objects(Block, descend_into=False))), 1)
         self.assertEqual(
-            len(list(m.component_objects(Disjunct))), 0)
+            len(list(m.component_objects(Disjunct))), 1)
 
-        # Each relaxed disjunct should have 3 vars, but i "d[i].c"
-        # Constraints
+        # Each relaxed disjunct should have 3 vars + the indicator_var
+        # reference, but i "d[i].c" Constraints
         for i in [1,2,3]:
             relaxed = transBlock.relaxedDisjuncts[i-1]
-            self.assertEqual(len(list(relaxed.component_objects(Var))), 3)
-            self.assertEqual(len(list(relaxed.component_data_objects(Var))), 3)
+            self.assertEqual(len(list(relaxed.component_objects(Var))), 4)
+            self.assertEqual(len(list(relaxed.component_data_objects(Var))), 4)
             self.assertEqual(
                 len(list(relaxed.component_objects(Constraint))), 4)
             self.assertEqual(
@@ -651,12 +660,12 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         relaxedDisjuncts = m._pyomo_gdp_hull_reformulation.relaxedDisjuncts
 
         disaggregatedVars = {
-            1: [relaxedDisjuncts[0].component('x[1]'),
-                relaxedDisjuncts[1].component('x[1]')],
-            2: [relaxedDisjuncts[2].component('x[2]'),
-                relaxedDisjuncts[3].component('x[2]')],
-            3: [relaxedDisjuncts[4].component('x[3]'),
-                relaxedDisjuncts[5].component('x[3]')],
+            1: [relaxedDisjuncts[0].disaggregatedVars.component('x[1]'),
+                relaxedDisjuncts[1].disaggregatedVars.component('x[1]')],
+            2: [relaxedDisjuncts[2].disaggregatedVars.component('x[2]'),
+                relaxedDisjuncts[3].disaggregatedVars.component('x[2]')],
+            3: [relaxedDisjuncts[4].disaggregatedVars.component('x[3]'),
+                relaxedDisjuncts[5].disaggregatedVars.component('x[3]')],
         }
 
         for i, disVars in iteritems(disaggregatedVars):
@@ -679,14 +688,14 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         relaxedDisjuncts = m._pyomo_gdp_hull_reformulation.relaxedDisjuncts
 
         disaggregatedVars = {
-            (1,'A'): [relaxedDisjuncts[0].component('a[1,A]'),
-                      relaxedDisjuncts[1].component('a[1,A]')],
-            (1,'B'): [relaxedDisjuncts[2].component('a[1,B]'),
-                      relaxedDisjuncts[3].component('a[1,B]')],
-            (2,'A'): [relaxedDisjuncts[4].component('a[2,A]'),
-                      relaxedDisjuncts[5].component('a[2,A]')],
-            (2,'B'): [relaxedDisjuncts[6].component('a[2,B]'),
-                      relaxedDisjuncts[7].component('a[2,B]')],
+            (1,'A'): [relaxedDisjuncts[0].disaggregatedVars.component('a[1,A]'),
+                      relaxedDisjuncts[1].disaggregatedVars.component('a[1,A]')],
+            (1,'B'): [relaxedDisjuncts[2].disaggregatedVars.component('a[1,B]'),
+                      relaxedDisjuncts[3].disaggregatedVars.component('a[1,B]')],
+            (2,'A'): [relaxedDisjuncts[4].disaggregatedVars.component('a[2,A]'),
+                      relaxedDisjuncts[5].disaggregatedVars.component('a[2,A]')],
+            (2,'B'): [relaxedDisjuncts[6].disaggregatedVars.component('a[2,B]'),
+                      relaxedDisjuncts[7].disaggregatedVars.component('a[2,B]')],
         }
 
         for i, disVars in iteritems(disaggregatedVars):
@@ -744,10 +753,12 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         # We end up with a transformation block for every SimpleDisjunction or
         # IndexedDisjunction.
         self.assertEqual(len(transBlock1.relaxedDisjuncts), 2)
-        self.assertIsInstance(transBlock1.relaxedDisjuncts[0].component("x"),
-                              Var)
-        self.assertTrue(transBlock1.relaxedDisjuncts[0].x.is_fixed())
-        self.assertEqual(value(transBlock1.relaxedDisjuncts[0].x), 0)
+        self.assertIsInstance(transBlock1.relaxedDisjuncts[0].disaggregatedVars.\
+                              component("x"), Var)
+        self.assertTrue(transBlock1.relaxedDisjuncts[0].disaggregatedVars.x.\
+                        is_fixed())
+        self.assertEqual(value(transBlock1.relaxedDisjuncts[0].\
+                               disaggregatedVars.x), 0)
         self.assertIsInstance(transBlock1.relaxedDisjuncts[0].component(
             "firstTerm[1].cons"), Constraint)
         # No constraint becuase disaggregated variable fixed to 0
@@ -758,8 +769,8 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertEqual(len(transBlock1.relaxedDisjuncts[0].component(
             "x_bounds")), 2)
 
-        self.assertIsInstance(transBlock1.relaxedDisjuncts[1].component("x"),
-                              Var)
+        self.assertIsInstance(transBlock1.relaxedDisjuncts[1].disaggregatedVars.\
+                              component("x"), Var)
         self.assertIsInstance(transBlock1.relaxedDisjuncts[1].component(
             "secondTerm[1].cons"), Constraint)
         self.assertEqual(len(transBlock1.relaxedDisjuncts[1].component(
@@ -773,8 +784,8 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertIsInstance(transBlock2, Block)
         self.assertIsInstance(transBlock2.component("relaxedDisjuncts"), Block)
         self.assertEqual(len(transBlock2.relaxedDisjuncts), 2)
-        self.assertIsInstance(transBlock2.relaxedDisjuncts[0].component("x"),
-                              Var)
+        self.assertIsInstance(transBlock2.relaxedDisjuncts[0].disaggregatedVars.\
+                              component("x"), Var)
         self.assertIsInstance(transBlock2.relaxedDisjuncts[0].component(
             "firstTerm[2].cons"), Constraint)
         # we have an equality constraint
@@ -785,8 +796,8 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertEqual(len(transBlock2.relaxedDisjuncts[0].component(
             "x_bounds")), 2)
 
-        self.assertIsInstance(transBlock2.relaxedDisjuncts[1].component("x"),
-                              Var)
+        self.assertIsInstance(transBlock2.relaxedDisjuncts[1].disaggregatedVars.\
+                              component("x"), Var)
         self.assertIsInstance(transBlock2.relaxedDisjuncts[1].component(
             "secondTerm[2].cons"), Constraint)
         self.assertEqual(len(transBlock2.relaxedDisjuncts[1].component(
@@ -807,10 +818,12 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertIsInstance(transBlock, Block)
         self.assertIsInstance(transBlock.component("relaxedDisjuncts"), Block)
         self.assertEqual(len(transBlock.relaxedDisjuncts), 4)
-        self.assertIsInstance(transBlock.relaxedDisjuncts[0].component("x"),
-                              Var)
-        self.assertTrue(transBlock.relaxedDisjuncts[0].x.is_fixed())
-        self.assertEqual(value(transBlock.relaxedDisjuncts[0].x), 0)
+        self.assertIsInstance(transBlock.relaxedDisjuncts[0].disaggregatedVars.\
+                              component("x"), Var)
+        self.assertTrue(transBlock.relaxedDisjuncts[0].disaggregatedVars.\
+                        x.is_fixed())
+        self.assertEqual(value(transBlock.relaxedDisjuncts[0].disaggregatedVars.\
+                               x), 0)
         self.assertIsInstance(transBlock.relaxedDisjuncts[0].component(
             "firstTerm[1].cons"), Constraint)
         # No constraint becuase disaggregated variable fixed to 0
@@ -821,8 +834,8 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertEqual(len(transBlock.relaxedDisjuncts[0].component(
             "x_bounds")), 2)
 
-        self.assertIsInstance(transBlock.relaxedDisjuncts[1].component("x"),
-                              Var)
+        self.assertIsInstance(transBlock.relaxedDisjuncts[1].disaggregatedVars.\
+                              component("x"), Var)
         self.assertIsInstance(transBlock.relaxedDisjuncts[1].component(
             "secondTerm[1].cons"), Constraint)
         self.assertEqual(len(transBlock.relaxedDisjuncts[1].component(
@@ -832,8 +845,8 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertEqual(len(transBlock.relaxedDisjuncts[1].component(
             "x_bounds")), 2)
 
-        self.assertIsInstance(transBlock.relaxedDisjuncts[2].component("x"),
-                              Var)
+        self.assertIsInstance(transBlock.relaxedDisjuncts[2].disaggregatedVars.\
+                              component("x"), Var)
         self.assertIsInstance(transBlock.relaxedDisjuncts[2].component(
             "firstTerm[2].cons"), Constraint)
         # we have an equality constraint
@@ -844,8 +857,8 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertEqual(len(transBlock.relaxedDisjuncts[2].component(
             "x_bounds")), 2)
 
-        self.assertIsInstance(transBlock.relaxedDisjuncts[3].component("x"),
-                              Var)
+        self.assertIsInstance(transBlock.relaxedDisjuncts[3].disaggregatedVars.\
+                              component("x"), Var)
         self.assertIsInstance(transBlock.relaxedDisjuncts[3].component(
             "secondTerm[2].cons"), Constraint)
         self.assertEqual(len(transBlock.relaxedDisjuncts[3].component(
@@ -870,9 +883,12 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertIsInstance(transBlock.relaxedDisjuncts, Block)
         self.assertEqual(len(transBlock.relaxedDisjuncts), 2)
 
-        self.assertIsInstance(transBlock.relaxedDisjuncts[0].x, Var)
-        self.assertTrue(transBlock.relaxedDisjuncts[0].x.is_fixed())
-        self.assertEqual(value(transBlock.relaxedDisjuncts[0].x), 0)
+        self.assertIsInstance(transBlock.relaxedDisjuncts[0].disaggregatedVars.x,
+                              Var)
+        self.assertTrue(transBlock.relaxedDisjuncts[0].disaggregatedVars.x.\
+                        is_fixed())
+        self.assertEqual(value(transBlock.relaxedDisjuncts[0].disaggregatedVars.\
+                               x), 0)
         self.assertIsInstance(transBlock.relaxedDisjuncts[0].component(
             "firstTerm[0].cons"), Constraint)
         self.assertEqual(len(transBlock.relaxedDisjuncts[0].component(
@@ -881,8 +897,10 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
                               Constraint)
         self.assertEqual(len(transBlock.relaxedDisjuncts[0].x_bounds), 2)
 
-        self.assertIsInstance(transBlock.relaxedDisjuncts[1].x, Var)
-        self.assertFalse(transBlock.relaxedDisjuncts[1].x.is_fixed())
+        self.assertIsInstance(transBlock.relaxedDisjuncts[1].disaggregatedVars.x,
+                              Var)
+        self.assertFalse(transBlock.relaxedDisjuncts[1].disaggregatedVars.\
+                         x.is_fixed())
         self.assertIsInstance(transBlock.relaxedDisjuncts[1].component(
             "secondTerm[0].cons"), Constraint)
         self.assertEqual(len(transBlock.relaxedDisjuncts[1].component(
@@ -1082,15 +1100,47 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
                                  pyomo.opt.TerminationCondition.optimal)
                 self.assertEqual(value(m.obj), case[4])
 
+    @unittest.skipIf(not linear_solvers, "No linear solver available")
+    def test_relaxation_feasibility_transform_inner_first(self):
+        # This test is identical to the above except that the
+        # reference_indicator_var transformation will be called on m.d1
+        # first. So this makes sure that we are still doing the right thing even
+        # if the indicator_var references already exist.
+        m = models.makeNestedDisjunctions_FlatDisjuncts()
+        TransformationFactory('gdp.hull').apply_to(m.d1)
+        TransformationFactory('gdp.hull').apply_to(m)
+
+        solver = SolverFactory(linear_solvers[0])
+
+        cases = [
+            (1,1,1,1,None),
+            (0,0,0,0,None),
+            (1,0,0,0,None),
+            (0,1,0,0,1.1),
+            (0,0,1,0,None),
+            (0,0,0,1,None),
+            (1,1,0,0,None),
+            (1,0,1,0,1.2),
+            (1,0,0,1,1.3),
+            (1,0,1,1,None),
+            ]
+        for case in cases:
+            m.d1.indicator_var.fix(case[0])
+            m.d2.indicator_var.fix(case[1])
+            m.d3.indicator_var.fix(case[2])
+            m.d4.indicator_var.fix(case[3])
+            results = solver.solve(m)
+            if case[4] is None:
+                self.assertEqual(results.solver.termination_condition,
+                                 pyomo.opt.TerminationCondition.infeasible)
+            else:
+                self.assertEqual(results.solver.termination_condition,
+                                 pyomo.opt.TerminationCondition.optimal)
+                self.assertEqual(value(m.obj), case[4])
+
     def test_create_using(self):
         m = models.makeNestedDisjunctions_FlatDisjuncts()
         self.diff_apply_to_and_create_using(m)
-
-    # TODO: test disjunct mappings: This is not the same as bigm because you
-    # don't move these blocks around in hull the way you do in bigm.
-
-    # And I think it is worth it to go through a full test case for this and
-    # actually make sure of the transformed constraints too.
 
     def check_outer_disaggregation_constraint(self, cons, var, disj1, disj2):
         hull = TransformationFactory('gdp.hull')
@@ -1240,10 +1290,12 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         self.assertIs(hull.get_disaggregation_constraint(m.d1.d4.indicator_var,
                                                           m.disj), dis[2,None])
 
-        # we should have two disjunct transformation blocks
+        # we should have four disjunct transformation blocks: 2 real ones and
+        # then two that are just home to indicator_var and disaggregated var
+        # References.
         disjBlocks = transBlock.relaxedDisjuncts
         self.assertTrue(disjBlocks.active)
-        self.assertEqual(len(disjBlocks), 2)
+        self.assertEqual(len(disjBlocks), 4)
 
         disj1 = disjBlocks[0]
         self.assertTrue(disj1.active)
@@ -1251,19 +1303,20 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         self.assertIs(m.d1, hull.get_src_disjunct(disj1))
 
         # check the disaggregated vars are here
-        self.assertIsInstance(disj1.x, Var)
-        self.assertEqual(disj1.x.lb, 0)
-        self.assertEqual(disj1.x.ub, 2)
-        self.assertIs(disj1.x, hull.get_disaggregated_var(m.x, m.d1))
-        self.assertIs(m.x, hull.get_src_var(disj1.x))
-        d3 = disj1.component("indicator_var")
+        self.assertIsInstance(disj1.disaggregatedVars.x, Var)
+        self.assertEqual(disj1.disaggregatedVars.x.lb, 0)
+        self.assertEqual(disj1.disaggregatedVars.x.ub, 2)
+        self.assertIs(disj1.disaggregatedVars.x, 
+                      hull.get_disaggregated_var(m.x, m.d1))
+        self.assertIs(m.x, hull.get_src_var(disj1.disaggregatedVars.x))
+        d3 = disj1.disaggregatedVars.component("indicator_var")
         self.assertEqual(d3.lb, 0)
         self.assertEqual(d3.ub, 1)
         self.assertIsInstance(d3, Var)
         self.assertIs(d3, hull.get_disaggregated_var(m.d1.d3.indicator_var,
                                                       m.d1))
         self.assertIs(m.d1.d3.indicator_var, hull.get_src_var(d3))
-        d4 = disj1.component("indicator_var_4")
+        d4 = disj1.disaggregatedVars.component("indicator_var_4")
         self.assertIsInstance(d4, Var)
         self.assertEqual(d4.lb, 0)
         self.assertEqual(d4.ub, 1)
@@ -1272,14 +1325,16 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         self.assertIs(m.d1.d4.indicator_var, hull.get_src_var(d4))
 
         # check inner disjunction disaggregated vars
-        x3 = m.d1._pyomo_gdp_hull_reformulation.relaxedDisjuncts[0].x
+        x3 = m.d1._pyomo_gdp_hull_reformulation.relaxedDisjuncts[0].\
+             disaggregatedVars.x
         self.assertIsInstance(x3, Var)
         self.assertEqual(x3.lb, 0)
         self.assertEqual(x3.ub, 2)
         self.assertIs(hull.get_disaggregated_var(m.x, m.d1.d3), x3)
         self.assertIs(hull.get_src_var(x3), m.x)
 
-        x4 = m.d1._pyomo_gdp_hull_reformulation.relaxedDisjuncts[1].x
+        x4 = m.d1._pyomo_gdp_hull_reformulation.relaxedDisjuncts[1].\
+             disaggregatedVars.x
         self.assertIsInstance(x4, Var)
         self.assertEqual(x4.lb, 0)
         self.assertEqual(x4.ub, 2)
@@ -1287,13 +1342,14 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         self.assertIs(hull.get_src_var(x4), m.x)
 
         # check the bounds constraints
-        self.check_bounds_constraint_ub(disj1.x_bounds, 2, disj1.x,
+        self.check_bounds_constraint_ub(disj1.x_bounds, 2,
+                                        disj1.disaggregatedVars.x,
                                         m.d1.indicator_var)
         self.check_bounds_constraint_ub(disj1.indicator_var_bounds, 1,
-                                        disj1.indicator_var,
+                                        disj1.disaggregatedVars.indicator_var,
                                         m.d1.indicator_var)
         self.check_bounds_constraint_ub(disj1.indicator_var_4_bounds, 1,
-                                        disj1.indicator_var_4,
+                                        disj1.disaggregatedVars.indicator_var_4,
                                         m.d1.indicator_var)
 
         # check the transformed constraints
@@ -1310,8 +1366,10 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         self.assertTrue(repn.is_linear())
         self.assertEqual(repn.constant, 0)
         self.assertEqual(len(repn.linear_vars), 3)
-        ct.check_linear_coef(self, repn, disj1.indicator_var, 1)
-        ct.check_linear_coef(self, repn, disj1.indicator_var_4, 1)
+        ct.check_linear_coef(self, repn, disj1.disaggregatedVars.indicator_var,
+                             1)
+        ct.check_linear_coef(self, repn,
+                             disj1.disaggregatedVars.indicator_var_4, 1)
         ct.check_linear_coef(self, repn, m.d1.indicator_var, -1)
 
         # inner disjunction disaggregation constraint
@@ -1331,7 +1389,7 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         self.assertEqual(len(repn.linear_vars), 3)
         ct.check_linear_coef(self, repn, x3, -1)
         ct.check_linear_coef(self, repn, x4, -1)
-        ct.check_linear_coef(self, repn, disj1.x, 1)
+        ct.check_linear_coef(self, repn, disj1.disaggregatedVars.x, 1)
 
         # disaggregated d3.x bounds constraints
         x3_bounds = disj1.component(
@@ -1339,7 +1397,8 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         original_cons = m.d1._pyomo_gdp_hull_reformulation.relaxedDisjuncts[0].\
                         x_bounds
         self.check_inner_disaggregated_var_bounds(x3_bounds, x3,
-                                                  disj1.indicator_var,
+                                                  disj1.disaggregatedVars.\
+                                                  indicator_var,
                                                   original_cons)
 
 
@@ -1349,7 +1408,8 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         original_cons = m.d1._pyomo_gdp_hull_reformulation.relaxedDisjuncts[1].\
                         x_bounds
         self.check_inner_disaggregated_var_bounds(x4_bounds, x4,
-                                                  disj1.indicator_var_4,
+                                                  disj1.disaggregatedVars.\
+                                                  indicator_var_4,
                                                   original_cons)
 
         # transformed x >= 1.2
@@ -1359,7 +1419,8 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
                             relaxedDisjuncts[0].component("d1.d3.c")
         original = m.d1.d3.c
         self.check_inner_transformed_constraint(cons, x3, 1.2,
-                                                disj1.indicator_var,
+                                                disj1.disaggregatedVars.\
+                                                indicator_var,
                                                 first_transformed, original)
 
         # transformed x >= 1.3
@@ -1369,22 +1430,23 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
                             relaxedDisjuncts[1].component("d1.d4.c")
         original = m.d1.d4.c
         self.check_inner_transformed_constraint(cons, x4, 1.3,
-                                                disj1.indicator_var_4,
+                                                disj1.disaggregatedVars.\
+                                                indicator_var_4,
                                                 first_transformed, original)
 
         # outer disjunction transformed constraint
         cons = disj1.component("d1.c")
-        self.check_outer_transformed_constraint(cons, disj1.x, 1,
-                                                m.d1.indicator_var)
+        self.check_outer_transformed_constraint(cons, disj1.disaggregatedVars.x,
+                                                1, m.d1.indicator_var)
 
         # and last, check the second transformed outer disjunct
-        disj2 = disjBlocks[1]
+        disj2 = disjBlocks[3]
         self.assertTrue(disj2.active)
         self.assertIs(disj2, m.d2.transformation_block())
         self.assertIs(m.d2, hull.get_src_disjunct(disj2))
 
         # disaggregated var
-        x2 = disj2.x
+        x2 = disj2.disaggregatedVars.x
         self.assertIsInstance(x2, Var)
         self.assertEqual(x2.lb, 0)
         self.assertEqual(x2.ub, 2)
@@ -1472,22 +1534,23 @@ class TestSpecialCases(unittest.TestCase):
 
         i = TransformationFactory('gdp.hull').create_using(m)
         rd = i._pyomo_gdp_hull_reformulation.relaxedDisjuncts[1]
-        # z should be disaggregated becuase we can't be sure it's not somewhere
+        varBlock = rd.disaggregatedVars
+        # z should be disaggregated because we can't be sure it's not somewhere
         # else on the model
-        self.assertEqual(sorted(rd.component_map(Var)), ['x','y','z'])
+        self.assertEqual(sorted(varBlock.component_map(Var)), ['x','y','z'])
         self.assertEqual(len(rd.component_map(Constraint)), 4)
         # bounds haven't changed on original
         self.assertEqual(i.d2.z.bounds, (7,9))
         # check disaggregated variable
-        self.assertIsInstance(rd.component("z"), Var)
-        self.assertEqual(rd.z.bounds, (0,9))
+        self.assertIsInstance(varBlock.component("z"), Var)
+        self.assertEqual(varBlock.z.bounds, (0,9))
         self.assertEqual(len(rd.z_bounds), 2)
         self.assertEqual(rd.z_bounds['lb'].lower, None)
         self.assertEqual(rd.z_bounds['lb'].upper, 0)
         self.assertEqual(rd.z_bounds['ub'].lower, None)
         self.assertEqual(rd.z_bounds['ub'].upper, 0)
         i.d2.indicator_var = 1
-        rd.z = 2
+        varBlock.z = 2
         self.assertEqual(rd.z_bounds['lb'].body(), 5)
         self.assertEqual(rd.z_bounds['ub'].body(), -7)
 
@@ -1495,20 +1558,21 @@ class TestSpecialCases(unittest.TestCase):
         m.d2.z.setub(-7)
         i = TransformationFactory('gdp.hull').create_using(m)
         rd = i._pyomo_gdp_hull_reformulation.relaxedDisjuncts[1]
-        self.assertEqual(sorted(rd.component_map(Var)), ['x','y','z'])
+        varBlock = rd.disaggregatedVars
+        self.assertEqual(sorted(varBlock.component_map(Var)), ['x','y','z'])
         self.assertEqual(len(rd.component_map(Constraint)), 4)
         # original bounds unchanged
         self.assertEqual(i.d2.z.bounds, (-9,-7))
         # check disaggregated variable
-        self.assertIsInstance(rd.component("z"), Var)
-        self.assertEqual(rd.z.bounds, (-9,0))
+        self.assertIsInstance(varBlock.component("z"), Var)
+        self.assertEqual(varBlock.z.bounds, (-9,0))
         self.assertEqual(len(rd.z_bounds), 2)
         self.assertEqual(rd.z_bounds['lb'].lower, None)
         self.assertEqual(rd.z_bounds['lb'].upper, 0)
         self.assertEqual(rd.z_bounds['ub'].lower, None)
         self.assertEqual(rd.z_bounds['ub'].upper, 0)
         i.d2.indicator_var = 1
-        rd.z = 2
+        varBlock.z = 2
         self.assertEqual(rd.z_bounds['lb'].body(), -11)
         self.assertEqual(rd.z_bounds['ub'].body(), 9)
 
@@ -1529,8 +1593,10 @@ class TestSpecialCases(unittest.TestCase):
         m = hull.create_using(model)
         self.assertEqual(m.d2.z.lb, -9)
         self.assertEqual(m.d2.z.ub, -7)
-        self.assertIsInstance(m.d2.transformation_block().component("z"), Var)
-        self.assertIs(m.d2.transformation_block().z,
+        z_disaggregated = m.d2.transformation_block().disaggregatedVars.\
+                          component("z")
+        self.assertIsInstance(z_disaggregated, Var)
+        self.assertIs(z_disaggregated,
                       hull.get_disaggregated_var(m.d2.z, m.d2))
 
         # we do declare z local
@@ -1545,7 +1611,8 @@ class TestSpecialCases(unittest.TestCase):
         # it is its own disaggregated variable
         self.assertIs(hull.get_disaggregated_var(m.d2.z, m.d2), m.d2.z)
         # it does not exist on the transformation block
-        self.assertIsNone(m.d2.transformation_block().component("z"))
+        self.assertIsNone(m.d2.transformation_block().disaggregatedVars.\
+                          component("z"))
 
 class UntransformableObjectsOnDisjunct(unittest.TestCase):
     def test_RangeSet(self):
@@ -1633,12 +1700,14 @@ class TestErrors(unittest.TestCase):
                  indicator_var
         self.assertIs(hull.get_disaggregated_var(d3_ind,
                                                   m.disjunction_disjuncts[0]),
-                      disjunct1.indicator_var)
-        self.assertIs(hull.get_src_var(disjunct1.indicator_var), d3_ind)
+                      disjunct1.disaggregatedVars.indicator_var)
+        self.assertIs(hull.get_src_var(
+            disjunct1.disaggregatedVars.indicator_var), d3_ind)
         self.assertIs(hull.get_disaggregated_var(d4_ind,
                                                   m.disjunction_disjuncts[0]),
-                      disjunct1.indicator_var_4)
-        self.assertIs(hull.get_src_var(disjunct1.indicator_var_4), d4_ind)
+                      disjunct1.disaggregatedVars.indicator_var_4)
+        self.assertIs(hull.get_src_var(
+            disjunct1.disaggregatedVars.indicator_var_4), d4_ind)
 
         relaxed_xor = disjunct1.component(
             "disjunction_disjuncts[0]._pyomo_gdp_hull_reformulation."
@@ -1654,8 +1723,10 @@ class TestErrors(unittest.TestCase):
         # nested disjuncts sum to the indicator variable of the outer disjunct.
         ct.check_linear_coef( self, repn,
                               m.disjunction.disjuncts[0].indicator_var, -1)
-        ct.check_linear_coef(self, repn, disjunct1.indicator_var, 1)
-        ct.check_linear_coef(self, repn, disjunct1.indicator_var_4, 1)
+        ct.check_linear_coef(self, repn,
+                             disjunct1.disaggregatedVars.indicator_var, 1)
+        ct.check_linear_coef(self, repn,
+                             disjunct1.disaggregatedVars.indicator_var_4, 1)
         self.assertEqual(repn.constant, 0)
 
         # but the disaggregation constraints are going to force them to 0 (which
@@ -1668,9 +1739,11 @@ class TestErrors(unittest.TestCase):
         self.assertTrue(repn.is_linear())
         self.assertEqual(len(repn.linear_vars), 2)
         self.assertEqual(repn.constant, 0)
-        ct.check_linear_coef(self, repn, disjunct1.indicator_var, -1)
         ct.check_linear_coef(self, repn,
-                             transBlock.relaxedDisjuncts[1].indicator_var, -1)
+                             disjunct1.disaggregatedVars.indicator_var, -1)
+        ct.check_linear_coef(self, repn,
+                             transBlock.relaxedDisjuncts[1].disaggregatedVars.\
+                             indicator_var, -1)
         d4_ind_dis = transBlock.disaggregationConstraints[2, None]
         self.assertEqual(d4_ind_dis.lower, 0)
         self.assertEqual(d4_ind_dis.upper, 0)
@@ -1678,9 +1751,11 @@ class TestErrors(unittest.TestCase):
         self.assertTrue(repn.is_linear())
         self.assertEqual(len(repn.linear_vars), 2)
         self.assertEqual(repn.constant, 0)
-        ct.check_linear_coef(self, repn, disjunct1.indicator_var_4, -1)
         ct.check_linear_coef(self, repn,
-                             transBlock.relaxedDisjuncts[1].indicator_var_9, -1)
+                             disjunct1.disaggregatedVars.indicator_var_4, -1)
+        ct.check_linear_coef(self, repn,
+                             transBlock.relaxedDisjuncts[1].disaggregatedVars.\
+                             indicator_var_9, -1)
 
     def test_mapping_method_errors(self):
         m = models.makeTwoTermDisj_Nonlinear()
@@ -1691,7 +1766,7 @@ class TestErrors(unittest.TestCase):
         with LoggingIntercept(log, 'pyomo.gdp.hull', logging.ERROR):
             self.assertRaisesRegexp(
                 AttributeError,
-                "'ConcreteModel' object has no attribute '_bigMConstraintMap'",
+                "'NoneType' object has no attribute '_bigMConstraintMap'",
                 hull.get_var_bounds_constraint,
                 m.w)
         self.assertRegexpMatches(
@@ -1704,21 +1779,22 @@ class TestErrors(unittest.TestCase):
         with LoggingIntercept(log, 'pyomo.gdp.hull', logging.ERROR):
             self.assertRaisesRegexp(
                 KeyError,
-                ".*_pyomo_gdp_hull_reformulation.relaxedDisjuncts\[1\].w",
+                ".*_pyomo_gdp_hull_reformulation.relaxedDisjuncts\[1\]."
+                "disaggregatedVars.w",
                 hull.get_disaggregation_constraint,
-                m.d[1].transformation_block().w,
+                m.d[1].transformation_block().disaggregatedVars.w,
                 m.disjunction)
         self.assertRegexpMatches(log.getvalue(), ".*It doesn't appear that "
                                  "'_pyomo_gdp_hull_reformulation."
-                                 "relaxedDisjuncts\[1\].w' is a "
-                                 "variable that was disaggregated by "
+                                 "relaxedDisjuncts\[1\].disaggregatedVars.w' "
+                                 "is a variable that was disaggregated by "
                                  "Disjunction 'disjunction'")
 
         log = StringIO()
         with LoggingIntercept(log, 'pyomo.gdp.hull', logging.ERROR):
             self.assertRaisesRegexp(
                 AttributeError,
-                "'ConcreteModel' object has no attribute '_disaggregatedVarMap'",
+                "'NoneType' object has no attribute '_disaggregatedVarMap'",
                 hull.get_src_var,
                 m.w)
         self.assertRegexpMatches(
@@ -1729,15 +1805,17 @@ class TestErrors(unittest.TestCase):
         with LoggingIntercept(log, 'pyomo.gdp.hull', logging.ERROR):
             self.assertRaisesRegexp(
                 KeyError,
-                ".*_pyomo_gdp_hull_reformulation.relaxedDisjuncts\[1\].w",
+                ".*_pyomo_gdp_hull_reformulation.relaxedDisjuncts\[1\]."
+                "disaggregatedVars.w",
                 hull.get_disaggregated_var,
-                m.d[1].transformation_block().w,
+                m.d[1].transformation_block().disaggregatedVars.w,
                 m.d[1])
         self.assertRegexpMatches(log.getvalue(),
                                  ".*It does not appear "
                                  "'_pyomo_gdp_hull_reformulation."
-                                 "relaxedDisjuncts\[1\].w' is a "
-                                 "variable which appears in disjunct 'd\[1\]'")
+                                 "relaxedDisjuncts\[1\].disaggregatedVars.w' "
+                                 "is a variable which appears in disjunct "
+                                 "'d\[1\]'")
 
         m.random_disjunction = Disjunction(expr=[m.w == 2, m.w >= 7])
         self.assertRaisesRegexp(
@@ -1823,9 +1901,10 @@ class BlocksOnDisjuncts(unittest.TestCase):
         self.assertIs(hull.get_disaggregated_var(m.x, m.disj1), m.x)
         self.assertEqual(m.x.lb, 0)
         self.assertEqual(m.x.ub, 5)
-        self.assertIsNone(m.disj1.transformation_block().component("x"))
-        self.assertIsInstance(m.disj1.transformation_block().component("y"),
-                              Var)
+        self.assertIsNone(m.disj1.transformation_block().disaggregatedVars.\
+                          component("x"))
+        self.assertIsInstance(m.disj1.transformation_block().disaggregatedVars.\
+                              component("y"), Var)
 
     # this doesn't require the block, I'm just coopting this test to make sure
     # of some nonlinear expressions.
@@ -1847,7 +1926,8 @@ class BlocksOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(cons.body)
         self.assertEqual(str(repn.nonlinear_expr),
                          "(0.9999*disj1.indicator_var + 0.0001)*"
-                         "(_pyomo_gdp_hull_reformulation.relaxedDisjuncts[0].y/"
+                         "(_pyomo_gdp_hull_reformulation.relaxedDisjuncts[0]."
+                         "disaggregatedVars.y/"
                          "(0.9999*disj1.indicator_var + 0.0001))**2")
         self.assertEqual(len(repn.nonlinear_vars), 2)
         self.assertIs(repn.nonlinear_vars[0], m.disj1.indicator_var)
@@ -1869,7 +1949,8 @@ class BlocksOnDisjuncts(unittest.TestCase):
         self.assertEqual(str(repn.nonlinear_expr),
                          "- ((0.9999*disj2.indicator_var + 0.0001)*"
                          "log(1 + "
-                         "_pyomo_gdp_hull_reformulation.relaxedDisjuncts[1].y/"
+                         "_pyomo_gdp_hull_reformulation.relaxedDisjuncts[1]."
+                         "disaggregatedVars.y/"
                          "(0.9999*disj2.indicator_var + 0.0001)))")
         self.assertEqual(len(repn.nonlinear_vars), 2)
         self.assertIs(repn.nonlinear_vars[0], m.disj2.indicator_var)
@@ -1888,9 +1969,10 @@ class DisaggregatingFixedVars(unittest.TestCase):
         hull.apply_to(m)
         # check that we did indeed disaggregate x
         transBlock = m.d[1]._transformation_block()
-        self.assertIsInstance(transBlock.component("x"), Var)
-        self.assertIs(hull.get_disaggregated_var(m.x, m.d[1]), transBlock.x)
-        self.assertIs(hull.get_src_var(transBlock.x), m.x)
+        self.assertIsInstance(transBlock.disaggregatedVars.component("x"), Var)
+        self.assertIs(hull.get_disaggregated_var(m.x, m.d[1]),
+                      transBlock.disaggregatedVars.x)
+        self.assertIs(hull.get_src_var(transBlock.disaggregatedVars.x), m.x)
 
     def test_do_not_disaggregate_fixed_variables(self):
         m = models.makeTwoTermDisj()
@@ -1899,8 +1981,7 @@ class DisaggregatingFixedVars(unittest.TestCase):
         hull.apply_to(m, assume_fixed_vars_permanent=True)
         # check that we didn't disaggregate x
         transBlock = m.d[1]._transformation_block()
-        self.assertIsNone(transBlock.component("x"))
-
+        self.assertIsNone(transBlock.disaggregatedVars.component("x"))
 
 class NameDeprecationTest(unittest.TestCase):
     def test_name_deprecated(self):

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -13,10 +13,11 @@ from six import string_types
 import pyomo.core.expr.current as EXPR
 from pyomo.core.expr.numvalue import nonpyomo_leaf_types, native_numeric_types
 from pyomo.gdp import GDP_Error, Disjunction
-from pyomo.gdp.disjunct import _DisjunctData
+from pyomo.gdp.disjunct import _DisjunctData, Disjunct
 from copy import deepcopy
 
 from pyomo.core.base.component import _ComponentBase, ComponentUID
+from pyomo.core import Block
 from pyomo.opt import TerminationCondition, SolverStatus
 from pyomo.common.deprecation import deprecation_warning
 from six import iterkeys
@@ -158,7 +159,8 @@ def get_src_disjunction(xor_constraint):
     # block while we do the transformation. And then this method could query
     # that map.
     m = xor_constraint.model()
-    for disjunction in m.component_data_objects(Disjunction):
+    for disjunction in m.component_data_objects(Disjunction,
+                                                descend_into=(Block, Disjunct)):
         if disjunction._algebraic_constraint:
             if disjunction._algebraic_constraint() is xor_constraint:
                 return disjunction

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -17,7 +17,7 @@ from pyomo.gdp.disjunct import _DisjunctData, Disjunct
 from copy import deepcopy
 
 from pyomo.core.base.component import _ComponentBase, ComponentUID
-from pyomo.core import Block
+from pyomo.core import Block, TraversalStrategy
 from pyomo.opt import TerminationCondition, SolverStatus
 from pyomo.common.deprecation import deprecation_warning
 from six import iterkeys
@@ -296,3 +296,86 @@ def _warn_for_active_disjunct(innerdisjunct, outerdisjunct, NAME_BUFFER):
                         outerdisjunct.getname(
                             fully_qualified=True,
                             name_buffer=NAME_BUFFER)))
+
+def assert_model_algebraic(instance):
+    """Checks if there are any active Disjuncts or Disjunctions reachable via
+    active Blocks. If there are not, it returns True. If there are, it issues
+    a warning detailing where in the model there are remaining non-algebraic
+    components, and returns False.
+
+    Parameters
+    ----------
+    instance: a Model or Block
+    """
+    disjunction_set = {i for i in instance.component_data_objects(
+        Disjunction, descend_into=(Block, Disjunct), active=None)}
+    active_disjunction_set = {i for i in instance.component_data_objects(
+        Disjunction, descend_into=(Block, Disjunct), active=True)}
+    disjuncts_in_disjunctions = set()
+    for i in disjunction_set:
+        disjuncts_in_disjunctions.update(i.disjuncts)
+    disjuncts_in_active_disjunctions = set()
+    for i in active_disjunction_set:
+        disjuncts_in_active_disjunctions.update(i.disjuncts)
+
+    for disjunct in instance.component_data_objects(
+            Disjunct, descend_into=(Block,),
+            descent_order=TraversalStrategy.PostfixDFS):
+        # check if it's relaxed
+        if disjunct.transformation_block is not None:
+            continue
+        # It's not transformed, check if we should complain
+        elif disjunct.active and _disjunct_not_fixed_true(disjunct) and \
+             _disjunct_on_active_block(disjunct):
+            # If someone thinks they've transformed the whole instance, but
+            # there is still an active Disjunct on the model, we will warn
+            # them. In the future this should be the writers' job.)
+            if disjunct not in disjuncts_in_disjunctions:
+                logger.warning('Disjunct "%s" is currently active, '
+                               'but was not found in any Disjunctions. '
+                               'This is generally an error as the model '
+                               'has not been fully relaxed to a '
+                               'pure algebraic form.' % (disjunct.name,))
+                return False
+            elif disjunct not in disjuncts_in_active_disjunctions:
+                logger.warning('Disjunct "%s" is currently active. While '
+                               'it participates in a Disjunction, '
+                               'that Disjunction is currently deactivated. '
+                               'This is generally an error as the '
+                               'model has not been fully relaxed to a pure '
+                               'algebraic form. Did you deactivate '
+                               'the Disjunction without addressing the '
+                               'individual Disjuncts?' % (disjunct.name,))
+                return False
+            else:
+                logger.warning('Disjunct "%s" is currently active. It must be '
+                               'transformed or deactivated before solving the '
+                               'model.' % (disjunct.name,))
+                return False
+    # We didn't find anything bad.
+    return True
+
+def _disjunct_not_fixed_true(disjunct):
+    # Return true if the disjunct indicator variable is not fixed to True
+    return not (disjunct.indicator_var.fixed and
+                disjunct.indicator_var.value == 1)
+
+def _disjunct_on_active_block(disjunct):
+    # Check first to make sure that the disjunct is not a descendent of an
+    # inactive Block or fixed and deactivated Disjunct, before raising a
+    # warning.
+    parent_block = disjunct.parent_block()
+    while parent_block is not None:
+        # deactivated Block
+        if parent_block.ctype is Block and not parent_block.active:
+            return False
+        # properly deactivated Disjunct
+        elif (parent_block.ctype is Disjunct and not parent_block.active
+              and parent_block.indicator_var.value == 0
+              and parent_block.indicator_var.fixed):
+            return False
+        else:
+            # Step up one level in the hierarchy
+            parent_block = parent_block.parent_block()
+            continue
+    return True

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -297,7 +297,7 @@ def _warn_for_active_disjunct(innerdisjunct, outerdisjunct, NAME_BUFFER):
                             fully_qualified=True,
                             name_buffer=NAME_BUFFER)))
 
-def assert_model_algebraic(instance):
+def check_model_algebraic(instance):
     """Checks if there are any active Disjuncts or Disjunctions reachable via
     active Blocks. If there are not, it returns True. If there are, it issues
     a warning detailing where in the model there are remaining non-algebraic


### PR DESCRIPTION
## Fixes # NA

## Summary/Motivation:

Previously, `TransformationFactory('gdp.bigm').apply_to(m.block)` and `TransformationFactory('gdp.bigm').apply_to(m, targets=m.block)` behaved differently because of the hack to expose the `indicator_var`s and other local variables to the writers. This is because the first automatically called the `gdp.reclassify` transformation whereas the second did not, since we have no way of knowing if someone expects their model to be completely transformed after using targets.

This PR deprecates `gdp.reclassify` and instead has the bigm and hull transformations create References to locally declared variables, which are stored on their own sub-block of the Disjunct's transformation Block. This exposes the local variables to the writers without ever changing the ctype of the `Disjunct`.

## Changes proposed in this PR:
- Modifies `gdp.bigm` and `gdp.hull` to add References to all locally declared Vars on the Disjunct transformation block.
- Adds `assert_model_algebraic` function to gdp.util to take the place of the validation we were doing in `gdp.reclassify` to check that the model was indeed completely transformed.
- Moves `hull` disaggregated variables to their own sub-block of the Disjunct transformation block. (This is peripheral to this PR, but means we have complete control over names on the Disjunct transformation block again, which is nice.)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
