### PR TITLE
Allow comparison between slices with one-dimensional slices in __getitem__ call

### DIFF
--- a/pyomo/core/base/indexed_component_slice.py
+++ b/pyomo/core/base/indexed_component_slice.py
@@ -276,6 +276,14 @@ class IndexedComponent_slice(object):
         return ((_iter.get_last_index(), _) for _ in _iter)
 
 
+def _tuple_from_possible_scalar(source):
+    if type(source) is not tuple:
+        # This will behave poorly for non-tuple,
+        # non-string iterables, but we do not 
+        # expect non-tuple, non-string iterables.
+        return (source,)
+    return source
+
 def _freeze(info):
     if info[0] == IndexedComponent_slice.slice_info:
         return (
@@ -286,15 +294,15 @@ def _freeze(info):
             info[1][3]  # elipsis index
         )
     elif info[0] & IndexedComponent_slice.ITEM_MASK:
+        index = _tuple_from_possible_scalar(info[1])
         return (
             info[0],
             tuple( (x.start,x.stop,x.step) if type(x) is slice else x
-                   for x in info[1] ),
+                   for x in index ),
             info[2:],
         )
     else:
         return info
-
 
 
 class _slice_generator(object):

--- a/pyomo/core/tests/unit/test_indexed_slice.py
+++ b/pyomo/core/tests/unit/test_indexed_slice.py
@@ -680,6 +680,19 @@ class TestComponentSlices(unittest.TestCase):
         finally:
             normalize_index.flatten = _old_flatten
 
+    def test_compare_1dim_slice(self):
+        m = ConcreteModel()
+        m.I = Set(initialize=range(2))
+        m.J = Set(initialize=range(2,4))
+        m.K = Set(initialize=['a','b'])
+
+        @m.Block(m.I, m.J)
+        def b(b, i, j):
+            b.v = Var(m.K)
+
+        self.assertEqual(m.b[0,:].v[:], m.b[0,:].v[:])
+        self.assertNotEqual(m.b[0,:].v[:], m.b[0,:].v['a'])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
The following code would fail due to `_freeze` not checking if `info[1]`, the index in a `__getitem__` call, is iterable.
```python
m = ConcreteModel()
m.I = Set(initialize=range(2))
m.J = Set(initialize=range(2,4))
m.K = Set(initialize=['a','b'])

@m.Block(m.I, m.J)
def b(b, i, j):
    b.v = Var(m.K)

test = m.b[0,:].v[:] == m.b[0,:].v[:]
```

Changes proposed in this PR:
- Convert non-tuple indices to tuples in `_freeze` function
- Add test containing the above code.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
