### PR TITLE
Resolve Parmest example incompatibility with Python<3.5

### DIFF
--- a/pyomo/contrib/parmest/examples/rooney_biegler/scipy_comparison.py
+++ b/pyomo/contrib/parmest/examples/rooney_biegler/scipy_comparison.py
@@ -68,12 +68,12 @@ r = residual(theta_hat, t, y)
 
 # calculate variance of the residuals
 # -2 because there are 2 fitted parameters
-sigre = r.T @ r / (len(y) - 2)
+sigre = np.matmul(r.T, r / (len(y) - 2))
 print("sigre = ",sigre)
 
 # approximate covariance
 # Need to divide by 2 because optimize.least_squares scaled the objective by 1/2
-cov = sigre * np.linalg.inv(sol.jac.T @ sol.jac)
+cov = sigre * np.linalg.inv(np.matmul(sol.jac.T, sol.jac))
 
 print("\ncovariance=\n",cov)
 

--- a/pyomo/contrib/parmest/examples/rooney_biegler/scipy_comparison.py
+++ b/pyomo/contrib/parmest/examples/rooney_biegler/scipy_comparison.py
@@ -60,8 +60,8 @@ sol = optimize.least_squares(residual, theta_guess,method='trf',args=(t,y),verbo
 theta_hat = sol.x
 
 print("\n")
-print("asymptote =",theta_hat[0])
-print("rate_constant =",theta_hat[1])
+print("asymptote =", theta_hat[0])
+print("rate_constant =", theta_hat[1])
 
 # calculate residuals
 r = residual(theta_hat, t, y)
@@ -69,13 +69,13 @@ r = residual(theta_hat, t, y)
 # calculate variance of the residuals
 # -2 because there are 2 fitted parameters
 sigre = np.matmul(r.T, r / (len(y) - 2))
-print("sigre = ",sigre)
+print("sigre = ", sigre)
 
 # approximate covariance
 # Need to divide by 2 because optimize.least_squares scaled the objective by 1/2
 cov = sigre * np.linalg.inv(np.matmul(sol.jac.T, sol.jac))
 
-print("\ncovariance=\n",cov)
+print("\ncovariance=\n", cov)
 
 ## solve with optimize.curve_fit
 print("Regress with OPTIMIZE.CURVE_FIT")
@@ -86,15 +86,15 @@ def model2(t, asymptote, rate_constant):
 theta_hat2, cov2 = optimize.curve_fit(model2, t, y, p0=theta_guess)
 
 print("\n")
-print("asymptote =",theta_hat2[0])
-print("rate_constant =",theta_hat2[1])
+print("asymptote =", theta_hat2[0])
+print("rate_constant =", theta_hat2[1])
 
-print("\ncovariance=\n",cov2)
+print("\ncovariance=\n", cov2)
 
 
 ## covariance matrix in Rooney and Biegler (2001)
-cov_paper = np.array([[6.22864, -0.4322],[-0.4322,0.04124]])
-print("\ncovariance from paper =\n",cov_paper)
+cov_paper = np.array([[6.22864, -0.4322], [-0.4322, 0.04124]])
+print("\ncovariance from paper =\n", cov_paper)
 
 '''
 These scipy results differ in the 3rd decimal place from the paper. It is possible


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This cleans up syntax in `parmest/examples/rooney_biegler/scipy_comparison.py` that is only valid in Python >= 3.5.

## Changes proposed in this PR:
- Remove use of the `@` operator
- Minor PEP8 reformatting

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
