### PR TITLE
Remove `six` from `neos`, `network`, and `opt`

### DIFF
--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -17,23 +17,17 @@
 import io
 import os
 import re
-import six
 import sys
 import time
 import socket
 import base64
 import tempfile
 import logging
+import http.client
 
 from pyomo.common.dependencies import attempt_import
 
-def _xmlrpclib_importer():
-    if six.PY2:
-        import xmlrpclib
-    else:
-        import xmlrpc.client as xmlrpclib
-    return xmlrpclib
-xmlrpclib = attempt_import('xmlrpclib', importer=_xmlrpclib_importer)[0]
+xmlrpclib = attempt_import('xmlrpc.client')[0]
 gzip = attempt_import('gzip')[0]
 
 logger = logging.getLogger('pyomo.neos')
@@ -50,75 +44,36 @@ class NEOS(object):
     #port = '3332'
 
 def ProxiedTransport():
-    if six.PY2:
-        from urlparse import urlparse
-        import httplib
-        # ProxiedTransport from Python 2.x documentation
-        # (https://docs.python.org/2/library/xmlrpclib.html)
-        class ProxiedTransport_PY2(xmlrpclib.Transport):
-            def set_proxy(self, proxy):
-                self.proxy = urlparse(proxy)
-                if not self.proxy.hostname:
-                    # User omitted scheme from the proxy; assume http
-                    self.proxy = urlparse('http://'+proxy)
+    from urllib.parse import urlparse
+    import http.client as httplib
+    # ProxiedTransport from Python 3.x documentation
+    # (https://docs.python.org/3/library/xmlrpc.client.html)
+    class ProxiedTransport_PY3(xmlrpclib.Transport):
+        def set_proxy(self, host):
+            self.proxy = urlparse(host)
+            if not self.proxy.hostname:
+                # User omitted scheme from the proxy; assume http
+                self.proxy = urlparse('http://'+host)
 
-            def make_connection(self, host):
-                target = urlparse(host)
-                if target.scheme:
-                    self.realhost = target.geturl()
-                else:
-                    self.realhost = '%s://%s' % (NEOS.scheme, target.geturl())
+        def make_connection(self, host):
+            scheme = urlparse(host).scheme
+            if not scheme:
+                scheme = NEOS.scheme
 
-                # Empirically, the connection class in Python 2.7 needs to
-                # match the PROXY connection scheme, and the final endpoint
-                # scheme needs to be specified in the POST below.
-                if self.proxy.scheme == 'https':
-                    connClass = httplib.HTTPSConnection
-                else:
-                    connClass = httplib.HTTPConnection
-                return connClass(self.proxy.hostname, self.proxy.port)
+            # Empirically, the connection class in Python 3.x needs to
+            # match the final endpoint connection scheme, NOT the proxy
+            # scheme.  The set_tunnel host then should NOT have a scheme
+            # attached to it.
+            if scheme == 'https':
+                connClass = httplib.HTTPSConnection
+            else:
+                connClass = httplib.HTTPConnection
 
+            connection = connClass(self.proxy.hostname, self.proxy.port)
+            connection.set_tunnel(host)
+            return connection
 
-            def send_request(self, connection, handler, request_body):
-                connection.putrequest(
-                    "POST", '%s%s' % (self.realhost, handler))
-
-            def send_host(self, connection, host):
-                connection.putheader('Host', self.realhost)
-
-        return ProxiedTransport_PY2()
-
-    else: # Python 3.x
-        from urllib.parse import urlparse
-        import http.client as httplib
-        # ProxiedTransport from Python 3.x documentation
-        # (https://docs.python.org/3/library/xmlrpc.client.html)
-        class ProxiedTransport_PY3(xmlrpclib.Transport):
-            def set_proxy(self, host):
-                self.proxy = urlparse(host)
-                if not self.proxy.hostname:
-                    # User omitted scheme from the proxy; assume http
-                    self.proxy = urlparse('http://'+host)
-
-            def make_connection(self, host):
-                scheme = urlparse(host).scheme
-                if not scheme:
-                    scheme = NEOS.scheme
-
-                # Empirically, the connection class in Python 3.x needs to
-                # match the final endpoint connection scheme, NOT the proxy
-                # scheme.  The set_tunnel host then should NOT have a scheme
-                # attached to it.
-                if scheme == 'https':
-                    connClass = httplib.HTTPSConnection
-                else:
-                    connClass = httplib.HTTPConnection
-
-                connection = connClass(self.proxy.hostname, self.proxy.port)
-                connection.set_tunnel(host)
-                return connection
-
-        return ProxiedTransport_PY3()
+    return ProxiedTransport_PY3()
 
 
 class kestrelAMPL(object):
