### PR TITLE
GDPopt RIC Option

### DIFF
--- a/pyomo/contrib/gdpopt/GDPopt.py
+++ b/pyomo/contrib/gdpopt/GDPopt.py
@@ -107,6 +107,13 @@ class GDPoptSolver(object):
         """
         config = self.CONFIG(kwds.pop('options', {}), preserve_implicit=True)
         config.set_value(kwds)
+        if config.strategy is None:
+            msg = 'Please specify solution strategy. Options are: \n'
+            msg += '    LOA:  Logic-based Outer Approximation\n'
+            msg += '    GLOA: Global Logic-based Outer Approximation\n'
+            msg += '    LBB:  Logic-based Branch and Bound\n'
+            msg += '    RIC:  Relaxation with Integer Cuts'
+            raise ValueError(msg)
 
         with setup_solver_environment(model, config) as solve_data:
             self._log_solver_intro_message(config)
@@ -122,7 +129,7 @@ class GDPoptSolver(object):
                 # TODO merge the solver results
                 return presolve_results  # problem presolved
 
-            if solve_data.active_strategy in {'LOA', 'GLOA'}:
+            if solve_data.active_strategy in {'LOA', 'GLOA', 'RIC'}:
                 # Initialize the master problem
                 with time_code(solve_data.timing, 'initialization'):
                     GDPopt_initialize_master(solve_data, config)
@@ -132,6 +139,8 @@ class GDPoptSolver(object):
                     GDPopt_iteration_loop(solve_data, config)
             elif solve_data.active_strategy == 'LBB':
                 _perform_branch_and_bound(solve_data)
+            else:
+                raise ValueError('Unrecognized strategy: ' + config.strategy)
 
         return solve_data.results
 

--- a/pyomo/contrib/gdpopt/config_options.py
+++ b/pyomo/contrib/gdpopt/config_options.py
@@ -20,6 +20,7 @@ def _get_GDPopt_config():
         'LOA',  # Logic-based outer approximation
         'GLOA',  # Global logic-based outer approximation
         'LBB',  # Logic-based branch-and-bound
+        'RIC',  # Relaxation with Integer Cuts
     }
     CONFIG = ConfigBlock("GDPopt")
     CONFIG.declare("iterlim", ConfigValue(
@@ -35,7 +36,7 @@ def _get_GDPopt_config():
             "need to set subsolver time limits as well."
     ))
     CONFIG.declare("strategy", ConfigValue(
-        default="LOA", domain=In(_supported_strategies),
+        default=None, domain=In(_supported_strategies),
         description="Decomposition strategy to use."
     ))
     CONFIG.declare("tee", ConfigValue(

--- a/pyomo/contrib/gdpopt/cut_generation.py
+++ b/pyomo/contrib/gdpopt/cut_generation.py
@@ -31,7 +31,10 @@ def add_subproblem_cuts(subprob_result, solve_data, config):
         return add_outer_approximation_cuts(subprob_result, solve_data, config)
     elif config.strategy == "GLOA":
         return add_affine_cuts(subprob_result, solve_data, config)
-
+    elif config.strategy == 'RIC':
+        pass
+    else:
+        raise ValueError('Unrecognized strategy: ' + config.strategy)
 
 def add_outer_approximation_cuts(nlp_result, solve_data, config):
     """Add outer approximation cuts to the linear GDP model."""

--- a/pyomo/contrib/gdpopt/iterate.py
+++ b/pyomo/contrib/gdpopt/iterate.py
@@ -46,6 +46,11 @@ def GDPopt_iteration_loop(solve_data, config):
                 nlp_result = solve_global_subproblem(mip_result, solve_data, config)
             if nlp_result.feasible:
                 add_affine_cuts(nlp_result, solve_data, config)
+        elif solve_data.active_strategy == 'RIC':
+            with time_code(solve_data.timing, 'nlp'):
+                nlp_result = solve_local_subproblem(mip_result, solve_data, config)
+        else:
+            raise ValueError('Unrecognized strategy: ' + solve_data.active_strategy)
 
         # Add integer cut
         add_integer_cut(

--- a/pyomo/contrib/gdpopt/mip_solve.py
+++ b/pyomo/contrib/gdpopt/mip_solve.py
@@ -201,8 +201,10 @@ def solve_LOA_master(solve_data, config):
 
         obj_expr = GDPopt.oa_obj.expr
         base_obj_expr = main_objective.expr
-    elif solve_data.active_strategy == 'GLOA':
+    elif solve_data.active_strategy in {'GLOA', 'RIC'}:
         obj_expr = base_obj_expr = main_objective.expr
+    else:
+        raise ValueError('Unrecognized strategy: ' + solve_data.active_strategy)
 
     mip_result = solve_linear_GDP(m, solve_data, config)
     if mip_result.feasible:

--- a/pyomo/contrib/gdpopt/nlp_solve.py
+++ b/pyomo/contrib/gdpopt/nlp_solve.py
@@ -27,15 +27,19 @@ from pyomo.opt import TerminationCondition as tc
 def solve_disjunctive_subproblem(mip_result, solve_data, config):
     """Set up and solve the disjunctive subproblem."""
     if config.force_subproblem_nlp:
-        if config.strategy == "LOA":
+        if config.strategy in {"LOA", "RIC"}:
             return solve_local_NLP(mip_result.var_values, solve_data, config)
         elif config.strategy == 'GLOA':
             return solve_global_subproblem(mip_result, solve_data, config)
+        else:
+            raise ValueError('Unrecognized strategy: ' + config.strategy)
     else:
-        if config.strategy == "LOA":
+        if config.strategy in {"LOA", "RIC"}:
             return solve_local_subproblem(mip_result, solve_data, config)
         elif config.strategy == 'GLOA':
             return solve_global_subproblem(mip_result, solve_data, config)
+        else:
+            raise ValueError('Unrecognized strategy: ' + config.strategy)
 
 
 def solve_linear_subproblem(mip_model, solve_data, config):

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -64,7 +64,7 @@ class TestGDPoptUnit(unittest.TestCase):
             solver_data = GDPoptSolveData()
             solver_data.timing = Container()
             with time_code(solver_data.timing, 'main', is_main_timer=True):
-                solve_linear_GDP(m, solver_data, GDPoptSolver.CONFIG(dict(mip_solver=mip_solver)))
+                solve_linear_GDP(m, solver_data, GDPoptSolver.CONFIG(dict(mip_solver=mip_solver, strategy='LOA')))
             self.assertIn("Linear GDP was unbounded. Resolving with arbitrary bound values",
                           output.getvalue().strip())
 
@@ -76,7 +76,7 @@ class TestGDPoptUnit(unittest.TestCase):
         m.o = Objective(expr=m.x)
         output = StringIO()
         with LoggingIntercept(output, 'pyomo.contrib.gdpopt', logging.INFO):
-            SolverFactory('gdpopt').solve(m, mip_solver=mip_solver)
+            SolverFactory('gdpopt').solve(m, mip_solver=mip_solver, strategy='LOA')
             self.assertIn("Your model is an LP (linear program).",
                           output.getvalue().strip())
             self.assertAlmostEqual(value(m.o.expr), 1)
@@ -89,7 +89,7 @@ class TestGDPoptUnit(unittest.TestCase):
         m.o = Objective(expr=m.x ** 2)
         output = StringIO()
         with LoggingIntercept(output, 'pyomo.contrib.gdpopt', logging.INFO):
-            SolverFactory('gdpopt').solve(m, nlp_solver=nlp_solver)
+            SolverFactory('gdpopt').solve(m, nlp_solver=nlp_solver, strategy='LOA')
             self.assertIn("Your model is an NLP (nonlinear program).",
                           output.getvalue().strip())
             self.assertAlmostEqual(value(m.o.expr), 1)
@@ -102,7 +102,7 @@ class TestGDPoptUnit(unittest.TestCase):
         m.o = Objective(expr=1)
         output = StringIO()
         with LoggingIntercept(output, 'pyomo.contrib.gdpopt', logging.INFO):
-            SolverFactory('gdpopt').solve(m, mip_solver=mip_solver)
+            SolverFactory('gdpopt').solve(m, mip_solver=mip_solver, strategy='LOA')
             self.assertIn("Your model is an LP (linear program).",
                           output.getvalue().strip())
             self.assertAlmostEqual(value(m.o.expr), 1)
@@ -114,7 +114,7 @@ class TestGDPoptUnit(unittest.TestCase):
         m.c = Constraint(expr=m.x ** 2 >= 1)
         output = StringIO()
         with LoggingIntercept(output, 'pyomo.contrib.gdpopt', logging.WARNING):
-            SolverFactory('gdpopt').solve(m, nlp_solver=nlp_solver)
+            SolverFactory('gdpopt').solve(m, nlp_solver=nlp_solver, strategy='LOA')
             self.assertIn("Model has no active objectives. Adding dummy objective.",
                           output.getvalue().strip())
 
@@ -124,35 +124,35 @@ class TestGDPoptUnit(unittest.TestCase):
         m.o = Objective(expr=m.x)
         m.o2 = Objective(expr=m.x + 1)
         with self.assertRaisesRegexp(ValueError, "Model has multiple active objectives"):
-            SolverFactory('gdpopt').solve(m)
+            SolverFactory('gdpopt').solve(m, strategy='LOA')
 
     def test_is_feasible_function(self):
         m = ConcreteModel()
         m.x = Var(bounds=(0, 3), initialize=2)
         m.c = Constraint(expr=m.x == 2)
-        self.assertTrue(is_feasible(m, GDPoptSolver.CONFIG()))
+        self.assertTrue(is_feasible(m, GDPoptSolver.CONFIG(dict(strategy='LOA'))))
 
         m.c2 = Constraint(expr=m.x <= 1)
-        self.assertFalse(is_feasible(m, GDPoptSolver.CONFIG()))
+        self.assertFalse(is_feasible(m, GDPoptSolver.CONFIG(dict(strategy='LOA'))))
 
         m = ConcreteModel()
         m.x = Var(bounds=(0, 3), initialize=2)
         m.c = Constraint(expr=m.x >= 5)
-        self.assertFalse(is_feasible(m, GDPoptSolver.CONFIG()))
+        self.assertFalse(is_feasible(m, GDPoptSolver.CONFIG(dict(strategy='LOA'))))
 
         m = ConcreteModel()
         m.x = Var(bounds=(3, 3), initialize=2)
-        self.assertFalse(is_feasible(m, GDPoptSolver.CONFIG()))
+        self.assertFalse(is_feasible(m, GDPoptSolver.CONFIG(dict(strategy='LOA'))))
 
         m = ConcreteModel()
         m.x = Var(bounds=(0, 1), initialize=2)
-        self.assertFalse(is_feasible(m, GDPoptSolver.CONFIG()))
+        self.assertFalse(is_feasible(m, GDPoptSolver.CONFIG(dict(strategy='LOA'))))
 
         m = ConcreteModel()
         m.x = Var(bounds=(0, 1), initialize=2)
         m.d = Disjunct()
         with self.assertRaisesRegexp(NotImplementedError, "Found active disjunct"):
-            is_feasible(m, GDPoptSolver.CONFIG())
+            is_feasible(m, GDPoptSolver.CONFIG(dict(strategy='LOA')))
 
 
 @unittest.skipIf(not LOA_solvers_available,
@@ -357,6 +357,216 @@ class TestGDPopt(unittest.TestCase):
 
         SolverFactory('gdpopt').solve(
             eight_process, strategy='LOA', init_strategy='custom_disjuncts',
+            custom_init_disjuncts=initialize,
+            mip_solver=mip_solver,
+            nlp_solver=nlp_solver,
+            call_after_subproblem_feasible=assert_correct_disjuncts_active)
+
+        self.assertTrue(fabs(value(eight_process.profit.expr) - 68) <= 1E-2)
+
+
+@unittest.skipIf(not LOA_solvers_available,
+                 "Required subsolvers %s are not available"
+                 % (LOA_solvers,))
+class TestGDPoptRIC(unittest.TestCase):
+    """Tests for the GDPopt solver plugin."""
+
+    def test_infeasible_GDP(self):
+        """Test for infeasible GDP."""
+        m = ConcreteModel()
+        m.x = Var(bounds=(0, 2))
+        m.d = Disjunction(expr=[
+            [m.x ** 2 >= 3, m.x >= 3],
+            [m.x ** 2 <= -1, m.x <= -1]])
+        m.o = Objective(expr=m.x)
+        output = StringIO()
+        with LoggingIntercept(output, 'pyomo.contrib.gdpopt', logging.WARNING):
+            SolverFactory('gdpopt').solve(
+                m, strategy='RIC',
+                mip_solver=mip_solver,
+                nlp_solver=nlp_solver)
+            self.assertIn("Set covering problem was infeasible.",
+                          output.getvalue().strip())
+
+    def test_GDP_nonlinear_objective(self):
+        m = ConcreteModel()
+        m.x = Var(bounds=(-1, 10))
+        m.y = Var(bounds=(2, 3))
+        m.d = Disjunction(expr=[
+            [m.x + m.y >= 5], [m.x - m.y <= 3]
+        ])
+        m.o = Objective(expr=m.x ** 2)
+        SolverFactory('gdpopt').solve(
+            m, strategy='RIC',
+            mip_solver=mip_solver,
+            nlp_solver=nlp_solver
+        )
+        self.assertAlmostEqual(value(m.o), 0)
+
+        m = ConcreteModel()
+        m.x = Var(bounds=(-1, 10))
+        m.y = Var(bounds=(2, 3))
+        m.d = Disjunction(expr=[
+            [m.x + m.y >= 5], [m.x - m.y <= 3]
+        ])
+        m.o = Objective(expr=-m.x ** 2, sense=maximize)
+        SolverFactory('gdpopt').solve(
+            m, strategy='RIC',
+            mip_solver=mip_solver,
+            nlp_solver=nlp_solver
+        )
+        self.assertAlmostEqual(value(m.o), 0)
+
+    def test_RIC_8PP_default_init(self):
+        """Test logic-based outer approximation with 8PP."""
+        exfile = import_file(
+            join(exdir, 'eight_process', 'eight_proc_model.py'))
+        eight_process = exfile.build_eight_process_flowsheet()
+        SolverFactory('gdpopt').solve(
+            eight_process, strategy='RIC',
+            mip_solver=mip_solver,
+            nlp_solver=nlp_solver,
+            tee=False)
+        self.assertTrue(fabs(value(eight_process.profit.expr) - 68) <= 1E-2)
+
+    @unittest.skipUnless(SolverFactory('gams').available(exception_flag=False), 'GAMS solver not available')
+    def test_RIC_8PP_gams_solver(self):
+        # Make sure that the duals are still correct
+        exfile = import_file(
+            join(exdir, 'eight_process', 'eight_proc_model.py'))
+        eight_process = exfile.build_eight_process_flowsheet()
+        SolverFactory('gdpopt').solve(
+            eight_process, strategy='RIC',
+            mip_solver=mip_solver,
+            nlp_solver='gams',
+            max_slack=0,
+            tee=False)
+        self.assertTrue(fabs(value(eight_process.profit.expr) - 68) <= 1E-2)
+
+    def test_RIC_8PP_force_NLP(self):
+        exfile = import_file(
+            join(exdir, 'eight_process', 'eight_proc_model.py'))
+        eight_process = exfile.build_eight_process_flowsheet()
+        SolverFactory('gdpopt').solve(
+            eight_process, strategy='RIC',
+            mip_solver=mip_solver,
+            nlp_solver=nlp_solver,
+            force_subproblem_nlp=True,
+            tee=False)
+        self.assertTrue(fabs(value(eight_process.profit.expr) - 68) <= 1E-2)
+
+    def test_RIC_strip_pack_default_init(self):
+        """Test logic-based outer approximation with strip packing."""
+        exfile = import_file(
+            join(exdir, 'strip_packing', 'strip_packing_concrete.py'))
+        strip_pack = exfile.build_rect_strip_packing_model()
+        SolverFactory('gdpopt').solve(
+            strip_pack, strategy='RIC',
+            mip_solver=mip_solver,
+            nlp_solver=nlp_solver)
+        self.assertTrue(
+            fabs(value(strip_pack.total_length.expr) - 11) <= 1E-2)
+
+    def test_RIC_constrained_layout_default_init(self):
+        """Test RIC with constrained layout."""
+        exfile = import_file(
+            join(exdir, 'constrained_layout', 'cons_layout_model.py'))
+        cons_layout = exfile.build_constrained_layout_model()
+        SolverFactory('gdpopt').solve(
+            cons_layout, strategy='RIC',
+            mip_solver=mip_solver,
+            nlp_solver=nlp_solver,
+            iterlim=120,
+            max_slack=5,  # problem is convex, so can decrease slack
+        )
+        objective_value = value(cons_layout.min_dist_cost.expr)
+        self.assertTrue(
+            fabs(objective_value - 41573) <= 200,
+            "Objective value of %s instead of 41573" % objective_value)
+
+    def test_RIC_8PP_maxBinary(self):
+        """Test logic-based OA with max_binary initialization."""
+        exfile = import_file(
+            join(exdir, 'eight_process', 'eight_proc_model.py'))
+        eight_process = exfile.build_eight_process_flowsheet()
+        SolverFactory('gdpopt').solve(
+            eight_process, strategy='RIC', init_strategy='max_binary',
+            mip_solver=mip_solver,
+            nlp_solver=nlp_solver)
+
+        self.assertTrue(fabs(value(eight_process.profit.expr) - 68) <= 1E-2)
+
+    def test_RIC_strip_pack_maxBinary(self):
+        """Test RIC with strip packing using max_binary initialization."""
+        exfile = import_file(
+            join(exdir, 'strip_packing', 'strip_packing_concrete.py'))
+        strip_pack = exfile.build_rect_strip_packing_model()
+        SolverFactory('gdpopt').solve(
+            strip_pack, strategy='RIC', init_strategy='max_binary',
+            mip_solver=mip_solver,
+            nlp_solver=nlp_solver)
+        self.assertTrue(
+            fabs(value(strip_pack.total_length.expr) - 11) <= 1E-2)
+
+    def test_RIC_8PP_fixed_disjuncts(self):
+        """Test RIC with 8PP using fixed disjuncts initialization."""
+        exfile = import_file(
+            join(exdir, 'eight_process', 'eight_proc_model.py'))
+        eight_process = exfile.build_eight_process_flowsheet()
+        initialize = [
+            # Use units 1, 4, 7, 8
+            eight_process.use_unit_1or2.disjuncts[0],
+            eight_process.use_unit_3ornot.disjuncts[1],
+            eight_process.use_unit_4or5ornot.disjuncts[0],
+            eight_process.use_unit_6or7ornot.disjuncts[1],
+            eight_process.use_unit_8ornot.disjuncts[0]
+        ]
+        for disj in eight_process.component_data_objects(Disjunct):
+            if disj in initialize:
+                disj.indicator_var.set_value(1)
+            else:
+                disj.indicator_var.set_value(0)
+        SolverFactory('gdpopt').solve(
+            eight_process, strategy='RIC', init_strategy='fix_disjuncts',
+            mip_solver=mip_solver,
+            nlp_solver=nlp_solver)
+
+        self.assertTrue(fabs(value(eight_process.profit.expr) - 68) <= 1E-2)
+
+    def test_RIC_custom_disjuncts(self):
+        """Test logic-based OA with custom disjuncts initialization."""
+        exfile = import_file(
+            join(exdir, 'eight_process', 'eight_proc_model.py'))
+        eight_process = exfile.build_eight_process_flowsheet()
+        initialize = [
+            # Use units 1, 4, 7, 8
+            [eight_process.use_unit_1or2.disjuncts[0],
+             eight_process.use_unit_3ornot.disjuncts[1],
+             eight_process.use_unit_4or5ornot.disjuncts[0],
+             eight_process.use_unit_6or7ornot.disjuncts[1],
+             eight_process.use_unit_8ornot.disjuncts[0]],
+            # Use units 2, 4, 6, 8
+            [eight_process.use_unit_1or2.disjuncts[1],
+             eight_process.use_unit_3ornot.disjuncts[1],
+             eight_process.use_unit_4or5ornot.disjuncts[0],
+             eight_process.use_unit_6or7ornot.disjuncts[0],
+             eight_process.use_unit_8ornot.disjuncts[0]]
+        ]
+
+        def assert_correct_disjuncts_active(nlp_model, solve_data):
+            if solve_data.master_iteration >= 1:
+                return  # only checking initialization
+            iter_num = solve_data.nlp_iteration
+            disjs_should_be_active = initialize[iter_num - 1]
+            for orig_disj, soln_disj in zip(
+                solve_data.original_model.GDPopt_utils.disjunct_list,
+                nlp_model.GDPopt_utils.disjunct_list
+            ):
+                if orig_disj in disjs_should_be_active:
+                    self.assertTrue(soln_disj.indicator_var.value == 1)
+
+        SolverFactory('gdpopt').solve(
+            eight_process, strategy='RIC', init_strategy='custom_disjuncts',
             custom_init_disjuncts=initialize,
             mip_solver=mip_solver,
             nlp_solver=nlp_solver,


### PR DESCRIPTION
## Changes proposed in this PR:
- Add an option to GDPopt to solve a relaxation with integer cuts but without outer approximation cuts or MC++
- Remove the default GDPopt strategy. The strategy must be specified now.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
