### PR TITLE
Resolve quotes when parsing /etc/os-release

### DIFF
--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -76,13 +76,12 @@ class FileDownloader(object):
                 if not line:
                     continue
                 key,val = line.lower().split('=')
+                if val[0] == val[-1] and val[0] in '"\'':
+                    val = val[1:-1]
                 if key == 'id':
                     dist = val
                 elif key == 'version_id':
-                    if val[0] == val[-1] and val[0] in '"\'':
-                        ver = val[1:-1]
-                    else:
-                        ver = val
+                    ver = val
         return cls._map_dist(dist), ver
 
     @classmethod

--- a/pyomo/scripting/tests/test_cmds.py
+++ b/pyomo/scripting/tests/test_cmds.py
@@ -48,7 +48,7 @@ class Test(unittest.TestCase):
             elif s.available():
                 self.assertTrue(
                     re.search("\n   \-%s " % solver, OUT),
-                    "'   +%s' not found in help --solvers" % solver)
+                    "'   -%s' not found in help --solvers" % solver)
             else:
                 self.assertTrue(
                     re.search("\n    %s " % solver, OUT),


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This resolves a parsing issue encountered on recent installs of RHEL7.

## Changes proposed in this PR:
- remove quote (`'` and `"`) for all field values when parsing `/etc/os-release`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
