### PR TITLE
Updating ReadTheDocs configuration

### DIFF
--- a/.readthedocs_requirements.txt
+++ b/.readthedocs_requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/PyUtilib/pyutilib
 Sphinx>2
-sphinx-rtd-theme>0.5
+sphinx-rtd-theme
 sphinxcontrib-jsmath
 sphinxcontrib-napoleon
 networkx

--- a/.readthedocs_requirements.txt
+++ b/.readthedocs_requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/PyUtilib/pyutilib
-Sphinx>2
+Sphinx>2,<3.5
 sphinx-rtd-theme
 sphinxcontrib-jsmath
 sphinxcontrib-napoleon

--- a/.readthedocs_requirements.txt
+++ b/.readthedocs_requirements.txt
@@ -1,5 +1,8 @@
 git+https://github.com/PyUtilib/pyutilib
-sphinx>=1.8.0
+Sphinx>2
+sphinx-rtd-theme>0.5
+sphinxcontrib-jsmath
+sphinxcontrib-napoleon
 networkx
 pandas
 numpy

--- a/.readthedocs_requirements.txt
+++ b/.readthedocs_requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/PyUtilib/pyutilib
-Sphinx>2
+Sphinx
 sphinx-rtd-theme
 sphinxcontrib-jsmath
 sphinxcontrib-napoleon

--- a/.readthedocs_requirements.txt
+++ b/.readthedocs_requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/PyUtilib/pyutilib
 Sphinx>2,<3.5
-sphinx-rtd-theme
+sphinx-rtd-theme>0.5
 sphinxcontrib-jsmath
 sphinxcontrib-napoleon
 networkx

--- a/.readthedocs_requirements.txt
+++ b/.readthedocs_requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/PyUtilib/pyutilib
-Sphinx>2,<3.5
+Sphinx>2
 sphinx-rtd-theme>0.5
 sphinxcontrib-jsmath
 sphinxcontrib-napoleon

--- a/.readthedocs_requirements.txt
+++ b/.readthedocs_requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/PyUtilib/pyutilib
-Sphinx
+Sphinx>2
 sphinx-rtd-theme
 sphinxcontrib-jsmath
 sphinxcontrib-napoleon

--- a/doc/OnlineDocs/_static/theme_overrides.css
+++ b/doc/OnlineDocs/_static/theme_overrides.css
@@ -9,7 +9,7 @@ code.xref.py {
 }
 
 /* method names should be bold */
