### PR TITLE
Allow flattener to find constraints that skip first index

### DIFF
--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -47,7 +47,18 @@ def generate_time_only_slices(obj, time):
     # We now form a temporary slice that slices over all the regular
     # indices for a fixed value of the time index.
     tmp_sliced = {i: slice(None) for i in regular_idx}
-    tmp_fixed = {time_idx: time.first()}
+
+    # Need to choose some arbitrary time index to fix, but indices
+    # may have been skipped, so choosing e.g. time.first() is not
+    # reliable. Approach here is to take the first index we encounter
+    # when iterating over obj.
+    for idx in obj:
+        if idx.__class__ is not tuple:
+            idx = (idx,)
+        t = idx[time_idx]
+        break
+    tmp_fixed = {time_idx: t}
+
     tmp_ellipsis = ellipsis_idx
     _slice = IndexedComponent_slice(
         obj, tmp_fixed, tmp_sliced, tmp_ellipsis

--- a/pyomo/dae/tests/test_flatten.py
+++ b/pyomo/dae/tests/test_flatten.py
@@ -187,6 +187,27 @@ class TestCategorize(unittest.TestCase):
             self.assertIn(self._hashRef(ref), ref_data)
 
 
+    def test_constraint_skip(self):
+        m = ConcreteModel()
+        m.time = ContinuousSet(bounds=(0,1))
+
+        m.v = Var(m.time)
+        def c_rule(m, t):
+            if t == m.time.first():
+                return Constraint.Skip
+            return m.v[t] == 1.
+
+        m.c = Constraint(m.time, rule=c_rule)
+        scalar, dae = flatten_dae_components(m, m.time, Constraint)
+
+        ref_data = {
+                self._hashRef(Reference(m.c[:])),
+                }
+        self.assertEqual(len(dae), len(ref_data))
+        for ref in dae:
+            self.assertIn(self._hashRef(ref), ref_data)
+
+
     # TODO: Add tests for Sets with dimen==None
 
 


### PR DESCRIPTION
## Summary/Motivation:
Flattener relies on iterating over a slice that is fixed at `time.first()`, but many constraints indexed by continuous sets skip this index, so the slice iteration find no matches and these constraints are omitted from the returned lists.

## Changes proposed in this PR:
- "Iterate" over the component, breaking after the first index, to get a valid time index
- Test with a constraint that skips at `time.first()`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
