### PR TITLE
Add a non-fatal timeout for nightly NEOS test

### DIFF
--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -147,7 +147,7 @@ class _RunnerResult(enum.Enum):
     unittest = 2
 
 
-def timeout(seconds, require_fork=False):
+def timeout(seconds, require_fork=False, timeout_raises=TimeoutError):
     """Function decorator to timeout the decorated function.
 
     This decorator will wrap a function call with a timeout, returning
@@ -167,6 +167,13 @@ def timeout(seconds, require_fork=False):
     ----------
     seconds: float
         Number of seconds to wait before timing out the function
+
+    require_fork: bool
+        Require support of the 'fork' interface.  If not present,
+        immediately raises unittest.SkipTest
+
+    timeout_raises: Exception
+        Exception class to raise in the event of a timeout
 
     Examples
     --------
@@ -238,7 +245,7 @@ def timeout(seconds, require_fork=False):
                 resultType, result, stdout = q.get(True, seconds)
             except queue.Empty:
                 test_proc.terminate()
-                raise TimeoutError(
+                raise timeout_raises(
                     "test timed out after %s seconds" % (seconds,)) from None
             finally:
                 _runner.data.pop(q, None)

--- a/pyomo/neos/plugins/kestrel_plugin.py
+++ b/pyomo/neos/plugins/kestrel_plugin.py
@@ -270,3 +270,9 @@ class SolverManager_NEOS(AsynchronousSolverManager):
 
         return None
 
+    def _kill_all_pending_jobs(self):
+        for ah in self._ah.values():
+            self.kestrel.kill(ah.job, ah.password)
+
+    def __exit__(self, t, v, traceback):
+        self._kill_all_pending_jobs()

--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -255,10 +255,17 @@ class TestSolvers_pyomo_cmd_min(RunAllNEOSSolvers, PyomoCommandDriver,
                                 unittest.TestCase):
     sense = pyo.minimize
 
-    # Add the CBC test to the nightly suite
+    # Add the CBC test to the nightly suite, but with a non-fatal
+    # (short) timeout
     @unittest.category('nightly')
-    def test_cbc(self):
-        super(TestSolvers_pyomo_cmd_min, self).test_cbc()
+    def test_cbc_nightly(self):
+        try:
+            test = unittest.timeout(60)(
+                super(TestSolvers_pyomo_cmd_min, self).test_cbc
+            )
+            test()
+        except TimeoutError:
+            self.skipTest("NEOS solve timed out")
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -161,8 +161,8 @@ class RunAllNEOSSolvers(object):
 class DirectDriver(object):
     def _run(self, opt, constrained=True):
         m = _model(self.sense)
-        solver_manager = pyo.SolverManagerFactory('neos')
-        results = solver_manager.solve(m, opt=opt)
+        with pyo.SolverManagerFactory('neos') as solver_manager:
+            results = solver_manager.solve(m, opt=opt)
 
         expected_y = {
             (pyo.minimize, True): -1,
@@ -238,6 +238,12 @@ class TestSolvers_direct_call_min(RunAllNEOSSolvers, DirectDriver,
 
     # Add the CBC test to the nightly suite, but with a non-fatal
     # (short) timeout
+    #
+    # TODO: remove queued job from NEOS servers.  Using timeout() leaves
+    # the queued problem on the NEOS servers, because timeout kills the
+    # forked process with SIGTERM.  Implementing a proper timeout will
+    # likely require reworking the AsynchronousSolverManager to accept a
+    # timeout through _perform_wait_any()
     @unittest.category('nightly', '!neos')
     @unittest.timeout(60, timeout_raises=unittest.SkipTest)
     def test_cbc_timeout(self):
@@ -261,6 +267,12 @@ class TestSolvers_pyomo_cmd_min(RunAllNEOSSolvers, PyomoCommandDriver,
 
     # Add the CBC test to the nightly suite, but with a non-fatal
     # (short) timeout
+    #
+    # TODO: remove queued job from NEOS servers.  Using timeout() leaves
+    # the queued problem on the NEOS servers, because timeout kills the
+    # forked process with SIGTERM.  Implementing a proper timeout will
+    # likely require reworking the AsynchronousSolverManager to accept a
+    # timeout through _perform_wait_any()
     @unittest.category('nightly', '!neos')
     @unittest.timeout(60, timeout_raises=unittest.SkipTest)
     def test_cbc_timeout(self):

--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -236,6 +236,13 @@ class TestSolvers_direct_call_min(RunAllNEOSSolvers, DirectDriver,
                                   unittest.TestCase):
     sense = pyo.minimize
 
+    # Add the CBC test to the nightly suite, but with a non-fatal
+    # (short) timeout
+    @unittest.category('nightly', '!neos')
+    @unittest.timeout(60, timeout_raises=unittest.SkipTest)
+    def test_cbc_timeout(self):
+        super(TestSolvers_direct_call_min, self).test_cbc()
+
 
 @unittest.category('neos')
 @unittest.skipIf(not neos_available, "Cannot make connection to NEOS server")
@@ -252,30 +259,12 @@ class TestSolvers_pyomo_cmd_min(RunAllNEOSSolvers, PyomoCommandDriver,
                                 unittest.TestCase):
     sense = pyo.minimize
 
-
-# Add the CBC test to the nightly suite, but with a non-fatal
-# (short) timeout
-
-@unittest.category('nightly')
-@unittest.skipIf(not neos_available, "Cannot make connection to NEOS server")
-@unittest.skipUnless(email_set, "NEOS_EMAIL not set")
-class TestSolvers_nonfatal_timeout(unittest.TestCase):
-
-    sense = pyo.minimize
-
-    def test_cbc_pyomo_command(self):
-        try:
-            runner = unittest.timeout(60)(PyomoCommandDriver._run)
-            runner(self, 'cbc')
-        except TimeoutError:
-            self.skipTest("NEOS solve timed out")
-
-    def test_cbc_direct(self):
-        try:
-            runner = unittest.timeout(60)(DirectDriver._run)
-            runner(self, 'cbc')
-        except TimeoutError:
-            self.skipTest("NEOS solve timed out")
+    # Add the CBC test to the nightly suite, but with a non-fatal
+    # (short) timeout
+    @unittest.category('nightly', '!neos')
+    @unittest.timeout(60, timeout_raises=unittest.SkipTest)
+    def test_cbc_timeout(self):
+        super(TestSolvers_pyomo_cmd_min, self).test_cbc()
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -236,10 +236,6 @@ class TestSolvers_direct_call_min(RunAllNEOSSolvers, DirectDriver,
                                   unittest.TestCase):
     sense = pyo.minimize
 
-    # Add the CBC test to the nightly suite
-    @unittest.category('nightly')
-    def test_cbc(self):
-        super(TestSolvers_direct_call_min, self).test_cbc()
 
 @unittest.category('neos')
 @unittest.skipIf(not neos_available, "Cannot make connection to NEOS server")
@@ -248,6 +244,7 @@ class TestSolvers_direct_call_max(RunAllNEOSSolvers, DirectDriver,
                                   unittest.TestCase):
     sense = pyo.maximize
 
+
 @unittest.category('neos')
 @unittest.skipIf(not neos_available, "Cannot make connection to NEOS server")
 @unittest.skipUnless(email_set, "NEOS_EMAIL not set")
@@ -255,15 +252,28 @@ class TestSolvers_pyomo_cmd_min(RunAllNEOSSolvers, PyomoCommandDriver,
                                 unittest.TestCase):
     sense = pyo.minimize
 
-    # Add the CBC test to the nightly suite, but with a non-fatal
-    # (short) timeout
-    @unittest.category('nightly')
-    def test_cbc_nightly(self):
+
+# Add the CBC test to the nightly suite, but with a non-fatal
+# (short) timeout
+
+@unittest.category('nightly')
+@unittest.skipIf(not neos_available, "Cannot make connection to NEOS server")
+@unittest.skipUnless(email_set, "NEOS_EMAIL not set")
+class TestSolvers_nonfatal_timeout(unittest.TestCase):
+
+    sense = pyo.minimize
+
+    def test_cbc_pyomo_command(self):
         try:
-            test = unittest.timeout(60)(
-                super(TestSolvers_pyomo_cmd_min, self).test_cbc
-            )
-            test()
+            runner = unittest.timeout(60)(PyomoCommandDriver._run)
+            runner(self, 'cbc')
+        except TimeoutError:
+            self.skipTest("NEOS solve timed out")
+
+    def test_cbc_direct(self):
+        try:
+            runner = unittest.timeout(60)(DirectDriver._run)
+            runner(self, 'cbc')
         except TimeoutError:
             self.skipTest("NEOS solve timed out")
 


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Recently, the NEOS server has been swamped, which causes the Pyomo automated tests to eventually time out.  This PR adds a timeout to the single NEOS test that is run as part of the nightly test suite.  It will not fix the GHA failures, as the singletest target will still timeout, but it will allow for a sufficient number of GHA jobs to complete so that we can process PRs with reasonable confidence.

## Changes proposed in this PR:
- add (non-fatal) time out the nightly NEOS test after 60 seconds

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
