### PR TITLE
PyMySQL 1.0.0 + Python 2.7/pypy2 Patch

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -247,10 +247,10 @@ jobs:
         pip install --cache-dir cache/pip ${PYTHON_CORE_PKGS}
         pip install --cache-dir cache/pip ${PYTHON_PACKAGES}
         # pymysql 1.0.0: No longer supports Python 2 or pypy2
-        if [[ ${{matrix.python}} != pypy2 ]] || [[ ${{matrix.python}} != 2.7 ]]; then
-            pip install pymysql
-        else
+        if [[ ${{matrix.python}} == pypy2 ]] || [[ ${{matrix.python}} == 2.7 ]]; then
             pip install pymysql==0.10.1
+        else
+            pip install pymysql
         fi
         if test -z "${{matrix.slim}}"; then
             pip install --cache-dir cache/pip cplex \

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -247,11 +247,8 @@ jobs:
         pip install --cache-dir cache/pip ${PYTHON_CORE_PKGS}
         pip install --cache-dir cache/pip ${PYTHON_PACKAGES}
         # pymysql 1.0.0: No longer supports Python 2 or pypy2
-        if [[ ${{matrix.python}} == pypy2 ]] || [[ ${{matrix.python}} == 2.7 ]]; then
-            pip install pymysql==0.10.1
-        else
-            pip install pymysql
-        fi
+        pip install --cache-dir cache/pip pymysql || \
+            pip install --cache-dir cache/pip pymysql==0.10.1
         if test -z "${{matrix.slim}}"; then
             pip install --cache-dir cache/pip cplex \
                 || echo "WARNING: CPLEX Community Edition is not available"

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -247,7 +247,7 @@ jobs:
         pip install --cache-dir cache/pip ${PYTHON_CORE_PKGS}
         pip install --cache-dir cache/pip ${PYTHON_PACKAGES}
         # pymysql 1.0.0: No longer supports Python 2 or pypy2
-        if [[ ${{matrix.python}} != pypy2 ] || [ ${{matrix.python}} != 2.7 ]]; then
+        if [[ ${{matrix.python}} != pypy2 ]] || [[ ${{matrix.python}} != 2.7 ]]; then
             pip install pymysql
         else
             pip install pymysql==0.10.1

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -247,7 +247,7 @@ jobs:
         pip install --cache-dir cache/pip ${PYTHON_CORE_PKGS}
         pip install --cache-dir cache/pip ${PYTHON_PACKAGES}
         # pymysql 1.0.0: No longer supports Python 2 or pypy2
-        if [[ ${{matrix.python}} != pypy2 || != 2.7 ]]; then
+        if [[ ${{matrix.python}} != pypy2 ] || [ ${{matrix.python}} != 2.7 ]]; then
             pip install pymysql
         else
             pip install pymysql==0.10.1

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -24,7 +24,7 @@ env:
       nose coverage
   PYTHON_BASE_PKGS: >
       ply six dill ipython networkx openpyxl pathos
-      pint pymysql pyro4 pyyaml sphinx_rtd_theme sympy xlrd
+      pint pyro4 pyyaml sphinx_rtd_theme sympy xlrd
       python-louvain
   PYTHON_NUMPY_PKGS: >
       numpy scipy pyodbc pandas matplotlib seaborn numdifftools
@@ -246,6 +246,12 @@ jobs:
         python -m pip install --cache-dir cache/pip --upgrade pip
         pip install --cache-dir cache/pip ${PYTHON_CORE_PKGS}
         pip install --cache-dir cache/pip ${PYTHON_PACKAGES}
+        # pymysql 1.0.0: No longer supports Python 2 or pypy2
+        if [[ ${{matrix.python}} != pypy2 || != 2.7 ]]; then
+            pip install pymysql
+        else
+            pip install pymysql==0.10.1
+        fi
         if test -z "${{matrix.slim}}"; then
             pip install --cache-dir cache/pip cplex \
                 || echo "WARNING: CPLEX Community Edition is not available"

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -246,7 +246,7 @@ jobs:
         pip install --cache-dir cache/pip ${PYTHON_CORE_PKGS}
         pip install --cache-dir cache/pip ${PYTHON_PACKAGES}
         # pymysql 1.0.0: No longer supports Python 2 or pypy2
