### PR TITLE
Update GHA conda, PySP parallel tests

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -70,6 +70,14 @@ jobs:
           PACKAGES: mpi4py openmpi
 
         - os: ubuntu-18.04
+          python: 3.8
+          other: /conda
+          skip_doctest: 1
+          TARGET: linux
+          PYENV: conda
+          PACKAGES: mpi4py openmpi
+
+        - os: ubuntu-18.04
           python: 3.9
           other: /slim
           slim: 1

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -34,12 +34,14 @@ jobs:
   build:
     name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.other }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, macos-latest, windows-latest]
         python: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
         other: [""]
+        category: ["nightly"]
         # Ubuntu-18.04 should be replaced with ubuntu-latest once PyNumero
         # build error is resolved:
         # https://github.com/Pyomo/pyomo/issues/1710
@@ -71,6 +73,14 @@ jobs:
           python: 3.9
           other: /slim
           slim: 1
+          skip_doctest: 1
+          TARGET: linux
+          PYENV: pip
+
+        - os: ubuntu-18.04
+          python: 3.6
+          other: /parallel
+          category: parallel
           skip_doctest: 1
           TARGET: linux
           PYENV: pip
@@ -452,7 +462,8 @@ jobs:
     - name: Run Pyomo tests
       if: matrix.mpi == 0
       run: |
-        test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries
+        test.pyomo -v --cat="${{matrix.category}}" \
+            pyomo `pwd`/pyomo-model-libraries
 
     - name: Run Pyomo MPI tests
       if: matrix.mpi != 0
@@ -493,6 +504,7 @@ jobs:
     needs: build
     if: always() # run even if a build job fails
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -244,6 +244,8 @@ jobs:
             || echo "WARNING: Gurobi is not available"
         pip install --cache-dir cache/pip xpress \
             || echo "WARNING: Xpress Community Edition is not available"
+        pip install --cache-dir cache/pip z3-solver \
+            || echo "WARNING: Z3 Solver is not available"
         python -c 'import sys; print("PYTHON_EXE=%s" \
             % (sys.executable,))' >> $GITHUB_ENV
         echo "NOSETESTS="`which nosetests` >> $GITHUB_ENV
@@ -262,10 +264,12 @@ jobs:
         conda install -q -y -c conda-forge ${PYTHON_PACKAGES}
         # Note: CPLEX 12.9 (the last version in conda that supports
         #    Python 2.7) causes a seg fault in the tests.
-        conda install -q -y -c ibmdecisionoptimization cplex=12.10 \
+        conda install -q -y -c ibmdecisionoptimization 'cplex>=12.10' \
             || echo "WARNING: CPLEX Community Edition is not available"
         conda install -q -y -c fico-xpress xpress \
             || echo "WARNING: Xpress Community Edition is not available"
+        conda install -q -y -c coda-forge pymumps \
+            || echo "WARNING: PyMUMPS is not available"
         python -c 'import sys; print("PYTHON_EXE=%s" \
             % (sys.executable,))' >> $GITHUB_ENV
         echo "NOSETESTS="`which nosetests` >> $GITHUB_ENV

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -243,6 +243,8 @@ jobs:
             || echo "WARNING: Gurobi is not available"
         pip install --cache-dir cache/pip xpress \
             || echo "WARNING: Xpress Community Edition is not available"
+        pip install --cache-dir cache/pip z3-solver \
+            || echo "WARNING: Z3 Solver is not available"
         python -c 'import sys; print("PYTHON_EXE=%s" \
             % (sys.executable,))' >> $GITHUB_ENV
         echo "NOSETESTS="`which nosetests` >> $GITHUB_ENV
@@ -261,10 +263,12 @@ jobs:
         conda install -q -y -c conda-forge ${PYTHON_PACKAGES}
         # Note: CPLEX 12.9 (the last version in conda that supports
         #    Python 2.7) causes a seg fault in the tests.
