### PR TITLE
Improve error message for disabled methods on Abstract components

### DIFF
--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -190,7 +190,8 @@ if test -z "$MODE" -o "$MODE" == test; then
                     -t $CODECOV_TOKEN --root `pwd` -e OS,python \
                     --name $CODECOV_JOB_NAME $CODECOV_ARGS \
                     | tee .cover.upload
-                if test $? == 0 -a `grep -i error .cover.upload | wc -l` -eq 0; then
+                if test $? == 0 -a `grep -i error .cover.upload \
+                        | grep -v branch= | wc -l` -eq 0; then
                     break
                 elif test $i -ge 4; then
                     exit 1

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -4415,58 +4415,58 @@ I : Size=1, Index=None, Ordered=Insertion
         with self.assertRaisesRegexp(
                 RuntimeError,
                 "Cannot iterate over AbstractFiniteSimpleSet 'I'"
-                " before it has been constructed \(initialized\)."):
+                " before it has been constructed \(initialized\)"):
             for i in m.I:
                 pass
 
         with self.assertRaisesRegexp(
                 RuntimeError,
                 "Cannot iterate over AbstractOrderedSimpleSet 'J'"
-                " before it has been constructed \(initialized\)."):
+                " before it has been constructed \(initialized\)"):
             for i in m.J:
                 pass
 
         with self.assertRaisesRegexp(
                 RuntimeError,
                 "Cannot iterate over AbstractSortedSimpleSet 'K'"
-                " before it has been constructed \(initialized\)."):
+                " before it has been constructed \(initialized\)"):
             for i in m.K:
                 pass
 
         with self.assertRaisesRegexp(
                 RuntimeError,
                 "Cannot test membership in AbstractFiniteSimpleSet 'I'"
-                " before it has been constructed \(initialized\)."):
+                " before it has been constructed \(initialized\)"):
             1 in m.I
 
         with self.assertRaisesRegexp(
                 RuntimeError,
                 "Cannot test membership in AbstractOrderedSimpleSet 'J'"
-                " before it has been constructed \(initialized\)."):
+                " before it has been constructed \(initialized\)"):
             1 in m.J
 
         with self.assertRaisesRegexp(
                 RuntimeError,
                 "Cannot test membership in AbstractSortedSimpleSet 'K'"
-                " before it has been constructed \(initialized\)."):
+                " before it has been constructed \(initialized\)"):
             1 in m.K
 
         with self.assertRaisesRegexp(
                 RuntimeError,
-                "Cannot access __len__ on AbstractFiniteSimpleSet 'I'"
-                " before it has been constructed \(initialized\)."):
+                "Cannot access '__len__' on AbstractFiniteSimpleSet 'I'"
+                " before it has been constructed \(initialized\)"):
             len(m.I)
 
         with self.assertRaisesRegexp(
                 RuntimeError,
-                "Cannot access __len__ on AbstractOrderedSimpleSet 'J'"
-                " before it has been constructed \(initialized\)."):
+                "Cannot access '__len__' on AbstractOrderedSimpleSet 'J'"
+                " before it has been constructed \(initialized\)"):
             len(m.J)
 
         with self.assertRaisesRegexp(
                 RuntimeError,
-                "Cannot access __len__ on AbstractSortedSimpleSet 'K'"
-                " before it has been constructed \(initialized\)."):
+                "Cannot access '__len__' on AbstractSortedSimpleSet 'K'"
+                " before it has been constructed \(initialized\)"):
             len(m.K)
 
     def test_set_end(self):

--- a/pyomo/core/tests/unit/test_util.py
+++ b/pyomo/core/tests/unit/test_util.py
@@ -59,7 +59,7 @@ class TestDisableMethods(unittest.TestCase):
         self.assertIs(type(x), _abstract_simple)
         self.assertIsInstance(x, _simple)
         with self.assertRaisesRegexp(
-                RuntimeError, "Cannot access a on _abstract_simple "
+                RuntimeError, "Cannot access 'a' on _abstract_simple "
                 "'foo' before it has been constructed"):
             x.a()
         with self.assertRaisesRegexp(
@@ -68,11 +68,11 @@ class TestDisableMethods(unittest.TestCase):
             x.b()
         self.assertEqual(x.c(), 'c')
         with self.assertRaisesRegexp(
-                RuntimeError, "Cannot access property d on _abstract_simple "
+                RuntimeError, "Cannot access property 'd' on _abstract_simple "
                 "'foo' before it has been constructed"):
             x.d
         with self.assertRaisesRegexp(
-                RuntimeError, "Cannot set property d on _abstract_simple "
+                RuntimeError, "Cannot set property 'd' on _abstract_simple "
                 "'foo' before it has been constructed"):
             x.d = 1
         with self.assertRaisesRegexp(
@@ -90,7 +90,7 @@ class TestDisableMethods(unittest.TestCase):
                 TypeError, "f\(\) takes "):
             x.f(1,2,3)
         with self.assertRaisesRegexp(
-                RuntimeError, "Cannot access f on _abstract_simple "
+                RuntimeError, "Cannot access 'f' on _abstract_simple "
                 "'foo' before it has been constructed"):
             x.f(1,2)
 


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
The discussion in #1881 raised the point that the error message users get when accessing a disabled method/property on an Abstract component could be made less cryptic.  This PR expands on the error message that the user sees.

## Changes proposed in this PR:
- Expand error message raised by disabled methods/properties

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
