### PR TITLE
Update merged reader test to reduce failures in OSX

### DIFF
--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -51,10 +51,17 @@ class TestTeeStream(unittest.TestCase):
             # flush() and short pause should help
             t.STDOUT.write("Hello\nWorld")
             t.STDOUT.flush()
-            time.sleep(tee._poll_interval*20)
+            time.sleep(tee._poll_interval*10)
             t.STDERR.write("interrupting\ncow")
             t.STDERR.flush()
-            time.sleep(tee._poll_interval*30)
+            # For determinism, it is important that the STDERR message
+            # appears in hte output stream before we start shutting down
+            # the TeeStream (which will dump the OUT and ERR in an
+            # arbitrary order)
+            i = 0
+            while i < 1000 and 'cow' not in a.getvalue():
+                time.sleep(tee._poll_interval)
+                i += 1
         self.assertEqual(a.getvalue(), "Hello\ninterrupting\ncowWorld")
         self.assertEqual(b.getvalue(), "Hello\ninterrupting\ncowWorld")
 


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
We are still observing intermittent test failures for the merged reader test.  This PR is a small change that reduces dependence on (arbitrary) delays in the test code to make the test more deterministic.

## Changes proposed in this PR:
- confirm that `stderr` has been output before closing the TeeStream object down (instead of just delaying for a short time)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
