### PR TITLE
Bundle GHA coverage report uploads

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,6 +14,6 @@ coverage:
 #    - !ci.appveyor.com
 codecov:
   notify:
-    # GHA: 4, Travis: 13, Jenkins: 6
-    after_n_builds: 22
+    # GHA: 5, Travis: 13, Jenkins: 6
+    after_n_builds: 22  # all but 2
     wait_for_ci: yes

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,6 +14,6 @@ coverage:
 #    - !ci.appveyor.com
 codecov:
   notify:
-    # GHA: 18, Travis: 13, Jenkins: 6
-    after_n_builds: 33
+    # GHA: 4, Travis: 13, Jenkins: 6
+    after_n_builds: 22
     wait_for_ci: yes

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -88,7 +88,8 @@ jobs:
         - {os: windows-latest, python: pypy3}
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Pyomo source
+      uses: actions/checkout@v2
 
     - name: Configure job parameters
       run: |
@@ -478,25 +479,34 @@ jobs:
           # TEST-*.xml
 
   cover:
-    name: process-coverage
+    name: process-coverage-${{ matrix.TARGET }}
     needs: build
     if: always() # run even if a build job fails
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+        include:
+        - os: ubuntu-latest
+          TARGET: linux
+        - os: macos-latest
+          TARGET: osx
+        - os: windows-latest
+          TARGET: win
+
     steps:
+    - name: Checkout Pyomo source
+      uses: actions/checkout@v2
+      # We need the source for .codecov.yml and running "coverage xml"
+
     - name: Pip package cache
       uses: actions/cache@v1
-      if: matrix.PYENV == 'pip'
       id: pip-cache
       with:
         path: cache/pip
         key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.8
-
-    - name: TPL package download cache
-      uses: actions/cache@v1
-      id: download-cache
-      with:
-        path: cache/download
-        key: download-${{env.CACHE_VER}}.0-${{runner.os}}
 
     - name: Download build artifacts
       uses: actions/download-artifact@v2
@@ -518,14 +528,36 @@ jobs:
         python -c 'import sys; print("PYTHON_EXE=%s" \
             % (sys.executable,))' >> $GITHUB_ENV
 
+    - name: Install Pyomo and PyUtilib
+      run: |
+        echo ""
+        echo "Clone Pyomo-model-libraries..."
+        git clone https://github.com/Pyomo/pyomo-model-libraries.git
+        echo ""
+        echo "Install PyUtilib..."
+        echo ""
+        $PYTHON_EXE -m pip install git+https://github.com/PyUtilib/pyutilib
+        echo ""
+        echo "Install Pyomo..."
+        echo ""
+        $PYTHON_EXE setup.py develop ${{matrix.setup_options}}
+        echo ""
+        echo "Set custom PYOMO_CONFIG_DIR"
+        echo ""
+        echo "PYOMO_CONFIG_DIR=${GITHUB_WORKSPACE}/config" >> $GITHUB_ENV
+
+    - name: Generate parse_table_datacmds
+      run: |
+        # Manually invoke the DAT parser so that parse_table_datacmds.py
+        # is generated before running "coverage xml"
+        $PYTHON_EXE -c "from pyomo.dataportal.parse_datacmds import \
+            parse_data_commands; parse_data_commands(data='')"
+
     - name: Update codecov uploader
       run: |
         set +e
-        CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh"
+        CODECOV="${GITHUB_WORKSPACE}/codecov.sh"
         echo "CODECOV=$CODECOV" >> $GITHUB_ENV
-        mkdir -p `basename $CODECOV`
-        # Always attempt to update the codecov script, but fall back on
-        # the previously cached script if it fails
         for i in `seq 3`; do
             echo "Downloading current codecov script (attempt ${i})"
             curl -L https://codecov.io/bash -o $CODECOV
@@ -536,17 +568,27 @@ jobs:
             echo "Pausing $DELAY seconds before re-attempting download"
             sleep $DELAY
         done
+        if test ! -e $CODECOV; then
+            echo "Failed to download codecov.sh"
+            exit 1
+        fi
 
     - name: Upload codecov reports
       run: |
         set +e
         function upload {
+            echo ""
+            echo "Build group: $1"
+            export CODECOV_NAME=$1
+            shift
+            rm -vf .coverage coverage.xml
+            echo "    $@" | sed 's/ /\n    /'
+            coverage combine --debug=dataio $@
             if test ! -e .coverage; then
                 echo "No coverage to upload."
                 return
             fi
-            coverage xml -i
-            export CODECOV_NAME=$BUILD_GROUP
+            coverage xml || coverage xml -i
             i=0
             while : ; do
                 ((i+=1))
@@ -566,31 +608,26 @@ jobs:
                 sleep $DELAY
             done
         }
-        ARTIFACTS=`ls -d artifacts/* | cut -d/ -f2 | cut -d- -f1 | sort | uniq`
-        for BUILD_GROUP in $ARTIFACTS; do
-            echo ""
-            echo "Build group: $BUILD_GROUP"
-            ls artifacts/${BUILD_GROUP}*/.coverage | sed 's/^/    /'
-            rm -vf .coverage coverage.xml
-            coverage combine artifacts/${BUILD_GROUP}*/.coverage
-            upload
+        for ARTIFACT in artifacts/*_*${{matrix.TARGET}}_*; do
+            NAME=`echo $ARTIFACT | cut -d/ -f2`
+            cp -v $ARTIFACT/.coverage .coverage-$NAME
         done
+        upload ${{matrix.TARGET}} .coverage-*_${{matrix.TARGET}}-*
+        if compgen -G ".coverage-*" > /dev/null; then
+            upload ${{matrix.TARGET}}/other .coverage-*
+        fi
         # Legacy builds that don't support coverage 5.x
-        echo ""
-        echo "Installing coverage 4.x for legacy builds"
-        pip install 'coverage<5'
-        BUILD_GROUP=legacy
-        echo ""
-        echo "Build group: $BUILD_GROUP"
-        rm -vf .coverage coverage.xml
-        coverage combine artifacts/*/.coverage
-        upload
+        if compgen -G ".coverage-*" > /dev/null; then
+            echo ""
+            echo "Installing coverage 4.x for legacy builds"
+            pip install 'coverage<5'
+            upload ${{matrix.TARGET}}/legacy .coverage-*
+        fi
 
     - name: Check codecov upload success
       run: |
         FAIL=`grep FAIL codecov.result | wc -l`
         ALL=`cat codecov.result | wc -l`
