### PR TITLE
ConfigValue: improve handling of enum.Enum domains

### DIFF
--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -179,11 +179,11 @@ class In(object):
     before looking them up in `domain`.
 
     """
-    def __new__(cls, domain, cast=None):
+    def __new__(cls, domain=None, cast=None):
         # Convenience: enum.Enum supported __contains__ through Python
         # 3.7.  If the domain is an Enum and cast is not specified,
         # automatically return an InEnum to handle casting and validation
-        if cast is None and inspect.isclass(domain) \
+        if cls is In and cast is None and inspect.isclass(domain) \
            and issubclass(domain, enum.Enum):
             return InEnum(domain)
         return super(In, cls).__new__(cls)

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -61,7 +61,9 @@ DEVELOPER_OPTION = 2
 def PositiveInt(val):
     """Domain validation function admitting strictly positive integers
 
-    This domain will admit positive integers, as well as any types that are convertible to positive integers.
+    This domain will admit positive integers (n > 0), as well as any
+    types that are convertible to positive integers.
+
     """
     ans = int(val)
     # We want to give an error for floating point numbers...
@@ -73,7 +75,9 @@ def PositiveInt(val):
 def NegativeInt(val):
     """Domain validation function admitting strictly negative integers
 
-    This domain will admit negative integers, as well as any types that are convertible to negative integers.
+    This domain will admit negative integers (n < 0), as well as any
+    types that are convertible to negative integers.
+
     """
     ans = int(val)
     if ans != float(val) or ans >= 0:
@@ -82,9 +86,11 @@ def NegativeInt(val):
     return ans
 
 def NonPositiveInt(val):
-    """Domain validation function admitting non-positive integers (smaller than or equal to zero)
+    """Domain validation function admitting integers <= 0
 
-    This domain will admit non-positive integers, as well as any types that are convertible to non-positive integers.
+    This domain will admit non-positive integers (n <= 0), as well as
+    any types that are convertible to non-positive integers.
+
     """
     ans = int(val)
     if ans != float(val) or ans > 0:
@@ -93,9 +99,11 @@ def NonPositiveInt(val):
     return ans
 
 def NonNegativeInt(val):
-    """Domain validation function admitting non-negative integers (greater than or equal to zero)
+    """Domain validation function admitting integers >= 0
 
-    This domain will admit non-negative integers, as well as any types that are convertible to non-negative integers.
+    This domain will admit non-negative integers (n >= 0), as well as
+    any types that are convertible to non-negative integers.
+
     """
     ans = int(val)
     if ans != float(val) or ans < 0:
@@ -104,9 +112,12 @@ def NonNegativeInt(val):
     return ans
 
 def PositiveFloat(val):
-    """Domain validation function admitting strictly positive floating point numbers
+    """Domain validation function admitting strictly positive numbers
 
-    This domain will admit positive floating point numbers, as well as any types that are convertible to positive floating point numbers.
+    This domain will admit positive floating point numbers (n > 0), as
+    well as any types that are convertible to positive floating point
+    numbers.
+
     """
     ans = float(val)
     if ans <= 0:
@@ -115,9 +126,12 @@ def PositiveFloat(val):
     return ans
 
 def NegativeFloat(val):
-    """Domain validation function admitting strictly negative floating point numbers
+    """Domain validation function admitting strictly negative numbers
 
-    This domain will admit negative floating point numbers, as well as any types that are convertible to negative floating point numbers.
+    This domain will admit negative floating point numbers (n < 0), as
+    well as any types that are convertible to negative floating point
+    numbers.
+
     """
     ans = float(val)
     if ans >= 0:
@@ -126,9 +140,12 @@ def NegativeFloat(val):
     return ans
 
 def NonPositiveFloat(val):
-    """Domain validation function admitting strictly non-positive floating point numbers (smaller than or equal to zero)
+    """Domain validation function admitting numbers less than or equal to 0
 
-    This domain will admit non-positive floating point numbers, as well as any types that are convertible to non-positive floating point numbers.
+    This domain will admit non-positive floating point numbers (n <= 0),
+    as well as any types that are convertible to non-positive floating
+    point numbers.
+
     """
     ans = float(val)
     if ans > 0:
@@ -137,9 +154,12 @@ def NonPositiveFloat(val):
     return ans
 
 def NonNegativeFloat(val):
-    """Domain validation function admitting strictly non-negative floating point numbers (greater than or equal to zero)
+    """Domain validation function admitting numbers greater than or equal to 0
 
