### PR TITLE
Improve performance of pyomo.dae 

### DIFF
--- a/pyomo/dae/contset.py
+++ b/pyomo/dae/contset.py
@@ -244,7 +244,7 @@ class ContinuousSet(SortedSimpleSet):
             raise ValueError("ContinuousSet '%s' must have at least two values"
                              " indicating the range over which a differential "
                              "equation is to be discretized" % self.name)
-        self._fe = sorted(self)
+        self._fe = list(self)
         timer.report()
 
     def find_nearest_index(self, target, tolerance=None):

--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -69,7 +69,7 @@ def generate_finite_elements(ds, nfe):
 
 
 def _add_point(ds):
-    sortds = sorted(ds)
+    sortds = list(ds)
     maxstep = sortds[1] - sortds[0]
     maxloc = 0
     for i in range(2, len(sortds)):
@@ -85,7 +85,7 @@ def generate_colloc_points(ds, tau):
     This function adds collocation points between the finite elements
     in the differential set
     """
-    fes = sorted(ds)
+    fes = list(ds)
     for i in range(1, len(fes)):
         h = fes[i] - fes[i - 1]
         for j in range(len(tau)):
@@ -360,7 +360,7 @@ def create_access_function(var):
 def create_partial_expression(scheme, expr, ind, loc):
     """
     This method returns a function which applies a discretization scheme
-    to an expression along a particular indexind set. This is admittedly a
+    to an expression along a particular indexing set. This is admittedly a
     convoluted looking implementation. The idea is that we only apply a
     discretization scheme to one indexing set at a time but we also want
     the function to be expanded over any other indexing sets.
@@ -403,13 +403,13 @@ def add_continuity_equations(block, d, i, loc):
         afinal = s.get_discretization_info()['afinal']
 
         def _fun(i):
-            tmp = sorted(s)
-            idx = tmp.index(i)
+            tmp = list(s)
+            idx = s.ord(i)-1
             low = s.get_lower_element_boundary(i)
             if i != low or idx == 0:
                 raise IndexError("list index out of range")
             low = s.get_lower_element_boundary(tmp[idx - 1])