@@ -168,7 +123,7 @@ class kestrelAMPL(object):
             result = self.neos.ping()
             logger.info("OK.")
         except (socket.error, xmlrpclib.ProtocolError,
-                six.moves.http_client.BadStatusLine):
+                http.client.BadStatusLine):
             e = sys.exc_info()[1]
             self.neos = None
             logger.info("Fail.")
@@ -336,10 +291,7 @@ class kestrelAMPL(object):
         if not solver_options_value == "":
             solver_options += "%s_options:%s\n" % (solver.lower(), solver_options_value)
         #
-        if six.PY2:
-            nl_string = base64.encodestring(zipped_nl_file.getvalue())
-        else:
-            nl_string = (base64.encodebytes(zipped_nl_file.getvalue())).decode('utf-8')
+        nl_string = (base64.encodebytes(zipped_nl_file.getvalue())).decode('utf-8')
         xml = """
               <document>
               <category>kestrel</category>

--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -23,7 +23,6 @@ import socket
 import base64
 import tempfile
 import logging
-import http.client
 
 from pyomo.common.dependencies import attempt_import
 
@@ -96,6 +95,7 @@ class kestrelAMPL(object):
             self.transport.close()
 
     def setup_connection(self):
+        import http.client
         # on *NIX, the proxy can show up either upper or lowercase.
         # Prefer lower case, and prefer HTTPS over HTTP if the
         # NEOS.scheme is https.

--- a/pyomo/neos/plugins/kestrel_plugin.py
+++ b/pyomo/neos/plugins/kestrel_plugin.py
@@ -11,7 +11,6 @@
 import logging
 import os
 import re
-import six
 import sys
 
 from pyomo.common.dependencies import attempt_import
@@ -23,7 +22,7 @@ from pyomo.opt.parallel.async_solver import (
 from pyomo.core.base import Block
 import pyomo.neos.kestrel
 
-xmlrpc_client = attempt_import('six.moves.xmlrpc_client')[0]
+xmlrpc_client = attempt_import('xmlrpc.client')[0]
 
 logger = logging.getLogger('pyomo.neos')
 
@@ -34,9 +33,7 @@ def _neos_error(msg, results, current_message):
 
     logger.error("%s  NEOS log:\n%s" % ( msg, current_message, ),
                  exc_info=sys.exc_info())
-    soln_data = results.data
-    if six.PY3:
-        soln_data = soln_data.decode('utf-8')
+    soln_data = results.data.decode('utf-8')
     for line in soln_data.splitlines():
         if error_re.search(line):
             logger.error(line)
@@ -211,10 +208,7 @@ class SolverManager_NEOS(AsynchronousSolverManager):
                 with open(opt._log_file, 'w') as OUTPUT:
                     OUTPUT.write(current_message)
                 with open(opt._soln_file, 'w') as OUTPUT:
-                    if six.PY2:
-                        OUTPUT.write(results.data)
-                    else:
-                        OUTPUT.write(results.data.decode('utf-8'))
+                    OUTPUT.write(results.data.decode('utf-8'))
 
                 rc = None
                 try:
@@ -269,8 +263,7 @@ class SolverManager_NEOS(AsynchronousSolverManager):
                     self._neos_log[jobNumber] = (
                         new_offset,
                         current_message + (
-                            message_fragment.data if six.PY2
-                            else (message_fragment.data).decode('utf-8') ) )
+                            (message_fragment.data).decode('utf-8') ) )
                 except xmlrpc_client.ProtocolError:
                     # The command probably timed out
                     pass

--- a/pyomo/network/arc.py
+++ b/pyomo/network/arc.py
@@ -18,7 +18,6 @@ from pyomo.core.base.misc import apply_indexed_rule
 from pyomo.core.base.plugin import ModelComponentFactory
 from pyomo.common.log import is_debug_set
 from pyomo.common.timing import ConstructionTimer
-from six import iteritems
 from weakref import ref as weakref_ref
 import logging, sys
 
@@ -157,7 +156,7 @@ class _ArcData(ActiveComponentData):
         if len(vals):
             raise ValueError(
                 "set_value passed unrecognized keywords in val:\n\t" +
-                "\n\t".join("%s = %s" % (k, v) for k, v in iteritems(vals)))
+                "\n\t".join("%s = %s" % (k, v) for k, v in vals.items()))
 
         if directed is not None:
             if source is None and destination is None:
@@ -351,7 +350,7 @@ class Arc(ActiveIndexedComponent):
             [("Size", len(self)),
              ("Index", self._index if self.is_indexed() else None),
              ("Active", self.active)],
-            iteritems(self),
+            self.items(),
             ("Ports", "Directed", "Active"),
             lambda k, v: ["(%s, %s)" % v.ports if v.ports is not None else None,
                           v.directed,

--- a/pyomo/network/decomposition.py
+++ b/pyomo/network/decomposition.py
@@ -18,7 +18,6 @@ from pyomo.common.collections import ComponentSet, ComponentMap, Bunch
 from pyomo.core.expr.current import identify_variables
 from pyomo.repn import generate_standard_repn
 import logging, time
-from six import iteritems
 
 from pyomo.common.dependencies import (
     networkx as nx, networkx_available,
@@ -455,7 +454,7 @@ class SequentialDecomposition(FOQUSGraph):
             # (via set_split_fraction or something else) that will be used here
             # and is only relevant to this SM, and if they didn't specify
             # anything, throw an error.
-            for name, mem in iteritems(src.vars):
+            for name, mem in src.vars.items():
                 if not src.is_extensive(name):
                     continue
                 evar = eblock.component(name)
@@ -546,7 +545,7 @@ class SequentialDecomposition(FOQUSGraph):
 
     def load_guesses(self, guesses, port, fixed):
         srcs = port.sources()
-        for name, mem in iteritems(port.vars):
+        for name, mem in port.vars.items():
             try:
                 entry = guesses[port][name]
             except KeyError:

--- a/pyomo/network/plugins/expand_arcs.py
+++ b/pyomo/network/plugins/expand_arcs.py
@@ -11,8 +11,6 @@
 import logging
 logger = logging.getLogger('pyomo.network')
 
-from six import iteritems, itervalues
-
 from pyomo.common.log import is_debug_set
 from pyomo.common.modeling import unique_component_name
 
@@ -47,7 +45,7 @@ class ExpandArcs(Transformation):
             # for all occurences of this member in related ports
             # and so we iterate over members deterministically
             ref = known_port_sets[id(matched_ports[port])]
-            for k, v in sorted(iteritems(ref)):
+            for k, v in sorted(ref.items()):
                 rule, kwds = port._rules[k]
                 if v[1] >= 0:
                     index_set = v[0].index_set()
@@ -115,7 +113,7 @@ class ExpandArcs(Transformation):
 
         # Validate all port sets and expand the empty ones
         known_port_sets = {}
-        for groupID, port_set in sorted(itervalues(port_groups)):
+        for groupID, port_set in sorted(port_groups.values()):
             known_port_sets[id(port_set)] \
                 = self._validate_and_expand_port_set(port_set)
 
@@ -125,7 +123,7 @@ class ExpandArcs(Transformation):
         ref = {}
         # First, go through the ports and get the superset of all fields
         for p in ports:
-            for k, v in iteritems(p.vars):
+            for k, v in p.vars.items():
                 if k in ref:
                     # We have already seen this var
                     continue
@@ -142,7 +140,7 @@ class ExpandArcs(Transformation):
             logger.warning(
                 "Cannot identify a reference port: no ports "
                 "in the port set have assigned variables:\n\t(%s)"
-                % ', '.join(sorted(p.name for p in itervalues(ports))))
+                % ', '.join(sorted(p.name for p in ports.values())))
             return ref
 
         # Now make sure that ports match
@@ -155,7 +153,7 @@ class ExpandArcs(Transformation):
                 empty_or_partial.append(p)
                 continue
 
-            for k, v in iteritems(ref):
+            for k, v in ref.items():
                 if k not in p.vars:
                     raise ValueError(
                         "Port mismatch: Port '%s' missing variable "
@@ -195,7 +193,7 @@ class ExpandArcs(Transformation):
 
         # as we are adding things to the model, sort by key so that
         # the order things are added is deterministic
-        sorted_refs = sorted(iteritems(ref))
+        sorted_refs = sorted(ref.items())
         if len(empty_or_partial) > 1:
             # This is expensive (names aren't cheap), but does result in
             # a deterministic ordering

--- a/pyomo/network/port.py
+++ b/pyomo/network/port.py
@@ -11,7 +11,6 @@
 __all__ = [ 'Port' ]
 
 import logging, sys
-from six import iteritems
 from weakref import ref as weakref_ref
 
 from pyomo.common.collections import ComponentMap
@@ -247,12 +246,12 @@ class _PortData(ComponentData):
             names: `bool`
                 If True, yield (name, index, var/expr) tuples
         """
