### PR TITLE
Remove references to the ordereddict package

### DIFF
--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -17,13 +17,8 @@ import gc
 import time
 import math
 
-try:
-    from collections import OrderedDict
-except ImportError:                         #pragma:nocover
-    from ordereddict import OrderedDict
-
 from pyomo.common import timing, PyomoAPIFactory
-from pyomo.common.collections import Container
+from pyomo.common.collections import Container, OrderedDict
 from pyomo.common.dependencies import pympler, pympler_available
 from pyomo.common.deprecation import deprecation_warning
 from pyomo.common.gc_manager import PauseGC

--- a/pyomo/core/kernel/block.py
+++ b/pyomo/core/kernel/block.py
@@ -11,15 +11,13 @@
 import sys
 import logging
 import math
-import collections
-if sys.version_info[:2] >= (3,6):
+
+from pyomo.common.collections import OrderedDict
+if sys.version_info[:2] >= (3,7):
+    # dict became ordered in CPython 3.6 and added to the standard in 3.7
     _ordered_dict_ = dict
 else:
-    try:
-        _ordered_dict_ = collections.OrderedDict
-    except ImportError:                         #pragma:nocover
-        import ordereddict
-        _ordered_dict_ = ordereddict.OrderedDict
+    _ordered_dict_ = OrderedDict
 
 from pyomo.core.expr.symbol_map import SymbolMap
 from pyomo.core.kernel.base import \

--- a/pyomo/core/kernel/dict_container.py
+++ b/pyomo/core/kernel/dict_container.py
@@ -34,8 +34,7 @@ logger = logging.getLogger('pyomo.core')
 # code a work around for the Python 2 case as we are moving
 # closer to a Python 3-only world these types of objects are
 # not memory bottlenecks.
