### PR TITLE
Standardize usage of string type comparison

### DIFF
--- a/examples/dae/ReactionKinetics.py
+++ b/examples/dae/ReactionKinetics.py
@@ -17,7 +17,7 @@
 from pyomo.environ import *
 from pyomo.dae import *
 
-from six import itervalues, iteritems, string_types
+from six import itervalues, iteritems
 
 try:
     import matplotlib.pyplot as plt
@@ -63,7 +63,7 @@ class Reaction(object):
 
     def _parse(self, _in):
         ans = {}
-        if isinstance(_in, string_types):
+        if isinstance(_in, str):
             _in = _in.split('+')
         for x in _in:
             coef, species = self._parseTerm(x)
@@ -71,7 +71,7 @@ class Reaction(object):
         return ans
         
     def _parseTerm(self, x):
-        if isinstance(x, string_types):
+        if isinstance(x, str):
             if '*' in x:
                 coef, species = x.split('*',1)
                 coef = float(coef)

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -203,7 +203,7 @@ class Path(object):
 
 class PathList(Path):
     def __call__(self, data):
-        if hasattr(data, "__iter__") and not isinstance(data, six.string_types):
+        if hasattr(data, "__iter__") and not isinstance(data, str):
             return [ super(PathList, self).__call__(i) for i in data ]
         else:
             return [ super(PathList, self).__call__(data) ]
@@ -963,10 +963,10 @@ class ConfigBase(object):
             # well
             if isinstance(name, argparse._ActionsContainer):
                 #hasattr(_group, 'title') and \
-                #    isinstance(_group.title, six.string_types):
+                #    isinstance(_group.title, str):
                 return 2, name
 
