### PR TITLE
Updating Jenkins driver to resolve codecov report upload

### DIFF
--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -187,7 +187,7 @@ if test -z "$MODE" -o "$MODE" == test; then
             while /bin/true; do
                 i=$[$i+1]
                 echo "Uploading coverage to codecov (attempt $i)"
-                codecov -X gcovcodecov -X gcov --no-color \
+                codecov -X gcovcodecov -X gcov -X s3 --no-color \
                     -t $CODECOV_TOKEN --root `pwd` -e OS,python \
                     --name $CODECOV_JOB_NAME $CODECOV_ARGS \
                     | tee .cover.upload


### PR DESCRIPTION
## Fixes #N/A.

## Summary/Motivation:
This PR is resolving issues where Jenkins codecov reports are not actually showing up on Codecov (and are preventing codecov from publishing reports to PRs)

## Changes proposed in this PR:
- disable use of the s3 upload channel

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
