### PR TITLE
pyomo.common.unittest: return the nosetests exit code

### DIFF
--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -596,4 +596,4 @@ def runtests(options):
 if __name__ == '__main__':
     parser = buildParser()
     options = parser.parse_args()
-    runtests(options)
+    sys.exit(runtests(options))


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This PR causes `python -m pyomo.common.unitttest` to return the exit code from nosetests (so that CI systems will correctly detect test failures)

## Changes proposed in this PR:
- return the `nosetests` return code from `pyomo.common.unittest` when run as a script

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
