### PR TITLE
Fixed quadratic term handling for QCQO problems in mosek_direct interface

### DIFF
--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -44,6 +44,7 @@ if six.PY2:
 else:
     from itertools import accumulate
 
+
 class DegreeError(ValueError):
     pass
 
@@ -250,7 +251,7 @@ class MOSEKDirect(DirectSolver):
                 self._pyomo_var_to_solver_var_map[j] for i, j in repn.quadratic_vars)
             qvals = tuple(v * 2 if qsubi[i] is qsubj[i] else v
                           for i, v in enumerate(repn.quadratic_coefs))
-            mosek_qexp = (qsubi, qsubj, qvals)
+            mosek_qexp = (qsubj, qsubi, qvals)
         return mosek_arow, mosek_qexp, referenced_vars
 
     def _get_expr_from_pyomo_expr(self, expr, max_degree=2):
@@ -355,7 +356,7 @@ class MOSEKDirect(DirectSolver):
             qcsubi = tuple(itertools.chain.from_iterable(q_is))
             qcsubj = tuple(itertools.chain.from_iterable(q_js))
             qcval = tuple(itertools.chain.from_iterable(q_vals))
-            qcsubk = tuple(i*len(q_is[i - con_num]) for i in sub)
+            qcsubk = tuple(i for i in sub for j in range(len(q_is[i-con_num])))
             self._solver_model.appendcons(num_lq)
             self._solver_model.putarowlist(sub, ptrb, ptre, asubs, avals)
             self._solver_model.putqcon(qcsubk, qcsubi, qcsubj, qcval)


### PR DESCRIPTION
## Fixes

## Summary/Motivation:
In quadratically-constrained-quadratic-objective QCQO problems, the quadratic terms were not being passed correctly. 

## Changes proposed in this PR:
-  The indices for the Q matrices were exchanged in the `_get_expr_from_pyomo_repn`. MOSEK's Optimizer API only accepts the lower triangular part of the Q matrix. Was returning (i, j), which was upper triangular, now changed to (j, i) i.e. lower triangular.
- The list of constraint indices passed to the `putqcon` method in the `_add_constraints` method was fixed.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