-        for name, mem in iteritems(self.vars):
+        for name, mem in self.vars.items():
             if not mem.is_indexed():
                 itr = {None: mem}
             else:
                 itr = mem
-            for idx, v in iteritems(itr):
+            for idx, v in itr.items():
                 if fixed is not None and v.is_fixed() != fixed:
                     continue
                 if expr_vars and v.is_expression_type():
@@ -378,7 +377,7 @@ class Port(IndexedComponent):
             for key in self._implicit:
                 tmp.add(None, key)
             if self._extends:
-                for key, val in iteritems(self._extends.vars):
+                for key, val in self._extends.vars.items():
                     tmp.add(val, key, self._extends.rule_for(key))
             if self._initialize:
                 self._add_from_container(tmp, self._initialize)
@@ -389,7 +388,7 @@ class Port(IndexedComponent):
 
     def _add_from_container(self, port, items):
         if type(items) is dict:
-            for key, val in iteritems(items):
+            for key, val in items.items():
                 if type(val) is tuple:
                     if len(val) == 2:
                         obj, rule = val
@@ -414,7 +413,7 @@ class Port(IndexedComponent):
     def _pprint(self, ostream=None, verbose=False):
         """Print component information."""
         def _line_generator(k, v):
-            for _k, _v in sorted(iteritems(v.vars)):
+            for _k, _v in sorted(v.vars.items()):
                 if _v is None:
                     _len = '-'
                 elif _v.is_indexed():
