### PR TITLE
Disable implicit ranged inequalities (a <= x <= b)

### DIFF
--- a/pyomo/core/expr/logical_expr.py
+++ b/pyomo/core/expr/logical_expr.py
@@ -15,7 +15,7 @@ from __future__ import division
 import types
 from itertools import islice
 
-_using_chained_inequality = True
+_using_chained_inequality = False
 import logging
 import traceback
 


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This disables the "implicit ranged inequality" syntax in Pyomo.  Prior to this, we supported expressing ranged inequality expression with this syntax:
```python
a <= x <= b
```
This PR turns support for that syntax off.  This PR is the first step toward addressing #1839 and #1496.


## Changes proposed in this PR:
- Disable chained inequalities

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
