### PR TITLE
Cyipopt scaling

### DIFF
--- a/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
@@ -26,7 +26,6 @@ except ImportError:
                       ' https://github.com/matthias-k/cyipopt.git')
 import numpy as np
 from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP
-from pyomo.core.base import Suffix
 import six
 import sys
 import os

--- a/pyomo/contrib/pynumero/algorithms/solvers/pyomo_ext_cyipopt.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/pyomo_ext_cyipopt.py
@@ -281,7 +281,10 @@ class PyomoExternalCyIpoptProblem(CyIpoptProblemInterface):
 
     def g_ub(self):
         return self._gU.copy()
-    
+
+    def scaling_factors(self):
+        return None, None, None
+
     def objective(self, primals):
         self._set_primals_if_necessary(primals)
         return self._pyomo_nlp.evaluate_objective()

--- a/pyomo/contrib/pynumero/algorithms/solvers/pyomo_ext_cyipopt.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/pyomo_ext_cyipopt.py
@@ -82,7 +82,7 @@ class ExternalInputOutputModel(object):
     # ToDo: Hessians not yet handled
 
 class PyomoExternalCyIpoptProblem(CyIpoptProblemInterface):
-    def __init__(self, pyomo_model, ex_input_output_model, inputs, outputs):
+    def __init__(self, pyomo_model, ex_input_output_model, inputs, outputs, outputs_eqn_scaling=None):
         """
         Create an instance of this class to pass as a problem to CyIpopt.
 
@@ -105,6 +105,11 @@ class PyomoExternalCyIpoptProblem(CyIpoptProblemInterface):
           The Pyomo model needs to have variables to represent the outputs from the
           external model. This is the list of those output variables in the order
           that corresponds to the numpy array returned from the evaluate_outputs call.
+
+        outputs_eqn_scaling : list or array-like or None
+          This sets the value of scaling parameters for the additional
+          output equations that are generated. No scaling is done if this
+          is set to None.
         """
         self._pyomo_model = pyomo_model
         self._ex_io_model = ex_input_output_model
@@ -191,6 +196,24 @@ class PyomoExternalCyIpoptProblem(CyIpoptProblemInterface):
         pyomo_nlp_con_ub = self._pyomo_nlp.constraints_ub()
         ex_con_ub = np.zeros(len(self._outputs), dtype=np.float64)
         self._gU = np.concatenate((pyomo_nlp_con_ub, ex_con_ub))
+
+        # create the scaling parameters if they are provided
+        have_scaling = False
+        self._obj_scaling = self._pyomo_nlp.get_obj_scaling()
+        self._primals_scaling = self._pyomo_nlp.get_primals_scaling()
+        pyomo_constraints_scaling = self._pyomo_nlp.get_constraints_scaling()
+        self._constraints_scaling = None
+        # check if we need constraint scaling, and if so, add in the
+        # outpts_eqn_scaling
+        if pyomo_constraints_scaling is not None or outputs_eqn_scaling is not None:
+            if pyomo_constraints_scaling is None:
+                pyomo_constraints_scaling = np.ones(self._pyomo_nlp.n_primals(), dtype=np.float64)
+            if outputs_eqn_scaling is None:
+                outputs_eqn_scaling = np.ones(len(self._outputs), dtype=np.float64)
+            if type(outputs_eqn_scaling) is list:
+                outputs_eqn_scaling = np.asarray(outputs_eqn_scaling, dtype=np.float64)
+            self._constraints_scaling = np.concatenate((pyomo_constraints_scaling,
+                                                       outputs_eqn_scaling))
 
         ### setup the jacobian structures
         self._jac_pyomo = self._pyomo_nlp.evaluate_jacobian()
@@ -283,7 +306,7 @@ class PyomoExternalCyIpoptProblem(CyIpoptProblemInterface):
         return self._gU.copy()
 
     def scaling_factors(self):
-        return None, None, None
+        return self._obj_scaling, self._primals_scaling, self._constraints_scaling
 
     def objective(self, primals):
         self._set_primals_if_necessary(primals)

--- a/pyomo/contrib/pynumero/algorithms/solvers/pyomo_ext_cyipopt.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/pyomo_ext_cyipopt.py
@@ -82,7 +82,8 @@ class ExternalInputOutputModel(object):
     # ToDo: Hessians not yet handled
 
 class PyomoExternalCyIpoptProblem(CyIpoptProblemInterface):
