### PR TITLE
Add support for deferred import of submodules

### DIFF
--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -215,7 +215,8 @@ doctest_global_setup = '''
 
 from pyomo.common.dependencies import (
     attempt_import, numpy_available, scipy_available, pandas_available,
-    yaml_available, networkx_available
+    yaml_available, networkx_available, matplotlib_available,
+    pympler_available, dill_available,
 )
 pint_available = attempt_import('pint', defer_check=False)[1]
 

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -11,6 +11,7 @@
 import inspect
 import importlib
 import logging
+from six import iteritems
 
 class DeferredImportError(ImportError):
     pass
@@ -48,12 +49,31 @@ class DeferredImportModule(object):
     attributes on this object will raise a DeferredImportError
     exception.
     """
-    def __init__(self, indicator):
+    def __init__(self, indicator, deferred_submodules, submodule_name):
         self._indicator_flag = indicator
+        self._submodule_name = submodule_name
+
+        if not deferred_submodules:
+            return
+        if submodule_name is None:
+            submodule_name = ''
+        for name in deferred_submodules:
+            if not name.startswith(submodule_name + '.'):
+                continue
+            _local_name = name[(1+len(submodule_name)):]
+            if '.' in _local_name:
+                continue
+            setattr(self, _local_name, DeferredImportModule(
+                indicator, deferred_submodules,
+                submodule_name + '.' + _local_name))
 
     def __getattr__(self, attr):
         self._indicator_flag.resolve()
-        return getattr(self._indicator_flag._module, attr)
+        _mod = self._indicator_flag._module
+        if self._submodule_name:
+            for _sub in self._submodule_name[1:].split('.'):
+                _mod = getattr(_mod, _sub)
+        return getattr(_mod, attr)
 
 
 class _DeferredImportIndicatorBase(object):
@@ -84,7 +104,8 @@ class DeferredImportIndicator(_DeferredImportIndicatorBase):
     """
 
     def __init__(self, name, alt_names, error_message, only_catch_importerror,
-                 minimum_version, original_globals, callback, importer):
+                 minimum_version, original_globals, callback, importer,
+                 deferred_submodules):
         self._names = [name]
         if alt_names:
             self._names += list(alt_names)
@@ -99,6 +120,7 @@ class DeferredImportIndicator(_DeferredImportIndicatorBase):
         self._importer = importer
         self._module = None
         self._available = None
+        self._deferred_submodules = deferred_submodules
 
     def resolve(self):
         if self._module is None:
@@ -133,11 +155,28 @@ class DeferredImportIndicator(_DeferredImportIndicatorBase):
         for name in self._names:
             if ( name in _globals
                  and isinstance(_globals[name], DeferredImportModule)
-                 and _globals[name]._indicator_flag is self ):
+                 and _globals[name]._indicator_flag is self
+                 and _globals[name]._submodule_name is None ):
                 _globals[name] = self._module
             for flag_name in (name+'_available', 'has_'+name, 'have_'+name):
                 if flag_name in _globals and _globals[flag_name] is self:
                     _globals[flag_name] = self._available
+        if not self._deferred_submodules:
+            return
+        for submod, alt_names in iteritems(self._deferred_submodules):
+            _mod_path = submod.split('.')[1:]
+            _names = [_mod_path[-1]]
+            if alt_names:
+                _names.extend(alt_names)
+            for name in _names:
+                if ( name in _globals
+                     and isinstance(_globals[name], DeferredImportModule)
+                     and _globals[name]._indicator_flag is self
+                     and _globals[name]._submodule_name == submod ):
+                    _mod = self._module
+                    for _sub in _mod_path:
+                        _mod = getattr(_mod, _sub)
+                    _globals[name] = _mod
 
     def __nonzero__(self):
         self.resolve()
@@ -185,7 +224,7 @@ def check_min_version(module, min_version):
 
 def attempt_import(name, error_message=None, only_catch_importerror=True,
                    minimum_version=None, alt_names=None, callback=None,
-                   importer=None, defer_check=True):
+                   importer=None, defer_check=True, deferred_submodules=None):
 
     """Attempt to import the specified module.
 
@@ -252,6 +291,13 @@ def attempt_import(name, error_message=None, only_catch_importerror=True,
         flag.  The method will return instances of DeferredImportModule
         and DeferredImportIndicator.
 
+    deferred_submodules: dict, optional
+        If provided, a mapping of submodules to within this module that
+        can be accessed without triggering a deferred import of this
+        module, to a list of alternate names by which to look for the
+        submodule in the globals() namespaces.  For example, the
+        deferred_submodules for matplotlib is {'pyplot': ['plt']}
+
     Returns
     -------
     : module
@@ -266,6 +312,26 @@ def attempt_import(name, error_message=None, only_catch_importerror=True,
     # If we are going to defer the check until later, return the
     # deferred import module object
     if defer_check:
+        if deferred_submodules:
+            # Ensures all names begin with '.'
+            #
+            # Fill in any missing submodules.  For example, if a user
+            # provides {'foo.bar.baz': ['bz']}, then expand the dict to
+            # {'.foo': None, '.foo.bar': None, '.foo.bar.baz': ['bz']}
+            deferred = {}
+            for _submod, _alt in iteritems(deferred_submodules):
+                if _submod[0] != '.':
+                    _submod = '.' + _submod
+                _mod_path = _submod.split('.')
+                for i in range(len(_mod_path)):
+                    _test_mod = '.'.join(_mod_path[:i])
+                    if _test_mod not in deferred:
+                        deferred[_test_mod] = None
+                deferred[_submod] = _alt
+            deferred.pop('', None)
+        else:
+            deferred = None
+
         indicator = DeferredImportIndicator(
             name=name,
             alt_names=alt_names,
@@ -274,8 +340,9 @@ def attempt_import(name, error_message=None, only_catch_importerror=True,
             minimum_version=minimum_version,
             original_globals=inspect.currentframe().f_back.f_globals,
             callback=callback,
-            importer=importer)
-        return DeferredImportModule(indicator), indicator
+            importer=importer,
+            deferred_submodules=deferred)
+        return DeferredImportModule(indicator, deferred, None), indicator
 
     try:
         if importer is None:
@@ -325,14 +392,18 @@ def _finalize_yaml(module, available):
 def _finalize_scipy(module, available):
     if available:
         # Import key subpackages that we will want to assume are present
+        import scipy.stats
         import scipy.sparse
         import scipy.spatial
-        import scipy.stats
 
 def _finalize_pympler(module, available):
     if available:
         # Import key subpackages that we will want to assume are present
         import pympler.muppy
+
+def _finalize_matplotlib(module, available):
+    if available:
+        import matplotlib.pyplot
 
 yaml, yaml_available = attempt_import('yaml', callback=_finalize_yaml)
 pympler, pympler_available = attempt_import(
@@ -342,3 +413,9 @@ scipy, scipy_available = attempt_import('scipy', callback=_finalize_scipy)
 networkx, networkx_available = attempt_import('networkx', alt_names=['nx'])
 pandas, pandas_available = attempt_import('pandas', alt_names=['pd'])
 dill, dill_available = attempt_import('dill')
+
+# Note that matplotlib.pyplot can generate a runtime error on OSX when
+# not installed as a Framework (as is the case in the CI systems)
+matplotlib, matplotlib_available = attempt_import(
+    'matplotlib', only_catch_importerror=False, callback=_finalize_matplotlib,
+    deferred_submodules={'pyplot': ['plt']})

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -409,7 +409,8 @@ yaml, yaml_available = attempt_import('yaml', callback=_finalize_yaml)
 pympler, pympler_available = attempt_import(
     'pympler', callback=_finalize_pympler)
 numpy, numpy_available = attempt_import('numpy', alt_names=['np'])
-scipy, scipy_available = attempt_import('scipy', callback=_finalize_scipy)
+scipy, scipy_available = attempt_import(
+    'scipy', callback=_finalize_scipy, deferred_submodules={'stats':None})
 networkx, networkx_available = attempt_import('networkx', alt_names=['nx'])
 pandas, pandas_available = attempt_import('pandas', alt_names=['pd'])
 dill, dill_available = attempt_import('dill')

--- a/pyomo/common/tests/test_dependencies.py
+++ b/pyomo/common/tests/test_dependencies.py
@@ -30,6 +30,17 @@ from pyomo.common.tests.dep_mod import (
 bogus, bogus_available \
     = attempt_import('nonexisting.module.bogus', defer_check=True)
 
+# global objects for the submodule tests
+def _finalize_pyo(module, available):
+    if available:
+        import pyomo.core
+
+pyo, pyo_available = attempt_import(
+    'pyomo', alt_names=['pyo'],
+    deferred_submodules={'version': None,
+                         'common.tests.dep_mod': ['dm']})
+dm = pyo.common.tests.dep_mod
+
 class TestDependencies(unittest.TestCase):
     def test_import_error(self):
         module_obj, module_available = attempt_import(
@@ -239,6 +250,31 @@ class TestDependencies(unittest.TestCase):
         self.assertTrue(avail)
         self.assertEqual(attempted_import, [True])
         self.assertIs(mod._indicator_flag._module, dep_mod)
+
+    def test_deferred_submodules(self):
+        import pyomo
+        pyo_ver = pyomo.version.version
+
+        self.assertIsInstance(pyo, DeferredImportModule)
+        self.assertIsNone(pyo._submodule_name)
+        self.assertEqual(pyo_available._deferred_submodules,
+                         {'.version': None,
+                          '.common': None,
+                          '.common.tests': None,
+                          '.common.tests.dep_mod': ['dm']})
+        # This doesn't cause test_mod to be resolved
+        version = pyo.version
+        self.assertIsInstance(pyo, DeferredImportModule)
+        self.assertIsNone(pyo._submodule_name)
+        self.assertIsInstance(dm, DeferredImportModule)
+        self.assertEqual(dm._submodule_name, '.common.tests.dep_mod')
+        self.assertIsInstance(version, DeferredImportModule)
+        self.assertEqual(version._submodule_name, '.version')
+        # This causes the global objects to be resolved
+        self.assertEqual(version.version, pyo_ver)
+        self.assertTrue(inspect.ismodule(pyo))
+        self.assertTrue(inspect.ismodule(dm))
+        
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
The `pyomo.common.dependencies.attempt_import()` system greatly simplifies management of slow-loading optional dependencies.  However, recent work with #1526 highlighted a limitation when working with deferred imports of submodules.  This PR extends the deferred import system to allow for declaring specific submodules to be deferred as well (that is, accessing that attribute on a `DeferredImportModule` will not immediately cause that module to be imported.

The primary motivation for this change is `matplotlib`, where the standard usage is not `import matplotlib`, but rather `import matplotlib.pyplot as plt`.  Which this PR, users can now do the following:

```python
from pyomo.common.dependencies import matplotlib, matplotlib_available
plt = matpltolib.pyplot
```

`matplotlib` will not actually be imported until `plt` is used (e.g., with `plt.gca()` or `plt.plot([0,1],[2,3])`).  At that point, both the `matplotlib` and `plt` objects in the current `globals()` will be replaced by the appropriate modules (as is the normal case with `attempt_import`; thereby ensuring that using `attempt_import` has minimal performance impact).

## Changes proposed in this PR:
- add a `defer_submodules` argument to `attempt_import` to support the deferred import of specific submodules
- add an `attempt_import` of `matplotlib` to `pyomo.common.dependencies`
- convert `parmest.graphics` to use the `scipy` / `numpy` / `matplotlib` from `pyomo.common.dependencies`
- add testing

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
