### PR TITLE
Update cplex solution parser for cplex 12.10

### DIFF
--- a/pyomo/core/kernel/block.py
+++ b/pyomo/core/kernel/block.py
@@ -458,7 +458,9 @@ class block(IBlock):
                 raise KeyError("Objective associated with symbol '%s' "
                                 "is not found on this block"
                                 % (label))
-            unseen_var_ids.remove(id(obj))
+            # Because of __default_objective__, an objective might
+            # appear twice in the objective dictionary.
+            unseen_var_ids.discard(id(obj))
             for _attr_key, attr_value in six.iteritems(entry):
                 attr_key = _attr_key[0].lower() + _attr_key[1:]
                 if attr_key in valid_import_suffixes:

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -776,9 +776,21 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                     break
                 tINPUT.close()
 
-            elif tokens[0].startswith("objectiveValue"):
+            elif tokens[0].startswith("objectiveValue") and tokens[0] != 'objectiveValues':
+                # prior to 12.10.0, the objective value came back as an
+                # attribute on the <header> tag
                 objective_value = (tokens[0].split('=')[1].strip()).lstrip("\"").rstrip("\"")
                 soln.objective['__default_objective__']['Value'] = float(objective_value)
+
+            elif tokens[0] == "objective":
+                # beginning in 12.10.0, CPLEX supports multiple
+                # objectives in an <objectiveValue> tag
+                fields = {}
+                for field in tokens[1:]:
+                    k,v = field.split('=')
+                    fields[k] = v.strip('"')
+                soln.objective.setdefault(fields['name'], {})['Value'] = float(fields['value'])
+
             elif tokens[0].startswith("solutionStatusValue"):
                pieces = tokens[0].split("=")
                solution_status = eval(pieces[1])


### PR DESCRIPTION
## Fixes #1766 

## Summary/Motivation:
Starting in CPLEX 12.10, cplex returns an `<objectiveValues>` tag as part of the solution output.  This was running afoul of the `sol` file parser.  This is an extension of PR #1779 to actually parse and return the named objective values in the results object.

## Changes proposed in this PR:
- parse the `<objectiveValues>` / `<objective>` tags in the cplex output
- update `kernel.block.load_solution()` to not throw errors when redundant objective values are encountered.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
