### PR TITLE
Move pyutilib LogHandler to pyomo.common.log

### DIFF
--- a/pyomo/common/log.py
+++ b/pyomo/common/log.py
@@ -8,14 +8,159 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 #
+#  This module was originally developed as part of the PyUtilib project
+#  Copyright (c) 2008 Sandia Corporation.
+#  This software is distributed under the BSD License.
+#  Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+#  the U.S. Government retains certain rights in this software.
+#  ___________________________________________________________________________
+#
 # Utility classes for working with the logger
 #
 
 import logging
-
-from pyutilib.misc import LogHandler
+import re
+import sys
+import textwrap
 
 from pyomo.common.fileutils import PYOMO_ROOT_DIR
+
+_indention = re.compile('\s*')
+_status_re = re.compile('^\[\s*[A-Za-z0-9\.]+\s*\]')
+
+
+class LogHandler(logging.Handler):
+
+    def __init__( self, base='', stream=None,
+                  level=logging.NOTSET, verbosity=None ):
+        logging.Handler.__init__(self, level=level)
+
+        if verbosity is None:
+            verbosity = lambda: True
+        if stream is None:
+            stream = sys.stdout
+
+        self.verbosity = verbosity
+        self.stream = stream
+        self.basepath = base
+        # Public attributes (because embedded constants in functions are evil)
+        self.wrap = 78
+        self.initial_indent = ''
+        self.subsequent_indent = ' '*4
+
+    def emit(self, record):
+        level = record.levelname
+        msg = record.getMessage()
+        # Most of the messages are either unformatted long lines or
+        # triple-quote blocks of text.  In the latter case, if the text
+        # starts on the same line as the triple-quote, then it is almost
+        # certainly NOT indented with the bulk of the text, which will
+        # cause dedent to get confused and not strip any leading
+        # whitespace.  This attempts to work around that case:
+        #
+        #if not ( msg.startswith('\n') or _indention.match(msg).group() ):
+        #    # copy the indention for the second line to the first:
+        #    lines = msg.splitlines()
+        #    if len(lines) > 1:
+        #        msg = _indention.match(lines[1]).group() + msg
+        #
+        # The problem with the above logic is that users may want a
+        # simple introductory line followed by an intented line (our
+        # tests did this!), and cannot specify it without adding an
+        # extra blank line to the output.  In contrast, it is possible
+        # for the user to fix the scenario above that motivated this
+        # code by just indenting their first line correctly.
+
+        # TBD: dedent does not convert \t to ' '*8. Should we do that?
+        msg = textwrap.dedent(msg)
+
+        # As textwrap only works on single paragraphs, we need to break
+        # up the incoming message into paragraphs before we pass it to
+        # textwrap.
+        paragraphs = []
+        indent = _indention.match(msg).group()
+        par_lines = []
+        for line in msg.splitlines():
+            leading = _indention.match(line).group()
+            content = line.strip()
+            if not content:
+                paragraphs.append((indent, par_lines))
+                par_lines = []
+                # Blank lines reset the indentation level
+                indent = None
+            elif indent == leading:
+                # Catch things like bulleted lists and '[FAIL]'
+                if len(content) > 1 and par_lines and (
+                        (content[1] == ' ' and content[0] in '-* ') or
+                        (content[0] == '[' and _status_re.match(content))):
+                    paragraphs.append((indent, par_lines))
+                    par_lines = []
+                par_lines.append( content )
+            else:
+                paragraphs.append((indent, par_lines))
+                par_lines = [ content ]
+                indent = leading
+        # Collect the final paragraph
+        if par_lines:
+            paragraphs.append((indent, par_lines))
+
+        # Skip any leading/trailing blank lines
+        while paragraphs and not paragraphs[-1][1]:
+            paragraphs.pop()
+        while paragraphs and not paragraphs[0][1]:
+            paragraphs.pop(0)
+
+        if self.verbosity():
+            #
+            # If verbosity is on, the first logged line is the file,
+            # line, and function name that called the logger.  The first
+            # line of the message is actually the second line of the
+            # output (and so is indented/wrapped the same as the rest of
+            # the message)
+            #
+            filename = record.pathname  # file path
+            lineno = record.lineno
+            try:
+                function = record.funcName
+            except AttributeError:
+                function = '(unknown)'
+            if self.basepath and filename.startswith(self.basepath):
+                filename = '[base]' + filename[len(self.basepath):]
+
+            self.stream.write(
+                '%s: "%s", %d, %s\n' %
+                ( level, filename, lineno, function.strip(), ))
+        else:
+            #
+            # If verbosity is off, prepend the log level name to the
+            # beginning of the message and format the line without the
+            # 'subsequent' indentation of the remainder of the message
+            #
+            if paragraphs:
+                firstPar = ' '.join(paragraphs.pop(0)[1]).strip()
+                if level:
+                    firstPar = ('%s: %s' % (level, firstPar))
+            else:
+                firstPar = level
+            self.stream.write( '%s\n' % (
+                textwrap.fill( firstPar,
+                               width=self.wrap,
+                               initial_indent=self.initial_indent,
+                               subsequent_indent=self.subsequent_indent ), ))
+        for indent, par in paragraphs:
+            if not indent:
+                indent = ''
+            # Bulleted lists get indented with a hanging indent
+            if par and len(par[0]) > 1 and par[0][0] in '-*':
+                hang = ' '*4
+            else:
+                hang = ''
+            self.stream.write( '%s\n' % (
+                textwrap.fill(
+                    ' '.join(par),
+                    width=self.wrap,
+                    initial_indent=self.subsequent_indent+indent,
+                    subsequent_indent=self.subsequent_indent+indent+hang ), ))
 
 #
 # Set up the root Pyomo namespace logger

