### PR TITLE
Resolve bugs deepcopying/pickling units

### DIFF
--- a/pyomo/core/base/units_container.py
+++ b/pyomo/core/base/units_container.py
@@ -107,6 +107,7 @@ information.
 #    * Further investigate issues surrounding absolute and relative temperatures (delta units)
 #    * Extend external function interface to support units for the arguments in addition to the function itself
 
+import logging
 import six
 import sys
 
@@ -118,6 +119,8 @@ from pyomo.core.expr import current as EXPR
 pint_module, pint_available = attempt_import(
     'pint', defer_check=True, error_message='The "pint" package failed '
     'to import. This package is necessary to use Pyomo units.')
+
+logger = logging.getLogger(__name__)
 
 class UnitsError(Exception):
     """
@@ -149,6 +152,8 @@ class _PyomoUnit(NumericValue):
     This module contains a global PyomoUnitsContainer object :py:data:`units`.
     See module documentation for more information.
     """
+    __slots__ = ('_pint_unit', '_pint_registry')
+
     def __init__(self, pint_unit, pint_registry):
         super(_PyomoUnit, self).__init__()
         assert pint_unit is not None
@@ -163,8 +168,6 @@ class _PyomoUnit(NumericValue):
     def _get_pint_registry(self):
         """ Return the pint registry (pint.UnitRegistry) object used to create this unit. """
         return self._pint_registry
-
-    # Todo: test pickle and implement __getstate__/__setstate__ to do the right thing
 
     def getname(self, fully_qualified=False, name_buffer=None):
         """
@@ -256,6 +259,43 @@ class _PyomoUnit(NumericValue):
         Note that :py:meth:`NumericValue.polynomial_degree` calls this method.
         """
         return 0
+
+    def __getstate__(self):
+        state = super(_PyomoUnit, self).__getstate__()
+        state['_pint_unit'] = str(self._pint_unit)
+        if self._pint_registry is not units._pint_registry:
+            # FIXME: we currently will not correctly unpickle units
+            # associated with a unit manager other than the default
+            # singleton.  If we wanted to support this, we would need to
+            # do something like create a global units manager registry
+            # that would associate each unit manager with a name.  We
+            # could then pickle that name and then attempt to restore
+            # the association with the original units manager.  As we
+            # expect all users to just use the global default, for the
+            # time being we will just issue a warning that things may
+            # break.
+            logger.warning(
+                "pickling a _PyomoUnit associated with a PyomoUnitsContainer "
+                "that is not the default singleton (%s.units).  Restoring "
+                "this pickle will attempt to return a unit associated with "
+                "the default singleton." % (__name__,))
+        return state
+
+    def __setstate__(self, state):
+        self._pint_registry = units._pint_registry
+        self._pint_unit = self._pint_registry(state.pop('_pint_unit')).units
+        super(_PyomoUnit, self).__setstate__(state)
+
+    def __deepcopy__(self, memo):
+        # Note that while it is possible to deepcopy the _pint_unit and
+        # _pint_registry object (in pint>0.10), that version does not
+        # support all Python versions currently supported by Pyomo.
+        # Further, Pyomo's use of units relies on a model using a single
+        # instance of the pint unit registry.  As we regularly assemble
+        # block models using multiple clones (deepcopies) of a base
+        # model, it is important that we treat _PyomoUnit objects
+        # as outside the model scope and DO NOT duplicate them.
+        return self
 
     def __float__(self):
         """
@@ -1111,7 +1151,6 @@ class UnitExtractionVisitor(EXPR.StreamBasedExpressionVisitor):
         raise TypeError('An unhandled expression node type: {} was encountered while retrieving the'
                 ' units of expression {}'.format(str(type(node)), str(node)))
 
-
 class PyomoUnitsContainer(object):
     """Class that is used to create and contain units in Pyomo.
 
@@ -1481,7 +1520,7 @@ class PyomoUnitsContainer(object):
         return dest_quantity.magnitude
 
 
