### PR TITLE
bug fix #285 for CPLEX 12.9.X and above

### DIFF
--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -160,7 +160,7 @@ class CPLEXDirect(DirectSolver):
                 for var in block.component_data_objects(ctype=pyomo.core.base.var.Var, descend_into=False, active=True, sort=False):
                     var.stale = True
         _log_file = self._log_file
-        if self.version() >= (12, 10):
+        if self.version() >= (12, 9):
             _log_file = open(self._log_file, 'w')
         try:
             if self._tee:
@@ -240,7 +240,7 @@ class CPLEXDirect(DirectSolver):
             t1 = time.time()
             self._wallclock_time = t1 - t0
         finally:
-            if self.version() >= (12, 10):
+            if self.version() >= (12, 9):
                 _log_file.close()
 
         # FIXME: can we get a return code indicating if CPLEX had a significant failure?


### PR DESCRIPTION
## Fixes # .
Issue #285 "Windows: CPLEX direct, solver_io="direct" throws error when tee=True and keepfiles=False"

## Summary/Motivation:
Seemed to be caused by CPLEX not releasing the log file after ```cplex.set_results_stream(filename)```. A similar fix was already implemented for versions 12.10 and above in cplex_direct.CPLEXDirect._apply_solver() lines 163 and 243.
The issue came up to me because I am using CPLEX 12.9.
Note that in the original issue, the user's version was 12.7. Thus, this may need further revieweing depending on the backward compatibility policy adopted for the project.

## Changes proposed in this PR:
- cplex_direct.CPLEXDirect._apply_solver() lines 163 and 243: The condition was updated to include versions 12.9: 
```if self.version() >= (12, 10):``` --> ```if self.version() >= (12, 9):```

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