-        # Fail if more than 1/9 codecov uploads fail
         echo "$FAIL of $ALL codecov uploads failed"
         if test $FAIL -gt 0; then
             grep FAIL codecov.result | sed 's/^/    /'

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -580,6 +580,8 @@ jobs:
             echo ""
             echo "Build group: $1"
             export CODECOV_NAME=$1
+            export TAG=$1
+            export GHA_OS_NAME=${{matrix.TARGET}}
             shift
             rm -vf .coverage coverage.xml
             echo "    $@" | sed 's/ /\n    /'
@@ -593,7 +595,8 @@ jobs:
             while : ; do
                 ((i+=1))
                 echo "Uploading coverage to codecov (attempt ${i})"
-                bash $CODECOV -Z -X gcov -X s3 -f coverage.xml
+                bash $CODECOV -Z --env TAG,GHA_OS_NAME -X gcov -X s3 \
+                    -f coverage.xml
                 if test $? == 0; then
                     echo "PASS $CODECOV_NAME" >> codecov.result
                     break

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -483,15 +483,46 @@ jobs:
     if: always() # run even if a build job fails
     runs-on: ubuntu-latest
     steps:
+    - name: Pip package cache
+      uses: actions/cache@v1
+      if: matrix.PYENV == 'pip'
+      id: pip-cache
+      with:
+        path: cache/pip
+        key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.8
+
+    - name: TPL package download cache
+      uses: actions/cache@v1
+      id: download-cache
+      with:
+        path: cache/download
+        key: download-${{env.CACHE_VER}}.0-${{runner.os}}
+
     - name: Download build artifacts
       uses: actions/download-artifact@v2
       with:
         path: artifacts
 
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install Python Packages (pip)
+      shell: bash # DO NOT REMOVE: see note above
+      run: |
+        python -c 'import sys;print(sys.executable)'
+        python -m pip install --cache-dir cache/pip --upgrade pip
+        pip install --cache-dir cache/pip ${PYTHON_CORE_PKGS} \
+            ${PYTHON_REQUIRED_PKGS}
+        python -c 'import sys; print("PYTHON_EXE=%s" \
+            % (sys.executable,))' >> $GITHUB_ENV
+
     - name: Update codecov uploader
       run: |
         set +e
         CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh"
+        mkdir -p `basename $CODECOV`
         echo "CODECOV=$CODECOV" >> $GITHUB_ENV
         # Always attempt to update the codecov script, but fall back on
         # the previously cached script if it fails

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -480,6 +480,7 @@ jobs:
   cover:
     name: process-coverage
     needs: build
+    if: always() # run even if a build job fails
     runs-on: ubuntu-latest
     steps:
     - name: Download build artifacts

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -94,6 +94,11 @@ jobs:
       run: |
         JOB="${{matrix.TARGET}}/${{matrix.python}}${{matrix.other}}"
         echo "GHA_JOBNAME=$JOB" | sed 's|/|_|g' >> $GITHUB_ENV
+        if test -z "${{matrix.other}}"; then
+            echo "GHA_JOBGROUP=${{matrix.TARGET}}" >> $GITHUB_ENV
+        else
+            echo "GHA_JOBGROUP=other" >> $GITHUB_ENV
+        fi
         # Note: pandas 1.0.3 causes gams 29.1.0 import to fail in python 3.8
         PYTHON_PACKAGES="${PYTHON_REQUIRED_PKGS}"
         if test -z "${{matrix.slim}}"; then
@@ -456,12 +461,34 @@ jobs:
         make -C doc/OnlineDocs doctest -d
 
     - name: Process code coverage report
-      env:
-        CODECOV_NAME: ${{matrix.TARGET}}/${{matrix.python}}${{matrix.other}}
       run: |
         coverage combine
         coverage report -i
         coverage xml -i
+
+    - name: Record build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{github.job}}_${{env.GHA_JOBGROUP}}-${{env.GHA_JOBNAME}}
+        path: |
+          .coverage
+          coverage.xml
+          # In general, do not record test results as artifacts to
+          #   manage total artifact storage
+          # TEST-*.xml
+
+  cover:
+    name: process-coverage
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@v2
+      with:
+        path: artifacts
+
+    - name: Update codecov uploader
+      run: |
         set +e
         # Always attempt to update the codecov script, but fall back on
         # the previously cached script if it fails
@@ -476,54 +503,46 @@ jobs:
             echo "Pausing $DELAY seconds before re-attempting download"
             sleep $DELAY
         done
