### PR TITLE
[WIP] parmest: add support for variable names with indices in covariance calculation 

### DIFF
--- a/pyomo/contrib/parmest/examples/rooney_biegler/rooney_biegler.py
+++ b/pyomo/contrib/parmest/examples/rooney_biegler/rooney_biegler.py
@@ -35,6 +35,29 @@ def rooney_biegler_model(data):
     model.SSE = pyo.Objective(rule = SSE_rule, sense=pyo.minimize)
 
     return model
+    
+def rooney_biegler_model_alternate(data):
+    ''' Alternate model definition used in a unit test
+    Here, the fitted parameters are defined as a single variable over a set
+    A bit silly for this specific example
+    '''
+
+    model = pyo.ConcreteModel()
+
+    model.var_names = pyo.Set(initialize=['asymptote','rate_constant'])
+
+    model.theta = pyo.Var(model.var_names, initialize={'asymptote':15, 'rate_constant':0.5})
+
+    def response_rule(m, h):
+        expr = m.theta['asymptote'] * (1 - pyo.exp(-m.theta['rate_constant'] * h))
+        return expr
+    model.response_function = pyo.Expression(data.hour, rule = response_rule)
+
+    def SSE_rule(m):
+        return sum((data.y[i] - m.response_function[data.hour[i]])**2 for i in data.index)
+    model.SSE = pyo.Objective(rule = SSE_rule, sense=pyo.minimize)
+
+    return model
 
 
 if __name__ == '__main__':

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -84,6 +84,40 @@ def _object_from_string(instance, vstr):
     return retval[indexstr]
 
 #=============================================
+def process_variable_names(vstr):
+    """
+    Process the name of a Var or Param (e.g. "pp.Keq_a[2]")
+    This function is needed to use calc_cov with IDAES models
+    
+    args:
+        vstr: a particular Var or Param (e.g. "pp.Keq_a[2]")
+    return:
+        str: updated string
+    """
+   
+    l = vstr.find('[')
+    if l == -1:
+        #indexstr = None
+        #basestr = vstr
+        return vstr
+    else:
+        r = vstr.find(']')
+        indexstr = vstr[l+1:r]
+        basestr = vstr[:l]
+        
+        # Process index
+        # Remove '
+        new_ = indexstr.replace("'","")
+        # Remove "
+        new_ = new_.replace('"',"")
+        # Remove empty space
+        new_ = new_.replace(' ',"")
+        
+        new_indexstr = ',$'.join(new_.split(','))
+        
+        return basestr + ':$' + new_indexstr
+
+#=============================================
 def _ef_ROOT_node_Object_from_string(efinstance, vstr):
     """
     Wrapper for _object_from_string for PySP extensive forms
@@ -507,8 +541,8 @@ class Estimator(object):
                 for v in self.theta_names:
 
                     #ind_vars.append(eval('ef.'+v))
-                    # This line needs to be updated to work with IDAES models
-                    ind_vars.append(self.ef_instance.MASTER_BLEND_VAR_RootNode[v])
+                    v_ = process_variable_names(v)
+                    ind_vars.append(self.ef_instance.MASTER_BLEND_VAR_RootNode[v_])
         
                 # calculate the reduced hessian
                 solve_result, inv_red_hes = inv_reduced_hessian_barrier(self.ef_instance, 

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -507,6 +507,7 @@ class Estimator(object):
                 for v in self.theta_names:
 
                     #ind_vars.append(eval('ef.'+v))
+                    # This line needs to be updated to work with IDAES models
                     ind_vars.append(self.ef_instance.MASTER_BLEND_VAR_RootNode[v])
         
                 # calculate the reduced hessian


### PR DESCRIPTION
## Fixes: Issue discovered with IDAES workspace (private)

## Summary/Motivation:
- PySP reformats the variable (fitted parameter) names when constructing the extensive form model
- Parmest needs to mimic this convention to work with (most) IDAES models

## Changes proposed in this PR:
- Add function to convert variable (fitted parameter) name string
- Use function when calculated inverse reduced Hessian in parmest

## Outstanding Tasks
- [x] Add test case for the new function
- [x] Add test case for parmest calc_cov workflow

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
