### PR TITLE
Resolve RTD documentation build warnings

### DIFF
--- a/doc/OnlineDocs/_static/theme_overrides.css
+++ b/doc/OnlineDocs/_static/theme_overrides.css
@@ -1,3 +1,46 @@
+/* links and fixed-with literals should NOT be bold */
+.rst-content code {
+    font-weight: normal !important;
+}
+
+/* internal reference links should be purple (not grey) */
+code.xref.py {
+    color: #8C1AFF;
+}
+
+/* Fix to RTD theme to allow table cell content to wrap */
+@media screen and (min-width: 767px) {
+  .wy-table-responsive table td {
+    white-space: normal !important;
+  }
+  .wy-table-responsive {
+    overflow: visible !important;
+  }
+}
+
+/* Remove space after tables in definition lists (e.g., for function
+   "Parameters" lists*/
+.rst-content dl div.wy-table-responsive {
+   margin-bottom: 12px !important;
+}
+
+/* Define a new "tight-table" class that we can use to format tighter
+   simple banded tables */
+.rst-content table.tight-table {
+   border-style: solid;
+   border-collapse: separate !important;
+}
+.rst-content table.tight-table td {
+   border-style: hidden !important;
+   padding-top: 4px !important;
+   padding-bottom: 4px !important;
+   padding-left: 8px !important;
+   padding-right: 8px !important;
+}
+
+
+/* OLD theme overrides
+
 code.docutils.literal{
     color:#8C1AFF;
     border: 0px;
@@ -15,3 +58,4 @@ code.docutils.literal{
     max-width: 100%;
     overflow: visible;
 }
+*/

--- a/doc/OnlineDocs/advanced_topics/pysp_rapper/bibliography.rst
+++ b/doc/OnlineDocs/advanced_topics/pysp_rapper/bibliography.rst
@@ -1,8 +1,0 @@
-Bibliography
-============
-
-.. [PyomoBookII] W. E. Hart, C. D. Laird, J.-P. Watson, D. L. Woodruff, G. A. Hackebeil, B. L. Nicholson, J. D. Siirola. Pyomo - Optimization Modeling in Python, 2nd Edition.  Springer Optimization and Its Applications, Vol 67.  Springer, 2017.
-
-.. [PyomoJournal] William E. Hart; Jean-Paul Watson; David L. Woodruff: "Pyomo: modeling and solving mathematical programs in Python," Mathematical Programming Computation, Volume 3, Number 3, August 2011
-
-.. [PySPJournal] Jean-Paul Watson; David L. Woodruff; William E. Hart: "Pyomo: modeling and solving mathematical programs in Python," Mathematical Programming Computation, Volume 4, Number 2, June 2012, Pages 109-142

--- a/doc/OnlineDocs/advanced_topics/pysp_rapper/index.rst
+++ b/doc/OnlineDocs/advanced_topics/pysp_rapper/index.rst
@@ -23,11 +23,3 @@ is somewhat orthogonal to the functionality provided by
    stochsolverapi.rst
    Abstractrapper.rst
    rap.rst
