### PR TITLE
Adding support for additional components in util/check_units.py

### DIFF
--- a/pyomo/util/check_units.py
+++ b/pyomo/util/check_units.py
@@ -18,7 +18,7 @@ from pyomo.core.base import (Objective, Constraint, Var, Param,
                              Suffix, Set, RangeSet, Block,
                              ExternalFunction, Expression,
                              value)
-from pyomo.dae import ContinuousSet
+from pyomo.dae import ContinuousSet, DerivativeVar
 from pyomo.mpec import Complementarity
 from pyomo.gdp import Disjunct, Disjunction
 from pyomo.core.expr.template_expr import IndexTemplate
@@ -140,6 +140,7 @@ _component_data_handlers = {
     Objective: _assert_units_consistent_property_expr,
     Constraint:  _assert_units_consistent_constraint_data,
     Var: _assert_units_consistent_expression,
+    DerivativeVar: _assert_units_consistent_expression,
     Expression: _assert_units_consistent_property_expr,
     Suffix: None,
     Param: _assert_units_consistent_expression,

--- a/pyomo/util/check_units.py
+++ b/pyomo/util/check_units.py
@@ -19,6 +19,7 @@ from pyomo.core.base import (Objective, Constraint, Var, Param,
                              ExternalFunction, Expression,
                              value)
 from pyomo.dae import ContinuousSet, DerivativeVar
+from pyomo.network import Port, Arc
 from pyomo.mpec import Complementarity
 from pyomo.gdp import Disjunct, Disjunction
 from pyomo.core.expr.template_expr import IndexTemplate
@@ -141,6 +142,8 @@ _component_data_handlers = {
     Constraint:  _assert_units_consistent_constraint_data,
     Var: _assert_units_consistent_expression,
     DerivativeVar: _assert_units_consistent_expression,
+    Port: None,
+    Arc: None,
     Expression: _assert_units_consistent_property_expr,
     Suffix: None,
     Param: _assert_units_consistent_expression,

--- a/pyomo/util/check_units.py
+++ b/pyomo/util/check_units.py
@@ -159,7 +159,7 @@ def _assert_units_consistent_block(obj):
     and checks if the units are consistent on each of them
     """
     # check all the component objects
-    for component in obj.component_objects(descend_into=True):
+    for component in obj.component_objects(descend_into=True, active=True):
         assert_units_consistent(component)
 
 _component_data_handlers = {

--- a/pyomo/util/tests/test_check_units.py
+++ b/pyomo/util/tests/test_check_units.py
@@ -13,6 +13,7 @@
 
 import pyutilib.th as unittest
 from pyomo.environ import *
+from pyomo.network import Port, Arc
 from pyomo.dae import ContinuousSet, DerivativeVar
 from pyomo.mpec import Complementarity, complements
 from pyomo.gdp import Disjunct, Disjunction
@@ -176,6 +177,11 @@ class TestUnitsChecking(unittest.TestCase):
         m.cset = ContinuousSet(bounds=(0,1))
         m.svar = Var(m.cset, units=u.m)
         m.dvar = DerivativeVar(sVar=m.svar, units=u.m/u.s)
+        def rule(m):
+            return dict(source=m.prt1, destination=m.prt2)
+        m.prt1 = Port()
+        m.prt2 = Port()
+        m.arc = Arc(rule=rule)
 
         # complementarities do not work yet
         # The expression system removes the u.m since it is multiplied by zero.

--- a/pyomo/util/tests/test_check_units.py
+++ b/pyomo/util/tests/test_check_units.py
@@ -177,11 +177,15 @@ class TestUnitsChecking(unittest.TestCase):
         m.cset = ContinuousSet(bounds=(0,1))
         m.svar = Var(m.cset, units=u.m)
         m.dvar = DerivativeVar(sVar=m.svar, units=u.m/u.s)
-        def rule(m):
+        def prt1_rule(m):
+            return {'avar': m.dx}
+        def prt2_rule(m):
+            return {'avar': m.dy}
+        m.prt1 = Port(rule=prt1_rule)
+        m.prt2 = Port(rule=prt2_rule)
+        def arcrule(m):
             return dict(source=m.prt1, destination=m.prt2)
-        m.prt1 = Port()
-        m.prt2 = Port()
-        m.arc = Arc(rule=rule)
+        m.arc = Arc(rule=arcrule)
 
         # complementarities do not work yet
         # The expression system removes the u.m since it is multiplied by zero.

--- a/pyomo/util/tests/test_check_units.py
+++ b/pyomo/util/tests/test_check_units.py
@@ -13,7 +13,7 @@
 
 import pyutilib.th as unittest
 from pyomo.environ import *
-from pyomo.dae import ContinuousSet
+from pyomo.dae import ContinuousSet, DerivativeVar
 from pyomo.mpec import Complementarity, complements
 from pyomo.gdp import Disjunct, Disjunction
 from pyomo.core.base.units_container import (
@@ -174,6 +174,8 @@ class TestUnitsChecking(unittest.TestCase):
         m.extfn = ExternalFunction(python_callback_function, units=u.m/u.s, arg_units=[u.m, u.s])
         m.conext = Constraint(expr=m.extfn(m.dx, m.t) - m.vx==0)
         m.cset = ContinuousSet(bounds=(0,1))
+        m.svar = Var(m.cset, units=u.m)
+        m.dvar = DerivativeVar(sVar=m.svar, units=u.m/u.s)
 
         # complementarities do not work yet
         # The expression system removes the u.m since it is multiplied by zero.


### PR DESCRIPTION
## Fixes # .
- Add support for DerivativeVar, Ports, and Arcs.

## Summary/Motivation:


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
