### PR TITLE
Timing updates

### DIFF
--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -9,15 +9,12 @@
 #  ___________________________________________________________________________
 
 import argparse
-import gzip
 import io
 import logging
 import os
 import platform
 import re
-import ssl
 import sys
-import zipfile
 
 from pyutilib.subprocess import run
 
@@ -28,6 +25,9 @@ import pyomo.common
 from pyomo.common.dependencies import attempt_import
 
 request = attempt_import('six.moves.urllib.request')[0]
+ssl = attempt_import('ssl')[0]
+zipfile = attempt_import('zipfile')[0]
+gzip = attempt_import('gzip')[0]
 distro, distro_available = attempt_import('distro')
 
 logger = logging.getLogger('pyomo.common.download')

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -127,17 +127,16 @@ class TransformationTimer(object):
 # TODO: Remove this bit for Pyomo 6.0 - we won't care about older versions
 if sys.version_info >= (3,3):
     # perf_counter is guaranteed to be monotonic and the most accurate timer
-    _time_source = time.perf_counter
-else:
+    default_timer = time.perf_counter
+elif sys.platform.startswith('win'):
     # On old Pythons, clock() is more accurate than time() on Windows
     # (.35us vs 15ms), but time() is more accurate than clock() on Linux
     # (1ns vs 1us).  It is unfortunate that time() is not monotonic, but
     # since the TicTocTimer is used for (potentially very accurate)
     # timers, we will sacrifice monotonicity on Linux for resolution.
-    if sys.platform.startswith('win'):
-        _time_source = time.clock
-    else:
-        _time_source = time.time
+    default_timer = time.clock
+else:
+    default_timer = time.time
 
 
 class TicTocTimer(object):
@@ -159,7 +158,7 @@ class TicTocTimer(object):
            logging package. Note: timing logged using logger.info
     """
     def __init__(self, ostream=_NotSpecified, logger=None):
-        self._lastTime = self._loadTime = _time_source()
+        self._lastTime = self._loadTime = default_timer()
         self.ostream = ostream
         self.logger = logger
         self._start_count = 0
@@ -183,7 +182,7 @@ class TicTocTimer(object):
                 class was constructed). Note: timing logged using logger.info
 
         """
-        self._lastTime = _time_source()
+        self._lastTime = default_timer()
         if msg is _NotSpecified:
             msg = "Resetting the tic/toc delta timer"
         if msg is not None:
@@ -218,11 +217,11 @@ class TicTocTimer(object):
             msg = 'File "%s", line %s in %s' % \
                   traceback.extract_stack(limit=2)[0][:3]
 
-        now = _time_source()
+        now = default_timer()
         if self._start_count or self._lastTime is None:
             ans = self._cumul
             if self._lastTime:
-                ans += _time_source() - self._lastTime
+                ans += default_timer() - self._lastTime
             if msg is not None:
                 msg = "[%8.2f|%4d] %s\n" % (ans, self._start_count, msg)
         elif delta:
@@ -252,7 +251,7 @@ class TicTocTimer(object):
 
     def stop(self):
         try:
-            delta = _time_source() - self._lastTime
+            delta = default_timer() - self._lastTime
         except TypeError:
             if self._lastTime is None:
                 raise RuntimeError(
@@ -266,7 +265,7 @@ class TicTocTimer(object):
         if self._lastTime:
             self.stop()
         self._start_count += 1
-        self._lastTime = _time_source()
+        self._lastTime = default_timer()
 
 _globalTimer = TicTocTimer()
 tic = _globalTimer.tic

--- a/pyomo/contrib/gdpopt/util.py
+++ b/pyomo/contrib/gdpopt/util.py
@@ -1,14 +1,23 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
 """Utility functions and classes for the GDPopt solver."""
+
 from __future__ import division
 
 import logging
-import timeit
 from contextlib import contextmanager
 from math import fabs
 
 import six
 
-from pyomo.common import deprecated
+from pyomo.common import deprecated, timing
 from pyomo.common.collections import ComponentSet, Container
 from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
 from pyomo.contrib.gdpopt.data_class import GDPoptSolveData
@@ -401,18 +410,18 @@ def time_code(timing_data_obj, code_block_name, is_main_timer=False):
     allowing calculation of total elapsed time 'on the fly' (e.g. to enforce
     a time limit) using `get_main_elapsed_time(timing_data_obj)`.
     """
-    start_time = timeit.default_timer()
+    start_time = timing.default_timer()
     if is_main_timer:
         timing_data_obj.main_timer_start_time = start_time
     yield
-    elapsed_time = timeit.default_timer() - start_time
+    elapsed_time = timing.default_timer() - start_time
     prev_time = timing_data_obj.get(code_block_name, 0)
     timing_data_obj[code_block_name] = prev_time + elapsed_time
 
 
 def get_main_elapsed_time(timing_data_obj):
     """Returns the time since entering the main `time_code` context"""
-    current_time = timeit.default_timer()
+    current_time = timing.default_timer()
     try:
         return current_time - timing_data_obj.main_timer_start_time
     except AttributeError as e:

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -131,6 +131,7 @@ class TestPyomoEnviron(unittest.TestCase):
             'cPickle',
             'csv',
             'ctypes',
+            'decimal',
             'glob',
             'inspect',
             'json',
@@ -149,6 +150,7 @@ class TestPyomoEnviron(unittest.TestCase):
             # From PyUtilib
             'difflib',
             'gzip',
+            'imp',
             'runpy',
             'tarfile',
             'zipfile',

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -120,9 +120,27 @@ class TestPyomoEnviron(unittest.TestCase):
         # Spot-check the (known) worst offenders.  The following are
         # modules from the "standard" library.  Their order in the list
         # of slow-loading TPLs can vary from platform to platform.
-        ref = {'tempfile', 'logging', 'ctypes', 'ssl', 'argparse',
-               'textwrap', 'inspect', 'xml', 'platform', 'uuid',
-               'optparse', 'filecmp'}
+        ref = {
+            'argparse',
+            'csv',
+            'ctypes',
+            'inspect',
+            'logging',
+            'platform',
+            'textwrap',
+            'tempfile',
+            'xml',
+            # From PySP
+            'filecmp',
+            'optparse',
+            'shelve',
+            'uuid',
+            # From PyUtilib
+            'difflib',
+            'runpy',
+            'tarfile',
+            'zipfile',
+        }
         # Non-standard-library TPLs that Pyomo will load unconditionally
         ref.add('six')
         ref.add('ply')

--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -21,7 +21,6 @@ import six
 import sys
 import time
 import socket
-import gzip
 import base64
 import tempfile
 import logging
@@ -35,6 +34,7 @@ def _xmlrpclib_importer():
         import xmlrpc.client as xmlrpclib
     return xmlrpclib
 xmlrpclib = attempt_import('xmlrpclib', importer=_xmlrpclib_importer)[0]
+gzip = attempt_import('gzip')[0]
 
 logger = logging.getLogger('pyomo.neos')
 


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This resolves some intermittent test failures due to an incomplete list of unconditional TPL imports.  It also (slightly) speeds up import of `pyomo.environ` by removing an unconditional import of `timeit` and `ssl`, and sets the stage for future updates for Pyomo 6.0

## Changes proposed in this PR:
- remove unconditional import of `ssl`, `timeit`, `gzip`, and `zipfile` in Pyomo
- `pyomo.common.timing` now exports a `default_timer` method for accessing the highest precision system timer
- update list of unconditional TPL imports
- improve timing test output formatting

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
