### PR TITLE
Fix retry codecov upload if codecov.sh script fails

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -427,7 +427,7 @@ jobs:
         while : ; do
             ((i+=1))
             echo "Uploading coverage to codecov (attempt ${i})"
-            bash $CODECOV -Z -X gcov -X s3 -f coverage.xml
+            bash $CODECOV -v -Z -X gcov -X s3 -f coverage.xml
             if test $? == 0; then
                 break
             elif test $i -ge 5; then

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -394,9 +394,9 @@ jobs:
     - name: Process code coverage report
       env:
         CODECOV_NAME: ${{matrix.TARGET}}/${{matrix.python}}${{matrix.NAME}}
-        CURL_HOME: ${{env.GITHUB_WORKSPACE}}
       run: |
         # Set up CURL options (for the codecov uploader)
+        export CURL_HOME="${GITHUB_WORKSPACE}"
         CURLRC="$(cat <<EOF
            retry = 0
            max-time = 30

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -94,7 +94,7 @@ jobs:
       id: download-cache
       with:
         path: cache/download
-        key: download-v3-${{runner.os}}
+        key: download-v4-${{runner.os}}
 
     - name: Configure curl
       run: |

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -213,10 +213,12 @@ jobs:
                 echo "IDAES Ipopt not available on OSX"
                 exit 0
             elif test "${{matrix.TARGET}}" == linux; then
-                curl --retry 8 -L $URL/idaes-solvers-ubuntu1804-64.tar.gz \
+                curl --max-time 150 --retry 8 \
+                    -L $URL/idaes-solvers-ubuntu1804-64.tar.gz \
                     > $IPOPT_TAR
             else
-                curl --retry 8 -L $URL/idaes-solvers-windows-64.tar.gz \
+                curl --max-time 150 --retry 8 \
+                    -L $URL/idaes-solvers-windows-64.tar.gz \
                     $URL/idaes-lib-windows-64.tar.gz > $IPOPT_TAR
             fi
         fi
@@ -309,7 +311,7 @@ jobs:
             mkdir -p "$INSTALL_DIR"
             INSTALLER="$INSTALL_DIR/gjh_asl_json.zip"
             URL="https://codeload.github.com/ghackebeil/gjh_asl_json/zip/master"
-            curl --retry 8 -L $URL > $INSTALLER
+            curl --max-time 150 --retry 8 -L $URL > $INSTALLER
             cd $INSTALL_DIR
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
@@ -398,9 +400,10 @@ jobs:
         coverage xml -i
         i=0
         set +e
+        CURLOPTS="--max-time 30 --retry 0"
         while : ; do
-            curl -L https://codecov.io/bash -o codecov.sh \
-                && bash codecov.sh -Z -X gcov -f coverage.xml
+            curl $CURLOPTS -L https://codecov.io/bash -o codecov.sh \
+                && bash codecov.sh -U "$CURLOPTS" -Z -X gcov -f coverage.xml
             if test $? == 0; then
                 break
             elif test $i -ge 5; then

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -427,7 +427,7 @@ jobs:
         while : ; do
             ((i+=1))
             echo "Uploading coverage to codecov (attempt ${i})"
-            bash $CODECOV -v -Z -X gcov -X s3 -f coverage.xml
+            bash $CODECOV -Z -X gcov -X s3 -f coverage.xml
             if test $? == 0; then
                 break
             elif test $i -ge 5; then

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -397,9 +397,10 @@ jobs:
         coverage report -i
         coverage xml -i
         i=0
+        set +e
         while : ; do
-            curl --retry 8 -L https://codecov.io/bash -o codecov.sh
-            bash codecov.sh -Z -X gcov -f coverage.xml
+            curl --retry 8 -L https://codecov.io/bash -o codecov.sh \
+                && bash codecov.sh -Z -X gcov -f coverage.xml
             if test $? == 0; then
                 break
             elif test $i -ge 4; then

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -96,6 +96,17 @@ jobs:
         path: cache/download
         key: download-v3-${{runner.os}}
 
+    - name: Configure curl
+      run: |
+        CURLRC="$(cat <<EOF
+           retry = 0
+           max-time = 30
+        EOF
+        )"
+        echo "$CURLRC" > ${GITHUB_WORKSPACE}/.curlrc
+        echo "$CURLRC" > ${GITHUB_WORKSPACE}/_curlrc
+        echo "::set-env name=CURL_HOME::$GITHUB_WORKSPACE"
+
     - name: Update OSX
       if: matrix.TARGET == 'osx'
       run: |
@@ -395,17 +406,6 @@ jobs:
       env:
         CODECOV_NAME: ${{matrix.TARGET}}/${{matrix.python}}${{matrix.NAME}}
       run: |
