### PR TITLE
Defer import of profiling packages

### DIFF
--- a/pyomo/pysp/util/misc.py
+++ b/pyomo/pysp/util/misc.py
@@ -20,16 +20,6 @@ import subprocess
 import traceback
 import inspect
 import argparse
-# for profiling
-try:
-    import cProfile as profile
-except ImportError:
-    import profile
-try:
-    import pstats
-    pstats_available=True
-except ImportError:
-    pstats_available=False
 
 from pyutilib.misc import PauseGC, import_file
 from pyutilib.services import TempfileManager
@@ -307,7 +297,20 @@ def launch_command(command,
 
         rc = 0
 
-        if pstats_available and (profile_count > 0):
+        if profile_count > 0:
+            # Defer import of profiling packages until we know that they
+            # are needed
+            try:
+                try:
+                    import cProfile as profile
+                except ImportError:
+                    import profile
+                import pstats
+            except ImportError:
+                configure_loggers(shutdown=True)
+                raise ValueError(
+                    "Cannot use the 'profile' option: the Python "
+                    "'profile' or 'pstats' package cannot be imported!")
             #
             # Call the main routine with profiling.
             #


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
The import of `profile` and `pstats` occasionally pop up as part of the slower-importing modules, causing intermittent failure of the `pyomo.environ.tests.test_environ:TestPyomoEnviron.test_tpl_import_time` test.  Instead of adding those modules to the known set of reference modules, this PR defers their import entirely unless pyomo or pysp explicitly are about to enable profiling.

## Changes proposed in this PR:
- defer import of `profile` and `pstats` modules in `pyomo.scripting.util` and `pyomo.pysp.util.misc`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
