### PR TITLE
Fix cloning AMPLExternalFunction objects after the external library is loaded

### DIFF
--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -111,6 +111,13 @@ class AMPLExternalFunction(ExternalFunction):
         self._so = None
         ExternalFunction.__init__(self, *args, **kwds)
 
+    def __getstate__(self):
+        state = super(AMPLExternalFunction, self).__getstate__()
+        # Remove reference to loaded library (they are not copyable or
+        # picklable)
+        state['_so'] = state['_known_functions'] = None
+        return state
+
     def _evaluate(self, args, fgh, fixed):
         if self._so is None:
             self.load_library()

--- a/pyomo/core/tests/unit/test_external.py
+++ b/pyomo/core/tests/unit/test_external.py
@@ -136,6 +136,33 @@ class TestAMPLExternalFunction(unittest.TestCase):
         res = opt.solve(model, tee=True)
         self.assertAlmostEqual(value(model.o), 0.885603194411, 7)
 
+    @unittest.skipIf(not check_available_solvers('ipopt'),
+                     "The 'ipopt' solver is not available")
+    def test_clone_gsl_function(self):
+        DLL = find_GSL()
+        if not DLL:
+            self.skipTest("Could not find the amplgsl.dll library")
+        m = ConcreteModel()
+        m.z_func = ExternalFunction(library=DLL, function="gsl_sf_gamma")
+        self.assertIsInstance(m.z_func, AMPLExternalFunction)
+        m.x = Var(initialize=3, bounds=(1e-5,None))
+        m.o = Objective(expr=m.z_func(m.x))
+
+        opt = SolverFactory('ipopt')
+
+        # Test a simple clone...
+        model2 = m.clone()
+        res = opt.solve(model2, tee=True)
+        self.assertAlmostEqual(value(model2.o), 0.885603194411, 7)
+
+        # Trigger the library to be loaded.  This tests that the CDLL
+        # objects that are created when the SO/DLL are loaded do not
+        # interfere with cloning the model.
+        self.assertAlmostEqual(value(m.o), 2)
+        model3 = m.clone()
+        res = opt.solve(model3, tee=True)
+        self.assertAlmostEqual(value(model3.o), 0.885603194411, 7)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
`AMPLExternalFunction` objects contain "uncopyable" attributes after teh SO/DLL has been loaded.  This PR updates `AMPLExternalFunction.__getstate__()` to *not* copy the `_so` and `_known_functions` attributes.  This makes the resulting state copyable/picklable, but forces the clone to re-load the external library.

This bug was originally reported by @esrawli when using GDPopt with models containing compiled external functions.

## Changes proposed in this PR:
- Map the `AMPLExternalFunction` `_so` and `_known_functions` attributes to `None` when deepcopying/cloning/pickling the component.
- Add a test to verify the previous error is resolved.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