-        i=0
-        while : ; do
-            ((i+=1))
-            echo "Uploading coverage to codecov (attempt ${i})"
-            bash $CODECOV -Z -X gcov -X s3 -f coverage.xml
-            if test $? == 0; then
-                echo "PASS" > ${GITHUB_WORKSPACE}/codecov.result
-                break
-            elif test $i -ge 2; then
-                # Do not fail the build just because the codecov upload fails
-                echo "FAIL" > ${GITHUB_WORKSPACE}/codecov.result
-                break
-            fi
-            DELAY=$(( RANDOM % 30 + 30))
-            echo "Pausing $DELAY seconds before re-attempting upload"
-            sleep $DELAY
+
+    - name: Upload codecov reports
+      run: |
+        set +e
+        ARTIFACTS=`ls -d artifacts/* | cut -d/ -f2 | cut -d- -f1 | sort | uniq`
+        for BUILD_GROUP in $ARTIFACTS; do
+            rm -vf .coverage coverage.xml
+            coverage combine artifacts/${BUILD_GROUP}*/.coverage
+            coverage xml -i
+            export CODECOV_NAME=$BUILD_GROUP
+            i=0
+            while : ; do
+                ((i+=1))
+                echo "Uploading coverage to codecov (attempt ${i})"
+                bash $CODECOV -Z -X gcov -X s3 -f coverage.xml
+                if test $? == 0; then
+                    echo "PASS $CODECOV_NAME" >> codecov.result
+                    break
+                elif test $i -ge 2; then
+                    # Do not fail the build (yet) just because the codecov
+                    # upload fails
+                    echo "FAIL $CODECOV_NAME" >> codecov.result
+                    break
+                fi
+                DELAY=$(( RANDOM % 30 + 30))
+                echo "Pausing $DELAY seconds before re-attempting upload"
+                sleep $DELAY
+            done
         done
-
-    - name: Record build artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{github.job}}_${{env.GHA_JOBNAME}}
-        path: |
-          codecov.result
-        # In general, do not record test results as artifacts to
-        #   manage total artifact storage
-        # TEST-*.xml
-
-  post:
-    name: post-build
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts
 
       - name: Check codecov upload success
         run: |
-          FAIL=`grep FAIL artifacts/*/codecov.result | wc -l`
-          ALL=`ls -1 artifacts/*/codecov.result | wc -l`
-          # Fail is more than 1/9 codecov uploads fail
+          FAIL=`grep FAIL codecov.result | wc -l`
+          ALL=`cat codecov.result | wc -l`
+          # Fail if more than 1/9 codecov uploads fail
           echo "$FAIL of $ALL codecov uploads failed"
           if test $FAIL -gt 0; then
-              grep FAIL artifacts/*/codecov.result | sed 's/^/    /'
-              if test $(( $FAIL * 9 )) -gt $ALL; then
-                  echo "More than 1/9 codecov uploads failed:"
+              grep FAIL codecov.result | sed 's/^/    /'
+              if test $FAIL -gt 1; then
+                  echo "More than 1 codecov upload failed."
                   exit 1
               fi
           fi

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -533,16 +533,16 @@ jobs:
             done
         done
 
-      - name: Check codecov upload success
-        run: |
-          FAIL=`grep FAIL codecov.result | wc -l`
-          ALL=`cat codecov.result | wc -l`
-          # Fail if more than 1/9 codecov uploads fail
-          echo "$FAIL of $ALL codecov uploads failed"
-          if test $FAIL -gt 0; then
-              grep FAIL codecov.result | sed 's/^/    /'
-              if test $FAIL -gt 1; then
-                  echo "More than 1 codecov upload failed."
-                  exit 1
-              fi
-          fi
+    - name: Check codecov upload success
+      run: |
+        FAIL=`grep FAIL codecov.result | wc -l`
+        ALL=`cat codecov.result | wc -l`
+        # Fail if more than 1/9 codecov uploads fail
+        echo "$FAIL of $ALL codecov uploads failed"
+        if test $FAIL -gt 0; then
+            grep FAIL codecov.result | sed 's/^/    /'
+            if test $FAIL -gt 1; then
+                echo "More than 1 codecov upload failed."
+                exit 1
+            fi
+        fi

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -510,6 +510,8 @@ jobs:
         set +e
         ARTIFACTS=`ls -d artifacts/* | cut -d/ -f2 | cut -d- -f1 | sort | uniq`
         for BUILD_GROUP in $ARTIFACTS; do
+            echo "Build group: $BUILD_GROUP"
+            ls artifacts/${BUILD_GROUP}*/.coverage | sed 's/^/    /'
             rm -vf .coverage coverage.xml
             coverage combine artifacts/${BUILD_GROUP}*/.coverage
             coverage xml -i

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -522,8 +522,8 @@ jobs:
       run: |
         set +e
         CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh"
-        mkdir -p `basename $CODECOV`
         echo "CODECOV=$CODECOV" >> $GITHUB_ENV
+        mkdir -p `basename $CODECOV`
         # Always attempt to update the codecov script, but fall back on
         # the previously cached script if it fails
         for i in `seq 3`; do
@@ -540,12 +540,10 @@ jobs:
     - name: Upload codecov reports
       run: |
         set +e
-        ARTIFACTS=`ls -d artifacts/* | cut -d/ -f2 | cut -d- -f1 | sort | uniq`
-        for BUILD_GROUP in $ARTIFACTS; do
-            echo "Build group: $BUILD_GROUP"
-            ls artifacts/${BUILD_GROUP}*/.coverage | sed 's/^/    /'
-            rm -vf .coverage coverage.xml
-            coverage combine artifacts/${BUILD_GROUP}*/.coverage
+        function upload {
+            if test ! -e .coverage; then
+                return
+            fi
             coverage xml -i
             export CODECOV_NAME=$BUILD_GROUP
             i=0
@@ -566,7 +564,22 @@ jobs:
                 echo "Pausing $DELAY seconds before re-attempting upload"
                 sleep $DELAY
             done
+        }
+        ARTIFACTS=`ls -d artifacts/* | cut -d/ -f2 | cut -d- -f1 | sort | uniq`
+        for BUILD_GROUP in $ARTIFACTS; do
+            echo "Build group: $BUILD_GROUP"
+            ls artifacts/${BUILD_GROUP}*/.coverage | sed 's/^/    /'
+            rm -vf .coverage coverage.xml
+            coverage combine artifacts/${BUILD_GROUP}*/.coverage
+            upload()
         done