-            lowidx = tmp.index(low)
+            lowidx = s.ord(low)-1
             return sum(v(tmp[lowidx + j]) * afinal[j] for j in range(ncp + 1))
         return _fun
     expr = create_partial_expression(_cont_exp, create_access_function(svar),
@@ -498,8 +498,8 @@ def _get_idx(l, ds, n, i, k):
     points and is not separated into finite elements and collocation
     points.
     """
-    t = sorted(ds)
-    tmp = t.index(ds._fe[i])
+    t = list(ds)
+    tmp = ds.ord(ds._fe[i])-1
     tik = t[tmp + k]
     if n is None:
         return tik

--- a/pyomo/dae/plugins/colloc.py
+++ b/pyomo/dae/plugins/colloc.py
@@ -44,12 +44,12 @@ def _lagrange_radau_transform(v, s):
     adot = s.get_discretization_info()['adot']
 
     def _fun(i):
-        tmp = sorted(s)
-        idx = tmp.index(i)
+        tmp = list(s)
+        idx = s.ord(i)-1
         if idx == 0:  # Don't apply this equation at initial point
             raise IndexError("list index out of range")
         low = s.get_lower_element_boundary(i)
-        lowidx = tmp.index(low)
+        lowidx = s.ord(low)-1
         return sum(v(tmp[lowidx + j]) * adot[j][idx - lowidx] *
                    (1.0 / (tmp[lowidx + ncp] - tmp[lowidx]))
                    for j in range(ncp + 1))
@@ -61,12 +61,12 @@ def _lagrange_radau_transform_order2(v, s):
     adotdot = s.get_discretization_info()['adotdot']
 
     def _fun(i):
-        tmp = sorted(s)
-        idx = tmp.index(i)
+        tmp = list(s)
+        idx = s.ord(i)-1
         if idx == 0:  # Don't apply this equation at initial point
             raise IndexError("list index out of range")
         low = s.get_lower_element_boundary(i)
-        lowidx = tmp.index(low)
+        lowidx = s.ord(low)-1
         return sum(v(tmp[lowidx + j]) * adotdot[j][idx - lowidx] *
                    (1.0 / (tmp[lowidx + ncp] - tmp[lowidx]) ** 2)
                    for j in range(ncp + 1))
@@ -78,8 +78,8 @@ def _lagrange_legendre_transform(v, s):
     adot = s.get_discretization_info()['adot']
 
     def _fun(i):
-        tmp = sorted(s)
-        idx = tmp.index(i)
+        tmp = list(s)
+        idx = s.ord(i)-1
         if idx == 0:  # Don't apply this equation at initial point
             raise IndexError("list index out of range")
         elif i in s.get_finite_elements():  # Don't apply at finite element
@@ -87,7 +87,7 @@ def _lagrange_legendre_transform(v, s):
                                             # added later
             raise IndexError("list index out of range")
         low = s.get_lower_element_boundary(i)
-        lowidx = tmp.index(low)
+        lowidx = s.ord(low)-1
         return sum(v(tmp[lowidx + j]) * adot[j][idx - lowidx] *
                    (1.0 / (tmp[lowidx + ncp + 1] - tmp[lowidx]))
                    for j in range(ncp + 1))
@@ -99,8 +99,8 @@ def _lagrange_legendre_transform_order2(v, s):
     adotdot = s.get_discretization_info()['adotdot']
 
     def _fun(i):
-        tmp = sorted(s)
-        idx = tmp.index(i)
+        tmp = list(s)
+        idx = s.ord(i)-1
         if idx == 0:  # Don't apply this equation at initial point
             raise IndexError("list index out of range")
         elif i in s.get_finite_elements():  # Don't apply at finite element
@@ -108,7 +108,7 @@ def _lagrange_legendre_transform_order2(v, s):
                                             # added later
             raise IndexError("list index out of range")
         low = s.get_lower_element_boundary(i)
-        lowidx = tmp.index(low)
+        lowidx = s.ord(low)-1
         return sum(v(tmp[lowidx + j]) * adotdot[j][idx - lowidx] *
                    (1.0 / (tmp[lowidx + ncp + 1] - tmp[lowidx]) ** 2) \
                    for j in range(ncp + 1))
@@ -433,7 +433,7 @@ class Collocation_Discretization_Transformation(Transformation):
                                     "used." % ds.name)
 
                 self._nfe[ds.name] = len(ds) - 1
-                self._fe[ds.name] = sorted(ds)
+                self._fe[ds.name] = list(ds)
                 generate_colloc_points(ds, self._tau[currentds])
                 # Adding discretization information to the continuousset
                 # object itself so that it can be accessed outside of the
@@ -509,26 +509,6 @@ class Collocation_Discretization_Transformation(Transformation):
                 for k in block.component_objects(Objective, descend_into=True):
                     # TODO: check this, reconstruct might not work
                     k.reconstruct()
-
-    def _get_idx(self, l, t, n, i, k):
-        """
-        This function returns the appropriate index for the ContinuousSet
-        and the derivative variables. It's needed because the collocation
-        constraints are indexed by finite element and collocation point
-        however a ContinuousSet contains a list of all the discretization
-        points and is not separated into finite elements and collocation
-        points.
-        """
-
-        tmp = t.index(t._fe[i])
-        tik = t[tmp + k]
-        if n is None:
-            return tik
-        else:
-            tmpn = n
-            if not isinstance(n, tuple):
-                tmpn = (n,)
-            return tmpn[0:l] + (tik,) + tmpn[l:]
 
     def reduce_collocation_points(self, instance, var=None, ncp=None,
                                   contset=None):
@@ -628,7 +608,7 @@ class Collocation_Discretization_Transformation(Transformation):
         instance.add_component(list_name, ConstraintList())
         conlist = instance.find_component(list_name)
 
-        t = sorted(ds)
+        t = list(ds)
         fe = ds._fe
         info = get_index_information(var, ds)
         tmpidx = info['non_ds']
@@ -645,8 +625,8 @@ class Collocation_Discretization_Transformation(Transformation):
                         conlist.add(var[idx(n, i, k)] ==
                                     var[idx(n, i, tot_ncp)])
                     else:
-                        tmp = t.index(fe[i])
-                        tmp2 = t.index(fe[i + 1])
+                        tmp = ds.ord(fe[i])-1
+                        tmp2 = ds.ord(fe[i + 1])-1
                         ti = t[tmp + k]
                         tfit = t[tmp2 - ncp + 1:tmp2 + 1]
                         coeff = self._interpolation_coeffs(ti, tfit)

--- a/pyomo/dae/plugins/finitedifference.py
+++ b/pyomo/dae/plugins/finitedifference.py
@@ -33,8 +33,8 @@ def _central_transform(v, s):
     derivatives
     """
     def _ctr_fun(i):
-        tmp = sorted(s)
-        idx = tmp.index(i)
+        tmp = list(s)
+        idx = s.ord(i)-1
         if idx == 0:  # Needed since '-1' is considered a valid index in Python
             raise IndexError("list index out of range")
         return 1 / (tmp[idx + 1] - tmp[idx - 1]) * \
@@ -48,8 +48,8 @@ def _central_transform_order2(v, s):
     derivatives
     """
     def _ctr_fun2(i):
-        tmp = sorted(s)
-        idx = tmp.index(i)
+        tmp = list(s)
+        idx = s.ord(i)-1
         if idx == 0:  # Needed since '-1' is considered a valid index in Python
             raise IndexError("list index out of range")
         return 1 / ((tmp[idx + 1] - tmp[idx]) * (tmp[idx] - tmp[idx - 1])) * \
@@ -62,8 +62,8 @@ def _forward_transform(v, s):
     Applies the Forward Difference formula of order O(h) for first derivatives
     """
     def _fwd_fun(i):
-        tmp = sorted(s)
-        idx = tmp.index(i)
+        tmp = list(s)
+        idx = s.ord(i)-1
         return 1 / (tmp[idx + 1] - tmp[idx]) * (v(tmp[idx + 1]) - v(tmp[idx]))
     return _fwd_fun
 
@@ -73,8 +73,8 @@ def _forward_transform_order2(v, s):
     Applies the Forward Difference formula of order O(h) for second derivatives
     """
     def _fwd_fun(i):
-        tmp = sorted(s)
-        idx = tmp.index(i)
+        tmp = list(s)
+        idx = s.ord(i)-1
         return 1 / ((tmp[idx + 2] - tmp[idx + 1]) *
                     (tmp[idx + 1] - tmp[idx])) *\
                (v(tmp[idx + 2]) - 2 * v(tmp[idx + 1]) + v(tmp[idx]))
@@ -86,8 +86,8 @@ def _backward_transform(v, s):
     Applies the Backward Difference formula of order O(h) for first derivatives
     """
     def _bwd_fun(i):
-        tmp = sorted(s)
-        idx = tmp.index(i)
+        tmp = list(s)
+        idx = s.ord(i)-1
         if idx == 0:  # Needed since '-1' is considered a valid index in Python
             raise IndexError("list index out of range")
         return 1 / (tmp[idx] - tmp[idx - 1]) * (v(tmp[idx]) - v(tmp[idx - 1]))
@@ -100,8 +100,8 @@ def _backward_transform_order2(v, s):
     derivatives
     """
     def _bwd_fun(i):
-        tmp = sorted(s)
-        idx = tmp.index(i)
+        tmp = list(s)
+        idx = s.ord(i)-1
 
         # This check is needed since '-1' is considered a valid index in Python
         if idx == 0 or idx == 1:
@@ -222,7 +222,7 @@ class Finite_Difference_Transformation(Transformation):
                                     "used." % ds.name)
 
                 self._nfe[ds.name] = len(ds) - 1
-                self._fe[ds.name] = sorted(ds)
+                self._fe[ds.name] = list(ds)
                 # Adding discretization information to the ContinuousSet
                 # object itself so that it can be accessed outside of the
                 # discretization object


### PR DESCRIPTION
## Summary/Motivation:
This PR removes unnecessary calls to `sorted` in Pyomo.DAE and replaces usage of `<list>.index()` with `<ContinuousSet>.ord()`. With these two minor changes the time to apply the discretization transformation is nearly halved on some large test problems. These changes were motivated by the profiling data in #1157. 

## Changes proposed in this PR:
- remove calls to `sorted` in Pyomo.DAE
- use `ord` instead of `index` for locating elements in a ContinuousSet

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
