### PR TITLE
PyNumero Updates

### DIFF
--- a/pyomo/contrib/pynumero/sparse/block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/block_vector.py
@@ -1387,7 +1387,6 @@ class BlockVector(np.ndarray, BaseBlockVector):
         # populate blocks in the right spaces
         for bid in mpi_bv.owned_blocks:
             mpi_bv.set_block(bid, self.get_block(bid))
-        mpi_bv.broadcast_block_sizes()
 
         return mpi_bv
 

--- a/pyomo/contrib/pynumero/sparse/mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/mpi_block_vector.py
@@ -285,7 +285,8 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
             indices = self._unique_owned_blocks
         local_size = np.sum(self._brow_lengths[indices])
         size = comm.allreduce(local_size)
-        return size
+        assert int(size) == size
+        return int(size)
 
     @property
     def ndim(self):

--- a/pyomo/contrib/pynumero/sparse/mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/mpi_block_vector.py
@@ -276,7 +276,7 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
         """
         Returns total number of elements in this MPIBlockVector
         """
-        comm: MPI.Comm = self._mpiw
+        comm = self._mpiw
         rank = comm.Get_rank()
         if rank == 0:
             indices = self._owned_blocks

--- a/pyomo/contrib/pynumero/sparse/mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/mpi_block_vector.py
@@ -276,6 +276,7 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
         """
         Returns total number of elements in this MPIBlockVector
         """
+        assert_block_structure(self)
         comm = self._mpiw
         rank = comm.Get_rank()
         if rank == 0:

--- a/pyomo/contrib/pynumero/sparse/mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/mpi_block_vector.py
@@ -118,7 +118,7 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
         obj._unique_owned_blocks = np.array(obj._unique_owned_blocks)
         obj._brow_lengths = np.empty(nblocks, dtype=np.float64)
         obj._brow_lengths.fill(np.nan)
-        obj._undefined_brows = set(range(nblocks))
+        obj._undefined_brows = set(obj._owned_blocks)
 
         # make some pointers unmutable. These arrays don't change after
         # MPIBlockVector has been created
@@ -126,6 +126,8 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
         obj._owned_blocks.flags.writeable = False
         obj._owned_mask.flags.writeable = False
         obj._unique_owned_blocks.flags.writeable = False
+
+        obj._broadcasted = False
 
         return obj
 
@@ -267,15 +269,15 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
         """
         Returns total number of elements in the MPIBlockVector
         """
-        assert_block_structure(self)
-        return np.sum(self._brow_lengths),
+        return (self.size,)
 
     @property
     def size(self):
         """
         Returns total number of elements in this MPIBlockVector
         """
-        assert_block_structure(self)
+        if not self._broadcasted:
+            self.broadcast_block_sizes()
         return np.sum(self._brow_lengths)
 
     @property
@@ -327,26 +329,29 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
         """Returns MPI communicator"""
         return self._mpiw
 
+    def is_broadcasted(self):
+        return self._broadcasted
+
     def block_sizes(self, copy=True):
         """
         Returns 1D-Array with sizes of individual blocks in this MPIBlockVector
         """
-        assert_block_structure(self)
+        if not self._broadcasted:
+            self.broadcast_block_sizes()
         if copy:
             return self._brow_lengths.copy()
         return self._brow_lengths
 
     def get_block_size(self, ndx):
-        if ndx in self._undefined_brows:
+        res = self._brow_lengths[ndx]
+        if res == np.nan:
             raise NotFullyDefinedBlockVectorError('The dimensions of the requested block are not defined.')
-        return self._brow_lengths[ndx]
+        return res
 
     def _set_block_size(self, ndx, size):
         if ndx in self._undefined_brows:
             self._undefined_brows.remove(ndx)
             self._brow_lengths[ndx] = size
