### PR TITLE
Move Container/Options/Bunch into just Bunch

### DIFF
--- a/examples/doc/pyomobook/attic/scripts/alltogether.py
+++ b/examples/doc/pyomobook/attic/scripts/alltogether.py
@@ -1,6 +1,6 @@
 import pyomo.environ
 from pyomo.opt import SolverFactory
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 
 import sys
 import math
@@ -39,7 +39,7 @@ model.skip_canonical_repn = True # for nonlinear models
 instance=model.create()
 
 SolverName = "asl"
-so = Options()
+so = Bunch()
 so.solver = "ipopt"
 opt=SolverFactory(SolverName, options=so)
 

--- a/examples/doc/pyomobook/attic/scripts/indexnonlinscript.py
+++ b/examples/doc/pyomobook/attic/scripts/indexnonlinscript.py
@@ -1,7 +1,7 @@
 import sys
 import pyomo.environ
 from pyomo.opt import SolverFactory
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 
 from indexnonlin import model
 
@@ -12,7 +12,7 @@ model.skip_canonical_repn = True # for nonlinear models
 instance=model.create()
 
 SolverName = "asl"
-so = Options()
+so = Bunch()
 so.solver = "ipopt"
 opt=SolverFactory(SolverName, options=so)
 

--- a/examples/doc/pyomobook/attic/scripts/mimic_pyomo/mimic_pyomo.py
+++ b/examples/doc/pyomobook/attic/scripts/mimic_pyomo/mimic_pyomo.py
@@ -1,9 +1,9 @@
 # Mimic the pyomo script
 from pyomo.core import *
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 
 # set high level options that mimic pyomo comand line
-options = Options()
+options = Bunch()
 options.model_file = 'DiseaseEstimation.py'
 options.data_files = ['DiseaseEstimation.dat']
 options.solver = 'ipopt'

--- a/examples/doc/pyomobook/attic/scripts/nonlinscript.py
+++ b/examples/doc/pyomobook/attic/scripts/nonlinscript.py
@@ -1,7 +1,7 @@
 import sys
 import pyomo.environ
 from pyomo.opt import SolverFactory
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 
 from nonlin import model
 
@@ -12,7 +12,7 @@ model.skip_canonical_repn = True # for nonlinear models
 instance=model.create()
 
 SolverName = "asl"
-so = Options()
+so = Bunch()
 so.solver = "ipopt"
 opt=SolverFactory(SolverName, options=so)
 

--- a/examples/doc/samples/pyomo_book/nonlinear_ReactorDesignTable.py
+++ b/examples/doc/samples/pyomo_book/nonlinear_ReactorDesignTable.py
@@ -1,6 +1,6 @@
 # nonlinear_ReactorDesignTable.py
 from pyomo.environ import *
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 
 # create the concrete model
 model = ConcreteModel()
@@ -36,7 +36,7 @@ model.cd_bal = Constraint(expr=(0 == -model.sv * model.cd \
                  + k3 * model.ca ** 2.0))
 
 # setup the solver options
-options = Options()
+options = Bunch()
 options.solver = 'ipopt'
 options.quiet = True
 

--- a/examples/doc/samples/pyomo_book/scripts_mimicPyomo.py
+++ b/examples/doc/samples/pyomo_book/scripts_mimicPyomo.py
@@ -1,9 +1,9 @@
 # Mimic the pyomo script
 from pyomo.environ import *
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 
 # set high level options that mimic pyomo comand line
-options = Options()
+options = Bunch()
 options.model_file = 'DiseaseEstimation.py'
 options.data_files = ['DiseaseEstimation.dat']
 options.solver = 'ipopt'

--- a/examples/pyomo/callbacks/sc.py
+++ b/examples/pyomo/callbacks/sc.py
@@ -8,7 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 from pyomo.core import *
 import math
 import random
@@ -45,7 +45,7 @@ def print_model_stats(options,model):
 
 def pyomo_create_model(options=None, model_options=None):
     if model_options is None:
-        model_options = Options()
+        model_options = Bunch()
     if model_options.type is None:
         model_options.type = 'fixed_set_size'
     #
@@ -185,24 +185,24 @@ def test_model(options=None):
 if __name__ == '__main__':
     test_model()
     #
-    options = Options()
+    options = Bunch()
     options.type = 'fixed_set_size'
     options.m = 11
     options.n = 21
     options.rho = 0.3
     test_model(options)
     #
-    options = Options()
+    options = Bunch()
     options.type = 'fixed_element_coverage'
     test_model(options)
     #
-    options = Options()
+    options = Bunch()
     options.m = 100
     options.n = 200
     options.type = 'fixed_probability'
     test_model(options)
     #
-    options = Options()
+    options = Bunch()
     options.type = 'fixed_element_coverage'
     options.m = 10
     options.n = 100

--- a/pyomo/bilevel/plugins/lcp.py
+++ b/pyomo/bilevel/plugins/lcp.py
@@ -8,7 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import six
 import logging
 
 from pyomo.core.base import Block, VarList, ConstraintList, Objective, Var, Constraint, maximize, ComponentUID, Set, TransformationFactory
@@ -287,7 +286,7 @@ class LinearComplementarity_BilevelTransformation(Base_BilevelTransformation):
                         exp -= B2_[uid] * lb_dual
                     if not ub_dual is None:
                         exp += B2_[uid] * ub_dual
-            if type(exp) in six.integer_types or type(exp) is float:
+            if type(exp) in [int, float]:
                 # TODO: Annotate the model as unbounded
                 raise IOError("Unbounded variable without side constraints")
             else:

--- a/pyomo/bilevel/tests/test_blp.py
+++ b/pyomo/bilevel/tests/test_blp.py
@@ -26,9 +26,8 @@ import pyomo.scripting.pyomo_main as pyomo_main
 from pyomo.scripting.util import cleanup
 from pyomo.environ import TransformationFactory
 
-from six import iteritems
-
 solvers = pyomo.opt.check_available_solvers('cplex', 'glpk', 'ipopt')
+
 
 class CommonTests:
 
@@ -148,7 +147,7 @@ class Solver(unittest.TestCase):
         self.assertEqual(len(refObj), len(ansObj))
         for i in range(len(refObj)):
             self.assertEqual(len(refObj[i]), len(ansObj[i]))
-            for key,val in iteritems(refObj[i]):
+            for key,val in refObj[i].items():
                 #self.assertEqual(val['Id'], ansObj[i].get(key,None)['Id'])
                 self.assertAlmostEqual(val['Value'], ansObj[i].get(key,None)['Value'], places=3)
 

--- a/pyomo/bilevel/tests/test_linear_dual.py
+++ b/pyomo/bilevel/tests/test_linear_dual.py
@@ -25,8 +25,6 @@ import pyomo.scripting.pyomo_main as pyomo_main
 from pyomo.scripting.util import cleanup
 import pyomo.environ
 
-from six import iteritems
-
 solvers = pyomo.opt.check_available_solvers('cplex', 'glpk')
 
 
