### PR TITLE
Improve log message when loading solution with 'warning' status

### DIFF
--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -222,7 +222,7 @@ class ModelSolutions(object):
             msg = getattr(results.solver, 'message', None)
             logger.warning(
                 'Loading a SolverResults object with a '
-                'warning status into model=%s;\n'
+                'warning status into model.name="%s";\n'
                 '  - termination condition: %s\n'
                 '  - message from solver: %s'
                 % (instance.name, tc, msg))

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -218,13 +218,17 @@ class ModelSolutions(object):
         # If there is a warning, then print a warning message.
         #
         if (results.solver.status == SolverStatus.warning):
+            tc = getattr(results.solver, 'termination_condition', None)
+            msg = getattr(results.solver, 'message', None)
             logger.warning(
                 'Loading a SolverResults object with a '
                 'warning status into model=%s;\n'
-                '    message from solver=%s'
-                % (instance.name, results.solver.Message))
+                '  - termination condition: %s\n'
+                '  - message from solver: %s'
+                % (instance.name, tc, msg))
         #
-        # If the solver status not one of either OK or Warning, then generate an error.
+        # If the solver status not one of either OK or Warning, then
+        # generate an error.
         #
         elif results.solver.status != SolverStatus.ok:
             if (results.solver.status == SolverStatus.aborted) and \


### PR DESCRIPTION
## Fixes #1634

## Summary/Motivation:
This is a simplification of (and supersedes) PR #1633, originally drafted by @samryan18.  The PR includes the termination condition in the log message generated whenever loading a solution with `SolverStatus.warning`.  It also clarifies (for the most common case) that the model is not unknown, but that the `model.name` is `"unknown"`.

## Changes proposed in this PR:
- Add the `termination_condition` to the log message generated when the result has a `solver.status == SolverStatus.warning`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
