### PR TITLE
Support explicit constants in ExternalFunction arguments

### DIFF
--- a/pyomo/repn/plugins/ampl/ampl_.py
+++ b/pyomo/repn/plugins/ampl/ampl_.py
@@ -556,6 +556,8 @@ class ProblemWriter_nl(AbstractProblemWriter):
                 for arg in exp.args:
                     if isinstance(arg, str):
                         OUTPUT.write(string_arg_str % (len(arg), arg))
+                    elif type(arg) in native_numeric_types:
+                        self._print_nonlinear_terms_NL(arg)
                     elif arg.is_fixed():
                         self._print_nonlinear_terms_NL(arg())
                     else:

--- a/pyomo/repn/tests/ampl/external_expression_constant.nl.baseline
+++ b/pyomo/repn/tests/ampl/external_expression_constant.nl.baseline
@@ -1,0 +1,23 @@
+g3 1 1 0	# problem unknown
+ 1 0 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 1 0 	# nonlinear vars in constraints, objectives, both
+ 0 1 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 0 1 	# nonzeros in Jacobian, obj. gradient
+ 1 1	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+F0 1 -1 gsl_hypot
+O0 0	#o
+f0 2	#hypot
+n3
+v0	#y
+x1	# initial guess
+0 4
+r	#0 ranges (rhs's)
+b	#1 bounds (on variables)
+2 0
+k0	#intermediate Jacobian column lengths
+G0 1
+0 0

--- a/pyomo/repn/tests/ampl/test_ampl_nl.py
+++ b/pyomo/repn/tests/ampl/test_ampl_nl.py
@@ -109,6 +109,27 @@ class TestNLWriter(unittest.TestCase):
         self.assertAlmostEqual(value(m.o), 25.0, 7)
         return m
 
+    def test_external_expression_constant(self):
+        DLL = find_GSL()
+        if not DLL:
+            self.skipTest("Could not find the amplgsl.dll library")
+
+        m = ConcreteModel()
+        m.y = Var(initialize=4, bounds=(0,None))
+        m.hypot = ExternalFunction(library=DLL, function="gsl_hypot")
+        m.o = Objective(expr=m.hypot(3, m.y))
+        self.assertAlmostEqual(value(m.o), 5.0, 7)
+
+        baseline_fname, test_fname = self._get_fnames()
+        self._cleanup(test_fname)
+        m.write(test_fname, format='nl',
+                    io_options={'symbolic_solver_labels':True})
+        self.assertTrue(cmp(
+            test_fname,
+            baseline_fname),
+            msg="Files %s and %s differ" % (test_fname, baseline_fname))
+        self._cleanup(test_fname)
+
     def test_external_expression_variable(self):
         m = self._external_model()
 


### PR DESCRIPTION
## Fixes #1090.

## Summary/Motivation:
This is a quick fix and test for #1090 (supplying constants as arguments to external functions caused a failure in the NL writer).  This is a slightly more general implementation than the one proposed in #1904 (fixing the second issue from #1903).

## Changes proposed in this PR:
- support constant (i.e., numeric types) as arguments to ExternalFunctions
- add a test verifying the bahavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
