### PR TITLE
Convert old deprecation messages to use pyomo.common.deprecation

### DIFF
--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -33,6 +33,8 @@ else:
 
 from six.moves import xrange
 
+from pyomo.common.deprecation import deprecated
+
 logger = logging.getLogger('pyomo.common.config')
 
 if 'PYOMO_CONFIG_DIR' in os.environ:
@@ -1464,9 +1466,9 @@ class ConfigList(ConfigBase):
         self._data[-1]._userSet = True
         self._userSet = True
 
+    @deprecated("ConfigList.add() has been deprecated.  Use append()",
+                version='5.7.2')
     def add(self, value=ConfigBase.NoArgument):
-        logger.warning(
-            "DEPRECATED: ConfigList.add() has been deprecated.  Use append()")
         return self.append(value)
 
     def _data_collector(self, level, prefix, visibility=None, docMode=False):

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -20,7 +20,7 @@ import math
 from pyomo.common import timing, PyomoAPIFactory
 from pyomo.common.collections import Container, OrderedDict
 from pyomo.common.dependencies import pympler, pympler_available
-from pyomo.common.deprecation import deprecation_warning
+from pyomo.common.deprecation import deprecated, deprecation_warning
 from pyomo.common.gc_manager import PauseGC
 from pyomo.common.plugin import ExtensionPoint
 
@@ -566,9 +566,10 @@ class Model(SimpleBlock):
         if cls != Model:
             return super(Model, cls).__new__(cls)
 
-        logger.warning(
-"""DEPRECATION WARNING: Using the 'Model' class is deprecated.  Please
-use the AbstractModel or ConcreteModel class instead.""")
+        deprecation_warning(
+            "Using the 'Model' class is deprecated.  Please use the "
+            "AbstractModel or ConcreteModel class instead.",
+            version='4.3.11323')
         return AbstractModel.__new__(AbstractModel)
 
     def __init__(self, name='unknown', **kwargs):
@@ -757,16 +758,17 @@ arguments (which have been ignored):"""
             dp = DataPortal(data_dict=arg, model=self)
         elif isinstance(arg, SolverResults):
             if len(arg.solution):
-                logger.warning(
-"""DEPRECATION WARNING: the Model.load() method is deprecated for
-loading solutions stored in SolverResults objects.  Call
-Model.solutions.load_from().""")
+                deprecation_warning(
+                    "The Model.load() method is deprecated for loading "
+                    "solutions stored in SolverResults objects.  Call"
+                    "Model.solutions.load_from().", version='4.3.11323')
                 self.solutions.load_from(arg)
             else:
-                logger.warning(
-"""DEPRECATION WARNING: the Model.load() method is deprecated for
-loading solutions stored in SolverResults objects.  By default, results
-from solvers are immediately loaded into the original model instance.""")
+                deprecation_warning(
+                    "The Model.load() method is deprecated for loading "
+                    "solutions stored in SolverResults objects.  By default, "
+                    "results from solvers are immediately loaded into "
+                    "the original model instance.", version='4.3.11323')
             return
         else:
             msg = "Cannot load model model data from with object of type '%s'"
@@ -900,30 +902,30 @@ from solvers are immediately loaded into the original model instance.""")
                 print("      Total memory = %d bytes following construction of component=%s (after garbage collection)" % (mem_used, component_name))
 
 
+    @deprecated("The Model.create() method is deprecated.  Call "
+                "Model.create_instance() to create a concrete instance "
+                "from an abstract model.  You do not need to call "
+                "Model.create() for a concrete model.", version='4.3.11323')
     def create(self, filename=None, **kwargs):
         """
         Create a concrete instance of this Model, possibly using data
         read in from a file.
         """
-        logger.warning(
-"""DEPRECATION WARNING: the Model.create() method is deprecated.  Call
-Model.create_instance() to create a concrete instance from an abstract
-model.  You do not need to call Model.create() for a concrete model.""")
         return self.create_instance(filename=filename, **kwargs)
 
+    @deprecated("Model.transform() is deprecated.", version='4.3.11323')
     def transform(self, name=None, **kwds):
         if name is None:
