### PR TITLE
Rename param._NotValid to param.Param.NoValue

### DIFF
--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -33,9 +33,11 @@ from pyomo.environ import (Set, RangeSet, Param, ConcreteModel,
                            cosh, tanh, asinh, acosh, atanh)
 from pyomo.common.log import LoggingIntercept
 from pyomo.common.tempfiles import TempfileManager
-from pyomo.core.base.param import _NotValid, _ParamData 
+from pyomo.core.base.param import _ParamData 
 
 from io import StringIO
+
+NoValue = Param.NoValue
 
 class ParamTester(object):
 
@@ -71,7 +73,7 @@ class ParamTester(object):
             self.assertRaises(TypeError, float, self.instance.A)
             self.assertRaises(TypeError, int, self.instance.A)
 
-        if self.instance.A._default_val is _NotValid:
+        if self.instance.A._default_val is NoValue:
             val_list = self.sparse_data.items()
         else:
             val_list = self.data.items()
@@ -121,7 +123,7 @@ class ParamTester(object):
                 test = self.instance.A[key]
                 self.assertEqual( value(test), val )
             except ValueError:
-                if val is not _NotValid:
+                if val is not NoValue:
                     raise
 
     def test_setitem_index_error(self):
@@ -208,7 +210,7 @@ class ParamTester(object):
         if len(keys) == len(sparse_keys):
             # No default value possible
             return
-        if self.instance.A._default_val is _NotValid:
+        if self.instance.A._default_val is NoValue:
             # No default value defined
             return
 
@@ -291,7 +293,7 @@ class ParamTester(object):
     def test_keys(self):
         test = self.instance.A.keys()
         #self.assertEqual( type(test), list )
-        if self.instance.A._default_val is _NotValid:
+        if self.instance.A._default_val is NoValue:
             self.assertEqual( sorted(test), sorted(self.sparse_data.keys()) )
         else:
             self.assertEqual( sorted(test), sorted(self.data.keys()) )
@@ -304,7 +306,7 @@ class ParamTester(object):
             test = self.instance.A.values()
             #self.assertEqual( type(test), list )
             test = zip(self.instance.A.keys(), test)
-            if self.instance.A._default_val is _NotValid:
+            if self.instance.A._default_val is NoValue:
                 self.validateDict(self.sparse_data.items(), test)
             else:
                 self.validateDict(self.data.items(), test)
@@ -316,12 +318,12 @@ class ParamTester(object):
     def test_items(self):
         expectException = False
         #                  len(self.sparse_data) < len(self.data) and \
-        #                  not self.instance.A._default_val is _NotValid and \
+        #                  not self.instance.A._default_val is NoValue and \
         #                  not self.instance.A.mutable
         try:
             test = self.instance.A.items()
             #self.assertEqual( type(test), list )
-            if self.instance.A._default_val is _NotValid:
+            if self.instance.A._default_val is NoValue:
                 self.validateDict(self.sparse_data.items(), test)
             else:
                 self.validateDict(self.data.items(), test)
@@ -342,7 +344,7 @@ class ParamTester(object):
         try:
             test = self.instance.A.values()
             test = zip(self.instance.A.keys(), test)
-            if self.instance.A._default_val is _NotValid:
+            if self.instance.A._default_val is NoValue:
                 self.validateDict(self.sparse_data.items(), test)
             else:
                 self.validateDict(self.data.items(), test)
@@ -358,7 +360,7 @@ class ParamTester(object):
         #                  not self.instance.A.mutable
         try:
             test = self.instance.A.items()
-            if self.instance.A._default_val is _NotValid:
+            if self.instance.A._default_val is NoValue:
                 self.validateDict(self.sparse_data.items(), test)
             else:
                 self.validateDict(self.data.items(), test)
@@ -404,7 +406,7 @@ class ParamTester(object):
 
     def test_len(self):
         #"""Check the use of len"""
-        if self.instance.A._default_val is _NotValid:
+        if self.instance.A._default_val is NoValue:
             self.assertEqual( len(self.instance.A), len(self.sparse_data) )
             self.assertEqual( len(list(self.instance.A.keys())), len(self.sparse_data) )
         else:
@@ -421,14 +423,14 @@ class ParamTester(object):
             # nothing to test
             return
         idx = list(set(self.data) - set(self.sparse_data))[0]
-        expectException = self.instance.A._default_val is _NotValid \
+        expectException = self.instance.A._default_val is NoValue \
                           and not self.instance.A.mutable
         try:
             test = self.instance.A[idx]
             if expectException:
                 self.fail("Expected the test to raise an exception")
             self.assertFalse(expectException)
