### PR TITLE
Move pyutilib.misc.timing into pyomo.common.timing

### DIFF
--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -8,7 +8,8 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
+from pyutilib.misc.redirect_io import capture_output
 
 from six import StringIO
 import time
@@ -16,7 +17,7 @@ import time
 from pyomo.common.log import LoggingIntercept
 from pyomo.common.timing import (ConstructionTimer, report_timing,
                                  TicTocTimer, HierarchicalTimer)
-from pyomo.environ import ConcreteModel, RangeSet, Var
+from pyomo.environ import ConcreteModel, RangeSet, Var, TransformationFactory
 
 class TestTiming(unittest.TestCase):
     def test_raw_construction_timer(self):
@@ -37,7 +38,22 @@ class TestTiming(unittest.TestCase):
            0 seconds to construct Block ConcreteModel; 1 index total
            0 seconds to construct RangeSet FiniteSimpleRangeSet; 1 index total
            0 seconds to construct Var x; 2 indicies total
+           0 seconds to construct Suffix Suffix; 1 index total
+           0 seconds to apply Transformation RelaxIntegerVars (in-place)
 """.strip()
+
+        xfrm = TransformationFactory('core.relax_integer_vars')
+
+        try:
+            with capture_output() as out:
+                report_timing()
+                m = ConcreteModel()
+                m.r = RangeSet(2)
+                m.x = Var(m.r)
+                xfrm.apply_to(m)
+            self.assertEqual(out.getvalue().strip(), ref)
+        finally:
+            report_timing(False)
 
         os = StringIO()
         try:
@@ -45,6 +61,7 @@ class TestTiming(unittest.TestCase):
             m = ConcreteModel()
             m.r = RangeSet(2)
             m.x = Var(m.r)
+            xfrm.apply_to(m)
             self.assertEqual(os.getvalue().strip(), ref)
         finally:
             report_timing(False)
@@ -53,22 +70,88 @@ class TestTiming(unittest.TestCase):
             m = ConcreteModel()
             m.r = RangeSet(2)
             m.x = Var(m.r)
+            xfrm.apply_to(m)
             self.assertEqual(os.getvalue().strip(), ref)
             self.assertEqual(buf.getvalue().strip(), "")
 
     def test_TicTocTimer_tictoc(self):
+        RES = 1e-2 # resolution (seconds)
         timer = TicTocTimer()
-        timer.tic('First lap.')
+        abs_time = time.time()
+
         time.sleep(0.1)
-        self.assertAlmostEqual(0.103, timer.toc(), 2)
+
+        with capture_output() as out:
+            start_time = time.time()
+            timer.tic(None)
+        self.assertEqual(out.getvalue(), '')
+
+        with capture_output() as out:
+            start_time = time.time()
+            timer.tic()
+        self.assertRegex(
+            out.getvalue(),
+            r'\[    [.0-9]+\] Resetting the tic/toc delta timer'
+        )
+
+        time.sleep(0.1)
+
+        with capture_output() as out:
+            delta = timer.toc()
+        self.assertAlmostEqual(time.time() - start_time, delta, delta=RES)
+        self.assertAlmostEqual(0, timer.toc(None), delta=RES)
+        self.assertRegex(
+            out.getvalue(),
+            r'\[\+   [.0-9]+\] .* in test_TicTocTimer_tictoc'
+        )
+        with capture_output() as out:
+            total = timer.toc(delta=False)
+        self.assertAlmostEqual(time.time() - abs_time, total, delta=RES)
+        self.assertRegex(
+            out.getvalue(),
+            r'\[    [.0-9]+\] .* in test_TicTocTimer_tictoc'
+        )
+
+        ref = 0
+        ref -= time.time()
+        time.sleep(0.1)
+        ref += time.time()
         timer.stop()
-        timer.tic('Stopped clock - resetting to 0.')
-        timer.start()
+        cumul_stop1 = timer.toc(None)
+        with self.assertRaisesRegex(
+                RuntimeError,
+                'Stopping a TicTocTimer that was already stopped'):
+            timer.stop()
         time.sleep(0.1)
-        self.assertAlmostEqual(0.103, timer.toc(), 2)
+        cumul_stop2 = timer.toc(None)
+        self.assertEqual(cumul_stop1, cumul_stop2)
+        timer.start()
+        ref -= time.time()
+        time.sleep(0.1)
+        ref += time.time()
+
+        with capture_output() as out:
+            delta = timer.toc()
+        self.assertAlmostEqual(ref, delta, delta=RES)
+        #self.assertAlmostEqual(0, timer.toc(None), delta=RES)
+        self.assertRegex(
+            out.getvalue(),
+            r'\[    [.0-9]+\|   1\] .* in test_TicTocTimer_tictoc'
+        )
+        with capture_output() as out:
+            # Note that delta is ignored if the timer is a cumulative timer
+            total = timer.toc(delta=False)
+        self.assertAlmostEqual(delta, total, delta=RES)
+        self.assertRegex(
+            out.getvalue(),
+            r'\[    [.0-9]+\|   1\] .* in test_TicTocTimer_tictoc'
+        )
 
     def test_HierarchicalTimer(self):
+        RES = 1e-2 # resolution (seconds)
+
         timer = HierarchicalTimer()
+        start_time = time.time()
         timer.start('all')
         time.sleep(0.02)
         for i in range(10):
@@ -81,6 +164,29 @@ class TestTiming(unittest.TestCase):
             timer.start('ab')
             timer.stop('ab')
             timer.stop('a')
+        end_time = time.time()
         timer.stop('all')
-        self.assertIn('Identifier', str(timer))
+        ref = \
+"""Identifier        ncalls   cumtime   percall      %
+---------------------------------------------------
+all                    1     [0-9.]+ +[0-9.]+ +100.0
+     ----------------------------------------------
+     a                10     [0-9.]+ +[0-9.]+ +[0-9.]+
+          -----------------------------------------
+          aa          50     [0-9.]+ +[0-9.]+ +[0-9.]+
+          ab          10     [0-9.]+ +[0-9.]+ +[0-9.]+
+          other      n/a     [0-9.]+ +n/a +[0-9.]+
+          =========================================
+     other           n/a     [0-9.]+ +n/a +[0-9.]+
+     ==============================================
+===================================================
+""".splitlines()
+        for l, r in zip(str(timer).splitlines(), ref):
+            self.assertRegex(l, r)
+
         self.assertEqual(1, timer.get_num_calls('all'))
+        self.assertAlmostEqual(
+            end_time - start_time, timer.get_total_time('all'), delta=RES)
+        self.assertEqual(100., timer.get_relative_percent_time('all'))
+        self.assertTrue(100. > timer.get_relative_percent_time('all.a'))
+        self.assertTrue(50. < timer.get_relative_percent_time('all.a'))

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -129,12 +129,13 @@ class TestTiming(unittest.TestCase):
         ref -= time.time()
         time.sleep(0.1)
 
-        # Note: pypy on GHA frequently has timing differences of 0.021s
+        # Note: pypy on GHA frequently has timing differences of >0.02s
         # for the following tests
         RES = 4e-2
 
         with capture_output() as out:
             delta = timer.toc()
+            timer.stop()
             ref += time.time()
         self.assertAlmostEqual(ref, delta, delta=RES)
         #self.assertAlmostEqual(0, timer.toc(None), delta=RES)

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -129,6 +129,10 @@ class TestTiming(unittest.TestCase):
         ref -= time.time()
         time.sleep(0.1)
 
+        # Note: pypy on GHA frequently has timing differences of 0.021s
+        # for the following tests
+        RES = 4e-2
+
         with capture_output() as out:
             delta = timer.toc()
             ref += time.time()

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -115,8 +115,8 @@ class TestTiming(unittest.TestCase):
         ref = 0
         ref -= time.time()
         time.sleep(0.1)
-        ref += time.time()
         timer.stop()
+        ref += time.time()
         cumul_stop1 = timer.toc(None)
         with self.assertRaisesRegex(
                 RuntimeError,
@@ -128,10 +128,10 @@ class TestTiming(unittest.TestCase):
         timer.start()
         ref -= time.time()
         time.sleep(0.1)
-        ref += time.time()
 
         with capture_output() as out:
             delta = timer.toc()
+            ref += time.time()
         self.assertAlmostEqual(ref, delta, delta=RES)
         #self.assertAlmostEqual(0, timer.toc(None), delta=RES)
         self.assertRegex(

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -38,6 +38,9 @@ def report_timing(stream=True):
         for h in _logger.handlers:
             _logger.removeHandler(h)
 
+class _NotSpecified(object): pass
+
+
 _construction_logger = logging.getLogger('pyomo.common.timing.construction')
 
 
@@ -50,7 +53,7 @@ class ConstructionTimer(object):
     def report(self):
         # Record the elapsed time, as some log handlers may not
         # immediately generate the messge string
-        self.timer = self.timer.toc(msg="")
+        self.timer = self.timer.toc(msg=None)
         _construction_logger.info(self)
 
     def __str__(self):
@@ -102,7 +105,7 @@ class TransformationTimer(object):
     def report(self):
         # Record the elapsed time, as some log handlers may not
         # immediately generate the message string
-        self.timer = self.timer.toc(msg="")
+        self.timer = self.timer.toc(msg=None)
         _transform_logger.info(self)
 
     def __str__(self):
@@ -162,42 +165,43 @@ class TicTocTimer(object):
         self._start_count = 0
         self._cumul = 0
 
-    def tic(self, msg=None, ostream=None, logger=None):
+    def tic(self, msg=_NotSpecified, ostream=None, logger=None):
         """Reset the tic/toc delta timer.
 
         This resets the reference time from which the next delta time is
         calculated to the current time.
 
         Args:
