### PR TITLE
Replace usage of `six` in Examples

### DIFF
--- a/examples/dae/ReactionKinetics.py
+++ b/examples/dae/ReactionKinetics.py
@@ -17,8 +17,6 @@
 from pyomo.environ import *
 from pyomo.dae import *
 
-from six import itervalues, iteritems
-
 try:
     import matplotlib.pyplot as plt
 except ImportError:
@@ -102,14 +100,14 @@ class ReactionNetwork(object):
         """
         self.add(rxn)
         tmp = Reaction( name= rxn.name+'_r', 
-                        reactants= [(b,a) for a,b in iteritems(rxn.products)],
-                        products= [(b,a) for a,b in iteritems(rxn.reactants)] )
+                        reactants= [(b,a) for a,b in rxn.products.items()],
+                        products= [(b,a) for a,b in rxn.reactants.items()] )
         self.add(tmp)
 
     def species(self):
         """Return the set of all species appearing int he Reaction Network"""
         ans = set()
-        for rxn in itervalues(self.reactions):
+        for rxn in self.reactions.values():
             ans.update( rxn.reactants )
             ans.update( rxn.products )
         return sorted(ans)
@@ -141,7 +139,7 @@ def create_kinetic_model(rxnNet, time):
 
     def reaction_rate(m, t, r):
         rhs = m.k[r]
-        for s, coef in iteritems(m.rxnNetwork.reactions[r].reactants):
+        for s, coef in m.rxnNetwork.reactions[r].reactants.items():
             rhs *= m.c[t,s]**coef
         return m.rate[t,r] == rhs
     model.reaction_rate = Constraint( model.TIME, model.REACTIONS,
@@ -197,7 +195,7 @@ def simple_simulation_model():
     results = solver.solve(model, tee=True)
 
     if plt is not None:
-        _tmp = sorted(iteritems(model.c))
+        _tmp = sorted(model.c.items())
         for _i, _x in enumerate('ABC'):
             plt.plot([x[0][0] for x in _tmp if x[0][1] == _x], 
                      [value(x[1]) for x in _tmp if x[0][1] == _x], 

--- a/examples/dae/disease_DAE.py
+++ b/examples/dae/disease_DAE.py
@@ -5,7 +5,6 @@
 # Scaling in Continuous Set
 from pyomo.environ import *
 from pyomo.dae import *
-from six.moves import xrange
 
 years = 20
 beta_py = 26
@@ -41,10 +40,10 @@ model.S_TRI = RangeSet(1,model.P_TRI)
 # Define indexed parameters
 beta_ndx = {}
 if (beta_py > 26) or (fepr > 1):
-    for i in xrange(1,fe+1):
+    for i in range(1,fe+1):
         beta_ndx[i] = (((i+1)/fepr)-1)%beta_py+1
 else:
-    for i in xrange(1,fe+1):
+    for i in range(1,fe+1):
         beta_ndx[i] = ((i-1)%beta_py)+1
 model.P_BETA_NDX = Param(model.S_FE, initialize=beta_ndx, default=1.0)
 

--- a/examples/gdp/eight_process/eight_proc_logical.py
+++ b/examples/gdp/eight_process/eight_proc_logical.py
@@ -24,13 +24,11 @@ http://dx.doi.org/10.1016/0098-1354(95)00219-7
 """
 from __future__ import division
 
-from six import iteritems
-
 from pyomo.core.expr.logical_expr import land, lor
 from pyomo.core.plugins.transform.logical_to_linear import update_boolean_vars_from_binary
 from pyomo.environ import (
     ConcreteModel, Constraint, ConstraintList, NonNegativeReals,
-    Objective, Param, RangeSet, Reference, Var, exp, minimize, BooleanVar, LogicalConstraint, )
+    Objective, Param, RangeSet, Reference, Var, exp, minimize, LogicalConstraint, )
 from pyomo.gdp import Disjunct, Disjunction
 from pyomo.opt import SolverFactory
 
@@ -152,7 +150,7 @@ def build_eight_process_flowsheet():
     """Bound definitions"""
     # x (flow) upper bounds
     x_ubs = {3: 2, 5: 2, 9: 2, 10: 1, 14: 1, 17: 2, 19: 2, 21: 2, 25: 3}
-    for i, x_ub in iteritems(x_ubs):
+    for i, x_ub in x_ubs.item():
         m.flow[i].setub(x_ub)
 
     # Optimal solution uses units 2, 4, 6, 8 with objective value 68.

