### PR TITLE
Small fixes in units: remove debug print statement and unnecessary get_units call

### DIFF
--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -1021,10 +1021,7 @@ class SimpleParam(_ParamData, Param):
         """
         return self._constructed and not self._mutable
 
-    def get_units(self):
-        """Return the units expression for this parameter"""
-        return self._units
-    
+
 class IndexedParam(Param):
 
     def __call__(self, exception=True):

--- a/pyomo/core/base/units_container.py
+++ b/pyomo/core/base/units_container.py
@@ -791,7 +791,6 @@ class UnitExtractionVisitor(EXPR.StreamBasedExpressionVisitor):
         for (arg_unit, unit_tuple) in zip(arg_units, list_of_unit_tuples):
             pyomo_arg_unit, pint_arg_unit = self._pyomo_units_container._get_units_tuple(arg_unit)
             pint_child_unit = unit_tuple[1]
-            print(pint_arg_unit, pint_child_unit)
             if not self._pint_units_equivalent(pint_arg_unit, pint_child_unit):
                 raise InconsistentUnitsError(arg_unit, unit_tuple[0], 'Inconsistent units found in ExternalFunction.')
 


### PR DESCRIPTION
## Fixes # .
- removing a debug print statement in the units_container.py file
- removed the call to get_units in SimpleParam. The implementation in _ParamData will work for SimpleParam as well.

## Summary/Motivation:


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
