### PR TITLE
GHA: add TPLs, update solver PATH & SLIM environment

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -42,7 +42,6 @@ jobs:
         python: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
         other: [""]
         category: ["nightly"]
-        slim: [""]
         # Ubuntu-18.04 should be replaced with ubuntu-latest once PyNumero
         # build error is resolved:
         # https://github.com/Pyomo/pyomo/issues/1710
@@ -300,7 +299,7 @@ jobs:
         echo "DOWNLOAD_DIR=$DOWNLOAD_DIR" >> $GITHUB_ENV
 
     - name: Install Ipopt
-      if: ! matrix.slim
+      if: ${{ ! matrix.slim }}
       run: |
         IPOPT_DIR=$TPL_DIR/ipopt
         echo "$IPOPT_DIR" >> $GITHUB_PATH
@@ -332,7 +331,7 @@ jobs:
         ls $IPOPT_DIR
 
     - name: Install GAMS
-      if: ! matrix.slim
+      if: ${{ ! matrix.slim }}
       # We install using Powershell because the GAMS installer hangs
       # when launched from bash on Windows
       shell: pwsh
@@ -368,7 +367,7 @@ jobs:
         ls $GAMS_DIR
 
     - name: Install GAMS Python bindings
-      if: ! matrix.slim
+      if: ${{ ! matrix.slim }}
       run: |
         GAMS_DIR="${env:TPL_DIR}/gams"
         py_ver=$($PYTHON_EXE -c 'import sys;v="_%s%s" % sys.version_info[:2] \
@@ -381,7 +380,7 @@ jobs:
         fi
 
     - name: Install BARON
-      if: ! matrix.slim
+      if: ${{ ! matrix.slim }}
       shell: pwsh
       run: |
         $BARON_DIR="${env:TPL_DIR}/baron"
@@ -413,7 +412,7 @@ jobs:
         ls $BARON_DIR
 
     - name: Install GJH_ASL_JSON
-      if: ! matrix.slim && matrix.TARGET != 'win'
+      if: ${{ ! matrix.slim && matrix.TARGET != 'win' }}
       run: |
         GJH_DIR="$TPL_DIR/gjh"
         echo "${GJH_DIR}" >> $GITHUB_PATH

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -42,6 +42,7 @@ jobs:
         python: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
         other: [""]
         category: ["nightly"]
+        slim: [""]
         # Ubuntu-18.04 should be replaced with ubuntu-latest once PyNumero
         # build error is resolved:
         # https://github.com/Pyomo/pyomo/issues/1710

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -338,12 +338,15 @@ jobs:
       # when launched from bash on Windows
       shell: pwsh
       run: |
-        $GAMS_DIR="${env:TPL_DIR}/gams"
-        echo "$GAMS_DIR" >> $GITHUB_PATH
-        echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$GAMS_DIR" >> $GITHUB_ENV
-        echo "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:$GAMS_DIR" >> $GITHUB_ENV
-        $INSTALLER="${env:DOWNLOAD_DIR}/gams_install.exe"
-        $URL="https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0"
+        $GAMS_DIR = "${env:TPL_DIR}/gams"
+        echo "$GAMS_DIR" | `
+            Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "LD_LIBRARY_PATH=${env:LD_LIBRARY_PATH}:$GAMS_DIR" `
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "DYLD_LIBRARY_PATH=${env:DYLD_LIBRARY_PATH}:$GAMS_DIR" `
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        $INSTALLER = "${env:DOWNLOAD_DIR}/gams_install.exe"
+        $URL = "https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0"
         if ( "${{matrix.TARGET}}" -eq "win" ) {
             $URL = "$URL/windows/windows_x64_64.exe"
         } elseif ( "${{matrix.TARGET}}" -eq "osx" ) {
@@ -387,9 +390,10 @@ jobs:
       if: ${{ ! matrix.slim }}
       shell: pwsh
       run: |
-        $BARON_DIR="${env:TPL_DIR}/baron"
-        echo "$BARON_DIR" >> $GITHUB_PATH
-        $URL="https://www.minlp.com/downloads/xecs/baron/current/"
+        $BARON_DIR = "${env:TPL_DIR}/baron"
+        echo "$BARON_DIR" | `
+            Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        $URL = "https://www.minlp.com/downloads/xecs/baron/current/"
         if ( "${{matrix.TARGET}}" -eq "win" ) {
             $INSTALLER = "${env:DOWNLOAD_DIR}/baron_install.exe"
             $URL += "baron-win64.exe"

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -27,7 +27,7 @@ env:
       pint pymysql pyro4 pyyaml sphinx_rtd_theme sympy xlrd
       python-louvain
   PYTHON_NUMPY_PKGS: >
-      numpy scipy pyodbc pandas matplotlib seaborn
+      numpy scipy pyodbc pandas matplotlib seaborn numdifftools
   CACHE_VER: v3
 
 jobs:
@@ -246,14 +246,17 @@ jobs:
         python -m pip install --cache-dir cache/pip --upgrade pip
         pip install --cache-dir cache/pip ${PYTHON_CORE_PKGS}
         pip install --cache-dir cache/pip ${PYTHON_PACKAGES}
-        pip install --cache-dir cache/pip cplex \
-            || echo "WARNING: CPLEX Community Edition is not available"
-        pip install --cache-dir cache/pip -i https://pypi.gurobi.com gurobipy \
-            || echo "WARNING: Gurobi is not available"
-        pip install --cache-dir cache/pip xpress \
-            || echo "WARNING: Xpress Community Edition is not available"
-        pip install --cache-dir cache/pip z3-solver \
-            || echo "WARNING: Z3 Solver is not available"
+        if test -z "${{matrix.slim}}"; then
+            pip install --cache-dir cache/pip cplex \
+                || echo "WARNING: CPLEX Community Edition is not available"
+            pip install --cache-dir cache/pip \
+                -i https://pypi.gurobi.com gurobipy \
+                || echo "WARNING: Gurobi is not available"
+            pip install --cache-dir cache/pip xpress \
+                || echo "WARNING: Xpress Community Edition is not available"
+            pip install --cache-dir cache/pip z3-solver \
+                || echo "WARNING: Z3 Solver is not available"
+        fi
         python -c 'import sys; print("PYTHON_EXE=%s" \
             % (sys.executable,))' >> $GITHUB_ENV
         echo "NOSETESTS="`which nosetests` >> $GITHUB_ENV
@@ -270,14 +273,18 @@ jobs:
         conda list --show-channel-urls
         conda install -q -y -c conda-forge ${PYTHON_CORE_PKGS}
         conda install -q -y -c conda-forge ${PYTHON_PACKAGES}
-        # Note: CPLEX 12.9 (the last version in conda that supports
-        #    Python 2.7) causes a seg fault in the tests.
-        conda install -q -y -c ibmdecisionoptimization 'cplex>=12.10' \
-            || echo "WARNING: CPLEX Community Edition is not available"
-        conda install -q -y -c fico-xpress xpress \
-            || echo "WARNING: Xpress Community Edition is not available"
-        conda install -q -y -c conda-forge pymumps \
-            || echo "WARNING: PyMUMPS is not available"
+        if test -z "${{matrix.slim}}"; then
+            # Note: CPLEX 12.9 (the last version in conda that supports
+            #    Python 2.7) causes a seg fault in the tests.
+            conda install -q -y -c ibmdecisionoptimization 'cplex>=12.10' \
+                || echo "WARNING: CPLEX Community Edition is not available"
+            conda install -q -y -c fico-xpress xpress \
+                || echo "WARNING: Xpress Community Edition is not available"
+            for PKG in casadi cyipopt pymumps; do
+                conda install -q -y -c conda-forge $PKG \
+                    || echo "WARNING: $PKG is not available"
+            done
+        fi
         python -c 'import sys; print("PYTHON_EXE=%s" \
             % (sys.executable,))' >> $GITHUB_ENV
         echo "NOSETESTS="`which nosetests` >> $GITHUB_ENV
@@ -292,6 +299,7 @@ jobs:
         echo "DOWNLOAD_DIR=$DOWNLOAD_DIR" >> $GITHUB_ENV
 
     - name: Install Ipopt
+      if: ! matrix.slim
       run: |
         IPOPT_DIR=$TPL_DIR/ipopt
         echo "$IPOPT_DIR" >> $GITHUB_PATH
@@ -322,6 +330,7 @@ jobs:
         tar -xzi < $IPOPT_TAR
 
     - name: Install GAMS
+      if: ! matrix.slim
       # We install using Powershell because the GAMS installer hangs
       # when launched from bash on Windows
       shell: pwsh
@@ -356,6 +365,7 @@ jobs:
         }
 
     - name: Install GAMS Python bindings
+      if: ! matrix.slim
       run: |
         GAMS_DIR="${env:TPL_DIR}/gams"
         py_ver=$($PYTHON_EXE -c 'import sys;v="_%s%s" % sys.version_info[:2] \
@@ -368,6 +378,7 @@ jobs:
         fi
 
     - name: Install BARON
+      if: ! matrix.slim
       shell: pwsh
       run: |
         $BARON_DIR="${env:TPL_DIR}/baron"
@@ -398,7 +409,7 @@ jobs:
         }
 
     - name: Install GJH_ASL_JSON
-      if: matrix.TARGET != 'win'
+      if: ! matrix.slim && matrix.TARGET != 'win'
       run: |
         GJH_DIR="$TPL_DIR/gjh"
         echo "${GJH_DIR}" >> $GITHUB_PATH

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -34,7 +34,7 @@ jobs:
   build:
     name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.other }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -328,7 +328,7 @@ jobs:
         fi
         cd $IPOPT_DIR
         tar -xzi < $IPOPT_TAR
