### PR TITLE
Update timing test thresholds

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -41,7 +41,6 @@ jobs:
         python: [3.9]
         other: [""]
         category: ["nightly"]
-        skip_doctest: [1]
         # Ubuntu-18.04 should be replaced with ubuntu-latest once PyNumero
         # build error is resolved:
         # https://github.com/Pyomo/pyomo/issues/1710
@@ -51,21 +50,25 @@ jobs:
           python: pypy3
           TARGET: linux
           PYENV: pip
+          skip_doctest: 1
 
         - os: ubuntu-18.04
           TARGET: linux
           PYENV: pip
+          skip_doctest: 1
 
         - os: macos-latest
           python: 3.8
           TARGET: osx
           PYENV: pip
+          skip_doctest: 1
 
         - os: windows-latest
           python: 3.7
           TARGET: win
           PYENV: conda
           PACKAGES: glpk
+          skip_doctest: 1
 
         - os: ubuntu-18.04
           python: 3.8

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -47,28 +47,19 @@ jobs:
 
         include:
         - os: ubuntu-18.04
-          python: pypy3
           TARGET: linux
           PYENV: pip
-          skip_doctest: 1
-
-        - os: ubuntu-18.04
-          TARGET: linux
-          PYENV: pip
-          skip_doctest: 1
 
         - os: macos-latest
           python: 3.8
           TARGET: osx
           PYENV: pip
-          skip_doctest: 1
 
         - os: windows-latest
           python: 3.7
           TARGET: win
           PYENV: conda
           PACKAGES: glpk
-          skip_doctest: 1
 
         - os: ubuntu-18.04
           python: 3.8
@@ -509,8 +500,8 @@ jobs:
         for cat in ${{matrix.category}}; do
             CATEGORY+=" --cat $cat"
         done
-        #$PYTHON_EXE -m pyomo.common.unittest pyomo `pwd`/pyomo-model-libraries -v $CATEGORY
-        $PYTHON_EXE -m pyomo.common.unittest pyomo.common -v
+        $PYTHON_EXE -m pyomo.common.unittest \
+            pyomo `pwd`/pyomo-model-libraries -v $CATEGORY
 
     - name: Run Pyomo MPI tests
       if: matrix.mpi != 0

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -47,6 +47,11 @@ jobs:
 
         include:
         - os: ubuntu-18.04
+          python: pypy3
+          TARGET: linux
+          PYENV: pip
+
+        - os: ubuntu-18.04
           TARGET: linux
           PYENV: pip
 
@@ -500,7 +505,8 @@ jobs:
         for cat in ${{matrix.category}}; do
             CATEGORY+=" --cat $cat"
         done
-        $PYTHON_EXE -m pyomo.common.unittest pyomo `pwd`/pyomo-model-libraries -v $CATEGORY
+        #$PYTHON_EXE -m pyomo.common.unittest pyomo `pwd`/pyomo-model-libraries -v $CATEGORY
+        $PYTHON_EXE -m pyomo.common.unittest pyomo.common -v
 
     - name: Run Pyomo MPI tests
       if: matrix.mpi != 0

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04]
-        python: [3.8]
+        python: [3.9]
         other: [""]
         category: ["nightly"]
         # Ubuntu-18.04 should be replaced with ubuntu-latest once PyNumero
@@ -51,7 +51,7 @@ jobs:
           PYENV: pip
 
         - os: macos-latest
-          python: 3.6
+          python: 3.8
           TARGET: osx
           PYENV: pip
 

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -41,6 +41,7 @@ jobs:
         python: [3.9]
         other: [""]
         category: ["nightly"]
+        skip_doctest: [1]
         # Ubuntu-18.04 should be replaced with ubuntu-latest once PyNumero
         # build error is resolved:
         # https://github.com/Pyomo/pyomo/issues/1710

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -513,7 +513,8 @@ jobs:
         for cat in ${{matrix.category}}; do
             CATEGORY+=" --cat $cat"
         done
-        $PYTHON_EXE -m pyomo.common.unittest pyomo `pwd`/pyomo-model-libraries -v $CATEGORY
+        $PYTHON_EXE -m pyomo.common.unittest \
+            pyomo `pwd`/pyomo-model-libraries -v $CATEGORY
 
     - name: Run Pyomo MPI tests
       if: matrix.mpi != 0

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -44,7 +44,6 @@ jobs:
         python: [3.6, 3.7, 3.8, 3.9, pypy3]
         other: [""]
         category: ["nightly"]
-        skip_doctest: [1]
         # Ubuntu-18.04 should be replaced with ubuntu-latest once PyNumero
         # build error is resolved:
         # https://github.com/Pyomo/pyomo/issues/1710

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -44,6 +44,7 @@ jobs:
         python: [3.6, 3.7, 3.8, 3.9, pypy3]
         other: [""]
         category: ["nightly"]
