### PR TITLE
Support setting Var, Param values with unit expressions

### DIFF
--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -988,12 +988,16 @@ This has resulted in the conversion of the source to dense form.
             dataGen = lambda k, v: [ v._value, ]
         else:
             dataGen = lambda k, v: [ v, ]
-        return ( [("Size", len(self)),
-                  ("Index", self._index if self.is_indexed() else None),
-                  ("Domain", self.domain.name),
-                  ("Default", default),
-                  ("Mutable", self._mutable),
-                  ],
+        headers = [
+            ("Size", len(self)),
+            ("Index", self._index if self.is_indexed() else None),
+            ("Domain", self.domain.name),
+            ("Default", default),
+            ("Mutable", self._mutable),
+        ]
+        if self._units is not None:
+            headers.append(('Units', str(self._units)))
+        return ( headers,
                  self.sparse_iteritems(),
                  ("Value",),
                  dataGen,

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -19,13 +19,14 @@ from pyomo.common.deprecation import deprecation_warning
 from pyomo.common.log import is_debug_set
 from pyomo.common.modeling import NoArgumentGiven
 from pyomo.common.timing import ConstructionTimer
-import pyomo.core.expr.current as expr
 from pyomo.core.base.plugin import ModelComponentFactory
 from pyomo.core.base.component import ComponentData
 from pyomo.core.base.indexed_component import IndexedComponent, \
     UnindexedComponent_set
 from pyomo.core.base.misc import apply_indexed_rule, apply_parameterized_indexed_rule
-from pyomo.core.base.numvalue import NumericValue, native_types
+from pyomo.core.base.numvalue import (
+    NumericValue, native_types, value as expr_value
+)
 from pyomo.core.base.set_types import Any, Reals
 from pyomo.core.base.units_container import units
 
@@ -144,7 +145,7 @@ class _ParamData(ComponentData, NumericValue):
             # a dimensionless value to a united param should be an error
             pass
         elif _comp._units is not None:
-            _src_magnitude = expr.value(value)
+            _src_magnitude = expr_value(value)
             _src_units = units.get_units(value)
             value = units.convert_value(
                 num_value=_src_magnitude, from_units=_src_units,

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -176,7 +176,7 @@ class _VarData(ComponentData, NumericValue):
         then the validation step is skipped.
         """
         if not valid and val is not None:
-            # TODO: warn/error: check if this Param has units: assigning
+            # TODO: warn/error: check if this Var has units: assigning
             # a dimensionless value to a united param should be an error
             if type(val) not in native_numeric_types:
                 if self.parent_component()._units is not None:
@@ -389,7 +389,7 @@ class _GeneralVarData(_VarData):
     def value(self, val):
         """Set the value for this variable."""
         if type(val) in native_numeric_types:
-            # TODO: warn/error: check if this Param has units: assigning
+            # TODO: warn/error: check if this Var has units: assigning
             # a dimensionless value to a united param should be an error
             pass
         elif self.parent_component()._units is not None:
@@ -466,7 +466,7 @@ class _GeneralVarData(_VarData):
                 "bound - legal types must be fixed expressions or variables."
                 % (type(val),))
         if type(val) in native_numeric_types or val is None:
-            # TODO: warn/error: check if this Param has units: assigning
+            # TODO: warn/error: check if this Var has units: assigning
             # a dimensionless value to a united param should be an error
             pass
         else:
@@ -492,7 +492,7 @@ class _GeneralVarData(_VarData):
                 "parameters"
                 % (type(val),))
         if type(val) in native_numeric_types or val is None:
-            # TODO: warn/error: check if this Param has units: assigning
+            # TODO: warn/error: check if this Var has units: assigning
             # a dimensionless value to a united param should be an error
             pass
         else:

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -177,7 +177,7 @@ class _VarData(ComponentData, NumericValue):
         """
         if not valid and val is not None:
             # TODO: warn/error: check if this Var has units: assigning
-            # a dimensionless value to a united param should be an error
+            # a dimensionless value to a united variable should be an error
             if type(val) not in native_numeric_types:
                 if self.parent_component()._units is not None:
                     _src_magnitude = value(val)
@@ -390,7 +390,7 @@ class _GeneralVarData(_VarData):
         """Set the value for this variable."""
         if type(val) in native_numeric_types:
             # TODO: warn/error: check if this Var has units: assigning
-            # a dimensionless value to a united param should be an error
+            # a dimensionless value to a united variable should be an error
             pass
         elif self.parent_component()._units is not None:
             _src_magnitude = value(val)
@@ -467,7 +467,7 @@ class _GeneralVarData(_VarData):
                 % (type(val),))
         if type(val) in native_numeric_types or val is None:
             # TODO: warn/error: check if this Var has units: assigning
-            # a dimensionless value to a united param should be an error
+            # a dimensionless value to a united variable should be an error
             pass
         else:
             if self.parent_component()._units is not None:
@@ -493,7 +493,7 @@ class _GeneralVarData(_VarData):
                 % (type(val),))
         if type(val) in native_numeric_types or val is None:
             # TODO: warn/error: check if this Var has units: assigning
-            # a dimensionless value to a united param should be an error
+            # a dimensionless value to a united variable should be an error
             pass
         else:
             if self.parent_component()._units is not None:

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -460,13 +460,24 @@ class _GeneralVarData(_VarData):
         the value is fixed (or None).
         """
         # Note: is_fixed(None) returns True
-        if is_fixed(val):
-            self._lb = val
-        else:
+        if not is_fixed(val):
             raise ValueError(
                 "Non-fixed input of type '%s' supplied as variable lower "
                 "bound - legal types must be fixed expressions or variables."
                 % (type(val),))
+        if type(val) in native_numeric_types or val is None
+            # TODO: warn/error: check if this Param has units: assigning
+            # a dimensionless value to a united param should be an error
+            pass
+        else:
+            if self.parent_component()._units is not None:
+                _src_magnitude = value(val)
+                _src_units = units.get_units(val)
+                val = units.convert_value(
+                    num_value=_src_magnitude, from_units=_src_units,
+                    to_units=self.parent_component()._units)
+        self._lb = val
+
 
     def setub(self, val):
         """
@@ -474,14 +485,24 @@ class _GeneralVarData(_VarData):
         the value is fixed (or None).
         """
         # Note: is_fixed(None) returns True
-        if is_fixed(val):
-            self._ub = val
-        else:
+        if not is_fixed(val):
             raise ValueError(
                 "Non-fixed input of type '%s' supplied as variable upper "
                 "bound - legal types are fixed expressions or variables."
                 "parameters"
                 % (type(val),))
+        if type(val) in native_numeric_types or val is None
+            # TODO: warn/error: check if this Param has units: assigning
+            # a dimensionless value to a united param should be an error
+            pass
+        else:
+            if self.parent_component()._units is not None:
+                _src_magnitude = value(val)
+                _src_units = units.get_units(val)
+                val = units.convert_value(
+                    num_value=_src_magnitude, from_units=_src_units,
+                    to_units=self.parent_component()._units)
+        self._ub = val
 
     def fix(self, value=NoArgumentGiven):
         """

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -465,7 +465,7 @@ class _GeneralVarData(_VarData):
                 "Non-fixed input of type '%s' supplied as variable lower "
                 "bound - legal types must be fixed expressions or variables."
                 % (type(val),))
