### PR TITLE
Update GHA and Jenkins drivers to support slim and cythonized builds

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -106,7 +106,7 @@ jobs:
         fi
         PYTHON_PACKAGES="$PYTHON_PACKAGES ${{matrix.PACKAGES}}"
         echo "PYTHON_PACKAGES=$PYTHON_PACKAGES" \
-            | tr '\n' ' ' | sed -r 's/ +/ /g' >> $GITHUB_ENV
+            | tr '\n' ' ' | sed 's/ \+/ /g' >> $GITHUB_ENV
 
     # Ideally we would cache the conda downloads; however, each cache is
     # over 850MB, and with 5 python versions, that would consume 4.2 of

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -105,8 +105,8 @@ jobs:
             PYTHON_PACKAGES="$PYTHON_PACKAGES ${PYTHON_NUMPY_PKGS}"
         fi
         PYTHON_PACKAGES="$PYTHON_PACKAGES ${{matrix.PACKAGES}}"
-        echo "PYTHON_PACKAGES=$PYTHON_PACKAGES" | sed -r 's/\n/ /g' \
-            >> $GITHUB_ENV
+        echo "PYTHON_PACKAGES=$PYTHON_PACKAGES" \
+            | tr '\n' ' ' | sed -r 's/ +/ /g' >> $GITHUB_ENV
 
     # Ideally we would cache the conda downloads; however, each cache is
     # over 850MB, and with 5 python versions, that would consume 4.2 of

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -99,7 +99,7 @@ jobs:
         if test -z "${{matrix.slim}}"; then
             PYTHON_PACKAGES="$PYTHON_PACKAGES ${PYTHON_BASE_PKGS}"
         fi
-        if [[ ${{matrix.python}} != pypy* -a ! "${{matrix.slim}}" ]]; then
+        if [[ ${{matrix.python}} != pypy* && ! "${{matrix.slim}}" ]]; then
             # NumPy and derivatives either don't build under pypy, or if
             # they do, the builds take forever.
             PYTHON_PACKAGES="$PYTHON_PACKAGES ${PYTHON_NUMPY_PKGS}"

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -105,7 +105,8 @@ jobs:
             PYTHON_PACKAGES="$PYTHON_PACKAGES ${PYTHON_NUMPY_PKGS}"
         fi
         PYTHON_PACKAGES="$PYTHON_PACKAGES ${{matrix.PACKAGES}}"
-        echo "PYTHON_PACKAGES=$PYTHON_PACKAGES" >> $GITHUB_ENV
+        echo "PYTHON_PACKAGES=$PYTHON_PACKAGES" | sed -r 's/\n/ /g' \
+            >> $GITHUB_ENV
 
     # Ideally we would cache the conda downloads; however, each cache is
     # over 850MB, and with 5 python versions, that would consume 4.2 of

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -19,11 +19,12 @@ defaults:
 
 env:
   PYTHONWARNINGS: ignore::UserWarning
+  PYTHON_CORE_PKGS: wheel
   PYTHON_REQUIRED_PKGS: >
       ply six nose coverage
   PYTHON_BASE_PKGS: >
-      cython dill ipython networkx openpyxl pathos
-      pint pymysql pyro4 pyyaml sphinx_rtd_theme sympy xlrd wheel
+      dill ipython networkx openpyxl pathos
+      pint pymysql pyro4 pyyaml sphinx_rtd_theme sympy xlrd
       python-louvain
   PYTHON_NUMPY_PKGS: >
       numpy scipy pyodbc pandas matplotlib seaborn
@@ -65,11 +66,20 @@ jobs:
 
         - os: ubuntu-latest
           python: 3.9
+          other: /slim
+          slim: 1
+          skip_doctest: 1
+          TARGET: linux
+          PYENV: pip
+
+        - os: ubuntu-latest
+          python: 3.6
           other: /cython
           setup_options: --with-cython
           skip_doctest: 1
           TARGET: linux
           PYENV: pip
+          PACKAGES: cython
 
         exclude:
         - {os: macos-latest, python: pypy2}