-    def __init__(self, pyomo_model, ex_input_output_model, inputs, outputs, outputs_eqn_scaling=None):
+    def __init__(self, pyomo_model, ex_input_output_model, inputs, outputs,
+                 outputs_eqn_scaling=None):
         """
         Create an instance of this class to pass as a problem to CyIpopt.
 
@@ -198,13 +199,12 @@ class PyomoExternalCyIpoptProblem(CyIpoptProblemInterface):
         self._gU = np.concatenate((pyomo_nlp_con_ub, ex_con_ub))
 
         # create the scaling parameters if they are provided
-        have_scaling = False
         self._obj_scaling = self._pyomo_nlp.get_obj_scaling()
         self._primals_scaling = self._pyomo_nlp.get_primals_scaling()
         pyomo_constraints_scaling = self._pyomo_nlp.get_constraints_scaling()
         self._constraints_scaling = None
         # check if we need constraint scaling, and if so, add in the
-        # outpts_eqn_scaling
+        # outputs_eqn_scaling
         if pyomo_constraints_scaling is not None or outputs_eqn_scaling is not None:
             if pyomo_constraints_scaling is None:
                 pyomo_constraints_scaling = np.ones(self._pyomo_nlp.n_primals(), dtype=np.float64)

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_cyipopt_interfaces.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_cyipopt_interfaces.py
@@ -29,7 +29,7 @@ try:
 except ImportError:
     raise unittest.SkipTest("Pynumero needs cyipopt to run CyIpoptSolver tests")
 
-from pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver import CyIpoptNLP, CyIpoptPyomoNLP
+from pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver import CyIpoptNLP
 
 
 def create_model1():
@@ -42,7 +42,7 @@ def create_model1():
     m.x[2].setlb(0.0)
     return m
 
-class TestCyIpoptNLPAndCyIpoptPyomoNLP(unittest.TestCase):
+class TestCyIpoptNLP(unittest.TestCase):
 
     def test_model1_CyIpoptNLP(self):
         model = create_model1()
@@ -50,13 +50,7 @@ class TestCyIpoptNLPAndCyIpoptPyomoNLP(unittest.TestCase):
         cynlp = CyIpoptNLP(nlp)
         self._check_model1(nlp, cynlp)
 
-    def test_model1_CyIpoptPyomoNLP(self):
-        model = create_model1()
-        nlp = PyomoNLP(model)
-        cynlp = CyIpoptPyomoNLP(nlp)
-        self._check_model1(nlp, cynlp)
-
-    def test_model1_CyIpoptPyomoNLP_scaling(self):
+    def test_model1_CyIpoptNLP_scaling(self):
         m = create_model1()
         m.scaling_factor = pyo.Suffix(direction=pyo.Suffix.EXPORT)
 
@@ -65,7 +59,7 @@ class TestCyIpoptNLPAndCyIpoptPyomoNLP(unittest.TestCase):
         m.scaling_factor[m.d] = 3.0  # scale the inequality constraint
         m.scaling_factor[m.x[1]] = 4.0  # scale one of the x variables
 
-        cynlp = CyIpoptPyomoNLP(PyomoNLP(m))
+        cynlp = CyIpoptNLP(PyomoNLP(m))
         obj_scaling, x_scaling, g_scaling = cynlp.scaling_factors()
         self.assertTrue(obj_scaling == 1e-6)
         self.assertTrue(len(x_scaling) == 3)
@@ -87,9 +81,9 @@ class TestCyIpoptNLPAndCyIpoptPyomoNLP(unittest.TestCase):
         m.scaling_factor[m.d] = 3.0  # scale the inequality constraint
         m.scaling_factor[m.x[1]] = 4.0  # scale the x variable
 
-        cynlp = CyIpoptPyomoNLP(PyomoNLP(m))
+        cynlp = CyIpoptNLP(PyomoNLP(m))
         obj_scaling, x_scaling, g_scaling = cynlp.scaling_factors()
-        self.assertTrue(obj_scaling == 1.0)
+        self.assertTrue(obj_scaling == None)
         self.assertTrue(len(x_scaling) == 3)
         # vars are in order x[2], x[3], x[1]
         self.assertTrue(x_scaling[0] == 1.0)
@@ -109,7 +103,7 @@ class TestCyIpoptNLPAndCyIpoptPyomoNLP(unittest.TestCase):
         m.scaling_factor[m.d] = 3.0  # scale the inequality constraint
         #m.scaling_factor[m.x] = 4.0  # scale the x variable
 
-        cynlp = CyIpoptPyomoNLP(PyomoNLP(m))
+        cynlp = CyIpoptNLP(PyomoNLP(m))
         obj_scaling, x_scaling, g_scaling = cynlp.scaling_factors()
         self.assertTrue(obj_scaling == 1e-6)
         self.assertTrue(len(x_scaling) == 3)
@@ -131,7 +125,7 @@ class TestCyIpoptNLPAndCyIpoptPyomoNLP(unittest.TestCase):
         m.scaling_factor[m.d] = 3.0  # scale the inequality constraint
         m.scaling_factor[m.x[1]] = 4.0  # scale the x variable
 
-        cynlp = CyIpoptPyomoNLP(PyomoNLP(m))
+        cynlp = CyIpoptNLP(PyomoNLP(m))
         obj_scaling, x_scaling, g_scaling = cynlp.scaling_factors()
         self.assertTrue(obj_scaling == 1e-6)
         self.assertTrue(len(x_scaling) == 3)
@@ -152,7 +146,7 @@ class TestCyIpoptNLPAndCyIpoptPyomoNLP(unittest.TestCase):
         #m.scaling_factor[m.d] = 3.0  # scale the inequality constraint
         #m.scaling_factor[m.x] = 4.0  # scale the x variable
 
-        cynlp = CyIpoptPyomoNLP(PyomoNLP(m))
+        cynlp = CyIpoptNLP(PyomoNLP(m))
         obj_scaling, x_scaling, g_scaling = cynlp.scaling_factors()
         self.assertTrue(obj_scaling is None)
         self.assertTrue(x_scaling is None)

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_cyipopt_interfaces.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_cyipopt_interfaces.py
@@ -34,7 +34,7 @@ from pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver import CyIpoptNLP
 
 def create_model1():
     m = pyo.ConcreteModel()
-    m.x = pyo.Var([1,2,3], initialize=4.0)
+    m.x = pyo.Var([1, 2, 3], initialize=4.0)
     m.d = pyo.Constraint(expr=m.x[1] + m.x[2] ** 2 <= 18.0)
     m.c = pyo.Constraint(expr=m.x[3] ** 2 + m.x[1] == 25)
     m.o = pyo.Objective(expr=m.x[1] ** 4 - 3 * m.x[1] * m.x[2] ** 3 + m.x[3] ** 2 - 8.0)

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_cyipopt_solver.py
@@ -10,6 +10,9 @@
 
 import pyutilib.th as unittest
 import pyomo.environ as pyo
+from pyutilib.misc import setup_redirect, reset_redirect
+from six import StringIO
+import os
 
 from pyomo.contrib.pynumero.dependencies import (
     numpy as np, numpy_available, scipy_sparse as spa, scipy_available
@@ -147,6 +150,42 @@ class TestCyIpoptSolver(unittest.TestCase):
         nlp.set_duals(y_sol)
         self.assertAlmostEqual(nlp.evaluate_objective(), -428.6362455416348, places=5)
         self.assertTrue(np.allclose(info['mult_g'], y_sol, rtol=1e-4))
+
+    def test_model1_with_scaling(self):
+        m = create_model1()
+        m.scaling_factor = pyo.Suffix(direction=pyo.Suffix.EXPORT)
+        m.scaling_factor[m.o] = 1e-6 # scale the objective
+        m.scaling_factor[m.c] = 2.0  # scale the equality constraint
+        m.scaling_factor[m.d] = 3.0  # scale the inequality constraint
+        m.scaling_factor[m.x[1]] = 4.0  # scale one of the x variables
+
+        cynlp = CyIpoptNLP(PyomoNLP(m))
+        options={'nlp_scaling_method': 'user-scaling',
+                 'output_file': '_cyipopt-scaling.log',
+                 'file_print_level':10,
+                 'max_iter': 0}
+        solver = CyIpoptSolver(cynlp, options=options)
+        x, info = solver.solve()
+
+        with open('_cyipopt-scaling.log', 'r') as fd:
+            solver_trace = fd.read()
+        os.remove('_cyipopt-scaling.log')
+
+        # check for the following strings in the log and then delete the log
+        self.assertIn('nlp_scaling_method = user-scaling', solver_trace)
+        self.assertIn('output_file = _cyipopt-scaling.log', solver_trace)
+        self.assertIn('objective scaling factor = 1e-06', solver_trace)
+        self.assertIn('x scaling provided', solver_trace)
+        self.assertIn('c scaling provided', solver_trace)
+        self.assertIn('d scaling provided', solver_trace)
+        self.assertIn('DenseVector "x scaling vector" with 3 elements:', solver_trace)
+        self.assertIn('x scaling vector[    1]= 1.0000000000000000e+00', solver_trace)
+        self.assertIn('x scaling vector[    2]= 1.0000000000000000e+00', solver_trace)
+        self.assertIn('x scaling vector[    3]= 4.0000000000000000e+00', solver_trace)
+        self.assertIn('DenseVector "c scaling vector" with 1 elements:', solver_trace)
+        self.assertIn('c scaling vector[    1]= 2.0000000000000000e+00', solver_trace)
+        self.assertIn('DenseVector "d scaling vector" with 1 elements:', solver_trace)
+        self.assertIn('d scaling vector[    1]= 3.0000000000000000e+00', solver_trace)
 
     def test_model2(self):
         model = create_model2()

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_cyipopt_solver.py
@@ -10,8 +10,6 @@
 
 import pyutilib.th as unittest
 import pyomo.environ as pyo
-from pyutilib.misc import setup_redirect, reset_redirect
-from six import StringIO
 import os
 
 from pyomo.contrib.pynumero.dependencies import (

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_pyomo_ext_cyipopt.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_pyomo_ext_cyipopt.py
@@ -8,6 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import os
 import pyutilib.th as unittest
 import pyomo.environ as pyo
 
@@ -105,6 +106,76 @@ class TestExternalInputOutputModel(unittest.TestCase):
         cyipopt_problem.load_x_into_pyomo(x)
         self.assertAlmostEqual(pyo.value(m.c1), 0.1, places=5)
         self.assertAlmostEqual(pyo.value(m.c2), 0.5, places=5)
+
+    def test_pyomo_external_model(self):
+        m = pyo.ConcreteModel()
+        m.Pin = pyo.Var(initialize=100, bounds=(0,None))
+        m.c1 = pyo.Var(initialize=1.0, bounds=(0,None))
+        m.c2 = pyo.Var(initialize=1.0, bounds=(0,None))
+        m.F = pyo.Var(initialize=10, bounds=(0,None))
+
+        m.P1 = pyo.Var()
+        m.P2 = pyo.Var()
+
+        m.F_con = pyo.Constraint(expr = m.F == 10)
+        m.Pin_con = pyo.Constraint(expr = m.Pin == 100)
+
+        # simple parameter estimation test
+        m.obj = pyo.Objective(expr= (m.P1 - 90)**2 + (m.P2 - 40)**2)
+
+        # set scaling parameters for the pyomo variables and constraints
+        m.scaling_factor = pyo.Suffix(direction=pyo.Suffix.EXPORT)
+        m.scaling_factor[m.obj] = 0.1 # scale the objective
+        m.scaling_factor[m.Pin] = 2.0 # scale the variable
+        m.scaling_factor[m.c1] = 3.0 # scale the variable
+        m.scaling_factor[m.c2] = 4.0 # scale the variable
+        m.scaling_factor[m.F] = 5.0 # scale the variable
+        m.scaling_factor[m.P1] = 6.0 # scale the variable
+        m.scaling_factor[m.P2] = 7.0 # scale the variable
+        m.scaling_factor[m.F_con] = 8.0 # scale the pyomo constraint
+        m.scaling_factor[m.Pin_con] = 9.0 # scale the pyomo constraint
+        
+        cyipopt_problem = \
+            PyomoExternalCyIpoptProblem(pyomo_model=m,
+                                        ex_input_output_model=PressureDropModel(),
+                                        inputs=[m.Pin, m.c1, m.c2, m.F],
+                                        outputs=[m.P1, m.P2],
+                                        outputs_eqn_scaling=[10.0, 11.0]
+                                        )
+
+        # solve the problem
+        options={'hessian_approximation':'limited-memory',
+                 'nlp_scaling_method': 'user-scaling',
+                 'output_file': '_cyipopt-pyomo-ext-scaling.log',
+                 'file_print_level':10,
+                 'max_iter': 0}
+        solver = CyIpoptSolver(cyipopt_problem, options=options)
+        x, info = solver.solve(tee=False)
+
+        with open('_cyipopt-pyomo-ext-scaling.log', 'r') as fd:
+            solver_trace = fd.read()
+        os.remove('_cyipopt-pyomo-ext-scaling.log')
+
+        self.assertIn('nlp_scaling_method = user-scaling', solver_trace)
+        self.assertIn('output_file = _cyipopt-pyomo-ext-scaling.log', solver_trace)
+        self.assertIn('objective scaling factor = 0.1', solver_trace)
+        self.assertIn('x scaling provided', solver_trace)
+        self.assertIn('c scaling provided', solver_trace)
+        self.assertIn('d scaling provided', solver_trace)
+        self.assertIn('DenseVector "x scaling vector" with 7 elements:', solver_trace)
+        self.assertIn('x scaling vector[    1]= 6.0000000000000000e+00', solver_trace)
+        self.assertIn('x scaling vector[    2]= 7.0000000000000000e+00', solver_trace)
+        self.assertIn('x scaling vector[    3]= 2.0000000000000000e+00', solver_trace)
+        self.assertIn('x scaling vector[    4]= 3.0000000000000000e+00', solver_trace)
+        self.assertIn('x scaling vector[    5]= 4.0000000000000000e+00', solver_trace)
+        self.assertIn('x scaling vector[    6]= 5.0000000000000000e+00', solver_trace)
+        self.assertIn('x scaling vector[    7]= 1.0000000000000000e+00', solver_trace)
+        self.assertIn('DenseVector "c scaling vector" with 5 elements:', solver_trace)
+        self.assertIn('c scaling vector[    1]= 8.0000000000000000e+00', solver_trace)
+        self.assertIn('c scaling vector[    2]= 9.0000000000000000e+00', solver_trace)
+        self.assertIn('c scaling vector[    3]= 1.0000000000000000e+00', solver_trace)
+        self.assertIn('c scaling vector[    4]= 1.0000000000000000e+01', solver_trace)
+        self.assertIn('c scaling vector[    5]= 1.1000000000000000e+01', solver_trace)
 
     def test_pyomo_external_model_dummy_var_initialization(self):
         m = pyo.ConcreteModel()

--- a/pyomo/contrib/pynumero/interfaces/ampl_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/ampl_nlp.py
@@ -424,6 +424,26 @@ class AslNLP(ExtendedNLP):
     def get_duals_ineq(self):
         return self._duals_ineq.copy()
 
+    # overloaded from NLP
+    def get_obj_scaling(self):
+        return None
+
+    # overloaded from NLP
+    def get_primals_scaling(self):
+        return None
+
+    # overloaded from NLP
+    def get_constraints_scaling(self):
+        return None
+
+    # overloaded from ExtendedNLP
+    def get_eq_constraints_scaling(self):
+        return None
+
+    # overloaded from ExtendedNLP
+    def get_ineq_constraints_scaling(self):
+        None
+
     def _evaluate_objective_and_cache_if_necessary(self):
         if not self._objective_is_cached:
             self._cached_objective = self._asl.eval_f(self._primals)

--- a/pyomo/contrib/pynumero/interfaces/ampl_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/ampl_nlp.py
@@ -428,21 +428,27 @@ class AslNLP(ExtendedNLP):
     def get_obj_scaling(self):
         return None
 
-    # overloaded from NLP
+    # overloaded from NLP - derived classes may implement
     def get_primals_scaling(self):
         return None
 
-    # overloaded from NLP
+    # overloaded from NLP - derived classes may implement
     def get_constraints_scaling(self):
         return None
 
     # overloaded from ExtendedNLP
     def get_eq_constraints_scaling(self):
+        constraints_scaling = self.get_constraints_scaling()
+        if constraints_scaling is not None:
+            return np.compress(self._con_full_eq_mask, constraints_scaling)
         return None
 
     # overloaded from ExtendedNLP
     def get_ineq_constraints_scaling(self):
-        None
+        constraints_scaling = self.get_constraints_scaling()
+        if constraints_scaling is not None:
+            return np.compress(self._con_full_ineq_mask, constraints_scaling)
+        return None
 
     def _evaluate_objective_and_cache_if_necessary(self):
         if not self._objective_is_cached:

--- a/pyomo/contrib/pynumero/interfaces/nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/nlp.py
@@ -231,6 +231,45 @@ class NLP(object):
         pass
 
     @abc.abstractmethod
+    def get_obj_scaling(self):
+        """ Return the desired scaling factor to use for the
+        for the objective function. None indicates no scaling.
+        This indicates potential scaling for the model, but the
+        evaluation methods should return *unscaled* values
+
+        Returns
+        -------
+        float or None
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_primals_scaling(self):
+        """ Return the desired scaling factors to use for the
+        for the primals. None indicates no scaling.
+        This indicates potential scaling for the model, but the
+        evaluation methods should return *unscaled* values
+
+        Returns
+        -------
+        array-like or None
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_constraints_scaling(self):
+        """ Return the desired scaling factors to use for the
+        for the constraints. None indicates no scaling.
+        This indicates potential scaling for the model, but the
+        evaluation methods should return *unscaled* values
+
+        Returns
+        -------
+        array-like or None
+        """
+        pass
+
+    @abc.abstractmethod
     def evaluate_objective(self):
         """Returns value of objective function evaluated at the 
         values given for the primal variables in set_primals
