### PR TITLE
Adding 3.9 to OSX/Win on release workflow

### DIFF
--- a/.coin-or/projDesc.xml
+++ b/.coin-or/projDesc.xml
@@ -287,7 +287,7 @@ Carl D. Laird, Chair, Pyomo Management Committee, cdlaird at sandia dot gov
 
 			<platform>
 				<operatingSystem>Any</operatingSystem>
-				<compiler>Python 2.7, 3.4, 3.5, 3.6, 3.7</compiler>
+				<compiler>Python 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9</compiler>
 			</platform>
 
 		</testedPlatforms>

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -91,7 +91,7 @@ jobs:
         include:
         - os: macos-latest
           TARGET: osx
-        python-version: [ 2.7, 3.5, 3.6, 3.7, 3.8 ]
+        python-version: [ 2.7, 3.5, 3.6, 3.7, 3.8, 3.9 ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -122,7 +122,7 @@ jobs:
         include:
         - os: windows-latest
           TARGET: win
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
To fully support Python 3.9, we need to build OSX and Windows release wheels with it.

## Changes proposed in this PR:
- Add 3.9 to OSX/Win on release workflow

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