@@ -425,7 +424,7 @@ class Port(IndexedComponent):
         return (
             [("Size", len(self)),
              ("Index", self._index if self.is_indexed() else None)],
-             iteritems(self._data),
+             self._data.items(),
              ( "Name", "Size", "Variable"),
              _line_generator)
 
@@ -445,7 +444,7 @@ class Port(IndexedComponent):
 
         ostream.write("\n")
         def _line_generator(k,v):
-            for _k, _v in sorted(iteritems(v.vars)):
+            for _k, _v in sorted(v.vars.items()):
                 if _v is None:
                     _val = '-'
                 elif not _v.is_indexed():
@@ -456,7 +455,7 @@ class Port(IndexedComponent):
                             x, value(_v[x])) for x in sorted(_v._data)))
                 yield _k, _val
         tabular_writer(ostream, prefix+tab,
-                       ((k, v) for k, v in iteritems(self._data)),
+                       ((k, v) for k, v in self._data.items()),
                        ("Name", "Value"), _line_generator)
 
     @staticmethod
@@ -619,7 +618,7 @@ class Port(IndexedComponent):
             if eblock.component("splitfrac") is None:
                 if not include_splitfrac:
                     num_data_objs = 0
-                    for k, v in iteritems(port.vars):
+                    for k, v in port.vars.items():
                         if port.is_extensive(k):
                             if v.is_indexed():
                                 num_data_objs += len(v)

--- a/pyomo/network/tests/test_arc.py
+++ b/pyomo/network/tests/test_arc.py
@@ -12,7 +12,7 @@
 #
 
 import pyomo.common.unittest as unittest
-from six import StringIO
+from io import StringIO
 import logging
 
 from pyomo.environ import ConcreteModel, AbstractModel, Var, Set, Constraint, RangeSet, NonNegativeReals, Reals, Binary, TransformationFactory, Block, value

--- a/pyomo/network/tests/test_port.py
+++ b/pyomo/network/tests/test_port.py
@@ -12,7 +12,7 @@
 #
 
 import pyomo.common.unittest as unittest