-        # Set up CURL options (for the codecov uploader)
-        export CURL_HOME="${GITHUB_WORKSPACE}"
-        CURLRC="$(cat <<EOF
-           retry = 0
-           max-time = 30
-        EOF
-        )"
-        echo "$CURLRC" > ${CURL_HOME}/.curlrc
-        echo "$CURLRC" > ${CURL_HOME}/_curlrc
-        #
-        # Process the report
         coverage combine
         coverage report -i
         coverage xml -i

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -412,9 +412,9 @@ jobs:
         set +e
         # Always attempt to update the codecov script, but fall back on
         # the previously cached script if it fails
-        CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh
+        CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh"
         for i in `seq 5`; do
-            echo "Downloading current codecov script (attempt $i)"
+            echo "Downloading current codecov script (attempt ${i})"
             curl -L https://codecov.io/bash -o $CODECOV
             if test $? == 0; then
                 break
@@ -426,7 +426,7 @@ jobs:
         i=0
         while : ; do
             ((i+=1))
-            echo "Uploading coverage to codecov (attempt $i)"
+            echo "Uploading coverage to codecov (attempt ${i})"
             bash $CODECOV -Z -X gcov -X s3 -f coverage.xml
             if test $? == 0; then
                 break

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -394,16 +394,26 @@ jobs:
     - name: Process code coverage report
       env:
         CODECOV_NAME: ${{matrix.TARGET}}/${{matrix.python}}${{matrix.NAME}}
+        CURL_HOME: ${{env.GITHUB_WORKSPACE}}
       run: |
+        # Set up CURL options (for the codecov uploader)
+        CURLRC="$(cat <<EOF
+           retry = 0
+           max-time = 30
+        EOF
+        )"
+        echo "$CURLRC" > ${CURL_HOME}/.curlrc
+        echo "$CURLRC" > ${CURL_HOME}/_curlrc
+        #
+        # Process the report
         coverage combine
         coverage report -i
         coverage xml -i
         i=0
         set +e
-        CURLOPTS="--max-time 30 --retry 0"
         while : ; do
-            curl $CURLOPTS -L https://codecov.io/bash -o codecov.sh \
-                && bash codecov.sh -U "$CURLOPTS" -Z -X gcov -f coverage.xml
+            curl -L https://codecov.io/bash -o codecov.sh \
+                && bash codecov.sh -Z -X gcov -f coverage.xml
             if test $? == 0; then
                 break
             elif test $i -ge 5; then

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -413,7 +413,7 @@ jobs:
         # Always attempt to update the codecov script, but fall back on
         # the previously cached script if it fails
         CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh"
-        for i in `seq 5`; do
+        for i in `seq 3`; do
             echo "Downloading current codecov script (attempt ${i})"
             curl -L https://codecov.io/bash -o $CODECOV
             if test $? == 0; then

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -409,11 +409,25 @@ jobs:
         coverage combine
         coverage report -i
         coverage xml -i
-        i=0
         set +e
+        # Always attempt to update the codecov script, but fall back on
+        # the previously cached script if it fails
+        CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh
+        for i in `seq 5`; do
+            echo "Downloading current codecov script (attempt $i)"
+            curl -L https://codecov.io/bash -o $CODECOV
+            if test $? == 0; then
+                break
+            fi
+            DELAY=$(( RANDOM % 30 + 30))
+            echo "Pausing $DELAY seconds before re-attempting download"
+            sleep $DELAY
+        done
+        i=0
         while : ; do
-            curl -L https://codecov.io/bash -o codecov.sh \
-                && bash codecov.sh -Z -X gcov -f coverage.xml
+            ((i+=1))
+            echo "Uploading coverage to codecov (attempt $i)"
+            bash $CODECOV -Z -X gcov -X s3 -f coverage.xml
             if test $? == 0; then
                 break
             elif test $i -ge 5; then

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -399,11 +399,11 @@ jobs:
         i=0
         set +e
         while : ; do
-            curl --retry 8 -L https://codecov.io/bash -o codecov.sh \
+            curl -L https://codecov.io/bash -o codecov.sh \
                 && bash codecov.sh -Z -X gcov -f coverage.xml
             if test $? == 0; then
                 break
-            elif test $i -ge 4; then
+            elif test $i -ge 5; then
                 exit 1
             fi
             DELAY=$(( RANDOM % 30 + 30))

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -426,7 +426,7 @@ jobs:
         while : ; do
             ((i+=1))
             echo "Uploading coverage to codecov (attempt ${i})"