-            if len(self._undefined_brows) == 0:
-                self._brow_lengths = np.asarray(self._brow_lengths, dtype=np.int64)
         else:
             if self._brow_lengths[ndx] != size:
                 raise ValueError('Incompatible dimensions for block {ndx}; '
@@ -361,6 +366,7 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
         this MPIBlockVector knows it's dimensions across all blocks. This method
         must be called before running any operations with the MPIBlockVector.
         """
+        assert_block_structure(self)
         rank = self._mpiw.Get_rank()
         num_processors = self._mpiw.Get_size()
 
@@ -396,7 +402,10 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
                 msg = 'The dimension of block {} was not specified in any process'.format(i)
 
             # here block_length must only have one element
-            self._set_block_size(i, block_length.pop())
+            self._brow_lengths[i] = block_length.pop()
+
+        self._brow_lengths = np.asarray(self._brow_lengths, dtype=np.int64)
+        self._broadcasted = True
 
     def finalize_block_sizes(self, broadcast=True, block_sizes=None):
         """
@@ -410,9 +419,9 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
         if broadcast:
             self.broadcast_block_sizes()
         else:
-            assert np.all((block_sizes - np.asarray(self._brow_lengths))[self._owned_blocks] == 0)
             self._undefined_brows = set()
             self._brow_lengths = block_sizes
+            self._broadcasted = True
 
     # Note: this requires communication but is only run in __new__
     def _assert_correct_owners(self, root=0):
@@ -550,7 +559,6 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
         assert_block_structure(self)
         for i in self._owned_blocks:
             result.set_block(i, self._block_vector.get_block(i).nonzero()[0])
-        result.broadcast_block_sizes()
         return (result,)
 
     def round(self, decimals=0, out=None):
@@ -612,7 +620,6 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
             assert self._mpiw == condition._mpiw, 'Need to have same communicator'
             for i in self._owned_blocks:
                 result.set_block(i, self.get_block(i).compress(condition.get_block(i)))
-            result.broadcast_block_sizes()
             return result
         if isinstance(condition, BlockVector):
             raise RuntimeError('Operation not supported by MPIBlockVector')
@@ -735,19 +742,19 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
         """
         Returns a copy of the MPIBlockVector structure filled with zeros
         """
+        print(self.is_broadcasted())
         result = MPIBlockVector(self.nblocks, self.rank_ownership, self.mpi_comm, assert_correct_owners=False)
-        result._block_vector = bv = BlockVector(self.nblocks)
-        for bid in np.nonzero(self._owned_mask)[0]:
+        if self.is_broadcasted():
+            result.finalize_block_sizes(broadcast=False, block_sizes=self.block_sizes(copy=False))
+        for bid in self.owned_blocks:
             block = self.get_block(bid)
             if block is not None:
                 if isinstance(block, BlockVector):
-                    bv.set_block(bid, self.get_block(bid).copy_structure())
+                    result.set_block(bid, block.copy_structure())
                 elif type(block) == np.ndarray:
-                    bv.set_block(bid, np.zeros(block.size))
+                    result.set_block(bid, np.zeros(block.size))
                 else:
                     raise NotImplementedError('Should never get here')
-        result._brow_lengths = self._brow_lengths.copy()
-        result._undefined_brows = set(self._undefined_brows)
         return result
 
     def fill(self, value):
@@ -781,6 +788,7 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
         float
 
         """
+        print(self.is_broadcasted())
         assert_block_structure(self)
         assert out is None
         if isinstance(other, MPIBlockVector):
@@ -801,7 +809,6 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
                 'Number of blocks mismatch: {} != {}'.format(self.nblocks, other.nblocks)
             return self.dot(other.toMPIBlockVector(self.rank_ownership, self.mpi_comm))
         elif isinstance(other, np.ndarray):
-            assert self.shape == other.shape, 'Dimension mismatch: {} != {}'.format(self.shape, other.shape)
             other_bv = self.copy_structure()
             other_bv.copyfrom(other)
             return self.dot(other_bv)
@@ -935,6 +942,8 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
         BlockVector
         """
         assert_block_structure(self)
+        if not self.is_broadcasted():
+            self.broadcast_block_sizes()
         result = self.make_local_structure_copy()
 
         local_data = np.zeros(self.size)
@@ -1241,7 +1250,7 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
             print(msg)
 
     def __len__(self):
-        return self.nblocks
+        raise NotImplementedError('Use size or nblocks')
 
     def __iter__(self):
         raise NotImplementedError('Not supported by MPIBlockVector')

--- a/pyomo/contrib/pynumero/sparse/tests/test_block_matrix.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_block_matrix.py
@@ -328,7 +328,7 @@ class TestBlockMatrix(unittest.TestCase):
         self.assertTrue(np.allclose(r.toarray(), dense_res))
 
         with self.assertRaises(Exception) as context:
-            mm = A_block.__radd__(A_block.toarray())
+            mm = A_block.toarray() + A_block
 
         with self.assertRaises(Exception) as context:
             mm = A_block + A_block.toarray()

--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_matrix.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_matrix.py
@@ -73,7 +73,6 @@ class TestMPIBlockMatrix(unittest.TestCase):
         serial_bm.set_block(1, 1, m)
         cls.square_serial_mat = serial_bm
 
-        bm.broadcast_block_sizes()
         cls.square_mpi_mat = bm
 
         # create mpi matrix
@@ -95,7 +94,6 @@ class TestMPIBlockMatrix(unittest.TestCase):
             bm.set_block(1, 1, m)
         bm.set_block(0, 1, m)
 
-        bm.broadcast_block_sizes()
         cls.square_mpi_mat2 = bm
 
         # create serial matrix image
@@ -117,7 +115,6 @@ class TestMPIBlockMatrix(unittest.TestCase):
             bm.set_block(0, 2, m2)
         if rank == 1:
             bm.set_block(1, 1, m)
-        bm.broadcast_block_sizes()
         cls.rectangular_mpi_mat = bm
 
         bm = BlockMatrix(2, 3)
@@ -133,8 +130,6 @@ class TestMPIBlockMatrix(unittest.TestCase):
     def test_shape(self):
         self.assertEqual(self.square_mpi_mat.shape, (8, 8))
         self.assertEqual(self.rectangular_mpi_mat.shape, (8, 10))
-        with self.assertRaises(NotFullyDefinedBlockMatrixError):
-            self.assertEqual(self.square_mpi_mat_no_broadcast.shape, (8, 8))
 
     def test_tocoo(self):
         with self.assertRaises(Exception) as context:
@@ -228,7 +223,6 @@ class TestMPIBlockMatrix(unittest.TestCase):
             bm.set_block(0, 0, m)
         if rank == 1:
             bm.set_block(1, 1, m)
-        bm.broadcast_block_sizes()
 
         serial_bm = BlockMatrix(2, 2)
         serial_bm.set_block(0, 0, m)
@@ -261,7 +255,6 @@ class TestMPIBlockMatrix(unittest.TestCase):
             bm.set_block(0, 0, m)
         if rank == 1:
             bm.set_block(1, 1, m)
-        bm.broadcast_block_sizes()
 
         serial_bm = BlockMatrix(2, 2)
         serial_bm.set_block(0, 0, m)
@@ -358,43 +351,35 @@ class TestMPIBlockMatrix(unittest.TestCase):
                 self.assertTrue(np.allclose(res.get_block(i, j).toarray().T,
                                             mat2.get_block(j, i).toarray()))
 
-    def test_add(self):
+    def _compare_mpi_and_serial_block_matrices(self, mpi_mat, serial_mat):
+        self.assertIsInstance(mpi_mat, MPIBlockMatrix)
+        rows, columns = np.nonzero(mpi_mat.ownership_mask)
+        for i, j in zip(rows, columns):
+            if mpi_mat.get_block(i, j) is not None:
+                self.assertTrue(np.allclose(mpi_mat.get_block(i, j).toarray(),
+                                            serial_mat.get_block(i, j).toarray()))
+            else:
+                self.assertIsNone(serial_mat.get_block(i, j))
 
+    def test_add(self):
         mat1 = self.square_mpi_mat
         mat2 = self.square_mpi_mat2
 
         serial_mat1 = self.square_serial_mat
         serial_mat2 = self.square_serial_mat2
 
-        res = mat1 + mat1
-        serial_res = serial_mat1 + serial_mat1
-        self.assertIsInstance(res, MPIBlockMatrix)
-        self.assertTrue(np.allclose(mat1.rank_ownership, res.rank_ownership))
-        rows, columns = np.nonzero(res.ownership_mask)
-        for i, j in zip(rows, columns):
-            if res.get_block(i, j) is not None:
-                self.assertTrue(np.allclose(res.get_block(i, j).toarray(),
-                                            serial_res.get_block(i, j).toarray()))
-            else:
-                self.assertIsNone(serial_res.get_block(i, j))
-
         res = mat1 + mat2
         serial_res = serial_mat1 + serial_mat2
-        self.assertIsInstance(res, MPIBlockMatrix)
-        rows, columns = np.nonzero(res.ownership_mask)
         self.assertTrue(np.allclose(mat1.rank_ownership, res.rank_ownership))
-        for i, j in zip(rows, columns):
-            if res.get_block(i, j) is not None:
-                self.assertTrue(np.allclose(res.get_block(i, j).toarray(),
-                                            serial_res.get_block(i, j).toarray()))
-            else:
-                self.assertIsNone(serial_res.get_block(i, j))
+        self._compare_mpi_and_serial_block_matrices(res, serial_res)
 
-        with self.assertRaises(Exception) as context:
-            res = mat1 + serial_mat2
+        res = mat1 + serial_mat2
+        self.assertTrue(np.allclose(mat1.rank_ownership, res.rank_ownership))
+        self._compare_mpi_and_serial_block_matrices(res, serial_res)
 
-        with self.assertRaises(Exception) as context:
-            res = serial_mat2 + mat1
+        res = serial_mat2 + mat1
+        self.assertTrue(np.allclose(mat1.rank_ownership, res.rank_ownership))
+        self._compare_mpi_and_serial_block_matrices(res, serial_res)
 
         with self.assertRaises(Exception) as context:
             res = mat1 + serial_mat2.tocoo()
@@ -410,33 +395,21 @@ class TestMPIBlockMatrix(unittest.TestCase):
         serial_mat1 = self.square_serial_mat
         serial_mat2 = self.square_serial_mat2
 
-        res = mat1 - mat1
-        serial_res = serial_mat1 - serial_mat1
-        self.assertIsInstance(res, MPIBlockMatrix)
-        self.assertTrue(np.allclose(mat1.rank_ownership, res.rank_ownership))
-        rows, columns = np.nonzero(res.ownership_mask)
-        for i, j in zip(rows, columns):
-            if res.get_block(i, j) is not None:
-                self.assertTrue(np.allclose(res.get_block(i, j).toarray(),
-                                            serial_res.get_block(i, j).toarray()))
-            else:
-                self.assertIsNone(serial_res.get_block(i, j))
-
         res = mat1 - mat2
         serial_res = serial_mat1 - serial_mat2
-        self.assertIsInstance(res, MPIBlockMatrix)
-        rows, columns = np.nonzero(res.ownership_mask)
-        for i, j in zip(rows, columns):
-            if res.get_block(i, j) is not None:
-                self.assertTrue(np.allclose(res.get_block(i, j).toarray(),
-                                            serial_res.get_block(i, j).toarray()))
-            else:
-                self.assertIsNone(serial_res.get_block(i, j))
+        self.assertTrue(np.allclose(mat1.rank_ownership, res.rank_ownership))
+        self._compare_mpi_and_serial_block_matrices(res, serial_res)
 
-        with self.assertRaises(Exception) as context:
-            res = mat1 - serial_mat2
-        with self.assertRaises(Exception) as context:
-            res = serial_mat2 - mat1
+        res = mat1 - serial_mat2
+        self._compare_mpi_and_serial_block_matrices(res, serial_res)
+
+        res = mat2 - mat1
+        serial_res = serial_mat2 - serial_mat1
+        self._compare_mpi_and_serial_block_matrices(res, serial_res)
+
+        res = serial_mat2 - mat1
+        self._compare_mpi_and_serial_block_matrices(res, serial_res)
+
         with self.assertRaises(Exception) as context:
             res = mat1 - serial_mat2.tocoo()
         with self.assertRaises(Exception) as context:
@@ -474,7 +447,6 @@ class TestMPIBlockMatrix(unittest.TestCase):
             bm.set_block(0, 0, m.copy())
         if rank == 1:
             bm.set_block(1, 1, m.copy())
-        bm.broadcast_block_sizes()
 
         serial_bm = BlockMatrix(2, 2)
         serial_bm.set_block(0, 0, m.copy())
@@ -483,22 +455,18 @@ class TestMPIBlockMatrix(unittest.TestCase):
         bm += bm
         serial_bm += serial_bm
 
+        print(bm.to_local_array())
+        print(m.toarray()*2)
+
         rows, columns = np.nonzero(bm.ownership_mask)
         for i, j in zip(rows, columns):
             if bm.get_block(i, j) is not None:
                 self.assertTrue(np.allclose(bm.get_block(i, j).toarray(),
                                             serial_bm.get_block(i, j).toarray()))
 
-        with self.assertRaises(Exception) as context:
-            bm += serial_bm
-
-        serial_bm2 = BlockMatrix(2, 2)
-        serial_bm2.set_block(0, 0, m.copy())
-        serial_bm2.set_block(0, 1, m.copy())
-        serial_bm2.set_block(1, 1, m.copy())
-
-        with self.assertRaises(Exception) as context:
-            bm += serial_bm2
+        bm += serial_bm
+        serial_bm += serial_bm
+        self._compare_mpi_and_serial_block_matrices(bm, serial_bm)
 
     def test_isub(self):
 
@@ -515,7 +483,6 @@ class TestMPIBlockMatrix(unittest.TestCase):
             bm.set_block(0, 0, m.copy())
         if rank == 1:
             bm.set_block(1, 1, m.copy())
-        bm.broadcast_block_sizes()
 
         serial_bm = BlockMatrix(2, 2)
         serial_bm.set_block(0, 0, m.copy())
@@ -530,8 +497,9 @@ class TestMPIBlockMatrix(unittest.TestCase):
                 self.assertTrue(np.allclose(bm.get_block(i, j).toarray(),
                                             serial_bm.get_block(i, j).toarray()))
 
-        with self.assertRaises(Exception) as context:
-            bm -= serial_bm
+        bm -= serial_bm
+        serial_bm -= serial_bm
+        self._compare_mpi_and_serial_block_matrices(bm, serial_bm)
 
     def test_imul(self):
 
@@ -548,7 +516,6 @@ class TestMPIBlockMatrix(unittest.TestCase):
             bm.set_block(0, 0, m)
         if rank == 1:
             bm.set_block(1, 1, m)
-        bm.broadcast_block_sizes()
 
         serial_bm = BlockMatrix(2, 2)
         serial_bm.set_block(0, 0, m)
@@ -578,7 +545,6 @@ class TestMPIBlockMatrix(unittest.TestCase):
             bm.set_block(0, 0, m)
         if rank == 1:
             bm.set_block(1, 1, m)
-        bm.broadcast_block_sizes()
 
         serial_bm = BlockMatrix(2, 2)
         serial_bm.set_block(0, 0, m)
@@ -608,7 +574,6 @@ class TestMPIBlockMatrix(unittest.TestCase):
             bm.set_block(0, 0, m)
         if rank == 1:
             bm.set_block(1, 1, m)
-        bm.broadcast_block_sizes()
 
         serial_bm = BlockMatrix(2, 2)
         serial_bm.set_block(0, 0, m)
@@ -638,7 +603,6 @@ class TestMPIBlockMatrix(unittest.TestCase):
             bm.set_block(0, 0, m)
         if rank == 1:
             bm.set_block(1, 1, m)
-        bm.broadcast_block_sizes()
 
         serial_bm = BlockMatrix(2, 2)
         serial_bm.set_block(0, 0, m)
@@ -1013,13 +977,11 @@ class TestMPIMatVec(unittest.TestCase):
         sub_m = coo_matrix(sub_m)
         m.set_block(rank, rank, sub_m.copy())
         m.set_block(3, rank, sub_m.copy())
-        m.broadcast_block_sizes()
 
         rank_ownership = np.array([0, 1, 2])
         v = MPIBlockVector(3, rank_ownership, comm)
         sub_v = np.ones(2)
         v.set_block(rank, sub_v)
-        v.broadcast_block_sizes()
 
         res = m._get_block_vector_for_dot_product(v)
 
@@ -1045,7 +1007,6 @@ class TestMPIMatVec(unittest.TestCase):
         else:
             m.set_block(rank, rank, sub_m.copy())
             m.set_block(3, rank, sub_m.copy())
-        m.broadcast_block_sizes()
 
         rank_ownership = np.array([-1, 1, 2])
         v = MPIBlockVector(3, rank_ownership, comm)
@@ -1053,7 +1014,6 @@ class TestMPIMatVec(unittest.TestCase):
         v.set_block(0, sub_v.copy())
         if rank != 0:
             v.set_block(rank, sub_v.copy())
-        v.broadcast_block_sizes()
 
         res = m._get_block_vector_for_dot_product(v)
 
@@ -1079,13 +1039,11 @@ class TestMPIMatVec(unittest.TestCase):
         else:
             m.set_block(rank, rank, sub_m.copy())
             m.set_block(3, rank, sub_m.copy())
-        m.broadcast_block_sizes()
 
         rank_ownership = np.array([0, 1, 2])
         v = MPIBlockVector(3, rank_ownership, comm)
         sub_v = np.ones(2)
         v.set_block(rank, sub_v.copy())
-        v.broadcast_block_sizes()
 
         res = m._get_block_vector_for_dot_product(v)
 
@@ -1118,13 +1076,11 @@ class TestMPIMatVec(unittest.TestCase):
         else:
             m.set_block(rank, rank, sub_m.copy())
             m.set_block(3, rank, sub_m.copy())
-        m.broadcast_block_sizes()
 
         rank_ownership = np.array([0, 1, 2])
         v = MPIBlockVector(3, rank_ownership, comm)
         sub_v = np.ones(2)
         v.set_block(rank, sub_v.copy())
-        v.broadcast_block_sizes()
 
         res = m._get_block_vector_for_dot_product(v)
 
@@ -1150,7 +1106,6 @@ class TestMPIMatVec(unittest.TestCase):
         else:
             m.set_block(rank, rank, sub_m.copy())
             m.set_block(3, rank, sub_m.copy())
-        m.broadcast_block_sizes()
 
         v = BlockVector(3)
         sub_v = np.ones(2)
@@ -1183,14 +1138,12 @@ class TestMPIMatVec(unittest.TestCase):
         m.set_block(rank, 3, sub_m.copy())
         m.set_block(3, rank, sub_m.copy())
         m.set_block(3, 3, sub_m.copy())
-        m.broadcast_block_sizes()
 
         rank_ownership = np.array([0, 1, 2, -1])
         v = MPIBlockVector(4, rank_ownership, comm)
         sub_v = np.ones(2)
         v.set_block(rank, sub_v.copy())
         v.set_block(3, sub_v.copy())
-        v.broadcast_block_sizes()
 
         res = m.dot(v)
         self.assertIsInstance(res, MPIBlockVector)

--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_matrix.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_matrix.py
@@ -455,9 +455,6 @@ class TestMPIBlockMatrix(unittest.TestCase):
         bm += bm
         serial_bm += serial_bm
 
-        print(bm.to_local_array())
-        print(m.toarray()*2)
-
         rows, columns = np.nonzero(bm.ownership_mask)
         for i, j in zip(rows, columns):
             if bm.get_block(i, j) is not None:

--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
@@ -89,8 +89,10 @@ class TestMPIBlockVector(unittest.TestCase):
 
     def test_size(self):
         v1 = self.v1
+        self.assertEqual(type(v1.size), int)
         self.assertEqual(v1.size, 10)
         v2 = self.v2
+        self.assertEqual(type(v2.size), int)
         self.assertEqual(v2.size, 20)
 
     def test_shape(self):

--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
@@ -499,7 +499,6 @@ class TestMPIBlockVector(unittest.TestCase):
         vv = BlockVector(3)
         vv.set_blocks([np.arange(3), np.arange(4), np.arange(2)])
         self.assertAlmostEqual(expected, v.dot(vv))
-        print(v.is_broadcasted())
         self.assertAlmostEqual(expected, v.dot(vv.flatten()))
 
     def test_add(self):

--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
@@ -59,7 +59,6 @@ class TestMPIBlockVector(unittest.TestCase):
             v1.set_block(3, np.ones(2))
 
         cls.v1 = v1
-        cls.v1.broadcast_block_sizes()
         v2 = MPIBlockVector(7, [0,0,1,1,2,2,-1], comm)
 
         rank = comm.Get_rank()
@@ -75,7 +74,6 @@ class TestMPIBlockVector(unittest.TestCase):
         v2.set_block(6, np.ones(2) * 3)
 
         cls.v2 = v2
-        cls.v2.broadcast_block_sizes()
 
     def test_nblocks(self):
         v1 = self.v1
@@ -106,12 +104,18 @@ class TestMPIBlockVector(unittest.TestCase):
         self.assertEqual(v1.ndim, 1)
 
     def test_has_none(self):
-        v = MPIBlockVector(4, [0,1,0,1], comm)
+        v = MPIBlockVector(4, [0, 1, 0, 1], comm)
         rank = comm.Get_rank()
         if rank == 0:
+            self.assertTrue(v.has_none)
             v.set_block(0, np.ones(3))
+            self.assertTrue(v.has_none)
             v.set_block(2, np.ones(3))
-        self.assertTrue(v.has_none)
+            self.assertFalse(v.has_none)
+        elif rank == 1:
+            self.assertTrue(v.has_none)
+        else:
+            self.assertFalse(v.has_none)
         self.assertFalse(self.v1.has_none)
 
     def test_any(self):
@@ -121,7 +125,6 @@ class TestMPIBlockVector(unittest.TestCase):
             v.set_block(0, np.ones(3))
         if rank == 1:
             v.set_block(1, np.zeros(3))
-        v.broadcast_block_sizes()
         self.assertTrue(v.any())
         self.assertTrue(self.v1.any())
         self.assertTrue(self.v2.any())
@@ -133,7 +136,6 @@ class TestMPIBlockVector(unittest.TestCase):
             v.set_block(0, np.ones(3))
         if rank == 1:
             v.set_block(1, np.zeros(3))
-        v.broadcast_block_sizes()
         self.assertFalse(v.all())
         if rank == 1:
             v.set_block(1, np.ones(3))
@@ -148,7 +150,6 @@ class TestMPIBlockVector(unittest.TestCase):
             v.set_block(0, np.arange(3) + 10)
         if rank == 1:
             v.set_block(1, np.arange(3))
-        v.broadcast_block_sizes()
         self.assertEqual(v.min(), 0.0)
         if rank == 1:
             v.set_block(1, -np.arange(3))
@@ -161,7 +162,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(3))
         v.set_block(2, -np.arange(6))
