### PR TITLE
Cleanup of code related to Python2/3 cross-compatibility (in kernel)

### DIFF
--- a/pyomo/core/kernel/block.py
+++ b/pyomo/core/kernel/block.py
@@ -12,12 +12,12 @@ import sys
 import logging
 import math
 
-from pyomo.common.collections import OrderedDict
 if sys.version_info[:2] >= (3,7):
     # dict became ordered in CPython 3.6 and added to the standard in 3.7
     _ordered_dict_ = dict
 else:
-    _ordered_dict_ = OrderedDict
+    import collections
+    _ordered_dict_ = collections.OrderedDict
 
 from pyomo.core.expr.symbol_map import SymbolMap
 from pyomo.core.kernel.base import \
@@ -27,8 +27,6 @@ from pyomo.core.kernel.heterogeneous_container import \
     IHeterogeneousContainer
 from pyomo.core.kernel.container_utils import \
     define_simple_containers
-
-import six
 
 logger = logging.getLogger('pyomo.core')
 
@@ -374,13 +372,13 @@ class block(IBlock):
         # values exist on the suffix and but only sparse
         # dual values exist in the results object) we clear
         # all active import suffixes.
-        for suffix in six.itervalues(valid_import_suffixes):
+        for suffix in valid_import_suffixes.values():
             suffix.clear()
 
         # Load problem (model) level suffixes. These would
         # only come from ampl interfaced solution suffixes
         # at this point in time.
-        for _attr_key, attr_value in six.iteritems(solution.problem):
+        for _attr_key, attr_value in solution.problem.items():
             attr_key = _attr_key[0].lower() + _attr_key[1:]
             if attr_key in valid_import_suffixes:
                 valid_import_suffixes[attr_key][self] = attr_value
@@ -393,7 +391,7 @@ class block(IBlock):
             var.stale = True
         var_skip_attrs = ['id','canonical_label']
         seen_var_ids = set()
-        for label, entry in six.iteritems(solution.variable):
+        for label, entry in solution.variable.items():
             var = symbol_map.getObject(label)
             if (var is None) or \
                (var is SymbolMap.UnknownSymbol):
@@ -419,7 +417,7 @@ class block(IBlock):
                                  "A new value is not expected "
                                  "in solution" % (var.name))
 
-            for _attr_key, attr_value in six.iteritems(entry):
+            for _attr_key, attr_value in entry.items():
                 attr_key = _attr_key[0].lower() + _attr_key[1:]
                 if attr_key == 'value':
                     if allow_consistent_values_for_fixed_vars and \
@@ -449,7 +447,7 @@ class block(IBlock):
         # they exist)
         #
         objective_skip_attrs = ['id','canonical_label','value']
-        for label,entry in six.iteritems(solution.objective):
+        for label,entry in solution.objective.items():
             obj = symbol_map.getObject(label)
             if (obj is None) or \
                (obj is SymbolMap.UnknownSymbol):
@@ -459,7 +457,7 @@ class block(IBlock):
             # Because of __default_objective__, an objective might
             # appear twice in the objective dictionary.
             unseen_var_ids.discard(id(obj))
-            for _attr_key, attr_value in six.iteritems(entry):
+            for _attr_key, attr_value in entry.items():
                 attr_key = _attr_key[0].lower() + _attr_key[1:]
                 if attr_key in valid_import_suffixes:
                     valid_import_suffixes[attr_key][obj] = \
@@ -469,7 +467,7 @@ class block(IBlock):
         # Load constraint solution
         #
         con_skip_attrs = ['id', 'canonical_label']
-        for label, entry in six.iteritems(solution.constraint):
+        for label, entry in solution.constraint.items():
             con = symbol_map.getObject(label)
             if con is SymbolMap.UnknownSymbol:
                 #
@@ -482,7 +480,7 @@ class block(IBlock):
                                    "is not found on this block"
                                    % (label))
             unseen_var_ids.remove(id(con))
-            for _attr_key, attr_value in six.iteritems(entry):
+            for _attr_key, attr_value in entry.items():
                 attr_key = _attr_key[0].lower() + _attr_key[1:]
                 if attr_key in valid_import_suffixes:
                     valid_import_suffixes[attr_key][con] = \

