### PR TITLE
Update unittest.timeout to work on Windows

### DIFF
--- a/pyomo/common/tests/test_unittest.py
+++ b/pyomo/common/tests/test_unittest.py
@@ -9,9 +9,30 @@
 #  ___________________________________________________________________________
 
 import datetime
+import multiprocessing
+import six
 import time
 
 import pyomo.common.unittest as unittest
+from pyomo.common.log import LoggingIntercept
+
+@unittest.timeout(1)
+def short_sleep():
+    return 42
+
+@unittest.timeout(0.01)
+def long_sleep():
+    time.sleep(1)
+    return 42
+
+@unittest.timeout(1)
+def raise_exception():
+    foo.bar
+
+@unittest.timeout(1)
+def fail():
+    raise AssertionError("0 != 1")
+
 
 class TestPyomoUnittest(unittest.TestCase):
     def test_assertStructuredAlmostEqual_comparison(self):
@@ -129,38 +150,73 @@ class TestPyomoUnittest(unittest.TestCase):
                                     '3 !~= 2.999'):
             self.assertStructuredAlmostEqual(a, b)
 
-    @unittest.timeout(1)
-    def short_sleep(self):
-        time.sleep(0.01)
-        return 42
-
-    @unittest.timeout(0.01)
-    def long_sleep(self):
-        time.sleep(1)
-        return 42
-
-    @unittest.timeout(1)
-    def raise_exception(self):
-        foo.bar
-        return 42
-
-    @unittest.timeout(1)
-    def fail(self):
-        self.assertEqual(0, 1)
-
-    def test_timeout(self):
-        self.assertEqual(self.short_sleep(), 42)
+    def test_timeout_fcn_call(self):
+        self.assertEqual(short_sleep(), 42)
         with self.assertRaisesRegex(
                 TimeoutError, 'test timed out after 0.01 seconds'):
-            self.long_sleep()
+            long_sleep()
         with self.assertRaisesRegex(
                 NameError,
                 f"name 'foo' is not defined\s+Original traceback:"):
-            self.raise_exception()
+            raise_exception()
+        with self.assertRaisesRegex(AssertionError, r"^0 != 1$"):
+            fail()
+
+    @unittest.timeout(1)
+    def test_timeout(self):
+        self.assertEqual(0, 0)
+
+    @unittest.expectedFailure
+    @unittest.timeout(0.01)
+    def test_timeout_timeout(self):
+        time.sleep(1)
+        self.assertEqual(0, 1)
+
+    @unittest.timeout(1)
+    def test_timeout_skip(self):
+        if TestPyomoUnittest.test_timeout_skip.skip:
+            self.skipTest("Skipping this test")
+        self.assertEqual(0, 1)
+
+    test_timeout_skip.skip = True
+
+    def test_timeout_skip_fails(self):
+        try:
+            with self.assertRaisesRegex(
+                    unittest.SkipTest, r"Skipping this test"):
+                self.test_timeout_skip()
+            TestPyomoUnittest.test_timeout_skip.skip = False
+            with self.assertRaisesRegex(AssertionError, r"0 != 1"):
+                self.test_timeout_skip()
+        finally:
+            TestPyomoUnittest.test_timeout_skip.skip = True
+
+    @unittest.timeout(1)
+    def bound_function(self):
+        self.assertEqual(0, 0)
+
+    def test_bound_function(self):
+        if multiprocessing.get_start_method() == 'fork':
+            self.bound_function()
+            return
+        LOG = six.StringIO()
+        with LoggingIntercept(LOG):
+            with self.assertRaises(TypeError):
+                self.bound_function()
+        self.assertIn("platform that does not support 'fork'", LOG.getvalue())
+
+    @unittest.timeout(1, require_fork=True)
+    def bound_function_require_fork(self):
+        self.assertEqual(0, 0)
+
+    def test_bound_function_require_fork(self):
+        if multiprocessing.get_start_method() == 'fork':
+            self.bound_function_require_fork()
+            return
         with self.assertRaisesRegex(
-                AssertionError,
-                r"^0 != 1$"):
-            self.fail()
+                unittest.SkipTest,
+                "timeout requires unavailable fork interface"):
+            self.bound_function_require_fork()
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -8,6 +8,8 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import enum
+import logging
 import math
 import six
 import sys
@@ -26,25 +28,47 @@ from pyomo.common.collections import Mapping, Sequence
 # This augments the unittest exports with two additional decorators
 __all__ = _unittest.__all__ + ['category', 'nottest']
 
-def _test_runner(q):
+def _runner(q, qualname):
     "Utility wrapper for running functions, used by timeout()"
