### PR TITLE
CUID-from-slice patch

### DIFF
--- a/pyomo/core/tests/unit/test_componentuid.py
+++ b/pyomo/core/tests/unit/test_componentuid.py
@@ -1085,8 +1085,7 @@ class TestComponentUID(unittest.TestCase):
         cuid_str = ComponentUID('b.b2[2,*].vn[**,**]')
         self.assertEqual(cuid, cuid_str)
         self.assertEqual(str(cuid), str(cuid_str))
-        with self.assertRaisesRegex(IndexError, r'.*simple slices.*'):
-            self.assertListSameComponents(m, cuid, cuid_str)
+        self.assertListSameComponents(m, cuid, cuid_str)
 
         _slice = m.b.b2[2,:].vn[...]
         cuid = ComponentUID(_slice)


### PR DESCRIPTION
## Fixes failing test

## Changes proposed in this PR:
- Remove assertion for error that is no longer raised. (Two ellipses in slice -> CUID)
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
