### PR TITLE
Update deferred imports (speed up `import pyomo.environ`)

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -332,5 +332,5 @@ pympler, pympler_available = attempt_import(
 numpy, numpy_available = attempt_import('numpy', alt_names=['np'])
 scipy, scipy_available = attempt_import('scipy', callback=_finalize_scipy)
 networkx, networkx_available = attempt_import('networkx', alt_names=['nx'])
-pandas, pandas_available = attempt_import('pandas')
+pandas, pandas_available = attempt_import('pandas', alt_names=['pd'])
 dill, dill_available = attempt_import('dill')


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
The Logical Expression system snuck in an unconditional import of sympy, which significantly impacts `pyomo.environ` import time.  This corrects the import so that sympy is not imported until the cnf walker is actually used.

## Changes proposed in this PR:
-Do not check `sympy_available` at the module scope and instead rely on a callback to populate module-level maps

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