-            msg (str): The message to print out.  If :const:`None`
-                (default), then prints out "Resetting the tic/toc delta
-                timer"; if it evaluates to :const:`False` (:const:`0`,
-                :const:`False`, :const:`""`) then no message is printed.
+            msg (str): The message to print out.  If not specified, then
+                prints out "Resetting the tic/toc delta timer"; if it
+                evaluates to :const:`False` (:const:`0`, :const:`False`,
+                :const:`""`) then no message is printed.
             ostream (FILE): an optional output stream (overrides the ostream
                 provided when the class was constructed).
             logger (Logger): an optional output stream using the python
                 logging package (overrides the ostream provided when the
                 class was constructed). Note: timing logged using logger.info
+
         """
         self._lastTime = _time_source()
-        if msg is None:
+        if msg is _NotSpecified:
             msg = "Resetting the tic/toc delta timer"
         if msg:
             self.toc(msg=msg, delta=False, ostream=ostream, logger=logger)
 
 
-    def toc(self, msg=None, delta=True, ostream=None, logger=None):
+    def toc(self, msg=_NotSpecified, delta=True, ostream=None, logger=None):
         """Print out the elapsed time.
 
         This resets the reference time from which the next delta time is
         calculated to the current time.
 
         Args:
-            msg (str): The message to print out.  If :const:`None`
-                (default), then print out the file name, line number,
-                and function that called this method; if it evaluates to
-                :const:`False` (:const:`0`, :const:`False`, :const:`""`)
-                then no message is printed.
+            msg (str): The message to print out.  If not specified, then
+                print out the file name, line number, and function that
+                called this method; if it evaluates to :const:`False`
+                (:const:`0`, :const:`False`, :const:`""`) then no
+                message is printed.
             delta (bool): print out the elapsed wall clock time since
                 the last call to :meth:`tic` or :meth:`toc`
                 (:const:`True` (default)) or since the module was first
