### PR TITLE
Make pyomo.common.timing tests more flexible

### DIFF
--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -35,12 +35,12 @@ class TestTiming(unittest.TestCase):
         m.x = Var([1,2])
 
         ref = """
-           0 seconds to construct Block ConcreteModel; 1 index total
-           0 seconds to construct RangeSet FiniteSimpleRangeSet; 1 index total
-           0 seconds to construct Var x; 2 indices total
-           0 seconds to construct Suffix Suffix; 1 index total
-           0 seconds to apply Transformation RelaxIntegerVars (in-place)
-""".strip()
+           (0(\.\d+)?) seconds to construct Block ConcreteModel; 1 index total
+           (0(\.\d+)?) seconds to construct RangeSet FiniteSimpleRangeSet; 1 index total
+           (0(\.\d+)?) seconds to construct Var x; 2 indices total
+           (0(\.\d+)?) seconds to construct Suffix Suffix; 1 index total
+           (0(\.\d+)?) seconds to apply Transformation RelaxIntegerVars \(in-place\)
+           """.strip()
 
         xfrm = TransformationFactory('core.relax_integer_vars')
 
@@ -51,7 +51,11 @@ class TestTiming(unittest.TestCase):
                 m.r = RangeSet(2)
                 m.x = Var(m.r)
                 xfrm.apply_to(m)
-            self.assertEqual(out.getvalue().strip(), ref)
+            result = out.getvalue().strip()
+            self.maxDiff = None
+            for l in result.splitlines():
+                self.assertRegex(str(l.strip()), "(0(\.\d+)?) seconds .*?")
+            # self.assertRegex(out.getvalue().strip(), ref)
         finally:
             report_timing(False)
 

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -36,10 +36,10 @@ class TestTiming(unittest.TestCase):
 
         ref = r"""
            (0(\.\d+)?) seconds to construct Block ConcreteModel; 1 index total
- +(0(\.\d+)?) seconds to construct RangeSet FiniteSimpleRangeSet; 1 index total
- +(0(\.\d+)?) seconds to construct Var x; 2 indices total
- +(0(\.\d+)?) seconds to construct Suffix Suffix; 1 index total
- +(0(\.\d+)?) seconds to apply Transformation RelaxIntegerVars \(in-place\)
+           (0(\.\d+)?) seconds to construct RangeSet FiniteSimpleRangeSet; 1 index total
+           (0(\.\d+)?) seconds to construct Var x; 2 indices total
+           (0(\.\d+)?) seconds to construct Suffix Suffix; 1 index total
+           (0(\.\d+)?) seconds to apply Transformation RelaxIntegerVars \(in-place\)
            """.strip()
 
         xfrm = TransformationFactory('core.relax_integer_vars')
@@ -51,7 +51,10 @@ class TestTiming(unittest.TestCase):
                 m.r = RangeSet(2)
                 m.x = Var(m.r)
                 xfrm.apply_to(m)
-            self.assertRegex(out.getvalue().strip(), ref)
+            result = out.getvalue().strip()
+            self.maxDiff = None
+            for l, r in zip(result.splitlines(), ref.splitlines()):
+                self.assertRegex(str(l.strip()), str(r.strip()))
         finally:
             report_timing(False)
 
@@ -62,7 +65,10 @@ class TestTiming(unittest.TestCase):
             m.r = RangeSet(2)
             m.x = Var(m.r)
             xfrm.apply_to(m)
-            self.assertRegex(os.getvalue().strip(), ref)
+            result = os.getvalue().strip()
+            self.maxDiff = None
+            for l, r in zip(result.splitlines(), ref.splitlines()):
+                self.assertRegex(str(l.strip()), str(r.strip()))
         finally:
             report_timing(False)
         buf = StringIO()
@@ -71,7 +77,10 @@ class TestTiming(unittest.TestCase):
             m.r = RangeSet(2)
             m.x = Var(m.r)
             xfrm.apply_to(m)
-            self.assertRegex(os.getvalue().strip(), ref)
+            result = os.getvalue().strip()
+            self.maxDiff = None
+            for l, r in zip(result.splitlines(), ref.splitlines()):
+                self.assertRegex(str(l.strip()), str(r.strip()))
             self.assertEqual(buf.getvalue().strip(), "")
 
     def test_TicTocTimer_tictoc(self):

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -36,10 +36,10 @@ class TestTiming(unittest.TestCase):
 
         ref = r"""
            (0(\.\d+)?) seconds to construct Block ConcreteModel; 1 index total
