### PR TITLE
Add test to monitor 'import pyomo.environ' time

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -162,16 +162,16 @@ class _DeferredOr(_DeferredImportIndicatorBase):
         return bool(self._a) or bool(self._b)
 
 
-try:
-    from packaging import version as _version
-    _parser = _version.parse
-except ImportError:
-    # pkg_resources is an order of magnitude slower to import than
-    # packaging.  Only use it if the preferred (but optional) packaging
-    # library is not present
-    from pkg_resources import parse_version as _parser
-
 def _check_version(module, min_version):
+    try:
+        from packaging import version as _version
+        _parser = _version.parse
+    except ImportError:
+        # pkg_resources is an order of magnitude slower to import than
+        # packaging.  Only use it if the preferred (but optional)
+        # packaging library is not present
+        from pkg_resources import parse_version as _parser
+
     version = getattr(module, '__version__', '0.0.0')
     return _parser(min_version) <= _parser(version)
 

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -123,7 +123,7 @@ class TestPyomoEnviron(unittest.TestCase):
         ref = {'tempfile', 'logging', 'ctypes', 'ssl', 'argparse',
                'textwrap', 'inspect', 'xml', 'platform'}
         # Non-standard-library TPLs that Pyomo will load unconditionally
-        #ref.add('six')
+        ref.add('six')
         ref.add('ply')
         if numpy_available:
             ref.add('numpy')

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -95,6 +95,9 @@ class TestPyomoEnviron(unittest.TestCase):
         pyutilib_time = sum(itervalues(data.pyutilib))
         tpl_time = sum(itervalues(data.tpl))
         total = float(pyomo_time + pyutilib_time + tpl_time)
+        print("Pyomo (by module time):")
+        print("\n".join("   %s: %s" % i for i in sorted(
+            data.pyomo.items(), key=lambda x: x[1])))
         print("TPLS:")
         print("\n".join("   %s: %s" % i for i in sorted(data.tpl.items())))
         tpl = {}
@@ -103,10 +106,13 @@ class TestPyomoEnviron(unittest.TestCase):
             tpl[_mod] = tpl.get(_mod,0) + v
         tpl_by_time = sorted(tpl.items(), key=lambda x: x[1])
         print("TPLS (by package time):")
-        print("\n".join("   %s: %s" % i for i in tpl_by_time))
-        print("Pyomo: %s (%0.2f)" % (pyomo_time, pyomo_time / total))
-        print("Pyutilib: %s (%0.2f)" % (pyutilib_time, pyutilib_time / total))
-        print("TPL: %s (%0.2f)" % (tpl_time, tpl_time / total))
+        print("\n".join("   %12s: %6d (%4.1f%%)" % (
+            m, t, 100*t/total) for m, t in tpl_by_time))
+        print("Pyomo:    %6d (%4.1f%%)" % (
+            pyomo_time, 100 * pyomo_time / total))
+        print("Pyutilib: %6d (%4.1f%%)" % (
+            pyutilib_time, 100 * pyutilib_time / total))
+        print("TPL:      %6d (%4.1f%%)" % (tpl_time, 100 * tpl_time / total))
         # Arbitrarily choose a threshold 10% more than the expected
         # value (at time of writing, TPL imports were 52-57% of the
         # import time on a development machine)
@@ -122,5 +128,6 @@ class TestPyomoEnviron(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    # Running this file as a script will print out the package timing
+    # information from test_tpl_import_time()
     unittest.main()
-

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -20,6 +20,9 @@ from six import iteritems, itervalues
 
 import pyutilib.th as unittest
 
+from pyomo.common.dependencies import numpy_available, attempt_import
+pyro4, pyro4_available = attempt_import('Pyro4')
+
 class ImportData(object):
     def __init__(self):
         self.tpl = {}
@@ -109,8 +112,13 @@ class TestPyomoEnviron(unittest.TestCase):
         # import time on a development machine)
         self.assertLess(tpl_time / total, 0.65)
         # Spot-check the (known) two worst offenders
-        self.assertEqual(tpl_by_time[-1][0], 'numpy')
-        self.assertEqual(tpl_by_time[-2][0], 'Pyro4')
+        if numpy_available and pyro4_available:
+            self.assertEqual(tpl_by_time[-1][0], 'numpy')
+            self.assertEqual(tpl_by_time[-2][0], 'Pyro4')
+        elif numpy_available:
+            self.assertEqual(tpl_by_time[-1][0], 'numpy')
+        elif pyro4_available:
+            self.assertEqual(tpl_by_time[-1][0], 'Pyro4')
 
 
 if __name__ == "__main__":

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -117,14 +117,13 @@ class TestPyomoEnviron(unittest.TestCase):
         # value (at time of writing, TPL imports were 52-57% of the
         # import time on a development machine)
         self.assertLess(tpl_time / total, 0.65)
-        # Spot-check the (known) two worst offenders
-        if numpy_available and pyro4_available:
-            self.assertEqual(tpl_by_time[-1][0], 'numpy')
-            self.assertEqual(tpl_by_time[-2][0], 'Pyro4')
-        elif numpy_available:
-            self.assertEqual(tpl_by_time[-1][0], 'numpy')
-        elif pyro4_available:
-            self.assertEqual(tpl_by_time[-1][0], 'Pyro4')
+        # Spot-check the (known) worst offenders
+        ref = {'six'}
+        if numpy_available:
+            ref.add('numpy')
+        if pyro4_available:
+            ref.add('Pyro4')
+        self.assertEqual(ref, set(_[0] for _ in tpl_by_time[-len(ref):]))
 
 
 if __name__ == "__main__":

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -117,13 +117,22 @@ class TestPyomoEnviron(unittest.TestCase):
         # value (at time of writing, TPL imports were 52-57% of the
         # import time on a development machine)
         self.assertLess(tpl_time / total, 0.65)
-        # Spot-check the (known) worst offenders
-        ref = {'six'}
+        # Spot-check the (known) worst offenders.  The following are
+        # modules from the "standard" library.  Their order in the list
+        # of slow-loading TPLs can vary from platform to platform.
+        ref = {'tempfile', 'logging', 'ctypes', 'ssl', 'argparse',
+               'textwrap', 'inspect', 'xml', 'platform'}
+        # Non-standard-library TPLs that Pyomo will load unconditionally
+        #ref.add('six')
+        ref.add('ply')
         if numpy_available:
             ref.add('numpy')
         if pyro4_available:
             ref.add('Pyro4')
-        self.assertEqual(ref, set(_[0] for _ in tpl_by_time[-len(ref):]))
+        diff = set(_[0] for _ in tpl_by_time[-4:]).difference(ref)
+        self.assertEqual(
+            diff, set(),
+            "Unexpected module found in 4 slowest-loading modules")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
We occasionally get additional TPLs that sneak in to being unconditionally imported through `pyomo.environ`.  This adds a simple test that monitors the import time for `pyomo.environ` and fails if the total TPL import time (everything other than `pyomo.*` and `pyutilib.*` imported through `pyomo.environ` exceeds 65% of the total import time.  It also "spot-checks" the four longest-loading unconditional TPLs, and will fail if that changes.

This test would have caught, e.g., the sympy import introduced by #1507 and fixed by #1576

## Changes proposed in this PR:
- Add test to monitor the import time of `pyomo.environ`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
