### PR TITLE
Add public API for checking Param mutability

### DIFF
--- a/pyomo/contrib/viewer/model_browser.py
+++ b/pyomo/contrib/viewer/model_browser.py
@@ -119,7 +119,7 @@ class ModelBrowser(_ModelBrowser, _ModelBrowserUI):
             self.setWindowTitle("Constraints")
         elif standard == "Param":
             components = Param
-            columns = ["name", "value", "_mutable"]
+            columns = ["name", "value", "mutable"]
             editable = ["value"]
             self.setWindowTitle("Parameters")
         elif standard == "Expression":
@@ -263,7 +263,7 @@ class ComponentDataItem(object):
             except:
                 return
         elif isinstance(self.data, _ParamData):
-            if not self.data._mutable: return
+            if not self.data.parent_component().mutable: return
             try:
                 self.data.value = val
             except:

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -225,8 +225,11 @@ class Param(IndexedComponent):
         initialize  
             A dictionary or rule for setting up this parameter with existing 
             model data
-        unit: pyomo unit expression                                                                                            
+        unit: pyomo unit expression
             An expression containing the units for the parameter
+        mutable: `boolean`
+            Flag indicating if the value of the parameter may change between
+            calls to a solver. Defaults to `False`
     """
 
     DefaultMutable = False
@@ -248,8 +251,8 @@ class Param(IndexedComponent):
         self._mutable       = kwd.pop('mutable', Param.DefaultMutable )
         self._default_val   = kwd.pop('default', _NotValid )
         self._dense_initialize = kwd.pop('initialize_as_dense', False)
-        self._units         = kwd.pop('units', None)                                                                           
-        if self._units is not None:                                                                                            
+        self._units         = kwd.pop('units', None)
+        if self._units is not None:
             self._mutable = True
         #
         if 'repn' in kwd:
@@ -289,6 +292,10 @@ class Param(IndexedComponent):
         if self._default_val is _NotValid:
             return self._data.__iter__()
         return self._index.__iter__()
+
+    @property
+    def mutable(self):
+        return self._mutable
 
     #
     # These are "sparse equivalent" access / iteration methods that

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -121,7 +121,7 @@ class ParamTester(object):
     def test_setitem_index_error(self):
         try:
             self.instance.A[2] = 4.3
-            if not self.instance.A._mutable:
+            if not self.instance.A.mutable:
                 self.fail("Expected setitem[%s] to fail for immutable Params"
                           % (idx,))
             self.fail("Expected KeyError because 2 is not a valid key")
@@ -129,7 +129,7 @@ class ParamTester(object):
             pass
         except TypeError:
             # immutable Params should raise a TypeError exception
-            if self.instance.A._mutable:
+            if self.instance.A.mutable:
                 raise
 
     def test_setitem_preexisting(self):
@@ -139,7 +139,7 @@ class ParamTester(object):
 
         idx = sorted(keys)[0]
         self.assertEqual(self.instance.A[idx], self.data[idx])
-        if self.instance.A._mutable:
+        if self.instance.A.mutable:
             self.assertTrue( isinstance( self.instance.A[idx],
                                          pyomo.core.base.param._ParamData ) )
         else:
@@ -147,7 +147,7 @@ class ParamTester(object):
 
         try:
             self.instance.A[idx] = 4.3
-            if not self.instance.A._mutable:
+            if not self.instance.A.mutable:
                 self.fail("Expected setitem[%s] to fail for immutable Params"
                           % (idx,))
             self.assertEqual( self.instance.A[idx], 4.3)
@@ -155,12 +155,12 @@ class ParamTester(object):
                                         pyomo.core.base.param._ParamData ) )
         except TypeError:
             # immutable Params should raise a TypeError exception
-            if self.instance.A._mutable:
+            if self.instance.A.mutable:
                 raise
 
         try:
             self.instance.A[idx] = -4.3
-            if not self.instance.A._mutable:
+            if not self.instance.A.mutable:
                 self.fail("Expected setitem[%s] to fail for immutable Params"
                           % (idx,))
             if self.expectNegativeDomainError:
@@ -174,12 +174,12 @@ class ParamTester(object):
                     % ( str(sys.exc_info()[1]), idx ) )
         except TypeError:
             # immutable Params should raise a TypeError exception
-            if self.instance.A._mutable:
+            if self.instance.A.mutable:
                 raise
 
         try:
             self.instance.A[idx] = 'x'
-            if not self.instance.A._mutable:
+            if not self.instance.A.mutable:
                 self.fail("Expected setitem[%s] to fail for immutable Params"
                           % (idx,))
             if self.expectTextDomainError:
@@ -193,7 +193,7 @@ class ParamTester(object):
                     % ( str(sys.exc_info()[1]), idx ) )
         except TypeError:
             # immutable Params should raise a TypeError exception
-            if self.instance.A._mutable:
+            if self.instance.A.mutable:
                 raise
 
     def test_setitem_default_override(self):
@@ -213,7 +213,7 @@ class ParamTester(object):
 
         self.assertEqual( value(self.instance.A[idx]),
                           self.instance.A._default_val )
-        if self.instance.A._mutable:
+        if self.instance.A.mutable:
             self.assertIsInstance( self.instance.A[idx],
                                    pyomo.core.base.param._ParamData )
         else:
@@ -222,7 +222,7 @@ class ParamTester(object):
 
         try:
             self.instance.A[idx] = 4.3
-            if not self.instance.A._mutable:
+            if not self.instance.A.mutable:
                 self.fail("Expected setitem[%s] to fail for immutable Params"
                           % (idx,))
             self.assertEqual( self.instance.A[idx], 4.3)
@@ -230,12 +230,12 @@ class ParamTester(object):
                                    pyomo.core.base.param._ParamData )
         except TypeError:
             # immutable Params should raise a TypeError exception
-            if self.instance.A._mutable:
+            if self.instance.A.mutable:
                 raise
 
         try:
             self.instance.A[idx] = -4.3
-            if not self.instance.A._mutable:
+            if not self.instance.A.mutable:
                 self.fail("Expected setitem[%s] to fail for immutable Params"
                           % (idx,))
             if self.expectNegativeDomainError:
@@ -249,12 +249,12 @@ class ParamTester(object):
                     % ( str(sys.exc_info()[1]), idx ) )
         except TypeError:
             # immutable Params should raise a TypeError exception
-            if self.instance.A._mutable:
+            if self.instance.A.mutable:
                 raise
 
         try:
             self.instance.A[idx] = 'x'
-            if not self.instance.A._mutable:
+            if not self.instance.A.mutable:
                 self.fail("Expected setitem[%s] to fail for immutable Params"
                           % (idx,))
             if self.expectTextDomainError:
@@ -268,7 +268,7 @@ class ParamTester(object):
                     % ( str(sys.exc_info()[1]), idx) )
         except TypeError:
             # immutable Params should raise a TypeError exception
-            if self.instance.A._mutable:
+            if self.instance.A.mutable:
                 raise
 
     def test_dim(self):
@@ -293,7 +293,7 @@ class ParamTester(object):
     def test_values(self):
         expectException = False
         #    len(self.sparse_data) < len(self.data) and \
-        #    not self.instance.A._mutable
+        #    not self.instance.A.mutable
         try:
             test = self.instance.A.values()
             #self.assertEqual( type(test), list )
@@ -311,7 +311,7 @@ class ParamTester(object):
         expectException = False
         #                  len(self.sparse_data) < len(self.data) and \
         #                  not self.instance.A._default_val is _NotValid and \
-        #                  not self.instance.A._mutable
+        #                  not self.instance.A.mutable
         try:
             test = self.instance.A.items()
             #self.assertEqual( type(test), list )
@@ -332,7 +332,7 @@ class ParamTester(object):
         expectException = False
         #                  len(self.sparse_data) < len(self.data) and \
         #                  not self.instance.A._default_val is None and \
-        #                  not self.instance.A._mutable
+        #                  not self.instance.A.mutable
         try:
             test = itervalues(self.instance.A)
             test = zip(self.instance.A.keys(), test)
@@ -349,7 +349,7 @@ class ParamTester(object):
         expectException = False
         #                  len(self.sparse_data) < len(self.data) and \
         #                  not self.instance.A._default_val is None and \
-        #                  not self.instance.A._mutable
+        #                  not self.instance.A.mutable
         try:
             test = iteritems(self.instance.A)
             if self.instance.A._default_val is _NotValid:
@@ -416,7 +416,7 @@ class ParamTester(object):
             return
         idx = list(set(self.data) - set(self.sparse_data))[0]
         expectException = self.instance.A._default_val is _NotValid \
-                          and not self.instance.A._mutable
+                          and not self.instance.A.mutable
         try:
             test = self.instance.A[idx]
             if expectException:

--- a/pyomo/repn/plugins/baron_writer.py
+++ b/pyomo/repn/plugins/baron_writer.py
@@ -364,7 +364,7 @@ class ProblemWriter_bar(AbstractProblemWriter):
         else:
             def mutable_param_gen(b):
                 for param in block.component_objects(Param):
-                    if param._mutable and param.is_indexed():
+                    if param.mutable and param.is_indexed():
                         param_data_iter = \
                             (param_data for index, param_data
                              in iteritems(param))
@@ -635,7 +635,7 @@ class ProblemWriter_bar(AbstractProblemWriter):
             # GAH: Not sure this is necessary, and also it would break for
             #      non-mutable indexed params so I am commenting out for now.
             #for param_data in active_components_data(block, Param, sort=sorter):
-                #instead of checking if param_data._mutable:
+                #instead of checking if param_data.mutable:
                 #if not param_data.is_constant():
                 #    create_symbol_func(symbol_map, param_data, labeler)
 


### PR DESCRIPTION
##  Summary/Motivation:
The only consistent way right now to check if a Param component (singleton or indexed) is mutable is to check the private `_mutable` attribute. This PR adds a `mutable` property to Param so that we have a clean, public API for checking the `_mutable` attribute. I also propagated the use of this property to other parts of the code base that were accessing the private attribute.

## Changes proposed in this PR:
- Add a `mutable` property to Param components
- Use `mutable` property in other files instead of the `_mutable` attribute

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
