### PR TITLE
Preserve CWD even when xpress import fails

### DIFF
--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -9,6 +9,7 @@
 #  ___________________________________________________________________________
 
 import logging
+import os
 import re
 import sys
 import time
@@ -59,6 +60,7 @@ class XpressDirect(DirectSolver):
         self._solver_con_to_pyomo_con_map = ComponentMap()
 
         self._name = None
+        _cwd = os.getcwd()
         try:
             import xpress 
             self._xpress = xpress
@@ -84,7 +86,9 @@ class XpressDirect(DirectSolver):
             # exception above!
             print("Import of xpress failed - xpress message=" + str(e) + "\n")
             self._python_api_exists = False
-            
+        finally:
+            os.chdir(_cwd)
+
         self._range_constraints = set()
 
         # TODO: this isn't a limit of XPRESS, which implements an SLP

--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -88,7 +88,7 @@ class XpressDirect(DirectSolver):
             self._python_api_exists = False
         finally:
             # In some versions of XPRESS (notably 8.9.0), `import
-            # xpress` temporarily changes the CWD.  If the import failes
+            # xpress` temporarily changes the CWD.  If the import fails
             # (e.g., due to an expired license), the CWD is not always
             # restored.  This block ensures that the CWD is preserved.
             os.chdir(_cwd)

--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -87,6 +87,10 @@ class XpressDirect(DirectSolver):
             print("Import of xpress failed - xpress message=" + str(e) + "\n")
             self._python_api_exists = False
         finally:
+            # In some versions of XPRESS (notably 8.9.0), `import
+            # xpress` temporarily changes the CWD.  If the import failes
+            # (e.g., due to an expired license), the CWD is not always
+            # restored.  This block ensures that the CWD is preserved.
             os.chdir(_cwd)
 
         self._range_constraints = set()


### PR DESCRIPTION
## Fixes # N/A

## Summary/Motivation:
The XPRESS python bindings (at least for 8.9.0) change the CWD during `import xpress`.  If the import faile (e.g., due to an expired license), the CWD is not restored to the original value.  This updates the `xpress_direct` (and hence the `xpress_persistent`) interface to always preserve the CWD when attempting to import xpress.

## Changes proposed in this PR:
- preserve CWD when attempting to `import xpress`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
