### PR TITLE
#1857 support . in index name

### DIFF
--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -42,7 +42,7 @@ def _name_index_generator(idx):
             ans = "%s" % (val,)
             if isinstance(val, str):
                 ans = ans.replace("\\", "\\\\").replace("'", "\\'")
-                if ',' in ans or "'" in ans:
+                if ',' in ans or "'" in ans or "." in ans:
                     ans = "'"+ans+"'"
         return ans
     if idx.__class__ is tuple:


### PR DESCRIPTION
## Fixes #1857 
Small fix to quote index names with a . in it. This way the name of the component can be used in the find_component function.
Look for example in issue #1857
## Summary/Motivation:


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
