### PR TITLE
GitHub Actions Workflow Manual Job Trigger

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        description: Git Hash (Optional)
+        required: false
 
 defaults:
   run:

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches-ignore:
       - master
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        description: Git Hash (Optional)
+        required: false
 
 defaults:
   run:

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        description: Git Hash (Optional)    
+        required: false
 
 jobs:
   manylinux:


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
There is now a GUI capability for manually trigger a GHA Workflow. It will run the selected workflow on the most recent commit to master by default; however, another hash on master can be specified. [Article on usage](https://levelup.gitconnected.com/how-to-manually-trigger-a-github-actions-workflow-4712542f1960)

(Potential use cases: Performance comparison between current status of master and devel branch; performance comparisons on previous commits; creation of release wheels for ANY commit, not just when new tags are pushed. See [on my fork](https://github.com/mrmundt/pyomo/actions?query=workflow%3A%22GitHub+CI%22) for an example.)

## Changes proposed in this PR:
- Add "Run workflow" trigger button for three existing GHA workflows

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