@@ -446,6 +485,32 @@ class ExtendedNLP(NLP):
         """Get a copy of the values of the dual variables of the inequality
         constraints as provided in set_duals_eq. These are the values
         that will be used in calls to the evaluation methods.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_eq_constraints_scaling(self):
+        """ Return the desired scaling factors to use for the
+        for the equality constraints. None indicates no scaling.
+        This indicates potential scaling for the model, but the
+        evaluation methods should return *unscaled* values
+
+        Returns
+        -------
+        array-like or None
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_ineq_constraints_scaling(self):
+        """ Return the desired scaling factors to use for the
+        for the inequality constraints. None indicates no scaling.
+        This indicates potential scaling for the model, but the
+        evaluation methods should return *unscaled* values
+
+        Returns
+        -------
+        array-like or None
         """
         pass
 

--- a/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
@@ -166,6 +166,37 @@ class PyomoNLP(AslNLP):
                 con_indices.append(con_id)
         return con_indices
 
+    # overloaded from NLP
+    def get_obj_scaling(self):
+        obj = self.get_pyomo_objective()
+        scaling_suffix = self._pyomo_model.component('scaling_factor')
+        if scaling_suffix and scaling_suffix.ctype is aml.Suffix and \
+           obj in scaling_suffix:
+            return scaling_suffix[obj]
+        return None
+
+    # overloaded from NLP
+    def get_primals_scaling(self):
+        scaling_suffix = self._pyomo_model.component('scaling_factor')
+        if scaling_suffix and scaling_suffix.ctype is aml.Suffix:
+            primals_scaling = np.ones(self.n_primals())
+            for i,v in enumerate(self.get_pyomo_variables()):
+                if v in scaling_suffix:
+                    primals_scaling[i] = scaling_suffix[v]
+            return primals_scaling
+        return None
+
+    # overloaded from NLP
+    def get_constraints_scaling(self):
+        scaling_suffix = self._pyomo_model.component('scaling_factor')
+        if scaling_suffix and scaling_suffix.ctype is aml.Suffix:
+            constraints_scaling = np.ones(self.n_constraints())
+            for i,c in enumerate(self.get_pyomo_constraints()):
+                if c in scaling_suffix:
+                    constraints_scaling[i] = scaling_suffix[c]
+            return constraints_scaling
+        return None
+
     def extract_subvector_grad_objective(self, pyomo_variables):
         """Compute the gradient of the objective and return the entries
         corresponding to the given Pyomo variables

--- a/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
@@ -51,6 +51,7 @@ class PyomoNLP(AslNLP):
                 raise NotImplementedError('The ASL interface and PyomoNLP in PyNumero currently only support single objective'
                                           ' problems. Deactivate any extra objectives you may have, or add a dummy objective'
                                           ' (f(x)=0) if you have a square problem.')
+            self._objective = objectives[0]
 
             # write the nl file for the Pyomo model and get the symbolMap
             fname, symbolMap = pyomo.opt.WriterFactory('nl')(pyomo_model, nl_file, lambda x:True, {})
@@ -81,6 +82,13 @@ class PyomoNLP(AslNLP):
         Return optimization model
         """
         return self._pyomo_model
+
+    def get_pyomo_objective(self):
+        """
+        Return an instance of the active objective function on the Pyomo model.
+        (there can be only one)
+        """
+        return self._objective
 
     def get_pyomo_variables(self):
         """


### PR DESCRIPTION
## Fixes # .
- Added scaling functionality to the CyIpopt interface
- Scaling was added to the pynumero nlp class hierarchy
- Scaling was also added to the PyomoExternalCyIpoptProblem class

## Summary/Motivation:
Scaling is often required on NLP problems, and this is also true when they have external models.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
