### PR TITLE
Do not cache the picklability of function types

### DIFF
--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -16,6 +16,7 @@
 #  ___________________________________________________________________________
 
 import argparse
+import builtins
 import enum
 import inspect
 import io
@@ -26,7 +27,7 @@ import platform
 import re
 import sys
 from textwrap import wrap
-import builtins
+import types
 
 from pyomo.common.deprecation import deprecated
 from pyomo.common.modeling import NoArgumentGiven
@@ -888,7 +889,8 @@ def _picklable(field,obj):
         return field if _picklable.known[ftype] else _UnpickleableDomain(obj)
     try:
         pickle.dumps(field)
-        _picklable.known[ftype] = True
+        if ftype not in _picklable.unknowable_types:
+            _picklable.known[ftype] = True
         return field
     except:
         # Contrary to the documentation, Python is not at all consistent
@@ -906,10 +908,16 @@ def _picklable(field,obj):
         # of RuntimeError).
         if isinstance(sys.exc_info()[0], RuntimeError):
             raise
-        _picklable.known[ftype] = False
+        if ftype not in _picklable.unknowable_types:
+            _picklable.known[ftype] = False
         return _UnpickleableDomain(obj)
 
 _picklable.known = {}
+# The "picklability" of some types is not categorically "knowable"
+# (e.g., functions can be pickled, but only if they are declared at the
+# module scope)
+_picklable.unknowable_types = {types.FunctionType,}
+
 
 class ConfigBase(object):
     __slots__ = ('_parent', '_name', '_userSet', '_userAccessed', '_data',

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -885,6 +885,10 @@ class _UnpickleableDomain(object):
 
 def _picklable(field,obj):
     ftype = type(field)
+    # If the field is a type (class, etc), cache the 'known' status of
+    # the actual field type and not the generic 'type' class
+    if ftype is type:
+        ftype = field
     if ftype in _picklable.known:
         return field if _picklable.known[ftype] else _UnpickleableDomain(obj)
     try:
@@ -916,7 +920,7 @@ _picklable.known = {}
 # The "picklability" of some types is not categorically "knowable"
 # (e.g., functions can be pickled, but only if they are declared at the
 # module scope)
-_picklable.unknowable_types = {types.FunctionType,}
+_picklable.unknowable_types = {type, types.FunctionType,}
 
 
 class ConfigBase(object):

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -2308,7 +2308,8 @@ c: 1.0
             self.assertIsNot(_picklable(local_class, obj), local_class)
             self.assertEqual(_picklable.known.get(local_class, None), False)
 
-        # Ensure that none of the added `type` to the known dict
+        # Ensure that none of the above added the type `type` to the
+        # "known" dict
         self.assertNotIn(type, _picklable.known)
 
 

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -2260,16 +2260,16 @@ c: 1.0
         # function types
         self.assertIs(_picklable(_display, obj), _display)
         if local_picklable:
-            self.assertIs(_picklable(local_fcn, obj), local_picklable)
+            self.assertIs(_picklable(local_fcn, obj), local_fcn)
         else:
-            self.assertIsNot(_picklable(local_fcn, obj), local_picklable)
+            self.assertIsNot(_picklable(local_fcn, obj), local_fcn)
 
         # Twice: implicit test that the result is not cached
         self.assertIs(_picklable(_display, obj), _display)
         if local_picklable:
-            self.assertIs(_picklable(local_fcn, obj), local_picklable)
+            self.assertIs(_picklable(local_fcn, obj), local_fcn)
         else:
-            self.assertIsNot(_picklable(local_fcn, obj), local_picklable)
+            self.assertIsNot(_picklable(local_fcn, obj), local_fcn)
 
         self.assertIn(types.FunctionType, _picklable.unknowable_types)
         self.assertNotIn(types.FunctionType, _picklable.known)

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -95,7 +95,7 @@ class TestTiming(unittest.TestCase):
 
     def test_TicTocTimer_tictoc(self):
         SLEEP = 0.1
-        RES = 0.01 # resolution (seconds): 1/10 the sleep
+        RES = 0.02 # resolution (seconds): 1/5 the sleep
         abs_time = time.time()
         timer = TicTocTimer()
 
@@ -155,8 +155,11 @@ class TestTiming(unittest.TestCase):
 
         # Note: pypy and osx (py3.8) on GHA occasionally have timing
         # differences of >0.01s for the following tests
-        if 'pypy_version_info' in dir(sys) or sys.platform == 'darwin':
-            RES *= 2
+        #
+        # Update: we relaxed the resolution for all tests to 0.2
+        #
+        # if 'pypy_version_info' in dir(sys) or sys.platform == 'darwin':
+        #     RES *= 2
 
         with capture_output() as out:
             ref += time.time()


### PR DESCRIPTION
## Fixes # N/A

## Summary/Motivation:
Function types are picklable based on how they were declared (module-level functions are picklable, but others are not).  This PR prevents the config system pickling scheme from caching the "picklability" of functions - and resolves an intermittent issue where the pickle tests passed / failed based on whether or not other modules had been imported / run before hand.

This also adds special handling for domains that are class types (not class instances).  In this case, we cache the actual type (and NOT the `type` type) for the same reasons that we do not cache the picklability of the `FunctionType`.

## Changes proposed in this PR:
- do not cache the picklability of function types in the config system
- when pickling classes, do not cache the picklability of the `type` class and instead cache the picklability of the actual class type in question
- add a test to verify stateless behavior for functions
- add tests for pickling classes

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
