### PR TITLE
Fix GDP error when using a disjunction with nested disjunctions as a target

### DIFF
--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -247,16 +247,13 @@ class BigM_Transformation(Transformation):
                     if t.is_indexed():
                         for disjunction in t.values():
                             for disj in disjunction.disjuncts:
-                                print("adding Disjunct %s" % disj.name)
                                 preprocessed_targets.append(disj)
                     else:
                         for disj in t.disjuncts:
-                            print("adding Disjunct %s" % disj.name)
                             preprocessed_targets.append(disj)
                 # now we are safe to put the disjunction, and if the target was
                 # anything else, then we don't need to worry because disjuncts
                 # are declared before disjunctions they appear in
-                print("adding target %s of type %s" % (t.name, t.ctype))
                 preprocessed_targets.append(t)
             targets = preprocessed_targets
 

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -213,6 +213,12 @@ class BigM_Transformation(Transformation):
             self.used_args.clear()
 
     def _apply_to_impl(self, instance, **kwds):
+        if not instance.ctype in (Block, Disjunct):
+            raise GDP_Error("Transformation called on %s of type %s. 'instance' "
+                            "must be a ConcreteModel, Block, or Disjunct (in "
+                            "the case of nested disjunctions)." %
+                            (instance.name, instance.ctype))
+
         config = self.CONFIG(kwds.pop('options', {}))
 
         # We will let args override suffixes and estimate as a last

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -31,9 +31,8 @@ from pyomo.gdp.util import ( _warn_for_active_logical_constraint, target_list,
                              get_src_constraint, get_transformed_constraints,
                              _get_constraint_transBlock, get_src_disjunct,
                              _warn_for_active_disjunction,
-                             _warn_for_active_disjunct, )
+                             _warn_for_active_disjunct, preprocess_targets)
 from pyomo.repn import generate_standard_repn
-
 from functools import wraps
 from weakref import ref as weakref_ref
 
@@ -241,21 +240,7 @@ class BigM_Transformation(Transformation):
             # we need to preprocess targets to make sure that if there are any
             # disjunctions in targets that their disjuncts appear before them in
             # the list.
-            preprocessed_targets = []
-            for t in targets:
-                if t.ctype is Disjunction:
-                    if t.is_indexed():
-                        for disjunction in t.values():
-                            for disj in disjunction.disjuncts:
-                                preprocessed_targets.append(disj)
-                    else:
-                        for disj in t.disjuncts:
-                            preprocessed_targets.append(disj)
-                # now we are safe to put the disjunction, and if the target was
-                # anything else, then we don't need to worry because disjuncts
-                # are declared before disjunctions they appear in
-                preprocessed_targets.append(t)
-            targets = preprocessed_targets
+            targets = preprocess_targets(targets)
 
         #  We need to check that all the targets are in fact on
         # instance. As we do this, we will use the set below to cache components

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -231,9 +231,32 @@ class BigM_Transformation(Transformation):
         targets = config.targets
         if targets is None:
             targets = (instance, )
-        # We need to check that all the targets are in fact on instance. As we
-        # do this, we will use the set below to cache components we know to be
-        # in the tree rooted at instance.
+        else:
+            # we need to preprocess targets to make sure that if there are any
+            # disjunctions in targets that their disjuncts appear before them in
+            # the list.
+            preprocessed_targets = []
+            for t in targets:
+                if t.ctype is Disjunction:
+                    if t.is_indexed():
+                        for disjunction in t.values():
+                            for disj in disjunction.disjuncts:
+                                print("adding Disjunct %s" % disj.name)
+                                preprocessed_targets.append(disj)
+                    else:
+                        for disj in t.disjuncts:
+                            print("adding Disjunct %s" % disj.name)
+                            preprocessed_targets.append(disj)
+                # now we are safe to put the disjunction, and if the target was
+                # anything else, then we don't need to worry because disjuncts
+                # are declared before disjunctions they appear in
+                print("adding target %s of type %s" % (t.name, t.ctype))
+                preprocessed_targets.append(t)
+            targets = preprocessed_targets
+
+        #  We need to check that all the targets are in fact on
+        # instance. As we do this, we will use the set below to cache components
+        # we know to be in the tree rooted at instance.
         knownBlocks = {}
         for t in targets:
             # check that t is in fact a child of instance

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -253,16 +253,13 @@ class Hull_Reformulation(Transformation):
                     if t.is_indexed():
                         for disjunction in t.values():
                             for disj in disjunction.disjuncts:
