### PR TITLE
GHA: fix installation of pymumps through conda

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -70,7 +70,7 @@ jobs:
           PACKAGES: mpi4py openmpi
 
         - os: ubuntu-18.04
-          python: 3.8
+          python: 3.7
           other: /conda
           skip_doctest: 1
           TARGET: linux
@@ -276,7 +276,7 @@ jobs:
             || echo "WARNING: CPLEX Community Edition is not available"
         conda install -q -y -c fico-xpress xpress \
             || echo "WARNING: Xpress Community Edition is not available"
-        conda install -q -y -c coda-forge pymumps \
+        conda install -q -y -c conda-forge pymumps \
             || echo "WARNING: PyMUMPS is not available"
         python -c 'import sys; print("PYTHON_EXE=%s" \
             % (sys.executable,))' >> $GITHUB_ENV

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -69,7 +69,7 @@ jobs:
           PACKAGES: mpi4py openmpi
 
         - os: ubuntu-18.04
-          python: 3.8
+          python: 3.7
           other: /conda
           skip_doctest: 1
           TARGET: linux
@@ -275,7 +275,7 @@ jobs:
             || echo "WARNING: CPLEX Community Edition is not available"
         conda install -q -y -c fico-xpress xpress \
             || echo "WARNING: Xpress Community Edition is not available"
-        conda install -q -y -c coda-forge pymumps \
+        conda install -q -y -c conda-forge pymumps \
             || echo "WARNING: PyMUMPS is not available"
         python -c 'import sys; print("PYTHON_EXE=%s" \
             % (sys.executable,))' >> $GITHUB_ENV


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This fixes a typo in the GHA build actions so that pymumps will install for conda targets.  This also switches the linux conda build from Python 3.8 to 3.7 (so that CPLEX is picked up - cplex community edition is not yet available for Python 3.8 under conda).

## Changes proposed in this PR:
- fix typo in pymumps install
- switch `linux/conda` from python 3.8 to python 3.7

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
