### PR TITLE
Replace `six` usage in pyomo.core

### DIFF
--- a/pyomo/core/__init__.py
+++ b/pyomo/core/__init__.py
@@ -8,7 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from six import iteritems, iterkeys
 from pyomo.core.expr.numvalue import (
     value, is_constant, is_fixed, is_variable_type,
     is_potentially_variable, NumericValue, ZeroConstant,

--- a/pyomo/core/base/__init__.py
+++ b/pyomo/core/base/__init__.py
@@ -11,7 +11,6 @@
 # TODO: this import is for historical backwards compatibility and should
 # probably be removed
 
-from six import iteritems, iterkeys
 import pyomo.core.expr.numvalue
 import pyomo.core.expr.logical_expr
 from pyomo.common.collections import ComponentMap

--- a/pyomo/core/base/_pyomo.py
+++ b/pyomo/core/base/_pyomo.py
@@ -34,7 +34,7 @@ from pyomo.core.base.plugin import (unique_component_name, Factory, implements,
 
 def predefined_sets():
     from pyomo.core.base.set import GlobalSets
-    return list((name, obj.doc) for name,obj in iteritems(GlobalSets))
+    return list((name, obj.doc) for name,obj in GlobalSets.items())
 
 
 def model_components():

--- a/pyomo/core/base/_pyomo.py
+++ b/pyomo/core/base/_pyomo.py
@@ -8,7 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from six import iteritems
 from pyomo.core.base.plugin import (unique_component_name, Factory, implements,
                                     Interface, Plugin, CreatePluginFactory,
                                     ExtensionPoint, TransformationTimer,

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1401,11 +1401,11 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         generator recursively descends into sub-blocks.
         """
         if not descend_into:
-            for x in self.component_map(ctype, active, sort).itervalues():
+            for x in self.component_map(ctype, active, sort).values():
                 yield x
             return
         for _block in self.block_data_objects(active, sort, descend_into, descent_order):
-            for x in _block.component_map(ctype, active, sort).itervalues():
+            for x in _block.component_map(ctype, active, sort).values():
                 yield x
 
     def component_data_objects(self,

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1339,7 +1339,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         """
         _sort_indices = SortComponents.sort_indices(sort)
         _subcomp = PseudoMap(self, ctype, active, sort)
-        for name, comp in _subcomp.iteritems():
+        for name, comp in _subcomp.items():
             # NOTE: Suffix has a dict interface (something other derived
             #   non-indexed Components may do as well), so we don't want
             #   to test the existence of iteritems as a check for
@@ -1348,7 +1348,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
             #   processing for the scalar components to catch the case
             #   where there are "sparse scalar components"
             if comp.is_indexed():
-                _items = comp.iteritems()
+                _items = comp.items()
             elif hasattr(comp, '_data'):
                 # This may be an empty Scalar component (e.g., from
                 # Constraint.Skip on a scalar Constraint)

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -368,7 +368,7 @@ class PseudoMap(object):
         # Ironically, the values are the fundamental thing that we
         # can (efficiently) iterate over in decl_order.  iterkeys
         # just wraps itervalues.
-        for obj in self.itervalues():
+        for obj in self.values():
             yield obj._name
 
     def values(self):
@@ -414,7 +414,7 @@ class PseudoMap(object):
         # Ironically, the values are the fundamental thing that we
         # can (efficiently) iterate over in decl_order.  iteritems
         # just wraps itervalues.
-        for obj in self.itervalues():
+        for obj in self.values():
             yield (obj._name, obj)
 
     @deprecated('The iterkeys method is deprecated. Use dict.keys().',

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -253,7 +253,7 @@ class PseudoMap(object):
         """
         TODO
         """
-        return self.iterkeys()
+        return self.keys()
 
     def __getitem__(self, key):
         """

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -1,5 +1,12 @@
-from six import itervalues, iteritems
-
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
 
 import logging
 from weakref import ref as weakref_ref
@@ -193,7 +200,7 @@ class _GeneralBooleanVarData(_BooleanVarData):
         if hasattr(_base, '__setstate__'):
             _base.__setstate__(state)
         else:
-            for key, val in iteritems(state):
+            for key, val in state.items():
                 # Note: per the Python data model docs, we explicitly
                 # set the attribute using object.__setattr__() instead
                 # of setting self.__dict__[key] = val.
@@ -296,7 +303,7 @@ class BooleanVar(IndexedComponent):
         """
         Set the 'stale' attribute of every variable data object to True.
         """
-        for boolvar_data in itervalues(self._data):
+        for boolvar_data in self._data.values():
             boolvar_data.stale = True
 
     def get_values(self, include_fixed_values=True):
@@ -305,9 +312,9 @@ class BooleanVar(IndexedComponent):
         """
         if include_fixed_values:
             return dict((idx, vardata.value)
-                        for idx, vardata in iteritems(self._data))
+                        for idx, vardata in self._data.items())
         return dict((idx, vardata.value)
-                    for idx, vardata in iteritems(self._data)
+                    for idx, vardata in self._data.items()
                     if not vardata.fixed)
 
     extract_values = get_values
@@ -319,7 +326,7 @@ class BooleanVar(IndexedComponent):
         The default behavior is to validate the values in the
         dictionary.
         """
-        for index, new_value in iteritems(new_values):
+        for index, new_value in new_values.items():
             self[index].set_value(new_value, valid)
 
 
@@ -437,7 +444,7 @@ class BooleanVar(IndexedComponent):
         return ( [("Size", len(self)),
                   ("Index", self._index if self.is_indexed() else None),
                   ],
-                 iteritems(self._data),
+                 self._data.items(),
                  ( "Value","Fixed","Stale"),
                  lambda k, v: [ v.value,
                                 v.fixed,
@@ -531,12 +538,12 @@ class IndexedBooleanVar(BooleanVar):
         Set the fixed indicator to True. Value argument is optional,
         indicating the variable should be fixed at its current value.
         """
-        for boolean_vardata in itervalues(self):
+        for boolean_vardata in self.values():
             boolean_vardata.fix(*val)
 
     def unfix(self):
         """Sets the fixed indicator to False."""
-        for boolean_vardata in itervalues(self):
+        for boolean_vardata in self.values():
             boolean_vardata.unfix()
 
     @property
@@ -576,7 +583,7 @@ class BooleanVarList(IndexedBooleanVar):
         # VarList (so we get potential domain errors), we will re-set
         # everything.
         if self._value_init_value.__class__ is dict:
-            for k,v in iteritems(self._value_init_value):
+            for k,v in self._value_init_value.items():
                 self[k] = v
 
     def add(self):

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -21,7 +21,6 @@ from pyomo.core.base.indexed_component import IndexedComponent, UnindexedCompone
 from pyomo.core.base.misc import apply_indexed_rule
 from pyomo.core.base.set import Set, BooleanSet
 from pyomo.core.base.util import is_functor
-from six.moves import xrange
 
 
 logger = logging.getLogger('pyomo.core')
@@ -574,7 +573,7 @@ class BooleanVarList(IndexedBooleanVar):
         # OR we can just add the correct number of sequential integers and
         # then let _validate_index complain when we set the value.
         if self._value_init_value.__class__ is dict:
-            for i in xrange(len(self._value_init_value)):
+            for i in range(len(self._value_init_value)):
                 self._index.add(i+1)
         super(BooleanVarList,self).construct(data)
         # Note that the current Var initializer silently ignores

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -9,11 +9,9 @@
 #  ___________________________________________________________________________
 
 import logging
-import six
 import sys
 from copy import deepcopy
 from pickle import PickleError
-from six import iteritems
 from weakref import ref as weakref_ref
 
 import pyomo.common
@@ -42,7 +40,7 @@ def _name_index_generator(idx):
             # requires escaping any single quotes in the string... which
             # in turn requires escaping the escape character.
             ans = "%s" % (val,)
-            if isinstance(val, six.string_types):
+            if isinstance(val, str):
                 ans = ans.replace("\\", "\\\\").replace("'", "\\'")
                 if ',' in ans or "'" in ans:
                     ans = "'"+ans+"'"
@@ -200,7 +198,7 @@ class _ComponentBase(PyomoObject):
             elif paranoid is not None:
                 raise PickleError()
             new_state = {}
-            for k,v in iteritems(state):
+            for k, v in state.items():
                 try:
                     if paranoid:
                         saved_memo = dict(memo)
@@ -267,7 +265,7 @@ class _ComponentBase(PyomoObject):
         """
         comp = self.parent_component()
         _attr, _data, _header, _fcn = comp._pprint()
-        if isinstance(type(_data), six.string_types):
+        if isinstance(type(_data), str):
             # If the component _pprint only returned a pre-formatted
             # result, then we have no way to only emit the information
             # for this _data object.
@@ -358,7 +356,7 @@ class _ComponentBase(PyomoObject):
         if _header is not None:
             if _fcn2 is not None:
                 _data_dict = dict(_data)
-                _data = iteritems(_data_dict)
+                _data = _data_dict.items()
             tabular_writer( ostream, '', _data, _header, _fcn )
             if _fcn2 is not None:
                 for _key in sorted_robust(_data_dict):
@@ -432,7 +430,7 @@ class Component(_ComponentBase):
         _base = super(Component,self)
         if hasattr(_base, '__getstate__'):
             state = _base.__getstate__()
-            for key,val in iteritems(self.__dict__):
+            for key,val in self.__dict__.items():
                 if key not in state:
                     state[key] = val
         else:
@@ -460,7 +458,7 @@ class Component(_ComponentBase):
         if hasattr(_base, '__setstate__'):
             _base.__setstate__(state)
         else:
-            for key, val in iteritems(state):
+            for key, val in state.items():
                 # Note: per the Python data model docs, we explicitly
                 # set the attribute using object.__setattr__() instead
                 # of setting self.__dict__[key] = val.
@@ -607,7 +605,7 @@ class Component(_ComponentBase):
 
     def clear_suffix_value(self, suffix_or_name, expand=True):
         """Clear the suffix value for this component data"""
-        if isinstance(suffix_or_name, six.string_types):
+        if isinstance(suffix_or_name, str):
             import pyomo.core.base.suffix
             for name_, suffix_ in pyomo.core.base.suffix.active_suffix_generator(self.model()):
                 if suffix_or_name == name_:
@@ -618,7 +616,7 @@ class Component(_ComponentBase):
 
     def set_suffix_value(self, suffix_or_name, value, expand=True):
         """Set the suffix value for this component data"""
-        if isinstance(suffix_or_name, six.string_types):
+        if isinstance(suffix_or_name, str):
             import pyomo.core.base.suffix
             for name_, suffix_ in pyomo.core.base.suffix.active_suffix_generator(self.model()):
                 if suffix_or_name == name_:
@@ -629,7 +627,7 @@ class Component(_ComponentBase):
 
     def get_suffix_value(self, suffix_or_name, default=None):
         """Get the suffix value for this component data"""
-        if isinstance(suffix_or_name, six.string_types):
+        if isinstance(suffix_or_name, str):
             import pyomo.core.base.suffix
             for name_, suffix_ in pyomo.core.base.suffix.active_suffix_generator(self.model()):
                 if suffix_or_name == name_:
@@ -772,7 +770,7 @@ class ComponentData(_ComponentBase):
         if hasattr(_base, '__setstate__'):
             _base.__setstate__(state)
         else:
-            for key, val in iteritems(state):
+            for key, val in state.items():
                 # Note: per the Python data model docs, we explicitly
                 # set the attribute using object.__setattr__() instead
                 # of setting self.__dict__[key] = val.
@@ -897,7 +895,7 @@ class ComponentData(_ComponentBase):
         if name_buffer is not None:
             # Iterate through the dictionary and generate all names in
             # the buffer
-            for idx, obj in iteritems(c):
+            for idx, obj in c.items():
                 name_buffer[id(obj)] = base + _name_index_generator(idx)
             if id(self) in name_buffer:
                 # Return the name if it is in the buffer
@@ -908,7 +906,7 @@ class ComponentData(_ComponentBase):
             # dictionary until we find this object.  This can be much
             # more expensive than if a buffer is provided.
             #
-            for idx, obj in iteritems(c):
+            for idx, obj in c.items():
                 if obj is self:
                     return base + _name_index_generator(idx)
         #
@@ -921,7 +919,7 @@ class ComponentData(_ComponentBase):
 
     def clear_suffix_value(self, suffix_or_name, expand=True):
         """Set the suffix value for this component data"""
-        if isinstance(suffix_or_name, six.string_types):
+        if isinstance(suffix_or_name, str):
             import pyomo.core.base.suffix
             for name_, suffix_ in pyomo.core.base.suffix.active_suffix_generator(self.model()):
                 if suffix_or_name == name_:
@@ -932,7 +930,7 @@ class ComponentData(_ComponentBase):
 
     def set_suffix_value(self, suffix_or_name, value, expand=True):
         """Set the suffix value for this component data"""
-        if isinstance(suffix_or_name, six.string_types):
+        if isinstance(suffix_or_name, str):
             import pyomo.core.base.suffix
             for name_, suffix_ in pyomo.core.base.suffix.active_suffix_generator(self.model()):
                 if suffix_or_name == name_:
@@ -943,7 +941,7 @@ class ComponentData(_ComponentBase):
 
     def get_suffix_value(self, suffix_or_name, default=None):
         """Get the suffix value for this component data"""
-        if isinstance(suffix_or_name, six.string_types):
+        if isinstance(suffix_or_name, str):
             import pyomo.core.base.suffix
             for name_, suffix_ in pyomo.core.base.suffix.active_suffix_generator(self.model()):
                 if suffix_or_name == name_:

--- a/pyomo/core/base/componentuid.py
+++ b/pyomo/core/base/componentuid.py
@@ -8,12 +8,9 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import bisect
 import codecs
 import re
 import ply.lex
-
-from six import PY2, string_types, iteritems
 
 from pyomo.common.collections import ComponentMap
 from pyomo.common.dependencies import pickle
@@ -59,7 +56,7 @@ class ComponentUID(object):
 
     @staticmethod
     def _safe_str(x):
-        if not isinstance(x, string_types):
+        if not isinstance(x, str):
             return ComponentUID._repr_map.get(
                 x.__class__, ComponentUID._pickle)(x)
         else:
@@ -93,7 +90,7 @@ class ComponentUID(object):
     def __init__(self, component, cuid_buffer=None, context=None):
         # A CUID can be initialized from either a reference component or
         # the string representation.
-        if isinstance(component, string_types):
+        if isinstance(component, str):
             if context is not None:
                 raise ValueError("Context is not allowed when initializing a "
                                  "ComponentUID object from a string type")
@@ -143,20 +140,10 @@ class ComponentUID(object):
 
     def __getstate__(self):
         ans = {x:getattr(self, x) for x in ComponentUID.__slots__}
-        if PY2:
-            # Ellipsis is not picklable
-            ans['_cids'] = tuple(
-                (k, tuple(_PickleEllipsis if i is Ellipsis else i
-                          for i in v)) for k,v in ans['_cids'])
         return ans
 
     def __setstate__(self, state):
-        if PY2:
-            # Ellipsis is not picklable
-            state['_cids'] = tuple(
-                (k, tuple(Ellipsis if i is _PickleEllipsis else i
-                          for i in v)) for k,v in state['_cids'])
-        for key, val in iteritems(state):
+        for key, val in state.items():
             setattr(self,key,val)
 
     def __hash__(self):
@@ -254,7 +241,7 @@ class ComponentUID(object):
                                  repr_version=2):
         def _record_indexed_object_cuid_strings_v1(obj, cuid_str):
             _unknown = lambda x: '?'+str(x)
-            for idx, data in iteritems(obj):
+            for idx, data in obj.items():
                 if idx.__class__ is tuple and len(idx) > 1:
                     cuid_strings[data] = cuid_str + ':' + ','.join(
                         ComponentUID._repr_v1_map.get(x.__class__, _unknown)(x)
@@ -265,7 +252,7 @@ class ComponentUID(object):
                             idx.__class__, _unknown)(idx)
 
         def _record_indexed_object_cuid_strings_v2(obj, cuid_str):
-            for idx, data in iteritems(obj):
+            for idx, data in obj.items():
                 if idx.__class__ is tuple and len(idx) > 1:
                     cuid_strings[data] = cuid_str + '[' + ','.join(
                         ComponentUID._safe_str(x) for x in idx) + ']'
@@ -439,7 +426,7 @@ class ComponentUID(object):
             elif cuid_buffer is not None:
                 if id(component) not in cuid_buffer:
                     c_local_name = c.local_name
-                    for idx, obj in iteritems(c):
+                    for idx, obj in c.items():
                         if idx.__class__ is not tuple or len(idx) == 1:
                             idx = (idx,)
                         cuid_buffer[id(obj)] = (c_local_name, idx)
@@ -698,10 +685,7 @@ def t_STAR(t):
 def t_PICKLE(t):
     start = 3 if t.value[1] == 'b' else 2
     unescaped = _re_escape_sequences.sub(_match_escape, t.value[start:-1])
-    if PY2:
-        rawstr = unescaped.encode('latin-1')
-    else:
-        rawstr = bytes(list(ord(_) for _ in unescaped))
+    rawstr = bytes(list(ord(_) for _ in unescaped))
     t.value = pickle.loads(rawstr)
     return t
 

--- a/pyomo/core/base/connector.py
+++ b/pyomo/core/base/connector.py
@@ -12,7 +12,6 @@ __all__ = [ 'Connector' ]
 
 import logging
 import sys
-from six import iteritems, itervalues
 from weakref import ref as weakref_ref
 
 from pyomo.common import deprecated
@@ -110,11 +109,11 @@ class _ConnectorData(ComponentData, NumericValue):
 
 
     def _iter_vars(self):
-        for var in itervalues(self.vars):
+        for var in self.vars.values():
             if not hasattr(var, 'is_indexed') or not var.is_indexed():
                 yield var
             else:
-                for v in itervalues(var):
+                for v in var.values():
                     yield v
 
 
@@ -195,21 +194,21 @@ class Connector(IndexedComponent):
             for key in self._implicit:
                 tmp.add(None,key)
             if self._extends:
-                for key, val in iteritems(self._extends.vars):
+                for key, val in self._extends.vars.items():
                     tmp.add(val,key)
-            for key, val in iteritems(self._initialize):
+            for key, val in self._initialize.items():
                 tmp.add(val,key)
             if self._rule:
                 items = apply_indexed_rule(
                     self, self._rule, self._parent(), idx)
-                for key, val in iteritems(items):
+                for key, val in items.items():
                     tmp.add(val,key)
 
 
     def _pprint(self, ostream=None, verbose=False):
         """Print component information."""
         def _line_generator(k,v):
-            for _k, _v in sorted(iteritems(v.vars)):
+            for _k, _v in sorted(v.vars.items()):
                 if _v is None:
                     _len = '-'
                 elif _k in v.aggregators:
@@ -222,7 +221,7 @@ class Connector(IndexedComponent):
         return ( [("Size", len(self)),
                   ("Index", self._index if self.is_indexed() else None),
                   ],
-                 iteritems(self._data),
+                 self._data.items(),
                  ( "Name","Size", "Variable", ),
                  _line_generator
              )
@@ -244,7 +243,7 @@ class Connector(IndexedComponent):
 
         ostream.write("\n")
         def _line_generator(k,v):
-            for _k, _v in sorted(iteritems(v.vars)):
+            for _k, _v in sorted(v.vars.items()):
                 if _v is None:
                     _val = '-'
                 elif not hasattr(_v, 'is_indexed') or not _v.is_indexed():
@@ -254,7 +253,7 @@ class Connector(IndexedComponent):
                         x, value(_v[x])) for x in sorted(_v._data) ),)
                 yield _k, _val
         tabular_writer( ostream, prefix+tab,
-                        ((k,v) for k,v in iteritems(self._data)),
+                        ((k,v) for k,v in self._data.items()),
                         ( "Name","Value" ), _line_generator )
 
 

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -12,7 +12,7 @@ __all__ = ['Constraint', '_ConstraintData', 'ConstraintList',
            'simple_constraint_rule', 'simple_constraintlist_rule']
 
 import inspect
-import six
+import io
 import sys
 import logging
 import math
@@ -38,16 +38,9 @@ from pyomo.core.base.util import (
     IndexedCallInitializer, CountedCallInitializer
 )
 
-from six import StringIO, iteritems
-
-if six.PY3:
-    from collections.abc import Sequence as collections_Sequence
-    def formatargspec(fn):
-        return str(inspect.signature(fn))
-else:
-    from collections import Sequence as collections_Sequence
-    def formatargspec(fn):
-        return str(inspect.formatargspec(*inspect.getargspec(fn)))
+from collections.abc import Sequence as collections_Sequence
+def formatargspec(fn):
+    return str(inspect.signature(fn))
 
 
 logger = logging.getLogger('pyomo.core')
@@ -526,7 +519,7 @@ class _GeneralConstraintData(_ConstraintData):
             if logical_expr._using_chained_inequality \
                and logical_expr._chainedInequality.prev is not None:
 
-                buf = StringIO()
+                buf = io.StringIO()
                 logical_expr._chainedInequality.prev.pprint(buf)
                 #
                 # We are about to raise an exception, so it's OK to
@@ -865,7 +858,7 @@ class Constraint(ActiveIndexedComponent):
              ("Index", self._index if self.is_indexed() else None),
              ("Active", self.active),
              ],
-            iteritems(self),
+            self.items(),
             ( "Lower","Body","Upper","Active" ),
             lambda k, v: [ "-Inf" if v.lower is None else v.lower,
                            v.body,
@@ -890,7 +883,7 @@ class Constraint(ActiveIndexedComponent):
 
         ostream.write("\n")
         tabular_writer( ostream, prefix+tab,
-                        ((k,v) for k,v in iteritems(self._data) if v.active),
+                        ((k,v) for k,v in self._data.items() if v.active),
                         ( "Lower","Body","Upper" ),
                         lambda k, v: [ value(v.lower),
                                        v.body(),

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -29,8 +29,6 @@ from pyomo.core.base.numvalue import (NumericValue,
                                       as_numeric)
 from pyomo.core.base.util import is_functor
 
-from six import iteritems
-
 logger = logging.getLogger('pyomo.core')
 
 
@@ -319,7 +317,7 @@ class Expression(IndexedComponent):
         tabular_writer(
             ostream,
             prefix+tab,
-            ((k,v) for k,v in iteritems(self._data)),
+            ((k,v) for k,v in self._data.items()),
             ( "Value", ),
             lambda k, v: \
                ["Undefined" if v.expr is None else v()])
@@ -332,7 +330,7 @@ class Expression(IndexedComponent):
     #
     def extract_values(self):
         return {key:expression_data.expr
-                for key, expression_data in iteritems(self)}
+                for key, expression_data in self.items()}
 
     #
     # takes as input a (index, value) dictionary for updating this
@@ -348,7 +346,7 @@ class Expression(IndexedComponent):
                 "="+self.name+"; no value with index "
                 "None in input new values map.")
 
-        for index, new_value in iteritems(new_values):
+        for index, new_value in new_values.items():
             self._data[index].set_value(new_value)
 
     def _getitem_when_not_present(self, index):

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -10,7 +10,6 @@
 
 import logging
 import os
-import six
 import types
 import weakref
 
@@ -177,7 +176,7 @@ class AMPLExternalFunction(ExternalFunction):
         def addfunc(name, f, _type, nargs, funcinfo, ae):
             # trap for Python 3, where the name comes in as bytes() and
             # not a string
-            if not isinstance(name, six.string_types):
+            if not isinstance(name, str):
                 name = name.decode()
             self._known_functions[str(name)] = (f, _type, nargs, funcinfo, ae)
         AE.Addfunc = _AMPLEXPORTS.ADDFUNC(addfunc)

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -21,12 +21,8 @@ from pyomo.core.base.global_set import UnindexedComponent_set
 from pyomo.common import DeveloperError
 from pyomo.common.deprecation import deprecation_warning
 
-from six import PY3, itervalues, iteritems, string_types
+from collections.abc import Sequence as collections_Sequence
 
-if PY3:
-    from collections.abc import Sequence as collections_Sequence
-else:
-    from collections import Sequence as collections_Sequence
     
 logger = logging.getLogger('pyomo.core')
 
@@ -67,7 +63,7 @@ def normalize_index(x):
             # new object)
             x = x[:i] + tuple(x[i]) + x[i + 1:]
         elif issubclass(_xi_class, collections_Sequence):
-            if issubclass(_xi_class, string_types):
+            if issubclass(_xi_class, str):
                 # This is very difficult to get to: it would require a
                 # user creating a custom derived string type
                 native_types.add(_xi_class)
@@ -801,7 +797,7 @@ value() function.""" % ( self.name, i ))
         return ( [("Size", len(self)),
                   ("Index", self._index if self.is_indexed() else None),
                   ],
-                 iteritems(self._data),
+                 self._data.items(),
                  ( "Object",),
                  lambda k, v: [ type(v) ]
                  )
@@ -812,17 +808,14 @@ value() function.""" % ( self.name, i ))
         all ComponentData instances.
         """
         result = {}
-        for index, component_data in iteritems(self):
+        for index, component_data in self.items():
             result[id(component_data)] = index
         return result
 
 
-# In Python3, the items(), etc methods of dict-like things return
-# generator-like objects.
-if PY3:
-    IndexedComponent.keys   = IndexedComponent.iterkeys
-    IndexedComponent.values = IndexedComponent.itervalues
-    IndexedComponent.items  = IndexedComponent.iteritems
+IndexedComponent.keys   = IndexedComponent.iterkeys
+IndexedComponent.values = IndexedComponent.itervalues
+IndexedComponent.items  = IndexedComponent.iteritems
 
 class ActiveIndexedComponent(IndexedComponent, ActiveComponent):
     """
@@ -847,13 +840,13 @@ class ActiveIndexedComponent(IndexedComponent, ActiveComponent):
         """Set the active attribute to True"""
         super(ActiveIndexedComponent, self).activate()
         if self.is_indexed():
-            for component_data in itervalues(self):
+            for component_data in self.values():
                 component_data.activate()
 
     def deactivate(self):
         """Set the active attribute to False"""
         super(ActiveIndexedComponent, self).deactivate()
         if self.is_indexed():
-            for component_data in itervalues(self):
+            for component_data in self.values():
                 component_data.deactivate()
 

--- a/pyomo/core/base/indexed_component_slice.py
+++ b/pyomo/core/base/indexed_component_slice.py
@@ -7,9 +7,10 @@
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
+
 import copy
-from six import iteritems, iterkeys, advance_iterator
 from pyomo.common import DeveloperError
+
 
 class IndexedComponent_slice(object):
     """Special class for slicing through hierarchical component trees
@@ -121,7 +122,7 @@ class IndexedComponent_slice(object):
     def __setstate__(self, state):
         """Deserialize the state into this object. """
         set_attr = super(IndexedComponent_slice, self).__setattr__
-        for k,v in iteritems(state):
+        for k,v in state.items():
             set_attr(k,v)
 
     def __deepcopy__(self, memo):
@@ -284,8 +285,8 @@ def _freeze(info):
         return (
             info[0],
             id(info[1][0]),  # id of the Component
-            tuple(iteritems(info[1][1])), # {idx: value} for fixed
-            tuple(iterkeys(info[1][2])),  # {idx: slice} for slices
+            tuple(info[1][1].items()), # {idx: value} for fixed
+            tuple(info[1][2].keys()),  # {idx: slice} for slices
             info[1][3]  # elipsis index
         )
     elif info[0] & IndexedComponent_slice.ITEM_MASK:
@@ -349,7 +350,7 @@ class _slice_generator(object):
             # Note: running off the end of the underlying iterator will
             # generate a StopIteration exception that will propagate up
             # and end this iterator.
-            index = advance_iterator(self.component_iter)
+            index = next(self.component_iter)
 
             # We want a tuple of indices, so convert scalars to tuples
             if normalize_index.flatten:
@@ -370,7 +371,7 @@ class _slice_generator(object):
                 continue
 
             valid = True
-            for key, val in iteritems(self.fixed):
+            for key, val in self.fixed.items():
                 # If this index of the component does not match all
                 # the specified fixed indices, don't return anything.
                 if not val == _idx[key]:
@@ -407,7 +408,7 @@ _IndexedComponent_slice = IndexedComponent_slice
 
 # Mock up a callable object with a "check_complete" method
 def _advance_iter(_iter):
-    return advance_iterator(_iter)
+    return next(_iter)
 def _advance_iter_check_complete():
     pass
 _advance_iter.check_complete = _advance_iter_check_complete

--- a/pyomo/core/base/instance2dat.py
+++ b/pyomo/core/base/instance2dat.py
@@ -11,7 +11,6 @@
 __all__ = ['instance2dat']
 
 import types
-from six import iteritems
 from pyomo.core.base import Set, Param, value
 
 
@@ -21,7 +20,7 @@ def instance2dat(instance, output_filename):
 
     output_file = open(output_filename,"w")
 
-    for set_name, set_object in iteritems(instance.component_map(Set, active=True)):
+    for set_name, set_object in instance.component_map(Set, active=True).items():
         if (set_object.initialize is not None) and (type(set_object.initialize) is types.FunctionType):
             continue
 
@@ -45,7 +44,8 @@ def instance2dat(instance, output_filename):
 
             output_file.write("\n")
 
-    for param_name, param_object in iteritems(instance.component_map(Param, active=True)):
+    for param_name, param_object in instance.component_map(Param,
+                                                           active=True).items():
         if (param_object._initialize is not None) and (type(param_object._initialize) is types.FunctionType):
             continue
         elif len(param_object) == 0:

--- a/pyomo/core/base/label.py
+++ b/pyomo/core/base/label.py
@@ -13,12 +13,8 @@ __all__ = ['CounterLabeler', 'NumericLabeler', 'CNameLabeler', 'TextLabeler',
            'ShortNameLabeler']
 
 import re
-import six
-if six.PY3:
-    _translate = str.translate
-else:
-    import string
-    _translate = string.translate
+
+_translate = str.translate
 
 from pyomo.core.base.componentuid import ComponentUID
 
@@ -40,7 +36,7 @@ class _CharMapper(object):
                   preserve or translate
         """
         self.table = {k if isinstance(k, int) else ord(k): v
-            for k,v in six.iteritems(dict(translate)) }
+            for k,v in dict(translate).items() }
         for c in preserve:
             _c = ord(c)
             if _c in self.table and self.table[_c] != c:
@@ -164,7 +160,7 @@ class ShortNameLabeler(object):
         else:
             self.labeler = AlphaNumericTextLabeler()
         self.known_labels = set() if caseInsensitive else None
-        if isinstance(legalRegex, six.string_types):
+        if isinstance(legalRegex, str):
             self.legalRegex = re.compile(legalRegex)
         else:
             self.legalRegex = legalRegex

--- a/pyomo/core/base/logical_constraint.py
+++ b/pyomo/core/base/logical_constraint.py
@@ -30,8 +30,6 @@ from pyomo.core.base.misc import (apply_indexed_rule,
                                   tabular_writer)
 from pyomo.core.base.set import Set
 
-from six import iteritems
-
 logger = logging.getLogger('pyomo.core')
 
 _rule_returned_none_error = """LogicalConstraint '%s': rule returned None.
@@ -356,7 +354,7 @@ class LogicalConstraint(ActiveIndexedComponent):
              ("Index", self._index if self.is_indexed() else None),
              ("Active", self.active),
              ],
-            iteritems(self),
+            self.items(),
             ("Body", "Active"),
             lambda k, v: [v.body, v.active, ]
         )
