### PR TITLE
Instantiate deferred submodules when main module is unavailable

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -150,7 +150,8 @@ class DeferredImportIndicator(_DeferredImportIndicatorBase):
                 for submod in self._deferred_submodules:
                     refmod = self._module
                     for name in submod.split('.')[1:]:
-                        setattr(refmod, name, ModuleUnavailable(err))
+                        if not hasattr(refmod, name):
+                            setattr(refmod, name, ModuleUnavailable(err))
                         refmod = getattr(refmod, name)
 
             # Replace myself in the original globals() where I was

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -150,9 +150,11 @@ class DeferredImportIndicator(_DeferredImportIndicatorBase):
                 for submod in self._deferred_submodules:
                     refmod = self._module
                     for name in submod.split('.')[1:]:
-                        if not hasattr(refmod, name):
+                        try:
+                            refmod = getattr(refmod, name)
+                        except DeferredImportError:
                             setattr(refmod, name, ModuleUnavailable(err))
-                        refmod = getattr(refmod, name)
+                            refmod = getattr(refmod, name)
 
             # Replace myself in the original globals() where I was
             # declared

--- a/pyomo/common/tests/test_dependencies.py
+++ b/pyomo/common/tests/test_dependencies.py
@@ -273,7 +273,25 @@ class TestDependencies(unittest.TestCase):
         self.assertEqual(version.version, pyo_ver)
         self.assertTrue(inspect.ismodule(pyo))
         self.assertTrue(inspect.ismodule(dm))
-        
+
+        with self.assertRaisesRegex(
+                ValueError,
+                "deferred_submodules is only valid if defer_check==True"):
+            mod, mod_available \
+                = attempt_import('nonexisting.module', defer_check=False,
+                                 deferred_submodules={'submod': None})
+
+        mod, mod_available \
+            = attempt_import('nonexisting.module', defer_check=True,
+                             deferred_submodules={'submod.subsubmod': None})
+        self.assertIs(type(mod), DeferredImportModule)
+        self.assertFalse(mod_available)
+        _mod = mod_available._module
+        self.assertIs(type(_mod), ModuleUnavailable)
+        self.assertTrue(hasattr(_mod, 'submod'))
+        self.assertIs(type(_mod.submod), ModuleUnavailable)
+        self.assertTrue(hasattr(_mod.submod, 'subsubmod'))
+        self.assertIs(type(_mod.submod.subsubmod), ModuleUnavailable)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
#1526 identified a problem with the deferred submodule import system (used to manage, e.g., `matplotlib.pyplot`) where when the module was resolved and found to be not available, the submodule no longer supported deferred resolution.  The solution is that the attributes for the deferred submodules must be added to the `ModuleUnavailable` object created when the top-level module is resolved.

This PR is required to resolve test failures in #1526.

## Changes proposed in this PR:
- instantiate `ModuleUnavailable` objects for attributes corresponding to "deferred submodules" when the module is not available.
- update tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
