### PR TITLE
Fix Model.compute_statistics()

### DIFF
--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -602,11 +602,11 @@ use the AbstractModel or ConcreteModel class instead.""")
         self.statistics.number_of_constraints = 0
         self.statistics.number_of_objectives = 0
         for block in self.block_data_objects(active=active):
-            for data in self.component_map(Var, active=active).itervalues():
+            for data in block.component_map(Var, active=active).itervalues():
                 self.statistics.number_of_variables += len(data)
-            for data in self.component_map(Objective, active=active).itervalues():
+            for data in block.component_map(Objective, active=active).itervalues():
                 self.statistics.number_of_objectives += len(data)
-            for data in self.component_map(Constraint, active=active).itervalues():
+            for data in block.component_map(Constraint, active=active).itervalues():
                 self.statistics.number_of_constraints += len(data)
 
     def nvariables(self):

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -592,12 +592,10 @@ use the AbstractModel or ConcreteModel class instead.""")
         self.solutions = ModelSolutions(self)
         self.config.preprocessor = 'pyomo.model.simple_preprocessor'
 
-    def compute_statistics(self, recompute=True, active=True):
+    def compute_statistics(self, active=True):
         """
         Compute model statistics
         """
-        if not recompute and len(self.statistics) > 0:
-            return
         self.statistics.number_of_variables = 0
         self.statistics.number_of_constraints = 0
         self.statistics.number_of_objectives = 0

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -592,11 +592,11 @@ use the AbstractModel or ConcreteModel class instead.""")
         self.solutions = ModelSolutions(self)
         self.config.preprocessor = 'pyomo.model.simple_preprocessor'
 
-    def compute_statistics(self, active=True):
+    def compute_statistics(self, recompute=True, active=True):
         """
         Compute model statistics
         """
-        if len(self.statistics) > 0:
+        if not recompute and len(self.statistics) > 0:
             return
         self.statistics.number_of_variables = 0
         self.statistics.number_of_constraints = 0

--- a/pyomo/core/tests/unit/test_model.py
+++ b/pyomo/core/tests/unit/test_model.py
@@ -432,6 +432,26 @@ class Test(unittest.TestCase):
         self.assertEqual(model.nobjectives(), 4)
         self.assertEqual(model.nconstraints(), 4)
 
+    def test_stats4(self):
+        model = ConcreteModel()
+        model.x = Var([1])
+
+        model.B = Block()
+        model.B.x = Var([1, 2, 3])
+        model.B.o = ObjectiveList()
+        model.B.o.add(model.B.x[1])
+        model.B.c = ConstraintList()
+        model.B.c.add(model.B.x[1] == 0)
+        model.B.c.add(model.B.x[2] == 0)
+        model.B.c.add(model.B.x[3] == 0)
+        self.assertEqual(model.nvariables(), 4)
+        self.assertEqual(model.nobjectives(), 1)
+        self.assertEqual(model.nconstraints(), 3)
+        model.clear()
+        self.assertEqual(model.nvariables(), 0)
+        self.assertEqual(model.nobjectives(), 0)
+        self.assertEqual(model.nconstraints(), 0)
+
     @unittest.skipIf(not 'glpk' in solvers, "glpk solver is not available")
     def test_solve_with_pickle(self):
         model = ConcreteModel()


### PR DESCRIPTION
## Fixes #1551 .

## Summary/Motivation:
compute_statistics should recompute the amount of variables, constraints and objectives when a Model changes. Models containing blocks should also calculate the amount of these statistics correctly. Currently compute_statistics never re-evaluates the statistics. When summing variables, constraints and objectives of blocks, only the amount on the Model is currently summed multiple times.

## Changes proposed in this PR:
- Add new test for a Model containing a Block.
- Fix component summation in compute_statistics.
- Add recompute argument to compute_statistics.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
