### PR TITLE
Switch parmest to use CIUD v2 representations

### DIFF
--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -485,7 +485,6 @@ class Estimator(object):
         
             # Generate the extensive form of the stochastic program using pysp
             self.ef_instance = stsolver.make_ef()
-            self.ef_instance.pprint()
 
             # need_gap is a holdover from solve_ef in rapper.py. Would we ever want
             # need_gap = True with parmest?

--- a/pyomo/pysp/embeddedsp.py
+++ b/pyomo/pysp/embeddedsp.py
@@ -34,6 +34,7 @@ from pyomo.pysp.annotations import (locate_annotations,
                                     StochasticConstraintBodyAnnotation,
                                     StochasticObjectiveAnnotation,
                                     StochasticVariableBoundsAnnotation)
+from pyomo.pysp.scenariotree import tree_structure
 from pyomo.pysp.scenariotree.tree_structure_model import \
     CreateAbstractScenarioTreeModel
 from pyomo.pysp.scenariotree.manager import \
@@ -399,7 +400,8 @@ class EmbeddedSP(object):
         self.time_stages = tuple(sorted(self.stage_to_variables_map))
         assert self.time_stages[0] == 1
         self.variable_symbols = ComponentUID.generate_cuid_string_map(
-            self.reference_model, ctype=Var, repr_version=1)
+            self.reference_model, ctype=Var,
+            repr_version=tree_structure.CUID_repr_version)
         # remove the parent blocks from this map
         keys_to_delete = []
         for var in self.variable_symbols:

--- a/pyomo/pysp/scenariotree/tree_structure.py
+++ b/pyomo/pysp/scenariotree/tree_structure.py
@@ -44,13 +44,16 @@ from six.moves import xrange
 
 logger = logging.getLogger('pyomo.pysp')
 
+CUID_repr_version = 1
+
 class _CUIDLabeler(object):
     def __init__(self):
         self._cuid_map = ComponentMap()
 
     def update_cache(self, block):
         self._cuid_map.update(
-            ComponentUID.generate_cuid_string_map(block, repr_version=1))
+            ComponentUID.generate_cuid_string_map(
+                block, repr_version=CUID_repr_version))
 
     def clear_cache(self):
         self._cuid_map = {}


### PR DESCRIPTION
## Fixes #1340

## Summary/Motivation:
Supersedes #1690 

This PR switches `parmest` over to using CUID "version 2" representations.  The version 2 CUID strings correctly quote/parse complex strings and values in component indexes.

## Changes proposed in this PR:
- `parmest` temporarily switches `pysp` over to CUID version 2 representations when generating the PySP model.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