-        v.broadcast_block_sizes()
         self.assertEqual(v.min(), -5.0)
         self.assertEqual(self.v1.min(), 0.0)
         self.assertEqual(self.v2.min(), 0.0)
@@ -173,7 +173,6 @@ class TestMPIBlockVector(unittest.TestCase):
             v.set_block(0, np.arange(3) + 10)
         if rank == 1:
             v.set_block(1, np.arange(3))
-        v.broadcast_block_sizes()
         self.assertEqual(v.max(), 12.0)
 
         v = MPIBlockVector(3, [0,1,-1], comm)
@@ -183,7 +182,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(3))
         v.set_block(2, np.arange(60))
-        v.broadcast_block_sizes()
         self.assertEqual(v.max(), 59.0)
         self.assertEqual(self.v1.max(), 1.0)
         self.assertEqual(self.v2.max(), 3.0)
@@ -196,7 +194,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(3) + 3)
         v.set_block(2, np.arange(3) + 6)
-        v.broadcast_block_sizes()
 
         b = np.arange(9)
         self.assertEqual(b.sum(), v.sum())
@@ -211,7 +208,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.ones(3))
         v.set_block(2, np.ones(3))
-        v.broadcast_block_sizes()
         self.assertEqual(1.0, v.prod())
         if rank == 1:
             v.set_block(1, np.ones(3) * 2)