-           +(0(\.\d+)?) seconds to construct RangeSet FiniteSimpleRangeSet; 1 index total
-           +(0(\.\d+)?) seconds to construct Var x; 2 indices total
-           +(0(\.\d+)?) seconds to construct Suffix Suffix; 1 index total
-           +(0(\.\d+)?) seconds to apply Transformation RelaxIntegerVars \(in-place\)
+ +(0(\.\d+)?) seconds to construct RangeSet FiniteSimpleRangeSet; 1 index total
+ +(0(\.\d+)?) seconds to construct Var x; 2 indices total
+ +(0(\.\d+)?) seconds to construct Suffix Suffix; 1 index total
+ +(0(\.\d+)?) seconds to apply Transformation RelaxIntegerVars \(in-place\)
            """.strip()
 
         xfrm = TransformationFactory('core.relax_integer_vars')

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -37,7 +37,7 @@ class TestTiming(unittest.TestCase):
         ref = """
            0 seconds to construct Block ConcreteModel; 1 index total
            0 seconds to construct RangeSet FiniteSimpleRangeSet; 1 index total
-           0 seconds to construct Var x; 2 indicies total
+           0 seconds to construct Var x; 2 indices total
            0 seconds to construct Suffix Suffix; 1 index total
            0 seconds to apply Transformation RelaxIntegerVars (in-place)
 """.strip()

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -131,7 +131,7 @@ class TestTiming(unittest.TestCase):
 
         # Note: pypy on GHA frequently has timing differences of >0.02s
         # for the following tests
-        RES = 4e-2
+        RES = 5e-2
 
         with capture_output() as out:
             delta = timer.toc()

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -51,12 +51,7 @@ class TestTiming(unittest.TestCase):
                 m.r = RangeSet(2)
                 m.x = Var(m.r)
                 xfrm.apply_to(m)
-            result = out.getvalue().strip()
-            self.maxDiff = None
-            for l, r in zip(result.splitlines(), ref.splitlines()):
-                print(l, r)
-                self.assertRegex(l.strip(), r.strip())
-            # self.assertRegex(out.getvalue().strip(), ref)
+            self.assertRegex(out.getvalue().strip(), ref)
         finally:
             report_timing(False)
 
@@ -67,7 +62,7 @@ class TestTiming(unittest.TestCase):
             m.r = RangeSet(2)
             m.x = Var(m.r)
             xfrm.apply_to(m)
-            self.assertEqual(os.getvalue().strip(), ref)
+            self.assertRegex(os.getvalue().strip(), ref)
         finally:
             report_timing(False)
         buf = StringIO()
@@ -76,7 +71,7 @@ class TestTiming(unittest.TestCase):
             m.r = RangeSet(2)
             m.x = Var(m.r)
             xfrm.apply_to(m)
-            self.assertEqual(os.getvalue().strip(), ref)
+            self.assertRegex(os.getvalue().strip(), ref)
             self.assertEqual(buf.getvalue().strip(), "")
 
     def test_TicTocTimer_tictoc(self):

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -39,7 +39,7 @@ class TestTiming(unittest.TestCase):
            (0(\.\d+)?) seconds to construct RangeSet FiniteSimpleRangeSet; 1 index total
            (0(\.\d+)?) seconds to construct Var x; 2 indices total
            (0(\.\d+)?) seconds to construct Suffix Suffix; 1 index total
-           (0(\.\d+)?) seconds to apply Transformation RelaxIntegerVars \(in-place\)
+           (0(\.\d+)?) seconds to apply Transformation RelaxIntegerVars (in-place)
            """.strip()
 
         xfrm = TransformationFactory('core.relax_integer_vars')
@@ -53,7 +53,7 @@ class TestTiming(unittest.TestCase):
                 xfrm.apply_to(m)
             result = out.getvalue().strip()
             self.maxDiff = None
-            for l in result.splitlines():
+            for l, r in zip(result.splitlines(), ref.splitlines()):
                 self.assertRegex(str(l.strip()), str(r.strip()))
             # self.assertRegex(out.getvalue().strip(), ref)
         finally:

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -34,12 +34,12 @@ class TestTiming(unittest.TestCase):
         m = ConcreteModel()
         m.x = Var([1,2])
 
-        ref = """
+        ref = r"""
            (0(\.\d+)?) seconds to construct Block ConcreteModel; 1 index total
            (0(\.\d+)?) seconds to construct RangeSet FiniteSimpleRangeSet; 1 index total
            (0(\.\d+)?) seconds to construct Var x; 2 indices total
            (0(\.\d+)?) seconds to construct Suffix Suffix; 1 index total