-    This domain will admit non-negative floating point numbers, as well as any types that are convertible to non-negative floating point numbers.
+    This domain will admit non-negative floating point numbers (n >= 0),
+    as well as any types that are convertible to non-negative floating
+    point numbers.
+
     """
     ans = float(val)
     if ans < 0:
@@ -149,7 +169,15 @@ def NonNegativeFloat(val):
 
 
 class In(object):
-    """Domain validation function admitting a list of possible values that a variable can be assigned to."""
+    """Domain validation function admitting a Container of possible values
+
+    This will admit any value that is in the `domain` Container (i.e.,
+    Container.__contains__() returns True).  Most common domains are
+    list, set, and dict objects.  If specified, incoming values are
+    first passed to `cast()` to convert them to the appropriate type
+    before looking them up in `domain`.
+
+    """
     def __init__(self, domain, cast=None):
         self._domain = domain
         self._cast = cast
@@ -200,6 +228,7 @@ class Path(object):
             os.path.expandvars(os.path.expanduser(path)))))
         #print "to '%s'" % (ans,)
         return ans
+
 
 class PathList(Path):
     def __call__(self, data):

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -253,6 +253,16 @@ def add_docstring_list(docstring, configdict, indent_by=4):
 
 
 class ConfigEnum(enum.Enum):
+    @deprecated("The ConfigEnum base class is deprecated.  "
+                "Directly inherit from enum.Enum and then use "
+                "In() or InEnum() as the ConfigValue 'domain' for "
+                "validation and int/string type conversions.", version='TBD')
+    def __new__(cls, value, *args):
+        member = object.__new__(cls)
+        member._value_ = value
+        member._args = args
+        return member
+
     @classmethod
     def from_enum_or_string(cls, arg):
         if type(arg) is str:

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -243,6 +243,30 @@ class TestConfigDomains(unittest.TestCase):
         c.b = '1'
         self.assertEqual(c.b, 1)
 
+    def test_In_enum(self):
+        class TestEnum(enum.Enum):
+            ITEM_ONE = 1
+            ITEM_TWO = 'two'
+
+        cfg = ConfigDict()
+        cfg.declare('enum', ConfigValue(
+            default=TestEnum.ITEM_TWO,
+            domain=In(TestEnum)
+        ))
+        self.assertEqual(cfg.enum, TestEnum.ITEM_TWO)
+        cfg.enum = 'ITEM_ONE'
+        self.assertEqual(cfg.enum, TestEnum.ITEM_ONE)
+        cfg.enum = TestEnum.ITEM_TWO
+        self.assertEqual(cfg.enum, TestEnum.ITEM_TWO)
+        cfg.enum = 1
+        self.assertEqual(cfg.enum, TestEnum.ITEM_ONE)
+        cfg.enum = 'two'
+        self.assertEqual(cfg.enum, TestEnum.ITEM_TWO)
+        with self.assertRaisesRegex(ValueError, '.*3 is not a valid'):
+            cfg.enum = 3
+        with self.assertRaisesRegex(ValueError, '.*invalid value'):
+            cfg.enum ='ITEM_THREE'
+
 
     def test_Path(self):
         def norm(x):
@@ -388,6 +412,22 @@ class TestConfigDomains(unittest.TestCase):
         self.assertEqual(TestEnum.from_enum_or_string('ITEM_ONE'),
                 TestEnum.ITEM_ONE)
 
+        cfg = ConfigDict()
+        cfg.declare('enum', ConfigValue(
+            default=2,
+            domain=TestEnum.from_enum_or_string
+        ))
+        self.assertEqual(cfg.enum, TestEnum.ITEM_TWO)
+        cfg.enum = 'ITEM_ONE'
+        self.assertEqual(cfg.enum, TestEnum.ITEM_ONE)
+        cfg.enum = TestEnum.ITEM_TWO
+        self.assertEqual(cfg.enum, TestEnum.ITEM_TWO)
+        cfg.enum = 1
+        self.assertEqual(cfg.enum, TestEnum.ITEM_ONE)
+        with self.assertRaisesRegex(ValueError, '.*3 is not a valid'):
+            cfg.enum = 3
+        with self.assertRaisesRegex(ValueError, '.*invalid value'):
+            cfg.enum ='ITEM_THREE'
 
 class TestImmutableConfigValue(unittest.TestCase):
     def test_immutable_config_value(self):

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -24,6 +24,7 @@
 #  ___________________________________________________________________________
 
 import argparse
+import enum
 import os
 import sys
 import os.path
@@ -43,7 +44,7 @@ from pyomo.common.config import (
     PositiveFloat, NegativeFloat, NonPositiveFloat, NonNegativeFloat,
     In, Path, PathList, ConfigEnum
 )
-
+from pyomo.common.log import LoggingIntercept
 
 # Utility to redirect display() to a string
 def _display(obj, *args):
@@ -374,10 +375,12 @@ class TestConfigDomains(unittest.TestCase):
         self.assertIs(type(c.a), list)
 
     def test_ConfigEnum(self):
-        class TestEnum(ConfigEnum):
-            ITEM_ONE = 1
-            ITEM_TWO = 2
-
+        out = StringIO()
+        with LoggingIntercept(out):
+            class TestEnum(ConfigEnum):
+                ITEM_ONE = 1
+                ITEM_TWO = 2
+        self.assertIn('The ConfigEnum base class is deprecated', out.getvalue())
         self.assertEqual(TestEnum.from_enum_or_string(1),
                 TestEnum.ITEM_ONE)
         self.assertEqual(TestEnum.from_enum_or_string(


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This improves handling for `enum.Enum` objects in `ConfigValue` domains.  Some users (notably IDAES) leverage `In()` for validating `ConfigValue` domains that should be Enum members.  This PR adds an improved domain manager, `InEnum` that not only tests membership, but will map valid values and names to the corresponding Enum member.  It is also more robust than using `In()`, as `enum.Enum` no longer supports checking values using `__contains__` beginning in Python 3.8.

For convenience and backwards compatibility, passing an `Enum` as the `domain` argument for `In()` will automatically return an `InEnum` instance.

## Changes proposed in this PR:
- deprecate the `ConfigEnum` class
- add `InEnum` domain validator
- update tests
- clean up some documentation

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