-                                print("adding Disjunct %s" % disj.name)
                                 preprocessed_targets.append(disj)
                     else:
                         for disj in t.disjuncts:
-                            print("adding Disjunct %s" % disj.name)
                             preprocessed_targets.append(disj)
                 # now we are safe to put the disjunction, and if the target was
                 # anything else, then we don't need to worry because disjuncts
                 # are declared before disjunctions they appear in
-                print("adding target %s of type %s" % (t.name, t.ctype))
                 preprocessed_targets.append(t)
             targets = preprocessed_targets
         knownBlocks = {}

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -29,7 +29,7 @@ from pyomo.gdp.util import ( _warn_for_active_logical_constraint,
                              is_child_of, get_src_disjunction,
                              get_src_constraint, get_transformed_constraints,
                              get_src_disjunct, _warn_for_active_disjunction,
-                             _warn_for_active_disjunct, )
+                             _warn_for_active_disjunct, preprocess_targets)
 from functools import wraps
 from weakref import ref as weakref_ref
 
@@ -247,21 +247,7 @@ class Hull_Reformulation(Transformation):
             # we need to preprocess targets to make sure that if there are any
             # disjunctions in targets that their disjuncts appear before them in
             # the list.
-            preprocessed_targets = []
-            for t in targets:
-                if t.ctype is Disjunction:
-                    if t.is_indexed():
-                        for disjunction in t.values():
-                            for disj in disjunction.disjuncts:
-                                preprocessed_targets.append(disj)
-                    else:
-                        for disj in t.disjuncts:
-                            preprocessed_targets.append(disj)
-                # now we are safe to put the disjunction, and if the target was
-                # anything else, then we don't need to worry because disjuncts
-                # are declared before disjunctions they appear in
-                preprocessed_targets.append(t)
-            targets = preprocessed_targets
+            targets = preprocess_targets(targets)
         knownBlocks = {}
         for t in targets:
             # check that t is in fact a child of instance

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -237,6 +237,28 @@ class Hull_Reformulation(Transformation):
         targets = self._config.targets
         if targets is None:
             targets = ( instance, )
+        else:
+            # we need to preprocess targets to make sure that if there are any
+            # disjunctions in targets that their disjuncts appear before them in
+            # the list.
+            preprocessed_targets = []
+            for t in targets:
+                if t.ctype is Disjunction:
+                    if t.is_indexed():
+                        for disjunction in t.values():
+                            for disj in disjunction.disjuncts:
+                                print("adding Disjunct %s" % disj.name)
+                                preprocessed_targets.append(disj)
+                    else:
+                        for disj in t.disjuncts:
+                            print("adding Disjunct %s" % disj.name)
+                            preprocessed_targets.append(disj)
+                # now we are safe to put the disjunction, and if the target was
+                # anything else, then we don't need to worry because disjuncts
+                # are declared before disjunctions they appear in
+                print("adding target %s of type %s" % (t.name, t.ctype))
+                preprocessed_targets.append(t)
+            targets = preprocessed_targets
         knownBlocks = {}
         for t in targets:
             # check that t is in fact a child of instance

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -230,6 +230,12 @@ class Hull_Reformulation(Transformation):
             NAME_BUFFER.clear()
 
     def _apply_to_impl(self, instance, **kwds):
+        if not instance.ctype in (Block, Disjunct):
+            raise GDP_Error("Transformation called on %s of type %s. 'instance' "
+                            "must be a ConcreteModel, Block, or Disjunct (in "
+                            "the case of nested disjunctions)." %
+                            (instance.name, instance.ctype))
+
         self._config = self.CONFIG(kwds.pop('options', {}))
         self._config.set_value(kwds)
         self._generate_debug_messages = is_debug_set(logger)

--- a/pyomo/gdp/tests/common_tests.py
+++ b/pyomo/gdp/tests/common_tests.py
@@ -12,6 +12,7 @@
 from pyomo.environ import TransformationFactory, ConcreteModel, Constraint, Var, Objective, Block, Any, RangeSet, Expression, value
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 from pyomo.core.base import constraint, ComponentUID
+from pyomo.core.base.block import _BlockData
 from pyomo.repn import generate_standard_repn
 import pyomo.gdp.tests.models as models
 from io import StringIO
