### PR TITLE
Improve error when attempting to construct RangeSet with external data

### DIFF
--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -2701,7 +2701,10 @@ class RangeSet(Component):
                              % (self.name, data))
         if data is not None:
             raise ValueError(
-                "RangeSet.construct() does not support the data= argument.")
+                "RangeSet.construct() does not support the data= argument.\n"
+                "Initialization data (range endpoints) can only be supplied "
+                "as numbers, constants, or Params to the RangeSet() "
+                "declaration")
         self._constructed = True
 
         args, ranges = self._init_data


### PR DESCRIPTION
## Fixes #1874

## Summary/Motivation:
Improves the error message produced when attempting to construct a `RangeSet` with external data (e.g., from a DAT file).

## Changes proposed in this PR:
- update `RangeSet.construct()` exception message.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
