### PR TITLE
Add Full Python 3.9 Test Suite

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, macos-latest, windows-latest]
-        python: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
+        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, pypy2, pypy3]
         other: [""]
         category: ["nightly"]
         # Ubuntu-18.04 should be replaced with ubuntu-latest once PyNumero

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -32,10 +32,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install twine wheel setuptools
+    # 12/17/2020 - Switched to fork of the manylinux-build action to support 
+    # Python 3.9. Will switch back once main action supports this.
     - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.2.2-manylinux2010_x86_64
+      uses: ahartikainen/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
       with:
-        python-versions: 'cp27-cp27mu cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38'
+        python-versions: 'cp27-cp27mu cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
         build-requirements: 'cython'
         package-path: ''
         pip-wheel-args: ''

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Pyomo is available under the BSD License, see the LICENSE.txt file.
 
 Pyomo is currently tested with the following Python implementations:
 
-* CPython: 2.7, 3.4, 3.5, 3.6, 3.7, 3.8
+* CPython: 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9
 * PyPy: 2, 3
 
 ### Installation

--- a/doc/OnlineDocs/installation.rst
+++ b/doc/OnlineDocs/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 Pyomo currently supports the following versions of Python:
 
-* CPython: 2.7, 3.4, 3.5, 3.6, 3.7, 3.8
+* CPython: 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9
 * PyPy: 2, 3
 
 

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,7 @@ def run_setup():
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: Jython',
         'Programming Language :: Python :: Implementation :: PyPy',


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
We want to fully support Python 3.9 in the next release. This updates relevant documentation and adds 3.9 to the full testing suite for GHA.

## Changes proposed in this PR:
- Update 3.9 testing in GitHub Actions
- Update Documentation

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
