### PR TITLE
Remove `six` from `repn` and `solvers`

### DIFF
--- a/pyomo/repn/beta/matrix.py
+++ b/pyomo/repn/beta/matrix.py
@@ -31,13 +31,7 @@ from pyomo.core.base.constraint import (Constraint,
 from pyomo.core.expr.numvalue import native_numeric_types
 from pyomo.repn import generate_standard_repn
 
-from six import iteritems, PY3
-from six.moves import xrange
-
-if PY3:
-    from collections.abc import Mapping as collections_Mapping
-else:
-    from collections import Mapping as collections_Mapping
+from collections.abc import Mapping
 
 
 logger = logging.getLogger('pyomo.core')
@@ -164,7 +158,7 @@ def compile_block_linear_constraints(parent_block,
                 # Note that as we may be removing items from the _data
                 # dictionary, we need to make a copy of the items list
                 # before iterating:
-                for index, constraint_data in list(iteritems(constraint)):
+                for index, constraint_data in list(constraint.items()):
 
                     if constraint_data.body.__class__ in native_numeric_types or constraint_data.body.polynomial_degree() <= 1:
 
@@ -459,7 +453,7 @@ class _LinearMatrixConstraintData(_LinearConstraintData):
         vals = comp._vals
         try:
             return sum(varmap[jcols[p]]() * vals[p]
-                       for p in xrange(prows[index],
+                       for p in range(prows[index],
                                        prows[index+1]))
         except (ValueError, TypeError):
             if exception:
@@ -517,7 +511,7 @@ class _LinearMatrixConstraintData(_LinearConstraintData):
         if prows[self._index] == prows[self._index+1]:
             return()
         variables = tuple(varmap[jcols[p]]
-                          for p in xrange(prows[self._index],
+                          for p in range(prows[self._index],
                                           prows[self._index+1])
                           if not varmap[jcols[p]].fixed)
 
@@ -533,7 +527,7 @@ class _LinearMatrixConstraintData(_LinearConstraintData):
         varmap = comp._varmap
         if prows[self._index] == prows[self._index+1]:
             return ()
-        coefs = tuple(vals[p] for p in xrange(prows[self._index],
+        coefs = tuple(vals[p] for p in range(prows[self._index],
                                               prows[self._index+1])
                       if not varmap[jcols[p]].fixed)
 
@@ -553,7 +547,7 @@ class _LinearMatrixConstraintData(_LinearConstraintData):
         if prows[self._index] == prows[self._index+1]:
             return 0
         terms = tuple(vals[p] * varmap[jcols[p]]()
-                      for p in xrange(prows[self._index],
+                      for p in range(prows[self._index],
                                       prows[self._index+1])
                       if varmap[jcols[p]].fixed)
 
@@ -575,7 +569,7 @@ class _LinearMatrixConstraintData(_LinearConstraintData):
         if prows[self._index] == prows[self._index+1]:
             return ZeroConstant
         return sum(varmap[jcols[p]] * vals[p]
-                   for p in xrange(prows[index],
+                   for p in range(prows[index],
                                    prows[index+1]))
 
     @property
@@ -623,8 +617,7 @@ class _LinearMatrixConstraintData(_LinearConstraintData):
 
 @ModelComponentFactory.register(
                    "A set of constraint expressions in Ax=b form.")
-class MatrixConstraint(collections_Mapping,
-                       IndexedConstraint):
+class MatrixConstraint(Mapping, IndexedConstraint):
 
     #
     # Bound types
@@ -679,7 +672,7 @@ class MatrixConstraint(collections_Mapping,
 
         _init = _LinearMatrixConstraintData
         self._data = tuple(_init(i, component=self)
-                           for i in xrange(len(self._range_types)))
+                           for i in range(len(self._range_types)))
 
     #
     # Override some IndexedComponent methods
@@ -692,7 +685,7 @@ class MatrixConstraint(collections_Mapping,
         return self._data.__len__()
 
     def __iter__(self):
-        return iter(i for i in xrange(len(self)))
+        return iter(i for i in range(len(self)))
 
     #
     # Remove methods that allow modifying this constraint

--- a/pyomo/repn/plugins/ampl/ampl_.py
+++ b/pyomo/repn/plugins/ampl/ampl_.py
@@ -37,9 +37,6 @@ from pyomo.core.kernel.block import IBlock
 from pyomo.core.kernel.expression import IIdentityExpression
 from pyomo.core.kernel.variable import IVariable
 
-from six import itervalues, iteritems
-from six.moves import xrange, zip
-
 logger = logging.getLogger('pyomo.core')
 
 _intrinsic_function_operators = {
@@ -317,7 +314,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
         if len(io_options):
             raise ValueError(
                 "ProblemWriter_nl passed unrecognized io_options:\n\t" +
-                "\n\t".join("%s = %s" % (k,v) for k,v in iteritems(io_options)))
+                "\n\t".join("%s = %s" % (k,v) for k,v in io_options.items()))
 
         if filename is None:
             filename = model.name + ".nl"
@@ -332,7 +329,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
             comment_str = _op_comment[optype]
             if type(template_str) is tuple:
                 op_strings = []
-                for i in xrange(len(template_str)):
+                for i in range(len(template_str)):
                     if symbolic_solver_labels:
                         op_strings.append(template_str[i].format(C=comment_str[i]))
                     else:
@@ -439,7 +436,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
             n = len(exp)
             if n > 2:
                 OUTPUT.write(nary_sum_str % (n))
-                for i in xrange(0,n):
+                for i in range(0,n):
                     assert(exp[i].__class__ is tuple)
                     coef = exp[i][0]
                     child_exp = exp[i][1]
@@ -447,7 +444,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
                         OUTPUT.write(coef_term_str % (coef))
                     self._print_nonlinear_terms_NL(child_exp)
             else: # n == 1 or 2
-                for i in xrange(0,n):
+                for i in range(0,n):
                     assert(exp[i].__class__ is tuple)
                     coef = exp[i][0]
                     child_exp = exp[i][1]
@@ -798,7 +795,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
         #         cntr))
         #     cntr += len(vars_counter)
         #     Vars_dict.update(vars_counter)
-        self._varID_map = dict((id(val),key) for key,val in iteritems(Vars_dict))
+        self._varID_map = dict((id(val),key) for key,val in Vars_dict.items())
         self_varID_map = self._varID_map
         # Use to label the rest of the components (which we will not encounter twice)
         trivial_labeler = _Counter(cntr)
@@ -1109,7 +1106,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
         if include_all_variable_bounds:
             # classify unused vars as linear
             AllVars = set(self_varID_map[id(vardata)]
-                          for vardata in itervalues(Vars_dict))
+                          for vardata in Vars_dict.values())
             UnusedVars = AllVars.difference(UsedVars)
             LinearVars.update(UnusedVars)
 
@@ -1313,7 +1310,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
         #
         # "F" lines
         #
-        for fcn, fid in sorted(itervalues(self.external_byFcn),
+        for fcn, fid in sorted(self.external_byFcn.values(),
                                key=operator.itemgetter(1)):
             OUTPUT.write("F%d 1 -1 %s\n" % (fid, fcn._function))
 
@@ -1441,7 +1438,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
             obj_s_lines = []
             mod_s_lines = []
             for suffix in suffixes:
-                for component_data, suffix_value in iteritems(suffix):
+                for component_data, suffix_value in suffix.items():
 
                     try:
                         symbol = symbol_map_byObject[id(component_data)]
@@ -1511,7 +1508,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
         if symbolic_solver_labels:
             rowf = open(rowfilename,'w')
 
-        cu = [0 for i in xrange(len(full_var_list))]
+        cu = [0 for i in range(len(full_var_list))]
         for con_ID in nonlin_con_order_list:
             con_data, wrapped_repn = Constraints_dict[con_ID]
             row_id = self_ampl_con_id[con_ID]
@@ -1557,7 +1554,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
         #
         # "O" lines
         #
-        for obj_ID, (obj, wrapped_repn) in iteritems(Objectives_dict):
+        for obj_ID, (obj, wrapped_repn) in Objectives_dict.items():
 
             k = 0
             if not obj.is_minimizing():
@@ -1605,7 +1602,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
             s_lines = []
             for dual_suffix in suffix_dict['dual']:
 
-                for constraint_data, suffix_value in iteritems(dual_suffix):
+                for constraint_data, suffix_value in dual_suffix.items():
                     try:
                         # a constraint might not be referenced
                         # (inactive / on inactive block)
@@ -1721,7 +1718,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
             OUTPUT.write("\t#intermediate Jacobian column lengths")
         OUTPUT.write("\n")
         ktot = 0
-        for i in xrange(n1):
+        for i in range(n1):
             ktot += cu[i]
             OUTPUT.write("%d\n"%(ktot))
         del cu
@@ -1784,7 +1781,7 @@ class ProblemWriter_nl(AbstractProblemWriter):
         # "G" lines
         #
         for obj_ID, (obj, wrapped_repn) in \
-               iteritems(Objectives_dict):
+               Objectives_dict.items():
 
             grad_entries = {}
             for idx, obj_var in enumerate(

--- a/pyomo/repn/plugins/baron_writer.py
+++ b/pyomo/repn/plugins/baron_writer.py
@@ -15,7 +15,7 @@
 import itertools
 import logging
 import math
-from six import iteritems, StringIO
+from io import StringIO
 
 from pyomo.common.collections import OrderedSet
 from pyomo.opt import ProblemFormat
@@ -233,7 +233,7 @@ class ProblemWriter_bar(AbstractProblemWriter):
                 if name == 'branching_priorities':
                     branching_priorities_suffixes.append(suffix)
                 elif name == 'constraint_types':
-                    for constraint_data, constraint_type in iteritems(suffix):
+                    for constraint_data, constraint_type in suffix.items():
                         if not _skip_trivial(constraint_data):
                             if constraint_type.lower() == 'relaxationonly':
                                 r_o_eqns.append(constraint_data)
@@ -363,7 +363,7 @@ class ProblemWriter_bar(AbstractProblemWriter):
                     if param.mutable and param.is_indexed():
                         param_data_iter = \
                             (param_data for index, param_data
-                             in iteritems(param))
+                             in param.items())
                     elif not param.is_indexed():
                         param_data_iter = iter([param])
                     else:
@@ -548,7 +548,7 @@ class ProblemWriter_bar(AbstractProblemWriter):
         if len(io_options):
             raise ValueError(
                 "ProblemWriter_baron_writer passed unrecognized io_options:\n\t" +
-                "\n\t".join("%s = %s" % (k,v) for k,v in iteritems(io_options)))
+                "\n\t".join("%s = %s" % (k,v) for k,v in io_options.items()))
 
         if symbolic_solver_labels and (labeler is not None):
             raise ValueError("Baron problem writer: Using both the "
@@ -579,7 +579,7 @@ class ProblemWriter_bar(AbstractProblemWriter):
         output_file.write("OPTIONS {\n")
         summary_found = False
         if len(solver_options):
-            for key, val in iteritems(solver_options):
+            for key, val in solver_options.items():
                 if (key.lower() == 'summary'):
                     summary_found = True
                 if key.endswith("Name"):
@@ -774,7 +774,7 @@ class ProblemWriter_bar(AbstractProblemWriter):
         # object, indexed by the relevant variable
         BranchingPriorityHeader = False
         for suffix in branching_priorities_suffixes:
-            for var_data, priority in iteritems(suffix):
+            for var_data, priority in suffix.items():
                 if id(var_data) not in referenced_variable_ids:
                     continue
                 if priority is not None:

--- a/pyomo/repn/plugins/cpxlp.py
+++ b/pyomo/repn/plugins/cpxlp.py
@@ -14,8 +14,6 @@
 
 import logging
 
-from six import iteritems
-
 from pyomo.common.gc_manager import PauseGC
 from pyomo.opt import ProblemFormat
 from pyomo.opt.base import AbstractProblemWriter, WriterFactory
@@ -129,7 +127,7 @@ class ProblemWriter_cpxlp(AbstractProblemWriter):
         if len(io_options):
             raise ValueError(
                 "ProblemWriter_cpxlp passed unrecognized io_options:\n\t" +
-                "\n\t".join("%s = %s" % (k,v) for k,v in iteritems(io_options)))
+                "\n\t".join("%s = %s" % (k,v) for k,v in io_options.items()))
 
         if symbolic_solver_labels and (labeler is not None):
             raise ValueError("ProblemWriter_cpxlp: Using both the "

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -12,7 +12,7 @@
 # Problem Writer for GAMS Format Files
 #
 
-from six import StringIO, iteritems
+from io import StringIO
 
 from pyomo.common.gc_manager import PauseGC
 from pyomo.core.expr import current as EXPR
@@ -390,7 +390,7 @@ class ProblemWriter_gams(AbstractProblemWriter):
             raise ValueError(
                 "GAMS writer passed unrecognized io_options:\n\t" +
                 "\n\t".join("%s = %s"
-                            % (k,v) for k,v in iteritems(io_options)))
+                            % (k,v) for k,v in io_options.items()))
 
         if solver is not None and solver.upper() not in valid_solvers:
             raise ValueError(

--- a/pyomo/repn/plugins/mps.py
+++ b/pyomo/repn/plugins/mps.py
@@ -14,8 +14,7 @@
 
 import logging
 
-from six import iteritems, StringIO
-from six.moves import xrange
+from io import StringIO
 
 from pyomo.common.gc_manager import PauseGC
 from pyomo.opt import ProblemFormat
@@ -130,7 +129,7 @@ class ProblemWriter_mps(AbstractProblemWriter):
         if len(io_options):
             raise ValueError(
                 "ProblemWriter_mps passed unrecognized io_options:\n\t" +
-                "\n\t".join("%s = %s" % (k,v) for k,v in iteritems(io_options)))
+                "\n\t".join("%s = %s" % (k,v) for k,v in io_options.items()))
 
         if symbolic_solver_labels and (labeler is not None):
             raise ValueError("ProblemWriter_mps: Using both the "
@@ -319,7 +318,7 @@ class ProblemWriter_mps(AbstractProblemWriter):
         variable_to_column = ComponentMap(
             (vardata, i) for i, vardata in enumerate(variable_list))
         # add one position for ONE_VAR_CONSTANT
-        column_data = [[] for i in xrange(len(variable_list)+1)]
+        column_data = [[] for i in range(len(variable_list)+1)]
         quadobj_data = []
         quadmatrix_data = []
         # constraint rhs

--- a/pyomo/repn/standard_repn.py
+++ b/pyomo/repn/standard_repn.py
@@ -36,12 +36,9 @@ from pyomo.core.kernel.expression import expression, noclone
 from pyomo.core.kernel.variable import IVariable, variable
 from pyomo.core.kernel.objective import objective
 
-from six import iteritems, StringIO, PY3
-from six.moves import zip
+from io import StringIO
 
 logger = logging.getLogger('pyomo.core')
-
-using_py3 = PY3
 
 
 #
@@ -590,10 +587,10 @@ def _collect_prod(exp, multiplier, idMap, compute_values, verbose, quadratic):
     ans = Results()
     ans.constant = multiplier*lhs.constant * rhs.constant
     if not (lhs.constant.__class__ in native_numeric_types and lhs.constant == 0):
-        for key, coef in iteritems(rhs.linear):
+        for key, coef in rhs.linear.items():
             ans.linear[key] = multiplier*coef*lhs.constant
     if not (rhs.constant.__class__ in native_numeric_types and rhs.constant == 0):
-        for key, coef in iteritems(lhs.linear):
+        for key, coef in lhs.linear.items():
             if key in ans.linear:
                 ans.linear[key] += multiplier*coef*rhs.constant
             else:
@@ -601,26 +598,26 @@ def _collect_prod(exp, multiplier, idMap, compute_values, verbose, quadratic):
 
     if quadratic:
         if not (lhs.constant.__class__ in native_numeric_types and lhs.constant == 0):
-            for key, coef in iteritems(rhs.quadratic):
+            for key, coef in rhs.quadratic.items():
                 ans.quadratic[key] = multiplier*coef*lhs.constant
         if not (rhs.constant.__class__ in native_numeric_types and rhs.constant == 0):
-            for key, coef in iteritems(lhs.quadratic):
+            for key, coef in lhs.quadratic.items():
                 if key in ans.quadratic:
                     ans.quadratic[key] += multiplier*coef*rhs.constant
                 else:
                     ans.quadratic[key] = multiplier*coef*rhs.constant
-        for lkey, lcoef in iteritems(lhs.linear):
-            for rkey, rcoef in iteritems(rhs.linear):
+        for lkey, lcoef in lhs.linear.items():
+            for rkey, rcoef in rhs.linear.items():
                 ndx = (lkey, rkey) if lkey <= rkey else (rkey, lkey)
                 if ndx in ans.quadratic:
                     ans.quadratic[ndx] += multiplier*lcoef*rcoef
                 else:
                     ans.quadratic[ndx] = multiplier*lcoef*rcoef
         # TODO - Use quicksum here?
-        el_linear = multiplier*sum(coef*idMap[key] for key, coef in iteritems(lhs.linear))
-        er_linear = multiplier*sum(coef*idMap[key] for key, coef in iteritems(rhs.linear))
-        el_quadratic = multiplier*sum(coef*idMap[key[0]]*idMap[key[1]] for key, coef in iteritems(lhs.quadratic))
-        er_quadratic = multiplier*sum(coef*idMap[key[0]]*idMap[key[1]] for key, coef in iteritems(rhs.quadratic))
+        el_linear = multiplier*sum(coef*idMap[key] for key, coef in lhs.linear.items())
+        er_linear = multiplier*sum(coef*idMap[key] for key, coef in rhs.linear.items())
+        el_quadratic = multiplier*sum(coef*idMap[key[0]]*idMap[key[1]] for key, coef in lhs.quadratic.items())
+        er_quadratic = multiplier*sum(coef*idMap[key[0]]*idMap[key[1]] for key, coef in rhs.quadratic.items())
         ans.nonl += el_linear*er_quadratic + el_quadratic*er_linear
 
     return ans
@@ -1427,7 +1424,7 @@ def preprocess_constraint(block,
         block._repn = ComponentMap()
     block_repn = block._repn
 
-    for index, constraint_data in iteritems(constraint):
+    for index, constraint_data in constraint.items():
 
         if not constraint_data.active:
             continue

--- a/pyomo/repn/tests/gams/test_gams.py
+++ b/pyomo/repn/tests/gams/test_gams.py
@@ -13,7 +13,7 @@
 
 import os
 
-from six import StringIO
+from io import StringIO
 
 from filecmp import cmp
 import pyomo.common.unittest as unittest

--- a/pyomo/repn/tests/test_standard.py
+++ b/pyomo/repn/tests/test_standard.py
@@ -25,15 +25,13 @@ from pyomo.environ import AbstractModel, ConcreteModel, Var, Param, Set, Express
 import pyomo.kernel
 from pyomo.core.base.numvalue import native_numeric_types, as_numeric
 
-from six import iteritems
-from six.moves import range
 
 class frozendict(dict):
     __slots__ = ('_hash',)
     def __hash__(self):
         rval = getattr(self, '_hash', None)
         if rval is None:
-            rval = self._hash = hash(frozenset(iteritems(self)))
+            rval = self._hash = hash(frozenset(self.items()))
         return rval
 
 

--- a/pyomo/repn/tests/test_util.py
+++ b/pyomo/repn/tests/test_util.py
@@ -1,7 +1,17 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
 import logging
 
 import pyomo.common.unittest as unittest
-from six import StringIO
+from io import StringIO
 
 from pyomo.common.log import LoggingIntercept
 from pyomo.repn.util import ftoa

--- a/pyomo/scripting/util.py
+++ b/pyomo/scripting/util.py
@@ -17,7 +17,6 @@ import traceback
 import types
 import time
 import json
-from six import iteritems
 from pyomo.common import pyomo_api
 from pyomo.common.deprecation import deprecated
 from pyomo.common.log import is_debug_set
@@ -241,7 +240,7 @@ def create_model(data):
     #
     _models = {}
     _model_IDS = set()
-    for _name, _obj in iteritems(data.local.usermodel.__dict__):
+    for _name, _obj in data.local.usermodel.__dict__.items():
         if isinstance(_obj, Model) and id(_obj) not in _model_IDS:
             _models[_name] = _obj
             _model_IDS.add(id(_obj))

--- a/pyomo/solvers/plugins/converter/model.py
+++ b/pyomo/solvers/plugins/converter/model.py
@@ -10,7 +10,6 @@
 
 
 import os
-from six import iteritems
 
 from pyomo.common.tempfiles import TempfileManager
 from pyomo.opt.base import ProblemFormat
@@ -53,7 +52,7 @@ class PyomoMIPConverter(object):
         # all non-consumed keywords are assumed to be options
         # that should be passed to the writer.
         io_options = {}
-        for kwd, value in iteritems(kwds):
+        for kwd, value in kwds.items():
             io_options[kwd] = value
         kwds.clear()
 
@@ -94,7 +93,7 @@ class PyomoMIPConverter(object):
                         "The following io_options will be ignored "
                         "(please create a bug report):\n\t" +
                         "\n\t".join("%s = %s" % (k,v)
-                                    for k,v in iteritems(io_options)))
+                                    for k,v in io_options.items()))
 
                 ans = pyomo.scripting.convert.\
                       pyomo2lp(['--output',problem_filename,args[2]])
@@ -140,7 +139,7 @@ class PyomoMIPConverter(object):
                         "The following io_options will be ignored "
                         "(please create a bug report):\n\t" +
                         "\n\t".join("%s = %s" % (k,v)
-                                    for k,v in iteritems(io_options)))
+                                    for k,v in io_options.items()))
 
                 ans = pyomo.scripting.convert.\
                       pyomo2bar(['--output',problem_filename,args[2]])
@@ -197,7 +196,7 @@ class PyomoMIPConverter(object):
                         "The following io_options will be ignored "
                         "(please create a bug report):\n\t" +
                         "\n\t".join("%s = %s" % (k,v)
-                                    for k,v in iteritems(io_options)))
+                                    for k,v in io_options.items()))
 
                 ans = pyomo.scripting.convert.\
                       pyomo2nl(['--output',problem_filename,args[2]])