-   bibliography.rst
-
-Indices and Tables
-------------------
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`

--- a/doc/OnlineDocs/advanced_topics/pysp_rapper/stochsolverapi.rst
+++ b/doc/OnlineDocs/advanced_topics/pysp_rapper/stochsolverapi.rst
@@ -1,4 +1,4 @@
-.. rapperAPI_:
+.. _rapperAPI:
 
 rapper API
 ===============

--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -222,4 +222,9 @@ ipopt_available = bool(pyomo.opt.check_available_solvers('ipopt'))
 sipopt_available = bool(pyomo.opt.check_available_solvers('ipopt_sens'))
 baron_available = bool(pyomo.opt.check_available_solvers('baron'))
 glpk_available = bool(pyomo.opt.check_available_solvers('glpk'))
+try:
+    import gurobipy
+    gurobipy_available = True
+except ImportError:
+    gurobipy_available = False
 '''

--- a/doc/OnlineDocs/contributed_packages/mindtpy.rst
+++ b/doc/OnlineDocs/contributed_packages/mindtpy.rst
@@ -67,11 +67,13 @@ The LP/NLP algorithm in MindtPy is implemeted based on the LazyCallback function
 .. _Quesada & Grossmann: https://www.sciencedirect.com/science/article/abs/pii/0098135492800288
 
 
-.. Note::
+.. note::
 
-The single tree implementation currently only works with CPLEX.
-To use LazyCallback function of CPLEX from Pyomo, the `CPLEX Python API`_ is required.
-This means both IBM ILOG CPLEX Optimization Studio and the CPLEX-Python modules should be installed on your computer.
+   The single tree implementation currently only works with CPLEX.  To
+   use LazyCallback function of CPLEX from Pyomo, the `CPLEX Python
+   API`_ is required.  This means both IBM ILOG CPLEX Optimization
+   Studio and the CPLEX-Python modules should be installed on your
+   computer.
 
 
 .. _CPLEX Python API: https://www.ibm.com/support/knowledgecenter/SSSA5P_12.7.1/ilog.odms.cplex.help/CPLEX/GettingStarted/topics/set_up/Python_setup.html

--- a/doc/OnlineDocs/docutils.conf
+++ b/doc/OnlineDocs/docutils.conf
@@ -1,0 +1,2 @@
+[writers]
+table_style=colwidths-auto

--- a/doc/OnlineDocs/pyomo_overview/math_modeling.rst
+++ b/doc/OnlineDocs/pyomo_overview/math_modeling.rst
@@ -70,33 +70,30 @@ used by optimization software packages, and few formats are recognized
 by many optimizers.  Thus the application of multiple optimization
 solvers to analyze a model introduces additional complexities.
 
+
 Pyomo is an AML that extends Python to include objects for mathematical
 modeling. [PyomoBookI]_, [PyomoBookII]_, and [PyomoJournal]_ compare
 Pyomo with other AMLs.  Although many good AMLs have been developed for
 optimization models, the following are motivating factors for the
 development of Pyomo:
 
-Open Source
-***********
+- *Open Source*
 
     Pyomo is developed within Pyomo's open source project to promote
     transparency of the modeling framework and encourage community
     development of Pyomo capabilities.
 
-Customizable Capability
-***********************
+- *Customizable Capability*
  
     Pyomo supports a customizable capability through the extensive use
     of plug-ins to modularize software components.
 
-Solver Integration
-******************
+- *Solver Integration*
   
     Pyomo models can be optimized with solvers that are written either
     in Python or in compiled, low-level languages.
 
-Programming Language
-********************
+- *Programming Language*
   
     Pyomo leverages a high-level programming language, which has several
     advantages over custom AMLs: a very robust language, extensive

--- a/pyomo/contrib/parmest/graphics.py
+++ b/pyomo/contrib/parmest/graphics.py
@@ -222,7 +222,7 @@ def pairwise_plot(theta_values, theta_star=None, alpha=None, distributions=[],
         Statistical distribution used to define a confidence region, 
         options = 'MVN' for multivariate_normal, 'KDE' for gaussian_kde, and 
         'Rect' for rectangular.
-		Confidence interval is a 2D slice, using linear interpolation at theta*.
+        Confidence interval is a 2D slice, using linear interpolation at theta*.
     axis_limits: dict, optional
         Axis limits in the format {variable: [min, max]}
     title: string, optional

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1270,22 +1270,37 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         return None
 
     def component_map(self, ctype=None, active=None, sort=False):
-        """
-        Returns a PseudoMap of the components in this block.
+        """Returns a PseudoMap of the components in this block.
 
-            ctype
-                None            - All components
-                ComponentType   - A single ComponentType
-                Iterable        - Iterate to generate ComponentTypes
+        Parameters
+        ----------
+        ctype:  None or type or iterable
+            Specifies the component types (`ctypes`) to include in the
+            resulting PseudoMap
 
-            active is None, True, False
-                None  - All
-                True  - Active
-                False - Inactive
+                =============   ===================
+                None            All components
+                type            A single component type
+                iterable        All component types in the iterable
+                =============   ===================
 
-            sort is True, False
-                True - Maps to Block.alphabetizeComponentAndIndex
-                False - Maps to Block.declarationOrder
+        active: None or bool
+            Filter components by the active flag
+
+                =====  ===============================
+                None   Return all components
+                True   Return only active components
+                False  Return only inactive components
+                =====  ===============================
+
+        sort: bool
+            Iterate over the components in a sorted otder
+
+                =====  ================================================
+                True   Iterate using Block.alphabetizeComponentAndIndex
+                False  Iterate using Block.declarationOrder
+                =====  ================================================
+
         """
         return PseudoMap(self, ctype, active, sort)
 

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -549,15 +549,20 @@ class Component(_ComponentBase):
         return self.name
 
     def getname(self, fully_qualified=False, name_buffer=None, relative_to=None):
-        """
-        Returns the component name associated with this object.
+        """Returns the component name associated with this object.
 
-        Arguments:
-            fully_qualified     Generate full name from nested block names
-            name_buffer         Can be used to optimize iterative name
-                                    generation (using a dictionary)
-            relative_to         When generating a fully qualified name,
-                                    stop at this block.
+        Parameters
+        ----------
+        fully_qualified: bool
+            Generate full name from nested block names
+
+        name_buffer: dict
+            A dictionary that caches encountered names and indices.
+            Providing a ``name_buffer`` can significantly speed up
+            iterative name generation
+
+        relative_to: Block
+            Generate fully_qualified names reletive to the specified block.
         """
         if fully_qualified:
             pb = self.parent_block()

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -1758,6 +1758,7 @@ class Set(IndexedComponent):
 
     This class provides a Pyomo component that is API-compatible with
     Python `set` objects, with additional features, including:
+
         1. Member validation and filtering.  The user can declare
            domains and provide callback functions to validate set
            members and to filter (ignore) potential members.
@@ -1770,58 +1771,69 @@ class Set(IndexedComponent):
 
     Parameters
     ----------
-        name : str, optional
-            The name of the set
-        doc : str, optional
-            A text string describing this component
-        initialize : initializer(iterable), optional
-            The initial values to store in the Set when it is
-            constructed.  Values passed to `initialize` may be
-            overridden by `data` passed to the :py:meth:`construct`
-            method.
-        dimen : initializer(int), optional
-            Specify the Set's arity (the required tuple length for all
-            members of the Set), or None if no arity is enforced
-        ordered : bool or Set.InsertionOrder or Set.SortedOrder or function
-            Specifies whether the set is ordered. Possible values are:
-                False               Unordered
-                True                Ordered by insertion order
-                Set.InsertionOrder  Ordered by insertion order [default]
-                Set.SortedOrder     Ordered by sort order
-                <function>          Ordered with this comparison function
-        within : initialiser(set), optional
-            A set that defines the valid values that can be contained
-            in this set
-        domain : initializer(set), optional
-            A set that defines the valid values that can be contained
-            in this set
-        bounds : initializer(tuple), optional
-            A tuple that specifies the bounds for valid Set values
-            (accepts 1-, 2-, or 3-tuple RangeSet arguments)
-        filter : initializer(rule), optional
-            A rule for determining membership in this set. This has the
-            functional form:
+    name : str, optional
+        The name of the set
 
-                ``f: Block, *data -> bool``
+    doc : str, optional
+        A text string describing this component
 
-            and returns True if the data belongs in the set.  Set will
-            quietly ignore any values where `filter` returns False.
-        validate : initializer(rule), optional
-            A rule for validating membership in this set. This has the
-            functional form:
+    initialize : initializer(iterable), optional
+        The initial values to store in the Set when it is
+        constructed.  Values passed to ``initialize`` may be
+        overridden by ``data`` passed to the :py:meth:`construct`
+        method.
 
-                ``f: Block, *data -> bool``
+    dimen : initializer(int), optional
+        Specify the Set's arity (the required tuple length for all
+        members of the Set), or None if no arity is enforced
 
-            and returns True if the data belongs in the set.  Set will
-            raise a ``ValueError`` for any values where `validate`
-            returns False.
+    ordered : bool or Set.InsertionOrder or Set.SortedOrder or function
+        Specifies whether the set is ordered.
+        Possible values are:
+
+          ======================  =====================================
+          ``False``               Unordered
+          ``True``                Ordered by insertion order
+          ``Set.InsertionOrder``  Ordered by insertion order [default]
+          ``Set.SortedOrder``     Ordered by sort order
+          ``<function>``          Ordered with this comparison function
+          ======================  =====================================
+
+    within : initialiser(set), optional
+        A set that defines the valid values that can be contained
+        in this set
+    domain : initializer(set), optional
+        A set that defines the valid values that can be contained
+        in this set
+    bounds : initializer(tuple), optional
+        A tuple that specifies the bounds for valid Set values
+        (accepts 1-, 2-, or 3-tuple RangeSet arguments)
+    filter : initializer(rule), optional
+        A rule for determining membership in this set. This has the
+        functional form:
+
+            ``f: Block, *data -> bool``
+
+        and returns True if the data belongs in the set.  Set will
+        quietly ignore any values where `filter` returns False.
+    validate : initializer(rule), optional
+        A rule for validating membership in this set. This has the
+        functional form:
+
+            ``f: Block, *data -> bool``
+
+        and returns True if the data belongs in the set.  Set will
+        raise a ``ValueError`` for any values where `validate`
+        returns False.
 
     Notes
     -----
-        `domain`, `within`, and `bounds` all provide restrictions on the
-        valid set values.  If more than one is specified, Set values
-        will be restricted to the intersection of `domain`, `within`,
-        and `bounds`.
+      .. note::
+
+        ``domain=``, ``within=``, and ``bounds=`` all provide
+        restrictions on the valid set values.  If more than one is
+        specified, Set values will be restricted to the intersection of
+        ``domain``, ``within``, and ``bounds``.
 
     """
 
@@ -2520,17 +2532,41 @@ class RangeSet(Component):
     unbounded). Similarly, boutique ranges (like semi-continuous
     domains) can be represented, e.g.:
 
-    ..code:
-        RangeSet(ranges=(NumericRange(0,0,0), NumericRange(1,100,0)))
+    .. doctest::
+
+       >>> from pyomo.core.base.range import NumericRange
+       >>> from pyomo.environ import RangeSet
+       >>> print(RangeSet(ranges=(NumericRange(0,0,0), NumericRange(1,100,0))))
+       ([0] | [1..100])
 
     The `RangeSet` object continues to support the notation for
     specifying discrete ranges using "[first=1], last, [step=1]" values:
 
-    ..code:
-        RangeSet(3)          # [1, 2, 3]
-        RangeSet(2,5)        # [2, 3, 4, 5]
-        RangeSet(2,5,2)      # [2, 4]
-        RangeSet(2.5,4,0.5)  # [2.5, 3, 3.5, 4]
+    .. doctest::
+
+        >>> r = RangeSet(3)
+        >>> print(r)
+        [1:3]
+        >>> print(list(r))
+        [1, 2, 3]
+
+        >>> r = RangeSet(2, 5)
+        >>> print(r)
+        [2:5]
+        >>> print(list(r))
+        [2, 3, 4, 5]
+
+        >>> r = RangeSet(2, 5, 2)
+        >>> print(r)
+        [2:4:2]
+        >>> print(list(r))
+        [2, 4]
+
+        >>> r = RangeSet(2.5, 4, 0.5)
+        >>> print(r)
+        ([2.5] | [3.0] | [3.5] | [4.0])
+        >>> print(list(r))
+        [2.5, 3.0, 3.5, 4.0]
 
     By implementing RangeSet using NumericRanges, the global Sets (like
     `Reals`, `Integers`, `PositiveReals`, etc.) are trivial


### PR DESCRIPTION
## Fixes # N/A

## Summary/Motivation:
This PR resolves various documentation build warnings that have crept into the RTD documentation

## Changes proposed in this PR:
- resolve various documentation warnings
- clean up the local customization of the RTD theme
- switch table layout to by default defer to the browser for column widths
- add doctest of a gurobi_persistent example
- remove redundant bibliography in rapper documentation

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
