### PR TITLE
Remove `six` in `pyomo.contrib`

### DIFF
--- a/pyomo/contrib/community_detection/tests/test_detection.py
+++ b/pyomo/contrib/community_detection/tests/test_detection.py
@@ -16,7 +16,7 @@ from __future__ import division
 import logging
 
 import pyomo.common.unittest as unittest
-from six import StringIO
+from io import StringIO
 
 from pyomo.common.dependencies import networkx_available
 from pyomo.common.log import LoggingIntercept

--- a/pyomo/contrib/fbbt/tests/test_fbbt.py
+++ b/pyomo/contrib/fbbt/tests/test_fbbt.py
@@ -17,7 +17,7 @@ from pyomo.common.errors import InfeasibleConstraintException
 from pyomo.core.expr.numeric_expr import (ProductExpression,
                                           UnaryFunctionExpression)
 import math
-from six import StringIO
+from io import StringIO
 
 
 class DummyExpr(ProductExpression):

--- a/pyomo/contrib/fme/fourier_motzkin_elimination.py
+++ b/pyomo/contrib/fme/fourier_motzkin_elimination.py
@@ -21,8 +21,6 @@ from pyomo.opt import TerminationCondition
 
 import logging
 
-from six import iteritems
-
 logger = logging.getLogger('pyomo.contrib.fme')
 NAME_BUFFER = {}
 
@@ -30,7 +28,7 @@ def _check_var_bounds_filter(constraint):
     """Check if the constraint is already implied by the variable bounds"""
     # this is one of our constraints, so we know that it is >=.
     min_lhs = 0
-    for v, coef in iteritems(constraint['map']):
+    for v, coef in constraint['map'].items():
         if coef > 0:
             if v.lb is None:
                 return True # we don't have var bounds with which to imply the

--- a/pyomo/contrib/fme/tests/test_fourier_motzkin_elimination.py
+++ b/pyomo/contrib/fme/tests/test_fourier_motzkin_elimination.py
@@ -27,7 +27,7 @@ from pyomo.repn.standard_repn import generate_standard_repn
 from pyomo.opt import SolverFactory, check_available_solvers
 import pyomo.contrib.fme.fourier_motzkin_elimination
 
-from six import StringIO
+from io import StringIO
 import logging
 import random
 

--- a/pyomo/contrib/gdpbb/test_GDPbb_deprecate.py
+++ b/pyomo/contrib/gdpbb/test_GDPbb_deprecate.py
@@ -1,7 +1,7 @@
 import logging
 
 import pyomo.common.unittest as unittest
-from six import StringIO
+from io import StringIO
 
 from pyomo.common.log import LoggingIntercept
 from pyomo.environ import ConcreteModel, Var, Objective

