### PR TITLE
Deprecate the use of base64.decodestring with python3

### DIFF
--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -316,7 +316,7 @@ class kestrelAMPL:
         if six.PY2:
             nl_string = base64.encodestring(zipped_nl_file.getvalue())
         else:
-            nl_string = (base64.encodestring(zipped_nl_file.getvalue())).decode('utf-8')
+            nl_string = (base64.encodebytes(zipped_nl_file.getvalue())).decode('utf-8')
         xml = """
               <document>
               <category>kestrel</category>


### PR DESCRIPTION
## Summary/Motivation:

`base64.encodestring` was [deprecated since python 3.1](https://docs.python.org/3.8/library/base64.html#base64.encodestring) and is removed in python 3.9 .

## Changes proposed in this PR:
- Move to `base64.encodebytes` instead when using python 3. This also fixes a failing test when using python 3.9 .

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