@@ -84,6 +94,18 @@ jobs:
       run: |
         JOB="${{matrix.TARGET}}/${{matrix.python}}${{matrix.other}}"
         echo "GHA_JOBNAME=$JOB" | sed 's|/|_|g' >> $GITHUB_ENV
+        # Note: pandas 1.0.3 causes gams 29.1.0 import to fail in python 3.8
+        PYTHON_PACKAGES="${PYTHON_REQUIRED_PKGS}"
+        if test -z "${{matrix.slim}}"; then
+            PYTHON_PACKAGES="$PYTHON_PACKAGES ${PYTHON_BASE_PKGS}"
+        fi
+        if [[ ${{matrix.python}} != pypy* -a ! "${{matrix.slim}}" ]]; then
+            # NumPy and derivatives either don't build under pypy, or if
+            # they do, the builds take forever.
+            PYTHON_PACKAGES="$PYTHON_PACKAGES ${PYTHON_NUMPY_PKGS}"
+        fi
+        PYTHON_PACKAGES="$PYTHON_PACKAGES ${{matrix.PACKAGES}}"
+        echo "PYTHON_PACKAGES=$PYTHON_PACKAGES" >> $GITHUB_ENV
 
     # Ideally we would cache the conda downloads; however, each cache is
     # over 850MB, and with 5 python versions, that would consume 4.2 of
@@ -194,14 +216,8 @@ jobs:
       run: |
         python -c 'import sys;print(sys.executable)'
         python -m pip install --cache-dir cache/pip --upgrade pip
-        # Note: pandas 1.0.3 causes gams 29.1.0 import to fail in python 3.8
-        pip install --cache-dir cache/pip ${PYTHON_BASE_PKGS} \
-            ${PYTHON_REQUIRED_PKGS} ${{matrix.PACKAGES}}
-        if [[ ${{matrix.python}} != pypy* ]]; then
-            # NumPy and derivatives either don't build under pypy, or if
-            # they do, the builds take forever.
-            pip install --cache-dir cache/pip ${PYTHON_NUMPY_PKGS}
-        fi
+        pip install --cache-dir cache/pip ${PYTHON_CORE_PKGS}
+        pip install --cache-dir cache/pip ${PYTHON_PACKAGES}
         pip install --cache-dir cache/pip cplex \
             || echo "WARNING: CPLEX Community Edition is not available"
         pip install --cache-dir cache/pip xpress \
@@ -220,8 +236,8 @@ jobs:
         conda info
         conda config --show-sources
         conda list --show-channel-urls
-        conda install -q -y -c conda-forge ${PYTHON_BASE_PKGS} \
-            ${PYTHON_NUMPY_PKGS} ${PYTHON_REQUIRED_PKGS} ${{matrix.PACKAGES}}
+        conda install -q -y -c conda-forge ${PYTHON_CORE_PKGS}
+        conda install -q -y -c conda-forge ${PYTHON_PACKAGES}
         # Note: CPLEX 12.9 (the last version in conda that supports
         #    Python 2.7) causes a seg fault in the tests.
         conda install -q -y -c ibmdecisionoptimization cplex=12.10 \

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -31,14 +31,15 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.NAME }}
+    name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.other }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
-        mpi: [0]
+        other: [""]
+
         include:
         - os: ubuntu-latest
           TARGET: linux
@@ -55,12 +56,20 @@ jobs:
 
         - os: ubuntu-latest
           python: 3.7
+          other: /mpi
           mpi: 3
           skip_doctest: 1
           TARGET: linux
           PYENV: conda
           PACKAGES: mpi4py openmpi
-          NAME: /mpi
+
+        - os: ubuntu-latest
+          python: 3.9
+          other: /cython
+          setup_options: --with-cython
+          skip_doctest: 1
+          TARGET: linux
+          PYENV: pip
 
         exclude:
         - {os: macos-latest, python: pypy2}
@@ -73,7 +82,7 @@ jobs:
 
     - name: Configure job parameters
       run: |
-        JOB="${{matrix.TARGET}}/${{matrix.python}}${{matrix.NAME}}"
+        JOB="${{matrix.TARGET}}/${{matrix.python}}${{matrix.other}}"
         echo "GHA_JOBNAME=$JOB" | sed 's|/|_|g' >> $GITHUB_ENV
 
     # Ideally we would cache the conda downloads; however, each cache is
