### PR TITLE
Don't attempt to scale references in scaling transformation

### DIFF
--- a/pyomo/core/plugins/transform/scaling.py
+++ b/pyomo/core/plugins/transform/scaling.py
@@ -9,6 +9,7 @@
 #  ___________________________________________________________________________
 
 from pyomo.core.base import Var, Constraint, Objective, _ConstraintData, _ObjectiveData, Suffix, value
+from pyomo.core.base.reference import _ReferenceDict
 from pyomo.core.plugins.transform.hierarchy import Transformation
 from pyomo.core.kernel.component_map import ComponentMap
 from pyomo.util.components import rename_components
@@ -127,6 +128,10 @@ class ScaleModel(Transformation):
         # for scaling vars in constraints
         variable_substitution_map = ComponentMap()
         for variable in [var for var in model.component_objects(ctype=Var, descend_into=True)]:
+            # Do not attempt to access reference variables.
+            # They have been broken by rename_components
+            if type(variable._data) is _ReferenceDict:
+                continue
             # set the bounds/value for the scaled variable
             for k in variable:
                 v = variable[k]
@@ -157,6 +162,10 @@ class ScaleModel(Transformation):
                                       for k in variable_substitution_map}
 
         for component in model.component_objects(ctype=(Constraint, Objective), descend_into=True):
+            # Do not attempt to access reference components.
+            # They have been broken by rename_components
+            if type(component._data) is _ReferenceDict:
+                continue
             for k in component:
                 c = component[k]
                 # perform the constraint/objective scaling and variable sub

--- a/pyomo/core/tests/transform/test_scaling.py
+++ b/pyomo/core/tests/transform/test_scaling.py
@@ -205,6 +205,5 @@ class TestScaleModelTransformation(unittest.TestCase):
                 orig_val*factor,
                 )
         
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Fixes # .
Addresses part of #1571 

## Summary/Motivation:
The scaling transformation currently breaks references (by renaming the underlying components), then tries to scale these references, causing errors to be raised from the depths of indexed_component_slice.py. The underlying issue is that references are being broken by the scaling transformation. This PR is a band-aid that allows the scaling transformation to be called when references are present. As long as these references are not "de-referenced" after the scaling transformation, the rest of the model should work just fine.

## Changes proposed in this PR:
- Scaling transformation no longer attempts to scale references
- Adds a small test where a model with references is scaled

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
