### PR TITLE
Move pyomo.misc Bunch/Container/Options import to pyomo.common.collections

### DIFF
--- a/pyomo/bilevel/plugins/solver1.py
+++ b/pyomo/bilevel/plugins/solver1.py
@@ -9,10 +9,10 @@
 #  ___________________________________________________________________________
 
 import time
-import pyutilib.misc
 from pyomo.core import TransformationFactory, Var, ComponentUID, Block, Objective, Set
 import pyomo.opt
 import pyomo.common
+from pyomo.common.collections import Bunch
 
 
 @pyomo.opt.SolverFactory.register('bilevel_ld',
@@ -156,7 +156,7 @@ class BILEVEL_Solver1(pyomo.opt.OptSolver):
             #
             # Return the sub-solver return condition value and log
             #
-            return pyutilib.misc.Bunch(rc=getattr(opt,'_rc', None),
+            return Bunch(rc=getattr(opt,'_rc', None),
                                        log=getattr(opt,'_log',None))
 
     def _postsolve(self):

--- a/pyomo/bilevel/plugins/solver2.py
+++ b/pyomo/bilevel/plugins/solver2.py
@@ -9,10 +9,9 @@
 #  ___________________________________________________________________________
 
 import time
-import pyutilib.misc
 import pyomo.opt
 from pyomo.core import TransformationFactory, Var, Set
-
+from pyomo.common.collections import Bunch
 
 
 @pyomo.opt.SolverFactory.register('bilevel_blp_global',
@@ -78,7 +77,7 @@ class BILEVEL_Solver2(pyomo.opt.OptSolver):
         #
         # Return the sub-solver return condition value and log
         #
-        return pyutilib.misc.Bunch(rc=getattr(opt,'_rc', None),
+        return Bunch(rc=getattr(opt,'_rc', None),
                                    log=getattr(opt,'_log',None))
 
     def _postsolve(self):

--- a/pyomo/bilevel/plugins/solver3.py
+++ b/pyomo/bilevel/plugins/solver3.py
@@ -9,10 +9,9 @@
 #  ___________________________________________________________________________
 
 import time
-import pyutilib.misc
 import pyomo.opt
-#from pyomo.bilevel.components import SubModel
 from pyomo.core import TransformationFactory, Var, Set
+from pyomo.common.collections import Bunch
 
 
 @pyomo.opt.SolverFactory.register('bilevel_blp_local',
@@ -81,7 +80,7 @@ class BILEVEL_Solver3(pyomo.opt.OptSolver):
         #
         # Return the sub-solver return condition value and log
         #
-        return pyutilib.misc.Bunch(rc=getattr(opt,'_rc', None), log=getattr(opt,'_log',None))
+        return Bunch(rc=getattr(opt,'_rc', None), log=getattr(opt,'_log',None))
 
     def _postsolve(self):
         #

--- a/pyomo/bilevel/plugins/solver4.py
+++ b/pyomo/bilevel/plugins/solver4.py
@@ -9,9 +9,9 @@
 #  ___________________________________________________________________________
 
 import time
-import pyutilib.misc
 import pyomo.opt
 from pyomo.core import TransformationFactory, Var, Set
+from pyomo.common.collections import Bunch
 
 
 @pyomo.opt.SolverFactory.register('bilevel_bqp',
@@ -99,7 +99,7 @@ class BILEVEL_Solver4(pyomo.opt.OptSolver):
         #
         # Return the sub-solver return condition value and log
         #
-        return pyutilib.misc.Bunch(rc=getattr(opt,'_rc', None),
+        return Bunch(rc=getattr(opt,'_rc', None),
                                    log=getattr(opt,'_log',None))
 
     def _postsolve(self):

--- a/pyomo/common/collections/__init__.py
+++ b/pyomo/common/collections/__init__.py
@@ -21,3 +21,5 @@ else:
 from .orderedset import OrderedDict, OrderedSet
 from .component_map import ComponentMap
 from .component_set import ComponentSet
+
+from pyutilib.misc import Bunch, Container, Options

--- a/pyomo/contrib/gdpbb/GDPbb.py
+++ b/pyomo/contrib/gdpbb/GDPbb.py
@@ -10,10 +10,8 @@ import heapq
 import logging
 import traceback
 
-from pyutilib.misc import Container
-
 from pyomo.common import deprecated
-from pyomo.common.collections import ComponentSet
+from pyomo.common.collections import ComponentSet, Container
 from pyomo.common.config import (ConfigBlock, ConfigValue, PositiveInt)
 from pyomo.contrib.gdpopt.util import create_utility_block, time_code, a_logger, restore_logger_level, \
     setup_results_object, get_main_elapsed_time, process_objective

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -17,13 +17,14 @@ from six import StringIO
 
 import pyutilib.th as unittest
 from pyomo.common.log import LoggingIntercept
+from pyomo.common.collections import Container
 from pyomo.contrib.gdpopt.GDPopt import GDPoptSolver
 from pyomo.contrib.gdpopt.data_class import GDPoptSolveData
 from pyomo.contrib.gdpopt.mip_solve import solve_linear_GDP
 from pyomo.contrib.gdpopt.util import is_feasible, time_code
 from pyomo.environ import ConcreteModel, Objective, SolverFactory, Var, value, Integers, Block, Constraint, maximize
 from pyomo.gdp import Disjunct, Disjunction
-from pyutilib.misc import import_file, Container
+from pyutilib.misc import import_file
 from pyomo.contrib.mcpp.pyomo_mcpp import mcpp_available
 from pyomo.opt import TerminationCondition
 

--- a/pyomo/contrib/gdpopt/util.py
+++ b/pyomo/contrib/gdpopt/util.py
@@ -7,10 +7,9 @@ from contextlib import contextmanager
 from math import fabs
 
 import six
-from pyutilib.misc import Container
 
 from pyomo.common import deprecated
-from pyomo.common.collections import ComponentSet
+from pyomo.common.collections import ComponentSet, Container
 from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
 from pyomo.contrib.gdpopt.data_class import GDPoptSolveData
 from pyomo.contrib.mcpp.pyomo_mcpp import mcpp_available, McCormick

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -47,7 +47,7 @@ from pyomo.core import (
     Block, ConstraintList, NonNegativeReals, Set, Suffix, Var,
     VarList, TransformationFactory, Objective)
 from pyomo.opt import SolverFactory, SolverResults
-from pyutilib.misc import Container
+from pyomo.common.collections import Container
 from pyomo.contrib.fbbt.fbbt import fbbt
 from pyomo.contrib.mindtpy.config_options import _get_GDPopt_config
 

--- a/pyomo/contrib/preprocessing/tests/test_induced_linearity.py
+++ b/pyomo/contrib/preprocessing/tests/test_induced_linearity.py
@@ -1,16 +1,25 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
 """Tests the induced linearity module."""
 import pyutilib.th as unittest
 from pyomo.contrib.preprocessing.plugins.induced_linearity import (
     _bilinear_expressions,
     detect_effectively_discrete_vars,
     determine_valid_values)
-from pyomo.common.collections import ComponentSet
+from pyomo.common.collections import ComponentSet, Bunch
 from pyomo.environ import (Binary, ConcreteModel, Constraint, ConstraintList,
                            Integers, RangeSet, SolverFactory,
                            TransformationFactory, Var, exp)
 from pyomo.gdp import Disjunct, Disjunction
 from pyomo.repn import generate_standard_repn
-from pyutilib.misc import Bunch
 
 glpk_available = SolverFactory('glpk').available()
 

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -22,9 +22,10 @@ try:
 except ImportError:                         #pragma:nocover
     from ordereddict import OrderedDict
 
-from pyutilib.misc import Container, PauseGC
+from pyutilib.misc import PauseGC
 
 from pyomo.common import timing, PyomoAPIFactory
+from pyomo.common.collections import Container
 from pyomo.common.dependencies import pympler, pympler_available
 from pyomo.common.deprecation import deprecation_warning
 from pyomo.common.plugin import ExtensionPoint

--- a/pyomo/dataportal/TableData.py
+++ b/pyomo/dataportal/TableData.py
@@ -12,7 +12,7 @@ __all__ = ['TableData']
 
 from six.moves import xrange
 
-from pyutilib.misc import Options
+from pyomo.common.collections import Options
 from pyomo.dataportal.process_data import _process_data
 
 

--- a/pyomo/dataportal/plugins/datacommands.py
+++ b/pyomo/dataportal/plugins/datacommands.py
@@ -10,8 +10,7 @@
 
 import os.path
 
-from pyutilib.misc import Options
-
+from pyomo.common.collections import Options
 from pyomo.dataportal.factory import DataManagerFactory
 from pyomo.dataportal.process_data import _process_include
 

--- a/pyomo/dataportal/plugins/json_dict.py
+++ b/pyomo/dataportal/plugins/json_dict.py
@@ -12,8 +12,7 @@ import os.path
 import json
 import six
 
-from pyutilib.misc import Options
-
+from pyomo.common.collections import Options
 from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 from pyomo.dataportal.factory import DataManagerFactory
 

--- a/pyomo/dataportal/process_data.py
+++ b/pyomo/dataportal/process_data.py
@@ -13,7 +13,7 @@ import re
 import copy
 import logging
 
-from pyutilib.misc import  Options
+from pyomo.common.collections import  Options
 from pyomo.common.errors import ApplicationError
 from pyutilib.misc import flatten
 

--- a/pyomo/duality/collect.py
+++ b/pyomo/duality/collect.py
@@ -10,7 +10,7 @@
 
 # Routines to collect data in a structured format
 
-from pyutilib.misc import Bunch
+from pyomo.common.collections import Bunch
 from pyomo.core.base import  Var, Constraint, Objective, maximize, minimize
 from pyomo.repn.standard_repn import generate_standard_repn
 

--- a/pyomo/mpec/plugins/pathampl.py
+++ b/pyomo/mpec/plugins/pathampl.py
@@ -10,10 +10,9 @@
 
 import logging
 
-from pyutilib.misc import Options
-
 from pyomo.opt.base.solvers import SolverFactory
 from pyomo.common import Executable
+from pyomo.common.collections import Options
 from pyomo.solvers.plugins.solvers.ASL import ASL
 
 logger = logging.getLogger('pyomo.solvers')

--- a/pyomo/mpec/plugins/solver1.py
+++ b/pyomo/mpec/plugins/solver1.py
@@ -9,10 +9,10 @@
 #  ___________________________________________________________________________
 
 import time
-import pyutilib.misc
 import pyomo.opt
 from pyomo.opt import SolverFactory
 from pyomo.core import TransformationFactory
+from pyomo.common.collections import Bunch
 
 
 @SolverFactory.register('mpec_nlp', doc='MPEC solver that optimizes a nonlinear transformation')
@@ -84,7 +84,7 @@ class MPEC_Solver1(pyomo.opt.OptSolver):
             #
             # Return the sub-solver return condition value and log
             #
-            return pyutilib.misc.Bunch(rc=getattr(opt,'_rc', None),
+            return Bunch(rc=getattr(opt,'_rc', None),
                                        log=getattr(opt,'_log',None))
 
     def _postsolve(self):

--- a/pyomo/mpec/plugins/solver2.py
+++ b/pyomo/mpec/plugins/solver2.py
@@ -9,10 +9,10 @@
 #  ___________________________________________________________________________
 
 import time
-import pyutilib.misc
 import pyomo.opt
 from pyomo.opt import SolverFactory
 from pyomo.core import TransformationFactory
+from pyomo.common.collections import Bunch
 
 
 @SolverFactory.register('mpec_minlp', doc='MPEC solver transforms to a MINLP')
@@ -83,7 +83,7 @@ class MPEC_Solver2(pyomo.opt.OptSolver):
             #
             # Return the sub-solver return condition value and log
             #
-            return pyutilib.misc.Bunch(rc=getattr(opt,'_rc', None),
+            return Bunch(rc=getattr(opt,'_rc', None),
                                        log=getattr(opt,'_log',None))
 
     def _postsolve(self):

--- a/pyomo/neos/plugins/NEOS.py
+++ b/pyomo/neos/plugins/NEOS.py
@@ -10,11 +10,11 @@
 
 import logging
 
-from pyutilib.misc import Bunch
 from pyutilib.services import TempfileManager
 
 from pyomo.opt.base import SolverFactory, ProblemFormat, ResultsFormat
 from pyomo.opt.solver import SystemCallSolver
+from pyomo.common.collections import Bunch
 
 logger = logging.getLogger('pyomo.neos')
 

--- a/pyomo/network/decomposition.py
+++ b/pyomo/network/decomposition.py
@@ -14,10 +14,9 @@ from pyomo.network import Port, Arc
 from pyomo.network.foqus_graph import FOQUSGraph
 from pyomo.core import Constraint, value, Objective, Var, ConcreteModel, \
     Binary, minimize, Expression
-from pyomo.common.collections import ComponentSet, ComponentMap
+from pyomo.common.collections import ComponentSet, ComponentMap, Options
 from pyomo.core.expr.current import identify_variables
 from pyomo.repn import generate_standard_repn
-from pyutilib.misc import Options
 import logging, time
 from six import iteritems
 

--- a/pyomo/opt/base/solvers.py
+++ b/pyomo/opt/base/solvers.py
@@ -21,7 +21,8 @@ import logging
 from pyomo.common.config import ConfigBlock, ConfigList, ConfigValue
 from pyomo.common import Factory
 from pyomo.common.errors import ApplicationError
-from pyutilib.misc import Options, quote_split
+from pyomo.common.collections import Options
+from pyutilib.misc import quote_split
 
 from pyomo.opt.base.problem import ProblemConfigFactory
 from pyomo.opt.base.convert import convert_problem

--- a/pyomo/opt/results/container.py
+++ b/pyomo/opt/results/container.py
@@ -13,7 +13,7 @@ __all__ = ['UndefinedData', 'undefined', 'ignore', 'ScalarData', 'ListContainer'
 import copy
 
 from pyutilib.math import infinity
-from pyutilib.misc import Bunch
+from pyomo.common.collections import Bunch
 import enum
 from six import StringIO
 from six.moves import xrange

--- a/pyomo/opt/results/solution.py
+++ b/pyomo/opt/results/solution.py
@@ -17,10 +17,9 @@ except:
     from ordereddict import OrderedDict
 from six import iterkeys, iteritems
 from six.moves import xrange
-from pyutilib.misc import Bunch
 import enum
-from pyutilib.math import as_number
 from pyomo.opt.results.container import MapContainer, ListContainer, ignore
+from pyomo.common.collections import Bunch
 
 default_print_options = Bunch(schema=False,
                               sparse=True,

--- a/pyomo/opt/solver/shellcmd.py
+++ b/pyomo/opt/solver/shellcmd.py
@@ -16,7 +16,7 @@ import time
 import logging
 
 from pyomo.common.errors import ApplicationError
-from pyutilib.misc import Bunch
+from pyomo.common.collections import Bunch
 from pyutilib.services import TempfileManager
 from pyutilib.subprocess import run
 

--- a/pyomo/pysp/phsolverserver.py
+++ b/pyomo/pysp/phsolverserver.py
@@ -16,8 +16,8 @@ import copy
 from optparse import OptionParser
 
 from pyomo.common.errors import ApplicationError
-import pyutilib.misc
-from pyutilib.misc import PauseGC
+from pyomo.common.collections import Bunch
+from pyutilib.misc import PauseGC, import_file
 from pyutilib.pyro import (TaskWorker,
                            TaskWorkerServer,
                            shutdown_pyro_components)
@@ -62,7 +62,7 @@ class PHPyroWorker(TaskWorker):
 
     def process(self, data):
 
-        data = pyutilib.misc.Bunch(**data)
+        data = Bunch(**data)
         result = None
         if data.action == "release":
 
@@ -968,8 +968,8 @@ class _PHSolverServer(_PHBase):
         elif module_name in sys.modules:
             this_module = sys.modules[module_name]
         else:
-            this_module = pyutilib.misc.import_file(module_name,
-                                                    clear_cache=True)
+            this_module = import_file(module_name,
+                                      clear_cache=True)
             self._modules_imported[module_name] = this_module
 
         module_attrname = function_name
@@ -1344,7 +1344,7 @@ def exec_phsolverserver(options):
                 # make sure "." is in the PATH.
                 original_path = list(sys.path)
                 sys.path.insert(0,'.')
-                pyutilib.misc.import_file(this_extension)
+                import_file(this_extension)
                 print("Module successfully loaded")
                 sys.path[:] = original_path # restore to what it was
 

--- a/pyomo/pysp/scenariotree/server_pyro.py
+++ b/pyomo/pysp/scenariotree/server_pyro.py
@@ -23,8 +23,7 @@ try:
 except:                                           #pragma:nocover
     import pickle
 
-from pyutilib.misc import Bunch
-
+from pyomo.common.collections import Bunch
 from pyomo.common.dependencies import attempt_import, dill, dill_available
 from pyomo.common import pyomo_command
 from pyomo.pysp.util.misc import (parse_command_line,
@@ -357,7 +356,7 @@ def exec_scenariotreeserver(options):
         #NOTE: this should perhaps be command-line driven, so it can
         #      be disabled if desired.
         print("ScenarioTreeServerPyro aborted. Sending shutdown request.")
-        shutdown_pyro_components(host=options.pyro_host,
+        pyu_pyro.shutdown_pyro_components(host=options.pyro_host,
                                  port=options.pyro_port,
                                  num_retries=0)
         raise

--- a/pyomo/pysp/solvers/spsolvershellcommand.py
+++ b/pyomo/pysp/solvers/spsolvershellcommand.py
@@ -9,11 +9,10 @@
 
 __all__ = ("SPSolverShellCommand",)
 
-import os
 import logging
 import pprint
 
-import pyutilib.misc
+import pyutilib.services
 
 import pyomo.common
 from pyomo.pysp.solvers.spsolver import SPSolver

--- a/pyomo/scripting/commands.py
+++ b/pyomo/scripting/commands.py
@@ -17,7 +17,7 @@ import subprocess
 import pyutilib.subprocess
 
 import pyutilib.pyro
-from pyutilib.misc import Options
+from pyomo.common.collections import Options
 from pyomo.opt import SolverResults
 from pyomo.common._command import pyomo_command
 import pyomo.scripting.pyomo_parser

--- a/pyomo/scripting/convert.py
+++ b/pyomo/scripting/convert.py
@@ -13,8 +13,7 @@ __all__ = ['pyomo2lp', 'pyomo2nl', 'pyomo2dakota']
 import os
 import sys
 
-from pyutilib.misc import Options, Container
-
+from pyomo.common.collections import Options, Container
 from pyomo.opt import ProblemFormat
 from pyomo.core.base import (Objective,
                              Var,

--- a/pyomo/scripting/driver_help.py
+++ b/pyomo/scripting/driver_help.py
@@ -18,9 +18,9 @@ import logging
 import socket
 
 import pyutilib.subprocess
-from pyutilib.misc import Options
 
 import pyomo.common
+from pyomo.common.collections import Options
 import pyomo.scripting.pyomo_parser
 
 logger = logging.getLogger('pyomo.solvers')
@@ -230,7 +230,8 @@ def help_environment():
         packages = []
         import pip
         for package in pip.get_installed_distributions():
-            packages.append( Options(name=package.project_name, version=package.version) )
+            packages.append(Options(name=package.project_name,
+                                    version=package.version))
         info.python.packages = packages
     except:
         pass

--- a/pyomo/scripting/plugins/convert.py
+++ b/pyomo/scripting/plugins/convert.py
@@ -12,7 +12,7 @@ import json
 import sys
 import argparse
 
-from pyutilib.misc import Options
+from pyomo.common.collections import Options
 from pyomo.opt import ProblemConfigFactory, guess_format
 from pyomo.scripting.pyomo_parser import add_subparser, CustomHelpFormatter
 

--- a/pyomo/scripting/pyomo_command.py
+++ b/pyomo/scripting/pyomo_command.py
@@ -8,10 +8,8 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-
-from pyutilib.misc import Options, Container
-
 from pyomo.common.dependencies import pympler_available
+from pyomo.common.collections import Options, Container
 import pyomo.scripting.util
 from pyomo.core import ConcreteModel
 

--- a/pyomo/scripting/pyro_mip_server.py
+++ b/pyomo/scripting/pyro_mip_server.py
@@ -33,6 +33,7 @@ from pyutilib.pyro import using_pyro4, TaskProcessingError
 from pyomo.common.errors import ApplicationError
 from pyomo.common import pyomo_command
 from pyomo.opt.base import SolverFactory, ConverterError
+from pyomo.common.collections import Bunch
 
 import six
 
@@ -43,7 +44,7 @@ class PyomoMIPWorker(pyutilib.pyro.TaskWorker):
 
     def process(self, data):
         self._worker_task_return_queue = self._current_task_client
-        data = pyutilib.misc.Bunch(**data)
+        data = Bunch(**data)
 
         if hasattr(data, 'action') and \
            data.action == 'Pyomo_pyro_mip_server_shutdown':

--- a/pyomo/scripting/tests/test_pms.py
+++ b/pyomo/scripting/tests/test_pms.py
@@ -19,9 +19,10 @@ from os.path import abspath, dirname
 from pyutilib.pyro import using_pyro4
 import pyutilib.th as unittest
 import pyutilib.services
-from pyutilib.misc import Options
+from pyomo.common.collections import Options
 import pyomo.opt
-from pyomo.environ import ConcreteModel, RangeSet, Var, Objective, Constraint, sum_product
+from pyomo.environ import (ConcreteModel, RangeSet, Var,
+                           Objective, Constraint, sum_product)
 import pyomo.scripting.pyro_mip_server
 
 

--- a/pyomo/solvers/plugins/smanager/pyro.py
+++ b/pyomo/solvers/plugins/smanager/pyro.py
@@ -20,7 +20,6 @@ except:
 
 import pyutilib.pyro
 from pyutilib.pyro import using_pyro4, TaskProcessingError
-import pyutilib.misc
 from pyomo.opt.base import OptSolver, SolverFactory
 from pyomo.opt.parallel.manager import ActionManagerError, ActionStatus
 from pyomo.opt.parallel.async_solver import (AsynchronousSolverManager,
@@ -31,6 +30,7 @@ import pyomo.core.base.suffix
 
 from pyomo.core.kernel.block import IBlock
 import pyomo.core.kernel.suffix
+from pyomo.common.collections import Bunch
 
 import six
 
@@ -157,7 +157,7 @@ class SolverManager_Pyro(PyroAsynchronousActionManager, AsynchronousSolverManage
                 with open(warm_start_file_name, 'r') as f:
                     warm_start_file_string = f.read()
 
-        data = pyutilib.misc.Bunch(opt=opt.type, \
+        data = Bunch(opt=opt.type, \
                                    file=problem_file_string, \
                                    filename=opt._problem_files[0], \
                                    warmstart_file=warm_start_file_string, \

--- a/pyomo/solvers/plugins/solvers/ASL.py
+++ b/pyomo/solvers/plugins/solvers/ASL.py
@@ -14,7 +14,7 @@ import six
 
 from pyomo.common import Executable
 from pyomo.common.errors import ApplicationError
-from pyutilib.misc import Options, Bunch
+from pyomo.common.collections import Options, Bunch
 from pyutilib.services import TempfileManager
 from pyutilib.subprocess import run
 

--- a/pyomo/solvers/plugins/solvers/BARON.py
+++ b/pyomo/solvers/plugins/solvers/BARON.py
@@ -15,7 +15,7 @@ import re
 import tempfile
 
 from pyomo.common import Executable
-from pyutilib.misc import Options, Bunch
+from pyomo.common.collections import Options, Bunch
 from pyutilib.services import TempfileManager
 from pyutilib.subprocess import run
 

--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -19,7 +19,7 @@ from six import iteritems, string_types
 
 from pyomo.common import Executable
 from pyomo.common.errors import ApplicationError
-from pyutilib.misc import Options, Bunch
+from pyomo.common.collections import Options, Bunch
 from pyutilib.services import TempfileManager
 from pyutilib.subprocess import run
 

--- a/pyomo/solvers/plugins/solvers/CONOPT.py
+++ b/pyomo/solvers/plugins/solvers/CONOPT.py
@@ -11,7 +11,7 @@
 import os
 
 from pyomo.common import Executable
-from pyutilib.misc import Options, Bunch
+from pyomo.common.collections import Options, Bunch
 from pyutilib.services import TempfileManager
 from pyutilib.subprocess import run
 

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -16,11 +16,11 @@ import logging
 
 from pyomo.common import Executable
 from pyomo.common.errors import ApplicationError
-from pyutilib.misc import Options, Bunch, yaml_fix
+from pyutilib.misc import yaml_fix
 from pyutilib.services import TempfileManager
 from pyutilib.subprocess import run
 
-from pyomo.common.collections import ComponentMap
+from pyomo.common.collections import ComponentMap, Options, Bunch
 from pyomo.opt.base import (
     ProblemFormat, ResultsFormat, OptSolver, BranchDirection,
 )

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -16,10 +16,11 @@ from pyomo.core.base import Constraint, Var, value, Objective
 from pyomo.opt import ProblemFormat, SolverFactory
 
 import pyomo.common
+from pyomo.common.collections import Options
 
 from pyomo.opt.base.solvers import _extract_version
 import pyutilib.subprocess
-from pyutilib.misc import Options, quote_split
+from pyutilib.misc import quote_split
 
 from pyomo.core.kernel.block import IBlock
 from pyomo.core.kernel.objective import IObjective

--- a/pyomo/solvers/plugins/solvers/GLPK.py
+++ b/pyomo/solvers/plugins/solvers/GLPK.py
@@ -14,10 +14,10 @@ import sys
 import csv
 
 import pyutilib.subprocess
-from pyutilib.misc import Bunch, Options
 from pyutilib.services import TempfileManager
 
 from pyomo.common import Executable
+from pyomo.common.collections import Bunch, Options
 from pyomo.opt import SolverFactory, OptSolver, ProblemFormat, ResultsFormat, SolverResults, TerminationCondition, SolutionStatus, ProblemSense
 from pyomo.opt.base.solvers import _extract_version
 from pyomo.opt.solver import SystemCallSolver

--- a/pyomo/solvers/plugins/solvers/GLPK_old.py
+++ b/pyomo/solvers/plugins/solvers/GLPK_old.py
@@ -14,7 +14,7 @@ import re
 import sys
 
 from pyomo.common.errors import ApplicationError
-from pyutilib.misc import Bunch, Options
+from pyomo.common.collections import Bunch, Options
 from pyutilib.services import TempfileManager
 import pyutilib.subprocess
 

--- a/pyomo/solvers/plugins/solvers/GUROBI.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI.py
@@ -16,7 +16,7 @@ import logging
 import subprocess
 
 from pyomo.common import Executable
-from pyutilib.misc import Options, Bunch
+from pyomo.common.collections import Options, Bunch
 from pyutilib.services import TempfileManager
 from pyutilib.subprocess import run
 

--- a/pyomo/solvers/plugins/solvers/IPOPT.py
+++ b/pyomo/solvers/plugins/solvers/IPOPT.py
@@ -11,7 +11,7 @@
 import os
 
 from pyomo.common import Executable
-from pyutilib.misc import Options, Bunch
+from pyomo.common.collections import Options, Bunch
 from pyutilib.services import TempfileManager
 from pyutilib.subprocess import run
 

--- a/pyomo/solvers/plugins/solvers/PICO.py
+++ b/pyomo/solvers/plugins/solvers/PICO.py
@@ -15,7 +15,7 @@ from six import iteritems
 
 from pyomo.common import Executable
 from pyomo.common.errors import  ApplicationError
-from pyutilib.misc import Options, Bunch
+from pyomo.common.collections import Options, Bunch
 from pyutilib.services import TempfileManager
 from pyutilib.subprocess import run
 

--- a/pyomo/solvers/plugins/solvers/SCIPAMPL.py
+++ b/pyomo/solvers/plugins/solvers/SCIPAMPL.py
@@ -11,7 +11,7 @@
 import os
 
 from pyomo.common import Executable
-from pyutilib.misc import Options, Bunch
+from pyomo.common.collections import Options, Bunch
 from pyutilib.services import TempfileManager
 from pyutilib.subprocess import run
 

--- a/pyomo/solvers/plugins/solvers/XPRESS.py
+++ b/pyomo/solvers/plugins/solvers/XPRESS.py
@@ -15,7 +15,8 @@ import logging
 
 from pyomo.common import Executable
 from pyomo.common.errors import ApplicationError
-from pyutilib.misc import Options, Bunch, yaml_fix
+from pyomo.common.collections import Options, Bunch
+from pyutilib.misc import yaml_fix
 from pyutilib.services import TempfileManager
 
 from pyomo.opt.base import ProblemFormat, ResultsFormat, OptSolver

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -13,9 +13,8 @@ import re
 import six
 import sys
 
-from pyutilib.misc import Bunch
 from pyutilib.services import TempfileManager
-from pyomo.common.collections import ComponentSet, ComponentMap
+from pyomo.common.collections import ComponentSet, ComponentMap, Bunch
 from pyomo.core.base import Suffix, Var, Constraint, SOSConstraint, Objective
 from pyomo.core.expr.numvalue import is_fixed
 from pyomo.core.expr.numvalue import value

--- a/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
@@ -16,10 +16,10 @@ from pyomo.core.base import SymbolMap, NumericLabeler, TextLabeler
 import pyutilib.services
 import pyomo.common
 from pyomo.common.errors import ApplicationError
-from pyomo.common.collections import ComponentMap, ComponentSet
+from pyomo.common.collections import ComponentMap, ComponentSet, Options
 import pyomo.opt.base.solvers
 from pyomo.opt.base.formats import ResultsFormat
-from pyutilib.misc import Options
+
 
 class DirectOrPersistentSolver(OptSolver):
     """

--- a/pyomo/solvers/plugins/solvers/direct_solver.py
+++ b/pyomo/solvers/plugins/solvers/direct_solver.py
@@ -17,7 +17,7 @@ from pyomo.core.kernel.block import IBlock
 from pyomo.core.base.suffix import active_import_suffix_generator
 from pyomo.core.kernel.suffix import import_suffix_generator
 from pyomo.common.errors import ApplicationError
-from pyutilib.misc import Options
+from pyomo.common.collections import Options
 
 logger = logging.getLogger('pyomo.solvers')
 

--- a/pyomo/solvers/plugins/solvers/glpk_direct.py
+++ b/pyomo/solvers/plugins/solvers/glpk_direct.py
@@ -38,7 +38,7 @@ def configure_glpk_direct():
         print("Import of glpk failed - glpk message="+str(e)+"\n")
         glpk_python_api_exists = False
 
-from pyutilib.misc import Bunch, Options
+from pyomo.common.collections import Bunch, Options
 
 from pyomo.opt.base import OptSolver
 from pyomo.opt.base.solvers import _extract_version, SolverFactory

--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -11,9 +11,9 @@
 import logging
 import re
 import sys
-from pyutilib.misc import Bunch
+
 from pyutilib.services import TempfileManager
-from pyomo.common.collections import ComponentSet, ComponentMap
+from pyomo.common.collections import ComponentSet, ComponentMap, Bunch
 from pyomo.core.expr.numvalue import is_fixed
 from pyomo.core.expr.numvalue import value
 from pyomo.repn import generate_standard_repn

--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -11,7 +11,6 @@
 import logging
 import re
 import sys
-from pyutilib.misc import Bunch
 from pyutilib.services import TempfileManager
 from pyomo.core.expr.numvalue import is_fixed
 from pyomo.core.expr.numvalue import value
@@ -28,7 +27,7 @@ from pyomo.core.kernel.conic import (_ConicBase,
                                      dual_exponential,
                                      dual_power)
 from pyomo.core.kernel.objective import minimize, maximize
-from pyomo.common.collections import ComponentSet, ComponentMap
+from pyomo.common.collections import ComponentSet, ComponentMap, Bunch
 from pyomo.opt.results.results_ import SolverResults
 from pyomo.opt.results.solution import Solution, SolutionStatus
 from pyomo.opt.results.solver import TerminationCondition, SolverStatus

--- a/pyomo/solvers/plugins/solvers/persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/persistent_solver.py
@@ -19,7 +19,7 @@ from pyomo.core.base.var import Var
 from pyomo.core.base.sos import SOSConstraint
 
 from pyomo.common.errors import ApplicationError
-from pyutilib.misc import Options
+from pyomo.common.collections import Options
 
 import time
 import logging

--- a/pyomo/solvers/plugins/solvers/ps.py
+++ b/pyomo/solvers/plugins/solvers/ps.py
@@ -10,7 +10,7 @@
 
 from six.moves import xrange
 
-from pyutilib.misc import Bunch
+from pyomo.common.collections import Bunch
 
 from pyomo.opt import SolverResults, ProblemSense, SolverStatus, SolutionStatus, TerminationCondition, SolverFactory
 from pyomo.opt.blackbox import solver

--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -12,9 +12,9 @@ import logging
 import re
 import sys
 import time
-from pyutilib.misc import Bunch
+
 from pyutilib.services import TempfileManager
-from pyomo.common.collections import ComponentSet, ComponentMap
+from pyomo.common.collections import ComponentSet, ComponentMap, Bunch
 from pyomo.core.expr.numvalue import is_fixed
 from pyomo.core.expr.numvalue import value
 from pyomo.repn import generate_standard_repn

--- a/pyomo/solvers/plugins/testdriver/mip.py
+++ b/pyomo/solvers/plugins/testdriver/mip.py
@@ -13,7 +13,7 @@ import os.path
 
 import pyutilib.autotest
 import pyomo.common
-from pyutilib.misc import Options
+from pyomo.common.collections import Options
 
 from pyomo.common.plugin import Plugin, implements, alias
 from pyomo.common.errors import ApplicationError

--- a/pyomo/solvers/tests/core/solvers.py
+++ b/pyomo/solvers/tests/core/solvers.py
@@ -18,7 +18,7 @@ from os.path import abspath, dirname
 import logging
 from functools import reduce
 
-from pyutilib.misc import Bunch, Options
+from pyomo.common.collections import Bunch, Options
 import pyutilib.th as unittest
 import pyutilib.autotest
 import pyomo.misc.plugin

--- a/pyomo/solvers/tests/solvers.py
+++ b/pyomo/solvers/tests/solvers.py
@@ -13,7 +13,7 @@ __all__ = ['test_solver_cases', 'available_solvers']
 import six
 import logging
 
-from pyutilib.misc import Options
+from pyomo.common.collections import Options
 from pyomo.opt import SolverFactory
 from pyomo.opt.base.solvers import UnknownSolver
 

--- a/pyomo/solvers/tests/testcases.py
+++ b/pyomo/solvers/tests/testcases.py
@@ -12,8 +12,8 @@ import sys
 import logging
 
 import pyutilib.th as unittest
-from pyutilib.misc import Options
 
+from pyomo.common.collections import Options
 from pyomo.opt import TerminationCondition
 from pyomo.solvers.tests.models.base import test_models
 from pyomo.solvers.tests.solvers import test_solver_cases

--- a/pyomo/util/model_size.py
+++ b/pyomo/util/model_size.py
@@ -1,11 +1,20 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
 """This module contains functions to interrogate the size of a Pyomo model."""
 import logging
 
-from pyomo.common.collections import ComponentSet
+from pyomo.common.collections import ComponentSet, Container
 from pyomo.core import Block, Constraint, Var
 from pyomo.core.expr import current as EXPR
 from pyomo.gdp import Disjunct, Disjunction
-from pyutilib.misc import Container
 
 
 default_logger = logging.getLogger('pyomo.util.model_size')


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
In order to facilitate an easier separation from PyUtilib, we are moving the pyutilib.misc Bunch/Container/Options master import statement to pyomo.common.collections. This way, when we have decided how to move over these three methods, it will be a simple swap.

## Changes proposed in this PR:
- Only one `import Bunch, Container, Options` statement from `pyutilib` in `pyomo.common.collections`
- Replace all imports with `pyomo.common.collections`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
