### PR TITLE
Residual pyutilib.common corrections

### DIFF
--- a/doc/OnlineDocs/tests/data/ABCD7.py
+++ b/doc/OnlineDocs/tests/data/ABCD7.py
@@ -1,5 +1,5 @@
 from pyomo.environ import *
-import pyutilib.common
+import pyomo.common
 import sys
 
 model = AbstractModel()
@@ -9,8 +9,8 @@ model.Y = Param(model.Z)
 
 try:
     instance = model.create_instance('ABCD7.dat')
-except pyutilib.common.ApplicationError:
-    print("ERROR")
+except pyomo.common.errors.ApplicationError as e:
+    print("ERROR "+str(e))
     sys.exit(1)
 
 print('Z '+str(sorted(list(instance.Z.data()))))

--- a/doc/OnlineDocs/tests/data/ABCD8.py
+++ b/doc/OnlineDocs/tests/data/ABCD8.py
@@ -1,5 +1,5 @@
 from pyomo.environ import *
-import pyutilib.common
+import pyomo.common
 import sys
 
 model = AbstractModel()
@@ -9,7 +9,7 @@ model.Y = Param(model.Z)
 
 try:
     instance = model.create_instance('ABCD8.dat')
-except pyutilib.common.ApplicationError as e:
+except pyomo.common.errors.ApplicationError as e:
     print("ERROR "+str(e))
     sys.exit(1)
 

--- a/doc/OnlineDocs/tests/data/ABCD9.py
+++ b/doc/OnlineDocs/tests/data/ABCD9.py
@@ -1,5 +1,5 @@
 from pyomo.environ import *
-import pyutilib.common
+import pyomo.common
 import sys
 
 model = AbstractModel()
@@ -9,7 +9,7 @@ model.Y = Param(model.Z)
 
 try:
     instance = model.create_instance('ABCD9.dat')
-except pyutilib.common.ApplicationError as e:
+except pyomo.common.errors.ApplicationError as e:
     print("ERROR "+str(e))
     sys.exit(1)
 

--- a/examples/doc/pyomobook/attic/ref-data-abstract/ABCD10.py
+++ b/examples/doc/pyomobook/attic/ref-data-abstract/ABCD10.py
@@ -1,5 +1,5 @@
 from pyomo.environ import *
-import pyutilib.common
+import pyomo.common
 import sys
 
 model = AbstractModel()
@@ -9,7 +9,7 @@ model.Y = Param(model.Z)
 
 try:
     instance = model.create_instance('ABCD10.dat')
-except pyutilib.common.ApplicationError, e:
+except pyomo.common.errors.ApplicationError as e:
     print("ERROR "+str(e))
     sys.exit(1)
 

--- a/examples/doc/pyomobook/data-abstract-ch/ABCD7.py
+++ b/examples/doc/pyomobook/data-abstract-ch/ABCD7.py
@@ -1,5 +1,5 @@
 from pyomo.environ import *
-import pyutilib.common
+import pyomo.common
 import sys
 
 model = AbstractModel()
@@ -9,7 +9,7 @@ model.Y = Param(model.Z)
 
 try:
     instance = model.create_instance('ABCD7.dat')
-except pyutilib.common.ApplicationError:
+except pyomo.common.errors.ApplicationError:
     print("ERROR")
     sys.exit(1)
 

--- a/examples/doc/pyomobook/data-abstract-ch/ABCD8.py
+++ b/examples/doc/pyomobook/data-abstract-ch/ABCD8.py
@@ -1,5 +1,5 @@
 from pyomo.environ import *
-import pyutilib.common
+import pyomo.common
 import sys
 
 model = AbstractModel()
@@ -9,7 +9,7 @@ model.Y = Param(model.Z)
 
 try:
     instance = model.create_instance('ABCD8.dat')
-except pyutilib.common.ApplicationError as e:
+except pyomo.common.errors.ApplicationError as e:
     print("ERROR "+str(e))
     sys.exit(1)
 

--- a/examples/doc/pyomobook/data-abstract-ch/ABCD9.py
+++ b/examples/doc/pyomobook/data-abstract-ch/ABCD9.py
@@ -1,5 +1,5 @@
 from pyomo.environ import *
-import pyutilib.common
+import pyomo.common
 import sys
 
 model = AbstractModel()
@@ -9,7 +9,7 @@ model.Y = Param(model.Z)
 
 try:
     instance = model.create_instance('ABCD9.dat')
-except pyutilib.common.ApplicationError as e:
+except pyomo.common.errors.ApplicationError as e:
     print("ERROR "+str(e))
     sys.exit(1)
 

--- a/pyomo/dataportal/plugins/sheet.py
+++ b/pyomo/dataportal/plugins/sheet.py
@@ -10,7 +10,6 @@
 
 import os.path
 import six
-import pyutilib.common
 from pyutilib.excel.spreadsheet import ExcelSpreadsheet, Interfaces
 
 from pyomo.dataportal import TableData
@@ -18,6 +17,7 @@ from pyomo.dataportal import TableData
 #     pyodbc_available, pyodbc_db_Table, pypyodbc_available, pypyodbc_db_Table
 # )
 from pyomo.dataportal.factory import DataManagerFactory
+from pyomo.common.errors import ApplicationError
 
 
 def _attempt_open_excel():
@@ -54,7 +54,7 @@ class SheetTable(TableData):
         else:
             try:
                 self.sheet = ExcelSpreadsheet(self.filename, ctype=self.ctype)
-            except pyutilib.common.ApplicationError:
+            except ApplicationError:
                 raise
 
     def read(self):

--- a/pyomo/pysp/lagrangeMorePR.py
+++ b/pyomo/pysp/lagrangeMorePR.py
@@ -638,7 +638,7 @@ if __name__ == "__main__":
 #except IOError, str:
 #    print "IO ERROR:"
 #    print str
-#except pyutilib.common.ApplicationError, str:
+#except pyomo.common.errors.ApplicationError, str:
 #    print "APPLICATION ERROR:"
 #    print str
 #except RuntimeError, str:

--- a/pyomo/pysp/lagrangeParam.py
+++ b/pyomo/pysp/lagrangeParam.py
@@ -730,7 +730,7 @@ if __name__ == "__main__":
 #except IOError, str:
 #    print "IO ERROR:"
 #    print str
-#except pyutilib.common.ApplicationError, str:
+#except pyomo.common.errors.ApplicationError, str:
 #    print "APPLICATION ERROR:"
 #    print str
 #except RuntimeError, str:


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
There were some residual changes necessary in `doc` and `examples` from the `pyutilib.common` change.

## Changes proposed in this PR:
- Change all references of `pyutilib.common` in `doc` and `examples`
- Sneaky typo fix in one of the examples

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
