### PR TITLE
Remove `six` from `gdp` and `mpec`

### DIFF
--- a/pyomo/gdp/basic_step.py
+++ b/pyomo/gdp/basic_step.py
@@ -9,8 +9,6 @@
 #  ___________________________________________________________________________
 import copy
 import itertools
-from six import iteritems
-from six.moves import xrange
 
 from pyomo.core import Block, ConstraintList, Set, Constraint
 from pyomo.core.base import Reference
@@ -59,11 +57,11 @@ def apply_basic_step(disjunctions_or_constraints):
                            "deactivated disjunction (%s)" % (d.name,))
 
     ans = Block(concrete=True)
-    ans.DISJUNCTIONS = Set(initialize=xrange(len(disjunctions)))
+    ans.DISJUNCTIONS = Set(initialize=range(len(disjunctions)))
     ans.INDEX = Set(
         dimen=len(disjunctions),
         initialize=_squish_singletons(itertools.product(
-            *tuple( xrange(len(d.disjuncts)) for d in disjunctions ))))
+            *tuple( range(len(d.disjuncts)) for d in disjunctions ))))
 
     #
     # Form the individual disjuncts for the new basic step
@@ -78,7 +76,7 @@ def apply_basic_step(disjunctions_or_constraints):
         for i in ans.DISJUNCTIONS:
             tmp = _pseudo_clone(disjunctions[i].disjuncts[
                 idx[i] if isinstance(idx, tuple) else idx])
-            for k,v in list(iteritems( tmp.component_map() )):
+            for k,v in list(tmp.component_map().items()):
                 if k == 'indicator_var':
                     continue
                 tmp.del_component(k)
@@ -107,7 +105,7 @@ def apply_basic_step(disjunctions_or_constraints):
     NAME_BUFFER = {}
     ans.indicator_links = ConstraintList()
     for i in ans.DISJUNCTIONS:
-        for j in xrange(len(disjunctions[i].disjuncts)):
+        for j in range(len(disjunctions[i].disjuncts)):
             orig_var = disjunctions[i].disjuncts[j].indicator_var
             ans.indicator_links.add(
                 orig_var ==
@@ -137,11 +135,11 @@ if __name__ == '__main__':
     from pyomo.environ import ConcreteModel, Constraint, Var
     m = ConcreteModel()
     def _d(d, i):
-        d.x = Var(xrange(i))
+        d.x = Var(range(i))
         d.silly = Constraint(expr=d.indicator_var == i)
     m.d = Disjunct([1,2], rule=_d)
     def _e(e, i):
-        e.y = Var(xrange(2,i))
+        e.y = Var(range(2,i))
     m.e = Disjunct([3,4,5], rule=_e)
 
     m.dd = Disjunction(expr=[m.d[1], m.d[2]])

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -12,7 +12,6 @@ import logging
 import sys
 import types
 
-from six import iteritems, itervalues
 from weakref import ref as weakref_ref
 
 from pyomo.common.errors import PyomoException
@@ -20,12 +19,12 @@ from pyomo.common.log import is_debug_set
 from pyomo.common.modeling import unique_component_name
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core import (
-    BooleanVar, ModelComponentFactory, Binary, Block, Var, ConstraintList, Any,
+    ModelComponentFactory, Binary, Block, Var, ConstraintList, Any,
     LogicalConstraintList, BooleanValue, value)
 from pyomo.core.base.component import (
     ActiveComponent, ActiveComponentData, ComponentData
 )
-from pyomo.core.base.numvalue import native_types, value
+from pyomo.core.base.numvalue import native_types
 from pyomo.core.base.block import _BlockData
 from pyomo.core.base.misc import apply_indexed_rule
 from pyomo.core.base.indexed_component import ActiveIndexedComponent
@@ -151,7 +150,7 @@ class Disjunct(Block):
         # call this method.
         ActiveComponent.activate(self)
         if self.is_indexed():
-            for component_data in itervalues(self):
+            for component_data in self.values():
                 component_data._activate_without_unfixing_indicator()
 
 
@@ -176,7 +175,7 @@ class IndexedDisjunct(Disjunct):
     #
     @property
     def active(self):
-        return any(d.active for d in itervalues(self._data))
+        return any(d.active for d in self._data.values())
 
 
 _DisjunctData._Block_reserved_words = set(dir(Disjunct()))
@@ -423,7 +422,7 @@ class Disjunction(ActiveIndexedComponent):
              ("Index", self._index if self.is_indexed() else None),
              ("Active", self.active),
              ],
