### PR TITLE
(re)Adding IndexedSet.data() method

### DIFF
--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -2203,7 +2203,10 @@ class Set(IndexedComponent):
 
 
 class IndexedSet(Set):
-    pass
+    def data(self):
+        "Return a dict containing the data() of each Set in this IndexedSet"
+        return {k: v.data() for k,v in iteritems(self)}
+
 
 class FiniteSimpleSet(_FiniteSetData, Set):
     def __init__(self, **kwds):

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -3828,12 +3828,15 @@ class TestSet(unittest.TestCase):
         m = ConcreteModel()
         m.I = Set([1,2,3], ordered=False)
         self.assertEqual(len(m.I), 0)
+        self.assertEqual(m.I.data(), {})
         m.I[1]
         self.assertEqual(len(m.I), 1)
         self.assertEqual(m.I[1], [])
+        self.assertEqual(m.I.data(), {1:()})
 
         self.assertEqual(m.I[2], [])
         self.assertEqual(len(m.I), 2)
+        self.assertEqual(m.I.data(), {1:(), 2:()})
 
         m.I[1].add(1)
         m.I[2].add(2)
@@ -3851,6 +3854,7 @@ class TestSet(unittest.TestCase):
         self.assertIs(type(m.I[1]), _FiniteSetData)
         self.assertIs(type(m.I[2]), _FiniteSetData)
         self.assertIs(type(m.I[3]), _FiniteSetData)
+        self.assertEqual(m.I.data(), {1:(1,), 2:(2,), 3:(4,)})
 
         # Explicit (constant) construction
         m = ConcreteModel()
@@ -3868,6 +3872,7 @@ class TestSet(unittest.TestCase):
         self.assertIs(type(m.I[1]), _InsertionOrderSetData)
         self.assertIs(type(m.I[2]), _InsertionOrderSetData)
         self.assertIs(type(m.I[3]), _InsertionOrderSetData)
+        self.assertEqual(m.I.data(), {1:(4,2,5), 2:(4,2,5), 3:(4,2,5)})
 
         # Explicit (constant) construction
         m = ConcreteModel()
@@ -3885,6 +3890,7 @@ class TestSet(unittest.TestCase):
         self.assertIs(type(m.I[1]), _SortedSetData)
         self.assertIs(type(m.I[2]), _SortedSetData)
         self.assertIs(type(m.I[3]), _SortedSetData)
+        self.assertEqual(m.I.data(), {1:(2,4,5), 2:(2,4,5), 3:(2,4,5)})
 
         # Explicit (procedural) construction
         m = ConcreteModel()
@@ -3896,6 +3902,7 @@ class TestSet(unittest.TestCase):
         self.assertEqual(sorted(m.I._data.keys()), [1,2])
         self.assertEqual(list(m.I[1]), [1,2,3])
         self.assertEqual(list(m.I[2]), [4,5,6])
+        self.assertEqual(m.I.data(), {1:(1,2,3), 2:(4,5,6)})
 
 
     def test_naming(self):

--- a/pyomo/core/tests/unit/test_sets.py
+++ b/pyomo/core/tests/unit/test_sets.py
@@ -939,13 +939,10 @@ class ArraySet(PyomoModel):
 
     def test_data(self):
         """Check that we can access the underlying set data"""
-        # try:
-        #     self.instance.A.data()
-        # except:
-        #     self.fail("Expected data() method to pass")
-        with self.assertRaisesRegexp(
-                AttributeError, ".*no attribute 'data'"):
+        try:
             self.instance.A.data()
+        except:
+            self.fail("Expected data() method to pass")
 
     def test_dim(self):
         """Check that a simple set has dimension zero for its indexing"""


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
The Pyomo Book (second edition) documented an `IndexedComponent.data()` method that returned the `data ()` from all Sets in the indexed set as a dict.  That method was removed as part of the Set rewrite.  This PR re-adds it, with the exception that the set members are returned as tuples instead of the raw _SetData objects.  That is, given:
```python
model = ConcreteModel()
model.A = Set(initialize=[1,2,3])
model.C = Set(model.A, initialize={1:[1], 2:[1,2]})
```
This implementation gives:
```python
>>> model.C.data()
{1: (1,), 2: (1, 2)}
```
whereas the old implementation gave:
```python
>>> model.C.data()
{1: <pyomo.core.base.sets._IndexedSetData object at 0x7f69aa765050>, 2: <pyomo.core.base.sets._IndexedSetData object at 0x7f69aa765170>}
```

This seems reasonable, as the `_SetData.data()` returns a tuple and not the `_SetData` itself (nor does it return the underlying data storage, which is kept private).  To have `IndexedSet.data()` return `_SetData` objects was both different from `_SetData.data()` and redundant (i.e., it was be identical to `dict(IndexedSet.items())`.

### Discussion topic

Should `IndexedSet.data()` be deprecated?  I think we need to restore the method -- if only to ensure compatibility with the Book-v2 -- but it is unclear if this is a reasonable API to preserve.

## Changes proposed in this PR:
- Add `IndexedSet.data()`
- Add tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
