### PR TITLE
Residual pyutilib.misc Options corrections

### DIFF
--- a/examples/doc/pyomobook/attic/scripts/alltogether.py
+++ b/examples/doc/pyomobook/attic/scripts/alltogether.py
@@ -1,6 +1,6 @@
 import pyomo.environ
 from pyomo.opt import SolverFactory
-from pyutilib.misc import Options
+from pyomo.common.collections import Options
 
 import sys
 import math

--- a/examples/doc/pyomobook/attic/scripts/indexnonlinscript.py
+++ b/examples/doc/pyomobook/attic/scripts/indexnonlinscript.py
@@ -1,6 +1,7 @@
+import sys
 import pyomo.environ
 from pyomo.opt import SolverFactory
-from pyutilib.misc import Options
+from pyomo.common.collections import Options
 
 from indexnonlin import model
 

--- a/examples/doc/pyomobook/attic/scripts/mimic_pyomo/mimic_pyomo.py
+++ b/examples/doc/pyomobook/attic/scripts/mimic_pyomo/mimic_pyomo.py
@@ -1,6 +1,6 @@
 # Mimic the pyomo script
 from pyomo.core import *
-from pyutilib.misc import Options
+from pyomo.common.collections import Options
 
 # set high level options that mimic pyomo comand line
 options = Options()

--- a/examples/doc/pyomobook/attic/scripts/nonlinscript.py
+++ b/examples/doc/pyomobook/attic/scripts/nonlinscript.py
@@ -1,6 +1,7 @@
+import sys
 import pyomo.environ
 from pyomo.opt import SolverFactory
-from pyutilib.misc import Options
+from pyomo.common.collections import Options
 
 from nonlin import model
 

--- a/examples/doc/samples/pyomo_book/nonlinear_ReactorDesignTable.py
+++ b/examples/doc/samples/pyomo_book/nonlinear_ReactorDesignTable.py
@@ -1,6 +1,6 @@
 # nonlinear_ReactorDesignTable.py
 from pyomo.environ import *
-from pyutilib.misc import Options
+from pyomo.common.collections import Options
 
 # create the concrete model
 model = ConcreteModel()
@@ -44,11 +44,11 @@ options.quiet = True
 instance = model.create()
 instance.sv.fixed = True
 sv_values = [1.0 + v * 0.05 for v in range(1, 20)]
-print "   ", 'sv'.rjust(10), 'cb'.rjust(10)
+print("   ", 'sv'.rjust(10), 'cb'.rjust(10))
 for sv_value in sv_values:
     instance.sv = sv_value
     results, opt = \
         scripting.util.apply_optimizer(options, instance)
     instance.load(results)
-    print "   ", str(instance.sv.value).rjust(10),\
-        str(instance.cb.value).rjust(15)
+    print("   ", str(instance.sv.value).rjust(10),\
+        str(instance.cb.value).rjust(15))

--- a/examples/doc/samples/pyomo_book/scripts_mimicPyomo.py
+++ b/examples/doc/samples/pyomo_book/scripts_mimicPyomo.py
@@ -1,6 +1,6 @@
 # Mimic the pyomo script
 from pyomo.environ import *
-from pyutilib.misc import Options
+from pyomo.common.collections import Options
 
 # set high level options that mimic pyomo comand line
 options = Options()

--- a/examples/pyomo/callbacks/sc.py
+++ b/examples/pyomo/callbacks/sc.py
@@ -8,7 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from pyutilib.misc import Options
+from pyomo.common.collections import Options
 from pyomo.core import *
 import math
 import random


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
There were some residual `Options` calls in `examples` that still used the `pyutilib` version. This corrects that.

## Changes proposed in this PR:
- Changing `pyutilib.misc` to `pyomo.common.collections`
- Adding parentheses to one example so it will actually run in newer versions of Python

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