-            bash $CODECOV -v -Z -X gcov -X s3 -f coverage.xml
+            bash $CODECOV -Z -X gcov -X s3 -f coverage.xml
             if test $? == 0; then
                 break
             elif test $i -ge 5; then

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -393,16 +393,26 @@ jobs:
     - name: Process code coverage report
       env:
         CODECOV_NAME: ${{matrix.TARGET}}/${{matrix.python}}${{matrix.NAME}}
+        CURL_HOME: ${{env.GITHUB_WORKSPACE}}
       run: |
+        # Set up CURL options (for the codecov uploader)
+        CURLRC="$(cat <<EOF
+           retry = 0
+           max-time = 30
+        EOF
+        )"
+        echo "$CURLRC" > ${CURL_HOME}/.curlrc
+        echo "$CURLRC" > ${CURL_HOME}/_curlrc
+        #
+        # Process the report
         coverage combine
         coverage report -i
         coverage xml -i
         i=0
         set +e
-        CURLOPTS="--max-time 30 --retry 0"
         while : ; do
-            curl $CURLOPTS -L https://codecov.io/bash -o codecov.sh \
-                && bash codecov.sh -U "$CURLOPTS" -Z -X gcov -f coverage.xml
+            curl -L https://codecov.io/bash -o codecov.sh \
+                && bash codecov.sh -Z -X gcov -f coverage.xml
             if test $? == 0; then
                 break
             elif test $i -ge 5; then

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -411,9 +411,9 @@ jobs:
         set +e
         # Always attempt to update the codecov script, but fall back on
         # the previously cached script if it fails
-        CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh
+        CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh"
         for i in `seq 5`; do
-            echo "Downloading current codecov script (attempt $i)"
+            echo "Downloading current codecov script (attempt ${i})"
             curl -L https://codecov.io/bash -o $CODECOV
             if test $? == 0; then
                 break
@@ -425,7 +425,7 @@ jobs:
         i=0
         while : ; do
             ((i+=1))
-            echo "Uploading coverage to codecov (attempt $i)"
+            echo "Uploading coverage to codecov (attempt ${i})"
             bash $CODECOV -Z -X gcov -X s3 -f coverage.xml
             if test $? == 0; then
                 break

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -398,11 +398,11 @@ jobs:
         i=0
         set +e
         while : ; do
-            curl --retry 8 -L https://codecov.io/bash -o codecov.sh \
+            curl -L https://codecov.io/bash -o codecov.sh \
                 && bash codecov.sh -Z -X gcov -f coverage.xml
             if test $? == 0; then
                 break
-            elif test $i -ge 4; then
+            elif test $i -ge 5; then
                 exit 1
             fi
             DELAY=$(( RANDOM % 30 + 30))

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -396,9 +396,10 @@ jobs:
         coverage report -i
         coverage xml -i
         i=0
+        set +e
         while : ; do
-            curl --retry 8 -L https://codecov.io/bash -o codecov.sh
-            bash codecov.sh -Z -X gcov -f coverage.xml
+            curl --retry 8 -L https://codecov.io/bash -o codecov.sh \
+                && bash codecov.sh -Z -X gcov -f coverage.xml
             if test $? == 0; then
                 break
             elif test $i -ge 4; then

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -212,10 +212,12 @@ jobs:
                 echo "IDAES Ipopt not available on OSX"
                 exit 0
             elif test "${{matrix.TARGET}}" == linux; then
-                curl --retry 8 -L $URL/idaes-solvers-ubuntu1804-64.tar.gz \
+                curl --max-time 150 --retry 8 \
+                    -L $URL/idaes-solvers-ubuntu1804-64.tar.gz \
                     > $IPOPT_TAR
             else
-                curl --retry 8 -L $URL/idaes-solvers-windows-64.tar.gz \
+                curl --max-time 150 --retry 8 \
+                    -L $URL/idaes-solvers-windows-64.tar.gz \
                     $URL/idaes-lib-windows-64.tar.gz > $IPOPT_TAR
             fi
         fi
@@ -308,7 +310,7 @@ jobs:
             mkdir -p "$INSTALL_DIR"
             INSTALLER="$INSTALL_DIR/gjh_asl_json.zip"
             URL="https://codeload.github.com/ghackebeil/gjh_asl_json/zip/master"
-            curl --retry 8 -L $URL > $INSTALLER
+            curl --max-time 150 --retry 8 -L $URL > $INSTALLER
             cd $INSTALL_DIR
             unzip -q $INSTALLER
             cd gjh_asl_json-master/Thirdparty
@@ -397,9 +399,10 @@ jobs:
         coverage xml -i
         i=0
         set +e
+        CURLOPTS="--max-time 30 --retry 0"
         while : ; do
