### PR TITLE
Define pprint() for ExternalFunction components

### DIFF
--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -3,7 +3,7 @@
 #  Pyomo: Python Optimization Modeling Objects
 #  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
 #  Under the terms of Contract DE-NA0003525 with National Technology and 
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
@@ -55,7 +55,7 @@ class ExternalFunction(Component):
         # block._add_temporary_set assumes ALL components define an
         # index.  Sigh.
         self._index = None
-        
+
     def get_units(self):
         """Return the units for this ExternalFunction"""
         return self._units
@@ -85,7 +85,7 @@ class ExternalFunction(Component):
                     pass
                 if not arg.__class__ in native_types and arg.is_potentially_variable():
                     pv = True
-            except AttributeError:    
+            except AttributeError:
                 args_[i] = NonNumericValue(arg)
         #
         if pv:
@@ -189,6 +189,17 @@ class AMPLExternalFunction(ExternalFunction):
         FUNCADD = CFUNCTYPE( None, POINTER(_AMPLEXPORTS) )
         FUNCADD(('funcadd_ASL', self._so))(byref(AE))
 
+    def _pprint(self):
+        return (
+            [ ('function', self._function),
+              ('library', self._library),
+              ('units', str(self._units)),
+              ('arg_units', [ str(u) for u in self._arg_units ]
+               if self._arg_units is not None else None),
+            ],
+            (), None, None
+        )
+
 
 class PythonCallbackFunction(ExternalFunction):
     global_registry = {}
@@ -237,6 +248,16 @@ class PythonCallbackFunction(ExternalFunction):
             raise RuntimeError(
                 "PythonCallbackFunction called with invalid Global ID" )
         return self._fcn(*args_[1:])
+
+    def _pprint(self):
+        return (
+            [ ('function', self._fcn.__qualname__),
+              ('units', str(self._units)),
+              ('arg_units', [ str(u) for u in self._arg_units[1:] ]
+               if self._arg_units is not None else None),
+            ],
+            (), None, None
+        )
 
 
 class _ARGLIST(Structure):

--- a/pyomo/core/tests/unit/test_external.py
+++ b/pyomo/core/tests/unit/test_external.py
@@ -9,6 +9,8 @@
 #  ___________________________________________________________________________
 #
 
+from io import StringIO
+
 import pyomo.common.unittest as unittest
 
 from pyomo.common.getGSL import find_GSL
@@ -16,6 +18,7 @@ from pyomo.environ import ConcreteModel, Var, Objective, SolverFactory, value
 from pyomo.core.base.external import (PythonCallbackFunction,
                                       ExternalFunction,
                                       AMPLExternalFunction)
+from pyomo.core.base.units_container import pint_available, units
 from pyomo.opt import check_available_solvers
 
 def _g(*args):
@@ -62,7 +65,34 @@ class TestPythonCallbackFunction(unittest.TestCase):
         with self.assertRaises(ValueError):
             m.f = ExternalFunction(_g, this_should_raise_error='foo')
 
-        
+    def test_pprint(self):
+        m = ConcreteModel()
+        m.h = ExternalFunction(_g)
+
+        out = StringIO()
+        m.pprint(ostream=out)
+        self.assertEqual(out.getvalue().strip(), """
+1 ExternalFunction Declarations
+    h : function=_g, units=None, arg_units=None
+
+1 Declarations: h
+        """.strip())
+
+        if not pint_available:
+            return
+        m.i = ExternalFunction(function=_h,
+                               units=units.kg, arg_units=[units.m, units.s])
+        out = StringIO()
+        m.pprint(ostream=out)
+        self.assertEqual(out.getvalue().strip(), """
+2 ExternalFunction Declarations
+    h : function=_g, units=None, arg_units=None
+    i : function=_h, units=kg, arg_units=['m', 's']
+
+2 Declarations: h i
+        """.strip())
+
+
 class TestAMPLExternalFunction(unittest.TestCase):
     def assertListsAlmostEqual(self, first, second, places=7, msg=None):
         self.assertEqual(len(first), len(second))
@@ -162,6 +192,33 @@ class TestAMPLExternalFunction(unittest.TestCase):
         model3 = m.clone()
         res = opt.solve(model3, tee=True)
         self.assertAlmostEqual(value(model3.o), 0.885603194411, 7)
+
+    def test_pprint(self):
+        m = ConcreteModel()
+        m.f = ExternalFunction(library="junk.so", function="junk")
+
+        out = StringIO()
+        m.pprint(ostream=out)
+        self.assertEqual(out.getvalue().strip(), """
+1 ExternalFunction Declarations
+    f : function=junk, library=junk.so, units=None, arg_units=None
+
+1 Declarations: f
+        """.strip())
+
+        if not pint_available:
+            return
+        m.g = ExternalFunction(library="junk.so", function="junk",
+                               units=units.kg, arg_units=[units.m, units.s])
+        out = StringIO()
+        m.pprint(ostream=out)
+        self.assertEqual(out.getvalue().strip(), """
+2 ExternalFunction Declarations
+    f : function=junk, library=junk.so, units=None, arg_units=None
+    g : function=junk, library=junk.so, units=kg, arg_units=['m', 's']
+
+2 Declarations: f g
+        """.strip())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fixes #1431

## Summary/Motivation:
The `ExternalFunction` components failed to implement `_pprint()`, which broke `pprint()` for all models containing an external function.  This resolves the problem by defining `_pprint()`

## Changes proposed in this PR:
- define `_pprint()` for `PythonCallbackFunction` and `AMPLExternalFunction`
- test `pprint()` for models with `ExternalFunction` components

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
