### PR TITLE
Baron: add 'WantDual=1' if a user specifies the 'rc' or 'dual' suffix

### DIFF
--- a/pyomo/solvers/plugins/solvers/BARON.py
+++ b/pyomo/solvers/plugins/solvers/BARON.py
@@ -251,6 +251,11 @@ class BARONSHELL(SystemCallSolver):
             else:
                 solver_options[key] = self.options[key]
 
+        for suffix in self._suffixes:
+            if re.match(suffix, 'dual') or re.match(suffix, 'rc'):
+                solver_options['WantDual'] = 1
+                break
+
         if 'solver_options' in kwds:
             raise ValueError("Baron solver options should be set "
                              "using the options object on this "

--- a/pyomo/solvers/tests/testcases.py
+++ b/pyomo/solvers/tests/testcases.py
@@ -269,76 +269,82 @@ ExpectedFailures['scip', 'nl', 'SOS1_simple'] = \
 #
 # BARON
 #
+#
+# The following were necessary before we started adding the 'WantDual'
+# option when a user explicitly defines a 'dual' or 'rc' suffix to
+# "force" Baron to run a local solve (if necessary) and always return
+# dual nformation.
+#
 
-# Known to fail through 18.11.15, but was resolved by 19.12.7
-ExpectedFailures['baron', 'bar', 'MILP_unbounded'] = (
-    lambda v: v <= (18,11,15),
-    ['dual'],
-    "Baron fails to report a MILP model as unbounded")
+# # Known to fail through 18.11.15, but was resolved by 19.12.7
+# ExpectedFailures['baron', 'bar', 'MILP_unbounded'] = (
+#     lambda v: v <= (18,11,15),
+#     ['dual'],
+#     "Baron fails to report a MILP model as unbounded")
 
-# Known to work through 18.11.15, and fail in 19.12.7
-MissingSuffixFailures['baron', 'bar', 'LP_piecewise'] = (
-    lambda v: v <= (15,0,0,0) or v > (18,11,15),
-    ['dual'],
-    "Baron will not return dual solution when a solution is "
-    "found during preprocessing.")
+# # Known to work through 18.11.15, and fail in 19.12.7
+# MissingSuffixFailures['baron', 'bar', 'LP_piecewise'] = (
+#     lambda v: v <= (15,0,0,0) or v > (18,11,15),
+#     ['dual'],
+#     "Baron will not return dual solution when a solution is "
+#     "found during preprocessing.")
 
-# Marking this test suffixes as fragile: Baron 20.4.14 will
-# intermittently return suffixes.
-MissingSuffixFailures['baron', 'bar', 'QP_simple'] = (
-    lambda v: v <= (15,2,0,0) or v > (18,11,15),
-    {'dual': (False, {}), 'rc': (False, {})},
-    "Baron will intermittently return dual solution when "
-    "a solution is found during preprocessing.")
+# # Marking this test suffixes as fragile: Baron 20.4.14 will
+# # intermittently return suffixes.
+# MissingSuffixFailures['baron', 'bar', 'QP_simple'] = (
+#     lambda v: v <= (15,2,0,0) or v > (18,11,15),
+#     {'dual': (False, {}), 'rc': (False, {})},
+#     "Baron will intermittently return dual solution when "
+#     "a solution is found during preprocessing.")
 
-# Known to fail through 17.4.1, but was resolved by 18.5.9
-MissingSuffixFailures['baron', 'bar', 'QCP_simple'] = (
-    lambda v: v <= (17,4,1) or v > (18,11,15),
-    ['dual','rc'],
-    "Baron will not return dual solution when a solution is "
-    "found during preprocessing.")
+# # Known to fail through 17.4.1, but was resolved by 18.5.9
+# MissingSuffixFailures['baron', 'bar', 'QCP_simple'] = (
+#     lambda v: v <= (17,4,1) or v > (18,11,15),
+#     ['dual','rc'],
+#     "Baron will not return dual solution when a solution is "
+#     "found during preprocessing.")
 
-# Known to work through 18.11.15, and fail in 19.12.7
-MissingSuffixFailures['baron', 'bar', 'LP_block'] = (
-    lambda v: v > (18,11,15),
-    ['dual'],
-    "Baron will not return dual solution when a solution is "
-    "found during preprocessing.")
+# # Known to work through 18.11.15, and fail in 19.12.7
+# MissingSuffixFailures['baron', 'bar', 'LP_block'] = (
+#     lambda v: v > (18,11,15),
+#     ['dual'],
+#     "Baron will not return dual solution when a solution is "
+#     "found during preprocessing.")
 
-# Known to work through 18.11.15, and fail in 19.12.7
-MissingSuffixFailures['baron', 'bar', 'LP_inactive_index'] = (
-    lambda v: v > (18,11,15),
-    ['dual'],
-    "Baron will not return dual solution when a solution is "
-    "found during preprocessing.")
+# # Known to work through 18.11.15, and fail in 19.12.7
+# MissingSuffixFailures['baron', 'bar', 'LP_inactive_index'] = (
+#     lambda v: v > (18,11,15),
+#     ['dual'],
+#     "Baron will not return dual solution when a solution is "
+#     "found during preprocessing.")
 
-# Known to work through 18.11.15, and fail in 19.12.7
-MissingSuffixFailures['baron', 'bar', 'LP_simple'] = (
-    lambda v: v > (18,11,15),
-    ['dual'],
-    "Baron will not return dual solution when a solution is "
-    "found during preprocessing.")
+# # Known to work through 18.11.15, and fail in 19.12.7
+# MissingSuffixFailures['baron', 'bar', 'LP_simple'] = (
+#     lambda v: v > (18,11,15),
+#     ['dual'],
+#     "Baron will not return dual solution when a solution is "
+#     "found during preprocessing.")
 
-# Known to work through 18.11.15, and fail in 19.12.7
-MissingSuffixFailures['baron', 'bar', 'LP_trivial_constraints'] = (
-    lambda v: v > (18,11,15),
-    ['dual'],
-    "Baron will not return dual solution when a solution is "
-    "found during preprocessing.")
+# # Known to work through 18.11.15, and fail in 19.12.7
+# MissingSuffixFailures['baron', 'bar', 'LP_trivial_constraints'] = (
+#     lambda v: v > (18,11,15),
+#     ['dual'],
+#     "Baron will not return dual solution when a solution is "
+#     "found during preprocessing.")
 
-# Known to work through 19.12.7, and fail in 20.4.14
-MissingSuffixFailures['baron', 'bar', 'LP_duals_minimize'] = (
-    lambda v: v > (19,12,7),
-    ['dual','rc'],
-    "Baron will not return dual solution when a solution is "
-    "found during preprocessing.")
+# # Known to work through 19.12.7, and fail in 20.4.14
+# MissingSuffixFailures['baron', 'bar', 'LP_duals_minimize'] = (
+#     lambda v: v > (19,12,7),
+#     ['dual','rc'],
+#     "Baron will not return dual solution when a solution is "
+#     "found during preprocessing.")
 
-# Known to work through 19.12.7, and fail in 20.4.14
-MissingSuffixFailures['baron', 'bar', 'LP_duals_maximize'] = (
-    lambda v: v > (19,12,7),
-    ['dual','rc'],
-    "Baron will not return dual solution when a solution is "
-    "found during preprocessing.")
+# # Known to work through 19.12.7, and fail in 20.4.14
+# MissingSuffixFailures['baron', 'bar', 'LP_duals_maximize'] = (
+#     lambda v: v > (19,12,7),
+#     ['dual','rc'],
+#     "Baron will not return dual solution when a solution is "
+#     "found during preprocessing.")
 
 
 


### PR DESCRIPTION
## Fixes #1537.

## Summary/Motivation:
By default, Baron will only report dual information if a KKT solve at the primal solution gives a point near the primal solution.  This causes Baron to be "inconsistent" as to when it will return dual information.  This PR adds the '`WantDual=1`' option to the Baron input any time a user specifies either the `dual` or `rc` Suffix, to trigger Baron to run a full local solve at the primal solution and always return dual information.

Thank you @ZedongPeng for digging up the existence of this solver option and bringing it to our attention!

## Changes proposed in this PR:
- Add the '`WantDual=1` Baron option any time a `rc` or `dual` suffix is declared on the model
- Update solver tests to indicate that we will expect Baron to return dual/rc information

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
