### PR TITLE
Import updates

### DIFF
--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -26,8 +26,6 @@ import base64
 import tempfile
 import logging
 
-from six.moves.http_client import BadStatusLine
-
 from pyomo.common.dependencies import attempt_import
 
 def _xmlrpclib_importer():
@@ -150,7 +148,8 @@ class kestrelAMPL:
         try:
             result = self.neos.ping()
             logger.info("OK.")
-        except (socket.error, xmlrpclib.ProtocolError, BadStatusLine):
+        except (socket.error, xmlrpclib.ProtocolError,
+                six.moves.http_clientBadStatusLine):
             e = sys.exc_info()[1]
             self.neos = None
             logger.info("Fail.")

--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -149,7 +149,7 @@ class kestrelAMPL:
             result = self.neos.ping()
             logger.info("OK.")
         except (socket.error, xmlrpclib.ProtocolError,
-                six.moves.http_clientBadStatusLine):
+                six.moves.http_client.BadStatusLine):
             e = sys.exc_info()[1]
             self.neos = None
             logger.info("Fail.")


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This updates an optional import to only import the http_client library when it is actually needed, resulting in a minor speedup to `import pyomo.environ`

## Changes proposed in this PR:
- do not explicitly import `six.moves.http_client` module

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
