### PR TITLE
Move pyutilib.common exception references to pyomo.common.errors

### DIFF
--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -8,6 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import sys
 
 class PyomoException(Exception):
     """
@@ -46,3 +47,27 @@ class InfeasibleConstraintException(PyomoException):
 class NondifferentiableError(PyomoException, ValueError):
     """A Pyomo-specific ValueError raised for non-differentiable expressions"""
     pass
+
+
+class WindowsError_def(Exception):
+    """
+    An exception used there is an error configuring a package.
+    """
+
+    def __init__(self, *args, **kargs):
+        Exception.__init__(self, *args, **kargs)  #pragma:nocover
+
+
+if (sys.platform[0:3] != "win"):
+    WindowsError = WindowsError_def
+else:
+    WindowsError = WindowsError
+
+
+class ApplicationError(Exception):
+    """
+    An exception used when an external application generates an error.
+    """
+
+    def __init__(self, *args, **kargs):
+        Exception.__init__(self, *args, **kargs)  #pragma:nocover

--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -49,25 +49,8 @@ class NondifferentiableError(PyomoException, ValueError):
     pass
 
 
-class WindowsError_def(Exception):
-    """
-    An exception used there is an error configuring a package.
-    """
-
-    def __init__(self, *args, **kargs):
-        Exception.__init__(self, *args, **kargs)  #pragma:nocover
-
-
-if (sys.platform[0:3] != "win"):
-    WindowsError = WindowsError_def
-else:
-    WindowsError = WindowsError
-
-
-class ApplicationError(Exception):
+class ApplicationError(PyomoException):
     """
     An exception used when an external application generates an error.
     """
-
-    def __init__(self, *args, **kargs):
-        Exception.__init__(self, *args, **kargs)  #pragma:nocover
+    pass

--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -8,7 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import sys
 
 class PyomoException(Exception):
     """

--- a/pyomo/dataportal/plugins/sheet.py
+++ b/pyomo/dataportal/plugins/sheet.py
@@ -10,7 +10,7 @@
 
 import os.path
 import six
-from pyomo.common.errors import ApplicationError
+import pyutilib.common
 from pyutilib.excel.spreadsheet import ExcelSpreadsheet, Interfaces
 
 from pyomo.dataportal import TableData
@@ -54,7 +54,7 @@ class SheetTable(TableData):
         else:
             try:
                 self.sheet = ExcelSpreadsheet(self.filename, ctype=self.ctype)
-            except ApplicationError:
+            except pyutilib.common.ApplicationError:
                 raise
 
     def read(self):

--- a/pyomo/dataportal/plugins/sheet.py
+++ b/pyomo/dataportal/plugins/sheet.py
@@ -10,7 +10,7 @@
 
 import os.path
 import six
-import pyutilib.common
+from pyomo.common.errors import ApplicationError
 from pyutilib.excel.spreadsheet import ExcelSpreadsheet, Interfaces
 
 from pyomo.dataportal import TableData
@@ -54,7 +54,7 @@ class SheetTable(TableData):
         else:
             try:
                 self.sheet = ExcelSpreadsheet(self.filename, ctype=self.ctype)
-            except pyutilib.common.ApplicationError:
+            except ApplicationError:
                 raise
 
     def read(self):

--- a/pyomo/dataportal/process_data.py
+++ b/pyomo/dataportal/process_data.py
@@ -14,7 +14,7 @@ import copy
 import logging
 
 from pyutilib.misc import  Options
