### PR TITLE
Add writer consistency checks between filenames and formats

### DIFF
--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1781,7 +1781,11 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
             # expected guess_format to create an NL file.
             format = ProblemFormat.cpxlp
         if filename is not None:
-            _format = guess_format(filename)
+            try:
+                _format = guess_format(filename)
+            except AttributeError:
+                # End up here if an ostream is passed to the filename argument
+                _format = None
             if format is None:
                 if _format is None:
                     raise ValueError(

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1780,14 +1780,21 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
             # user did something like 'model.write("f.nl")' and
             # expected guess_format to create an NL file.
             format = ProblemFormat.cpxlp
-        if (filename is not None) and (format is None):
-            format = guess_format(filename)
+        if filename is not None:
+            _format = guess_format(filename)
             if format is None:
-                raise ValueError(
-                    "Could not infer file format from file name '%s'.\n"
-                    "Either provide a name with a recognized extension "
-                    "or specify the format using the 'format' argument."
-                    % filename)
+                if _format is None:
+                    raise ValueError(
+                        "Could not infer file format from file name '%s'.\n"
+                        "Either provide a name with a recognized extension "
+                        "or specify the format using the 'format' argument."
+                        % filename)
+                else:
+                    format = _format
+            elif format != _format and _format is not None:
+                logger.warning(
+                    "Filename '%s' likely does not match specified "
+                    "file format (%s)" % (filename, format))
         problem_writer = WriterFactory(format)
         if problem_writer is None:
             raise ValueError(

--- a/pyomo/opt/base/solvers.py
+++ b/pyomo/opt/base/solvers.py
@@ -930,10 +930,15 @@ def default_config_block(solver, init=False):
                 'Print the results object after optimization.',
                 None) ).declare_as_argument(dest="show_results")
     postsolve.declare('results format', ConfigValue(
-                None,
-                str,
-                'Specify the results format:  json or yaml.',
-                None) ).declare_as_argument('--results-format', dest="results_format", metavar="FORMAT").declare_as_argument('--json', dest="results_format", action="store_const", const="json", help="Store results in JSON format")
+        None,
+        str,
+        'Specify the results format:  json or yaml.',
+        None)
+    ).declare_as_argument(
+        '--results-format', dest="results_format", metavar="FORMAT"
+    ).declare_as_argument(
+        '--json', dest="results_format", action="store_const",
+        const="json", help="Store results in JSON format")
     postsolve.declare('summary', ConfigValue(
                 False,
                 bool,

--- a/pyomo/opt/plugins/sol.py
+++ b/pyomo/opt/plugins/sol.py
@@ -58,17 +58,21 @@ class ResultsReader_sol(results.AbstractResultsReader):
         if res is None:
             res = SolverResults()
         #
-        msg = ""
-        line = fin.readline()
-        if line.strip() == "":
+        # Some solvers (minto) do not write a message.  We will assume
+        # all non-blank lines up the 'Options' line is the message.
+        msg = []
+        while True:
             line = fin.readline()
-        while line:
-            if line[0] == '\n' or (line[0] == '\r' and line[1] == '\n'):
+            if not line:
+                # EOF
                 break
-            msg += line
-            line = fin.readline()
+            line = line.strip()
+            if line == 'Options':
+                break
+            if line:
+                msg.append(line)
+        msg = '\n'.join(msg)
         z = []
-        line = fin.readline()
         if line[:7] == "Options":
             line = fin.readline()
             nopts = int(line)

--- a/pyomo/opt/results/results_.py
+++ b/pyomo/opt/results/results_.py
@@ -14,8 +14,10 @@ import math
 import sys
 import copy
 import json
+import logging
+import os.path
 
-from pyomo.common.dependencies import yaml, yaml_load_args
+from pyomo.common.dependencies import yaml, yaml_load_args, yaml_available
 import pyomo.opt
 from pyomo.opt.results.container import (undefined,
                                          ignore,
@@ -29,6 +31,7 @@ import pyomo.opt.results.solver
 from six import iteritems, StringIO
 from six.moves import xrange
 
+logger = logging.getLogger(__name__)
 
 class SolverResults(MapContainer):
 
@@ -75,18 +78,38 @@ class SolverResults(MapContainer):
         return tmp
 
     def write(self, **kwds):
-        if 'filename' in kwds:
-            OUTPUT = open(kwds['filename'],"w")
-            del kwds['filename']
-            kwds['ostream']=OUTPUT
-            self.write(**kwds)
-            OUTPUT.close()
-            return
+        _fmt = kwds.pop('format', None)
+        if _fmt:
+            _fmt = _fmt.lower()
+        fname = kwds.pop('filename', None)
 
-        if not 'format' in kwds or kwds['format'] == 'yaml':
-            self.write_yaml(**kwds)
+        if fname:
+            ext = os.path.splitext(fname)[1].lstrip('.')
+            normalized_ext = {
+                'json': 'json',
+                'jsn': 'json',
+                'yaml': 'yaml',
+                'yml': 'yaml',
+            }.get(ext, ext)
+            if not _fmt:
+                _fmt = normalized_ext
+            elif normalized_ext:
+                logger.warning(
+                    "writing results to file (%s) using what appears "
+                    "to be an incompatible format (%s)" % (fname, _fmt))
+            with open(fname, "w") as OUTPUT:
+                kwds['ostream'] = OUTPUT
+                kwds['format'] = _fmt
+                self.write(**kwds)
         else:
-            self.write_json(**kwds)
+            if not _fmt:
+                _fmt = 'yaml' if yaml_available else 'json'
+            if _fmt == 'yaml':
+                self.write_yaml(**kwds)
+            elif _fmt == 'json':
+                self.write_json(**kwds)
+            else:
+                raise ValueError("Unknown results file format: %s" % (_fmt,))
 
     def write_json(self, **kwds):
         if 'ostream' in kwds:

--- a/pyomo/opt/results/results_.py
+++ b/pyomo/opt/results/results_.py
@@ -103,7 +103,7 @@ class SolverResults(MapContainer):
                 self.write(**kwds)
         else:
             if not _fmt:
-                _fmt = 'yaml' if yaml_available else 'json'
+                _fmt = 'yaml'
             if _fmt == 'yaml':
                 self.write_yaml(**kwds)
             elif _fmt == 'json':

--- a/pyomo/opt/results/results_.py
+++ b/pyomo/opt/results/results_.py
@@ -90,10 +90,10 @@ class SolverResults(MapContainer):
                 'jsn': 'json',
                 'yaml': 'yaml',
                 'yml': 'yaml',
-            }.get(ext, ext)
+            }.get(ext, None)
             if not _fmt:
                 _fmt = normalized_ext
-            elif normalized_ext:
+            elif normalized_ext and _fmt != normalized_ext:
                 logger.warning(
                     "writing results to file (%s) using what appears "
                     "to be an incompatible format (%s)" % (fname, _fmt))

--- a/pyomo/scripting/util.py
+++ b/pyomo/scripting/util.py
@@ -69,11 +69,6 @@ def setup_environment(data):
     if postsolve:
         if not yaml_available and data.options.postsolve.results_format == 'yaml':
             raise ValueError("Configuration specifies a yaml file, but pyyaml is not installed!")
-        if data.options.postsolve.results_format is None:
-            if yaml_available:
-                data.options.postsolve.results_format = 'yaml'
-            else:
-                data.options.postsolve.results_format = 'json'
     #
     global start_time
     start_time = time.time()


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
There is an issue where we do not perform consistency checks between filenames specified by the user and the file format specified by the user.  The simplest example of this is:
```
pyomo solve --solver cbc model.py --save-results=results.json
```
In this case, Pyomo will create a `results.json` file and write data to it in YAML format.  This PR does a couple things: the default results format is pulled from the filename extension (if applicable), and for the cases where both a filename and a format is specified, if they don't match (in the Windows sense of checking extensions), then a warning is emitted to the user.

## Changes proposed in this PR:
- infer the results format from the specified filename (if applicable)
- warn when a writer (model or results) is asked to write to a file in a different format than would normally be inferred by the file extension.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
