### PR TITLE
Add `get_units` to Param API

### DIFF
--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -965,6 +965,10 @@ This has resulted in the conversion of the source to dense form.
                  ("Value",),
                  dataGen,
                  )
+    
+    def get_units(self):
+    """Return the units expression for this parameter"""
+    return self._units
 
 
 class SimpleParam(_ParamData, Param):
@@ -1020,10 +1024,6 @@ class SimpleParam(_ParamData, Param):
         can change later.
         """
         return self._constructed and not self._mutable
-
-    def get_units(self):
-        """Return the units expression for this parameter"""
-        return self._units
     
 class IndexedParam(Param):
 

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -967,8 +967,8 @@ This has resulted in the conversion of the source to dense form.
                  )
     
     def get_units(self):
-    """Return the units expression for this parameter"""
-    return self._units
+        """Return the units expression for this parameter"""
+        return self._units
 
 
 class SimpleParam(_ParamData, Param):


### PR DESCRIPTION


## Fixes # .
* Move the get_units-function from SimpleParam-class to Param-class so it also can be used in IndexedParam-objects (Or as alternative, implement the function also in IndexedParam-class.

## Summary/Motivation:
* conversion of units is not possible in IndexedParam-objects due to the missing getter-function in that class (currently only implemented in SimpleParam-class)

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
