### PR TITLE
Cyipopt exception handling

### DIFF
--- a/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
@@ -347,7 +347,7 @@ def _redirect_stdout():
     newstdout = os.dup(1)
 
     # /dev/null is used just to discard what is being printed
-    devnull = os.open('/dev/null', os.O_WRONLY)
+    devnull = os.open(os.devnull, os.O_WRONLY)
 
     # Duplicate the file descriptor for /dev/null
     # and overwrite the value for stdout (file descriptor 1)

--- a/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
@@ -21,6 +21,7 @@ objects for the matrices (e.g., AmplNLP and PyomoNLP)
 """
 import six
 import sys
+import logging
 import os
 import abc
 
@@ -46,6 +47,8 @@ from pyomo.core.base import Block, Objective, minimize
 from pyomo.opt import (
     SolverStatus, SolverResults, TerminationCondition, ProblemSense
 )
+
+logger = logging.getLogger(__name__)
 
 # This maps the cyipopt STATUS_MESSAGES back to string representations
 # of the Ipopt ApplicationReturnStatus enum
@@ -528,7 +531,10 @@ class PyomoCyIpoptSolver(object):
                 os.dup2(newstdout, 1)
             solverStatus = SolverStatus.ok
         except:
+            msg = "Exception encountered during cyipopt solve:"
+            logger.error(msg, exc_info=sys.exc_info())
             solverStatus = SolverStatus.unknown
+            raise
         wall_time = timer.toc("")
 
         results = SolverResults()


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This PR fixes recent build problems on Windows by resolving a portability issue in pynumero (`/dev/null` doesn't exist on Windows).  It also ports a fix from [carldlaird/external-interface-hessians](https://github.com/carldlaird/pyomo/tree/external-interface-hessians) to not suppress exceptions coming from the cyipopt solver.

## Changes proposed in this PR:
- Windows portability fix: use `os.devnull`
- Do not suppress exceptions raised by ciyipopt

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
