### PR TITLE
Prevent exception from DeferredImportModule in `nose --with-coverage`

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -109,6 +109,8 @@ class DeferredImportModule(object):
     def __init__(self, indicator, deferred_submodules, submodule_name):
         self._indicator_flag = indicator
         self._submodule_name = submodule_name
+        self.__file__ = None # Disable nose's coverage of this module
+        self.__spec__ = None # Indicate that this is not a "real" module
 
         if not deferred_submodules:
             return


### PR DESCRIPTION
## Fixes #1947

## Summary/Motivation:
`attempt_import()` support of "deep imports" of deferred modules broke `nose`'s coverage plugin.  This patch provides a workaround.

## Changes proposed in this PR:
- Prevent use of `nose --with-coverage` from generting an import exception for unavailable DeferredImportModules

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
