### PR TITLE
Rename assertRelativeEqual -> assertStructuredAlmostEqual

### DIFF
--- a/pyomo/common/tests/test_unittest.py
+++ b/pyomo/common/tests/test_unittest.py
@@ -13,105 +13,115 @@ import datetime
 import pyomo.common.unittest as unittest
 
 class TestPyomoUnittest(unittest.TestCase):
-    def test_assertRelativeEqual_comparison(self):
+    def test_assertStructuredAlmostEqual_comparison(self):
         a = 1
         b = 1
-        self.assertRelativeEqual(a, b)
-        # default relative tolerance is 1e-7.  This should have a delta
+        self.assertStructuredAlmostEqual(a, b)
+        # default relative tolerance is 1e-7.  This should have a reltol
         # of "exactly" 1e-7, but due to roundoff error, it is not.  The
         # choice of 9.999e-8 and 9.999-e7 is specifically so that
         # roundoff error doesn't cause tests to fail
         b -= 9.999e-8
-        self.assertRelativeEqual(a, b)
+        self.assertStructuredAlmostEqual(a, b)
         b -= 9.999e-8
         with self.assertRaisesRegex(self.failureException, '1 !~= 0.9999'):
-            self.assertRelativeEqual(a, b)
+            self.assertStructuredAlmostEqual(a, b)
 
         b = 1
-        self.assertRelativeEqual(a, b, delta=1e-6)
+        self.assertStructuredAlmostEqual(a, b, reltol=1e-6)
         b -= 9.999e-7
-        self.assertRelativeEqual(a, b, delta=1e-6)
+        self.assertStructuredAlmostEqual(a, b, reltol=1e-6)
         b -= 9.999e-7
         with self.assertRaisesRegex(self.failureException, '1 !~= 0.999'):
-            self.assertRelativeEqual(a, b, delta=1e-6)
+            self.assertStructuredAlmostEqual(a, b, reltol=1e-6)
 
         b = 1
-        self.assertRelativeEqual(a, b, places=6)
+        self.assertStructuredAlmostEqual(a, b, places=6)
         b -= 9.999e-7
-        self.assertRelativeEqual(a, b, places=6)
+        self.assertStructuredAlmostEqual(a, b, places=6)
         b -= 9.999e-7
         with self.assertRaisesRegex(self.failureException, '1 !~= 0.999'):
-            self.assertRelativeEqual(a, b, places=6)
-        
-    def test_assertRelativeEqual_errorChecking(self):
-        with self.assertRaisesRegex(ValueError, 
-                                    "Cannot specify both places and delta"):
-            self.assertRelativeEqual(1,1,places=7,delta=1)
-        
-    def test_assertRelativeEqual_str(self):
-        self.assertRelativeEqual("hi", "hi")
-        with self.assertRaisesRegex(self.failureException, "'hi' !~= 'hello'"):
-            self.assertRelativeEqual("hi", "hello")
-        with self.assertRaisesRegex(self.failureException, "'hi' !~= \['h',"):
-            self.assertRelativeEqual("hi", ['h','i'])
+            self.assertStructuredAlmostEqual(a, b, places=6)
 
-    def test_assertRelativeEqual_othertype(self):
+        self.assertStructuredAlmostEqual(10, 10.01, reltol=1e-3)
+        with self.assertRaisesRegex(self.failureException, '10 !~= 10.01'):
+            self.assertStructuredAlmostEqual(10, 10.01, abstol=1e-3)
+
+    def test_assertStructuredAlmostEqual_errorChecking(self):
+        with self.assertRaisesRegex(
+                ValueError, "Cannot specify more than one of "
+                "{places, delta, abstol}"):
+            self.assertStructuredAlmostEqual(1, 1, places=7, delta=1)
+
+    def test_assertStructuredAlmostEqual_str(self):
+        self.assertStructuredAlmostEqual("hi", "hi")
+        with self.assertRaisesRegex(
+                self.failureException, "'hi' !~= 'hello'"):
+            self.assertStructuredAlmostEqual("hi", "hello")
+        with self.assertRaisesRegex(
+                self.failureException, "'hi' !~= \['h',"):
+            self.assertStructuredAlmostEqual("hi", ['h','i'])
+
+    def test_assertStructuredAlmostEqual_othertype(self):
         a = datetime.datetime(1,1,1)
         b = datetime.datetime(1,1,1)
-        self.assertRelativeEqual(a, b)
+        self.assertStructuredAlmostEqual(a, b)
         b = datetime.datetime(1,1,2)
-        with self.assertRaisesRegex(self.failureException,
-                                    "datetime.* !~= datetime"):
-            self.assertRelativeEqual(a, b)
-        
-    def test_assertRelativeEqual_list(self):
+        with self.assertRaisesRegex(
+                self.failureException, "datetime.* !~= datetime"):
+            self.assertStructuredAlmostEqual(a, b)
+
+    def test_assertStructuredAlmostEqual_list(self):
         a = [1,2]
         b = [1,2,3]
-        with self.assertRaisesRegex(self.failureException,
-                                    'sequences are different sizes \(2 != 3\)'):
-            self.assertRelativeEqual(a, b)
-        self.assertRelativeEqual(a, b, allow_second_superset=True)
+        with self.assertRaisesRegex(
+                self.failureException,
+                'sequences are different sizes \(2 != 3\)'):
+            self.assertStructuredAlmostEqual(a, b)
+        self.assertStructuredAlmostEqual(a, b, allow_second_superset=True)
         a.append(3)
-        
 
