### PR TITLE
Update expected CBC test failures

### DIFF
--- a/pyomo/solvers/tests/checks/test_no_solution_behavior.py
+++ b/pyomo/solvers/tests/checks/test_no_solution_behavior.py
@@ -75,15 +75,6 @@ def create_test_method(model,
             # file with garbage values in it for a failed solve
             self.assertEqual(len(results.solution), 1)
 
-    # 03/23/2021: IDAES-ext added CBC 2.10.4 to their official release
-    #             This is causing failures in this test.
-    #             Manually turning off CBC tests until a solution can be found.
-    #             - mrmundt
-    if solver == 'cbc':
-        def skipping_test(self):
-            self.skipTest('SKIP: cbc currently does not work.')
-        return skipping_test
-
     # Skip this test if the status is 'skip'
     if test_case.status == 'skip':
         def skipping_test(self):

--- a/pyomo/solvers/tests/checks/test_pickle.py
+++ b/pyomo/solvers/tests/checks/test_pickle.py
@@ -103,15 +103,6 @@ def create_test_method(model, solver, io,
         # then unpickle and load status
         inst, res = pickle.loads(pickle.dumps([instance3,status3]))
 
-    # 03/23/2021: IDAES-ext added CBC 2.10.4 to their official release
-    #             This is causing failures in this test.
-    #             Manually turning off CBC tests until a solution can be found.
-    #             - mrmundt
-    if solver == 'cbc':
-        def skipping_test(self):
-            self.skipTest('SKIP: cbc currently does not work.')
-        return skipping_test
-
     # Skip this test if the status is 'skip'
     if test_case.status == 'skip':
         def skipping_test(self):

--- a/pyomo/solvers/tests/checks/test_writers.py
+++ b/pyomo/solvers/tests/checks/test_writers.py
@@ -118,15 +118,6 @@ def create_test_method(model,
         except OSError:
             pass
 
-    # 03/23/2021: IDAES-ext added CBC 2.10.4 to their official release
-    #             This is causing failures in this test.
-    #             Manually turning off CBC tests until a solution can be found.
-    #             - mrmundt
-    if solver == 'cbc':
-        def skipping_test(self):
-            self.skipTest('SKIP: cbc currently does not work.')
-        return skipping_test
-
     # Skip this test if the status is 'skip'
     if test_case.status == 'skip':
         def skipping_test(self):

--- a/pyomo/solvers/tests/testcases.py
+++ b/pyomo/solvers/tests/testcases.py
@@ -106,8 +106,25 @@ ExpectedFailures['glpk', 'mps', 'LP_duals_maximize'] = \
 
 ExpectedFailures['cbc', 'nl', 'MILP_unbounded'] = \
     (lambda v: v <= _trunk_version,
-     "Cbc fails to report a MILP model as unbounded when it"
-     "is defined as an NL file.")
+     "Cbc fails to report an unbounded MILP model as unbounded through "
+     "the NL interface (through 2.9.x), and fails with invalid free() "
+     "(in 2.10.x).")
+
+ExpectedFailures['cbc', 'nl', 'LP_unbounded'] = \
+    (lambda v: v[:2] == (2, 10),
+     "Cbc fails (invalid free()) for unbounded LP models through "
+     "the NL interface in 2.10.x versions "
+     "(reported upstream as coin-or/Cbc#389)")
+
+ExpectedFailures['cbc', 'nl', 'SOS1_simple'] = \
+    (lambda v: v[:2] == (2, 10),
+     "Cbc segfaults for SOS constraints in the NL interface "
+     "(reported upstream as coin-or/Cbc#388)")
+
+ExpectedFailures['cbc', 'nl', 'SOS2_simple'] = \
+    (lambda v: v[:2] == (2, 10),
+     "Cbc segfaults for SOS constraints in the NL interface "
+     "(reported upstream as coin-or/Cbc#388)")
 
 #
 # PICO


### PR DESCRIPTION
## Fixes #1295

## Summary/Motivation:
In #1882 we disabled all CBC tests because newer builds of CBC started exhibiting new failures.  We have since looked in to the failures and have reported the relevant ones upstream (as coin-or/Cbc#388 and coin-or/Cbc#389).  This re-enables the CBC tests with appropriate version-specific skips.

This "fixes" #1295 by marking these new failures as "expected" (as they have been verified as CBC issues and not Pyomo interface issues)

## Changes proposed in this PR:
- Set `LP_unbounded`, `SOS1_simple`, and `SOS2_simple` as expected failures in CBC 2.10.x

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