--- a/pyomo/contrib/gdpopt/GDPopt.py
+++ b/pyomo/contrib/gdpopt/GDPopt.py
@@ -32,8 +32,7 @@
 """
 from __future__ import division
 
-import six
-from six import StringIO
+from io import StringIO
 
 from pyomo.common.config import (
     add_docstring_list
@@ -245,14 +244,6 @@ DOI: 10.1016/S0098-1354(00)00581-0.
 
     _metasolver = False
 
-    if six.PY2:
-        __doc__ = """
-    Keyword arguments below are specified for the :code:`solve` function.
-        
-    """ + add_docstring_list(__doc__, CONFIG)
-
-
-if six.PY3:
-    # Add the CONFIG arguments to the solve method docstring
-    GDPoptSolver.solve.__doc__ = add_docstring_list(
-        GDPoptSolver.solve.__doc__, GDPoptSolver.CONFIG, indent_by=8)
+# Add the CONFIG arguments to the solve method docstring
+GDPoptSolver.solve.__doc__ = add_docstring_list(
+    GDPoptSolver.solve.__doc__, GDPoptSolver.CONFIG, indent_by=8)

--- a/pyomo/contrib/gdpopt/cut_generation.py
+++ b/pyomo/contrib/gdpopt/cut_generation.py
@@ -13,7 +13,6 @@ from __future__ import division
 
 from collections import namedtuple
 from math import copysign, fabs
-from six import iteritems
 from pyomo.common.collections import ComponentMap, ComponentSet
 from pyomo.contrib.gdp_bounds.info import disjunctive_bounds
 from pyomo.contrib.gdpopt.util import time_code, constraints_in_True_disjuncts
@@ -121,10 +120,10 @@ def add_outer_approximation_cuts(nlp_result, solve_data, config):
                     copysign(1, sign_adjust * dual_value) * (
                         value(constr.body) - rhs + sum(
                             value(jac) * (var - value(var))
-                            for var, jac in iteritems(jacobian.jac))
+                            for var, jac in jacobian.jac.items())
                         ) - slack_var <= 0)
                 if new_oa_cut.polynomial_degree() not in (1, 0):
-                    for var, jac in iteritems(jacobian.jac):
+                    for var, jac in jacobian.jac.items():
                         print(var.name, value(jac))
                 oa_cuts.add(expr=new_oa_cut)
                 counter += 1

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -13,7 +13,7 @@ import logging
 from math import fabs
 from os.path import join, normpath
 
-from six import StringIO
+from io import StringIO
 
 import pyomo.common.unittest as unittest
 from pyomo.common.log import LoggingIntercept

--- a/pyomo/contrib/gdpopt/util.py
+++ b/pyomo/contrib/gdpopt/util.py
@@ -15,8 +15,6 @@ import logging
 from contextlib import contextmanager
 from math import fabs
 
-import six
-
 from pyomo.common import deprecated, timing
 from pyomo.common.collections import ComponentSet, Bunch
 from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
@@ -426,9 +424,9 @@ def get_main_elapsed_time(timing_data_obj):
         return current_time - timing_data_obj.main_timer_start_time
     except AttributeError as e:
         if 'main_timer_start_time' in str(e):
-            six.raise_from(e, AttributeError(
+            raise e from AttributeError(
                 "You need to be in a 'time_code' context to use `get_main_elapsed_time()`."
-            ))
+            )
 
 
 @deprecated(

--- a/pyomo/contrib/interior_point/interface.py
+++ b/pyomo/contrib/interior_point/interface.py
@@ -9,7 +9,6 @@
 #  ___________________________________________________________________________
 
 from abc import ABCMeta, abstractmethod
-import six
 from pyomo.contrib.pynumero.interfaces import pyomo_nlp, ampl_nlp
 from pyomo.contrib.pynumero.sparse import BlockMatrix, BlockVector
 import numpy as np
@@ -17,7 +16,7 @@ import scipy.sparse
 from pyomo.common.timing import HierarchicalTimer
 
 
-class BaseInteriorPointInterface(six.with_metaclass(ABCMeta, object)):
+class BaseInteriorPointInterface(object, metaclass=ABCMeta):
     @abstractmethod
     def n_primals(self):
         pass

--- a/pyomo/contrib/interior_point/linalg/base_linear_solver_interface.py
+++ b/pyomo/contrib/interior_point/linalg/base_linear_solver_interface.py
@@ -1,9 +1,8 @@
 from abc import ABCMeta, abstractmethod
-import six
 import logging
 
 
-class LinearSolverInterface(six.with_metaclass(ABCMeta, object)):
+class LinearSolverInterface(object, metaclass=ABCMeta):
     @classmethod
     def getLoggerName(cls):
         return 'linear_solver'

--- a/pyomo/contrib/mcpp/pyomo_mcpp.py
+++ b/pyomo/contrib/mcpp/pyomo_mcpp.py
@@ -15,7 +15,6 @@ from __future__ import division
 import ctypes
 import logging
 import os
-import six
 
 from pyomo.common.fileutils import Library
 from pyomo.core import value, Expression
@@ -204,8 +203,7 @@ class MCPP_visitor(StreamBasedExpressionVisitor):
         super(MCPP_visitor, self).__init__()
         self.mcpp = _MCPP_lib()
         so_file_version = self.mcpp.get_version()
-        if six.PY3:
-            so_file_version = so_file_version.decode("utf-8")
+        so_file_version = so_file_version.decode("utf-8")
         if not so_file_version == __version__:
             raise MCPP_Error(
                 "Shared object file version %s is out of date with MC++ interface version %s. "
@@ -304,8 +302,7 @@ class MCPP_visitor(StreamBasedExpressionVisitor):
 
         if ans is None:
             msg = self.mcpp.get_last_exception_message()
-            if six.PY3:
-                msg = msg.decode("utf-8")
+            msg = msg.decode("utf-8")
             raise MCPP_Error(msg)
 
         return ans
@@ -427,8 +424,7 @@ class McCormick(object):
 
     def __repn__(self):
         repn = self.mcpp.toString(self.mc_expr)
-        if six.PY3:
-            repn = repn.decode("utf-8")
+        repn = repn.decode("utf-8")
         return repn
 
     def __str__(self):

--- a/pyomo/contrib/mcpp/test_mcpp.py
+++ b/pyomo/contrib/mcpp/test_mcpp.py
@@ -12,7 +12,7 @@ from __future__ import division
 import logging
 from math import pi
 
-from six import StringIO
+from io import StringIO
 
 import pyomo.common.unittest as unittest
 from pyomo.common.log import LoggingIntercept

--- a/pyomo/contrib/mindtpy/tests/MINLP2_simple.py
+++ b/pyomo/contrib/mindtpy/tests/MINLP2_simple.py
@@ -35,8 +35,6 @@ Ref:
 """
 from __future__ import division
 
