### PR TITLE
Prevent infinite loop when BARON terminates without a solution

### DIFF
--- a/pyomo/solvers/plugins/solvers/BARON.py
+++ b/pyomo/solvers/plugins/solvers/BARON.py
@@ -474,8 +474,8 @@ class BARONSHELL(SystemCallSolver):
             #
             # Scan through the first part of the solution file, until the
             # termination message '*** Normal completion ***'
-            line = ''
-            while '***' not in line:
+            line = '\n'
+            while line and '***' not in line:
                 line = INPUT.readline()
                 if 'Problem solved during preprocessing' in line:
                     SolvedDuringPreprocessing = True


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
@natalieisenberg reported that when BARON is run with a time limit that expires before the first incumbent is identified, the solution reader would get stuck in an infinite loop.  This updates the solution file parser so that it can escape that loop.

## Changes proposed in this PR:
- exit the solution file header parser if the end of file is encountered before the marker we are looking for

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
