### PR TITLE
Add deprecated support for Var(within=RealSet)

### DIFF
--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -3990,7 +3990,7 @@ def DeclareGlobalSet(obj, caller_globals=None):
 
         global_name = None
 
-        def __new__(cls, **kwds):
+        def __new__(cls, *args, **kwds):
             """Hijack __new__ to mock up old RealSet el al. interface
 
             In the original Set implementation (Pyomo<=5.6.7), the
@@ -4003,6 +4003,17 @@ def DeclareGlobalSet(obj, caller_globals=None):
             """
             if cls is GlobalSet and GlobalSet.global_name \
                and issubclass(GlobalSet, RangeSet):
+                deprecation_warning(
+                    "The use of RealSet, IntegerSet, BinarySet and "
+                    "BooleanSet as Pyomo Set class generators is "
+                    "deprecated.  Please either use one of the pre-declared "
+                    "global Sets (e.g., Reals, NonNegativeReals, Integers, "
+                    "PositiveIntegers, Binary), or create a custom RangeSet.",
+                    version='TBD')
+                # Note: we will completely ignore any positional
+                # arguments.  In this situation, these could be the
+                # parent_block and any indices; e.g.,
+                #    Var(m.I, within=RealSet)
                 base_set = GlobalSets[GlobalSet.global_name]
                 bounds = kwds.pop('bounds', None)
                 range_init = SetInitializer(base_set)
@@ -4021,7 +4032,7 @@ def DeclareGlobalSet(obj, caller_globals=None):
                         cls_name is not None or bounds is not None):
                     ans._name += str(ans.bounds())
             else:
-                ans = super(GlobalSet, cls).__new__(cls, **kwds)
+                ans = super(GlobalSet, cls).__new__(cls, *args, **kwds)
             if kwds:
                 raise RuntimeError("Unexpected keyword arguments: %s" % (kwds,))
             return ans

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -3333,20 +3333,49 @@ class TestGlobalSets(unittest.TestCase):
                 RangeSet( name='foo', ranges=(NR(0,2,1),) ), NS)
 
     def test_RealSet_IntegerSet(self):
-        a = SetModule.RealSet()
+        output = StringIO()
+        with LoggingIntercept(output, 'pyomo.core'):
+            a = SetModule.RealSet()
+        self.assertIn('DEPRECATED: The use of RealSet,', output.getvalue())
         self.assertEqual(a, Reals)
         self.assertIsNot(a, Reals)
 
-        a = SetModule.RealSet(bounds=(1,3))
+        output = StringIO()
+        with LoggingIntercept(output, 'pyomo.core'):
+            a = SetModule.RealSet(bounds=(1,3))
+        self.assertIn('DEPRECATED: The use of RealSet,', output.getvalue())
         self.assertEqual(a.bounds(), (1,3))
 
-        a = SetModule.IntegerSet()
+        output = StringIO()
+        with LoggingIntercept(output, 'pyomo.core'):
+            a = SetModule.IntegerSet()
+        self.assertIn('DEPRECATED: The use of RealSet,', output.getvalue())
         self.assertEqual(a, Integers)
         self.assertIsNot(a, Integers)
 
-        a = SetModule.IntegerSet(bounds=(1,3))
+        output = StringIO()
+        with LoggingIntercept(output, 'pyomo.core'):
+            a = SetModule.IntegerSet(bounds=(1,3))
+        self.assertIn('DEPRECATED: The use of RealSet,', output.getvalue())
         self.assertEqual(a.bounds(), (1,3))
         self.assertEqual(list(a), [1,2,3])
+
+        m = ConcreteModel()
+
+        output = StringIO()
+        with LoggingIntercept(output, 'pyomo.core'):
+            m.x = Var(within=SetModule.RealSet)
+        self.assertIn('DEPRECATED: The use of RealSet,', output.getvalue())
+
+        output = StringIO()
+        with LoggingIntercept(output, 'pyomo.core'):
+            m.y = Var(within=SetModule.RealSet())
+        self.assertIn('DEPRECATED: The use of RealSet,', output.getvalue())
+
+        output = StringIO()
+        with LoggingIntercept(output, 'pyomo.core'):
+            m.z = Var(within=SetModule.RealSet(bounds=(0,None)))
+        self.assertIn('DEPRECATED: The use of RealSet,', output.getvalue())
 
         with self.assertRaisesRegex(
                 RuntimeError, "Unexpected keyword arguments: \{'foo': 5\}"):


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
A [StackOverflow post](https://stackoverflow.com/questions/63819785/why-does-a-decision-variable-domain-declaration-not-work-in-pyomo-v5-7-that-work) reported that the following no longer works after the Set rewrite:
```python
model.x = Var(within=RealSet)
```

This PR fixes that use case, and adds a deprecation warning for any explicit use of `RealSet`, `IntegerSet`, `BinarySet`, and `BooleanSet` to declare domains or new global set instances with different domains.  Both use cases are legacy uses from the original Set system and not documented in either the online docs or the Book, although they may appear in old examples.

## Changes proposed in this PR:
- (re)Add support for `Var(within=RealSet)`
- Deprecate the use of RealSet, et al. for declaring model domains
- Update tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