@@ -154,7 +152,7 @@ class Solver(unittest.TestCase):
         self.assertEqual(len(refObj), len(ansObj))
         for i in range(len(refObj)):
             self.assertEqual(len(refObj[i]), len(ansObj[i]))
-            for key,val in iteritems(refObj[i]):
+            for key,val in refObj[i].items():
                 #self.assertEqual(val['Id'], ansObj[i].get(key,None)['Id'])
                 self.assertAlmostEqual(val['Value'], ansObj[i].get(key,None)['Value'], places=3)
 

--- a/pyomo/common/collections/__init__.py
+++ b/pyomo/common/collections/__init__.py
@@ -23,5 +23,4 @@ else:
 from .orderedset import OrderedDict, OrderedSet
 from .component_map import ComponentMap
 from .component_set import ComponentSet
-
-from pyutilib.misc import Bunch, Container, Options
+from .bunch import Bunch

--- a/pyomo/common/collections/__init__.py
+++ b/pyomo/common/collections/__init__.py
@@ -24,3 +24,5 @@ from .orderedset import OrderedDict, OrderedSet
 from .component_map import ComponentMap
 from .component_set import ComponentSet
 from .bunch import Bunch
+
+from pyutilib.misc import Options, Container

--- a/pyomo/common/collections/__init__.py
+++ b/pyomo/common/collections/__init__.py
@@ -24,5 +24,3 @@ from .orderedset import OrderedDict, OrderedSet
 from .component_map import ComponentMap
 from .component_set import ComponentSet
 from .bunch import Bunch
-
-from pyutilib.misc import Options, Container

--- a/pyomo/common/collections/bunch.py
+++ b/pyomo/common/collections/bunch.py
@@ -1,0 +1,121 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+#  This module was originally developed as part of the PyUtilib project
+#  Copyright (c) 2008 Sandia Corporation.
+#  This software is distributed under the BSD License.
+#  Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+#  the U.S. Government retains certain rights in this software.
+#  ___________________________________________________________________________
+
+import shlex
+
+
+class Bunch(dict):
+    """
+    A class that can be used to store a bunch of data dynamically.
+    This class allows all other attributes to have a default value of None. 
+    This borrows the output formatting ideas from the
+    ActiveState Code Container (recipe 496697).
+    """
+
+    def __init__(self, *args, **kw):
+        for arg in args:
+            for item in shlex.split(arg):
+                r = item.find('=')
+                if r != -1:
+                    try:
+                        val = eval(item[r + 1:])
+                    except:
+                        val = item[r + 1:]
+                    kw[item[:r]] = val
+        dict.__init__(self, kw)
+        self.__dict__.update(kw)
+        if not '_name_' in kw:
+            self._name_ = self.__class__.__name__
+
+    def update(self, d):
+        """
+        The update is specialized for JSON-like data.  This
+        recursively replaces dictionaries with Container objects.
+        """
+        for k in d:
+            if type(d[k]) is dict:
+                tmp = Bunch()
+                tmp.update(d[k])
+                self.__setattr__(k, tmp)
+            elif type(d[k]) is list:
+                val = []
+                for i in d[k]:
+                    if type(i) is dict:
+                        tmp = Bunch()
+                        tmp.update(i)
+                        val.append(tmp)
+                    else:
+                        val.append(i)
+                self.__setattr__(k, val)
+            else:
+                self.__setattr__(k, d[k])
+
+    def set_name(self, name):
+        self._name_ = name
+
+    def __setitem__(self, name, val):
+        self.__setattr__(name, val)
+
+    def __getitem__(self, name):
+        return self.__getattr__(name)
+
+    def __setattr__(self, name, val):
+        if name[0] != '_':
+            dict.__setitem__(self, name, val)
+        self.__dict__[name] = val
+
+    def __getattr__(self, name):
+        try:
+            return dict.__getitem__(self, name)
+        except:
+            if name[0] == '_':
+                raise AttributeError("Unknown attribute %s" % name)
+        return None
+
+    def __repr__(self):
+        attrs = sorted("%s = %r" % (k, v) for k, v in self.__dict__.items()
+                       if not k.startswith("_"))
+        return "%s(%s)" % (self.__class__.__name__, ", ".join(attrs))
+
+    def __str__(self):
+        return self.as_string()
+
+    def __str__(self, nesting=0, indent=''):
+        attrs = []
+        indentation = indent + "    " * nesting
+        for k, v in self.__dict__.items():
+            if not k.startswith("_"):
+                text = [indentation, k, ":"]
+                if isinstance(v, Bunch):
+                    if len(v) > 0:
+                        text.append('\n')
+                    text.append(v.__str__(nesting + 1))
+                elif isinstance(v, list):
+                    if len(v) == 0:
+                        text.append(' []')
+                    else:
+                        for v_ in v:
+                            text.append('\n' + indentation + "-")
+                            if isinstance(v_, Bunch):
+                                text.append('\n' + v_.__str__(nesting + 1))
+                            else:
+                                text.append(" " + repr(v_))
+                else:
+                    text.append(' ' + repr(v))
+                attrs.append("".join(text))
+        attrs.sort()
+        return "\n".join(attrs)

--- a/pyomo/common/tests/test_bunch.py
+++ b/pyomo/common/tests/test_bunch.py
@@ -1,0 +1,77 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+#  This module was originally developed as part of the PyUtilib project
+#  Copyright (c) 2008 Sandia Corporation.
+#  This software is distributed under the BSD License.
+#  Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+#  the U.S. Government retains certain rights in this software.
+#  ___________________________________________________________________________
+
+import pickle
+import unittest
+from pyomo.common.collections import Bunch
+
+class Test(unittest.TestCase):
+    def test_Bunch1(self):
+        opt = Bunch('a=None c=d e="1 2 3"', foo=1, bar='x')
+        self.assertEqual(opt.ll, None)
+        self.assertEqual(opt.a, None)
+        self.assertEqual(opt.c, 'd')
+        self.assertEqual(opt.e, '1 2 3')
+        self.assertEqual(opt.foo, 1)
+        self.assertEqual(opt.bar, 'x')
+        self.assertEqual(opt['bar'], 'x')
+        opt.xx = 1
+        opt['yy'] = 2
+        self.assertEqual(
+            set(opt.keys()), set(['a', 'bar', 'c', 'foo', 'e', 'xx', 'yy']))
+        opt.x = Bunch(a=1, b=2)
+        self.assertEqual(
+            set(opt.keys()), set(
+                ['a', 'bar', 'c', 'foo', 'e', 'xx', 'yy', 'x']))
+        self.assertEqual(
+            repr(opt),
+            "Bunch(a = None, bar = 'x', c = 'd', e = '1 2 3', foo = 1, x = Bunch(a = 1, b = 2), xx = 1, yy = 2)")
+        self.assertEqual(
+            str(opt), """a: None
+bar: 'x'
+c: 'd'
+e: '1 2 3'
+foo: 1
+x:
+    a: 1
+    b: 2
+xx: 1
+yy: 2""")
+        opt._name_ = 'BUNCH'
+        self.assertEqual(
+            set(opt.keys()), set(
+                ['a', 'bar', 'c', 'foo', 'e', 'xx', 'yy', 'x']))
+        self.assertEqual(
+            repr(opt),
+            "Bunch(a = None, bar = 'x', c = 'd', e = '1 2 3', foo = 1, x = Bunch(a = 1, b = 2), xx = 1, yy = 2)")
+        self.assertEqual(
+            str(opt), """a: None
+bar: 'x'
+c: 'd'
+e: '1 2 3'
+foo: 1
+x:
+    a: 1
+    b: 2
+xx: 1
+yy: 2""")
+
+    def test_Container2(self):
+        o1 = Bunch('a=None c=d e="1 2 3"', foo=1, bar='x')
+        s = pickle.dumps(o1)
+        o2 = pickle.loads(s)
+        self.assertEqual(o1, o2)