-class DictContainer(IHomogeneousContainer,
-                    collections_MutableMapping):
+class DictContainer(IHomogeneousContainer, MutableMapping):
     """
     A partial implementation of the IHomogeneousContainer
     interface that provides dict-like storage functionality.
@@ -159,7 +158,7 @@ class DictContainer(IHomogeneousContainer,
     # plain dictionary mapping key->(type(val), id(val)) and
     # compare that instead.
     def __eq__(self, other):
-        if not isinstance(other, collections_Mapping):
+        if not isinstance(other, Mapping):
             return False
         return {key:(type(val), id(val))
                     for key, val in self.items()} == \

--- a/pyomo/core/kernel/dict_container.py
+++ b/pyomo/core/kernel/dict_container.py
@@ -10,28 +10,19 @@
 
 import sys
 import logging
-import collections
-if sys.version_info[:2] >= (3,6):
-    _ordered_dict_ = dict
-else:
-    try:
-        _ordered_dict_ = collections.OrderedDict
-    except ImportError:                           #pragma:nocover
-        import ordereddict
-        _ordered_dict_ = ordereddict.OrderedDict
+
+from pyomo.common.collections import OrderedDict, Mapping, MutableMapping
 
 from pyomo.core.kernel.homogeneous_container import \
     IHomogeneousContainer
 
-import six
-from six import itervalues
-
-if six.PY3:
-    from collections.abc import MutableMapping as collections_MutableMapping
-    from collections.abc import Mapping as collections_Mapping
+if sys.version_info[:2] >= (3,7):
+    # dict became ordered in CPython 3.6 and added to the standard in 3.7
+    _ordered_dict_ = dict
 else:
-    from collections import MutableMapping as collections_MutableMapping
-    from collections import Mapping as collections_Mapping
+    _ordered_dict_ = OrderedDict
+
+from six import itervalues
 
 logger = logging.getLogger('pyomo.core')
 

--- a/pyomo/dataportal/process_data.py
+++ b/pyomo/dataportal/process_data.py
@@ -13,7 +13,7 @@ import re
 import copy
 import logging
 
-from pyomo.common.collections import  Options
+from pyomo.common.collections import Options, OrderedDict
 from pyomo.common.errors import ApplicationError
 from pyutilib.misc import flatten
 
@@ -22,11 +22,6 @@ from pyomo.dataportal.parse_datacmds import (
 )
 from pyomo.dataportal.factory import DataManagerFactory, UnknownDataManager
 from pyomo.core.base.set import UnknownSetDimen
-
-try:
-    from collections import OrderedDict
-except:
-    from ordereddict import OrderedDict
 
 from six.moves import xrange
 try:

--- a/pyomo/opt/parallel/local.py
+++ b/pyomo/opt/parallel/local.py
@@ -13,10 +13,7 @@ __all__ = ()
 
 import time
 
-try:
-    from collections import OrderedDict
-except ImportError:                         #pragma:nocover
-    from ordereddict import OrderedDict
+from pyomo.common.collections import OrderedDict
 
 import pyomo.opt
 from pyomo.opt.parallel.manager import (ActionManagerError,

--- a/pyomo/opt/parallel/pyro.py
+++ b/pyomo/opt/parallel/pyro.py
@@ -10,11 +10,7 @@
 
 __all__ = ("PyroAsynchronousActionManager",)
 
-try:
-    from collections import OrderedDict
-except ImportError:                         #pragma:nocover
-    from ordereddict import OrderedDict
-
+from pyomo.common.collections import OrderedDict
 from pyomo.common.dependencies import attempt_import
 from pyomo.opt.parallel.manager import \
     (AsynchronousActionManager,

--- a/pyomo/opt/results/solution.py
+++ b/pyomo/opt/results/solution.py
@@ -11,15 +11,11 @@
 __all__ = ['SolutionStatus', 'Solution']
 
 import math
-try:
-    from collections import OrderedDict
-except:
-    from ordereddict import OrderedDict
 from six import iterkeys, iteritems
 from six.moves import xrange
 import enum
 from pyomo.opt.results.container import MapContainer, ListContainer, ignore
-from pyomo.common.collections import Bunch
+from pyomo.common.collections import Bunch, OrderedDict
 
 default_print_options = Bunch(schema=False,
                               sparse=True,

--- a/pyomo/pysp/scenariotree/tree_structure.py
+++ b/pyomo/pysp/scenariotree/tree_structure.py
@@ -20,12 +20,7 @@ import copy
 import math
 import logging
 
-try:
-    from collections import OrderedDict
-except ImportError:                         #pragma:nocover
-    from ordereddict import OrderedDict
-
-from pyomo.common.collections import ComponentMap
+from pyomo.common.collections import ComponentMap, OrderedDict
 from pyomo.core import (value, minimize, maximize,
                         Var, Expression, Block,
                         Objective, SOSConstraint,

--- a/pyomo/pysp/solvers/admm.py
+++ b/pyomo/pysp/solvers/admm.py
@@ -18,11 +18,7 @@ import math
 #       (this has to do with fixing distributed variable id
 #        creation on the new scenario tree manager)
 
-try:
-    from collections import OrderedDict
-except ImportError:                         #pragma:nocover
-    from ordereddict import OrderedDict
-
+from pyomo.common.collections import OrderedDict
 from pyomo.core import (Block, Set, Expression, Param, maximize)
 from pyomo.pysp.util.configured_object import PySPConfiguredObject
 from pyomo.pysp.util.config import (PySPConfigValue,

--- a/pyomo/pysp/solvers/benders.py
+++ b/pyomo/pysp/solvers/benders.py
@@ -28,11 +28,7 @@ import logging
 import time
 import itertools
 
-try:
-    from collections import OrderedDict
-except ImportError:                         #pragma:nocover
-    from ordereddict import OrderedDict
-
+from pyomo.common.collections import OrderedDict
 from pyomo.opt import (SolverFactory,
                        TerminationCondition,
                        undefined)

--- a/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanager.py
+++ b/pyomo/pysp/tests/scenariotreemanager/test_scenariotreemanager.py
@@ -13,15 +13,13 @@ import os
 import time
 import subprocess
 import sys
-import collections
-if sys.version_info[:2] >= (3,6):
+
+from pyomo.common.collections import OrderedDict
+if sys.version_info[:2] >= (3,7):
+    # dict became ordered in CPython 3.6 and added to the standard in 3.7
     _ordered_dict_ = dict
 else:
-    try:
-        _ordered_dict_ = collections.OrderedDict
-    except ImportError:                         #pragma:nocover
-        import ordereddict
-        _ordered_dict_ = ordereddict.OrderedDict
+    _ordered_dict_ = OrderedDict
 
 from pyutilib.pyro import using_pyro3, using_pyro4
 import pyutilib.th as unittest


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This removes references to the ordereddict package (only needed in Python versions prior to 2.7, which we no longer support).  It also corrects the minimum version at which Python's `dict` switched to insertion ordering.

## Changes proposed in this PR:
- remove references to OrderedDict.
- correct the version test for when Python's (not CPython's) `dict` became ordered by default

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
