### PR TITLE
Update management of matplotlib imports

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -422,8 +422,15 @@ def _finalize_pympler(module, available):
         import pympler.muppy
 
 def _finalize_matplotlib(module, available):
-    if available:
-        import matplotlib.pyplot
+    if not available:
+        return
+    # You must switch matplotlib backends *before* importing pyplot.  If
+    # we are in the middle of testing, we need to switch the backend to
+    # 'Agg', otherwise attempts to generate plots on CI services without
+    # terminal windows will fail.
+    if 'nose' in sys.modules or 'nose2' in sys.modules:
+        matplotlob.use('Agg')
+    import matplotlib.pyplot
 
 yaml, yaml_available = attempt_import('yaml', callback=_finalize_yaml)
 pympler, pympler_available = attempt_import(

--- a/pyomo/contrib/mcpp/test_mcpp.py
+++ b/pyomo/contrib/mcpp/test_mcpp.py
@@ -16,6 +16,7 @@ from six import StringIO
 
 import pyutilib.th as unittest
 from pyomo.common.log import LoggingIntercept
+from pyomo.common.dependencies import matplotlib
 from pyomo.contrib.mcpp.pyomo_mcpp import McCormick as mc, mcpp_available, MCPP_Error
 from pyomo.core import (
     ConcreteModel, Expression, Var, acos, asin, atan, cos, exp, quicksum, sin,
@@ -201,7 +202,7 @@ def make2dPlot(expr, numticks=10, show_plot=False):
         mc_cvVals[i] = mc_expr.convex()
         fvals[i] = value(expr)
     if show_plot:
-        import matplotlib.pyplot as plt
+        plt = matplotlib.pyplot
         plt.plot(xaxis, fvals, 'r', xaxis, mc_ccVals, 'b--', xaxis,
                  mc_cvVals, 'b--', xaxis, aff_cc, 'k|', xaxis, aff_cv, 'k|')
         plt.show()
@@ -252,7 +253,7 @@ def make3dPlot(expr, numticks=30, show_plot=False):
             fvals[i + (numticks + 1) * j] = value(expr)
 
     if show_plot:
-        import matplotlib.pyplot as plt
+        plt = matplotlib.pyplot
         from mpl_toolkits.mplot3d import Axes3D
         assert Axes3D  # silence pyflakes
 

--- a/pyomo/contrib/parmest/examples/reactor_design/datarec_example.py
+++ b/pyomo/contrib/parmest/examples/reactor_design/datarec_example.py
@@ -10,11 +10,8 @@
 
 import numpy as np
 import pandas as pd
-import matplotlib.pylab as plt
 import pyomo.contrib.parmest.parmest as parmest
-from reactor_design import reactor_design_model
-
-plt.close('all')
+from .reactor_design import reactor_design_model
 
 np.random.seed(1234)
 

--- a/pyomo/contrib/parmest/tests/test_parmest.py
+++ b/pyomo/contrib/parmest/tests/test_parmest.py
@@ -8,15 +8,11 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-try:
-    import matplotlib
-    matplotlib.use('Agg')
-except:
-    pass
 from pyomo.common.dependencies import (
     numpy as np, numpy_available,
     pandas as pd, pandas_available,
     scipy, scipy_available,
+    matplotlib, matplotlib_available,
 )
 imports_present = numpy_available & pandas_available & scipy_available
 

--- a/pyomo/contrib/parmest/tests/test_scenariocreator.py
+++ b/pyomo/contrib/parmest/tests/test_scenariocreator.py
@@ -8,16 +8,11 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-# the matpolotlib stuff is to avoid $DISPLAY errors on Travis (DLW Oct 2018)
-try:
-    import matplotlib
-    matplotlib.use('Agg')
-except:
-    pass
 from pyomo.common.dependencies import (
     numpy as np, numpy_available,
     pandas as pd, pandas_available,
     scipy, scipy_available,
+    matplotlib, matplotlib_available,
 )
 imports_present = numpy_available & pandas_available & scipy_available
 

--- a/pyomo/solvers/tests/core/test_param_perf.py
+++ b/pyomo/solvers/tests/core/test_param_perf.py
@@ -12,8 +12,11 @@ import os
 thisdir = os.path.dirname(os.path.abspath(__file__))
 
 import time
+from pyomo.common.dependencies import matplotlib, matplotlib_available
 from pyomo.core import ConcreteModel, RangeSet, Set, Param
 import pyutilib.th as unittest
+
+plt = matplotlib.pyplot
 
 _plot_filename = os.path.join(thisdir, "param_performance.pdf")
 _pdf_out = None
@@ -21,23 +24,14 @@ _pdf_out = None
 def setUpModule():
     global _plot_filename
     global _pdf_out
-    try:
-        import matplotlib
-        matplotlib.use('Agg')
-        from matplotlib.backends.backend_pdf import PdfPages
-        _pdf_out = PdfPages(_plot_filename)
-    except:
-        _pdf_out = None
 
 def tearDownModule():
     global _pdf_out
-    if _pdf_out:
+    if _pdf_out is not None:
         _pdf_out.close()
+        _pdf_out = None
 
 def plot_results(page_title, results):
-
-    import matplotlib.pyplot as plt
-
     pyomo_set_iter_time = results.pop('pyomo set iter')
     python_set_iter_time = results.pop('python set iter')
     pyomo_set_contains_time = results.pop('pyomo set contains')
@@ -111,6 +105,10 @@ def plot_results(page_title, results):
     plt.legend((p1[0],p2[0]),
                ('Consruction','Access All'),loc=4)
 
+    global _pdf_out
+    if _pdf_out is None:
+        from matplotlib.backends.backend_pdf import PdfPages
+        _pdf_out = PdfPages(_plot_filename)
     plt.savefig(_pdf_out,format='pdf')
 
 def _setup_cls(self):
@@ -275,10 +273,8 @@ class TestParamPerformanceRangeSet(unittest.TestCase,
 
     @classmethod
     def tearDownClass(self):
-        try:
+        if matplotlib_available:
             plot_results("Param Usage - Large RangeSet Index", self.results)
-        except:
-            print("Results plotting failed")
 
 
 @unittest.category('performance')
@@ -331,10 +327,8 @@ class TestParamPerformanceSetProduct(unittest.TestCase,
 
     @classmethod
     def tearDownClass(self):
-        try:
+        if matplotlib_available:
             plot_results("Param Usage - High Dimensional Set Product Index", self.results)
-        except:
-            print("Results plotting failed")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Thes PR standardizes / centralizes the import of matplotlib across Pyomo.  It also centralizes the backend switch to `Agg` when `nose` is running,  This should help resolve testing issues on #1526 

## Changes proposed in this PR:
- standardize core / tests to import matplotlib through pyomo.common.dependencies
- centralize the switch to 'Agg' backend if nose is running
- prevent the param performance tester from creating param_performance.pdf unless the tests are actually run

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
