### PR TITLE
Allow assigning None to a unitted variable

### DIFF
--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -392,7 +392,7 @@ class _GeneralVarData(_VarData):
             # TODO: warn/error: check if this Var has units: assigning
             # a dimensionless value to a united variable should be an error
             pass
-        elif self.parent_component()._units is not None:
+        elif val is not None and self.parent_component()._units is not None:
             _src_magnitude = value(val)
             _src_units = units.get_units(val)
             val = units.convert_value(

--- a/pyomo/core/tests/unit/test_var.py
+++ b/pyomo/core/tests/unit/test_var.py
@@ -1383,6 +1383,8 @@ class MiscVarTests(unittest.TestCase):
         self.assertEqual(value(m.x), 5)
         m.x = 6*units.g
         self.assertEqual(value(m.x), 6)
+        m.x = None
+        self.assertIsNone(m.x.value, None)
         m.x = 7*units.kg
         self.assertEqual(value(m.x), 7000)
         with self.assertRaises(UnitsError):


### PR DESCRIPTION
## Fixes #N/A

Related to IDAES/idaes-pse#346

## Summary/Motivation:
#1966 added support for setting the value of unitted Var and Param objects with unit expressions.  However, it introduced a bug where you could no longer set the value of a unitted Var to `None`.  This PR fixed that issue.

## Changes proposed in this PR:
- allow setting the value of a unitted Var to `None`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
