### PR TITLE
Resolve errors cloning Ports

### DIFF
--- a/pyomo/network/port.py
+++ b/pyomo/network/port.py
@@ -65,9 +65,21 @@ class _PortData(ComponentData):
 
     def __getstate__(self):
         state = super(_PortData, self).__getstate__()
+        state['_arcs'] = [i() for i in self._arcs]
+        state['_sources'] = [i() for i in self._sources]
+        state['_dests'] = [i() for i in self._dests]
+
         for i in _PortData.__slots__:
+            if i in {'_arcs', '_sources', '_dests'}:
+                continue
             state[i] = getattr(self, i)
         return state
+
+    def __setstate__(self, state):
+        state['_arcs'] = [weakref_ref(i) for i in state['_arcs']]
+        state['_sources'] = [weakref_ref(i) for i in state['_sources']]
+        state['_dests'] = [weakref_ref(i) for i in state['_dests']]
+        super(_PortData, self).__setstate__(state)
 
     # Note: None of the slots on this class need to be edited, so we
     # don't need to implement a specialized __setstate__ method, and

--- a/pyomo/network/port.py
+++ b/pyomo/network/port.py
@@ -65,14 +65,12 @@ class _PortData(ComponentData):
 
     def __getstate__(self):
         state = super(_PortData, self).__getstate__()
-        state['_arcs'] = [i() for i in self._arcs]
-        state['_sources'] = [i() for i in self._sources]
-        state['_dests'] = [i() for i in self._dests]
-
         for i in _PortData.__slots__:
-            if i in {'_arcs', '_sources', '_dests'}:
-                continue
             state[i] = getattr(self, i)
+
+        # Remove/resolve weak references
+        for i in ('_arcs', '_sources', '_dests'):
+            state[i] = [ref() for ref in state[i]]
         return state
 
     def __setstate__(self, state):

--- a/pyomo/network/tests/test_arc.py
+++ b/pyomo/network/tests/test_arc.py
@@ -15,8 +15,10 @@ import pyomo.common.unittest as unittest
 from six import StringIO
 import logging
 
-from pyomo.environ import ConcreteModel, AbstractModel, Var, Set, Constraint, RangeSet, NonNegativeReals, Reals, Binary, TransformationFactory, Block
+from pyomo.environ import ConcreteModel, AbstractModel, Var, Set, Constraint, RangeSet, NonNegativeReals, Reals, Binary, TransformationFactory, Block, value
 from pyomo.network import Arc, Port
+from pyomo.core.expr.visitor import identify_variables
+from pyomo.common.collections.component_set import ComponentSet
 
 class TestArc(unittest.TestCase):
 
@@ -1875,6 +1877,40 @@ class TestArc(unittest.TestCase):
 
 28 Declarations: comp feed tru node1 node2 multi prod stream0 stream1 stream2 stream3 stream4 stream5 stream6 stream7 stream8 stream9 stream10 stream1_expanded stream2_expanded stream3_expanded stream4_expanded stream5_expanded stream6_expanded stream7_expanded stream8_expanded stream9_expanded stream10_expanded
 """)
+
+    def test_clone(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var()
+        m.p1 = Port()
+        m.p2 = Port()
+        m.p1.add(m.x, 'v')
+        m.p2.add(m.y, 'v')
+        m.arc = Arc(source=m.p1, destination=m.p2)
+
+        m2 = m.clone()
+        self.assertEqual(len(m2.p1.arcs()), 1)
+        self.assertEqual(len(m2.p2.arcs()), 1)
+        self.assertIs(m2.p1.arcs()[0], m2.arc)
+        self.assertIs(m2.p2.arcs()[0], m2.arc)
+
+        self.assertIsNot(m2.p1.arcs()[0], m.arc)
+        self.assertIsNot(m2.p2.arcs()[0], m.arc)
+
+        TransformationFactory('network.expand_arcs').apply_to(m2)
+        all_cons = list(m2.component_data_objects(Constraint))
+        self.assertEqual(len(all_cons), 1)
+        c = all_cons[0]
+        self.assertAlmostEqual(value(c.lower), 0)
+        self.assertAlmostEqual(value(c.upper), 0)
+        c_vars = ComponentSet(identify_variables(c.body))
+        self.assertIn(m2.x, c_vars)
+        self.assertIn(m2.y, c_vars)
+        self.assertNotIn(m.x, c_vars)
+        self.assertNotIn(m.y, c_vars)
+        m2.x.value = 1.25
+        m2.y.value = 1.25
+        self.assertAlmostEqual(value(c.body), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fixes #1880 .

## Summary/Motivation:
This PR ensures that the weak references in Ports are cloned correctly.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
