### PR TITLE
PyNumero PyomoNLP should expose nl file options

### DIFF
--- a/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
@@ -32,7 +32,7 @@ __all__ = ['PyomoNLP']
 
 # TODO: There are todos in the code below
 class PyomoNLP(AslNLP):
-    def __init__(self, pyomo_model):
+    def __init__(self, pyomo_model, nl_file_options=None):
         """
         Pyomo nonlinear program interface
 
@@ -69,8 +69,10 @@ class PyomoNLP(AslNLP):
             self._objective = objectives[0]
 
             # write the nl file for the Pyomo model and get the symbolMap
+            if nl_file_options is None:
+                nl_file_options = dict()
             fname, symbolMap = WriterFactory('nl')(
-                pyomo_model, nl_file, lambda x:True, {'skip_trivial_constraints': True})
+                pyomo_model, nl_file, lambda x:True, nl_file_options)
 
             # create component maps from vardata to idx and condata to idx
             self._vardata_to_idx = vdidx = ComponentMap()

--- a/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
@@ -70,7 +70,7 @@ class PyomoNLP(AslNLP):
 
             # write the nl file for the Pyomo model and get the symbolMap
             fname, symbolMap = WriterFactory('nl')(
-                pyomo_model, nl_file, lambda x:True, {})
+                pyomo_model, nl_file, lambda x:True, {'skip_trivial_constraints': True})
 
             # create component maps from vardata to idx and condata to idx
             self._vardata_to_idx = vdidx = ComponentMap()


### PR DESCRIPTION
## Changes proposed in this PR:
- PyNumero PyomoNLP should write NL file with skip_trivial_constraints=True

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
