### PR TITLE
Add tee keyword to solve_consistent_initial_conditions

### DIFF
--- a/pyomo/dae/initialization.py
+++ b/pyomo/dae/initialization.py
@@ -87,7 +87,7 @@ def get_inconsistent_initial_conditions(model, time, tol=1e-8, t0=None,
     return list(inconsistent)
 
 
-def solve_consistent_initial_conditions(model, time, solver):
+def solve_consistent_initial_conditions(model, time, solver, tee=False):
     """
     Solves a model with all Constraints and Blocks deactivated except
     at the initial value of the Set time. Reactivates Constraints and
@@ -97,7 +97,7 @@ def solve_consistent_initial_conditions(model, time, solver):
         model: Model that will be solved
         time: Set whose initial conditions will remain active for solve
         solver: Something that implements a solve method that accepts
-                a model as an argument
+                a model and tee keyword as arguments
 
     Returns:
         The object returned by the solver's solve method
@@ -123,7 +123,7 @@ def solve_consistent_initial_conditions(model, time, solver):
     timelist = list(time)[1:]
     deactivated_dict = deactivate_model_at(model, time, timelist)
 
-    result = solver.solve(model)
+    result = solver.solve(model, tee=tee)
 
     for t in timelist:
         for comp in deactivated_dict[t]:


### PR DESCRIPTION
## Summary/Motivation:
Want to be able to set `tee` for the consistent initial condition solve from outside this function.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
