### PR TITLE
Remove truthiness assumption for sequence in TuplizeValuesInitializer

### DIFF
--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -411,7 +411,7 @@ class TuplizeValuesInitializer(InitializerBase):
             return _val
         elif _val is Set.Skip:
             return _val
-        elif not _val:
+        elif _val is None:
             return _val
 
         if not isinstance(_val, collections_Sequence):

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -1781,7 +1781,10 @@ class Test_SetOperator(unittest.TestCase):
         # ValueError: The truth value of a MultiIndex is ambiguous. 
         # Use a.empty, a.bool(), a.item(), a.any() or a.all().
         iterables = [['bar', 'baz', 'foo', 'qux'], ['one', 'two']]
-        pandas_index = pd.MultiIndex.from_product(iterables, names=['first', 'second'])
+        pandas_index = pd.MultiIndex.from_product(
+            iterables, 
+            names=['first', 'second']
+        )
 
         model = ConcreteModel()
         model.a = Set(initialize=pandas_index,

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -1785,13 +1785,16 @@ class Test_SetOperator(unittest.TestCase):
         model.a = Set(initialize=pandas_index,
                       dimen=pandas_index.nlevels)
 
-        # test that dimension is inferred correctly
+        # we will confirm that dimension is inferred correctly
         model.b = Set(initialize=pandas_index)
 
-        for s in (model.a, model.b):
-            self.assertIsInstance(s, Set)
-            self.assertEquals(list(s), list(pandas_index))
-            self.assertEquals(s.dimen, pandas_index.nlevels)
+        self.assertIsInstance(model.a, Set)
+        self.assertEquals(list(model.a), list(pandas_index))
+        self.assertEquals(model.a.dimen, pandas_index.nlevels)
+
+        self.assertIsInstance(model.b, Set)
+        self.assertEquals(list(model.b), list(pandas_index))
+        self.assertEquals(model.b.dimen, pandas_index.nlevels)
 
 
 class TestSetUnion(unittest.TestCase):

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -1785,6 +1785,7 @@ class Test_SetOperator(unittest.TestCase):
         model.a = Set(initialize=pandas_index,
                       dimen=pandas_index.nlevels)
         self.assertIsInstance(model.a, Set)
+        self.assertEquals(list(model.a), list(pandas_index))
 
 
 class TestSetUnion(unittest.TestCase):

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -25,6 +25,7 @@ import pyutilib.th as unittest
 
 from pyomo.common import DeveloperError
 from pyomo.common.dependencies import numpy as np, numpy_available
+from pyomo.common.dependencies import pandas as pd, pandas_available
 from pyomo.common.log import LoggingIntercept
 from pyomo.core.expr import native_numeric_types, native_types
 import pyomo.core.base.set as SetModule
@@ -63,12 +64,6 @@ from pyomo.environ import (
     AbstractModel, ConcreteModel, Block, Var, Param, Suffix, Constraint,
     Objective,
 )
-
-try:
-    import pandas as pd
-    pandas_available = True
-except:
-    pandas_available = False
 
 
 class Test_SetInitializer(unittest.TestCase):

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -64,6 +64,12 @@ from pyomo.environ import (
     Objective,
 )
 
+try:
+    import pandas as pd
+    pandas_available = True
+except:
+    pandas_available = False
+
 
 class Test_SetInitializer(unittest.TestCase):
     def test_single_set(self):

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -1784,8 +1784,14 @@ class Test_SetOperator(unittest.TestCase):
         model = ConcreteModel()
         model.a = Set(initialize=pandas_index,
                       dimen=pandas_index.nlevels)
-        self.assertIsInstance(model.a, Set)
-        self.assertEquals(list(model.a), list(pandas_index))
+
+        # test that dimension is inferred correctly
+        model.b = Set(initialize=pandas_index)
+
+        for s in (model.a, model.b):
+            self.assertIsInstance(s, Set)
+            self.assertEquals(list(s), list(pandas_index))
+            self.assertEquals(s.dimen, pandas_index.nlevels)
 
 
 class TestSetUnion(unittest.TestCase):

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -1774,6 +1774,21 @@ class Test_SetOperator(unittest.TestCase):
         self.assertEqual(i.x[1].domain, i.A*i.B)
         self.assertEqual(i.x[1], [])
 
+    @unittest.skipIf(not pandas_available, "pandas is not available")
+    def test_pandas_multiindex_set_init(self):
+        # Test that TuplizeValuesInitializer does not assume truthiness
+        # If it does, pandas will complain with the following error:
+        # ValueError: The truth value of a MultiIndex is ambiguous. 
+        # Use a.empty, a.bool(), a.item(), a.any() or a.all().
+        iterables = [['bar', 'baz', 'foo', 'qux'], ['one', 'two']]
+        pandas_index = pd.MultiIndex.from_product(iterables, names=['first', 'second'])
+
+        model = ConcreteModel()
+        model.a = Set(initialize=pandas_index,
+                      dimen=pandas_index.nlevels)
+        self.assertIsInstance(model.a, Set)
+
+
 class TestSetUnion(unittest.TestCase):
     def test_pickle(self):
         a = SetOf([1,3,5]) | SetOf([2,3,4])


### PR DESCRIPTION
## Fixes #1564 

## Summary/Motivation:
`TuplizeValuesInitializer` should not assume that the sequence can be truthy. pandas indices [do not support this](https://pandas.pydata.org/pandas-docs/version/0.15/gotchas.html) and will raise a ValueError.

## Changes proposed in this PR:
- remove assumption that the param in this initializer can be considered truthy/falsey and instead, just explicitly check whether it is None
- behavior should remain unchanged for empty sequences (or empty non-sequences) which will still be caught by the `if len(_val) == 0` check

Thanks @stigrs !

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