@@ -207,9 +211,10 @@ class TicTocTimer(object):
             logger (Logger): an optional output stream using the python
                 logging package (overrides the ostream provided when the
                 class was constructed). Note: timing logged using logger.info
+
         """
 
-        if msg is None:
+        if msg is _NotSpecified:
             msg = 'File "%s", line %s in %s' % \
                   traceback.extract_stack(limit=2)[0][:3]
 

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -6,6 +6,13 @@
 #  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________ 
+#
+#  This module was originally developed as part of the PyUtilib project
+#  Copyright (c) 2008 Sandia Corporation.
+#  This software is distributed under the BSD License.
+#  Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+#  the U.S. Government retains certain rights in this software.
 #  ___________________________________________________________________________
 
 import sys
@@ -291,11 +298,11 @@ class _HierarchicalHelper(object):
                 else:
                     _percent = float('nan')
                 s += indent
-                s += ( name_formatter + '{ncalls:>9d} {aggtime:>9.3f} '
+                s += ( name_formatter + '{ncalls:>9d} {cumtime:>9.3f} '
                        '{percall:>9.3f} {percent:>6.1f}\n' ).format(
                            name=name,
                            ncalls=timer.n_calls,
-                           aggtime=timer.total_time,
+                           cumtime=timer.total_time,
                            percall=timer.total_time/timer.n_calls,
                            percent=_percent )
                 s += timer.to_str(
@@ -308,11 +315,11 @@ class _HierarchicalHelper(object):
             else:
                 _percent = float('nan')
             s += indent
-            s += ( name_formatter + '{ncalls:>9} {aggtime:>9.3f} '
+            s += ( name_formatter + '{ncalls:>9} {cumtime:>9.3f} '
                    '{percall:>9} {percent:>6.1f}\n' ).format(
                        name='other',
                        ncalls='n/a',
-                       aggtime=other_time,
+                       cumtime=other_time,
                        percall='n/a',
                        percent=_percent )
             s += underline.replace('-', '=')
@@ -347,7 +354,7 @@ class HierarchicalTimer(object):
     ...
     >>> timer.stop('all')
     >>> print(timer)
-    Identifier        ncalls   aggtime   percall      %
+    Identifier        ncalls   cumtime   percall      %
     ---------------------------------------------------
     all                    1     2.248     2.248  100.0
          ----------------------------------------------
@@ -365,10 +372,10 @@ class HierarchicalTimer(object):
 
     The columns are:
       ncalls : The number of times the timer was started and stopped
-      aggtime: The aggregate time (in seconds) the timer was active
+      cumtime: The cumulative time (in seconds) the timer was active
                (started but not stopped)
-      percall: aggtime (in seconds) / ncalls
-      %      : This is aggtime of the timer divided by aggtime of the
+      percall: cumtime (in seconds) / ncalls
+      %      : This is cumtime of the timer divided by cumtime of the
                parent timer times 100
 
 
@@ -489,22 +496,22 @@ class HierarchicalTimer(object):
     def __str__(self):
         stage_identifier_lengths = self._get_identifier_len()
         name_formatter = '{name:<' + str(sum(stage_identifier_lengths)) + '}'
-        s = ( name_formatter + '{ncalls:>9} {aggtime:>9} '
+        s = ( name_formatter + '{ncalls:>9} {cumtime:>9} '
               '{percall:>9} {percent:>6}\n').format(
                   name='Identifier',
                   ncalls='ncalls',
-                  aggtime='aggtime',
+                  cumtime='cumtime',
                   percall='percall',
                   percent='%')
         underline = '-' * (sum(stage_identifier_lengths) + 36) + '\n'
         s += underline
         sub_stage_identifier_lengths = stage_identifier_lengths[1:]
         for name, timer in self.timers.items():
-            s += ( name_formatter + '{ncalls:>9d} {aggtime:>9.3f} '
+            s += ( name_formatter + '{ncalls:>9d} {cumtime:>9.3f} '
                    '{percall:>9.3f} {percent:>6.1f}\n').format(
                        name=name,
                        ncalls=timer.n_calls,
-                       aggtime=timer.total_time,
+                       cumtime=timer.total_time,
                        percall=timer.total_time/timer.n_calls,
                        percent=self.get_total_percent_time(name))
             s += timer.to_str(

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -1,6 +1,19 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
 import sys
 import logging
-from pyutilib.misc.timing import TicTocTimer
+import time
+import traceback
+
+__all__ = ('TicTocTimer', 'tic', 'toc')
 
 _logger = logging.getLogger('pyomo.common.timing')
 _logger.propagate = False
@@ -95,3 +108,509 @@ class TransformationTimer(object):
             return "TransformationTimer object for %s; %s elapsed seconds" % (
                 name,
                 self.timer.toc("") )
+
+#
+# Setup the timer
+#
+if sys.version_info >= (3,3):
+    # perf_counter is guaranteed to be monotonic and the most accurate timer
+    _time_source = time.perf_counter
+else:
+    # On old Pythons, clock() is more accurate than time() on Windows
+    # (.35us vs 15ms), but time() is more accurate than clock() on Linux
+    # (1ns vs 1us).  It is unfortunate that time() is not monotonic, but
+    # since the TicTocTimer is used for (potentially very accurate)
+    # timers, we will sacrifice monotonicity on Linux for resolution.
+    if sys.platform.startswith('win'):
+        _time_source = time.clock
+    else:
+        _time_source = time.time
+
+class TicTocTimer(object):
+    """A class to calculate and report elapsed time.
+
+    Examples:
+       >>> from pyomo.common.timing import TicTocTimer
+       >>> timer = TicTocTimer()
+       >>> timer.tic('starting timer') # starts the elapsed time timer (from 0)
+       >>> # ... do task 1
+       >>> timer.toc('task 1') # prints the elapsed time for task 1
+
+    If no ostream or logger is provided, then output is printed to sys.stdout
+
+    Args:
+        ostream (FILE): an optional output stream to print the timing
+            information
+        logger (Logger): an optional output stream using the python
+           logging package. Note: timing logged using logger.info
+    """
+    def __init__(self, ostream=None, logger=None):
+        self._lastTime = self._loadTime = _time_source()
+        self._ostream = ostream
+        self._logger = logger
+        self._start_count = 0
+        self._cumul = 0
+
+    def tic(self, msg=None, ostream=None, logger=None):
+        """Reset the tic/toc delta timer.
+
+        This resets the reference time from which the next delta time is
+        calculated to the current time.
+
+        Args:
+            msg (str): The message to print out.  If :const:`None`
+                (default), then prints out "Resetting the tic/toc delta
+                timer"; if it evaluates to :const:`False` (:const:`0`,
+                :const:`False`, :const:`""`) then no message is printed.
+            ostream (FILE): an optional output stream (overrides the ostream
+                provided when the class was constructed).
+            logger (Logger): an optional output stream using the python
+                logging package (overrides the ostream provided when the
+                class was constructed). Note: timing logged using logger.info
+        """
+        self._lastTime = _time_source()
+        if msg is None:
+            msg = "Resetting the tic/toc delta timer"
+        if msg:
+            self.toc(msg=msg, delta=False, ostream=ostream, logger=logger)
+
+
+    def toc(self, msg=None, delta=True, ostream=None, logger=None):
+        """Print out the elapsed time.
+
+        This resets the reference time from which the next delta time is
+        calculated to the current time.
+
+        Args:
+            msg (str): The message to print out.  If :const:`None`
+                (default), then print out the file name, line number,
+                and function that called this method; if it evaluates to
+                :const:`False` (:const:`0`, :const:`False`, :const:`""`)
+                then no message is printed.
+            delta (bool): print out the elapsed wall clock time since
+                the last call to :meth:`tic` or :meth:`toc`
+                (:const:`True` (default)) or since the module was first
+                loaded (:const:`False`).
+            ostream (FILE): an optional output stream (overrides the ostream
+                provided when the class was constructed).
+            logger (Logger): an optional output stream using the python
+                logging package (overrides the ostream provided when the
+                class was constructed). Note: timing logged using logger.info
+        """
+
+        if msg is None:
+            msg = 'File "%s", line %s in %s' % \
+                  traceback.extract_stack(limit=2)[0][:3]
+
+        now = _time_source()
+        if self._start_count or self._lastTime is None:
+            ans = self._cumul
+            if self._lastTime:
+                ans += _time_source() - self._lastTime
+            if msg:
+                msg = "[%8.2f|%4d] %s\n" % (ans, self._start_count, msg)
+        elif delta:
+            ans = now - self._lastTime
+            self._lastTime = now
+            if msg:
+                msg = "[+%7.2f] %s\n" % (ans, msg)
+        else:
+            ans = now - self._loadTime
+            if msg:
+                msg = "[%8.2f] %s\n" % (ans, msg)
+
+        if msg:
+            if ostream is None:
+                ostream = self._ostream
+                if ostream is None and logger is None:
+                    ostream = sys.stdout
+            if ostream is not None:
+                ostream.write(msg)
+
+            if logger is None:
+                logger = self._logger
+            if logger is not None:
+                logger.info(msg)
+
+        return ans
+
+    def stop(self):
+        try:
+            delta = _time_source() - self._lastTime
+        except TypeError:
+            if self._lastTime is None:
+                raise RuntimeError(
+                    "Stopping a TicTocTimer that was already stopped")
+            raise
+        self._cumul += delta
+        self._lastTime = None
+        return delta
+
+    def start(self):
+        if self._lastTime:
+            self.stop()
+        self._start_count += 1
+        self._lastTime = _time_source()
+
+_globalTimer = TicTocTimer()
+tic = _globalTimer.tic
+toc = _globalTimer.toc
+
+
+class _HierarchicalHelper(object):
+    def __init__(self):
+        self.tic_toc = TicTocTimer()
+        self.timers = dict()
+        self.total_time = 0
+        self.n_calls = 0
+
+    def start(self):
+        self.n_calls += 1
+        self.tic_toc.start()
+
+    def stop(self):
+        self.total_time += self.tic_toc.stop()
+
+    def to_str(self, indent, stage_identifier_lengths):
+        s = ''
+        if len(self.timers) > 0:
+            underline = indent + '-' * (sum(stage_identifier_lengths) + 36) + '\n'
+            s += underline
+            name_formatter = '{name:<' + str(sum(stage_identifier_lengths)) + '}'
+            other_time = self.total_time
+            sub_stage_identifier_lengths = stage_identifier_lengths[1:]
+            for name, timer in self.timers.items():
+                if self.total_time > 0:
+                    _percent = timer.total_time / self.total_time * 100
+                else:
+                    _percent = float('nan')
+                s += indent
+                s += ( name_formatter + '{ncalls:>9d} {cumtime:>9.3f} '
+                       '{percall:>9.3f} {percent:>6.1f}\n' ).format(
+                           name=name,
+                           ncalls=timer.n_calls,
+                           cumtime=timer.total_time,
+                           percall=timer.total_time/timer.n_calls,
+                           percent=_percent )
+                s += timer.to_str(
+                    indent=indent + ' '*stage_identifier_lengths[0],
+                    stage_identifier_lengths=sub_stage_identifier_lengths)
+                other_time -= timer.total_time
+
+            if self.total_time > 0:
+                _percent = other_time / self.total_time * 100
+            else:
+                _percent = float('nan')
+            s += indent
+            s += ( name_formatter + '{ncalls:>9} {cumtime:>9.3f} '
+                   '{percall:>9} {percent:>6.1f}\n' ).format(
+                       name='other',
+                       ncalls='n/a',
+                       cumtime=other_time,
+                       percall='n/a',
+                       percent=_percent )
+            s += underline.replace('-', '=')
+        return s
+
+
+class HierarchicalTimer(object):
+    """A class for hierarchical timing.
+
+    Examples
+    --------
+    >>> import time
+    >>> from pyomo.common.timing import HierarchicalTimer
+    >>> timer = HierarchicalTimer()
+    >>> timer.start('all')
+    >>> time.sleep(0.2)
+    >>> for i in range(10):
+    ...     timer.start('a')
+    ...     time.sleep(0.1)
+    ...     for i in range(5):
+    ...         timer.start('aa')
+    ...         time.sleep(0.01)
+    ...         timer.stop('aa')
+    ...     timer.start('ab')
+    ...     timer.stop('ab')
+    ...     timer.stop('a')
+    ...
+    >>> for i in range(10):
+    ...     timer.start('b')
+    ...     time.sleep(0.02)
+    ...     timer.stop('b')
+    ...
+    >>> timer.stop('all')
+    >>> print(timer)
+    Identifier        ncalls   cumtime   percall      %
+    ---------------------------------------------------
+    all                    1     2.248     2.248  100.0
+         ----------------------------------------------
+         a                10     1.787     0.179   79.5
+              -----------------------------------------
+              aa          50     0.733     0.015   41.0
+              ab          10     0.000     0.000    0.0
+              other      n/a     1.055       n/a   59.0
+              =========================================
+         b                10     0.248     0.025   11.0
+         other           n/a     0.213       n/a    9.5
+         ==============================================
+    ===================================================
+    <BLANKLINE>
+
+    The columns are:
+      ncalls : The number of times the timer was started and stopped
+      cumtime: The cumulative time (in seconds) the timer was active
+               (started but not stopped)
+      percall: cumtime (in seconds) / ncalls
+      %      : This is cumtime of the timer divided by cumtime of the
+               parent timer times 100
+
+
+    >>> print('a total time: %f' % timer.get_total_time('all.a'))
+    a total time: 1.902037
+    >>> print('ab num calls: %d' % timer.get_num_calls('all.a.ab'))
+    ab num calls: 10
+    >>> print('aa %% time: %f' % timer.get_relative_percent_time('all.a.aa'))
+    aa % time: 44.144148
+    >>> print('aa %% total: %f' % timer.get_total_percent_time('all.a.aa'))
+    aa % total: 35.976058
+
+    Internal Workings
+    -----------------
+    The HierarchicalTimer use a stack to track which timers are active
+    at any point in time. Additionally, each timer has a dictionary of
+    timers for its children timers. Consider
+
+    >>> timer = HierarchicalTimer()
+    >>> timer.start('all')
+    >>> timer.start('a')
+    >>> timer.start('aa')
+
+    After the above code is run, self.stack will be ['all', 'a', 'aa']
+    and self.timers will have one key, 'all' and one value which will be
+    a _HierarchicalHelper. The _HierarchicalHelper has its own timers
+    dictionary:
+
+    {'a': _HierarchicalHelper}
+
+    and so on. This way, we can easily access any timer with something
+    that looks like the stack. The logic is recursive (although the
+    code is not).
+
+    """
+    def __init__(self):
+        self.stack = list()
+        self.timers = dict()
+
+    def _get_timer(self, identifier, should_exist=False):
+        """
+
+        This method gets the timer associated with the current state
+        of self.stack and the specified identifier.
+
+        Parameters
+        ----------
+        identifier: str
+            The name of the timer
+        should_exist: bool
+            The should_exist is True, and the timer does not already
+            exist, an error will be raised. If should_exist is False, and
+            the timer does not already exist, a new timer will be made.
+
+        Returns
+        -------
+        timer: _HierarchicalHelper
+
+        """
+        parent = self._get_timer_from_stack(self.stack)
+        if identifier in parent.timers:
+            return parent.timers[identifier]
+        else:
+            if should_exist:
+                raise RuntimeError(
+                    'Could not find timer {0}'.format(
+                        '.'.join(self.stack + [identifier])))
+            parent.timers[identifier] = _HierarchicalHelper()
+            return parent.timers[identifier]
+
+    def start(self, identifier):
+        """
+        Start incrementing the timer identified with identifier
+
+        Parameters
+        ----------
+        identifier: str
+            The name of the timer
+        """
+        timer = self._get_timer(identifier)
+        timer.start()
+        self.stack.append(identifier)
+
+    def stop(self, identifier):
+        """
+        Stop incrementing the timer identified with identifier
+
+        Parameters
+        ----------
+        identifier: str
+            The name of the timer
+        """
+        if identifier != self.stack[-1]:
+            raise ValueError(
+                str(identifier) + ' is not the currently active timer.  '
+                'The only timer that can currently be stopped is '
+                + '.'.join(self.stack))
+        self.stack.pop()
+        timer = self._get_timer(identifier, should_exist=True)
+        timer.stop()
+
+    def _get_identifier_len(self):
+        stage_timers = list(self.timers.items())
+        stage_lengths = list()
+
+        while len(stage_timers) > 0:
+            new_stage_timers = list()
+            max_len = 0
+            for identifier, timer in stage_timers:
+                new_stage_timers.extend(timer.timers.items())
+                if len(identifier) > max_len:
+                    max_len = len(identifier)
+            stage_lengths.append(max(max_len, len('other')))
+            stage_timers = new_stage_timers
+
+        return stage_lengths
+
+    def __str__(self):
+        stage_identifier_lengths = self._get_identifier_len()
+        name_formatter = '{name:<' + str(sum(stage_identifier_lengths)) + '}'
+        s = ( name_formatter + '{ncalls:>9} {cumtime:>9} '
+              '{percall:>9} {percent:>6}\n').format(
+                  name='Identifier',
+                  ncalls='ncalls',
+                  cumtime='cumtime',
+                  percall='percall',
+                  percent='%')
+        underline = '-' * (sum(stage_identifier_lengths) + 36) + '\n'
+        s += underline
+        sub_stage_identifier_lengths = stage_identifier_lengths[1:]
+        for name, timer in self.timers.items():
+            s += ( name_formatter + '{ncalls:>9d} {cumtime:>9.3f} '
+                   '{percall:>9.3f} {percent:>6.1f}\n').format(
+                       name=name,
+                       ncalls=timer.n_calls,
+                       cumtime=timer.total_time,
+                       percall=timer.total_time/timer.n_calls,
+                       percent=self.get_total_percent_time(name))
+            s += timer.to_str(
+                indent=' '*stage_identifier_lengths[0],
+                stage_identifier_lengths=sub_stage_identifier_lengths)
+        s += underline.replace('-', '=')
+        return s
+
+    def reset(self):
+        """
+        Completely reset the timer.
+        """
+        self.stack = list()
+        self.timers = dict()
+
+    def _get_timer_from_stack(self, stack):
+        """
+        This method gets the timer associated with stack.
+
+        Parameters
+        ----------
+        stack: list of str
+            A list of identifiers.
+
+        Returns
+        -------
+        timer: _HierarchicalHelper
+        """
+        tmp = self
+        for i in stack:
+            tmp = tmp.timers[i]
+        return tmp
+
+    def get_total_time(self, identifier):
+        """
+        Parameters
+        ----------
+        identifier: str
+            The full name of the timer including parent timers separated
+            with dots.
+
+        Returns
+        -------
+        total_time: float
+            The total time spent with the specified timer active.
+        """
+        stack = identifier.split('.')
+        timer = self._get_timer_from_stack(stack)
+        return timer.total_time
+
+    def get_num_calls(self, identifier):
+        """
+        Parameters
+        ----------
+        identifier: str
+            The full name of the timer including parent timers separated
+            with dots.
+
+        Returns
+        -------
+        num_calss: int
+            The number of times start was called for the specified timer.
+        """
+        stack = identifier.split('.')
+        timer = self._get_timer_from_stack(stack)
+        return timer.n_calls
+
+    def get_relative_percent_time(self, identifier):
+        """
+        Parameters
+        ----------
+        identifier: str
+            The full name of the timer including parent timers separated
+            with dots.
+
+        Returns
+        -------
+        percent_time: float
+            The percent of time spent in the specified timer
+            relative to the timer's immediate parent.
+        """
+        stack = identifier.split('.')
+        timer = self._get_timer_from_stack(stack)
+        parent = self._get_timer_from_stack(stack[:-1])
+        if parent is self:
+            return self.get_total_percent_time(identifier)
+        else:
+            if parent.total_time > 0:
+                return timer.total_time / parent.total_time * 100
+            else:
+                return float('nan')
+
+    def get_total_percent_time(self, identifier):
+        """
+        Parameters
+        ----------
+        identifier: str
+            The full name of the timer including parent timers separated
+            with dots.
+
+        Returns
+        -------
+        percent_time: float
+            The percent of time spent in the specified timer
+            relative to the total time in all timers.
+        """
+        stack = identifier.split('.')
+        timer = self._get_timer_from_stack(stack)
+        total_time = 0
+        for _timer in self.timers.values():
+            total_time += _timer.total_time
+        if total_time > 0:
+            return timer.total_time / total_time * 100
+        else:
+            return float('nan')

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -295,7 +295,7 @@ class _HierarchicalHelper(object):
             name_formatter = '{name:<' + str(sum(stage_identifier_lengths)) + '}'
             other_time = self.total_time
             sub_stage_identifier_lengths = stage_identifier_lengths[1:]
-            for name, timer in self.timers.items():
+            for name, timer in sorted(self.timers.items()):
                 if self.total_time > 0:
                     _percent = timer.total_time / self.total_time * 100
                 else:
@@ -509,7 +509,7 @@ class HierarchicalTimer(object):
         underline = '-' * (sum(stage_identifier_lengths) + 36) + '\n'
         s += underline
         sub_stage_identifier_lengths = stage_identifier_lengths[1:]
-        for name, timer in self.timers.items():
+        for name, timer in sorted(self.timers.items()):
             s += ( name_formatter + '{ncalls:>9d} {cumtime:>9.3f} '
                    '{percall:>9.3f} {percent:>6.1f}\n').format(
                        name=name,

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -34,6 +34,8 @@ def report_timing(stream=True):
             _logger.removeHandler(h)
 
 _construction_logger = logging.getLogger('pyomo.common.timing.construction')
+
+
 class ConstructionTimer(object):
     fmt = "%%6.%df seconds to construct %s %s; %d %s total"
     def __init__(self, obj):
@@ -80,6 +82,8 @@ class ConstructionTimer(object):
 
 
 _transform_logger = logging.getLogger('pyomo.common.timing.transformation')
+
+
 class TransformationTimer(object):
     fmt = "%%6.%df seconds to apply Transformation %s%s"
     def __init__(self, obj, mode=None):
@@ -112,6 +116,7 @@ class TransformationTimer(object):
 #
 # Setup the timer
 #
+# TODO: Remove this bit for Pyomo 6.0 - we won't care about older versions
 if sys.version_info >= (3,3):
     # perf_counter is guaranteed to be monotonic and the most accurate timer
     _time_source = time.perf_counter
@@ -125,6 +130,7 @@ else:
         _time_source = time.clock
     else:
         _time_source = time.time
+
 
 class TicTocTimer(object):
     """A class to calculate and report elapsed time.
