### PR TITLE
Resolve test xpress interface test failures with xpress 8.11

### DIFF
--- a/pyomo/solvers/tests/checks/test_xpress_persistent.py
+++ b/pyomo/solvers/tests/checks/test_xpress_persistent.py
@@ -25,10 +25,10 @@ class TestXpressPersistent(unittest.TestCase):
         self.assertEqual(opt.get_xpress_attribute('rows'), 1)
 
         res = opt.solve()
-        self.assertAlmostEqual(m.x.value, -0.4)
-        self.assertAlmostEqual(m.y.value, 0.2)
+        self.assertAlmostEqual(m.x.value, -0.4, delta=1e-6)
+        self.assertAlmostEqual(m.y.value, 0.2, delta=1e-6)
         opt.load_duals()
-        self.assertAlmostEqual(m.dual[m.c1], -0.4)
+        self.assertAlmostEqual(m.dual[m.c1], -0.4, delta=1e-6)
         del m.dual
 
         m.c2 = pe.Constraint(expr=m.y >= -m.x + 1)
@@ -37,8 +37,8 @@ class TestXpressPersistent(unittest.TestCase):
         self.assertEqual(opt.get_xpress_attribute('rows'), 2)
 
         res = opt.solve(save_results=False, load_solutions=False)
-        self.assertAlmostEqual(m.x.value, -0.4)
-        self.assertAlmostEqual(m.y.value, 0.2)
+        self.assertAlmostEqual(m.x.value, -0.4, delta=1e-6)
+        self.assertAlmostEqual(m.y.value, 0.2, delta=1e-6)
         opt.load_vars()
         self.assertAlmostEqual(m.x.value, 0, delta=1e-6)
         self.assertAlmostEqual(m.y.value, 1, delta=2e-6)
@@ -51,8 +51,8 @@ class TestXpressPersistent(unittest.TestCase):
         self.assertEqual(opt.get_xpress_control('feastol'), 1e-6)
         res = opt.solve(options={'feastol': '1e-7'})
         self.assertEqual(opt.get_xpress_control('feastol'), 1e-7)
-        self.assertAlmostEqual(m.x.value, -0.4)
-        self.assertAlmostEqual(m.y.value, 0.2)
+        self.assertAlmostEqual(m.x.value, -0.4, delta=1e-6)
+        self.assertAlmostEqual(m.y.value, 0.2, delta=1e-6)
 
         m.x.setlb(-5)
         m.x.setub(5)


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This PR relaxes certain test tolerances to avoid test failures with the most recent xpress solver version (8.11)

## Changes proposed in this PR:
- relax xpress test tolerances

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