+        # Legacy builds that don't support coverage 5.x
+        pip install 'coverage<5'
+        BUILD_GROUP=legacy
+        echo "Build group: $BUILD_GROUP"
+        rm -vf .coverage coverage.xml
+        coverage combine artifacts/*/.coverage
+        upload()
 
     - name: Check codecov upload success
       run: |

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -595,7 +595,7 @@ jobs:
             while : ; do
                 ((i+=1))
                 echo "Uploading coverage to codecov (attempt ${i})"
-                bash $CODECOV -Z --env TAG,GHA_OS_NAME -X gcov -X s3 \
+                bash $CODECOV -Z -e TAG,GHA_OS_NAME -X gcov -X s3 \
                     -f coverage.xml
                 if test $? == 0; then
                     echo "PASS $CODECOV_NAME" >> codecov.result

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -571,7 +571,7 @@ jobs:
             ls artifacts/${BUILD_GROUP}*/.coverage | sed 's/^/    /'
             rm -vf .coverage coverage.xml
             coverage combine artifacts/${BUILD_GROUP}*/.coverage
-            upload()
+            upload
         done
         # Legacy builds that don't support coverage 5.x
         pip install 'coverage<5'
@@ -579,7 +579,7 @@ jobs:
         echo "Build group: $BUILD_GROUP"
         rm -vf .coverage coverage.xml
         coverage combine artifacts/*/.coverage
-        upload()
+        upload
 
     - name: Check codecov upload success
       run: |

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -490,9 +490,10 @@ jobs:
     - name: Update codecov uploader
       run: |
         set +e
+        CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh"
+        echo "CODECOV=$CODECOV" >> $GITHUB_ENV
         # Always attempt to update the codecov script, but fall back on
         # the previously cached script if it fails
-        CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh"
         for i in `seq 3`; do
             echo "Downloading current codecov script (attempt ${i})"
             curl -L https://codecov.io/bash -o $CODECOV

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -542,6 +542,7 @@ jobs:
         set +e
         function upload {
             if test ! -e .coverage; then
+                echo "No coverage to upload."
                 return
             fi
             coverage xml -i
@@ -567,6 +568,7 @@ jobs:
         }
         ARTIFACTS=`ls -d artifacts/* | cut -d/ -f2 | cut -d- -f1 | sort | uniq`
         for BUILD_GROUP in $ARTIFACTS; do
+            echo ""
             echo "Build group: $BUILD_GROUP"
             ls artifacts/${BUILD_GROUP}*/.coverage | sed 's/^/    /'
             rm -vf .coverage coverage.xml
@@ -574,8 +576,11 @@ jobs:
             upload
         done
         # Legacy builds that don't support coverage 5.x
+        echo ""
+        echo "Installing coverage 4.x for legacy builds"
         pip install 'coverage<5'
         BUILD_GROUP=legacy
+        echo ""
         echo "Build group: $BUILD_GROUP"
         rm -vf .coverage coverage.xml
         coverage combine artifacts/*/.coverage

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -515,6 +515,24 @@ jobs:
         python -c 'import sys; print("PYTHON_EXE=%s" \
             % (sys.executable,))' >> $GITHUB_ENV
 
+    - name: Install Pyomo and PyUtilib
+      run: |
+        echo ""
+        echo "Clone Pyomo-model-libraries..."
+        git clone https://github.com/Pyomo/pyomo-model-libraries.git
+        echo ""
+        echo "Install PyUtilib..."
+        echo ""
+        $PYTHON_EXE -m pip install git+https://github.com/PyUtilib/pyutilib
+        echo ""
+        echo "Install Pyomo..."
+        echo ""
+        $PYTHON_EXE setup.py develop ${{matrix.setup_options}}
+        echo ""
+        echo "Set custom PYOMO_CONFIG_DIR"
+        echo ""
+        echo "PYOMO_CONFIG_DIR=${GITHUB_WORKSPACE}/config" >> $GITHUB_ENV
+
     - name: Generate parse_table_datacmds
       run: |
         # Manually invoke the DAT parser so that parse_table_datacmds.py

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -539,6 +539,8 @@ jobs:
     - name: Upload codecov reports
       run: |
         set +e
+        pwd
+        ls -a
         function upload {
             if test ! -e .coverage; then
                 echo "No coverage to upload."
@@ -574,7 +576,7 @@ jobs:
             echo ""
             echo "Build group: $BUILD_GROUP"
             rm -vf .coverage coverage.xml
-            ls .coverage-{BUILD_GROUP}* | sed 's/^/    /'
+            ls .coverage-${BUILD_GROUP}* | sed 's/^/    /'
             coverage combine .coverage-${BUILD_GROUP}*/.coverage
             upload
         done

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -594,7 +594,7 @@ jobs:
             while : ; do
                 ((i+=1))
                 echo "Uploading coverage to codecov (attempt ${i})"
-                bash $CODECOV -Z --env TAG,GHA_OS_NAME -X gcov -X s3 \
+                bash $CODECOV -Z -e TAG,GHA_OS_NAME -X gcov -X s3 \
                     -f coverage.xml
                 if test $? == 0; then
                     echo "PASS $CODECOV_NAME" >> codecov.result

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -570,7 +570,7 @@ jobs:
             ls artifacts/${BUILD_GROUP}*/.coverage | sed 's/^/    /'
             rm -vf .coverage coverage.xml
             coverage combine artifacts/${BUILD_GROUP}*/.coverage
-            upload()
+            upload
         done
         # Legacy builds that don't support coverage 5.x
         pip install 'coverage<5'
