### PR TITLE
Improve NEOS email verification error message

### DIFF
--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -231,7 +231,7 @@ class kestrelAMPL:
 
         raise RuntimeError(
             "NEOS requires a valid email address (default '%s' not valid). "
-            "Please set the 'EMAIL' environment variable.")
+            "Please set the 'EMAIL' environment variable." % (email,))
 
     def getJobAndPassword(self):
         """

--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -221,16 +221,17 @@ class kestrelAMPL:
     def getEmailAddress(self):
         # Note: the NEOS email address parser is more restrictive than
         # the email.utils parser
-        m = _email_re.match(os.environ.get('EMAIL', ''))
-        if m:
-            return m.group()
-        m = _email_re.match(
-            "%s@%s" % (self.getUserName(), self.getHostName()))
-        if m:
-            return m.group()
+        email = os.environ.get('EMAIL', '')
+        if _email_re.match(email):
+            return email
+        if not email:
+            email = "%s@%s" % (self.getUserName(), self.getHostName())
+            if _email_re.match(email):
+                return email
 
-        raise RuntimeError("NEOS requires a valid email address.  "
-                           "Please set the 'EMAIL' environment variable")
+        raise RuntimeError(
+            "NEOS requires a valid email address (default '%s' not valid). "
+            "Please set the 'EMAIL' environment variable.")
 
     def getJobAndPassword(self):
         """


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This PR improved the error message generated when the NEOS interface can't identify a suitable email address.

## Changes proposed in this PR:
- include attempted email address in the error message from Kestrel

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
