### PR TITLE
Add support for class method Initializers

### DIFF
--- a/pyomo/core/base/util.py
+++ b/pyomo/core/base/util.py
@@ -167,7 +167,7 @@ def Initializer(init,
         if init is arg_not_specified:
             return None
         return ConstantInitializer(init)
-    elif inspect.isfunction(init):
+    elif inspect.isfunction(init) or inspect.ismethod(init):
         if not allow_generators and inspect.isgeneratorfunction(init):
             raise ValueError("Generator functions are not allowed")
         # Historically pyomo.core.base.misc.apply_indexed_rule
@@ -175,7 +175,12 @@ def Initializer(init,
         # indexed components).  We will preserve that functionality
         # here.
         _args = getargspec(init)
-        if len(_args.args) == 1 and _args.varargs is None:
+        _nargs = len(_args.args)
+        if inspect.ismethod(init) and init.im_self is not None:
+            # Ignore 'self' for bound instance methods and 'cls' for
+            # @classmethods
+            _nargs -= 1
+        if _nargs == 1 and _args.varargs is None:
             return ScalarCallInitializer(init)
         else:
             return IndexedCallInitializer(init)
@@ -395,8 +400,11 @@ class CountedCallInitializer(InitializerBase):
         # Note that this code will only be called once, and only if
         # the object is not a scalar.
         _args = getargspec(self._fcn)
+        _nargs = len(_args.args)
+        if inspect.ismethod(self._fcn) and self._fcn.im_self is not None:
+            _nargs -= 1
         _len = len(idx) if idx.__class__ is tuple else 1
-        if _len + 2 == len(_args.args):
+        if _len + 2 == _nargs:
             self._is_counted_rule = True
         else:
             self._is_counted_rule = False

--- a/pyomo/core/base/util.py
+++ b/pyomo/core/base/util.py
@@ -176,7 +176,7 @@ def Initializer(init,
         # here.
         _args = getargspec(init)
         _nargs = len(_args.args)
-        if inspect.ismethod(init) and init.im_self is not None:
+        if inspect.ismethod(init) and init.__self__ is not None:
             # Ignore 'self' for bound instance methods and 'cls' for
             # @classmethods
             _nargs -= 1
@@ -401,7 +401,7 @@ class CountedCallInitializer(InitializerBase):
         # the object is not a scalar.
         _args = getargspec(self._fcn)
         _nargs = len(_args.args)
-        if inspect.ismethod(self._fcn) and self._fcn.im_self is not None:
+        if inspect.ismethod(self._fcn) and self._fcn.__self__ is not None:
             _nargs -= 1
         _len = len(idx) if idx.__class__ is tuple else 1
         if _len + 2 == _nargs:

--- a/pyomo/core/tests/unit/test_util.py
+++ b/pyomo/core/tests/unit/test_util.py
@@ -138,6 +138,7 @@ class Test_Initializer(unittest.TestCase):
             a.indices()
         self.assertEqual(a(None, 1), 5)
 
+
     def test_dict(self):
         m = ConcreteModel()
         a = Initializer({1:5})
@@ -147,6 +148,7 @@ class Test_Initializer(unittest.TestCase):
         self.assertTrue(a.contains_indices())
         self.assertEqual(list(a.indices()), [1])
         self.assertEqual(a(None, 1), 5)
+
 
     def test_sequence(self):
         m = ConcreteModel()
@@ -164,6 +166,7 @@ class Test_Initializer(unittest.TestCase):
         self.assertFalse(a.verified)
         self.assertFalse(a.contains_indices())
         self.assertEqual(a(None, 1), [0,5])
+
 
     def test_function(self):
         m = ConcreteModel()
@@ -219,6 +222,193 @@ class Test_Initializer(unittest.TestCase):
         self.assertEqual(next(c), 4)
 
 
+    def test_method(self):
+        class Init(object):
+            def a_init(self, m):
+                return 0
+
+            def x_init(self, m, i):
+                return i+1
+
+            def x2_init(self, m):
+                return 0
+
+            def y_init(self, m, i, j):
+                return j*(i+1)
+
+        init = Init()
+
+        m = ConcreteModel()
+        a = Initializer(init.a_init)
+        self.assertIs(type(a), ScalarCallInitializer)
+        self.assertFalse(a.constant())
+        self.assertFalse(a.verified)
+        self.assertFalse(a.contains_indices())
+        self.assertEqual(a(None, 1), 0)
+
+        m.x = Var([1,2,3])
+        a = Initializer(init.x_init)
+        self.assertIs(type(a), IndexedCallInitializer)
+        self.assertFalse(a.constant())
+        self.assertFalse(a.verified)
+        self.assertFalse(a.contains_indices())
+        self.assertEqual(a(None, 1), 2)
+
+        a = Initializer(init.x2_init)
+        self.assertIs(type(a), ScalarCallInitializer)
+        self.assertFalse(a.constant())
+        self.assertFalse(a.verified)
+        self.assertFalse(a.contains_indices())
+        self.assertEqual(a(None, 1), 0)
+
+        m.y = Var([1,2,3], [4,5,6])
+        a = Initializer(init.y_init)
+        self.assertIs(type(a), IndexedCallInitializer)
+        self.assertFalse(a.constant())
+        self.assertFalse(a.verified)
+        self.assertFalse(a.contains_indices())
+        self.assertEqual(a(None, (1, 4)), 8)
+
+        b = CountedCallInitializer(m.x, a)
+        self.assertIs(type(b), CountedCallInitializer)
+        self.assertFalse(b.constant())
+        self.assertFalse(b.verified)
+        self.assertFalse(a.contains_indices())
+        self.assertFalse(b._scalar)
+        self.assertIs(a._fcn, b._fcn)
+        c = b(None, 1)
+        self.assertIs(type(c), CountedCallGenerator)
+        self.assertEqual(next(c), 2)
+        self.assertEqual(next(c), 3)
+        self.assertEqual(next(c), 4)
+
+
+    def test_classmethod(self):
+        class Init(object):
+            @classmethod
+            def a_init(cls, m):
+                return 0
+
+            @classmethod
+            def x_init(cls, m, i):
+                return i+1
+
+            @classmethod
+            def x2_init(cls, m):
+                return 0
+
+            @classmethod
+            def y_init(cls, m, i, j):
+                return j*(i+1)
+
+        m = ConcreteModel()
+        a = Initializer(Init.a_init)
+        self.assertIs(type(a), ScalarCallInitializer)
+        self.assertFalse(a.constant())
+        self.assertFalse(a.verified)
+        self.assertFalse(a.contains_indices())
+        self.assertEqual(a(None, 1), 0)
+
+        m.x = Var([1,2,3])
+        a = Initializer(Init.x_init)
+        self.assertIs(type(a), IndexedCallInitializer)
+        self.assertFalse(a.constant())
+        self.assertFalse(a.verified)
+        self.assertFalse(a.contains_indices())
+        self.assertEqual(a(None, 1), 2)
+
+        a = Initializer(Init.x2_init)
+        self.assertIs(type(a), ScalarCallInitializer)
+        self.assertFalse(a.constant())
+        self.assertFalse(a.verified)
+        self.assertFalse(a.contains_indices())
+        self.assertEqual(a(None, 1), 0)
+
+        m.y = Var([1,2,3], [4,5,6])
+        a = Initializer(Init.y_init)
+        self.assertIs(type(a), IndexedCallInitializer)
+        self.assertFalse(a.constant())
+        self.assertFalse(a.verified)
+        self.assertFalse(a.contains_indices())
+        self.assertEqual(a(None, (1, 4)), 8)
+
+        b = CountedCallInitializer(m.x, a)
+        self.assertIs(type(b), CountedCallInitializer)
+        self.assertFalse(b.constant())
+        self.assertFalse(b.verified)
+        self.assertFalse(a.contains_indices())
+        self.assertFalse(b._scalar)
+        self.assertIs(a._fcn, b._fcn)
+        c = b(None, 1)
+        self.assertIs(type(c), CountedCallGenerator)
+        self.assertEqual(next(c), 2)
+        self.assertEqual(next(c), 3)
+        self.assertEqual(next(c), 4)
+
+
+    def test_staticmethod(self):
+        class Init(object):
+            @staticmethod
+            def a_init(m):
+                return 0
+
+            @staticmethod
+            def x_init(m, i):
+                return i+1
+
+            @staticmethod
+            def x2_init(m):
+                return 0
+
+            @staticmethod
+            def y_init(m, i, j):
+                return j*(i+1)
+
+        m = ConcreteModel()
+        a = Initializer(Init.a_init)
+        self.assertIs(type(a), ScalarCallInitializer)
+        self.assertFalse(a.constant())
+        self.assertFalse(a.verified)
+        self.assertFalse(a.contains_indices())
+        self.assertEqual(a(None, 1), 0)
+
+        m.x = Var([1,2,3])
+        a = Initializer(Init.x_init)
+        self.assertIs(type(a), IndexedCallInitializer)
+        self.assertFalse(a.constant())
+        self.assertFalse(a.verified)
+        self.assertFalse(a.contains_indices())
+        self.assertEqual(a(None, 1), 2)
+
+        a = Initializer(Init.x2_init)
+        self.assertIs(type(a), ScalarCallInitializer)
+        self.assertFalse(a.constant())
+        self.assertFalse(a.verified)
+        self.assertFalse(a.contains_indices())
+        self.assertEqual(a(None, 1), 0)
+
+        m.y = Var([1,2,3], [4,5,6])
+        a = Initializer(Init.y_init)
+        self.assertIs(type(a), IndexedCallInitializer)
+        self.assertFalse(a.constant())
+        self.assertFalse(a.verified)
+        self.assertFalse(a.contains_indices())
+        self.assertEqual(a(None, (1, 4)), 8)
+
+        b = CountedCallInitializer(m.x, a)
+        self.assertIs(type(b), CountedCallInitializer)
+        self.assertFalse(b.constant())
+        self.assertFalse(b.verified)
+        self.assertFalse(a.contains_indices())
+        self.assertFalse(b._scalar)
+        self.assertIs(a._fcn, b._fcn)
+        c = b(None, 1)
+        self.assertIs(type(c), CountedCallGenerator)
+        self.assertEqual(next(c), 2)
+        self.assertEqual(next(c), 3)
+        self.assertEqual(next(c), 4)
+
+
     def test_generator_fcn(self):
         m = ConcreteModel()
         def a_init(m):
@@ -254,6 +444,48 @@ class Test_Initializer(unittest.TestCase):
         self.assertFalse(a.verified)
         self.assertEqual(list(a(None, (1, 4))), [4,2])
 
+
+    def test_generator_method(self):
+        class Init(object):
+            def a_init(self, m):
+                yield 0
+                yield 3
+
+            def x_init(self, m, i):
+                yield i
+                yield i+1
+
+            def y_init(self, m, i, j):
+                yield j
+                yield i+1
+        init = Init()
+
+        m = ConcreteModel()
+        with self.assertRaisesRegexp(
+                ValueError, "Generator functions are not allowed"):
+            a = Initializer(init.a_init)
+
+        a = Initializer(init.a_init, allow_generators=True)
+        self.assertIs(type(a), ScalarCallInitializer)
+        self.assertFalse(a.constant())
+        self.assertFalse(a.verified)
+        self.assertEqual(list(a(None, 1)), [0,3])
+
+        m.x = Var([1,2,3])
+        a = Initializer(init.x_init, allow_generators=True)
+        self.assertIs(type(a), IndexedCallInitializer)
+        self.assertFalse(a.constant())
+        self.assertFalse(a.verified)
+        self.assertEqual(list(a(None, 1)), [1,2])
+
+        m.y = Var([1,2,3], [4,5,6])
+        a = Initializer(init.y_init, allow_generators=True)
+        self.assertIs(type(a), IndexedCallInitializer)
+        self.assertFalse(a.constant())
+        self.assertFalse(a.verified)
+        self.assertEqual(list(a(None, (1, 4))), [4,2])
+
+
     def test_generators(self):
         m = ConcreteModel()
         with self.assertRaisesRegexp(
@@ -278,6 +510,7 @@ class Test_Initializer(unittest.TestCase):
         self.assertTrue(a.constant())
         self.assertFalse(a.verified)
         self.assertEqual(list(a(None, 1)), [0,3])
+
 
     def test_pickle(self):
         m = ConcreteModel()


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This resolves a regression pointed out by users where class methods (bound instance methods, `@classmethod` and `@staticmethod` functions) could no longer be used to initialize components.

## Changes proposed in this PR:
- Add support for class methods in the `initializer()` logic
- Add tests verifying bound instance methods, bound instance generators, `@classmethod` and `@staticmethod`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
