### PR TITLE
Replace pyutilib.th use in APPSI

### DIFF
--- a/pyomo/contrib/appsi/examples/tests/test_examples.py
+++ b/pyomo/contrib/appsi/examples/tests/test_examples.py
@@ -1,5 +1,5 @@
 from pyomo.contrib.appsi.examples import getting_started
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 import pyomo.environ as pe
 
 

--- a/pyomo/contrib/appsi/solvers/tests/test_gurobi_persistent.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_gurobi_persistent.py
@@ -1,4 +1,4 @@
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 import pyomo.environ as pe
 from pyomo.contrib.appsi.solvers.gurobi import Gurobi
 from pyomo.contrib.appsi.base import TerminationCondition

--- a/pyomo/contrib/appsi/solvers/tests/test_solvers.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_solvers.py
@@ -1,5 +1,5 @@
 import pyomo.environ as pe
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 from parameterized import parameterized
 from pyomo.contrib.appsi.base import TerminationCondition, Results, Solver
 from pyomo.contrib.appsi.solvers import Gurobi, Ipopt, Cplex, Cbc

--- a/pyomo/contrib/appsi/writers/tests/test_nl_writer.py
+++ b/pyomo/contrib/appsi/writers/tests/test_nl_writer.py
@@ -1,4 +1,4 @@
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 import pyomo.environ as pe
 from pyomo.contrib import appsi
 import os


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
There were a few residual uses of `pyutilib.th` in `pyomo.contrib.appsi` that were missed in the original PR.

## Changes proposed in this PR:
- Convert `pyutilib.th` to `pyomo.common.unittest`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