-            curl -L https://codecov.io/bash -o codecov.sh \
-                && bash codecov.sh -Z -X gcov -f coverage.xml
+            curl $CURLOPTS -L https://codecov.io/bash -o codecov.sh \
+                && bash codecov.sh -U "$CURLOPTS" -Z -X gcov -f coverage.xml
             if test $? == 0; then
                 break
             elif test $i -ge 5; then

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -412,7 +412,7 @@ jobs:
         # Always attempt to update the codecov script, but fall back on
         # the previously cached script if it fails
         CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh"
-        for i in `seq 5`; do
+        for i in `seq 3`; do
             echo "Downloading current codecov script (attempt ${i})"
             curl -L https://codecov.io/bash -o $CODECOV
             if test $? == 0; then

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -408,11 +408,25 @@ jobs:
         coverage combine
         coverage report -i
         coverage xml -i
-        i=0
         set +e
+        # Always attempt to update the codecov script, but fall back on
+        # the previously cached script if it fails
+        CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh
+        for i in `seq 5`; do
+            echo "Downloading current codecov script (attempt $i)"
+            curl -L https://codecov.io/bash -o $CODECOV
+            if test $? == 0; then
+                break
+            fi
+            DELAY=$(( RANDOM % 30 + 30))
+            echo "Pausing $DELAY seconds before re-attempting download"
+            sleep $DELAY
+        done
+        i=0
         while : ; do
-            curl -L https://codecov.io/bash -o codecov.sh \
-                && bash codecov.sh -Z -X gcov -f coverage.xml
+            ((i+=1))
+            echo "Uploading coverage to codecov (attempt $i)"
+            bash $CODECOV -Z -X gcov -X s3 -f coverage.xml
             if test $? == 0; then
                 break
             elif test $i -ge 5; then

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -95,6 +95,17 @@ jobs:
         path: cache/download
         key: download-v3-${{runner.os}}
 
+    - name: Configure curl
+      run: |
+        CURLRC="$(cat <<EOF
+           retry = 0
+           max-time = 30
+        EOF
+        )"
+        echo "$CURLRC" > ${GITHUB_WORKSPACE}/.curlrc
+        echo "$CURLRC" > ${GITHUB_WORKSPACE}/_curlrc
+        echo "::set-env name=CURL_HOME::$GITHUB_WORKSPACE"
+
     - name: Update OSX
       if: matrix.TARGET == 'osx'
       run: |
@@ -394,17 +405,6 @@ jobs:
       env:
         CODECOV_NAME: ${{matrix.TARGET}}/${{matrix.python}}${{matrix.NAME}}
       run: |
-        # Set up CURL options (for the codecov uploader)
-        export CURL_HOME="${GITHUB_WORKSPACE}"
-        CURLRC="$(cat <<EOF
-           retry = 0
-           max-time = 30
-        EOF
-        )"
-        echo "$CURLRC" > ${CURL_HOME}/.curlrc
-        echo "$CURLRC" > ${CURL_HOME}/_curlrc
-        #
-        # Process the report
         coverage combine
         coverage report -i
         coverage xml -i

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -426,7 +426,7 @@ jobs:
         while : ; do
             ((i+=1))
             echo "Uploading coverage to codecov (attempt ${i})"
-            bash $CODECOV -Z -X gcov -X s3 -f coverage.xml
+            bash $CODECOV -v -Z -X gcov -X s3 -f coverage.xml
             if test $? == 0; then
                 break
             elif test $i -ge 5; then

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -393,9 +393,9 @@ jobs:
     - name: Process code coverage report
       env:
         CODECOV_NAME: ${{matrix.TARGET}}/${{matrix.python}}${{matrix.NAME}}
-        CURL_HOME: ${{env.GITHUB_WORKSPACE}}
       run: |
         # Set up CURL options (for the codecov uploader)
+        export CURL_HOME="${GITHUB_WORKSPACE}"
         CURLRC="$(cat <<EOF
            retry = 0
            max-time = 30

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -93,7 +93,7 @@ jobs:
       id: download-cache
       with:
         path: cache/download
-        key: download-v3-${{runner.os}}
+        key: download-v4-${{runner.os}}
 
     - name: Configure curl
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ after_success:
   - |
     i=0
     while : ; do
-        i=$[$i+1]
+        ((i+=1))
         echo "Uploading coverage to codecov (attempt $i)"
         ${DOC} codecov --env TAG -X gcov -X s3
         if test $? == 0; then


### PR DESCRIPTION
## Fixes #N/A .

## Summary/Motivation:
The GitHub Actions workflow was not actually retrying the upload if connections to the codecov servers failed.  The PR sets the "`set +e`" bash option prevents bash from immediately aborting so that we can process the script error code.

## Changes proposed in this PR:
- add `set +e` to the core of the codecov upload subroutine
- cleanly handle codecov.sh download failures as well

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
