### PR TITLE
Improve robustness of pint units comparisons

### DIFF
--- a/pyomo/util/check_units.py
+++ b/pyomo/util/check_units.py
@@ -68,9 +68,13 @@ def assert_units_equivalent(*args):
     # this call will raise an exception if an inconsistency is found
     pint_units = [units._get_pint_units(arg) for arg in args]
     pint_unit_compare = pint_units[0]
+    registry = units._pint_registry
     for pint_unit in pint_units[1:]:
-        # this call will raise an exception if an inconsistency is found
-        if not pint_unit == pint_unit_compare:
+        # We first do the easy check for equivalence, but if that fails,
+        # we fall back on the more expensive conversion to base units
+        if pint_unit != pint_unit_compare and (
+                registry.get_base_units(pint_unit)
+                != registry.get_base_units(pint_unit_compare) ):
             raise UnitsError(
                 "Units between {} and {} are not consistent.".format(
                     str(pint_unit_compare), str(pint_unit)))

--- a/pyomo/util/check_units.py
+++ b/pyomo/util/check_units.py
@@ -68,13 +68,8 @@ def assert_units_equivalent(*args):
     # this call will raise an exception if an inconsistency is found
     pint_units = [units._get_pint_units(arg) for arg in args]
     pint_unit_compare = pint_units[0]
-    registry = units._pint_registry
-    for pint_unit in pint_units[1:]:
-        # We first do the easy check for equivalence, but if that fails,
-        # we fall back on the more expensive conversion to base units
-        if pint_unit != pint_unit_compare and (
-                registry.get_base_units(pint_unit)
-                != registry.get_base_units(pint_unit_compare) ):
+    for pint_unit in pint_units:
+        if not units._equivalent_pint_units(pint_unit_compare, pint_unit):
             raise UnitsError(
                 "Units between {} and {} are not consistent.".format(
                     str(pint_unit_compare), str(pint_unit)))


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Follow-on to #1794 to improve the robustness of pint unit comparisons within the units visitor.

## Changes proposed in this PR:
- use consistent robust check for units equivalence across the walker and checker logic

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