@@ -1496,6 +1497,21 @@ def check_disjunctData_only_targets_transformed(self, transformation):
                       m.disjunct[1].innerdisjunct[i])
         self.assertIs(m.disjunct[1].innerdisjunct[i].transformation_block(),
                       disjBlock[j])
+
+def check_nested_disjunction_target(self, transformation):
+    m = models.makeNestedDisjunctions_NestedDisjuncts()
+    transform = TransformationFactory('gdp.%s' % transformation)
+    transform.apply_to(m, targets=[m.disj])
+
+    # the bug that inspired this test throws an error while doing the
+    # transformation, so we'll just do a quick check that all the GDP
+    # components think they are transformed.
+    self.assertIsInstance(m.disj.algebraic_constraint(), Constraint)
+    self.assertIsInstance(m.d1.disj2.algebraic_constraint(), Constraint)
+    self.assertIsInstance(m.d1.transformation_block(), _BlockData)
+    self.assertIsInstance(m.d2.transformation_block(), _BlockData)
+    self.assertIsInstance(m.d1.d3.transformation_block(), _BlockData)
+    self.assertIsInstance(m.d1.d4.transformation_block(), _BlockData)
 
 # checks for handling of benign types that could be on disjuncts we're
 # transforming

--- a/pyomo/gdp/tests/models.py
+++ b/pyomo/gdp/tests/models.py
@@ -541,9 +541,7 @@ def makeDisjunctInMultipleDisjunctions():
 def makeDuplicatedNestedDisjunction():
     """Not a transformable model (because of disjuncts shared between 
     disjunctions): A SimpleDisjunction where one of the disjuncts contains
-    two SimpleDisjunctions with the same Disjuncts. This is a lazy
-    way to test that we complain about untransformed disjunctions we encounter
-    while transforming a disjunct.
+    two SimpleDisjunctions with the same Disjuncts.
     """
     m = ConcreteModel()
     m.x = Var(bounds=(0, 8))

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -702,9 +702,6 @@ class TwoTermIndexedDisj(unittest.TestCase, CommonTests):
         m = models.makeTwoTermMultiIndexedDisjunction()
         self.diff_apply_to_and_create_using(m)
 
-    def test_targets_with_container_as_arg(self):
-        ct.check_targets_with_container_as_arg(self, 'bigm')
-
 class DisjOnBlock(unittest.TestCase, CommonTests):
     # when the disjunction is on a block, we want all of the stuff created by
     # the transformation to go on that block also so that solving the block
@@ -1971,6 +1968,9 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
     def test_disjunctData_only_targets_transformed(self):
         ct.check_disjunctData_only_targets_transformed(self, 'bigm')
 
+    def test_cannot_call_transformation_on_disjunction(self):
+        ct.check_cannot_call_transformation_on_disjunction(self, 'bigm')
+
     def test_disjunction_target_err(self):
         ct.check_disjunction_target_err(self, 'bigm')
 
@@ -2159,10 +2159,6 @@ class BlocksOnDisjuncts(unittest.TestCase):
         self.assertEqual(repn.linear_coefs[0], 1)
         self.assertIs(repn.linear_vars[1], m.b.d.indicator_var)
         self.assertEqual(repn.linear_coefs[1], -10)
-
-class InnerDisjunctionSharedDisjuncts(unittest.TestCase):
-    def test_activeInnerDisjunction_err(self):
-        ct.check_activeInnerDisjunction_err(self, 'bigm')
 
 class UntransformableObjectsOnDisjunct(unittest.TestCase):
     def test_RangeSet(self):

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -1980,6 +1980,9 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
     def test_nested_disjunction_target(self):
         ct.check_nested_disjunction_target(self, 'bigm')
 
+    def test_target_appears_twice(self):
+        ct.check_target_appears_twice(self, 'bigm')
+
     def test_create_using(self):
         m = models.makeNestedDisjunctions()
         self.diff_apply_to_and_create_using(m)

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -1974,6 +1974,9 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
     def test_disjunction_target_err(self):
         ct.check_disjunction_target_err(self, 'bigm')
 