-        if [[ ${{matrix.python}} != pypy2 || != 2.7 ]]; then
+        if [[ ${{matrix.python}} != pypy2 ] || [ ${{matrix.python}} != 2.7 ]]; then
             pip install pymysql
         else
             pip install pymysql==0.10.1

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -246,10 +246,10 @@ jobs:
         pip install --cache-dir cache/pip ${PYTHON_CORE_PKGS}
         pip install --cache-dir cache/pip ${PYTHON_PACKAGES}
         # pymysql 1.0.0: No longer supports Python 2 or pypy2
-        if [[ ${{matrix.python}} != pypy2 ]] || [[ ${{matrix.python}} != 2.7 ]]; then
-            pip install pymysql
-        else
+        if [[ ${{matrix.python}} == pypy2 ]] || [[ ${{matrix.python}} == 2.7 ]]; then
             pip install pymysql==0.10.1
+        else
+            pip install pymysql
         fi
         if test -z "${{matrix.slim}}"; then
             pip install --cache-dir cache/pip cplex \

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -246,11 +246,8 @@ jobs:
         pip install --cache-dir cache/pip ${PYTHON_CORE_PKGS}
         pip install --cache-dir cache/pip ${PYTHON_PACKAGES}
         # pymysql 1.0.0: No longer supports Python 2 or pypy2
-        if [[ ${{matrix.python}} == pypy2 ]] || [[ ${{matrix.python}} == 2.7 ]]; then
-            pip install pymysql==0.10.1
-        else
-            pip install pymysql
-        fi
+        pip install --cache-dir cache/pip pymysql || \
+            pip install --cache-dir cache/pip pymysql==0.10.1
         if test -z "${{matrix.slim}}"; then
             pip install --cache-dir cache/pip cplex \
                 || echo "WARNING: CPLEX Community Edition is not available"

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -21,7 +21,7 @@ env:
       nose coverage
   PYTHON_BASE_PKGS: >
       ply six dill ipython networkx openpyxl pathos
-      pint pymysql pyro4 pyyaml sphinx_rtd_theme sympy xlrd
+      pint pyro4 pyyaml sphinx_rtd_theme sympy xlrd
       python-louvain
   PYTHON_NUMPY_PKGS: >
       numpy scipy pyodbc pandas matplotlib seaborn numdifftools
@@ -245,6 +245,12 @@ jobs:
         python -m pip install --cache-dir cache/pip --upgrade pip
         pip install --cache-dir cache/pip ${PYTHON_CORE_PKGS}
         pip install --cache-dir cache/pip ${PYTHON_PACKAGES}
+        # pymysql 1.0.0: No longer supports Python 2 or pypy2
+        if [[ ${{matrix.python}} != pypy2 || != 2.7 ]]; then
+            pip install pymysql
+        else
+            pip install pymysql==0.10.1
+        fi
         if test -z "${{matrix.slim}}"; then
             pip install --cache-dir cache/pip cplex \
                 || echo "WARNING: CPLEX Community Edition is not available"

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -246,7 +246,7 @@ jobs:
         pip install --cache-dir cache/pip ${PYTHON_CORE_PKGS}
         pip install --cache-dir cache/pip ${PYTHON_PACKAGES}
         # pymysql 1.0.0: No longer supports Python 2 or pypy2
-        if [[ ${{matrix.python}} != pypy2 ] || [ ${{matrix.python}} != 2.7 ]]; then
+        if [[ ${{matrix.python}} != pypy2 ]] || [[ ${{matrix.python}} != 2.7 ]]; then
             pip install pymysql
         else
             pip install pymysql==0.10.1


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
The newest version of PyMySQL ([1.0.0](https://pypi.org/project/PyMySQL/1.0.0/)) no longer supports Python 2.7 and pypy2. This is a quick patch for the GitHub Actions suite to avoid errors in the pypy2 and 2.7 tests.

## Changes proposed in this PR:
- Remove `pymysql` from `PYTHON_BASE_PACKAGES` 
- Try to install most recent version of `pymysql` and fall back on `0.10.1` upon failure

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