-            iteritems(self),
+            self.items(),
             ( "Disjuncts", "Active", "XOR" ),
             lambda k, v: [ [x.name for x in v.disjuncts], v.active, v.xor]
             )
@@ -469,4 +468,4 @@ class IndexedDisjunction(Disjunction):
     #
     @property
     def active(self):
-        return any(d.active for d in itervalues(self._data))
+        return any(d.active for d in self._data.values())

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -35,7 +35,6 @@ from pyomo.gdp.util import (
 from pyomo.repn import generate_standard_repn
 
 from functools import wraps
-from six import iterkeys, iteritems
 from weakref import ref as weakref_ref
 
 logger = logging.getLogger('pyomo.gdp.bigm')
@@ -289,7 +288,7 @@ class BigM_Transformation(Transformation):
         return transBlock
 
     def _transform_block(self, obj, bigM):
-        for i in sorted(iterkeys(obj)):
+        for i in sorted(obj.keys()):
             self._transform_blockData(obj[i], bigM)
 
     def _transform_blockData(self, obj, bigM):
@@ -345,7 +344,7 @@ class BigM_Transformation(Transformation):
             transBlock = self._add_transformation_block(obj.parent_block())
 
         # relax each of the disjunctionDatas
-        for i in sorted(iterkeys(obj)):
+        for i in sorted(obj.keys()):
             self._transform_disjunctionData(obj[i], bigM, i, transBlock)
 
         # deactivate so the writers don't scream
@@ -526,7 +525,7 @@ class BigM_Transformation(Transformation):
         # we need to leave those on the disjunct.
         disjunctList = toBlock.relaxedDisjuncts
         to_delete = []
-        for idx, disjunctBlock in iteritems(fromBlock.relaxedDisjuncts):
+        for idx, disjunctBlock in fromBlock.relaxedDisjuncts.items():
             newblock = disjunctList[len(disjunctList)]
             newblock.transfer_attributes_from(disjunctBlock)
 
@@ -565,7 +564,7 @@ class BigM_Transformation(Transformation):
         # directly.  (We are passing the disjunct through so that when
         # we find constraints, _xform_constraint will have access to
         # the correct indicator variable.)
-        for i in sorted(iterkeys(block)):
+        for i in sorted(block.keys()):
             self._transform_block_components( block[i], disjunct, bigMargs,
                                               arg_list, suffix_list)
 
@@ -625,7 +624,7 @@ class BigM_Transformation(Transformation):
         # add mapping of transformed constraint to original constraint
         constraintMap['srcConstraints'][newConstraint] = obj
 
-        for i in sorted(iterkeys(obj)):
+        for i in sorted(obj.keys()):
             c = obj[i]
             if not c.active:
                 continue
@@ -777,7 +776,7 @@ class BigM_Transformation(Transformation):
 
         # use the precomputed traversal up the blocks
         for arg in arg_list:
-            for block, val in iteritems(arg):
+            for block, val in arg.items():
                 (lower, upper, 
                  need_lower, need_upper) = self._process_M_value(val, lower,
                                                                  upper,
@@ -909,7 +908,7 @@ class BigM_Transformation(Transformation):
 
         # clean up if we unfixed things (fixed_vars is empty if we were assuming
         # fixed vars are fixed for life)
-        for v, val in iteritems(fixed_vars):
+        for v, val in fixed_vars.items():
             v.fix(val)
 
         return tuple(M)

--- a/pyomo/gdp/plugins/cuttingplane.py
+++ b/pyomo/gdp/plugins/cuttingplane.py
@@ -16,7 +16,7 @@ convex GDPs.
 """
 from __future__ import division
 
-from pyomo.common.config import (ConfigBlock, ConfigValue, PositiveFloat,
+from pyomo.common.config import (ConfigBlock, ConfigValue,
                                  NonNegativeFloat, PositiveInt, In)
 from pyomo.common.modeling import unique_component_name
 from pyomo.core import ( Any, Block, Constraint, Objective, Param, Var,
@@ -34,8 +34,6 @@ from pyomo.gdp.util import ( verify_successful_solve, NORMAL,
 
 from pyomo.contrib.fme.fourier_motzkin_elimination import \
     Fourier_Motzkin_Elimination_Transformation
-
-from six import iteritems
 
 import logging
 
@@ -193,7 +191,7 @@ def create_cuts_fme(transBlock_rHull, var_info, hull_to_bigm_map,
                  do_integer_arithmetic=integer_arithmetic,
                  projected_constraints_name="fme_constraints")
     fme_results = tight_constraints.fme_constraints
-    projected_constraints = [cons for i, cons in iteritems(fme_results)]
+    projected_constraints = [cons for i, cons in fme_results.items()]
 
     # we created these constraints with the variables from rHull. We
     # actually need constraints for BigM and rBigM now!

--- a/pyomo/gdp/plugins/gdp_var_mover.py
+++ b/pyomo/gdp/plugins/gdp_var_mover.py
@@ -20,9 +20,6 @@ from pyomo.gdp import Disjunct, GDP_Error, Disjunction
 from pyomo.core import TraversalStrategy, TransformationFactory
 from pyomo.core.base.indexed_component import ActiveIndexedComponent
 from pyomo.common.deprecation import deprecated
-from pyomo.common.modeling import unique_component_name
-
-from six import itervalues
 
 logger = logging.getLogger('pyomo.gdp')
                 
@@ -50,7 +47,7 @@ class HACK_GDP_Disjunct_Reclassifier(Transformation):
         for disjunct_component in disjunct_generator:
             # Check that the disjuncts being reclassified are all relaxed or
             # are not on an active block.
-            for disjunct in itervalues(disjunct_component):
+            for disjunct in disjunct_component.values():
                 if (disjunct.active and
                         self._disjunct_not_relaxed(disjunct) and
                         self._disjunct_on_active_block(disjunct) and
@@ -111,7 +108,7 @@ class HACK_GDP_Disjunct_Reclassifier(Transformation):
             # block, as the component_objects generator will not
             # return anything when active=True and the block is
             # deactivated.
-            for disjunct in itervalues(disjunct_component._data):
+            for disjunct in disjunct_component._data.values():
                 if self._disjunct_not_relaxed(disjunct):
                     disjunct._deactivate_without_fixing_indicator()
                 else:

--- a/pyomo/gdp/tests/common_tests.py
+++ b/pyomo/gdp/tests/common_tests.py
@@ -14,7 +14,7 @@ from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 from pyomo.core.base import constraint, ComponentUID
 from pyomo.repn import generate_standard_repn
 import pyomo.gdp.tests.models as models
-from six import StringIO, iteritems
+from io import StringIO
 import random
 
 # utitility functions
@@ -774,7 +774,7 @@ def check_indexedBlock_only_targets_transformed(self, transformation):
         ]
     }
 
-    for blocknum, lst in iteritems(pairs):
+    for blocknum, lst in pairs.items():
         for comp, i, j in lst:
             original = m.b[blocknum].component(comp)
             if blocknum == 0:

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -10,7 +10,9 @@
 
 import pyomo.common.unittest as unittest
 
-from pyomo.environ import TransformationFactory, Block, Set, Constraint, ComponentMap, Suffix, ConcreteModel, Var, Any, value
+from pyomo.environ import (TransformationFactory, Block, Set, Constraint,
+                           ComponentMap, Suffix, ConcreteModel, Var,
+                           Any, value)
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 from pyomo.core.base import constraint, _ConstraintData
 from pyomo.repn import generate_standard_repn
@@ -22,7 +24,7 @@ import pyomo.gdp.tests.common_tests as ct
 
 import random
 
-from six import StringIO
+from io import StringIO
 
 class CommonTests:
     def diff_apply_to_and_create_using(self, model):

--- a/pyomo/gdp/tests/test_cuttingplane.py
+++ b/pyomo/gdp/tests/test_cuttingplane.py
@@ -10,9 +10,9 @@
 
 import pyomo.common.unittest as unittest
 
-from pyomo.environ import (ConcreteModel, Var, Constraint, Objective, Block,
+from pyomo.environ import (Var, Constraint, Objective, Block,
                            TransformationFactory, value, maximize, Suffix)
-from pyomo.gdp import Disjunct, Disjunction, GDP_Error
+from pyomo.gdp import GDP_Error
 from pyomo.gdp.plugins.cuttingplane import create_cuts_fme 
 
 import pyomo.opt
@@ -20,7 +20,6 @@ import pyomo.gdp.tests.models as models
 from pyomo.repn import generate_standard_repn
 from pyomo.gdp.tests.common_tests import diff_apply_to_and_create_using
 
-from six import StringIO
 
 solvers = pyomo.opt.check_available_solvers('ipopt', 'gurobi')
 

--- a/pyomo/gdp/tests/test_disjunct.py
+++ b/pyomo/gdp/tests/test_disjunct.py
@@ -13,8 +13,6 @@ import pyomo.common.unittest as unittest
 from pyomo.core import ConcreteModel, Var, Constraint
 from pyomo.gdp import Disjunction, Disjunct
 
-from six import iterkeys
-
 
 class TestDisjunction(unittest.TestCase):
     def test_empty_disjunction(self):
@@ -44,7 +42,7 @@ class TestDisjunction(unittest.TestCase):
         self.assertEqual(len(m.component_map(Disjunction)), 1)
         self.assertEqual(len(m.component_map(Disjunct)), 1)
 
-        implicit_disjuncts = list(iterkeys(m.component_map(Disjunct)))
+        implicit_disjuncts = list(m.component_map(Disjunct).keys())
         self.assertEqual(implicit_disjuncts[0][:2], "d_")
         disjuncts = m.d.disjuncts
         self.assertEqual(len(disjuncts), 2)
@@ -58,7 +56,7 @@ class TestDisjunction(unittest.TestCase):
         m.e = Disjunction(expr=[m.y<=0, m.x>=1])
         self.assertEqual(len(m.component_map(Disjunction)), 2)
         self.assertEqual(len(m.component_map(Disjunct)), 2)
-        implicit_disjuncts = list(iterkeys(m.component_map(Disjunct)))
+        implicit_disjuncts = list(m.component_map(Disjunct).keys())
         self.assertEqual(implicit_disjuncts[1][:12], "e_disjuncts_")
         disjuncts = m.e.disjuncts
         self.assertEqual(len(disjuncts), 2)
@@ -81,7 +79,7 @@ class TestDisjunction(unittest.TestCase):
             _gen() ])
         self.assertEqual(len(m.component_map(Disjunction)), 3)
         self.assertEqual(len(m.component_map(Disjunct)), 3)
-        implicit_disjuncts = list(iterkeys(m.component_map(Disjunct)))
+        implicit_disjuncts = list(m.component_map(Disjunct).keys())
         self.assertEqual(implicit_disjuncts[2][:12], "f_disjuncts")
         disjuncts = m.f.disjuncts
         self.assertEqual(len(disjuncts), 3)

--- a/pyomo/gdp/tests/test_gdp.py
+++ b/pyomo/gdp/tests/test_gdp.py
@@ -31,8 +31,6 @@ from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 import pyomo.opt
 from pyomo.environ import SolverFactory, TransformationFactory
 
-from six import iteritems
-
 solvers = pyomo.opt.check_available_solvers('cplex', 'glpk','gurobi')
 
 
@@ -205,7 +203,7 @@ class Solver(unittest.TestCase):
         self.assertEqual(len(refObj), len(ansObj))
         for i in range(len(refObj)):
             self.assertEqual(len(refObj[i]), len(ansObj[i]))
-            for key,val in iteritems(refObj[i]):
+            for key,val in refObj[i].items():
                 self.assertAlmostEqual(
                     val.get('Value', None),
                     ansObj[i].get(key,{}).get('Value', None),

--- a/pyomo/gdp/tests/test_gdp_reclassification_error.py
+++ b/pyomo/gdp/tests/test_gdp_reclassification_error.py
@@ -15,7 +15,7 @@ from pyomo.gdp import Disjunct, Disjunction
 from pyomo.gdp.util import check_model_algebraic
 from pyomo.common.log import LoggingIntercept
 import logging
-from six import StringIO
+from io import StringIO
 
 
 class TestGDPReclassificationError(unittest.TestCase):

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -27,7 +27,7 @@ linear_solvers = pyomo.opt.check_available_solvers(
     'glpk','cbc','gurobi','cplex')
 
 import random
-from six import iteritems, StringIO
+from io import StringIO
 
 EPS = TransformationFactory('gdp.hull').CONFIG.EPS
 
@@ -339,7 +339,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
             mappings[m.y] = disjBlock[i].disaggregatedVars.y
             mappings[m.x] = disjBlock[i].disaggregatedVars.x
 
-            for orig, disagg in iteritems(mappings):
+            for orig, disagg in mappings.items():
                 self.assertIs(hull.get_src_var(disagg), orig)
                 self.assertIs(hull.get_disaggregated_var(orig, m.d[i]), disagg)
 
@@ -359,7 +359,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
             mappings[disjBlock[i].disaggregatedVars.w] = disjBlock[i].w_bounds
             mappings[disjBlock[i].disaggregatedVars.y] = disjBlock[i].y_bounds
             mappings[disjBlock[i].disaggregatedVars.x] = disjBlock[i].x_bounds
-            for var, cons in iteritems(mappings):
+            for var, cons in mappings.items():
                 self.assertIs(hull.get_var_bounds_constraint(var), cons)
 
     def test_create_using_nonlinear(self):
@@ -676,7 +676,7 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
                 relaxedDisjuncts[5].disaggregatedVars.component('x[3]')],
         }
 
-        for i, disVars in iteritems(disaggregatedVars):
+        for i, disVars in disaggregatedVars.items():
             cons = hull.get_disaggregation_constraint(m.x[i],
                                                        m.disjunction[i])
             self.assertEqual(cons.lower, 0)
@@ -706,7 +706,7 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
                       relaxedDisjuncts[7].disaggregatedVars.component('a[2,B]')],
         }
 
-        for i, disVars in iteritems(disaggregatedVars):
+        for i, disVars in disaggregatedVars.items():
             cons = hull.get_disaggregation_constraint(m.a[i],
                                                        m.disjunction[i])
             self.assertEqual(cons.lower, 0)

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -16,7 +16,6 @@ from pyomo.core.base.component import _ComponentBase
 
 from pyomo.core import Block, TraversalStrategy
 from pyomo.opt import TerminationCondition, SolverStatus
-from six import iterkeys
 from weakref import ref as weakref_ref
 import logging
 
@@ -252,7 +251,7 @@ def _warn_for_active_disjunction(disjunction, disjunct, NAME_BUFFER):
     assert disjunction.active
     problemdisj = disjunction
     if disjunction.is_indexed():
-        for i in sorted(iterkeys(disjunction)):
+        for i in sorted(disjunction.keys()):
             if disjunction[i].active:
                 # a _DisjunctionData is active, we will yell about
                 # it specifically.
@@ -275,7 +274,7 @@ def _warn_for_active_disjunct(innerdisjunct, outerdisjunct, NAME_BUFFER):
     assert innerdisjunct.active
     problemdisj = innerdisjunct
     if innerdisjunct.is_indexed():
-        for i in sorted(iterkeys(innerdisjunct)):
+        for i in sorted(innerdisjunct.keys()):
             if innerdisjunct[i].active:
                 # This shouldn't be true, we will complain about it.
                 problemdisj = innerdisjunct[i]

--- a/pyomo/mpec/complementarity.py
+++ b/pyomo/mpec/complementarity.py
@@ -8,7 +8,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from six import iteritems
 from collections import namedtuple
 
 from pyomo.common.log import is_debug_set
@@ -267,7 +266,7 @@ Error thrown for Complementarity "%s".""" % ( b.name, ) )
              ("Index", self._index if self.is_indexed() else None),
              ("Active", self.active),
              ],
