### PR TITLE
BUG FIX: Fix handling of <objectiveValues> in CPLEX.py

### DIFF
--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -776,6 +776,9 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                     break
                 tINPUT.close()
 
+            elif tokens[0] == "objectiveValues":
+                pass
+
             elif tokens[0].startswith("objectiveValue"):
                 objective_value = (tokens[0].split('=')[1].strip()).lstrip("\"").rstrip("\"")
                 soln.objective['__default_objective__']['Value'] = float(objective_value)


### PR DESCRIPTION
## Fixes #1766
## Summary/Motivation:
@ZedongPeng reported a bug in `CPLEX.py`. 
This bug is caused because of XML tag `<objectiveValues>` in .sol file generated by CPLEX 20.1.0.0.
This also enter the following IF statement in CPLEX.py line 779.

```python3
elif tokens[0].startswith("objectiveValue"):
```

## Changes proposed in this PR:
Described new IF statement to handle `<objectValues>`.

### Legal Acknowledgement
By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.