-        ls $IPOPT_DIR
+        ls -l $IPOPT_DIR
 
     - name: Install GAMS
       if: ${{ ! matrix.slim }}
@@ -364,7 +364,7 @@ jobs:
                 "-q -d $GAMS_DIR" -Wait
             mv $GAMS_DIR/*/* $GAMS_DIR/.
         }
-        ls $GAMS_DIR
+        ls -l $GAMS_DIR
 
     - name: Install GAMS Python bindings
       if: ${{ ! matrix.slim }}
@@ -409,7 +409,7 @@ jobs:
             unzip -q $INSTALLER
             mv baron-* $BARON_DIR
         }
-        ls $BARON_DIR
+        ls -l $BARON_DIR
 
     - name: Install GJH_ASL_JSON
       if: ${{ ! matrix.slim && matrix.TARGET != 'win' }}
@@ -431,7 +431,7 @@ jobs:
             mv bin "$INSTALL_DIR/bin"
         fi
         cp -rp "$INSTALL_DIR/bin" "$GJH_DIR"
-        ls $GJH_DIR
+        ls -l $GJH_DIR
 
     - name: Install Pyomo and PyUtilib
       run: |

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -328,6 +328,7 @@ jobs:
         fi
         cd $IPOPT_DIR
         tar -xzi < $IPOPT_TAR
+        ls $IPOPT_DIR
 
     - name: Install GAMS
       if: ! matrix.slim
@@ -363,6 +364,7 @@ jobs:
                 "-q -d $GAMS_DIR" -Wait
             mv $GAMS_DIR/*/* $GAMS_DIR/.
         }
