### PR TITLE
Add an option to specify the path to ipopt

### DIFF
--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -339,9 +339,12 @@ class Estimator(object):
         If True, print diagnostics from the solver
     solver_options: dict, optional
         Provides options to the solver (also the name of an attribute)
+    solver_path: string, optional
+        Absolute or relative path to the solver executable (e.g., ~/Ipopt/ipopt)
     """
     def __init__(self, model_function, data, theta_names, obj_function=None, 
-                 tee=False, diagnostic_mode=False, solver_options=None):
+                 tee=False, diagnostic_mode=False, solver_options=None,
+                 solver_path=None):
         
         self.model_function = model_function
         self.callback_data = data
@@ -355,6 +358,7 @@ class Estimator(object):
         self.tee = tee
         self.diagnostic_mode = diagnostic_mode
         self.solver_options = solver_options
+        self.solver_path = solver_path
         
         self._second_stage_cost_exp = "SecondStageCost"
         self._numbers_list = list(range(len(data)))
@@ -479,7 +483,7 @@ class Estimator(object):
             if not calc_cov:
                 # Do not calculate the reduced hessian
 
-                solver = SolverFactory('ipopt')
+                solver = SolverFactory('ipopt', executable=self.solver_path)
                 if self.solver_options is not None:
                     for key in self.solver_options:
                         solver.options[key] = self.solver_options[key]
@@ -581,9 +585,9 @@ class Estimator(object):
 
             model = stsolver.make_ef()
             stream_solver = True
-            ipopt = SolverFactory('ipopt')
-            sipopt = SolverFactory('ipopt_sens')
-            kaug = SolverFactory('k_aug')
+            ipopt = SolverFactory('ipopt', executable=self.solver_path)
+            sipopt = SolverFactory('ipopt_sens', executable=self.solver_path)
+            kaug = SolverFactory('k_aug', executable=self.solver_path)
 
             #: ipopt suffixes  REQUIRED FOR K_AUG!
             model.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT_EXPORT)
@@ -676,7 +680,7 @@ class Estimator(object):
             pyo.TerminationCondition.infeasible is the worst.
         """
 
-        optimizer = pyo.SolverFactory('ipopt')
+        optimizer = pyo.SolverFactory('ipopt', executable=self.solver_path)
         dummy_tree = lambda: None # empty object (we don't need a tree)
         dummy_tree.CallbackModule = None
         dummy_tree.CallbackFunction = self._instance_creation_callback


### PR DESCRIPTION
## Fixes #1566 

## Summary/Motivation:

Adds an optional keyword argument to the constructor to allow for the user to specify the path to ipopt. There are pros and cons:
Cons:
- One could change one's PATH rather than using this option
- I don't know how to test it
- I didn't document it other than in the api docstring because I don't know how to test an example either

Pros:
- It works
- It is documented in the API section of the documentation
- It only adds one line, so if we are worried about code coverage, surely we can find a place to use a list
comprehension instead of a loop to get that line back.

## Changes proposed in this PR:
- add an optional constructor arg and an attribute to the estimator object that specifies a path to the solver 
- add the executable keyword arg to all SolverFactory calls

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