@@ -230,7 +226,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.ones(3))
         v.set_block(2, np.ones(3))
-        v.broadcast_block_sizes()
         res = v.conj()
         self.assertTrue(isinstance(res, MPIBlockVector))
         self.assertEqual(res.nblocks, v.nblocks)
@@ -245,7 +240,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.ones(3))
         v.set_block(2, np.ones(3))
-        v.broadcast_block_sizes()
         res = v.conjugate()
         self.assertTrue(isinstance(res, MPIBlockVector))
         self.assertEqual(res.nblocks, v.nblocks)
@@ -260,7 +254,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.array([0,0,2]))
         v.set_block(2, np.ones(3))
-        v.broadcast_block_sizes()
         res = v.nonzero()[0]
         self.assertTrue(isinstance(res, MPIBlockVector))
         self.assertEqual(res.nblocks, v.nblocks)
@@ -286,7 +279,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(3) + 3 + 0.01)
         v.set_block(2, np.arange(3) + 6 + 0.01)
-        v.broadcast_block_sizes()
 
         res = v.round()
         self.assertTrue(isinstance(res, MPIBlockVector))
@@ -305,7 +297,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(3) + 3)
         v.set_block(2, np.arange(3) + 6)
-        v.broadcast_block_sizes()
 
         res = v.clip(min=2.0)
         self.assertTrue(isinstance(res, MPIBlockVector))
