### PR TITLE
Fix solver options typo in parmest

### DIFF
--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -481,8 +481,8 @@ class Estimator(object):
 
                 solver = SolverFactory('ipopt')
                 if self.solver_options is not None:
-                    for key in sopts:
-                        solver.options[key] = sopts[key]
+                    for key in self.solver_options:
+                        solver.options[key] = self.solver_options[key]
 
                 if need_gap:
                     solve_result = solver.solve(self.ef_instance, tee = self.tee, load_solutions=False)

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -84,8 +84,13 @@ class parmest_object_Tester_RB(unittest.TestCase):
         def SSE(model, data):  
             expr = sum((data.y[i] - model.response_function[data.hour[i]])**2 for i in data.index)
             return expr
+
+        solver_options = {
+                'tol': 1e-8,
+                }
         
-        self.pest = parmest.Estimator(rooney_biegler_model, data, theta_names, SSE)
+        self.pest = parmest.Estimator(rooney_biegler_model, data, theta_names, SSE,
+                solver_options=solver_options)
 
     def test_theta_est(self):
         objval, thetavals = self.pest.theta_est()


### PR DESCRIPTION
## Fixes # .
An undefined reference was being used to set solver options in `_Q_opt` method in Parmest. 

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
