### PR TITLE
Integrate `pyomo.common.timing` docs into RTD

### DIFF
--- a/doc/OnlineDocs/library_reference/common/index.rst
+++ b/doc/OnlineDocs/library_reference/common/index.rst
@@ -1,0 +1,11 @@
+Common Utilities
+================
+
+Pyomo provides a set of general-purpose utilites through
+``pyomo.common``.  These utilities are self-contained and do not import
+or rely on any other parts of Pyomo.
+
+.. toctree::
+   :maxdepth: 1
+
+   timing.rst

--- a/doc/OnlineDocs/library_reference/common/timing.rst
+++ b/doc/OnlineDocs/library_reference/common/timing.rst
@@ -1,0 +1,7 @@
+
+pyomo.common.timing
+===================
+
+.. automodule:: pyomo.common.timing
+   :members:
+   :member-order: bysource

--- a/doc/OnlineDocs/library_reference/index.rst
+++ b/doc/OnlineDocs/library_reference/index.rst
@@ -10,6 +10,7 @@ Python scripts using Pyomo.
 .. toctree::
    :maxdepth: 1
 
+   common/index.rst
    aml/index.rst
    expressions/index.rst
    solvers/index.rst

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -146,8 +146,12 @@ class TicTocTimer(object):
        >>> from pyomo.common.timing import TicTocTimer
        >>> timer = TicTocTimer()
        >>> timer.tic('starting timer') # starts the elapsed time timer (from 0)
+       [    0.00] starting timer
        >>> # ... do task 1
-       >>> timer.toc('task 1') # prints the elapsed time for task 1
+       >>> dT = timer.toc('task 1')
+       [+   0.00] task 1
+       >>> print("elapsed time: %0.1f" % dT)
+       elapsed time: 0.0
 
     If no ostream or logger is provided, then output is printed to sys.stdout
 
@@ -361,7 +365,7 @@ class HierarchicalTimer(object):
     ...     timer.stop('b')
     ...
     >>> timer.stop('all')
-    >>> print(timer)
+    >>> print(timer)       # doctest: +SKIP
     Identifier        ncalls   cumtime   percall      %
     ---------------------------------------------------
     all                    1     2.248     2.248  100.0
@@ -379,40 +383,51 @@ class HierarchicalTimer(object):
     <BLANKLINE>
 
     The columns are:
-      ncalls : The number of times the timer was started and stopped
-      cumtime: The cumulative time (in seconds) the timer was active
-               (started but not stopped)
-      percall: cumtime (in seconds) / ncalls
-      %      : This is cumtime of the timer divided by cumtime of the
-               parent timer times 100
 
+      ncalls
+          The number of times the timer was started and stopped
+      cumtime
+          The cumulative time (in seconds) the timer was active
+          (started but not stopped)
+      percall
+          cumtime (in seconds) / ncalls
+      "%"
+          This is cumtime of the timer divided by cumtime of the
+          parent timer times 100
 
-    >>> print('a total time: %f' % timer.get_total_time('all.a'))
+    >>> print('a total time: %f' % timer.get_total_time('all.a')) \
+        # doctest: +SKIP
     a total time: 1.902037
-    >>> print('ab num calls: %d' % timer.get_num_calls('all.a.ab'))
+    >>> print('ab num calls: %d' % timer.get_num_calls('all.a.ab')) \
+        # doctest: +SKIP
     ab num calls: 10
-    >>> print('aa %% time: %f' % timer.get_relative_percent_time('all.a.aa'))
+    >>> print('aa %% time: %f' % timer.get_relative_percent_time('all.a.aa')) \
+        # doctest: +SKIP
     aa % time: 44.144148
-    >>> print('aa %% total: %f' % timer.get_total_percent_time('all.a.aa'))
+    >>> print('aa %% total: %f' % timer.get_total_percent_time('all.a.aa')) \
+        # doctest: +SKIP
     aa % total: 35.976058
 
-    Internal Workings
-    -----------------
-    The HierarchicalTimer use a stack to track which timers are active
-    at any point in time. Additionally, each timer has a dictionary of
-    timers for its children timers. Consider
+
+    Notes
+    -----
+
+    The :py:class:`HierarchicalTimer` use a stack to track which timers
+    are active at any point in time. Additionally, each timer has a
+    dictionary of timers for its children timers. Consider
 
     >>> timer = HierarchicalTimer()
     >>> timer.start('all')
     >>> timer.start('a')
     >>> timer.start('aa')
 
-    After the above code is run, self.stack will be ['all', 'a', 'aa']
-    and self.timers will have one key, 'all' and one value which will be
-    a _HierarchicalHelper. The _HierarchicalHelper has its own timers
-    dictionary:
+    After the above code is run, ``timer.stack`` will be
+    ``['all', 'a', 'aa']`` and ``timer.timers`` will have one key,
+    ``'all'`` and one value which will be a
+    :py:class:`_HierarchicalHelper`. The :py:class:`_HierarchicalHelper`
+    has its own timers dictionary:
 
-    {'a': _HierarchicalHelper}
+        ``{'a': _HierarchicalHelper}``
 
     and so on. This way, we can easily access any timer with something
     that looks like the stack. The logic is recursive (although the


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This integrates the `pyomo.common.timing` documentation into the RTD build.

Note: this PR will have conflicts with #1916, as both contain (identical) stubs for documenting `pyomo.common`.  Whichever one is merged first will require a quick cleanup of the other to resolve a documentation conflict.

## Changes proposed in this PR:
- Integrate `pyomo.common.timing` documentation into RTD
- Update pyomo.common.timing` doctest so that they pass cleanly

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
