### PR TITLE
Update pynumero's mumps interface to use attempt_import

### DIFF
--- a/pyomo/contrib/pynumero/linalg/mumps_interface.py
+++ b/pyomo/contrib/pynumero/linalg/mumps_interface.py
@@ -10,11 +10,11 @@
 from scipy.sparse import isspmatrix_coo, coo_matrix
 import numpy as np
 
-try:
-    import mumps
-except ImportError as e:
-    raise ImportError('Error importing mumps. Install pymumps '
-                      'conda install -c conda-forge pymumps')
+from pyomo.common.dependencies import attempt_import
+mumps, mumps_available = attempt_import(
+    'mumps', error_message="Error importing mumps. PyNumero's "
+    "mumps_interface requires pymumps; install it with, e.g., "
+    "'conda install -c conda-forge pymumps'")
 
 from pyomo.contrib.pynumero.sparse import BlockVector
 

--- a/pyomo/contrib/pynumero/linalg/tests/test_mumps_interface.py
+++ b/pyomo/contrib/pynumero/linalg/tests/test_mumps_interface.py
@@ -14,14 +14,14 @@ try:
 except ImportError:
     raise unittest.SkipTest("Pynumero needs scipy and numpy to run linear solver tests")
 
-try:
-    from pyomo.contrib.pynumero.linalg.mumps_interface import MumpsCentralizedAssembledLinearSolver
-except ImportError:
-    raise unittest.SkipTest("Pynumero needs pymumps to run linear solver tests")
+from pyomo.contrib.pynumero.linalg.mumps_interface import (
+    mumps_available, MumpsCentralizedAssembledLinearSolver
+)
 
 from pyomo.contrib.pynumero.sparse import BlockMatrix, BlockVector
 
-
+@unittest.skipIf(not mumps_available,
+                 "Pynumero needs pymumps to run linear solver tests")
 class TestMumpsLinearSolver(unittest.TestCase):
     def test_mumps_linear_solver(self):
         A = np.array([[ 1,  7,  3],


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This cleans up the import of mumps (pymumps) in PyNumero by using attempt_import().  In particular, this allows testing code to:
```python
from pyomo.contrib.pynumero.linalg.mumps_interface import (
    mumps_available, MumpsCentralizedAssembledLinearSolver
)
```

which in turn makes skipping tests cleaner.  We were getting the following output:
```
Failure: SkipTest (Pynumero needs pymumps to run linear solver tests) ... ok
```
With this PR, we now get:
```
test_mumps_linear_solver (test_mumps_interface.TestMumpsLinearSolver) ... SKIP: Pynumero needs pymumps to run linear solver tests
```
## Changes proposed in this PR:
- use `attempt_import` to (conditionally) import pymumps

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
