### PR TITLE
Track changes in cyipopt API

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -409,12 +409,12 @@ def attempt_import(name, error_message=None, only_catch_importerror=None,
             error_message = "The %s module version %s does not satisfy " \
                             "the minimum version %s" % (
                                 name, version, minimum_version)
-    except catch_exceptions:
-        pass
+    except catch_exceptions as e:
+        _err = str(e)
 
     if not error_message:
         error_message = "The %s module (an optional Pyomo dependency) " \
-                        "failed to import" % (name,)
+                        "failed to import: %s" % (name, _err)
 
     module = ModuleUnavailable(error_message)
     if callback is not None:

--- a/pyomo/common/tests/test_dependencies.py
+++ b/pyomo/common/tests/test_dependencies.py
@@ -230,16 +230,18 @@ class TestDependencies(unittest.TestCase):
         log = StringIO()
         with LoggingIntercept(log, 'pyomo.common'):
             mod.generate_import_warning()
-        self.assertEqual(
-            log.getvalue(), "The pyomo.common.tests.dep_mod_except module "
-            "(an optional Pyomo dependency) failed to import\n")
+        self.assertIn(
+            "The pyomo.common.tests.dep_mod_except module "
+            "(an optional Pyomo dependency) failed to import",
+            log.getvalue())
 
         log = StringIO()
         with LoggingIntercept(log, 'pyomo.core.base'):
             mod.generate_import_warning('pyomo.core.base')
-        self.assertEqual(
-            log.getvalue(), "The pyomo.common.tests.dep_mod_except module "
-            "(an optional Pyomo dependency) failed to import\n")
+        self.assertIn(
+            "The pyomo.common.tests.dep_mod_except module "
+            "(an optional Pyomo dependency) failed to import",
+            log.getvalue())
 
     def test_importer(self):
         attempted_import = []

--- a/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
@@ -109,6 +109,8 @@ _cyipopt_status_enum = [
                                 b"NaN or Inf) from the NLP; see also option "
                                 b"check_derivatives_for_naninf"),
     "Unrecoverable_Exception", b"Some uncaught Ipopt exception encountered.",
+    "NonIpopt_Exception_Thrown", b"Unknown Exception caught in Ipopt.",
+    # Note that the concluding "." was missing before cyipopt 1.0.3
     "NonIpopt_Exception_Thrown", b"Unknown Exception caught in Ipopt",
     "Insufficient_Memory", b"Not enough memory.",
     "Internal_Error", (b"An unknown internal error occurred. Please contact "

--- a/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
@@ -70,27 +70,46 @@ logger = logging.getLogger(__name__)
 # This maps the cyipopt STATUS_MESSAGES back to string representations
 # of the Ipopt ApplicationReturnStatus enum
 _cyipopt_status_enum = [
-    'Solve_Succeeded', b'Algorithm terminated successfully at a locally optimal point, satisfying the convergence tolerances (can be specified by options).',
-    'Solved_To_Acceptable_Level', b'Algorithm stopped at a point that was converged, not to "desired" tolerances, but to "acceptable" tolerances (see the acceptable-... options).',
-    'Infeasible_Problem_Detected', b'Algorithm converged to a point of local infeasibility. Problem may be infeasible.',
-    'Search_Direction_Becomes_Too_Small', b'Algorithm proceeds with very little progress.',
-    'Diverging_Iterates', b'It seems that the iterates diverge.',
-    'User_Requested_Stop', b'The user call-back function intermediate_callback (see Section 3.3.4 in the documentation) returned false, i.e., the user code requested a premature termination of the optimization.',
-    'Feasible_Point_Found', b'Feasible point for square problem found.',
-    'Maximum_Iterations_Exceeded', b'Maximum number of iterations exceeded (can be specified by an option).',
-    'Restoration_Failed', b'Restoration phase failed, algorithm doesn\'t know how to proceed.',
-    'Error_In_Step_Computation', b'An unrecoverable error occurred while Ipopt tried to compute the search direction.',
-    'Maximum_CpuTime_Exceeded', b'Maximum CPU time exceeded.',
-    'Not_Enough_Degrees_Of_Freedom', b'Problem has too few degrees of freedom.',
-    'Invalid_Problem_Definition', b'Invalid problem definition.',
-    'Invalid_Option', b'Invalid option encountered.',
-    'Invalid_Number_Detected', b'Algorithm received an invalid number (such as NaN or Inf) from the NLP; see also option check_derivatives_for_naninf.',
-    # Note that the concluding '.' was missing before cyipopt 1.0.3
-    'Invalid_Number_Detected', b'Algorithm received an invalid number (such as NaN or Inf) from the NLP; see also option check_derivatives_for_naninf',
-    'Unrecoverable_Exception', b'Some uncaught Ipopt exception encountered.',
-    'NonIpopt_Exception_Thrown', b'Unknown Exception caught in Ipopt',
-    'Insufficient_Memory', b'Not enough memory.',
-    'Internal_Error', b'An unknown internal error occurred. Please contact the Ipopt authors through the mailing list.'
+    "Solve_Succeeded", (b"Algorithm terminated successfully at a locally "
+                        b"optimal point, satisfying the convergence tolerances "
+                        b"(can be specified by options)."),
+    "Solved_To_Acceptable_Level", (b"Algorithm stopped at a point that was "
+                                   b"converged, not to \"desired\" tolerances, "
+                                   b"but to \"acceptable\" tolerances (see the "
+                                   b"acceptable-... options)."),
+    "Infeasible_Problem_Detected", (b"Algorithm converged to a point of local "
+                                    b"infeasibility. Problem may be "
+                                    b"infeasible."),
+    "Search_Direction_Becomes_Too_Small", (b"Algorithm proceeds with very "
+                                           b"little progress."),
+    "Diverging_Iterates", b"It seems that the iterates diverge.",
+    "User_Requested_Stop", (b"The user call-back function intermediate_callback "
+                            b"(see Section 3.3.4 in the documentation) returned "
+                            b"false, i.e., the user code requested a premature "
+                            b"termination of the optimization."),
+    "Feasible_Point_Found", b"Feasible point for square problem found.",
+    "Maximum_Iterations_Exceeded", (b"Maximum number of iterations exceeded "
+                                    b"(can be specified by an option)."),
+    "Restoration_Failed", (b"Restoration phase failed, algorithm doesn\'t know "
+                           b"how to proceed."),
+    "Error_In_Step_Computation", (b"An unrecoverable error occurred while Ipopt "
+                                  b"tried to compute the search direction."),
+    "Maximum_CpuTime_Exceeded", b"Maximum CPU time exceeded.",
+    "Not_Enough_Degrees_Of_Freedom", b"Problem has too few degrees of freedom.",
+    "Invalid_Problem_Definition", b"Invalid problem definition.",
+    "Invalid_Option", b"Invalid option encountered.",
+    "Invalid_Number_Detected", (b"Algorithm received an invalid number (such as "
+                                b"NaN or Inf) from the NLP; see also option "
+                                b"check_derivatives_for_naninf."),
+    # Note that the concluding "." was missing before cyipopt 1.0.3
+    "Invalid_Number_Detected", (b"Algorithm received an invalid number (such as "
+                                b"NaN or Inf) from the NLP; see also option "
+                                b"check_derivatives_for_naninf"),
+    "Unrecoverable_Exception", b"Some uncaught Ipopt exception encountered.",
+    "NonIpopt_Exception_Thrown", b"Unknown Exception caught in Ipopt",
+    "Insufficient_Memory", b"Not enough memory.",
+    "Internal_Error", (b"An unknown internal error occurred. Please contact "
+                       b"the Ipopt authors through the mailing list."),
 ]
 _cyipopt_status_enum = {
     _cyipopt_status_enum[i+1]: _cyipopt_status_enum[i]

--- a/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
@@ -84,6 +84,8 @@ _cyipopt_status_enum = [
     'Not_Enough_Degrees_Of_Freedom', b'Problem has too few degrees of freedom.',
     'Invalid_Problem_Definition', b'Invalid problem definition.',
     'Invalid_Option', b'Invalid option encountered.',
+    'Invalid_Number_Detected', b'Algorithm received an invalid number (such as NaN or Inf) from the NLP; see also option check_derivatives_for_naninf.',
+    # Note that the concluding '.' was missing before cyipopt 1.0.3
     'Invalid_Number_Detected', b'Algorithm received an invalid number (such as NaN or Inf) from the NLP; see also option check_derivatives_for_naninf',
     'Unrecoverable_Exception', b'Some uncaught Ipopt exception encountered.',
     'NonIpopt_Exception_Thrown', b'Unknown Exception caught in Ipopt',

--- a/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
@@ -31,6 +31,9 @@ from pyomo.common.dependencies import (
 
 def _cyipopt_importer():
     import cyipopt
+    # cyipopt before version 1.0.3 called the problem class "Problem"
+    if not hasattr(cyipopt, 'Problem'):
+        cyipopt.Problem = cyipopt.problem
     # cyipopt before version 1.0.3 put the __version__ flag in the ipopt
     # module (which was deprecated starting in 1.0.3)
     if not hasattr(cyipopt, '__version__'):
@@ -434,7 +437,7 @@ class CyIpoptSolver(object):
         nx = len(xstart)
         ng = len(gl)
 
-        cyipopt_solver = cyipopt.problem(
+        cyipopt_solver = cyipopt.Problem(
             n=nx,
             m=ng,
             problem_obj=self._problem,
@@ -553,7 +556,7 @@ class PyomoCyIpoptSolver(object):
         nx = len(xl)
         ng = len(gl)
 
-        cyipopt_solver = cyipopt.problem(
+        cyipopt_solver = cyipopt.Problem(
             n=nx,
             m=ng,
             problem_obj=problem,

--- a/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
@@ -10,7 +10,7 @@
 """
 The cyipopt_solver module includes the python interface to the
 Cythonized ipopt solver cyipopt (see more:
-https://github.com/matthias-k/cyipopt.git). To use the solver,
+https://github.com/mechmotum/cyipopt.git). To use the solver,
 you can create a derived implementation from the abstract base class
 CyIpoptProblemInterface that provides the necessary methods.
 
@@ -46,7 +46,7 @@ def _cyipopt_importer():
 cyipopt, cyipopt_available = attempt_import(
      'ipopt',
      error_message='cyipopt solver relies on the ipopt module from cyipopt. '
-     'See https://github.com/matthias-k/cyipopt.git for cyipopt '
+     'See https://github.com/mechmotum/cyipopt.git for cyipopt '
      'installation instructions.',
      importer=_cyipopt_importer,
 )

--- a/pyomo/contrib/pynumero/interfaces/tests/test_dynamic_model.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_dynamic_model.py
@@ -25,7 +25,7 @@ if not AmplInterface.available():
         "Pynumero needs the ASL extension to run CyIpoptSolver tests")
 
 from pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver import (
-    CyIpoptSolver, CyIpoptNLP, ipopt, ipopt_available,
+    CyIpoptSolver, CyIpoptNLP, cyipopt_available,
 )
 
 from pyomo.contrib.pynumero.interfaces.external_grey_box import ExternalGreyBoxModel, ExternalGreyBoxBlock
@@ -368,9 +368,12 @@ def create_pyomo_external_grey_box_model(A1, A2, c1, c2, N, dt):
 
     return m2
 
+
 class TestGreyBoxModel(unittest.TestCase):
 
-    @unittest.skipIf(not ipopt_available, "CyIpopt needed to run tests with solve")
+    @unittest.skipIf(
+        not pyo.SolverFactory('ipopt').available(exception_flag=False),
+        "Ipopt needed to run tests with solve")
     def test_compare_evaluations(self):
         A1 = 5
         A2 = 10
@@ -471,7 +474,9 @@ class TestGreyBoxModel(unittest.TestCase):
         mex_nlp.evaluate_hessian_lag(out=mex_h)
         check_sparse_matrix_specific_order(self, m_h, m_x_order, m_x_order, mex_h, mex_x_order, mex_x_order, x1_x2_map, x1_x2_map)
 
-    @unittest.skipIf(not ipopt_available, "CyIpopt needed to run tests with solve")
+
+    @unittest.skipIf(not cyipopt_available,
+                     "CyIpopt needed to run tests with solve")
     def test_solve(self):
         A1 = 5
         A2 = 10

--- a/pyomo/contrib/pynumero/interfaces/tests/test_external_grey_box_model.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_external_grey_box_model.py
@@ -24,7 +24,7 @@ if not AmplInterface.available():
         "Pynumero needs the ASL extension to run cyipopt tests")
 
 from pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver import (
-    ipopt, ipopt_available,
+    cyipopt_available,
 )
 
 from ..external_grey_box import ExternalGreyBoxModel, ExternalGreyBoxBlock
@@ -1217,7 +1217,8 @@ class TestPyomoGreyBoxNLP(unittest.TestCase):
             with self.assertRaises(AttributeError):
                 h = pyomo_nlp.evaluate_hessian_lag()
 
-    @unittest.skipIf(not ipopt_available, "CyIpopt needed to run tests with solve")
+    @unittest.skipIf(not cyipopt_available,
+                     "CyIpopt needed to run tests with solve")
     def test_external_greybox_solve(self):
         self._test_external_greybox_solve(ex_models.PressureDropTwoEqualitiesTwoOutputs(), False)
         self._test_external_greybox_solve(ex_models.PressureDropTwoEqualitiesTwoOutputsWithHessian(), True)
@@ -1423,7 +1424,8 @@ class TestPyomoGreyBoxNLP(unittest.TestCase):
         comparison_cs = np.asarray([3.1, 3.2, 4.1, 4.2, 1, 2.2], dtype=np.float64)
         check_vectors_specific_order(self, cs, c_order, comparison_cs, comparison_c_order)
 
-    @unittest.skipIf(not ipopt_available, "CyIpopt needed to run tests with solve")
+    @unittest.skipIf(not cyipopt_available,
+                     "CyIpopt needed to run tests with solve")
     def test_external_greybox_solve_scaling(self):
         m = pyo.ConcreteModel()
         m.mu = pyo.Var(bounds=(0,None), initialize=1)

--- a/pyomo/contrib/pynumero/interfaces/tests/test_pyomo_grey_box_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_pyomo_grey_box_nlp.py
@@ -24,7 +24,7 @@ if not AmplInterface.available():
         "Pynumero needs the ASL extension to run cyipopt tests")
 
 from pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver import (
-    ipopt, ipopt_available,
+    cyipopt_available,
 )
 
 from pyomo.contrib.pynumero.interfaces.external_grey_box import ExternalGreyBoxBlock
@@ -1419,7 +1419,8 @@ class TestPyomoNLPWithGreyBoxModels(unittest.TestCase):
             with self.assertRaises(NotImplementedError):
                 h = pyomo_nlp.evaluate_hessian_lag()
 
-    @unittest.skipIf(not ipopt_available, "CyIpopt needed to run tests with solve")
+    @unittest.skipIf(not cyipopt_available,
+                     "CyIpopt needed to run tests with solve")
     def test_external_greybox_solve(self):
         self._test_external_greybox_solve(ex_models.PressureDropTwoEqualitiesTwoOutputs(), False)
         self._test_external_greybox_solve(ex_models.PressureDropTwoEqualitiesTwoOutputsWithHessian(), True)
@@ -1623,7 +1624,8 @@ class TestPyomoNLPWithGreyBoxModels(unittest.TestCase):
         comparison_cs = np.asarray([3.1, 3.2, 4.1, 4.2, 1, 2.2], dtype=np.float64)
         check_vectors_specific_order(self, cs, c_order, comparison_cs, comparison_c_order)
 
-    @unittest.skipIf(not ipopt_available, "CyIpopt needed to run tests with solve")
+    @unittest.skipIf(not cyipopt_available,
+                     "CyIpopt needed to run tests with solve")
     def test_external_greybox_solve_scaling(self):
         m = pyo.ConcreteModel()
         m.mu = pyo.Var(bounds=(0,None), initialize=1)
@@ -1706,7 +1708,8 @@ class TestPyomoNLPWithGreyBoxModels(unittest.TestCase):
         self.assertIn('DenseVector "d scaling vector" with 1 elements:', solver_trace)
         self.assertIn('d scaling vector[    1]= 1.0000000000000000e+00', solver_trace) # pcon
 
-    @unittest.skipIf(not ipopt_available, "CyIpopt needed to run tests with solve")
+    @unittest.skipIf(not cyipopt_available,
+                     "CyIpopt needed to run tests with solve")
     def test_duals_after_solve(self):
         m = pyo.ConcreteModel()
         m.p = pyo.Var(initialize=1)

--- a/pyomo/contrib/pynumero/tests/test_cyipopt_examples.py
+++ b/pyomo/contrib/pynumero/tests/test_cyipopt_examples.py
@@ -37,8 +37,9 @@ if not AmplInterface.available():
         "Pynumero needs the ASL extension to run CyIpopt tests")
 
 import pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver as cyipopt_solver
-if not cyipopt_solver.ipopt_available:
-    raise unittest.SkipTest("PyNumero needs CyIpopt installed to run CyIpopt tests")
+if not cyipopt_solver.cyipopt_available:
+    raise unittest.SkipTest(
+        "PyNumero needs CyIpopt installed to run CyIpopt tests")
 import cyipopt as cyipopt_core
 
 example_dir = os.path.join(this_file_dir(), '..', 'examples')

--- a/pyomo/contrib/pynumero/tests/test_cyipopt_examples.py
+++ b/pyomo/contrib/pynumero/tests/test_cyipopt_examples.py
@@ -46,10 +46,8 @@ example_dir = os.path.join(this_file_dir(), '..', 'examples')
 
 class TestPyomoCyIpoptSolver(unittest.TestCase):
     def test_status_maps(self):
-        self.assertEqual(len(cyipopt_core.STATUS_MESSAGES),
-                         len(cyipopt_solver._cyipopt_status_enum))
-        self.assertEqual(len(cyipopt_core.STATUS_MESSAGES),
-                         len(cyipopt_solver._ipopt_term_cond))
+        # verify that all status messages from cyipopy can be cleanly
+        # mapped back to a Pyomo TerminationCondition
         for msg in cyipopt_core.STATUS_MESSAGES.values():
             self.assertIn(msg, cyipopt_solver._cyipopt_status_enum)
         for status in cyipopt_solver._cyipopt_status_enum.values():


### PR DESCRIPTION
## Fixes #1912.

## Summary/Motivation:
Beginning in 1.0.3, cyipopt has changed it's API.  This PR updates our importer to work with old and new API layouts.

## Changes proposed in this PR:
- Update cyipopt importer to generate a common layout for all versions of cyipopt
- Update reference to main cyipopt GitHub page
- Update `attempt_import()`'s `DeferredImportError` to include the original import error message (to assist with tracking down dependencies)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
