### PR TITLE
improving interval arithmetic for some special cases

### DIFF
--- a/pyomo/contrib/fbbt/fbbt.py
+++ b/pyomo/contrib/fbbt/fbbt.py
@@ -148,7 +148,7 @@ def _prop_bnds_leaf_to_root_PowExpression(node, bnds_dict, feasibility_tol):
     arg1, arg2 = node.args
     lb1, ub1 = bnds_dict[arg1]
     lb2, ub2 = bnds_dict[arg2]
-    bnds_dict[node] = interval.power(lb1, ub1, lb2, ub2)
+    bnds_dict[node] = interval.power(lb1, ub1, lb2, ub2, feasibility_tol=feasibility_tol)
 
 
 def _prop_bnds_leaf_to_root_ReciprocalExpression(node, bnds_dict, feasibility_tol):
@@ -388,7 +388,7 @@ def _prop_bnds_leaf_to_root_sqrt(node, bnds_dict, feasibility_tol):
     assert len(node.args) == 1
     arg = node.args[0]
     lb1, ub1 = bnds_dict[arg]
-    bnds_dict[node] = interval.power(lb1, ub1, 0.5, 0.5)
+    bnds_dict[node] = interval.power(lb1, ub1, 0.5, 0.5, feasibility_tol=feasibility_tol)
 
 
 _unary_leaf_to_root_map = dict()
@@ -792,7 +792,7 @@ def _prop_bnds_root_to_leaf_log10(node, bnds_dict, feasibility_tol):
     arg = node.args[0]
     lb0, ub0 = bnds_dict[node]
     lb1, ub1 = bnds_dict[arg]
-    _lb1, _ub1 = interval.power(10, 10, lb0, ub0)
+    _lb1, _ub1 = interval.power(10, 10, lb0, ub0, feasibility_tol=feasibility_tol)
     if _lb1 > lb1:
         lb1 = _lb1
     if _ub1 < ub1:

--- a/pyomo/contrib/fbbt/interval.py
+++ b/pyomo/contrib/fbbt/interval.py
@@ -44,7 +44,7 @@ def inv(xl, xu, feasibility_tol):
     but should be very slightly positive) should not be an issue. Suppose xu is 2 and xl is 1e-15 but should be -1e-15.
     The bounds obtained from this function will be [0.5, 1e15] or [0.5, inf), depending on the value of
     feasibility_tol. The true bounds are (-inf, -1e15] U [0.5, inf), where U is union. The exclusion of (-inf, -1e15]
