### PR TITLE
MANIFEST File

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,4 @@
 include README.md
 include LICENSE.txt
-include pyomo/contrib/mcpp/mcppInterface.cpp
-include pyomo/contrib/pynumero/src/ma27Interface.cpp
-include pyomo/contrib/pynumero/src/ma57Interface.cpp
-include pyomo/contrib/pynumero/src/AmplInterface.cpp
-include pyomo/contrib/pynumero/src/tests/simple_test.cpp
+include pyomo/contrib/mcpp/*.cpp
+include pyomo/contrib/pynumero/src/*.cpp

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include README.md
+include LICENSE.txt
+inclue pyomo/contrib/mcpp/mcppInterface.cpp
+inclue pyomo/contrib/pynumero/src/ma27Interface.cpp
+inclue pyomo/contrib/pynumero/src/ma57Interface.cpp
+inclue pyomo/contrib/pynumero/src/AmplInterface.cpp
+inclue pyomo/contrib/pynumero/src/tests/simple_test.cpp

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include README.md
 include LICENSE.txt
-inclue pyomo/contrib/mcpp/mcppInterface.cpp
-inclue pyomo/contrib/pynumero/src/ma27Interface.cpp
-inclue pyomo/contrib/pynumero/src/ma57Interface.cpp
-inclue pyomo/contrib/pynumero/src/AmplInterface.cpp
-inclue pyomo/contrib/pynumero/src/tests/simple_test.cpp
+include pyomo/contrib/mcpp/mcppInterface.cpp
+include pyomo/contrib/pynumero/src/ma27Interface.cpp
+include pyomo/contrib/pynumero/src/ma57Interface.cpp
+include pyomo/contrib/pynumero/src/AmplInterface.cpp
+include pyomo/contrib/pynumero/src/tests/simple_test.cpp

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ def run_setup():
       packages=find_packages(exclude=("scripts",)),
       package_data={"pyomo.contrib.viewer":["*.ui"]},
       ext_modules = ext_modules,
+      include_package_data=True,
       entry_points="""
         [console_scripts]
         pyomo = pyomo.scripting.pyomo_main:main_console_script


### PR DESCRIPTION
## Summary/Motivation:
This PR adds a MANIFEST.in file so that the cpp files for pynumero and the MC++ interface get distributed by PyPI. This allows users to pip install and then use the pyomo build-extensions command. Currently, that command only works if you install from source (because the cpp files don't exist if you install with pip).

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