@@ -343,7 +334,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4))
         v.set_block(2, np.arange(2))
-        v.broadcast_block_sizes()
 
         cond = MPIBlockVector(3, [0, 1, -1], comm)
         rank = comm.Get_rank()
@@ -352,7 +342,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             cond.set_block(1, np.array([True, True, True, False]))
         cond.set_block(2, np.array([True, True]))
-        cond.broadcast_block_sizes()
 
         res = v.compress(cond)
         self.assertTrue(isinstance(res, MPIBlockVector))
@@ -458,7 +447,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4))
         v.set_block(2, np.arange(2))
-        v.broadcast_block_sizes()
 
         vv = MPIBlockVector(3, [0, 1, -1], comm)
         v.copyto(vv)
@@ -482,7 +470,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4))
         v.set_block(2, np.arange(2))
-        v.broadcast_block_sizes()
 
         v.fill(7.0)
         self.assertTrue(isinstance(v, MPIBlockVector))
@@ -504,7 +491,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4))
         v.set_block(2, np.arange(2))
-        v.broadcast_block_sizes()
 
         all_v = np.concatenate([np.arange(3), np.arange(4), np.arange(2)])
         expected = all_v.dot(all_v)
@@ -513,6 +499,7 @@ class TestMPIBlockVector(unittest.TestCase):
         vv = BlockVector(3)
         vv.set_blocks([np.arange(3), np.arange(4), np.arange(2)])
         self.assertAlmostEqual(expected, v.dot(vv))
