### PR TITLE
Fix multiple References to local variables in nested disjuncts

### DIFF
--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -37,6 +37,8 @@ from pyomo.repn import generate_standard_repn
 from functools import wraps
 from weakref import ref as weakref_ref
 
+from nose.tools import set_trace
+
 logger = logging.getLogger('pyomo.gdp.bigm')
 
 NAME_BUFFER = {}
@@ -493,7 +495,14 @@ class BigM_Transformation(Transformation):
                 continue
             # get this disjunction's relaxation block.
             transBlock = obj.algebraic_constraint().parent_block()
+            # ESJ TODO: I'm confused. Since we created references above, what is
+            # here that we still need to make a reference to? Why is this
+            # breaking the constraint mapping and causing us to not recognize an
+            # untransformed inner disjunction?
+            for block in transBlock.relaxedDisjuncts.values():
+                block.localVarReferences.deactivate()
 
+            transBlock.pprint()
             # move transBlock up to parent component
             self._transfer_transBlock_data(transBlock, destinationBlock)
             # we leave the transformation block because it still has the XOR

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -26,12 +26,12 @@ from pyomo.core.base.external import ExternalFunction
 from pyomo.core.base import Transformation, TransformationFactory, Reference
 import pyomo.core.expr.current as EXPR
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
-from pyomo.gdp.util import (
-    _warn_for_active_logical_constraint, target_list, is_child_of, get_src_disjunction,
-    get_src_constraint, get_transformed_constraints,
-    _get_constraint_transBlock, get_src_disjunct,
-    _warn_for_active_disjunction,
-    _warn_for_active_disjunct, )
+from pyomo.gdp.util import ( _warn_for_active_logical_constraint, target_list,
+                             is_child_of, get_src_disjunction,
+                             get_src_constraint, get_transformed_constraints,
+                             _get_constraint_transBlock, get_src_disjunct,
+                             _warn_for_active_disjunction,
+                             _warn_for_active_disjunct, )
 from pyomo.repn import generate_standard_repn
 
 from functools import wraps
@@ -555,7 +555,8 @@ class BigM_Transformation(Transformation):
 
     def _warn_for_active_logical_statement(
             self, logical_statment, disjunct, infodict, bigMargs, suffix_list):
-        _warn_for_active_logical_constraint(logical_statment, disjunct, NAME_BUFFER)
+        _warn_for_active_logical_constraint(logical_statment, disjunct,
+                                            NAME_BUFFER)
 
     def _transform_block_on_disjunct(self, block, disjunct, bigMargs, arg_list,
                                      suffix_list):

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -673,21 +673,13 @@ class Hull_Reformulation(Transformation):
         # As opposed to bigm, in hull the only special thing we need to do for
         # nested Disjunctions is to make sure that we move up local var
         # references and also references to the disaggregated variables so that
-        # all will be accessible after we transform this Disjunct.The indicator
+        # all will be accessible after we transform this Disjunct. The indicator
         # variables and disaggregated variables of the inner disjunction will
         # need to be disaggregated again, but the transformed constraints will
         # not be. But this way nothing will get double-bigm-ed. (If an
         # untransformed disjunction is lurking here, we will catch it below).
 
-        # add references to all local variables on block (including the
-        # indicator_var)
         disjunctBlock = disjunct._transformation_block()
-        varRefBlock = disjunctBlock.localVarReferences
-        for v in block.component_objects(Var, descend_into=Block, active=None):
-            varRefBlock.add_component(unique_component_name(
-                varRefBlock, v.getname(fully_qualified=True,
-                                       name_buffer=NAME_BUFFER)), Reference(v))
-
         destinationBlock = disjunctBlock.parent_block()
         for obj in block.component_data_objects(
                 Disjunction,
@@ -701,6 +693,16 @@ class Hull_Reformulation(Transformation):
             transBlock = obj.algebraic_constraint().parent_block()
 
             self._transfer_var_references(transBlock, destinationBlock)
+
+        # add references to all local variables on block (including the
+        # indicator_var). Note that we do this after we have moved up the
+        # transformation blocks for nested disjunctions, so that we don't have
+        # duplicate references.
+        varRefBlock = disjunctBlock.localVarReferences
+        for v in block.component_objects(Var, descend_into=Block, active=None):
+            varRefBlock.add_component(unique_component_name(
+                varRefBlock, v.getname(fully_qualified=True,
+                                       name_buffer=NAME_BUFFER)), Reference(v))
 
         # Look through the component map of block and transform everything we
         # have a handler for. Yell if we don't know how to handle it. (Note that

--- a/pyomo/gdp/tests/common_tests.py
+++ b/pyomo/gdp/tests/common_tests.py
@@ -9,7 +9,9 @@
 #  ___________________________________________________________________________
 
 
-from pyomo.environ import TransformationFactory, ConcreteModel, Constraint, Var, Objective, Block, Any, RangeSet, Expression, value
+from pyomo.environ import (TransformationFactory, ConcreteModel, Constraint,
+                           Var, Objective, Block, Any, RangeSet, Expression,
+                           value)
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 from pyomo.core.base import constraint, ComponentUID
 from pyomo.repn import generate_standard_repn
@@ -68,8 +70,8 @@ def checkb0TargetsInactive(self, m):
 
 def checkb0TargetsTransformed(self, m, transformation):
     trans = TransformationFactory('gdp.%s' % transformation)
-    disjBlock = m.b[0].component("_pyomo_gdp_%s_reformulation" % transformation).\
-                relaxedDisjuncts
+    disjBlock = m.b[0].component(
+        "_pyomo_gdp_%s_reformulation" % transformation).relaxedDisjuncts
     self.assertEqual(len(disjBlock), 2)
     self.assertIsInstance(disjBlock[0].component("b[0].disjunct[0].c"),
                           Constraint)

--- a/pyomo/gdp/tests/common_tests.py
+++ b/pyomo/gdp/tests/common_tests.py
@@ -745,15 +745,15 @@ def check_indexedBlock_only_targets_transformed(self, transformation):
         m,
         targets=[m.b])
 