-    fcn, args, kwargs = _test_runner.data[q]
+    resultType = _RunnerResult.call
+    if q in _runner.data:
+        fcn, args, kwargs = _runner.data[q]
+    elif isinstance(qualname, str):
+        # Use unittest to instantiate the TestCase and run it
+        resultType = _RunnerResult.unittest
+        def fcn():
+            s = _unittest.TestLoader().loadTestsFromName(qualname)
+            r = _unittest.TestResult()
+            s.run(r)
+            return r.errors + r.failures, r.skipped
+        args = ()
+        kwargs = {}
+    else:
+        qualname, fcn, args, kwargs = qualname
+    _runner.data[qualname] = None
     try:
-        q.put((False, fcn(*args, **kwargs)))
+        q.put((resultType, fcn(*args, **kwargs)))
     except:
         import traceback
         etype, e, tb = sys.exc_info()
         if not isinstance(e, AssertionError):
             e = etype("%s\nOriginal traceback:\n%s" % (
                 e, ''.join(traceback.format_tb(tb))))
-        q.put((True, e))
+        q.put((_RunnerResult.exception, e))
+    finally:
+        _runner.data.pop(qualname)
 
-# Data structure for passing functions/arguments to the _test_runner
+# Data structure for passing functions/arguments to the _runner
 # without forcing them to be pickled / unpickled
-_test_runner.data = {}
+_runner.data = {}
+
+class _RunnerResult(enum.Enum):
+    exception = 0
+    call = 1
+    unittest = 2
 
 
-def timeout(seconds):
+def timeout(seconds, require_fork=False):
     """Function decorator to timeout the decorated function.
 
     This decorator will wrap a function call with a timeout, returning
@@ -88,30 +112,69 @@ def timeout(seconds):
     import multiprocessing
     import queue
     def timeout_decorator(fcn):
-        if multiprocessing.get_start_method() != 'fork':
-            return skip("unittest.timeout() requires "
-                        "multiprocessing.get_start_method()=='fork'")(fcn)
         @functools.wraps(fcn)
         def test_timer(*args, **kwargs):
+            qualname = '%s.%s' % (fcn.__module__, fcn.__qualname__)
+            if qualname in _runner.data:
+                return fcn(*args, **kwargs)
+            if require_fork and multiprocessing.get_start_method() != 'fork':
+                raise _unittest.SkipTest(
+                    "timeout requires unavailable fork interface")
+
             q = multiprocessing.Queue()
-            _test_runner.data[q] = (fcn, args, kwargs)
+            if multiprocessing.get_start_method() == 'fork':
+                # Option 1: leverage fork if possible.  This minimizes
+                # the reliance on serialization and ensures that the
+                # wrapped function operates in the same environment.
+                _runner.data[q] = (fcn, args, kwargs)
+                runner_args = (q, qualname)
+            elif (args and fcn.__name__.startswith('test')
+                  and _unittest.case.TestCase in args[0].__class__.__mro__):
+                # Option 2: this is wrapping a unittest.  Re-run
+                # unittest in the child process with this function as
+                # the sole target.  This ensures that things like setUp
+                # and tearDown are correctly called.
+                runner_args = (q, qualname)
+            else:
+                # Option 3: attempt to serialize the function and all
+                # arguments and send them to the (spawned) child
+                # process.  The wrapped function cannot count on any
+                # environment configuration that it does not set up
+                # itself.
+                runner_args = (q, (qualname, test_timer, args, kwargs))
             test_proc = multiprocessing.Process(
-                target=_test_runner, args=(q,))
-            test_proc.daemon = False
-            test_proc.start()
+                target=_runner, args=runner_args)
+            test_proc.daemon = True
             try:
-                exception_raised, result = q.get(True, seconds)
+                test_proc.start()
+            except:
+                if type(runner_args[1]) is tuple:
+                    logging.getLogger(__name__).error(
+                        "Exception raised spawning timeout subprocess "
+                        "on a platform that does not support 'fork'.  "
+                        "It is likely that either the wrapped function or "
+                        "one of its arguments is not serializable")
+                raise
+            try:
+                resultType, result = q.get(True, seconds)
             except queue.Empty:
                 test_proc.terminate()
                 raise TimeoutError(
                     "test timed out after %s seconds" % (seconds,)) from None
             finally:
-                _test_runner.data.pop(q)
+                _runner.data.pop(q, None)
             test_proc.join()
-            if exception_raised:
-                raise result
-            else:
+            if resultType == _RunnerResult.call:
                 return result
+            elif resultType == _RunnerResult.unittest:
+                for name, msg in result[0]:
+                    with args[0].subTest(name):
+                        raise args[0].failureException(msg)
+                for name, msg in result[1]:
+                    with args[0].subTest(name):
+                        args[0].skipTest(msg)
+            else:
+                raise result
         return test_timer
     return timeout_decorator
 


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This updates the `unittest.timeout()` to provide improved support for Windows and OSX platforms.  The original implementation only worked for the `fork` multiprocessing interface.  This adds reasonable support for `spawn`, with special handling for decorated test cases.

## Changes proposed in this PR:
- Add support for the `spawn` multiprocessing interface for `unittest.timeout()`
- Capture and return the stderr/stdout from the subprocess.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