-        conda install -q -y -c ibmdecisionoptimization cplex=12.10 \
+        conda install -q -y -c ibmdecisionoptimization 'cplex>=12.10' \
             || echo "WARNING: CPLEX Community Edition is not available"
         conda install -q -y -c fico-xpress xpress \
             || echo "WARNING: Xpress Community Edition is not available"
+        conda install -q -y -c coda-forge pymumps \
+            || echo "WARNING: PyMUMPS is not available"
         python -c 'import sys; print("PYTHON_EXE=%s" \
             % (sys.executable,))' >> $GITHUB_ENV
         echo "NOSETESTS="`which nosetests` >> $GITHUB_ENV

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -31,12 +31,14 @@ jobs:
   build:
     name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.other }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04]
         python: [3.8]
         other: [""]
+        category: ["nightly"]
         # Ubuntu-18.04 should be replaced with ubuntu-latest once PyNumero
         # build error is resolved:
         # https://github.com/Pyomo/pyomo/issues/1710
@@ -70,6 +72,14 @@ jobs:
           python: 3.9
           other: /slim
           slim: 1
+          skip_doctest: 1
+          TARGET: linux
+          PYENV: pip
+
+        - os: ubuntu-18.04
+          python: 3.6
+          other: /parallel
+          category: parallel
           skip_doctest: 1
           TARGET: linux
           PYENV: pip
@@ -451,7 +461,8 @@ jobs:
     - name: Run Pyomo tests
       if: matrix.mpi == 0
       run: |
-        test.pyomo -v --cat="nightly" pyomo `pwd`/pyomo-model-libraries
+        test.pyomo -v --cat="${{matrix.category}}" \
+            pyomo `pwd`/pyomo-model-libraries
 
     - name: Run Pyomo MPI tests
       if: matrix.mpi != 0
@@ -492,6 +503,7 @@ jobs:
     needs: build
     if: always() # run even if a build job fails
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -69,6 +69,14 @@ jobs:
           PACKAGES: mpi4py openmpi
 
         - os: ubuntu-18.04
+          python: 3.8
+          other: /conda
+          skip_doctest: 1
+          TARGET: linux
+          PYENV: conda
+          PACKAGES: mpi4py openmpi
+
+        - os: ubuntu-18.04
           python: 3.9
           other: /slim
           slim: 1

--- a/pyomo/pysp/phsolverserver.py
+++ b/pyomo/pysp/phsolverserver.py
@@ -781,7 +781,7 @@ class _PHSolverServer(_PHBase):
             auxilliary_values["solve_time"], auxilliary_values["pyomo_solve_time"] = \
                 extract_solve_times(results, default=None)
 
-            auxilliary_values['solution_status'] = solution0.status.key
+            auxilliary_values['solution_status'] = solution0.status.name
 
             solve_method_result = (variable_values, suffix_values, auxilliary_values)
 

--- a/pyomo/pysp/phsolverserver.py
+++ b/pyomo/pysp/phsolverserver.py
@@ -66,7 +66,7 @@ class PHPyroWorker(TaskWorker):
         result = None
         if data.action == "release":
 
-            del self._phsolverserver_map[name]
+            del self._phsolverserver_map[data.object_name]
             result = True
 
         elif data.action == "initialize":


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This adds two new GHA builds:
- test the "`parallel`" category.
- test a conda build on Linux

This also adds the `z3-solver` package to PIP environments and `PyMUMPS` to conda environments.  It also sets a shorter (1-hour) job timeout.  The net effect of these changes should be to (hopefully) completely replace all Travis builds.

As part of this, this PR resolves some test failures due to bugs in `phsolverserver.py`

## Changes proposed in this PR:
- Add `linux/conda` build (testing nightly tests on linux in a conda environment)
- Add `linux/parallel` (testing the parallel test category on linux in a pip environment)
- Add a 60-minute job timeout
- Fix some bugs in `phsolverserver.py`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
