### PR TITLE
BUG FIX: Missing imports from persistent_solver

### DIFF
--- a/pyomo/solvers/plugins/solvers/persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/persistent_solver.py
@@ -14,7 +14,7 @@ from pyomo.core.kernel.block import IBlock
 from pyomo.core.base.suffix import active_import_suffix_generator
 from pyomo.core.kernel.suffix import import_suffix_generator
 from pyomo.core.expr.numvalue import native_numeric_types, value
-import pyomo.core.expr.visitor as EXPR
+from pyomo.core.expr.visitor import evaluate_expression
 from pyomo.core.base.constraint import Constraint
 from pyomo.core.base.var import Var
 from pyomo.core.base.sos import SOSConstraint
@@ -31,7 +31,7 @@ def _convert_to_const(val):
     if val.__class__ in native_numeric_types:
         return val
     elif val.is_expression_type():
-        return EXPR.evaluate_expression(val)
+        return evaluate_expression(val)
     else:
         return value(val)
 

--- a/pyomo/solvers/plugins/solvers/persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/persistent_solver.py
@@ -13,7 +13,8 @@ from pyomo.core.base.block import _BlockData
 from pyomo.core.kernel.block import IBlock
 from pyomo.core.base.suffix import active_import_suffix_generator
 from pyomo.core.kernel.suffix import import_suffix_generator
-from pyomo.core.expr.numvalue import native_numeric_types
+from pyomo.core.expr.numvalue import native_numeric_types, value
+import pyomo.core.expr.visitor as EXPR
 from pyomo.core.base.constraint import Constraint
 from pyomo.core.base.var import Var
 from pyomo.core.base.sos import SOSConstraint


### PR DESCRIPTION
## Fixes #1765 

## Summary/Motivation:
@bknueven reported a bug in `persistent_solver.py`. Upon further inspection, it's actually two bugs - caused by missing import statements. This PR resolves both bugs.

## Changes proposed in this PR:
- Import `value`
- Import `evaluate_expression`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