@@ -377,7 +375,7 @@ class LogicalConstraint(ActiveIndexedComponent):
 
         ostream.write("\n")
         tabular_writer(ostream, prefix + tab,
-                       ((k, v) for k, v in iteritems(self._data) if v.active),
+                       ((k, v) for k, v in self._data.items() if v.active),
                        ("Body",),
                        lambda k, v: [v.body(), ])
 

--- a/pyomo/core/base/matrix_constraint.py
+++ b/pyomo/core/base/matrix_constraint.py
@@ -22,13 +22,7 @@ from pyomo.core.base.constraint import (IndexedConstraint,
 from pyomo.common.gc_manager import PauseGC
 from pyomo.common.log import is_debug_set
 
-import six
-from six.moves import xrange
-
-if six.PY3:
-    from collections.abc import Mapping as collections_Mapping
-else:
-    from collections import Mapping as collections_Mapping
+from collections.abc import Mapping as collections_Mapping
 
 
 logger = logging.getLogger('pyomo.core')
@@ -85,7 +79,7 @@ class _MatrixConstraintData(_ConstraintData):
         variables = []
         coefficients = []
         constant = 0
-        for p in xrange(indptr[index],
+        for p in range(indptr[index],
                         indptr[index+1]):
             v = x[indices[p]]
             c = data[p]
@@ -145,7 +139,7 @@ class _MatrixConstraintData(_ConstraintData):
         indices = comp._A_indices
         indptr = comp._A_indptr
         x = comp._x
-        ptrs = xrange(indptr[index],
+        ptrs = range(indptr[index],
                       indptr[index+1])
         try:
             return sum(x[indices[p]].value * data[p]
@@ -232,7 +226,7 @@ class _MatrixConstraintData(_ConstraintData):
         indices = comp._A_indices
         indptr = comp._A_indptr
         x = comp._x
-        ptrs = xrange(indptr[index],
+        ptrs = range(indptr[index],
                       indptr[index+1])
         return LinearExpression(
             linear_vars=[x[indices[p]] for p in ptrs],
@@ -364,7 +358,7 @@ class MatrixConstraint(collections_Mapping,
         ref = weakref.ref(self)
         with PauseGC():
             self._data = tuple(_MatrixConstraintData(i, ref)
-                               for i in xrange(len(self._lower)))
+                               for i in range(len(self._lower)))
 
     #
     # Override some IndexedComponent methods
@@ -377,7 +371,7 @@ class MatrixConstraint(collections_Mapping,
         return self._data.__len__()
 
     def __iter__(self):
-        return iter(i for i in xrange(len(self)))
+        return iter(i for i in range(len(self)))
 
     #
     # Remove methods that allow modifying this constraint

--- a/pyomo/core/base/misc.py
+++ b/pyomo/core/base/misc.py
@@ -14,8 +14,6 @@ import logging
 import sys
 import types
 
-from six import itervalues, string_types
-
 logger = logging.getLogger('pyomo.core')
 
 
@@ -179,7 +177,7 @@ def sorted_robust(arg):
 
 
 def _to_ustr(obj):
-    if not isinstance(obj, string_types):
+    if not isinstance(obj, str):
         try:
             obj = str(obj)
         except:
@@ -259,7 +257,7 @@ def tabular_writer(ostream, prefix, data, header, row_generator):
     _width = ["%"+str(i)+"s" for i in _width]
 
     if any( ' ' in r[-1]
-            for x in itervalues(_rows) if x is not None
+            for x in _rows.values() if x is not None
             for r in x  ):
         _width[-1] = '%s'
     for _key in sorted_robust(_rows):

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -36,8 +36,6 @@ from pyomo.core.base.misc import apply_indexed_rule, tabular_writer
 from pyomo.core.base.set import Set
 from pyomo.core.base import minimize, maximize
 
-from six import iteritems
-
 logger = logging.getLogger('pyomo.core')
 
 _rule_returned_none_error = """Objective '%s': rule returned None.
@@ -402,7 +400,7 @@ class Objective(ActiveIndexedComponent):
              ("Index", self._index if self.is_indexed() else None),
              ("Active", self.active)
              ],
-            iteritems(self._data),
+            self._data.items(),
             ( "Active","Sense","Expression"),
             lambda k, v: [ v.active,
                            ("minimize" if (v.sense == minimize) else "maximize"),
@@ -426,7 +424,7 @@ class Objective(ActiveIndexedComponent):
 
         ostream.write("\n")
         tabular_writer( ostream, prefix+tab,
-                        ((k,v) for k,v in iteritems(self._data) if v.active),
+                        ((k,v) for k,v in self._data.items() if v.active),
                         ( "Active","Value" ),
                         lambda k, v: [ v.active, value(v), ] )
 

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -24,11 +24,9 @@ from pyomo.core.base.component import ComponentData
 from pyomo.core.base.indexed_component import IndexedComponent, \
     UnindexedComponent_set
 from pyomo.core.base.misc import apply_indexed_rule, apply_parameterized_indexed_rule
-from pyomo.core.base.numvalue import NumericValue, native_types, value
+from pyomo.core.base.numvalue import NumericValue, native_types
 from pyomo.core.base.set_types import Any, Reals
 from pyomo.core.base.units_container import units
-
-from six import iteritems, iterkeys, next, itervalues
 
 logger = logging.getLogger('pyomo.core')
 
@@ -311,27 +309,27 @@ class Param(IndexedComponent):
 
     def sparse_keys(self):
         """Return a list of keys in the defined parameters"""
-        return list(iterkeys(self._data))
+        return list(self._data.keys())
 
     def sparse_values(self):
         """Return a list of the defined param data objects"""
-        return list(itervalues(self._data))
+        return list(self._data.values())
 
     def sparse_items(self):
         """Return a list (index,data) tuples for defined parameters"""
-        return list(iteritems(self._data))
+        return list(self._data.items())
 
     def sparse_iterkeys(self):
         """Return an iterator for the keys in the defined parameters"""
-        return iterkeys(self._data)
+        return self._data.keys()
 
     def sparse_itervalues(self):
         """Return an iterator for the defined param data objects"""
-        return itervalues(self._data)
+        return self._data.values()
 
     def sparse_iteritems(self):
         """Return an iterator of (index,data) tuples for defined parameters"""
-        return iteritems(self._data)
+        return self._data.items()
 
     def extract_values(self):
         """
@@ -412,7 +410,7 @@ class Param(IndexedComponent):
         #
         if check:
             if _isDict:
-                for index, new_value in iteritems(new_values):
+                for index, new_value in new_values.items():
                     self[index] = new_value
             else:
                 for index in self._index:
@@ -428,7 +426,7 @@ class Param(IndexedComponent):
                 # index is not already in the _data dict.  As these
                 # cases are rare, we will recover from the exception
                 # instead of incurring the penalty of checking.
-                for index, new_value in iteritems(new_values):
+                for index, new_value in new_values.items():
                     if index not in self._data:
                         self._data[index] = _ParamData(self)
                     self._data[index]._value = new_value
@@ -910,7 +908,7 @@ This has resulted in the conversion of the source to dense form.
         #
         if data is not None:
             try:
-                for key, val in iteritems(data):
+                for key, val in data.items():
                     self._setitem_when_not_present(
                         self._validate_index(key), val)
             except Exception:

--- a/pyomo/core/base/range.py
+++ b/pyomo/core/base/range.py
@@ -9,14 +9,7 @@
 #  ___________________________________________________________________________
 
 import math
-
-from six import iteritems, PY3
-from six.moves import xrange
-
-if PY3:
-    from collections.abc import Sequence as collections_Sequence
-else:
-    from collections import Sequence as collections_Sequence
+from collections.abc import Sequence as collections_Sequence
 
 try:
     from math import remainder
@@ -132,7 +125,7 @@ class NumericRange(object):
 
         This method must be defined because this class uses slots.
         """
-        for key, val in iteritems(state):
+        for key, val in state.items():
             # Note: per the Python data model docs, we explicitly
             # set the attribute using object.__setattr__() instead
             # of setting self.__dict__[key] = val.
@@ -475,7 +468,7 @@ class NumericRange(object):
         assert new_step % cnr.step == 0
         _dir = math.copysign(1, cnr.step)
         _subranges = []
-        for i in xrange(int(abs(new_step // cnr.step))):
+        for i in range(int(abs(new_step // cnr.step))):
             if ( cnr.end is not None
                  and _dir*(cnr.start + i*cnr.step) > _dir*cnr.end ):
                 # Once we walk past the end of the range, we are done
@@ -619,7 +612,7 @@ class NumericRange(object):
                             t.start, start, 0, (t.closed[0], False)
                         ))
                     if s.step: # i.e., not a single point
-                        for i in xrange(int(start//s.step), int(end//s.step)):
+                        for i in range(int(start//s.step), int(end//s.step)):
                             _new_subranges.append(NumericRange(
                                 i*s.step, (i+1)*s.step, 0, '()'
                             ))
@@ -796,7 +789,7 @@ class NonNumericRange(object):
 
         This method must be defined because this class uses slots.
         """
-        for key, val in iteritems(state):
+        for key, val in state.items():
             # Note: per the Python data model docs, we explicitly
             # set the attribute using object.__setattr__() instead
             # of setting self.__dict__[key] = val.
@@ -927,7 +920,7 @@ class RangeProduct(object):
 
         This method must be defined because this class uses slots.
         """
-        for key, val in iteritems(state):
+        for key, val in state.items():
             # Note: per the Python data model docs, we explicitly
             # set the attribute using object.__setattr__() instead
             # of setting self.__dict__[key] = val.
@@ -981,7 +974,7 @@ class RangeProduct(object):
                     tmp.append(rp)
                     continue
 
-                for dim in xrange(N):
+                for dim in range(N):
                     remainder = []
                     for r in rp.range_lists[dim]:
                         remainder.extend(
@@ -1005,7 +998,7 @@ class RangeProduct(object):
             if type(other) is not RangeProduct or len(other.range_lists) != N:
                 return []
 
-            for dim in xrange(N):
+            for dim in range(N):
                 tmp = []
                 for r in ans[dim]:
                     tmp.extend(r.range_intersection(other.range_lists[dim]))

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -665,7 +665,7 @@ def Reference(reference, ctype=_NotSpecified):
         if not slice_idx:
             index = SetOf(_ReferenceSet(reference))
         else:
-            wildcards = sum((sorted(lvl.items())) for lvl in slice_idx
+            wildcards = sum((sorted(lvl.items()) for lvl in slice_idx
                              if lvl is not None), [])
             # Wildcards is a list of (coordinate, set) tuples.  Coordinate
             # is that within the subsets list, and set is a wildcard set.

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -23,10 +23,8 @@ from pyomo.core.base.indexed_component_slice import (
 )
 from pyomo.core.base.util import flatten_tuple
 
-import six
-from six import iteritems, itervalues, advance_iterator
-
 _NotSpecified = object()
+
 
 class _fill_in_known_wildcards(object):
     """Variant of "six.advance_iterator" that substitutes wildcard values
@@ -182,7 +180,7 @@ class _ReferenceDict(MutableMapping):
 
     def __contains__(self, key):
         try:
-            advance_iterator(self._get_iter(self._slice, key))
+            next(self._get_iter(self._slice, key))
             # This calls IC_slice_iter.__next__, which calls
             # _fill_in_known_wildcards.
             return True
@@ -207,7 +205,7 @@ class _ReferenceDict(MutableMapping):
         try:
             # This calls IC_slice_iter.__next__, which calls
             # _fill_in_known_wildcards.
-            return advance_iterator(
+            return next(
                 self._get_iter(self._slice, key, get_if_not_present=True)
             )
         except SliceEllipsisLookupError:
@@ -248,7 +246,7 @@ class _ReferenceDict(MutableMapping):
             raise DeveloperError(
                 "Unexpected slice _call_stack operation: %s" % op)
         try:
-            advance_iterator(self._get_iter(tmp, key, get_if_not_present=True))
+            next(self._get_iter(tmp, key, get_if_not_present=True))
         except StopIteration:
             pass
 
@@ -265,7 +263,7 @@ class _ReferenceDict(MutableMapping):
             assert len(tmp._call_stack) == 1
             _iter = self._get_iter(tmp, key)
             try:
-                advance_iterator(_iter)
+                next(_iter)
                 del _iter._iter_stack[0].component[_iter.get_last_index()]
                 return
             except StopIteration:
@@ -280,7 +278,7 @@ class _ReferenceDict(MutableMapping):
             raise DeveloperError(
                 "Unexpected slice _call_stack operation: %s" % op)
         try:
-            advance_iterator(self._get_iter(tmp, key))
+            next(self._get_iter(tmp, key))
         except StopIteration:
             pass
 
@@ -336,9 +334,8 @@ class _ReferenceDict(MutableMapping):
                                      get_if_not_present=get_if_not_present)
         )
 
-if six.PY3:
-    _ReferenceDict.items = _ReferenceDict.iteritems
-    _ReferenceDict.values = _ReferenceDict.itervalues
+_ReferenceDict.items = _ReferenceDict.iteritems
+_ReferenceDict.values = _ReferenceDict.itervalues
 
 
 class _ReferenceDict_mapping(UserDict):
@@ -370,7 +367,7 @@ class _ReferenceSet(collections_Set):
 
     def __contains__(self, key):
         try:
-            advance_iterator(self._get_iter(self._slice, key))
+            next(self._get_iter(self._slice, key))
             return True
         except SliceEllipsisLookupError:
             if type(key) is tuple and len(key) == 1:
@@ -490,7 +487,7 @@ def _identify_wildcard_sets(iter_stack, index):
         if len(index[i]) != len(level):
             return None
         # if any wildcard "subset" differs in position or set.
-        if any(index[i].get(j,None) is not _set for j,_set in iteritems(level)):
+        if any(index[i].get(j,None) is not _set for j,_set in level.items()):
             return None
         # These checks seem to intentionally preclude
         #     m.b1[:].v and m.b2[1,:].v
@@ -617,12 +614,12 @@ def Reference(reference, ctype=_NotSpecified):
         index = None
     elif isinstance(reference, Mapping):
         _data = _ReferenceDict_mapping(dict(reference))
-        _iter = itervalues(_data)
+        _iter = _data.values()
         slice_idx = None
         index = SetOf(_data)
     elif isinstance(reference, Sequence):
         _data = _ReferenceDict_mapping(OrderedDict(enumerate(reference)))
-        _iter = itervalues(_data)
+        _iter = _data.values()
         slice_idx = None
         index = OrderedSetOf(_data)
     else:
@@ -668,7 +665,7 @@ def Reference(reference, ctype=_NotSpecified):
         if not slice_idx:
             index = SetOf(_ReferenceSet(reference))
         else:
-            wildcards = sum((sorted(iteritems(lvl)) for lvl in slice_idx
+            wildcards = sum((sorted(lvl.items())) for lvl in slice_idx
                              if lvl is not None), [])
             # Wildcards is a list of (coordinate, set) tuples.  Coordinate
             # is that within the subsets list, and set is a wildcard set.

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -12,12 +12,8 @@ import inspect
 import itertools
 import logging
 import math
-import six
 import sys
 import weakref
-
-from six import iteritems
-from six.moves import xrange
 
 from pyomo.common.deprecation import deprecated, deprecation_warning
 from pyomo.common.errors import DeveloperError, PyomoException
@@ -44,14 +40,9 @@ from pyomo.core.base.global_set import (
 )
 from pyomo.core.base.misc import sorted_robust
 
-if six.PY3:
-    from collections.abc import Sequence as collections_Sequence
-    def formatargspec(fn):
-        return str(inspect.signature(fn))
-else:
-    from collections import Sequence as collections_Sequence
-    def formatargspec(fn):
-        return str(inspect.formatargspec(*inspect.getargspec(fn)))
+from collections.abc import Sequence as collections_Sequence
+def formatargspec(fn):
+    return str(inspect.signature(fn))
 
 
 logger = logging.getLogger('pyomo.core')
@@ -442,7 +433,7 @@ class TuplizeValuesInitializer(InitializerBase):
                 "Cannot tuplize list data for set %%s%%s because its "
                 "length %s is not a multiple of dimen=%s" % (len(_val), d))
 
-        return list(tuple(_val[d*i:d*(i+1)]) for i in xrange(len(_val)//d))
+        return list(tuple(_val[d*i:d*(i+1)]) for i in range(len(_val)//d))
 
 
 class _NotFound(object):
@@ -653,7 +644,7 @@ class _SetData(_SetDataBase):
             if len(vals) < 2:
                 return (vals[0], vals[0], 0)
             step = vals[1]-vals[0]
-            for i in xrange(2, len(vals)):
+            for i in range(2, len(vals)):
                 if step != vals[i] - vals[i-1]:
                     return self.bounds() + (None,)
             return (vals[0], vals[-1], step)
@@ -1549,7 +1540,7 @@ class _OrderedSetData(_OrderedSetMixin, _FiniteSetData):
     def remove(self, val):
         idx = self._values.pop(val)
         self._ordered_values.pop(idx)
-        for i in xrange(idx, len(self._ordered_values)):
+        for i in range(idx, len(self._ordered_values)):
             self._values[self._ordered_values[i]] -= 1
 
     def discard(self, val):
@@ -2196,7 +2187,7 @@ class Set(IndexedComponent):
             [("Size", len(self._data)),
              ("Index", self._index if self.is_indexed() else None),
              ("Ordered", _ordered),],
-            iteritems(self._data),
+            self._data.items(),
             ("Dimen","Domain","Size","Members",),
             lambda k, v: [
                 Set._pprint_dimen(v),
@@ -2209,7 +2200,7 @@ class Set(IndexedComponent):
 class IndexedSet(Set):
     def data(self):
         "Return a dict containing the data() of each Set in this IndexedSet"
-        return {k: v.data() for k,v in iteritems(self)}
+        return {k: v.data() for k,v in self.items()}
 
 
 class FiniteSimpleSet(_FiniteSetData, Set):
@@ -2329,7 +2320,7 @@ class SetOf(_FiniteSetMixin, _SetData, Component):
             [("Dimen", self.dimen),
              ("Size", len(self)),
              ("Bounds", self.bounds())],
-            iteritems( {None: self} ),
+            {None: self}.items() ,
             ("Ordered", "Members",),
             lambda k, v: [
                 v.isordered(),
@@ -2889,7 +2880,7 @@ class RangeSet(Component):
             [("Dimen", self.dimen),
              ("Size", len(self) if self.isfinite() else 'Inf'),
              ("Bounds", self.bounds())],
-            iteritems( {None: self} ),
+            {None: self}.items(),
             ("Finite","Members",),
             lambda k, v: [
                 v.isfinite(),#isinstance(v, _FiniteSetMixin),
@@ -3617,7 +3608,7 @@ class SetProduct(SetOperator):
         nested tuples (so this only needs to check the top-level terms)
 
         """
-        for i in xrange(len(val)-1, -1, -1):
+        for i in range(len(val)-1, -1, -1):
             if val[i].__class__ is tuple:
                 val = val[:i] + val[i] + val[i+1:]
         return val
@@ -3739,7 +3730,7 @@ class SetProduct_InfiniteSet(SetProduct):
         for cuts in self._cutPointGenerator(subsets, len(_val)):
             if all(_val[cuts[i]:cuts[i+1]] in s for i,s in enumerate(subsets)):
                 offset = index[firstNonDimSet]
-                for i in xrange(1,len(subsets)):
+                for i in range(1,len(subsets)):
                     index[firstNonDimSet+i] = offset + cuts[i]
                 return val, index
         return None
@@ -3763,7 +3754,7 @@ class SetProduct_InfiniteSet(SetProduct):
         cutIters = [None] * (len(subsets)+1)
         cutPoints = [0] * (len(subsets)+1)
         i = 1
-        cutIters[i] = iter(xrange(val_len+1))
+        cutIters[i] = iter(range(val_len+1))
         cutPoints[-1] = val_len
         while i > 0:
             try:
@@ -3772,7 +3763,7 @@ class SetProduct_InfiniteSet(SetProduct):
                     if setDims[i] is not None:
                         cutIters[i+1] = iter((cutPoints[i]+setDims[i],))
                     else:
-                        cutIters[i+1] = iter(xrange(cutPoints[i], val_len+1))
+                        cutIters[i+1] = iter(range(cutPoints[i], val_len+1))
                     i += 1
                 elif cutPoints[i] > val_len:
                     i -= 1
@@ -3839,7 +3830,7 @@ class SetProduct_OrderedSet(_OrderedSetMixin, SetProduct_FiniteSet):
         val, cutPoints = found
         if cutPoints is not None:
             val = tuple( val[cutPoints[i]:cutPoints[i+1]]
-                          for i in xrange(len(self._sets)) )
+                          for i in range(len(self._sets)) )
         _idx = tuple(s.ord(val[i])-1 for i,s in enumerate(self._sets))
         _len = list(len(_) for _ in self._sets)
         _len.append(1)

--- a/pyomo/core/base/sos.py
+++ b/pyomo/core/base/sos.py
@@ -12,8 +12,6 @@ __all__ = ['SOSConstraint']
 
 import sys
 import logging
-import six
-from six.moves import zip, xrange
 
 from pyomo.common.log import is_debug_set
 from pyomo.common.timing import ConstructionTimer
@@ -244,7 +242,7 @@ class SOSConstraint(ActiveIndexedComponent):
                 else:
                     _sosSet = self._sosSet
 
-                for index, sosSet in six.iteritems(_sosSet):
+                for index, sosSet in _sosSet.items():
                     if generate_debug_messages:     #pragma:nocover
                         logger.debug("  Constructing "+self.name+" index "+str(index))
 
@@ -306,7 +304,7 @@ class SOSConstraint(ActiveIndexedComponent):
         soscondata.level = self._sosLevel
 
         if weights is None:
-            soscondata.set_items(variables, list(xrange(1, len(variables)+1)))
+            soscondata.set_items(variables, list(range(1, len(variables)+1)))
         else:
             soscondata.set_items(variables, weights)
 

--- a/pyomo/core/base/suffix.py
+++ b/pyomo/core/base/suffix.py
@@ -20,7 +20,6 @@ from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base.plugin import ModelComponentFactory
 from pyomo.core.base.component import ActiveComponent
 
-from six import iteritems, itervalues
 from pyomo.common.deprecation import deprecated
 
 logger = logging.getLogger('pyomo.core')
@@ -40,11 +39,11 @@ logger = logging.getLogger('pyomo.core')
 
 def active_export_suffix_generator(a_block, datatype=False):
     if (datatype is False):
-        for name, suffix in iteritems(a_block.component_map(Suffix, active=True)):
+        for name, suffix in a_block.component_map(Suffix, active=True).items():
             if suffix.export_enabled() is True:
                 yield name, suffix
     else:
-        for name, suffix in iteritems(a_block.component_map(Suffix, active=True)):
+        for name, suffix in a_block.component_map(Suffix, active=True).items():
             if (suffix.export_enabled() is True) and \
                (suffix.get_datatype() is datatype):
                 yield name, suffix
@@ -52,11 +51,11 @@ def active_export_suffix_generator(a_block, datatype=False):
 
 def export_suffix_generator(a_block, datatype=False):
     if (datatype is False):
-        for name, suffix in iteritems(a_block.component_map(Suffix)):
+        for name, suffix in a_block.component_map(Suffix).items():
             if suffix.export_enabled() is True:
                 yield name, suffix
     else:
-        for name, suffix in iteritems(a_block.component_map(Suffix)):
+        for name, suffix in a_block.component_map(Suffix).items():
             if (suffix.export_enabled() is True) and \
                (suffix.get_datatype() is datatype):
                 yield name, suffix
@@ -64,11 +63,11 @@ def export_suffix_generator(a_block, datatype=False):
 
 def active_import_suffix_generator(a_block, datatype=False):
     if (datatype is False):
-        for name, suffix in iteritems(a_block.component_map(Suffix, active=True)):
+        for name, suffix in a_block.component_map(Suffix, active=True).items():
             if suffix.import_enabled() is True:
                 yield name, suffix
     else:
-        for name, suffix in iteritems(a_block.component_map(Suffix, active=True)):
+        for name, suffix in a_block.component_map(Suffix, active=True).items():
             if (suffix.import_enabled() is True) and \
                (suffix.get_datatype() is datatype):
                 yield name, suffix
@@ -76,11 +75,11 @@ def active_import_suffix_generator(a_block, datatype=False):
 
 def import_suffix_generator(a_block, datatype=False):
     if (datatype is False):
-        for name, suffix in iteritems(a_block.component_map(Suffix)):
+        for name, suffix in a_block.component_map(Suffix).items():
             if suffix.import_enabled() is True:
                 yield name, suffix
     else:
-        for name, suffix in iteritems(a_block.component_map(Suffix)):
+        for name, suffix in a_block.component_map(Suffix).items():
             if (suffix.import_enabled() is True) and \
                (suffix.get_datatype() is datatype):
                 yield name, suffix
@@ -88,11 +87,11 @@ def import_suffix_generator(a_block, datatype=False):
 
 def active_local_suffix_generator(a_block, datatype=False):
     if (datatype is False):
-        for name, suffix in iteritems(a_block.component_map(Suffix, active=True)):
+        for name, suffix in a_block.component_map(Suffix, active=True).items():
             if suffix.get_direction() is Suffix.LOCAL:
                 yield name, suffix
     else:
-        for name, suffix in iteritems(a_block.component_map(Suffix, active=True)):
+        for name, suffix in a_block.component_map(Suffix, active=True).items():
             if (suffix.get_direction() is Suffix.LOCAL) and \
                (suffix.get_datatype() is datatype):
                 yield name, suffix
@@ -100,11 +99,11 @@ def active_local_suffix_generator(a_block, datatype=False):
 
 def local_suffix_generator(a_block, datatype=False):
     if (datatype is False):
-        for name, suffix in iteritems(a_block.component_map(Suffix)):
+        for name, suffix in a_block.component_map(Suffix).items():
             if suffix.get_direction() is Suffix.LOCAL:
                 yield name, suffix
     else:
-        for name, suffix in iteritems(a_block.component_map(Suffix)):
+        for name, suffix in a_block.component_map(Suffix).items():
             if (suffix.get_direction() is Suffix.LOCAL) and \
                (suffix.get_datatype() is datatype):
                 yield name, suffix
@@ -112,20 +111,20 @@ def local_suffix_generator(a_block, datatype=False):
 
 def active_suffix_generator(a_block, datatype=False):
     if (datatype is False):
-        for name, suffix in iteritems(a_block.component_map(Suffix, active=True)):
+        for name, suffix in a_block.component_map(Suffix, active=True).items():
             yield name, suffix
     else:
-        for name, suffix in iteritems(a_block.component_map(Suffix, active=True)):
+        for name, suffix in a_block.component_map(Suffix, active=True).items():
             if suffix.get_datatype() is datatype:
                 yield name, suffix
 
 
 def suffix_generator(a_block, datatype=False):
     if (datatype is False):
-        for name, suffix in iteritems(a_block.component_map(Suffix)):
+        for name, suffix in a_block.component_map(Suffix).items():
             yield name, suffix
     else:
-        for name, suffix in iteritems(a_block.component_map(Suffix)):
+        for name, suffix in a_block.component_map(Suffix).items():
             if suffix.get_datatype() is datatype:
                 yield name, suffix
 
@@ -264,7 +263,7 @@ class Suffix(ComponentMap, ActiveComponent):
         if expand:
 
             try:
-                items = iteritems(data)
+                items = data.items()
             except AttributeError:
                 items = data
 
@@ -293,7 +292,7 @@ class Suffix(ComponentMap, ActiveComponent):
         itself is kept.
         """
         if expand and component.is_indexed():
-            for component_ in itervalues(component):
+            for component_ in component.values():
                 self[component_] = value
         else:
             self[component] = value
@@ -320,7 +319,7 @@ class Suffix(ComponentMap, ActiveComponent):
         Clears suffix information for a component.
         """
         if expand and component.is_indexed():
-            for component_ in itervalues(component):
+            for component_ in component.values():
                 try:
                     del self[component_]
                 except KeyError:
@@ -412,7 +411,7 @@ class Suffix(ComponentMap, ActiveComponent):
             [('Direction', self.SuffixDirectionToStr[self._direction]),
              ('Datatype', self.SuffixDatatypeToStr[self._datatype]),
              ],
-            ((str(k), v) for k, v in itervalues(self._dict)),
+            ((str(k), v) for k, v in self._dict.values()),
             ("Value",),
             lambda k, v: [v]
         )

--- a/pyomo/core/base/units_container.py
+++ b/pyomo/core/base/units_container.py
@@ -1110,7 +1110,7 @@ external
                 # check if the unit is an offset unit and throw an exception if necessary
                 # TODO: should we prevent delta versions: delta_degC and delta_degF as well?
                 pint_unit_container = pint_module.util.to_units_container(pint_unit, pint_registry)
-                for (u, e) in six.iteritems(pint_unit_container):
+                for (u, e) in pint_unit_container.items():
                     if not pint_registry._units[u].is_multiplicative:
                         raise UnitsError('Pyomo units system does not support the offset units "{}".'
                                          ' Use absolute units (e.g. kelvin instead of degC) instead.'

--- a/pyomo/core/base/units_container.py
+++ b/pyomo/core/base/units_container.py
@@ -108,7 +108,6 @@ information.
 #    * Extend external function interface to support units for the arguments in addition to the function itself
 
 import logging
-import six
 import sys
 
 from pyomo.common.dependencies import attempt_import
@@ -370,10 +369,7 @@ class _PyomoUnit(NumericValue):
         retstr = u'{:!~C}'.format(self._pint_unit)
         if retstr == '':
             retstr = 'dimensionless'
-        if six.PY2:
-            return str(retstr.encode('utf8'))
-        else:
-            return retstr
+        return retstr
 
     def to_string(self, verbose=None, labeler=None, smap=None,
                   compute_values=False):

--- a/pyomo/core/base/util.py
+++ b/pyomo/core/base/util.py
@@ -13,21 +13,10 @@
 #
 import functools
 import inspect
-import six
 
-from six import iteritems, iterkeys
-from six.moves import xrange
-
-if six.PY2:
-    getargspec = inspect.getargspec
-    from collections import Sequence as collections_Sequence
-    from collections import Mapping as collections_Mapping
-else:
-    # For our needs, getfullargspec is a drop-in replacement for
-    # getargspec (which was removed in Python 3.x)
-    getargspec = inspect.getfullargspec
-    from collections.abc import Sequence as collections_Sequence
-    from collections.abc import Mapping as collections_Mapping
+getargspec = inspect.getfullargspec
+from collections.abc import Sequence as collections_Sequence
+from collections.abc import Mapping as collections_Mapping
 
 
 from pyomo.common import DeveloperError
@@ -82,10 +71,7 @@ def _disable_method(fcn, msg=None):
     # an error).  For backwards compatability with Python 2.x, we will
     # create a temporary (local) function using exec that matches the
     # function signature passed in and raises an exception
-    if six.PY2:
-        args = str(inspect.formatargspec(*getargspec(fcn)))
-    else:
-        args = str(inspect.signature(fcn))
+    args = str(inspect.signature(fcn))
     assert args == '(self)' or args.startswith('(self,')
 
     # lambda comes through with a function name "<lambda>".  We will
@@ -204,7 +190,7 @@ def Initializer(init,
     elif isinstance(init, collections_Mapping):
         return ItemInitializer(init)
     elif isinstance(init, collections_Sequence) \
-            and not isinstance(init, six.string_types):
+            and not isinstance(init, str):
         if treat_sequences_as_mappings:
             return ItemInitializer(init)
         else:
@@ -248,7 +234,7 @@ class InitializerBase(object):
         return {k:getattr(self,k) for k in self.__slots__}
 
     def __setstate__(self, state):
-        for key, val in iteritems(state):
+        for key, val in state.items():
             object.__setattr__(self, key, val)
 
     def constant(self):
@@ -299,9 +285,9 @@ class ItemInitializer(InitializerBase):
 
     def indices(self):
         try:
-            return iterkeys(self._dict)
+            return self._dict.keys()
         except AttributeError:
-            return xrange(len(self._dict))
+            return range(len(self._dict))
 
 
 class IndexedCallInitializer(InitializerBase):

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -559,7 +559,7 @@ class Var(IndexedComponent):
         """
         Set the 'stale' attribute of every variable data object to True.
         """
-        for var_data in self._data.items():
+        for var_data in self._data.values():
             var_data.stale = True
 
     def get_values(self, include_fixed_values=True):

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -26,10 +26,8 @@ from pyomo.core.base.set import Set, _SetDataBase
 from pyomo.core.base.units_container import units
 from pyomo.core.base.util import is_functor
 
-from six import iteritems, itervalues
-from six.moves import xrange
-
 logger = logging.getLogger('pyomo.core')
+
 
 class _VarData(ComponentData, NumericValue):
     """
@@ -561,7 +559,7 @@ class Var(IndexedComponent):
         """
         Set the 'stale' attribute of every variable data object to True.
         """
-        for var_data in itervalues(self._data):
+        for var_data in self._data.items():
             var_data.stale = True
 
     def get_values(self, include_fixed_values=True):
@@ -569,9 +567,9 @@ class Var(IndexedComponent):
         Return a dictionary of index-value pairs.
         """
         if include_fixed_values:
-            return {idx:vardata.value for idx,vardata in iteritems(self._data)}
+            return {idx:vardata.value for idx,vardata in self._data.items()}
         return {idx:vardata.value
-                            for idx, vardata in iteritems(self._data)
+                            for idx, vardata in self._data.items()
                                                 if not vardata.fixed}
 
     extract_values = get_values
@@ -583,7 +581,7 @@ class Var(IndexedComponent):
         The default behavior is to validate the values in the
         dictionary.
         """
-        for index, new_value in iteritems(new_values):
+        for index, new_value in new_values.items():
             self[index].set_value(new_value, valid)
 
     def get_units(self):
@@ -774,7 +772,7 @@ class Var(IndexedComponent):
         return ( [("Size", len(self)),
                   ("Index", self._index if self.is_indexed() else None),
                   ],
-                 iteritems(self._data),
+                 self._data.items(),
                  ( "Lower","Value","Upper","Fixed","Stale","Domain"),
                  lambda k, v: [ value(v.lb),
                                 v.value,
@@ -942,14 +940,14 @@ class IndexedVar(Var):
         """
         Set the lower bound for this variable.
         """
-        for vardata in itervalues(self):
+        for vardata in self.values():
             vardata.setlb(val)
 
     def setub(self, val):
         """
         Set the upper bound for this variable.
         """
-        for vardata in itervalues(self):
+        for vardata in self.values():
             vardata.setub(val)
 
     def fix(self, value=NoArgumentGiven):
@@ -957,12 +955,12 @@ class IndexedVar(Var):
         Set the fixed indicator to True. Value argument is optional,
         indicating the variable should be fixed at its current value.
         """
-        for vardata in itervalues(self):
+        for vardata in self.values():
             vardata.fix(value=value)
 
     def unfix(self):
         """Sets the fixed indicator to False."""
-        for vardata in itervalues(self):
+        for vardata in self.values():
             vardata.unfix()
 
     @property
@@ -974,7 +972,7 @@ class IndexedVar(Var):
     @domain.setter
     def domain(self, domain):
         """Sets the domain for all variables in this container."""
-        for vardata in itervalues(self):
+        for vardata in self.values():
             vardata.domain = domain
 
     free=unfix
@@ -1008,7 +1006,7 @@ class VarList(IndexedVar):
         # OR we can just add the correct number of sequential integers and
         # then let _validate_index complain when we set the value.
         if self._value_init_value.__class__ is dict:
-            for i in xrange(len(self._value_init_value)):
+            for i in range(len(self._value_init_value)):
                 self._index.add(i+1)
         super(VarList,self).construct(data)
         # Note that the current Var initializer silently ignores
@@ -1017,7 +1015,7 @@ class VarList(IndexedVar):
         # VarList (so we get potential domain errors), we will re-set
         # everything.
         if self._value_init_value.__class__ is dict:
-            for k,v in iteritems(self._value_init_value):
+            for k,v in self._value_init_value.items():
                 self[k] = v
 
     def add(self):

--- a/pyomo/core/beta/dict_objects.py
+++ b/pyomo/core/beta/dict_objects.py
@@ -24,14 +24,8 @@ from pyomo.core.base.objective import (IndexedObjective,
 from pyomo.core.base.expression import (IndexedExpression,
                                         _ExpressionData)
 
-import six
-
-if six.PY3:
-    from collections.abc import MutableMapping as collections_MutableMapping
-    from collections.abc import Mapping as collections_Mapping
-else:
-    from collections import MutableMapping as collections_MutableMapping
-    from collections import Mapping as collections_Mapping
+from collections.abc import MutableMapping as collections_MutableMapping
+from collections.abc import Mapping as collections_Mapping
 
 logger = logging.getLogger('pyomo.core')
 

--- a/pyomo/core/beta/list_objects.py
+++ b/pyomo/core/beta/list_objects.py
@@ -24,12 +24,7 @@ from pyomo.core.base.objective import (IndexedObjective,
 from pyomo.core.base.expression import (IndexedExpression,
                                         _ExpressionData)
 
-import six
-
-if six.PY3:
-    from collections.abc import MutableSequence as collections_MutableSequence
-else:
-    from collections import MutableSequence as collections_MutableSequence
+from collections.abc import MutableSequence as collections_MutableSequence
 
 logger = logging.getLogger('pyomo.core')
 

--- a/pyomo/core/beta/list_objects.py
+++ b/pyomo/core/beta/list_objects.py
@@ -24,7 +24,7 @@ from pyomo.core.base.objective import (IndexedObjective,
 from pyomo.core.base.expression import (IndexedExpression,
                                         _ExpressionData)
 
-from collections.abc import MutableSequence as collections_MutableSequence
+from collections.abc import MutableSequence
 
 logger = logging.getLogger('pyomo.core')
 
@@ -35,7 +35,7 @@ logger = logging.getLogger('pyomo.core')
 # be implemented on top of these classes.
 #
 
-class ComponentList(collections_MutableSequence):
+class ComponentList(MutableSequence):
 
     def __init__(self, interface_datatype, *args):
         self._interface_datatype = interface_datatype

--- a/pyomo/core/expr/boolean_value.py
+++ b/pyomo/core/expr/boolean_value.py
@@ -1,9 +1,7 @@
 import sys
 import logging
-from six import iteritems
 
 from pyomo.common.deprecation import deprecated
-from pyomo.core.expr.expr_errors import TemplateExpressionError
 from pyomo.core.expr.numvalue import native_types, native_logical_types
 from pyomo.core.expr.expr_common import _and, _or, _equiv, _inv, _xor, _impl
 from pyomo.core.pyomoobject import PyomoObject
@@ -76,7 +74,7 @@ class BooleanValue(PyomoObject):
         if hasattr(_base, '__setstate__'):
             return _base.__setstate__(state)
         else:
-            for key, val in iteritems(state):
+            for key, val in state.items():
                 # Note: per the Python data model docs, we explicitly
                 # set the attribute using object.__setattr__() instead
                 # of setting self.__dict__[key] = val.

--- a/pyomo/core/expr/cnf_walker.py
+++ b/pyomo/core/expr/cnf_walker.py
@@ -1,4 +1,13 @@
-from six import iterkeys
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
 
 from pyomo.common import DeveloperError
 from pyomo.common.collections import ComponentMap
@@ -60,7 +69,7 @@ class _PyomoSympyLogicalBimap(object):
         return sympy_obj
 
     def sympyVars(self):
-        return iterkeys(self.sympy2pyomo)
+        return self.sympy2pyomo.keys()
 
 
 class _Pyomo2SympyVisitor(StreamBasedExpressionVisitor):

--- a/pyomo/core/expr/numvalue.py
+++ b/pyomo/core/expr/numvalue.py
@@ -15,7 +15,6 @@ __all__ = ('value', 'is_constant', 'is_fixed', 'is_variable_type',
 
 import sys
 import logging
-from six import iteritems, PY3
 
 from pyomo.common.deprecation import deprecated
 from pyomo.core.expr.expr_common import \
@@ -99,12 +98,6 @@ native_integer_types = set([ int, bool ])
 native_boolean_types = set([ int, bool, str ])
 native_logical_types = {bool, }
 pyomo_constant_types = set()  # includes NumericConstant
-try:
-    native_numeric_types.add(long)
-    native_integer_types.add(long)
-    native_boolean_types.add(long)
-except:
-    pass
 
 #: Python set used to identify numeric constants and related native
 #: types.  This set includes
@@ -113,12 +106,9 @@ except:
 #:
 #: :data:`native_types` = :data:`native_numeric_types <pyomo.core.expr.numvalue.native_numeric_types>` + { str }
 native_types = set([ bool, str, type(None), slice ])
-if PY3:
-    native_types.add(bytes)
-    native_boolean_types.add(bytes)
-else:
-    native_types.add(unicode)
-    native_boolean_types.add(unicode)
+
+native_types.add(bytes)
+native_boolean_types.add(bytes)
 
 native_types.update( native_numeric_types )
 native_types.update( native_integer_types )
@@ -589,7 +579,7 @@ class NumericValue(PyomoObject):
         if hasattr(_base, '__setstate__'):
             return _base.__setstate__(state)
         else:
-            for key, val in iteritems(state):
+            for key, val in state.items():
                 # Note: per the Python data model docs, we explicitly
                 # set the attribute using object.__setattr__() instead
                 # of setting self.__dict__[key] = val.

--- a/pyomo/core/expr/symbol_map.py
+++ b/pyomo/core/expr/symbol_map.py
@@ -9,7 +9,7 @@
 #  ___________________________________________________________________________
 
 from weakref import ref as weakref_ref
-from six import iteritems
+
 
 class SymbolMap(object):
     """
@@ -52,9 +52,9 @@ class SymbolMap(object):
         #
         return {
             'bySymbol': tuple(
-                (key, obj()) for key, obj in iteritems(self.bySymbol) ),
+                (key, obj()) for key, obj in self.bySymbol.items() ),
             'aliases': tuple(
-                (key, obj()) for key, obj in iteritems(self.aliases) ),
+                (key, obj()) for key, obj in self.aliases.items() ),
         }
 
     def __setstate__(self, state):

--- a/pyomo/core/expr/sympy_tools.py
+++ b/pyomo/core/expr/sympy_tools.py
@@ -8,7 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from six import iterkeys
 from pyomo.common import DeveloperError
 from pyomo.common.collections import ComponentMap
 from pyomo.common.dependencies import attempt_import
@@ -128,7 +127,7 @@ class PyomoSympyBimap(object):
         return sympy_obj
 
     def sympyVars(self):
-        return iterkeys(self.sympy2pyomo)
+        return self.sympy2pyomo.keys()
 
 # =====================================================
 # sympyify_expression

--- a/pyomo/core/expr/template_expr.py
+++ b/pyomo/core/expr/template_expr.py
@@ -82,7 +82,7 @@ class GetItemExpression(ExpressionBase):
         # storage scheme), but as of now [30 Apr 20], there are no known
         # Components where this assumption will cause problems.
         return any( getattr(x, 'is_potentially_variable', _false)()
-                    for x in getattr(base, '_data', {})).values() 
+                    for x in getattr(base, '_data', {}).values() )
 
     def _is_fixed(self, values):
         if not all(values[1:]):

--- a/pyomo/core/expr/template_expr.py
+++ b/pyomo/core/expr/template_expr.py
@@ -12,8 +12,6 @@ import copy
 import itertools
 import logging
 import sys
-from six import itervalues
-from six.moves import builtins
 
 from pyomo.core.expr.expr_errors import TemplateExpressionError
 from pyomo.core.expr.numvalue import (
@@ -83,20 +81,20 @@ class GetItemExpression(ExpressionBase):
         # storage scheme), but as of now [30 Apr 20], there are no known
         # Components where this assumption will cause problems.
         return any( getattr(x, 'is_potentially_variable', _false)()
-                    for x in itervalues(getattr(base, '_data', {})) )
+                    for x in getattr(base, '_data', {})).values() 
 
     def _is_fixed(self, values):
         if not all(values[1:]):
             return False
         _true = lambda: True
         return all( getattr(x, 'is_fixed', _true)()
-                    for x in itervalues(values[0]) )
+                    for x in values[0].values() )
 
     def _compute_polynomial_degree(self, result):
         if any(x != 0 for x in result[1:]):
             return None
         ans = 0
-        for x in itervalues(result[0]):
+        for x in result[0].values():
             if x.__class__ in nonpyomo_leaf_types \
                or not hasattr(x, 'polynomial_degree'):
                 continue

--- a/pyomo/core/expr/template_expr.py
+++ b/pyomo/core/expr/template_expr.py
@@ -12,6 +12,7 @@ import copy
 import itertools
 import logging
 import sys
+import builtins
 
 from pyomo.core.expr.expr_errors import TemplateExpressionError
 from pyomo.core.expr.numvalue import (

--- a/pyomo/core/expr/visitor.py
+++ b/pyomo/core/expr/visitor.py
@@ -12,16 +12,10 @@ from __future__ import division
 
 import inspect
 import logging
-import six
 from copy import deepcopy
 from collections import deque
 
-if six.PY2:
-    getargspec = inspect.getargspec
-else:
-    # For our needs, getfullargspec is a drop-in replacement for
-    # getargspec (which was removed in Python 3.x)
-    getargspec = inspect.getfullargspec
+getargspec = inspect.getfullargspec
 
 logger = logging.getLogger('pyomo.core')
 
@@ -29,11 +23,6 @@ from .symbol_map import SymbolMap
 from . import expr_common as common
 from .expr_errors import TemplateExpressionError
 from pyomo.common.deprecation import deprecation_warning
-
-from pyomo.core.expr.boolean_value import (
-    BooleanValue,)
-
-
 from pyomo.core.expr.numvalue import (
     nonpyomo_leaf_types,
     native_numeric_types,

--- a/pyomo/core/plugins/transform/add_slack_vars.py
+++ b/pyomo/core/plugins/transform/add_slack_vars.py
@@ -10,8 +10,6 @@
 
 from pyomo.core import TransformationFactory, Var, NonNegativeReals, Constraint, Objective, Block, value
 
-from six import iterkeys
-
 from pyomo.common.modeling import unique_component_name
 from pyomo.core.plugins.transform.hierarchy import NonIsomorphicTransformation
 from pyomo.common.config import ConfigBlock, ConfigValue

--- a/pyomo/core/plugins/transform/discrete_vars.py
+++ b/pyomo/core/plugins/transform/discrete_vars.py
@@ -11,8 +11,6 @@
 import logging
 logger = logging.getLogger('pyomo.core')
 
-from six import itervalues
-
 from pyomo.common import deprecated
 from pyomo.core.base import (
     Transformation,
@@ -37,7 +35,7 @@ class RelaxIntegerVars(Transformation):
     def _apply_to(self, model, **kwds):
         options = kwds.pop('options', {})
         if kwds.get('undo', options.get('undo', False)):
-            for v, d in itervalues(model._relaxed_integer_vars[None]):
+            for v, d in model._relaxed_integer_vars[None].values():
                 bounds = v.bounds
                 v.domain = d
                 v.setlb(bounds[0])

--- a/pyomo/core/plugins/transform/expand_connectors.py
+++ b/pyomo/core/plugins/transform/expand_connectors.py
@@ -230,7 +230,7 @@ class ExpandConnectors(Transformation):
 
         # as we are adding things to the model, sort by key so that
         # the order things are added is deterministic
-        sorted_refs = sorted(ref.item())
+        sorted_refs = sorted(ref.items())
         if len(empty_or_partial) > 1:
             # This is expensive (names aren't cheap), but does result in
             # a deterministic ordering

--- a/pyomo/core/plugins/transform/expand_connectors.py
+++ b/pyomo/core/plugins/transform/expand_connectors.py
@@ -11,8 +11,6 @@
 import logging
 logger = logging.getLogger('pyomo.core')
 
-from six import next, iteritems, itervalues
-
 from pyomo.common.collections import ComponentMap, ComponentSet
 from pyomo.common.log import is_debug_set
 from pyomo.core.expr import current as EXPR
@@ -111,7 +109,7 @@ class ExpandConnectors(Transformation):
 
         # Validate all connector sets and expand the empty ones
         known_conn_sets = {}
-        for groupID, conn_set in sorted(itervalues(connector_groups)):
+        for groupID, conn_set in sorted(connector_groups.values()):
             known_conn_sets[id(conn_set)] \
                 = self._validate_and_expand_connector_set(conn_set)
 
@@ -124,7 +122,7 @@ class ExpandConnectors(Transformation):
                 cList )
             connId = next(iter(conn_set))
             ref = known_conn_sets[id(matched_connectors[connId])]
-            for k,v in sorted(iteritems(ref)):
+            for k,v in sorted(ref.items()):
                 if v[1] >= 0:
                     _iter = v[0]
                 else:
@@ -148,7 +146,7 @@ class ExpandConnectors(Transformation):
         # Now, go back and implement VarList aggregators
         for conn in connector_list:
             block = conn.parent_block()
-            for var, aggregator in iteritems(conn.aggregators):
+            for var, aggregator in conn.aggregators.items():
                 c = Constraint(expr=aggregator(block, conn.vars[var]))
                 block.add_component(
                     '%s.%s.aggregate' % (
@@ -162,7 +160,7 @@ class ExpandConnectors(Transformation):
         ref = {}
         # First, go through the connectors and get the superset of all fields
         for c in connectors:
-            for k,v in iteritems(c.vars):
+            for k,v in c.vars.items():
                 if k in ref:
                     # We have already seen this var
                     continue
@@ -194,7 +192,7 @@ class ExpandConnectors(Transformation):
                 empty_or_partial.append(c)
                 continue
 
-            for k,v in iteritems(ref):
+            for k,v in ref.items():
                 if k not in c.vars:
                     raise ValueError(
                         "Connector mismatch: Connector '%s' missing variable "
@@ -232,7 +230,7 @@ class ExpandConnectors(Transformation):
 
         # as we are adding things to the model, sort by key so that
         # the order things are added is deterministic
-        sorted_refs = sorted(iteritems(ref))
+        sorted_refs = sorted(ref.item())
         if len(empty_or_partial) > 1:
             # This is expensive (names aren't cheap), but does result in
             # a deterministic ordering

--- a/pyomo/core/plugins/transform/model.py
+++ b/pyomo/core/plugins/transform/model.py
@@ -18,8 +18,6 @@
 from pyomo.core.base import Objective, Constraint
 import array
 
-from six.moves import xrange
-
 def to_standard_form(self):
     """
     Produces a standard-form representation of the model. Returns
@@ -309,12 +307,12 @@ def to_standard_form(self):
         if len(tmp_name) > maxColWidth:
             maxColWidth = len(tmp_name)
         varNames[colID[name]] = tmp_name
-    for i in xrange(0, nSlack):
+    for i in range(0, nSlack):
         tmp_name = " _slack_%i" % i
         if len(tmp_name) > maxColWidth:
             maxColWidth = len(tmp_name)
         varNames.append(tmp_name)
-    for i in xrange(0, nExcess):
+    for i in range(0, nExcess):
         tmp_name = " _excess_%i" % i
         if len(tmp_name) > maxColWidth:
             maxColWidth = len(tmp_name)
@@ -322,7 +320,7 @@ def to_standard_form(self):
 
     # Variable names
     line = " "*maxConNameLen + (" "*constraintPadding) + " "
-    for col in xrange(0, nVariables):
+    for col in range(0, nVariables):
         # Format entry
         token = varNames[col]
 
@@ -337,7 +335,7 @@ def to_standard_form(self):
     print(" "*maxConNameLen + (" "*constraintPadding) + "+--" + \
           " "*((maxColWidth+2)*nVariables - 4) + "--+" + '\n')
     line = " "*maxConNameLen + (" "*constraintPadding) + "|"
-    for col in xrange(0, nVariables):
+    for col in range(0, nVariables):
         # Format entry
         token = numFmt % costs[col]
         if len(token) > maxColWidth:
@@ -358,12 +356,12 @@ def to_standard_form(self):
           " "*((maxColWidth+2)*nVariables - 4) + "--+" + \
           (" "*constraintPadding) + "+--" + \
           (" "*(maxConstraintColWidth-1)) + "--+"+'\n')
-    for row in xrange(0, nConstraints):
+    for row in range(0, nConstraints):
         # Print constraint name
         line = conNames[row] + (" "*constraintPadding) + (" "*(maxConNameLen - len(conNames[row]))) + "|"
 
         # Print each coefficient
-        for col in xrange(0, nVariables):
+        for col in range(0, nVariables):
             # Format entry
             token = numFmt % coefficients[nVariables*row + col]
             if len(token) > maxColWidth:

--- a/pyomo/core/plugins/transform/radix_linearization.py
+++ b/pyomo/core/plugins/transform/radix_linearization.py
@@ -14,8 +14,6 @@ from pyomo.core.base import Transformation, TransformationFactory, Var, Constrai
 from pyomo.core.base.numvalue import as_numeric
 from pyomo.core.base.var import _VarData
 
-from six import iteritems
-
 import logging
 logger = logging.getLogger(__name__)
 
@@ -137,7 +135,7 @@ class RadixLinearization(Transformation):
                          bounds=(0,2**-precision) )
 
         # Actually discretize the terms we have marked for discretization
-        for _id, _idx in iteritems(_discretize):
+        for _id, _idx in _discretize.items():
             if verbose:
                 logger.info("Discretizing variable %s as %s" %
                             (_counts[_id][0].name, _idx))

--- a/pyomo/core/tests/examples/test_convert.py
+++ b/pyomo/core/tests/examples/test_convert.py
@@ -25,7 +25,7 @@ import pyutilib.th as unittest
 import pyomo.scripting.convert as main
 from pyomo.common.tee import capture_output
 
-from six import StringIO
+from io import StringIO
 
 if os.path.exists(sys.exec_prefix+os.sep+'bin'+os.sep+'coverage'):
     executable=sys.exec_prefix+os.sep+'bin'+os.sep+'coverage -x '

--- a/pyomo/core/tests/examples/test_pyomo.py
+++ b/pyomo/core/tests/examples/test_pyomo.py
@@ -26,7 +26,7 @@ import pyomo.core
 import pyomo.scripting.pyomo_main as main
 from pyomo.opt import check_available_solvers
 
-from six import StringIO
+from io import StringIO
 
 if os.path.exists(sys.exec_prefix+os.sep+'bin'+os.sep+'coverage'):
     executable=sys.exec_prefix+os.sep+'bin'+os.sep+'coverage -x '

--- a/pyomo/core/tests/transform/test_add_slacks.py
+++ b/pyomo/core/tests/transform/test_add_slacks.py
@@ -12,7 +12,7 @@ import os
 from os.path import abspath, dirname
 currdir = dirname(abspath(__file__))+os.sep
 
-from six import StringIO
+from io import StringIO
 from pyomo.common.log import LoggingIntercept
 
 import pyutilib.th as unittest

--- a/pyomo/core/tests/unit/test_action.py
+++ b/pyomo/core/tests/unit/test_action.py
@@ -15,7 +15,7 @@
 # Array1                    Test arrays of parameters
 #
 
-from six import StringIO
+from io import StringIO
 import os
 
 import pyutilib.th as unittest

--- a/pyomo/core/tests/unit/test_base_misc.py
+++ b/pyomo/core/tests/unit/test_base_misc.py
@@ -11,7 +11,7 @@
 #
 # Unit Tests for pyomo.base.misc
 #
-from six import StringIO, iteritems
+from io import StringIO
 
 import pyutilib.th as unittest
 
@@ -23,7 +23,7 @@ class TestTabularWriter(unittest.TestCase):
         # table alignment
         os = StringIO()
         data = {1: ("a", 1), (2,3): ("∧", 2)}
-        tabular_writer(os, "", iteritems(data), ["s", "val"], lambda k,v: v)
+        tabular_writer(os, "", data.items(), ["s", "val"], lambda k,v: v)
         ref = u"""
 Key    : s : val
      1 : a :   1

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -11,12 +11,10 @@
 # Unit Tests for Elements of a Block
 #
 
+import io
 import os
 import sys
-import six
 import types
-
-from six import StringIO, iterkeys
 
 from copy import deepcopy
 from os.path import abspath, dirname, join
@@ -770,7 +768,7 @@ class TestBlock(unittest.TestCase):
         b.clear()
         b.transfer_attributes_from(c)
         self.assertEqual(list(b.component_map()), ['y','x','z'])
-        self.assertEqual(sorted(list(iterkeys(c))), ['x','y','z'])
+        self.assertEqual(sorted(list(c.keys())), ['x','y','z'])
         self.assertIs(b.x, c['x'])
         self.assertIsNot(b.y, c['y'])
         self.assertIs(b.y, b_y)
@@ -1174,7 +1172,7 @@ class TestBlock(unittest.TestCase):
         self.assertEqual( [], list(m.component_map(Constraint)) )
 
     def test_replace_attribute_with_component(self):
-        OUTPUT = StringIO()
+        OUTPUT = io.StringIO()
         with LoggingIntercept(OUTPUT, 'pyomo.core'):
             self.block.x = 5
             self.block.x = Var()
@@ -1182,7 +1180,7 @@ class TestBlock(unittest.TestCase):
                       OUTPUT.getvalue())
 
     def test_replace_component_with_component(self):
-        OUTPUT = StringIO()
+        OUTPUT = io.StringIO()
         with LoggingIntercept(OUTPUT, 'pyomo.core'):
             self.block.x = Var()
             self.block.x = Var()
@@ -1362,7 +1360,7 @@ class TestBlock(unittest.TestCase):
         def assertWorks(self, key, pm):
             self.assertIs(pm[key.local_name], key)
         def assertFails(self, key, pm):
-            if not isinstance(key, six.string_types):
+            if not isinstance(key, str):
                 key = key.local_name
             self.assertRaises(KeyError, pm.__getitem__, key)
 
@@ -2063,7 +2061,7 @@ class TestBlock(unittest.TestCase):
         m.b.c = Constraint(expr=m.x**2 + m.y[1] + m.b.x**2 + m.b.y[1] <= 10)
 
         # Check the paranoid warning
-        OUTPUT = StringIO()
+        OUTPUT = io.StringIO()
         with LoggingIntercept(OUTPUT, 'pyomo.core'):
             nb = deepcopy(m.b)
         # without the scope, the whole model is cloned!
@@ -2076,7 +2074,7 @@ class TestBlock(unittest.TestCase):
         self.assertFalse(hasattr(nb, 'bad2'))
 
         # Simple tests for the subblock
-        OUTPUT = StringIO()
+        OUTPUT = io.StringIO()
         with LoggingIntercept(OUTPUT, 'pyomo.core'):
             nb = m.b.clone()
         self.assertNotIn("'unknown' contains an uncopyable field 'bad1'",
@@ -2088,7 +2086,7 @@ class TestBlock(unittest.TestCase):
         self.assertFalse(hasattr(nb, 'bad2'))
 
         # more involved tests for the model
-        OUTPUT = StringIO()
+        OUTPUT = io.StringIO()
         with LoggingIntercept(OUTPUT, 'pyomo.core'):
             n = m.clone()
         self.assertIn("'unknown' contains an uncopyable field 'bad1'",
@@ -2163,7 +2161,7 @@ class TestBlock(unittest.TestCase):
 
     def test_pprint(self):
         m = HierarchicalModel().model
-        buf = StringIO()
+        buf = io.StringIO()
         m.pprint(ostream=buf)
         ref = """3 Set Declarations
     a1_IDX : Size=1, Index=None, Ordered=Insertion
@@ -2435,7 +2433,7 @@ class TestBlock(unittest.TestCase):
 
         correct_s = 'Testing pprint of a custom block.'
         b = TempBlock(concrete=True)
-        stream = StringIO()
+        stream = io.StringIO()
         b.pprint(ostream=stream)
         self.assertEqual(correct_s, stream.getvalue())
 
@@ -2572,7 +2570,7 @@ class TestBlock(unittest.TestCase):
         m = ConcreteModel()
         def b_rule(b, a=None):
             b.p = Param(initialize=a)
-        OUTPUT = StringIO()
+        OUTPUT = io.StringIO()
         with LoggingIntercept(OUTPUT, 'pyomo.core'):
             m.b = Block(rule=b_rule, options={'a': 5})
         self.assertIn("The Block 'options=' keyword is deprecated.",
@@ -2582,7 +2580,7 @@ class TestBlock(unittest.TestCase):
         m = ConcreteModel()
         def b_rule(b, i, **kwds):
             b.p = Param(initialize=kwds.get('a', {}).get(i, 0))
-        OUTPUT = StringIO()
+        OUTPUT = io.StringIO()
         with LoggingIntercept(OUTPUT, 'pyomo.core'):
             m.b = Block([1,2,3], rule=b_rule, options={'a': {1:5, 2:10}})
         self.assertIn("The Block 'options=' keyword is deprecated.",

--- a/pyomo/core/tests/unit/test_check.py
+++ b/pyomo/core/tests/unit/test_check.py
@@ -16,7 +16,7 @@
 #
 
 import os
-from six import StringIO
+from io import StringIO
 
 import pyutilib.th as unittest
 

--- a/pyomo/core/tests/unit/test_component.py
+++ b/pyomo/core/tests/unit/test_component.py
@@ -10,13 +10,13 @@
 #
 # Unit Tests for components
 #
-from six import StringIO
+from io import StringIO
 import pyutilib.th as unittest
 
 from pyomo.common import DeveloperError
 import pyomo.core.base._pyomo
 from pyomo.environ import (
-    ConcreteModel, Component, Block, Var, Set, Param,
+    ConcreteModel, Component, Block, Var, Set,
 )
 
 class TestComponent(unittest.TestCase):

--- a/pyomo/core/tests/unit/test_componentuid.py
+++ b/pyomo/core/tests/unit/test_componentuid.py
@@ -13,7 +13,7 @@
 import pickle
 from collections import namedtuple
 from datetime import datetime
-from six import StringIO, itervalues
+from io import StringIO
 
 import pyutilib.th as unittest
 from pyomo.environ import (
@@ -275,14 +275,14 @@ class TestComponentUID(unittest.TestCase):
         cuid = ComponentUID('b:1,$2.c.a:*')
         comp = cuid.find_component_on(self.m)
         self.assertIs(comp.ctype, Param)
-        cList = list(itervalues(comp))
+        cList = list(comp.values())
         self.assertEqual(len(cList), 3)
         self.assertEqual(cList, list(self.m.b[1,'2'].c.a[:]))
 
         cuid = ComponentUID('b[*,*]')
         comp = cuid.find_component_on(self.m)
         self.assertIs(comp.ctype, Block)
-        cList = list(itervalues(comp))
+        cList = list(comp.values())
         self.assertEqual(len(cList), 9)
         self.assertEqual(cList, list(self.m.b.values()))
 
@@ -291,7 +291,7 @@ class TestComponentUID(unittest.TestCase):
         cuid = ComponentUID('b[*,*].c.a[**]')
         comp = cuid.find_component_on(self.m)
         self.assertIs(comp.ctype, Param)
-        cList = list(itervalues(comp))
+        cList = list(comp.values())
         self.assertEqual(len(cList), 3)
         self.assertEqual(cList, list(self.m.b[1,'2'].c.a[:]))
 
@@ -299,7 +299,7 @@ class TestComponentUID(unittest.TestCase):
         cuid = ComponentUID('b[*,*].c.a')
         comp = cuid.find_component_on(self.m)
         self.assertIs(comp.ctype, IndexedComponent)
-        cList = list(itervalues(comp))
+        cList = list(comp.values())
         self.assertEqual(len(cList), 1)
         self.assertIs(cList[0], self.m.b[1,'2'].c.a)
 

--- a/pyomo/core/tests/unit/test_componentuid.py
+++ b/pyomo/core/tests/unit/test_componentuid.py
@@ -11,7 +11,6 @@
 # Unit Tests for ComponentUID
 #
 import pickle
-import sys
 from collections import namedtuple
 from datetime import datetime
 from six import StringIO, itervalues
@@ -1266,6 +1265,7 @@ class TestComponentUID(unittest.TestCase):
                 "with argument \('foo',\)" % (
                     IndexedComponent_slice.del_attribute,)):
             cuid = ComponentUID(_slice)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/core/tests/unit/test_connector.py
+++ b/pyomo/core/tests/unit/test_connector.py
@@ -19,7 +19,7 @@ from os.path import abspath, dirname
 currdir = dirname(abspath(__file__))+os.sep
 
 import pyutilib.th as unittest
-from six import StringIO
+from io import StringIO
 
 from pyomo.environ import ConcreteModel, AbstractModel, Connector, Var, NonNegativeReals, Set, Constraint, TransformationFactory, Binary, Reals, VarList
 

--- a/pyomo/core/tests/unit/test_deprecation.py
+++ b/pyomo/core/tests/unit/test_deprecation.py
@@ -12,7 +12,7 @@ import pyutilib.th as unittest
 import sys
 
 from importlib import import_module
-from six import StringIO
+from io import StringIO
 
 from pyomo.common.log import LoggingIntercept
 

--- a/pyomo/core/tests/unit/test_expression.py
+++ b/pyomo/core/tests/unit/test_expression.py
@@ -10,7 +10,7 @@
 
 import copy
 
-from six import StringIO
+from io import StringIO
 from pyomo.core.expr import expr_common
 
 

--- a/pyomo/core/tests/unit/test_logical_expr.py
+++ b/pyomo/core/tests/unit/test_logical_expr.py
@@ -13,7 +13,7 @@
 
 import pickle
 import os
-import six
+import io
 import sys
 from os.path import abspath, dirname
 currdir = dirname(abspath(__file__))+os.sep
@@ -676,7 +676,7 @@ class TestMultiArgumentExpressions(unittest.TestCase):
             return inequality(m.vmin[i]**2, m.v[i], m.vmax[i]**2)
         m.con = Constraint(m.s, rule=_con)
 
-        OUT = six.StringIO()
+        OUT = io.StringIO()
         for i in m.s:
             OUT.write(str(_con(m,i)))
             OUT.write("\n")

--- a/pyomo/core/tests/unit/test_logical_expr_expanded.py
+++ b/pyomo/core/tests/unit/test_logical_expr_expanded.py
@@ -1,15 +1,22 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
 # -*- coding: utf-8 -*-
 """
 Testing for the logical expression system
 """
 from __future__ import division
 import operator
-import platform
-import sys
 from itertools import product
 
 import pyutilib.th as unittest
-import six
 
 from pyomo.core.expr.cnf_walker import to_cnf
 from pyomo.core.expr.sympy_tools import sympy_available
@@ -277,17 +284,9 @@ class TestLogicalClasses(unittest.TestCase):
 
         # These errors differ between python versions, regrettably
         comparison_error_msg = "(?:(?:unorderable types)|(?:not supported between instances of))"
-        if six.PY3:
-            for invalid_expr_fcn in invalid_comparison_generator():
-                with self.assertRaisesRegex(TypeError, comparison_error_msg):
-                    _ = invalid_expr_fcn()
-        else:  # Python 2
-            pass
-            # Note: Python 2 behavior is weird, returning native type bool:
-            # m.Y1 >= 0  -> True
-            # m.Y1 <= 0  -> False
-            # m.Y1 > 0   -> True
-            # m.Y1 < 0   -> False
+        for invalid_expr_fcn in invalid_comparison_generator():
+            with self.assertRaisesRegex(TypeError, comparison_error_msg):
+                _ = invalid_expr_fcn()
 
     def test_invalid_conversion(self):
         m = ConcreteModel()

--- a/pyomo/core/tests/unit/test_misc.py
+++ b/pyomo/core/tests/unit/test_misc.py
@@ -22,7 +22,7 @@ from pyomo.core import (AbstractModel, ConcreteModel, Block, Set, Param, Var,
                         Objective, Constraint, Reals, display)
 from pyomo.common.tee import capture_output
 
-from six import StringIO
+from io import StringIO
 
 def rule1(model):
     return (1,model.x+model.y[1],2)

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -35,7 +35,7 @@ from pyomo.common.log import LoggingIntercept
 from pyomo.common.tempfiles import TempfileManager
 from pyomo.core.base.param import _NotValid, _ParamData 
 
-from six import iteritems, itervalues, StringIO
+from io import StringIO
 
 class ParamTester(object):
 
@@ -116,7 +116,7 @@ class ParamTester(object):
             pass
 
     def test_getitem(self):
-        for key, val in iteritems(self.data):
+        for key, val in self.data.items():
             try:
                 test = self.instance.A[key]
                 self.assertEqual( value(test), val )
@@ -340,7 +340,7 @@ class ParamTester(object):
         #                  not self.instance.A._default_val is None and \
         #                  not self.instance.A.mutable
         try:
-            test = itervalues(self.instance.A)
+            test = self.instance.A.values()
             test = zip(self.instance.A.keys(), test)
             if self.instance.A._default_val is _NotValid:
                 self.validateDict(self.sparse_data.items(), test)
@@ -357,7 +357,7 @@ class ParamTester(object):
         #                  not self.instance.A._default_val is None and \
         #                  not self.instance.A.mutable
         try:
-            test = iteritems(self.instance.A)
+            test = self.instance.A.items()
             if self.instance.A._default_val is _NotValid:
                 self.validateDict(self.sparse_data.items(), test)
             else:

--- a/pyomo/core/tests/unit/test_pickle.py
+++ b/pyomo/core/tests/unit/test_pickle.py
@@ -12,7 +12,6 @@
 #
 
 import pickle
-import six
 import os
 import sys
 from os.path import abspath, dirname
@@ -306,9 +305,7 @@ class Test(unittest.TestCase):
         model.con = Constraint(rule=rule1)
         model.con2 = Constraint(model.a, rule=rule2)
         instance = model.create_instance()
-        if (not six.PY3) and ('dill' in sys.modules):
-            pickle.dumps(instance)
-        elif using_pypy:
+        if using_pypy:
             str_ = pickle.dumps(instance)
             tmp_ = pickle.loads(str_)
         else:

--- a/pyomo/core/tests/unit/test_reference.py
+++ b/pyomo/core/tests/unit/test_reference.py
@@ -16,12 +16,12 @@ from os.path import abspath, dirname
 currdir = dirname(abspath(__file__))+os.sep
 
 import pyutilib.th as unittest
-from six import itervalues, StringIO, iterkeys, iteritems
+from io import StringIO
 
 from pyomo.environ import (
     ConcreteModel, Block, Var, Set, RangeSet, Param, value,
 )
-from pyomo.common.collections import OrderedDict, ComponentSet
+from pyomo.common.collections import ComponentSet
 from pyomo.core.base.var import IndexedVar
 from pyomo.core.base.set import SetProduct, UnorderedSetOf
 from pyomo.core.base.indexed_component import (
@@ -124,16 +124,16 @@ class TestReferenceDict(unittest.TestCase):
         rd = _ReferenceDict(m.b[:,4].x[8,:])
 
         self.assertEqual(
-            list(iterkeys(rd)),
+            list(rd.keys()),
             [(1,10), (1,11), (2,10), (2,11)]
         )
         self.assertEqual(
-            list(itervalues(rd)),
+            list(rd.values()),
             [m.b[1,4].x[8,10], m.b[1,4].x[8,11],
              m.b[2,4].x[8,10], m.b[2,4].x[8,11]]
         )
         self.assertEqual(
-            list(iteritems(rd)),
+            list(rd.items()),
             [((1,10), m.b[1,4].x[8,10]),
              ((1,11), m.b[1,4].x[8,11]),
              ((2,10), m.b[2,4].x[8,10]),
@@ -144,86 +144,86 @@ class TestReferenceDict(unittest.TestCase):
         m = self.m
 
         rd = _ReferenceDict(m.b[:,:].x[:,:])
-        self.assertEqual( sum(x.value for x in itervalues(rd)), 0 )
+        self.assertEqual( sum(x.value for x in rd.values()), 0 )
         rd[1,5,7,10] = 10
         self.assertEqual( m.b[1,5].x[7,10].value, 10 )
-        self.assertEqual( sum(x.value for x in itervalues(rd)), 10 )
+        self.assertEqual( sum(x.value for x in rd.values()), 10 )
 
         rd = _ReferenceDict(m.b[:,4].x[8,:])
-        self.assertEqual( sum(x.value for x in itervalues(rd)), 0 )
+        self.assertEqual( sum(x.value for x in rd.values()), 0 )
         rd[1,10] = 20
         self.assertEqual( m.b[1,4].x[8,10].value, 20 )
-        self.assertEqual( sum(x.value for x in itervalues(rd)), 20 )
+        self.assertEqual( sum(x.value for x in rd.values()), 20 )
 
     def test_attribute_assignment(self):
         m = self.m
 
         rd = _ReferenceDict(m.b[:,:].x[:,:].value)
-        self.assertEqual( sum(x for x in itervalues(rd)), 0 )
+        self.assertEqual( sum(x for x in rd.values()), 0 )
         rd[1,5,7,10] = 10
         self.assertEqual( m.b[1,5].x[7,10].value, 10 )
-        self.assertEqual( sum(x for x in itervalues(rd)), 10 )
+        self.assertEqual( sum(x for x in rd.values()), 10 )
 
         rd = _ReferenceDict(m.b[:,4].x[8,:].value)
-        self.assertEqual( sum(x for x in itervalues(rd)), 0 )
+        self.assertEqual( sum(x for x in rd.values()), 0 )
         rd[1,10] = 20
         self.assertEqual( m.b[1,4].x[8,10].value, 20 )
-        self.assertEqual( sum(x for x in itervalues(rd)), 20 )
+        self.assertEqual( sum(x for x in rd.values()), 20 )
 
         m.x = Var([1,2], initialize=0)
         rd = _ReferenceDict(m.x[:])
-        self.assertEqual( sum(x.value for x in itervalues(rd)), 0 )
+        self.assertEqual( sum(x.value for x in rd.values()), 0 )
         rd[2] = 10
         self.assertEqual( m.x[1].value, 0 )
         self.assertEqual( m.x[2].value, 10 )
-        self.assertEqual( sum(x.value for x in itervalues(rd)), 10 )
+        self.assertEqual( sum(x.value for x in rd.values()), 10 )
 
     def test_single_attribute_assignment(self):
         m = self.m
 
         rd = _ReferenceDict(m.b[1,5].x[:,:])
-        self.assertEqual( sum(x.value for x in itervalues(rd)), 0 )
+        self.assertEqual( sum(x.value for x in rd.values()), 0 )
         rd[7,10].value = 10
         self.assertEqual( m.b[1,5].x[7,10].value, 10 )
-        self.assertEqual( sum(x.value for x in itervalues(rd)), 10 )
+        self.assertEqual( sum(x.value for x in rd.values()), 10 )
 
         rd = _ReferenceDict(m.b[1,4].x[8,:])
-        self.assertEqual( sum(x.value for x in itervalues(rd)), 0 )
+        self.assertEqual( sum(x.value for x in rd.values()), 0 )
         rd[10].value = 20
         self.assertEqual( m.b[1,4].x[8,10].value, 20 )
-        self.assertEqual( sum(x.value for x in itervalues(rd)), 20 )
+        self.assertEqual( sum(x.value for x in rd.values()), 20 )
 
     def test_nested_attribute_assignment(self):
         m = self.m
 
         rd = _ReferenceDict(m.b[:,:].x[:,:])
-        self.assertEqual( sum(x.value for x in itervalues(rd)), 0 )
+        self.assertEqual( sum(x.value for x in rd.values()), 0 )
         rd[1,5,7,10].value = 10
         self.assertEqual( m.b[1,5].x[7,10].value, 10 )
-        self.assertEqual( sum(x.value for x in itervalues(rd)), 10 )
+        self.assertEqual( sum(x.value for x in rd.values()), 10 )
 
         rd = _ReferenceDict(m.b[:,4].x[8,:])
-        self.assertEqual( sum(x.value for x in itervalues(rd)), 0 )
+        self.assertEqual( sum(x.value for x in rd.values()), 0 )
         rd[1,10].value = 20
         self.assertEqual( m.b[1,4].x[8,10].value, 20 )
-        self.assertEqual( sum(x.value for x in itervalues(rd)), 20 )
+        self.assertEqual( sum(x.value for x in rd.values()), 20 )
 
     def test_single_deletion(self):
         m = self.m
 
         rd = _ReferenceDict(m.b[1,5].x[:,:])
-        self.assertEqual(len(list(x.value for x in itervalues(rd))), 2*2)
+        self.assertEqual(len(list(x.value for x in rd.values())), 2*2)
         self.assertTrue((7,10) in rd)
         del rd[7,10]
         self.assertFalse((7,10) in rd)
-        self.assertEqual(len(list(x.value for x in itervalues(rd))), 3)
+        self.assertEqual(len(list(x.value for x in rd.values())), 3)
 
         rd = _ReferenceDict(m.b[1,4].x[8,:])
-        self.assertEqual(len(list(x.value for x in itervalues(rd))), 2)
+        self.assertEqual(len(list(x.value for x in rd.values())), 2)
         self.assertTrue((10) in rd)
         del rd[10]
         self.assertFalse(10 in rd)
-        self.assertEqual(len(list(x.value for x in itervalues(rd))), 2-1)
+        self.assertEqual(len(list(x.value for x in rd.values())), 2-1)
 
         with self.assertRaisesRegexp(
                 KeyError,
@@ -241,25 +241,25 @@ class TestReferenceDict(unittest.TestCase):
         m = self.m
 
         rd = _ReferenceDict(m.b[:,:].x[:,:])
-        self.assertEqual(len(list(x.value for x in itervalues(rd))), 2*2*2*2)
+        self.assertEqual(len(list(x.value for x in rd.values())), 2*2*2*2)
         self.assertTrue((1,5,7,10) in rd)
         del rd[1,5,7,10]
         self.assertFalse((1,5,7,10) in rd)
-        self.assertEqual(len(list(x.value for x in itervalues(rd))), 2*2*2*2-1)
+        self.assertEqual(len(list(x.value for x in rd.values())), 2*2*2*2-1)
 
         rd = _ReferenceDict(m.b[:,4].x[8,:])
-        self.assertEqual(len(list(x.value for x in itervalues(rd))), 2*2)
+        self.assertEqual(len(list(x.value for x in rd.values())), 2*2)
         self.assertTrue((1,10) in rd)
         del rd[1,10]
         self.assertFalse((1,10) in rd)
-        self.assertEqual(len(list(x.value for x in itervalues(rd))), 2*2-1)
+        self.assertEqual(len(list(x.value for x in rd.values())), 2*2-1)
 
     def test_attribute_deletion(self):
         m = self.m
 
         rd = _ReferenceDict(m.b[:,:].z)
         rd._slice.attribute_errors_generate_exceptions = False
-        self.assertEqual(len(list(x.value for x in itervalues(rd))), 2*2)
+        self.assertEqual(len(list(x.value for x in rd.values())), 2*2)
         self.assertTrue((1,5) in rd)
         self.assertTrue( hasattr(m.b[1,5], 'z') )
         self.assertTrue( hasattr(m.b[2,5], 'z') )
@@ -267,11 +267,11 @@ class TestReferenceDict(unittest.TestCase):
         self.assertFalse((1,5) in rd)
         self.assertFalse( hasattr(m.b[1,5], 'z') )
         self.assertTrue( hasattr(m.b[2,5], 'z') )
-        self.assertEqual(len(list(x.value for x in itervalues(rd))), 3)
+        self.assertEqual(len(list(x.value for x in rd.values())), 3)
 
         rd = _ReferenceDict(m.b[2,:].z)
         rd._slice.attribute_errors_generate_exceptions = False
-        self.assertEqual(len(list(x.value for x in itervalues(rd))), 2)
+        self.assertEqual(len(list(x.value for x in rd.values())), 2)
         self.assertTrue(5 in rd)
         self.assertTrue( hasattr(m.b[2,4], 'z') )
         self.assertTrue( hasattr(m.b[2,5], 'z') )
@@ -279,7 +279,7 @@ class TestReferenceDict(unittest.TestCase):
         self.assertFalse(5 in rd)
         self.assertTrue( hasattr(m.b[2,4], 'z') )
         self.assertFalse( hasattr(m.b[2,5], 'z') )
-        self.assertEqual(len(list(x.value for x in itervalues(rd))), 2-1)
+        self.assertEqual(len(list(x.value for x in rd.values())), 2-1)
 
 class TestReferenceSet(unittest.TestCase):
     def test_lookup_and_iter_dense_data(self):

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -12,8 +12,7 @@ import copy
 import itertools
 import logging
 import pickle
-from six import StringIO, PY2
-from six.moves import xrange
+from io import StringIO
 from collections import namedtuple as NamedTuple
 
 try:
@@ -3487,7 +3486,7 @@ def _init_set(m, *args):
     n = 1
     for i in args:
         n *= i
-    return xrange(n)
+    return range(n)
 
 
 class TestSet(unittest.TestCase):
@@ -4188,7 +4187,7 @@ class TestSet(unittest.TestCase):
 
         m = ConcreteModel()
         m.I_index = RangeSet(3)
-        m.I = Set(m.I_index, initialize=lambda m,i: xrange(i+1),
+        m.I = Set(m.I_index, initialize=lambda m,i: range(i+1),
                   domain=Integers)
         m.J = Set(ordered=False)
         m.K = Set(initialize=[(1,2), (3,4)], ordered=Set.SortedOrder)
@@ -4303,8 +4302,8 @@ class TestSet(unittest.TestCase):
         m.I = Set(initialize=[1,2,3])
         m.J = Set(initialize=[4,5,6])
         m.K = Set(initialize=[(1,4),(2,6),(3,5)], within=m.I*m.J)
-        m.II = Set([1,2,3], initialize={1:[0], 2:[1,2], 3: xrange(3)})
-        m.JJ = Set([1,2,3], initialize={1:[0], 2:[1,2], 3: xrange(3)})
+        m.II = Set([1,2,3], initialize={1:[0], 2:[1,2], 3: range(3)})
+        m.JJ = Set([1,2,3], initialize={1:[0], 2:[1,2], 3: range(3)})
         m.KK = Set([1,2], initialize=[], dimen=lambda m,i: i)
 
         output = StringIO()
@@ -5596,18 +5595,13 @@ class TestIssues(unittest.TestCase):
             "Testing for set subsets with 'a in b' is deprecated.",
             output.getvalue()
         )
-        if PY2:
+        # Note that pypy raises a different exception from cpython
+        err = "((unhashable type: 'OrderedSimpleSet')" \
+            "|('OrderedSimpleSet' objects are unhashable))"
+        with self.assertRaisesRegexp(TypeError, err):
             self.assertFalse(m.s in m.t)
-            with self.assertRaisesRegexp(KeyError, "Index 's' is not valid"):
-                m.x[m.s].display()
-        else:
-            # Note that pypy raises a different exception from cpython
-            err = "((unhashable type: 'OrderedSimpleSet')" \
-                "|('OrderedSimpleSet' objects are unhashable))"
-            with self.assertRaisesRegexp(TypeError, err):
-                self.assertFalse(m.s in m.t)
-            with self.assertRaisesRegexp(TypeError, err):
-                m.x[m.s].display()
+        with self.assertRaisesRegexp(TypeError, err):
+            m.x[m.s].display()
 
         self.assertEqual(list(m.x), ['one'])
 

--- a/pyomo/core/tests/unit/test_sets.py
+++ b/pyomo/core/tests/unit/test_sets.py
@@ -2721,9 +2721,7 @@ class TestSetsInPython3(unittest.TestCase):
         buf = StringIO()
         m3.pprint(ostream=buf)
         self.assertEqual(ref, buf.getvalue())
-        #
-        # six.iterkeys()
-        #
+
         m = ConcreteModel()
         v = {1:2,3:4,5:6}
         m.INDEX = Set(initialize=v.keys())

--- a/pyomo/core/tests/unit/test_sets.py
+++ b/pyomo/core/tests/unit/test_sets.py
@@ -30,7 +30,7 @@ import copy
 import itertools
 import os
 from os.path import abspath, dirname
-from six import StringIO, iterkeys
+from io import StringIO
 
 currdir = dirname(abspath(__file__))+os.sep
 
@@ -2726,7 +2726,7 @@ class TestSetsInPython3(unittest.TestCase):
         #
         m = ConcreteModel()
         v = {1:2,3:4,5:6}
-        m.INDEX = Set(initialize=iterkeys(v))
+        m.INDEX = Set(initialize=v.keys())
         m.p = Param(m.INDEX, initialize=v)
         buf = StringIO()
         m.pprint(ostream=buf)

--- a/pyomo/core/tests/unit/test_sos.py
+++ b/pyomo/core/tests/unit/test_sos.py
@@ -14,7 +14,6 @@
 import os
 from os.path import abspath, dirname
 currdir = dirname(abspath(__file__))+os.sep
-from six.moves import xrange
 import pyutilib.th as unittest
 from pyomo.environ import ConcreteModel, AbstractModel, SOSConstraint, Var, Set
 
@@ -112,18 +111,18 @@ class TestExamples(unittest.TestCase):
 
     def test1(self):
         M = ConcreteModel()
-        M.x = Var(xrange(20))
+        M.x = Var(range(20))
         M.c = SOSConstraint(var=M.x, sos=1)
         self.assertEqual(set((v.name,w) for v,w in M.c.get_items()),
-                         set((M.x[i].name, i+1) for i in xrange(20)))
+                         set((M.x[i].name, i+1) for i in range(20)))
 
     def test2(self):
         # Use an index set, which is a subset of M.x.index_set()
         M = ConcreteModel()
-        M.x = Var(xrange(20))
-        M.c = SOSConstraint(var=M.x, index=list(xrange(10)), sos=1)
+        M.x = Var(range(20))
+        M.c = SOSConstraint(var=M.x, index=list(range(10)), sos=1)
         self.assertEqual(set((v.name,w) for v,w in M.c.get_items()),
-                         set((M.x[i].name, i+1) for i in xrange(10)))
+                         set((M.x[i].name, i+1) for i in range(10)))
 
     def test3(self):
         # User-specified weights

--- a/pyomo/core/tests/unit/test_suffix.py
+++ b/pyomo/core/tests/unit/test_suffix.py
@@ -29,7 +29,7 @@ from pyomo.core.base.suffix import \
      suffix_generator)
 from pyomo.environ import ConcreteModel, Suffix, Var, Param, Set, Objective, Constraint, Block, sum_product
 
-from six import StringIO
+from io import StringIO
 
 def simple_con_rule(model,i):
     return model.x[i] == 1

--- a/pyomo/core/tests/unit/test_units.py
+++ b/pyomo/core/tests/unit/test_units.py
@@ -26,7 +26,7 @@ import pyomo.core.expr.current as EXPR
 from pyomo.core.base.units_container import (
     pint_available, InconsistentUnitsError, UnitsError, PyomoUnitsContainer,
 )
-from six import StringIO
+from io import StringIO
 
 def python_callback_function(arg1, arg2):
     return 42.0

--- a/pyomo/core/tests/unit/test_var_set_bounds.py
+++ b/pyomo/core/tests/unit/test_var_set_bounds.py
@@ -16,7 +16,6 @@ from os.path import abspath, dirname
 currdir = dirname(abspath(__file__))+os.sep
 
 import pyutilib.th as unittest
-from six.moves import xrange
 
 from pyomo.opt import check_available_solvers
 from pyomo.environ import ConcreteModel, RangeSet, Var, Set, Objective, Constraint, SolverFactory, AbstractModel
@@ -152,6 +151,8 @@ class TestVarSetBounds(unittest.TestCase):
         self.model.con2 = Constraint(expr=self.model.y[2] <= 2.9)
         
         self.instance = self.model.create_instance()
+        # !! THIS SEEMS LIKE A BUG!! - mrmundt
+        # I think it's supposed to be SolverFactory
         self.opt = solver["glpk"]
         self.results = self.opt.solve(self.instance)
         self.instance.load(self.results)
@@ -239,7 +240,7 @@ class TestVarSetBounds(unittest.TestCase):
     @unittest.skipIf(not 'glpk' in solvers, "glpk solver is not available")
     def Xtest_rangeset_domain(self):
         self.model = ConcreteModel()
-        self.model.y = Var([1,2], within=xrange(4))
+        self.model.y = Var([1,2], within=range(4))
         
         self.model.obj = Objective(expr=self.model.y[1]-self.model.y[2])
         self.model.con1 = Constraint(expr=self.model.y[1] >= 1.1)

--- a/pyomo/core/tests/unit/test_visitor.py
+++ b/pyomo/core/tests/unit/test_visitor.py
@@ -34,7 +34,7 @@ from pyomo.core.base.param import _ParamData, SimpleParam
 from pyomo.core.expr.template_expr import IndexTemplate
 from pyomo.core.expr.expr_errors import TemplateExpressionError
 from pyomo.common.log import LoggingIntercept
-from six import StringIO
+from io import StringIO
 
 
 class TestExpressionUtilities(unittest.TestCase):

--- a/pyomo/core/util.py
+++ b/pyomo/core/util.py
@@ -14,7 +14,6 @@
 
 __all__ = ['sum_product', 'summation', 'dot_product', 'sequence', 'prod', 'quicksum']
 
-from six.moves import xrange
 from pyomo.core.expr.numvalue import native_numeric_types
 from pyomo.core.expr.numeric_expr import decompose_term
 from pyomo.core.expr import current as EXPR
@@ -269,10 +268,10 @@ def sequence(*args):
     if len(args) > 3:
         raise ValueError('sequence expected at most 3 arguments, got %d' % len(args))
     if len(args) == 1:
-        return xrange(1,args[0]+1)
+        return range(1,args[0]+1)
     if len(args) == 2:
-        return xrange(args[0],args[1]+1)
-    return xrange(args[0],args[1]+1,args[2])
+        return range(args[0],args[1]+1)
+    return range(args[0],args[1]+1,args[2])
 
 
 def xsequence(*args):

--- a/pyomo/scripting/plugins/extras.py
+++ b/pyomo/scripting/plugins/extras.py
@@ -8,7 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import six
 from pyomo.scripting.pyomo_parser import add_subparser, CustomHelpFormatter
 
 from pyomo.common.deprecation import deprecated
@@ -28,8 +27,6 @@ def get_packages():
         ('ipython[notebook]', 'IPython'),
         ('pyro4', 'Pyro4'),
     ]
-    if six.PY2:
-        packages.append(('pyro','Pyro'))
     return packages
 
 @deprecated(
@@ -96,7 +93,7 @@ def install_extras(args=[], quiet=False):
     print("Installation Summary")
     print('-'*60)
     print(' ')
-    for package, result in sorted(six.iteritems(results)):
+    for package, result in sorted(results.items()):
         if result:
             print("YES %s" % package)
         else:

--- a/pyomo/scripting/plugins/extras.py
+++ b/pyomo/scripting/plugins/extras.py
@@ -8,6 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import six
 from pyomo.scripting.pyomo_parser import add_subparser, CustomHelpFormatter
 
 from pyomo.common.deprecation import deprecated
@@ -27,6 +28,8 @@ def get_packages():
         ('ipython[notebook]', 'IPython'),
         ('pyro4', 'Pyro4'),
     ]
+    if six.PY2:
+        packages.append(('pyro','Pyro'))
     return packages
 
 @deprecated(
@@ -93,7 +96,7 @@ def install_extras(args=[], quiet=False):
     print("Installation Summary")
     print('-'*60)
     print(' ')
-    for package, result in sorted(results.items()):
+    for package, result in sorted(six.iteritems(results)):
         if result:
             print("YES %s" % package)
         else:

--- a/pyomo/scripting/pyro_mip_server.py
+++ b/pyomo/scripting/pyro_mip_server.py
@@ -35,7 +35,6 @@ from pyomo.opt.base import SolverFactory, ConverterError
 from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
-import six
 
 class PyomoMIPWorker(pyutilib.pyro.TaskWorker):
 
@@ -131,10 +130,7 @@ class PyomoMIPWorker(pyutilib.pyro.TaskWorker):
             # wire with Pyro4. Also, the base64 bytes must be wrapped
             # in a str object to avoid a different set of Pyro4 errors
             # related to its default serializer (Serpent)
-            if six.PY3:
-                results = str(base64.encodebytes(results))
-            else:
-                results = base64.encodestring(results)
+            results = str(base64.encodebytes(results))
 
         return results
 

--- a/pyomo/scripting/pyro_mip_server.py
+++ b/pyomo/scripting/pyro_mip_server.py
@@ -35,6 +35,7 @@ from pyomo.opt.base import SolverFactory, ConverterError
 from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
+import six
 
 class PyomoMIPWorker(pyutilib.pyro.TaskWorker):
 
@@ -130,7 +131,10 @@ class PyomoMIPWorker(pyutilib.pyro.TaskWorker):
             # wire with Pyro4. Also, the base64 bytes must be wrapped
             # in a str object to avoid a different set of Pyro4 errors
             # related to its default serializer (Serpent)
-            results = str(base64.encodebytes(results))
+            if six.PY3:
+                results = str(base64.encodebytes(results))
+            else:
+                results = base64.encodestring(results)
 
         return results
 

--- a/pyomo/scripting/tests/test_pms.py
+++ b/pyomo/scripting/tests/test_pms.py
@@ -9,7 +9,6 @@
 #  ___________________________________________________________________________
 #
 
-import six
 import pickle
 import base64
 import ast
@@ -86,11 +85,7 @@ class Test(unittest.TestCase):
             # avoid errors when transmitting the pickled
             # form of the results object with the default Pyro4
             # serializer (Serpent)
-            if six.PY3:
-                results = base64.decodebytes(
-                    ast.literal_eval(results))
-            else:
-                results = base64.decodestring(results)
+            results = base64.decodebytes(ast.literal_eval(results))
 
         results = pickle.loads(results)
 

--- a/pyomo/scripting/tests/test_pms.py
+++ b/pyomo/scripting/tests/test_pms.py
@@ -9,6 +9,7 @@
 #  ___________________________________________________________________________
 #
 
+import six
 import pickle
 import base64
 import ast
@@ -85,7 +86,11 @@ class Test(unittest.TestCase):
             # avoid errors when transmitting the pickled
             # form of the results object with the default Pyro4
             # serializer (Serpent)
-            results = base64.decodebytes(ast.literal_eval(results))
+            if six.PY3:
+                results = base64.decodebytes(
+                    ast.literal_eval(results))
+            else:
+                results = base64.decodestring(results)
 
         results = pickle.loads(results)
 

--- a/pyomo/util/slices.py
+++ b/pyomo/util/slices.py
@@ -8,15 +8,12 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import six
-
 from pyomo.core.base.indexed_component import normalize_index
 from pyomo.core.base.indexed_component_slice import IndexedComponent_slice
 from pyomo.core.base.global_set import UnindexedComponent_set
-from pyomo.common.collections import ComponentSet, ComponentMap
 
 def _to_iterable(source):
-    iterable_scalars = six.string_types + (six.binary_type, six.text_type)
+    iterable_scalars = (str, bytes)
     if hasattr(source, '__iter__'):
         if isinstance(source, iterable_scalars):
             yield source

--- a/pyomo/util/slices.py
+++ b/pyomo/util/slices.py
@@ -8,12 +8,15 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import six
+
 from pyomo.core.base.indexed_component import normalize_index
 from pyomo.core.base.indexed_component_slice import IndexedComponent_slice
 from pyomo.core.base.global_set import UnindexedComponent_set
+from pyomo.common.collections import ComponentSet, ComponentMap
 
 def _to_iterable(source):
-    iterable_scalars = (str, bytes)
+    iterable_scalars = six.string_types + (six.binary_type, six.text_type)
     if hasattr(source, '__iter__'):
         if isinstance(source, iterable_scalars):
             yield source

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -8,8 +8,8 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import io
 import logging
-import six
 import pyutilib.th as unittest
 
 from pyomo.common.log import LoggingIntercept
@@ -169,12 +169,9 @@ class Test_calc_var(unittest.TestCase):
         # Starting with an invalid guess (above TC) should raise an
         # exception
         m.x.set_value(600)
-        output = six.StringIO()
+        output = io.StringIO()
         with LoggingIntercept(output, 'pyomo', logging.WARNING):
-            if six.PY2:
-                expectedException = ValueError
-            else:
-                expectedException = TypeError
+            expectedException = TypeError
             with self.assertRaises(expectedException):
                 calculate_variable_from_constraint(m.x, m.f, linesearch=False)
         self.assertIn('Encountered an error evaluating the expression '
@@ -190,7 +187,7 @@ class Test_calc_var(unittest.TestCase):
         calculate_variable_from_constraint(m.x, m.c, linesearch=True)
         self.assertAlmostEqual(value(m.x), 0.046415888)
         m.x = .1
-        output = six.StringIO()
+        output = io.StringIO()
         with LoggingIntercept(output, 'pyomo', logging.WARNING):
             with self.assertRaises(ValueError):
                 # Note that the ValueError is different between Python 2

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -8,196 +8,210 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from pyomo.core.expr.numvalue import native_numeric_types, value
-from pyomo.core.expr.calculus.derivatives import differentiate
-
 import logging
-logger = logging.getLogger(__name__)
+import six
+import pyutilib.th as unittest
 
-def calculate_variable_from_constraint(variable, constraint,
-                                       eps=1e-8, iterlim=1000,
-                                       linesearch=True, alpha_min=1e-8):
-    """Calculate the variable value given a specified equality constraint
+from pyomo.common.log import LoggingIntercept
+from pyomo.environ import ConcreteModel, Var, Constraint, value, exp
+from pyomo.util.calc_var_value import calculate_variable_from_constraint
+from pyomo.core.expr.calculus.diff_with_sympy import differentiate_available
 
-    This function calculates the value of the specified variable
-    necessary to make the provided equality constraint feasible
-    (assuming any other variables values are fixed).  The method first
-    attempts to solve for the variable value assuming it appears
-    linearly in the constraint.  If that doesn't converge the constraint
-    residual, it falls back on Newton's method using exact (symbolic)
-    derivatives.
+class Test_calc_var(unittest.TestCase):
+    def test_initialize_value(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var(initialize=0)
+        m.c = Constraint(expr=m.x == 5)
 
-    Parameters:
-    -----------
-    variable: `pyomo.core.base.var._VarData`
-        The variable to solve for
-    constraint: `pyomo.core.base.constraint._ConstraintData`
-        The equality constraint to use to solve for the variable value
-    eps: `float`
-        The tolerance to use to determine equality [default=1e-8].
-    iterlim: `int`
-        The maximum number of iterations if this method has to fall back
-        on using Newton's method.  Raises RuntimeError on iteration
-        limit [default=1000]
-    linesearch: `bool`
-        Decides whether or not to use the linesearch (recommended).
-        [default=True]
-    alpha_min: `float`
-        The minimum fractional step to use in the linesearch [default=1e-8].
+        m.x.set_value(None)
+        calculate_variable_from_constraint(m.x, m.c)
+        self.assertEqual(value(m.x), 5)
 
-    Returns:
-    --------
-    None
+        m.x.set_value(None)
+        m.x.setlb(3)
+        calculate_variable_from_constraint(m.x, m.c)
+        self.assertEqual(value(m.x), 5)
 
-    Note: this is an unconstrained solver and is NOT guaranteed to
-    respect the variable bounds.
+        m.x.set_value(None)
+        m.x.setlb(-10)
+        calculate_variable_from_constraint(m.x, m.c)
+        self.assertEqual(value(m.x), 5)
 
-    """
-    upper = value(constraint.upper)
-    if value(constraint.lower) != upper:
-        raise ValueError("Constraint must be an equality constraint")
+        m.x.set_value(None)
+        m.x.setub(10)
+        calculate_variable_from_constraint(m.x, m.c)
+        self.assertEqual(value(m.x), 5)
 
-    if variable.value is None:
-        if variable.lb is None:
-            if variable.ub is None:
-                # no variable values, and no lower or upper bound - set
-                # initial value to 0.0
-                variable.set_value(0)
+        m.x.set_value(None)
+        m.x.setlb(3)
+        calculate_variable_from_constraint(m.x, m.c)
+        self.assertEqual(value(m.x), 5)
+
+        m.x.set_value(None)
+        m.x.setlb(None)
+        calculate_variable_from_constraint(m.x, m.c)
+        self.assertEqual(value(m.x), 5)
+
+        m.x.set_value(None)
+        m.x.setub(-10)
+        calculate_variable_from_constraint(m.x, m.c)
+        self.assertEqual(value(m.x), 5)
+
+        m.lt = Constraint(expr=m.x <= m.y)
+        with self.assertRaisesRegexp(
+                ValueError, "Constraint must be an equality constraint"):
+            calculate_variable_from_constraint(m.x, m.lt)
+
+
+    def test_linear(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.c = Constraint(expr=5*m.x == 10)
+
+        calculate_variable_from_constraint(m.x, m.c)
+        self.assertEqual(value(m.x), 2)
+
+
+    @unittest.skipIf(not differentiate_available, "this test requires sympy")
+    def test_nonlinear(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var(initialize=0)
+
+        m.c = Constraint(expr=m.x**2 == 16)
+        m.x.set_value(1.0) # set an initial value
+        calculate_variable_from_constraint(m.x, m.c, linesearch=False)
+        self.assertAlmostEqual(value(m.x), 4)
+
+        # test that infeasible constraint throws error
+        m.d = Constraint(expr=m.x**2 == -1)
+        m.x.set_value(1.25) # set the initial value
+        with self.assertRaisesRegexp(
+               RuntimeError, 'Iteration limit \(10\) reached'):
+           calculate_variable_from_constraint(
+               m.x, m.d, iterlim=10, linesearch=False)
+
+        # same problem should throw a linesearch error if linesearch is on
+        m.x.set_value(1.25) # set the initial value
+        with self.assertRaisesRegexp(
+                RuntimeError, "Linesearch iteration limit reached"):
+           calculate_variable_from_constraint(
+               m.x, m.d, iterlim=10, linesearch=True)
+
+        # same problem should raise an error if initialized at 0
+        m.x = 0
+        with self.assertRaisesRegexp(
+                RuntimeError, "Initial value for variable results in a "
+                "derivative value that is very close to zero."):
+            calculate_variable_from_constraint(m.x, m.c)
+
+        # same problem should raise a value error if we are asked to
+        # solve for a variable that is not present
+        with self.assertRaisesRegexp(
+                ValueError, "Variable derivative == 0"):
+            calculate_variable_from_constraint(m.y, m.c)
+
+
+        # should succeed with or without a linesearch
+        m.e = Constraint(expr=(m.x - 2.0)**2 - 1 == 0)
+        m.x.set_value(3.1)
+        calculate_variable_from_constraint(m.x, m.e, linesearch=False)
+        self.assertAlmostEqual(value(m.x), 3)
+
+        m.x.set_value(3.1)
+        calculate_variable_from_constraint(m.x, m.e, linesearch=True)
+        self.assertAlmostEqual(value(m.x), 3)
+
+
+        # we expect this to succeed with the linesearch
+        m.f = Constraint(expr=1.0/(1.0+exp(-m.x))-0.5 == 0)
+        m.x.set_value(3.0)
+        calculate_variable_from_constraint(m.x, m.f, linesearch=True)
+        self.assertAlmostEqual(value(m.x), 0)
+
+        # we expect this to fail without a linesearch
+        m.x.set_value(3.0)
+        with self.assertRaisesRegexp(
+                RuntimeError, "Newton's method encountered a derivative "
+                "that was too close to zero"):
+            calculate_variable_from_constraint(m.x, m.f, linesearch=False)
+
+        # Calculate the bubble point of Benzene.  THe first step
+        # computed by calculate_variable_from_constraint will make the
+        # second term become complex, and the evaluation will fail.
+        # This tests that the algorithm cleanly continues
+        m = ConcreteModel()
+        m.x = Var()
+        m.pc = 48.9e5
+        m.tc = 562.2
+        m.psc = {'A': -6.98273,
+                 'B': 1.33213,
+                 'C': -2.62863,
+                 'D': -3.33399,
+        }
+        m.p = 101325
+        @m.Constraint()
+        def f(m):
+            return m.pc * \
+                exp((m.psc['A'] * (1 - m.x / m.tc) +
+                     m.psc['B'] * (1 - m.x / m.tc)**1.5 +
+                     m.psc['C'] * (1 - m.x / m.tc)**3 +
+                     m.psc['D'] * (1 - m.x / m.tc)**6
+                 ) / (1 - (1 - m.x / m.tc))) - m.p == 0
+        m.x.set_value(298.15)
+        calculate_variable_from_constraint(m.x, m.f, linesearch=False)
+        self.assertAlmostEqual(value(m.x), 353.31855602)
+        m.x.set_value(298.15)
+        calculate_variable_from_constraint(m.x, m.f, linesearch=True)
+        self.assertAlmostEqual(value(m.x), 353.31855602)
+
+        # Starting with an invalid guess (above TC) should raise an
+        # exception
+        m.x.set_value(600)
+        output = six.StringIO()
+        with LoggingIntercept(output, 'pyomo', logging.WARNING):
+            if six.PY2:
+                expectedException = ValueError
             else:
-                # no variable value or lower bound - set to 0 or upper
-                # bound whichever is lower
-                variable.set_value(min(0, variable.ub))
-        elif variable.ub is None:
-            # no variable value or upper bound - set to 0 or lower
-            # bound, whichever is higher
-            variable.set_value(max(0, variable.lb))
-        else:
-            # we have upper and lower bounds
-            if variable.lb <= 0 and variable.ub >= 0:
-                # set the initial value to 0 if bounds bracket 0
-                variable.set_value(0)
-            else:
-                # set the initial value to the midpoint of the bounds
-                variable.set_value((variable.lb+variable.ub)/2.0)
+                expectedException = TypeError
+            with self.assertRaises(expectedException):
+                calculate_variable_from_constraint(m.x, m.f, linesearch=False)
+        self.assertIn('Encountered an error evaluating the expression '
+                      'at the initial guess', output.getvalue())
 
-    # store the initial value to use later if necessary
-    orig_initial_value = variable.value
+        # This example triggers an expression evaluation error if the
+        # linesearch is turned off because the first step in Newton's
+        # method will cause the LHS to become complex
+        m = ConcreteModel()
+        m.x = Var()
+        m.c = Constraint(expr=(1/m.x**3)**0.5 == 100)
+        m.x = .1
+        calculate_variable_from_constraint(m.x, m.c, linesearch=True)
+        self.assertAlmostEqual(value(m.x), 0.046415888)
+        m.x = .1
+        output = six.StringIO()
+        with LoggingIntercept(output, 'pyomo', logging.WARNING):
+            with self.assertRaises(ValueError):
+                # Note that the ValueError is different between Python 2
+                # and Python 3: in Python 2 it is a specific error
+                # "negative number cannot be raised to a fractional
+                # power", and We mock up that error in Python 3 by
+                # raising a generic ValueError in
+                # calculate_variable_from_constraint
+                calculate_variable_from_constraint(m.x, m.c, linesearch=False)
+        self.assertIn("Newton's method encountered an error evaluating "
+                      "the expression.", output.getvalue())
 
-    # solve the common case where variable is linear with coefficient of 1.0
-    x1 = value(variable)
-    # Note: both the direct (linear) calculation and Newton's method
-    # below rely on a numerically feasible initial starting point.
-    # While we have strategies for dealing with hitting numerically
-    # invalid (e.g., sqrt(-1)) conditions below, if the initial point is
-    # not valid, we will allow that exception to propagate up
-    try:
-        residual_1 = value(constraint.body)
-    except:
-        logger.error(
-            "Encountered an error evaluating the expression at the "
-            "initial guess.\n\tPlease provide a different initial guess.")
-        raise
-
-    variable.set_value(x1 - (residual_1-upper))
-    residual_2 = value(constraint.body, exception=False)
-
-    # If we encounter an error while evaluating the expression at the
-    # linear intercept calculated assuming the derivative was 1.  This
-    # is most commonly due to nonlinear expressions (like sqrt())
-    # becoming invalid/complex.  We will skip the rest of the
-    # "shortcuts" that assume the expression is linear and move directly
-    # to using Newton's method.
-
-    if residual_2 is not None and type(residual_2) is not complex:
-        # if the variable appears linearly with a coefficient of 1, then we
-        # are done
-        if abs(residual_2-upper) < eps:
-            return
-
-        # Assume the variable appears linearly and calculate the coefficient
-        x2 = value(variable)
-        slope = float(residual_1 - residual_2) / (x1 - x2)
-        intercept = (residual_1-upper) - slope*x1
-        if slope:
-            variable.set_value(-intercept/slope)
-            body_val = value(constraint.body, exception=False)
-            if body_val is not None and abs(body_val-upper) < eps:
-                return
-
-    # Variable appears nonlinearly; solve using Newton's method
-    variable.set_value(orig_initial_value) # restore initial value
-    expr = constraint.body - constraint.upper
-    expr_deriv = differentiate(expr, wrt=variable, mode=differentiate.Modes.sympy)
-
-    if type(expr_deriv) in native_numeric_types and expr_deriv == 0:
-        raise ValueError("Variable derivative == 0, cannot solve for variable")
-
-    if abs(value(expr_deriv)) < 1e-12:
-        raise RuntimeError(
-            'Initial value for variable results in a derivative value that is '
-            'very close to zero.\n\tPlease provide a different initial guess.')
-
-    iter_left = iterlim
-    fk = residual_1 - upper
-    while abs(fk) > eps and iter_left:
-        iter_left -= 1
-        if not iter_left:
-            raise RuntimeError(
-                "Iteration limit (%s) reached; remaining residual = %s"
-                % (iterlim, value(expr)) )
-
-        # compute step
-        xk = value(variable)
-        try:
-            fk = value(expr)
-            if type(fk) is complex:
-                raise ValueError(
-                    "Complex numbers are not allowed in Newton's method.")
-        except:
-            # We hit numerical problems with the last step (possible if
-            # the line search is turned off)
-            logger.error(
-                "Newton's method encountered an error evaluating the "
-                "expression.\n\tPlease provide a different initial guess "
-                "or enable the linesearch if you have not.")
-            raise
-        fpk = value(expr_deriv)
-        if abs(fpk) < 1e-12:
-            raise RuntimeError(
-                "Newton's method encountered a derivative that was too "
-                "close to zero.\n\tPlease provide a different initial guess "
-                "or enable the linesearch if you have not.")
-        pk = -fk/fpk
-        alpha = 1.0
-        xkp1 = xk + alpha * pk
-        variable.set_value(xkp1)
-
-        # perform line search
-        if linesearch:
-            c1 = 0.999 # ensure sufficient progress
-            while alpha > alpha_min:
-                # check if the value at xkp1 has sufficient reduction in
-                # the residual
-                fkp1 = value(expr, exception=False)
-                # HACK for Python3 support, pending resolution of #879
-                # Issue #879 also pertains to other checks for "complex"
-                # in this method.
-                if type(fkp1) is complex:
-                    # We cannot perform computations on complex numbers
-                    fkp1 = None
-                if fkp1 is not None and fkp1**2 < c1*fk**2:
-                    # found an alpha value with sufficient reduction
-                    # continue to the next step
-                    fk = fkp1
-                    break
-                alpha /= 2.0
-                xkp1 = xk + alpha * pk
-                variable.set_value(xkp1)
-
-            if alpha <= alpha_min:
-                residual = value(expr, exception=False)
-                if residual is None or type(residual) is complex:
-                    residual = "{function evaluation error}"
-                raise RuntimeError(
-                    "Linesearch iteration limit reached; remaining "
-                    "residual = %s." % (residual,))
+        # This is a completely contrived example where the linesearch
+        # hits the iteration limit before Newton's method ever finds a
+        # feasible step
+        m = ConcreteModel()
+        m.x = Var()
+        m.c = Constraint(expr=m.x**0.5 == -1e-8)
+        m.x = 1e-8#197.932807183
+        with self.assertRaisesRegexp(
+                RuntimeError, "Linesearch iteration limit reached; "
+                "remaining residual = {function evaluation error}"):
+            calculate_variable_from_constraint(m.x, m.c, linesearch=True,
+                                               alpha_min=.5)


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
A task in the Pyomo 6.0 release is to replace instances of `six` with the appropriate Python 3 uses. This starts that effort in `pyomo.core`

## Changes proposed in this PR:
- Replace instances of `six` in `pyomo.core`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