@@ -366,7 +375,7 @@ jobs:
         echo ""
         echo "Install Pyomo..."
         echo ""
-        $PYTHON_EXE setup.py develop
+        $PYTHON_EXE setup.py develop ${{matrix.setup_options}}
         echo ""
         echo "Set custom PYOMO_CONFIG_DIR"
         echo ""
@@ -431,7 +440,7 @@ jobs:
 
     - name: Process code coverage report
       env:
-        CODECOV_NAME: ${{matrix.TARGET}}/${{matrix.python}}${{matrix.NAME}}
+        CODECOV_NAME: ${{matrix.TARGET}}/${{matrix.python}}${{matrix.other}}
       run: |
         coverage combine
         coverage report -i

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -104,7 +104,8 @@ jobs:
             PYTHON_PACKAGES="$PYTHON_PACKAGES ${PYTHON_NUMPY_PKGS}"
         fi
         PYTHON_PACKAGES="$PYTHON_PACKAGES ${{matrix.PACKAGES}}"
-        echo "PYTHON_PACKAGES=$PYTHON_PACKAGES" >> $GITHUB_ENV
+        echo "PYTHON_PACKAGES=$PYTHON_PACKAGES" | sed -r 's/\n/ /g' \
+            >> $GITHUB_ENV
 
     # Ideally we would cache the conda downloads; however, each cache is
     # over 850MB, and with 5 python versions, that would consume 4.2 of

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -105,7 +105,7 @@ jobs:
         fi
         PYTHON_PACKAGES="$PYTHON_PACKAGES ${{matrix.PACKAGES}}"
         echo "PYTHON_PACKAGES=$PYTHON_PACKAGES" \
-            | tr '\n' ' ' | sed -r 's/ +/ /g' >> $GITHUB_ENV
+            | tr '\n' ' ' | sed 's/ \+/ /g' >> $GITHUB_ENV
 
     # Ideally we would cache the conda downloads; however, each cache is
     # over 850MB, and with 5 python versions, that would consume 4.2 of

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -16,11 +16,12 @@ defaults:
 
 env:
   PYTHONWARNINGS: ignore::UserWarning
+  PYTHON_CORE_PKGS: wheel
   PYTHON_REQUIRED_PKGS: >
       ply six nose coverage
   PYTHON_BASE_PKGS: >
-      cython dill ipython networkx openpyxl pathos
-      pint pymysql pyro4 pyyaml sphinx_rtd_theme sympy xlrd wheel
+      dill ipython networkx openpyxl pathos
+      pint pymysql pyro4 pyyaml sphinx_rtd_theme sympy xlrd
       python-louvain
   PYTHON_NUMPY_PKGS: >
       numpy scipy pyodbc pandas matplotlib seaborn
@@ -64,11 +65,20 @@ jobs:
 
         - os: ubuntu-latest
           python: 3.9
+          other: /slim
+          slim: 1
+          skip_doctest: 1
+          TARGET: linux
+          PYENV: pip
+
+        - os: ubuntu-latest
+          python: 3.6
           other: /cython
           setup_options: --with-cython
           skip_doctest: 1
           TARGET: linux
           PYENV: pip
+          PACKAGES: cython
 
         exclude:
         - {os: macos-latest, python: pypy2}
@@ -83,6 +93,18 @@ jobs:
       run: |
         JOB="${{matrix.TARGET}}/${{matrix.python}}${{matrix.other}}"
         echo "GHA_JOBNAME=$JOB" | sed 's|/|_|g' >> $GITHUB_ENV
+        # Note: pandas 1.0.3 causes gams 29.1.0 import to fail in python 3.8
+        PYTHON_PACKAGES="${PYTHON_REQUIRED_PKGS}"
+        if test -z "${{matrix.slim}}"; then
+            PYTHON_PACKAGES="$PYTHON_PACKAGES ${PYTHON_BASE_PKGS}"
+        fi
+        if [[ ${{matrix.python}} != pypy* -a ! "${{matrix.slim}}" ]]; then
+            # NumPy and derivatives either don't build under pypy, or if
+            # they do, the builds take forever.
+            PYTHON_PACKAGES="$PYTHON_PACKAGES ${PYTHON_NUMPY_PKGS}"
+        fi
+        PYTHON_PACKAGES="$PYTHON_PACKAGES ${{matrix.PACKAGES}}"
+        echo "PYTHON_PACKAGES=$PYTHON_PACKAGES" >> $GITHUB_ENV
 
     # Ideally we would cache the conda downloads; however, each cache is
     # over 850MB, and with 5 python versions, that would consume 4.2 of