-from six import iteritems
-
 from pyomo.environ import (Binary, ConcreteModel, Constraint, NonNegativeReals,
                            Objective, RangeSet, Var, minimize, log)
 
@@ -84,5 +82,5 @@ class SimpleMINLP(ConcreteModel):
         """Bound definitions"""
         # x (continuous) upper bounds
         x_ubs = {1: 2, 2: 2, 3: 1, 4: 100}
-        for i, x_ub in iteritems(x_ubs):
+        for i, x_ub in x_ubs.items():
             X[i].setub(x_ub)

--- a/pyomo/contrib/mindtpy/tests/MINLP_simple.py
+++ b/pyomo/contrib/mindtpy/tests/MINLP_simple.py
@@ -26,8 +26,6 @@ Ref:
 """
 from __future__ import division
 
-from six import iteritems
-
 from pyomo.environ import (Binary, ConcreteModel, Constraint,
                            NonNegativeReals, Objective,
                            RangeSet, Var, minimize)
@@ -80,5 +78,5 @@ class SimpleMINLP(ConcreteModel):
         """Bound definitions"""
         # x (continuous) upper bounds
         x_ubs = {1: 4, 2: 4}
-        for i, x_ub in iteritems(x_ubs):
+        for i, x_ub in x_ubs.items():
             X[i].setub(x_ub)

--- a/pyomo/contrib/mindtpy/tests/constraint_qualification_example.py
+++ b/pyomo/contrib/mindtpy/tests/constraint_qualification_example.py
@@ -10,8 +10,6 @@ The expected optimal solution value is 3.
 """
 from __future__ import division
 
-from six import iteritems
-
 from pyomo.environ import (Binary, ConcreteModel, Constraint, Reals,
                            Objective, Param, RangeSet, Var, exp, minimize, log)
 

--- a/pyomo/contrib/mindtpy/tests/eight_process_problem.py
+++ b/pyomo/contrib/mindtpy/tests/eight_process_problem.py
@@ -23,8 +23,6 @@ http://dx.doi.org/10.1016/0098-1354(95)00219-7
 """
 from __future__ import division
 
-from six import iteritems
-
 from pyomo.environ import (Binary, ConcreteModel, Constraint, NonNegativeReals,
                            Objective, Param, RangeSet, Var, exp, minimize)
 
@@ -154,5 +152,5 @@ class EightProcessFlowsheet(ConcreteModel):
         # x_ubs = {3: 2, 5: 2, 9: 2, 10: 1, 14: 1, 17: 2, 19: 2, 21: 2, 25: 3}
         x_ubs = {2: 10, 3: 2, 4: 10, 5: 2, 9: 2, 10: 1, 14: 1, 17: 2, 18: 10, 19: 2,
                  20: 10, 21: 2, 22: 10, 25: 3}  # add bounds for variables in nonlinear constraints
-        for i, x_ub in iteritems(x_ubs):
+        for i, x_ub in x_ubs.items():
             X[i].setub(x_ub)

--- a/pyomo/contrib/multistart/reinit.py
+++ b/pyomo/contrib/multistart/reinit.py
@@ -4,8 +4,6 @@ from __future__ import division
 import logging
 import random
 
-from six.moves import range
-
 from pyomo.core import Var
 
 logger = logging.getLogger('pyomo.contrib.multistart')

--- a/pyomo/contrib/multistart/test_multi.py
+++ b/pyomo/contrib/multistart/test_multi.py
@@ -1,8 +1,7 @@
 import logging
 from itertools import product
 
-from six import StringIO
-from six.moves import range
+from io import StringIO
 
 import pyomo.common.unittest as unittest
 from pyomo.common.log import LoggingIntercept

--- a/pyomo/contrib/parmest/mpi_utils.py
+++ b/pyomo/contrib/parmest/mpi_utils.py
@@ -10,7 +10,6 @@
 
 from collections import OrderedDict
 import importlib
-from six import iteritems
 """
 This module is a collection of classes that provide a
 friendlier interface to MPI (through mpi4py). They help