-            iteritems(self._data),
+            self._data.items(),
             ( "Arg0","Arg1","Active" ),
             (_table_data, _conditional_block_printer),
             )

--- a/pyomo/mpec/plugins/mpec1.py
+++ b/pyomo/mpec/plugins/mpec1.py
@@ -20,8 +20,6 @@ from pyomo.core.base import (Transformation,
 from pyomo.mpec.complementarity import Complementarity
 from pyomo.gdp import Disjunct
 
-from six import iterkeys
-
 logger = logging.getLogger('pyomo.core')
 
 
@@ -66,7 +64,7 @@ class MPEC1_Transformation(Transformation):
                                                           descend_into=(Block, Disjunct),
                                                           sort=SortComponents.deterministic):
             block = complementarity.parent_block()
-            for index in sorted(iterkeys(complementarity)):
+            for index in sorted(complementarity.keys()):
                 _data = complementarity[index]
                 if not _data.active:
                     continue

--- a/pyomo/mpec/plugins/mpec2.py
+++ b/pyomo/mpec/plugins/mpec2.py
@@ -9,7 +9,6 @@
 #  ___________________________________________________________________________
 
 import logging
-from six import iterkeys
 
 from pyomo.core.expr import inequality
 from pyomo.core.base import (Transformation,
@@ -46,7 +45,7 @@ class MPEC2_Transformation(Transformation):
                                                           sort=SortComponents.deterministic):
             block = complementarity.parent_block()
 
