### PR TITLE
Add RenameClass metaclass

### DIFF
--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -243,7 +243,11 @@ texinfo_documents = [
 
 # -- Check which conditional dependencies are available ------------------
 # Used for skipping certain doctests
-
+from sphinx.ext.doctest import doctest
+doctest_default_flags = (
+    doctest.ELLIPSIS + doctest.NORMALIZE_WHITESPACE +
+    doctest.IGNORE_EXCEPTION_DETAIL + doctest.DONT_ACCEPT_TRUE_FOR_1
+)
 doctest_global_setup = '''
 
 from pyomo.common.dependencies import (

--- a/doc/OnlineDocs/library_reference/common/index.rst
+++ b/doc/OnlineDocs/library_reference/common/index.rst
@@ -10,4 +10,5 @@ or rely on any other parts of Pyomo.
 
    config.rst
    dependencies.rst
+   deprecation.rst
    timing.rst

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -330,7 +330,7 @@ def attempt_import(name, error_message=None, only_catch_importerror=None,
     the module scope but not imported until they are actually used by
     the module (thereby speeding up the initial package import).
     Deferred imports are handled by two helper classes
-    (:py:class`DeferredImportModule` and
+    (:py:class:`DeferredImportModule` and
     :py:class:`DeferredImportIndicator`).  Upon actual import,
     :py:meth:`DeferredImportIndicator.resolve()` attempts to replace
     those objects (in both the local and original global namespaces)
@@ -529,7 +529,7 @@ def declare_deferred_modules_as_importable(globals_dict):
     :py:class:`DeferredImportModule` is returned and named ``spa``.
     However, if the import has already been triggered, then ``spa`` will
     either be the ``scipy.sparse`` module, or a
-    py:class:`ModuleUnavailable` instance.
+    :py:class:`ModuleUnavailable` instance.
 
     """
     _global_name = globals_dict['__name__'] + '.'

--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -406,7 +406,7 @@ class RenamedClass(type):
 
         # Add the new class as a "base class" of the renamed class (this
         # makes issubclass(renamed, new_class) work correctly).  As we
-        # sill never create an actual instance of renamed, this doesn't
+        # still never create an actual instance of renamed, this doesn't
         # affect the API)
         if new_class is not None and new_class not in renamed_bases:
             renamed_bases.append(new_class)

--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -13,6 +13,7 @@
 import logging
 import functools
 import inspect
+import itertools
 import sys
 import textwrap
 import types
@@ -297,3 +298,118 @@ def relocated_module_attribute(local, target, version, remove_in=None):
             _module = sys.modules[_module.__name__] \
                       = _ModuleGetattrBackport_27(_module)
     _module.__relocated_attrs__[local] = (target, version, remove_in)
+
+
+class RenamedClass(type):
+    """Metaclass to provide a deprecation path for renamed classes
+
+    This metaclass provides a mechanism for renaming old classes while
+    still preserving isinstance / issubclass relationships.
+
+    Example
+    -------
+        >>> from pyomo.common.deprecation import RenamedClass
+        >>> class NewClass(object):
+        ...     pass
+        >>> class OldClass(metaclass=RenamedClass):
+        ...     __renamed__new_class__ = NewClass
+        ...     __renamed__version__ = '6.0'
+
+        Deriving from the old class generates a warning:
+
+        >>> class DerivedOldClass(OldClass):
+        ...     pass
+        WARNING: DEPRECATED: Declaring class 'DerivedOldClass' derived from
+            'OldClass'. The class 'OldClass' has been renamed to 'NewClass'
+            (deprecated in 6.0) ...
+
+        As does instantiating the old class:
+
+        >>> old = OldClass()
+        WARNING: DEPRECATED: Instantiating class 'OldClass'.  The class
+            'OldClass' has been renamed to 'NewClass'  (deprecated in 6.0) ...
+
+        Finally, isinstance and issubclass still work, for example:
+
+        >>> isinstance(old, NewClass)
+        True
+        >>> class NewSubclass(NewClass):
+        ...     pass
+        >>> new = NewSubclass()
+        >>> isinstance(new, OldClass)
+        WARNING: DEPRECATED: Checking type relative to 'OldClass'.  The class
+            'OldClass' has been renamed to 'NewClass'  (deprecated in 6.0) ...
+        True
+
+    """
+    def __new__(cls, name, bases, classdict, *args, **kwargs):
+        new_class = classdict.get('__renamed__new_class__', None)
+        if new_class is not None:
+            def __renamed__new__(cls, *args, **kwargs):
+                cls.__renamed__warning__(
+                    "Instantiating class '%s'." % (cls.__name__,))
+                return new_class(*args, **kwargs)
+            classdict['__new__'] = __renamed__new__
+
+            def __renamed__warning__(msg):
+                version = classdict.get('__renamed__version__')
+                remove_in = classdict.get('__renamed__remove_in__')
+                deprecation_warning(
+                    "%s  The class '%s' has been renamed to '%s'" % (
+                        msg, name, new_class.__name__),
+                    version=version, remove_in=remove_in)
+            classdict['__renamed__warning__'] = __renamed__warning__
+
+            if '__renamed__version__' not in classdict:
+                raise TypeError(
+                    "Declaring class '%s' using the RenamedClass metaclass, "
+                    "but without specifying the __renamed__version__ class "
+                    "attribute" % (name,))
+
+        renamed_bases = []
+        for base in bases:
+            new_class = getattr(base, '__renamed__new_class__', None)
+            if new_class is not None:
+                base.__renamed__warning__(
+                    "Declaring class '%s' derived from '%s'." % (
+                        name, base.__name__,))
+                base = new_class
+                # Flag that this class is derived from a renamed class
+                classdict.setdefault('__renamed__new_class__', None)
+            # Avoid duplicates (in case someone does a diamond between
+            # the renamed class and [a class dervied from] the new
+            # class)
+            if base not in renamed_bases:
+                renamed_bases.append(base)
+
+        # Add the new class as a "base class" of the renamed class (this
+        # makes issubclass(renamed, new_class) work correctly).  As we
+        # sill never create an actual instance of renamed, this doesn't
+        # affect the API)
+        if new_class is not None and new_class not in renamed_bases:
+            renamed_bases.append(new_class)
+
+        if new_class is None and '__renamed__new_class__' not in classdict:
+            if not any(hasattr(base, '__renamed__new_class__') for mro in
+                       itertools.chain.from_iterable(
+                           base.__mro__ for base in renamed_bases)):
+                raise TypeError(
+                    "Declaring class '%s' using the RenamedClass metaclass, "
+                    "but without specifying the __renamed__new_class__ class "
+                    "attribute" % (name,))
+
+        return super().__new__(
+            cls, name, tuple(renamed_bases), classdict, *args, **kwargs)
+
+    def __instancecheck__(cls, instance):
+        # Note: the warning is issued by subclasscheck
+        return any(cls.__subclasscheck__(c)
+            for c in {type(instance), instance.__class__})
+
+    def __subclasscheck__(cls, subclass):
+        cls.__renamed__warning__(
+            "Checking type relative to '%s'." % (cls.__name__,))
+        if subclass is cls:
+            return True
+        else:
+            return issubclass(subclass, getattr(cls, '__renamed__new_class__'))

--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -116,7 +116,7 @@ def _wrap_func(func, msg, logger, version, remove_in):
     return wrapper
 
 
-def deprecation_warning(msg, logger='pyomo.core', version=None,
+def deprecation_warning(msg, logger=None, version=None,
                         remove_in=None, calling_frame=None):
     """Standardized formatter for deprecation warnings
 
@@ -125,6 +125,21 @@ def deprecation_warning(msg, logger='pyomo.core', version=None,
 
     Args:
         msg (str): the deprecation message to format
+
+        logger (str): the logger to use for emitting the warning
+            (default: the calling pyomo package, or "pyomo")
+
+        version (str): [required] the version in which the decorated
+            object was deprecated.  General practice is to set version
+            to '' or 'TBD' during development and update it to the
+            actual release as part of the release process.
+
+        remove_in (str): the version in which the decorated object will be
+            removed from the code.
+
+        calling_frame (frame): the original frame context that triggered
+            the deprecation warning.
+
     """
     msg = textwrap.fill(
         'DEPRECATED: %s' % (_default_msg(None, msg, version, remove_in),),
@@ -141,10 +156,17 @@ def deprecation_warning(msg, logger='pyomo.core', version=None,
         info = inspect.getframeinfo(calling_frame)
         msg += "\n(called from %s:%s)" % (info.filename.strip(), info.lineno)
 
+    if logger is None:
+        if calling_frame is not None:
+            logger = calling_frame.f_globals['__package__']
+            if not logger.startswith('pyomo'):
+                logger = None
+        if logger is None:
+            logger = 'pyomo'
     logging.getLogger(logger).warning(msg)
 
 
-def deprecated(msg=None, logger='pyomo.core', version=None, remove_in=None):
+def deprecated(msg=None, logger=None, version=None, remove_in=None):
     """Indicate that a function, method or class is deprecated.
 
     This decorator will cause a warning to be logged when the wrapped
@@ -158,7 +180,7 @@ def deprecated(msg=None, logger='pyomo.core', version=None, remove_in=None):
             removed in a future release.")
 
         logger (str): the logger to use for emitting the warning
-            (default: "pyomo")
+            (default: the calling pyomo package, or "pyomo")
 
         version (str): [required] the version in which the decorated
             object was deprecated.  General practice is to set version

--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -8,7 +8,15 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-"""Decorator for deprecating functions."""
+"""This module provides utilities for deprecating functionality.
+
+.. autosummary::
+
+   deprecated
+   deprecation_warning
+   relocated_module_attribute
+   RenamedClass
+"""
 
 import logging
 import functools
@@ -167,7 +175,7 @@ def deprecation_warning(msg, logger=None, version=None,
 
 
 def deprecated(msg=None, logger=None, version=None, remove_in=None):
-    """Indicate that a function, method or class is deprecated.
+    """Decorator to indicate that a function, method or class is deprecated.
 
     This decorator will cause a warning to be logged when the wrapped
     function or method is called, or when the deprecated class is

--- a/pyomo/common/tests/test_dependencies.py
+++ b/pyomo/common/tests/test_dependencies.py
@@ -241,7 +241,7 @@ class TestDependencies(unittest.TestCase):
         # Test generate warning
         log = StringIO()
         dep = StringIO()
-        with LoggingIntercept(dep, 'pyomo'):
+        with LoggingIntercept(dep, 'pyomo.common.tests'):
             with LoggingIntercept(log, 'pyomo.common'):
                 mod.generate_import_warning()
         self.assertIn(

--- a/pyomo/common/tests/test_deprecated.py
+++ b/pyomo/common/tests/test_deprecated.py
@@ -24,7 +24,7 @@ from pyomo.common.log import LoggingIntercept
 from io import StringIO
 
 import logging
-logger = logging.getLogger('pyomo.common')
+logger = logging.getLogger('local')
 
 
 class TestDeprecated(unittest.TestCase):
@@ -32,7 +32,7 @@ class TestDeprecated(unittest.TestCase):
 
     def test_deprecation_warning(self):
         DEP_OUT = StringIO()
-        with LoggingIntercept(DEP_OUT, 'pyomo.core'):
+        with LoggingIntercept(DEP_OUT, 'pyomo'):
             deprecation_warning(None, version='1.2', remove_in='3.4')
 
         self.assertIn('DEPRECATED: This has been deprecated',
@@ -41,7 +41,7 @@ class TestDeprecated(unittest.TestCase):
                       DEP_OUT.getvalue().replace('\n',' '))
 
         DEP_OUT = StringIO()
-        with LoggingIntercept(DEP_OUT, 'pyomo.core'):
+        with LoggingIntercept(DEP_OUT, 'pyomo'):
             deprecation_warning("custom message here", version='1.2', remove_in='3.4')
 
         self.assertIn('DEPRECATED: custom message here',
@@ -87,8 +87,8 @@ class TestDeprecated(unittest.TestCase):
         # Test the default argument
         DEP_OUT = StringIO()
         FCN_OUT = StringIO()
-        with LoggingIntercept(DEP_OUT, 'pyomo.core'):
-            with LoggingIntercept(FCN_OUT, 'pyomo.common'):
+        with LoggingIntercept(DEP_OUT, 'pyomo'):
+            with LoggingIntercept(FCN_OUT, 'local'):
                 foo()
         # Test that the function produces output
         self.assertIn('yeah', FCN_OUT.getvalue())
@@ -100,8 +100,8 @@ class TestDeprecated(unittest.TestCase):
         # Test that the function argument gets passed in
         DEP_OUT = StringIO()
         FCN_OUT = StringIO()
-        with LoggingIntercept(DEP_OUT, 'pyomo.core'):
-            with LoggingIntercept(FCN_OUT, 'pyomo.common'):
+        with LoggingIntercept(DEP_OUT, 'pyomo'):
+            with LoggingIntercept(FCN_OUT, 'local'):
                 foo("custom")
         # Test that the function produces output
         self.assertNotIn('yeah', FCN_OUT.getvalue())
@@ -130,8 +130,8 @@ class TestDeprecated(unittest.TestCase):
         # Test the default argument
         DEP_OUT = StringIO()
         FCN_OUT = StringIO()
-        with LoggingIntercept(DEP_OUT, 'pyomo.core'):
-            with LoggingIntercept(FCN_OUT, 'pyomo.common'):
+        with LoggingIntercept(DEP_OUT, 'pyomo'):
+            with LoggingIntercept(FCN_OUT, 'local'):
                 foo()
         # Test that the function produces output
         self.assertIn('yeah', FCN_OUT.getvalue())
@@ -143,8 +143,8 @@ class TestDeprecated(unittest.TestCase):
         # Test that the function argument gets passed in
         DEP_OUT = StringIO()
         FCN_OUT = StringIO()
-        with LoggingIntercept(DEP_OUT, 'pyomo.core'):
-            with LoggingIntercept(FCN_OUT, 'pyomo.common'):
+        with LoggingIntercept(DEP_OUT, 'pyomo'):
+            with LoggingIntercept(FCN_OUT, 'local'):
                 foo("custom")
         # Test that the function produces output
         self.assertNotIn('yeah', FCN_OUT.getvalue())
@@ -173,8 +173,8 @@ class TestDeprecated(unittest.TestCase):
         # Test the default argument
         DEP_OUT = StringIO()
         FCN_OUT = StringIO()
-        with LoggingIntercept(DEP_OUT, 'pyomo.core'):
-            with LoggingIntercept(FCN_OUT, 'pyomo.common'):
+        with LoggingIntercept(DEP_OUT, 'pyomo'):
+            with LoggingIntercept(FCN_OUT, 'local'):
                 foo()
         # Test that the function produces output
         self.assertIn('yeah', FCN_OUT.getvalue())
@@ -186,8 +186,8 @@ class TestDeprecated(unittest.TestCase):
         # Test that the function argument gets passed in
         DEP_OUT = StringIO()
         FCN_OUT = StringIO()
-        with LoggingIntercept(DEP_OUT, 'pyomo.core'):
-            with LoggingIntercept(FCN_OUT, 'pyomo.common'):
+        with LoggingIntercept(DEP_OUT, 'pyomo'):
+            with LoggingIntercept(FCN_OUT, 'local'):
                 foo("custom")
         # Test that the function produces output
         self.assertNotIn('yeah', FCN_OUT.getvalue())
@@ -199,7 +199,7 @@ class TestDeprecated(unittest.TestCase):
 
 
     def test_with_custom_logger(self):
-        @deprecated('This is a custom message', logger='pyomo.common',
+        @deprecated('This is a custom message', logger='local',
                     version='test')
         def foo(bar='yeah'):
             """Show that I am a good person.
@@ -217,8 +217,8 @@ class TestDeprecated(unittest.TestCase):
         # Test the default argument
         DEP_OUT = StringIO()
         FCN_OUT = StringIO()
-        with LoggingIntercept(DEP_OUT, 'pyomo.core'):
-            with LoggingIntercept(FCN_OUT, 'pyomo.common'):
+        with LoggingIntercept(DEP_OUT, 'pyomo'):
+            with LoggingIntercept(FCN_OUT, 'local'):
                 foo()
         # Test that the function produces output
         self.assertIn('yeah', FCN_OUT.getvalue())
@@ -231,8 +231,8 @@ class TestDeprecated(unittest.TestCase):
         # Test that the function argument gets passed in
         DEP_OUT = StringIO()
         FCN_OUT = StringIO()
-        with LoggingIntercept(DEP_OUT, 'pyomo.core'):
-            with LoggingIntercept(FCN_OUT, 'pyomo.common'):
+        with LoggingIntercept(DEP_OUT, 'pyomo'):
+            with LoggingIntercept(FCN_OUT, 'local'):
                 foo("custom")
         # Test that the function produces output
         self.assertNotIn('yeah', FCN_OUT.getvalue())
@@ -257,8 +257,8 @@ class TestDeprecated(unittest.TestCase):
         # Test the default argument
         DEP_OUT = StringIO()
         FCN_OUT = StringIO()
-        with LoggingIntercept(DEP_OUT, 'pyomo.core'):
-            with LoggingIntercept(FCN_OUT, 'pyomo.common'):
+        with LoggingIntercept(DEP_OUT, 'pyomo'):
+            with LoggingIntercept(FCN_OUT, 'local'):
                 foo()
         # Test that the function produces output
         self.assertIn('yeah', FCN_OUT.getvalue())
@@ -283,8 +283,8 @@ class TestDeprecated(unittest.TestCase):
         # Test the default argument
         DEP_OUT = StringIO()
         FCN_OUT = StringIO()
-        with LoggingIntercept(DEP_OUT, 'pyomo.core'):
-            with LoggingIntercept(FCN_OUT, 'pyomo.common'):
+        with LoggingIntercept(DEP_OUT, 'pyomo'):
+            with LoggingIntercept(FCN_OUT, 'local'):
                 foo().bar()
         # Test that the function produces output
         self.assertIn('yeah', FCN_OUT.getvalue())
@@ -310,8 +310,8 @@ class TestDeprecated(unittest.TestCase):
         # Test the default argument
         DEP_OUT = StringIO()
         FCN_OUT = StringIO()
-        with LoggingIntercept(DEP_OUT, 'pyomo.core'):
-            with LoggingIntercept(FCN_OUT, 'pyomo.common'):
+        with LoggingIntercept(DEP_OUT, 'pyomo'):
+            with LoggingIntercept(FCN_OUT, 'local'):
                 foo().bar()
         # Test that the function produces output
         self.assertIn('yeah', FCN_OUT.getvalue())
@@ -337,7 +337,7 @@ class TestRelocated(unittest.TestCase):
         warning = "DEPRECATED: the 'myFoo' class has been moved to " \
                   "'pyomo.common.tests.relocated.Bar'"
         OUT = StringIO()
-        with LoggingIntercept(OUT, 'pyomo.core'):
+        with LoggingIntercept(OUT, 'pyomo'):
             from pyomo.common.tests.test_deprecated import myFoo
         self.assertEqual(myFoo.data, 42)
         self.assertIn(warning, OUT.getvalue().replace('\n', ' '))
@@ -356,7 +356,7 @@ class TestRelocated(unittest.TestCase):
                   "'pyomo.common.tests.relocated.Bar'"
 
         OUT = StringIO()
-        with LoggingIntercept(OUT, 'pyomo.core'):
+        with LoggingIntercept(OUT, 'pyomo'):
             self.assertIs(relocated.Foo_2, relocated.Bar)
             self.assertEqual(relocated.Foo_2.data, 42)
         self.assertIn(warning, OUT.getvalue().replace('\n', ' '))
@@ -369,7 +369,7 @@ class TestRelocated(unittest.TestCase):
                   "'pyomo.common.tests.test_deprecated.Bar'"
 
         OUT = StringIO()
-        with LoggingIntercept(OUT, 'pyomo.core'):
+        with LoggingIntercept(OUT, 'pyomo'):
             from pyomo.common.tests.relocated import Foo
             self.assertEqual(Foo.data, 21)
         self.assertIn(warning, OUT.getvalue().replace('\n', ' '))

--- a/pyomo/common/tests/test_tempfile.py
+++ b/pyomo/common/tests/test_tempfile.py
@@ -332,7 +332,7 @@ class Test(unittest.TestCase):
             TempfileManager.tempdir = None
 
             log = StringIO()
-            with LoggingIntercept(log, 'pyomo.core'):
+            with LoggingIntercept(log, 'pyomo'):
                 fname = TempfileManager.create_tempfile()
             self.assertIn(
                 "The use of the PyUtilib TempfileManager.tempdir "
@@ -340,7 +340,7 @@ class Test(unittest.TestCase):
                 "temporary files", log.getvalue().replace("\n", " "))
 
             log = StringIO()
-            with LoggingIntercept(log, 'pyomo.core'):
+            with LoggingIntercept(log, 'pyomo'):
                 dname = TempfileManager.create_tempdir()
             self.assertIn(
                 "The use of the PyUtilib TempfileManager.tempdir "

--- a/pyomo/util/tests/test_infeasible.py
+++ b/pyomo/util/tests/test_infeasible.py
@@ -82,16 +82,18 @@ class TestInfeasible(unittest.TestCase):
         m = self.build_model()
         depr = StringIO()
         output = StringIO()
-        with LoggingIntercept(depr, 'pyomo'):
-            with LoggingIntercept(output, 'pyomo.util', logging.INFO):
-                log_active_constraints(m)
+        with LoggingIntercept(depr, 'pyomo.util', logging.WARNING):
+            log_active_constraints(m)
         self.assertIn("log_active_constraints is deprecated.", depr.getvalue())
+        with LoggingIntercept(output, 'pyomo.util', logging.INFO):
+            log_active_constraints(m)
         expected_output = [
             "c1 active", "c2 active", "c3 active", "c4 active",
             "c5 active", "c6 active", "c7 active", "c8 active",
             "c9 active", "c11 active"
         ]
-        self.assertEqual(expected_output, output.getvalue().splitlines())
+        self.assertEqual(expected_output,
+                         output.getvalue()[len(depr.getvalue()):].splitlines())
 
     def test_log_close_to_bounds(self):
         """Test logging of variables and constraints near bounds."""


### PR DESCRIPTION
## Fixes # N/A

## Summary/Motivation:
This adds a new metaclass that we can use to provide a deprecation path when renaming classes.  The advantage of using a metaclass is so that users receive deprecation warnings not only when instantiating the deprecated class name, but also when deriving from the old class and when using the old class in `isinstance()` and `issubclass()` tests.

This also cleans up the deprecation warnings so that the warnings are sent to a logger associated with the calling module's namespace (instead of routing all deprecation warnings through the `pyomo.core` namespace.

## Changes proposed in this PR:
- Add a `RenamedClass` metaclass
- Update the deprecation warnings to emit warnings using a logger tied to the module that called either `@deprecated` or `deprecation_warning()`.
- Add deprecation documentation to the RTD library reference
- Add tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
