### PR TITLE
Resolve changes in manylinux wheel uploads

### DIFF
--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -42,10 +42,13 @@ jobs:
         package-path: ''
         pip-wheel-args: ''
         # When locally testing, --no-deps flag is necessary (PyUtilib dependency will trigger an error otherwise)
-    - name: Consolidate and Delete linux wheels
+    - name: Consolidate wheels
       run: |
+        sudo find . -name \*.whl
         sudo test -d dist || mkdir -v dist
         sudo compgen -G "*.whl" > /dev/null && mv -v *.whl dist/
+    - name: Consolidate and Delete linux wheels
+      run: |
         sudo rm -rfv dist/*-linux_x86_64.whl
     - name: Upload artifact
       uses: actions/upload-artifact@v1

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         sudo test -d dist || mkdir -v dist
         sudo find . -name \*.whl | grep -v /dist/ | xargs -n1 -i mv -v "{}" dist/
-    - name: Consolidate and Delete linux wheels
+    - name: Delete linux wheels
       run: |
         sudo rm -rfv dist/*-linux_x86_64.whl
     - name: Upload artifact

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -44,9 +44,8 @@ jobs:
         # When locally testing, --no-deps flag is necessary (PyUtilib dependency will trigger an error otherwise)
     - name: Consolidate wheels
       run: |
-        sudo find . -name \*.whl
         sudo test -d dist || mkdir -v dist
-        sudo compgen -G "*.whl" > /dev/null && mv -v *.whl dist/
+        sudo find . -name \*.whl | grep -v /dist/ | xargs -n1 -i mv -v "{}" dist/
     - name: Consolidate and Delete linux wheels
       run: |
         sudo rm -rfv dist/*-linux_x86_64.whl

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       git-ref:
-        description: Git Hash (Optional)    
+        description: Git Hash (Optional)
         required: false
 
 jobs:
@@ -32,7 +32,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install twine wheel setuptools
-    # 12/17/2020 - Switched to fork of the manylinux-build action to support 
+    # 12/17/2020 - Switched to fork of the manylinux-build action to support
     # Python 3.9. Will switch back once main action supports this.
     - name: Build manylinux Python wheels
       uses: ahartikainen/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
@@ -54,7 +54,7 @@ jobs:
       with:
         name: manylinux-wheels
         path: dist
-        
+
   generictarball:
     name: ${{ matrix.TARGET }}
     runs-on: ${{ matrix.os }}
@@ -109,7 +109,7 @@ jobs:
     - name: Build OSX Python wheels
       run: |
         python setup.py  --with-cython sdist --format=gztar bdist_wheel
-        
+
     - name: Upload artifact
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -42,9 +42,11 @@ jobs:
         package-path: ''
         pip-wheel-args: ''
         # When locally testing, --no-deps flag is necessary (PyUtilib dependency will trigger an error otherwise)
-    - name: Delete linux wheels
+    - name: Consolidate and Delete linux wheels
       run: |
-        sudo rm -rf dist/*-linux_x86_64.whl
+        sudo test -d dist || mkdir -v dist
+        sudo compgen -G "*.whl" > /dev/null && mv -v *.whl dist/
+        sudo rm -rfv dist/*-linux_x86_64.whl
     - name: Upload artifact
       uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Implement a more robust approach to locating and uploading generated manylinux wheels

## Changes proposed in this PR:
- Move any build wheels into a `dist` directory before uploading
- Update action line endings

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