-            for index in sorted(iterkeys(complementarity)):
+            for index in sorted(complementarity.keys()):
                 _data = complementarity[index]
                 if not _data.active:
                     continue

--- a/pyomo/mpec/plugins/mpec3.py
+++ b/pyomo/mpec/plugins/mpec3.py
@@ -17,8 +17,6 @@ from pyomo.core.base import (Transformation,
 from pyomo.mpec.complementarity import Complementarity
 from pyomo.gdp import Disjunct
 
-from six import iterkeys
-
 logger = logging.getLogger('pyomo.core')
 
 
@@ -41,7 +39,7 @@ class MPEC3_Transformation(Transformation):
                                                           descend_into=(Block, Disjunct),
                                                           sort=SortComponents.deterministic):
             block = complementarity.parent_block()
-            for index in sorted(iterkeys(complementarity)):
+            for index in sorted(complementarity.keys()):
                 _data = complementarity[index]
                 if not _data.active:
                     continue

--- a/pyomo/mpec/plugins/mpec4.py
+++ b/pyomo/mpec/plugins/mpec4.py
@@ -9,7 +9,6 @@
 #  ___________________________________________________________________________
 
 import logging
-from six import iterkeys
 
 from pyomo.core.base import (Transformation,
                              TransformationFactory,
@@ -55,7 +54,7 @@ class MPEC4_Transformation(Transformation):
                                                descend_into=(Block, Disjunct),
                                                sort=SortComponents.deterministic):
             cobjs.append(cobj)