--- a/pyomo/solvers/plugins/solvers/BARON.py
+++ b/pyomo/solvers/plugins/solvers/BARON.py
@@ -26,8 +26,6 @@ from pyomo.opt.results import (
 )
 from pyomo.opt.solver import SystemCallSolver
 
-from six.moves import zip
-
 logger = logging.getLogger('pyomo.solvers')
 
 @SolverFactory.register('baron',  doc='The BARON MINLP solver')

--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -15,7 +15,6 @@ import re
 import time
 import logging
 import subprocess
-from six import iteritems
 
 from pyomo.common import Executable
 from pyomo.common.errors import ApplicationError
@@ -344,7 +343,7 @@ class CBCSHELL(SystemCallSolver):
             self._results_file = self._soln_file
 
         def _check_and_escape_options(options):
-            for key, val in iteritems(self.options):
+            for key, val in self.options.items():
                 tmp_k = str(key)
                 _bad = ' ' in tmp_k
 

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -37,9 +37,6 @@ from pyomo.util.components import iter_component
 
 logger = logging.getLogger('pyomo.solvers')
 
-from six import iteritems
-from six.moves import xrange
-
 
 def _validate_file_name(cplex, filename, description):
     """Validate filenames against the set of allowable chaacters in CPLEX.
@@ -691,7 +688,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 variable_value = None
                 variable_reduced_cost = None
                 variable_status = None
-                for i in xrange(1,len(tokens)):
+                for i in range(1,len(tokens)):
                     field_name =  tokens[i].split('=')[0]
                     field_value = tokens[i].split('=')[1].lstrip("\"").rstrip("\"")
                     if field_name == "name":
@@ -727,7 +724,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 is_range = False
                 rlabel = None
                 rkey = None
-                for i in xrange(1,len(tokens)):
+                for i in range(1,len(tokens)):
                     field_name =  tokens[i].split('=')[0]
                     field_value = tokens[i].split('=')[1].lstrip("\"").rstrip("\"")
                     if field_name == "name":
@@ -849,13 +846,13 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
 
         # For the range constraints, supply only the dual with the largest
         # magnitude (at least one should always be numerically zero)
-        for key,(ld,ud) in iteritems(range_duals):
+        for key,(ld,ud) in range_duals.items():
             if abs(ld) > abs(ud):
                 soln_constraints['r_l_'+key] = {"Dual" : ld}
             else:
                 soln_constraints['r_l_'+key] = {"Dual" : ud}                # Use the same key
         # slacks
-        for key,(ls,us) in iteritems(range_slacks):
+        for key,(ls,us) in range_slacks.items():
             if abs(ls) > abs(us):
                 soln_constraints.setdefault('r_l_'+key,{})["Slack"] = ls
             else:

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -8,7 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from six import StringIO, iteritems
+from io import StringIO
 import shlex
 from tempfile import mkdtemp
 import os, sys, math, logging, shutil, time, subprocess
@@ -486,7 +486,7 @@ class GAMSDirect(_GAMSSolver):
         soln.gap = abs(results.problem.upper_bound \
                        - results.problem.lower_bound)
 
-        for sym, ref in iteritems(symbolMap.bySymbol):
+        for sym, ref in symbolMap.bySymbol.items():
             obj = ref()
             if isinstance(model, IBlock):
                 # Kernel variables have no 'parent_component'
@@ -1007,7 +1007,7 @@ class GAMSShell(_GAMSSolver):
                        - results.problem.lower_bound)
 
         has_rc_info = True
-        for sym, ref in iteritems(symbolMap.bySymbol):
+        for sym, ref in symbolMap.bySymbol.items():
             obj = ref()
             if isinstance(model, IBlock):
                 # Kernel variables have no 'parent_component'

--- a/pyomo/solvers/plugins/solvers/GLPK.py
+++ b/pyomo/solvers/plugins/solvers/GLPK.py
@@ -22,8 +22,6 @@ from pyomo.opt import SolverFactory, OptSolver, ProblemFormat, ResultsFormat, So
 from pyomo.opt.base.solvers import _extract_version
 from pyomo.opt.solver import SystemCallSolver
 
-from six import iteritems
-
 logger = logging.getLogger('pyomo.solvers')
 
 _glpk_version = None
@@ -449,7 +447,7 @@ class GLPKSHELL(SystemCallSolver):
             # For the range constraints, supply only the dual with the largest
             # magnitude (at least one should always be numerically zero)
             scon = soln.Constraint
-            for key, (ld,ud) in iteritems(range_duals):
+            for key, (ld,ud) in range_duals.items():
                 if abs(ld) > abs(ud):
                     scon['r_l_'+key] = {"Dual":ld}
                 else:

--- a/pyomo/solvers/plugins/solvers/GLPK_old.py
+++ b/pyomo/solvers/plugins/solvers/GLPK_old.py
@@ -26,7 +26,6 @@ from pyomo.opt.solver import SystemCallSolver
 from pyomo.solvers.mockmip import MockMIP
 from pyomo.solvers.plugins.solvers.GLPK import _glpk_version, configure_glpk
 
-from six import iteritems
 import logging
 logger = logging.getLogger('pyomo.solvers')
 
@@ -395,7 +394,7 @@ class GLPKSHELL_4_42(SystemCallSolver):
             # For the range constraints, supply only the dual with the largest
             # magnitude (at least one should always be numerically zero)
             scon = soln.Constraint
-            for key,(ld,ud) in iteritems(range_duals):
+            for key,(ld,ud) in range_duals.items():
                 if abs(ld) > abs(ud):
                     scon['r_l_'+key] = {"Dual":ld}
                 else:

--- a/pyomo/solvers/plugins/solvers/GUROBI.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI.py
@@ -27,8 +27,6 @@ from pyomo.core.kernel.block import IBlock
 
 logger = logging.getLogger('pyomo.solvers')
 
-from six import iteritems
-
 
 @SolverFactory.register('gurobi', doc='The GUROBI LP/MIP solver')
 class GUROBI(OptSolver):
@@ -504,13 +502,13 @@ class GUROBISHELL(ILMLicensedSystemCallSolver):
 
         # For the range constraints, supply only the dual with the largest
         # magnitude (at least one should always be numerically zero)
-        for key,(ld,ud) in iteritems(range_duals):
+        for key,(ld,ud) in range_duals.items():
             if abs(ld) > abs(ud):
                 soln_constraints['r_l_'+key] = {"Dual" : ld}
             else:
                 soln_constraints['r_l_'+key] = {"Dual" : ud}                # Use the same key
         # slacks
-        for key,(ls,us) in iteritems(range_slacks):
+        for key,(ls,us) in range_slacks.items():
             if abs(ls) > abs(us):
                 soln_constraints.setdefault('r_l_'+key,{})["Slack"] = ls
             else:

--- a/pyomo/solvers/plugins/solvers/PICO.py
+++ b/pyomo/solvers/plugins/solvers/PICO.py
@@ -11,7 +11,6 @@
 import re
 import os
 import subprocess
-from six import iteritems
 
 from pyomo.common import Executable
 from pyomo.common.errors import  ApplicationError
@@ -181,7 +180,7 @@ class PICOSHELL(SystemCallSolver):
             #self._results_file = self.tmpDir+os.sep+"PICO.osrl.xml"
 
         def _check_and_escape_options(options):
-            for key, val in iteritems(self.options):
+            for key, val in self.options.items():
                 tmp_k = str(key)
                 _bad = ' ' in tmp_k
 
@@ -409,7 +408,7 @@ class PICOSHELL(SystemCallSolver):
                         range_duals.setdefault(var[4:],[0,0])[1] = val
             # For the range constraints, supply only the dual with the largest
             # magnitude (at least one should always be numerically zero)
-            for key,(ld,ud) in iteritems(range_duals):
+            for key,(ld,ud) in range_duals.items():
                 if abs(ld) > abs(ud):
                     soln_constraints['r_l_'+key] = {"Dual" : ld}
                 else:

--- a/pyomo/solvers/plugins/solvers/XPRESS.py
+++ b/pyomo/solvers/plugins/solvers/XPRESS.py
@@ -12,7 +12,6 @@
 import os
 import re
 import logging
-from six import string_types
 
 from pyomo.common import Executable
 from pyomo.common.errors import ApplicationError
@@ -302,7 +301,7 @@ class XPRESS_shell(ILMLicensedSystemCallSolver):
                 results.solver.termination_message = ' '.join(tokens)
 
         try:
-            if isinstance(results.solver.termination_message, string_types):
+            if isinstance(results.solver.termination_message, str):
                 results.solver.termination_message = results.solver.termination_message.replace(':', '\\x3a')
         except:
             pass

--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -10,7 +10,6 @@
 
 import logging
 import re
-import six
 import sys
 import itertools
 import operator
@@ -35,14 +34,7 @@ from pyomo.opt.results.solver import TerminationCondition, SolverStatus
 logger = logging.getLogger('pyomo.solvers')
 inf = float('inf')
 
-if six.PY2:
-    def accumulate(it):
-        total = 0
-        for x in it:
-            total += x
-            yield total
-else:
-    from itertools import accumulate
+from itertools import accumulate, filterfalse
 
 
 class DegreeError(ValueError):
@@ -332,7 +324,7 @@ class MOSEKDirect(DirectSolver):
         lq = tuple(filter(operator.attrgetter("_linear_canonical_form"),
                           con_seq))
         conic = tuple(filter(lambda x: isinstance(x, _ConicBase), con_seq))
-        lq_ex = tuple(six.moves.filterfalse(lambda x: isinstance(
+        lq_ex = tuple(filterfalse(lambda x: isinstance(
             x, _ConicBase) or (x._linear_canonical_form), con_seq))
         lq_all = lq + lq_ex
         num_lq = len(lq) + len(lq_ex)

--- a/pyomo/solvers/tests/checks/test_BARON.py
+++ b/pyomo/solvers/tests/checks/test_BARON.py
@@ -10,7 +10,7 @@
 
 """Tests the BARON interface."""
 
-from six import StringIO
+from io import StringIO
 
 import pyomo.common.unittest as unittest
 

--- a/pyomo/solvers/tests/checks/test_no_solution_behavior.py
+++ b/pyomo/solvers/tests/checks/test_no_solution_behavior.py
@@ -22,7 +22,7 @@ from pyomo.solvers.tests.models.base import test_models
 from pyomo.solvers.tests.testcases import test_scenarios
 from pyomo.common.log import LoggingIntercept
 
-from six import StringIO
+from io import StringIO
 
 # The test directory
 thisDir = os.path.dirname(os.path.abspath( __file__ ))

--- a/pyomo/solvers/tests/models/base.py
+++ b/pyomo/solvers/tests/models/base.py
@@ -10,7 +10,6 @@
 
 from os.path import join, dirname, abspath
 import json
-import six
 
 import pyomo.common.unittest as unittest
 
@@ -415,7 +414,7 @@ class _BaseTestModel(object):
 
 if __name__ == "__main__":
     import pyomo.solvers.tests.models
-    for key, value in six.iteritems(_test_models):
+    for key, value in _test_models.items():
         print(key)
         obj = value()
         obj.generate_model()

--- a/pyomo/solvers/tests/piecewise_linear/problems/tester.py
+++ b/pyomo/solvers/tests/piecewise_linear/problems/tester.py
@@ -11,8 +11,6 @@
 from pyomo.environ import Var, maximize, value
 from pyomo.opt import SolverFactory
 
-from six import itervalues
-
 opt = SolverFactory('cplexamp',solve_io='nl')
 
 kwds = {'pw_constr_type':'UB','pw_repn':'DCC','sense':maximize,'force_pw':True}
@@ -46,8 +44,8 @@ for problem_name in problem_names:
 
     res = dict()
     for block in inst.block_data_objects(active=True):
-        for variable in itervalues(block.component_map(Var, active=True)):
-            for var in itervalues(variable):
+        for variable in block.component_map(Var, active=True).values():
+            for var in variable.values():
                 name = var.name
                 if (name[:2] == 'Fx') or (name[:1] == 'x'):
                     res[name] = value(var)

--- a/pyomo/solvers/tests/solvers.py
+++ b/pyomo/solvers/tests/solvers.py
@@ -10,7 +10,6 @@
 
 __all__ = ['test_solver_cases', 'available_solvers']
 
-import six
 import logging
 
 from pyomo.common.collections import Bunch
@@ -426,7 +425,7 @@ def test_solver_cases(*args):
         #
         # Error Checks
         #
-        for sc in six.itervalues(_test_solver_cases):
+        for sc in _test_solver_cases.values():
             if sc.capabilities is None:
                 sc.capabilities = set([])
             if sc.export_suffixes is None:


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
Part of the Pyomo 6.0 effort is to replace the usage of six with the appropriate Python 3 methods. This does just that in the `repn` and `solvers` directories.

## Changes proposed in this PR:
- Remove `six` from `pyomo.repn`
- Remove `six` from `pyomo.solvers`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
