### PR TITLE
Rebuild GHA download caches (bump cache version)

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -24,7 +24,7 @@ env:
       pint pymysql pyro4 pyyaml sphinx_rtd_theme sympy xlrd wheel
   PYTHON_NUMPY_PKGS: >
       numpy scipy pyodbc pandas matplotlib seaborn
-  CACHE_VER: v1
+  CACHE_VER: v2
 
 jobs:
   build:

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -21,7 +21,7 @@ env:
       pint pymysql pyro4 pyyaml sphinx_rtd_theme sympy xlrd wheel
   PYTHON_NUMPY_PKGS: >
       numpy scipy pyodbc pandas matplotlib seaborn
-  CACHE_VER: v1
+  CACHE_VER: v2
 
 jobs:
   build:


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This forces GHA to rebuild the download caches, which will resolve OSX / py3.7 and py3.8 build errors.

## Changes proposed in this PR:
- Bump cache version to force a cache rebuild

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