-            for index in sorted(iterkeys(cobj)):
+            for index in sorted(cobj.keys()):
                 _cdata = cobj[index]
                 if not _cdata.active:
                     continue

--- a/pyomo/mpec/tests/test_minlp.py
+++ b/pyomo/mpec/tests/test_minlp.py
@@ -24,8 +24,6 @@ import pyomo.opt
 import pyomo.scripting.pyomo_main as pyomo_main
 from pyomo.scripting.util import cleanup
 
-from six import iteritems
-
 solvers = pyomo.opt.check_available_solvers('cplex', 'glpk')
 
 class CommonTests:
@@ -107,7 +105,7 @@ class CommonTests:
         self.assertEqual(len(refObj), len(ansObj))
         for i in range(len(refObj)):
             self.assertEqual(len(refObj[i]), len(ansObj[i]))
-            for key,val in iteritems(refObj[i]):
+            for key,val in refObj[i].items():
                 self.assertAlmostEqual(val['Value'], ansObj[i].get(key,None)['Value'], places=3)
 
 

--- a/pyomo/mpec/tests/test_nlp.py
+++ b/pyomo/mpec/tests/test_nlp.py
@@ -24,8 +24,6 @@ import pyomo.opt
 import pyomo.scripting.pyomo_main as pyomo_main
 from pyomo.scripting.util import cleanup
 
