### PR TITLE
Fix identification of Pyomo root dir in unittest.runtests()

### DIFF
--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -494,8 +494,7 @@ def buildParser():
 
 def runtests(options):
 
-    import pyomo
-    basedir = os.path.dirname(pyomo.__file__)
+    from pyomo.common.fileutils import PYOMO_ROOT_DIR as basedir
     env = os.environ.copy()
     os.chdir(basedir)
 


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
There is an issue in the new `pyomo.common.unittest.runtests()` driver where it was not correctly identifying the root directory for the pyomo installation.  This fixes that by leveraging `pyomo.common.fileutils.PYOMO_ROOT_DIR`.  The test drivers did not pick up on this because they always supplied absolute paths.

## Changes proposed in this PR:
- Switch `pyomo.common.unittest.runtests()` to use  `pyomo.common.fileutils.PYOMO_ROOT_DIR`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
