### PR TITLE
Fix standard repn of external functions with fixed arguments

### DIFF
--- a/pyomo/repn/standard_repn.py
+++ b/pyomo/repn/standard_repn.py
@@ -908,7 +908,7 @@ def _collect_comparison(exp, multiplier, idMap, compute_values, verbose, quadrat
 
 def _collect_external_fn(exp, multiplier, idMap, compute_values, verbose, quadratic):
     if compute_values and exp.is_fixed():
-        return Results(nonl=multiplier*value(exp))
+        return Results(constant=multiplier*value(exp))
     return Results(nonl=multiplier*exp)
 
 

--- a/pyomo/repn/tests/test_standard.py
+++ b/pyomo/repn/tests/test_standard.py
@@ -4147,14 +4147,21 @@ class Test(unittest.TestCase):
         e = 100*m.g(1,2.0,'3')
         rep = generate_standard_repn(e, compute_values=True)
         self.assertEqual(str(rep.to_expression()), "300")
+        self.assertEqual(rep.polynomial_degree(), 0)
         rep = generate_standard_repn(e, compute_values=False)
+        self.assertEqual(rep.polynomial_degree(), 0)
         # The function ID is inconsistent, so we don't do a test
         #self.assertEqual(str(rep.to_expression()), "100*g(0, 1, 2.0, '3')")
 
         e = 100*m.g(1,2.0,'3',m.v)
         rep = generate_standard_repn(e, compute_values=True)
         self.assertEqual(str(rep.to_expression()), "400")
+        self.assertEqual(rep.polynomial_degree(), 0)
         rep = generate_standard_repn(e, compute_values=False)
+        # FIXME: this is a lie: the degree should be 0, but because
+        # compute_falues=False creates a "structural" standard repn, the
+        # computed degree appears to be general nonlinear.
+        self.assertEqual(rep.polynomial_degree(), None)
         # The function ID is inconsistent, so we don't do a test
         #self.assertEqual(str(rep.to_expression()), "100*g(0, 1, 2.0, '3', v)")
 


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This resolves an issue with `generate_standard_repn()` where expressions containing external functions with fixed / constant inputs were being categorized as general nonlinear expressions instead of constant expressions (reported by @nareshsusarla / @michaelbynum).

## Changes proposed in this PR:
- Resolve external functions with fixed/constant arguments as constants when `compute_values=True`
- Update standard_repn tests to check this condition

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