-    should be acceptable. Additionally, it very important to return [0, 1/xu] when xl is 0.
+    should be acceptable. Additionally, it very important to return a non-negative interval when xl is non-negative.
     """
     if xu <= 0 <= xl:
         if abs(xl - xu) <= feasibility_tol:

--- a/pyomo/contrib/fbbt/interval.py
+++ b/pyomo/contrib/fbbt/interval.py
@@ -39,19 +39,43 @@ def mul(xl, xu, yl, yu):
 
 
 def inv(xl, xu, feasibility_tol):
-    if xl <= feasibility_tol and xu >= -feasibility_tol:
-        # if the denominator (x) can include 0, then 1/x is unbounded.
-        lb = -inf
+    """
+    The case where xl is very slightly positive but should be very slightly negative (or xu is very slightly negative
+    but should be very slightly positive) should not be an issue. Suppose xu is 2 and xl is 1e-15 but should be -1e-15.
+    The bounds obtained from this function will be [0.5, 1e15] or [0.5, inf), depending on the value of
+    feasibility_tol. The true bounds are (-inf, -1e15] U [0.5, inf), where U is union. The exclusion of (-inf, -1e15]
+    should be acceptable. Additionally, it very important to return [0, 1/xu] when xl is 0.
+    """
+    if xu <= 0 <= xl:
+        if abs(xl - xu) <= feasibility_tol:
+            raise IntervalException(f'Division by zero in inv; xl: {xl}; xu: {xu}')
+        else:
+            raise InfeasibleConstraintException(f'lower bound is greater than upper bound in inv; xl: {xl}; xu: {xu}')
+    elif 0 <= xl <= feasibility_tol:
+        # xu must be strictly positive
         ub = inf
-    else:
+        lb = 1.0 / xu
+    elif xl > feasibility_tol:
+        # xl and xu must be strictly positive
         ub = 1.0 / xl
         lb = 1.0 / xu
+    elif -feasibility_tol <= xu <= 0:
+        # xl must be strictly negative
+        lb = -inf
+        ub = 1.0 / xl
+    elif xu < -feasibility_tol:
+        # xl and xu must be strictly negative
+        ub = 1.0 / xl
+        lb = 1.0 / xu
+    else:
+        # everything else
+        lb = -inf
+        ub = inf
     return lb, ub
 
 
 def div(xl, xu, yl, yu, feasibility_tol):
-    if yl <= feasibility_tol and yu >= -feasibility_tol:
-        # if the denominator (y) can include 0, then x/y is unbounded.
+    if xl <= 0 <= xu and yl <= 0 <= yu:
         lb = -inf
         ub = inf
     else:
@@ -59,7 +83,7 @@ def div(xl, xu, yl, yu, feasibility_tol):
     return lb, ub
 
 
-def power(xl, xu, yl, yu):
+def power(xl, xu, yl, yu, feasibility_tol):
     """
     Compute bounds on x**y.
     """
@@ -67,7 +91,7 @@ def power(xl, xu, yl, yu):
         """
         If x is always positive, things are simple. We only need to worry about the sign of y.
         """
-        if yl < 0 and yu > 0:
+        if yl < 0 < yu:
             lb = min(xu ** yl, xl ** yu)
             ub = max(xl ** yl, xu ** yu)
         elif yl >= 0:
@@ -82,9 +106,13 @@ def power(xl, xu, yl, yu):
         if yl >= 0:
             lb = min(xl ** yl, xl ** yu)
             ub = max(xu ** yl, xu ** yu)
+        elif yu <= 0:
+            lb, ub = inv(*power(xl, xu, *sub(0, 0, yl, yu), feasibility_tol), feasibility_tol)
         else:
-            lb = -inf
-            ub = inf
+            lb1, ub1 = power(xl, xu, 0, yu, feasibility_tol)
+            lb2, ub2 = power(xl, xu, yl, 0, feasibility_tol)
+            lb = min(lb1, lb2)
+            ub = max(ub1, ub2)
     elif yl == yu and yl == round(yl):
         # the exponent is an integer, so x can be negative
         """
@@ -140,7 +168,7 @@ def power(xl, xu, yl, yu):
             msg += 'The upper bound of a variable raised to the power of {0} is {1}'.format(yl, xu)
             raise InfeasibleConstraintException(msg)
         xl = 0
-        lb, ub = power(xl, xu, yl, yu)
+        lb, ub = power(xl, xu, yl, yu, feasibility_tol)
     else:
         lb = -inf
         ub = inf