-            logger.warning(
-"""DEPRECATION WARNING: Model.transform() is deprecated.  Use
-the TransformationFactory iterator to get the list of known
-transformations.""")
+            deprecation_warning(
+                "Use the TransformationFactory iterator to get the list "
+                "of known transformations.", version='4.3.11323')
             return list(TransformationFactory)
 
-        logger.warning(
-"""DEPRECATION WARNING: Model.transform() is deprecated.  Use
-TransformationFactory('%s') to construct a transformation object, or
-TransformationFactory('%s').apply_to(model) to directly apply the
-transformation to the model instance.""" % (name,name,) )
+        deprecation_warning(
+            "Use TransformationFactory('%s') to construct a transformation "
+            "object, or TransformationFactory('%s').apply_to(model) to "
+            "directly apply the transformation to the model instance." % (
+                name,name,), version='4.3.11323')
 
         xfrm = TransformationFactory(name)
         if xfrm is None:

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -14,6 +14,7 @@ import sys
 import logging
 from weakref import ref as weakref_ref
 
+from pyomo.common.deprecation import deprecated
 from pyomo.common.timing import ConstructionTimer
 
 from pyomo.core.base.component import ComponentData
@@ -195,16 +196,17 @@ class _GeneralExpressionDataImpl(_ExpressionData):
 
     # for backwards compatibility reasons
     @property
+    @deprecated("The .value property getter on _GeneralExpressionDataImpl "
+                "is deprecated. Use the .expr property getter instead",
+                version='4.3.11323')
     def value(self):
-        logger.warning("DEPRECATED: The .value property getter on "
-                       "_GeneralExpressionDataImpl is deprecated. Use "
-                       "the .expr property getter instead")
         return self._expr
+
     @value.setter
+    @deprecated("The .value property setter on _GeneralExpressionDataImpl "
+                "is deprecated. Use the set_value(expr) method instead",
+                version='4.3.11323')
     def value(self, expr):
-        logger.warning("DEPRECATED: The .value property setter on "
-                       "_GeneralExpressionDataImpl is deprecated. Use "
-                       "the set_value(expr) method instead")
         self.set_value(expr)
 
     def set_value(self, expr):
@@ -445,16 +447,17 @@ class SimpleExpression(_GeneralExpressionData, Expression):
 
     # for backwards compatibility reasons
     @property
+    @deprecated("The .value property getter on SimpleExpression "
+                "is deprecated. Use the .expr property getter instead",
+                version='4.3.11323')
     def value(self):
-        logger.warning("DEPRECATED: The .value property getter on "
-                       "SimpleExpression is deprecated. Use "
-                       "the .expr property getter instead")
         return self.expr
+
     @value.setter
+    @deprecated("The .value property setter on SimpleExpression "
+                "is deprecated. Use the set_value(expr) method instead",
+                version='4.3.11323')
     def value(self, expr):
-        logger.warning("DEPRECATED: The .value property setter on "
-                       "SimpleExpression is deprecated. Use the "
-                       "set_value(expr) method instead")
         self.set_value(expr)
 
     def set_value(self, expr):

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -19,6 +19,7 @@ from pyomo.core.base.component import Component, ActiveComponent
 from pyomo.core.base.config import PyomoOptions
 from pyomo.core.base.global_set import UnindexedComponent_set
 from pyomo.common import DeveloperError
+from pyomo.common.deprecation import deprecation_warning
 
 from six import PY3, itervalues, iteritems, string_types
 
@@ -604,10 +605,10 @@ You can silence this warning by one of three ways:
                         "Indexed components can only be indexed with simple "
                         "slices: start and stop values are not allowed.")
                 if val.step is not None:
-                    logger.warning(
-                        "DEPRECATION WARNING: The special wildcard slice "
-                        "(::0) is deprecated.  Please use an ellipsis (...) "
-                        "to indicate '0 or more' indices")
+                    deprecation_warning(
+                        "The special wildcard slice (::0) is deprecated.  "
+                        "Please use an ellipsis (...) to indicate "
+                        "'0 or more' indices", version='4.4')
                     val = Ellipsis
                 else:
                     if ellipsis is None:

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -21,6 +21,7 @@ import logging
 from weakref import ref as weakref_ref
 import inspect
 
