### PR TITLE
Disable the OS package cache for OSX

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -96,6 +96,7 @@ jobs:
 
     - name: OS package cache
       uses: actions/cache@v1
+      if: matrix.TARGET != 'osx'
       id: os-cache
       with:
         path: cache/os

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -95,6 +95,7 @@ jobs:
 
     - name: OS package cache
       uses: actions/cache@v1
+      if: matrix.TARGET != 'osx'
       id: os-cache
       with:
         path: cache/os

--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -213,8 +213,13 @@ texinfo_documents = [
 
 doctest_global_setup = '''
 
-import pyomo.opt
+from pyomo.common.dependencies import (
+    attempt_import, numpy_available, scipy_available, pandas_available,
+    yaml_available, networkx_available
+)
+pint_available = attempt_import('pint', defer_check=False)[1]
 
+import pyomo.opt
 # Not using SolverFactory to check solver availability because
 # as of June 2020 there is no way to supress warnings when 
 # solvers are not available

--- a/pyomo/core/base/units_container.py
+++ b/pyomo/core/base/units_container.py
@@ -24,7 +24,7 @@ PyomoUnitsContainer. You can use the module level instance already defined as
 this module using common notation.
 
     .. doctest::
-        :skipif: not pint_available
+       :skipif: not pint_available
 
        >>> from pyomo.environ import units as u
        >>> print(3.0*u.kg)
@@ -38,7 +38,7 @@ like the objective function, constraint, or expression using
 There are other methods there that may be helpful for verifying correct units on a model.
 
     .. doctest::
-        :skipif: not pint_available
+       :skipif: not pint_available
 
        >>> from pyomo.environ import ConcreteModel, Var, Objective
        >>> from pyomo.environ import units as u

--- a/pyomo/core/base/units_container.py
+++ b/pyomo/core/base/units_container.py
@@ -24,6 +24,7 @@ PyomoUnitsContainer. You can use the module level instance already defined as
 this module using common notation.
 
     .. doctest::
+        :skipif: not pint_available
 
        >>> from pyomo.environ import units as u
        >>> print(3.0*u.kg)
@@ -37,6 +38,7 @@ like the objective function, constraint, or expression using
 There are other methods there that may be helpful for verifying correct units on a model.
 
     .. doctest::
+        :skipif: not pint_available
 
        >>> from pyomo.environ import ConcreteModel, Var, Objective
        >>> from pyomo.environ import units as u
@@ -1154,6 +1156,7 @@ class PyomoUnitsContainer(object):
         Then we can add this to the container with:
 
         .. doctest::
+            :skipif: not pint_available
             :hide:
 
             # get a local units object (to avoid duplicate registration
@@ -1164,6 +1167,7 @@ class PyomoUnitsContainer(object):
             ...     tmp = FILE.write("USD = [currency]\\n")
 
         .. doctest::
+            :skipif: not pint_available
 
             >>> u.load_definitions_from_file('my_additional_units.txt')
             >>> print(u.USD)
@@ -1184,6 +1188,7 @@ class PyomoUnitsContainer(object):
         unit, use
 
         .. doctest::
+            :skipif: not pint_available
             :hide:
 
             # get a local units object (to avoid duplicate registration
@@ -1192,6 +1197,7 @@ class PyomoUnitsContainer(object):
             >>> u = _units.PyomoUnitsContainer()
 
         .. doctest::
+            :skipif: not pint_available
 
             >>> u.load_definitions_from_strings(['USD = [currency]'])
             >>> print(u.USD)


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Disable package OS caching on OSX.  We regularly see cases where Python 3.7 and 3.8 tests begin to fail because the OSX image was updated and becomes incompatible with the cached os update packages.  Disabling the caches may slow OSX builds down slightly, but should make them more reliable.

## Changes proposed in this PR:
- Disable OS package download cache for OSX builds

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