+        ls $GAMS_DIR
 
     - name: Install GAMS Python bindings
       if: ! matrix.slim
@@ -407,6 +409,7 @@ jobs:
             unzip -q $INSTALLER
             mv baron-* $BARON_DIR
         }
+        ls $BARON_DIR
 
     - name: Install GJH_ASL_JSON
       if: ! matrix.slim && matrix.TARGET != 'win'
@@ -428,6 +431,7 @@ jobs:
             mv bin "$INSTALL_DIR/bin"
         fi
         cp -rp "$INSTALL_DIR/bin" "$GJH_DIR"
+        ls $GJH_DIR
 
     - name: Install Pyomo and PyUtilib
       run: |

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -328,6 +328,8 @@ jobs:
         fi
         cd $IPOPT_DIR
         tar -xzi < $IPOPT_TAR
+        echo ""
+        echo "$IPOPT_DIR"
         ls -l $IPOPT_DIR
 
     - name: Install GAMS
@@ -364,6 +366,8 @@ jobs:
                 "-q -d $GAMS_DIR" -Wait
             mv $GAMS_DIR/*/* $GAMS_DIR/.
         }
+        echo ""
+        echo "$GAMS_DIR"
         ls -l $GAMS_DIR
 
     - name: Install GAMS Python bindings
@@ -409,6 +413,8 @@ jobs:
             unzip -q $INSTALLER
             mv baron-* $BARON_DIR
         }
+        echo ""
+        echo "$BARON_DIR"
         ls -l $BARON_DIR
 
     - name: Install GJH_ASL_JSON
@@ -431,6 +437,8 @@ jobs:
             mv bin "$INSTALL_DIR/bin"
         fi
         cp -rp "$INSTALL_DIR/bin" "$GJH_DIR"
+        echo ""
+        echo "$GJH_DIR"
         ls -l $GJH_DIR
 
     - name: Install Pyomo and PyUtilib
@@ -482,6 +490,7 @@ jobs:
 
     - name: Report pyomo plugin information
       run: |
+        echo "$PATH"
         pyomo help --solvers || exit 1
         pyomo help --transformations || exit 1
         pyomo help --writers || exit 1

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -21,9 +21,9 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYTHON_REQUIRED_PKGS: >
-      ply six nose coverage
+      nose coverage
   PYTHON_BASE_PKGS: >
-      dill ipython networkx openpyxl pathos
+      ply six dill ipython networkx openpyxl pathos
       pint pymysql pyro4 pyyaml sphinx_rtd_theme sympy xlrd
       python-louvain
   PYTHON_NUMPY_PKGS: >

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -327,6 +327,7 @@ jobs:
         fi
         cd $IPOPT_DIR
         tar -xzi < $IPOPT_TAR
+        ls $IPOPT_DIR
 
     - name: Install GAMS
       if: ! matrix.slim
@@ -362,6 +363,7 @@ jobs:
                 "-q -d $GAMS_DIR" -Wait
             mv $GAMS_DIR/*/* $GAMS_DIR/.
         }