@@ -578,7 +578,7 @@ jobs:
         echo "Build group: $BUILD_GROUP"
         rm -vf .coverage coverage.xml
         coverage combine artifacts/*/.coverage
-        upload()
+        upload
 
     - name: Check codecov upload success
       run: |

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -546,7 +546,7 @@ jobs:
                 echo "No coverage to upload."
                 return
             fi
-            coverage xml -i
+            coverage xml || coverage xml -i
             export CODECOV_NAME=$BUILD_GROUP
             i=0
             while : ; do
@@ -577,7 +577,7 @@ jobs:
             echo "Build group: $BUILD_GROUP"
             rm -vf .coverage coverage.xml
             ls .coverage-${BUILD_GROUP}* | sed 's/^/    /'
-            coverage combine .coverage-${BUILD_GROUP}*/.coverage
+            coverage combine --debug=config,dataio .coverage-${BUILD_GROUP}*
             upload
         done
         # Legacy builds that don't support coverage 5.x
@@ -588,7 +588,7 @@ jobs:
         echo ""
         echo "Build group: $BUILD_GROUP"
         rm -vf .coverage coverage.xml
-        coverage combine .coverage-*
+        coverage combine --debug=config,dataio .coverage-*
         upload
 
     - name: Check codecov upload success

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -482,6 +482,8 @@ jobs:
     if: always() # run even if a build job fails
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
+
     - name: Pip package cache
       uses: actions/cache@v1
       if: matrix.PYENV == 'pip'

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -541,6 +541,7 @@ jobs:
         set +e
         function upload {
             if test ! -e .coverage; then
+                echo "No coverage to upload."
                 return
             fi
             coverage xml -i
@@ -566,6 +567,7 @@ jobs:
         }
         ARTIFACTS=`ls -d artifacts/* | cut -d/ -f2 | cut -d- -f1 | sort | uniq`
         for BUILD_GROUP in $ARTIFACTS; do
+            echo ""
             echo "Build group: $BUILD_GROUP"
             ls artifacts/${BUILD_GROUP}*/.coverage | sed 's/^/    /'
             rm -vf .coverage coverage.xml
@@ -573,8 +575,11 @@ jobs:
             upload
         done
         # Legacy builds that don't support coverage 5.x
+        echo ""
+        echo "Installing coverage 4.x for legacy builds"
         pip install 'coverage<5'
         BUILD_GROUP=legacy
+        echo ""
         echo "Build group: $BUILD_GROUP"
         rm -vf .coverage coverage.xml
         coverage combine artifacts/*/.coverage

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -87,7 +87,8 @@ jobs:
         - {os: windows-latest, python: pypy3}
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Pyomo source
+      uses: actions/checkout@v2
 
     - name: Configure job parameters
       run: |
@@ -482,7 +483,9 @@ jobs:
     if: always() # run even if a build job fails
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Pyomo source
+      uses: actions/checkout@v2
+      # We need the source for .codecov.yml and running "coverage xml"
 
     - name: Pip package cache
       uses: actions/cache@v1
@@ -491,13 +494,6 @@ jobs:
       with:
         path: cache/pip
         key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.8
-
-    - name: TPL package download cache
-      uses: actions/cache@v1
-      id: download-cache
-      with:
-        path: cache/download
-        key: download-${{env.CACHE_VER}}.0-${{runner.os}}
 
     - name: Download build artifacts
       uses: actions/download-artifact@v2
@@ -519,10 +515,17 @@ jobs:
         python -c 'import sys; print("PYTHON_EXE=%s" \
             % (sys.executable,))' >> $GITHUB_ENV
 
+    - name: Generate parse_table_datacmds
+      run: |
+        # Manually invoke the DAT parser so that parse_table_datacmds.py
+        # is generated before running "coverage xml"
+        $PYTHON_EXE -c "from pyomo.dataportal.parse_datacmds import \
+            parse_data_commands; parse_data_commands(data='')"
+
     - name: Update codecov uploader
       run: |
         set +e
-        CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh"
+        CODECOV="${GITHUB_WORKSPACE}/codecov.sh"
         echo "CODECOV=$CODECOV" >> $GITHUB_ENV
         mkdir -p `basename $CODECOV`
         # Always attempt to update the codecov script, but fall back on
@@ -537,6 +540,10 @@ jobs:
             echo "Pausing $DELAY seconds before re-attempting download"
             sleep $DELAY
         done
+        if test ! -e $CODECOV; then
+            echo "Failed to download codecov.sh"
+            exit 1
+        fi
 
     - name: Upload codecov reports
       run: |
@@ -579,7 +586,7 @@ jobs:
             echo "Build group: $BUILD_GROUP"
             rm -vf .coverage coverage.xml
             ls .coverage-${BUILD_GROUP}* | sed 's/^/    /'
-            coverage combine --debug=config,dataio .coverage-${BUILD_GROUP}*
+            coverage combine --debug=dataio .coverage-${BUILD_GROUP}*
             upload
         done
         # Legacy builds that don't support coverage 5.x
@@ -590,7 +597,7 @@ jobs:
         echo ""
         echo "Build group: $BUILD_GROUP"
         rm -vf .coverage coverage.xml
-        coverage combine --debug=config,dataio .coverage-*
+        coverage combine --debug=dataio .coverage-*
         upload
 
     - name: Check codecov upload success

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -509,6 +509,8 @@ jobs:
         set +e
         ARTIFACTS=`ls -d artifacts/* | cut -d/ -f2 | cut -d- -f1 | sort | uniq`
         for BUILD_GROUP in $ARTIFACTS; do
+            echo "Build group: $BUILD_GROUP"
+            ls artifacts/${BUILD_GROUP}*/.coverage | sed 's/^/    /'
             rm -vf .coverage coverage.xml
             coverage combine artifacts/${BUILD_GROUP}*/.coverage
             coverage xml -i

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -545,9 +545,6 @@ jobs:
         set +e
         CODECOV="${GITHUB_WORKSPACE}/codecov.sh"
         echo "CODECOV=$CODECOV" >> $GITHUB_ENV