@@ -193,14 +215,8 @@ jobs:
       run: |
         python -c 'import sys;print(sys.executable)'
         python -m pip install --cache-dir cache/pip --upgrade pip
-        # Note: pandas 1.0.3 causes gams 29.1.0 import to fail in python 3.8
-        pip install --cache-dir cache/pip ${PYTHON_BASE_PKGS} \
-            ${PYTHON_REQUIRED_PKGS} ${{matrix.PACKAGES}}
-        if [[ ${{matrix.python}} != pypy* ]]; then
-            # NumPy and derivatives either don't build under pypy, or if
-            # they do, the builds take forever.
-            pip install --cache-dir cache/pip ${PYTHON_NUMPY_PKGS}
-        fi
+        pip install --cache-dir cache/pip ${PYTHON_CORE_PKGS}
+        pip install --cache-dir cache/pip ${PYTHON_PACKAGES}
         pip install --cache-dir cache/pip cplex \
             || echo "WARNING: CPLEX Community Edition is not available"
         pip install --cache-dir cache/pip xpress \
@@ -219,8 +235,8 @@ jobs:
         conda info
         conda config --show-sources
         conda list --show-channel-urls
-        conda install -q -y -c conda-forge ${PYTHON_BASE_PKGS} \
-            ${PYTHON_NUMPY_PKGS} ${PYTHON_REQUIRED_PKGS} ${{matrix.PACKAGES}}
+        conda install -q -y -c conda-forge ${PYTHON_CORE_PKGS}
+        conda install -q -y -c conda-forge ${PYTHON_PACKAGES}
         # Note: CPLEX 12.9 (the last version in conda that supports
         #    Python 2.7) causes a seg fault in the tests.
         conda install -q -y -c ibmdecisionoptimization cplex=12.10 \

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -98,7 +98,7 @@ jobs:
         if test -z "${{matrix.slim}}"; then
             PYTHON_PACKAGES="$PYTHON_PACKAGES ${PYTHON_BASE_PKGS}"
         fi
-        if [[ ${{matrix.python}} != pypy* -a ! "${{matrix.slim}}" ]]; then
+        if [[ ${{matrix.python}} != pypy* && ! "${{matrix.slim}}" ]]; then
             # NumPy and derivatives either don't build under pypy, or if
             # they do, the builds take forever.
             PYTHON_PACKAGES="$PYTHON_PACKAGES ${PYTHON_NUMPY_PKGS}"

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -28,14 +28,15 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.NAME }}
+    name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.other }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python: [3.8]
-        mpi: [0]
+        other: [""]
+
         include:
         - os: ubuntu-latest
           TARGET: linux
@@ -54,12 +55,20 @@ jobs:
 
         - os: ubuntu-latest
           python: 3.7
+          other: /mpi
           mpi: 3
           skip_doctest: 1
           TARGET: linux
           PYENV: conda
           PACKAGES: mpi4py openmpi
-          NAME: /mpi
+
+        - os: ubuntu-latest
+          python: 3.9
+          other: /cython
+          setup_options: --with-cython
+          skip_doctest: 1
+          TARGET: linux
+          PYENV: pip
 
         exclude:
         - {os: macos-latest, python: pypy2}
@@ -67,13 +76,12 @@ jobs:
         - {os: windows-latest, python: pypy2}
         - {os: windows-latest, python: pypy3}
 
-
     steps:
     - uses: actions/checkout@v2
 
     - name: Configure job parameters
       run: |
-        JOB="${{matrix.TARGET}}/${{matrix.python}}${{matrix.NAME}}"
+        JOB="${{matrix.TARGET}}/${{matrix.python}}${{matrix.other}}"
         echo "GHA_JOBNAME=$JOB" | sed 's|/|_|g' >> $GITHUB_ENV
 
     # Ideally we would cache the conda downloads; however, each cache is
