### PR TITLE
Block initialization improvement

### DIFF
--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -703,7 +703,7 @@ arguments (which have been ignored):"""
         # If someone passed a rule for creating the instance, fire the
         # rule before constructing the components.
         if instance._rule is not None:
-            instance._rule(instance)
+            instance._rule(instance, next(iter(self.index_set())))
 
         if namespaces:
             _namespaces = list(namespaces)

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1844,6 +1844,9 @@ class Block(ActiveIndexedComponent):
         # As concrete applies to the Block at declaration time, we will
         # not use an initializer.
         _concrete = kwargs.pop('concrete', False)
+        # As dense applies to the whole container, we will not use an
+        # initializer
+        self._dense = kwargs.pop('dense', True)
         kwargs.setdefault('ctype', Block)
         ActiveIndexedComponent.__init__(self, *args, **kwargs)
         if _options is not None:
@@ -1938,7 +1941,8 @@ class Block(ActiveIndexedComponent):
         try:
             if self.is_indexed():
                 # We can only populate Blocks with finite indexing sets
-                if self.index_set().isfinite():
+                if self.index_set().isfinite() and (
+                        self._dense or self._rule is not None):
                     for _idx in self.index_set():
                         # Trigger population & call the rule
                         self._getitem_when_not_present(_idx)

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -24,14 +24,9 @@ from operator import itemgetter
 from six import iteritems, iterkeys, itervalues, StringIO, string_types, \
     advance_iterator, PY3
 
-if PY3:
-    from collections.abc import Mapping as collections_Mapping
-else:
-    from collections import Mapping as collections_Mapping
-
 from pyutilib.misc.indent_io import StreamIndenter
 
-from pyomo.common.collections import ComponentMap
+from pyomo.common.collections import ComponentMap, Mapping
 from pyomo.common.deprecation import deprecated, deprecation_warning
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base.plugin import ModelComponentFactory
@@ -768,7 +763,7 @@ class _BlockData(ActiveComponentData):
             src_comp_map = src.component_map()
             src_raw_dict = {k:v for k,v in iteritems(src.__dict__)
                             if k not in src_comp_map}
-        elif isinstance(src, collections_Mapping):
+        elif isinstance(src, Mapping):
             src_comp_map = {}
             src_raw_dict = src
         else:

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1968,7 +1968,7 @@ class Block(ActiveIndexedComponent):
                     for name, obj in iteritems(_predefined_components):
                         if not obj._constructed:
                             obj.construct(data.get(name, None))
-                # Trigger the (normal) intialization of the block
+                # Trigger the (normal) initialization of the block
                 self._getitem_when_not_present(_idx)
         finally:
             # We must allow that id(self) may no longer be in

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -291,12 +291,13 @@ class PseudoMap(object):
         # list will be walked and sorted before returning the first
         # element.
         sort_order = self._sorted
-        self._sorted = False
-        for x in itervalues(self):
+        try:
+            self._sorted = False
+            for x in itervalues(self):
+                return True
+            return False
+        finally:
             self._sorted = sort_order
-            return True
-        self._sorted = sort_order
-        return False
 
     __bool__ = __nonzero__
 

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1365,25 +1365,29 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
                     if compData.active == active:
                         yield (name, idx), compData
 
+    @deprecated("The all_components method is deprecated.  "
+                "Use the Block.component_objects() method.",
+                version="4.1.10486")
     def all_components(self, *args, **kwargs):
-        logger.warning(
-            "DEPRECATED: The all_components method is deprecated.  Use the Block.component_objects() method.")
         return self.component_objects(*args, **kwargs)
 
+    @deprecated("The active_components method is deprecated.  "
+                "Use the Block.component_objects() method.",
+                version="4.1.10486")
     def active_components(self, *args, **kwargs):
-        logger.warning(
-            "DEPRECATED: The active_components method is deprecated.  Use the Block.component_objects() method.")
         kwargs['active'] = True
         return self.component_objects(*args, **kwargs)
 
+    @deprecated("The all_component_data method is deprecated.  "
+                "Use the Block.component_data_objects() method.",
+                version="4.1.10486")
     def all_component_data(self, *args, **kwargs):
-        logger.warning(
-            "DEPRECATED: The all_component_data method is deprecated.  Use the Block.component_data_objects() method.")
         return self.component_data_objects(*args, **kwargs)
 
+    @deprecated("The active_component_data method is deprecated.  "
+                "Use the Block.component_data_objects() method.",
+                version="4.1.10486")
     def active_component_data(self, *args, **kwargs):
-        logger.warning(
-            "DEPRECATED: The active_component_data method is deprecated.  Use the Block.component_data_objects() method.")
         kwargs['active'] = True
         return self.component_data_objects(*args, **kwargs)
 
@@ -1459,14 +1463,16 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
                                                  sort=sort):
                 yield x
 
+    @deprecated("The all_blocks method is deprecated.  "
+                "Use the Block.block_data_objects() method.",
+                version="4.1.10486")
     def all_blocks(self, *args, **kwargs):
-        logger.warning(
-            "DEPRECATED: The all_blocks method is deprecated.  Use the Block.block_data_objects() method.")
         return self.block_data_objects(*args, **kwargs)
 
+    @deprecated("The active_blocks method is deprecated.  "
+                "Use the Block.block_data_objects() method.",
+                version="4.1.10486")
     def active_blocks(self, *args, **kwargs):
-        logger.warning(
-            "DEPRECATED: The active_blocks method is deprecated.  Use the Block.block_data_objects() method.")
         kwargs['active'] = True
         return self.block_data_objects(*args, **kwargs)
 
@@ -2129,41 +2135,33 @@ def generate_cuid_names(block,
 #
 # Deprecated functions.
 #
+@deprecated("The active_components function is deprecated.  "
+            "Use the Block.component_objects() method.",
+            version="4.1.10486")
 def active_components(block, ctype, sort_by_names=False, sort_by_keys=False):
-    """DEPRECATED: The active_components function is deprecated.
-
-    Use the Block.component_objects() method.
-    """
-    logger.warning(active_components.__doc__)
     return block.component_objects(ctype, active=True, sort=sort_by_names)
 
 
+@deprecated("The components function is deprecated.  "
+            "Use the Block.component_objects() method.",
+            version="4.1.10486")
 def components(block, ctype, sort_by_names=False, sort_by_keys=False):
-    """DEPRECATED: The components function is deprecated.
-
-    Use the Block.component_objects() method.
-    """
-    logger.warning(components.__doc__)
     return block.component_objects(ctype, active=False, sort=sort_by_names)
 
 
+@deprecated("The active_components_data function is deprecated.  "
+            "Use the Block.component_data_objects() method.",
+            version="4.1.10486")
 def active_components_data(block, ctype,
                            sort=None, sort_by_keys=False, sort_by_names=False):
-    """DEPRECATED: The active_components_data function is deprecated.
-
-    Use the Block.component_data_objects() method.
-    """
-    logger.warning(active_components_data.__doc__)
     return block.component_data_objects(ctype=ctype, active=True, sort=sort)
 
 
+@deprecated("The components_data function is deprecated.  "
+            "Use the Block.component_data_objects() method.",
+            version="4.1.10486")
 def components_data(block, ctype,
                     sort=None, sort_by_keys=False, sort_by_names=False):
-    """DEPRECATED: The components_data function is deprecated.
-
-    Use the Block.component_data_objects() method.
-    """
-    logger.warning(components_data.__doc__)
     return block.component_data_objects(ctype=ctype, active=False, sort=sort)
 
 

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -2022,11 +2022,8 @@ class SimpleBlock(_BlockData, Block):
         # trigger the Block rule
         self._data[None] = self
 
-    def display(self, filename=None, ostream=None, prefix=""):
-        """
-        Display values in the block
-        """
-        Block.display(self, filename, ostream, prefix)
+    # We want scalar Blocks to pick up the Block display method
+    display = Block.display
 
 
 class IndexedBlock(Block):

--- a/pyomo/mpec/complementarity.py
+++ b/pyomo/mpec/complementarity.py
@@ -192,6 +192,7 @@ Error thrown for Complementarity "%s".""" % ( b.name, ) )
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ctype', Complementarity)
+        kwargs.setdefault('dense', False)
         _init = tuple( _arg for _arg in (
             kwargs.pop('initialize', None),
             kwargs.pop('rule', None),


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Block was inconsistent in how it applied certain initialization routines.  This made it particularly onerous when declaring derived Block classes that wanted to perform additional initialization (outside of a rule).  This PR implements a general cleanup of the Block initialization, including:
- switch to using the `Initializer()` function
- deprecation of the (best that I can tell completely unused) `options=` argument
- centralizing all block data initialization in `_getitem_when_not_present`

## Changes proposed in this PR:
- switch Block to leverage `Initializer()`
- standardize initialization in `_getitem_when_not_present`
- resolve edge cases for constructing nested abstract blocks (and add tests)
- deprecate the `Block(options=...)` argument
- add a `Block(dense=...)` argument to control if indexed blocks are created densely when no rule is provided (default = `True`)
- general cleanup of imports
- switch to using the `@deprecated()` decorator

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
