### PR TITLE
Timing improvements

### DIFF
--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -51,10 +51,10 @@ class TestTeeStream(unittest.TestCase):
             # flush() and short pause should help
             t.STDOUT.write("Hello\nWorld")
             t.STDOUT.flush()
-            time.sleep(tee._poll_interval*2)
+            time.sleep(tee._poll_interval*20)
             t.STDERR.write("interrupting\ncow")
             t.STDERR.flush()
-            time.sleep(tee._poll_interval*3)
+            time.sleep(tee._poll_interval*30)
         self.assertEqual(a.getvalue(), "Hello\ninterrupting\ncowWorld")
         self.assertEqual(b.getvalue(), "Hello\ninterrupting\ncowWorld")
 

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -11,6 +11,7 @@
 import pyomo.common.unittest as unittest
 from pyomo.common.tee import capture_output
 
+import gc
 from io import StringIO
 import sys
 import time
@@ -21,6 +22,14 @@ from pyomo.common.timing import (ConstructionTimer, report_timing,
 from pyomo.environ import ConcreteModel, RangeSet, Var, TransformationFactory
 
 class TestTiming(unittest.TestCase):
+    def setUp(self):
+        self.reenable_gc = gc.isenabled()
+        gc.disable()
+
+    def tearDown(self):
+        if self.reenable_gc:
+            gc.enable()
+
     def test_raw_construction_timer(self):
         a = ConstructionTimer(None)
         self.assertIn(
@@ -86,7 +95,7 @@ class TestTiming(unittest.TestCase):
 
     def test_TicTocTimer_tictoc(self):
         SLEEP = 0.1
-        RES = 0.02 # resolution (seconds): 1/5 the sleep
+        RES = 0.01 # resolution (seconds): 1/10 the sleep
         timer = TicTocTimer()
         abs_time = time.time()
 
@@ -143,7 +152,7 @@ class TestTiming(unittest.TestCase):
         # Note: pypy on GHA frequently has timing differences of >0.05s
         # for the following tests
         if 'pypy_version_info' in dir(sys):
-            RES = 6.5e-2
+            RES = 0.065
 
         with capture_output() as out:
             delta = timer.toc()
@@ -165,7 +174,7 @@ class TestTiming(unittest.TestCase):
         )
 
     def test_HierarchicalTimer(self):
-        RES = 1e-2 # resolution (seconds)
+        RES = 0.01 # resolution (seconds)
 
         timer = HierarchicalTimer()
         start_time = time.time()

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -152,6 +152,7 @@ class TestPyomoEnviron(unittest.TestCase):
             'gzip',
             'imp',
             'runpy',
+            'six',
             'tarfile',
             'zipfile',
         }


### PR DESCRIPTION
## Fixes # N/A

## Summary/Motivation:
This improves two timing-related issues in Pyomo:
- the `test_timing.py` have been somewhat fragile.  This PR disables the GC during the tests to hopefully reduce the test-to-test variability
- This does an overhaul of the polling interval used by TeeStream to poll more aggressively at the beginning of the subprocess and then slower as the process proceeds.  This reduces the overhead that TeeStream adds to short-running processes.  This partially addresses platform runtime differences observed in IDAES/idaes-pse#293.

## Changes proposed in this PR:
- Move polling to leverage a "sliding scale" for both processing output and thread cleanup
- Disable GC during `pyomo.common.timing` tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