--- a/pyomo/core/kernel/constraint.py
+++ b/pyomo/core/kernel/constraint.py
@@ -20,8 +20,6 @@ from pyomo.core.kernel.base import \
 from pyomo.core.kernel.container_utils import \
     define_simple_containers
 
-from six.moves import zip
-
 _pos_inf = float('inf')
 _neg_inf = float('-inf')
 

--- a/pyomo/core/kernel/container_utils.py
+++ b/pyomo/core/kernel/container_utils.py
@@ -12,8 +12,6 @@ from pyomo.core.kernel.dict_container import DictContainer
 from pyomo.core.kernel.tuple_container import TupleContainer
 from pyomo.core.kernel.list_container import ListContainer
 
-import six
-
 def define_homogeneous_container_type(namespace,
                                       name,
                                       container_class,
@@ -34,17 +32,11 @@ def define_homogeneous_container_type(namespace,
             _ctype = <ctype>
 
             ### if ### <use_slots>
-            __slots__ = ["_parent",
+            __slots__ = ("_parent",
                          "_storage_key",
                          "_active",
-                         "_data"]
-            if six.PY3:
-                # Prior to Python 3, the abc module does not
-                # use empty __slots__ declarations on the
-                # base classes. Therefore, we do not need a
-                # __weakref__ slot because there is already
-                # a __dict__ in the class hierarchy.
-                __slots__.append("__weakref__")
+                         "_data",
+                         "__weakref__")
             ### fi ###
 
             def __init__(self, *args, **kwds):
@@ -57,13 +49,11 @@ def define_homogeneous_container_type(namespace,
     cls_dict = {}
     cls_dict['_ctype'] = ctype
     if use_slots:
-        cls_dict['__slots__'] = ["_parent",
+        cls_dict['__slots__'] = ("_parent",
                                  "_storage_key",
                                  "_active",
-                                 "_data"]
-        if six.PY3:
-            cls_dict['__slots__'].append("__weakref__")
-        cls_dict['__slots__'] = tuple(cls_dict['__slots__'])
+                                 "_data",
+                                 "__weakref__")
 
     def _init(self, *args, **kwds):
         self._parent = None

--- a/pyomo/core/kernel/dict_container.py
+++ b/pyomo/core/kernel/dict_container.py
@@ -10,8 +10,7 @@
 
 import sys
 import logging
-
-from pyomo.common.collections import OrderedDict, Mapping, MutableMapping
+import collections.abc
 
 from pyomo.core.kernel.homogeneous_container import \
     IHomogeneousContainer
@@ -20,21 +19,13 @@ if sys.version_info[:2] >= (3,7):
     # dict became ordered in CPython 3.6 and added to the standard in 3.7
     _ordered_dict_ = dict
 else:
-    _ordered_dict_ = OrderedDict
-
-from six import itervalues
+    _ordered_dict_ = collections.OrderedDict
 
 logger = logging.getLogger('pyomo.core')
 
-# Note that prior to Python 3, collections
-# is not defined with an empty __slots__
-# attribute. Therefore, in Python 2, all implementations of
-# this class will have a __dict__ member whether or not they
-# declare __slots__. I don't believe it is worth trying to
-# code a work around for the Python 2 case as we are moving
-# closer to a Python 3-only world these types of objects are
-# not memory bottlenecks.
-class DictContainer(IHomogeneousContainer, MutableMapping):
+
+class DictContainer(IHomogeneousContainer,
+                    collections.abc.MutableMapping):
     """
     A partial implementation of the IHomogeneousContainer
     interface that provides dict-like storage functionality.
@@ -84,7 +75,7 @@ class DictContainer(IHomogeneousContainer, MutableMapping):
 
     def children(self):
         """A generator over the children of this container."""
-        return itervalues(self._data)
+        return self._data.values()
 
     #
     # Define the MutableMapping abstract methods
@@ -158,7 +149,7 @@ class DictContainer(IHomogeneousContainer, MutableMapping):
     # plain dictionary mapping key->(type(val), id(val)) and
     # compare that instead.
     def __eq__(self, other):
-        if not isinstance(other, Mapping):
+        if not isinstance(other, collections.abc.Mapping):
             return False
         return {key:(type(val), id(val))
                     for key, val in self.items()} == \

--- a/pyomo/core/kernel/list_container.py
+++ b/pyomo/core/kernel/list_container.py
@@ -9,21 +9,14 @@
 #  ___________________________________________________________________________
 
 import logging
+import collections.abc
 
 from pyomo.core.kernel.tuple_container import TupleContainer
-
-import six
-from six.moves import xrange as range
-
-if six.PY3:
-    from collections.abc import MutableSequence as collections_MutableSequence
-else:
-    from collections import MutableSequence as collections_MutableSequence
 
 logger = logging.getLogger('pyomo.core')
 
 class ListContainer(TupleContainer,
-                    collections_MutableSequence):
+                    collections.abc.MutableSequence):
     """
     A partial implementation of the IHomogeneousContainer
     interface that provides list-like storage functionality.

--- a/pyomo/core/kernel/matrix_constraint.py
+++ b/pyomo/core/kernel/matrix_constraint.py
@@ -17,8 +17,6 @@ from pyomo.core.kernel.constraint import \
     (IConstraint,
      constraint_tuple)
 
-from six.moves import zip, xrange
-
 _noarg = object()
 
 #
@@ -61,8 +59,8 @@ class _MatrixConstraintData(IConstraint):
                 "No variable order has been assigned")
         A = parent._A
         if parent._sparse:
-            for k in xrange(A.indptr[self._storage_key],
-                            A.indptr[self._storage_key+1]):
+            for k in range(A.indptr[self._storage_key],
+                           A.indptr[self._storage_key+1]):
                 yield x[A.indices[k]], A.data[k]
         else:
             for item in zip(x, A[self._storage_key,:].tolist()):
@@ -260,7 +258,7 @@ class matrix_constraint(constraint_tuple):
         assert m > 0
         assert n > 0
         cons = (_MatrixConstraintData(i)
-                for i in xrange(m))
+                for i in range(m))
         super(matrix_constraint, self).__init__(cons)
 
         if sparse:

--- a/pyomo/core/kernel/piecewise_library/transforms.py
+++ b/pyomo/core/kernel/piecewise_library/transforms.py
@@ -18,10 +18,6 @@ Optimization: Unifying framework and Extensions (Vielma, \
 Nemhauser 2008)
 """
 
-# ****** NOTE: Nothing in this file relies on integer division *******
-#              I predict this will save numerous headaches as
-#              well as gratuitous calls to float() in this code
-from __future__ import division
 import logging
 import bisect
 
@@ -51,7 +47,6 @@ from pyomo.core.kernel.piecewise_library.util import \
      generate_gray_code,
      PiecewiseValidationError)
 
-from six.moves import xrange
 
 logger = logging.getLogger('pyomo.core')
 
@@ -305,7 +300,7 @@ class PiecewiseLinearFunction(object):
                 % (str(breakpoints)))
 
         ftype, slopes = characterize_function(breakpoints, values)
-        for i in xrange(1, len(slopes)):
+        for i in range(1, len(slopes)):
             if (slopes[i-1] is not None) and \
                (slopes[i] is not None) and \
                (abs(slopes[i-1] - slopes[i]) <= equal_slopes_tolerance):
@@ -547,7 +542,7 @@ class piecewise_convex(TransformedPiecewiseLinearFunction):
         breakpoints = self.breakpoints
         values = self.values
         self.c = constraint_list()
-        for i in xrange(len(breakpoints)-1):
+        for i in range(len(breakpoints)-1):
             X0 = breakpoints[i]
             F_AT_X0 = values[i]
             dF_AT_X0 = (values[i+1] - F_AT_X0) / \
@@ -627,7 +622,7 @@ class piecewise_sos2(TransformedPiecewiseLinearFunction):
 
         # create vars
         y_tuple = tuple(variable(lb=0)
-                        for i in xrange(len(self.breakpoints)))
+                        for i in range(len(self.breakpoints)))
         y = self.v = variable_tuple(y_tuple)
 
         # create piecewise constraints
@@ -683,7 +678,7 @@ class piecewise_dcc(TransformedPiecewiseLinearFunction):
         polytopes = range(len(self.breakpoints)-1)
         vertices = range(len(self.breakpoints))
         def polytope_verts(p):
-            return xrange(p,p+2)
+            return range(p,p+2)
 
         # create vars
         self.v = variable_dict()
@@ -1031,7 +1026,7 @@ class piecewise_dlog(TransformedPiecewiseLinearFunction):
         polytopes = range(len(breakpoints)-1)
         vertices = range(len(breakpoints))
         def polytope_verts(p):
-            return xrange(p,p+2)
+            return range(p,p+2)
 
         # create vars
         self.v = variable_dict()
@@ -1105,7 +1100,7 @@ class piecewise_dlog(TransformedPiecewiseLinearFunction):
             step = N//(2**i)
             tmp = []
             while start < N:
-                tmp.extend(j-1 for j in xrange(start,start+step))
+                tmp.extend(j-1 for j in range(start,start+step))
                 start += 2*step
             B_LEFT.append(tmp)
 
@@ -1216,10 +1211,10 @@ class piecewise_log(TransformedPiecewiseLinearFunction):
         N = 2**n
         S = range(n)
         G = generate_gray_code(n)
-        L = tuple([k for k in xrange(N+1)
+        L = tuple([k for k in range(N+1)
                    if ((k == 0) or (G[k-1][s] == 1))
                    and ((k == N) or (G[k][s] == 1))] for s in S)
-        R = tuple([k for k in xrange(N+1)
+        R = tuple([k for k in range(N+1)
                    if ((k == 0) or (G[k-1][s] == 0))
                    and ((k == N) or (G[k][s] == 0))] for s in S)
         return S, L, R

--- a/pyomo/core/kernel/piecewise_library/util.py
+++ b/pyomo/core/kernel/piecewise_library/util.py
@@ -11,9 +11,6 @@
 import operator
 import itertools
 
-from six.moves import xrange
-from six import advance_iterator
-
 from pyomo.common.dependencies import (
     numpy, numpy_available, scipy, scipy_available
 )
@@ -27,7 +24,7 @@ def is_constant(vals):
     if len(vals) <= 1:
         return True
     it = iter(vals)
-    advance_iterator(it)
+    next(it)
     op = operator.eq
     return all(itertools.starmap(op, zip(it,vals)))
 
@@ -36,7 +33,7 @@ def is_nondecreasing(vals):
     if len(vals) <= 1:
         return True
     it = iter(vals)
-    advance_iterator(it)
+    next(it)
     op = operator.ge
     return all(itertools.starmap(op, zip(it,vals)))
 
@@ -45,7 +42,7 @@ def is_nonincreasing(vals):
     if len(vals) <= 1:
         return True
     it = iter(vals)
-    advance_iterator(it)
+    next(it)
     op = operator.le
     return all(itertools.starmap(op, zip(it,vals)))
 
@@ -61,24 +58,17 @@ def log2floor(n):
     using floating point calculations. Input argument must
     be a positive integer."""
     assert n > 0
-    try:
-        return n.bit_length() - 1
-    except AttributeError:                        #pragma:nocover
-        # int.bit_length() was introduced in Python 2.7.  Fallback to a
-        # brute-force calculation if bit_length is not available.
-        s = bin(n)         # binary representation:  bin(37) --> '0b100101'
-        s = s.lstrip('0b') # remove leading zeros and 'b'
-        return len(s) - 1
+    return n.bit_length() - 1
 
 def generate_gray_code(nbits):
     """Generates a Gray code of nbits as list of lists"""
-    bitset = [0 for i in xrange(nbits)]
+    bitset = [0 for i in range(nbits)]
     # important that we copy bitset each time
     graycode = [list(bitset)]
 
-    for i in xrange(2,(1<<nbits)+1):
+    for i in range(2,(1<<nbits)+1):
         if i%2:
-            for j in xrange(-1,-nbits,-1):
+            for j in range(-1,-nbits,-1):
                 if bitset[j]:
                     bitset[j-1]=bitset[j-1]^1
                     break
@@ -124,7 +114,7 @@ def characterize_function(breakpoints, values):
 
     step = False
     slopes = []
-    for i in xrange(1, len(breakpoints)):
+    for i in range(1, len(breakpoints)):
         if breakpoints[i] != breakpoints[i-1]:
             slope = float(values[i] - values[i-1]) / \
                     (breakpoints[i] - breakpoints[i-1])

--- a/pyomo/core/kernel/sos.py
+++ b/pyomo/core/kernel/sos.py
@@ -15,7 +15,6 @@ from pyomo.core.kernel.base import \
 from pyomo.core.kernel.container_utils import \
     define_simple_containers
 
-from six.moves import zip
 
 class ISOS(ICategorizedObject):
     """

--- a/pyomo/core/kernel/suffix.py
+++ b/pyomo/core/kernel/suffix.py
@@ -20,8 +20,6 @@ from pyomo.core.kernel.container_utils import (
     define_homogeneous_container_type
 )
 
-import six
-
 logger = logging.getLogger('pyomo.core')
 
 _noarg = object()
@@ -64,9 +62,8 @@ class suffix(ISuffix):
                  "_storage_key",
                  "_active",
                  "_direction",
-                 "_datatype")
-    if six.PY3:
-        __slots__ = list(__slots__) + ["__weakref__"]
+                 "_datatype",
+                 "__weakref__")
 
     # neither sent to solver or received from solver
     LOCAL  = 0

--- a/pyomo/core/kernel/tuple_container.py
+++ b/pyomo/core/kernel/tuple_container.py
@@ -8,20 +8,14 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import collections.abc
+
 from pyomo.core.kernel.homogeneous_container import \
     IHomogeneousContainer
 
-import six
-
-if six.PY3:
-    from collections.abc import Sequence as collections_Sequence
-    from collections.abc import Set as collections_Set
-else:
-    from collections import Sequence as collections_Sequence
-    from collections import Set as collections_Set
 
 class TupleContainer(IHomogeneousContainer,
-                     collections_Sequence):
+                     collections.abc.Sequence):
     """
     A partial implementation of the IHomogeneousContainer
     interface that provides tuple-like storage functionality.
@@ -121,8 +115,8 @@ class TupleContainer(IHomogeneousContainer,
     # Convert both objects to a plain tuple of (type(val),
     # id(val)) tuples and compare that instead.
     def __eq__(self, other):
-        if not isinstance(other, (collections_Set,
-                                  collections_Sequence)):
+        if not isinstance(other, (collections.abc.Set,
+                                  collections.abc.Sequence)):
             return False
         return tuple((type(val), id(val))
                      for val in self) == \

--- a/pyomo/core/tests/unit/kernel/test_block.py
+++ b/pyomo/core/tests/unit/kernel/test_block.py
@@ -14,6 +14,7 @@ import pickle
 import random
 import collections
 import itertools
+from io import StringIO
 
 import pyutilib.th as unittest
 from pyomo.core.expr.numvalue import native_numeric_types
@@ -59,8 +60,6 @@ from pyomo.core.kernel.block import (IBlock,
                                      block_list)
 from pyomo.core.kernel.sos import sos
 from pyomo.opt.results import Solution
-
-from six import StringIO
 
 def _path_to_object_exists(obj, descendent):
     if descendent is obj:

--- a/pyomo/core/tests/unit/kernel/test_component_map.py
+++ b/pyomo/core/tests/unit/kernel/test_component_map.py
@@ -8,6 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import collections.abc
 import pickle
 
 import pyutilib.th as unittest
@@ -28,15 +29,6 @@ from pyomo.core.kernel.block import (block,
                                      block_dict,
                                      block_list)
 from pyomo.core.kernel.suffix import suffix
-
-import six
-
-if six.PY3:
-    from collections.abc import Mapping as collections_Mapping
-    from collections.abc import MutableMapping as collections_MutableMapping
-else:
-    from collections import Mapping as collections_Mapping
-    from collections import MutableMapping as collections_MutableMapping
 
 
 class TestComponentMap(unittest.TestCase):
@@ -114,10 +106,10 @@ class TestComponentMap(unittest.TestCase):
 
     def test_type(self):
         cmap = ComponentMap()
-        self.assertTrue(isinstance(cmap, collections_Mapping))
-        self.assertTrue(isinstance(cmap, collections_MutableMapping))
-        self.assertTrue(issubclass(type(cmap), collections_Mapping))
-        self.assertTrue(issubclass(type(cmap), collections_MutableMapping))
+        self.assertTrue(isinstance(cmap, collections.abc.Mapping))
+        self.assertTrue(isinstance(cmap, collections.abc.MutableMapping))
+        self.assertTrue(issubclass(type(cmap), collections.abc.Mapping))
+        self.assertTrue(issubclass(type(cmap), collections.abc.MutableMapping))
 
     def test_str(self):
         cmap = ComponentMap()

--- a/pyomo/core/tests/unit/kernel/test_component_set.py
+++ b/pyomo/core/tests/unit/kernel/test_component_set.py
@@ -8,6 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import collections.abc
 import pickle
 
 import pyutilib.th as unittest
@@ -28,15 +29,6 @@ from pyomo.core.kernel.block import (block,
                                      block_dict,
                                      block_list)
 from pyomo.core.kernel.suffix import suffix
-
-import six
-
-if six.PY3:
-    from collections.abc import Set as collections_Set
-    from collections.abc import MutableSet as collections_MutableSet
-else:
-    from collections import Set as collections_Set
-    from collections import MutableSet as collections_MutableSet
 
 
 class TestComponentSet(unittest.TestCase):
@@ -115,10 +107,10 @@ class TestComponentSet(unittest.TestCase):
 
     def test_type(self):
         cset = ComponentSet()
-        self.assertTrue(isinstance(cset, collections_Set))
-        self.assertTrue(isinstance(cset, collections_MutableSet))
-        self.assertTrue(issubclass(type(cset), collections_Set))
-        self.assertTrue(issubclass(type(cset), collections_MutableSet))
+        self.assertTrue(isinstance(cset, collections.abc.Set))
+        self.assertTrue(isinstance(cset, collections.abc.MutableSet))
+        self.assertTrue(issubclass(type(cset), collections.abc.Set))
+        self.assertTrue(issubclass(type(cset), collections.abc.MutableSet))
 
     def test_str(self):
         cset = ComponentSet()

--- a/pyomo/core/tests/unit/kernel/test_dict_container.py
+++ b/pyomo/core/tests/unit/kernel/test_dict_container.py
@@ -8,7 +8,9 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import collections.abc
 import pickle
+from io import StringIO
 
 import pyutilib.th as unittest
 import pyomo.kernel as pmo
@@ -21,16 +23,6 @@ from pyomo.core.kernel.homogeneous_container import \
 from pyomo.core.kernel.dict_container import DictContainer
 from pyomo.core.kernel.block import (block,
                                      block_dict)
-
-import six
-from six import StringIO
-
-if six.PY3:
-    from collections.abc import Mapping as collections_Mapping
-    from collections.abc import MutableMapping as collections_MutableMapping
-else:
-    from collections import Mapping as collections_Mapping
-    from collections import MutableMapping as collections_MutableMapping
 
 #
 # There are no fully implemented test suites in this
@@ -139,10 +131,10 @@ class _TestDictContainerBase(object):
         self.assertTrue(isinstance(cdict, ICategorizedObjectContainer))
         self.assertTrue(isinstance(cdict, IHomogeneousContainer))
         self.assertTrue(isinstance(cdict, DictContainer))
-        self.assertTrue(isinstance(cdict, collections_Mapping))
-        self.assertTrue(isinstance(cdict, collections_MutableMapping))
-        self.assertTrue(issubclass(type(cdict), collections_Mapping))
-        self.assertTrue(issubclass(type(cdict), collections_MutableMapping))
+        self.assertTrue(isinstance(cdict, collections.abc.Mapping))
+        self.assertTrue(isinstance(cdict, collections.abc.MutableMapping))
+        self.assertTrue(issubclass(type(cdict), collections.abc.Mapping))
+        self.assertTrue(issubclass(type(cdict), collections.abc.MutableMapping))
 
     def test_len1(self):
         cdict = self._container_type()
@@ -606,8 +598,8 @@ class _TestActiveDictContainerBase(_TestDictContainerBase):
         self.assertTrue(isinstance(cdict, ICategorizedObjectContainer))
         self.assertTrue(isinstance(cdict, IHomogeneousContainer))
         self.assertTrue(isinstance(cdict, DictContainer))
-        self.assertTrue(isinstance(cdict, collections_Mapping))
-        self.assertTrue(isinstance(cdict, collections_MutableMapping))
+        self.assertTrue(isinstance(cdict, collections.abc.Mapping))
+        self.assertTrue(isinstance(cdict, collections.abc.MutableMapping))
 
     def test_active(self):
         children = {}

--- a/pyomo/core/tests/unit/kernel/test_expression.py
+++ b/pyomo/core/tests/unit/kernel/test_expression.py
@@ -37,8 +37,6 @@ from pyomo.core.kernel.parameter import parameter
 from pyomo.core.kernel.objective import objective
 from pyomo.core.kernel.block import block
 
-import six
-
 try:
     import numpy
     numpy_available = True
@@ -257,12 +255,7 @@ class Test_noclone(unittest.TestCase):
         self.assertIs(type(e.expr), parameter)
         self.assertEqual((1/e)(), 0.5)
         self.assertEqual((parameter(1)/e)(), 0.5)
-        # since the type returned is int, this should result
-        # in the behavior used by the interpreter
-        if six.PY3:
-            self.assertEqual((1/e.expr()), 0.5)
-        else:
-            self.assertEqual((1/e.expr()), 0)
+        self.assertEqual((1/e.expr()), 0.5)
 
     def test_to_string(self):
         b = block()
@@ -409,12 +402,7 @@ class _Test_expression_base(object):
         self.assertIs(type(e.expr), int)
         self.assertEqual((1/e)(), 0.5)
         self.assertEqual((parameter(1)/e)(), 0.5)
-        # since the type returned is int, this should result
-        # in the behavior used by the interpreter
-        if six.PY3:
-            self.assertEqual((1/e.expr), 0.5)
-        else:
-            self.assertEqual((1/e.expr), 0)
+        self.assertEqual((1/e.expr), 0.5)
 
     def test_to_string(self):
         b = block()

--- a/pyomo/core/tests/unit/kernel/test_list_container.py
+++ b/pyomo/core/tests/unit/kernel/test_list_container.py
@@ -8,7 +8,9 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import collections.abc
 import pickle
+from io import StringIO
 
 import pyutilib.th as unittest
 import pyomo.kernel as pmo
@@ -21,16 +23,6 @@ from pyomo.core.kernel.homogeneous_container import \
 from pyomo.core.kernel.list_container import ListContainer
 from pyomo.core.kernel.block import (block,
                                      block_list)
-
-import six
-from six import StringIO
-
-if six.PY3:
-    from collections.abc import Sequence as collections_Sequence
-    from collections.abc import MutableSequence as collections_MutableSequence
-else:
-    from collections import Sequence as collections_Sequence
-    from collections import MutableSequence as collections_MutableSequence
 
 #
 # There are no fully implemented test suites in this
@@ -97,10 +89,10 @@ class _TestListContainerBase(object):
         self.assertTrue(isinstance(clist, ICategorizedObjectContainer))
         self.assertTrue(isinstance(clist, IHomogeneousContainer))
         self.assertTrue(isinstance(clist, ListContainer))
-        self.assertTrue(isinstance(clist, collections_Sequence))
-        self.assertTrue(issubclass(type(clist), collections_Sequence))
-        self.assertTrue(isinstance(clist, collections_MutableSequence))
-        self.assertTrue(issubclass(type(clist), collections_MutableSequence))
+        self.assertTrue(isinstance(clist, collections.abc.Sequence))
+        self.assertTrue(issubclass(type(clist), collections.abc.Sequence))
+        self.assertTrue(isinstance(clist, collections.abc.MutableSequence))
+        self.assertTrue(issubclass(type(clist), collections.abc.MutableSequence))
 
     def test_len1(self):
         c = self._container_type()
@@ -652,10 +644,10 @@ class _TestActiveListContainerBase(_TestListContainerBase):
         self.assertTrue(isinstance(clist, ICategorizedObjectContainer))
         self.assertTrue(isinstance(clist, IHomogeneousContainer))
         self.assertTrue(isinstance(clist, ListContainer))
-        self.assertTrue(isinstance(clist, collections_Sequence))
-        self.assertTrue(issubclass(type(clist), collections_Sequence))
-        self.assertTrue(isinstance(clist, collections_MutableSequence))
-        self.assertTrue(issubclass(type(clist), collections_MutableSequence))
+        self.assertTrue(isinstance(clist, collections.abc.Sequence))
+        self.assertTrue(issubclass(type(clist), collections.abc.Sequence))
+        self.assertTrue(isinstance(clist, collections.abc.MutableSequence))
+        self.assertTrue(issubclass(type(clist), collections.abc.MutableSequence))
 
     def test_active(self):
         index = list(range(4))

--- a/pyomo/core/tests/unit/kernel/test_suffix.py
+++ b/pyomo/core/tests/unit/kernel/test_suffix.py
@@ -8,6 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import collections.abc
 import pickle
 
 import pyutilib.th as unittest
@@ -27,16 +28,6 @@ from pyomo.core.kernel.constraint import (constraint,
                                           constraint_list)
 from pyomo.core.kernel.block import (block,
                                      block_dict)
-
-import six
-
-if six.PY3:
-    from collections.abc import Mapping as collections_Mapping
-    from collections.abc import MutableMapping as collections_MutableMapping
-else:
-    from collections import Mapping as collections_Mapping
-    from collections import MutableMapping as collections_MutableMapping
-
 
 class Test_suffix(unittest.TestCase):
 
@@ -113,10 +104,10 @@ class Test_suffix(unittest.TestCase):
     def test_type(self):
         s = suffix()
         self.assertTrue(isinstance(s, ICategorizedObject))
-        self.assertTrue(isinstance(s, collections_Mapping))
-        self.assertTrue(isinstance(s, collections_MutableMapping))
-        self.assertTrue(issubclass(type(s), collections_Mapping))
-        self.assertTrue(issubclass(type(s), collections_MutableMapping))
+        self.assertTrue(isinstance(s, collections.abc.Mapping))
+        self.assertTrue(isinstance(s, collections.abc.MutableMapping))
+        self.assertTrue(issubclass(type(s), collections.abc.Mapping))
+        self.assertTrue(issubclass(type(s), collections.abc.MutableMapping))
 
     def test_import_export_enabled(self):
         s = suffix()

--- a/pyomo/core/tests/unit/kernel/test_tuple_container.py
+++ b/pyomo/core/tests/unit/kernel/test_tuple_container.py
@@ -8,6 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import collections.abc
 import pickle
 
 import pyutilib.th as unittest
@@ -20,13 +21,6 @@ from pyomo.core.kernel.homogeneous_container import \
 from pyomo.core.kernel.tuple_container import TupleContainer
 from pyomo.core.kernel.block import (block,
                                      block_list)
-
-import six
-
-if six.PY3:
-    from collections.abc import Sequence as collections_Sequence
-else:
-    from collections import Sequence as collections_Sequence
 
 #
 # There are no fully implemented test suites in this
@@ -74,8 +68,8 @@ class _TestTupleContainerBase(object):
         self.assertTrue(isinstance(ctuple, ICategorizedObjectContainer))
         self.assertTrue(isinstance(ctuple, IHomogeneousContainer))
         self.assertTrue(isinstance(ctuple, TupleContainer))
-        self.assertTrue(isinstance(ctuple, collections_Sequence))
-        self.assertTrue(issubclass(type(ctuple), collections_Sequence))
+        self.assertTrue(isinstance(ctuple, collections.abc.Sequence))
+        self.assertTrue(issubclass(type(ctuple), collections.abc.Sequence))
 
     def test_len1(self):
         c = self._container_type()
@@ -466,8 +460,8 @@ class _TestActiveTupleContainerBase(_TestTupleContainerBase):
         self.assertTrue(isinstance(ctuple, ICategorizedObjectContainer))
         self.assertTrue(isinstance(ctuple, IHomogeneousContainer))
         self.assertTrue(isinstance(ctuple, TupleContainer))
-        self.assertTrue(isinstance(ctuple, collections_Sequence))
-        self.assertTrue(issubclass(type(ctuple), collections_Sequence))
+        self.assertTrue(isinstance(ctuple, collections.abc.Sequence))
+        self.assertTrue(issubclass(type(ctuple), collections.abc.Sequence))
 
     def test_active(self):
         index = list(range(4))

--- a/pyomo/kernel/util.py
+++ b/pyomo/kernel/util.py
@@ -21,8 +21,6 @@ from pyomo.core.kernel.base import \
      _convert_ctype,
      _convert_descend_into)
 
-import six
-
 def preorder_traversal(node,
                        ctype=_no_ctype,
                        active=True,
@@ -162,7 +160,7 @@ def generate_names(node,
 
     # skip the root object
     try:
-        six.next(traversal)
+        next(traversal)
     except StopIteration:
         # might be an empty traversal
         return names


### PR DESCRIPTION
Pretty self-explanatory...

Mostly driven by grep-ing for six in pyomo/core/kernel and pyomo/core/tests/unit/kernel

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
