### PR TITLE
Fix integer conversion of string arguments in ProgressiveHedging

### DIFF
--- a/pyomo/pysp/ph.py
+++ b/pyomo/pysp/ph.py
@@ -1945,10 +1945,10 @@ class ProgressiveHedging(_PHBase):
         # and in that order.
         def convert_value_string_to_number(s):
             try:
-                return float(s)
+                return int(s)
             except ValueError:
                 try:
-                    return int(s)
+                    return float(s)
                 except ValueError:
                     return s
 


### PR DESCRIPTION

## Fixes # .

## Summary/Motivation:

The comment `ProgressiveHedging` suggests that an attempt is made to convert string arguments to numbers. It says that integer is tried first, and then float. However, the implementation is opposite and consequently all integer arguments are converted to floats. This has caused a problem in my CBC model when I try to pass an integer value.

## Changes proposed in this PR:
- The changes here switch the order of the conversion attempts to reflect the written comment and allow integer arguments to be passed correctly.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
