### PR TITLE
Deprecate CUID targets in add_slack_variables transformation

### DIFF
--- a/pyomo/core/plugins/transform/add_slack_vars.py
+++ b/pyomo/core/plugins/transform/add_slack_vars.py
@@ -10,9 +10,6 @@ from pyomo.core.base.component import ComponentUID
 from pyomo.core.base import Constraint, _ConstraintData
 from pyomo.common.deprecation import deprecation_warning
 
-import logging
-logger = logging.getLogger('pyomo.core')
-
 def target_list(x):
     deprecation_msg = ("In future releases ComponentUID targets will no longer "
                        "be supported. Specify targets as a Constraint or list "

--- a/pyomo/core/plugins/transform/add_slack_vars.py
+++ b/pyomo/core/plugins/transform/add_slack_vars.py
@@ -11,11 +11,15 @@ from pyomo.core.base import Constraint, _ConstraintData
 from pyomo.common.deprecation import deprecation_warning
 
 def target_list(x):
-    deprecation_msg = ("In future releases ComponentUID targets will no longer "
-                       "be supported. Specify targets as a Constraint or list "
-                       "of Constraints.")
+    deprecation_msg = ("In future releases ComponentUID targets will no "
+                      "longer be supported in the core.add_slack_variables "
+                      "transformation. Specify targets as a Constraint or "
+                      "list of Constraints.")
     if isinstance(x, ComponentUID):
-        deprecation_warning(deprecation_msg)
+        if deprecation_msg:
+            deprecation_warning(deprecation_msg)
+            # only emit the message once
+            deprecation_msg = None
         # [ESJ 07/15/2020] We have to just pass it through because we need the
         # instance in order to be able to do anything about it...
         return [ x ]
@@ -25,7 +29,9 @@ def target_list(x):
         ans = []
         for i in x:
             if isinstance(i, ComponentUID):
-                deprecation_warning(deprecation_msg)
+                if deprecation_msg:
+                    deprecation_warning(deprecation_msg)
+                    deprecation_msg = None
                 # same as above...
                 ans.append(i)
             elif isinstance(i, (Constraint, _ConstraintData)):


### PR DESCRIPTION
## Fixes # NA

## Summary/Motivation:

Deprecates the requirement that targets for `core.add_slack_variables` are a list of ComponentUIDs. Instead, they are expected to be a Constraint or list of Constraints.

## Changes proposed in this PR:
- Changes to ConfigBlock for handling transformation arguments
- Deprecates cuid targets in favor of Constraints or lists of Constraints
- Updates tests accordingly

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