+    def test_nested_disjunction_target(self):
+        ct.check_nested_disjunction_target(self, 'bigm')
+
     def test_create_using(self):
         m = models.makeNestedDisjunctions()
         self.diff_apply_to_and_create_using(m)

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -751,8 +751,8 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
     def test_disjunction_data_target_any_index(self):
         ct.check_disjunction_data_target_any_index(self, 'hull')
 
-    def test_targets_with_container_as_arg(self):
-        ct.check_targets_with_container_as_arg(self, 'hull')
+    def test_cannot_call_transformation_on_disjunction(self):
+        ct.check_cannot_call_transformation_on_disjunction(self, 'hull')
 
     def check_trans_block_disjunctions_of_disjunct_datas(self, m):
         transBlock1 = m.component("_pyomo_gdp_hull_reformulation")
@@ -1538,7 +1538,7 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
 
         # transform inner problem with bigm, outer with hull and make sure it
         # still works
-        TransformationFactory('gdp.bigm').apply_to(m.d1.disj2)
+        TransformationFactory('gdp.bigm').apply_to(m, targets=(m.d1.disj2))
         hull.apply_to(m)
 
         SolverFactory(linear_solvers[0]).solve(m)
@@ -1914,10 +1914,6 @@ class TestErrors(unittest.TestCase):
             hull.get_disaggregated_var,
             m.w,
             m.random_disjunction.disjuncts[0])
-
-class InnerDisjunctionSharedDisjuncts(unittest.TestCase):
-    def test_activeInnerDisjunction_err(self):
-        ct.check_activeInnerDisjunction_err(self, 'hull')
 
 class BlocksOnDisjuncts(unittest.TestCase):
     def setUp(self):

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -1081,6 +1081,9 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
     def test_nested_disjunction_target(self):
         ct.check_nested_disjunction_target(self, 'hull')
 
+    def test_target_appears_twice(self):
+        ct.check_target_appears_twice(self, 'hull')
+
     @unittest.skipIf(not linear_solvers, "No linear solver available")
     def test_relaxation_feasibility(self):
         m = models.makeNestedDisjunctions_FlatDisjuncts()

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -1075,6 +1075,9 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
     def test_disjunction_target_err(self):
         ct.check_disjunction_target_err(self, 'hull')
 
+    def test_nested_disjunction_target(self):
+        ct.check_nested_disjunction_target(self, 'hull')
+
     @unittest.skipIf(not linear_solvers, "No linear solver available")
     def test_relaxation_feasibility(self):
         m = models.makeNestedDisjunctions_FlatDisjuncts()

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -80,7 +80,22 @@ def clone_without_expression_components(expr, substitute=None):
                                                 remove_named_expressions=True)
     return visitor.dfs_postorder_stack(expr)
 
-
+def preprocess_targets(targets):
+    preprocessed_targets = []
+    for t in targets:
+        if t.ctype is Disjunction:
+            if t.is_indexed():
+                for disjunction in t.values():
+                    for disj in disjunction.disjuncts:
+                        preprocessed_targets.append(disj)
+            else:
+                for disj in t.disjuncts:
+                    preprocessed_targets.append(disj)
+        # now we are safe to put the disjunction, and if the target was
+        # anything else, then we don't need to worry because disjuncts
+        # are declared before disjunctions they appear in
+        preprocessed_targets.append(t)
+    return preprocessed_targets
 
 def target_list(x):
     if isinstance(x, _ComponentBase):


### PR DESCRIPTION
## Fixes #1933 

## Summary/Motivation:

GDP transformations usually get lucky because they transform objects in declaration order, and Disjuncts have to be declared before the Disjunctions they appear in. However, you can mess up this order in the `targets` list. In particular, in the referenced issue, you can give a Disjunction which contains nested Disjunctions as a target. This bypasses the depth-first-search transformation order, so GDP fails to transform the nested stuff and then blames you.

## Changes proposed in this PR:
- Preprocess targets so that Disjuncts always appear before the Disjunctions that contain them in the list.
- Remove tests for the active Disjunction error, as that is now unreachable, I think
- Be more careful about the argument to the transformation: must be Block-like so that we are sure we catch this in targets

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
