### PR TITLE
Remove `six` in `dae`, `dataportal`, and `duality`

### DIFF
--- a/pyomo/dae/diffvar.py
+++ b/pyomo/dae/diffvar.py
@@ -131,7 +131,7 @@ class DerivativeVar(Var):
                     "The variable %s is indexed by multiple ContinuousSets. "
                     "The desired ContinuousSet must be specified using the "
                     "keyword argument 'wrt'" % sVar)
-            wrt = [next(sVar._contset.keys()), ]
+            wrt = [next(iter(sVar._contset.keys())), ]
         elif type(wrt) is ContinuousSet:
             if wrt not in sVar._contset:
                 raise DAE_Error(

--- a/pyomo/dae/diffvar.py
+++ b/pyomo/dae/diffvar.py
@@ -14,7 +14,6 @@ from pyomo.core.base.set import UnknownSetDimen
 from pyomo.core.base.var import Var
 from pyomo.core.base.plugin import ModelComponentFactory
 from pyomo.dae.contset import ContinuousSet
-from six import iterkeys
 
 __all__ = ('DerivativeVar', 'DAE_Error',)
 
@@ -132,7 +131,7 @@ class DerivativeVar(Var):
                     "The variable %s is indexed by multiple ContinuousSets. "
                     "The desired ContinuousSet must be specified using the "
                     "keyword argument 'wrt'" % sVar)
