### PR TITLE
TicTocTimer: make logger and ostream public attributes

### DIFF
--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -160,8 +160,8 @@ class TicTocTimer(object):
     """
     def __init__(self, ostream=_NotSpecified, logger=None):
         self._lastTime = self._loadTime = _time_source()
-        self._ostream = ostream
-        self._logger = logger
+        self.ostream = ostream
+        self.logger = logger
         self._start_count = 0
         self._cumul = 0
 
@@ -237,12 +237,12 @@ class TicTocTimer(object):
 
         if msg is not None:
             if logger is _NotSpecified:
-                logger = self._logger
+                logger = self.logger
             if logger is not None:
                 logger.info(msg)
 
             if ostream is _NotSpecified:
-                ostream = self._ostream
+                ostream = self.ostream
                 if ostream is _NotSpecified and logger is None:
                     ostream = sys.stdout
             if ostream is not None:


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
The discussion around Pyomo/mpi-sppy#19 pointed out that it would be good for the TicTocTimer's `ostream` and `logger` attributes to be public, so that users could (officially) change them after creating the timer object.

This is a "nonfunctional change": it only makes the `ostream` and `logger` "public" attributes.

## Changes proposed in this PR:
- Make `ostream` and `logger` public attributes of the `TicTocTimer`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
