### PR TITLE
Defer import of guppy module within PySP

### DIFF
--- a/pyomo/pysp/ph.py
+++ b/pyomo/pysp/ph.py
@@ -16,14 +16,9 @@ import inspect
 import uuid
 from math import fabs, sqrt
 
-try:
-    from guppy import hpy
-    guppy_available = True
-except ImportError:
-    guppy_available = False
-
 import pyutilib.common
 
+from pyomo.common.dependencies import attempt_import
 from pyomo.core import Var, Set, BooleanSet, IntegerSet, Suffix, value, minimize, maximize
 from pyomo.opt import (UndefinedData,
                        undefined,
@@ -63,6 +58,9 @@ from pyomo.opt.parallel.local import SolverManager_Serial
 
 from six import iterkeys, itervalues, iteritems
 from six.moves import xrange
+
+guppy, guppy_available = attempt_import('guppy')
+
 
 logger = logging.getLogger('pyomo.pysp')
 
@@ -4375,7 +4373,7 @@ class ProgressiveHedging(_PHBase):
                 # gather and report memory statistics (for leak
                 # detection purposes) if specified.
                 if (guppy_available) and (self._profile_memory >= 1):
-                    print(hpy().heap())
+                    print(guppy.hpy().heap())
 
                     #print "New (persistent) objects constructed during PH iteration "+str(self._current_iteration)+":"
                     #memory_tracker.print_diff(summary1=summary_last_iteration,

--- a/pyomo/pysp/phinit.py
+++ b/pyomo/pysp/phinit.py
@@ -13,17 +13,12 @@ import time
 import contextlib
 import random
 import argparse
-try:
-    from guppy import hpy
-    guppy_available = True
-except ImportError:
-    guppy_available = False
 
 from pyutilib.pyro import shutdown_pyro_components
 from pyutilib.misc import import_file
 
 from pyomo.common import pyomo_command
-from pyomo.common.dependencies import pympler_available
+from pyomo.common.dependencies import pympler_available, attempt_import
 from pyomo.common.plugin import ExtensionPoint, SingletonPlugin
 from pyomo.core.base import maximize, minimize, Var, Suffix
 from pyomo.opt.base import SolverFactory
@@ -40,6 +35,8 @@ from pyomo.pysp.scenariotree.instance_factory import \
 from pyomo.pysp.solutionwriter import ISolutionWriterExtension
 from pyomo.pysp.util.misc import (launch_command,
                                   load_extensions)
+
+guppy, guppy_available = attempt_import('guppy')
 
 #
 # utility method to construct an option parser for ph arguments,


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
`guppy` imports are occasionally showing up in the list of slow-loading modules on OSX GHA runners.  This PR defers the import checks for `guppy` until PH actually needs to know if it is available.

## Changes proposed in this PR:
- use `pyomo.common.dependencies.attempt_import` for `guppy` imports in PySP

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