--- a/examples/gdp/eight_process/eight_proc_model.py
+++ b/examples/gdp/eight_process/eight_proc_model.py
@@ -24,8 +24,6 @@ http://dx.doi.org/10.1016/0098-1354(95)00219-7
 """
 from __future__ import division
 
-from six import iteritems
-
 from pyomo.environ import (ConcreteModel, Constraint, NonNegativeReals,
                            Objective, Param, RangeSet, Var, exp, minimize)
 from pyomo.gdp import Disjunction
@@ -174,7 +172,7 @@ def build_eight_process_flowsheet():
     """Bound definitions"""
     # x (flow) upper bounds
     x_ubs = {3: 2, 5: 2, 9: 2, 10: 1, 14: 1, 17: 2, 19: 2, 21: 2, 25: 3}
-    for i, x_ub in iteritems(x_ubs):
+    for i, x_ub in x_ubs.items():
         m.flow[i].setub(x_ub)
 
     # Optimal solution uses units 2, 4, 6, 8 with objective value 68.

--- a/examples/gdp/eight_process/eight_proc_verbose_model.py
+++ b/examples/gdp/eight_process/eight_proc_verbose_model.py
@@ -9,7 +9,6 @@ from __future__ import division
 from pyomo.environ import (ConcreteModel, Constraint, NonNegativeReals,
                            Objective, Param, RangeSet, Var, exp, minimize)
 from pyomo.gdp import Disjunct, Disjunction
-from six import iteritems
 
 
 def build_eight_process_flowsheet():
@@ -146,7 +145,7 @@ def build_eight_process_flowsheet():
     """Bound definitions"""
     # x (flow) upper bounds
     x_ubs = {3: 2, 5: 2, 9: 2, 10: 1, 14: 1, 17: 2, 19: 2, 21: 2, 25: 3}
-    for i, x_ub in iteritems(x_ubs):
+    for i, x_ub in x_ubs.items():
         m.flow[i].setub(x_ub)
 
     # # optimal solution

--- a/examples/pyomo/callbacks/sc.py
+++ b/examples/pyomo/callbacks/sc.py
@@ -12,7 +12,6 @@ from pyomo.common.collections import Bunch
 from pyomo.core import *
 import math
 import random
-from six.moves import xrange
 
 def print_model_stats(options,model):
     print("-"*40)
@@ -73,7 +72,7 @@ def pyomo_create_model(options=None, model_options=None):
         #
         def S_rule(model):
             ans = set()
-            for j in xrange(1,n+1):
+            for j in range(1,n+1):
                 tmp = list(range(1,m+1))
                 random.shuffle( tmp )
                 for i in range(0,p):
@@ -93,7 +92,7 @@ def pyomo_create_model(options=None, model_options=None):
         #
         def S_rule(model):
             ans = set()
-            for i in xrange(1,m+1):
+            for i in range(1,m+1):
                 tmp = list(range(1,n+1))
                 random.shuffle( tmp )
                 for j in range(0,p):
@@ -107,8 +106,8 @@ def pyomo_create_model(options=None, model_options=None):
         #
         def S_rule(model):
             ans = set()
-            for j in xrange(1,n+1):
-                for i in xrange(1,m+1):
+            for j in range(1,n+1):
+                for i in range(1,m+1):
                     if random.uniform(0,1) < rho:
                         ans.add( (i, j) )
             return ans
@@ -120,8 +119,8 @@ def pyomo_create_model(options=None, model_options=None):
         #
         def S_rule(model):
             ans = set()
-            for j in xrange(1,n+1):
-                for i in xrange(1,m+1):
+            for j in range(1,n+1):
+                for i in range(1,m+1):
                     if random.uniform(0,1) < rho:
                         ans.add( (i, j) )
             return ans

--- a/examples/pyomo/p-median/solver2.py
+++ b/examples/pyomo/p-median/solver2.py
@@ -15,8 +15,6 @@ from pyomo.opt import *
 import random
 import copy
 
-from six.moves import xrange
-
 @plugin_factory
 class MySolver(object):
 
@@ -28,7 +26,7 @@ class MySolver(object):
     # Solve the specified problem and return
     # a SolverResults object
     def solve(self, instance, **kwds):
-        print "Starting random heuristic"
+        print("Starting random heuristic")
         val, sol = self._random(instance)
         n = value(instance.N)
         # Setup results
@@ -50,12 +48,12 @@ class MySolver(object):
     # Perform a random search
     def _random(self, instance):
         sol = [0]*instance.N.value
-        for j in xrange(instance.P.value):
+        for j in range(instance.P.value):
             sol[j] = 1
         # Generate 100 random solutions, and keep the best
         best = None
         best_sol = []
-        for kk in xrange(100):
+        for kk in range(100):
             random.shuffle(sol)
             # Compute value
             val=0.0

--- a/examples/pyomo/quadratic/example2.py
+++ b/examples/pyomo/quadratic/example2.py
@@ -13,12 +13,10 @@
 
 from pyomo.core import *
 
-from six.moves import xrange
-
 model = AbstractModel()
 
 def indices_rule(model):
-    return xrange(1,4)
+    return range(1,4)
 model.indices = Set(initialize=indices_rule, within=PositiveIntegers)
 
 model.x = Var(model.indices, within=Reals)

--- a/examples/pyomo/sos/sos2_piecewise.py
+++ b/examples/pyomo/sos/sos2_piecewise.py
@@ -18,7 +18,6 @@ f(x) = |
 """
 
 from pyomo.core import *
-from six.moves import xrange
 
 model = ConcreteModel()
 
