### PR TITLE
Manually add commit HASH to codecov upload on GitHub Actions 

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -663,17 +663,22 @@ jobs:
             i=0
             while : ; do
                 ((i+=1))
+                rm -f codecov.log
                 echo "Uploading coverage to codecov (attempt ${i})"
                 bash $CODECOV -Z -e TAG,GHA_OS_NAME -X gcov -X s3 \
-                    -f coverage.xml -C $SHA
+                    -f coverage.xml -C $SHA | tee codecov.log
                 if test $? == 0; then
                     echo "PASS $CODECOV_NAME" >> codecov.result
                     break
                 elif test $i -ge 2; then
-                    # Do not fail the build (yet) just because the codecov
-                    # upload fails
-                    echo "FAIL $CODECOV_NAME" >> codecov.result
-                    break
+                    if test `grep successfully codecov.log | wc -l` -gt 0; then
+                        echo "PASS $CODECOV_NAME (implied)" >> codecov.result
+                    else
+                        # Do not fail the build (yet) just because the
+                        # codecov upload fails
+                        echo "FAIL $CODECOV_NAME" >> codecov.result
+                        break
+                    fi
                 fi
                 DELAY=$(( RANDOM % 30 + 30))
                 echo "Pausing $DELAY seconds before re-attempting upload"

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -661,7 +661,7 @@ jobs:
                 ((i+=1))
                 echo "Uploading coverage to codecov (attempt ${i})"
                 bash $CODECOV -Z -e TAG,GHA_OS_NAME -X gcov -X s3 \
-                    -f coverage.xml
+                    -f coverage.xml -C $GITHUB_SHA
                 if test $? == 0; then
                     echo "PASS $CODECOV_NAME" >> codecov.result
                     break

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -62,7 +62,7 @@ jobs:
           PACKAGES: glpk
 
         - os: ubuntu-18.04
-          python: 3.7
+          python: 3.8
           other: /mpi
           mpi: 3
           skip_doctest: 1
@@ -87,14 +87,6 @@ jobs:
           PYENV: pip
 
         - os: ubuntu-18.04
-          python: 3.7
-          other: /singletest
-          category: neos
-          skip_doctest: 1
-          TARGET: linux
-          PYENV: pip
-
-        - os: ubuntu-18.04
           python: 3.6
           other: /cython
           setup_options: --with-cython
@@ -102,6 +94,14 @@ jobs:
           TARGET: linux
           PYENV: pip
           PACKAGES: cython
+
+        - os: ubuntu-18.04
+          python: 3.7
+          other: /singletest
+          category: neos
+          skip_doctest: 1
+          TARGET: linux
+          PYENV: pip
 
         exclude:
         - {os: macos-latest, python: pypy3}
@@ -195,7 +195,6 @@ jobs:
         for pkg in bash pkg-config unixodbc freetds glpk; do
             brew list $pkg || brew install $pkg
         done
-        #brew link --overwrite gcc
 
     - name: Update Linux
       if: matrix.TARGET == 'linux'

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -641,6 +641,11 @@ jobs:
     - name: Upload codecov reports
       run: |
         set +e
+        if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+            SHA=$(jq --raw-output .pull_request.head.sha "$GITHUB_EVENT_PATH")
+        else
+            SHA=$GITHUB_SHA
+        fi
         function upload {
             echo ""
             echo "Build group: $1"
@@ -661,7 +666,7 @@ jobs:
                 ((i+=1))
                 echo "Uploading coverage to codecov (attempt ${i})"
                 bash $CODECOV -Z -e TAG,GHA_OS_NAME -X gcov -X s3 \
-                    -f coverage.xml -C $GITHUB_SHA
+                    -f coverage.xml -C $SHA
                 if test $? == 0; then
                     echo "PASS $CODECOV_NAME" >> codecov.result
                     break

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -650,17 +650,22 @@ jobs:
             i=0
             while : ; do
                 ((i+=1))
+                rm -f codecov.log
                 echo "Uploading coverage to codecov (attempt ${i})"
                 bash $CODECOV -Z -e TAG,GHA_OS_NAME -X gcov -X s3 \
-                    -f coverage.xml -C $SHA
+                    -f coverage.xml -C $SHA | tee codecov.log
                 if test $? == 0; then
                     echo "PASS $CODECOV_NAME" >> codecov.result
                     break
                 elif test $i -ge 2; then
-                    # Do not fail the build (yet) just because the codecov
-                    # upload fails
-                    echo "FAIL $CODECOV_NAME" >> codecov.result
-                    break
+                    if test `grep successfully codecov.log | wc -l` -gt 0; then
+                        echo "PASS $CODECOV_NAME (implied)" >> codecov.result
+                    else
+                        # Do not fail the build (yet) just because the
+                        # codecov upload fails
+                        echo "FAIL $CODECOV_NAME" >> codecov.result
+                        break
+                    fi
                 fi
                 DELAY=$(( RANDOM % 30 + 30))
                 echo "Pausing $DELAY seconds before re-attempting upload"

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -86,7 +86,7 @@ jobs:
           PYENV: pip
 
         - os: ubuntu-18.04
-          python: 3.7
+          python: 3.6
           other: /cython
           setup_options: --with-cython
           skip_doctest: 1

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -647,7 +647,7 @@ jobs:
                 ((i+=1))
                 echo "Uploading coverage to codecov (attempt ${i})"
                 bash $CODECOV -Z -e TAG,GHA_OS_NAME -X gcov -X s3 \
-                    -f coverage.xml
+                    -f coverage.xml -C $GITHUB_SHA
                 if test $? == 0; then
                     echo "PASS $CODECOV_NAME" >> codecov.result
                     break

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -627,6 +627,11 @@ jobs:
     - name: Upload codecov reports
       run: |
         set +e
+        if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+            SHA=$(jq --raw-output .pull_request.head.sha "$GITHUB_EVENT_PATH")
+        else
+            SHA=$GITHUB_SHA
+        fi
         function upload {
             echo ""
             echo "Build group: $1"
@@ -647,7 +652,7 @@ jobs:
                 ((i+=1))
                 echo "Uploading coverage to codecov (attempt ${i})"
                 bash $CODECOV -Z -e TAG,GHA_OS_NAME -X gcov -X s3 \
-                    -f coverage.xml -C $GITHUB_SHA
+                    -f coverage.xml -C $SHA
                 if test $? == 0; then
                     echo "PASS $CODECOV_NAME" >> codecov.result
                     break


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
It was recently discovered that Codecov report uploads on GitHub Actions do not always upload under the appropriate HASH. This PR adds a flag to manually pass the HASH to the uploader.

## Changes proposed in this PR:
- Add `-C $GITHUB_SHA` to GHA

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
