### PR TITLE
Rename log_active_constraints to log_model_constraints

### DIFF
--- a/pyomo/util/blockutil.py
+++ b/pyomo/util/blockutil.py
@@ -13,7 +13,11 @@
 
 __all__ = ['has_discrete_variables']
 
-from pyomo.core.base import Var
+import logging
+
+from pyomo.core import Var, Constraint, TraversalStrategy
+
+logger = logging.getLogger(__name__)
 
 
 def has_discrete_variables(block):
@@ -21,3 +25,14 @@ def has_discrete_variables(block):
         if not vardata.is_continuous():
             return True
     return False
+
+
+def log_model_constraints(m, logger=logger, active=True):
+    """Prints the model constraints in the model."""
+    for constr in m.component_data_objects(
+            ctype=Constraint, active=active, descend_into=True,
+            descent_order=TraversalStrategy.PrefixDepthFirstSearch):
+        logger.info("%s %s" % (
+            constr.name,
+            ("active" if constr.active else "deactivated")
+        ))

--- a/pyomo/util/infeasible.py
+++ b/pyomo/util/infeasible.py
@@ -1,14 +1,24 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
 """Module with diagnostic utilities for infeasible models."""
-from pyomo.core import Constraint, Var, value, TraversalStrategy
+from pyomo.core import Constraint, Var, value
 from math import fabs
 import logging
 
+from pyomo.common import deprecated
 from pyomo.core.expr.visitor import identify_variables
+from pyomo.util.blockutil import log_model_constraints
 
-logger = logging.getLogger('pyomo.util.infeasible')
-logger.setLevel(logging.INFO)
-
+logger = logging.getLogger(__name__)
 
 def log_infeasible_constraints(
         m, tol=1E-6, logger=logger,
@@ -171,10 +181,8 @@ def log_close_to_bounds(m, tol=1E-6, logger=logger):
                 logger.info('{} near LB'.format(constr.name))
 
 
+@deprecated("log_active_constraints is deprecated.  "
+            "Please use pyomo.util.blockutil.log_model_constraints()",
+            version="TBD")
 def log_active_constraints(m, logger=logger):
-    """Prints the active constraints in the model."""
-    for constr in m.component_data_objects(
-        ctype=Constraint, active=True, descend_into=True,
-        descent_order=TraversalStrategy.PrefixDepthFirstSearch
-    ):
-        logger.info("%s active" % constr.name)
+    log_model_constraints(m, logger)

--- a/pyomo/util/tests/test_blockutil.py
+++ b/pyomo/util/tests/test_blockutil.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import logging
+
+from six import StringIO
+
+import pyutilib.th as unittest
+
+from pyomo.common.log import LoggingIntercept
+from pyomo.environ import ConcreteModel, Constraint, Var, inequality
+from pyomo.util.blockutil import (
+    log_model_constraints,
+)
+
+class TestBlockutil(unittest.TestCase):
+    """Tests block utilities."""
+
+    def test_log_model_constraints(self):
+        m = ConcreteModel()
+        m.x = Var(initialize=1)
+        m.c1 = Constraint(expr=m.x >= 2)
+        m.c2 = Constraint(expr=m.x == 4)
+        m.c3 = Constraint(expr=m.x <= 0)
+        m.y = Var(bounds=(0, 2), initialize=1.9999999)
+        m.c4 = Constraint(expr=m.y >= m.y.value)
+        m.z = Var(bounds=(0, 6))
+        m.c5 = Constraint(expr=inequality(5, m.z, 10), doc="Range infeasible")
+        m.c6 = Constraint(expr=m.x + m.y <= 6, doc="Feasible")
+        m.c7 = Constraint(expr=m.z == 6, doc="Equality infeasible")
+        m.c8 = Constraint(expr=inequality(3, m.x, 6), doc="Range lb infeasible")
+        m.c9 = Constraint(expr=inequality(0, m.x, 0.5), doc="Range ub infeasible")
+        m.c10 = Constraint(expr=m.y >= 3, doc="Inactive")
+        m.c10.deactivate()
+        m.c11 = Constraint(expr=m.y <= m.y.value)
+        m.yy = Var(bounds=(0, 1), initialize=1E-7, doc="Close to lower bound")
+        m.y3 = Var(bounds=(0, 1E-7), initialize=0, doc="Bounds too close")
+        m.y4 = Var(bounds=(0, 1), initialize=2, doc="Fixed out of bounds.")
+        m.y4.fix()
+
+        output = StringIO()
+        with LoggingIntercept(output, 'pyomo.util', logging.INFO):
+            log_model_constraints(m)
+        expected_output = [
+            "c1 active", "c2 active", "c3 active", "c4 active",
+            "c5 active", "c6 active", "c7 active", "c8 active",
+            "c9 active", "c11 active"
+        ]
+        self.assertEqual(expected_output, output.getvalue().splitlines())

--- a/pyomo/util/tests/test_infeasible.py
+++ b/pyomo/util/tests/test_infeasible.py
@@ -1,4 +1,13 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
 """Tests infeasible model debugging utilities."""
 import logging
 
@@ -61,7 +70,7 @@ class TestInfeasible(unittest.TestCase):
         m.x.setlb(2)
         m.x.setub(0)
         output = StringIO()
-        with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
+        with LoggingIntercept(output, 'pyomo.util', logging.INFO):
             log_infeasible_bounds(m)
         expected_output = [
             "VAR x: 1 >/= LB 2", "VAR x: 1 </= UB 0", "VAR y4: 2 </= UB 1",
@@ -71,9 +80,12 @@ class TestInfeasible(unittest.TestCase):
     def test_log_active_constraints(self):
         """Test for logging of active constraints."""
         m = self.build_model()
+        depr = StringIO()
         output = StringIO()
-        with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
-            log_active_constraints(m)
+        with LoggingIntercept(depr, 'pyomo'):
+            with LoggingIntercept(output, 'pyomo.util', logging.INFO):
+                log_active_constraints(m)
+        self.assertIn("log_active_constraints is deprecated.", depr.getvalue())
         expected_output = [
             "c1 active", "c2 active", "c3 active", "c4 active",
             "c5 active", "c6 active", "c7 active", "c8 active",


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
The `pyomo.util.infeasible.log_active_constraints()` method has caused confusion (it logs activated constraint data objects, not constraints that are "active" [at their bounds] given the current variable values).  This renames the function to `pyomo.util.blockutil.log_model_constraints()` with an optional `active=` argument that defaults to True for backwards compatibility. 

## Changes proposed in this PR:
- rename `pyomo.util.infeasible.log_active_constraints()` -> `pyomo.util.blockutil.log_model_constraints()`
- deprecate `pyomo.util.infeasible.log_active_constraints()`
- update tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
