### PR TITLE
Make Constraint.Feasible be an alias for Constraint.Skip

### DIFF
--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -494,15 +494,14 @@ class _GeneralConstraintData(_ConstraintData):
             self._upper = None
             self._equality = False
 
-            if expr is Constraint.Infeasible:
+            if expr is Constraint.Skip:
+                del self.parent_component()[self.index()]
+                return
+            elif expr is Constraint.Infeasible:
                 del self.parent_component()[self.index()]
                 raise ValueError(
                     "Constraint '%s' is always infeasible"
                     % (self.name,) )
-            elif ( expr is Constraint.Skip or
-                   expr is Constraint.Feasible ):
-                del self.parent_component()[self.index()]
-                return
             else:
                 raise ValueError(
                     "Constraint '%s' does not have a proper "
@@ -760,7 +759,7 @@ class Constraint(ActiveIndexedComponent):
 
     _ComponentDataClass = _GeneralConstraintData
     class Infeasible(object): pass
-    class Feasible(object): pass
+    Feasible = IndexedComponent.Skip
     NoConstraint = ActiveIndexedComponent.Skip
     Violated = Infeasible
     Satisfied = Feasible

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -759,7 +759,7 @@ class Constraint(ActiveIndexedComponent):
 
     _ComponentDataClass = _GeneralConstraintData
     class Infeasible(object): pass
-    Feasible = IndexedComponent.Skip
+    Feasible = ActiveIndexedComponent.Skip
     NoConstraint = ActiveIndexedComponent.Skip
     Violated = Infeasible
     Satisfied = Feasible


### PR DESCRIPTION
## Fixes #1672.

## Summary/Motivation:
Historically, Pyomo Constraints supported three special flags:
- `Constraint.Skip` - no constraint specified (i.e., a sparse indexed constraint)
- `Constraint.Feasible` - a trivially feasible constraint.  This was usually encountered when the constraint expression was a constant that evaluated to True
- `Constraint.Infeasible` - a trivially infeasible constraint.  This was usually encountered when a constraint expression was a constant that evaluated to False 

Pyomo has always treated `Constraint.Feasible` the same as `Constraint.Skip`: that is, the `_ConstraintData` was completely removed from the Constraint component.  This PR makes that official by making `Constraint.Feasible` be an alias of `Constraint.Skip`.

This became an issue after we centralized the processing of `Skip` in the `IndexedComponent._setitem_when_not_present()` method.  As `Skip` is defined on `IndexedComponent`, we chould provide special handling there and avoid creating the Data object to begin with.  However, as was pointed out in #1672, `Constraint.Feasible` was not handled by this code, forcing the `_ConstraintData` object to be created and then subsequently removed by the `set_value()` method (which in turn triggered a very costly enumeration of the indexing set).

## Changes proposed in this PR:
- Make `Constraint.Feasible` be an alias of `Constraint.Skip`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
