### PR TITLE
Relax tee/timeout test timing to improve robustness

### DIFF
--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -51,10 +51,10 @@ class TestTeeStream(unittest.TestCase):
             # flush() and short pause should help
             t.STDOUT.write("Hello\nWorld")
             t.STDOUT.flush()
-            time.sleep(tee._poll_interval*1.1)
+            time.sleep(tee._poll_interval*2)
             t.STDERR.write("interrupting\ncow")
             t.STDERR.flush()
-            time.sleep(tee._poll_interval*2)
+            time.sleep(tee._poll_interval*3)
         self.assertEqual(a.getvalue(), "Hello\ninterrupting\ncowWorld")
         self.assertEqual(b.getvalue(), "Hello\ninterrupting\ncowWorld")
 
@@ -71,7 +71,7 @@ class TestTeeStream(unittest.TestCase):
                 # nondeterministic, so a short pause should help
                 t.STDERR.write("Hello\n")
                 t.STDERR.flush()
-                time.sleep(tee._poll_interval*1.1)
+                time.sleep(tee._poll_interval*2)
                 t.STDOUT.write("World\n")
         finally:
             tee._peek_available = _tmp

--- a/pyomo/common/tests/test_unittest.py
+++ b/pyomo/common/tests/test_unittest.py
@@ -16,7 +16,7 @@ import time
 import pyomo.common.unittest as unittest
 from pyomo.common.log import LoggingIntercept
 
-@unittest.timeout(1)
+@unittest.timeout(10)
 def short_sleep():
     return 42
 
@@ -25,11 +25,11 @@ def long_sleep():
     time.sleep(1)
     return 42
 
-@unittest.timeout(1)
+@unittest.timeout(10)
 def raise_exception():
     foo.bar
 
-@unittest.timeout(1)
+@unittest.timeout(10)
 def fail():
     raise AssertionError("0 != 1")
 
@@ -162,7 +162,7 @@ class TestPyomoUnittest(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, r"^0 != 1$"):
             fail()
 
-    @unittest.timeout(1)
+    @unittest.timeout(10)
     def test_timeout(self):
         self.assertEqual(0, 0)
 
@@ -172,9 +172,9 @@ class TestPyomoUnittest(unittest.TestCase):
         time.sleep(1)
         self.assertEqual(0, 1)
 
-    @unittest.timeout(1)
+    @unittest.timeout(10)
     def test_timeout_skip(self):
-        if TestPyomoUnittest.test_timeout_skip.skip:
+        if not TestPyomoUnittest.test_timeout_skip.skip:
             self.skipTest("Skipping this test")
         self.assertEqual(0, 1)
 
@@ -191,7 +191,7 @@ class TestPyomoUnittest(unittest.TestCase):
         finally:
             TestPyomoUnittest.test_timeout_skip.skip = True
 
-    @unittest.timeout(1)
+    @unittest.timeout(10)
     def bound_function(self):
         self.assertEqual(0, 0)
 
@@ -205,7 +205,7 @@ class TestPyomoUnittest(unittest.TestCase):
                 self.bound_function()
         self.assertIn("platform that does not support 'fork'", LOG.getvalue())
 
-    @unittest.timeout(1, require_fork=True)
+    @unittest.timeout(10, require_fork=True)
     def bound_function_require_fork(self):
         self.assertEqual(0, 0)
 

--- a/pyomo/common/tests/test_unittest.py
+++ b/pyomo/common/tests/test_unittest.py
@@ -174,7 +174,7 @@ class TestPyomoUnittest(unittest.TestCase):
 
     @unittest.timeout(10)
     def test_timeout_skip(self):
-        if not TestPyomoUnittest.test_timeout_skip.skip:
+        if TestPyomoUnittest.test_timeout_skip.skip:
             self.skipTest("Skipping this test")
         self.assertEqual(0, 1)
 


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This increases some delay times to improve test robustness on GHA.

## Changes proposed in this PR:
- Increase delay in `test_tee.py`
- Increase timeouts in `test_unittest.py` for tests not expected to timeout 

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
