### PR TITLE
reduce errors logged with value when exception is False

### DIFF
--- a/pyomo/core/expr/visitor.py
+++ b/pyomo/core/expr/visitor.py
@@ -929,6 +929,9 @@ def sizeof_expression(expr):
 
 class _EvaluationVisitor(ExpressionValueVisitor):
 
+    def __init__(self, exception):
+        self.exception = exception
+
     def visit(self, node, values):
         """ Visit nodes that have been expanded """
         return node._apply_operation(values)
@@ -946,9 +949,9 @@ class _EvaluationVisitor(ExpressionValueVisitor):
             return False, None
 
         if node.is_numeric_type():
-            return True, value(node)
+            return True, value(node, exception=self.exception)
         elif node.is_logical_type():
-            return True, value(node)
+            return True, value(node, exception=self.exception)
         else:
             return True, node
 
@@ -1036,7 +1039,7 @@ def evaluate_expression(exp, exception=True, constant=False):
     if constant:
         visitor = _EvaluateConstantExpressionVisitor()
     else:
-        visitor = _EvaluationVisitor()
+        visitor = _EvaluationVisitor(exception=exception)
     try:
         return visitor.dfs_postorder_stack(exp)
 

--- a/pyomo/core/tests/unit/test_numeric_expr.py
+++ b/pyomo/core/tests/unit/test_numeric_expr.py
@@ -22,6 +22,8 @@ currdir = dirname(abspath(__file__))+os.sep
 
 from filecmp import cmp
 import pyomo.common.unittest as unittest
+from pyomo.common.log import LoggingIntercept
+from io import StringIO
 
 from pyomo.environ import ConcreteModel, AbstractModel, RangeSet, Var, Param, Set, Constraint, ConstraintList, Expression, Objective, Reals, ExternalFunction, PositiveReals, log10, exp, floor, ceil, log, cos, sin, tan, acos, asin, atan, sinh, cosh, tanh, acosh, asinh, atanh, sqrt, value, quicksum, sum_product, is_fixed, is_constant
 from pyomo.kernel import variable, expression, objective
@@ -5242,6 +5244,18 @@ class TestDirect_LinearExpression(unittest.TestCase):
 
         self.assertFalse(is_fixed(m.c1.body))
         self.assertEqual(polynomial_degree(m.c1.body), 1)
+
+
+class TestEvaluation(unittest.TestCase):
+    def test_log_error(self):
+        m = ConcreteModel()
+        m.x = Var()
+        e = m.x**2
+        os = StringIO()
+        with LoggingIntercept(os, 'pyomo'):
+            e_val = value(e, exception=False)
+            self.assertIsNone(e_val)
+        self.assertEqual(os.getvalue(), '')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary/Motivation:
When evaluating expressions with `value(expr, exception=False)`, errors still get logged when variables do not have values. This PR propagates the `exception` flag to the `_EvaluationVisitor` to prevent logging such errors.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