+        ls $GAMS_DIR
 
     - name: Install GAMS Python bindings
       if: ! matrix.slim
@@ -406,6 +408,7 @@ jobs:
             unzip -q $INSTALLER
             mv baron-* $BARON_DIR
         }
+        ls $BARON_DIR
 
     - name: Install GJH_ASL_JSON
       if: ! matrix.slim && matrix.TARGET != 'win'
@@ -427,6 +430,7 @@ jobs:
             mv bin "$INSTALL_DIR/bin"
         fi
         cp -rp "$INSTALL_DIR/bin" "$GJH_DIR"
+        ls $GJH_DIR
 
     - name: Install Pyomo and PyUtilib
       run: |

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -18,9 +18,9 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYTHON_REQUIRED_PKGS: >
-      ply six nose coverage
+      nose coverage
   PYTHON_BASE_PKGS: >
-      dill ipython networkx openpyxl pathos
+      ply six dill ipython networkx openpyxl pathos
       pint pymysql pyro4 pyyaml sphinx_rtd_theme sympy xlrd
       python-louvain
   PYTHON_NUMPY_PKGS: >

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -39,6 +39,7 @@ jobs:
         python: [3.8]
         other: [""]
         category: ["nightly"]
+        slim: [""]
         # Ubuntu-18.04 should be replaced with ubuntu-latest once PyNumero
         # build error is resolved:
         # https://github.com/Pyomo/pyomo/issues/1710

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -327,7 +327,7 @@ jobs:
         fi
         cd $IPOPT_DIR
         tar -xzi < $IPOPT_TAR