-            wrt = [next(iterkeys(sVar._contset)), ]
+            wrt = [next(sVar._contset.keys()), ]
         elif type(wrt) is ContinuousSet:
             if wrt not in sVar._contset:
                 raise DAE_Error(

--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -18,7 +18,7 @@ from pyomo.core.base.misc import apply_indexed_rule
 from pyomo.core.base.block import IndexedBlock, SortComponents
 from pyomo.dae import ContinuousSet, DAE_Error
 
-from six import iterkeys, itervalues, StringIO
+from io import StringIO
 
 logger = logging.getLogger('pyomo.dae')
 
@@ -119,7 +119,7 @@ def expand_components(block):
     # BlockData will be added to the indexed Block but will not be
     # constructed correctly.
     for blk in block.component_objects(Block, descend_into=True):
-        missing_idx = set(blk._index) - set(iterkeys(blk._data))
+        missing_idx = set(blk._index) - set(blk._data.keys())
         if missing_idx:
             blk._dae_missing_idx = missing_idx
 
@@ -259,7 +259,7 @@ def _update_var(v):
     #       Var (which is now a IndexedComponent). However, it
     #       would be much slower to rely on that method to generate new
     #       _VarData for a large number of new indices.
-    new_indices = set(v._index) - set(iterkeys(v._data))
+    new_indices = set(v._index) - set(v._data.keys())
     for index in new_indices:
         v.add(index)
 
@@ -430,7 +430,7 @@ def block_fully_discretized(b):
     Checks to see if all ContinuousSets in a block have been discretized
     """
 
-    for i in itervalues(b.component_map(ContinuousSet)):
+    for i in b.component_map(ContinuousSet).values():
         if 'scheme' not in i.get_discretization_info():
             return False
     return True

--- a/pyomo/dae/plugins/colloc.py
+++ b/pyomo/dae/plugins/colloc.py
@@ -9,8 +9,6 @@
 #  ___________________________________________________________________________
 
 import logging
-from six.moves import xrange
-from six import next
 
 # If the user has numpy then the collocation points and the a matrix for
 # the Runge-Kutta basis formulation will be calculated as needed.
@@ -617,9 +615,9 @@ class Collocation_Discretization_Transformation(Transformation):
         # Iterate over non_ds indices
         for n in tmpidx:
             # Iterate over finite elements
-            for i in xrange(0, len(fe) - 1):
+            for i in range(0, len(fe) - 1):
                 # Iterate over collocation points
-                for k in xrange(1, tot_ncp - ncp + 1):
+                for k in range(1, tot_ncp - ncp + 1):
                     if ncp == 1:
                         # Constant over each finite element
                         conlist.add(var[idx(n, i, k)] ==
@@ -632,7 +630,7 @@ class Collocation_Discretization_Transformation(Transformation):
                         coeff = self._interpolation_coeffs(ti, tfit)
                         conlist.add(var[idx(n, i, k)] ==
                                     sum(var[idx(n, i, j)] * next(coeff)
-                                        for j in xrange(tot_ncp - ncp + 1,
+                                        for j in range(tot_ncp - ncp + 1,
                                                         tot_ncp + 1)))
 
         return instance

--- a/pyomo/dae/simulator.py
+++ b/pyomo/dae/simulator.py
@@ -15,8 +15,6 @@ from pyomo.core.expr import current as EXPR
 from pyomo.core.expr.numvalue import native_numeric_types
 from pyomo.core.expr.template_expr import IndexTemplate, _GetItemIndexer
 
-from six import iterkeys
-
 import logging
 
 __all__ = ('Simulator', )
@@ -622,7 +620,7 @@ class Simulator:
         # parameters
         algvars = []
 
-        for item in iterkeys(templatemap):
+        for item in templatemap.keys():
             if item.base.name in derivs:
                 # Make sure there are no DerivativeVars in the
                 # template map

--- a/pyomo/dae/tests/test_colloc.py
+++ b/pyomo/dae/tests/test_colloc.py
@@ -18,7 +18,7 @@ from pyomo.dae.diffvar import DAE_Error
 
 from pyomo.repn import generate_standard_repn
 
-from six import StringIO
+from io import StringIO
 
 from pyomo.common.log import  LoggingIntercept
 

--- a/pyomo/dae/tests/test_contset.py
+++ b/pyomo/dae/tests/test_contset.py
@@ -20,7 +20,7 @@ import pyomo.common.unittest as unittest
 from pyomo.environ import ConcreteModel, AbstractModel, Set
 from pyomo.dae import ContinuousSet
 from pyomo.common.log import LoggingIntercept
-from six import StringIO
+from io import StringIO
 
 currdir = dirname(abspath(__file__)) + os.sep
 

--- a/pyomo/dae/tests/test_finite_diff.py
+++ b/pyomo/dae/tests/test_finite_diff.py
@@ -16,7 +16,7 @@ from pyomo.environ import (Var, Set, ConcreteModel,
 from pyomo.dae import ContinuousSet, DerivativeVar
 from pyomo.dae.diffvar import DAE_Error
 
-from six import StringIO
+from io import StringIO
 
 from pyomo.common.log import LoggingIntercept
 

--- a/pyomo/dae/tests/test_misc.py
+++ b/pyomo/dae/tests/test_misc.py
@@ -14,7 +14,7 @@ Unit Tests for pyomo.dae.misc
 import os
 from os.path import abspath, dirname
 
-from six import StringIO, iterkeys
+from io import StringIO
 
 import pyomo.common.unittest as unittest
 
@@ -484,7 +484,7 @@ class TestDaeMisc(unittest.TestCase):
 
         generate_finite_elements(model.t, 5)
 
-        missing_idx = set(model.blk._index) - set(iterkeys(model.blk._data))
+        missing_idx = set(model.blk._index) - set(model.blk._data.keys())
         model.blk._dae_missing_idx = missing_idx
 
         update_contset_indexed_component(model.blk, expansion_map)
@@ -537,7 +537,7 @@ class TestDaeMisc(unittest.TestCase):
 
         generate_finite_elements(model.t, 5)
 
-        missing_idx = set(model.blk._index) - set(iterkeys(model.blk._data))
+        missing_idx = set(model.blk._index) - set(model.blk._data.keys())
         model.blk._dae_missing_idx = missing_idx
 
         update_contset_indexed_component(model.blk, expansion_map)
@@ -592,7 +592,7 @@ class TestDaeMisc(unittest.TestCase):
 
         generate_finite_elements(model.t, 5)
 
-        missing_idx = set(model.blk._index) - set(iterkeys(model.blk._data))
+        missing_idx = set(model.blk._index) - set(model.blk._data.keys())
         model.blk._dae_missing_idx = missing_idx
 
         update_contset_indexed_component(model.blk, expansion_map)
@@ -647,7 +647,7 @@ class TestDaeMisc(unittest.TestCase):
 
         generate_finite_elements(model.t, 5)
 
-        missing_idx = set(model.blk._index) - set(iterkeys(model.blk._data))
+        missing_idx = set(model.blk._index) - set(model.blk._data.keys())
         model.blk._dae_missing_idx = missing_idx
 
         update_contset_indexed_component(model.blk, expansion_map)

--- a/pyomo/dataportal/TableData.py
+++ b/pyomo/dataportal/TableData.py
@@ -10,8 +10,6 @@
 
 __all__ = ['TableData']
 
-from six.moves import xrange
-
 from pyomo.common.collections import Bunch
 from pyomo.dataportal.process_data import _process_data
 
@@ -111,7 +109,7 @@ class TableData(object):
 
         header_index = []
         if self.options.select is None:
-            for i in xrange(len(headers)):
+            for i in range(len(headers)):
                 header_index.append(i)
         else:
             for i in self.options.select:
@@ -227,7 +225,7 @@ class TableData(object):
             # Create column names
             if self.options.columns is None:
                 cols = []
-                for i in xrange(self.options.set.dimen):
+                for i in range(self.options.set.dimen):
                     cols.append(self.options.set.local_name+str(i))
                 tmp.append(cols)
             # Get rows
@@ -262,7 +260,7 @@ class TableData(object):
             # Create column names
             if self.options.columns is None:
                 cols = []
-                for i in xrange(len(tmp[0])-len(_param)):
+                for i in range(len(tmp[0])-len(_param)):
                     cols.append('I'+str(i))
                 for param in _param:
                     cols.append(param)

--- a/pyomo/dataportal/parse_datacmds.py
+++ b/pyomo/dataportal/parse_datacmds.py
@@ -18,7 +18,6 @@ import os.path
 import ply.lex as lex
 import ply.yacc as yacc
 from inspect import getfile, currentframe
-from six.moves import xrange
 
 from pyomo.common.fileutils import this_file
 from pyomo.core.base.util import flatten_tuple
@@ -255,13 +254,13 @@ def p_statement(p):
     if stmt == 'set':
         if p[2][-1] == '[':
             # Just turn off the flatten_list and see what happens
-            p[0] = ['set', p[2][:-1], '['] + list(flatten_tuple([p[i] for i in xrange(3,len(p)-1)]))
+            p[0] = ['set', p[2][:-1], '['] + list(flatten_tuple([p[i] for i in range(3,len(p)-1)]))
         else:
-            p[0] = list(flatten_tuple([p[i] for i in xrange(1,len(p)-1)]))
+            p[0] = list(flatten_tuple([p[i] for i in range(1,len(p)-1)]))
     elif stmt == 'param':
-        p[0] = list(flatten_tuple([p[i] for i in xrange(1,len(p)-1)]))
+        p[0] = list(flatten_tuple([p[i] for i in range(1,len(p)-1)]))
     elif stmt == 'include':
-        p[0] = [p[i] for i in xrange(1,len(p)-1)]
+        p[0] = [p[i] for i in range(1,len(p)-1)]
     elif stmt == 'load':
         p[0] = [p[1]]+ p[2]
     elif stmt == 'store':

--- a/pyomo/dataportal/plugins/db_table.py
+++ b/pyomo/dataportal/plugins/db_table.py
@@ -13,7 +13,6 @@ import re
 import sys
 import shutil
 from decimal import Decimal
-from six import iteritems
 
 from pyomo.common.dependencies import attempt_import
 from pyomo.dataportal import TableData
@@ -233,7 +232,7 @@ class pyodbc_db_Table(db_Table):
                     config = ODBCConfig()
                     dsninfo = self.create_dsn_dict(connection, config)
                     connstr = []
-                    for k,v in iteritems(dsninfo):
+                    for k, v in dsninfo.items():
                         if ' ' in v and (v[0] != "{" or v[-1] != "}"):
                             connstr.append("%s={%s}" % (k.upper(),v))
                         else:

--- a/pyomo/dataportal/plugins/json_dict.py
+++ b/pyomo/dataportal/plugins/json_dict.py
@@ -10,7 +10,6 @@
 
 import os.path
 import json
-import six
 
 from pyomo.common.collections import Bunch
 from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
@@ -120,18 +119,7 @@ class JSONDictionary(object):
         if not os.path.exists(self.filename):
             raise IOError("Cannot find file '%s'" % self.filename)
         INPUT = open(self.filename, 'r')
-        if six.PY2 and self.options.convert_unicode:
-            def _byteify(data, ignore_dicts=False):
-                if isinstance(data, six.text_type):
-                    return data.encode('utf-8') 
-                if isinstance(data, list):
-                    return [ _byteify(item, True) for item in data ]
-                if isinstance(data, dict) and not ignore_dicts:
-                    return dict( (_byteify(key, True), _byteify(value, True)) for (key, value) in data.iteritems() )
-                return data
-            jdata = json.load(INPUT, object_hook=_byteify)
-        else:
-            jdata = json.load(INPUT)
+        jdata = json.load(INPUT)
         INPUT.close()
         if jdata is None or len(jdata) == 0:
             raise IOError("Empty JSON data file")

--- a/pyomo/dataportal/plugins/sheet.py
+++ b/pyomo/dataportal/plugins/sheet.py
@@ -9,7 +9,6 @@
 #  ___________________________________________________________________________
 
 import os.path
-import six
 from pyutilib.excel.spreadsheet import ExcelSpreadsheet, Interfaces
 
 from pyomo.dataportal import TableData
@@ -61,7 +60,7 @@ class SheetTable(TableData):
         if self.sheet is None:
             return
         tmp = self.sheet.get_range(self.options.range, raw=True)
-        if type(tmp) is float or type(tmp) in six.integer_types:
+        if type(tmp) is float or type(tmp) is int:
             if not self.options.param is None:
                 self._info = ["param"] + list(self.options.param) + [":=",tmp]
             elif len(self.options.symbol_map) == 1:

--- a/pyomo/dataportal/process_data.py
+++ b/pyomo/dataportal/process_data.py
@@ -24,8 +24,6 @@ from pyomo.dataportal.factory import DataManagerFactory, UnknownDataManager
 from pyomo.core.base.set import UnknownSetDimen
 from pyomo.core.base.util import flatten_tuple
 
-from six.moves import xrange
-
 numlist = {bool, int, float}
 
 logger = logging.getLogger('pyomo.core')
@@ -224,7 +222,7 @@ def _process_set(cmd, _model, _data):
         i += 1
         while i<len(cmd):
             ndx=cmd[i]
-            for j in xrange(0,len(ndx1)):
+            for j in range(0,len(ndx1)):
                 if cmd[i+j+1] == "+":
                     #print("DATA %s %s" % (ndx1[j], cmd[i]))
                     _data[cmd[1]][None].append((ndx1[j], cmd[i]))

--- a/pyomo/duality/plugins.py
+++ b/pyomo/duality/plugins.py
@@ -9,7 +9,6 @@
 #  ___________________________________________________________________________
 
 import logging
-from six import iteritems
 
 from pyomo.common.deprecation import deprecated
 from pyomo.core.base import (Transformation,
@@ -123,7 +122,7 @@ class LinearDual_PyomoTransformation(Transformation):
         # Construct the constraints
         #
         for cname in A:
-            for ndx, terms in iteritems(A[cname]):
+            for ndx, terms in A[cname].items():
                 expr = 0
                 for term in terms:
                     expr += term.coef * getvar(term.var, term.ndx)
@@ -144,7 +143,7 @@ class LinearDual_PyomoTransformation(Transformation):
                     c_name = "%s[%s]" % (cname, str(ndx))
                 setattr(dual, c_name, c)
             #
-            for (name, ndx), domain in iteritems(v_domain):
+            for (name, ndx), domain in v_domain.items():
                 v = getvar(name, ndx)
                 flag = type(ndx) is tuple and (ndx[-1] == 'lb' or ndx[-1] == 'ub')
                 if domain == 1:

--- a/pyomo/duality/tests/test_linear_dual.py
+++ b/pyomo/duality/tests/test_linear_dual.py
@@ -25,8 +25,6 @@ from pyomo.scripting.util import cleanup
 import pyomo.scripting.pyomo_main as main
 
 
-from six import iteritems
-
 solver = None
 class CommonTests(object):
 
@@ -143,7 +141,7 @@ class Solver(unittest.TestCase):
         self.assertEqual(len(refObj), len(ansObj))
         for i in range(len(refObj)):
             self.assertEqual(len(refObj[i]), len(ansObj[i]))
-            for key,val in iteritems(refObj[i]):
+            for key,val in refObj[i].items():
                 self.assertAlmostEqual(val['Value'], ansObj[i].get(key,None)['Value'], places=3)
 
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Part of the Pyomo 6.0 effort is to replace the usage of `six` with the appropriate Python 3 methods. This does just that in the `dae`, `duality`, and `dataportal` directories.

## Changes proposed in this PR:
- Remove `six` in `pyomo.dae`
- Remove `six` in `pyomo.dataportal`
- Remove `six` in `pyomo.duality`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
