### PR TITLE
Basic step bugfixes: indicator_var references and improper basic steps with ConstraintDatas

### DIFF
--- a/pyomo/gdp/basic_step.py
+++ b/pyomo/gdp/basic_step.py
@@ -13,6 +13,8 @@ from six import iteritems
 from six.moves import xrange
 
 from pyomo.core import Block, ConstraintList, Set, Constraint
+from pyomo.core.base import Reference
+from pyomo.common.modeling import unique_component_name
 from pyomo.gdp.disjunct import Disjunct, Disjunction
 
 import logging
@@ -84,23 +86,38 @@ def apply_basic_step(disjunctions_or_constraints):
         # Copy in the constraints corresponding to the improper disjunctions
         ans.disjuncts[idx].improper_constraints = ConstraintList()
         for constr in constraints:
-            for indx in constr:
+            if constr.is_indexed():
+                for indx in constr:
+                    ans.disjuncts[idx].improper_constraints.add(
+                        (constr[indx].lower, constr[indx].body, constr[indx].upper)
+                    )
+                    constr[indx].deactivate()
+            # need this so that we can take an improper basic step with a
+            # ConstraintData
+            else:
                 ans.disjuncts[idx].improper_constraints.add(
-                    (constr[indx].lower, constr[indx].body, constr[indx].upper)
+                    (constr.lower, constr.body, constr.upper)
                 )
-                constr[indx].deactivate()
+                constr.deactivate()
 
     #
     # Link the new disjunct indicator_var's to the original
     # indicator_var's.  Since only one of the new
     #
+    NAME_BUFFER = {}
     ans.indicator_links = ConstraintList()
     for i in ans.DISJUNCTIONS:
         for j in xrange(len(disjunctions[i].disjuncts)):
+            orig_var = disjunctions[i].disjuncts[j].indicator_var
             ans.indicator_links.add(
-                disjunctions[i].disjuncts[j].indicator_var ==
+                orig_var ==
                 sum( ans.disjuncts[idx].indicator_var for idx in ans.INDEX
                      if (idx[i] if isinstance(idx, tuple) else idx) == j ))
+            # and throw on a Reference to original on the block
+            name_base = orig_var.getname(fully_qualified=True,
+                                         name_buffer=NAME_BUFFER)
+            ans.add_component(unique_component_name( ans, name_base),
+                              Reference(orig_var))
 
     # Form the new disjunction
     ans.disjunction = Disjunction(expr=[ans.disjuncts[i] for i in ans.INDEX])


### PR DESCRIPTION
## Fixes # NA

## Summary/Motivation:

 Fixes a couple bugs in GDP basic steps.

## Changes proposed in this PR:
- Fixes a bug introduced by #1502: Since basic steps uses the indicator_vars of Disjuncts it deactivates when it creates the constraints linking the original indicator_vars to the new ones, it needs to add References to the original indicator_vars.
- Makes it possible to do an improper basic step with a `ConstraintData`
- Adds tests for both the above

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