-    disjBlock1 = m.b[0].component("_pyomo_gdp_%s_reformulation" % transformation).\
-                 relaxedDisjuncts
+    disjBlock1 = m.b[0].component(
+        "_pyomo_gdp_%s_reformulation" % transformation).relaxedDisjuncts
     self.assertEqual(len(disjBlock1), 2)
     self.assertIsInstance(disjBlock1[0].component("b[0].disjunct[0].c"),
                           Constraint)
     self.assertIsInstance(disjBlock1[1].component("b[0].disjunct[1].c"),
                           Constraint)
-    disjBlock2 = m.b[1].component("_pyomo_gdp_%s_reformulation" % transformation).\
-                 relaxedDisjuncts
+    disjBlock2 = m.b[1].component(
+        "_pyomo_gdp_%s_reformulation" % transformation).relaxedDisjuncts
     self.assertEqual(len(disjBlock2), 2)
     self.assertIsInstance(disjBlock2[0].component("b[1].disjunct0.c"),
                           Constraint)
@@ -895,7 +895,8 @@ def check_trans_block_created(self, transformation):
     self.assertIsInstance(disjBlock, Block)
     self.assertEqual(len(disjBlock), 2)
     # and that it didn't get created on the model
-    self.assertIsNone(m.component('_pyomo_gdp_%s_reformulation' % transformation))
+    self.assertIsNone(
+        m.component('_pyomo_gdp_%s_reformulation' % transformation))
 
 
 # disjunction generation tests: These all suppose that you are doing some sort
@@ -1050,7 +1051,8 @@ def check_transformation_simple_block(self, transformation):
     TransformationFactory('gdp.%s' % transformation).apply_to(m.b)
 
     # transformation block not on m
