### PR TITLE
Deprecrate pyomo install-extras

### DIFF
--- a/pyomo/scripting/plugins/extras.py
+++ b/pyomo/scripting/plugins/extras.py
@@ -33,8 +33,7 @@ def get_packages():
     return packages
 
 @deprecated(
-        "Use of the pyomo install-extras is deprecated. There are known bugs, "
-        "and we do not recommend the use of this code. "
+        "Use of the pyomo install-extras is deprecated."
         "The current recommended course of action is to manually install "
         "optional dependencies as needed.",
         version='TBD')

--- a/pyomo/scripting/plugins/extras.py
+++ b/pyomo/scripting/plugins/extras.py
@@ -34,7 +34,9 @@ def get_packages():
 
 @deprecated(
         "Use of the pyomo install-extras is deprecated. There are known bugs, "
-        "and we do not recommend the use of this code. ",
+        "and we do not recommend the use of this code. "
+        "The current recommended course of action is to manually install "
+        "optional dependencies as needed.",
         version='TBD')
 def install_extras(args=[], quiet=False):
     #

--- a/pyomo/scripting/plugins/extras.py
+++ b/pyomo/scripting/plugins/extras.py
@@ -11,6 +11,8 @@
 import six
 from pyomo.scripting.pyomo_parser import add_subparser, CustomHelpFormatter
 
+from pyomo.common.deprecation import deprecated
+
 def get_packages():
     packages = [
         'sympy', 
@@ -30,6 +32,10 @@ def get_packages():
         packages.append(('pyro','Pyro'))
     return packages
 
+@deprecated(
+        "Use of the pyomo install-extras is deprecated. There are known bugs, "
+        "and we do not recommend the use of this code. ",
+        version='TBD')
 def install_extras(args=[], quiet=False):
     #
     # Verify that pip is installed


### PR DESCRIPTION
## Fixes #435 , #1482 

## Summary/Motivation:
There have been issues with the `install-extras` subcommand for two years. This PR adds the deprecation message.

## Changes proposed in this PR:
- Deprecate `pyomo install-extras`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
