### PR TITLE
Performance: fix unnecessary recursion in check_units

### DIFF
--- a/pyomo/contrib/parmest/graphics.py
+++ b/pyomo/contrib/parmest/graphics.py
@@ -21,11 +21,15 @@ except ImportError:
 try:
     # matplotlib.pyplot can generate a runtime error on OSX when not
     # installed as a Framework (as is the case in the CI systems)
+    #
+    # occasionally dependent conda packages for older distributions
+    # (e.g. python 3.5) get released that are either broken not
+    # compatible, resulting in a SyntaxError
     import seaborn as sns
     import matplotlib.pyplot as plt
     import matplotlib.tri as tri
     from matplotlib.lines import Line2D
-except (ImportError, RuntimeError):
+except (ImportError, RuntimeError, SyntaxError):
     imports_available = False
 
 

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -121,7 +121,8 @@ class TestPyomoEnviron(unittest.TestCase):
         # modules from the "standard" library.  Their order in the list
         # of slow-loading TPLs can vary from platform to platform.
         ref = {'tempfile', 'logging', 'ctypes', 'ssl', 'argparse',
-               'textwrap', 'inspect', 'xml', 'platform'}
+               'textwrap', 'inspect', 'xml', 'platform', 'uuid',
+               'optparse'}
         # Non-standard-library TPLs that Pyomo will load unconditionally
         ref.add('six')
         ref.add('ply')

--- a/pyomo/util/check_units.py
+++ b/pyomo/util/check_units.py
@@ -159,7 +159,7 @@ def _assert_units_consistent_block(obj):
     and checks if the units are consistent on each of them
     """
     # check all the component objects
-    for component in obj.component_objects(descend_into=True, active=True):
+    for component in obj.component_objects(descend_into=False, active=True):
         assert_units_consistent(component)
 
 _component_data_handlers = {


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
There was a bug in the check_units file that caused us to get all components (descend_into=True), but then also recurse into all blocks as well. This resulted in significantly increased computational time for checking units.


## Changes proposed in this PR:
- Do not descend into subblocks when processing check_units on a block
- Update parmest seaborn import to catch error in recent conda python 3.5 packages
- Add additional modules from the standard library that occasionally appear in the list of slowest-loading modules

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
