### PR TITLE
Use name buffer in add slacks transformation

### DIFF
--- a/pyomo/core/plugins/transform/add_slack_vars.py
+++ b/pyomo/core/plugins/transform/add_slack_vars.py
@@ -125,11 +125,12 @@ class AddSlackVariables(NonIsomorphicTransformation):
                 raise RuntimeError("Lower bound exceeds upper bound in "
                                    "constraint %s" % cons.name)
             if not cons.active: continue
+            cons_name = cons.getname(fully_qualified=True,
+                                     name_buffer=NAME_BUFFER)
             if cons.lower is not None:
                 # we add positive slack variable to body:
                 # declare positive slack
-                varName = "_slack_plus_" + cons.getname(fully_qualified=True,
-                                                        name_buffer=NAME_BUFFER)
+                varName = "_slack_plus_" + cons_name
                 posSlack = Var(within=NonNegativeReals)
                 xblock.add_component(varName, posSlack)
                 # add positive slack to body expression
@@ -139,8 +140,7 @@ class AddSlackVariables(NonIsomorphicTransformation):
             if cons.upper is not None:
                 # we subtract a positive slack variable from the body:
                 # declare slack
-                varName = "_slack_minus_" + cons.getname(fully_qualified=True,
-                                                        name_buffer=NAME_BUFFER)
+                varName = "_slack_minus_" + cons_name
                 negSlack = Var(within=NonNegativeReals)
                 xblock.add_component(varName, negSlack)
                 # add negative slack to body expression


### PR DESCRIPTION
## Fixes # NA

## Summary/Motivation:

The `core.add_slack_variables` transformation had two calls to the name method to name the Constraints it creates. This meant it scaled quadratically in the number of constraints rather than linearly... This changes to the `getname` method using a name buffer, and gets the name once per constraint.

## Changes proposed in this PR:
- replace `name` with `getname` and add name buffer
- get the name of each constraint only once.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
