### PR TITLE
Improve sorted_robust for (nested) tuple items

### DIFF
--- a/pyomo/core/base/misc.py
+++ b/pyomo/core/base/misc.py
@@ -111,7 +111,7 @@ class _robust_sort_keyfcn(object):
 
     """
     def __init__(self):
-        self._typemap = {}
+        self._typemap = {tuple: (3, tuple.__name__)}
 
     def __call__(self, val):
         """Generate a tuple ( str(type_name), val ) for sorting the value.
@@ -147,6 +147,8 @@ class _robust_sort_keyfcn(object):
             self._typemap[_type] = i, _typename
         if i == 1:
             return _typename, val
+        elif i == 3:
+            return _typename, tuple(self(v) for v in val)
         elif i == 2:
             return _typename, str(val)
         else:

--- a/pyomo/core/tests/unit/test_base_misc.py
+++ b/pyomo/core/tests/unit/test_base_misc.py
@@ -15,7 +15,7 @@ from io import StringIO
 
 import pyutilib.th as unittest
 
-from pyomo.core.base.misc import tabular_writer
+from pyomo.core.base.misc import tabular_writer, sorted_robust
 
 class TestTabularWriter(unittest.TestCase):
     def test_unicode_table(self):
@@ -30,6 +30,25 @@ Key    : s : val
 (2, 3) : ∧ :   2
 """
         self.assertEqual(ref.strip(), os.getvalue().strip())
+
+
+class TestSortedRobust(unittest.TestCase):
+    def test_sorted_robust(self):
+        # Note: as types are sorted by name, int < str < tuple
+        a = sorted_robust([3,2,1])
+        self.assertEqual(a, [1,2,3])
+
+        a = sorted_robust([3,'2',1])
+        self.assertEqual(a, [1,3,'2'])
+
+        a = sorted_robust([('str1','str1'), (1, 'str2')])
+        self.assertEqual(a, [(1, 'str2'), ('str1','str1')])
+
+        a = sorted_robust([((1,), 'str2'), ('str1','str1')])
+        self.assertEqual(a, [('str1','str1'), ((1,), 'str2')])
+
+        a = sorted_robust([('str1','str1'), ((1,), 'str2')])
+        self.assertEqual(a, [('str1','str1'), ((1,), 'str2')])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This resolves an issue with `sorted_robust` reported by @emma58 in [#567](https://github.com/Pyomo/pyomo/issues/567#issuecomment-786162744) where the comparison would raise an exception when passed lists containing tuples that themselves contain non-comparable types.

## Changes proposed in this PR:
- Recursively expand tuples when necessary to perform robust comparison
- Add tests for sorted_robust

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