-from six import StringIO
+from io import StringIO
 
 from pyomo.environ import ConcreteModel, AbstractModel, Var, Set, NonNegativeReals, Binary, Reals, Integers, RangeSet
 from pyomo.network import Port, Arc

--- a/pyomo/opt/base/solvers.py
+++ b/pyomo/opt/base/solvers.py
@@ -29,9 +29,6 @@ from pyomo.opt.base.convert import convert_problem
 from pyomo.opt.base.formats import ResultsFormat, ProblemFormat
 import pyomo.opt.base.results
 
-from six import iteritems
-from six.moves import xrange
-
 logger = logging.getLogger('pyomo.opt')
 
 # The version string is first searched for trunk/Trunk, and if
@@ -52,7 +49,7 @@ def _extract_version(x, length=4):
         # version is greater/less than some other version, it makes
         # since that a solver advertising trunk should always be greater
         # than a version check, hence returning a tuple of infinities
-        return tuple(float('inf') for i in xrange(length))
+        return tuple(float('inf') for i in range(length))
     m = re.search('[0-9]+(\.[0-9]+){1,3}',x)
     if not m is None:
         version = tuple(int(i) for i in m.group(0).split('.')[:length])
@@ -679,7 +676,7 @@ class OptSolver(object):
             if len(kwds):
                 raise ValueError(
                     "Solver="+self.type+" passed unrecognized keywords: \n\t"
-                    +("\n\t".join("%s = %s" % (k,v) for k,v in iteritems(kwds))))
+                    +("\n\t".join("%s = %s" % (k,v) for k,v in kwds.items())))
 
         if (type(self._problem_files) in (list,tuple)) and \
            (not isinstance(self._problem_files[0], str)):

--- a/pyomo/opt/parallel/manager.py
+++ b/pyomo/opt/parallel/manager.py
@@ -12,7 +12,6 @@
 __all__ = ['ActionManagerError', 'ActionHandle', 'AsynchronousActionManager', 'ActionStatus', 'FailedActionHandle', 'solve_all_instances']
 
 import enum
-from six import itervalues
 
 class ActionStatus(str, enum.Enum):
     done='done'
@@ -145,7 +144,7 @@ class AsynchronousActionManager(object):
         #
         ahs = set()
         if len(args) == 0:
-            ahs.update(ah for ah in itervalues(self.event_handle)
+            ahs.update(ah for ah in self.event_handle.values()
                        if ah.status == ActionStatus.queued)
         else:
             ahs = self._flatten(*args)

--- a/pyomo/opt/plugins/sol.py
+++ b/pyomo/opt/plugins/sol.py
@@ -21,9 +21,6 @@ from pyomo.opt import (SolverResults,
                        SolverStatus,
                        TerminationCondition)
 
-from six.moves import xrange
-from six import string_types
-
 
 @results.ReaderFactory.register(str(ResultsFormat.sol))
 class ResultsReader_sol(results.AbstractResultsReader):
@@ -79,7 +76,7 @@ class ResultsReader_sol(results.AbstractResultsReader):
             if nopts > 4:           # WEH - when is this true?
                 nopts -= 2
                 need_vbtol = True
-            for i in xrange(nopts + 4):
+            for i in range(nopts + 4):
                 line = fin.readline()
                 z += [int(line)]
             if need_vbtol:          # WEH - when is this true?
@@ -113,7 +110,7 @@ class ResultsReader_sol(results.AbstractResultsReader):
             objno = [int(t[1]), int(t[2])]
         res.solver.message = msg.strip()
         res.solver.message = res.solver.message.replace("\n","; ")
-        if isinstance(res.solver.message, string_types):
+        if isinstance(res.solver.message, str):
             res.solver.message = res.solver.message.replace(':', '\\x3a')
         ##res.solver.instanceName = osrl.header.instanceName
         ##res.solver.systime = osrl.header.time
@@ -177,7 +174,7 @@ class ResultsReader_sol(results.AbstractResultsReader):
                 i = i + 1
             soln_constraint = soln.constraint
             if any(re.match(suf,"dual") for suf in suffixes):
-                for i in xrange(0,len(y)):
+                for i in range(0,len(y)):
                     soln_constraint["c"+str(i)] = {"Dual" : y[i]}
 
             ### Read suffixes ###
@@ -211,10 +208,10 @@ class ResultsReader_sol(results.AbstractResultsReader):
                 if any(re.match(suf,suffix_name) for suf in suffixes):
                     # ignore translation of the table number to string value for now,
                     # this information can be obtained from the solver documentation
-                    for n in xrange(tabline):
+                    for n in range(tabline):
                         fin.readline()
                     if kind == 0: # Var
-                        for cnt in xrange(nvalues):
+                        for cnt in range(nvalues):
                             suf_line = fin.readline().split()
                             key = "v"+suf_line[0]
                             if key not in soln_variable:
@@ -222,7 +219,7 @@ class ResultsReader_sol(results.AbstractResultsReader):
                             soln_variable[key][suffix_name] = \
                                 convert_function(suf_line[1])
                     elif kind == 1: # Con
-                        for cnt in xrange(nvalues):
+                        for cnt in range(nvalues):
                             suf_line = fin.readline().split()
                             key = "c"+suf_line[0]
                             if key not in soln_constraint:
@@ -239,19 +236,19 @@ class ResultsReader_sol(results.AbstractResultsReader):
                             soln_constraint[key][translated_suffix_name] = \
                                 convert_function(suf_line[1])
                     elif kind == 2: # Obj
-                        for cnt in xrange(nvalues):
+                        for cnt in range(nvalues):
                             suf_line = fin.readline().split()
                             soln.objective.setdefault("o"+suf_line[0],{})[suffix_name] = \
                                 convert_function(suf_line[1])
                     elif kind == 3: # Prob
                         # Skip problem kind suffixes for now. Not sure the
                         # best place to put them in the results object
-                        for cnt in xrange(nvalues):
+                        for cnt in range(nvalues):
                             suf_line = fin.readline().split()
                             soln.problem[suffix_name] = convert_function(suf_line[1])
                 else:
                     # do not store the suffix in the solution object
-                    for cnt in xrange(nvalues):
+                    for cnt in range(nvalues):
                         fin.readline()
                 line = fin.readline()
 

--- a/pyomo/opt/results/container.py
+++ b/pyomo/opt/results/container.py
@@ -16,8 +16,7 @@ from math import inf
 from pyomo.common.collections import Bunch
 
 import enum
-from six import StringIO
-from six.moves import xrange
+from io import StringIO
 
 
 class ScalarType(str, enum.Enum):
@@ -210,7 +209,7 @@ class ListContainer(object):
             return ignore
         ostream.write("\n")
         i=0
-        for i in xrange(len(self._list)):
+        for i in range(len(self._list)):
             item = self._list[i]
             ostream.write(prefix+'- ')
             item.pprint(ostream, option, from_list=True, prefix=prefix+"  ", repn=repn[i])

--- a/pyomo/opt/results/results_.py
+++ b/pyomo/opt/results/results_.py
@@ -28,8 +28,7 @@ from pyomo.opt.results.solution import default_print_options as dpo
 import pyomo.opt.results.problem
 import pyomo.opt.results.solver
 
-from six import iteritems, StringIO
-from six.moves import xrange
+from io import StringIO
 
 logger = logging.getLogger(__name__)
 
@@ -138,12 +137,12 @@ class SolverResults(MapContainer):
                     # extracted in a solution.
                     soln[data] = "No values"
                     continue
-                for kk,vv in iteritems(data_value):
+                for kk,vv in data_value.items():
                     # TODO: remove this if-block.  This is a hack
                     if not type(vv) is dict:
                         vv = {'Value':vv}
                     tmp = {}
-                    for k,v in iteritems(vv):
+                    for k,v in vv.items():
                         # TODO: remove this if-block.  This is a hack
                         if v is not None and math.fabs(v) > 1e-16:
                             tmp[k] = v
@@ -171,7 +170,7 @@ class SolverResults(MapContainer):
         ostream.write("# ==========================================================\n")
         ostream.write("# = Solver Results                                         =\n")
         ostream.write("# ==========================================================\n")
-        for i in xrange(len(self._order)):
+        for i in range(len(self._order)):
             key = self._order[i]
             if not key in repn:
                 continue
@@ -203,7 +202,7 @@ class SolverResults(MapContainer):
             repn = yaml.load(istream, **yaml_load_args)
         else:
             repn = json.load(istream)
-        for i in xrange(len(self._order)):
+        for i in range(len(self._order)):
             key = self._order[i]
             if not key in repn:
                 continue

--- a/pyomo/opt/results/solution.py
+++ b/pyomo/opt/results/solution.py
@@ -11,8 +11,6 @@
 __all__ = ['SolutionStatus', 'Solution']
 
 import math
-from six import iterkeys, iteritems
-from six.moves import xrange
 import enum
 from pyomo.opt.results.container import MapContainer, ListContainer, ignore
 from pyomo.common.collections import Bunch, OrderedDict
@@ -128,26 +126,26 @@ class Solution(MapContainer):
                 id_nonzeros_map = {} # are any of the non-id entries are non-zero?
                 entries_to_print = False
 
-                for entry_name, entry_dict in iteritems(value):
+                for entry_name, entry_dict in value.items():
                     entry_id = id_ctr
                     id_ctr += 1
                     id_name_map[entry_id] = entry_name
                     id_dict_map[entry_id] = entry_dict
                     id_nonzeros_map[entry_id] = False # until proven otherwise
-                    for attr_name, attr_value in iteritems(entry_dict):
+                    for attr_name, attr_value in entry_dict.items():
                         if print_zeros or math.fabs(attr_value) > 1e-16:
                             id_nonzeros_map[entry_id] = True
                             entries_to_print = True
 
                 if entries_to_print:
-                    for entry_id in sorted(iterkeys(id_dict_map), key=lambda id:id_name_map[id]):
+                    for entry_id in sorted(id_dict_map.keys(), key=lambda id:id_name_map[id]):
                         if id_nonzeros_map[entry_id]:
                             if first:
                                 ostream.write("\n")
                                 first = False
                             ostream.write(prefix+str(id_name_map[entry_id])+":\n")
                             entry_dict = id_dict_map[entry_id]
-                            for attr_name in sorted(iterkeys(entry_dict)):
+                            for attr_name in sorted(entry_dict.keys()):
                                 attr_value = entry_dict[attr_name]
                                 if isinstance(attr_value,float) and (math.floor(attr_value) == attr_value):
                                     attr_value = int(attr_value)
@@ -199,7 +197,7 @@ class SolutionSet(ListContainer):
             ostream.write(prefix+spaces+key+": "+str(repn[0][key])+'\n')
             spaces="  "
         i=0
-        for i in xrange(len(self._list)):
+        for i in range(len(self._list)):
             item = self._list[i]
             ostream.write(prefix+'- ')
             item.pprint(ostream, option, from_list=True, prefix=prefix+"  ", repn=repn[i+1])

--- a/pyomo/opt/solver/shellcmd.py
+++ b/pyomo/opt/solver/shellcmd.py
@@ -15,7 +15,7 @@ import sys
 import time
 import logging
 import subprocess
-from six import StringIO
+from io import StringIO
 
 from pyomo.common.errors import ApplicationError
 from pyomo.common.collections import Bunch

--- a/pyomo/opt/tests/base/test_soln.py
+++ b/pyomo/opt/tests/base/test_soln.py
@@ -26,8 +26,6 @@ import pyomo.opt
 
 from pyomo.common.dependencies import yaml, yaml_available
 
-from six import iterkeys
-
 old_tempdir = TempfileManager.tempdir
 
 class Test(unittest.TestCase):
@@ -192,7 +190,7 @@ class Test(unittest.TestCase):
         self.soln.variable[1]["Value"] = 0.0
         self.soln.variable[4]["Value"] =0.3
         self.soln.variable[4]["Slack"] = 0.4
-        self.assertEqual(list(iterkeys(self.soln.variable)),[1,2,4])
+        self.assertEqual(list(self.soln.variable.keys()),[1,2,4])
         self.assertEqual(self.soln.variable[1]["Value"],0.0)
         self.assertEqual(self.soln.variable[4]["Value"],0.3)
         self.assertEqual(self.soln.variable[4]["Slack"],0.4)


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
Part of the Pyomo 6.0 effort is to replace the usage of `six` with the appropriate Python 3 methods. This does just that in the `neos`, `network`, and `opt` directories.

## Changes proposed in this PR:
- Remove `six` from `pyomo.neos`
- Remove `six` from `pyomo.network`
- Remove `six` from `pyomo.opt`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