@@ -285,11 +291,11 @@ class _HierarchicalHelper(object):
                 else:
                     _percent = float('nan')
                 s += indent
-                s += ( name_formatter + '{ncalls:>9d} {cumtime:>9.3f} '
+                s += ( name_formatter + '{ncalls:>9d} {aggtime:>9.3f} '
                        '{percall:>9.3f} {percent:>6.1f}\n' ).format(
                            name=name,
                            ncalls=timer.n_calls,
-                           cumtime=timer.total_time,
+                           aggtime=timer.total_time,
                            percall=timer.total_time/timer.n_calls,
                            percent=_percent )
                 s += timer.to_str(
@@ -302,11 +308,11 @@ class _HierarchicalHelper(object):
             else:
                 _percent = float('nan')
             s += indent
-            s += ( name_formatter + '{ncalls:>9} {cumtime:>9.3f} '
+            s += ( name_formatter + '{ncalls:>9} {aggtime:>9.3f} '
                    '{percall:>9} {percent:>6.1f}\n' ).format(
                        name='other',
                        ncalls='n/a',
-                       cumtime=other_time,
+                       aggtime=other_time,
                        percall='n/a',
                        percent=_percent )
             s += underline.replace('-', '=')
@@ -341,7 +347,7 @@ class HierarchicalTimer(object):
     ...
     >>> timer.stop('all')
     >>> print(timer)
-    Identifier        ncalls   cumtime   percall      %
+    Identifier        ncalls   aggtime   percall      %
     ---------------------------------------------------
     all                    1     2.248     2.248  100.0
          ----------------------------------------------
@@ -359,10 +365,10 @@ class HierarchicalTimer(object):
 
     The columns are:
       ncalls : The number of times the timer was started and stopped
-      cumtime: The cumulative time (in seconds) the timer was active
+      aggtime: The aggregate time (in seconds) the timer was active
                (started but not stopped)
-      percall: cumtime (in seconds) / ncalls
-      %      : This is cumtime of the timer divided by cumtime of the
+      percall: aggtime (in seconds) / ncalls
+      %      : This is aggtime of the timer divided by aggtime of the
                parent timer times 100
 
 
@@ -483,22 +489,22 @@ class HierarchicalTimer(object):
     def __str__(self):
         stage_identifier_lengths = self._get_identifier_len()
         name_formatter = '{name:<' + str(sum(stage_identifier_lengths)) + '}'
-        s = ( name_formatter + '{ncalls:>9} {cumtime:>9} '
+        s = ( name_formatter + '{ncalls:>9} {aggtime:>9} '
               '{percall:>9} {percent:>6}\n').format(
                   name='Identifier',
                   ncalls='ncalls',
-                  cumtime='cumtime',
+                  aggtime='aggtime',
                   percall='percall',
                   percent='%')
         underline = '-' * (sum(stage_identifier_lengths) + 36) + '\n'
         s += underline
         sub_stage_identifier_lengths = stage_identifier_lengths[1:]
         for name, timer in self.timers.items():
-            s += ( name_formatter + '{ncalls:>9d} {cumtime:>9.3f} '
+            s += ( name_formatter + '{ncalls:>9d} {aggtime:>9.3f} '
                    '{percall:>9.3f} {percent:>6.1f}\n').format(
                        name=name,
                        ncalls=timer.n_calls,
-                       cumtime=timer.total_time,
+                       aggtime=timer.total_time,
                        percall=timer.total_time/timer.n_calls,
                        percent=self.get_total_percent_time(name))
             s += timer.to_str(

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -20,8 +20,6 @@ import logging
 import time
 import traceback
 
-__all__ = ('TicTocTimer', 'tic', 'toc')
-
 _logger = logging.getLogger('pyomo.common.timing')
 _logger.propagate = False
 _logger.setLevel(logging.WARNING)

--- a/pyomo/contrib/interior_point/interface.py
+++ b/pyomo/contrib/interior_point/interface.py
@@ -1,10 +1,20 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
 from abc import ABCMeta, abstractmethod
 import six
 from pyomo.contrib.pynumero.interfaces import pyomo_nlp, ampl_nlp
 from pyomo.contrib.pynumero.sparse import BlockMatrix, BlockVector
 import numpy as np
 import scipy.sparse
-from pyutilib.misc.timing import HierarchicalTimer
+from pyomo.common.timing import HierarchicalTimer
 
 
 class BaseInteriorPointInterface(six.with_metaclass(ABCMeta, object)):

--- a/pyomo/contrib/interior_point/interior_point.py
+++ b/pyomo/contrib/interior_point/interior_point.py
@@ -1,9 +1,19 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
 from pyomo.contrib.pynumero.interfaces.utils import build_bounds_mask, build_compression_matrix
 import numpy as np
 import logging
 import time
 from .linalg.results import LinearSolverStatus
-from pyutilib.misc.timing import HierarchicalTimer
+from pyomo.common.timing import HierarchicalTimer
 import enum
 
 

--- a/pyomo/pysp/plugins/interscenario.py
+++ b/pyomo/pysp/plugins/interscenario.py
@@ -15,7 +15,7 @@ from six.moves import xrange
 import weakref
 
 from pyutilib.misc import reset_redirect, setup_redirect
-from pyutilib.misc.timing import toc
+from pyomo.common.timing import toc
 
 from pyomo.core import (
     minimize, value, TransformationFactory,


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
To prepare for Pyomo's 6.0 release, we would like to do our best to move PyUtilib dependencies into Pyomo. This is the beginning of that work - moving pyutilib.misc.timing into pyomo.common.timing.

## Changes proposed in this PR:
- Add `pyutilib.misc.timing` code into `pyomo.common.timing`
- Update all references to `pyutilib.misc.timing`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