-class DeferredUnitsSingleton(PyomoUnitsContainer):
+class _DeferredUnitsSingleton(PyomoUnitsContainer):
     """A class supporting deferred interrogation of pint_available.
 
     This class supports creating a module-level singleton, but deferring
@@ -1511,4 +1550,4 @@ class DeferredUnitsSingleton(PyomoUnitsContainer):
 # all units within a Pyomo model. If pint is not available, this will
 # cause an error at the first usage See module level documentation for
 # an example.
-units = DeferredUnitsSingleton()
+units = _DeferredUnitsSingleton()

--- a/pyomo/core/tests/unit/test_units.py
+++ b/pyomo/core/tests/unit/test_units.py
@@ -10,14 +10,21 @@
 #  ___________________________________________________________________________
 #
 #
+import pickle
 
 import pyutilib.th as unittest
-from pyomo.environ import ConcreteModel, Var, Param, Set, Constraint, Objective, Expression, ExternalFunction, value, log, log10, exp, sqrt, cos, sin, tan, asin, acos, atan, cosh, sinh, tanh, asinh, acosh, atanh, ceil, floor, sum_product, maximize, units
+from pyomo.environ import (
+    ConcreteModel, Var, Param, Set, Constraint, Objective, Expression,
+    ExternalFunction, value, sum_product, maximize, units,
+    log, log10, exp, sqrt, cos, sin, tan, asin, acos, atan, cosh, sinh,
+    tanh, asinh, acosh, atanh, ceil, floor,
+)
+from pyomo.common.log import LoggingIntercept
 from pyomo.util.check_units import assert_units_consistent
 from pyomo.core.expr import inequality
 import pyomo.core.expr.current as EXPR
 from pyomo.core.base.units_container import (
-    pint_available, InconsistentUnitsError, UnitsError,
+    pint_available, InconsistentUnitsError, UnitsError, PyomoUnitsContainer,
 )
 from six import StringIO
 
@@ -544,6 +551,57 @@ class TestPyomoUnit(unittest.TestCase):
         u.load_definitions_from_strings(["USD = [currency]"])
         expr = 3.0*u.USD
         self._get_check_units_ok(expr, u, 'USD')
+
+    def test_clone(self):
+        m = ConcreteModel()
+        m.x = Var(units=units.kg)
+        m.c = Constraint(expr=m.x**2 <= 10*units.kg**2)
+        i = m.clone()
+        self.assertIs(m.x._units, i.x._units)
+        self.assertEqual(str(m.c.upper), str(i.c.upper))
+        base = StringIO()
+        m.pprint(base)
+        test = StringIO()
+        i.pprint(test)
+        self.assertEqual(base.getvalue(), test.getvalue())
+
+    def test_pickle(self):
+        m = ConcreteModel()
+        m.x = Var(units=units.kg)
+        m.c = Constraint(expr=m.x**2 <= 10*units.kg**2)
+        i = pickle.loads(pickle.dumps(m))
+        self.assertIsNot(m.x._units, i.x._units)
+        self.assertEqual(m.x._units, i.x._units)
+        self.assertEqual(str(m.c.upper), str(i.c.upper))
+        base = StringIO()
+        m.pprint(base)
+        test = StringIO()
+        i.pprint(test)
+        self.assertEqual(base.getvalue(), test.getvalue())
+
+        # Test pickling a custom units manager
+        um = PyomoUnitsContainer()
+        m = ConcreteModel()
+        m.x = Var(units=um.kg)
+        m.c = Constraint(expr=m.x**2 <= 10*um.kg**2)
+        log = StringIO()
+        with LoggingIntercept(log, 'pyomo.core.base'):
+            i = pickle.loads(pickle.dumps(m))
+        self.assertIn(
+            "pickling a _PyomoUnit associated with a PyomoUnitsContainer "
+            "that is not the default singleton "
+            "(pyomo.core.base.units_container.units)", log.getvalue())
+        self.assertIsNot(m.x._units, i.x._units)
+        # Note that since the pickle is restored using the default
+        # global PyomoUnitsContainer, the units will not longer compare
+        # equal
+        self.assertNotEqual(m.x._units, i.x._units)
+        self.assertEqual(str(m.c.upper), str(i.c.upper))
+        base = StringIO()
+        m.pprint(base)
+        test = StringIO()
+        i.pprint(test)
+        self.assertEqual(base.getvalue(), test.getvalue())
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This PR resolves issues where the `_PyomoUnit` object was not deepcopied / pickled correctly.  The root cause was because `_PyomoUnit` inherited from a slotized class (`NumericValue`) without implementing a `__getstate__` method.  Further, the default behavior of `__deepcopy__` is undesirable, as `pint` unit comparisong rely on all units referring to the same `UnitRegistry`, implying that a single registry must be used for all parts of a model (including sections generated by cloning other parts of the model).

This issue was originally reported by @esrawli when using  GDPopt with models containing units.  

## Changes proposed in this PR:
- implement `__getstate__`, `__setstate__` and `__deepcopy__` for `_PyomoUnit`
- add tests verifying expected behavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