-        ls $IPOPT_DIR
+        ls -l $IPOPT_DIR
 
     - name: Install GAMS
       if: ${{ ! matrix.slim }}
@@ -363,7 +363,7 @@ jobs:
                 "-q -d $GAMS_DIR" -Wait
             mv $GAMS_DIR/*/* $GAMS_DIR/.
         }
-        ls $GAMS_DIR
+        ls -l $GAMS_DIR
 
     - name: Install GAMS Python bindings
       if: ${{ ! matrix.slim }}
@@ -408,7 +408,7 @@ jobs:
             unzip -q $INSTALLER
             mv baron-* $BARON_DIR
         }
-        ls $BARON_DIR
+        ls -l $BARON_DIR
 
     - name: Install GJH_ASL_JSON
       if: ${{ ! matrix.slim && matrix.TARGET != 'win' }}
@@ -430,7 +430,7 @@ jobs:
             mv bin "$INSTALL_DIR/bin"
         fi
         cp -rp "$INSTALL_DIR/bin" "$GJH_DIR"
-        ls $GJH_DIR
+        ls -l $GJH_DIR
 
     - name: Install Pyomo and PyUtilib
       run: |

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.other }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -39,7 +39,6 @@ jobs:
         python: [3.8]
         other: [""]
         category: ["nightly"]
-        slim: [""]
         # Ubuntu-18.04 should be replaced with ubuntu-latest once PyNumero
         # build error is resolved:
         # https://github.com/Pyomo/pyomo/issues/1710
@@ -299,7 +298,7 @@ jobs:
         echo "DOWNLOAD_DIR=$DOWNLOAD_DIR" >> $GITHUB_ENV
 
     - name: Install Ipopt
-      if: ! matrix.slim
+      if: ${{ ! matrix.slim }}
       run: |
         IPOPT_DIR=$TPL_DIR/ipopt
         echo "$IPOPT_DIR" >> $GITHUB_PATH
@@ -331,7 +330,7 @@ jobs:
         ls $IPOPT_DIR
 
     - name: Install GAMS
-      if: ! matrix.slim
+      if: ${{ ! matrix.slim }}
       # We install using Powershell because the GAMS installer hangs
       # when launched from bash on Windows
       shell: pwsh
@@ -367,7 +366,7 @@ jobs:
         ls $GAMS_DIR
 
     - name: Install GAMS Python bindings
-      if: ! matrix.slim
+      if: ${{ ! matrix.slim }}
       run: |
         GAMS_DIR="${env:TPL_DIR}/gams"
         py_ver=$($PYTHON_EXE -c 'import sys;v="_%s%s" % sys.version_info[:2] \
@@ -380,7 +379,7 @@ jobs:
         fi
 
     - name: Install BARON
-      if: ! matrix.slim
+      if: ${{ ! matrix.slim }}
       shell: pwsh
       run: |
         $BARON_DIR="${env:TPL_DIR}/baron"
@@ -412,7 +411,7 @@ jobs:
         ls $BARON_DIR
 
     - name: Install GJH_ASL_JSON
-      if: ! matrix.slim && matrix.TARGET != 'win'
+      if: ${{ ! matrix.slim && matrix.TARGET != 'win' }}
       run: |
         GJH_DIR="$TPL_DIR/gjh"
         echo "${GJH_DIR}" >> $GITHUB_PATH

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -327,6 +327,8 @@ jobs:
         fi
         cd $IPOPT_DIR
         tar -xzi < $IPOPT_TAR
+        echo ""
+        echo "$IPOPT_DIR"
         ls -l $IPOPT_DIR
 
     - name: Install GAMS
@@ -363,6 +365,8 @@ jobs:
                 "-q -d $GAMS_DIR" -Wait
             mv $GAMS_DIR/*/* $GAMS_DIR/.
         }
+        echo ""
+        echo "$GAMS_DIR"
         ls -l $GAMS_DIR
 
     - name: Install GAMS Python bindings
