### PR TITLE
Force DAT tabmodule regeneration if source is newer

### DIFF
--- a/pyomo/dataportal/tests/test_dat_parser.py
+++ b/pyomo/dataportal/tests/test_dat_parser.py
@@ -1,0 +1,34 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+
+import os
+import time
+
+import pyutilib.th as unittest
+
+import pyomo.dataportal.parse_datacmds as parser
+
+class TestDatParser(unittest.TestCase):
+    def test_update_parsetable(self):
+        parser.parse_data_commands('')
+        self.assertIsNotNone(parser.dat_yaccer)
+        _tabfile = parser.dat_yaccer_tabfile
+        mtime = os.path.getmtime(_tabfile)
+        if _tabfile[-1] == 'c':
+            _tabfile = _tabfile[:-1]
+        time.sleep(0.01)
+        with open(parser.__file__, 'a'):
+            os.utime(parser.__file__, None)
+        parser.dat_lexer = None
+        parser.dat_yaccer = None
+        parser.parse_data_commands('')
+        self.assertIsNotNone(parser.dat_yaccer)
+        self.assertLess(mtime, os.path.getmtime(_tabfile))


### PR DESCRIPTION
## Fixes #1396

## Summary/Motivation:
#1396 reported a case where PLY's automated mechansims for detecting when the parse table needs to be regenerated failed.  This PR adds a check that if the PLY parser definition file is newer than the parse table file, it forces a table regeneration.  This PR includes a test of this functionality.

## Changes proposed in this PR:
- Regenerate `parse_table_datacmds.py` when it is older than `parse_datacmds.py`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
