### PR TITLE
Setting version number for new deprecation warnings

### DIFF
--- a/pyomo/contrib/preprocessing/plugins/constraint_tightener.py
+++ b/pyomo/contrib/preprocessing/plugins/constraint_tightener.py
@@ -27,7 +27,7 @@ class TightenContraintFromVars(IsomorphicTransformation):
         "Use of the constraint tightener transformation is deprecated. "
         "Its functionality may be partially replicated using "
         "`pyomo.contrib.fbbt.compute_bounds_on_expr(constraint.body)`.",
-        version='TBD', remove_in='TBD')
+        version='5.7')
     def __init__(self):
         super(TightenContraintFromVars, self).__init__()
 

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -471,7 +471,7 @@ class Component(_ComponentBase):
         return self._ctype
 
     @deprecated("Component.type() method has been replaced by the "
-                ".ctype property.", version='TBD')
+                ".ctype property.", version='5.7')
     def type(self):
         """Return the class type for this component"""
         return self.ctype
@@ -781,7 +781,7 @@ class ComponentData(_ComponentBase):
         return _parent._ctype
 
     @deprecated("Component.type() method has been replaced by the "
-                ".ctype property.", version='TBD')
+                ".ctype property.", version='5.7')
     def type(self):
         """Return the class type for this component"""
         return self.ctype

--- a/pyomo/core/base/rangeset.py
+++ b/pyomo/core/base/rangeset.py
@@ -16,4 +16,4 @@ from pyomo.common.deprecation import deprecation_warning
 deprecation_warning(
     'The pyomo.core.base.rangeset module is deprecated.  '
     'Import RangeSet objects from pyomo.core.base.set or pyomo.core.',
-    version='TBD')
+    version='5.7')

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -191,7 +191,7 @@ def process_setarg(arg):
 @deprecated('The set_options decorator is deprecated; create Sets from '
             'functions explicitly by passing the function to the Set '
             'constructor using the "initialize=" keyword argument.',
-            version='TBD')
+            version='5.7')
 def set_options(**kwds):
     """
     This is a decorator for set initializer functions.  This
@@ -476,7 +476,7 @@ class _SetData(_SetDataBase):
             if isinstance(value, _SetData):
                 deprecation_warning(
                     "Testing for set subsets with 'a in b' is deprecated.  "
-                    "Use 'a.issubset(b)'.", version='TBD')
+                    "Use 'a.issubset(b)'.", version='5.7')
                 return value.issubset(self)
             else:
                 return False
@@ -803,7 +803,7 @@ class _SetData(_SetDataBase):
         return (interval.start, interval.end, interval.step)
 
     @property
-    @deprecated("The 'virtual' attribute is no longer supported", version='TBD')
+    @deprecated("The 'virtual' attribute is no longer supported", version='5.7')
     def virtual(self):
         return isinstance(self, (_AnySet, SetOperator, _InfiniteRangeSetData))
 
@@ -816,7 +816,7 @@ class _SetData(_SetDataBase):
 
     @property
     @deprecated("The 'concrete' attribute is no longer supported.  "
-                "Use isdiscrete() or isfinite()", version='TBD')
+                "Use isdiscrete() or isfinite()", version='5.7')
     def concrete(self):
         return self.isfinite()
 
@@ -829,18 +829,18 @@ class _SetData(_SetDataBase):
 
     @property
     @deprecated("The 'ordered' attribute is no longer supported.  "
-                "Use isordered()", version='TBD')
+                "Use isordered()", version='5.7')
     def ordered(self):
         return self.isordered()
 
     @property
     @deprecated("'filter' is no longer a public attribute.",
-                version='TBD')
+                version='5.7')
     def filter(self):
         return None
 
     @deprecated("check_values() is deprecated: Sets only contain valid members",
-                version='TBD')
+                version='5.7')
     def check_values(self):
         """
         Verify that the values in this set are valid.
@@ -1158,14 +1158,14 @@ class _FiniteSetMixin(object):
 
     @property
     @deprecated("The 'value' attribute is deprecated.  Use .data() to "
-                "retrieve the values in a finite set.", version='TBD')
+                "retrieve the values in a finite set.", version='5.7')
     def value(self):
         return set(self)
 
     @property
     @deprecated("The 'value_list' attribute is deprecated.  Use "
                 ".ordered_data() to retrieve the values from a finite set "
-                "in a deterministic order.", version='TBD')
+                "in a deterministic order.", version='5.7')
     def value_list(self):
         return list(self.ordered_data())
 
@@ -1285,7 +1285,7 @@ class _FiniteSetData(_FiniteSetMixin, _SetData):
 
     @property
     @deprecated("'filter' is no longer a public attribute.",
-                version='TBD')
+                version='5.7')
     def filter(self):
         return self._filter
 