+from pyomo.common.deprecation import deprecated
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.expr.numvalue import value
 from pyomo.core.base.plugin import ModelComponentFactory
@@ -502,16 +503,15 @@ class SimpleObjective(_GeneralObjectiveData, Objective):
 
     # for backwards compatibility reasons
     @property
+    @deprecated("The .value property getter on SimpleObjective is deprecated. "
+                "Use the .expr property getter instead", version='4.3.11323')
     def value(self):
-        logger.warning("DEPRECATED: The .value property getter on "
-                       "SimpleObjective is deprecated. Use "
-                       "the .expr property getter instead")
         return self.expr
+
     @value.setter
+    @deprecated("The .value property setter on SimpleObjective is deprecated. "
+                "Use the set_value(expr) method instead", version='4.3.11323')
     def value(self, expr):
-        logger.warning("DEPRECATED: The .value property setter on "
-                       "SimpleObjective is deprecated. Use the "
-                       "set_value(expr) method instead")
         self.set_value(expr)
 
     @property

--- a/pyomo/core/base/piecewise.py
+++ b/pyomo/core/base/piecewise.py
@@ -47,6 +47,7 @@ import enum
 
 from pyutilib.misc import flatten_tuple
 
+from pyomo.common.deprecation import deprecation_warning
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base.plugin import ModelComponentFactory
 from pyomo.core.base.block import Block, _BlockData
@@ -1064,11 +1065,11 @@ class Piecewise(Block):
         pw_rep = translate_repn.get(pw_rep,pw_rep)
         if (pw_rep == PWRepn.BIGM_BIN) or \
            (pw_rep == PWRepn.BIGM_SOS1):
-            logger.warning(
-                "DEPRECATED: The 'BIGM_BIN' and 'BIGM_SOS1' "
+            deprecation_warning(
+                "The 'BIGM_BIN' and 'BIGM_SOS1' "
                 "piecewise representations will be removed in "
                 "a future version of Pyomo. They produce incorrect "
-                "results in certain cases")
+                "results in certain cases", version='5.3')
         # translate the user input to the enum type
         bound_type = kwds.pop('pw_constr_type',None)
         bound_type = translate_bound.get(bound_type,bound_type)

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -129,6 +129,9 @@ def process_setarg(arg):
     # DEPRECATED: This functionality has never been documented,
     # and I don't know of a use of it in the wild.
     if hasattr(arg, 'set_options'):
+        deprecation_warning("The set_options set attribute is deprecated.  "
+                            "Please explicitly construct complex sets",
+                            version='TBD')
         # If the argument has a set_options attribute, then use
         # it to initialize a set
         args = arg.set_options

--- a/pyomo/core/expr/boolean_value.py
+++ b/pyomo/core/expr/boolean_value.py
@@ -2,6 +2,7 @@ import sys
 import logging
 from six import iteritems
 
+from pyomo.common.deprecation import deprecated
 from pyomo.core.expr.expr_errors import TemplateExpressionError
 from pyomo.core.expr.numvalue import native_types, native_logical_types
 from pyomo.core.expr.expr_common import _and, _or, _equiv, _inv, _xor, _impl
@@ -100,9 +101,9 @@ class BooleanValue(PyomoObject):
     def local_name(self):
         return self.getname(fully_qualified=False)
 
+    @deprecated("The cname() method has been renamed to getname().",
+                version='5.0')
     def cname(self, *args, **kwds):
-        logger.warning(
-            "DEPRECATED: The cname() method has been renamed to getname()." )
         return self.getname(*args, **kwds)
 
     def is_constant(self):

--- a/pyomo/core/expr/numvalue.py
+++ b/pyomo/core/expr/numvalue.py
@@ -17,6 +17,7 @@ import sys
 import logging
 from six import iteritems, PY3
 