-        self.assertRelativeEqual(a, b)
+
+        self.assertStructuredAlmostEqual(a, b)
         b[1] -= 1.999e-7
-        self.assertRelativeEqual(a, b)
+        self.assertStructuredAlmostEqual(a, b)
         b[1] -= 1.999e-7
         with self.assertRaisesRegex(self.failureException, '2 !~= 1.999'):
-            self.assertRelativeEqual(a, b)
+            self.assertStructuredAlmostEqual(a, b)
 
-    def test_assertRelativeEqual_dict(self):
+    def test_assertStructuredAlmostEqual_dict(self):
         a = {1:2, 3:4}
         b = {1:2, 3:4, 5:6}
-        with self.assertRaisesRegex(self.failureException,
-                                    'mappings are different sizes \(2 != 3\)'):
-            self.assertRelativeEqual(a, b)
-        self.assertRelativeEqual(a, b, allow_second_superset=True)
+        with self.assertRaisesRegex(
+                self.failureException,
+                'mappings are different sizes \(2 != 3\)'):
+            self.assertStructuredAlmostEqual(a, b)
+        self.assertStructuredAlmostEqual(a, b, allow_second_superset=True)
         a[5] = 6
-        
 
-        self.assertRelativeEqual(a, b)
+
+        self.assertStructuredAlmostEqual(a, b)
         b[1] -= 1.999e-7
-        self.assertRelativeEqual(a, b)
+        self.assertStructuredAlmostEqual(a, b)
         b[1] -= 1.999e-7
         with self.assertRaisesRegex(self.failureException, '2 !~= 1.999'):
-            self.assertRelativeEqual(a, b)
+            self.assertStructuredAlmostEqual(a, b)
 
         del b[1]
         b[6] = 6
-        with self.assertRaisesRegex(self.failureException,
-                                    'key \(1\) from first not found in second'):
-            self.assertRelativeEqual(a, b)
+        with self.assertRaisesRegex(
+                self.failureException,
+                'key \(1\) from first not found in second'):
+            self.assertStructuredAlmostEqual(a, b)
 
-    def test_assertRelativeEqual_nested(self):
+    def test_assertStructuredAlmostEqual_nested(self):
         a = {1.1: [1,2,3], 'a': 'hi', 3: {1:2, 3:4}}
         b = {1.1: [1,2,3], 'a': 'hi', 3: {1:2, 3:4}}
-        self.assertRelativeEqual(a, b)
+        self.assertStructuredAlmostEqual(a, b)
         b[1.1][2] -= 1.999e-7
         b[3][1] -= 9.999e-8
-        self.assertRelativeEqual(a, b)
+        self.assertStructuredAlmostEqual(a, b)
         b[1.1][2] -= 1.999e-7
         with self.assertRaisesRegex(self.failureException,
                                     '3 !~= 2.999'):
-            self.assertRelativeEqual(a, b)
+            self.assertStructuredAlmostEqual(a, b)

--- a/pyomo/common/tests/test_unittest.py
+++ b/pyomo/common/tests/test_unittest.py
@@ -43,9 +43,11 @@ class TestPyomoUnittest(unittest.TestCase):
         with self.assertRaisesRegex(self.failureException, '1 !~= 0.999'):
             self.assertStructuredAlmostEqual(a, b, places=6)
 
-        self.assertStructuredAlmostEqual(10, 10.01, reltol=1e-3)
         with self.assertRaisesRegex(self.failureException, '10 !~= 10.01'):
             self.assertStructuredAlmostEqual(10, 10.01, abstol=1e-3)
+        self.assertStructuredAlmostEqual(10, 10.01, reltol=1e-3)
+        with self.assertRaisesRegex(self.failureException, '10 !~= 10.01'):
+            self.assertStructuredAlmostEqual(10, 10.01, delta=1e-3)
 
     def test_assertStructuredAlmostEqual_errorChecking(self):
         with self.assertRaisesRegex(

--- a/pyomo/core/tests/diet/test_diet.py
+++ b/pyomo/core/tests/diet/test_diet.py
@@ -99,7 +99,7 @@ class Test(unittest.TestCase):
         del dat_results['Solver'][0]['Time']
         del db_results['Solver'][0]['Time']
         # Compare baselines
-        self.assertRelativeEqual(dat_results, db_results)
+        self.assertStructuredAlmostEqual(dat_results, db_results)
         os.remove(dat_results_file)
         os.remove(db_results_file)
 
@@ -125,7 +125,7 @@ class Test(unittest.TestCase):
         del dat_results['Solver'][0]['Time']
         del sqlite_results['Solver'][0]['Time']
         # Compare baselines
-        self.assertRelativeEqual(dat_results, sqlite_results)
+        self.assertStructuredAlmostEqual(dat_results, sqlite_results)
         os.remove(dat_results_file)
         os.remove(sqlite_results_file)
 


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
During recent discussions, the team proposed renaming the recently-added `assertRelativeEqual` to the more descriptive `assertStructuredAlmostEqual`.  This PR also adds support for both absolute and relative tolerances (through the `abstol` and `reltol` parameters), and moves the `places` and `delta` arguments to specify absolute tolerances (for consistency with `assertAlmostEqual`.

## Changes proposed in this PR:
- rename `assertRelativeEqual` to `assertStructuredAlmostEqual`
- add support for both `abstol` and `reltol` comparisons
- make `places` and `delta` aliases for absolute tolerances 
- clean up exception handling to suppress the `During handling of the above exception, another exception occurred` message

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
