### PR TITLE
Add skip_stale_vars option for store_to function

### DIFF
--- a/examples/doc/pyomobook/cplex.log
+++ b/examples/doc/pyomobook/cplex.log
@@ -1,6 +1,0 @@
-
-Log started (V12.10.0.0) Fri Nov  6 13:52:35 2020
-
-
-Log started (V12.10.0.0) Fri Nov  6 13:52:35 2020
-

--- a/examples/doc/pyomobook/cplex.log
+++ b/examples/doc/pyomobook/cplex.log
@@ -1,0 +1,6 @@
+
+Log started (V12.10.0.0) Fri Nov  6 13:52:35 2020
+
+
+Log started (V12.10.0.0) Fri Nov  6 13:52:35 2020
+

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -287,7 +287,7 @@ class ModelSolutions(object):
                 ignore_invalid_labels=ignore_invalid_labels,
                 ignore_fixed_vars=ignore_fixed_vars)
 
-    def store_to(self, results, cuid=False):
+    def store_to(self, results, cuid=False, skip_stale_vars=True):
         """
         Return a Solution() object that is populated with the values in the model.
         """
@@ -318,7 +318,7 @@ class ModelSolutions(object):
                 soln.objective[ sm.getSymbol(obj, labeler) ] = vals
             entry = soln_._entry['variable']
             for obj in instance.component_data_objects(Var, active=True):
-                if obj.stale:
+                if obj.stale and skip_stale_vars:
                     continue
                 vals = entry.get(id(obj), None)
                 if vals is None:

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -287,7 +287,7 @@ class ModelSolutions(object):
                 ignore_invalid_labels=ignore_invalid_labels,
                 ignore_fixed_vars=ignore_fixed_vars)
 
-    def store_to(self, results, cuid=False, skip_stale_vars=True):
+    def store_to(self, results, cuid=False, skip_stale_vars=False):
         """
         Return a Solution() object that is populated with the values in the model.
         """

--- a/pyomo/core/tests/unit/test_model.py
+++ b/pyomo/core/tests/unit/test_model.py
@@ -266,14 +266,35 @@ class Test(unittest.TestCase):
         self.assertMatchesJsonBaseline(
             join(currdir,"solve1b.out"), join(currdir,"solve1b.txt"),
             tolerance=1e-4)
-
+            
+    def test_store_to_skip_stale_vars(self):
         # test store_to() function with skip_stale_vars=True
-        results = opt.solve(model)
-        model.solutions.store_to(results, skip_stale_vars=True)
-        results.write(filename=join(currdir,"solve1b.out"), format='json')
-        self.assertMatchesJsonBaseline(
-            join(currdir,"solve1b.out"), join(currdir,"solve1b.txt"),
-            tolerance=1e-4)
+        model = ConcreteModel()
+        model.A = RangeSet(1,4)
+        model.x = Var(model.A, bounds=(-1,1))
+        def obj_rule(model):
+            return sum_product(model.x)
+        model.obj = Objective(rule=obj_rule)
+        def c_rule(model):
+            expr = 0
+            for i in model.A:
+                expr += i*model.x[i]
+            return expr == 0
+        model.c = Constraint(rule=c_rule)
+        opt = SolverFactory('glpk')
+        results = opt.solve(model, symbolic_solver_labels=True)
+        model.solutions.store_to(results,skip_stale_vars=False)
+        for index in model.A:
+            self.assertIn(model.x[index].getname(), results.solution.variable.keys())
+        model.x[1].fix()
+        results = opt.solve(model, symbolic_solver_labels=True)
+        model.solutions.store_to(results,skip_stale_vars=True)
+        for index in model.A:
+            if index == 1:
+                self.assertNotIn(model.x[index].getname(), results.solution.variable.keys())
+            else:
+                self.assertIn(model.x[index].getname(), results.solution.variable.keys())
+
 
     def test_display(self):
         model = ConcreteModel()

--- a/pyomo/core/tests/unit/test_model.py
+++ b/pyomo/core/tests/unit/test_model.py
@@ -283,11 +283,11 @@ class Test(unittest.TestCase):
         model.c = Constraint(rule=c_rule)
         opt = SolverFactory('glpk')
         results = opt.solve(model, symbolic_solver_labels=True)
+        model.x[1].fix()
+        results = opt.solve(model, symbolic_solver_labels=True)
         model.solutions.store_to(results,skip_stale_vars=False)
         for index in model.A:
             self.assertIn(model.x[index].getname(), results.solution.variable.keys())
-        model.x[1].fix()
-        results = opt.solve(model, symbolic_solver_labels=True)
         model.solutions.store_to(results,skip_stale_vars=True)
         for index in model.A:
             if index == 1:

--- a/pyomo/core/tests/unit/test_model.py
+++ b/pyomo/core/tests/unit/test_model.py
@@ -267,6 +267,14 @@ class Test(unittest.TestCase):
             join(currdir,"solve1b.out"), join(currdir,"solve1b.txt"),
             tolerance=1e-4)
 
+        # test store_to() function with skip_stale_vars=True
+        results = opt.solve(model)
+        model.solutions.store_to(results, skip_stale_vars=True)
+        results.write(filename=join(currdir,"solve1b.out"), format='json')
+        self.assertMatchesJsonBaseline(
+            join(currdir,"solve1b.out"), join(currdir,"solve1b.txt"),
+            tolerance=1e-4)
+
     def test_display(self):
         model = ConcreteModel()
         model.A = RangeSet(1,4)


### PR DESCRIPTION
## Fixes #1658.

## Summary/Motivation:
This Pull Request inserts add a `skip_stale_vars` option to control whether to skip the `stale=True` variables when storing variables.

## Changes proposed in this PR:
- `store_to(self, results, cuid=False)` to `store_to(self, results, cuid=False, skip_stale_vars=True)`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