--- a/pyomo/contrib/fbbt/interval.py
+++ b/pyomo/contrib/fbbt/interval.py
@@ -46,11 +46,10 @@ def inv(xl, xu, feasibility_tol):
     feasibility_tol. The true bounds are (-inf, -1e15] U [0.5, inf), where U is union. The exclusion of (-inf, -1e15]
     should be acceptable. Additionally, it very important to return a non-negative interval when xl is non-negative.
     """
-    if xu <= 0 <= xl:
-        if abs(xl - xu) <= feasibility_tol:
-            raise IntervalException(f'Division by zero in inv; xl: {xl}; xu: {xu}')
-        else:
-            raise InfeasibleConstraintException(f'lower bound is greater than upper bound in inv; xl: {xl}; xu: {xu}')
+    if xu - xl <= -feasibility_tol:
+        raise InfeasibleConstraintException(f'lower bound is greater than upper bound in inv; xl: {xl}; xu: {xu}')
+    elif xu <= 0 <= xl:
+        raise IntervalException(f'Division by zero in inv; xl: {xl}; xu: {xu}')
     elif 0 <= xl <= feasibility_tol:
         # xu must be strictly positive
         ub = inf

--- a/pyomo/contrib/fbbt/interval.py
+++ b/pyomo/contrib/fbbt/interval.py
@@ -97,11 +97,9 @@ def power(xl, xu, yl, yu, feasibility_tol):
         elif yl >= 0:
             lb = min(xl**yl, xl**yu)
             ub = max(xu**yl, xu**yu)
-        elif yu <= 0:
+        else:  # yu <= 0:
             lb = min(xu**yl, xu**yu)
             ub = max(xl**yl, xl**yu)
-        else:
-            raise DeveloperError()
     elif xl == 0:
         if yl >= 0:
             lb = min(xl ** yl, xl ** yu)

--- a/pyomo/contrib/fbbt/tests/test_fbbt.py
+++ b/pyomo/contrib/fbbt/tests/test_fbbt.py
@@ -236,10 +236,9 @@ class TestFBBT(unittest.TestCase):
                     yu = np.inf
                 else:
                     yu = m.y.ub
-                for _x in x:
-                    _y = np.exp(np.log(abs(z)) / _x)
-                    self.assertTrue(np.all(yl <= _y))
-                    self.assertTrue(np.all(yu >= _y))
+                y = np.exp(np.split(np.log(np.abs(z)), len(z)) / x)
+                self.assertTrue(np.all(yl <= y))
+                self.assertTrue(np.all(yu >= y))
 
     def test_x_sq(self):
         m = pyo.ConcreteModel()

--- a/pyomo/contrib/fbbt/tests/test_fbbt.py
+++ b/pyomo/contrib/fbbt/tests/test_fbbt.py
@@ -811,3 +811,12 @@ class TestFBBT(unittest.TestCase):
         self.assertAlmostEqual(m.x.ub, xu)
         self.assertAlmostEqual(m.y.lb, yl)
         self.assertAlmostEqual(m.y.ub, yu)
+
+    def test_negative_power(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var()
+        e = (m.x**2 + m.y**2)**(-0.5)
+        lb, ub = compute_bounds_on_expr(e)
+        self.assertAlmostEqual(lb, 0)
+        self.assertIsNone(ub)

--- a/pyomo/contrib/fbbt/tests/test_interval.py
+++ b/pyomo/contrib/fbbt/tests/test_interval.py
@@ -147,10 +147,10 @@ class TestInterval(unittest.TestCase):
 
     @unittest.skipIf(not numpy_available, 'Numpy is not available.')
     def test_pow2(self):
-        xl = np.linspace(-2, 2, 17)
-        xu = np.linspace(-2, 2, 17)
-        yl = np.linspace(-2, 2, 17)
-        yu = np.linspace(-2, 2, 17)
+        xl = np.linspace(-2, 2, 9)
+        xu = np.linspace(-2, 2, 9)
+        yl = np.linspace(-2, 2, 9)
+        yu = np.linspace(-2, 2, 9)
         for _xl in xl:
             for _xu in xu:
                 if _xl > _xu:
@@ -175,20 +175,11 @@ class TestInterval(unittest.TestCase):
                                 nan_fill = ub - 1
                             else:
                                 nan_fill = 0
-                            x = np.linspace(_xl, _xu, 17)
-                            y = np.linspace(_yl, _yu, 17)
-                            all_values = list()
-                            for _x in x:
-                                z = _x**y
-                                #np.nan_to_num(z, copy=False, nan=nan_fill, posinf=np.inf, neginf=-np.inf)
-                                tmp = []
-                                for _z in z:
-                                    if math.isnan(_z):
-                                        tmp.append(nan_fill)
-                                    else:
-                                        tmp.append(_z)
-                                all_values.append(np.array(tmp))
-                            all_values = np.array(all_values)
+                            x = np.linspace(_xl, _xu, 30)
+                            y = np.linspace(_yl, _yu, 30)
+                            z = x**np.split(y, len(y))
+                            z[np.isnan(z)] = nan_fill
+                            all_values = z
                             estimated_lb = all_values.min()
                             estimated_ub = all_values.max()
                             self.assertTrue(lb - 1e-8 <= estimated_lb)


### PR DESCRIPTION
## Summary/Motivation:
The ultimate goal of this PR is for 
```
import pyomo.environ as pe
from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr

m = pe.ConcreteModel()
m.x = pe.Var()
m.y = pe.Var()
e = (m.x**2 + m.y**2)**(-0.5)
compute_bounds_on_expr(e)
```

to produce

```
(0, None)
```

instead of 

```
(None, None)
```

Both of these are valid, but the former is much more useful. In the end, this took a rework of the interval `div` and `inv` functions. 



### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