@@ -32,11 +31,11 @@ F = {1:[1,4,9],2:[1,4,9]}
 
 # Indexing set required for the SOSConstraint declaration
 def SOS_indices_init(model,t):
-    return [(t,i) for i in xrange(len(DOMAIN_PTS[t]))]
+    return [(t,i) for i in range(len(DOMAIN_PTS[t]))]
 model.SOS_indices = Set(model.index_set,dimen=2, ordered=True, initialize=SOS_indices_init)
 
 def sos_var_indices_init(model):
-    return [(t,i) for t in model.index_set for i in xrange(len(DOMAIN_PTS[t]))]
+    return [(t,i) for t in model.index_set for i in range(len(DOMAIN_PTS[t]))]
 model.sos_var_indices = Set(ordered=True, dimen=2,initialize=sos_var_indices_init)
 
 model.x = Var(model.index_set) # domain variable
@@ -46,14 +45,14 @@ model.y = Var(model.sos_var_indices,within=NonNegativeReals) # SOS2 variable
 model.obj = Objective(expr=sum_product(model.Fx), sense=maximize)
 
 def constraint1_rule(model,t):
-    return model.x[t] == sum(model.y[t,i]*DOMAIN_PTS[t][i] for i in xrange(len(DOMAIN_PTS[t])) )
+    return model.x[t] == sum(model.y[t,i]*DOMAIN_PTS[t][i] for i in range(len(DOMAIN_PTS[t])) )
 def constraint2_rule(model,t):
     # Uncomment below for F defined as dictionary
-    return model.Fx[t] == sum(model.y[t,i]*F[t][i] for i in xrange(len(DOMAIN_PTS[t])) )
+    return model.Fx[t] == sum(model.y[t,i]*F[t][i] for i in range(len(DOMAIN_PTS[t])) )
     # Uncomment below for F defined as lambda function
-    #return model.Fx[t] == sum(model.y[t,i]*F(DOMAIN_PTS[t][i]) for i in xrange(len(DOMAIN_PTS[t])) )
+    #return model.Fx[t] == sum(model.y[t,i]*F(DOMAIN_PTS[t][i]) for i in range(len(DOMAIN_PTS[t])) )
 def constraint3_rule(model,t):
-    return sum(model.y[t,j] for j in xrange(len(DOMAIN_PTS[t]))) == 1
+    return sum(model.y[t,j] for j in range(len(DOMAIN_PTS[t]))) == 1
 
 model.constraint1 = Constraint(model.index_set,rule=constraint1_rule)
 model.constraint2 = Constraint(model.index_set,rule=constraint2_rule)

--- a/examples/pyomo/suffixes/gurobi_ampl_basis.py
+++ b/examples/pyomo/suffixes/gurobi_ampl_basis.py
@@ -23,7 +23,6 @@
 # gurobi_ampl version 6.5.0.
 from pyomo.environ import *
 
-import six
 
 #
 # Create the gurobi_ampl solver plugin using the ASL interface

--- a/examples/pyomo/suffixes/gurobi_ampl_example.py
+++ b/examples/pyomo/suffixes/gurobi_ampl_example.py
@@ -19,7 +19,6 @@
 # solver is in the current search path for executables
 # on this system. This example was tested using Gurobi
 # Solver 5.0.0
-import six
 
 import pyomo.environ
 from pyomo.core import *
@@ -85,24 +84,24 @@ opt.options['bestbound'] = 1
 model.sstatus[model.x[1]] = sstatus_table['low']
 
 def print_model_suffixes(model):
-    # Six.Print_ all suffix values for all model components in a nice table
-    six.print_("\t",end='')
+    # print all suffix values for all model components in a nice table
+    print("\t",end='')
     for name,suffix in active_import_suffix_generator(model):
-            six.print_("%10s" % (name),end='')
-    six.print_("")
+            print("%10s" % (name),end='')
+    print("")
     for i in model.s:
-        six.print_(model.x[i].name+"\t",end='')
+        print(model.x[i].name+"\t",end='')
         for name,suffix in active_import_suffix_generator(model):
-            six.print_("%10s" % (suffix.get(model.x[i])),end='')
-        six.print_("")
+            print("%10s" % (suffix.get(model.x[i])),end='')
+        print("")
     for i in model.s:
-        six.print_(model.con[i].name+"\t",end='')
+        print(model.con[i].name+"\t",end='')
         for name,suffix in active_import_suffix_generator(model):
-            six.print_("%10s" % (suffix.get(model.con[i])),end='')
-        six.print_("")
-    six.print_(model.obj.name+"\t",end='')
+            print("%10s" % (suffix.get(model.con[i])),end='')
+        print("")
+    print(model.obj.name+"\t",end='')
     for name,suffix in active_import_suffix_generator(model):
-        six.print_("%10s" % (suffix.get(model.obj)),end='')
+        print("%10s" % (suffix.get(model.obj)),end='')
     print("")
     print("")
 


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
Part of the Pyomo 6.0 effort is to replace the usage of `six` with the appropriate Python 3 methods. This does just that in the `examples` directory.

## Changes proposed in this PR:
- Replace usage of `six` in `examples`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