@@ -366,7 +374,7 @@ jobs:
         echo ""
         echo "Install Pyomo..."
         echo ""
-        $PYTHON_EXE setup.py develop
+        $PYTHON_EXE setup.py develop ${{matrix.setup_options}}
         echo ""
         echo "Set custom PYOMO_CONFIG_DIR"
         echo ""
@@ -431,7 +439,7 @@ jobs:
 
     - name: Process code coverage report
       env:
-        CODECOV_NAME: ${{matrix.TARGET}}/${{matrix.python}}${{matrix.NAME}}
+        CODECOV_NAME: ${{matrix.TARGET}}/${{matrix.python}}${{matrix.other}}
       run: |
         coverage combine
         coverage report -i

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -104,8 +104,8 @@ jobs:
             PYTHON_PACKAGES="$PYTHON_PACKAGES ${PYTHON_NUMPY_PKGS}"
         fi
         PYTHON_PACKAGES="$PYTHON_PACKAGES ${{matrix.PACKAGES}}"
-        echo "PYTHON_PACKAGES=$PYTHON_PACKAGES" | sed -r 's/\n/ /g' \
-            >> $GITHUB_ENV
+        echo "PYTHON_PACKAGES=$PYTHON_PACKAGES" \
+            | tr '\n' ' ' | sed -r 's/ +/ /g' >> $GITHUB_ENV
 
     # Ideally we would cache the conda downloads; however, each cache is
     # over 850MB, and with 5 python versions, that would consume 4.2 of

--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -25,6 +25,9 @@
 #
 # DISABLE_COVERAGE: if nonempty, then coverage analysis is disabled
 #
+# PYOMO_SETUP_ARGS: passed to the 'python setup.py develop' command
+#     (e.g., to specify --with-cython)
+#
 # PYOMO_DOWNLOAD_ARGS: passed to the 'pyomo download-extensions" command
 #     (e.g., to set up local SSL certificate authorities)
 #
@@ -52,16 +55,21 @@ MODE="$1"
 if test -z "$MODE" -o "$MODE" == setup; then
     # Clean old PYC files and remove any previous virtualenv
     echo "#"
-    echo "# Cleaning out old .pyc files"
+    echo "# Removing python virtual environment"
     echo "#"
     rm -rf ${WORKSPACE}/python
-    find ${WORKSPACE}/pyomo -name \*.pyc -delete
-    find ${WORKSPACE}/pyutilib -name \*.pyc -delete
+    echo "#"
+    echo "# Cleaning out old .pyc and cython files"
+    echo "#"
+    for EXT in pyc pyx pyd so dylib dll; do
+        find ${WORKSPACE}/pyomo -name \*.$EXT -delete
+        find ${WORKSPACE}/pyutilib -name \*.$EXT -delete
+    done
 
     # Set up the local lpython
     echo ""
     echo "#"
-    echo "# Setting up virutal environment"
+    echo "# Setting up virtual environment"
     echo "#"
     virtualenv python $VENV_SYSTEM_PACKAGES --clear
     # Put the venv at the beginning of the PATH
@@ -81,7 +89,7 @@ if test -z "$MODE" -o "$MODE" == setup; then
     python setup.py develop || exit 1
     popd
     pushd "$WORKSPACE/pyomo" || exit 1
-    python setup.py develop || exit 1
+    python setup.py develop $PYOMO_SETUP_ARGS || exit 1
     popd
     #
     # DO NOT install pyomo-model-libraries


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This adds cythonized and slim builds to the Github Actions, and adds a hook to the Jenkins driver to enable cythonization.  This moves us closer to no longer needing Travis builds.

## Changes proposed in this PR:
- Add the ability to configure "slim" and "cythonized" builds to GHA
- Set up a `linux/3.9/slim` and `linux/3.6/cython` builds to both the PR and Branch testing
- Add a hook to the Jenkins driver so that the caller can specify `--with-cython` to `setup.py develop`
- Add the first test of Pyomo with Python 3.9

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