-code.sig-name.descname {
+code.descname {
     font-weight: bold !important;
     color: black;
 }

--- a/doc/OnlineDocs/_static/theme_overrides.css
+++ b/doc/OnlineDocs/_static/theme_overrides.css
@@ -8,13 +8,12 @@ code.xref.py {
     color: #8C1AFF;
 }
 
-/* method signitures should be in fixed-width font, names should be bold
-   arguments should be black*/
+/* method names should be bold */
 code.sig-name.descname {
-    font-family: monospace;
     font-weight: bold !important;
     color: black;
 }
+/* method argument lists shoult *not* be bold, argument names in black */
 dl.py.method dt {
     font-weight: normal;
 }

--- a/doc/OnlineDocs/_static/theme_overrides.css
+++ b/doc/OnlineDocs/_static/theme_overrides.css
@@ -8,6 +8,20 @@ code.xref.py {
     color: #8C1AFF;
 }
 
+/* method signitures should be in fixed-width font, names should be bold
+   arguments should be black*/
+code.sig-name.descname {
+    font-family: monospace;
+    font-weight: bold !important;
+    color: black;
+}
+dl.py.method dt {
+    font-weight: normal;
+}
+dl.py.method dt em span.n {
+    color: black;
+}
+
 /* Fix to RTD theme to allow table cell content to wrap */
 @media screen and (min-width: 767px) {
   .wy-table-responsive table td {

--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -101,7 +101,7 @@ language = None
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+#pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False

--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -101,7 +101,7 @@ language = None
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
-#pygments_style = 'sphinx'
+pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False

--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -123,9 +123,10 @@ numfig = True
 #html_theme = 'alabaster'
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
+html_theme = 'sphinx_rtd_theme'
+html4_writer = True
 if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
     # Override default css to get a larger width for local build
     def setup(app):

--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -36,6 +36,17 @@ try:
 finally:
     sys.path.pop(0)
 
+# -- Options for intersphinx ---------------------------------------------
+
+intersphinx_mapping = {
+    'matplotlib': ('https://matplotlib.org/stable/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
+    'pandas': ('https://pandas.pydata.org/docs/', None),
+    'scikit-learn': ('https://scikit-learn.org/stable/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'Sphinx': ('https://www.sphinx-doc.org/en/stable/', None),
+}
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -46,6 +57,7 @@ needs_sphinx = '1.8'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.intersphinx',
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',
@@ -124,7 +136,12 @@ numfig = True
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 html_theme = 'sphinx_rtd_theme'
-html4_writer = True
+
+# Force HTML4: the Paramters/Returns/Return type formatting is strange
+# in HTML5
+#html4_writer = True
+#html5_writer = True
+
 if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]

--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -45,16 +45,18 @@ needs_sphinx = '1.8'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.coverage',
-              'sphinx.ext.mathjax',
-              'sphinx.ext.viewcode',
-              'sphinx.ext.napoleon',
-              'sphinx.ext.ifconfig',
-              'sphinx.ext.inheritance_diagram',
-              'sphinx.ext.autosummary',
-              'sphinx.ext.doctest']
-    #'sphinx.ext.githubpages']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.coverage',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.inheritance_diagram',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.doctest',
+    #'sphinx.ext.githubpages',
+]
 
 viewcode_follow_imported_members = True
 #napoleon_include_private_with_doc = True
@@ -104,6 +106,13 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+# If true, doctest flags (comments looking like # doctest: FLAG, ...) at
+# the ends of lines and <BLANKLINE> markers are removed for all code
+# blocks showing interactive Python sessions (i.e. doctests)
+trim_doctest_flags = True
+
+# If true, figures, tables and code-blocks are automatically numbered if
+# they have a caption.
 numfig = True
 
 # -- Options for HTML output ----------------------------------------------

--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -137,9 +137,11 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 html_theme = 'sphinx_rtd_theme'
 
-# Force HTML4: the Paramters/Returns/Return type formatting is strange
-# in HTML5
-#html4_writer = True
+# Force HTML4: If we don't explicitly force HTML4, then the background
+# of the Paramters/Returns/Return type headers is shaded the same as the
+# method prototype (tested 15 April 21 with Sphinx=3.5.4 and
+# sphinx-rtd-theme=0.5.2).
+html4_writer = True
 #html5_writer = True
 
 if not on_rtd:  # only import and set the theme if we're building docs locally

--- a/pyomo/common/modeling.py
+++ b/pyomo/common/modeling.py
@@ -9,6 +9,7 @@
 #  ___________________________________________________________________________
 
 from random import random
+import sys
 
 
 def randint(a,b):
@@ -35,14 +36,41 @@ def unique_component_name(instance, name):
             name += str(randint(0,9))
 
 
-class NoArgumentGiven(object):
+class FlagType(type):
+    """Metaclass to simplify the repr(type) and str(type)
+
+    This metaclass redefines the ``str()`` and ``repr()`` of resulting
+    classes.  The str() of the class returns only the class' ``__name__``,
+    whereas the repr() returns either the qualified class name
+    (``__qualname__``) is Sphinx has been imported, or else the
+    fully-qualified class name (``__module__ + '.' + __qualname__``).
+
+    This is useful for defining "flag types" that are default arguments
+    in functions so that the Sphinx-generated documentation is "cleaner"
+
+    """
+    if 'sphinx' in sys.modules or 'Sphinx' in sys.modules:
+        def __repr__(cls):
+            return cls.__qualname__
+    else:
+        def __repr__(cls):
+            return cls.__module__ + "." + cls.__qualname__
+
+    def __str__(cls):
+        return __name__
+
+
+class NOTSET(object, metaclass=FlagType):
     """
     Class to be used to indicate that an optional argument
     was not specified, if `None` may be ambiguous. Usage:
 
-      >>> def foo(value=NoArgumentGiven):
-      >>>     if value is NoArgumentGiven:
+      >>> def foo(value=NOTSET):
+      >>>     if value is NOTSET:
       >>>         pass  # no argument was provided to `value`
 
     """
     pass
+
+# Backward compatibility with the previous name for this flag
+NoArgumentGiven = NOTSET

--- a/pyomo/common/modeling.py
+++ b/pyomo/common/modeling.py
@@ -42,7 +42,7 @@ class FlagType(type):
     This metaclass redefines the ``str()`` and ``repr()`` of resulting
     classes.  The str() of the class returns only the class' ``__name__``,
     whereas the repr() returns either the qualified class name
-    (``__qualname__``) is Sphinx has been imported, or else the
+    (``__qualname__``) if Sphinx has been imported, or else the
     fully-qualified class name (``__module__ + '.' + __qualname__``).
 
     This is useful for defining "flag types" that are default arguments


### PR DESCRIPTION
## Fixes # NA

## Summary/Motivation:
This updates the RTD configuration to improve rendering of API documentation.  In particular, by using a newer version of Sphinx than the default, code comments containing `doctest:` directives will be removed from the rendered output. This also improves the formatting of method signatures so that they are more readable.  Finally, this contains additional improvements to the `pyomo.common.timing` documentation, including a metaclass so that the `_NotSpecified` flag is better rendered in the documentation.

## Changes proposed in this PR:
- Update RTD configuration so that online documentation is rendered more closely to the result obtained locally.
- Adding a `FlagType` metaclass to improve the rendering of "flag types" in the RTD documentation
- updating `pyomo.common.timing` documrntation
- adding hooks for (future) use of intersphinx references

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