@@ -118,7 +117,7 @@ class ParallelTaskManager:
             local_data = OrderedDict()
             assert (len(global_data) == self._n_total_tasks)
             idx = 0
-            for k,v in iteritems(global_data):
+            for k, v in global_data.items():
                 if idx in self._local_map:
                     local_data[k] = v
                 idx += idx

--- a/pyomo/contrib/preprocessing/plugins/constraint_tightener.py
+++ b/pyomo/contrib/preprocessing/plugins/constraint_tightener.py
@@ -1,7 +1,5 @@
 import logging
 
-from six.moves import zip
-
 from pyomo.common import deprecated
 from pyomo.core import Constraint, value, TransformationFactory
 from pyomo.core.plugins.transform.hierarchy import IsomorphicTransformation

--- a/pyomo/contrib/preprocessing/plugins/detect_fixed_vars.py
+++ b/pyomo/contrib/preprocessing/plugins/detect_fixed_vars.py
@@ -11,8 +11,6 @@
 """Transformation to detect variables fixed by bounds and fix them."""
 from math import fabs
 
-from six import iteritems
-
 from pyomo.core.base.plugin import TransformationFactory
 from pyomo.common.collections import ComponentMap
 from pyomo.common.config import (ConfigBlock, ConfigValue, NonNegativeFloat,
@@ -70,8 +68,7 @@ class FixedVarDetector(IsomorphicTransformation):
 
     def revert(self, instance):
         """Revert variables fixed by the transformation."""
-        for var, var_value in iteritems(
-                instance._xfrm_detect_fixed_vars_old_values):
+        for var, var_value in instance._xfrm_detect_fixed_vars_old_values.items():
             var.unfix()
             var.set_value(var_value)
 

--- a/pyomo/contrib/preprocessing/tests/test_int_to_binary.py
+++ b/pyomo/contrib/preprocessing/tests/test_int_to_binary.py
@@ -15,7 +15,7 @@ from pyomo.environ import TransformationFactory as xfrm
 from pyomo.common.log import LoggingIntercept
 
 import logging
-from six import StringIO
+from io import StringIO
 
 class TestIntToBinary(unittest.TestCase):
     """Tests integer to binary variable reformulation."""

--- a/pyomo/contrib/preprocessing/util.py
+++ b/pyomo/contrib/preprocessing/util.py
@@ -1,6 +1,6 @@
 import logging
 
-from six import StringIO
+from io import StringIO
 
 from pyomo.common.log import LoggingIntercept
 

--- a/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
@@ -19,7 +19,6 @@ that works with problems derived from AslNLP as long as those
 classes return numpy ndarray objects for the vectors and coo_matrix
 objects for the matrices (e.g., AmplNLP and PyomoNLP)
 """
-import six
 import sys
 import logging
 import os
@@ -103,8 +102,7 @@ _ipopt_term_cond = {
     'Internal_Error': TerminationCondition.internalSolverError,
 }
 
-@six.add_metaclass(abc.ABCMeta)
-class CyIpoptProblemInterface(object):
+class CyIpoptProblemInterface(object, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def x_init(self):
         """Return the initial values for x as a numpy ndarray

--- a/pyomo/contrib/pynumero/algorithms/solvers/pyomo_ext_cyipopt.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/pyomo_ext_cyipopt.py
@@ -8,7 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 import numpy as np
-import six
 import abc
 from pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver import CyIpoptProblemInterface
 from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP
@@ -41,8 +40,8 @@ Todo:
    * Remove the dummy variable and constraint once Pyomo supports non-removal of certain
      variables
 """
-@six.add_metaclass(abc.ABCMeta)
-class ExternalInputOutputModel(object):
+
+class ExternalInputOutputModel(object, metaclass=abc.ABCMeta):
     """
     This is the base class for building external input output models
     for use with Pyomo and CyIpopt

--- a/pyomo/contrib/pynumero/interfaces/external_grey_box.py
+++ b/pyomo/contrib/pynumero/interfaces/external_grey_box.py
@@ -20,7 +20,6 @@ from pyomo.core.base.util import Initializer
 
 from ..sparse.block_matrix import BlockMatrix
 
-from six import iteritems
 
 logger = logging.getLogger('pyomo.contrib.pynumero')
 
@@ -353,7 +352,7 @@ class ExternalGreyBoxBlock(Block):
 
         if self._init_model is not None:
             block = self.parent_block()
-            for index, data in iteritems(self):
+            for index, data in self.items():
                 data.set_external_model(self._init_model(block, index))
 
 

--- a/pyomo/contrib/pynumero/interfaces/nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/nlp.py
@@ -49,13 +49,12 @@ evaluate_jacobian_ineq.
 .. rubric:: Contents
 
 """
-import six
 import abc
 
 __all__ = ['NLP']
 
-@six.add_metaclass(abc.ABCMeta)
-class NLP(object):
+
+class NLP(object, metaclass=abc.ABCMeta):
     def __init__(self):
         pass
     
@@ -365,8 +364,8 @@ class NLP(object):
         primals and duals defined in the set methods"""
         pass
 
-@six.add_metaclass(abc.ABCMeta)
-class ExtendedNLP(NLP):
+
+class ExtendedNLP(NLP, metaclass=abc.ABCMeta):
     """ This interface extends the NLP interface to support a presentation
     of the problem that separates equality and inequality constraints
     """

--- a/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
@@ -14,8 +14,6 @@ the Ampl Solver Library (ASL) implementation
 
 import os
 import numpy as np
-import six
-from six.moves import xrange
 
 from scipy.sparse import coo_matrix
 from pyomo.common.deprecation import deprecated
@@ -79,7 +77,7 @@ class PyomoNLP(AslNLP):
             self._condata_to_idx = cdidx = ComponentMap()
 
             # TODO: Are these names totally consistent?
-            for name, obj in six.iteritems(symbolMap.bySymbol):
+            for name, obj in symbolMap.bySymbol.items():
                 if name[0] == 'v':
                     vdidx[obj()] = int(name[1:])
                 elif name[0] == 'c':
@@ -105,14 +103,14 @@ class PyomoNLP(AslNLP):
             equality_mask = self._con_full_eq_mask
             self._condata_to_eq_idx = ComponentMap(
                     (con, full_to_equality[i])
-                    for con, i in six.iteritems(self._condata_to_idx)
+                    for con, i in self._condata_to_idx.items()
                     if equality_mask[i]
                     )
             full_to_inequality = self._con_full_ineq_map
             inequality_mask = self._con_full_ineq_mask
             self._condata_to_ineq_idx = ComponentMap(
                     (con, full_to_inequality[i])
-                    for con, i in six.iteritems(self._condata_to_idx)
+                    for con, i in self._condata_to_idx.items()
                     if inequality_mask[i]
                     )
 
@@ -140,7 +138,7 @@ class PyomoNLP(AslNLP):
         the order corresponding to the primals
         """
         # ToDo: is there a more efficient way to do this
-        idx_to_vardata = {i:v for v,i in six.iteritems(self._vardata_to_idx)}
+        idx_to_vardata = {i:v for v,i in self._vardata_to_idx.items()}
         return [idx_to_vardata[i] for i in range(len(idx_to_vardata))]
 
     def get_pyomo_constraints(self):
@@ -149,7 +147,7 @@ class PyomoNLP(AslNLP):
         the order corresponding to the primals
         """
         # ToDo: is there a more efficient way to do this
-        idx_to_condata = {i:v for v,i in six.iteritems(self._condata_to_idx)}
+        idx_to_condata = {i:v for v,i in self._condata_to_idx.items()}
         return [idx_to_condata[i] for i in range(len(idx_to_condata))]
 
     def get_pyomo_equality_constraints(self):
@@ -158,7 +156,7 @@ class PyomoNLP(AslNLP):
         the order corresponding to the equality constraints.
         """
         idx_to_condata = {i: c for c, i in
-                six.iteritems(self._condata_to_eq_idx)}
+                self._condata_to_eq_idx.items()}
         return [idx_to_condata[i] for i in range(len(idx_to_condata))]
 
     def get_pyomo_inequality_constraints(self):
@@ -167,7 +165,7 @@ class PyomoNLP(AslNLP):
         the order corresponding to the inequality constraints.
         """
         idx_to_condata = {i: c for c, i in
-                six.iteritems(self._condata_to_ineq_idx)}
+                self._condata_to_ineq_idx.items()}
         return [idx_to_condata[i] for i in range(len(idx_to_condata))]
 
     @deprecated(msg='This method has been replaced with primals_names', version='6.0.0.dev0', remove_in='6.0')
