### PR TITLE
Require email address when using NEOS interface

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -29,6 +29,7 @@ env:
   PYTHON_NUMPY_PKGS: >
       numpy scipy pyodbc pandas matplotlib seaborn numdifftools
   CACHE_VER: v3
+  NEOS_EMAIL: tests@pyomo.org
 
 jobs:
   build:

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -26,6 +26,7 @@ env:
   PYTHON_NUMPY_PKGS: >
       numpy scipy pyodbc pandas matplotlib seaborn numdifftools
   CACHE_VER: v3
+  NEOS_EMAIL: tests@pyomo.org
 
 jobs:
   build:

--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -209,29 +209,16 @@ class kestrelAMPL:
             % (NEOS.scheme, jobNumber,password))
         return (jobNumber,password)
 
-    def getUserName(self):
-        for _ in ('LOGNAME','USER','USERNAME'):
-            uname = os.getenv(_)
-            if uname is not None:
-                return uname
-
-    def getHostName(self):
-        return socket.getfqdn(socket.gethostname())
-
     def getEmailAddress(self):
         # Note: the NEOS email address parser is more restrictive than
         # the email.utils parser
-        email = os.environ.get('EMAIL', '')
+        email = os.environ.get('NEOS_EMAIL', '')
         if _email_re.match(email):
             return email
-        if not email:
-            email = "%s@%s" % (self.getUserName(), self.getHostName())
-            if _email_re.match(email):
-                return email
 
         raise RuntimeError(
             "NEOS requires a valid email address (default '%s' not valid). "
-            "Please set the 'EMAIL' environment variable." % (email,))
+            "Please set the 'NEOS_EMAIL' environment variable." % (email,))
 
     def getJobAndPassword(self):
         """

--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -217,8 +217,8 @@ class kestrelAMPL:
             return email
 
         raise RuntimeError(
-            "NEOS requires a valid email address (default '%s' not valid). "
-            "Please set the 'NEOS_EMAIL' environment variable." % (email,))
+            "NEOS requires a valid email address. "
+            "Please set the 'NEOS_EMAIL' environment variable.")
 
     def getJobAndPassword(self):
         """

--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -33,6 +33,10 @@ try:
 except:
     pass
 
+email_set = True
+if os.environ.get('NEOS_EMAIL') is None:
+    email_set = False
+
 
 #
 # Because the Kestrel tests require connections to the NEOS server, and
@@ -42,6 +46,7 @@ except:
 #
 @unittest.category('nightly')
 @unittest.skipIf(not neos_available, "Cannot make connection to NEOS server")
+@unittest.skipIf(not email_set, "NEOS_EMAIL not set")
 class TestKestrel(unittest.TestCase):
 
     @unittest.skipIf(not yaml_available, "YAML is not available")


### PR DESCRIPTION
## Partially addresses #1785  .

## Summary/Motivation:
This reverts some of the functionality added in #1782, namely the automatic generation of an email address when using the NEOS interface. With this change users will be required to supply an email address using the `NEOS_EMAIL` environment variable.

## Changes proposed in this PR:
- Don't automatically generate an email address when using NEOS

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
