### PR TITLE
Defer the check for z3 availability

### DIFF
--- a/pyomo/contrib/gdpopt/tests/test_LBB.py
+++ b/pyomo/contrib/gdpopt/tests/test_LBB.py
@@ -6,7 +6,7 @@ from os.path import abspath, dirname, join, normpath
 import pyutilib.th as unittest
 from pyutilib.misc import import_file
 
-from pyomo.contrib.satsolver.satsolver import _z3_available
+from pyomo.contrib.satsolver.satsolver import z3_available
 from pyomo.environ import SolverFactory, value, ConcreteModel, Var, Objective, maximize
 from pyomo.gdp import Disjunction
 from pyomo.opt import TerminationCondition
@@ -136,7 +136,7 @@ class TestGDPopt_LBB(unittest.TestCase):
 
 
 @unittest.skipUnless(solver_available, "Required subsolver %s is not available" % (minlp_solver,))
-@unittest.skipUnless(_z3_available, "Z3 SAT solver is not available.")
+@unittest.skipUnless(z3_available, "Z3 SAT solver is not available.")
 class TestGDPopt_LBB_Z3(unittest.TestCase):
     """Tests for logic-based branch and bound with Z3 SAT solver integration."""
 

--- a/pyomo/contrib/satsolver/satsolver.py
+++ b/pyomo/contrib/satsolver/satsolver.py
@@ -1,5 +1,6 @@
 import math 
 
+from pyomo.common.dependencies import attempt_import
 from pyomo.core import value, SymbolMap, NumericLabeler, Var, Constraint
 from pyomo.core.expr.logical_expr import (
     EqualityExpression,
@@ -24,11 +25,7 @@ from pyomo.core.expr.visitor import (
 )
 from pyomo.gdp import Disjunction
 
-_z3_available = True
-try:
-    import z3
-except ImportError:
-    _z3_available = False
+z3, z3_available = attempt_import('z3')
 
 
 def satisfiable(model, logger=None):

--- a/pyomo/contrib/satsolver/test_satsolver.py
+++ b/pyomo/contrib/satsolver/test_satsolver.py
@@ -3,7 +3,7 @@ from os.path import abspath, dirname, join, normpath
 import pyutilib.th as unittest
 from pyutilib.misc import import_file
 
-from pyomo.contrib.satsolver.satsolver import satisfiable, _z3_available
+from pyomo.contrib.satsolver.satsolver import satisfiable, z3_available
 from pyomo.core.base.set_types import PositiveIntegers, NonNegativeReals, Binary
 from pyomo.environ import (
     ConcreteModel, Var, Constraint, Objective, sin, cos, tan, asin, acos, atan, sqrt, log,
@@ -14,7 +14,7 @@ currdir = dirname(abspath(__file__))
 exdir = normpath(join(currdir, '..', '..', '..', 'examples', 'gdp'))
 
 
-@unittest.skipUnless(_z3_available, "Z3 SAT solver is not available.")
+@unittest.skipUnless(z3_available, "Z3 SAT solver is not available.")
 class SatSolverTests(unittest.TestCase):
 
     def test_simple_sat_model(self):


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This defers the attempt to import Z3 in `contrib.satsolver.satsolver` until either the interface needs to use Z3 or a ckient checks `z3_available`.  This reduces the import time for `pyomo.environ` on platforms with Z3 by ~40%

## Changes proposed in this PR:
- Use `attempt_import` to manage the import of the z3 solver interface.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
