### PR TITLE
Update Mosek tests, fixed variable bounds

### DIFF
--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -293,10 +293,16 @@ class MOSEKDirect(DirectSolver):
         vnames = tuple(self._symbol_map.getSymbol(
             v, self._labeler) for v in var_seq)
         vtypes = tuple(map(self._mosek_vartype_from_var, var_seq))
-        lbs = tuple(-inf if value(v.lb) is None else value(v.lb)
-                    for v in var_seq)
-        ubs = tuple(inf if value(v.ub) is None else value(v.ub)
-                    for v in var_seq)
+        lbs = tuple( value(v) if v.fixed
+                     else -inf if value(v.lb) is None
+                     else value(v.lb)
+                     for v in var_seq
+        )
+        ubs = tuple( value(v) if v.fixed
+                     else inf if value(v.ub) is None
+                     else value(v.ub)
+                     for v in var_seq
+        )
         fxs = tuple(v.is_fixed() for v in var_seq)
         bound_types = tuple(map(self._mosek_bounds, lbs, ubs, fxs))
         self._solver_model.appendvars(len(var_seq))

--- a/pyomo/solvers/plugins/solvers/mosek_persistent.py
+++ b/pyomo/solvers/plugins/solvers/mosek_persistent.py
@@ -208,10 +208,16 @@ class MOSEKPersistent(PersistentSolver, MOSEKDirect):
             for v in solver_vars:
                 var_ids.append(self._pyomo_var_to_solver_var_map[v])
             vtypes = tuple(map(self._mosek_vartype_from_var, solver_vars))
-            lbs = tuple(-float('inf') if value(v.lb) is None else value(v.lb)
-                        for v in solver_vars)
-            ubs = tuple(float('inf') if value(v.ub) is None else value(v.ub)
-                        for v in solver_vars)
+            lbs = tuple( value(v) if v.fixed
+                         else -float('inf') if value(v.lb) is None
+                         else value(v.lb)
+                         for v in solver_vars
+            )
+            ubs = tuple( value(v) if v.fixed
+                         else float('inf') if value(v.ub) is None
+                         else value(v.ub)
+                         for v in solver_vars
+            )
             fxs = tuple(v.is_fixed() for v in solver_vars)
             bound_types = tuple(map(self._mosek_bounds, lbs, ubs, fxs))
             self._solver_model.putvartypelist(var_ids, vtypes)

--- a/pyomo/solvers/tests/checks/test_pickle.py
+++ b/pyomo/solvers/tests/checks/test_pickle.py
@@ -45,12 +45,17 @@ def create_test_method(model, solver, io,
         load_solutions = (not model_class.solve_should_fail) and \
                          (test_case.status != 'expected failure')
 
-        opt, status = model_class.solve(solver,
-                                        io,
-                                        test_case.testcase.io_options,
-                                        test_case.testcase.options,
-                                        symbolic_labels,
-                                        load_solutions)
+        try:
+            opt, status = model_class.solve(solver,
+                                            io,
+                                            test_case.testcase.io_options,
+                                            test_case.testcase.options,
+                                            symbolic_labels,
+                                            load_solutions)
+        except:
+            if test_case.status == 'expected failure':
+                return
+            raise
         m = pickle.loads(pickle.dumps(model_class.model))
 
         #

--- a/pyomo/solvers/tests/solvers.py
+++ b/pyomo/solvers/tests/solvers.py
@@ -97,7 +97,7 @@ def test_solver_cases(*args):
                                    'conic_constraints'])
     
         _test_solver_cases['mosek', 'python'] = initialize(
-            name='mosek_direct',
+            name='mosek',
             io='python',
             capabilities=_mosek_capabilities,
             import_suffixes=['dual', 'rc', 'slack'])
@@ -105,9 +105,9 @@ def test_solver_cases(*args):
         #
         # MOSEK Persistent
         #
-        _test_solver_cases['mosek_persistent','python'] = initialize(
-                name = 'mosek_persistent',
-                io = 'python',
+        _test_solver_cases['mosek','persistent'] = initialize(
+                name = 'mosek',
+                io = 'persistent',
                 capabilities=_mosek_capabilities,
                 import_suffixes=['dual','rc','slack'])
 

--- a/pyomo/solvers/tests/testcases.py
+++ b/pyomo/solvers/tests/testcases.py
@@ -45,17 +45,12 @@ MissingSuffixFailures = {}
 # MOSEK
 #
 
-ExpectedFailures['mosek_direct', 'python', 'QCP_simple'] = \
-    (lambda v: True,
-     "Conic constraints not yet handled by this interface")
+for _io in ('python', 'persistent'):
+    for _test in ('QCP_simple', 'QCP_simple_nosuffixes', 'MIQCP_simple'):
+        ExpectedFailures['mosek', _io, _test] = (
+            lambda v: True,
+            "Mosek does not handle nonconvex quadratic constraints")
 
-ExpectedFailures['mosek_direct', 'python', 'QCP_simple_nosuffixes'] = \
-    (lambda v: True,
-     "Conic constraints not yet handled by this interface")
-
-ExpectedFailures['mosek_direct', 'python', 'MIQCP_simple'] = \
-    (lambda v: True,
-     "Conic constraints not yet handled by this interface")
 #
 # CPLEX
 #


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This updates the Mosek tests in preparation for enabling automated testing against Mosek.

## Changes proposed in this PR:
- Update expected failures (the QCP and QCQP tests are nonconvex and fail in mosek)
- Mosek expects that the upper and lower bounds of fixed variables are equal.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