+        print(v.is_broadcasted())
         self.assertAlmostEqual(expected, v.dot(vv.flatten()))
 
     def test_add(self):
@@ -523,7 +510,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4))
         v.set_block(2, np.arange(2))
-        v.broadcast_block_sizes()
 
         res = v + v
         self.assertTrue(isinstance(res, MPIBlockVector))
@@ -572,7 +558,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4))
         v.set_block(2, np.arange(2))
-        v.broadcast_block_sizes()
 
         res = v - v
         self.assertTrue(isinstance(res, MPIBlockVector))
@@ -621,7 +606,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4))
         v.set_block(2, np.arange(2))
-        v.broadcast_block_sizes()
 
         res = v * v
         self.assertTrue(isinstance(res, MPIBlockVector))
@@ -670,7 +654,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4) + 1.0)
         v.set_block(2, np.arange(2) + 1.0)
-        v.broadcast_block_sizes()
 
         res = v / v
         self.assertTrue(isinstance(res, MPIBlockVector))
@@ -720,7 +703,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4) + 1.0)
         v.set_block(2, np.arange(2) + 1.0)
-        v.broadcast_block_sizes()
 
         res = v // v
         self.assertTrue(isinstance(res, MPIBlockVector))
@@ -777,7 +759,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4))
         v.set_block(2, np.arange(2))