-        mkdir -p `basename $CODECOV`
-        # Always attempt to update the codecov script, but fall back on
-        # the previously cached script if it fails
         for i in `seq 3`; do
             echo "Downloading current codecov script (attempt ${i})"
             curl -L https://codecov.io/bash -o $CODECOV

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -479,6 +479,7 @@ jobs:
   cover:
     name: process-coverage
     needs: build
+    if: always() # run even if a build job fails
     runs-on: ubuntu-latest
     steps:
     - name: Download build artifacts

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -478,10 +478,23 @@ jobs:
           # TEST-*.xml
 
   cover:
-    name: process-coverage
+    name: process-coverage-${{ matrix.TARGET }}
     needs: build
     if: always() # run even if a build job fails
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+        include:
+        - os: ubuntu-latest
+          TARGET: linux
+        - os: macos-latest
+          TARGET: osx
+        - os: windows-latest
+          TARGET: win
+
     steps:
     - name: Checkout Pyomo source
       uses: actions/checkout@v2
@@ -489,7 +502,6 @@ jobs:
 
     - name: Pip package cache
       uses: actions/cache@v1
-      if: matrix.PYENV == 'pip'
       id: pip-cache
       with:
         path: cache/pip
@@ -563,15 +575,19 @@ jobs:
     - name: Upload codecov reports
       run: |
         set +e
-        pwd
-        ls -a
         function upload {
+            echo ""
+            echo "Build group: $1"
+            export CODECOV_NAME=$1
+            shift
+            rm -vf .coverage coverage.xml
+            echo "    $@" | sed 's/ /\n    /'
+            coverage combine --debug=dataio $@
             if test ! -e .coverage; then
                 echo "No coverage to upload."
                 return
             fi
             coverage xml || coverage xml -i
-            export CODECOV_NAME=$BUILD_GROUP
             i=0
             while : ; do
                 ((i+=1))
@@ -591,35 +607,24 @@ jobs:
                 sleep $DELAY
             done
         }
-        for ARTIFACT in artifacts/*; do
+        for ARTIFACT in artifacts/*_*${{matrix.TARGET}}_*; do
             NAME=`echo $ARTIFACT | cut -d/ -f2`
             cp $ARTIFACT/.coverage .coverage-$NAME
         done
-        BUILD_GROUPS=`ls .coverage-* | cut -d- -f2 | sort | uniq`
-        for BUILD_GROUP in $BUILD_GROUPS; do
-            echo ""
-            echo "Build group: $BUILD_GROUP"
-            rm -vf .coverage coverage.xml
-            ls .coverage-${BUILD_GROUP}* | sed 's/^/    /'
-            coverage combine --debug=dataio .coverage-${BUILD_GROUP}*
-            upload
-        done
+        upload ${{matrix.TARGET}} .coverage-${{matrix.TARGET}}*
+        upload ${{matrix.TARGET}}/other .coverage-*
         # Legacy builds that don't support coverage 5.x
-        echo ""
-        echo "Installing coverage 4.x for legacy builds"
-        pip install 'coverage<5'
-        BUILD_GROUP=legacy
-        echo ""
-        echo "Build group: $BUILD_GROUP"
-        rm -vf .coverage coverage.xml
-        coverage combine --debug=dataio .coverage-*
-        upload
+        if compgen -G ".coverage-*" > /dev/null; then
+            echo ""
+            echo "Installing coverage 4.x for legacy builds"
+            pip install 'coverage<5'
+            upload ${{matrix.TARGET}}/legacy .coverage-*
+        fi
 
     - name: Check codecov upload success
       run: |
         FAIL=`grep FAIL codecov.result | wc -l`
         ALL=`cat codecov.result | wc -l`
-        # Fail if more than 1/9 codecov uploads fail
         echo "$FAIL of $ALL codecov uploads failed"
         if test $FAIL -gt 0; then
             grep FAIL codecov.result | sed 's/^/    /'

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -482,16 +482,47 @@ jobs:
     if: always() # run even if a build job fails
     runs-on: ubuntu-latest
     steps:
+    - name: Pip package cache
+      uses: actions/cache@v1
+      if: matrix.PYENV == 'pip'
+      id: pip-cache
+      with:
+        path: cache/pip
+        key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.8
+
+    - name: TPL package download cache
+      uses: actions/cache@v1
+      id: download-cache
+      with:
+        path: cache/download
+        key: download-${{env.CACHE_VER}}.0-${{runner.os}}
+
     - name: Download build artifacts
       uses: actions/download-artifact@v2
       with:
         path: artifacts
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install Python Packages (pip)
+      shell: bash # DO NOT REMOVE: see note above
+      run: |
+        python -c 'import sys;print(sys.executable)'
+        python -m pip install --cache-dir cache/pip --upgrade pip
+        pip install --cache-dir cache/pip ${PYTHON_CORE_PKGS} \
+            ${PYTHON_REQUIRED_PKGS}
+        python -c 'import sys; print("PYTHON_EXE=%s" \
+            % (sys.executable,))' >> $GITHUB_ENV
 
     - name: Update codecov uploader
       run: |
         set +e
         CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh"
         echo "CODECOV=$CODECOV" >> $GITHUB_ENV
+        mkdir -p `basename $CODECOV`
         # Always attempt to update the codecov script, but fall back on
         # the previously cached script if it fails
         for i in `seq 3`; do

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -539,12 +539,10 @@ jobs:
     - name: Upload codecov reports
       run: |
         set +e
-        ARTIFACTS=`ls -d artifacts/* | cut -d/ -f2 | cut -d- -f1 | sort | uniq`
-        for BUILD_GROUP in $ARTIFACTS; do
-            echo "Build group: $BUILD_GROUP"
-            ls artifacts/${BUILD_GROUP}*/.coverage | sed 's/^/    /'
-            rm -vf .coverage coverage.xml
-            coverage combine artifacts/${BUILD_GROUP}*/.coverage
+        function upload {
+            if test ! -e .coverage; then
+                return
+            fi
             coverage xml -i
             export CODECOV_NAME=$BUILD_GROUP
             i=0
@@ -565,7 +563,22 @@ jobs:
                 echo "Pausing $DELAY seconds before re-attempting upload"
                 sleep $DELAY
             done
+        }
+        ARTIFACTS=`ls -d artifacts/* | cut -d/ -f2 | cut -d- -f1 | sort | uniq`
+        for BUILD_GROUP in $ARTIFACTS; do
+            echo "Build group: $BUILD_GROUP"
+            ls artifacts/${BUILD_GROUP}*/.coverage | sed 's/^/    /'
+            rm -vf .coverage coverage.xml
+            coverage combine artifacts/${BUILD_GROUP}*/.coverage
+            upload()
         done