@@ -408,6 +412,8 @@ jobs:
             unzip -q $INSTALLER
             mv baron-* $BARON_DIR
         }
+        echo ""
+        echo "$BARON_DIR"
         ls -l $BARON_DIR
 
     - name: Install GJH_ASL_JSON
@@ -430,6 +436,8 @@ jobs:
             mv bin "$INSTALL_DIR/bin"
         fi
         cp -rp "$INSTALL_DIR/bin" "$GJH_DIR"
+        echo ""
+        echo "$GJH_DIR"
         ls -l $GJH_DIR
 
     - name: Install Pyomo and PyUtilib
@@ -481,6 +489,7 @@ jobs:
 
     - name: Report pyomo plugin information
       run: |
+        echo "$PATH"
         pyomo help --solvers || exit 1
         pyomo help --transformations || exit 1
         pyomo help --writers || exit 1

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -24,7 +24,7 @@ env:
       pint pymysql pyro4 pyyaml sphinx_rtd_theme sympy xlrd
       python-louvain
   PYTHON_NUMPY_PKGS: >
-      numpy scipy pyodbc pandas matplotlib seaborn
+      numpy scipy pyodbc pandas matplotlib seaborn numdifftools
   CACHE_VER: v3
 
 jobs:
@@ -245,14 +245,17 @@ jobs:
         python -m pip install --cache-dir cache/pip --upgrade pip
         pip install --cache-dir cache/pip ${PYTHON_CORE_PKGS}
         pip install --cache-dir cache/pip ${PYTHON_PACKAGES}
-        pip install --cache-dir cache/pip cplex \
-            || echo "WARNING: CPLEX Community Edition is not available"
-        pip install --cache-dir cache/pip -i https://pypi.gurobi.com gurobipy \
-            || echo "WARNING: Gurobi is not available"
-        pip install --cache-dir cache/pip xpress \
-            || echo "WARNING: Xpress Community Edition is not available"
-        pip install --cache-dir cache/pip z3-solver \
-            || echo "WARNING: Z3 Solver is not available"
+        if test -z "${{matrix.slim}}"; then
+            pip install --cache-dir cache/pip cplex \
+                || echo "WARNING: CPLEX Community Edition is not available"
+            pip install --cache-dir cache/pip \
+                -i https://pypi.gurobi.com gurobipy \
+                || echo "WARNING: Gurobi is not available"
+            pip install --cache-dir cache/pip xpress \
+                || echo "WARNING: Xpress Community Edition is not available"
+            pip install --cache-dir cache/pip z3-solver \
+                || echo "WARNING: Z3 Solver is not available"
+        fi
         python -c 'import sys; print("PYTHON_EXE=%s" \
             % (sys.executable,))' >> $GITHUB_ENV
         echo "NOSETESTS="`which nosetests` >> $GITHUB_ENV
@@ -269,14 +272,18 @@ jobs:
         conda list --show-channel-urls
         conda install -q -y -c conda-forge ${PYTHON_CORE_PKGS}
         conda install -q -y -c conda-forge ${PYTHON_PACKAGES}
-        # Note: CPLEX 12.9 (the last version in conda that supports
-        #    Python 2.7) causes a seg fault in the tests.
-        conda install -q -y -c ibmdecisionoptimization 'cplex>=12.10' \
-            || echo "WARNING: CPLEX Community Edition is not available"
-        conda install -q -y -c fico-xpress xpress \
-            || echo "WARNING: Xpress Community Edition is not available"
-        conda install -q -y -c conda-forge pymumps \
-            || echo "WARNING: PyMUMPS is not available"
+        if test -z "${{matrix.slim}}"; then
+            # Note: CPLEX 12.9 (the last version in conda that supports
+            #    Python 2.7) causes a seg fault in the tests.
+            conda install -q -y -c ibmdecisionoptimization 'cplex>=12.10' \
+                || echo "WARNING: CPLEX Community Edition is not available"
+            conda install -q -y -c fico-xpress xpress \
+                || echo "WARNING: Xpress Community Edition is not available"
+            for PKG in casadi cyipopt pymumps; do
+                conda install -q -y -c conda-forge $PKG \
+                    || echo "WARNING: $PKG is not available"
+            done
+        fi
         python -c 'import sys; print("PYTHON_EXE=%s" \
             % (sys.executable,))' >> $GITHUB_ENV
         echo "NOSETESTS="`which nosetests` >> $GITHUB_ENV