-            if not isinstance(name, six.string_types):
+            if not isinstance(name, str):
                 raise RuntimeError(
                     'Unknown datatype (%s) for argparse group on '
                     'configuration definition %s' %

--- a/pyomo/common/fileutils.py
+++ b/pyomo/common/fileutils.py
@@ -14,7 +14,7 @@ import inspect
 import logging
 import os
 import platform
-import six
+from six import itervalues
 import importlib.util
 import sys
 
@@ -110,14 +110,14 @@ def find_path(name, validate, cwd=True, mode=os.R_OK, ext=None,
         locations.append(os.getcwd())
 
     if allow_pathlist_deep_references or os.path.basename(name) == name:
-        if isinstance(pathlist, six.string_types):
+        if isinstance(pathlist, str):
             locations.extend( pathlist.split(os.pathsep) )
         else:
             locations.extend(pathlist)
 
     extlist = ['']
     if ext:
-        if isinstance(ext, six.string_types):
+        if isinstance(ext, str):
             extlist.append(ext)
         else:
             extlist.extend(ext)
@@ -142,6 +142,7 @@ def find_file(filename, cwd=True, mode=os.R_OK, ext=None, pathlist=[],
     Parameters
     ----------
     filename : str
+    
         The file name to locate.  The file name may contain references
         to a user's home directory (``~user``), environment variables
         (``${HOME}/bin``), and shell wildcards (``?`` and ``*``); all of
@@ -312,7 +313,7 @@ def find_library(libname, cwd=True, include_PATH=True, pathlist=None):
         pathlist.extend(os.environ.get('LD_LIBRARY_PATH','').split(os.pathsep))
         if include_PATH:
             pathlist.append( os.path.join(config.PYOMO_CONFIG_DIR, 'bin') )
-    elif isinstance(pathlist, six.string_types):
+    elif isinstance(pathlist, str):
         pathlist = pathlist.split(os.pathsep)
     else:
         pathlist = list(pathlist)
@@ -379,7 +380,7 @@ def find_executable(exename, cwd=True, include_PATH=True, pathlist=None):
     """
     if pathlist is None:
         pathlist = [ os.path.join(config.PYOMO_CONFIG_DIR, 'bin') ]
-    elif isinstance(pathlist, six.string_types):
+    elif isinstance(pathlist, str):
         pathlist = pathlist.split(os.pathsep)
     else:
         pathlist = list(pathlist)
@@ -653,7 +654,7 @@ class PathManager(object):
         through the PATH.
 
         """
-        for _path in six.itervalues(self._pathTo):
+        for _path in itervalues(self._pathTo):
             _path.rehash()
 
 #

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -8,8 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import math
-import six
 
 # Import base classes privately (so that we have handles on them)
 import pyutilib.th.pyunit as _pyunit
@@ -157,7 +155,7 @@ class TestCase(_pyunit.TestCase):
                             str(e), _unittest.case.safe_repr(key)))
             return # PASS!
 
-        elif any(isinstance(_, six.string_types) for _ in args):
+        elif any(isinstance(_, str) for _ in args):
             if first == second:
                 return # PASS!
 

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -18,7 +18,7 @@ import time
 import math
 
 from pyomo.common import timing, PyomoAPIFactory
-from pyomo.common.collections import Container, OrderedDict
+from pyomo.common.collections import Container
 from pyomo.common.dependencies import pympler, pympler_available
 from pyomo.common.deprecation import deprecated, deprecation_warning
 from pyomo.common.gc_manager import PauseGC
@@ -46,11 +46,7 @@ from pyomo.core.base.label import CNameLabeler, CuidLabeler
 
 from pyomo.opt.results import SolverResults, Solution, SolverStatus, UndefinedData
 
-from six import itervalues, iteritems, StringIO, string_types
-try:
-    unicode
-except:
-    basestring = unicode = str
+from six import itervalues, iteritems, StringIO
 
 logger = logging.getLogger('pyomo.core')
 id_func = id
@@ -649,7 +645,7 @@ class Model(SimpleBlock):
         # filename is specified.  A concrete model is already
         # constructed, so passing in a data file is a waste of time.
         #
-        if self.is_constructed() and isinstance(filename, string_types):
+        if self.is_constructed() and isinstance(filename, str):
             msg = "The filename=%s will not be loaded - supplied as an " \
                   "argument to the create_instance() method of a "\
                   "concrete instance with name=%s." % (filename, name)
@@ -751,7 +747,7 @@ arguments (which have been ignored):"""
                 "The report_timing argument to Model.load() is deprecated.  "
                 "Use pyomo.common.timing.report_timing() to enable reporting "
                 "construction timing")
-        if arg is None or isinstance(arg, basestring):
+        if arg is None or isinstance(arg, str):
             dp = DataPortal(filename=arg, model=self)
         elif type(arg) is DataPortal:
             dp = arg
@@ -829,6 +825,8 @@ arguments (which have been ignored):"""
 
                 self._initialize_component(modeldata, namespaces, component_name, profile_memory)
                 if False:
+                    # !!THIS SEEMS LIKE A BUG!! - mrmundt
+                    # there is no start_time
                     total_time = time.time() - start_time
                     if isinstance(component, IndexedComponent):
                         clen = len(component)
@@ -841,7 +839,7 @@ arguments (which have been ignored):"""
                     tmp_clone_counter = expr_common.clone_counter
                     if clone_counter != tmp_clone_counter:
                         clone_counter = tmp_clone_counter
-                        print("             Cloning detected! (clone count: %d)" % clone_counters)
+                        print("             Cloning detected! (clone count: %d)" % clone_counter)
 
             # Note: As is, connectors are expanded when using command-line pyomo but not calling model.create(...) in a Python script.
             # John says this has to do with extension points which are called from commandline but not when writing scripts.

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -824,22 +824,6 @@ arguments (which have been ignored):"""
                     continue
 
                 self._initialize_component(modeldata, namespaces, component_name, profile_memory)
-                if False:
-                    # !!THIS SEEMS LIKE A BUG!! - mrmundt
-                    # there is no start_time
-                    total_time = time.time() - start_time
-                    if isinstance(component, IndexedComponent):
-                        clen = len(component)
-                    else:
-                        assert isinstance(component, Component)
-                        clen = 1
-                    print("    %%6.%df seconds required to construct component=%s; %d indices total" \
-                              % (total_time>=0.005 and 2 or 0, component_name, clen) \
-                              % total_time)
-                    tmp_clone_counter = expr_common.clone_counter
-                    if clone_counter != tmp_clone_counter:
-                        clone_counter = tmp_clone_counter
-                        print("             Cloning detected! (clone count: %d)" % clone_counter)
 
             # Note: As is, connectors are expanded when using command-line pyomo but not calling model.create(...) in a Python script.
             # John says this has to do with extension points which are called from commandline but not when writing scripts.

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -21,12 +21,12 @@ import textwrap
 
 from inspect import isclass
 from operator import itemgetter
-from six import iteritems, iterkeys, itervalues, StringIO, string_types, \
+from six import iteritems, iterkeys, itervalues, StringIO, \
     advance_iterator, PY3
 
 from pyutilib.misc.indent_io import StreamIndenter
 
-from pyomo.common.collections import ComponentMap, Mapping
+from pyomo.common.collections import Mapping
 from pyomo.common.deprecation import deprecated, deprecation_warning
 from pyomo.common.log import is_debug_set
 from pyomo.common.timing import ConstructionTimer
@@ -1265,7 +1265,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         return that component IFF the component is a child of this
         block. Returns None on lookup failure.
         """
-        if isinstance(name_or_object, string_types):
+        if isinstance(name_or_object, str):
             if name_or_object in self._decl:
                 return self._decl_order[self._decl[name_or_object]][0]
         else:

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -9,11 +9,10 @@
 #  ___________________________________________________________________________
 
 import logging
-import six
 import sys
 from copy import deepcopy
 from pickle import PickleError
-from six import iteritems, string_types
+from six import iteritems
 from weakref import ref as weakref_ref
 
 from pyutilib.misc.indent_io import StreamIndenter
@@ -43,7 +42,7 @@ def _name_index_generator(idx):
             # requires escaping any single quotes in the string... which
             # in turn requires escaping the escape character.
             ans = "%s" % (val,)
-            if isinstance(val, six.string_types):
+            if isinstance(val, str):
                 ans = ans.replace("\\", "\\\\").replace("'", "\\'")
                 if ',' in ans or "'" in ans:
                     ans = "'"+ans+"'"
@@ -268,7 +267,7 @@ class _ComponentBase(PyomoObject):
         """
         comp = self.parent_component()
         _attr, _data, _header, _fcn = comp._pprint()
-        if isinstance(type(_data), six.string_types):
+        if isinstance(type(_data), str):
             # If the component _pprint only returned a pre-formatted
             # result, then we have no way to only emit the information
             # for this _data object.
@@ -608,7 +607,7 @@ class Component(_ComponentBase):
 
     def clear_suffix_value(self, suffix_or_name, expand=True):
         """Clear the suffix value for this component data"""
-        if isinstance(suffix_or_name, six.string_types):
+        if isinstance(suffix_or_name, str):
             import pyomo.core.base.suffix
             for name_, suffix_ in pyomo.core.base.suffix.active_suffix_generator(self.model()):
                 if suffix_or_name == name_:
@@ -619,7 +618,7 @@ class Component(_ComponentBase):
 
     def set_suffix_value(self, suffix_or_name, value, expand=True):
         """Set the suffix value for this component data"""
-        if isinstance(suffix_or_name, six.string_types):
+        if isinstance(suffix_or_name, str):
             import pyomo.core.base.suffix
             for name_, suffix_ in pyomo.core.base.suffix.active_suffix_generator(self.model()):
                 if suffix_or_name == name_:
@@ -630,7 +629,7 @@ class Component(_ComponentBase):
 
     def get_suffix_value(self, suffix_or_name, default=None):
         """Get the suffix value for this component data"""
-        if isinstance(suffix_or_name, six.string_types):
+        if isinstance(suffix_or_name, str):
             import pyomo.core.base.suffix
             for name_, suffix_ in pyomo.core.base.suffix.active_suffix_generator(self.model()):
                 if suffix_or_name == name_:
@@ -922,7 +921,7 @@ class ComponentData(_ComponentBase):
 
     def clear_suffix_value(self, suffix_or_name, expand=True):
         """Set the suffix value for this component data"""
-        if isinstance(suffix_or_name, six.string_types):
+        if isinstance(suffix_or_name, str):
             import pyomo.core.base.suffix
             for name_, suffix_ in pyomo.core.base.suffix.active_suffix_generator(self.model()):
                 if suffix_or_name == name_:
@@ -933,7 +932,7 @@ class ComponentData(_ComponentBase):
 
     def set_suffix_value(self, suffix_or_name, value, expand=True):
         """Set the suffix value for this component data"""
-        if isinstance(suffix_or_name, six.string_types):
+        if isinstance(suffix_or_name, str):
             import pyomo.core.base.suffix
             for name_, suffix_ in pyomo.core.base.suffix.active_suffix_generator(self.model()):
                 if suffix_or_name == name_:
@@ -944,7 +943,7 @@ class ComponentData(_ComponentBase):
 
     def get_suffix_value(self, suffix_or_name, default=None):
         """Get the suffix value for this component data"""
-        if isinstance(suffix_or_name, six.string_types):
+        if isinstance(suffix_or_name, str):
             import pyomo.core.base.suffix
             for name_, suffix_ in pyomo.core.base.suffix.active_suffix_generator(self.model()):
                 if suffix_or_name == name_:

--- a/pyomo/core/base/componentuid.py
+++ b/pyomo/core/base/componentuid.py
@@ -8,12 +8,11 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import bisect
 import codecs
 import re
 import ply.lex
 
-from six import PY2, string_types, iteritems
+from six import PY2, iteritems
 
 from pyomo.common.collections import ComponentMap
 from pyomo.common.dependencies import pickle
@@ -59,7 +58,7 @@ class ComponentUID(object):
 
     @staticmethod
     def _safe_str(x):
-        if not isinstance(x, string_types):
+        if not isinstance(x, str):
             return ComponentUID._repr_map.get(
                 x.__class__, ComponentUID._pickle)(x)
         else:
@@ -93,7 +92,7 @@ class ComponentUID(object):
     def __init__(self, component, cuid_buffer=None, context=None):
         # A CUID can be initialized from either a reference component or
         # the string representation.
-        if isinstance(component, string_types):
+        if isinstance(component, str):
             if context is not None:
                 raise ValueError("Context is not allowed when initializing a "
                                  "ComponentUID object from a string type")

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -10,7 +10,6 @@
 
 import logging
 import os
-import six
 import types
 import weakref
 
@@ -24,11 +23,6 @@ from pyomo.core.base.component import Component
 from pyomo.core.base.units_container import units
 
 __all__  = ( 'ExternalFunction', )
-
-try:
-    basestring
-except:
-    basestring = str
 
 logger = logging.getLogger('pyomo.core')
 
@@ -177,7 +171,7 @@ class AMPLExternalFunction(ExternalFunction):
         def addfunc(name, f, _type, nargs, funcinfo, ae):
             # trap for Python 3, where the name comes in as bytes() and
             # not a string
-            if not isinstance(name, six.string_types):
+            if not isinstance(name, str):
                 name = name.decode()
             self._known_functions[str(name)] = (f, _type, nargs, funcinfo, ae)
         AE.Addfunc = _AMPLEXPORTS.ADDFUNC(addfunc)

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -21,7 +21,7 @@ from pyomo.core.base.global_set import UnindexedComponent_set
 from pyomo.common import DeveloperError
 from pyomo.common.deprecation import deprecation_warning
 
-from six import PY3, itervalues, iteritems, string_types
+from six import PY3, itervalues, iteritems
 
 if PY3:
     from collections.abc import Sequence as collections_Sequence
@@ -67,7 +67,7 @@ def normalize_index(x):
             # new object)
             x = x[:i] + tuple(x[i]) + x[i + 1:]
         elif issubclass(_xi_class, collections_Sequence):
-            if issubclass(_xi_class, string_types):
+            if issubclass(_xi_class, str):
                 # This is very difficult to get to: it would require a
                 # user creating a custom derived string type
                 native_types.add(_xi_class)

--- a/pyomo/core/base/label.py
+++ b/pyomo/core/base/label.py
@@ -164,7 +164,7 @@ class ShortNameLabeler(object):
         else:
             self.labeler = AlphaNumericTextLabeler()
         self.known_labels = set() if caseInsensitive else None
-        if isinstance(legalRegex, six.string_types):
+        if isinstance(legalRegex, str):
             self.legalRegex = re.compile(legalRegex)
         else:
             self.legalRegex = legalRegex

--- a/pyomo/core/base/misc.py
+++ b/pyomo/core/base/misc.py
@@ -14,7 +14,7 @@ import logging
 import sys
 import types
 
-from six import itervalues, string_types
+from six import itervalues
 
 logger = logging.getLogger('pyomo.core')
 
@@ -179,7 +179,7 @@ def sorted_robust(arg):
 
 
 def _to_ustr(obj):
-    if not isinstance(obj, string_types):
+    if not isinstance(obj, str):
         try:
             obj = str(obj)
         except:

--- a/pyomo/core/base/util.py
+++ b/pyomo/core/base/util.py
@@ -186,7 +186,7 @@ def Initializer(init,
     elif isinstance(init, collections_Mapping):
         return ItemInitializer(init)
     elif isinstance(init, collections_Sequence) \
-            and not isinstance(init, six.string_types):
+            and not isinstance(init, str):
         if treat_sequences_as_mappings:
             return ItemInitializer(init)
         else:

--- a/pyomo/core/expr/numvalue.py
+++ b/pyomo/core/expr/numvalue.py
@@ -15,7 +15,7 @@ __all__ = ('value', 'is_constant', 'is_fixed', 'is_variable_type',
 
 import sys
 import logging
-from six import iteritems, PY3
+from six import iteritems
 
 from pyomo.common.deprecation import deprecated
 from pyomo.core.expr.expr_common import \
@@ -99,12 +99,6 @@ native_integer_types = set([ int, bool ])
 native_boolean_types = set([ int, bool, str ])
 native_logical_types = {bool, }
 pyomo_constant_types = set()  # includes NumericConstant
-try:
-    native_numeric_types.add(long)
-    native_integer_types.add(long)
-    native_boolean_types.add(long)
-except:
-    pass
 
 #: Python set used to identify numeric constants and related native
 #: types.  This set includes
@@ -113,12 +107,8 @@ except:
 #:
 #: :data:`native_types` = :data:`native_numeric_types <pyomo.core.expr.numvalue.native_numeric_types>` + { str }
 native_types = set([ bool, str, type(None), slice ])
-if PY3:
-    native_types.add(bytes)
-    native_boolean_types.add(bytes)
-else:
-    native_types.add(unicode)
-    native_boolean_types.add(unicode)
+native_types.add(bytes)
+native_boolean_types.add(bytes)
 
 native_types.update( native_numeric_types )
 native_types.update( native_integer_types )

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -13,7 +13,6 @@
 
 import os
 import sys
-import six
 import types
 
 from six import StringIO, iterkeys
@@ -1362,7 +1361,7 @@ class TestBlock(unittest.TestCase):
         def assertWorks(self, key, pm):
             self.assertIs(pm[key.local_name], key)
         def assertFails(self, key, pm):
-            if not isinstance(key, six.string_types):
+            if not isinstance(key, str):
                 key = key.local_name
             self.assertRaises(KeyError, pm.__getitem__, key)
 

--- a/pyomo/core/tests/unit/test_numvalue.py
+++ b/pyomo/core/tests/unit/test_numvalue.py
@@ -24,11 +24,8 @@ from pyomo.environ import (value, ConcreteModel, Param, Var,
 from pyomo.core.expr.numvalue import (NumericConstant,
                                       as_numeric,
                                       is_numeric_data)
+long = int
 
-try:
-    unicode
-except:
-    long = int
 try:
     import numpy
     numpy_available=True

--- a/pyomo/core/tests/unit/test_numvalue.py
+++ b/pyomo/core/tests/unit/test_numvalue.py
@@ -24,7 +24,6 @@ from pyomo.environ import (value, ConcreteModel, Param, Var,
 from pyomo.core.expr.numvalue import (NumericConstant,
                                       as_numeric,
                                       is_numeric_data)
-long = int
 
 try:
     import numpy
@@ -66,7 +65,7 @@ class Test_value(unittest.TestCase):
         self.assertEqual(val, value(val))
 
     def test_long(self):
-        val = long(1e10)
+        val = int(1e10)
         self.assertEqual(val, value(val))
 
     def test_string(self):
@@ -158,7 +157,7 @@ class Test_value(unittest.TestCase):
         self.assertEqual(val, value(val))
 
     def test_long(self):
-        val = long(1e10)
+        val = int(1e10)
         self.assertEqual(val, value(val))
 
     def test_nan(self):
@@ -250,7 +249,7 @@ class Test_polydegree(unittest.TestCase):
         self.assertEqual(0, polynomial_degree(val))
 
     def test_long(self):
-        val = long(1e10)
+        val = int(1e10)
         self.assertEqual(0, polynomial_degree(val))
 
     def test_nan(self):
@@ -328,7 +327,7 @@ class Test_is_constant(unittest.TestCase):
         self.assertTrue(is_constant(1))
 
     def test_long(self):
-        val = long(1e10)
+        val = int(1e10)
         self.assertTrue(is_constant(val))
 
     def test_string(self):
@@ -376,7 +375,7 @@ class Test_is_fixed(unittest.TestCase):
         self.assertTrue(is_fixed(1))
 
     def test_long(self):
-        val = long(1e10)
+        val = int(1e10)
         self.assertTrue(is_fixed(val))
 
     def test_string(self):
@@ -420,7 +419,7 @@ class Test_is_variable_type(unittest.TestCase):
         self.assertFalse(is_variable_type(1))
 
     def test_long(self):
-        val = long(1e10)
+        val = int(1e10)
         self.assertFalse(is_variable_type(val))
 
     def test_string(self):
@@ -455,7 +454,7 @@ class Test_is_potentially_variable(unittest.TestCase):
         self.assertFalse(is_potentially_variable(1))
 
     def test_long(self):
-        val = long(1e10)
+        val = int(1e10)
         self.assertFalse(is_potentially_variable(val))
 
     def test_string(self):
@@ -513,7 +512,7 @@ class Test_as_numeric(unittest.TestCase):
         self.assertEqual(nval/2, 0.5)
 
     def test_long(self):
-        val = long(1e10)
+        val = int(1e10)
         nval = as_numeric(val)
         self.assertEqual(1.0e10, nval)
         #self.assertEqual(val, as_numeric(val))

--- a/pyomo/dataportal/plugins/db_table.py
+++ b/pyomo/dataportal/plugins/db_table.py
@@ -8,12 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-try:
-    unicode
-except:
-    basestring = str
-    long = int
-
 import os.path
 import re
 import sys
@@ -110,7 +104,7 @@ or that there is a bug in the ODBC connector.
                     ttmp.append(float(data))
                 elif data is None:
                     ttmp.append('.')
-                elif isinstance(data, str) or isinstance(data, basestring):
+                elif isinstance(data, str):
                     nulidx = data.find('\x00')
                     if nulidx > -1:
                         data = data[:nulidx]
@@ -122,7 +116,7 @@ or that there is a bug in the ODBC connector.
         #
         # Process data from the table
         #
-        if type(tmp) in (int,long,float):
+        if type(tmp) in (int, float):
             if not self.options.param is None:
                 self._info = ["param", self.options.param.local_name, ":=", tmp]
             elif len(self.options.symbol_map) == 1:

--- a/pyomo/dataportal/process_data.py
+++ b/pyomo/dataportal/process_data.py
@@ -25,15 +25,8 @@ from pyomo.dataportal.factory import DataManagerFactory, UnknownDataManager
 from pyomo.core.base.set import UnknownSetDimen
 
 from six.moves import xrange
-try:
-    unicode
-except:
-    unicode = str
-try:
-    long
-    numlist = {bool, int, float, long}
-except:
-    numlist = {bool, int, float}
+
+numlist = {bool, int, float}
 
 logger = logging.getLogger('pyomo.core')
 

--- a/pyomo/mpec/tests/test_path.py
+++ b/pyomo/mpec/tests/test_path.py
@@ -17,7 +17,6 @@ from os.path import abspath, dirname, normpath, join
 currdir = dirname(abspath(__file__))
 exdir = normpath(join(currdir,'..','..','..','examples','mpec'))
 
-import six
 import pyutilib.th as unittest
 
 from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
@@ -113,7 +112,7 @@ class CommonTests:
         self.assertEqual(len(refObj), len(ansObj))
         for i in range(len(refObj)):
             self.assertEqual(len(refObj[i]), len(ansObj[i]))
-            if isinstance(refObj[i], six.string_types):
+            if isinstance(refObj[i], str):
                 continue
             for key,val in iteritems(refObj[i]):
                 self.assertAlmostEqual(val['Value'], ansObj[i].get(key,None)['Value'], places=2)

--- a/pyomo/neos/plugins/kestrel_plugin.py
+++ b/pyomo/neos/plugins/kestrel_plugin.py
@@ -79,7 +79,7 @@ class SolverManager_NEOS(AsynchronousSolverManager):
             raise ActionManagerError(
                 "No solver passed to %s, use keyword option 'solver'"
                 % (type(self).__name__) )
-        if not isinstance(solver, six.string_types):
+        if not isinstance(solver, str):
             solver_name = solver.name
             if solver_name == 'asl':
                 solver_name = \
@@ -102,7 +102,7 @@ class SolverManager_NEOS(AsynchronousSolverManager):
         if solver is not None:
             user_solver_options.update(solver.options)
         _options = kwds.pop('options', {})
-        if isinstance(_options, six.string_types):
+        if isinstance(_options, str):
             _options = OptSolver._options_string_to_dict(_options)
         user_solver_options.update(_options)
         user_solver_options.update(

--- a/pyomo/opt/base/convert.py
+++ b/pyomo/opt/base/convert.py
@@ -17,11 +17,6 @@ from pyomo.opt.base.formats import guess_format
 from pyomo.opt.base.error import ConverterError
 from pyomo.common import Factory
 
-try:
-    unicode
-except NameError:
-    basestring = unicode = str
-
 
 # WEH - Should we treat these as singleton objects?  Not for now, since
 # I can't think of a case where that would impact performance
@@ -53,7 +48,7 @@ def convert_problem(args,
     # Setup list of source problem types
     #
     tmp = args[0]
-    if isinstance(tmp,basestring):
+    if isinstance(tmp, str):
         fname = tmp.split(os.sep)[-1]
         if os.sep in fname:   #pragma:nocover
             fname = tmp.split(os.sep)[-1]

--- a/pyomo/opt/base/solvers.py
+++ b/pyomo/opt/base/solvers.py
@@ -29,7 +29,6 @@ from pyomo.opt.base.convert import convert_problem
 from pyomo.opt.base.formats import ResultsFormat, ProblemFormat
 import pyomo.opt.base.results
 
-import six
 from six import iteritems
 from six.moves import xrange
 
@@ -758,14 +757,14 @@ class OptSolver(object):
         ans = []
         for key in options:
             val = options[key]
-            if isinstance(val, six.string_types) and ' ' in val:
+            if isinstance(val, str) and ' ' in val:
                 ans.append("%s=\"%s\"" % (str(key), str(val)))
             else:
                 ans.append("%s=%s" % (str(key), str(val)))
         return ' '.join(ans)
 
     def set_options(self, istr):
-        if isinstance(istr, six.string_types):
+        if isinstance(istr, str):
             istr = self._options_string_to_dict(istr)
         for key in istr:
             if not istr[key] is None:

--- a/pyomo/opt/base/solvers.py
+++ b/pyomo/opt/base/solvers.py
@@ -491,8 +491,8 @@ class OptSolver(object):
             Whether or not the solver has the specified capability.
         """
         if not isinstance(cap, str):
-            raise TypeError("Expected argument to be of type '%s', not " + \
-                  "'%s'." % (str(type(str())), str(type(cap))))
+            raise TypeError("""Expected argument to be of type '%s', not 
+                  '%s'.""" % (str(type(str())), str(type(cap))))
         else:
             val = self._capabilities[str(cap)]
             if val is None:
@@ -682,13 +682,8 @@ class OptSolver(object):
                     "Solver="+self.type+" passed unrecognized keywords: \n\t"
                     +("\n\t".join("%s = %s" % (k,v) for k,v in iteritems(kwds))))
 
-        if six.PY3:
-            compare_type = str
-        else:
-            compare_type = basestring
-
         if (type(self._problem_files) in (list,tuple)) and \
-           (not isinstance(self._problem_files[0], compare_type)):
+           (not isinstance(self._problem_files[0], str)):
             self._problem_files = self._problem_files[0]._problem_files()
         if self._results_format is None:
             self._results_format = self._default_results_format(self._problem_format)

--- a/pyomo/opt/base/solvers.py
+++ b/pyomo/opt/base/solvers.py
@@ -490,8 +490,8 @@ class OptSolver(object):
             Whether or not the solver has the specified capability.
         """
         if not isinstance(cap, str):
-            raise TypeError("""Expected argument to be of type '%s', not 
-                  '%s'.""" % (str(type(str())), str(type(cap))))
+            raise TypeError("Expected argument to be of type '%s', not "
+                "'%s'." % (type(str()), type(cap)))
         else:
             val = self._capabilities[str(cap)]
             if val is None:

--- a/pyomo/opt/parallel/local.py
+++ b/pyomo/opt/parallel/local.py
@@ -21,8 +21,6 @@ from pyomo.opt.parallel.manager import (ActionManagerError,
                                         ActionHandle)
 from pyomo.opt.parallel.async_solver import AsynchronousSolverManager, SolverManagerFactory
 
-from six import string_types
-
 
 @SolverManagerFactory.register("serial", doc="Synchronously execute solvers locally")
 class SolverManager_Serial(AsynchronousSolverManager):
@@ -47,7 +45,7 @@ class SolverManager_Serial(AsynchronousSolverManager):
                 % (type(self).__name__) )
 
         time_start = time.time()
-        if isinstance(opt, string_types):
+        if isinstance(opt, str):
             with pyomo.opt.SolverFactory(opt) as _opt:
                 results = _opt.solve(*args, **kwds)
         else:

--- a/pyomo/opt/plugins/colin_xml_io.py
+++ b/pyomo/opt/plugins/colin_xml_io.py
@@ -16,13 +16,6 @@ from pyomo.opt.blackbox.problem_io import BlackBoxOptProblemIOFactory
 import xml.dom.minidom
 from pyutilib.misc import tostr
 
-try:
-    unicode
-    intlist = [int, long, float]
-except:
-    basestring = str
-    intlist = [int, float]
-
 
 @BlackBoxOptProblemIOFactory.register('colin')
 class ColinXmlIO(object):
@@ -74,9 +67,9 @@ class ColinXmlIO(object):
         for key in response:
             elt = doc.createElement(str(key))
             root.appendChild(elt)
-            if isinstance(response[key], basestring):
+            if isinstance(response[key], str):
                 text_elt = doc.createTextNode( response[key] )
-            elif type(response[key]) in intlist:
+            elif type(response[key]) in [int, float]:
                 text_elt = doc.createTextNode( str(response[key]) )
             else:
                 text_elt = doc.createTextNode( tostr(response[key]) )

--- a/pyomo/opt/plugins/dakota_text_io.py
+++ b/pyomo/opt/plugins/dakota_text_io.py
@@ -17,14 +17,13 @@ Define the plugin for DAKOTA TEXT IO
 """
 
 import re
-import six
 from pyomo.opt.blackbox.problem_io import BlackBoxOptProblemIOFactory
 
 
 def as_number(value):
     if type(value) in [int, float]:
         return value
-    if isinstance(value, six.string_types):
+    if isinstance(value, str):
         try:
             tmp = int(value)
             return tmp

--- a/pyomo/opt/results/container.py
+++ b/pyomo/opt/results/container.py
@@ -19,10 +19,6 @@ import enum
 from six import StringIO
 from six.moves import xrange
 
-try:
-    unicode
-except NameError:
-    basestring = unicode = str
 
 class ScalarType(str, enum.Enum):
     int='int'
@@ -129,7 +125,7 @@ class ScalarData(object):
                     ostream.write(prefix+'Type: '+self.yaml_fix(self.scalar_type)+'\n')
 
     def yaml_fix(self, val):
-        if not isinstance(val,basestring):
+        if not isinstance(val, str):
             return val
         return val.replace(':','\\x3a')
 
@@ -370,7 +366,7 @@ class MapContainer(dict):
         return tmp
 
     def _convert(self, name):
-        if not isinstance(name,basestring):
+        if not isinstance(name, str):
             return name
         tmp = name.replace('_',' ')
         return tmp[0].upper() + tmp[1:]

--- a/pyomo/opt/results/solution.py
+++ b/pyomo/opt/results/solution.py
@@ -46,18 +46,8 @@ class SolutionStatus(str, enum.Enum):
         return self.value
 
 
-try:
-    unicode
-except NameError:
-    basestring = unicode = str
-
-try:
-    long
-    intlist = (int, long)
-    numlist = (float, int, long)
-except:
-    intlist = (int, )
-    numlist = (float, int)
+intlist = (int, )
+numlist = (float, int)
 
 
 class Solution(MapContainer):

--- a/pyomo/repn/plugins/ampl/ampl_.py
+++ b/pyomo/repn/plugins/ampl/ampl_.py
@@ -14,11 +14,6 @@
 
 __all__ = ['ProblemWriter_nl']
 
-try:
-    basestring
-except:
-    basestring = str
-
 import itertools
 import logging
 import operator
@@ -562,7 +557,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
                                     exp.nargs(),
                                     exp.name))
                 for arg in exp.args:
-                    if isinstance(arg, basestring):
+                    if isinstance(arg, str):
                         OUTPUT.write(string_arg_str % (len(arg), arg))
                     elif arg.is_fixed():
                         self._print_nonlinear_terms_NL(arg())

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -12,7 +12,7 @@
 # Problem Writer for GAMS Format Files
 #
 
-from six import StringIO, string_types, iteritems
+from six import StringIO, iteritems
 
 from pyomo.common.gc_manager import PauseGC
 from pyomo.core.expr import current as EXPR
@@ -459,7 +459,7 @@ class ProblemWriter_gams(AbstractProblemWriter):
         # immediately anyway.
         with PauseGC() as pgc:
             try:
-                if isinstance(output_filename, string_types):
+                if isinstance(output_filename, str):
                     output_file = open(output_filename, "w")
                 else:
                     # Support passing of stream such as a StringIO
@@ -487,7 +487,7 @@ class ProblemWriter_gams(AbstractProblemWriter):
                     put_results_format=put_results_format,
                 )
             finally:
-                if isinstance(output_filename, string_types):
+                if isinstance(output_filename, str):
                     output_file.close()
 
         return output_filename, symbolMap

--- a/pyomo/repn/standard_repn.py
+++ b/pyomo/repn/standard_repn.py
@@ -237,12 +237,6 @@ def generate_standard_repn(expr, idMap=None, compute_values=True, verbose=False,
         Results = ResultsWithQuadratics
     else:
         Results = ResultsWithoutQuadratics
-    #
-    # Use a custom isclose function
-    #
-    global isclose
-    if not compute_values:
-        isclose = isclose_const
 
     if True:
         #

--- a/pyomo/repn/standard_repn.py
+++ b/pyomo/repn/standard_repn.py
@@ -21,8 +21,6 @@ from pyomo.core.base import (Constraint,
                              Objective,
                              ComponentMap)
 
-from math import isclose
-
 from pyomo.core.expr import current as EXPR
 from pyomo.core.base.objective import (_GeneralObjectiveData,
                                        SimpleObjective)
@@ -40,10 +38,6 @@ from pyomo.core.kernel.objective import objective
 
 from six import iteritems, StringIO, PY3
 from six.moves import zip
-try:
-    basestring
-except:
-    basestring = str
 
 logger = logging.getLogger('pyomo.core')
 

--- a/pyomo/solvers/plugins/converter/ampl.py
+++ b/pyomo/solvers/plugins/converter/ampl.py
@@ -17,11 +17,6 @@ from pyomo.common.tempfiles import TempfileManager
 from pyomo.opt.base import ProblemFormat, ConverterError
 from pyomo.opt.base.convert import ProblemConverterFactory
 
-try:
-    unicode
-except:
-    basestring = unicode = str
-
 
 @ProblemConverterFactory.register('ampl')
 class AmplMIPConverter(object):
@@ -44,7 +39,7 @@ class AmplMIPConverter(object):
 
     def apply(self, *args, **kwargs):
         """Convert an instance of one type into another"""
-        if not isinstance(args[2],basestring):
+        if not isinstance(args[2], str):
             raise ConverterError("Can only apply ampl to convert file data")
         _exec = pyomo.common.Executable("ampl")
         if not _exec:

--- a/pyomo/solvers/plugins/converter/glpsol.py
+++ b/pyomo/solvers/plugins/converter/glpsol.py
@@ -9,7 +9,6 @@
 #  ___________________________________________________________________________
 
 import os
-import six
 
 import subprocess
 import pyomo.common
@@ -44,7 +43,7 @@ class GlpsolMIPConverter(object):
 
     def apply(self, *args, **kwargs):
         """Convert an instance of one type into another"""
-        if not isinstance(args[2],six.string_types):
+        if not isinstance(args[2], str):
             raise ConverterError("Can only apply glpsol to convert file data")
         _exec = pyomo.common.Executable("glpsol")
         if not _exec:

--- a/pyomo/solvers/plugins/converter/model.py
+++ b/pyomo/solvers/plugins/converter/model.py
@@ -10,7 +10,7 @@
 
 
 import os
-from six import iteritems, PY3
+from six import iteritems
 
 from pyomo.common.tempfiles import TempfileManager
 from pyomo.opt.base import ProblemFormat
@@ -57,13 +57,7 @@ class PyomoMIPConverter(object):
             io_options[kwd] = value
         kwds.clear()
 
-        # basestring is gone in Python 3.x, merged with str.
-        if PY3:
-            compare_type = str
-        else:
-            compare_type = basestring
-
-        if isinstance(args[2], compare_type):
+        if isinstance(args[2], str):
             instance = None
         else:
             instance = args[2]

--- a/pyomo/solvers/plugins/converter/pico.py
+++ b/pyomo/solvers/plugins/converter/pico.py
@@ -8,7 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import six
 import os.path
 import subprocess
 
@@ -60,7 +59,7 @@ class PicoMIPConverter(object):
             target="lp"
         # NOTE: if you have an extra "." in the suffix, the pico_convert program fails to output to the correct filename.
         output_filename = TempfileManager.create_tempfile(suffix = 'pico_convert.' + target)
-        if not isinstance(args[2],six.string_types):
+        if not isinstance(args[2], str):
             fname= TempfileManager.create_tempfile(suffix= 'pico_convert.' +str(args[0]))
             args[2].write(filename=fname, format=args[1])
             cmd = pico_convert_cmd +" --output="+output_filename+" "+target+" "+fname

--- a/pyomo/solvers/plugins/smanager/pyro.py
+++ b/pyomo/solvers/plugins/smanager/pyro.py
@@ -70,7 +70,7 @@ class SolverManager_Pyro(PyroAsynchronousActionManager, AsynchronousSolverManage
             raise ActionManagerError(
                 "No solver passed to %s, use keyword option 'solver'"
                 % (type(self).__name__) )
-        if isinstance(opt, six.string_types):
+        if isinstance(opt, str):
             opt = SolverFactory(opt, solver_io=kwds.pop('solver_io', None))
 
         #

--- a/pyomo/solvers/plugins/solvers/ASL.py
+++ b/pyomo/solvers/plugins/solvers/ASL.py
@@ -10,7 +10,6 @@
 
 
 import os
-import six
 import subprocess
 
 from pyomo.common import Executable
@@ -163,7 +162,7 @@ class ASL(SystemCallSolver):
         for key in self.options:
             if key == 'solver':
                 continue
-            if isinstance(self.options[key],six.string_types) and \
+            if isinstance(self.options[key], str) and \
                (' ' in self.options[key]):
                 opt.append(key+"=\""+str(self.options[key])+"\"")
                 cmd.append(str(key)+"="+str(self.options[key]))
@@ -181,7 +180,7 @@ class ASL(SystemCallSolver):
         return Bunch(cmd=cmd, log_file=self._log_file, env=env)
 
     def _presolve(self, *args, **kwds):
-        if (not isinstance(args[0], six.string_types)) and \
+        if (not isinstance(args[0], str)) and \
            (not isinstance(args[0], IBlock)):
             self._instance = args[0]
             xfrm = TransformationFactory('mpec.nl')

--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -15,7 +15,7 @@ import re
 import time
 import logging
 import subprocess
-from six import iteritems, string_types
+from six import iteritems
 
 from pyomo.common import Executable
 from pyomo.common.errors import ApplicationError
@@ -253,11 +253,11 @@ class CBCSHELL(SystemCallSolver):
         # create the temporary file - assuming that the user has already, via some external
         # mechanism, invoked warm_start() with a instance to create the warm start file.
         if self._warm_start_solve and \
-                isinstance(args[0], string_types):
+                isinstance(args[0], str):
             # we assume the user knows what they are doing...
             pass
         elif self._warm_start_solve and \
-                (not isinstance(args[0], string_types)):
+                (not isinstance(args[0], str)):
             # assign the name of the warm start file *before* calling the base class
             # presolve - the base class method ends up creating the command line,
             # and the warm start file-name is (obviously) needed there.
@@ -273,7 +273,7 @@ class CBCSHELL(SystemCallSolver):
         # NB: we must let the base class presolve run first so that the
         # symbol_map is actually constructed!
 
-        if (len(args) > 0) and (not isinstance(args[0], string_types)):
+        if (len(args) > 0) and (not isinstance(args[0], str)):
 
             if len(args) != 1:
                 raise ValueError(

--- a/pyomo/solvers/plugins/solvers/CONOPT.py
+++ b/pyomo/solvers/plugins/solvers/CONOPT.py
@@ -23,11 +23,6 @@ from pyomo.opt.solver import  SystemCallSolver
 import logging
 logger = logging.getLogger('pyomo.solvers')
 
-try:
-    unicode
-except:
-    basestring = str
-
 
 @SolverFactory.register('conopt', doc='The CONOPT NLP solver')
 class CONOPT(SystemCallSolver):
@@ -138,7 +133,7 @@ class CONOPT(SystemCallSolver):
         for key in self.options:
             if key == 'solver':
                 continue
-            if isinstance(self.options[key], basestring) and ' ' in self.options[key]:
+            if isinstance(self.options[key], str) and ' ' in self.options[key]:
                 opt.append(key+"=\""+str(self.options[key])+"\"")
                 cmd.append(str(key)+"="+str(self.options[key]))
             elif key == 'subsolver':

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -41,10 +41,6 @@ logger = logging.getLogger('pyomo.solvers')
 from six import iteritems
 from six.moves import xrange
 
-try:
-    unicode
-except:
-    basestring = unicode = str
 
 def _validate_file_name(cplex, filename, description):
     """Validate filenames against the set of allowable chaacters in CPLEX.
@@ -317,11 +313,11 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
         # create the temporary file - assuming that the user has already, via some external
         # mechanism, invoked warm_start() with a instance to create the warm start file.
         if self._warm_start_solve and \
-           isinstance(args[0], basestring):
+           isinstance(args[0], str):
             # we assume the user knows what they are doing...
             pass
         elif self._warm_start_solve and \
-             (not isinstance(args[0], basestring)):
+             (not isinstance(args[0], str)):
             # assign the name of the warm start file *before* calling the base class
             # presolve - the base class method ends up creating the command line,
             # and the warm start file-name is (obviously) needed there.
@@ -338,7 +334,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
 
         if (
             self._priorities_solve
-            and not isinstance(args[0], basestring)
+            and not isinstance(args[0], str)
             and not user_priorities
         ):
             self._priorities_file_name = TempfileManager.create_tempfile(
@@ -351,7 +347,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
         # NB: we must let the base class presolve run first so that the
         # symbol_map is actually constructed!
 
-        if (len(args) > 0) and (not isinstance(args[0], basestring)):
+        if (len(args) > 0) and (not isinstance(args[0], str)):
 
             if len(args) != 1:
                 raise ValueError(
@@ -437,7 +433,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
         for key in self.options:
             if key == 'relax_integrality' or key == 'mipgap':
                 continue
-            elif isinstance(self.options[key], basestring) and \
+            elif isinstance(self.options[key], str) and \
                  (' ' in self.options[key]):
                 opt = ' '.join(key.split('_'))+' '+str(self.options[key])
             else:

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -8,7 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from six import StringIO, iteritems, string_types
+from six import StringIO, iteritems
 from tempfile import mkdtemp
 import os, sys, math, logging, shutil, time, subprocess
 
@@ -69,7 +69,7 @@ class _GAMSSolver(object):
         return self._default_variable_value
 
     def set_options(self, istr):
-        if isinstance(istr, string_types):
+        if isinstance(istr, str):
             istr = self._options_string_to_dict(istr)
         for key in istr:
             if not istr[key] is None:

--- a/pyomo/solvers/plugins/solvers/GLPK.py
+++ b/pyomo/solvers/plugins/solvers/GLPK.py
@@ -22,7 +22,7 @@ from pyomo.opt import SolverFactory, OptSolver, ProblemFormat, ResultsFormat, So
 from pyomo.opt.base.solvers import _extract_version
 from pyomo.opt.solver import SystemCallSolver
 
-from six import iteritems, string_types
+from six import iteritems
 
 logger = logging.getLogger('pyomo.solvers')
 
@@ -183,16 +183,12 @@ class GLPKSHELL(SystemCallSolver):
             cmd.insert(0, self._timer)
         for key in self.options:
             opt = self.options[key]
-            if opt is None or (isinstance(opt, string_types) and opt.strip() == ''):
+            if opt is None or (isinstance(opt, str) and opt.strip() == ''):
                 # Handle the case for options that must be
                 # specified without a value
                 cmd.append("--%s" % key)
             else:
                 cmd.extend(["--%s" % key, str(opt)])
-            #if isinstance(opt, basestring) and ' ' in opt:
-            #    cmd.append('--%s "%s"' % (key, str(opt)))
-            #else:
-            #    cmd.append('--%s %s' % (key, str(opt)))
 
         if self._timelimit is not None and self._timelimit > 0.0:
             cmd.extend(['--tmlim', str(self._timelimit)])

--- a/pyomo/solvers/plugins/solvers/GLPK_old.py
+++ b/pyomo/solvers/plugins/solvers/GLPK_old.py
@@ -26,7 +26,7 @@ from pyomo.opt.solver import SystemCallSolver
 from pyomo.solvers.mockmip import MockMIP
 from pyomo.solvers.plugins.solvers.GLPK import _glpk_version, configure_glpk
 
-from six import iteritems, string_types
+from six import iteritems
 import logging
 logger = logging.getLogger('pyomo.solvers')
 
@@ -124,16 +124,12 @@ class GLPKSHELL_4_42(SystemCallSolver):
             cmd.insert(0, self._timer)
         for key in self.options:
             opt = self.options[key]
-            if opt is None or (isinstance(opt, string_types) and opt.strip() == ''):
+            if opt is None or (isinstance(opt, str) and opt.strip() == ''):
                 # Handle the case for options that must be
                 # specified without a value
                 cmd.append("--%s" % key)
             else:
                 cmd.extend(["--%s" % key, str(opt)])
-            #if isinstance(opt, basestring) and ' ' in opt:
-            #    cmd.append('--%s "%s"' % (key, str(opt)))
-            #else:
-            #    cmd.append('--%s %s' % (key, str(opt)))
 
         if self._timelimit is not None and self._timelimit > 0.0:
             cmd.extend(['--tmlim', str(self._timelimit)])
@@ -488,11 +484,6 @@ class GLPKSHELL_old(SystemCallSolver):
                 cmd.append("--%s" % key)
             else:
                 cmd.extend(["--%s" % key, str(opt)])
-            #if isinstance(self.options[key], basestring) \
-            #       and ' ' in self.options[key]:
-            #    cmd.append('--%s "%s"' % (key, str(self.options[key])))
-            #else:
-            #    cmd.append('--%s %s' % (key, str(self.options[key])))
 
         if self._timelimit is not None and self._timelimit > 0.0:
             cmd.extend(['--tmlim', str(self._timelimit)])

--- a/pyomo/solvers/plugins/solvers/GUROBI.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI.py
@@ -29,11 +29,6 @@ logger = logging.getLogger('pyomo.solvers')
 
 from six import iteritems
 
-try:
-    unicode
-except:
-    basestring = str
-
 
 @SolverFactory.register('gurobi', doc='The GUROBI LP/MIP solver')
 class GUROBI(OptSolver):
@@ -218,11 +213,11 @@ class GUROBISHELL(ILMLicensedSystemCallSolver):
         # create the temporary file - assuming that the user has already, via some external
         # mechanism, invoked warm_start() with a instance to create the warm start file.
         if self._warm_start_solve and \
-           isinstance(args[0], basestring):
+           isinstance(args[0], str):
             # we assume the user knows what they are doing...
             pass
         elif self._warm_start_solve and \
-             (not isinstance(args[0], basestring)):
+             (not isinstance(args[0], str)):
             # assign the name of the warm start file *before* calling the base class
             # presolve - the base class method ends up creating the command line,
             # and the warm start file-name is (obviously) needed there.
@@ -237,7 +232,7 @@ class GUROBISHELL(ILMLicensedSystemCallSolver):
         # NB: we must let the base class presolve run first so that the
         # symbol_map is actually constructed!
 
-        if (len(args) > 0) and (not isinstance(args[0], basestring)):
+        if (len(args) > 0) and (not isinstance(args[0], str)):
 
             if len(args) != 1:
                 raise ValueError(
@@ -390,13 +385,13 @@ class GUROBISHELL(ILMLicensedSystemCallSolver):
         extract_rc = False
         for suffix in self._suffixes:
             flag=False
-            if re.match(suffix,"dual"):
+            if re.match(suffix, "dual"):
                 extract_duals = True
                 flag=True
-            if re.match(suffix,"slack"):
+            if re.match(suffix, "slack"):
                 extract_slacks = True
                 flag=True
-            if re.match(suffix,"rc"):
+            if re.match(suffix, "rc"):
                 extract_rc = True
                 flag=True
             if not flag:

--- a/pyomo/solvers/plugins/solvers/IPOPT.py
+++ b/pyomo/solvers/plugins/solvers/IPOPT.py
@@ -23,11 +23,6 @@ from pyomo.opt.solver import  SystemCallSolver
 import logging
 logger = logging.getLogger('pyomo.solvers')
 
-try:
-    unicode
-except:
-    basestring = str
-
 
 @SolverFactory.register('ipopt', doc='The Ipopt NLP solver')
 class IPOPT(SystemCallSolver):
@@ -141,7 +136,7 @@ class IPOPT(SystemCallSolver):
             else:
                 if key == "option_file_name":
                     ofn_option_used = True
-                if isinstance(self.options[key], basestring) and ' ' in self.options[key]:
+                if isinstance(self.options[key], str) and ' ' in self.options[key]:
                     env_opt.append(key+"=\""+str(self.options[key])+"\"")
                     cmd.append(str(key)+"="+str(self.options[key]))
                 else:

--- a/pyomo/solvers/plugins/solvers/SCIPAMPL.py
+++ b/pyomo/solvers/plugins/solvers/SCIPAMPL.py
@@ -23,11 +23,6 @@ from pyomo.opt.solver import SystemCallSolver
 import logging
 logger = logging.getLogger('pyomo.solvers')
 
-try:
-    unicode
-except:
-    basestring = str
-
 
 @SolverFactory.register('scip', doc='The SCIP LP/MIP solver')
 class SCIPAMPL(SystemCallSolver):
@@ -137,7 +132,7 @@ class SCIPAMPL(SystemCallSolver):
         for key in self.options:
             if key == 'solver':
                 continue
-            if isinstance(self.options[key], basestring) and ' ' in self.options[key]:
+            if isinstance(self.options[key], str) and ' ' in self.options[key]:
                 env_opt.append(key+"=\""+str(self.options[key])+"\"")
             else:
                 env_opt.append(key+"="+str(self.options[key]))

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -10,7 +10,6 @@
 
 import logging
 import re
-import six
 import sys
 
 from pyomo.common.tempfiles import TempfileManager
@@ -168,7 +167,7 @@ class CPLEXDirect(DirectSolver):
         # least as far back as CPLEX 12.5.1 [the oldest version
         # supported by IBM as of 1 Oct 2020]
         if self.version() >= (12, 5, 1) \
-           and isinstance(self._log_file, six.string_types):
+           and isinstance(self._log_file, str):
             _log_file = (open(self._log_file, 'a'),)
             _close_log_file = True
         else:

--- a/pyomo/util/slices.py
+++ b/pyomo/util/slices.py
@@ -15,7 +15,7 @@ from pyomo.core.base.indexed_component_slice import IndexedComponent_slice
 from pyomo.core.base.global_set import UnindexedComponent_set
 
 def _to_iterable(source):
-    iterable_scalars = str + (six.binary_type, six.text_type)
+    iterable_scalars = (str,) + (six.binary_type, six.text_type)
     if hasattr(source, '__iter__'):
         if isinstance(source, iterable_scalars):
             yield source

--- a/pyomo/util/slices.py
+++ b/pyomo/util/slices.py
@@ -8,14 +8,12 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import six
-
 from pyomo.core.base.indexed_component import normalize_index
 from pyomo.core.base.indexed_component_slice import IndexedComponent_slice
 from pyomo.core.base.global_set import UnindexedComponent_set
 
 def _to_iterable(source):
-    iterable_scalars = (str,) + (six.binary_type, six.text_type)
+    iterable_scalars = (str, bytes)
     if hasattr(source, '__iter__'):
         if isinstance(source, iterable_scalars):
             yield source

--- a/pyomo/util/slices.py
+++ b/pyomo/util/slices.py
@@ -13,10 +13,9 @@ import six
 from pyomo.core.base.indexed_component import normalize_index
 from pyomo.core.base.indexed_component_slice import IndexedComponent_slice
 from pyomo.core.base.global_set import UnindexedComponent_set
-from pyomo.common.collections import ComponentSet, ComponentMap
 
 def _to_iterable(source):
-    iterable_scalars = six.string_types + (six.binary_type, six.text_type)
+    iterable_scalars = str + (six.binary_type, six.text_type)
     if hasattr(source, '__iter__'):
         if isinstance(source, iterable_scalars):
             yield source


### PR DESCRIPTION
## Fixes #1823 

## Summary/Motivation:
This addresses an inconsistency in usage of type comparison relating to string. Since we no longer support Python 2.x, we can convert to using just the Python 3.x standard.

## Changes proposed in this PR:
- Replace all instances of `basestring` and `six.string_types` with `str`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
