### PR TITLE
Update parmest/rapper handling of indexed stage variables

### DIFF
--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -376,8 +376,19 @@ class Estimator(object):
             model.parmest_dummy_var = pyo.Var(initialize = 1.0)
             
         for theta in self.theta_names:
+            #First, leverage the parser in ComponentUID to locate the
+            #component.  If that fails, fall back on the original
+            #(insecure) use of 'eval'
+            var_validate = model.find_component(theta)
+            if var_validate is None:
+                try:
+                    var_validate = eval('model.'+theta)
+                except:
+                    pass
             try:
-                var_validate = eval('model.'+theta)
+                # If the variable was not found, or the component that
+                # was found is not a variable, this will generate an
+                # exception (and the warning in the 'except'
                 var_validate.fixed = False
             except:
                 print(theta +' is not a variable')

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -10,11 +10,13 @@
 
 import re
 import importlib as im
+import logging
 import types
 import json
 from itertools import combinations
 
 from pyomo.common.dependencies import (
+    attempt_import,
     numpy as np, numpy_available,
     pandas as pd, pandas_available,
     scipy, scipy_available,
@@ -23,7 +25,9 @@ from pyomo.common.dependencies import (
 import pyomo.environ as pyo
 import pyomo.pysp.util.rapper as st
 from pyomo.pysp.scenariotree import tree_structure
-from pyomo.pysp.scenariotree.tree_structure_model import CreateAbstractScenarioTreeModel
+from pyomo.pysp.scenariotree.tree_structure_model import (
+    CreateAbstractScenarioTreeModel
+)
 from pyomo.opt import SolverFactory
 from pyomo.environ import Block, ComponentUID
 
@@ -35,14 +39,10 @@ from pyomo.contrib.parmest.graphics import (fit_rect_dist,
 
 parmest_available = numpy_available & pandas_available & scipy_available
 
-if numpy_available and scipy_available:
-    from pyomo.contrib.pynumero.asl import AmplInterface
-    asl_available = AmplInterface.available()
-else:
-    asl_available = False
+inverse_reduced_hessian, inverse_reduced_hessian_available = attempt_import(
+    'pyomo.contrib.interior_point.inverse_reduced_hessian')
 
-if asl_available:
-    from pyomo.contrib.interior_point.inverse_reduced_hessian import inv_reduced_hessian_barrier
+logger = logging.getLogger(__name__)
 
 __version__ = 0.1
 
@@ -382,21 +382,21 @@ class Estimator(object):
             var_cuid = ComponentUID(theta)
             var_validate = var_cuid.find_component_on(model)
             if var_validate is None:
+                logger.warning(
+                    "theta_name[%s] (%s) was not found on the model",
+                    (i, theta))
+            else:
                 try:
-                    var_validate = eval('model.'+theta)
+                    # If the component that was found is not a variable,
+                    # this will generate an exception (and the warning
+                    # in the 'except'
+                    var_validate.fixed = False
+                    # We want to standardize on the CUID string
+                    # representation (which is what PySP will use
+                    # internally)
+                    self.theta_names[i] = repr(var_cuid)
                 except:
-                    pass
-            try:
-                # If the variable was not found, or the component that
-                # was found is not a variable, this will generate an
-                # exception (and the warning in the 'except'
-                var_validate.fixed = False
-                # We want to standardize on the CUID string
-                # representation (which is what PySP will use
-                # internally)
-                self.theta_names[i] = repr(var_cuid)
-            except:
-                print(theta +' is not a variable')
+                    logger.warning(theta + ' is not a variable')
         
         if self.obj_function:
             for obj in model.component_objects(Objective):
@@ -526,8 +526,12 @@ class Estimator(object):
                 else:
                     solve_result = solver.solve(self.ef_instance, tee = self.tee)
 
-            elif not asl_available:
-                raise ImportError("parmest requires ASL to calculate the covariance matrix with solver 'ipopt'")
+            # The import error will be raised when we attempt to use
+            # inv_reduced_hessian_barrier below.
+            #
+            #elif not asl_available:
+            #    raise ImportError("parmest requires ASL to calculate the "
+            #                      "covariance matrix with solver 'ipopt'")
             else:
                 # parmest makes the fitted parameters stage 1 variables
                 # thus we need to convert from var names (string) to 
@@ -539,10 +543,12 @@ class Estimator(object):
                     ind_vars.append(self.ef_instance.MASTER_BLEND_VAR_RootNode[v])
         
                 # calculate the reduced hessian
-                solve_result, inv_red_hes = inv_reduced_hessian_barrier(self.ef_instance, 
-                    independent_variables= ind_vars,
-                    solver_options=self.solver_options,
-                    tee=self.tee)
+                solve_result, inv_red_hes = \
+                    inverse_reduced_hessian.inv_reduced_hessian_barrier(
+                        self.ef_instance,
+                        independent_variables= ind_vars,
+                        solver_options=self.solver_options,
+                        tee=self.tee)
             
             # Extract solution from pysp
             stsolver.scenario_tree.pullScenarioSolutionsFromInstances()
@@ -589,7 +595,7 @@ class Estimator(object):
                 for exp_i in self.ef_instance.component_objects(Block, descend_into=False):
                     vals = {}
                     for var in return_values:
-                        exp_i_var = eval('exp_i.'+ str(var))
+                        exp_i_var = exp_i.find_component(str(var))
                         temp = [pyo.value(_) for _ in exp_i_var.itervalues()]
                         if len(temp) == 1:
                             vals[var] = temp[0]

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -376,9 +376,9 @@ class Estimator(object):
             model.parmest_dummy_var = pyo.Var(initialize = 1.0)
             
         for theta in self.theta_names:
-            #First, leverage the parser in ComponentUID to locate the
-            #component.  If that fails, fall back on the original
-            #(insecure) use of 'eval'
+            # First, leverage the parser in ComponentUID to locate the
+            # component.  If that fails, fall back on the original
+            # (insecure) use of 'eval'
             var_validate = model.find_component(theta)
             if var_validate is None:
                 try:

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -389,7 +389,7 @@ class Estimator(object):
                 try:
                     # If the component that was found is not a variable,
                     # this will generate an exception (and the warning
-                    # in the 'except'
+                    # in the 'except')
                     var_validate.fixed = False
                     # We want to standardize on the CUID string
                     # representation (which is what PySP will use

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -53,44 +53,44 @@ class Object_from_string_Tester(unittest.TestCase):
         # TBD add a block
         if imports_present:
             np.random.seed(1134)
-        
+
     def tearDown(self):
         pass
-    
+
     def test_Var(self):
         # just making sure it executes
         pyo_Var_obj = parmest._object_from_string(self.instance, "x[b]")
         fixstatus = pyo_Var_obj.fixed
         self.assertEqual(fixstatus, False)
 
-        
+
 @unittest.skipIf(not parmest.parmest_available,
                  "Cannot test parmest: required dependencies are missing")
 @unittest.skipIf(not ipopt_available, "The 'ipopt' command is not available")
 class parmest_object_Tester_RB(unittest.TestCase):
-    
+
     def setUp(self):
         from pyomo.contrib.parmest.examples.rooney_biegler.rooney_biegler import rooney_biegler_model
-           
+
         data = pd.DataFrame(data=[[1,8.3],[2,10.3],[3,19.0],
                                   [4,16.0],[5,15.6],[6,19.8]], columns=['hour', 'y'])
-        
+
         theta_names = ['asymptote', 'rate_constant']
-        
-        def SSE(model, data):  
+
+        def SSE(model, data):
             expr = sum((data.y[i] - model.response_function[data.hour[i]])**2 for i in data.index)
             return expr
 
         solver_options = {
                 'tol': 1e-8,
                 }
-        
+
         self.pest = parmest.Estimator(rooney_biegler_model, data, theta_names, SSE,
                 solver_options=solver_options)
 
     def test_theta_est(self):
         objval, thetavals = self.pest.theta_est()
-        
+
         self.assertAlmostEqual(objval, 4.4675, places=2)
         self.assertAlmostEqual(thetavals['asymptote'], 19.2189, places=2) # 19.1426 from the paper
         self.assertAlmostEqual(thetavals['rate_constant'], 0.5312, places=2) # 0.5311 from the paper
@@ -99,65 +99,65 @@ class parmest_object_Tester_RB(unittest.TestCase):
                      "parmest.graphics imports are unavailable")
     def test_bootstrap(self):
         objval, thetavals = self.pest.theta_est()
-        
+
         num_bootstraps=10
         theta_est = self.pest.theta_est_bootstrap(num_bootstraps, return_samples=True)
-        
+
         num_samples = theta_est['samples'].apply(len)
         self.assertTrue(len(theta_est.index), 10)
         self.assertTrue(num_samples.equals(pd.Series([6]*10)))
 
         del theta_est['samples']
-        
+
         # apply cofidence region test
         CR = self.pest.confidence_region_test(theta_est, 'MVN', [0.5, 0.75, 1.0])
-        
+
         self.assertTrue(set(CR.columns) >= set([0.5, 0.75, 1.0]))
-        self.assertTrue(CR[0.5].sum() == 5) 
+        self.assertTrue(CR[0.5].sum() == 5)
         self.assertTrue(CR[0.75].sum() == 7)
         self.assertTrue(CR[1.0].sum() == 10) # all true
-        
+
         graphics.pairwise_plot(theta_est)
         graphics.pairwise_plot(theta_est, thetavals)
         graphics.pairwise_plot(theta_est, thetavals, 0.8, ['MVN', 'KDE', 'Rect'])
-        
+
     @unittest.skipIf(not graphics.imports_available,
                      "parmest.graphics imports are unavailable")
     def test_likelihood_ratio(self):
         objval, thetavals = self.pest.theta_est()
-        
+
         asym = np.arange(10, 30, 2)
         rate = np.arange(0, 1.5, 0.25)
         theta_vals = pd.DataFrame(list(product(asym, rate)), columns=self.pest.theta_names)
-        
+
         obj_at_theta = self.pest.objective_at_theta(theta_vals)
-        
+
         LR = self.pest.likelihood_ratio_test(obj_at_theta, objval, [0.8, 0.9, 1.0])
-        
+
         self.assertTrue(set(LR.columns) >= set([0.8, 0.9, 1.0]))
-        self.assertTrue(LR[0.8].sum() == 7) 
+        self.assertTrue(LR[0.8].sum() == 7)
         self.assertTrue(LR[0.9].sum() == 11)
         self.assertTrue(LR[1.0].sum() == 60) # all true
-        
+
         graphics.pairwise_plot(LR, thetavals, 0.8)
 
     def test_leaveNout(self):
-        lNo_theta = self.pest.theta_est_leaveNout(1) 
+        lNo_theta = self.pest.theta_est_leaveNout(1)
         self.assertTrue(lNo_theta.shape == (6,2))
-        
+
         results = self.pest.leaveNout_bootstrap_test(1, None, 3, 'Rect', [0.5, 1.0])
         self.assertTrue(len(results) == 6) # 6 lNo samples
         i = 1
         samples = results[i][0] # list of N samples that are left out
-        lno_theta = results[i][1] 
-        bootstrap_theta = results[i][2] 
+        lno_theta = results[i][1]
+        bootstrap_theta = results[i][2]
         self.assertTrue(samples == [1]) # sample 1 was left out
         self.assertTrue(lno_theta.shape[0] == 1) # lno estimate for sample 1
         self.assertTrue(set(lno_theta.columns) >= set([0.5, 1.0]))
         self.assertTrue(lno_theta[1.0].sum() == 1) # all true
         self.assertTrue(bootstrap_theta.shape[0] == 3) # bootstrap for sample 1
         self.assertTrue(bootstrap_theta[1.0].sum() == 3) # all true
-        
+
     def test_diagnostic_mode(self):
         self.pest.diagnostic_mode = True
 
@@ -166,7 +166,7 @@ class parmest_object_Tester_RB(unittest.TestCase):
         asym = np.arange(10, 30, 2)
         rate = np.arange(0, 1.5, 0.25)
         theta_vals = pd.DataFrame(list(product(asym, rate)), columns=self.pest.theta_names)
-        
+
         obj_at_theta = self.pest.objective_at_theta(theta_vals)
 
         self.pest.diagnostic_mode = False
@@ -186,7 +186,7 @@ class parmest_object_Tester_RB(unittest.TestCase):
         else:
             retcode = subprocess.call([sys.executable, rbpath])
         assert(retcode == 0)
-        
+
     @unittest.skip("Presently having trouble with mpiexec on appveyor")
     def test_parallel_parmest(self):
         """ use mpiexec and mpi4py """
@@ -210,7 +210,7 @@ class parmest_object_Tester_RB(unittest.TestCase):
         # this will fail if k_aug is not installed
         objval, thetavals, Hessian = self.pest.theta_est(solver="k_aug")
         self.assertAlmostEqual(objval, 4.4675, places=2)
-        
+
 
 '''
 The test cases above were developed with a transcription mistake in the dataset.
@@ -220,42 +220,42 @@ This test works with the correct dataset.
                  "Cannot test parmest: required dependencies are missing")
 @unittest.skipIf(not ipopt_available, "The 'ipopt' command is not available")
 class parmest_object_Tester_RB_match_paper(unittest.TestCase):
-    
+
     def setUp(self):
         from pyomo.contrib.parmest.examples.rooney_biegler.rooney_biegler import rooney_biegler_model
-           
+
         data = pd.DataFrame(data=[[1,8.3],[2,10.3],[3,19.0],
                                   [4,16.0],[5,15.6],[7,19.8]], columns=['hour', 'y'])
-        
+
         theta_names = ['asymptote', 'rate_constant']
-        
-        def SSE(model, data):  
+
+        def SSE(model, data):
             expr = sum((data.y[i] - model.response_function[data.hour[i]])**2 for i in data.index)
             return expr
-        
+
         self.pest = parmest.Estimator(rooney_biegler_model, data, theta_names, SSE)
-    
+
     def test_theta_est(self):
         objval, thetavals = self.pest.theta_est(calc_cov=False)
-        
+
         self.assertAlmostEqual(objval, 4.3317112, places=2)
         self.assertAlmostEqual(thetavals['asymptote'], 19.1426, places=2) # 19.1426 from the paper
         self.assertAlmostEqual(thetavals['rate_constant'], 0.5311, places=2) # 0.5311 from the paper
-    
+
     @unittest.skipIf(not asl_available, "Cannot test covariance matrix: required ASL dependency is missing")
     def test_theta_est_cov(self):
         objval, thetavals, cov = self.pest.theta_est(calc_cov=True)
-        
+
         self.assertAlmostEqual(objval, 4.3317112, places=2)
         self.assertAlmostEqual(thetavals['asymptote'], 19.1426, places=2) # 19.1426 from the paper
         self.assertAlmostEqual(thetavals['rate_constant'], 0.5311, places=2) # 0.5311 from the paper
-        
+
         # Covariance matrix
         self.assertAlmostEqual(cov[0,0], 6.30579403, places=2) # 6.22864 from paper
         self.assertAlmostEqual(cov[0,1], -0.4395341, places=2) # -0.4322 from paper
         self.assertAlmostEqual(cov[1,0], -0.4395341, places=2) # -0.4322 from paper
         self.assertAlmostEqual(cov[1,1], 0.04193591, places=2) # 0.04124 from paper
-        
+
         ''' Why does the covariance matrix from parmest not match the paper? Parmest is
         calculating the exact reduced Hessian. The paper (Rooney and Bielger, 2001) likely
         employed the first order approximation common for nonlinear regression. The paper
@@ -263,7 +263,7 @@ class parmest_object_Tester_RB_match_paper(unittest.TestCase):
         The formula used in parmest was verified against equations (7-5-15) and (7-5-16) in
         "Nonlinear Parameter Estimation", Y. Bard, 1974.
         '''
-        
+
 
 @unittest.skipIf(not parmest.parmest_available,
                  "Cannot test parmest: required dependencies are missing")
@@ -344,16 +344,16 @@ class Test_parmest_indexed_variables(unittest.TestCase):
         self.assertAlmostEqual(cov[1,0], -0.4395341, places=2) # -0.4322 from paper
         self.assertAlmostEqual(cov[1,1], 0.04193591, places=2) # 0.04124 from paper
 
-        
+
 
 @unittest.skipIf(not imports_present, "Cannot test parmest: required dependencies are missing")
 @unittest.skipIf(not ipopt_available, "The 'ipopt' solver is not available")
 class parmest_object_Tester_reactor_design(unittest.TestCase):
-    
+
     def setUp(self):
         from pyomo.contrib.parmest.examples.reactor_design.reactor_design import reactor_design_model
-          
-        # Data from the design 
+
+        # Data from the design
         data = pd.DataFrame(data=[[1.05, 10000, 3458.4, 1060.8, 1683.9, 1898.5],
                                   [1.10, 10000, 3535.1, 1064.8, 1613.3, 1893.4],
                                   [1.15, 10000, 3609.1, 1067.8, 1547.5, 1887.8],
@@ -372,12 +372,12 @@ class parmest_object_Tester_reactor_design(unittest.TestCase):
                                   [1.80, 10000, 4392.8, 1056.0,  977.7, 1786.7],
                                   [1.85, 10000, 4442.6, 1052.8,  948.4, 1778.1],
                                   [1.90, 10000, 4491.3, 1049.4,  920.5, 1769.4],
-                                  [1.95, 10000, 4538.8, 1045.8,  893.9, 1760.8]], 
+                                  [1.95, 10000, 4538.8, 1045.8,  893.9, 1760.8]],
                           columns=['sv', 'caf', 'ca', 'cb', 'cc', 'cd'])
 
         theta_names = ['k1', 'k2', 'k3']
-        
-        def SSE(model, data): 
+
+        def SSE(model, data):
             expr = (float(data['ca']) - model.ca)**2 + \
                    (float(data['cb']) - model.cb)**2 + \
                    (float(data['cc']) - model.cc)**2 + \
@@ -385,44 +385,44 @@ class parmest_object_Tester_reactor_design(unittest.TestCase):
             return expr
 
         solver_options = {"max_iter": 6000}
-        
+
         self.pest = parmest.Estimator(reactor_design_model, data,
                                       theta_names, SSE, solver_options)
 
     def test_theta_est(self):
         objval, thetavals = self.pest.theta_est()
-        
-        self.assertAlmostEqual(thetavals['k1'], 5.0/6.0, places=4) 
-        self.assertAlmostEqual(thetavals['k2'], 5.0/3.0, places=4) 
-        self.assertAlmostEqual(thetavals['k3'], 1.0/6000.0, places=7) 
+
+        self.assertAlmostEqual(thetavals['k1'], 5.0/6.0, places=4)
+        self.assertAlmostEqual(thetavals['k2'], 5.0/3.0, places=4)
+        self.assertAlmostEqual(thetavals['k3'], 1.0/6000.0, places=7)
 
     def test_return_values(self):
         objval, thetavals, data_rec =\
             self.pest.theta_est(return_values=['ca', 'cb', 'cc', 'cd', 'caf'])
         self.assertAlmostEqual(data_rec["cc"].loc[18], 893.84924, places=3)
 
-        
-        
+
+
 @unittest.skipIf(not parmest.parmest_available,
                  "Cannot test parmest: required dependencies are missing")
 @unittest.skipIf(not graphics.imports_available,
                  "parmest.graphics imports are unavailable")
 @unittest.skipIf(is_osx, "Disabling graphics tests on OSX due to issue in Matplotlib, see Pyomo PR #1337")
 class parmest_graphics(unittest.TestCase):
-    
+
     def setUp(self):
         self.A = pd.DataFrame(np.random.randint(0,100,size=(100,4)), columns=list('ABCD'))
         self.B = pd.DataFrame(np.random.randint(0,100,size=(100,4)), columns=list('ABCD'))
-        
+
     def test_pairwise_plot(self):
         graphics.pairwise_plot(self.A, alpha=0.8, distributions=['Rect', 'MVN', 'KDE'])
-        
+
     def test_grouped_boxplot(self):
-        graphics.grouped_boxplot(self.A, self.B, normalize=True, 
+        graphics.grouped_boxplot(self.A, self.B, normalize=True,
                                 group_names=['A', 'B'])
-        
+
     def test_grouped_violinplot(self):
         graphics.grouped_violinplot(self.A, self.B)
-        
+
 if __name__ == '__main__':
     unittest.main()

--- a/pyomo/pysp/util/rapper.py
+++ b/pyomo/pysp/util/rapper.py
@@ -6,6 +6,7 @@ Author: David L. Woodruff, started February 2017
 """
 
 import inspect
+from pyomo.core.base.component import _name_index_generator
 from pyomo.environ import SolverFactory
 from pyomo.pysp.scenariotree.instance_factory \
     import ScenarioTreeInstanceFactory
@@ -307,7 +308,7 @@ class StochSolver:
             var_name, index = root_node._variable_ids[variable_id]
             name = var_name
             if index is not None:
-                name += "["+str(index)+"]"
+                name += _name_index_generator(index)
             yield name, root_node._solution[variable_id]
 
     #=========================

--- a/pyomo/pysp/util/rapper.py
+++ b/pyomo/pysp/util/rapper.py
@@ -53,7 +53,7 @@ def _kwfromphopts(phopts):
                     float(phopts["--scenario-tree-downsample-fraction"])
         else:
             kwargs['downsample_fraction'] = None
-            
+
         if "--scenario-bundle-specification" in phopts:
             kwargs['bundles'] = phopts["--scenario-tree-bundle-specification"]
         else:
@@ -68,19 +68,19 @@ class StochSolver:
     abstract models.
     Inspired by the IDAES use case and by daps ability to create tree models.
     Author: David L. Woodruff, February 2017
-    
-    Args: 
-      fsfile (str): is a path to the file that contains the scenario 
+
+    Args:
+      fsfile (str): is a path to the file that contains the scenario
                     callback for concrete or the reference model for abstract.
-      fsfct (str, or fct, or None): 
+      fsfct (str, or fct, or None):
          |  str:   callback function name in the file
          |  fct:   callback function (fsfile is ignored)
          |  None:  it is a AbstractModel
-      tree_model (concrete model, or networkx tree, or path): 
+      tree_model (concrete model, or networkx tree, or path):
         gives the tree as a concrete model (which could be a fct)
         or a valid networkx scenario tree
         or path to AMPL data file.
-      phopts: dictionary of ph options; needed during construction 
+      phopts: dictionary of ph options; needed during construction
               if there is bundling.
 
     Attributes:
@@ -110,7 +110,7 @@ class StochSolver:
                 print ("ERROR in StochSolver called from",inspect.stack()[1][3])
                 raise RuntimeError("fsfct is None, so assuming",
                       "AbstractModel but could not find all ingredients.")
-                
+
         else:  # concrete model
             if  callable(fsfct):
                 scen_function = fsfct
@@ -131,7 +131,7 @@ class StochSolver:
 
                 scenario_instance_factory = ScenarioTreeInstanceFactory(scen_function, tree_model)
 
-            else: 
+            else:
                 # DLW March 21: still not correct
                 scenario_instance_factory = \
                     ScenarioTreeInstanceFactory(scen_function, tree_model)
@@ -142,7 +142,7 @@ class StochSolver:
                 scenario_instance_factory.generate_scenario_tree(**kwargs) #verbose = True)
             instances = scenario_instance_factory. \
                         construct_instances_for_scenario_tree(self.scenario_tree)
-            self.scenario_tree.linkInInstances(instances)        
+            self.scenario_tree.linkInInstances(instances)
 
     #=========================
     def make_ef(self,
@@ -153,7 +153,7 @@ class StochSolver:
                 cc_indicator_var_name=None,
                 cc_alpha=0.0):
         """ Make an ef object (used by solve_ef); all Args are optional.
-        
+
         Args:
             verbose (boolean): indicates verbosity to PySP for construction
             generate_weighted_cvar (boolean): indicates we want weighted CVar
@@ -172,7 +172,7 @@ class StochSolver:
                                          risk_alpha = risk_alpha,
                                          cc_indicator_var_name = cc_indicator_var_name,
                                          cc_alpha = cc_alpha)
-    
+
     def solve_ef(self, subsolver, sopts = None, tee = False, need_gap = False,
                  verbose=False,
                  generate_weighted_cvar = False,
@@ -183,7 +183,7 @@ class StochSolver:
 
         """Solve the stochastic program directly using the extensive form.
         All Args other than subsolver are optional.
-       
+
         Args:
             subsolver (str): the solver to call (e.g., 'ipopt')
             sopts (dict):  solver options
@@ -209,7 +209,7 @@ class StochSolver:
            This needs more work to deal with solver failure (dlw, March, 2018)
 
         """
-        
+
         self.ef_instance = self.make_ef(verbose=verbose,
                                         generate_weighted_cvar = generate_weighted_cvar,
                                         cvar_weight = cvar_weight,
@@ -254,7 +254,7 @@ class StochSolver:
         Returns: the ph object
 
         Note:
-            Updates the scenario tree, populated with the xbar values; 
+            Updates the scenario tree, populated with the xbar values;
             however, you probably want to do
             obj, xhat = ph.compute_and_report_inner_bound_using_xhat()
             where ph is the return value.
@@ -269,13 +269,13 @@ class StochSolver:
         phargslist.append('--solver')
         phargslist.append(str(subsolver))
         phargslist = _optiondict_2_list(phopts, args_list = phargslist)
-                    
+
         # Subproblem options go to PH as space-delimited, equals-separated pairs.
         if sopts is not None:
             soptstring = ""
             for key in sopts:
                 soptstring += key + '=' + str(sopts[key]) + ' '
-            phargslist.append('--scenario-solver-options')    
+            phargslist.append('--scenario-solver-options')
             phargslist.append(soptstring)
         phoptions = parser.parse_args(phargslist)
 


### PR DESCRIPTION
## Fixes #1340

## Summary/Motivation:
`parmest` / `rapper` were fragile in their handling of indexed stage variables.  This PR updates how `parmest` locates stage (theta) variables to first leverage the parsers in ComponentUID (through `block.find_component()`) before falling back on the previous (insecure) use of `eval()`.  This also updates how `rapper` reports the root node solution back to leverage `_name_index_generator` from `component.py` to generate consistent indices for reporting indexed root node variable solutions.

## Changes proposed in this PR:
- use `_name_index_generator` to generate the index strings in `rapper`'s `root_Var_solution`
- use `block.find_component()` to identify theta variables by name.
- map all incoming `theta_names` to the `repr(CUID)` of the identified component
- add a test (originally from #1690) to verify this behavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