-            expectException = self.instance.A._default_val is _NotValid
+            expectException = self.instance.A._default_val is NoValue
             try:
                 ans = value(test)
                 self.assertEquals(ans, value(self.instance.A._default_val))
@@ -452,7 +454,7 @@ class ArrayParam_mutable_sparse_noDefault\
         ParamTester.setUp(self, mutable=True, initialize={1:1.3}, **kwds)
 
         self.sparse_data = {1:1.3}
-        self.data = {1:1.3, 3:_NotValid}
+        self.data = {1:1.3, 3:NoValue}
 
 class ArrayParam_mutable_sparse_intDefault\
           (ParamTester, unittest.TestCase):
@@ -581,7 +583,7 @@ class ArrayParam_immutable_sparse_noDefault\
         ParamTester.setUp(self, mutable=False, initialize={1:1.3}, **kwds)
 
         self.sparse_data = {1:1.3}
-        self.data = {1:1.3, 3:_NotValid}
+        self.data = {1:1.3, 3:NoValue}
 
 
 class ArrayParam_immutable_sparse_intDefault\
@@ -811,7 +813,7 @@ class ScalarTester(ParamTester):
 
     def test_value_scalar(self):
         #"""Check the value of the parameter"""
-        if self.data.get(None,_NotValid) is _NotValid:
+        if self.data.get(None,NoValue) is NoValue:
             self.assertRaises(ValueError, value, self.instance.A)
             self.assertRaises(TypeError, float, self.instance.A)
             self.assertRaises(TypeError, int, self.instance.A)
@@ -826,8 +828,8 @@ class ScalarTester(ParamTester):
 
     def test_call(self):
         #"""Check the use of the __call__ method"""
-        if self.sparse_data.get(None,0) is _NotValid or \
-           self.data.get(None,_NotValid) is _NotValid: #not self.sparse_data:
+        if self.sparse_data.get(None,0) is NoValue or \
+           self.data.get(None,NoValue) is NoValue: #not self.sparse_data:
             self.assertRaisesRegexp(
                 ValueError, ".*currently set to an invalid value",
                 self.instance.A.__call__ )
@@ -836,8 +838,8 @@ class ScalarTester(ParamTester):
 
     def test_get_valueattr(self):
         self.assertEqual( self.instance.A._value,
-                          self.sparse_data.get(None,_NotValid) )
-        if self.data.get(None,0) is _NotValid: #not self.sparse_data:
+                          self.sparse_data.get(None,NoValue) )
+        if self.data.get(None,0) is NoValue: #not self.sparse_data:
             try:
                 value(self.instance.A)
                 self.fail("Expected value error")
@@ -852,8 +854,8 @@ class ScalarTester(ParamTester):
         self.assertEqual(self.instance.A(), 4.3)
 
     def test_get_value(self):
-        if self.sparse_data.get(None,0) is _NotValid or \
-           self.data.get(None,_NotValid) is _NotValid: #not self.sparse_data:
+        if self.sparse_data.get(None,0) is NoValue or \
+           self.data.get(None,NoValue) is NoValue: #not self.sparse_data:
             try:
                 value(self.instance.A)
                 self.fail("Expected value error")
@@ -886,7 +888,7 @@ class ScalarParam_mutable_noDefault(ScalarTester, unittest.TestCase):
         ScalarTester.setUp(self, mutable=True, **kwds)
 
         self.sparse_data = {}
-        self.data = {None:_NotValid}
+        self.data = {None:NoValue}
 
 
 class ScalarParam_mutable_init(ScalarTester, unittest.TestCase):
@@ -1355,7 +1357,7 @@ p : Size=1, Index=None, Domain=Any, Default=None, Mutable=True
 q : Size=3, Index=Any, Domain=Any, Default=None, Mutable=True
     Key : Value
       1 : None
-      2 : <class 'pyomo.core.base.param._NotValid'>
+      2 : <class 'pyomo.core.base.param.Param.NoValue'>
       a : b
             """.strip())
 


### PR DESCRIPTION
## Fixes #907

## Summary/Motivation:
#907 pointed out that a public API was returning an object that was (by convention) "private".  This renames the `pyomo.core.base.param._NotValid` to `pyomo.core.base.param.Param.NoValue` and updates the documentation to match.

## Changes proposed in this PR:
- rename `pyomo.core.base.param._NotValid` to `pyomo.core.base.param.Param.NoValue`
- update documentation string

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