@@ -1950,7 +1950,7 @@ class Set(IndexedComponent):
 
 
     @deprecated("check_values() is deprecated: Sets only contain valid members",
-                version='TBD')
+                version='5.7')
     def check_values(self):
         """
         Verify that the values in this set are valid.
@@ -2927,7 +2927,7 @@ class SetOperator(_SetData, Set):
             deprecation_warning(
                 "Providing construction data to SetOperator objects is "
                 "deprecated.  This data is ignored and in a future version "
-                "will not be allowed", version='TBD')
+                "will not be allowed", version='5.7')
             fail = len(data) > 1 or None not in data
             if not fail:
                 _data = data[None]
@@ -3043,7 +3043,7 @@ class SetOperator(_SetData, Set):
     @property
     @deprecated("SetProduct.set_tuple is deprecated.  "
                 "Use SetProduct.subsets() to get the operator arguments.",
-                version='TBD')
+                version='5.7')
     def set_tuple(self):
         # Despite its name, in the old SetProduct, set_tuple held a list
         return list(self.subsets())
@@ -3856,7 +3856,7 @@ class _AnyWithNoneSet(_AnySet):
     # the class because we will always create a global instance for
     # backwards compatability with the Book.
     @deprecated("The AnyWithNone set is deprecated.  "
-                "Use Any, which includes None", version='TBD')
+                "Use Any, which includes None", version='5.7')
     def get(self, val, default=None):
         return super(_AnyWithNoneSet, self).get(val, default)
 
@@ -4108,14 +4108,14 @@ BooleanSet = Boolean.__class__
 
 class RealInterval(RealSet):
     @deprecated("RealInterval has been deprecated.  Please use "
-                "RangeSet(lower, upper, 0)", version='TBD')
+                "RangeSet(lower, upper, 0)", version='5.7')
     def __new__(cls, **kwds):
         kwds.setdefault('class_name', 'RealInterval')
         return super(RealInterval, cls).__new__(RealSet, **kwds)
 
 class IntegerInterval(IntegerSet):
     @deprecated("IntegerInterval has been deprecated.  Please use "
-                "RangeSet(lower, upper, 1)", version='TBD')
+                "RangeSet(lower, upper, 1)", version='5.7')
     def __new__(cls, **kwds):
         kwds.setdefault('class_name', 'IntegerInterval')
         return super(IntegerInterval, cls).__new__(IntegerSet, **kwds)

--- a/pyomo/core/base/sets.py
+++ b/pyomo/core/base/sets.py
@@ -23,4 +23,4 @@ from pyomo.common.deprecation import deprecation_warning
 deprecation_warning(
     'The pyomo.core.base.sets module is deprecated.  '
     'Import Set objects from pyomo.core.base.set or pyomo.core.',
-    version='TBD')
+    version='5.7')

--- a/pyomo/core/base/template_expr.py
+++ b/pyomo/core/base/template_expr.py
@@ -16,4 +16,4 @@ from pyomo.common.deprecation import deprecation_warning
 deprecation_warning(
     'The pyomo.core.base.template_expr module is deprecated.  '
     'Import expression template objects from pyomo.core.expr.template_expr.',
-    version='TBD')
+    version='5.7')

--- a/pyomo/core/plugins/transform/discrete_vars.py
+++ b/pyomo/core/plugins/transform/discrete_vars.py
@@ -90,7 +90,7 @@ class RelaxDiscreteVars(RelaxIntegerVars):
 
     @deprecated(
         "core.relax_discrete is deprecated.  Use core.relax_integer_vars",
-        version='TBD')
+        version='5.7')
     def __init__(self, **kwds):
         super(RelaxDiscreteVars, self).__init__(**kwds)
 
@@ -135,6 +135,6 @@ class FixIntegerVars(Transformation):
 class FixDiscreteVars(FixIntegerVars):
     @deprecated(
         "core.fix_discrete is deprecated.  Use core.fix_integer_vars",
-        version='TBD')
+        version='5.7')
     def __init__(self, **kwds):
         super(FixDiscreteVars, self).__init__(**kwds)

--- a/pyomo/core/plugins/transform/relax_integrality.py
+++ b/pyomo/core/plugins/transform/relax_integrality.py
@@ -24,6 +24,6 @@ class RelaxIntegrality(RelaxIntegerVars):
 
     @deprecated(
         "core.relax_integrality is deprecated.  Use core.relax_integer_vars",
-        version='TBD')
+        version='5.7')
     def __init__(self, **kwds):
         super(RelaxIntegrality, self).__init__(**kwds)

--- a/pyomo/gdp/plugins/chull.py
+++ b/pyomo/gdp/plugins/chull.py
@@ -2,6 +2,6 @@ from pyomo.common.deprecation import deprecation_warning
 deprecation_warning(
     'The pyomo.gdp.plugins.chull module is deprecated.  '
     'Import the Hull reformulation objects from pyomo.gdp.plugins.hull.',
-    version='TBD')
+    version='5.7')
 
 from .hull import _Deprecated_Name_Hull as ConvexHull_Transformation

--- a/pyomo/gdp/plugins/gdp_var_mover.py
+++ b/pyomo/gdp/plugins/gdp_var_mover.py
@@ -43,7 +43,7 @@ class HACK_GDP_Disjunct_Reclassifier(Transformation):
                 "Validation that the model has been completely transformed "
                 "to an algebraic model has been moved to the "
                 "check_model_algebraic function in gdp.util.",
-                version='TBD')
+                version='5.7')
     def _apply_to(self, instance, **kwds):
         assert not kwds  # no keywords expected to the transformation
         disjunct_generator = instance.component_objects(

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -1034,6 +1034,6 @@ class Hull_Reformulation(Transformation):
 class _Deprecated_Name_Hull(Hull_Reformulation):
     @deprecated("The 'gdp.chull' name is deprecated. Please use the more apt 'gdp.hull' instead.",
                 logger='pyomo.gdp',
-                version="TBD", remove_in="TBD")
+                version="5.7")
     def __init__(self):
         super(_Deprecated_Name_Hull, self).__init__()


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Setting the version number for all deprecationwarnings added to the 5.7 release.

## Changes proposed in this PR:
- replacing version='TBD' with '5.7'

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
