### PR TITLE
Inequality function should work with floats

### DIFF
--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -601,18 +601,20 @@ class _GeneralConstraintData(_ConstraintData):
                         "using '<=', '>=', or '=='."
                         % (self.name))
 
-                if not expr.arg(1).is_potentially_variable():
+                arg0 = as_numeric(expr.arg(0))
+                arg1 = as_numeric(expr.arg(1))
+                if not arg1.is_potentially_variable():
                     self._lower = None
-                    self._body  = expr.arg(0)
-                    self._upper = as_numeric(expr.arg(1))
-                elif not expr.arg(0).is_potentially_variable():
-                    self._lower = as_numeric(expr.arg(0))
-                    self._body  = expr.arg(1)
+                    self._body  = arg0
+                    self._upper = arg1
+                elif not arg0.is_potentially_variable():
+                    self._lower = arg0
+                    self._body  = arg1
                     self._upper = None
                 else:
                     self._lower = None
-                    self._body = expr.arg(0)
-                    self._body -= expr.arg(1)
+                    self._body = arg0
+                    self._body -= arg1
                     self._upper = ZeroConstant
 
 

--- a/pyomo/core/tests/unit/test_con.py
+++ b/pyomo/core/tests/unit/test_con.py
@@ -568,6 +568,27 @@ class TestConstraintCreation(unittest.TestCase):
         self.assertEqual(model.c.equality, True)
         model.del_component(model.c)
 
+    def test_inequality(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.c = Constraint(expr=inequality(lower=-1, body=m.x))
+        self.assertEqual(m.c.lower.value, -1)
+        self.assertIs(m.c.body, m.x)
+        self.assertIs(m.c.upper, None)
+
+        del m.c
+        m.c = Constraint(expr=inequality(body=m.x, upper=1))
+        self.assertIs(m.c.lower, None)
+        self.assertIs(m.c.body, m.x)
+        self.assertEqual(m.c.upper.value, 1)
+
+        del m.c
+        m.c = Constraint(expr=inequality(lower=-1, body=m.x, upper=1))
+        self.assertEqual(m.c.lower.value, -1)
+        self.assertIs(m.c.body, m.x)
+        self.assertEqual(m.c.upper.value, 1)
+
+
 class TestSimpleCon(unittest.TestCase):
 
     def test_set_expr_explicit_multivariate(self):


### PR DESCRIPTION
## Summary/Motivation:
Currently, the following produces an exception.

```
import pyomo.environ as pe
m = pe.ConcreteModel()
m.x = pe.Var()
e = pe.inequality(lower=-1, body=m.x)
m.c = pe.Constraint(expr=e)
```

This PR fixes it.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