--- a/pyomo/common/tests/test_log.py
+++ b/pyomo/common/tests/test_log.py
@@ -1,0 +1,208 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+#  This module was originally developed as part of the PyUtilib project
+#  Copyright (c) 2008 Sandia Corporation.
+#  This software is distributed under the BSD License.
+#  Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+#  the U.S. Government retains certain rights in this software.
+#  ___________________________________________________________________________
+
+
+import logging
+import os
+from inspect import currentframe, getframeinfo
+from six import StringIO
+
+import pyutilib.th as unittest
+
+from pyomo.common.log import LogHandler
+
+logger = logging.getLogger('pyomo.common.log.testing')
+filename = getframeinfo(currentframe()).filename
+
+class TestLogging(unittest.TestCase):
+    def setUp(self):
+        self.stream = StringIO()
+
+    def tearDown(self):
+        logger.removeHandler(self.handler)
+
+    def test_simple_log(self):
+        # Testing positional base, configurable verbosity
+        self.handler = LogHandler(
+            os.path.dirname(__file__),
+            stream = self.stream,
+            verbosity=lambda: logger.isEnabledFor(logging.DEBUG))
+        logger.addHandler(self.handler)
+
+        logger.setLevel(logging.WARNING)
+        logger.info("(info)")
+        self.assertEqual(self.stream.getvalue(), "")
+        logger.warn("(warn)")
+        ans = "WARNING: (warn)\n"
+        self.assertEqual(self.stream.getvalue(), ans)
+
+        logger.setLevel(logging.DEBUG)
+        logger.warn("(warn)")
+        lineno = getframeinfo(currentframe()).lineno - 1
+        ans += 'WARNING: "[base]%stest_log.py", %d, test_simple_log\n' \
+               '    (warn)\n' % (os.path.sep, lineno,)
+        self.assertEqual(self.stream.getvalue(), ans)
+
+    def test_alternate_base(self):
+        self.handler = LogHandler(
+            base = 'log_config',
+            stream = self.stream)
+        logger.addHandler(self.handler)
+
+        logger.setLevel(logging.WARNING)
+        logger.info("(info)")
+        self.assertEqual(self.stream.getvalue(), "")
+        logger.warn("(warn)")
+        lineno = getframeinfo(currentframe()).lineno - 1
+        ans = 'WARNING: "%s", %d, test_alternate_base\n' \
+               '    (warn)\n' % (filename, lineno,)
+        self.assertEqual(self.stream.getvalue(), ans)
+
+    def test_no_base(self):
+        self.handler = LogHandler(
+            stream = self.stream)
+        logger.addHandler(self.handler)
+
+        logger.setLevel(logging.WARNING)
+        logger.info("(info)")
+        self.assertEqual(self.stream.getvalue(), "")
+        logger.warn("(warn)")
+        lineno = getframeinfo(currentframe()).lineno - 1
+        ans = 'WARNING: "%s", %d, test_no_base\n' \
+               '    (warn)\n' % (filename, lineno,)
+        self.assertEqual(self.stream.getvalue(), ans)
+
+    def test_no_message(self):
+        self.handler = LogHandler(
+            os.path.dirname(__file__),
+            stream = self.stream,
+            verbosity=lambda: logger.isEnabledFor(logging.DEBUG))
+        logger.addHandler(self.handler)
+
+        logger.setLevel(logging.WARNING)
+        logger.info("")
+        self.assertEqual(self.stream.getvalue(), "")
+
+        logger.warn("")
+        ans = "WARNING\n"
+        self.assertEqual(self.stream.getvalue(), ans)
+
+        logger.setLevel(logging.DEBUG)
+        logger.warn("")
+        lineno = getframeinfo(currentframe()).lineno - 1
+        ans += 'WARNING: "[base]%stest_log.py", %d, test_no_message\n' \
+               % (os.path.sep, lineno,)
+        self.assertEqual(self.stream.getvalue(), ans)
+
+    def test_numbered_level(self):
+        testname ='test_numbered_level'
+        self.handler = LogHandler(
+            os.path.dirname(__file__),
+            stream = self.stream,
+            verbosity=lambda: logger.isEnabledFor(logging.DEBUG))
+        logger.addHandler(self.handler)
+
+        logger.setLevel(logging.WARNING)
+        logger.log(45, "(hi)")
+        ans = "Level 45: (hi)\n"
+        self.assertEqual(self.stream.getvalue(), ans)
+
+        logger.log(45, "")
+        ans += "Level 45\n"
+        self.assertEqual(self.stream.getvalue(), ans)
+
+        logger.setLevel(logging.DEBUG)
+        logger.log(45, "(hi)")
+        lineno = getframeinfo(currentframe()).lineno - 1
+        ans += 'Level 45: "[base]%stest_log.py", %d, %s\n' \
+               '    (hi)\n' % (os.path.sep, lineno, testname)
+        self.assertEqual(self.stream.getvalue(), ans)
+
+        logger.log(45, "")
+        lineno = getframeinfo(currentframe()).lineno - 1
+        ans += 'Level 45: "[base]%stest_log.py", %d, %s\n' \
+               % (os.path.sep, lineno, testname)
+        self.assertEqual(self.stream.getvalue(), ans)
+
+    def test_long_messages(self):
+        self.handler = LogHandler(
+            os.path.dirname(__file__),
+            stream = self.stream,
+            verbosity=lambda: logger.isEnabledFor(logging.DEBUG))
+        logger.addHandler(self.handler)
+
+        msg = ("This is a long message\n\n"
+               "With some kind of internal formatting\n"
+               "    - including a bulleted list\n"
+               "    - list 2  ")
+        logger.setLevel(logging.WARNING)
+        logger.warn(msg)
+        ans = ( "WARNING: This is a long message\n\n"
+                "    With some kind of internal formatting\n"
+                "        - including a bulleted list\n"
+                "        - list 2\n" )
+        self.assertEqual(self.stream.getvalue(), ans)
+
+        logger.setLevel(logging.DEBUG)
+        logger.info(msg)
+        lineno = getframeinfo(currentframe()).lineno - 1
+        ans += ( 'INFO: "[base]%stest_log.py", %d, test_long_messages\n'
+                 "    This is a long message\n\n"
+                 "    With some kind of internal formatting\n"
+                 "        - including a bulleted list\n"
+                 "        - list 2\n" % (os.path.sep, lineno,))
+        self.assertEqual(self.stream.getvalue(), ans)
+
+        # test trailing newline
+        msg += "\n"
+        logger.setLevel(logging.WARNING)
+        logger.warn(msg)
+        ans += ( "WARNING: This is a long message\n\n"
+                "    With some kind of internal formatting\n"
+                "        - including a bulleted list\n"
+                "        - list 2\n" )
+        self.assertEqual(self.stream.getvalue(), ans)
+
+        logger.setLevel(logging.DEBUG)
+        logger.info(msg)
+        lineno = getframeinfo(currentframe()).lineno - 1
+        ans += ( 'INFO: "[base]%stest_log.py", %d, test_long_messages\n'
+                 "    This is a long message\n\n"
+                 "    With some kind of internal formatting\n"
+                 "        - including a bulleted list\n"
+                 "        - list 2\n" % (os.path.sep, lineno,))
+        self.assertEqual(self.stream.getvalue(), ans)
+
+        # test initial and final blank lines
+        msg = "\n" + msg + "\n\n"
+        logger.setLevel(logging.WARNING)
+        logger.warn(msg)
+        ans += ( "WARNING: This is a long message\n\n"
+                "    With some kind of internal formatting\n"
+                "        - including a bulleted list\n"
+                "        - list 2\n" )
+        self.assertEqual(self.stream.getvalue(), ans)
+
+        logger.setLevel(logging.DEBUG)
+        logger.info(msg)
+        lineno = getframeinfo(currentframe()).lineno - 1
+        ans += ( 'INFO: "[base]%stest_log.py", %d, test_long_messages\n'
+                 "    This is a long message\n\n"
+                 "    With some kind of internal formatting\n"
+                 "        - including a bulleted list\n"
+                 "        - list 2\n" % (os.path.sep, lineno,))
+        self.assertEqual(self.stream.getvalue(), ans)


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
In order to facilitate separating Pyomo and PyUtilib, this PR moves the LogHandler from `pyutilib.misc.log_config` to `pyomo.common.log`. 

## Changes proposed in this PR:
- Move `LogHandler` to `pyomo.common.log`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