+        # Legacy builds that don't support coverage 5.x
+        pip install 'coverage<5'
+        BUILD_GROUP=legacy
+        echo "Build group: $BUILD_GROUP"
+        rm -vf .coverage coverage.xml
+        coverage combine artifacts/*/.coverage
+        upload()
 
     - name: Check codecov upload success
       run: |

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -489,9 +489,10 @@ jobs:
     - name: Update codecov uploader
       run: |
         set +e
+        CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh"
+        echo "CODECOV=$CODECOV" >> $GITHUB_ENV
         # Always attempt to update the codecov script, but fall back on
         # the previously cached script if it fails
-        CODECOV="${GITHUB_WORKSPACE}/cache/download/codecov.sh"
         for i in `seq 3`; do
             echo "Downloading current codecov script (attempt ${i})"
             curl -L https://codecov.io/bash -o $CODECOV

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -93,6 +93,11 @@ jobs:
       run: |
         JOB="${{matrix.TARGET}}/${{matrix.python}}${{matrix.other}}"
         echo "GHA_JOBNAME=$JOB" | sed 's|/|_|g' >> $GITHUB_ENV
+        if test -z "${{matrix.other}}"; then
+            echo "GHA_JOBGROUP=${{matrix.TARGET}}" >> $GITHUB_ENV
+        else
+            echo "GHA_JOBGROUP=other" >> $GITHUB_ENV
+        fi
         # Note: pandas 1.0.3 causes gams 29.1.0 import to fail in python 3.8
         PYTHON_PACKAGES="${PYTHON_REQUIRED_PKGS}"
         if test -z "${{matrix.slim}}"; then
@@ -455,12 +460,34 @@ jobs:
         make -C doc/OnlineDocs doctest -d
 
     - name: Process code coverage report
-      env:
-        CODECOV_NAME: ${{matrix.TARGET}}/${{matrix.python}}${{matrix.other}}
       run: |
         coverage combine
         coverage report -i
         coverage xml -i
+
+    - name: Record build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{github.job}}_${{env.GHA_JOBGROUP}}-${{env.GHA_JOBNAME}}
+        path: |
+          .coverage
+          coverage.xml
+          # In general, do not record test results as artifacts to
+          #   manage total artifact storage
+          # TEST-*.xml
+
+  cover:
+    name: process-coverage
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@v2
+      with:
+        path: artifacts
+
+    - name: Update codecov uploader
+      run: |
         set +e
         # Always attempt to update the codecov script, but fall back on
         # the previously cached script if it fails
@@ -475,54 +502,46 @@ jobs:
             echo "Pausing $DELAY seconds before re-attempting download"
             sleep $DELAY
         done
-        i=0
-        while : ; do
-            ((i+=1))
-            echo "Uploading coverage to codecov (attempt ${i})"
-            bash $CODECOV -Z -X gcov -X s3 -f coverage.xml
-            if test $? == 0; then
-                echo "PASS" > ${GITHUB_WORKSPACE}/codecov.result
-                break
-            elif test $i -ge 2; then
-                # Do not fail the build just because the codecov upload fails
-                echo "FAIL" > ${GITHUB_WORKSPACE}/codecov.result
-                break
-            fi
-            DELAY=$(( RANDOM % 30 + 30))
-            echo "Pausing $DELAY seconds before re-attempting upload"
-            sleep $DELAY
+
+    - name: Upload codecov reports
+      run: |
+        set +e
+        ARTIFACTS=`ls -d artifacts/* | cut -d/ -f2 | cut -d- -f1 | sort | uniq`
+        for BUILD_GROUP in $ARTIFACTS; do
+            rm -vf .coverage coverage.xml
+            coverage combine artifacts/${BUILD_GROUP}*/.coverage
+            coverage xml -i
+            export CODECOV_NAME=$BUILD_GROUP
+            i=0
+            while : ; do
+                ((i+=1))
+                echo "Uploading coverage to codecov (attempt ${i})"
+                bash $CODECOV -Z -X gcov -X s3 -f coverage.xml
+                if test $? == 0; then
+                    echo "PASS $CODECOV_NAME" >> codecov.result
+                    break
+                elif test $i -ge 2; then
+                    # Do not fail the build (yet) just because the codecov
+                    # upload fails
+                    echo "FAIL $CODECOV_NAME" >> codecov.result
+                    break
+                fi
+                DELAY=$(( RANDOM % 30 + 30))
+                echo "Pausing $DELAY seconds before re-attempting upload"
+                sleep $DELAY
+            done
         done
-
-    - name: Record build artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{github.job}}_${{env.GHA_JOBNAME}}
-        path: |
-          codecov.result
-        # In general, do not record test results as artifacts to
-        #   manage total artifact storage
-        # TEST-*.xml
-
-  post:
-    name: post-build
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts
 
       - name: Check codecov upload success
         run: |