--- a/pyomo/contrib/gdpbb/GDPbb.py
+++ b/pyomo/contrib/gdpbb/GDPbb.py
@@ -11,7 +11,7 @@ import logging
 import traceback
 
 from pyomo.common import deprecated
-from pyomo.common.collections import ComponentSet, Container
+from pyomo.common.collections import ComponentSet, Bunch
 from pyomo.common.config import (ConfigBlock, ConfigValue, PositiveInt)
 from pyomo.contrib.gdpopt.util import create_utility_block, time_code, a_logger, restore_logger_level, \
     setup_results_object, get_main_elapsed_time, process_objective
@@ -112,7 +112,7 @@ class GDPbbSolver(object):
         self.validate_model(model)
         # Set solver as an MINLP
         solve_data = GDPbbSolveData()
-        solve_data.timing = Container()
+        solve_data.timing = Bunch()
         solve_data.original_model = model
         solve_data.results = SolverResults()
 

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -17,7 +17,7 @@ from six import StringIO
 
 import pyutilib.th as unittest
 from pyomo.common.log import LoggingIntercept
-from pyomo.common.collections import Container
+from pyomo.common.collections import Bunch
 from pyomo.common.fileutils import import_file
 from pyomo.contrib.gdpopt.GDPopt import GDPoptSolver
 from pyomo.contrib.gdpopt.data_class import GDPoptSolveData
@@ -62,7 +62,7 @@ class TestGDPoptUnit(unittest.TestCase):
         output = StringIO()
         with LoggingIntercept(output, 'pyomo.contrib.gdpopt', logging.WARNING):
             solver_data = GDPoptSolveData()