-        v.broadcast_block_sizes()
 
         v += v
         self.assertTrue(isinstance(v, MPIBlockVector))
@@ -795,7 +776,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4))
         v.set_block(2, np.arange(2))
-        v.broadcast_block_sizes()
 
         v = MPIBlockVector(3, [0,1,-1], comm)
         rank = comm.Get_rank()
@@ -804,7 +784,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4, dtype='d'))
         v.set_block(2, np.arange(2, dtype='d'))
-        v.broadcast_block_sizes()
 
         v += 7.0
         self.assertTrue(isinstance(v, MPIBlockVector))
@@ -824,7 +803,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4))
         v.set_block(2, np.arange(2))
-        v.broadcast_block_sizes()
 
         v -= v
         self.assertTrue(isinstance(v, MPIBlockVector))
@@ -842,7 +820,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4))
         v.set_block(2, np.arange(2))
-        v.broadcast_block_sizes()
 
         v = MPIBlockVector(3, [0,1,-1], comm)
         rank = comm.Get_rank()
@@ -851,7 +828,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4, dtype='d'))
         v.set_block(2, np.arange(2, dtype='d'))
-        v.broadcast_block_sizes()
 
         v -= 7.0
         self.assertTrue(isinstance(v, MPIBlockVector))
@@ -871,7 +847,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4))
         v.set_block(2, np.arange(2))
-        v.broadcast_block_sizes()
 
         v *= v
         self.assertTrue(isinstance(v, MPIBlockVector))
@@ -889,7 +864,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4))
         v.set_block(2, np.arange(2))
-        v.broadcast_block_sizes()
 
         v = MPIBlockVector(3, [0,1,-1], comm)
         rank = comm.Get_rank()
@@ -898,7 +872,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4, dtype='d'))
         v.set_block(2, np.arange(2, dtype='d'))
-        v.broadcast_block_sizes()
 
         v *= 7.0
         self.assertTrue(isinstance(v, MPIBlockVector))
@@ -918,7 +891,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4) + 1.0)
         v.set_block(2, np.arange(2) + 1.0)
-        v.broadcast_block_sizes()
 
         v /= v
         self.assertTrue(isinstance(v, MPIBlockVector))
@@ -936,7 +908,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4) + 1.0)
         v.set_block(2, np.arange(2) + 1.0)
