### PR TITLE
MOSEK interface improvements (license check, python 2.x)

### DIFF
--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -10,6 +10,7 @@
 
 import logging
 import re
+import six
 import sys
 import itertools
 import operator
@@ -35,6 +36,14 @@ from pyomo.opt.results.solver import TerminationCondition, SolverStatus
 logger = logging.getLogger('pyomo.solvers')
 inf = float('inf')
 
+if six.PY2:
+    def accumulate(it):
+        total = 0
+        for x in it:
+            total += x
+            yield total
+else:
+    from itertools import accumulate
 
 class DegreeError(ValueError):
     pass
@@ -318,7 +327,7 @@ class MOSEKDirect(DirectSolver):
         lq = tuple(filter(operator.attrgetter("_linear_canonical_form"),
                           con_seq))
         conic = tuple(filter(lambda x: isinstance(x, _ConicBase), con_seq))
-        lq_ex = tuple(itertools.filterfalse(lambda x: isinstance(
+        lq_ex = tuple(six.moves.filterfalse(lambda x: isinstance(
             x, _ConicBase) or (x._linear_canonical_form), con_seq))
         lq_all = lq + lq_ex
         num_lq = len(lq) + len(lq_ex)
@@ -341,7 +350,7 @@ class MOSEKDirect(DirectSolver):
             sub = range(con_num, con_num + num_lq)
             sub_names = tuple(self._symbol_map.getSymbol(c, self._labeler)
                               for c in lq_all)
-            ptre = tuple(itertools.accumulate(list(map(len, l_ids))))
+            ptre = tuple(accumulate(list(map(len, l_ids))))
             ptrb = (0,) + ptre[:-1]
             asubs = tuple(itertools.chain.from_iterable(l_ids))
             avals = tuple(itertools.chain.from_iterable(l_coefs))

--- a/pyomo/solvers/tests/checks/test_MOSEKDirect.py
+++ b/pyomo/solvers/tests/checks/test_MOSEKDirect.py
@@ -10,24 +10,18 @@
 
 import pyutilib.th as unittest
 
-from pyomo.opt import (TerminationCondition,
-                       SolutionStatus)
+from pyomo.opt import (
+    TerminationCondition, SolutionStatus, check_available_solvers,
+)
 import pyomo.environ as pyo
 import pyomo.kernel as pmo
 import sys
 
-try:
-    import mosek
-    mosek_available = True
-    mosek_version = mosek.Env().getversion()
-except ImportError:
-    mosek_available = False
-    modek_version = None
-
 diff_tol = 1e-3
 
+mosek_available = check_available_solvers('mosek_direct')
 
-@unittest.skipIf(not mosek_available,
+@unittest.skipIf(not mosek_available ,
                  "MOSEK's python bindings are not available")
 class MOSEKDirectTests(unittest.TestCase):
 
@@ -178,7 +172,8 @@ class MOSEKDirectTests(unittest.TestCase):
         model.c.body += b.r1 + b.r2
         del b
 
-        if mosek_version >= (9, 0, 0):
+        import mosek
+        if mosek.Env().getversion() >= (9, 0, 0):
             b = model.primal_exponential = pmo.block()
             b.x1 = pmo.variable(lb=0)
             b.x2 = pmo.variable()

--- a/pyomo/solvers/tests/checks/test_MOSEKPersistent.py
+++ b/pyomo/solvers/tests/checks/test_MOSEKPersistent.py
@@ -1,22 +1,16 @@
 import pyutilib.th as unittest
 
-from pyomo.opt import (TerminationCondition,
-                       SolutionStatus,
-                       SolverStatus)
+from pyomo.opt import (
+    TerminationCondition, SolutionStatus, SolverStatus,
+    check_available_solvers,
+)
 import pyomo.environ as pyo
 import pyomo.kernel as pmo
 import sys
 
-try:
-    import mosek
-    mosek_available = True
-    mosek_version = mosek.Env().getversion()
-except ImportError:
-    mosek_available = False
-    modek_version = None
-
 diff_tol = 1e-3
 
+mosek_available = check_available_solvers('mosek_direct')
 
 @unittest.skipIf(not mosek_available, "MOSEK's python bindings are missing.")
 class MOSEKPersistentTests(unittest.TestCase):

--- a/pyomo/solvers/tests/solvers.py
+++ b/pyomo/solvers/tests/solvers.py
@@ -56,7 +56,7 @@ def initialize(**kwds):
     elif (obj.name == "gurobi") and \
        (not GUROBISHELL.license_is_valid()):
         obj.available = False
-    elif (obj.name == "mosek_direct") and \
+    elif (obj.name in {"mosek_direct", "mosek_persistent"}) and \
        (not MOSEKDirect.license_is_valid()):
         obj.available = False
     else:


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This PR resolves some incompatibilities with Python 2.7 and improves the testing so that the tests are correctly skipped if MOSEK is installed, but does not have a valid license.

## Changes proposed in this PR:
- Python 2.7 compatibility wrappers for itertools methods
- skip `mosek_direct` and `mosek_persistent` tests when MOSEK is present but does not have a valid liense

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
