### PR TITLE
Resolve table formatting with unicode character data

### DIFF
--- a/pyomo/core/base/misc.py
+++ b/pyomo/core/base/misc.py
@@ -178,15 +178,15 @@ def sorted_robust(arg):
         return sorted(arg, key=_robust_sort_keyfcn())
 
 
-def _safe_to_str(obj):
+def _to_ustr(obj):
     if not isinstance(obj, string_types):
         try:
             obj = str(obj)
         except:
-            return "None"
+            return u"None"
     # If this is a Python 2.x string, then we want to decode it to a
     # proper unicode string so that len() counts embedded multibyte
-    # characters as a single codepoint (so the resulting tabulat
+    # characters as a single codepoint (so the resulting tabular
     # alignment is correct)
     if hasattr(obj, 'decode'):
         return obj.decode('utf-8')
@@ -204,12 +204,14 @@ def tabular_writer(ostream, prefix, data, header, row_generator):
       line of the table
     """
 
+    prefix = _to_ustr(prefix)
+
     _rows = {}
     #_header = ("Key","Initial Value","Lower Bound","Upper Bound",
     #           "Current Value","Fixed","Stale")
     # NB: _width is a list because we will change these values
     if header:
-        header = ('Key',) + tuple(_safe_to_str(x) for x in header)
+        header = (u"Key",) + tuple(_to_ustr(x) for x in header)
         _width = [len(x) for x in header]
     else:
         _width = None
@@ -223,13 +225,13 @@ def tabular_writer(ostream, prefix, data, header, row_generator):
 
         if isinstance(_rowSet, types.GeneratorType):
             _rows[_key] = [
-                ((_safe_to_str("" if i else _key),) if header else ()) +
-                tuple( _safe_to_str(x) for x in _r )
+                ((_to_ustr("" if i else _key),) if header else ()) +
+                tuple( _to_ustr(x) for x in _r )
                 for i,_r in enumerate(_rowSet) ]
         else:
             _rows[_key] = [
-                ((_safe_to_str(_key),) if header else ()) +
-                tuple( _safe_to_str(x) for x in _rowSet) ]
+                ((_to_ustr(_key),) if header else ()) +
+                tuple( _to_ustr(x) for x in _rowSet) ]
 
         for _row in _rows[_key]:
             if not _width:

--- a/pyomo/core/base/misc.py
+++ b/pyomo/core/base/misc.py
@@ -14,7 +14,7 @@ import logging
 import sys
 import types
 
-from six import itervalues
+from six import itervalues, string_types
 
 logger = logging.getLogger('pyomo.core')
 
@@ -179,6 +179,14 @@ def sorted_robust(arg):
 
 
 def _safe_to_str(obj):
+    if isinstance(obj, string_types):
+        # If this is a Python 2.x string, then we want to decode it to
+        # unicode so that len() counts embedded multibyte characters as
+        # a single codepoint (so the resulting tabulat alignment is
+        # correct)
+        if hasattr(obj, 'decode'):
+            return obj.decode('utf-8')
+        return obj
     try:
         return str(obj)
     except:
@@ -201,7 +209,7 @@ def tabular_writer(ostream, prefix, data, header, row_generator):
     #           "Current Value","Fixed","Stale")
     # NB: _width is a list because we will change these values
     if header:
-        header = ('Key',) + tuple(header)
+        header = ('Key',) + tuple(_safe_to_str(x) for x in header)
         _width = [len(x) for x in header]
     else:
         _width = None

--- a/pyomo/core/base/misc.py
+++ b/pyomo/core/base/misc.py
@@ -179,18 +179,18 @@ def sorted_robust(arg):
 
 
 def _safe_to_str(obj):
-    if isinstance(obj, string_types):
-        # If this is a Python 2.x string, then we want to decode it to
-        # unicode so that len() counts embedded multibyte characters as
-        # a single codepoint (so the resulting tabulat alignment is
-        # correct)
-        if hasattr(obj, 'decode'):
-            return obj.decode('utf-8')
-        return obj
-    try:
-        return str(obj)
-    except:
-        return "None"
+    if not isinstance(obj, string_types):
+        try:
+            obj = str(obj)
+        except:
+            return "None"
+    # If this is a Python 2.x string, then we want to decode it to a
+    # proper unicode string so that len() counts embedded multibyte
+    # characters as a single codepoint (so the resulting tabulat
+    # alignment is correct)
+    if hasattr(obj, 'decode'):
+        return obj.decode('utf-8')
+    return obj
 
 def tabular_writer(ostream, prefix, data, header, row_generator):
     """Output data in tabular form

--- a/pyomo/core/tests/unit/test_base_misc.py
+++ b/pyomo/core/tests/unit/test_base_misc.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*- 
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Unit Tests for pyomo.base.misc
+#
+from six import StringIO, iteritems
+
+import pyutilib.th as unittest
+
+from pyomo.core.base.misc import tabular_writer
+
+class TestTabularWriter(unittest.TestCase):
+    def test_unicode_table(self):
+        # Test that an embedded unicode character does not foul up the
+        # table alignment
+        os = StringIO()
+        data = {1: ("a", 1), (2,3): ("∧", 2)}
+        tabular_writer(os, "", iteritems(data), ["s", "val"], lambda k,v: v)
+        ref = u"""
+Key    : s : val
+     1 : a :   1
+(2, 3) : ∧ :   2
+"""
+        self.assertEqual(ref.strip(), os.getvalue().strip())
+
+if __name__ == "__main__":
+    unittest.main()
+    

--- a/pyomo/core/tests/unit/test_misc.py
+++ b/pyomo/core/tests/unit/test_misc.py
@@ -8,8 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 #
-# Unit Tests for pyomo.base.misc
-#
 
 import re
 import os
@@ -181,6 +179,7 @@ class TestComponent(unittest.TestCase):
         m.b.v = Var()
         m.c = Block()
         self.assertRaises(RuntimeError, m.b.v.getname, fully_qualified=True, relative_to=m.c)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
The `tabular_writer` does not produce aligned columns in Python 2.7 when provided unicode characters in the table data.  This updates the `tabular_writer` so that strings are properly converted to unicode if necessary so that the resulting tables are well-aligned.

This bug was identified by @qtothec as part of PR #1507.

## Changes proposed in this PR:
- Encode python 2.7 strings as unicode (UTF-8) before computing the string length so the resulting table is correctly formatted.
- Add a test to verify this behavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
