### PR TITLE
Fix bug in identify_mutable_parameters

### DIFF
--- a/pyomo/core/expr/visitor.py
+++ b/pyomo/core/expr/visitor.py
@@ -1181,7 +1181,8 @@ class _MutableParamVisitor(SimpleExpressionVisitor):
             return
 
         # TODO: Confirm that this has the right semantics
-        if not node.is_variable_type() and not node.is_constant():
+        if (not node.is_variable_type() and node.is_fixed()
+                and not node.is_constant()):
             if id(node) in self.seen:
                 return
             self.seen.add(id(node))

--- a/pyomo/core/expr/visitor.py
+++ b/pyomo/core/expr/visitor.py
@@ -1181,7 +1181,7 @@ class _MutableParamVisitor(SimpleExpressionVisitor):
             return
 
         # TODO: Confirm that this has the right semantics
-        if not node.is_variable_type() and node.is_fixed():
+        if not node.is_variable_type() and not node.is_constant():
             if id(node) in self.seen:
                 return
             self.seen.add(id(node))

--- a/pyomo/core/tests/unit/test_visitor.py
+++ b/pyomo/core/tests/unit/test_visitor.py
@@ -33,6 +33,7 @@ from pyomo.core.expr.visitor import (
 from pyomo.core.base.param import _ParamData, SimpleParam
 from pyomo.core.expr.template_expr import IndexTemplate
 from pyomo.core.expr.expr_errors import TemplateExpressionError
+from pyomo.common.collections import ComponentSet
 from pyomo.common.log import LoggingIntercept
 from io import StringIO
 
@@ -190,6 +191,17 @@ class TestIdentifyParams(unittest.TestCase):
         self.assertEqual( list(identify_mutable_parameters(m.b+m.e)), [ m.b, m.a ] )
         self.assertEqual( list(identify_mutable_parameters(m.E[0])), [ m.a ] )
         self.assertEqual( list(identify_mutable_parameters(m.E[1])), [ m.b ] )
+
+    def test_identify_mutable_parameters_logical_expr(self):
+        #
+        # Identify mutable params in logical expressions
+        #
+        m = ConcreteModel()
+        m.a = Param(initialize=0, mutable=True)
+        expr = m.a+1 == 0
+        param_set = ComponentSet(identify_mutable_parameters(expr))
+        self.assertEqual(len(param_set), 1)
+        self.assertIn(m.a, param_set)
 
     def test_identify_mutable_parameters_params(self):
         m = ConcreteModel()

--- a/pyomo/core/tests/unit/test_visitor.py
+++ b/pyomo/core/tests/unit/test_visitor.py
@@ -168,6 +168,23 @@ class TestIdentifyParams(unittest.TestCase):
         self.assertEqual( list(identify_mutable_parameters(
             m.a**m.b[1] + m.b[2]*m.b[3]*m.b[2])), [] )
 
+    def test_identify_mutable_parameters_constants(self):
+        #
+        # SimpleParams and NumericConstants are not recognized
+        #
+        m = ConcreteModel()
+        m.x = Var(initialize=1)
+        m.x.fix()
+        m.p = Param(initialize=2, mutable=False)
+        m.p_m = Param(initialize=3, mutable=True)
+        e1 = (m.x + m.p + 5)
+        self.assertEqual(list(identify_mutable_parameters(e1)), [])
+
+        e2 = (5*m.x + 3*m.p_m + m.p == 0)
+        mut_params = list(identify_mutable_parameters(e2))
+        self.assertEqual(len(mut_params), 1)
+        self.assertIs(mut_params[0], m.p_m)
+
     def test_identify_duplicate_params(self):
         #
         # Identify mutable params when there are duplicates

--- a/pyomo/core/tests/unit/test_visitor.py
+++ b/pyomo/core/tests/unit/test_visitor.py
@@ -19,7 +19,7 @@ import pyomo.common.unittest as unittest
 from pyomo.common.unittest import nottest
 
 from pyomo.environ import ConcreteModel, RangeSet, Param, Var, Expression, ExternalFunction, VarList, sum_product, inequality, quicksum, sin, tanh
-from pyomo.core.expr.numvalue import nonpyomo_leaf_types
+from pyomo.core.expr.numvalue import nonpyomo_leaf_types, NumericConstant
 from pyomo.core.expr.numeric_expr import (
     SumExpression, ProductExpression, 
     MonomialTermExpression, LinearExpression)
@@ -177,10 +177,10 @@ class TestIdentifyParams(unittest.TestCase):
         m.x.fix()
         m.p = Param(initialize=2, mutable=False)
         m.p_m = Param(initialize=3, mutable=True)
-        e1 = (m.x + m.p + 5)
+        e1 = (m.x + m.p + NumericConstant(5))
         self.assertEqual(list(identify_mutable_parameters(e1)), [])
 
-        e2 = (5*m.x + 3*m.p_m + m.p == 0)
+        e2 = (5*m.x + NumericConstant(3)*m.p_m + m.p == 0)
         mut_params = list(identify_mutable_parameters(e2))
         self.assertEqual(len(mut_params), 1)
         self.assertIs(mut_params[0], m.p_m)

--- a/pyomo/core/tests/unit/test_visitor.py
+++ b/pyomo/core/tests/unit/test_visitor.py
@@ -77,7 +77,7 @@ class TestExpressionUtilities(unittest.TestCase):
 
     def test_identify_vars_expr(self):
         #
-        # Identify variables when there are duplicates
+        # Identify variables in named expressions
         #
         m = ConcreteModel()
         m.a = Var(initialize=1)
@@ -157,7 +157,7 @@ class TestIdentifyParams(unittest.TestCase):
         m.a = Var(initialize=1)
         m.b = Var(m.I, initialize=1)
         #
-        # There are no variables in expressions with only vars
+        # There are no parameters in expressions with only vars
         #
         self.assertEqual( list(identify_mutable_parameters(m.a)), [] )
         self.assertEqual( list(identify_mutable_parameters(m.b[1])), [] )
@@ -180,7 +180,7 @@ class TestIdentifyParams(unittest.TestCase):
 
     def test_identify_mutable_parameters_expr(self):
         #
-        # Identify variables when there are duplicates
+        # Identify mutable params in named expressions
         #
         m = ConcreteModel()
         m.a = Param(initialize=1, mutable=True)


### PR DESCRIPTION
## Fixes #1877 .

## Summary/Motivation:
Fixes an apparent bug in `identify_mutable_parameters`. 
The logic used to identify a "mutable parameter" was
```python
not node.is_variable_type() and node.is_fixed()
```
I'm not sure how this has not been identifying all numeric constants as mutable params, but the bug only seems to appear in certain types of expressions. This logic has been changed to the following, which seems to fix the bug.
```python
not node.is_variable_type() and not node.is_constant()
```

## Changes proposed in this PR:
- Change logic as described above
- Add test that fails with old logic

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
