### PR TITLE
GHA: update idaes-ext download

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -272,11 +272,16 @@ jobs:
         IPOPT_TAR=${DOWNLOAD_DIR}/ipopt.tar.gz
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
-            URL=https://github.com/IDAES/idaes-ext/releases/download/2.0.0
             if test "${{matrix.TARGET}}" == osx; then
                 echo "IDAES Ipopt not available on OSX"
                 exit 0
-            elif test "${{matrix.TARGET}}" == linux; then
+            fi
+            URL=https://github.com/IDAES/idaes-ext
+            RELEASE=$(curl --max-time 150 --retry 8 \
+                -L -s -H 'Accept: application/json' ${URL}/releases/latest)
+            VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+            URL=${URL}/releases/download/$VER
+            if test "${{matrix.TARGET}}" == linux; then
                 curl --max-time 150 --retry 8 \
                     -L $URL/idaes-solvers-ubuntu1804-64.tar.gz \
                     > $IPOPT_TAR

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -28,7 +28,7 @@ env:
       python-louvain
   PYTHON_NUMPY_PKGS: >
       numpy scipy pyodbc pandas matplotlib seaborn
-  CACHE_VER: v2
+  CACHE_VER: v3
 
 jobs:
   build:

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -119,7 +119,7 @@ jobs:
     # the 5 GB GitHub allows.
     #
     #- name: Conda package cache
-    #  uses: actions/cache@v1
+    #  uses: actions/cache@v2
     #  if: matrix.PYENV == 'conda'
     #  id: conda-cache
     #  with:
@@ -127,7 +127,7 @@ jobs:
     #    key: conda-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
     - name: Pip package cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       if: matrix.PYENV == 'pip'
       id: pip-cache
       with:
@@ -135,7 +135,7 @@ jobs:
         key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
     - name: OS package cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       if: matrix.TARGET != 'osx'
       id: os-cache
       with:
@@ -143,7 +143,7 @@ jobs:
         key: pkg-${{env.CACHE_VER}}.0-${{runner.os}}
 
     - name: TPL package download cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       id: download-cache
       with:
         path: cache/download
@@ -507,7 +507,7 @@ jobs:
       # We need the source for .codecov.yml and running "coverage xml"
 
     - name: Pip package cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       id: pip-cache
       with:
         path: cache/pip

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -25,7 +25,7 @@ env:
       python-louvain
   PYTHON_NUMPY_PKGS: >
       numpy scipy pyodbc pandas matplotlib seaborn
-  CACHE_VER: v2
+  CACHE_VER: v3
 
 jobs:
   build:

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -118,7 +118,7 @@ jobs:
     # the 5 GB GitHub allows.
     #
     #- name: Conda package cache
-    #  uses: actions/cache@v1
+    #  uses: actions/cache@v2
     #  if: matrix.PYENV == 'conda'
     #  id: conda-cache
     #  with:
@@ -126,7 +126,7 @@ jobs:
     #    key: conda-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
     - name: Pip package cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       if: matrix.PYENV == 'pip'
       id: pip-cache
       with:
@@ -134,7 +134,7 @@ jobs:
         key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
     - name: OS package cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       if: matrix.TARGET != 'osx'
       id: os-cache
       with:
@@ -142,7 +142,7 @@ jobs:
         key: pkg-${{env.CACHE_VER}}.0-${{runner.os}}
 
     - name: TPL package download cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       id: download-cache
       with:
         path: cache/download
@@ -506,7 +506,7 @@ jobs:
       # We need the source for .codecov.yml and running "coverage xml"
 
     - name: Pip package cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       id: pip-cache
       with:
         path: cache/pip

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -271,11 +271,16 @@ jobs:
         IPOPT_TAR=${DOWNLOAD_DIR}/ipopt.tar.gz
         if test ! -e $IPOPT_TAR; then
             echo "...downloading Ipopt"
-            URL=https://github.com/IDAES/idaes-ext/releases/download/2.0.0
             if test "${{matrix.TARGET}}" == osx; then
                 echo "IDAES Ipopt not available on OSX"
                 exit 0
-            elif test "${{matrix.TARGET}}" == linux; then
+            fi
+            URL=https://github.com/IDAES/idaes-ext
+            RELEASE=$(curl --max-time 150 --retry 8 \
+                -L -s -H 'Accept: application/json' ${URL}/releases/latest)
+            VER=$(echo $RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+            URL=${URL}/releases/download/$VER
+            if test "${{matrix.TARGET}}" == linux; then
                 curl --max-time 150 --retry 8 \
                     -L $URL/idaes-solvers-ubuntu1804-64.tar.gz \
                     > $IPOPT_TAR


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This updates the GHA workflow to download the most recent `IDAES/idaes-ext` release when rebuilding the package download cache.  This also updates the caches to use to the `actions/cache@v2`, and triggers a rebuild of all the caches.  

This change will cause the GHA build to pick up a newer release that includes `k_aug` (necessary for testing #1613)

## Changes proposed in this PR:
- Always download the most recent `IDAES/idaes-ext` 
- Update to `actions/cache@v2`
- Trigger a rebuild of all caches

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