-            solver_data.timing = Container()
+            solver_data.timing = Bunch()
             with time_code(solver_data.timing, 'main', is_main_timer=True):
                 solve_linear_GDP(m, solver_data, GDPoptSolver.CONFIG(dict(mip_solver=mip_solver)))
             self.assertIn("Linear GDP was unbounded. Resolving with arbitrary bound values",

--- a/pyomo/contrib/gdpopt/util.py
+++ b/pyomo/contrib/gdpopt/util.py
@@ -18,7 +18,7 @@ from math import fabs
 import six
 
 from pyomo.common import deprecated, timing
-from pyomo.common.collections import ComponentSet, Container
+from pyomo.common.collections import ComponentSet, Bunch
 from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
 from pyomo.contrib.gdpopt.data_class import GDPoptSolveData
 from pyomo.contrib.mcpp.pyomo_mcpp import mcpp_available, McCormick
@@ -484,7 +484,7 @@ def setup_solver_environment(model, config):
     solve_data = GDPoptSolveData()  # data object for storing solver state
     solve_data.config = config
     solve_data.results = SolverResults()
-    solve_data.timing = Container()
+    solve_data.timing = Bunch()
     min_logging_level = logging.INFO if config.tee else None
     with time_code(solve_data.timing, 'total', is_main_timer=True), \
             lower_logger_level_to(config.logger, min_logging_level), \

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -47,7 +47,7 @@ from pyomo.core import (
     Block, ConstraintList, NonNegativeReals, Set, Suffix, Var,
     VarList, TransformationFactory, Objective)
 from pyomo.opt import SolverFactory, SolverResults
-from pyomo.common.collections import Container
+from pyomo.common.collections import Bunch
 from pyomo.contrib.fbbt.fbbt import fbbt
 from pyomo.contrib.mindtpy.config_options import _get_GDPopt_config
 
@@ -126,7 +126,7 @@ class MindtPySolver(object):
 
         solve_data = MindtPySolveData()
         solve_data.results = SolverResults()
-        solve_data.timing = Container()
+        solve_data.timing = Bunch()
         solve_data.curr_int_sol = []
         solve_data.prev_int_sol = []
 

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -17,7 +17,7 @@ import gc
 import math
 
 from pyomo.common import timing, PyomoAPIFactory
-from pyomo.common.collections import Container
+from pyomo.common.collections import Bunch
 from pyomo.common.dependencies import pympler, pympler_available
 from pyomo.common.deprecation import deprecated, deprecation_warning
 from pyomo.common.gc_manager import PauseGC
@@ -61,7 +61,7 @@ def global_option(function, name, value):
     return wrapper_function
 
 
-class PyomoConfig(Container):
+class PyomoConfig(Bunch):
     """
     This is a pyomo-specific configuration object, which is a subclass of Container.
     """
@@ -69,7 +69,7 @@ class PyomoConfig(Container):
     _option = {}
 
     def __init__(self, *args, **kw):
-        Container.__init__(self, *args, **kw)
+        Bunch.__init__(self, *args, **kw)
         self.set_name('PyomoConfig')
         #
         # Create the nested options specified by the the PyomoConfig._option
@@ -79,7 +79,7 @@ class PyomoConfig(Container):
             d = self
             for attr in item[:-1]:
                 if not attr in d:
-                    d[attr] = Container()
+                    d[attr] = Bunch()
                 d = d[attr]
             d[item[-1]] = PyomoConfig._option[item]
 
@@ -573,7 +573,7 @@ class Model(SimpleBlock):
         #
         SimpleBlock.__init__(self, **kwargs)
         self._name = name
-        self.statistics = Container()
+        self.statistics = Bunch()
         self.config = PyomoConfig()
         self.solutions = ModelSolutions(self)
         self.config.preprocessor = 'pyomo.model.simple_preprocessor'

--- a/pyomo/dataportal/TableData.py
+++ b/pyomo/dataportal/TableData.py
@@ -12,7 +12,7 @@ __all__ = ['TableData']
 
 from six.moves import xrange
 
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 from pyomo.dataportal.process_data import _process_data
 
 
@@ -28,7 +28,7 @@ class TableData(object):
         """
         self._info=None
         self._data=None
-        self.options = Options()
+        self.options = Bunch()
         self.options.ncolumns = 1
 
     def available(self):

--- a/pyomo/dataportal/plugins/datacommands.py
+++ b/pyomo/dataportal/plugins/datacommands.py
@@ -10,7 +10,7 @@
 
 import os.path
 
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 from pyomo.dataportal.factory import DataManagerFactory
 from pyomo.dataportal.process_data import _process_include
 
@@ -20,7 +20,7 @@ class PyomoDataCommands(object):
 
     def __init__(self):
         self._info = []
-        self.options = Options()
+        self.options = Bunch()
 
     def available(self):
         return True

--- a/pyomo/dataportal/plugins/json_dict.py
+++ b/pyomo/dataportal/plugins/json_dict.py
@@ -12,7 +12,7 @@ import os.path
 import json
 import six
 
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 from pyomo.dataportal.factory import DataManagerFactory
 
@@ -93,7 +93,7 @@ class JSONDictionary(object):
 
     def __init__(self):
         self._info = {}
-        self.options = Options()
+        self.options = Bunch()
 
     def available(self):
         return True
@@ -192,7 +192,7 @@ class YamlDictionary(object):
 
     def __init__(self):
         self._info = {}
-        self.options = Options()
+        self.options = Bunch()
 
     def available(self):
         return yaml_available

--- a/pyomo/dataportal/process_data.py
+++ b/pyomo/dataportal/process_data.py
@@ -14,7 +14,7 @@ import copy
 import logging
 
 from pyomo.common.log import is_debug_set
-from pyomo.common.collections import Options, OrderedDict
+from pyomo.common.collections import Bunch, OrderedDict
 from pyomo.common.errors import ApplicationError
 
 from pyomo.dataportal.parse_datacmds import (
@@ -694,7 +694,7 @@ def _process_table(cmd, _model, _data, _default, options=None):
     #print("_param %s" % _param)
     #print("_labels %s" % _labels)
 #
-    options = Options(**_options)
+    options = Bunch(**_options)
     for key in options:
         if not key in ['columns']:
             raise ValueError("Unknown table option '%s'" % key)
@@ -827,7 +827,7 @@ def _process_load(cmd, _model, _data, _default, options=None):
     if len(cmd) < 2:
         raise IOError("The 'load' command must specify a filename")
 
-    options = Options(**_options)
+    options = Bunch(**_options)
     for key in options:
         if not key in ['range','filename','format','using','driver','query','table','user','password','database']:
             raise ValueError("Unknown load option '%s'" % key)

--- a/pyomo/mpec/plugins/pathampl.py
+++ b/pyomo/mpec/plugins/pathampl.py
@@ -12,7 +12,7 @@ import logging
 
 from pyomo.opt.base.solvers import SolverFactory
 from pyomo.common import Executable
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 from pyomo.solvers.plugins.solvers.ASL import ASL
 
 logger = logging.getLogger('pyomo.solvers')
@@ -32,7 +32,7 @@ class PATHAMPL(ASL):
         #
         # Define solver capabilities, which default to 'None'
         #
-        self._capabilities = Options()
+        self._capabilities = Bunch()
         self._capabilities.linear = True
 
     def _default_executable(self):

--- a/pyomo/network/decomposition.py
+++ b/pyomo/network/decomposition.py
@@ -14,7 +14,7 @@ from pyomo.network import Port, Arc
 from pyomo.network.foqus_graph import FOQUSGraph
 from pyomo.core import Constraint, value, Objective, Var, ConcreteModel, \
     Binary, minimize, Expression
-from pyomo.common.collections import ComponentSet, ComponentMap, Options
+from pyomo.common.collections import ComponentSet, ComponentMap, Bunch
 from pyomo.core.expr.current import identify_variables
 from pyomo.repn import generate_standard_repn
 import logging, time
@@ -146,7 +146,7 @@ class SequentialDecomposition(FOQUSGraph):
     def __init__(self, **kwds):
         """Pass kwds to update the options attribute after setting defaults"""
         self.cache = {}
-        options = self.options = Options()
+        options = self.options = Bunch()
         # defaults
         options["graph"] = None
         options["tear_set"] = None

--- a/pyomo/opt/base/solvers.py
+++ b/pyomo/opt/base/solvers.py
@@ -22,7 +22,7 @@ import shlex
 from pyomo.common.config import ConfigBlock, ConfigList, ConfigValue
 from pyomo.common import Factory
 from pyomo.common.errors import ApplicationError
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 
 from pyomo.opt.base.problem import ProblemConfigFactory
 from pyomo.opt.base.convert import convert_problem
@@ -340,7 +340,7 @@ class OptSolver(object):
         # through the solve command. Everything else is reset inside
         # presolve
         #
-        self.options = Options()
+        self.options = Bunch()
         if 'options' in kwds and not kwds['options'] is None:
             for key in kwds['options']:
                 setattr(self.options, key, kwds['options'][key])
@@ -389,7 +389,7 @@ class OptSolver(object):
 
         # We define no capabilities for the generic solver; base
         # classes must override this
-        self._capabilities = Options()
+        self._capabilities = Bunch()
 
     @staticmethod
     def _options_string_to_dict(istr):
@@ -561,7 +561,7 @@ class OptSolver(object):
 
         orig_options = self.options
 
-        self.options = Options()
+        self.options = Bunch()
         self.options.update(orig_options)
         self.options.update(kwds.pop('options', {}))
         self.options.update(

--- a/pyomo/scripting/commands.py
+++ b/pyomo/scripting/commands.py
@@ -16,7 +16,7 @@ import signal
 import subprocess
 
 import pyutilib.pyro
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 from pyomo.opt import SolverResults
 from pyomo.common._command import pyomo_command
 import pyomo.scripting.pyomo_parser
@@ -138,7 +138,7 @@ def pyomo(args=None):
 def results_schema():
     if len(sys.argv) > 1:
         print("results_schema  - Print the predefined schema in a SolverResults object")
-    options = Options(schema=True)
+    options = Bunch(schema=True)
     r=SolverResults()
     repn = r._repn_(options)
     r.pprint(sys.stdout, options, repn=repn)

--- a/pyomo/scripting/convert.py
+++ b/pyomo/scripting/convert.py
@@ -13,7 +13,7 @@ __all__ = ['pyomo2lp', 'pyomo2nl', 'pyomo2dakota']
 import os
 import sys
 
-from pyomo.common.collections import Options, Container
+from pyomo.common.collections import Bunch
 from pyomo.opt import ProblemFormat
 from pyomo.core.base import (Objective,
                              Var,
@@ -24,7 +24,7 @@ from pyomo.core.base import (Objective,
 _format = None
 
 
-def convert(options=Options(), parser=None, model_format=None):
+def convert(options=Bunch(), parser=None, model_format=None):
     global _format
     if not model_format is None:
         _format = model_format
@@ -40,7 +40,7 @@ def convert(options=Options(), parser=None, model_format=None):
             options.model.save_file = 'unknown.'+str(_format)
     options.model.save_format = _format
 
-    data = Options(options=options)
+    data = Bunch(options=options)
 
     model_data = None
     try:
@@ -49,7 +49,7 @@ def convert(options=Options(), parser=None, model_format=None):
         pyomo.scripting.util.apply_preprocessing(data, parser=parser)
 
         if data.error:
-            return Container()
+            return Bunch()
 
         model_data = pyomo.scripting.util.create_model(data)
 
@@ -73,7 +73,7 @@ def convert(options=Options(), parser=None, model_format=None):
 
     return model_data
 
-def convert_dakota(options=Options(), parser=None):
+def convert_dakota(options=Bunch(), parser=None):
     #
     # Import plugins
     #

--- a/pyomo/scripting/driver_help.py
+++ b/pyomo/scripting/driver_help.py
@@ -19,7 +19,7 @@ import socket
 import subprocess
 
 import pyomo.common
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 import pyomo.scripting.pyomo_parser
 
 logger = logging.getLogger('pyomo.solvers')
@@ -221,9 +221,9 @@ def help_api(options):
                     print("    "+line)
 
 def help_environment():
-    info = Options()
+    info = Bunch()
     #
-    info.python = Options()
+    info.python = Bunch()
     info.python.version = '%d.%d.%d' % sys.version_info[:3]
     info.python.executable = sys.executable
     info.python.platform = sys.platform
@@ -231,13 +231,13 @@ def help_environment():
         packages = []
         import pip
         for package in pip.get_installed_distributions():
-            packages.append(Options(name=package.project_name,
+            packages.append(Bunch(name=package.project_name,
                                     version=package.version))
         info.python.packages = packages
     except:
         pass
     #
-    info.environment = Options()
+    info.environment = Bunch()
     path = os.environ.get('PATH', None)
     if not path is None:
         info.environment['shell path'] = path.split(os.pathsep)

--- a/pyomo/scripting/plugins/convert.py
+++ b/pyomo/scripting/plugins/convert.py
@@ -12,7 +12,7 @@ import json
 import sys
 import argparse
 
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 from pyomo.opt import ProblemConfigFactory, guess_format
 from pyomo.scripting.pyomo_parser import add_subparser, CustomHelpFormatter
 
@@ -42,7 +42,7 @@ def create_parser(parser=None):
     return parser
 
 
-def run_convert(options=Options(), parser=None):
+def run_convert(options=Bunch(), parser=None):
     from pyomo.scripting.convert import convert, convert_dakota
     if options.model.save_format is None and options.model.save_file:
         options.model.save_format = options.model.save_file.split('.')[-1]

--- a/pyomo/scripting/pyomo_command.py
+++ b/pyomo/scripting/pyomo_command.py
@@ -9,7 +9,7 @@
 #  ___________________________________________________________________________
 
 from pyomo.common.dependencies import pympler_available
-from pyomo.common.collections import Options, Container
+from pyomo.common.collections import Bunch
 import pyomo.scripting.util
 from pyomo.core import ConcreteModel
 
@@ -273,12 +273,12 @@ def add_misc_group(parser):
     return group
 
 
-def run_pyomo(options=Options(), parser=None):
-    data = Options(options=options)
+def run_pyomo(options=Bunch(), parser=None):
+    data = Bunch(options=options)
 
     if options.model.filename == '':
         parser.print_help()
-        return Container()
+        return Bunch()
 
     try:
         pyomo.scripting.util.setup_environment(data)
@@ -307,7 +307,7 @@ def run_pyomo(options=Options(), parser=None):
                                           model=ConcreteModel(),
                                           instance=None,
                                           results=None)
-            return Container()                                   #pragma:nocover
+            return Bunch()                                   #pragma:nocover
 
     try:
         model_data = pyomo.scripting.util.create_model(data)
@@ -330,7 +330,7 @@ def run_pyomo(options=Options(), parser=None):
                                           model=model_data.model,
                                           instance=model_data.instance,
                                           results=None)
-            return Container(instance=model_data.instance)
+            return Bunch(instance=model_data.instance)
 
     try:
         opt_data = pyomo.scripting.util.apply_optimizer(data,
@@ -361,7 +361,7 @@ def run_pyomo(options=Options(), parser=None):
                                       instance=model_data.instance,
                                       results=opt_data.results)
 
-        return Container(options=options,
+        return Bunch(options=options,
                          instance=model_data.instance,
                          results=opt_data.results,
                          local=opt_data.local)

--- a/pyomo/scripting/tests/test_pms.py
+++ b/pyomo/scripting/tests/test_pms.py
@@ -19,7 +19,7 @@ from os.path import abspath, dirname
 from pyutilib.pyro import using_pyro4
 import pyutilib.th as unittest
 
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 import pyomo.opt
 from pyomo.environ import (ConcreteModel, RangeSet, Var,
@@ -63,7 +63,7 @@ class Test(unittest.TestCase):
         model.c = Constraint(rule=c_rule)
 
         #
-        data = Options()
+        data = Bunch()
         data.suffixes = {}
         data.solver_options = {}
         data.warmstart_filename = None

--- a/pyomo/scripting/util.py
+++ b/pyomo/scripting/util.py
@@ -30,7 +30,7 @@ from pyomo.common.dependencies import (
     pympler, pympler_available,
 )
 from pyomo.common.plugin import ExtensionPoint, Plugin, implements
-from pyomo.common.collections import Container, Options
+from pyomo.common.collections import Bunch
 from pyomo.opt import ProblemFormat
 from pyomo.opt.base import SolverFactory
 from pyomo.opt.parallel import SolverManagerFactory
@@ -38,7 +38,7 @@ from pyomo.dataportal import DataPortal
 from pyomo.core import IPyomoScriptCreateModel, IPyomoScriptCreateDataPortal, IPyomoScriptPrintModel, IPyomoScriptModifyInstance, IPyomoScriptPrintInstance, IPyomoScriptSaveInstance, IPyomoScriptPrintResults, IPyomoScriptSaveResults, IPyomoScriptPostprocess, IPyomoScriptPreprocess, Model, TransformationFactory, Suffix, display
 
 
-memory_data = Options()
+memory_data = Bunch()
 # Importing IPython is slow; defer the import to the point that it is
 # actually needed.
 IPython_available = None
@@ -156,7 +156,7 @@ def apply_preprocessing(data, parser=None):
     Returned:
         error: This is true if an error has occurred.
     """
-    data.local = Options()
+    data.local = Bunch()
     #
     if not data.options.runtime.logging == 'quiet':
         sys.stdout.write('[%8.2f] Applying Pyomo preprocessing actions\n' % (time.time()-start_time))
@@ -274,8 +274,8 @@ def create_model(data):
         else:
             model_options = data.options.model.options.value()
             tick = time.time()
-            model = ep.service().apply( options = Container(*data.options),
-                                       model_options=Container(*model_options) )
+            model = ep.service().apply( options = Bunch(*data.options),
+                                       model_options=Bunch(*model_options) )
             if data.options.runtime.report_timing is True:
                 print("      %6.2f seconds required to construct instance" % (time.time() - tick))
                 data.local.time_initial_import = None
@@ -474,8 +474,8 @@ def create_model(data):
             data.local.max_memory = mem_used
         print("   Total memory = %d bytes following Pyomo instance creation" % mem_used)
 
-    return Options(model=model, instance=instance,
-                   smap_id=smap_id, filename=fname, local=data.local )
+    return Bunch(model=model, instance=instance,
+                 smap_id=smap_id, filename=fname, local=data.local )
 
 @pyomo_api(namespace='pyomo.script')
 def apply_optimizer(data, instance=None):
@@ -620,7 +620,7 @@ def apply_optimizer(data, instance=None):
             data.local.max_memory = mem_used
         print("   Total memory = %d bytes following optimization" % mem_used)
 
-    return Options(results=results, opt=solver, local=data.local)
+    return Bunch(results=results, opt=solver, local=data.local)
 
 
 @pyomo_api(namespace='pyomo.script')
@@ -826,9 +826,9 @@ class PyomoCommandLogContext(object):
 
     def __init__(self, options):
         if options is None:
-            options = Options()
+            options = Bunch()
         if options.runtime is None:
-            options.runtime = Options()
+            options.runtime = Bunch()
         self.options = options
         self.fileLogger = None
         self.original = None
@@ -927,7 +927,7 @@ def run_command(command=None, parser=None, args=None, name='unknown', data=None,
                 _options = parser.parse_args(args=args)
             # Replace the parser options object with a
             # pyomo.common.collections.Options object
-            options = Options()
+            options = Bunch()
             for key in dir(_options):
                 if key[0] != '_':
                     val = getattr(_options, key)
@@ -936,7 +936,7 @@ def run_command(command=None, parser=None, args=None, name='unknown', data=None,
         except SystemExit:
             # the parser throws a system exit if "-h" is specified - catch
             # it to exit gracefully.
-            return Container(retval=None, errorcode=0)
+            return Bunch(retval=None, errorcode=0)
     #
     # Configure loggers
     #
@@ -950,7 +950,7 @@ def run_command(command=None, parser=None, args=None, name='unknown', data=None,
             gc.enable()
         TempfileManager.pop(remove=not options.runtime.keep_files)
 
-    return Container(retval=retval, errorcode=errorcode)
+    return Bunch(retval=retval, errorcode=errorcode)
 
 
 def _run_command_impl(command, parser, args, name, data, options):

--- a/pyomo/solvers/plugins/solvers/ASL.py
+++ b/pyomo/solvers/plugins/solvers/ASL.py
@@ -14,7 +14,7 @@ import subprocess
 
 from pyomo.common import Executable
 from pyomo.common.errors import ApplicationError
-from pyomo.common.collections import Options, Bunch
+from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
 from pyomo.opt.base import ProblemFormat, ResultsFormat
@@ -53,7 +53,7 @@ class ASL(SystemCallSolver):
         #
         # Note: Undefined capabilities default to 'None'
         #
-        self._capabilities = Options()
+        self._capabilities = Bunch()
         self._capabilities.linear = True
         self._capabilities.integer = True
         self._capabilities.quadratic_objective = True

--- a/pyomo/solvers/plugins/solvers/BARON.py
+++ b/pyomo/solvers/plugins/solvers/BARON.py
@@ -15,7 +15,7 @@ import re
 import tempfile
 
 from pyomo.common import Executable
-from pyomo.common.collections import Options, Bunch
+from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
 from pyomo.opt.base import ProblemFormat, ResultsFormat, OptSolver
@@ -50,7 +50,7 @@ class BARONSHELL(SystemCallSolver):
         self._valid_result_formats[ProblemFormat.bar] = [ResultsFormat.soln]
         self.set_problem_format(ProblemFormat.bar)
 
-        self._capabilities = Options()
+        self._capabilities = Bunch()
         self._capabilities.linear = True
         self._capabilities.quadratic_objective = True
         self._capabilities.quadratic_constraint = True

--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -19,7 +19,7 @@ from six import iteritems
 
 from pyomo.common import Executable
 from pyomo.common.errors import ApplicationError
-from pyomo.common.collections import Options, Bunch
+from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
 from pyomo.core.kernel.block import IBlock
@@ -161,7 +161,7 @@ class CBCSHELL(SystemCallSolver):
         self._valid_result_formats[ProblemFormat.mps] = [ResultsFormat.soln]
 
         # Note: Undefined capabilities default to 'None'
-        self._capabilities = Options()
+        self._capabilities = Bunch()
         self._capabilities.linear = True
         self._capabilities.integer = True
         # The quadratic capabilities may be true but there is

--- a/pyomo/solvers/plugins/solvers/CONOPT.py
+++ b/pyomo/solvers/plugins/solvers/CONOPT.py
@@ -12,7 +12,7 @@ import os
 import subprocess
 
 from pyomo.common import Executable
-from pyomo.common.collections import Options, Bunch
+from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
 from pyomo.opt.base import ProblemFormat, ResultsFormat
@@ -47,7 +47,7 @@ class CONOPT(SystemCallSolver):
         self.set_problem_format(ProblemFormat.nl)
 
         # Note: Undefined capabilities default to 'None'
-        self._capabilities = Options()
+        self._capabilities = Bunch()
         self._capabilities.linear = True
         self._capabilities.integer = True
         self._capabilities.quadratic_objective = True

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -19,7 +19,7 @@ from pyomo.common import Executable
 from pyomo.common.errors import ApplicationError
 from pyomo.common.tempfiles import TempfileManager
 
-from pyomo.common.collections import ComponentMap, Options, Bunch
+from pyomo.common.collections import ComponentMap, Bunch
 from pyomo.opt.base import (
     ProblemFormat, ResultsFormat, OptSolver, BranchDirection,
 )
@@ -169,7 +169,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
         self.set_problem_format(ProblemFormat.cpxlp)
 
         # Note: Undefined capabilities default to 'None'
-        self._capabilities = Options()
+        self._capabilities = Bunch()
         self._capabilities.linear = True
         self._capabilities.quadratic_objective = True
         self._capabilities.quadratic_constraint = True
@@ -619,7 +619,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 results.solver.termination_message = ' '.join(tokens)
 
         try:
-            if isinstance(results.solver.termination_message, basestring):
+            if isinstance(results.solver.termination_message, str):
                 results.solver.termination_message = results.solver.termination_message.replace(':', '\\x3a')
         except:
             pass

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -17,7 +17,7 @@ from pyomo.core.base import Constraint, Var, value, Objective
 from pyomo.opt import ProblemFormat, SolverFactory
 
 import pyomo.common
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 from pyomo.common.tee import TeeStream
 
 from pyomo.opt.base.solvers import _extract_version
@@ -45,7 +45,7 @@ class _GAMSSolver(object):
         self._default_variable_value = None
         self._metasolver = False
 
-        self._capabilities = Options()
+        self._capabilities = Bunch()
         self._capabilities.linear = True
         self._capabilities.quadratic_objective = True
         self._capabilities.quadratic_constraint = True
@@ -53,7 +53,7 @@ class _GAMSSolver(object):
         self._capabilities.sos1 = False
         self._capabilities.sos2 = False
 
-        self.options = Options()
+        self.options = Bunch()
 
     def version(self):
         """Returns a 4-tuple describing the solver executable version."""

--- a/pyomo/solvers/plugins/solvers/GLPK.py
+++ b/pyomo/solvers/plugins/solvers/GLPK.py
@@ -17,7 +17,7 @@ import subprocess
 from pyomo.common.tempfiles import TempfileManager
 
 from pyomo.common import Executable
-from pyomo.common.collections import Bunch, Options
+from pyomo.common.collections import Bunch
 from pyomo.opt import SolverFactory, OptSolver, ProblemFormat, ResultsFormat, SolverResults, TerminationCondition, SolutionStatus, ProblemSense
 from pyomo.opt.base.solvers import _extract_version
 from pyomo.opt.solver import SystemCallSolver
@@ -136,7 +136,7 @@ class GLPKSHELL(SystemCallSolver):
         self.set_problem_format(ProblemFormat.cpxlp)
 
         # Note: Undefined capabilities default to 'None'
-        self._capabilities = Options()
+        self._capabilities = Bunch()
         self._capabilities.linear = True
         self._capabilities.integer = True
 

--- a/pyomo/solvers/plugins/solvers/GLPK_old.py
+++ b/pyomo/solvers/plugins/solvers/GLPK_old.py
@@ -15,7 +15,7 @@ import sys
 import subprocess
 
 from pyomo.common.errors import ApplicationError
-from pyomo.common.collections import Bunch, Options
+from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
 from pyomo.common import Executable
@@ -77,7 +77,7 @@ class GLPKSHELL_4_42(SystemCallSolver):
         self.set_problem_format(ProblemFormat.cpxlp)
 
         # Note: Undefined capabilities default to 'None'
-        self._capabilities = Options()
+        self._capabilities = Bunch()
         self._capabilities.linear = True
         self._capabilities.integer = True
 
@@ -427,7 +427,7 @@ class GLPKSHELL_old(SystemCallSolver):
         self.set_problem_format(ProblemFormat.cpxlp)
 
         # Note: Undefined capabilities default to 'None'
-        self._capabilities = Options()
+        self._capabilities = Bunch()
         self._capabilities.linear = True
         self._capabilities.integer = True
 

--- a/pyomo/solvers/plugins/solvers/GUROBI.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI.py
@@ -16,7 +16,7 @@ import logging
 import subprocess
 
 from pyomo.common import Executable
-from pyomo.common.collections import Options, Bunch
+from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
 from pyomo.opt.base import ProblemFormat, ResultsFormat, OptSolver
@@ -104,7 +104,7 @@ class GUROBISHELL(ILMLicensedSystemCallSolver):
         self.set_problem_format(ProblemFormat.cpxlp)
 
         # Note: Undefined capabilities default to 'None'
-        self._capabilities = Options()
+        self._capabilities = Bunch()
         self._capabilities.linear = True
         self._capabilities.quadratic_objective = True
         self._capabilities.quadratic_constraint = True

--- a/pyomo/solvers/plugins/solvers/IPOPT.py
+++ b/pyomo/solvers/plugins/solvers/IPOPT.py
@@ -12,7 +12,7 @@ import os
 import subprocess
 
 from pyomo.common import Executable
-from pyomo.common.collections import Options, Bunch
+from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
 from pyomo.opt.base import ProblemFormat, ResultsFormat
@@ -46,7 +46,7 @@ class IPOPT(SystemCallSolver):
         self.set_problem_format(ProblemFormat.nl)
 
         # Note: Undefined capabilities default to 'None'
-        self._capabilities = Options()
+        self._capabilities = Bunch()
         self._capabilities.linear = True
         self._capabilities.integer = False
         self._capabilities.quadratic_objective = True

--- a/pyomo/solvers/plugins/solvers/PICO.py
+++ b/pyomo/solvers/plugins/solvers/PICO.py
@@ -15,7 +15,7 @@ from six import iteritems
 
 from pyomo.common import Executable
 from pyomo.common.errors import  ApplicationError
-from pyomo.common.collections import Options, Bunch
+from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
 from pyomo.opt.base import ProblemFormat, ResultsFormat, OptSolver
@@ -91,7 +91,7 @@ class PICOSHELL(SystemCallSolver):
         self.set_problem_format(ProblemFormat.cpxlp)
 
         # Note: Undefined capabilities default to 'None'
-        self._capabilities = Options()
+        self._capabilities = Bunch()
         self._capabilities.linear = True
         self._capabilities.integer = True
         #self._capabilities.sos1 = True

--- a/pyomo/solvers/plugins/solvers/SCIPAMPL.py
+++ b/pyomo/solvers/plugins/solvers/SCIPAMPL.py
@@ -12,7 +12,7 @@ import os
 import subprocess
 
 from pyomo.common import Executable
-from pyomo.common.collections import Options, Bunch
+from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
 from pyomo.opt.base import ProblemFormat, ResultsFormat
@@ -45,7 +45,7 @@ class SCIPAMPL(SystemCallSolver):
         self.set_problem_format(ProblemFormat.nl)
 
         # Note: Undefined capabilities default to 'None'
-        self._capabilities = Options()
+        self._capabilities = Bunch()
         self._capabilities.linear = True
         self._capabilities.integer = True
         self._capabilities.quadratic_objective = True

--- a/pyomo/solvers/plugins/solvers/XPRESS.py
+++ b/pyomo/solvers/plugins/solvers/XPRESS.py
@@ -16,7 +16,7 @@ from six import string_types
 
 from pyomo.common import Executable
 from pyomo.common.errors import ApplicationError
-from pyomo.common.collections import Options, Bunch
+from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
 from pyomo.opt.base import ProblemFormat, ResultsFormat, OptSolver
@@ -99,7 +99,7 @@ class XPRESS_shell(ILMLicensedSystemCallSolver):
         #
 
         # Note: Undefined capabilities default to 'None'
-        self._capabilities = Options()
+        self._capabilities = Bunch()
         self._capabilities.linear = True
         self._capabilities.quadratic_objective = True
         self._capabilities.quadratic_constraint = True

--- a/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
@@ -15,7 +15,7 @@ from pyomo.opt.base.solvers import OptSolver
 from pyomo.core.base import SymbolMap, NumericLabeler, TextLabeler
 import pyomo.common
 from pyomo.common.errors import ApplicationError
-from pyomo.common.collections import ComponentMap, ComponentSet, Options
+from pyomo.common.collections import ComponentMap, ComponentSet, Bunch
 from pyomo.common.tempfiles import TempfileManager
 import pyomo.opt.base.solvers
 from pyomo.opt.base.formats import ResultsFormat
@@ -101,7 +101,7 @@ class DirectOrPersistentSolver(OptSolver):
         self._symbolic_solver_labels = False
         """A bool. If true then the solver components will be given names corresponding to the pyomo component names."""
 
-        self._capabilites = Options()
+        self._capabilites = Bunch()
 
         self._referenced_variables = ComponentMap()
         """dict: {var: count} where count is the number of constraints/objective referencing the var"""

--- a/pyomo/solvers/plugins/solvers/direct_solver.py
+++ b/pyomo/solvers/plugins/solvers/direct_solver.py
@@ -17,7 +17,7 @@ from pyomo.core.kernel.block import IBlock
 from pyomo.core.base.suffix import active_import_suffix_generator
 from pyomo.core.kernel.suffix import import_suffix_generator
 from pyomo.common.errors import ApplicationError
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 
 logger = logging.getLogger('pyomo.solvers')
 
@@ -106,7 +106,7 @@ class DirectSolver(DirectOrPersistentSolver):
 
         orig_options = self.options
 
-        self.options = Options()
+        self.options = Bunch()
         self.options.update(orig_options)
         self.options.update(kwds.pop('options', {}))
         self.options.update(

--- a/pyomo/solvers/plugins/solvers/glpk_direct.py
+++ b/pyomo/solvers/plugins/solvers/glpk_direct.py
@@ -38,7 +38,7 @@ def configure_glpk_direct():
         print("Import of glpk failed - glpk message="+str(e)+"\n")
         glpk_python_api_exists = False
 
-from pyomo.common.collections import Bunch, Options
+from pyomo.common.collections import Bunch
 
 from pyomo.opt.base import OptSolver
 from pyomo.opt.base.solvers import _extract_version, SolverFactory
@@ -104,7 +104,7 @@ class GLPKDirect ( OptSolver ):
         self._timelimit = None
 
         # Note: Undefined capabilities default to 'None'
-        self._capabilities = Options()
+        self._capabilities = Bunch()
         self._capabilities.linear = True
         self._capabilities.integer = True
 

--- a/pyomo/solvers/plugins/solvers/persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/persistent_solver.py
@@ -20,7 +20,7 @@ from pyomo.core.base.var import Var
 from pyomo.core.base.sos import SOSConstraint
 
 from pyomo.common.errors import ApplicationError
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 
 import time
 import logging
@@ -449,7 +449,7 @@ class PersistentSolver(DirectOrPersistentSolver):
 
         orig_options = self.options
 
-        self.options = Options()
+        self.options = Bunch()
         self.options.update(orig_options)
         self.options.update(kwds.pop('options', {}))
         self.options.update(self._options_string_to_dict(kwds.pop('options_string', '')))

--- a/pyomo/solvers/tests/core/solvers.py
+++ b/pyomo/solvers/tests/core/solvers.py
@@ -18,7 +18,7 @@ from os.path import abspath, dirname
 import logging
 from functools import reduce
 
-from pyomo.common.collections import Bunch, Options
+from pyomo.common.collections import Bunch
 import pyutilib.th as unittest
 import pyutilib.autotest
 import pyomo.misc.plugin
@@ -268,7 +268,7 @@ def test_solvers(options=None, argv=None):
     else:
         sys.argv=argv
     # Create the tests defined in the YAML configuration file
-    autotest_options = Options()
+    autotest_options = Bunch()
     autotest_options.testname_format = "%s_TEST_%s"
     pyutilib.autotest.create_test_suites(filename=currdir+'test_solvers.yml', _globals=globals(), options=autotest_options)
     # Execute the tests, using a custom test runner

--- a/pyomo/solvers/tests/solvers.py
+++ b/pyomo/solvers/tests/solvers.py
@@ -13,7 +13,7 @@ __all__ = ['test_solver_cases', 'available_solvers']
 import six
 import logging
 
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 from pyomo.opt import SolverFactory
 from pyomo.opt.base.solvers import UnknownSolver
 
@@ -36,7 +36,7 @@ licensed_solvers_with_demo_mode = {'baron',}
 # interfaces may be used for the same "solver"
 #
 def initialize(**kwds):
-    obj = Options(**kwds)
+    obj = Bunch(**kwds)
     #
     # Set obj.available
     #

--- a/pyomo/solvers/tests/testcases.py
+++ b/pyomo/solvers/tests/testcases.py
@@ -13,7 +13,7 @@ import logging
 
 import pyutilib.th as unittest
 
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 from pyomo.opt import TerminationCondition
 from pyomo.solvers.tests.models.base import test_models
 from pyomo.solvers.tests.solvers import test_solver_cases
@@ -397,7 +397,7 @@ def test_scenarios(arg=None):
                     msg=case[2]
 
             # Return scenario dimensions and scenario information
-            yield (model, solver, io), Options(
+            yield (model, solver, io), Bunch(
                 status=status, msg=msg, model=_model, solver=None,
                 testcase=_solver_case, demo_limits=_solver_case.demo_limits,
                 exclude_suffixes=exclude_suffixes)
@@ -477,11 +477,12 @@ def run_test_scenarios(options):
     # Summarize the runtime statistics, by solver
     #
     summary = {}
-    total = Options(NumEPass=0, NumEFail=0, NumUPass=0, NumUFail=0)
+    total = Bunch(NumEPass=0, NumEFail=0, NumUPass=0, NumUFail=0)
     for key in stat:
         model, solver, io = key
         if not solver in summary:
-            summary[solver] = Options(NumEPass=0, NumEFail=0, NumUPass=0, NumUFail=0)
+            summary[solver] = Bunch(NumEPass=0, NumEFail=0,
+                                    NumUPass=0, NumUFail=0)
         _pass, _str = stat[key]
         if _pass:
             if _str == "Expected failure":

--- a/pyomo/util/model_size.py
+++ b/pyomo/util/model_size.py
@@ -11,7 +11,7 @@
 """This module contains functions to interrogate the size of a Pyomo model."""
 import logging
 
-from pyomo.common.collections import ComponentSet, Container
+from pyomo.common.collections import ComponentSet, Bunch
 from pyomo.core import Block, Constraint, Var
 from pyomo.core.expr import current as EXPR
 from pyomo.gdp import Disjunct, Disjunction
@@ -21,7 +21,7 @@ default_logger = logging.getLogger('pyomo.util.model_size')
 default_logger.setLevel(logging.INFO)
 
 
-class ModelSizeReport(Container):
+class ModelSizeReport(Bunch):
     """Stores model size information.
 
     Activated blocks are those who have an active flag of True and whose
@@ -86,7 +86,7 @@ def build_model_size_report(model):
     activated_vars.update(
         disj.indicator_var for disj in activated_disjuncts)
 
-    report.activated = Container()
+    report.activated = Bunch()
     report.activated.variables = len(activated_vars)
     report.activated.binary_variables = sum(
         1 for v in activated_vars if v.is_binary())
@@ -101,7 +101,7 @@ def build_model_size_report(model):
         1 for c in activated_constraints
         if c.body.polynomial_degree() not in (1, 0))
 
-    report.overall = Container()
+    report.overall = Bunch()
     block_like = (Block, Disjunct)
     all_vars = ComponentSet(
         model.component_data_objects(Var, descend_into=block_like))
@@ -125,7 +125,7 @@ def build_model_size_report(model):
             Constraint, descend_into=block_like)
         if c.body.polynomial_degree() not in (1, 0))
 
-    report.warning = Container()
+    report.warning = Bunch()
     report.warning.unassociated_disjuncts = sum(
         1 for d in model.component_data_objects(
             Disjunct, descend_into=block_like)


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
We are separating PyUtilib from Pyomo. This PR reflects the movement of `pyutilib.misc.Container` into `pyomo.common.collections.Bunch` and renaming all instances of `Options` and `Container` to `Bunch`.

(**EDIT**: Also worth noting, this is the last remaining piece of `pyutilib.misc` in Pyomo.)

## Changes proposed in this PR:
- Move `Container` from `pyutilib.misc` into `Bunch` in `pyomo.common.collections`
- Rename all instances of `Options` and `Container` to `Bunch`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
