### PR TITLE
Increase CtypesEnviron ctypes.CDLL load timeout to 10 seconds

### DIFF
--- a/pyomo/common/env.py
+++ b/pyomo/common/env.py
@@ -42,7 +42,7 @@ def _attempt_ctypes_cdll(name):
         return False
 
 
-def _load_dll(name, timeout=1):
+def _load_dll(name, timeout=10):
     """Load a DLL with a timeout
 
     On some platforms and some DLLs (notably Windows GitHub Actions with
@@ -57,6 +57,11 @@ def _load_dll(name, timeout=1):
     interface only spawns the subprocess if ctypes.util.find_library
     actually locates the target library.  This will have a measurable
     impact on Windows (where the DLLs exist), but not on other platforms.
+
+    The default timeout of 10 is arbitrary.  For simeple situations, 1
+    seems adequate.  However, more complex examples have been observed
+    that needed timeout==5.  Using a default of 10 is simply doubling
+    that observed case.
 
     """
     if not ctypes.util.find_library(name):

--- a/pyomo/common/env.py
+++ b/pyomo/common/env.py
@@ -47,7 +47,7 @@ def _load_dll(name, timeout=10):
 
     On some platforms and some DLLs (notably Windows GitHub Actions with
     Python 3.5, 3.6, and 3.7 and the msvcr90.dll) we have observed
-    behavior where the ctypes.CDLL() call hangs indefinitely.  This uses
+    behavior where the ctypes.CDLL() call hangs indefinitely. This uses
     multiprocessing to attempt the import in a subprocess (with a
     timeout) and then only calls the import in the main process if the
     subprocess succeeded.
@@ -55,12 +55,12 @@ def _load_dll(name, timeout=10):
     Performance note: CtypesEnviron only ever attempts to load a DLL
     once (the DLL reference is then held in a class attribute), and this
     interface only spawns the subprocess if ctypes.util.find_library
-    actually locates the target library.  This will have a measurable
+    actually locates the target library. This will have a measurable
     impact on Windows (where the DLLs exist), but not on other platforms.
 
-    The default timeout of 10 is arbitrary.  For simeple situations, 1
-    seems adequate.  However, more complex examples have been observed
-    that needed timeout==5.  Using a default of 10 is simply doubling
+    The default timeout of 10 is arbitrary. For simple situations, 1
+    seems adequate. However, more complex examples have been observed
+    that needed timeout==5. Using a default of 10 is simply doubling
     that observed case.
 
     """


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
@eslickj has observed situations with IDAES models where the default timeout when attempting to load MSVCRT runtimes was too aggressive.  Through debugging, he found that 4 seconds was too short and 5 appeared to be long enough.  This PR moved the timeout to be 10 (i.e., 2 * 5 seconds).

## Changes proposed in this PR:
- Increase timeout when loading libraries through CtypesEnviron to 10 seconds

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
