### PR TITLE
Error and warning options in solve_consistent_initial_conditions

### DIFF
--- a/pyomo/dae/initialization.py
+++ b/pyomo/dae/initialization.py
@@ -99,6 +99,11 @@ def solve_consistent_initial_conditions(model, time, solver, tee=False,
         time: Set whose initial conditions will remain active for solve
         solver: Something that implements a solve method that accepts
                 a model and tee keyword as arguments
+        tee: tee argument that will be sent to solver's solve method
+        allow_skip: If True, KeyErrors due to Constraint.Skip being
+                    used will be ignored
+        suppress_warnings: If True, warnings due to ignored
+                           KeyErrors will be suppressed
 
     Returns:
         The object returned by the solver's solve method

--- a/pyomo/dae/initialization.py
+++ b/pyomo/dae/initialization.py
@@ -87,7 +87,8 @@ def get_inconsistent_initial_conditions(model, time, tol=1e-8, t0=None,
     return list(inconsistent)
 
 
-def solve_consistent_initial_conditions(model, time, solver, tee=False):
+def solve_consistent_initial_conditions(model, time, solver, tee=False,
+        allow_skip=True, suppress_warnings=False):
     """
     Solves a model with all Constraints and Blocks deactivated except
     at the initial value of the Set time. Reactivates Constraints and
@@ -121,7 +122,12 @@ def solve_consistent_initial_conditions(model, time, solver, tee=False):
 
     t0 = time.first()
     timelist = list(time)[1:]
-    deactivated_dict = deactivate_model_at(model, time, timelist)
+    deactivated_dict = deactivate_model_at(
+            model,
+            time,
+            timelist,
+            allow_skip=allow_skip,
+            suppress_warnings=suppress_warnings)
 
     result = solver.solve(model, tee=tee)
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
I want to set error/warning options of `deactivate_model_at` from a call to `solve_consistent_initial_conditions`.

## Changes proposed in this PR:
- Add `allow_skip` and `suppress_warnings` options in `solve_consistent_initial_conditions`, which are just sent to `deactivate_model_at`.
- Add a test that raises an error due to `allow_skip=False`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
