### PR TITLE
OnlineDocs: remove some material from sparse sets that doesn't make sense here

### DIFF
--- a/doc/OnlineDocs/pyomo_modeling_components/Sets.rst
+++ b/doc/OnlineDocs/pyomo_modeling_components/Sets.rst
@@ -356,22 +356,10 @@ One may want to have a constraint that holds
    >>> for i in model.I, k in model.K, v in model.V[k] # doctest: +SKIP
 
 There are many ways to accomplish this, but one good way is to create a
-set of tuples composed of all of ``model.k, model.V[k]`` pairs.  This
+set of tuples composed of all ``model.k, model.V[k]`` pairs.  This
 can be done as follows:
 
 .. literalinclude:: ../script_spy_files/Spy4Sets_Define_constraint_tuples.spy
-   :language: python
-
-So then if there was a constraint defining rule such as
-
-.. doctest::
-
-   >>> def MyC_rule(model, i, k, v): # doctest: +SKIP
-   >>>    return ...                 # doctest: +SKIP
-
-Then a constraint could be declared using
-
-.. literalinclude:: ../script_spy_files/Spy4Sets_Define_another_constraint.spy
    :language: python
 
 Here is the first few lines of a model that illustrates this:


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

There was some text in the documentation for sparse sets that came from another source and did not make sense here.

## Changes proposed in this PR:
-  Remove a few  lines of text from the sparse index sets section.
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