-from six import iteritems
-
 solvers = pyomo.opt.check_available_solvers('ipopt')
 
 
@@ -113,7 +111,7 @@ class CommonTests:
         self.assertEqual(len(refObj), len(ansObj))
         for i in range(len(refObj)):
             self.assertEqual(len(refObj[i]), len(ansObj[i]))
-            for key,val in iteritems(refObj[i]):
+            for key,val in refObj[i].items():
                 self.assertAlmostEqual(val['Value'], ansObj[i].get(key,None)['Value'], places=2)
 
 

--- a/pyomo/mpec/tests/test_path.py
+++ b/pyomo/mpec/tests/test_path.py
@@ -24,8 +24,6 @@ import pyomo.opt
 import pyomo.scripting.pyomo_main as pyomo_main
 from pyomo.scripting.util import cleanup
 
-from six import iteritems
-
 solvers = pyomo.opt.check_available_solvers('path')
 
 class CommonTests:
@@ -114,7 +112,7 @@ class CommonTests:
             self.assertEqual(len(refObj[i]), len(ansObj[i]))
             if isinstance(refObj[i], str):
                 continue
-            for key,val in iteritems(refObj[i]):
+            for key,val in refObj[i].items():
                 self.assertAlmostEqual(val['Value'], ansObj[i].get(key,None)['Value'], places=2)
 
 


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
Part of the Pyomo 6.0 effort is to replace the usage of `six` with the appropriate Python 3 methods. This does just that in the `gdp` and `mpec` directories.

## Changes proposed in this PR:
- Remove `six` in `pyomo.gdp`
- Remove `six` in `pyomo.mpec`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