-           .*(0(\.\d+)?) seconds to apply Transformation RelaxIntegerVars (in-place)
+           (0(\.\d+)?) seconds to apply Transformation RelaxIntegerVars \(in-place\)
            """.strip()
 
         xfrm = TransformationFactory('core.relax_integer_vars')
@@ -52,6 +52,7 @@ class TestTiming(unittest.TestCase):
                 m.x = Var(m.r)
                 xfrm.apply_to(m)
             result = out.getvalue().strip()
+            self.maxDiff = None
             for l, r in zip(result.splitlines(), ref.splitlines()):
                 print(l, r)
                 self.assertRegex(l.strip(), r.strip())

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -39,7 +39,7 @@ class TestTiming(unittest.TestCase):
            (0(\.\d+)?) seconds to construct RangeSet FiniteSimpleRangeSet; 1 index total
            (0(\.\d+)?) seconds to construct Var x; 2 indices total
            (0(\.\d+)?) seconds to construct Suffix Suffix; 1 index total
-           (0(\.\d+)?) seconds to apply Transformation RelaxIntegerVars (in-place)
+           .*(0(\.\d+)?) seconds to apply Transformation RelaxIntegerVars (in-place)
            """.strip()
 
         xfrm = TransformationFactory('core.relax_integer_vars')
@@ -52,9 +52,9 @@ class TestTiming(unittest.TestCase):
                 m.x = Var(m.r)
                 xfrm.apply_to(m)
             result = out.getvalue().strip()
-            self.maxDiff = None
             for l, r in zip(result.splitlines(), ref.splitlines()):
-                self.assertRegex(str(l.strip()), str(r.strip()))
+                print(l, r)
+                self.assertRegex(l.strip(), r.strip())
             # self.assertRegex(out.getvalue().strip(), ref)
         finally:
             report_timing(False)

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -54,7 +54,7 @@ class TestTiming(unittest.TestCase):
             result = out.getvalue().strip()
             self.maxDiff = None
             for l in result.splitlines():
-                self.assertRegex(str(l.strip()), "(0(\.\d+)?) seconds .*?")
+                self.assertRegex(str(l.strip()), str(r.strip()))
             # self.assertRegex(out.getvalue().strip(), ref)
         finally:
             report_timing(False)

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -36,10 +36,10 @@ class TestTiming(unittest.TestCase):
 
         ref = r"""
            (0(\.\d+)?) seconds to construct Block ConcreteModel; 1 index total
-           (0(\.\d+)?) seconds to construct RangeSet FiniteSimpleRangeSet; 1 index total
-           (0(\.\d+)?) seconds to construct Var x; 2 indices total
-           (0(\.\d+)?) seconds to construct Suffix Suffix; 1 index total
-           (0(\.\d+)?) seconds to apply Transformation RelaxIntegerVars \(in-place\)
+           +(0(\.\d+)?) seconds to construct RangeSet FiniteSimpleRangeSet; 1 index total
+           +(0(\.\d+)?) seconds to construct Var x; 2 indices total
+           +(0(\.\d+)?) seconds to construct Suffix Suffix; 1 index total
+           +(0(\.\d+)?) seconds to apply Transformation RelaxIntegerVars \(in-place\)
            """.strip()
 
         xfrm = TransformationFactory('core.relax_integer_vars')

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -80,7 +80,7 @@ class ConstructionTimer(object):
                                 _type,
                                 name,
                                 idx,
-                                'indicies' if idx > 1 else 'index',
+                                'indices' if idx > 1 else 'index',
                             ) % total_time
         except TypeError:
             return "ConstructionTimer object for %s %s; %s elapsed seconds" % (

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -832,7 +832,7 @@ from solvers are immediately loaded into the original model instance.""")
                     else:
                         assert isinstance(component, Component)
                         clen = 1
-                    print("    %%6.%df seconds required to construct component=%s; %d indicies total" \
+                    print("    %%6.%df seconds required to construct component=%s; %d indices total" \
                               % (total_time>=0.005 and 2 or 0, component_name, clen) \
                               % total_time)
                     tmp_clone_counter = expr_common.clone_counter

--- a/pyomo/pysp/ph.py
+++ b/pyomo/pysp/ph.py
@@ -1156,7 +1156,7 @@ class _PHBase(object):
     #
     # a utility intended for folks who are brave enough to script
     # variable bounds setting in a python file.  same functionality as
-    # above, but applied to all indicies of the variable, in all
+    # above, but applied to all indices of the variable, in all
     # scenarios.
     #
     """
@@ -2137,7 +2137,7 @@ class ProgressiveHedging(_PHBase):
                 self._mapped_module_name[sys_modules_key] = module_name
 
 
-        # a set of all valid PH iteration indicies is generally useful for plug-ins, so create it here.
+        # a set of all valid PH iteration indices is generally useful for plug-ins, so create it here.
         self._iteration_index_set = Set(name="PHIterations")
         self._iteration_index_set.construct()
         for i in range(0,self._max_iterations + 1):


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
The new tests for `pyomo.common.timing` aren't fully reliable because of rigidity. This PR makes them more flexible.

## Changes proposed in this PR:
- Introduce regex
- Change `RES` value

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
