### PR TITLE
Provide email address to NEOS solvers

### DIFF
--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -13,7 +13,7 @@
 # This software is a modified version of the Kestrel interface
 # package that is provided by NEOS:  http://www.neos-server.org
 #
-import email.utils
+
 import io
 import os
 import re
@@ -37,6 +37,8 @@ xmlrpclib = attempt_import('xmlrpclib', importer=_xmlrpclib_importer)[0]
 gzip = attempt_import('gzip')[0]
 
 logger = logging.getLogger('pyomo.neos')
+
+_email_re = re.compile(r'([^@]+@[^@]+\.[a-zA-Z0-9]+)$')
 
 class NEOS(object):
     # NEOS currently only supports HTTPS access
@@ -219,13 +221,13 @@ class kestrelAMPL:
     def getEmailAddress(self):
         # Note: the NEOS email address parser is more restrictive than
         # the email.utils parser
-        addr = email.utils.parseaddr(os.getenv('EMAIL'))[1]
-        if addr and re.search('\.[a-zA-Z0-9]+$', addr):
-            return addr
-        addr = email.utils.parseaddr(
-            "%s@%s" % (self.getUserName(), self.getHostName()))[1]
-        if addr and re.search('\.[a-zA-Z0-9]+$', addr):
-            return addr
+        m = _email_re.match(os.environ.get('EMAIL', ''))
+        if m:
+            return m.group()
+        m = _email_re.match(
+            "%s@%s" % (self.getUserName(), self.getHostName()))
+        if m:
+            return m.group()
 
         raise RuntimeError("NEOS requires a valid email address.  "
                            "Please set the 'EMAIL' environment variable")

--- a/pyomo/neos/plugins/kestrel_plugin.py
+++ b/pyomo/neos/plugins/kestrel_plugin.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import six
+import sys
 
 from pyomo.common.dependencies import attempt_import
 from pyomo.opt import SolverFactory, SolverManagerFactory, OptSolver
@@ -31,7 +32,8 @@ def _neos_error(msg, results, current_message):
     error_re = re.compile('error', flags=re.I)
     warn_re = re.compile('warn', flags=re.I)
 
-    logger.error("%s  NEOS log:\n%s" % ( msg, current_message, ))
+    logger.error("%s  NEOS log:\n%s" % ( msg, current_message, ),
+                 exc_info=sys.exc_info())
     soln_data = results.data
     if six.PY3:
         soln_data = soln_data.decode('utf-8')


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
NEOS has updated its requirements and not rejects any jobs that do not provide an email address as part of the XML problem definition.  This PR adds an the `<email>` field to the document specification.  The interface uses the contents of the `EMAIL` environment variable (if present) otherwise reverts to `user@{fully-qualified hostname}`.  If neither of those appear to be a valid email address, then the Kestrel interface raises an `RuntimeError`

## Changes proposed in this PR:
- add `<email>` section to the NEOS XML document
- switch the username to be the email address (instead of `{user} on {host}`).  This may help address #910.
- retrieve the email address from the EMAIL environment variable, or use `user@{fully-qualified hostname}`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