@@ -291,6 +298,7 @@ jobs:
         echo "DOWNLOAD_DIR=$DOWNLOAD_DIR" >> $GITHUB_ENV
 
     - name: Install Ipopt
+      if: ! matrix.slim
       run: |
         IPOPT_DIR=$TPL_DIR/ipopt
         echo "$IPOPT_DIR" >> $GITHUB_PATH
@@ -321,6 +329,7 @@ jobs:
         tar -xzi < $IPOPT_TAR
 
     - name: Install GAMS
+      if: ! matrix.slim
       # We install using Powershell because the GAMS installer hangs
       # when launched from bash on Windows
       shell: pwsh
@@ -355,6 +364,7 @@ jobs:
         }
 
     - name: Install GAMS Python bindings
+      if: ! matrix.slim
       run: |
         GAMS_DIR="${env:TPL_DIR}/gams"
         py_ver=$($PYTHON_EXE -c 'import sys;v="_%s%s" % sys.version_info[:2] \
@@ -367,6 +377,7 @@ jobs:
         fi
 
     - name: Install BARON
+      if: ! matrix.slim
       shell: pwsh
       run: |
         $BARON_DIR="${env:TPL_DIR}/baron"
@@ -397,7 +408,7 @@ jobs:
         }
 
     - name: Install GJH_ASL_JSON
-      if: matrix.TARGET != 'win'
+      if: ! matrix.slim && matrix.TARGET != 'win'
       run: |
         GJH_DIR="$TPL_DIR/gjh"
         echo "${GJH_DIR}" >> $GITHUB_PATH

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -337,12 +337,15 @@ jobs:
       # when launched from bash on Windows
       shell: pwsh
       run: |
