### PR TITLE
doc: clarify unit conversion

### DIFF
--- a/pyomo/core/base/units_container.py
+++ b/pyomo/core/base/units_container.py
@@ -15,8 +15,8 @@
 This module provides support for including units within Pyomo expressions. This module
 can be used to define units on a model, and to check the consistency of units
 within the underlying constraints and expressions in the model. The module also
-supports conversion of units within expressions to support construction of constraints
-that contain embedded unit conversions.
+supports conversion of units within expressions using the `convert` method to support
+construction of constraints that contain embedded unit conversions.
 
 To use this package within your Pyomo model, you first need an instance of a
 PyomoUnitsContainer. You can use the module level instance already defined as


### PR DESCRIPTION
## Fixes #1656

## Summary/Motivation:
Clarify in the docs that units have to be converted manually such that they can be used in the same expression as discussed in #1656

## Changes proposed in this PR:
- Clarification in the docs

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