-import pyutilib.common
+from pyomo.common.errors import ApplicationError
 from pyutilib.misc import flatten
 
 from pyomo.dataportal.parse_datacmds import (
@@ -856,7 +856,7 @@ def _process_load(cmd, _model, _data, _default, options=None):
         data = DataManagerFactory(tmp)
         if (data is None) or \
            isinstance(data, UnknownDataManager):
-            raise pyutilib.common.ApplicationError("Data manager '%s' is not available." % tmp)
+            raise ApplicationError("Data manager '%s' is not available." % tmp)
     else:
         try:
             data = DataManagerFactory(options.using)
@@ -864,7 +864,7 @@ def _process_load(cmd, _model, _data, _default, options=None):
             data = None
         if (data is None) or \
            isinstance(data, UnknownDataManager):
-            raise pyutilib.common.ApplicationError("Data manager '%s' is not available." % options.using)
+            raise ApplicationError("Data manager '%s' is not available." % options.using)
     set_name=None
     #
     # Create symbol map

--- a/pyomo/dataportal/tests/test_dataportal.py
+++ b/pyomo/dataportal/tests/test_dataportal.py
@@ -15,9 +15,10 @@ import os
 from os.path import abspath, dirname
 pyomo_dir=dirname(dirname(abspath(__file__)))+os.sep+".."
 
-import pyutilib.common
+import pyutilib.misc
 import pyutilib.th as unittest
 
+from pyomo.common.errors import ApplicationError
 from pyomo.dataportal.factory import DataManagerFactory
 from pyomo.environ import AbstractModel, ConcreteModel, Set, DataPortal, Param, Boolean, Any, value
 
@@ -65,7 +66,7 @@ class PyomoTableData(unittest.TestCase):
             td.read()
             td.close()
             self.assertEqual( td._info, ['set', 'X', ':=', ('A1', 2.0, 3.0, 4.0), ('A5', 6.0, 7.0, 8.0), ('A9', 10.0, 11.0, 12.0), ('A13', 14.0, 15.0, 16.0)])
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             pass
 
     def test_read_param1(self):
@@ -76,7 +77,7 @@ class PyomoTableData(unittest.TestCase):
             td.read()
             td.close()
             self.assertEqual( td._info, ['param', ':', 'bb', 'cc', 'dd', ':=', 'A1', 2.0, 3.0, 4.0, 'A5', 6.0, 7.0, 8.0, 'A9', 10.0, 11.0, 12.0, 'A13', 14.0, 15.0, 16.0])
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             pass
 
     def test_read_param2(self):
@@ -87,7 +88,7 @@ class PyomoTableData(unittest.TestCase):
             td.read()
             td.close()
             self.assertEqual( td._info, ['param', ':', 'X', ':', 'bb', 'cc', 'dd', ':=', 'A1', 2.0, 3.0, 4.0, 'A5', 6.0, 7.0, 8.0, 'A9', 10.0, 11.0, 12.0, 'A13', 14.0, 15.0, 16.0])
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             pass
 
     def test_read_param3(self):
@@ -98,7 +99,7 @@ class PyomoTableData(unittest.TestCase):
             td.read()
             td.close()
             self.assertEqual( td._info, ['param', ':', 'X', ':', 'a', ':=', 'A1', 2.0, 3.0, 4.0, 'A5', 6.0, 7.0, 8.0, 'A9', 10.0, 11.0, 12.0, 'A13', 14.0, 15.0, 16.0])
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             pass
 
     def test_read_param4(self):
@@ -109,7 +110,7 @@ class PyomoTableData(unittest.TestCase):
             td.read()
             td.close()
             self.assertEqual( td._info, ['param', ':', 'X', ':', 'a', 'b', ':=', 'A1', 2.0, 3.0, 4.0, 'A5', 6.0, 7.0, 8.0, 'A9', 10.0, 11.0, 12.0, 'A13', 14.0, 15.0, 16.0])
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             pass
 
     def test_read_array1(self):
@@ -120,7 +121,7 @@ class PyomoTableData(unittest.TestCase):
             td.read()
             td.close()
             self.assertEqual( td._info, ['param', 'X', ':', 'bb', 'cc', 'dd', ':=', 'A1', 2.0, 3.0, 4.0, 'A5', 6.0, 7.0, 8.0, 'A9', 10.0, 11.0, 12.0, 'A13', 14.0, 15.0, 16.0])
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             pass
 
     def test_read_array2(self):
@@ -131,7 +132,7 @@ class PyomoTableData(unittest.TestCase):
             td.read()
             td.close()
             self.assertEqual( td._info, ['param', 'X', '(tr)',':', 'bb', 'cc', 'dd', ':=', 'A1', 2.0, 3.0, 4.0, 'A5', 6.0, 7.0, 8.0, 'A9', 10.0, 11.0, 12.0, 'A13', 14.0, 15.0, 16.0])
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             pass
 
     def test_error1(self):

--- a/pyomo/opt/base/solvers.py
+++ b/pyomo/opt/base/solvers.py
@@ -20,7 +20,7 @@ import logging
 
 from pyutilib.misc.config import ConfigBlock, ConfigList, ConfigValue
 from pyomo.common import Factory
-from pyutilib.common import ApplicationError
+from pyomo.common.errors import ApplicationError
 from pyutilib.misc import Options, quote_split
 
 from pyomo.opt.base.problem import ProblemConfigFactory

--- a/pyomo/opt/solver/ilmcmd.py
+++ b/pyomo/opt/solver/ilmcmd.py
@@ -16,7 +16,7 @@ import os
 
 import pyomo.common
 import pyutilib.subprocess
-from pyomo.common.errors import ApplicationError, WindowsError
+from pyomo.common.errors import ApplicationError
 
 import pyomo.opt.solver.shellcmd
 from pyomo.opt.solver.shellcmd import SystemCallSolver
@@ -48,7 +48,7 @@ class ILMLicensedSystemCallSolver(SystemCallSolver):
                     # user hits Ctrl-C.
                     cmd.append("-batch")
                 [rc,log] = pyutilib.subprocess.run(cmd)
-            except WindowsError:
+            except OSError:
                 msg = sys.exc_info()[1]
                 raise ApplicationError("Could not execute the command: ilmtest\n\tError message: "+msg)
             sys.stdout.flush()

--- a/pyomo/opt/solver/ilmcmd.py
+++ b/pyomo/opt/solver/ilmcmd.py
@@ -16,7 +16,7 @@ import os
 
 import pyomo.common
 import pyutilib.subprocess
-import pyutilib.common
+from pyomo.common.errors import ApplicationError, WindowsError
 
 import pyomo.opt.solver.shellcmd
 from pyomo.opt.solver.shellcmd import SystemCallSolver
@@ -48,9 +48,9 @@ class ILMLicensedSystemCallSolver(SystemCallSolver):
                     # user hits Ctrl-C.
                     cmd.append("-batch")
                 [rc,log] = pyutilib.subprocess.run(cmd)
-            except pyutilib.common.WindowsError:
+            except WindowsError:
                 msg = sys.exc_info()[1]
-                raise pyutilib.common.ApplicationError("Could not execute the command: ilmtest\n\tError message: "+msg)
+                raise ApplicationError("Could not execute the command: ilmtest\n\tError message: "+msg)
             sys.stdout.flush()
             for line in log.split("\n"):
                 tokens = re.split('[\t ]+',line.strip())

--- a/pyomo/opt/solver/shellcmd.py
+++ b/pyomo/opt/solver/shellcmd.py
@@ -15,7 +15,7 @@ import sys
 import time
 import logging
 
-from pyutilib.common import ApplicationError, WindowsError
+from pyomo.common.errors import ApplicationError, WindowsError
 from pyutilib.misc import Bunch
 from pyutilib.services import TempfileManager
 from pyutilib.subprocess import run

--- a/pyomo/opt/solver/shellcmd.py
+++ b/pyomo/opt/solver/shellcmd.py
@@ -15,7 +15,7 @@ import sys
 import time
 import logging
 
-from pyomo.common.errors import ApplicationError, WindowsError
+from pyomo.common.errors import ApplicationError
 from pyutilib.misc import Bunch
 from pyutilib.services import TempfileManager
 from pyutilib.subprocess import run
@@ -306,7 +306,7 @@ class SystemCallSolver(OptSolver):
                 tee   = self._tee,
                 define_signal_handlers = self._define_signal_handlers
              )
