### PR TITLE
Adding Casadi to the GHA test environment

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -25,7 +25,7 @@ env:
   PYTHON_BASE_PKGS: >
       ply six dill ipython networkx openpyxl pathos
       pint pyro4 pyyaml sphinx_rtd_theme sympy xlrd
-      python-louvain
+      python-louvain casadi
   PYTHON_NUMPY_PKGS: >
       numpy scipy pyodbc pandas matplotlib seaborn numdifftools
   CACHE_VER: v3

--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -25,9 +25,9 @@ env:
   PYTHON_BASE_PKGS: >
       ply six dill ipython networkx openpyxl pathos
       pint pyro4 pyyaml sphinx_rtd_theme sympy xlrd
-      python-louvain casadi
+      python-louvain
   PYTHON_NUMPY_PKGS: >
-      numpy scipy pyodbc pandas matplotlib seaborn numdifftools
+      numpy scipy pyodbc pandas matplotlib seaborn numdifftools casadi
   CACHE_VER: v3
   NEOS_EMAIL: tests@pyomo.org
 

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -22,7 +22,7 @@ env:
   PYTHON_BASE_PKGS: >
       ply six dill ipython networkx openpyxl pathos
       pint pyro4 pyyaml sphinx_rtd_theme sympy xlrd
-      python-louvain
+      python-louvain casadi
   PYTHON_NUMPY_PKGS: >
       numpy scipy pyodbc pandas matplotlib seaborn numdifftools
   CACHE_VER: v3

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -22,9 +22,9 @@ env:
   PYTHON_BASE_PKGS: >
       ply six dill ipython networkx openpyxl pathos
       pint pyro4 pyyaml sphinx_rtd_theme sympy xlrd
-      python-louvain casadi
+      python-louvain
   PYTHON_NUMPY_PKGS: >
-      numpy scipy pyodbc pandas matplotlib seaborn numdifftools
+      numpy scipy pyodbc pandas matplotlib seaborn numdifftools casadi
   CACHE_VER: v3
   NEOS_EMAIL: tests@pyomo.org
 


### PR DESCRIPTION
## Summary/Motivation:
Adding Casadi to the GHA test environment. This drastically improves the test coverage for the DAE simulator in our GHA tests.

Edit: I added Casadi to the list of Numpy packages (even though I don't think Numpy is a requirement) to avoid trying to install Casadi in the pypy build

## Changes proposed in this PR:
- Add Casadi to GHA

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
