### PR TITLE
Improve robustness of doctest tests

### DIFF
--- a/doc/OnlineDocs/contributed_packages/sensitivity_toolbox.rst
+++ b/doc/OnlineDocs/contributed_packages/sensitivity_toolbox.rst
@@ -66,13 +66,11 @@ And finally we call sIPOPT:
 
     >>> m_sipopt = sipopt(m,[m.eta1,m.eta2], [m.perturbed_eta1,m.perturbed_eta2], streamSoln=True)
     Ipopt ...: run_sens=yes
-    ...
-    ******************************************************************************
+    ...***************************************************************************
     This program contains Ipopt, a library for large-scale nonlinear optimization.
      Ipopt is released as open source code under the Eclipse Public License (EPL).
              For more information visit http://projects.coin-or.org/Ipopt
-    ...
-    ******************************************************************************
+    ...***************************************************************************
     ...
     EXIT: Optimal Solution Found.
 

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -620,6 +620,13 @@ Key information from the ConfigDict is automatically transferred over
 to the ArgumentParser object:
 
 .. doctest::
+   :hide:
+
+    >>> import os
+    >>> original_environ, os.environ = os.environ, os.environ.copy()
+    >>> os.environ['COLUMNS'] = '80'
+
+.. doctest::
 
     >>> print(parser.format_help())
     usage: tester [-h] [--iterlim INT] [--lbfgs] [--disable-linesearch]
@@ -637,6 +644,11 @@ to the ArgumentParser object:
       --abstol FLOAT, -a FLOAT
                             absolute convergence tolerance
     <BLANKLINE>
+
+.. doctest::
+   :hide:
+
+    >>> os.environ = original_environ
 
 Parsed arguments can then be imported back into the ConfigDict:
 

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -526,7 +526,7 @@ class TestConfig(unittest.TestCase):
     def setUp(self):
         # Save the original environment, then force a fixed column width
         # so tests do not fail on some platforms (notably, OSX)
-        self.original_environ = os.environ
+        self.original_environ, os.environ = os.environ, os.environ.copy()
         os.environ["COLUMNS"] = "80"
 
         self.config = config = ConfigDict(


### PR DESCRIPTION
## Fixes # N/A

## Summary/Motivation:
This small PR improves the robustness of doctests when running on a developer's machine.

## Changes proposed in this PR:
- Support using vanilla Ipopt for `sensitivity_toolbox` tests
- Force consistent `config.py` output when running on terminals with width != 80

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