-        except WindowsError:
+        except OSError:
             err = sys.exc_info()[1]
             msg = 'Could not execute the command: %s\tError message: %s'
             raise ApplicationError(msg % (command.cmd, err))

--- a/pyomo/opt/tests/base/test_ampl.py
+++ b/pyomo/opt/tests/base/test_ampl.py
@@ -18,7 +18,7 @@ currdir = dirname(abspath(__file__))+os.sep
 
 import pyutilib.th as unittest
 import pyutilib.services
-import pyutilib.common
+from pyomo.common.errors import ApplicationError
 
 import pyomo.opt
 
@@ -52,7 +52,7 @@ class Test(unittest.TestCase):
         """ Convert from MOD+DAT to NL """
         try:
             self.model.write(currdir+'test3.nl')
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             err = sys.exc_info()[1]
             if pyomo.common.Executable("ampl"):
                 self.fail("Unexpected ApplicationError - ampl is enabled "
@@ -71,7 +71,7 @@ class Test(unittest.TestCase):
         self.model = pyomo.opt.AmplModel(currdir+'test3.mod')
         try:
             self.model.write(currdir+'test3.lp')
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             err = sys.exc_info()[1]
             if pyomo.common.Executable("glpsol"):
                 self.fail("Unexpected ApplicationError - glpsol is enabled "
@@ -92,7 +92,7 @@ class Test(unittest.TestCase):
         self.model = pyomo.opt.AmplModel(currdir+'test3.mod')
         try:
             self.model.write(currdir+'test3.mps')
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             err = sys.exc_info()[1]
             if pyomo.common.Executable("ampl"):
                 self.fail("Unexpected ApplicationError - ampl is enabled "
@@ -111,7 +111,7 @@ class Test(unittest.TestCase):
         self.model = pyomo.opt.AmplModel(currdir+'test3a.mod', currdir+'test3a.dat')
         try:
             self.model.write(currdir+'test3a.nl')
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             err = sys.exc_info()[1]
             if pyomo.common.Executable("ampl"):
                 self.fail("Unexpected ApplicationError - ampl is enabled "
@@ -130,7 +130,7 @@ class Test(unittest.TestCase):
         self.model = pyomo.opt.AmplModel(currdir+'test3a.mod', currdir+'test3a.dat')
         try:
             self.model.write(currdir+'test3a.lp')
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             err = sys.exc_info()[1]
             if pyomo.common.Executable("glpsol"):
                 self.fail("Unexpected ApplicationError - glpsol is enabled "
@@ -151,7 +151,7 @@ class Test(unittest.TestCase):
         self.model = pyomo.opt.AmplModel(currdir+'test3a.mod', currdir+'test3a.dat')
         try:
             self.model.write(currdir+'test3a.mps')
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             err = sys.exc_info()[1]
             if pyomo.common.Executable("ampl"):
                 self.fail("Unexpected ApplicationError - ampl is enabled "

--- a/pyomo/opt/tests/base/test_convert.py
+++ b/pyomo/opt/tests/base/test_convert.py
@@ -18,7 +18,7 @@ currdir = dirname(abspath(__file__))+os.sep
 
 import pyutilib.th as unittest
 import pyutilib.services
-import pyutilib.common
+from pyomo.common.errors import ApplicationError
 
 import pyomo.opt
 
@@ -139,7 +139,7 @@ class OptConvertDebug(unittest.TestCase):
         try:
             ans = pyomo.opt.convert_problem( (currdir+"unknown.nl",), None, [pyomo.opt.ProblemFormat.cpxlp])
             self.fail("Expected pyomo.opt.ConverterError exception")
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             if pyomo.common.Executable("pico_convert"):
                 self.fail("Expected ApplicationError because pico_convert is not available")
             return
@@ -172,7 +172,7 @@ class OptConvertDebug(unittest.TestCase):
         try:
             ans = pyomo.opt.convert_problem( (currdir+"test3.mod",currdir+"test5.dat"), None, [pyomo.opt.ProblemFormat.cpxlp])
             self.fail("Expected pyomo.opt.ConverterError exception because we provided a MOD file with a 'data;' declaration")
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             if pyomo.common.Executable("glpsol"):
                 self.fail("Expected ApplicationError because glpsol is not available")
             return

--- a/pyomo/opt/tests/solver/test_shellcmd.py
+++ b/pyomo/opt/tests/solver/test_shellcmd.py
@@ -14,7 +14,7 @@
 import os
 
 import pyutilib.th as unittest
-from pyutilib.common import ApplicationError
+from pyomo.common.errors import ApplicationError
 
 from pyomo.opt.base import UnknownSolver
 from pyomo.opt.base.solvers import SolverFactory

--- a/pyomo/pysp/computeconf.py
+++ b/pyomo/pysp/computeconf.py
@@ -15,7 +15,7 @@ import math
 import time
 import traceback
 
-from pyutilib.common import ApplicationError
+from pyomo.common.errors import ApplicationError
 
 from pyomo.core import minimize
 # this is a hack, in order to pick up the UndefinedData class. this is

--- a/pyomo/pysp/drive_lagrangian_cc.py
+++ b/pyomo/pysp/drive_lagrangian_cc.py
@@ -17,7 +17,7 @@ import sys
 import operator
 import traceback
 
-import pyutilib.common
+from pyomo.common.errors import ApplicationError
 
 from pyomo.opt import SolverManagerFactory
 
@@ -464,7 +464,7 @@ def main(args=None):
       msg = sys.exc_info()[1]
       print("IO ERROR:")
       print(msg)
-   except pyutilib.common.ApplicationError:
+   except ApplicationError:
       msg = sys.exc_info()[1]
       print("APPLICATION ERROR:")
       print(msg)

--- a/pyomo/pysp/ph.py
+++ b/pyomo/pysp/ph.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     guppy_available = False
 
-import pyutilib.common
+from pyomo.common.errors import ApplicationError
 
 from pyomo.core import Var, Set, BooleanSet, IntegerSet, Suffix, value, minimize, maximize
 from pyomo.opt import (UndefinedData,
@@ -4243,7 +4243,7 @@ class ProgressiveHedging(_PHBase):
                     print("")
                     self._current_iteration -= 1
                     break
-                except pyutilib.common._exceptions.ApplicationError:
+                except ApplicationError:
                     print("")
                     print(" ** Caught ApplicationError exception. "
                           "Attempting to gracefully exit PH")

--- a/pyomo/pysp/phsolverserver.py
+++ b/pyomo/pysp/phsolverserver.py
@@ -15,7 +15,7 @@ import time
 import copy
 from optparse import OptionParser
 
-import pyutilib.common
+from pyomo.common.errors import ApplicationError
 import pyutilib.misc
 from pyutilib.misc import PauseGC
 from pyutilib.pyro import (TaskWorker,
@@ -1161,7 +1161,7 @@ class _PHSolverServer(_PHBase):
                                         data.warmstart,
                                         data.variable_transmission)
                     successful_solve = True
-                except pyutilib.common.ApplicationError as exc:
+                except ApplicationError as exc:
                     print("Solve failed for object=%s - this was attempt=%d"
                           % (data.name, attempts_so_far))
                     if (attempts_so_far == max_num_attempts):

--- a/pyomo/pysp/util/misc.py
+++ b/pyomo/pysp/util/misc.py
@@ -22,7 +22,7 @@ import argparse
 
 from pyutilib.misc import PauseGC, import_file
 from pyutilib.services import TempfileManager
-from pyutilib.common import ApplicationError
+from pyomo.common.errors import ApplicationError
 from pyomo.opt.base import ConverterError
 from pyomo.common.dependencies import attempt_import
 from pyomo.common.plugin import (ExtensionPoint,

--- a/pyomo/scripting/pyro_mip_server.py
+++ b/pyomo/scripting/pyro_mip_server.py
@@ -30,7 +30,7 @@ except:
 import pyutilib.services
 import pyutilib.pyro
 from pyutilib.pyro import using_pyro4, TaskProcessingError
-import pyutilib.common
+from pyomo.common.errors import ApplicationError
 from pyomo.common import pyomo_command
 from pyomo.opt.base import SolverFactory, ConverterError
 
@@ -233,7 +233,7 @@ def main():
                 sys.stderr.write("CONVERTER ERROR:\n")
                 sys.stderr.write(str(sys.exc_info()[1])+"\n")
                 raise
-            except pyutilib.common.ApplicationError:
+            except ApplicationError:
                 sys.stderr.write("APPLICATION ERROR:\n")
                 sys.stderr.write(str(sys.exc_info()[1])+"\n")
                 raise

--- a/pyomo/solvers/plugins/converter/ampl.py
+++ b/pyomo/solvers/plugins/converter/ampl.py
@@ -10,7 +10,7 @@
 
 import os.path
 import pyutilib.subprocess
-import pyutilib.common
+from pyomo.common.errors import ApplicationError
 import pyomo.common
 
 from pyomo.opt.base import ProblemFormat, ConverterError
@@ -79,5 +79,5 @@ class AmplMIPConverter(object):
         #
         output = pyutilib.subprocess.run(cmd)
         if not os.path.exists(output_filename):       #pragma:nocover
-            raise pyutilib.common.ApplicationError("Problem launching 'ampl' to create '%s': %s" % (output_filename, output))
+            raise ApplicationError("Problem launching 'ampl' to create '%s': %s" % (output_filename, output))
         return (output_filename,),None # empty variable map

--- a/pyomo/solvers/plugins/converter/glpsol.py
+++ b/pyomo/solvers/plugins/converter/glpsol.py
@@ -12,8 +12,8 @@ import os
 import six
 
 import pyutilib.subprocess
-import pyutilib.common
 import pyomo.common
+from pyomo.common.errors import ApplicationError
 from pyomo.opt.base import ProblemFormat, ConverterError
 from pyomo.opt.base.convert import ProblemConverterFactory
 
@@ -105,7 +105,7 @@ class GlpsolMIPConverter(object):
             cmd.append(modfile)
         pyutilib.subprocess.run(cmd)
         if not os.path.exists(ofile):       #pragma:nocover
-            raise pyutilib.common.ApplicationError("Problem launching 'glpsol' to create "+ofile)
+            raise ApplicationError("Problem launching 'glpsol' to create "+ofile)
         if os.path.exists(modfile):
             os.remove(modfile)
         return (ofile,),None # empty variable map

--- a/pyomo/solvers/plugins/converter/pico.py
+++ b/pyomo/solvers/plugins/converter/pico.py
@@ -12,9 +12,9 @@ import six
 
 import os.path
 
-import pyutilib.common
 import pyutilib.subprocess
 import pyomo.common
+from pyomo.common.errors import ApplicationError
 
 from pyomo.opt.base import ProblemFormat, ConverterError
 
@@ -73,6 +73,6 @@ class PicoMIPConverter(object):
         print("Running command: "+cmd)
         pyutilib.subprocess.run(cmd)
         if not os.path.exists(output_filename):       #pragma:nocover
-            raise pyutilib.common.ApplicationError(\
+            raise ApplicationError(\
                     "Problem launching 'pico_convert' to create "+output_filename)
         return (output_filename,),None # no variable map at the moment

--- a/pyomo/solvers/plugins/solvers/ASL.py
+++ b/pyomo/solvers/plugins/solvers/ASL.py
@@ -13,7 +13,7 @@ import os
 import six
 
 from pyomo.common import Executable
-from pyutilib.common import ApplicationError
+from pyomo.common.errors import ApplicationError
 from pyutilib.misc import Options, Bunch
 from pyutilib.services import TempfileManager
 from pyutilib.subprocess import run

--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -18,7 +18,7 @@ import logging
 from six import iteritems, string_types
 
 from pyomo.common import Executable
-from pyutilib.common import ApplicationError
+from pyomo.common.errors import ApplicationError
 from pyutilib.misc import Options, Bunch
 from pyutilib.services import TempfileManager
 from pyutilib.subprocess import run

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -15,7 +15,7 @@ import time
 import logging
 
 from pyomo.common import Executable
-from pyutilib.common import ApplicationError
+from pyomo.common.errors import ApplicationError
 from pyutilib.misc import Options, Bunch, yaml_fix
 from pyutilib.services import TempfileManager
 from pyutilib.subprocess import run

--- a/pyomo/solvers/plugins/solvers/GLPK_old.py
+++ b/pyomo/solvers/plugins/solvers/GLPK_old.py
@@ -13,7 +13,7 @@ import os
 import re
 import sys
 
-from pyutilib.common import ApplicationError
+from pyomo.common.errors import ApplicationError
 from pyutilib.misc import Bunch, Options
 from pyutilib.services import TempfileManager
 import pyutilib.subprocess

--- a/pyomo/solvers/plugins/solvers/PICO.py
+++ b/pyomo/solvers/plugins/solvers/PICO.py
@@ -14,7 +14,7 @@ import os
 from six import iteritems
 
 from pyomo.common import Executable
-from pyutilib.common import  ApplicationError
+from pyomo.common.errors import  ApplicationError
 from pyutilib.misc import Options, Bunch
 from pyutilib.services import TempfileManager
 from pyutilib.subprocess import run

--- a/pyomo/solvers/plugins/solvers/XPRESS.py
+++ b/pyomo/solvers/plugins/solvers/XPRESS.py
@@ -14,7 +14,7 @@ import re
 import logging
 
 from pyomo.common import Executable
-from pyutilib.common import ApplicationError
+from pyomo.common.errors import ApplicationError
 from pyutilib.misc import Options, Bunch, yaml_fix
 from pyutilib.services import TempfileManager
 

--- a/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
@@ -13,8 +13,9 @@ from pyomo.core.base.block import Block, _BlockData
 from pyomo.core.kernel.block import IBlock
 from pyomo.opt.base.solvers import OptSolver
 from pyomo.core.base import SymbolMap, NumericLabeler, TextLabeler
-import pyutilib.common
+import pyutilib.services
 import pyomo.common
+from pyomo.common.errors import ApplicationError
 from pyomo.common.collections import ComponentMap, ComponentSet
 import pyomo.opt.base.solvers
 from pyomo.opt.base.formats import ResultsFormat
@@ -294,7 +295,7 @@ class DirectOrPersistentSolver(OptSolver):
             return self._python_api_exists
         else:
             if self._python_api_exists is False:
-                raise pyutilib.common.ApplicationError(("No Python bindings available for {0} solver " +
+                raise ApplicationError(("No Python bindings available for {0} solver " +
                                                         "plugin").format(type(self)))
             else:
                 return True

--- a/pyomo/solvers/plugins/solvers/direct_solver.py
+++ b/pyomo/solvers/plugins/solvers/direct_solver.py
@@ -16,7 +16,7 @@ from pyomo.core.base.block import _BlockData
 from pyomo.core.kernel.block import IBlock
 from pyomo.core.base.suffix import active_import_suffix_generator
 from pyomo.core.kernel.suffix import import_suffix_generator
-from pyutilib.common import ApplicationError
+from pyomo.common.errors import ApplicationError
 from pyutilib.misc import Options
 
 logger = logging.getLogger('pyomo.solvers')

--- a/pyomo/solvers/plugins/solvers/persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/persistent_solver.py
@@ -18,7 +18,7 @@ from pyomo.core.base.constraint import Constraint
 from pyomo.core.base.var import Var
 from pyomo.core.base.sos import SOSConstraint
 
-from pyutilib.common import ApplicationError
+from pyomo.common.errors import ApplicationError
 from pyutilib.misc import Options
 
 import time

--- a/pyomo/solvers/plugins/testdriver/mip.py
+++ b/pyomo/solvers/plugins/testdriver/mip.py
@@ -16,6 +16,7 @@ import pyomo.common
 from pyutilib.misc import Options
 
 from pyomo.common.plugin import Plugin, implements, alias
+from pyomo.common.errors import ApplicationError
 import pyomo.opt
 
 old_tempdir = pyutilib.services.TempfileManager.tempdir
@@ -30,7 +31,7 @@ class PyomoMIPTestDriver(Plugin):
         try:
             cls.pico_convert =  pyomo.common.Executable("pico_convert")
             cls.pico_convert_available= cls.pico_convert.available()
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             cls.pico_convert_available=False
 
     def tearDownClass(self, cls, options):

--- a/pyomo/solvers/plugins/testdriver/model.py
+++ b/pyomo/solvers/plugins/testdriver/model.py
@@ -18,6 +18,7 @@ import pyutilib.autotest
 import pyomo.common
 
 import pyomo.common.plugin
+from pyomo.common.errors import ApplicationError
 import pyomo.opt
 
 old_tempdir = None
@@ -34,7 +35,7 @@ class PyomoTestDriver(pyomo.common.plugin.Plugin):
         try:
             cls.pico_convert =  pyomo.common.Executable("pico_convert")
             cls.pico_convert_available= cls.pico_convert.available()
-        except pyutilib.common.ApplicationError:
+        except ApplicationError:
             cls.pico_convert_available=False
 
     def tearDownClass(self, cls, options):

--- a/pyomo/solvers/tests/mip/test_convert.py
+++ b/pyomo/solvers/tests/mip/test_convert.py
@@ -20,7 +20,7 @@ currdir = dirname(abspath(__file__))+os.sep
 
 import pyutilib.th as unittest
 from pyutilib.services import TempfileManager
-from pyutilib.common import ApplicationError
+from pyomo.common.errors import ApplicationError
 
 from pyomo.opt import ProblemFormat, ConverterError, convert_problem
 from pyomo.common import Executable

--- a/pyomo/solvers/tests/mip/test_solver.py
+++ b/pyomo/solvers/tests/mip/test_solver.py
@@ -18,7 +18,6 @@ currdir = dirname(abspath(__file__))+os.sep
 
 import pyutilib.th as unittest
 import pyutilib.services
-import pyutilib.common
 
 import pyomo.opt
 import pyomo.solvers.plugins.solvers
@@ -83,7 +82,6 @@ class OptSolverDebug(unittest.TestCase):
         ans = pyomo.opt.SolverFactory("stest2")
         # No exception should be generated
         ans.available()
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
To prepare for Pyomo's 6.0 release, we would like to do our best to move PyUtilib dependencies into Pyomo. This is the effort to move necessary pyutilib.common exceptions into pyomo.common.errors.

## Changes proposed in this PR:
- Add `pyutilib.common` code into `pyomo.common.errors`
- Update all references to items from `pyutilib.common`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
