### PR TITLE
Relax tictoc timing test threshold

### DIFF
--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -85,11 +85,12 @@ class TestTiming(unittest.TestCase):
             self.assertEqual(buf.getvalue().strip(), "")
 
     def test_TicTocTimer_tictoc(self):
-        RES = 1e-2 # resolution (seconds)
+        SLEEP = 0.1
+        RES = 0.02 # resolution (seconds): 1/5 the sleep
         timer = TicTocTimer()
         abs_time = time.time()
 
-        time.sleep(0.1)
+        time.sleep(SLEEP)
 
         with capture_output() as out:
             start_time = time.time()
@@ -104,7 +105,7 @@ class TestTiming(unittest.TestCase):
             r'\[    [.0-9]+\] Resetting the tic/toc delta timer'
         )
 
-        time.sleep(0.1)
+        time.sleep(SLEEP)
 
         with capture_output() as out:
             delta = timer.toc()
@@ -124,7 +125,7 @@ class TestTiming(unittest.TestCase):
 
         ref = 0
         ref -= time.time()
-        time.sleep(0.1)
+        time.sleep(SLEEP)
         timer.stop()
         ref += time.time()
         cumul_stop1 = timer.toc(None)
@@ -132,12 +133,12 @@ class TestTiming(unittest.TestCase):
                 RuntimeError,
                 'Stopping a TicTocTimer that was already stopped'):
             timer.stop()
-        time.sleep(0.1)
+        time.sleep(SLEEP)
         cumul_stop2 = timer.toc(None)
         self.assertEqual(cumul_stop1, cumul_stop2)
         timer.start()
         ref -= time.time()
-        time.sleep(0.1)
+        time.sleep(SLEEP)
 
         # Note: pypy on GHA frequently has timing differences of >0.05s
         # for the following tests


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
We are starting to see intermittent test failures due to the tic toc timer test resolution.  This relaxes the test threshold slightly to reduce the frequency of false failures.

## Changes proposed in this PR:
- Relax tic tic timer test threshold to 1/5 of the sleep time.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