-        $GAMS_DIR="${env:TPL_DIR}/gams"
-        echo "$GAMS_DIR" >> $GITHUB_PATH
-        echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$GAMS_DIR" >> $GITHUB_ENV
-        echo "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:$GAMS_DIR" >> $GITHUB_ENV
-        $INSTALLER="${env:DOWNLOAD_DIR}/gams_install.exe"
-        $URL="https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0"
+        $GAMS_DIR = "${env:TPL_DIR}/gams"
+        echo "$GAMS_DIR" | `
+            Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "LD_LIBRARY_PATH=${env:LD_LIBRARY_PATH}:$GAMS_DIR" `
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "DYLD_LIBRARY_PATH=${env:DYLD_LIBRARY_PATH}:$GAMS_DIR" `
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        $INSTALLER = "${env:DOWNLOAD_DIR}/gams_install.exe"
+        $URL = "https://d37drm4t2jghv5.cloudfront.net/distributions/29.1.0"
         if ( "${{matrix.TARGET}}" -eq "win" ) {
             $URL = "$URL/windows/windows_x64_64.exe"
         } elseif ( "${{matrix.TARGET}}" -eq "osx" ) {
@@ -386,9 +389,10 @@ jobs:
       if: ${{ ! matrix.slim }}
       shell: pwsh
       run: |
-        $BARON_DIR="${env:TPL_DIR}/baron"
-        echo "$BARON_DIR" >> $GITHUB_PATH
-        $URL="https://www.minlp.com/downloads/xecs/baron/current/"
+        $BARON_DIR = "${env:TPL_DIR}/baron"
+        echo "$BARON_DIR" | `
+            Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        $URL = "https://www.minlp.com/downloads/xecs/baron/current/"
         if ( "${{matrix.TARGET}}" -eq "win" ) {
             $INSTALLER = "${env:DOWNLOAD_DIR}/baron_install.exe"
             $URL += "baron-win64.exe"

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -12,6 +12,7 @@ import pyomo.common.unittest as unittest
 from pyutilib.misc.redirect_io import capture_output
 
 from six import StringIO
+import sys
 import time
 
 from pyomo.common.log import LoggingIntercept
@@ -138,9 +139,10 @@ class TestTiming(unittest.TestCase):
         ref -= time.time()
         time.sleep(0.1)
 
-        # Note: pypy on GHA frequently has timing differences of >0.02s
+        # Note: pypy on GHA frequently has timing differences of >0.05s
         # for the following tests
-        RES = 5e-2
+        if 'pypy_version_info' in dir(sys):
+            RES = 6.5e-2
 
         with capture_output() as out:
             delta = timer.toc()

--- a/pyomo/contrib/interior_point/tests/test_inverse_reduced_hessian.py
+++ b/pyomo/contrib/interior_point/tests/test_inverse_reduced_hessian.py
@@ -99,7 +99,7 @@ class TestInverseReducedHessian(unittest.TestCase):
 
         return model
 
-    @unittest.skipIf(not numdiff_available, "numdiff missing")
+    @unittest.skipIf(not numdiff_available, "numdifftools missing")
     @unittest.skipIf(not pandas_available, "pandas missing")
     def test_3x3_using_linear_regression(self):
         """ simple linear regression with two x columns, so 3x3 Hessian"""        
@@ -133,7 +133,7 @@ class TestInverseReducedHessian(unittest.TestCase):
         np.testing.assert_array_almost_equal(HInv, H_inv_red_hess, decimal=3)
 
 
-    @unittest.skipIf(not numdiff_available, "numdiff missing")
+    @unittest.skipIf(not numdiff_available, "numdifftools missing")
     @unittest.skipIf(not pandas_available, "pandas missing")
     def test_with_binding_constraint(self):
         """ there is a binding constraint"""        

--- a/pyomo/contrib/sensitivity_toolbox/tests/test_sens.py
+++ b/pyomo/contrib/sensitivity_toolbox/tests/test_sens.py
@@ -29,7 +29,7 @@ opt = SolverFactory('ipopt_sens', solver_io='nl')
 class TestSensitivityToolbox(unittest.TestCase):
 
     #test arguments
-    @unittest.skipIf(not opt.available(False), "ipopt_sense is not available")
+    @unittest.skipIf(not opt.available(False), "ipopt_sens is not available")
     def test_bad_arg(self):
         m = ConcreteModel()
         m.t = ContinuousSet(bounds=(0,1))

--- a/pyomo/gdp/tests/test_cuttingplane.py
+++ b/pyomo/gdp/tests/test_cuttingplane.py
@@ -527,7 +527,7 @@ class TwoTermDisj(unittest.TestCase):
     # problem as constraints are never *exactly* satisfied. (The problem being
     # that we need to consider exactly satisfied equalities interesting for
     # FME.)
-    @unittest.skipIf('gurobi' not in solvers, "Ipopt solver not available")
+    @unittest.skipIf('gurobi' not in solvers, "Gurobi solver not available")
     def test_equality_constraints_on_disjuncts_with_fme(self):
         m = models.oneVarDisj_2pts()
         m.obj.expr = m.x + m.disj1.indicator_var


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This PR updates TPL management in the GHA drivers.  It adds three new TPLS (`numdifftools`, `cyipopt`, `casadi`).  It reorganizes installations so that a SLIM build is really slim (the starting environment has just `wheel`, `nose`, and `coverage`) and no solvers are installed.  This will help to ensure that truly required TPLs are correctly added to the `install_requires` in `setup.py`.  Finally, it resolves a problem with the Baron and GAMS installations where they were not being added to the system search PATH.

## Changes proposed in this PR:
- add `numdifftools`, `cyipopt`, `casadi`
- remove solvers, `ply`, and `six` from SLIM build environments
- correct update of `$GITHUB_PATH` in powershell steps

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