-          FAIL=`grep FAIL artifacts/*/codecov.result | wc -l`
-          ALL=`ls -1 artifacts/*/codecov.result | wc -l`
-          # Fail is more than 1/9 codecov uploads fail
+          FAIL=`grep FAIL codecov.result | wc -l`
+          ALL=`cat codecov.result | wc -l`
+          # Fail if more than 1/9 codecov uploads fail
           echo "$FAIL of $ALL codecov uploads failed"
           if test $FAIL -gt 0; then
-              grep FAIL artifacts/*/codecov.result | sed 's/^/    /'
-              if test $(( $FAIL * 9 )) -gt $ALL; then
-                  echo "More than 1/9 codecov uploads failed:"
+              grep FAIL codecov.result | sed 's/^/    /'
+              if test $FAIL -gt 1; then
+                  echo "More than 1 codecov upload failed."
                   exit 1
               fi
           fi

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -579,6 +579,8 @@ jobs:
             echo ""
             echo "Build group: $1"
             export CODECOV_NAME=$1
+            export TAG=$1
+            export GHA_OS_NAME=${{matrix.TARGET}}
             shift
             rm -vf .coverage coverage.xml
             echo "    $@" | sed 's/ /\n    /'
@@ -592,7 +594,8 @@ jobs:
             while : ; do
                 ((i+=1))
                 echo "Uploading coverage to codecov (attempt ${i})"
-                bash $CODECOV -Z -X gcov -X s3 -f coverage.xml
+                bash $CODECOV -Z --env TAG,GHA_OS_NAME -X gcov -X s3 \
+                    -f coverage.xml
                 if test $? == 0; then
                     echo "PASS $CODECOV_NAME" >> codecov.result
                     break

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -609,10 +609,12 @@ jobs:
         }
         for ARTIFACT in artifacts/*_*${{matrix.TARGET}}_*; do
             NAME=`echo $ARTIFACT | cut -d/ -f2`
-            cp $ARTIFACT/.coverage .coverage-$NAME
+            cp -v $ARTIFACT/.coverage .coverage-$NAME
         done
-        upload ${{matrix.TARGET}} .coverage-${{matrix.TARGET}}*
-        upload ${{matrix.TARGET}}/other .coverage-*
+        upload ${{matrix.TARGET}} .coverage-*_${{matrix.TARGET}}-*
+        if compgen -G ".coverage-*" > /dev/null; then
+            upload ${{matrix.TARGET}}/other .coverage-*
+        fi
         # Legacy builds that don't support coverage 5.x
         if compgen -G ".coverage-*" > /dev/null; then
             echo ""

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -532,16 +532,16 @@ jobs:
             done
         done
 
-      - name: Check codecov upload success
-        run: |
-          FAIL=`grep FAIL codecov.result | wc -l`
-          ALL=`cat codecov.result | wc -l`
-          # Fail if more than 1/9 codecov uploads fail
-          echo "$FAIL of $ALL codecov uploads failed"
-          if test $FAIL -gt 0; then
-              grep FAIL codecov.result | sed 's/^/    /'
-              if test $FAIL -gt 1; then
-                  echo "More than 1 codecov upload failed."
-                  exit 1
-              fi
-          fi
+    - name: Check codecov upload success
+      run: |
+        FAIL=`grep FAIL codecov.result | wc -l`
+        ALL=`cat codecov.result | wc -l`
+        # Fail if more than 1/9 codecov uploads fail
+        echo "$FAIL of $ALL codecov uploads failed"
+        if test $FAIL -gt 0; then
+            grep FAIL codecov.result | sed 's/^/    /'
+            if test $FAIL -gt 1; then
+                echo "More than 1 codecov upload failed."
+                exit 1
+            fi
+        fi

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -565,13 +565,17 @@ jobs:
                 sleep $DELAY
             done
         }
-        ARTIFACTS=`ls -d artifacts/* | cut -d/ -f2 | cut -d- -f1 | sort | uniq`
-        for BUILD_GROUP in $ARTIFACTS; do
+        for ARTIFACT in artifacts/*; do
+            NAME=`echo $ARTIFACT | cut -d/ -f2`
+            cp $ARTIFACT/.coverage .coverage-$NAME
+        done
+        BUILD_GROUPS=`ls .coverage-* | cut -d- -f2 | sort | uniq`
+        for BUILD_GROUP in $BUILD_GROUPS; do
             echo ""
             echo "Build group: $BUILD_GROUP"
-            ls artifacts/${BUILD_GROUP}*/.coverage | sed 's/^/    /'
             rm -vf .coverage coverage.xml
-            coverage combine artifacts/${BUILD_GROUP}*/.coverage
+            ls .coverage-{BUILD_GROUP}* | sed 's/^/    /'
+            coverage combine .coverage-${BUILD_GROUP}*/.coverage
             upload
         done
         # Legacy builds that don't support coverage 5.x
@@ -582,7 +586,7 @@ jobs:
         echo ""
         echo "Build group: $BUILD_GROUP"
         rm -vf .coverage coverage.xml
-        coverage combine artifacts/*/.coverage
+        coverage combine .coverage-*
         upload
 
     - name: Check codecov upload success


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
CodeCov has been hanging and not reporting coverage information reliably to either PRs or for the master branch.  This discussion (https://community.codecov.io/t/codecov-stuck-in-processing-for-commits-of-a-public-github-repository/2157/10) indicates that a potential cause could be attempting to upload too many reports.

This PR reworks out build infrastructure to bundle the coverage reports from the individual jobs into a smaller set of reports (nominally, 5 reports instead of 20+)

## Changes proposed in this PR:
- set up post-build jobs to combine coverage reports before uploading them to CodeCov

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
