### PR TITLE
updating methods for differentiating pyomo expressions

### DIFF
--- a/pyomo/core/expr/calculus/diff_with_pyomo.py
+++ b/pyomo/core/expr/calculus/diff_with_pyomo.py
@@ -53,6 +53,15 @@ def _diff_SumExpression(node, val_dict, der_dict):
         der_dict[arg] += der
 
 
+def _diff_LinearExpression(node: _expr.LinearExpression, val_dict, der_dict):
+    der = der_dict[node]
+    for ndx, v in enumerate(node.linear_vars):
+        coef = node.linear_coefs[ndx]
+        der_dict[v] += der * val_dict[coef]
+        der_dict[coef] += der * val_dict[v]
+
+    der_dict[node.constant] += der
+
 def _diff_PowExpression(node, val_dict, der_dict):
     """
 
@@ -325,6 +334,16 @@ _diff_map[_expr.MonomialTermExpression] = _diff_ProductExpression
 _diff_map[_expr.NegationExpression] = _diff_NegationExpression
 _diff_map[_expr.UnaryFunctionExpression] = _diff_UnaryFunctionExpression
 _diff_map[_expr.ExternalFunctionExpression] = _diff_ExternalFunctionExpression
+_diff_map[_expr.LinearExpression] = _diff_LinearExpression
+
+_diff_map[_expr.NPV_ProductExpression] = _diff_ProductExpression
+_diff_map[_expr.NPV_DivisionExpression] = _diff_DivisionExpression
+_diff_map[_expr.NPV_ReciprocalExpression] = _diff_ReciprocalExpression
+_diff_map[_expr.NPV_PowExpression] = _diff_PowExpression
+_diff_map[_expr.NPV_SumExpression] = _diff_SumExpression
+_diff_map[_expr.NPV_NegationExpression] = _diff_NegationExpression
+_diff_map[_expr.NPV_UnaryFunctionExpression] = _diff_UnaryFunctionExpression
+_diff_map[_expr.NPV_ExternalFunctionExpression] = _diff_ExternalFunctionExpression
 
 
 class _NamedExpressionCollector(ExpressionValueVisitor):
@@ -392,6 +411,18 @@ class _ReverseADVisitorLeafToRoot(ExpressionValueVisitor):
             if node not in self.der_dict:
                 self.der_dict[node] = 0
             return True, node
+
+        if node.__class__ is _expr.LinearExpression:
+            for v in node.linear_vars + node.linear_coefs + [node.constant]:
+                val = value(v)
+                self.val_dict[v] = val
+                if v not in self.der_dict:
+                    self.der_dict[v] = 0
+            val = value(node)
+            self.val_dict[node] = val
+            if node not in self.der_dict:
+                self.der_dict[node] = 0
+            return True, val
 
         if not node.is_expression_type():
             val = value(node)
@@ -487,6 +518,18 @@ class _ReverseSDVisitorLeafToRoot(ExpressionValueVisitor):
             if node not in self.der_dict:
                 self.der_dict[node] = 0
             return True, node
+
+        if node.__class__ is _expr.LinearExpression:
+            for v in node.linear_vars + node.linear_coefs + [node.constant]:
+                val = v
+                self.val_dict[v] = val
+                if v not in self.der_dict:
+                    self.der_dict[v] = 0
+            val = node
+            self.val_dict[node] = val
+            if node not in self.der_dict:
+                self.der_dict[node] = 0
+            return True, val
 
         if not node.is_expression_type():
             val = node

--- a/pyomo/core/expr/calculus/diff_with_pyomo.py
+++ b/pyomo/core/expr/calculus/diff_with_pyomo.py
@@ -53,7 +53,7 @@ def _diff_SumExpression(node, val_dict, der_dict):
         der_dict[arg] += der
 
 
-def _diff_LinearExpression(node: _expr.LinearExpression, val_dict, der_dict):
+def _diff_LinearExpression(node, val_dict, der_dict):
     der = der_dict[node]
     for ndx, v in enumerate(node.linear_vars):
         coef = node.linear_coefs[ndx]

--- a/pyomo/core/tests/unit/test_derivs.py
+++ b/pyomo/core/tests/unit/test_derivs.py
@@ -2,6 +2,7 @@ import pyutilib.th as unittest
 import pyomo.environ as pe
 from pyomo.core.expr.calculus.diff_with_pyomo import reverse_ad, reverse_sd
 from pyomo.common.getGSL import find_GSL
+from pyomo.core.expr.numeric_expr import LinearExpression
 
 
 tol = 6
@@ -220,3 +221,25 @@ class TestDerivs(unittest.TestCase):
         derivs = reverse_ad(e)
         self.assertAlmostEqual(derivs[m.x], approx_deriv(e, m.x), tol)
         self.assertAlmostEqual(derivs[m.y], approx_deriv(e, m.y), tol)
+
+    def test_linear_expression(self):
+        m = pe.ConcreteModel()
+        m.x = pe.Var(initialize=2)
+        m.y = pe.Var(initialize=3)
+        m.p = pe.Param(initialize=2.5, mutable=True)
+        e = LinearExpression(constant=m.p, linear_vars=[m.x, m.y], linear_coefs=[1.8, m.p])
+        e = pe.log(e)
+        derivs = reverse_ad(e)
+        symbolic = reverse_sd(e)
+        for v in [m.x, m.y, m.p]:
+            self.assertAlmostEqual(derivs[v], pe.value(symbolic[v]), tol)
+            self.assertAlmostEqual(derivs[v], approx_deriv(e, v), tol)
+
+    def test_NPV(self):
+        m = pe.ConcreteModel()
+        m.p = pe.Param(initialize=2, mutable=True)
+        e = pe.log(m.p)
+        derivs = reverse_ad(e)
+        symbolic = reverse_sd(e)
+        self.assertAlmostEqual(derivs[m.p], pe.value(symbolic[m.p]), tol)
+        self.assertAlmostEqual(derivs[m.p], approx_deriv(e, m.p), tol)

--- a/pyomo/core/tests/unit/test_derivs.py
+++ b/pyomo/core/tests/unit/test_derivs.py
@@ -224,8 +224,8 @@ class TestDerivs(unittest.TestCase):
 
     def test_linear_expression(self):
         m = pe.ConcreteModel()
-        m.x = pe.Var(initialize=2)
-        m.y = pe.Var(initialize=3)
+        m.x = pe.Var(initialize=2.0)
+        m.y = pe.Var(initialize=3.0)
         m.p = pe.Param(initialize=2.5, mutable=True)
         e = LinearExpression(constant=m.p, linear_vars=[m.x, m.y], linear_coefs=[1.8, m.p])
         e = pe.log(e)
@@ -237,7 +237,7 @@ class TestDerivs(unittest.TestCase):
 
     def test_NPV(self):
         m = pe.ConcreteModel()
-        m.p = pe.Param(initialize=2, mutable=True)
+        m.p = pe.Param(initialize=2.0, mutable=True)
         e = pe.log(m.p)
         derivs = reverse_ad(e)
         symbolic = reverse_sd(e)


### PR DESCRIPTION
## Fixes #1662 .

## Changes proposed in this PR:
- Adds support for differentiating NPV expressions
- Adds support for differentiating LinearExpression

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
