### PR TITLE
Remove Pyomo appdirs dependency

### DIFF
--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -24,6 +24,14 @@ else:
     PYOMO_CONFIG_DIR = os.path.abspath(
         os.path.join(os.environ.get('HOME', ''), '.pyomo'))
 
+# Note that alternative platform-independent implementation of the above
+# could be to use:
+#
+#   PYOMO_CONFIG_DIR = os.path.abspath(appdirs.user_data_dir('pyomo'))
+#
+# But would require re-adding the hard dependency on appdirs.  For now
+# (13 Jul 20), the above appears to be sufficiently robust.
+
 USER_OPTION = 0
 ADVANCED_OPTION = 1
 DEVELOPER_OPTION = 2

--- a/pyomo/core/base/config.py
+++ b/pyomo/core/base/config.py
@@ -1,4 +1,3 @@
-import appdirs
 import os
 import json
 

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,6 @@ def run_setup():
       python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       install_requires=[
           'PyUtilib>=6.0.1.dev0',
-          'appdirs',
           'enum34;python_version<"3.4"',
           'ply',
           'six>=1.4',


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Pyomo hasn't directly used appdirs since Jan 2019 (d1db9c5).  This PR removes `appdirs` from the delendency list and add a breadcrumb comment to the one place in Pyomo where we once used it.

## Changes proposed in this PR:
- Remove `appdirs` dependency

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