@@ -505,13 +503,13 @@ class PyomoGreyBoxNLP(NLP):
         self._vardata_to_idx = ComponentMap(self._pyomo_nlp._vardata_to_idx)
         for data in greybox_data:
             # check that none of the inputs / outputs are fixed
-            for v in six.itervalues(data.inputs):
+            for v in data.inputs.values():
                 if v.fixed:
                     raise NotImplementedError('Found a grey box model input that is fixed: {}.'
                                               ' This interface does not currently support fixed'
                                               ' variables. Please add a constraint instead.'
                                               ''.format(v.getname(fully_qualified=True)))
-            for v in six.itervalues(data.outputs):
+            for v in data.outputs.values():
                 if v.fixed:
                     raise NotImplementedError('Found a grey box model output that is fixed: {}.'
                                               ' This interface does not currently support fixed'
@@ -1162,13 +1160,13 @@ class _ExternalGreyBoxModelHelper(object):
         # store the map of input indices (0 .. n_inputs) to
         # the indices in the full primals vector
         self._inputs_to_primals_map = np.fromiter(
-            (vardata_to_idx[v] for v in six.itervalues(self._block.inputs)),
+            (vardata_to_idx[v] for v in self._block.inputs.values()),
             dtype=np.int64, count=n_inputs)
 
         # store the map of output indices (0 .. n_outputs) to
         # the indices in the full primals vector
         self._outputs_to_primals_map = np.fromiter(
-            (vardata_to_idx[v] for v in six.itervalues(self._block.outputs)),
+            (vardata_to_idx[v] for v in self._block.outputs.values()),
             dtype=np.int64, count=n_outputs)
 
         if self._ex_model.n_outputs() == 0 and \
@@ -1180,12 +1178,12 @@ class _ExternalGreyBoxModelHelper(object):
         self._ex_eq_duals_to_full_map = None
         if n_eq_constraints > 0:
             self._ex_eq_duals_to_full_map = \
-                list(xrange(con_offset, con_offset + n_eq_constraints))
+                list(range(con_offset, con_offset + n_eq_constraints))
 
         self._ex_output_duals_to_full_map = None
         if n_outputs > 0:
             self._ex_output_duals_to_full_map = \
-                list(xrange(con_offset + n_eq_constraints, con_offset + n_eq_constraints + n_outputs))
+                list(range(con_offset + n_eq_constraints, con_offset + n_eq_constraints + n_outputs))
 
         # we need to change the column indices in the jacobian
         # from the 0..n_inputs provided by the external model
@@ -1291,7 +1289,7 @@ class _ExternalGreyBoxModelHelper(object):
                 
                 # We also need tocreate the irow, jcol, nnz structure for the
                 # output variable portion of h(u)-o=0
-                self._additional_output_entries_irow = np.asarray(xrange(self._ex_model.n_outputs()))
+                self._additional_output_entries_irow = np.asarray(range(self._ex_model.n_outputs()))
                 self._additional_output_entries_jcol = self._outputs_to_primals_map
                 self._additional_output_entries_data = -1.0*np.ones(self._ex_model.n_outputs())
 

--- a/pyomo/contrib/trustregion/GeometryGenerator.py
+++ b/pyomo/contrib/trustregion/GeometryGenerator.py
@@ -12,7 +12,7 @@ import logging
 
 # This is an auto geometry generator for quadratic ROM
 import numpy as np
-from six import StringIO
+from io import StringIO
 from pyomo.contrib.trustregion.cache import GeometryCache
 
 logger = logging.getLogger('pyomo.contrib.trustregion')

--- a/pyomo/contrib/trustregion/readgjh.py
+++ b/pyomo/contrib/trustregion/readgjh.py
@@ -8,7 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import glob, six
+import glob
 
 # build obj gradient and constraint Jacobian
 # from a gjh file written by the ASL gjh 'solver'
@@ -53,7 +53,7 @@ def readgjh(fname=None):
             #
             # The following replaces int(filter(str.isdigit,data)),
             # which only works in 2.x
-            data_as_int = int(''.join(six.moves.filter(str.isdigit, data)))
+            data_as_int = int(''.join(filter(str.isdigit, data)))
             row = data_as_int - 1  # subtract 1 to index from 0
             data = f.readline()
 


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
Part of the Pyomo 6.0 effort is to replace the usage of `six` with the appropriate Python 3 methods. This does just that in the `pyomo/contrib` directory.

## Changes proposed in this PR:
- Remove `six` from `pyomo.contrib`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
