### PR TITLE
Fix bug in sensitivity_toolbox RangeInequality handling

### DIFF
--- a/pyomo/contrib/sensitivity_toolbox/sens.py
+++ b/pyomo/contrib/sensitivity_toolbox/sens.py
@@ -153,49 +153,31 @@ def sipopt(instance, paramSubList, perturbList,
                     substitute=variableSubMap,
                     remove_named_expressions=True).dfs_postorder_stack(cc.expr))
         else:
-            try:
-                b.constList.add(expr=ExpresssionReplacementVisitor(
+            if cc.lower is None or cc.upper is None:
+                b.constList.add(expr=ExpressionReplacementVisitor(
                     substitute=variableSubMap,
                     remove_named_expressions=True).dfs_postorder_stack(cc.expr))
-            except:
-                # Params in either the upper or lower bounds of a ranged 
-                # inequaltiy will result in an invalid expression (you cannot 
-                # have variables in the bounds of a constraint).  If we hit that
-                # problem, we will break up the ranged inequality into separate
-                # constraints
+            else:
+                # Constraint must be a ranged inequality, break into separate constraints
 
-                # Note that the test for lower / upper == None is probably not
-                # necessary, as the only way we should get here (especially if
-                # we are more careful about the exception that we catch) is if
-                # this is a ranged inequality and we are attempting to insert a
-                # variable into either the lower or upper bound.
-                if cc.lower is not None:
-                    b.constList.add(expr=ExpressionReplacementVisitor(
-                        substitute=variableSubMap,
-                        remove_named_expressions=True).dfs_postorder_stack(
-                            cc.lower) <= ExpressionReplacementVisitor(
-                                substitute=variableSubMap,
-                                remove_named_expressions=
-                                  True).dfs_postorder_stack(cc.body)
-                                )
-                #if cc.lower is not None:
-                #    b.constList.add(expr=0<=ExpressionReplacementVisitor(
-                #        substitute=variableSubMap,
-                #        remove_named_expressions=True).dfs_postorder_stack(
-                #            cc.lower) - ExpressionReplacementVisitor(
-                #                substitute=variableSubMap,
-                #                remove_named_expressions=
-                #                  True).dfs_postorder_stack(cc.body)
-                #                )
-                if cc.upper is not None:
-                    b.constList.add(expr=ExpressionReplacementVisitor(
-                        substitute=variableSubMap,
-                        remove_named_expressions=True).dfs_postorder_stack(
-                            cc.upper) >= ExpressionReplacementVisitor(
-                                substitute=variableSubMap,
-                                remove_named_expressions=
-                                  True).dfs_postorder_stack(cc.body)
-                                )
+                # Add constraint for lower bound
+                b.constList.add(expr=ExpressionReplacementVisitor(
+                    substitute=variableSubMap,
+                    remove_named_expressions=True).dfs_postorder_stack(
+                        cc.lower) <= ExpressionReplacementVisitor(
+                            substitute=variableSubMap,
+                            remove_named_expressions=
+                            True).dfs_postorder_stack(cc.body)
+                    )
+                # Add constraint for upper bound
+                b.constList.add(expr=ExpressionReplacementVisitor(
+                    substitute=variableSubMap,
+                    remove_named_expressions=True).dfs_postorder_stack(
+                        cc.upper) >= ExpressionReplacementVisitor(
+                            substitute=variableSubMap,
+                            remove_named_expressions=
+                            True).dfs_postorder_stack(cc.body)
+                    )
         cc.deactivate()
 
     #paramData to varData constraint list


### PR DESCRIPTION
##  Summary/Motivation:
#1517 revealed a bug in the sensitivity toolbox where a typo in a class name was being swallowed by a try/except statement that wasn't catching a specific exception. Luckily, the code in the except statement was still "doing the right thing" so users should not have noticed any issues. The problem had to do with the logic around handling of ranged inequalities in the sensitivity toolbox. I reworked the logic to fix the typo and remove the try/except statement completely.

## Changes proposed in this PR:
- Fix typo in sensitivity toolbox and rework logic for handling ranged inequalities

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
