### PR TITLE
Replace ubuntu-latest with ubuntu-18.04 in GitHub Action Workflows

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -37,12 +37,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest, windows-latest]
         python: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
         other: [""]
 
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-18.04
           TARGET: linux
           PYENV: pip
 
@@ -55,7 +55,7 @@ jobs:
           PYENV: conda
           PACKAGES: glpk
 
-        - os: ubuntu-latest
+        - os: ubuntu-18.04
           python: 3.7
           other: /mpi
           mpi: 3
@@ -64,7 +64,7 @@ jobs:
           PYENV: conda
           PACKAGES: mpi4py openmpi
 
-        - os: ubuntu-latest
+        - os: ubuntu-18.04
           python: 3.9
           other: /slim
           slim: 1
@@ -72,7 +72,7 @@ jobs:
           TARGET: linux
           PYENV: pip
 
-        - os: ubuntu-latest
+        - os: ubuntu-18.04
           python: 3.6
           other: /cython
           setup_options: --with-cython
@@ -491,10 +491,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest, windows-latest]
 
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-18.04
           TARGET: linux
         - os: macos-latest
           TARGET: osx

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -40,6 +40,9 @@ jobs:
         os: [ubuntu-18.04, macos-latest, windows-latest]
         python: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
         other: [""]
+        # Ubuntu-18.04 should be replaced with ubuntu-latest once PyNumero
+        # build error is resolved:
+        # https://github.com/Pyomo/pyomo/issues/1710
 
         include:
         - os: ubuntu-18.04

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -34,12 +34,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
         python: [3.8]
         other: [""]
 
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-18.04
           TARGET: linux
           PYENV: pip
 
@@ -54,7 +54,7 @@ jobs:
           PYENV: conda
           PACKAGES: glpk
 
-        - os: ubuntu-latest
+        - os: ubuntu-18.04
           python: 3.7
           other: /mpi
           mpi: 3
@@ -63,7 +63,7 @@ jobs:
           PYENV: conda
           PACKAGES: mpi4py openmpi
 
-        - os: ubuntu-latest
+        - os: ubuntu-18.04
           python: 3.9
           other: /slim
           slim: 1
@@ -71,7 +71,7 @@ jobs:
           TARGET: linux
           PYENV: pip
 
-        - os: ubuntu-latest
+        - os: ubuntu-18.04
           python: 3.6
           other: /cython
           setup_options: --with-cython
@@ -490,10 +490,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest, windows-latest]
 
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-18.04
           TARGET: linux
         - os: macos-latest
           TARGET: osx

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -37,6 +37,9 @@ jobs:
         os: [ubuntu-18.04]
         python: [3.8]
         other: [""]
+        # Ubuntu-18.04 should be replaced with ubuntu-latest once PyNumero
+        # build error is resolved:
+        # https://github.com/Pyomo/pyomo/issues/1710
 
         include:
         - os: ubuntu-18.04


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
`ubuntu-latest` is moving soon to `ubuntu-20.04` instead of `ubuntu-18.04`. This will cause failures in AMPL/MP, so to protect from that, this PR preemptively changes to explicitly designating the runner for Linux runs as `ubuntu-18.04`.

## Changes proposed in this PR:
- Change `ubuntu-latest` to `ubuntu-18.04`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
