### PR TITLE
Adjust Jenkins Test Script for Virtualenv Invocation

### DIFF
--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -71,7 +71,15 @@ if test -z "$MODE" -o "$MODE" == setup; then
     echo "#"
     echo "# Setting up virtual environment"
     echo "#"
-    virtualenv python $VENV_SYSTEM_PACKAGES --clear
+    majorversion=$(python -c 'import sys; print(sys.version_info[0])')
+    minorversion=$(python -c 'import sys; print(sys.version_info[1])')
+    if [ $majorversion -lt 3 ]; then
+       virtualenv python $VENV_SYSTEM_PACKAGES --clear
+    elif [ $minorversion -lt 6 ]; then
+       virtualenv python $VENV_SYSTEM_PACKAGES --clear
+    else
+        python3 -m venv $VENV_SYSTEM_PACKAGES ${WORKSPACE}/python
+    fi
     # Put the venv at the beginning of the PATH
     export PATH="$WORKSPACE/python/bin:$PATH"
     # Because modules set the PYTHONPATH, we need to make sure that the
@@ -94,14 +102,6 @@ if test -z "$MODE" -o "$MODE" == setup; then
     #
     # DO NOT install pyomo-model-libraries
     #
-
-    #
-    # #! lines cannot exceed 128 characters, which Jenkins will
-    # periodically do, especially for matrix jobs.  We will make
-    # the virtualenv relocatable to shorten the line, instead relying
-    # on the virtualenv being the first thing on the PATH.
-    #
-    virtualenv --relocatable python
 
     # Set up coverage tracking for subprocesses
     if test -z "$DISABLE_COVERAGE"; then

--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -78,7 +78,7 @@ if test -z "$MODE" -o "$MODE" == setup; then
     elif [ $minorversion -lt 6 ]; then
        virtualenv python $VENV_SYSTEM_PACKAGES --clear
     else
-        python3 -m venv $VENV_SYSTEM_PACKAGES ${WORKSPACE}/python
+        python -m venv $VENV_SYSTEM_PACKAGES ${WORKSPACE}/python
     fi
     # Put the venv at the beginning of the PATH
     export PATH="$WORKSPACE/python/bin:$PATH"

--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -73,13 +73,7 @@ if test -z "$MODE" -o "$MODE" == setup; then
     echo "#"
     pyver=$(python -c 'import sys; print("%d%02d" % sys.version_info[:2])')
     if [ $pyver -lt 306 ]; then
-        #
-        # #! lines cannot exceed 128 characters, which Jenkins will
-        # periodically do, especially for matrix jobs.  We will make
-        # the virtualenv relocatable to shorten the line, instead relying
-        # on the virtualenv being the first thing on the PATH.
-        #
-        virtualenv python $VENV_SYSTEM_PACKAGES --clear --relocatable
+        virtualenv python $VENV_SYSTEM_PACKAGES --clear
     else
         python -m venv $VENV_SYSTEM_PACKAGES ${WORKSPACE}/python
     fi

--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -71,8 +71,14 @@ if test -z "$MODE" -o "$MODE" == setup; then
     echo "#"
     echo "# Setting up virtual environment"
     echo "#"
-    pyver=$(python -c 'import sys; print("%d%d" % sys.version_info[:2])')
-    if [ $pyver -lt 36 ]; then
+    pyver=$(python -c 'import sys; print("%d%02d" % sys.version_info[:2])')
+    if [ $pyver -lt 306 ]; then
+        #
+        # #! lines cannot exceed 128 characters, which Jenkins will
+        # periodically do, especially for matrix jobs.  We will make
+        # the virtualenv relocatable to shorten the line, instead relying
+        # on the virtualenv being the first thing on the PATH.
+        #
         virtualenv python $VENV_SYSTEM_PACKAGES --clear --relocatable
     else
         python -m venv $VENV_SYSTEM_PACKAGES ${WORKSPACE}/python

--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -71,12 +71,9 @@ if test -z "$MODE" -o "$MODE" == setup; then
     echo "#"
     echo "# Setting up virtual environment"
     echo "#"
-    majorversion=$(python -c 'import sys; print(sys.version_info[0])')
-    minorversion=$(python -c 'import sys; print(sys.version_info[1])')
-    if [ $majorversion -lt 3 ]; then
-       virtualenv python $VENV_SYSTEM_PACKAGES --clear
-    elif [ $minorversion -lt 6 ]; then
-       virtualenv python $VENV_SYSTEM_PACKAGES --clear
+    pyver=$(python -c 'import sys; print("%d%d" % sys.version_info[:2])')
+    if [ $pyver -lt 36 ]; then
+        virtualenv python $VENV_SYSTEM_PACKAGES --clear --relocatable
     else
         python -m venv $VENV_SYSTEM_PACKAGES ${WORKSPACE}/python
     fi


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
Jenkins tests have been having issues with Python 3.6+. This is a fix to resolve that issue.

## Changes proposed in this PR:
- Use `python -m venv` instead of `virtualenv` for Python 3.6+

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