-        v.broadcast_block_sizes()
 
         v = MPIBlockVector(3, [0,1,-1], comm)
         rank = comm.Get_rank()
@@ -945,7 +916,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4, dtype='d'))
         v.set_block(2, np.arange(2, dtype='d'))
-        v.broadcast_block_sizes()
 
         v /= 2.0
         self.assertTrue(isinstance(v, MPIBlockVector))
@@ -964,7 +934,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.ones(4) * 2)
         v.set_block(2, np.ones(2) * 4)
-        v.broadcast_block_sizes()
 
         v1 = MPIBlockVector(3, [0, 1, -1], comm)
         rank = comm.Get_rank()
@@ -973,7 +942,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v1.set_block(1, np.ones(4) * 8)
         v1.set_block(2, np.ones(2) * 4)
-        v1.broadcast_block_sizes()
 
         res = v <= v1
 
@@ -1043,7 +1011,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.ones(4) * 2)
         v.set_block(2, np.ones(2) * 4)
-        v.broadcast_block_sizes()
 
         v1 = MPIBlockVector(3, [0,1,-1], comm)
         rank = comm.Get_rank()
@@ -1052,7 +1019,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v1.set_block(1, np.ones(4) * 8)
         v1.set_block(2, np.ones(2) * 4)
-        v1.broadcast_block_sizes()
 
         res = v < v1
 
@@ -1122,7 +1088,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.ones(4) * 2)
         v.set_block(2, np.ones(2) * 4)
-        v.broadcast_block_sizes()
 
         v1 = MPIBlockVector(3, [0,1,-1], comm)
         rank = comm.Get_rank()
@@ -1131,7 +1096,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v1.set_block(1, np.ones(4) * 8)
         v1.set_block(2, np.ones(2) * 4)
-        v1.broadcast_block_sizes()
 
         res = v >= v1
 
@@ -1201,7 +1165,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.ones(4) * 2)
         v.set_block(2, np.ones(2) * 4)
-        v.broadcast_block_sizes()
 
         v1 = MPIBlockVector(3, [0,1,-1], comm)
         rank = comm.Get_rank()
@@ -1210,7 +1173,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v1.set_block(1, np.ones(4) * 8)
         v1.set_block(2, np.ones(2) * 4)
-        v1.broadcast_block_sizes()
 
         res = v > v1
 
@@ -1280,7 +1242,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.ones(4) * 2)
         v.set_block(2, np.ones(2) * 4)
-        v.broadcast_block_sizes()
 
         v1 = MPIBlockVector(3, [0,1,-1], comm)
         rank = comm.Get_rank()
@@ -1289,7 +1250,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v1.set_block(1, np.ones(4) * 8)
         v1.set_block(2, np.ones(2) * 4)
-        v1.broadcast_block_sizes()
 
         res = v == v1
 
@@ -1359,7 +1319,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.ones(4) * 2)
         v.set_block(2, np.ones(2) * 4)
-        v.broadcast_block_sizes()
 
         v1 = MPIBlockVector(3, [0,1,-1], comm)
         rank = comm.Get_rank()
@@ -1368,7 +1327,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v1.set_block(1, np.ones(4) * 8)
         v1.set_block(2, np.ones(2) * 4)
-        v1.broadcast_block_sizes()
 
         res = v != v1
 
@@ -1482,7 +1440,6 @@ class TestMPIBlockVector(unittest.TestCase):
             v.set_block(0, np.ones(3) * 0.5)
         if rank == 1:
             v.set_block(1, np.ones(2) * 0.8)
-        v.broadcast_block_sizes()
 
         bv = BlockVector(2)
         bv.set_block(0, np.ones(3) * 0.5)
@@ -1605,22 +1562,9 @@ class TestMPIBlockVector(unittest.TestCase):
             v.set_block(0, np.ones(3))
         if rank == 1:
             v.set_block(1, np.zeros(2))
-        v.broadcast_block_sizes()
 
         self.assertTrue(0 in v)
         self.assertFalse(3 in v)
-
-    def test_len(self):
-
-        v = MPIBlockVector(2, [0,1], comm)
-
-        rank = comm.Get_rank()
-        if rank == 0:
-            v.set_block(0, np.ones(3))
-        if rank == 1:
-            v.set_block(1, np.zeros(2))
-        v.broadcast_block_sizes()
-        self.assertEqual(len(v), 2)
 
     def test_copyfrom(self):
 
@@ -1631,7 +1575,6 @@ class TestMPIBlockVector(unittest.TestCase):
         if rank == 1:
             v.set_block(1, np.arange(4))
         v.set_block(2, np.arange(2))
-        v.broadcast_block_sizes()
 
         bv = BlockVector(3)
         bv.set_blocks([np.arange(3), np.arange(4), np.arange(2)])


### PR DESCRIPTION
## Changes proposed in this PR:
- The user should not have to call `broadcast_block_sizes`
- Many operations do not need sizes to be broadcast
- I also cleaned up some of the `MPIBlockMatrix` operations to reuse common code 

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
