### PR TITLE
Initialize self.tempdir in TempfileManagerClass

### DIFF
--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -34,9 +34,8 @@ deletion_errors_are_fatal = True
 class TempfileManagerClass:
     """A class that manages temporary files."""
 
-    tempdir = None
-
     def __init__(self, **kwds):
+        self.tempdir = None
         self._tempfiles = [[]]
         self._ctr = -1
 
@@ -188,5 +187,6 @@ class TempfileManagerClass:
 
         if len(self._tempfiles) == 0:
             self._tempfiles = [[]]
+
 
 TempfileManager = TempfileManagerClass()


### PR DESCRIPTION
## Fixes #1803 

## Summary/Motivation:
`TempfileManager.tempdir` was not being initialized correctly. This fixes the initialization of the class option to resolve the occasional `FileNotFoundError` bug.

## Changes proposed in this PR:
- Bug fix: Initialize `self.tempdir`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