-    self.assertIsNone(m.component("_pyomo_gdp_%s_reformulation" % transformation))
+    self.assertIsNone(
+        m.component("_pyomo_gdp_%s_reformulation" % transformation))
 
     # transformation block on m.b
     self.assertIsInstance(m.b.component("_pyomo_gdp_%s_reformulation" %
@@ -1060,7 +1062,8 @@ def check_transform_block_data(self, transformation):
     m = models.makeDisjunctionsOnIndexedBlock()
     TransformationFactory('gdp.%s' % transformation).apply_to(m.b[0])
 
-    self.assertIsNone(m.component("_pyomo_gdp_%s_reformulation" % transformation))
+    self.assertIsNone(
+        m.component("_pyomo_gdp_%s_reformulation" % transformation))
 
     self.assertIsInstance(m.b[0].component("_pyomo_gdp_%s_reformulation" %
                                            transformation), Block)
@@ -1070,7 +1073,8 @@ def check_simple_block_target(self, transformation):
     TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=[m.b])
 
     # transformation block not on m
-    self.assertIsNone(m.component("_pyomo_gdp_%s_reformulation" % transformation))
+    self.assertIsNone(
+        m.component("_pyomo_gdp_%s_reformulation" % transformation))
 
     # transformation block on m.b
     self.assertIsInstance(m.b.component("_pyomo_gdp_%s_reformulation" %
@@ -1081,7 +1085,8 @@ def check_block_data_target(self, transformation):
     TransformationFactory('gdp.%s' % transformation).apply_to(m,
                                                               targets=[m.b[0]])
 
-    self.assertIsNone(m.component("_pyomo_gdp_%s_reformulation" % transformation))
+    self.assertIsNone(
+        m.component("_pyomo_gdp_%s_reformulation" % transformation))
 
     self.assertIsInstance(m.b[0].component("_pyomo_gdp_%s_reformulation" %
                                            transformation), Block)
@@ -1093,7 +1098,8 @@ def check_indexed_block_target(self, transformation):
     # We expect the transformation block on each of the BlockDatas. Because
     # it is always going on the parent block of the disjunction.
 
-    self.assertIsNone(m.component("_pyomo_gdp_%s_reformulation" % transformation))
+    self.assertIsNone(
+        m.component("_pyomo_gdp_%s_reformulation" % transformation))
 
     for i in [0,1]:
         self.assertIsInstance( m.b[i].component("_pyomo_gdp_%s_reformulation" %
@@ -1498,6 +1504,20 @@ def check_disjunctData_only_targets_transformed(self, transformation):
                       m.disjunct[1].innerdisjunct[i])
         self.assertIs(m.disjunct[1].innerdisjunct[i].transformation_block(),
                       disjBlock[j])
+
+def check_unique_reference_to_nested_indicator_var(self, transformation):
+    m = models.makeNestedDisjunctions_NestedDisjuncts()
+    TransformationFactory('gdp.%s' % transformation).apply_to(m)
+    # find the references to the nested indicator var
+    num_references_d3 = 0
+    num_references_d4 = 0
+    for v in m.component_data_objects(Var, active=True, descend_into=Block):
+        if v is m.d1.d3.indicator_var:
+            num_references_d3 += 1
+        if v is m.d1.d4.indicator_var:
+            num_references_d4 += 1
+    self.assertEqual(num_references_d3, 1)
+    self.assertEqual(num_references_d4, 1)
 
 # checks for handling of benign types that could be on disjuncts we're
 # transforming

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -26,8 +26,6 @@ import random
 
 from io import StringIO
 
-from nose.tools import set_trace
-
 class CommonTests:
     def diff_apply_to_and_create_using(self, model):
         ct.diff_apply_to_and_create_using(self, model, 'gdp.bigm')
@@ -1805,7 +1803,6 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -11)
         self.assertEqual(u_val, 7)
 
-        set_trace()
         ((l_val, l_src, l_key),
          (u_val, u_src, u_key)) = bigm.get_M_value_src(m.disjunct[1].c)
         self.assertIsNone(l_src)

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -26,6 +26,8 @@ import random
 
 from io import StringIO
 
+from nose.tools import set_trace
+
 class CommonTests:
     def diff_apply_to_and_create_using(self, model):
         ct.diff_apply_to_and_create_using(self, model, 'gdp.bigm')
@@ -1803,6 +1805,7 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -11)
         self.assertEqual(u_val, 7)
 
+        set_trace()
         ((l_val, l_src, l_key),
          (u_val, u_src, u_key)) = bigm.get_M_value_src(m.disjunct[1].c)
         self.assertIsNone(l_src)

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -1959,6 +1959,9 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         self.assertEqual(cons8.upper, 2)
         self.check_bigM_constraint(cons8, m.a, 21, m.disjunct[1].indicator_var)
 
+    def test_unique_reference_to_nested_indicator_var(self):
+        ct.check_unique_reference_to_nested_indicator_var(self, 'bigm')
+
     def test_disjunct_targets_inactive(self):
         ct.check_disjunct_targets_inactive(self, 'bigm')
 

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -1063,7 +1063,6 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
     def test_unique_reference_to_nested_indicator_var(self):
         ct.check_unique_reference_to_nested_indicator_var(self, 'hull')
 
-
     def test_disjunct_targets_inactive(self):
         ct.check_disjunct_targets_inactive(self, 'hull')
 

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -1060,6 +1060,10 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         # version. (But this behaves the same as bigm)
         ct.check_mappings_between_disjunctions_and_xors(self, 'hull')
 
+    def test_unique_reference_to_nested_indicator_var(self):
+        ct.check_unique_reference_to_nested_indicator_var(self, 'hull')
+
+
     def test_disjunct_targets_inactive(self):
         ct.check_disjunct_targets_inactive(self, 'hull')
 


### PR DESCRIPTION
## Fixes #1932 

## Summary/Motivation:

Previously, in the bigm and hull transformations, we created References to the local variables (including the indicator variables) on nested disjuncts both while transforming the inner disjunction and while transforming the parent disjunct. This causes problems for things like persistent solvers.

## Changes proposed in this PR:
- Move the transformation blocks of nested Disjuncts to the parent block of the parent Disjunct *before* creating References to the local variables on the parent Disjunct. This keeps us from referencing the references and then also moving them up.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