-        if type(val) in native_numeric_types or val is None
+        if type(val) in native_numeric_types or val is None:
             # TODO: warn/error: check if this Param has units: assigning
             # a dimensionless value to a united param should be an error
             pass
@@ -491,7 +491,7 @@ class _GeneralVarData(_VarData):
                 "bound - legal types are fixed expressions or variables."
                 "parameters"
                 % (type(val),))
-        if type(val) in native_numeric_types or val is None
+        if type(val) in native_numeric_types or val is None:
             # TODO: warn/error: check if this Param has units: assigning
             # a dimensionless value to a united param should be an error
             pass

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -796,9 +796,13 @@ class Var(IndexedComponent):
 
     def _pprint(self):
         """Print component information."""
-        return ( [("Size", len(self)),
-                  ("Index", self._index if self.is_indexed() else None),
-                  ],
+        headers = [
+            ("Size", len(self)),
+            ("Index", self._index if self.is_indexed() else None),
+        ]
+        if self._units is not None:
+            headers.append(('Units', str(self._units)))
+        return ( headers,
                  self._data.items(),
                  ( "Lower","Value","Upper","Fixed","Stale","Domain"),
                  lambda k, v: [ value(v.lb),

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -1381,7 +1381,7 @@ q : Size=3, Index=Any, Domain=Any, Default=None, Mutable=True
             log.getvalue())
         self.assertEqual(value(m.p), 'a')
 
-    @unittest.skipUnless(pint_available, "units tests requires pint module")
+    @unittest.skipUnless(pint_available, "units test requires pint module")
     def test_set_value_units(self):
         m = ConcreteModel()
         m.p = Param(units=units.g)

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -1394,6 +1394,17 @@ q : Size=3, Index=Any, Domain=Any, Default=None, Mutable=True
         with self.assertRaises(UnitsError):
             m.p = 1*units.s
 
+        out = StringIO()
+        m.pprint(ostream=out)
+        self.assertEqual(out.getvalue().strip(), """
+1 Param Declarations
+    p : Size=1, Index=None, Domain=Any, Default=None, Mutable=True, Units=g
+        Key  : Value
+        None : 7000.0
+
+1 Declarations: p
+        """.strip())
+
 
 def createNonIndexedParamMethod(func, init_xy, new_xy, tol=1e-10):
 

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -34,6 +34,7 @@ from pyomo.environ import (Set, RangeSet, Param, ConcreteModel,
 from pyomo.common.log import LoggingIntercept
 from pyomo.common.tempfiles import TempfileManager
 from pyomo.core.base.param import _ParamData 
+from pyomo.core.base.units_container import units, pint_available, UnitsError
 
 from io import StringIO
 
@@ -1379,6 +1380,19 @@ q : Size=3, Index=Any, Domain=Any, Default=None, Mutable=True
             "domain of this Param (p) to be 'Any'",
             log.getvalue())
         self.assertEqual(value(m.p), 'a')
+
+    @unittest.skipUnless(pint_available, "units tests requires pint module")
+    def test_set_value_units(self):
+        m = ConcreteModel()
+        m.p = Param(units=units.g)
+        m.p = 5
+        self.assertEqual(value(m.p), 5)
+        m.p = 6*units.g
+        self.assertEqual(value(m.p), 6)
+        m.p = 7*units.kg
+        self.assertEqual(value(m.p), 7000)
+        with self.assertRaises(UnitsError):
+            m.p = 1*units.s
 
 
 def createNonIndexedParamMethod(func, init_xy, new_xy, tol=1e-10):

--- a/pyomo/core/tests/unit/test_var.py
+++ b/pyomo/core/tests/unit/test_var.py
@@ -18,6 +18,8 @@ import os
 from os.path import abspath, dirname
 currdir = dirname(abspath(__file__))+os.sep
 
+from io import StringIO
+
 import pyomo.common.unittest as unittest
 
 from pyomo.core.base import IntegerSet
@@ -1386,6 +1388,17 @@ class MiscVarTests(unittest.TestCase):
         with self.assertRaises(UnitsError):
             m.x = 1*units.s
 
+        out = StringIO()
+        m.pprint(ostream=out)
+        self.assertEqual(out.getvalue().strip(), """
+1 Var Declarations
+    x : Size=1, Index=None, Units=g
+        Key  : Lower : Value  : Upper : Fixed : Stale : Domain
+        None :  None : 7000.0 :  None : False : False :  Reals
+
+1 Declarations: x
+        """.strip())
+
     @unittest.skipUnless(pint_available, "units tests requires pint module")
     def test_set_bounds_units(self):
         m = ConcreteModel()
@@ -1407,6 +1420,7 @@ class MiscVarTests(unittest.TestCase):
         self.assertEqual(m.x.ub, 4000)
         with self.assertRaises(UnitsError):
             m.x.setlb(1*units.s)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/core/tests/unit/test_var.py
+++ b/pyomo/core/tests/unit/test_var.py
@@ -1375,7 +1375,7 @@ class MiscVarTests(unittest.TestCase):
         model.C = model.A | model.B
         model.x = Var(model.C)
 
-    @unittest.skipUnless(pint_available, "units tests requires pint module")
+    @unittest.skipUnless(pint_available, "units test requires pint module")
     def test_set_value_units(self):
         m = ConcreteModel()
         m.x = Var(units=units.g)
@@ -1399,7 +1399,7 @@ class MiscVarTests(unittest.TestCase):
 1 Declarations: x
         """.strip())
 
-    @unittest.skipUnless(pint_available, "units tests requires pint module")
+    @unittest.skipUnless(pint_available, "units test requires pint module")
     def test_set_bounds_units(self):
         m = ConcreteModel()
         m.x = Var(units=units.g)


### PR DESCRIPTION
## Fixes IDAES/idaes-pse#250

## Summary/Motivation:
We currently do not support setting `Var` or `Param` objects with defined units using unit expressions.  This PR adds basic support for passing unit expressions to `x.value = `, `x.set_value()`, and for `Var`, `x.setlb()` and `x.setub()`.  With this, "obvious" code like the following will work:

```python
>>> from pyomo.environ import *
>>> m = ConcreteModel()
>>> m.x = Var(units=units.kg)
>>> m.x = 5*units.lb
>>> m.pprint()
1 Var Declarations
    x : Size=1, Index=None, Units=kg
        Key  : Lower : Value              : Upper : Fixed : Stale : Domain
        None :  None : 2.2679618500000003 :  None : False : False :  Reals

1 Declarations: x
```

Note that this is completely backwards compatible, that is:

```python
>>> m.x = 5
>>> m.pprint()
1 Var Declarations
    x : Size=1, Index=None, Units=kg
        Key  : Lower : Value : Upper : Fixed : Stale : Domain
        None :  None :     5 :  None : False : False :  Reals

1 Declarations: x
```

Also, the changes should have little to no impact on runtime for non-united models or in "normal" usage when setting native numeric types (simple testing indicates an overhead of ~0.1s when assigning 1 million variable values on a VM).

Finally, this is not meant to be the "final" fix for managing variables / parameters with units, but rather a targeted patch to resolve current issues with models leveraging units with minimal change to the currently behavior or performance.  a PEP proposing more significant changes will come later.

## Changes proposed in this PR:
- support assigning Var, Param values from unit expressions
- support setting Var bounds with unit expressions
- include units in the `pprint()` for components where units are defined
- this includes a small fix so updating most mutable Param values is O(1) instead of O(n)
- add tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
