### PR TITLE
Explicitly close log files for cplex_direct

### DIFF
--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -10,6 +10,7 @@
 
 import logging
 import re
+import six
 import sys
 import pyomo.common
 from pyutilib.misc import Bunch

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -159,18 +159,27 @@ class CPLEXDirect(DirectSolver):
             for block in self._pyomo_model.block_data_objects(descend_into=True, active=True):
                 for var in block.component_data_objects(ctype=pyomo.core.base.var.Var, descend_into=False, active=True, sort=False):
                     var.stale = True
-        _log_file = self._log_file
-        if self.version() >= (12, 10):
-            _log_file = open(self._log_file, 'w')
+        # In recent versions of CPLEX it is helpful to manually open the
+        # log file and then explicitly close it after CPLEX is finished.
+        # This ensures that the file is closed (and unlocked) on Windows
+        # before the TempfileManager (or user) attempts to delete the
+        # log file.  Passing in an opened file object is supported at
+        # least as far back as CPLEX 12.5.1 [the oldest version
+        # supported by IBM as of 1 Oct 2020]
+        if self.version() >= (12, 5, 1) \
+           and isinstance(self._log_file, six.string_types):
+            _log_file = (open(self._log_file, 'a'),)
+            _close_log_file = True
+        else:
+            _log_file = (self._log_file,)
+            _close_log_file = False
+        if self._tee:
+            def _process_stream(arg):
+                sys.stdout.write(arg)
+                return arg
+            _log_file += (_process_stream,)
         try:
-            if self._tee:
-                def _process_stream(arg):
-                    sys.stdout.write(arg)
-                    return arg
-                self._solver_model.set_results_stream(_log_file, _process_stream)
-            else:
-                self._solver_model.set_results_stream(_log_file)
-            
+            self._solver_model.set_results_stream(*_log_file)
             if self._keepfiles:
                 print("Solver log file: "+self._log_file)
             
@@ -240,7 +249,8 @@ class CPLEXDirect(DirectSolver):
             t1 = time.time()
             self._wallclock_time = t1 - t0
         finally:
-            if self.version() >= (12, 10):
+            self._solver_model.set_results_stream(None)
+            if _close_log_file:
                 _log_file.close()
 
         # FIXME: can we get a return code indicating if CPLEX had a significant failure?

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -252,7 +252,7 @@ class CPLEXDirect(DirectSolver):
         finally:
             self._solver_model.set_results_stream(None)
             if _close_log_file:
-                _log_file.close()
+                _log_file[0].close()
 
         # FIXME: can we get a return code indicating if CPLEX had a significant failure?
         return Bunch(rc=None, log=None)


### PR DESCRIPTION
## Fixes #285

## Summary/Motivation:
This is an expanded version of the fix proposed in #1648 that explicitly opens (and closes) the log file for all versions of cplex >= 12.5.1 (the oldest version of cplex supported by IBM for which documentation is still available).  In addition to updating the cplex version for which we explicitly open (and then subsequently close) the log file, this PR also explicitly "de-registers" it from the cplex library (by calling `set_results_stream(None)`).

## Changes proposed in this PR:
- Explicitly open (and then subsequently close) the cplex log file for all versions of cplex >= 12.5.1
- Explicitly de-register the results file by calling `set_results_stream(None)`
- Simplify the logic around the results stream management
- add additional documentation explaining why we are opening the log file.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
