### PR TITLE
Update directory for upload-artifact on Release Workflow

### DIFF
--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -44,12 +44,12 @@ jobs:
         # When locally testing, --no-deps flag is necessary (PyUtilib dependency will trigger an error otherwise)
     - name: Delete linux wheels
       run: |
-        sudo rm -rf wheelhouse/*-linux_x86_64.whl
+        sudo rm -rf dist/*-linux_x86_64.whl
     - name: Upload artifact
       uses: actions/upload-artifact@v1
       with:
         name: manylinux-wheels
-        path: wheelhouse
+        path: dist
         
   generictarball:
     name: ${{ matrix.TARGET }}


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
The manylinux action changed its default creation directory from `wheelhouse` to `dist`. We haven't done a release since this change.

## Changes proposed in this PR:
- Change from `wheelhouse` to `dist`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
