### PR TITLE
Remove `six` dependency

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -20,7 +20,7 @@ env:
   PYTHON_REQUIRED_PKGS: >
       nose coverage parameterized pybind11
   PYTHON_BASE_PKGS: >
-      ply six dill ipython networkx openpyxl pathos
+      ply dill ipython networkx openpyxl pathos
       pint pyro4 pyyaml sphinx_rtd_theme sympy xlrd
       python-louvain
   PYTHON_NUMPY_PKGS: >

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -23,7 +23,7 @@ env:
   PYTHON_REQUIRED_PKGS: >
       nose coverage parameterized pybind11
   PYTHON_BASE_PKGS: >
-      ply six dill ipython networkx openpyxl pathos
+      ply dill ipython networkx openpyxl pathos
       pint pyro4 pyyaml sphinx_rtd_theme sympy xlrd
       python-louvain
   PYTHON_NUMPY_PKGS: >

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -16,7 +16,6 @@ import sys
 import subprocess
 
 from collections import namedtuple
-from six import iteritems, itervalues
 
 import pyomo.common.unittest as unittest
 
@@ -58,7 +57,7 @@ def collect_import_time(module):
                 inner = data.pop()
                 inner.tpl = {
                     (k if '(from' in k else "%s (from %s)" % (k, _module),
-                     v) for k,v in iteritems(inner.tpl) }
+                     v) for k,v in inner.tpl.items() }
                 if _module.startswith('pyomo'):
                     data[_level].update(inner)
                     data[_level].pyomo[_module] = _self
@@ -94,9 +93,9 @@ class TestPyomoEnviron(unittest.TestCase):
                      "Import timing introduced in python 3.7")
     def test_tpl_import_time(self):
         data = collect_import_time('pyomo.environ')
-        pyomo_time = sum(itervalues(data.pyomo))
-        pyutilib_time = sum(itervalues(data.pyutilib))
-        tpl_time = sum(itervalues(data.tpl))
+        pyomo_time = sum(data.pyomo.values())
+        pyutilib_time = sum(data.pyutilib.values())
+        tpl_time = sum(data.tpl.values())
         total = float(pyomo_time + pyutilib_time + tpl_time)
         print("Pyomo (by module time):")
         print("\n".join("   %s: %s" % i for i in sorted(
@@ -107,7 +106,7 @@ class TestPyomoEnviron(unittest.TestCase):
         print("\n".join(_line_fmt % (k[:k.find(' ')], v, k[k.find(' '):])
                         for k,v in sorted(data.tpl.items())))
         tpl = {}
-        for k, v in iteritems(data.tpl):
+        for k, v in data.tpl.items():
             _mod = k[:k.find(' ')].split('.')[0]
             tpl[_mod] = tpl.get(_mod,0) + v
         tpl_by_time = sorted(tpl.items(), key=lambda x: x[1])
@@ -157,7 +156,6 @@ class TestPyomoEnviron(unittest.TestCase):
             'zipfile',
         }
         # Non-standard-library TPLs that Pyomo will load unconditionally
-        ref.add('six')
         ref.add('ply')
         if numpy_available:
             ref.add('numpy')

--- a/pyomo/util/tests/test_blockutil.py
+++ b/pyomo/util/tests/test_blockutil.py
@@ -11,7 +11,7 @@
 
 import logging
 
-from six import StringIO
+from io import StringIO
 
 import pyomo.common.unittest as unittest
 

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -9,7 +9,8 @@
 #  ___________________________________________________________________________
 
 import logging
-import six
+from io import StringIO
+
 import pyomo.common.unittest as unittest
 
 from pyomo.common.log import LoggingIntercept
@@ -169,13 +170,9 @@ class Test_calc_var(unittest.TestCase):
         # Starting with an invalid guess (above TC) should raise an
         # exception
         m.x.set_value(600)
-        output = six.StringIO()
+        output = StringIO()
         with LoggingIntercept(output, 'pyomo', logging.WARNING):
-            if six.PY2:
-                expectedException = ValueError
-            else:
-                expectedException = TypeError
-            with self.assertRaises(expectedException):
+            with self.assertRaises(TypeError):
                 calculate_variable_from_constraint(m.x, m.f, linesearch=False)
         self.assertIn('Encountered an error evaluating the expression '
                       'at the initial guess', output.getvalue())
@@ -190,7 +187,7 @@ class Test_calc_var(unittest.TestCase):
         calculate_variable_from_constraint(m.x, m.c, linesearch=True)
         self.assertAlmostEqual(value(m.x), 0.046415888)
         m.x = .1
-        output = six.StringIO()
+        output = StringIO()
         with LoggingIntercept(output, 'pyomo', logging.WARNING):
             with self.assertRaises(ValueError):
                 # Note that the ValueError is different between Python 2

--- a/pyomo/util/tests/test_components.py
+++ b/pyomo/util/tests/test_components.py
@@ -8,7 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from six.moves import zip_longest
+from itertools import zip_longest
 
 import pyomo.common.unittest as unittest
 

--- a/pyomo/util/tests/test_infeasible.py
+++ b/pyomo/util/tests/test_infeasible.py
@@ -11,7 +11,7 @@
 """Tests infeasible model debugging utilities."""
 import logging
 
-from six import StringIO
+from io import StringIO
 
 import pyomo.common.unittest as unittest
 from pyomo.common.log import LoggingIntercept

--- a/pyomo/util/tests/test_model_size.py
+++ b/pyomo/util/tests/test_model_size.py
@@ -12,7 +12,7 @@
 import logging
 from os.path import abspath, dirname, join, normpath
 
-from six import StringIO
+from io import StringIO
 
 import pyomo.common.unittest as unittest
 from pyomo.common.log import LoggingIntercept

--- a/scripts/performance/compare_components.py
+++ b/scripts/performance/compare_components.py
@@ -44,9 +44,6 @@ try:
 except:
     pympler_available = False
 
-import six
-from six.moves import xrange as range
-from six.moves import zip
 
 pympler_kwds = {}
 

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,6 @@ def run_setup():
       install_requires=[
           'PyUtilib>=6.0.1.dev0',
           'ply',
-          'six>=1.4',
       ],
       packages=find_packages(exclude=("scripts",)),
       package_data={"pyomo.contrib.viewer":["*.ui"]},


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
As part of Pyomo 6.0, we want to remove all instances of `six`. This removes all of the remaining ones, including entirely removing the dependency.

## Changes proposed in this PR:
- Remove `six` from residual files
- Remove `six` as a dependency

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