+from pyomo.common.deprecation import deprecated
 from pyomo.core.expr.expr_common import \
     (_add, _sub, _mul, _div, _pow,
      _neg, _abs, _radd,
@@ -613,9 +614,9 @@ class NumericValue(PyomoObject):
     def local_name(self):
         return self.getname(fully_qualified=False)
 
+    @deprecated("The cname() method has been renamed to getname().",
+                version='5.0')
     def cname(self, *args, **kwds):
-        logger.warning(
-            "DEPRECATED: The cname() method has been renamed to getname()." )
         return self.getname(*args, **kwds)
 
     def is_numeric_type(self):

--- a/pyomo/core/kernel/suffix.py
+++ b/pyomo/core/kernel/suffix.py
@@ -11,6 +11,7 @@
 import logging
 
 from pyomo.common.collections import ComponentMap
+from pyomo.common.deprecation import deprecated
 from pyomo.core.kernel.base import (
     ICategorizedObject, _abstract_readonly_property
 )
@@ -150,49 +151,43 @@ class suffix(ISuffix):
     # Methods that are deprecated
     #
 
+    @deprecated("suffix.set_all_values will be removed in the future.",
+                version='5.3')
     def set_all_values(self, value):
-        logger.warning("DEPRECATION WARNING: suffix.set_all_values "
-                       "will be removed in the future.")
         for ndx in self:
             self[ndx] = value
 
+    @deprecated("suffix.clear_value will be removed in the future. "
+                "Use 'del suffix[key]' instead.", version='5.3')
     def clear_value(self, component):
-        logger.warning("DEPRECATION WARNING: suffix.clear_value "
-                       "will be removed in the future. Use "
-                       "'del suffix[key]' instead.")
         try:
             del self[component]
         except KeyError:
             pass
 
+    @deprecated("suffix.clear_all_values is replaced with suffix.clear",
+                version='5.3')
     def clear_all_values(self):
-        logger.warning(
-            "DEPRECATION WARNING: suffix.clear_all_values "
-            "is replaced with suffix.clear")
         self.clear()
 
+    @deprecated("suffix.get_datatype is replaced with the property "
+                "suffix.datatype", version='5.3')
     def get_datatype(self):
-        logger.warning(
-            "DEPRECATION WARNING: suffix.get_datatype is replaced "
-            "with the property suffix.datatype")
         return self.datatype
 
+    @deprecated("suffix.set_datatype is replaced with the property "
+                "setter suffix.datatype", version='5.3')
     def set_datatype(self, datatype):
-        logger.warning(
-            "DEPRECATION WARNING: suffix.set_datatype is replaced "
-            "with the property setter suffix.datatype")
         self.datatype = datatype
 
+    @deprecated("suffix.get_direction is replaced with the property "
+                "suffix.direction", version='5.3')
     def get_direction(self):
-        logger.warning(
-            "DEPRECATION WARNING: suffix.get_direction is replaced "
-            "with the property suffix.direction")
         return self.direction
 
+    @deprecated("suffix.set_direction is replaced with the property "
+                "setter suffix.direction", version='5.3')
     def set_direction(self, direction):
-        logger.warning(
-            "DEPRECATION WARNING: suffix.set_direction is replaced "
-            "with the property setter suffix.direction")
         self.direction = direction
 
 # A list of convenient suffix generators, including:

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -15,7 +15,7 @@ import logging
 from pyomo.common.collections import ComponentMap, ComponentSet
 from pyomo.common.config import ConfigBlock, ConfigValue
 from pyomo.common.modeling import unique_component_name
-from pyomo.common.deprecation import deprecated
+from pyomo.common.deprecation import deprecated, deprecation_warning
 from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
 from pyomo.core import (
     Block, BooleanVar, Connector, Constraint, Param, Set, SetOf, Suffix, Var,
@@ -218,8 +218,8 @@ class BigM_Transformation(Transformation):
         # the tree. Suffixes lower down in the tree override ones higher
         # up.
         if 'default_bigM' in kwds:
-            logger.warn("DEPRECATED: the 'default_bigM=' argument has been "
-                        "replaced by 'bigM='")
+            deprecation_warning("the 'default_bigM=' argument has been "
+                                "replaced by 'bigM='", version='5.4')
             config.bigM = kwds.pop('default_bigM')
 
         config.set_value(kwds)


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This converts old deprecation messages (either printed to screen or emitted via the logger) to use the `pyomo.common.deprecation` functionality.

## Changes proposed in this PR:
- convert `logger.warn('DEPRECAT #...` and `print('DEPRECAT #...` to use `@deprecated()` or `deprecation_warning`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