+        skip_doctest: [1]
         # Ubuntu-18.04 should be replaced with ubuntu-latest once PyNumero
         # build error is resolved:
         # https://github.com/Pyomo/pyomo/issues/1710

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -156,7 +156,7 @@ class TestTiming(unittest.TestCase):
         # Note: pypy on GHA frequently has timing differences of >0.05s
         # for the following tests
         if 'pypy_version_info' in dir(sys):
-            RES = 0.065
+            RES = 0.01
 
         # Note: osx(python 3.8) on GHA frequently has timing differences
         # of >0.02s

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -153,15 +153,10 @@ class TestTiming(unittest.TestCase):
         timer.start()
         time.sleep(SLEEP)
 
-        # Note: pypy on GHA frequently has timing differences of >0.05s
-        # for the following tests
-        if 'pypy_version_info' in dir(sys):
-            RES = 0.01
-
-        # Note: osx(python 3.8) on GHA frequently has timing differences
-        # of >0.02s
-        if sys.platform == 'darwin':
-            RES = 0.01
+        # Note: pypy and osx (py3.8) on GHA occasionally have timing
+        # differences of >0.01s for the following tests
+        if 'pypy_version_info' in dir(sys) or sys.platform == 'darwin':
+            RES *= 2
 
         with capture_output() as out:
             ref += time.time()

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -161,7 +161,7 @@ class TestTiming(unittest.TestCase):
         # Note: osx(python 3.8) on GHA frequently has timing differences
         # of >0.02s
         if sys.platform == 'darwin':
-            RES = 0.03
+            RES = 0.01
 
         with capture_output() as out:
             ref += time.time()

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -96,8 +96,8 @@ class TestTiming(unittest.TestCase):
     def test_TicTocTimer_tictoc(self):
         SLEEP = 0.1
         RES = 0.01 # resolution (seconds): 1/10 the sleep
-        timer = TicTocTimer()
         abs_time = time.time()
+        timer = TicTocTimer()
 
         time.sleep(SLEEP)
 
@@ -116,28 +116,31 @@ class TestTiming(unittest.TestCase):
 
         time.sleep(SLEEP)
 
+        ref = time.time()
         with capture_output() as out:
             delta = timer.toc()
-        self.assertAlmostEqual(time.time() - start_time, delta, delta=RES)
+        self.assertAlmostEqual(ref - start_time, delta, delta=RES)
         self.assertAlmostEqual(0, timer.toc(None), delta=RES)
         self.assertRegex(
             out.getvalue(),
             r'\[\+   [.0-9]+\] .* in test_TicTocTimer_tictoc'
         )
+        ref = time.time()
         with capture_output() as out:
             total = timer.toc(delta=False)
-        self.assertAlmostEqual(time.time() - abs_time, total, delta=RES)
+        self.assertAlmostEqual(ref - abs_time, total, delta=RES)
         self.assertRegex(
             out.getvalue(),
             r'\[    [.0-9]+\] .* in test_TicTocTimer_tictoc'
         )
 
-        ref = 0
-        ref -= time.time()
+        ref *= -1
         time.sleep(SLEEP)
-        timer.stop()
+
         ref += time.time()
+        timer.stop()
         cumul_stop1 = timer.toc(None)
+        self.assertAlmostEqual(ref, cumul_stop1, delta=RES)
         with self.assertRaisesRegex(
                 RuntimeError,
                 'Stopping a TicTocTimer that was already stopped'):
@@ -145,8 +148,9 @@ class TestTiming(unittest.TestCase):
         time.sleep(SLEEP)
         cumul_stop2 = timer.toc(None)
         self.assertEqual(cumul_stop1, cumul_stop2)
-        timer.start()
+
         ref -= time.time()
+        timer.start()
         time.sleep(SLEEP)
 
         # Note: pypy on GHA frequently has timing differences of >0.05s
@@ -154,10 +158,15 @@ class TestTiming(unittest.TestCase):
         if 'pypy_version_info' in dir(sys):
             RES = 0.065
 
+        # Note: osx(python 3.8) on GHA frequently has timing differences
+        # of >0.02s
+        if sys.platform == 'darwin':
+            RES = 0.03
+
         with capture_output() as out:
-            delta = timer.toc()
-            timer.stop()
             ref += time.time()
+            timer.stop()
+            delta = timer.toc()
         self.assertAlmostEqual(ref, delta, delta=RES)
         #self.assertAlmostEqual(0, timer.toc(None), delta=RES)
         self.assertRegex(


### PR DESCRIPTION
## Fixes # N/A

## Summary/Motivation:
This is another attempt to reduce variation in the `pyomo.common.timing` tests.  Verified that recent changes appear to enable tighter thresholds for pypy, but slightly looser thresholds for OSX.

## Changes proposed in this PR:
- Improve robustness of timing tests (the reference timer better tracks the TicToc timer)
- Tighten the acceptable pypy delta
- Loosen (slightly) the acceptable OSX delta

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
