### PR TITLE
Improve quoting in component names and indices

### DIFF
--- a/examples/pyomobook/abstract-ch/AbstHLinScript.txt
+++ b/examples/pyomobook/abstract-ch/AbstHLinScript.txt
@@ -1,4 +1,4 @@
-Model Simple Linear (H)
+Model 'Simple Linear (H)'
 
   Variables:
     x : Size=2, Index=A

--- a/examples/pyomobook/optimization-ch/ConcHLinScript.txt
+++ b/examples/pyomobook/optimization-ch/ConcHLinScript.txt
@@ -1,4 +1,4 @@
-Model Linear (H)
+Model 'Linear (H)'
 
   Variables:
     x : Size=2, Index=x_index

--- a/pyomo/contrib/community_detection/tests/test_detection.py
+++ b/pyomo/contrib/community_detection/tests/test_detection.py
@@ -644,8 +644,8 @@ class TestDecomposition(unittest.TestCase):
 
         community_map_object = cmo = detect_communities(model, random_seed=5)
         correct_partition = {3: 0, 4: 1, 5: 0, 6: 0, 7: 1, 8: 0}
-        correct_components = {'b[0].B[2].c', 'b[0].c2[1]', 'b[0].c1[3]', 'equality_constraint_list[1]',
-                              'b[1].c2[2]', 'b[1].x', 'b[0].x', 'b[0].y', 'b[0].z', 'b[0].obj[2]', 'b[1].c1[2]'}
+        correct_components = {"b[0].'B[2].c'", "b[0].'c2[1]'", "b[0].'c1[3]'", 'equality_constraint_list[1]',
+                              "b[1].'c2[2]'", 'b[1].x', 'b[0].x', 'b[0].y', 'b[0].z', "b[0].'obj[2]'", "b[1].'c1[2]'"}
 
         structured_model = cmo.generate_structured_model()
         self.assertIsInstance(structured_model, Block)

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -669,7 +669,9 @@ arguments (which have been ignored):"""
             timing.report_timing()
 
         if name is None:
-            name = self.name
+            # Preserve only the local name (not the FQ name, as that may
+            # have been quoted or otherwise escaped)
+            name = self.local_name
         if filename is not None:
             if data is not None:
                 logger.warning("Model.create_instance() passed both 'filename' "

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -18,7 +18,9 @@ import pyomo.common
 from pyomo.common.deprecation import deprecated, relocated_module_attribute
 from pyomo.common.factory import Factory
 from pyomo.common.fileutils import StreamIndenter
+from pyomo.common.modeling import NOTSET
 from pyomo.core.pyomoobject import PyomoObject
+from pyomo.core.base.component_namer import name_repr, index_repr
 from pyomo.core.base.misc import tabular_writer, sorted_robust
 
 logger = logging.getLogger('pyomo.core')
@@ -39,44 +41,21 @@ class ModelComponentFactoryClass(Factory):
 ModelComponentFactory = ModelComponentFactoryClass('model component')
 
 
-def _name_index_generator(idx):
-    """
-    Return a string representation of an index.
-    """
-    def _escape(val):
-        if type(val) is tuple:
-            ans = "(" + ','.join(_escape(_) for _ in val) + ")"
-        else:
-            # We need to quote set members (because people put things
-            # like spaces - or worse commas - in their set names).  Our
-            # plan is to put the strings in single quotes... but that
-            # requires escaping any single quotes in the string... which
-            # in turn requires escaping the escape character.
-            ans = "%s" % (val,)
-            if isinstance(val, str):
-                ans = ans.replace("\\", "\\\\").replace("'", "\\'")
-                if ',' in ans or "'" in ans:
-                    ans = "'"+ans+"'"
-        return ans
-    if idx.__class__ is tuple:
-        return "[" + ",".join(_escape(i) for i in idx) + "]"
-    else:
-        return "[" + _escape(idx) + "]"
-
-
-def name(component, index=None, fully_qualified=False, relative_to=None):
+def name(component, index=NOTSET, fully_qualified=False, relative_to=None):
     """
     Return a string representation of component for a specific
     index value.
     """
-    base = component.getname(fully_qualified=fully_qualified, relative_to=relative_to)
-    if index is None:
+    base = component.getname(
+        fully_qualified=fully_qualified, relative_to=relative_to
+    )
+    if index is NOTSET:
         return base
     else:
         if index not in component.index_set():
             raise KeyError( "Index %s is not valid for component %s"
                             % (index, component.name) )
-        return base + _name_index_generator( index )
+        return base + index_repr( index )
 
 
 @deprecated(msg="The cname() function has been renamed to name()",
@@ -576,21 +555,25 @@ class Component(_ComponentBase):
         relative_to: Block
             Generate fully_qualified names reletive to the specified block.
         """
+        local_name = self._name
         if fully_qualified:
             pb = self.parent_block()
             if relative_to is None:
                 relative_to = self.model()
             if pb is not None and pb is not relative_to:
                 ans = pb.getname(fully_qualified, name_buffer, relative_to) \
-                      + "." + self._name
+                      + "." + name_repr(local_name)
             elif pb is None and relative_to != self.model():
                 raise RuntimeError(
                     "The relative_to argument was specified but not found "
                     "in the block hierarchy: %s" % str(relative_to))
             else:
-                ans = self._name
+                ans = name_repr(local_name)
         else:
-            ans = self._name
+            # Note: we want "getattr(x.parent_block(), x.localname) == x"
+            # so we do not want to call _safe_name_str, as that could
+            # add quotes or otherwise escape the string.
+            ans = local_name
         if name_buffer is not None:
             name_buffer[id(self)] = ans
         return ans
@@ -909,7 +892,7 @@ class ComponentData(_ComponentBase):
             # Iterate through the dictionary and generate all names in
             # the buffer
             for idx, obj in c.items():
-                name_buffer[id(obj)] = base + _name_index_generator(idx)
+                name_buffer[id(obj)] = base + index_repr(idx)
             if id(self) in name_buffer:
                 # Return the name if it is in the buffer
                 return name_buffer[id(self)]
@@ -921,7 +904,7 @@ class ComponentData(_ComponentBase):
             #
             for idx, obj in c.items():
                 if obj is self:
-                    return base + _name_index_generator(idx)
+                    return base + index_repr(idx)
         #
         raise RuntimeError("Fatal error: cannot find the component data in "
                            "the owning component's _data dictionary.")

--- a/pyomo/core/base/component_namer.py
+++ b/pyomo/core/base/component_namer.py
@@ -1,0 +1,53 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import re
+
+literals = '()[],.'
+
+re_number = re.compile(
+    r'(?:[-+]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][-+]?[0-9]+)?|-?inf|nan)')
+
+def name_repr(x, unknown_handler=str):
+    if not isinstance(x, str):
+        return _repr_map.get(x.__class__, unknown_handler)(x)
+    else:
+        x = repr(x)
+        if x[1] == '|':
+            return x
+        if any(_ in x for _ in ('\\' + literals)):
+            return x
+        if re_number.fullmatch(x[1:-1]):
+            return x
+        return x[1:-1]
+
+def tuple_repr(x, unknown_handler=str):
+    return '(' + ','.join(name_repr(_, unknown_handler) for _ in x) \
+        + (',)' if len(x) == 1 else ')')
+
+def index_repr(idx, unknown_handler=str):
+    """
+    Return a string representation of an index.
+    """
+    if idx.__class__ is tuple and len(idx) > 1:
+        idx_str = ",".join(name_repr(i, unknown_handler) for i in idx)
+    else:
+        idx_str = name_repr(idx, unknown_handler)
+    return "[" + idx_str + "]"
+
+_repr_map = {
+    slice: lambda x: '*',
+    Ellipsis.__class__: lambda x: '**',
+    int: repr,
+    float: repr,
+    str: repr,
+    # Note: the function is unbound at this point; extract with __func__
+    tuple: tuple_repr,
+}

--- a/pyomo/core/base/componentuid.py
+++ b/pyomo/core/base/componentuid.py
@@ -615,7 +615,7 @@ def _match_escape(match):
 _re_number = re.compile(
     r'(?:[-+]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][-+]?[0-9]+)?|-?inf|nan)')
 
-# Ignore whitespace (space, tab, and linefeed)
+# Ignore whitespace (tab, and linefeed)
 t_ignore = "\t\r"
 
 literals = '()[],.'

--- a/pyomo/core/base/componentuid.py
+++ b/pyomo/core/base/componentuid.py
@@ -15,6 +15,10 @@ import ply.lex
 from pyomo.common.collections import ComponentMap
 from pyomo.common.dependencies import pickle
 from pyomo.common.deprecation import deprecated
+from pyomo.core.base.component_namer import (
+    literals, name_repr as __name_repr, index_repr as __index_repr,
+    re_number as _re_number,
+)
 from pyomo.core.base.indexed_component_slice import IndexedComponent_slice
 from pyomo.core.base.reference import Reference
 
@@ -22,6 +26,14 @@ from pyomo.core.base.reference import Reference
 class _NotSpecified(object):
     pass
 
+def _pickle(x):
+    return '|'+repr(pickle.dumps(x, protocol=2))
+
+def _name_repr(x):
+    return __name_repr(x, _pickle)
+
+def _index_repr(x):
+    return __index_repr(x, _pickle)
 
 class ComponentUID(object):
     """
@@ -44,39 +56,7 @@ class ComponentUID(object):
 
     __slots__ = ( '_cids', )
 
-    @staticmethod
-    def _safe_str_tuple(x):
-        return '(' + ','.join(ComponentUID._safe_str(_) for _ in x) + ',)'
-
-    @staticmethod
-    def _pickle(x):
-        return '|'+repr(pickle.dumps(x, protocol=2))
-
-    @staticmethod
-    def _safe_str(x):
-        if not isinstance(x, str):
-            return ComponentUID._repr_map.get(
-                x.__class__, ComponentUID._pickle)(x)
-        else:
-            x = repr(x)
-            if x[1] == '|':
-                return x
-            if any(_ in x for _ in ('\\ ' + literals)):
-                return x
-            if _re_number.match(x[1:-1]):
-                return x
-            return x[1:-1]
-
     _lex = None
-    _repr_map = {
-        slice: lambda x: '*',
-        Ellipsis.__class__: lambda x: '**',
-        int: repr,
-        float: repr,
-        str: repr,
-        # Note: the function is unbound at this point; extract with __func__
-        tuple: _safe_str_tuple.__func__,
-    }
     _repr_v1_map = {
         slice: lambda x: '*',
         Ellipsis.__class__: lambda x: '**',
@@ -110,9 +90,9 @@ class ComponentUID(object):
         "Return a 'nicely formatted' string representation of the CUID"
         a = ""
         for name, args in self._cids:
-            a += '.' + self._safe_str(name)
+            a += '.' + _name_repr(name)
             if args:
-                a += '[' + ','.join(self._safe_str(x) for x in args) + ']'
+                a += '[' + ','.join(_name_repr(x) for x in args) + ']'
         return a[1:]  # Strip off the leading '.'
 
     # str() is sufficiently safe / unique to be usable as repr()
@@ -251,12 +231,7 @@ class ComponentUID(object):
 
         def _record_indexed_object_cuid_strings_v2(obj, cuid_str):
             for idx, data in obj.items():
-                if idx.__class__ is tuple and len(idx) > 1:
-                    cuid_strings[data] = cuid_str + '[' + ','.join(
-                        ComponentUID._safe_str(x) for x in idx) + ']'
-                else:
-                    cuid_strings[data] \
-                        = cuid_str + '[' + ComponentUID._safe_str(idx) + ']'
+                cuid_strings[data] = cuid_str + _index_repr(idx)
 
         _record_indexed_object_cuid_strings = {
             1: _record_indexed_object_cuid_strings_v1,
@@ -264,7 +239,7 @@ class ComponentUID(object):
         }[repr_version]
         _record_name = {
             1: str,
-            2: ComponentUID._safe_str,
+            2: _name_repr,
         }[repr_version]
 
         model = block.model()
@@ -641,7 +616,7 @@ _re_number = re.compile(
     r'(?:[-+]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][-+]?[0-9]+)?|-?inf|nan)')
 
 # Ignore whitespace (space, tab, and linefeed)
-t_ignore = " \t\r"
+t_ignore = "\t\r"
 
 literals = '()[],.'
 
@@ -653,9 +628,9 @@ tokens = [
     "PICKLE", # a pickled index object
 ]
 
-# Numbers only appear in getitem lists, so they must be followed by a
-# delimiter token (one of ' ,]')
-@ply.lex.TOKEN(_re_number.pattern+r'(?=[\s\],])')
+# Numbers should only appear in getitem lists, so they must be followed
+# by a delimiter token (one of ',]')
+@ply.lex.TOKEN(_re_number.pattern+r'(?=[,\]])')
 def t_NUMBER(t):
     t.value = _int_or_float(t.value)
     return t

--- a/pyomo/core/base/label.py
+++ b/pyomo/core/base/label.py
@@ -157,7 +157,8 @@ class ShortNameLabeler(object):
             self.labeler = labeler
         else:
             self.labeler = AlphaNumericTextLabeler()
-        self.known_labels = set() if caseInsensitive else None
+        self.known_labels = set()
+        self.caseInsensitive = caseInsensitive
         if isinstance(legalRegex, str):
             self.legalRegex = re.compile(legalRegex)
         else:
@@ -172,7 +173,7 @@ class ShortNameLabeler(object):
         elif lbl_len == self.limit and lbl.startswith(self.prefix) \
              and lbl.endswith(self.suffix):
             shorten = True
-        elif self.known_labels is not None and lbl.upper() in self.known_labels:
+        elif (lbl.upper() if self.caseInsensitive else lbl) in self.known_labels:
             shorten = True
         elif self.legalRegex and not self.legalRegex.match(lbl):
             shorten = True
@@ -187,5 +188,5 @@ class ShortNameLabeler(object):
                     "label limited to %d characters" % (self.limit,)) 
             lbl = self.prefix + lbl[tail:] + suffix
         if self.known_labels is not None:
-            self.known_labels.add(lbl.upper())
+            self.known_labels.add(lbl.upper() if self.caseInsensitive else lbl)
         return lbl

--- a/pyomo/core/tests/unit/test_componentuid.py
+++ b/pyomo/core/tests/unit/test_componentuid.py
@@ -79,7 +79,7 @@ class TestComponentUID(unittest.TestCase):
             (('c',tuple()), ('a',())) )
         with self.assertRaisesRegex(
                 ValueError,
-                r"Context 'b\[1,2\]' does not apply to component 's'"):
+                r"Context 'b\[1,'2'\]' does not apply to component 's'"):
             ComponentUID(self.m.s, context=self.m.b[1,'2'])
         with self.assertRaisesRegex(
                 ValueError,

--- a/pyomo/core/tests/unit/test_connector.py
+++ b/pyomo/core/tests/unit/test_connector.py
@@ -283,7 +283,7 @@ class TestConnector(unittest.TestCase):
         os = StringIO()
         m.component('c.expanded').pprint(ostream=os)
         self.assertEqual(os.getvalue(),
-"""c.expanded : Size=1, Index=c.expanded_index, Active=True
+"""c.expanded : Size=1, Index='c.expanded_index', Active=True
     Key : Lower : Body : Upper : Active
       1 :   1.0 :    x :   1.0 :   True
 """)
@@ -317,7 +317,7 @@ class TestConnector(unittest.TestCase):
         os = StringIO()
         m.component('c.expanded').pprint(ostream=os)
         self.assertEqual(os.getvalue(),
-"""c.expanded : Size=2, Index=c.expanded_index, Active=True
+"""c.expanded : Size=2, Index='c.expanded_index', Active=True
     Key : Lower : Body : Upper : Active
       1 :   1.0 :    x :   1.0 :   True
       2 :   1.0 :    y :   1.0 :   True
@@ -352,7 +352,7 @@ class TestConnector(unittest.TestCase):
         os = StringIO()
         m.component('c.expanded').pprint(ostream=os)
         self.assertEqual(os.getvalue(),
-"""c.expanded : Size=2, Index=c.expanded_index, Active=True
+"""c.expanded : Size=2, Index='c.expanded_index', Active=True
     Key : Lower : Body  : Upper : Active
       1 :   1.0 :   - x :   1.0 :   True
       2 :   1.0 : 1 + y :   1.0 :   True
@@ -387,7 +387,7 @@ class TestConnector(unittest.TestCase):
         os = StringIO()
         m.component('c.expanded').pprint(ostream=os)
         self.assertEqual(os.getvalue(),
-"""c.expanded : Size=3, Index=c.expanded_index, Active=True
+"""c.expanded : Size=3, Index='c.expanded_index', Active=True
     Key : Lower : Body : Upper : Active
       1 :   1.0 : x[1] :   1.0 :   True
       2 :   1.0 : x[2] :   1.0 :   True
@@ -429,10 +429,10 @@ class TestConnector(unittest.TestCase):
         os = StringIO()
         m.component('c.expanded').pprint(ostream=os)
         self.assertEqual(os.getvalue(),
-"""c.expanded : Size=2, Index=c.expanded_index, Active=True
-    Key : Lower : Body            : Upper : Active
-      1 :   0.0 : x - ECON.auto.x :   0.0 :   True
-      2 :   0.0 : y - ECON.auto.y :   0.0 :   True
+"""c.expanded : Size=2, Index='c.expanded_index', Active=True
+    Key : Lower : Body              : Upper : Active
+      1 :   0.0 : x - 'ECON.auto.x' :   0.0 :   True
+      2 :   0.0 : y - 'ECON.auto.y' :   0.0 :   True
 """)
 
 
@@ -465,10 +465,10 @@ class TestConnector(unittest.TestCase):
         os = StringIO()
         m.component('c.expanded').pprint(ostream=os)
         self.assertEqual(os.getvalue(),
-"""c.expanded : Size=2, Index=c.expanded_index, Active=True
-    Key : Lower : Body                : Upper : Active
-      1 :   0.0 :   - x - ECON.auto.x :   0.0 :   True
-      2 :   0.0 : 1 + y - ECON.auto.y :   0.0 :   True
+"""c.expanded : Size=2, Index='c.expanded_index', Active=True
+    Key : Lower : Body                  : Upper : Active
+      1 :   0.0 :   - x - 'ECON.auto.x' :   0.0 :   True
+      2 :   0.0 : 1 + y - 'ECON.auto.y' :   0.0 :   True
 """)
 
 
@@ -509,11 +509,11 @@ class TestConnector(unittest.TestCase):
         os = StringIO()
         m.component('c.expanded').pprint(ostream=os)
         self.assertEqual(os.getvalue(),
-"""c.expanded : Size=3, Index=c.expanded_index, Active=True
-    Key : Lower : Body                  : Upper : Active
-      1 :   0.0 : x[1] - ECON.auto.x[1] :   0.0 :   True
-      2 :   0.0 : x[2] - ECON.auto.x[2] :   0.0 :   True
-      3 :   0.0 :       y - ECON.auto.y :   0.0 :   True
+"""c.expanded : Size=3, Index='c.expanded_index', Active=True
+    Key : Lower : Body                    : Upper : Active
+      1 :   0.0 : x[1] - 'ECON.auto.x'[1] :   0.0 :   True
+      2 :   0.0 : x[2] - 'ECON.auto.x'[2] :   0.0 :   True
+      3 :   0.0 :       y - 'ECON.auto.y' :   0.0 :   True
 """)
 
     def test_expand_multiple_empty_indexed(self):
@@ -564,21 +564,21 @@ class TestConnector(unittest.TestCase):
         os = StringIO()
         m.component('c.expanded').pprint(ostream=os)
         self.assertEqual(os.getvalue(),
-"""c.expanded : Size=3, Index=c.expanded_index, Active=True
-    Key : Lower : Body                   : Upper : Active
-      1 :   0.0 : x[1] - ECON1.auto.x[1] :   0.0 :   True
-      2 :   0.0 : x[2] - ECON1.auto.x[2] :   0.0 :   True
-      3 :   0.0 :       y - ECON1.auto.y :   0.0 :   True
+"""c.expanded : Size=3, Index='c.expanded_index', Active=True
+    Key : Lower : Body                     : Upper : Active
+      1 :   0.0 : x[1] - 'ECON1.auto.x'[1] :   0.0 :   True
+      2 :   0.0 : x[2] - 'ECON1.auto.x'[2] :   0.0 :   True
+      3 :   0.0 :       y - 'ECON1.auto.y' :   0.0 :   True
 """)
 
         os = StringIO()
         m.component('d.expanded').pprint(ostream=os)
         self.assertEqual(os.getvalue(),
-"""d.expanded : Size=3, Index=d.expanded_index, Active=True
-    Key : Lower : Body                              : Upper : Active
-      1 :   0.0 : ECON2.auto.x[1] - ECON1.auto.x[1] :   0.0 :   True
-      2 :   0.0 : ECON2.auto.x[2] - ECON1.auto.x[2] :   0.0 :   True
-      3 :   0.0 :       ECON2.auto.y - ECON1.auto.y :   0.0 :   True
+"""d.expanded : Size=3, Index='d.expanded_index', Active=True
+    Key : Lower : Body                                  : Upper : Active
+      1 :   0.0 : 'ECON2.auto.x'[1] - 'ECON1.auto.x'[1] :   0.0 :   True
+      2 :   0.0 : 'ECON2.auto.x'[2] - 'ECON1.auto.x'[2] :   0.0 :   True
+      3 :   0.0 :       'ECON2.auto.y' - 'ECON1.auto.y' :   0.0 :   True
 """)
 
 
@@ -624,7 +624,7 @@ class TestConnector(unittest.TestCase):
         os = StringIO()
         m.component('c.expanded').pprint(ostream=os)
         self.assertEqual(os.getvalue(),
-"""c.expanded : Size=3, Index=c.expanded_index, Active=True
+"""c.expanded : Size=3, Index='c.expanded_index', Active=True
     Key : Lower : Body         : Upper : Active
       1 :   0.0 : x[1] - a2[1] :   0.0 :   True
       2 :   0.0 : x[2] - a2[2] :   0.0 :   True
@@ -634,7 +634,7 @@ class TestConnector(unittest.TestCase):
         os = StringIO()
         m.component('d.expanded').pprint(ostream=os)
         self.assertEqual(os.getvalue(),
-"""d.expanded : Size=3, Index=d.expanded_index, Active=True
+"""d.expanded : Size=3, Index='d.expanded_index', Active=True
     Key : Lower : Body          : Upper : Active
       1 :   0.0 : a1[1] - a2[1] :   0.0 :   True
       2 :   0.0 : a1[2] - a2[2] :   0.0 :   True
@@ -683,8 +683,8 @@ class TestConnector(unittest.TestCase):
         self.assertEqual(os.getvalue(),
 """ECON1 : Size=1, Index=None
     Key  : Name : Size : Variable
-    None :    x :    2 :           a2
-         :    y :    1 : ECON1.auto.y
+    None :    x :    2 :             a2
+         :    y :    1 : 'ECON1.auto.y'
 """)
 
         self.assertEqual(len(list(m.component_objects(Constraint))), 5)
@@ -698,21 +698,21 @@ class TestConnector(unittest.TestCase):
         os = StringIO()
         m.component('c.expanded').pprint(ostream=os)
         self.assertEqual(os.getvalue(),
-"""c.expanded : Size=3, Index=c.expanded_index, Active=True
-    Key : Lower : Body             : Upper : Active
-      1 :   0.0 :     x[1] - a2[1] :   0.0 :   True
-      2 :   0.0 :     x[2] - a2[2] :   0.0 :   True
-      3 :   0.0 : y - ECON1.auto.y :   0.0 :   True
+"""c.expanded : Size=3, Index='c.expanded_index', Active=True
+    Key : Lower : Body               : Upper : Active
+      1 :   0.0 :       x[1] - a2[1] :   0.0 :   True
+      2 :   0.0 :       x[2] - a2[2] :   0.0 :   True
+      3 :   0.0 : y - 'ECON1.auto.y' :   0.0 :   True
 """)
 
         os = StringIO()
         m.component('d.expanded').pprint(ostream=os)
         self.assertEqual(os.getvalue(),
-"""d.expanded : Size=3, Index=d.expanded_index, Active=True
-    Key : Lower : Body                   : Upper : Active
-      1 :   0.0 : ECON2.auto.x[1] - x[1] :   0.0 :   True
-      2 :   0.0 : ECON2.auto.x[2] - x[2] :   0.0 :   True
-      3 :   0.0 :                 b1 - y :   0.0 :   True
+"""d.expanded : Size=3, Index='d.expanded_index', Active=True
+    Key : Lower : Body                     : Upper : Active
+      1 :   0.0 : 'ECON2.auto.x'[1] - x[1] :   0.0 :   True
+      2 :   0.0 : 'ECON2.auto.x'[2] - x[2] :   0.0 :   True
+      3 :   0.0 :                   b1 - y :   0.0 :   True
 """)
 
 
@@ -751,19 +751,19 @@ class TestConnector(unittest.TestCase):
         os = StringIO()
         m.component('c.expanded').pprint(ostream=os)
         self.assertEqual(os.getvalue(),
-"""c.expanded : Size=2, Index=c.expanded_index, Active=True
-    Key : Lower : Body                      : Upper : Active
-      1 :   0.0 : flow[1] - ECON1.auto.flow :   0.0 :   True
-      2 :   0.0 :  phase - ECON1.auto.phase :   0.0 :   True
+"""c.expanded : Size=2, Index='c.expanded_index', Active=True
+    Key : Lower : Body                        : Upper : Active
+      1 :   0.0 : flow[1] - 'ECON1.auto.flow' :   0.0 :   True
+      2 :   0.0 :  phase - 'ECON1.auto.phase' :   0.0 :   True
 """)
 
         os = StringIO()
         m.component('d.expanded').pprint(ostream=os)
         self.assertEqual(os.getvalue(),
-"""d.expanded : Size=2, Index=d.expanded_index, Active=True
-    Key : Lower : Body                      : Upper : Active
-      1 :   0.0 : ECON2.auto.flow - flow[2] :   0.0 :   True
-      2 :   0.0 :  ECON2.auto.phase - phase :   0.0 :   True
+"""d.expanded : Size=2, Index='d.expanded_index', Active=True
+    Key : Lower : Body                        : Upper : Active
+      1 :   0.0 : 'ECON2.auto.flow' - flow[2] :   0.0 :   True
+      2 :   0.0 :  'ECON2.auto.phase' - phase :   0.0 :   True
 """)
 
         os = StringIO()
@@ -799,7 +799,7 @@ class TestConnector(unittest.TestCase):
         os = StringIO()
         m.component('eq.expanded').pprint(ostream=os)
         self.assertEqual(os.getvalue(),
-"""eq.expanded : Size=1, Index=eq.expanded_index, Active=True
+"""eq.expanded : Size=1, Index='eq.expanded_index', Active=True
     Key : Lower : Body  : Upper : Active
       1 :   0.0 : x - y :   0.0 :   True
 """)

--- a/pyomo/core/tests/unit/test_dict_objects.py
+++ b/pyomo/core/tests/unit/test_dict_objects.py
@@ -258,10 +258,10 @@ class _TestComponentDictBase(object):
                               for i in index)
         index_to_string = {}
         index_to_string['a'] = '[a]'
+        index_to_string['a,b'] = "['a,b']"
         index_to_string[1] = '[1]'
         index_to_string[None] = '[None]'
-        # I don't like that (1,) looks the same as 1, but oh well
-        index_to_string[(1,)] = '[1]'
+        index_to_string[(1,)] = '[(1,)]'
         index_to_string[(1,2)] = '[1,2]'
         prefix = "c"
         for i in index:

--- a/pyomo/core/tests/unit/test_labelers.py
+++ b/pyomo/core/tests/unit/test_labelers.py
@@ -73,7 +73,7 @@ class LabelerTests(unittest.TestCase):
         self.assertEqual(lbl(self.long1), 'myverylongcomponentname')
         self.assertEqual(lbl(m.myblock), 'myblock')
         self.assertEqual(lbl(m.myblock.mystreet), 'myblock.mystreet')
-        self.assertEqual(lbl(self.thecopy), 'myblock.mystreet')
+        self.assertEqual(lbl(self.thecopy), "'myblock.mystreet'")
         self.assertEqual(lbl(m.ind[3]), 'ind[3]')
         self.assertEqual(lbl(m.ind[10]), 'ind[10]')
         self.assertEqual(lbl(m.ind[1]), 'ind[1]')
@@ -87,7 +87,7 @@ class LabelerTests(unittest.TestCase):
         self.assertEqual(lbl(self.long1), 'myverylongcomponentname')
         self.assertEqual(lbl(m.myblock), 'myblock')
         self.assertEqual(lbl(m.myblock.mystreet), 'myblock_mystreet')
-        self.assertEqual(lbl(self.thecopy), 'myblock_mystreet')
+        self.assertEqual(lbl(self.thecopy), '_myblock_mystreet_')
         self.assertEqual(lbl(m.ind[3]), 'ind(3)')
         self.assertEqual(lbl(m.ind[10]), 'ind(10)')
         self.assertEqual(lbl(m.ind[1]), 'ind(1)')
@@ -101,7 +101,7 @@ class LabelerTests(unittest.TestCase):
         self.assertEqual(lbl(self.long1), 'myverylongcomponentname')
         self.assertEqual(lbl(m.myblock), 'myblock')
         self.assertEqual(lbl(m.myblock.mystreet), 'myblock_mystreet')
-        self.assertEqual(lbl(self.thecopy), 'myblock_mystreet')
+        self.assertEqual(lbl(self.thecopy), '_myblock_mystreet_')
         self.assertEqual(lbl(m.ind[3]), 'ind_3_')
         self.assertEqual(lbl(m.ind[10]), 'ind_10_')
         self.assertEqual(lbl(m.ind[1]), 'ind_1_')
@@ -115,7 +115,7 @@ class LabelerTests(unittest.TestCase):
         self.assertEqual(lbl(self.long1), 'myverylongcomponentname')
         self.assertEqual(lbl(m.myblock), 'myblock')
         self.assertEqual(lbl(m.myblock.mystreet), 'myblock.mystreet')
-        self.assertEqual(lbl(self.thecopy), 'myblock.mystreet')
+        self.assertEqual(lbl(self.thecopy), "'myblock.mystreet'")
         self.assertEqual(lbl(m.ind[3]), 'ind[3]')
         self.assertEqual(lbl(m.ind[10]), 'ind[10]')
         self.assertEqual(lbl(m.ind[1]), 'ind[1]')
@@ -149,10 +149,13 @@ class LabelerTests(unittest.TestCase):
         self.assertEqual(lbl(m.ind[3]), 'ind_3_')
         self.assertEqual(lbl(m.ind[10]), 'ind_10_')
         self.assertEqual(lbl(m.ind[1]), 'ind_1_')
+        self.assertEqual(lbl(self.thecopy), '_myblock_mystreet_')
 
         # Test name collision
+        m._myblock = Block()
+        m._myblock.mystreet_ = Var()
         self.assertEqual(lbl(m.mycomp), 'mycomp_6_')
-        self.assertEqual(lbl(self.thecopy), 'myblock_mystreet_7_')
+        self.assertEqual(lbl(m._myblock.mystreet_), 'myblock_mystreet__7_')
         self.assertEqual(lbl(m.MyComp), 'MyComp_8_')
 
     def test_shortnamelabeler_prefix(self):
@@ -170,10 +173,13 @@ class LabelerTests(unittest.TestCase):
         self.assertEqual(lbl(m.ind[3]), 'ind_3_')
         self.assertEqual(lbl(m.ind[10]), 'ind_10_')
         self.assertEqual(lbl(m.ind[1]), 'ind_1_')
+        self.assertEqual(lbl(self.thecopy), '_myblock_mystreet_')
 
         # Test name collision
+        m._myblock = Block()
+        m._myblock.mystreet_ = Var()
         self.assertEqual(lbl(m.mycomp), 's_mycomp_5_')
-        self.assertEqual(lbl(self.thecopy), 's_yblock_mystreet_6_')
+        self.assertEqual(lbl(m._myblock.mystreet_), 's_block_mystreet__6_')
         self.assertEqual(lbl(m.MyComp), 's_MyComp_7_')
 
     def test_case_sensitive_shortnamelabeler(self):
@@ -191,10 +197,13 @@ class LabelerTests(unittest.TestCase):
         self.assertEqual(lbl(m.ind[3]), 'ind_3_')
         self.assertEqual(lbl(m.ind[10]), 'ind_10_')
         self.assertEqual(lbl(m.ind[1]), 'ind_1_')
+        self.assertEqual(lbl(self.thecopy), '_myblock_mystreet_')
 
         # Test name collision
-        self.assertEqual(lbl(m.mycomp), 'mycomp')
-        self.assertEqual(lbl(self.thecopy), 'myblock_mystreet')
+        m._myblock = Block()
+        m._myblock.mystreet_ = Var()
+        self.assertEqual(lbl(m.mycomp), 'mycomp_6_')
+        self.assertEqual(lbl(m._myblock.mystreet_), 'myblock_mystreet__7_')
         self.assertEqual(lbl(m.MyComp), 'MyComp')
 
     def test_case_shortnamelabeler_overflow(self):

--- a/pyomo/core/tests/unit/test_sets.py
+++ b/pyomo/core/tests/unit/test_sets.py
@@ -1515,7 +1515,8 @@ class TestRealSet(unittest.TestCase):
 
     def test_RealInterval(self):
         x = RealInterval()
-        self.assertEqual(x.name, "RealInterval(None, None)")
+        self.assertEqual(x.name, "'RealInterval(None, None)'")
+        self.assertEqual(x.local_name, "RealInterval(None, None)")
         self.assertFalse(None in x)
         self.assertTrue(10 in x)
         self.assertTrue(1.1 in x)
@@ -1528,7 +1529,8 @@ class TestRealSet(unittest.TestCase):
         self.assertTrue(-10 in x)
 
         x = RealInterval(bounds=(-1,1))
-        self.assertEqual(x.name, "RealInterval(-1, 1)")
+        self.assertEqual(x.name, "'RealInterval(-1, 1)'")
+        self.assertEqual(x.local_name, "RealInterval(-1, 1)")
         self.assertFalse(10 in x)
         self.assertFalse(1.1 in x)
         self.assertTrue(1 in x)
@@ -1668,7 +1670,8 @@ class TestIntegerSet(unittest.TestCase):
     def test_IntegerInterval(self):
         x = IntegerInterval()
         self.assertFalse(None in x)
-        self.assertEqual(x.name, "IntegerInterval(None, None)")
+        self.assertEqual(x.name, "'IntegerInterval(None, None)'")
+        self.assertEqual(x.local_name, "IntegerInterval(None, None)")
         self.assertTrue(10 in x)
         self.assertFalse(1.1 in x)
         self.assertTrue(1 in x)
@@ -1681,7 +1684,8 @@ class TestIntegerSet(unittest.TestCase):
 
         x = IntegerInterval(bounds=(-1,1))
         self.assertFalse(None in x)
-        self.assertEqual(x.name, "IntegerInterval(-1, 1)")
+        self.assertEqual(x.name, "'IntegerInterval(-1, 1)'")
+        self.assertEqual(x.local_name, "IntegerInterval(-1, 1)")
         self.assertFalse(10 in x)
         self.assertFalse(1.1 in x)
         self.assertTrue(1 in x)

--- a/pyomo/core/tests/unit/test_template_expr.py
+++ b/pyomo/core/tests/unit/test_template_expr.py
@@ -626,7 +626,8 @@ class TestTemplateSubstitution(unittest.TestCase):
 
         self.assertEqual(
             str(E),
-            'dxdt[{TIME},2]  ==  {TIME}*x[{TIME},1]**2 + y**2 + x[{TIME},3] + x[{TIME},1]' )
+            "'dxdt[{TIME},2]'  ==  "
+            "{TIME}*'x[{TIME},1]'**2 + y**2 + 'x[{TIME},3]' + 'x[{TIME},1]'" )
 
         _map[idx1].set_value( value(m.x[value(t), 1]) )
         _map[idx2].set_value( value(m.dxdt[value(t), 2]) )

--- a/pyomo/dae/tests/test_simulator.py
+++ b/pyomo/dae/tests/test_simulator.py
@@ -513,11 +513,11 @@ class TestSimulator(unittest.TestCase):
         self.assertTrue(
             isinstance(mysim._rhsdict[_GetItemIndexer(m.dv[t])], Param))
         self.assertEqual(
-            mysim._rhsdict[_GetItemIndexer(m.dv[t])].name, 'v[{t}]')
+            mysim._rhsdict[_GetItemIndexer(m.dv[t])].name, "'v[{t}]'")
         self.assertTrue(
             isinstance(mysim._rhsdict[_GetItemIndexer(m.dw[t])], Param))
         self.assertEqual(
-            mysim._rhsdict[_GetItemIndexer(m.dw[t])].name, 'v[{t}]')
+            mysim._rhsdict[_GetItemIndexer(m.dw[t])].name, "'v[{t}]'")
         self.assertEqual(len(mysim._rhsfun(0, [0, 0])), 2)
         self.assertIsNone(mysim._tsim)
         self.assertIsNone(mysim._simsolution)
@@ -598,13 +598,13 @@ class TestSimulator(unittest.TestCase):
             isinstance(mysim._rhsdict[_GetItemIndexer(m.dw3[1, t, 3])],
                        EXPR.SumExpression))
         self.assertEqual(
-            mysim._rhsdict[_GetItemIndexer(m.dw1[t, 1])].name, 'w1[{t},1]')
+            mysim._rhsdict[_GetItemIndexer(m.dw1[t, 1])].name, "'w1[{t},1]'")
         self.assertEqual(
-            mysim._rhsdict[_GetItemIndexer(m.dw1[t, 3])].name, 'w1[{t},3]')
+            mysim._rhsdict[_GetItemIndexer(m.dw1[t, 3])].name, "'w1[{t},3]'")
         self.assertEqual(
-            mysim._rhsdict[_GetItemIndexer(m.dw2[1, t])].name, 'w2[1,{t}]')
+            mysim._rhsdict[_GetItemIndexer(m.dw2[1, t])].name, "'w2[1,{t}]'")
         self.assertEqual(
-            mysim._rhsdict[_GetItemIndexer(m.dw2[3, t])].name, 'w2[3,{t}]')
+            mysim._rhsdict[_GetItemIndexer(m.dw2[3, t])].name, "'w2[3,{t}]'")
 
         self.assertEqual(len(mysim._rhsfun(0, [0] * 12)), 12)
         self.assertIsNone(mysim._tsim)
@@ -692,13 +692,13 @@ class TestSimulator(unittest.TestCase):
             mysim._rhsdict[_GetItemIndexer(m.dw3[1, t, 2, 2])],
             EXPR.SumExpression))
         self.assertEqual(mysim._rhsdict[_GetItemIndexer(m.dw1[t, 1, 1])].name,
-                         'w1[{t},1,1]')
+                         "'w1[{t},1,1]'")
         self.assertEqual(mysim._rhsdict[_GetItemIndexer(m.dw1[t, 2, 2])].name,
-                         'w1[{t},2,2]')
+                         "'w1[{t},2,2]'")
         self.assertEqual(mysim._rhsdict[_GetItemIndexer(m.dw2[1, 1, t])].name,
-                         'w2[1,1,{t}]')
+                         "'w2[1,1,{t}]'")
         self.assertEqual(mysim._rhsdict[_GetItemIndexer(m.dw2[2, 2, t])].name,
-                         'w2[2,2,{t}]')
+                         "'w2[2,2,{t}]'")
 
         self.assertEqual(len(mysim._rhsfun(0, [0] * 8)), 8)
         self.assertIsNone(mysim._tsim)

--- a/pyomo/gdp/tests/jobshop_large_bigm.lp
+++ b/pyomo/gdp/tests/jobshop_large_bigm.lp
@@ -216,421 +216,421 @@ c_e__pyomo_gdp_bigm_reformulation_disj_xor(F_G_4)_:
 +1 NoClash(F_G_4_1)_binary_indicator_var
 = 1
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(0)_NoClash(A_B_3_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(0)__NoClash(A_B_3_0)_c_(ub)_:
 +96 NoClash(A_B_3_0)_binary_indicator_var
 -1 t(A)
 +1 t(B)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(1)_NoClash(A_B_3_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(1)__NoClash(A_B_3_1)_c_(ub)_:
 +97 NoClash(A_B_3_1)_binary_indicator_var
 +1 t(A)
 -1 t(B)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(2)_NoClash(A_B_5_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(2)__NoClash(A_B_5_0)_c_(ub)_:
 +94 NoClash(A_B_5_0)_binary_indicator_var
 -1 t(A)
 +1 t(B)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(3)_NoClash(A_B_5_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(3)__NoClash(A_B_5_1)_c_(ub)_:
 +95 NoClash(A_B_5_1)_binary_indicator_var
 +1 t(A)
 -1 t(B)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(4)_NoClash(A_C_1_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(4)__NoClash(A_C_1_0)_c_(ub)_:
 +98 NoClash(A_C_1_0)_binary_indicator_var
 -1 t(A)
 +1 t(C)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(5)_NoClash(A_C_1_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(5)__NoClash(A_C_1_1)_c_(ub)_:
 +95 NoClash(A_C_1_1)_binary_indicator_var
 +1 t(A)
 -1 t(C)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(6)_NoClash(A_D_3_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(6)__NoClash(A_D_3_0)_c_(ub)_:
 +102 NoClash(A_D_3_0)_binary_indicator_var
 -1 t(A)
 +1 t(D)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(7)_NoClash(A_D_3_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(7)__NoClash(A_D_3_1)_c_(ub)_:
 +92 NoClash(A_D_3_1)_binary_indicator_var
 +1 t(A)
 -1 t(D)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(8)_NoClash(A_E_3_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(8)__NoClash(A_E_3_0)_c_(ub)_:
 +99 NoClash(A_E_3_0)_binary_indicator_var
 -1 t(A)
 +1 t(E)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(9)_NoClash(A_E_3_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(9)__NoClash(A_E_3_1)_c_(ub)_:
 +96 NoClash(A_E_3_1)_binary_indicator_var
 +1 t(A)
 -1 t(E)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(10)_NoClash(A_E_5_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(10)__NoClash(A_E_5_0)_c_(ub)_:
 +96 NoClash(A_E_5_0)_binary_indicator_var
 -1 t(A)
 +1 t(E)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(11)_NoClash(A_E_5_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(11)__NoClash(A_E_5_1)_c_(ub)_:
 +92 NoClash(A_E_5_1)_binary_indicator_var
 +1 t(A)
 -1 t(E)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(12)_NoClash(A_F_1_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(12)__NoClash(A_F_1_0)_c_(ub)_:
 +94 NoClash(A_F_1_0)_binary_indicator_var
 -1 t(A)
 +1 t(F)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(13)_NoClash(A_F_1_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(13)__NoClash(A_F_1_1)_c_(ub)_:
 +95 NoClash(A_F_1_1)_binary_indicator_var
 +1 t(A)
 -1 t(F)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(14)_NoClash(A_F_3_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(14)__NoClash(A_F_3_0)_c_(ub)_:
 +96 NoClash(A_F_3_0)_binary_indicator_var
 -1 t(A)
 +1 t(F)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(15)_NoClash(A_F_3_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(15)__NoClash(A_F_3_1)_c_(ub)_:
 +98 NoClash(A_F_3_1)_binary_indicator_var
 +1 t(A)
 -1 t(F)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(16)_NoClash(A_G_5_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(16)__NoClash(A_G_5_0)_c_(ub)_:
 +101 NoClash(A_G_5_0)_binary_indicator_var
 -1 t(A)
 +1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(17)_NoClash(A_G_5_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(17)__NoClash(A_G_5_1)_c_(ub)_:
 +89 NoClash(A_G_5_1)_binary_indicator_var
 +1 t(A)
 -1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(18)_NoClash(B_C_2_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(18)__NoClash(B_C_2_0)_c_(ub)_:
 +101 NoClash(B_C_2_0)_binary_indicator_var
 -1 t(B)
 +1 t(C)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(19)_NoClash(B_C_2_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(19)__NoClash(B_C_2_1)_c_(ub)_:
 +89 NoClash(B_C_2_1)_binary_indicator_var
 +1 t(B)
 -1 t(C)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(20)_NoClash(B_D_2_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(20)__NoClash(B_D_2_0)_c_(ub)_:
 +100 NoClash(B_D_2_0)_binary_indicator_var
 -1 t(B)
 +1 t(D)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(21)_NoClash(B_D_2_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(21)__NoClash(B_D_2_1)_c_(ub)_:
 +95 NoClash(B_D_2_1)_binary_indicator_var
 +1 t(B)
 -1 t(D)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(22)_NoClash(B_D_3_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(22)__NoClash(B_D_3_0)_c_(ub)_:
 +102 NoClash(B_D_3_0)_binary_indicator_var
 -1 t(B)
 +1 t(D)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(23)_NoClash(B_D_3_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(23)__NoClash(B_D_3_1)_c_(ub)_:
 +91 NoClash(B_D_3_1)_binary_indicator_var
 +1 t(B)
 -1 t(D)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(24)_NoClash(B_E_2_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(24)__NoClash(B_E_2_0)_c_(ub)_:
 +96 NoClash(B_E_2_0)_binary_indicator_var
 -1 t(B)
 +1 t(E)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(25)_NoClash(B_E_2_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(25)__NoClash(B_E_2_1)_c_(ub)_:
 +95 NoClash(B_E_2_1)_binary_indicator_var
 +1 t(B)
 -1 t(E)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(26)_NoClash(B_E_3_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(26)__NoClash(B_E_3_0)_c_(ub)_:
 +99 NoClash(B_E_3_0)_binary_indicator_var
 -1 t(B)
 +1 t(E)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(27)_NoClash(B_E_3_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(27)__NoClash(B_E_3_1)_c_(ub)_:
 +95 NoClash(B_E_3_1)_binary_indicator_var
 +1 t(B)
 -1 t(E)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(28)_NoClash(B_E_5_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(28)__NoClash(B_E_5_0)_c_(ub)_:
 +97 NoClash(B_E_5_0)_binary_indicator_var
 -1 t(B)
 +1 t(E)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(29)_NoClash(B_E_5_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(29)__NoClash(B_E_5_1)_c_(ub)_:
 +92 NoClash(B_E_5_1)_binary_indicator_var
 +1 t(B)
 -1 t(E)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(30)_NoClash(B_F_3_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(30)__NoClash(B_F_3_0)_c_(ub)_:
 +96 NoClash(B_F_3_0)_binary_indicator_var
 -1 t(B)
 +1 t(F)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(31)_NoClash(B_F_3_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(31)__NoClash(B_F_3_1)_c_(ub)_:
 +97 NoClash(B_F_3_1)_binary_indicator_var
 +1 t(B)
 -1 t(F)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(32)_NoClash(B_G_2_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(32)__NoClash(B_G_2_0)_c_(ub)_:
 +100 NoClash(B_G_2_0)_binary_indicator_var
 -1 t(B)
 +1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(33)_NoClash(B_G_2_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(33)__NoClash(B_G_2_1)_c_(ub)_:
 +95 NoClash(B_G_2_1)_binary_indicator_var
 +1 t(B)
 -1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(34)_NoClash(B_G_5_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(34)__NoClash(B_G_5_0)_c_(ub)_:
 +102 NoClash(B_G_5_0)_binary_indicator_var
 -1 t(B)
 +1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(35)_NoClash(B_G_5_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(35)__NoClash(B_G_5_1)_c_(ub)_:
 +89 NoClash(B_G_5_1)_binary_indicator_var
 +1 t(B)
 -1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(36)_NoClash(C_D_2_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(36)__NoClash(C_D_2_0)_c_(ub)_:
 +94 NoClash(C_D_2_0)_binary_indicator_var
 -1 t(C)
 +1 t(D)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(37)_NoClash(C_D_2_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(37)__NoClash(C_D_2_1)_c_(ub)_:
 +101 NoClash(C_D_2_1)_binary_indicator_var
 +1 t(C)
 -1 t(D)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(38)_NoClash(C_D_4_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(38)__NoClash(C_D_4_0)_c_(ub)_:
 +97 NoClash(C_D_4_0)_binary_indicator_var
 -1 t(C)
 +1 t(D)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(39)_NoClash(C_D_4_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(39)__NoClash(C_D_4_1)_c_(ub)_:
 +94 NoClash(C_D_4_1)_binary_indicator_var
 +1 t(C)
 -1 t(D)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(40)_NoClash(C_E_2_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(40)__NoClash(C_E_2_0)_c_(ub)_:
 +90 NoClash(C_E_2_0)_binary_indicator_var
 -1 t(C)
 +1 t(E)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(41)_NoClash(C_E_2_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(41)__NoClash(C_E_2_1)_c_(ub)_:
 +101 NoClash(C_E_2_1)_binary_indicator_var
 +1 t(C)
 -1 t(E)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(42)_NoClash(C_F_1_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(42)__NoClash(C_F_1_0)_c_(ub)_:
 +94 NoClash(C_F_1_0)_binary_indicator_var
 -1 t(C)
 +1 t(F)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(43)_NoClash(C_F_1_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(43)__NoClash(C_F_1_1)_c_(ub)_:
 +98 NoClash(C_F_1_1)_binary_indicator_var
 +1 t(C)
 -1 t(F)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(44)_NoClash(C_F_4_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(44)__NoClash(C_F_4_0)_c_(ub)_:
 +97 NoClash(C_F_4_0)_binary_indicator_var
 -1 t(C)
 +1 t(F)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(45)_NoClash(C_F_4_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(45)__NoClash(C_F_4_1)_c_(ub)_:
 +100 NoClash(C_F_4_1)_binary_indicator_var
 +1 t(C)
 -1 t(F)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(46)_NoClash(C_G_2_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(46)__NoClash(C_G_2_0)_c_(ub)_:
 +94 NoClash(C_G_2_0)_binary_indicator_var
 -1 t(C)
 +1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(47)_NoClash(C_G_2_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(47)__NoClash(C_G_2_1)_c_(ub)_:
 +101 NoClash(C_G_2_1)_binary_indicator_var
 +1 t(C)
 -1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(48)_NoClash(C_G_4_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(48)__NoClash(C_G_4_0)_c_(ub)_:
 +96 NoClash(C_G_4_0)_binary_indicator_var
 -1 t(C)
 +1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(49)_NoClash(C_G_4_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(49)__NoClash(C_G_4_1)_c_(ub)_:
 +99 NoClash(C_G_4_1)_binary_indicator_var
 +1 t(C)
 -1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(50)_NoClash(D_E_2_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(50)__NoClash(D_E_2_0)_c_(ub)_:
 +96 NoClash(D_E_2_0)_binary_indicator_var
 -1 t(D)
 +1 t(E)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(51)_NoClash(D_E_2_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(51)__NoClash(D_E_2_1)_c_(ub)_:
 +100 NoClash(D_E_2_1)_binary_indicator_var
 +1 t(D)
 -1 t(E)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(52)_NoClash(D_E_3_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(52)__NoClash(D_E_3_0)_c_(ub)_:
 +94 NoClash(D_E_3_0)_binary_indicator_var
 -1 t(D)
 +1 t(E)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(53)_NoClash(D_E_3_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(53)__NoClash(D_E_3_1)_c_(ub)_:
 +101 NoClash(D_E_3_1)_binary_indicator_var
 +1 t(D)
 -1 t(E)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(54)_NoClash(D_F_3_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(54)__NoClash(D_F_3_0)_c_(ub)_:
 +91 NoClash(D_F_3_0)_binary_indicator_var
 -1 t(D)
 +1 t(F)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(55)_NoClash(D_F_3_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(55)__NoClash(D_F_3_1)_c_(ub)_:
 +103 NoClash(D_F_3_1)_binary_indicator_var
 +1 t(D)
 -1 t(F)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(56)_NoClash(D_F_4_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(56)__NoClash(D_F_4_0)_c_(ub)_:
 +93 NoClash(D_F_4_0)_binary_indicator_var
 -1 t(D)
 +1 t(F)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(57)_NoClash(D_F_4_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(57)__NoClash(D_F_4_1)_c_(ub)_:
 +99 NoClash(D_F_4_1)_binary_indicator_var
 +1 t(D)
 -1 t(F)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(58)_NoClash(D_G_2_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(58)__NoClash(D_G_2_0)_c_(ub)_:
 +100 NoClash(D_G_2_0)_binary_indicator_var
 -1 t(D)
 +1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(59)_NoClash(D_G_2_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(59)__NoClash(D_G_2_1)_c_(ub)_:
 +100 NoClash(D_G_2_1)_binary_indicator_var
 +1 t(D)
 -1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(60)_NoClash(D_G_4_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(60)__NoClash(D_G_4_0)_c_(ub)_:
 +92 NoClash(D_G_4_0)_binary_indicator_var
 -1 t(D)
 +1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(61)_NoClash(D_G_4_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(61)__NoClash(D_G_4_1)_c_(ub)_:
 +98 NoClash(D_G_4_1)_binary_indicator_var
 +1 t(D)
 -1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(62)_NoClash(E_F_3_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(62)__NoClash(E_F_3_0)_c_(ub)_:
 +95 NoClash(E_F_3_0)_binary_indicator_var
 -1 t(E)
 +1 t(F)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(63)_NoClash(E_F_3_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(63)__NoClash(E_F_3_1)_c_(ub)_:
 +100 NoClash(E_F_3_1)_binary_indicator_var
 +1 t(E)
 -1 t(F)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(64)_NoClash(E_G_2_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(64)__NoClash(E_G_2_0)_c_(ub)_:
 +100 NoClash(E_G_2_0)_binary_indicator_var
 -1 t(E)
 +1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(65)_NoClash(E_G_2_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(65)__NoClash(E_G_2_1)_c_(ub)_:
 +96 NoClash(E_G_2_1)_binary_indicator_var
 +1 t(E)
 -1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(66)_NoClash(E_G_5_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(66)__NoClash(E_G_5_0)_c_(ub)_:
 +99 NoClash(E_G_5_0)_binary_indicator_var
 -1 t(E)
 +1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(67)_NoClash(E_G_5_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(67)__NoClash(E_G_5_1)_c_(ub)_:
 +91 NoClash(E_G_5_1)_binary_indicator_var
 +1 t(E)
 -1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(68)_NoClash(F_G_4_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(68)__NoClash(F_G_4_0)_c_(ub)_:
 +98 NoClash(F_G_4_0)_binary_indicator_var
 -1 t(F)
 +1 t(G)
 <= 92
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(69)_NoClash(F_G_4_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(69)__NoClash(F_G_4_1)_c_(ub)_:
 +98 NoClash(F_G_4_1)_binary_indicator_var
 +1 t(F)
 -1 t(G)

--- a/pyomo/gdp/tests/jobshop_large_hull.lp
+++ b/pyomo/gdp/tests/jobshop_large_hull.lp
@@ -42,422 +42,422 @@ c_u_Feas(G)_:
 <= -17
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_B_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars__t(B)_
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_B_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars__t(B)_
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_C_1)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars__t(C)_
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_D_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars__t(D)_
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_E_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars__t(E)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars__t(E)_
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_E_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars__t(E)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars__t(E)_
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_F_1)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars__t(F)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars__t(F)_
 +1 t(F)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_F_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars__t(F)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars__t(F)_
 +1 t(F)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_G_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars__t(G)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars__t(G)_
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_C_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars__t(C)_
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_D_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars__t(D)_
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_D_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars__t(D)_
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_E_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars__t(E)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars__t(E)_
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_E_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars__t(E)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars__t(E)_
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_E_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars__t(E)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars__t(E)_
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_F_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars__t(F)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars__t(F)_
 +1 t(F)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_G_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars__t(G)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars__t(G)_
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_G_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars__t(G)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars__t(G)_
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_C_D_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars__t(D)_
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_C_D_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars__t(D)_
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_C_E_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars__t(E)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars__t(E)_
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_C_F_1)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars__t(F)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars__t(F)_
 +1 t(F)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_C_F_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars__t(F)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars__t(F)_
 +1 t(F)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_C_G_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars__t(G)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars__t(G)_
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_C_G_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars__t(G)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars__t(G)_
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_D_E_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars__t(E)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars__t(E)_
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_D_E_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars__t(E)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars__t(E)_
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_D_F_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars__t(F)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars__t(F)_
 +1 t(F)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_D_F_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars__t(F)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars__t(F)_
 +1 t(F)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_D_G_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars__t(G)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars__t(G)_
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_D_G_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars__t(G)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars__t(G)_
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_E_F_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars__t(F)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars__t(F)_
 +1 t(F)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_E_G_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars__t(G)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars__t(G)_
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_E_G_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars__t(G)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars__t(G)_
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_F_G_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars_t(G)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars__t(G)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars__t(G)_
 +1 t(G)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_B_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars__t(A)_
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_B_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars__t(A)_
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_C_1)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars__t(A)_
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_D_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars__t(A)_
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_E_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars__t(A)_
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_E_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars__t(A)_
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_F_1)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars__t(A)_
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_F_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars__t(A)_
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_G_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars__t(A)_
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_C_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars__t(B)_
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_D_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars__t(B)_
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_D_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars__t(B)_
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_E_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars__t(B)_
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_E_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars__t(B)_
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_E_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars__t(B)_
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_F_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars__t(B)_
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_G_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars__t(B)_
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_G_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars__t(B)_
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_C_D_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars__t(C)_
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_C_D_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars__t(C)_
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_C_E_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars__t(C)_
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_C_F_1)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars__t(C)_
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_C_F_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars__t(C)_
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_C_G_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars__t(C)_
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_C_G_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars__t(C)_
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_D_E_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars__t(D)_
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_D_E_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars__t(D)_
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_D_F_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars__t(D)_
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_D_F_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars__t(D)_
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_D_G_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars__t(D)_
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_D_G_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars__t(D)_
 +1 t(D)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_E_F_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars__t(E)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars__t(E)_
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_E_G_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars__t(E)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars__t(E)_
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_E_G_5)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars__t(E)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars__t(E)_
 +1 t(E)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_F_G_4)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars__t(F)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars__t(F)_
 +1 t(F)
 = 0
 
@@ -636,1120 +636,1120 @@ c_e__pyomo_gdp_hull_reformulation_disj_xor(F_G_4)_:
 +1 NoClash(F_G_4_1)_binary_indicator_var
 = 1
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)__t(B)_bounds_(ub)_:
 -92 NoClash(A_B_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)__t(A)_bounds_(ub)_:
 -92 NoClash(A_B_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_NoClash(A_B_3_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)__NoClash(A_B_3_0)_c_(ub)_:
 +4 NoClash(A_B_3_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars__t(A)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)__t(B)_bounds_(ub)_:
 -92 NoClash(A_B_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)__t(A)_bounds_(ub)_:
 -92 NoClash(A_B_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_NoClash(A_B_3_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)__NoClash(A_B_3_1)_c_(ub)_:
 +5 NoClash(A_B_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)__t(B)_bounds_(ub)_:
 -92 NoClash(A_B_5_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)__t(A)_bounds_(ub)_:
 -92 NoClash(A_B_5_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_NoClash(A_B_5_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)__NoClash(A_B_5_0)_c_(ub)_:
 +2 NoClash(A_B_5_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars__t(A)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)__t(B)_bounds_(ub)_:
 -92 NoClash(A_B_5_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)__t(A)_bounds_(ub)_:
 -92 NoClash(A_B_5_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_NoClash(A_B_5_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)__NoClash(A_B_5_1)_c_(ub)_:
 +3 NoClash(A_B_5_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)__t(C)_bounds_(ub)_:
 -92 NoClash(A_C_1_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)__t(A)_bounds_(ub)_:
 -92 NoClash(A_C_1_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_NoClash(A_C_1_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)__NoClash(A_C_1_0)_c_(ub)_:
 +6 NoClash(A_C_1_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars__t(A)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)__t(C)_bounds_(ub)_:
 -92 NoClash(A_C_1_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)__t(A)_bounds_(ub)_:
 -92 NoClash(A_C_1_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_NoClash(A_C_1_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)__NoClash(A_C_1_1)_c_(ub)_:
 +3 NoClash(A_C_1_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)__t(D)_bounds_(ub)_:
 -92 NoClash(A_D_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)__t(A)_bounds_(ub)_:
 -92 NoClash(A_D_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_NoClash(A_D_3_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)__NoClash(A_D_3_0)_c_(ub)_:
 +10 NoClash(A_D_3_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars__t(A)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)__t(D)_bounds_(ub)_:
 -92 NoClash(A_D_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)__t(A)_bounds_(ub)_:
 -92 NoClash(A_D_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_NoClash(A_D_3_1)_c(ub)_:
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars_t(D)
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)__NoClash(A_D_3_1)_c_(ub)_:
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)__t(E)_bounds_(ub)_:
 -92 NoClash(A_E_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)__t(A)_bounds_(ub)_:
 -92 NoClash(A_E_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_NoClash(A_E_3_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)__NoClash(A_E_3_0)_c_(ub)_:
 +7 NoClash(A_E_3_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars__t(A)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)__t(E)_bounds_(ub)_:
 -92 NoClash(A_E_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)__t(A)_bounds_(ub)_:
 -92 NoClash(A_E_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_NoClash(A_E_3_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)__NoClash(A_E_3_1)_c_(ub)_:
 +4 NoClash(A_E_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)__t(E)_bounds_(ub)_:
 -92 NoClash(A_E_5_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)__t(A)_bounds_(ub)_:
 -92 NoClash(A_E_5_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_NoClash(A_E_5_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)__NoClash(A_E_5_0)_c_(ub)_:
 +4 NoClash(A_E_5_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars__t(A)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)__t(E)_bounds_(ub)_:
 -92 NoClash(A_E_5_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)__t(A)_bounds_(ub)_:
 -92 NoClash(A_E_5_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_NoClash(A_E_5_1)_c(ub)_:
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars_t(E)
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)__NoClash(A_E_5_1)_c_(ub)_:
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)__t(F)_bounds_(ub)_:
 -92 NoClash(A_F_1_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)__t(A)_bounds_(ub)_:
 -92 NoClash(A_F_1_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_NoClash(A_F_1_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)__NoClash(A_F_1_0)_c_(ub)_:
 +2 NoClash(A_F_1_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars__t(A)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)__t(F)_bounds_(ub)_:
 -92 NoClash(A_F_1_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)__t(A)_bounds_(ub)_:
 -92 NoClash(A_F_1_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_NoClash(A_F_1_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)__NoClash(A_F_1_1)_c_(ub)_:
 +3 NoClash(A_F_1_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)__t(F)_bounds_(ub)_:
 -92 NoClash(A_F_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)__t(A)_bounds_(ub)_:
 -92 NoClash(A_F_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_NoClash(A_F_3_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)__NoClash(A_F_3_0)_c_(ub)_:
 +4 NoClash(A_F_3_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars__t(A)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)__t(F)_bounds_(ub)_:
 -92 NoClash(A_F_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)__t(A)_bounds_(ub)_:
 -92 NoClash(A_F_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_NoClash(A_F_3_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)__NoClash(A_F_3_1)_c_(ub)_:
 +6 NoClash(A_F_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)__t(G)_bounds_(ub)_:
 -92 NoClash(A_G_5_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)__t(A)_bounds_(ub)_:
 -92 NoClash(A_G_5_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_NoClash(A_G_5_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)__NoClash(A_G_5_0)_c_(ub)_:
 +9 NoClash(A_G_5_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars__t(A)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)__t(G)_bounds_(ub)_:
 -92 NoClash(A_G_5_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)__t(A)_bounds_(ub)_:
 -92 NoClash(A_G_5_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_NoClash(A_G_5_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)__NoClash(A_G_5_1)_c_(ub)_:
 -3 NoClash(A_G_5_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)__t(C)_bounds_(ub)_:
 -92 NoClash(B_C_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)__t(B)_bounds_(ub)_:
 -92 NoClash(B_C_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_NoClash(B_C_2_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)__NoClash(B_C_2_0)_c_(ub)_:
 +9 NoClash(B_C_2_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars__t(B)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)__t(C)_bounds_(ub)_:
 -92 NoClash(B_C_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)__t(B)_bounds_(ub)_:
 -92 NoClash(B_C_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_NoClash(B_C_2_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)__NoClash(B_C_2_1)_c_(ub)_:
 -3 NoClash(B_C_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)__t(D)_bounds_(ub)_:
 -92 NoClash(B_D_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)__t(B)_bounds_(ub)_:
 -92 NoClash(B_D_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_NoClash(B_D_2_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)__NoClash(B_D_2_0)_c_(ub)_:
 +8 NoClash(B_D_2_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars__t(B)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)__t(D)_bounds_(ub)_:
 -92 NoClash(B_D_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)__t(B)_bounds_(ub)_:
 -92 NoClash(B_D_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_NoClash(B_D_2_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)__NoClash(B_D_2_1)_c_(ub)_:
 +3 NoClash(B_D_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)__t(D)_bounds_(ub)_:
 -92 NoClash(B_D_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)__t(B)_bounds_(ub)_:
 -92 NoClash(B_D_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_NoClash(B_D_3_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)__NoClash(B_D_3_0)_c_(ub)_:
 +10 NoClash(B_D_3_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars__t(B)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)__t(D)_bounds_(ub)_:
 -92 NoClash(B_D_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)__t(B)_bounds_(ub)_:
 -92 NoClash(B_D_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_NoClash(B_D_3_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)__NoClash(B_D_3_1)_c_(ub)_:
 -1 NoClash(B_D_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)__t(E)_bounds_(ub)_:
 -92 NoClash(B_E_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)__t(B)_bounds_(ub)_:
 -92 NoClash(B_E_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_NoClash(B_E_2_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)__NoClash(B_E_2_0)_c_(ub)_:
 +4 NoClash(B_E_2_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars__t(B)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)__t(E)_bounds_(ub)_:
 -92 NoClash(B_E_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)__t(B)_bounds_(ub)_:
 -92 NoClash(B_E_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_NoClash(B_E_2_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)__NoClash(B_E_2_1)_c_(ub)_:
 +3 NoClash(B_E_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)__t(E)_bounds_(ub)_:
 -92 NoClash(B_E_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)__t(B)_bounds_(ub)_:
 -92 NoClash(B_E_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_NoClash(B_E_3_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)__NoClash(B_E_3_0)_c_(ub)_:
 +7 NoClash(B_E_3_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars__t(B)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)__t(E)_bounds_(ub)_:
 -92 NoClash(B_E_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)__t(B)_bounds_(ub)_:
 -92 NoClash(B_E_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_NoClash(B_E_3_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)__NoClash(B_E_3_1)_c_(ub)_:
 +3 NoClash(B_E_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)__t(E)_bounds_(ub)_:
 -92 NoClash(B_E_5_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)__t(B)_bounds_(ub)_:
 -92 NoClash(B_E_5_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_NoClash(B_E_5_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)__NoClash(B_E_5_0)_c_(ub)_:
 +5 NoClash(B_E_5_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars__t(B)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)__t(E)_bounds_(ub)_:
 -92 NoClash(B_E_5_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)__t(B)_bounds_(ub)_:
 -92 NoClash(B_E_5_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_NoClash(B_E_5_1)_c(ub)_:
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars_t(E)
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)__NoClash(B_E_5_1)_c_(ub)_:
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)__t(F)_bounds_(ub)_:
 -92 NoClash(B_F_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)__t(B)_bounds_(ub)_:
 -92 NoClash(B_F_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_NoClash(B_F_3_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)__NoClash(B_F_3_0)_c_(ub)_:
 +4 NoClash(B_F_3_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars__t(B)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)__t(F)_bounds_(ub)_:
 -92 NoClash(B_F_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)__t(B)_bounds_(ub)_:
 -92 NoClash(B_F_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_NoClash(B_F_3_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)__NoClash(B_F_3_1)_c_(ub)_:
 +5 NoClash(B_F_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)__t(G)_bounds_(ub)_:
 -92 NoClash(B_G_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)__t(B)_bounds_(ub)_:
 -92 NoClash(B_G_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_NoClash(B_G_2_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)__NoClash(B_G_2_0)_c_(ub)_:
 +8 NoClash(B_G_2_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars__t(B)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)__t(G)_bounds_(ub)_:
 -92 NoClash(B_G_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)__t(B)_bounds_(ub)_:
 -92 NoClash(B_G_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_NoClash(B_G_2_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)__NoClash(B_G_2_1)_c_(ub)_:
 +3 NoClash(B_G_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)__t(G)_bounds_(ub)_:
 -92 NoClash(B_G_5_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)__t(B)_bounds_(ub)_:
 -92 NoClash(B_G_5_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_NoClash(B_G_5_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)__NoClash(B_G_5_0)_c_(ub)_:
 +10 NoClash(B_G_5_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars__t(B)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)__t(G)_bounds_(ub)_:
 -92 NoClash(B_G_5_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)__t(B)_bounds_(ub)_:
 -92 NoClash(B_G_5_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_NoClash(B_G_5_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)__NoClash(B_G_5_1)_c_(ub)_:
 -3 NoClash(B_G_5_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)__t(D)_bounds_(ub)_:
 -92 NoClash(C_D_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)__t(C)_bounds_(ub)_:
 -92 NoClash(C_D_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_NoClash(C_D_2_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)__NoClash(C_D_2_0)_c_(ub)_:
 +2 NoClash(C_D_2_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars_t(C)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars__t(C)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)__t(D)_bounds_(ub)_:
 -92 NoClash(C_D_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)__t(C)_bounds_(ub)_:
 -92 NoClash(C_D_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_NoClash(C_D_2_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)__NoClash(C_D_2_1)_c_(ub)_:
 +9 NoClash(C_D_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)__t(D)_bounds_(ub)_:
 -92 NoClash(C_D_4_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)__t(C)_bounds_(ub)_:
 -92 NoClash(C_D_4_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_NoClash(C_D_4_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)__NoClash(C_D_4_0)_c_(ub)_:
 +5 NoClash(C_D_4_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars_t(C)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars_t(D)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars__t(C)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)__t(D)_bounds_(ub)_:
 -92 NoClash(C_D_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)__t(C)_bounds_(ub)_:
 -92 NoClash(C_D_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_NoClash(C_D_4_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)__NoClash(C_D_4_1)_c_(ub)_:
 +2 NoClash(C_D_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)__t(E)_bounds_(ub)_:
 -92 NoClash(C_E_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)__t(C)_bounds_(ub)_:
 -92 NoClash(C_E_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_NoClash(C_E_2_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)__NoClash(C_E_2_0)_c_(ub)_:
 -2 NoClash(C_E_2_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars_t(C)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars__t(C)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)__t(E)_bounds_(ub)_:
 -92 NoClash(C_E_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)__t(C)_bounds_(ub)_:
 -92 NoClash(C_E_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_NoClash(C_E_2_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)__NoClash(C_E_2_1)_c_(ub)_:
 +9 NoClash(C_E_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)__t(F)_bounds_(ub)_:
 -92 NoClash(C_F_1_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)__t(C)_bounds_(ub)_:
 -92 NoClash(C_F_1_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_NoClash(C_F_1_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)__NoClash(C_F_1_0)_c_(ub)_:
 +2 NoClash(C_F_1_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars_t(C)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars__t(C)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)__t(F)_bounds_(ub)_:
 -92 NoClash(C_F_1_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)__t(C)_bounds_(ub)_:
 -92 NoClash(C_F_1_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_NoClash(C_F_1_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)__NoClash(C_F_1_1)_c_(ub)_:
 +6 NoClash(C_F_1_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)__t(F)_bounds_(ub)_:
 -92 NoClash(C_F_4_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)__t(C)_bounds_(ub)_:
 -92 NoClash(C_F_4_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_NoClash(C_F_4_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)__NoClash(C_F_4_0)_c_(ub)_:
 +5 NoClash(C_F_4_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars_t(C)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars__t(C)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)__t(F)_bounds_(ub)_:
 -92 NoClash(C_F_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)__t(C)_bounds_(ub)_:
 -92 NoClash(C_F_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_NoClash(C_F_4_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)__NoClash(C_F_4_1)_c_(ub)_:
 +8 NoClash(C_F_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)__t(G)_bounds_(ub)_:
 -92 NoClash(C_G_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)__t(C)_bounds_(ub)_:
 -92 NoClash(C_G_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_NoClash(C_G_2_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)__NoClash(C_G_2_0)_c_(ub)_:
 +2 NoClash(C_G_2_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars_t(C)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars__t(C)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)__t(G)_bounds_(ub)_:
 -92 NoClash(C_G_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)__t(C)_bounds_(ub)_:
 -92 NoClash(C_G_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_NoClash(C_G_2_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)__NoClash(C_G_2_1)_c_(ub)_:
 +9 NoClash(C_G_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)__t(G)_bounds_(ub)_:
 -92 NoClash(C_G_4_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)__t(C)_bounds_(ub)_:
 -92 NoClash(C_G_4_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_NoClash(C_G_4_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)__NoClash(C_G_4_0)_c_(ub)_:
 +4 NoClash(C_G_4_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars_t(C)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars__t(C)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)__t(G)_bounds_(ub)_:
 -92 NoClash(C_G_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)__t(C)_bounds_(ub)_:
 -92 NoClash(C_G_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_NoClash(C_G_4_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)__NoClash(C_G_4_1)_c_(ub)_:
 +7 NoClash(C_G_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)__t(E)_bounds_(ub)_:
 -92 NoClash(D_E_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)__t(D)_bounds_(ub)_:
 -92 NoClash(D_E_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_NoClash(D_E_2_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)__NoClash(D_E_2_0)_c_(ub)_:
 +4 NoClash(D_E_2_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars_t(D)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars__t(D)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)__t(E)_bounds_(ub)_:
 -92 NoClash(D_E_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)__t(D)_bounds_(ub)_:
 -92 NoClash(D_E_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_NoClash(D_E_2_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)__NoClash(D_E_2_1)_c_(ub)_:
 +8 NoClash(D_E_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)__t(E)_bounds_(ub)_:
 -92 NoClash(D_E_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)__t(D)_bounds_(ub)_:
 -92 NoClash(D_E_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_NoClash(D_E_3_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)__NoClash(D_E_3_0)_c_(ub)_:
 +2 NoClash(D_E_3_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars_t(D)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars_t(E)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars__t(D)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)__t(E)_bounds_(ub)_:
 -92 NoClash(D_E_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)__t(D)_bounds_(ub)_:
 -92 NoClash(D_E_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_NoClash(D_E_3_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)__NoClash(D_E_3_1)_c_(ub)_:
 +9 NoClash(D_E_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)__t(F)_bounds_(ub)_:
 -92 NoClash(D_F_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)__t(D)_bounds_(ub)_:
 -92 NoClash(D_F_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_NoClash(D_F_3_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)__NoClash(D_F_3_0)_c_(ub)_:
 -1 NoClash(D_F_3_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars_t(D)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars__t(D)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)__t(F)_bounds_(ub)_:
 -92 NoClash(D_F_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)__t(D)_bounds_(ub)_:
 -92 NoClash(D_F_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_NoClash(D_F_3_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)__NoClash(D_F_3_1)_c_(ub)_:
 +11 NoClash(D_F_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)__t(F)_bounds_(ub)_:
 -92 NoClash(D_F_4_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)__t(D)_bounds_(ub)_:
 -92 NoClash(D_F_4_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_NoClash(D_F_4_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)__NoClash(D_F_4_0)_c_(ub)_:
 +1 NoClash(D_F_4_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars_t(D)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars__t(D)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)__t(F)_bounds_(ub)_:
 -92 NoClash(D_F_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)__t(D)_bounds_(ub)_:
 -92 NoClash(D_F_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_NoClash(D_F_4_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)__NoClash(D_F_4_1)_c_(ub)_:
 +7 NoClash(D_F_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)__t(G)_bounds_(ub)_:
 -92 NoClash(D_G_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)__t(D)_bounds_(ub)_:
 -92 NoClash(D_G_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_NoClash(D_G_2_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)__NoClash(D_G_2_0)_c_(ub)_:
 +8 NoClash(D_G_2_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars_t(D)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars__t(D)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)__t(G)_bounds_(ub)_:
 -92 NoClash(D_G_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)__t(D)_bounds_(ub)_:
 -92 NoClash(D_G_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_NoClash(D_G_2_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)__NoClash(D_G_2_1)_c_(ub)_:
 +8 NoClash(D_G_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)__t(G)_bounds_(ub)_:
 -92 NoClash(D_G_4_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)__t(D)_bounds_(ub)_:
 -92 NoClash(D_G_4_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_NoClash(D_G_4_0)_c(ub)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars_t(D)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars_t(G)
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)__NoClash(D_G_4_0)_c_(ub)_:
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars__t(D)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)__t(G)_bounds_(ub)_:
 -92 NoClash(D_G_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_t(D)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)__t(D)_bounds_(ub)_:
 -92 NoClash(D_G_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars_t(D)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars__t(D)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_NoClash(D_G_4_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)__NoClash(D_G_4_1)_c_(ub)_:
 +6 NoClash(D_G_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars_t(D)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars__t(D)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)__t(F)_bounds_(ub)_:
 -92 NoClash(E_F_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)__t(E)_bounds_(ub)_:
 -92 NoClash(E_F_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_NoClash(E_F_3_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)__NoClash(E_F_3_0)_c_(ub)_:
 +3 NoClash(E_F_3_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars_t(E)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars_t(F)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars__t(E)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)__t(F)_bounds_(ub)_:
 -92 NoClash(E_F_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)__t(E)_bounds_(ub)_:
 -92 NoClash(E_F_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_NoClash(E_F_3_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)__NoClash(E_F_3_1)_c_(ub)_:
 +8 NoClash(E_F_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars__t(E)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)__t(G)_bounds_(ub)_:
 -92 NoClash(E_G_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)__t(E)_bounds_(ub)_:
 -92 NoClash(E_G_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_NoClash(E_G_2_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)__NoClash(E_G_2_0)_c_(ub)_:
 +8 NoClash(E_G_2_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars_t(E)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars__t(E)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)__t(G)_bounds_(ub)_:
 -92 NoClash(E_G_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)__t(E)_bounds_(ub)_:
 -92 NoClash(E_G_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_NoClash(E_G_2_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)__NoClash(E_G_2_1)_c_(ub)_:
 +4 NoClash(E_G_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars__t(E)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)__t(G)_bounds_(ub)_:
 -92 NoClash(E_G_5_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)__t(E)_bounds_(ub)_:
 -92 NoClash(E_G_5_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_NoClash(E_G_5_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)__NoClash(E_G_5_0)_c_(ub)_:
 +7 NoClash(E_G_5_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars_t(E)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars__t(E)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)__t(G)_bounds_(ub)_:
 -92 NoClash(E_G_5_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_t(E)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)__t(E)_bounds_(ub)_:
 -92 NoClash(E_G_5_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars_t(E)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars__t(E)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_NoClash(E_G_5_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)__NoClash(E_G_5_1)_c_(ub)_:
 -1 NoClash(E_G_5_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars_t(E)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars__t(E)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)__t(G)_bounds_(ub)_:
 -92 NoClash(F_G_4_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)__t(F)_bounds_(ub)_:
 -92 NoClash(F_G_4_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_NoClash(F_G_4_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)__NoClash(F_G_4_0)_c_(ub)_:
 +6 NoClash(F_G_4_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars_t(F)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars_t(G)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars__t(F)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_t(G)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)__t(G)_bounds_(ub)_:
 -92 NoClash(F_G_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars__t(G)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_t(F)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)__t(F)_bounds_(ub)_:
 -92 NoClash(F_G_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars_t(F)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars__t(F)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_NoClash(F_G_4_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)__NoClash(F_G_4_1)_c_(ub)_:
 +6 NoClash(F_G_4_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars_t(F)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars_t(G)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars__t(F)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars__t(G)_
 <= 0
 
 c_e_ONE_VAR_CONSTANT: 
@@ -1765,215 +1765,215 @@ bounds
    0 <= t(F) <= 92
    0 <= t(G) <= 92
    0 <= NoClash(A_B_3_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars__t(B)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_B_3_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars__t(B)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_B_5_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars__t(B)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_B_5_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(B) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars__t(B)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_C_1_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars__t(C)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_C_1_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars__t(C)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_D_3_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars__t(D)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(6)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_D_3_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars__t(D)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(7)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_E_3_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars__t(E)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(8)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_E_3_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars__t(E)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(9)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_E_5_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars__t(E)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(10)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_E_5_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars__t(E)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(11)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_F_1_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars__t(F)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(12)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_F_1_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars__t(F)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(13)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_F_3_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars__t(F)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(14)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_F_3_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars__t(F)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(15)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_G_5_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(16)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(A_G_5_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars_t(A) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(17)_disaggregatedVars__t(A)_ <= 92
    0 <= NoClash(B_C_2_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars__t(C)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(18)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_C_2_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars_t(C) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars__t(C)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(19)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_D_2_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars__t(D)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(20)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_D_2_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars__t(D)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(21)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_D_3_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars__t(D)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(22)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_D_3_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars__t(D)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(23)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_E_2_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars__t(E)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(24)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_E_2_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars__t(E)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(25)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_E_3_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars__t(E)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(26)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_E_3_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars__t(E)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(27)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_E_5_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars__t(E)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(28)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_E_5_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars__t(E)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(29)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_F_3_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars__t(F)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(30)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_F_3_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars__t(F)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(31)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_G_2_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(32)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_G_2_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(33)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_G_5_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(34)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(B_G_5_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars_t(B) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(35)_disaggregatedVars__t(B)_ <= 92
    0 <= NoClash(C_D_2_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars__t(D)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(36)_disaggregatedVars__t(C)_ <= 92
    0 <= NoClash(C_D_2_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars__t(D)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(37)_disaggregatedVars__t(C)_ <= 92
    0 <= NoClash(C_D_4_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars__t(D)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(38)_disaggregatedVars__t(C)_ <= 92
    0 <= NoClash(C_D_4_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars_t(D) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars__t(D)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(39)_disaggregatedVars__t(C)_ <= 92
    0 <= NoClash(C_E_2_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars__t(E)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(40)_disaggregatedVars__t(C)_ <= 92
    0 <= NoClash(C_E_2_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars__t(E)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(41)_disaggregatedVars__t(C)_ <= 92
    0 <= NoClash(C_F_1_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars__t(F)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(42)_disaggregatedVars__t(C)_ <= 92
    0 <= NoClash(C_F_1_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars__t(F)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(43)_disaggregatedVars__t(C)_ <= 92
    0 <= NoClash(C_F_4_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars__t(F)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(44)_disaggregatedVars__t(C)_ <= 92
    0 <= NoClash(C_F_4_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars__t(F)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(45)_disaggregatedVars__t(C)_ <= 92
    0 <= NoClash(C_G_2_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(46)_disaggregatedVars__t(C)_ <= 92
    0 <= NoClash(C_G_2_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(47)_disaggregatedVars__t(C)_ <= 92
    0 <= NoClash(C_G_4_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(48)_disaggregatedVars__t(C)_ <= 92
    0 <= NoClash(C_G_4_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars_t(C) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(49)_disaggregatedVars__t(C)_ <= 92
    0 <= NoClash(D_E_2_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars__t(E)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(50)_disaggregatedVars__t(D)_ <= 92
    0 <= NoClash(D_E_2_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars__t(E)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(51)_disaggregatedVars__t(D)_ <= 92
    0 <= NoClash(D_E_3_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars__t(E)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(52)_disaggregatedVars__t(D)_ <= 92
    0 <= NoClash(D_E_3_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars_t(E) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars__t(E)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(53)_disaggregatedVars__t(D)_ <= 92
    0 <= NoClash(D_F_3_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars__t(F)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(54)_disaggregatedVars__t(D)_ <= 92
    0 <= NoClash(D_F_3_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars__t(F)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(55)_disaggregatedVars__t(D)_ <= 92
    0 <= NoClash(D_F_4_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars__t(F)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(56)_disaggregatedVars__t(D)_ <= 92
    0 <= NoClash(D_F_4_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars__t(F)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(57)_disaggregatedVars__t(D)_ <= 92
    0 <= NoClash(D_G_2_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(58)_disaggregatedVars__t(D)_ <= 92
    0 <= NoClash(D_G_2_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(59)_disaggregatedVars__t(D)_ <= 92
    0 <= NoClash(D_G_4_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(60)_disaggregatedVars__t(D)_ <= 92
    0 <= NoClash(D_G_4_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars_t(D) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(61)_disaggregatedVars__t(D)_ <= 92
    0 <= NoClash(E_F_3_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars__t(F)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(62)_disaggregatedVars__t(E)_ <= 92
    0 <= NoClash(E_F_3_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars_t(F) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars__t(F)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(63)_disaggregatedVars__t(E)_ <= 92
    0 <= NoClash(E_G_2_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(64)_disaggregatedVars__t(E)_ <= 92
    0 <= NoClash(E_G_2_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(65)_disaggregatedVars__t(E)_ <= 92
    0 <= NoClash(E_G_5_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(66)_disaggregatedVars__t(E)_ <= 92
    0 <= NoClash(E_G_5_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars_t(E) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(67)_disaggregatedVars__t(E)_ <= 92
    0 <= NoClash(F_G_4_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(68)_disaggregatedVars__t(F)_ <= 92
    0 <= NoClash(F_G_4_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars_t(G) <= 92
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars_t(F) <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars__t(G)_ <= 92
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(69)_disaggregatedVars__t(F)_ <= 92
 binary
   NoClash(A_B_3_0)_binary_indicator_var
   NoClash(A_B_3_1)_binary_indicator_var

--- a/pyomo/gdp/tests/jobshop_small_bigm.lp
+++ b/pyomo/gdp/tests/jobshop_small_bigm.lp
@@ -36,37 +36,37 @@ c_e__pyomo_gdp_bigm_reformulation_disj_xor(B_C_2)_:
 +1 NoClash(B_C_2_1)_binary_indicator_var
 = 1
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(0)_NoClash(A_B_3_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(0)__NoClash(A_B_3_0)_c_(ub)_:
 +19 NoClash(A_B_3_0)_binary_indicator_var
 -1 t(A)
 +1 t(B)
 <= 19
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(1)_NoClash(A_B_3_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(1)__NoClash(A_B_3_1)_c_(ub)_:
 +24 NoClash(A_B_3_1)_binary_indicator_var
 +1 t(A)
 -1 t(B)
 <= 19
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(2)_NoClash(A_C_1_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(2)__NoClash(A_C_1_0)_c_(ub)_:
 +21 NoClash(A_C_1_0)_binary_indicator_var
 -1 t(A)
 +1 t(C)
 <= 19
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(3)_NoClash(A_C_1_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(3)__NoClash(A_C_1_1)_c_(ub)_:
 +24 NoClash(A_C_1_1)_binary_indicator_var
 +1 t(A)
 -1 t(C)
 <= 19
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(4)_NoClash(B_C_2_0)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(4)__NoClash(B_C_2_0)_c_(ub)_:
 +25 NoClash(B_C_2_0)_binary_indicator_var
 -1 t(B)
 +1 t(C)
 <= 19
 
-c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(5)_NoClash(B_C_2_1)_c(ub)_:
+c_u__pyomo_gdp_bigm_reformulation_relaxedDisjuncts(5)__NoClash(B_C_2_1)_c_(ub)_:
 +20 NoClash(B_C_2_1)_binary_indicator_var
 +1 t(B)
 -1 t(C)

--- a/pyomo/gdp/tests/jobshop_small_hull.lp
+++ b/pyomo/gdp/tests/jobshop_small_hull.lp
@@ -22,38 +22,38 @@ c_u_Feas(C)_:
 <= -6
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_B_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars__t(B)_
 +1 t(B)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_A_C_1)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars__t(C)_
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(0_B_C_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(C)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars__t(C)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars__t(C)_
 +1 t(C)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_B_3)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars__t(A)_
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_A_C_1)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(A)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars__t(A)_
 +1 t(A)
 = 0
 
 c_e__pyomo_gdp_hull_reformulation_disaggregationConstraints(1_B_C_2)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(B)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars__t(B)_
 +1 t(B)
 = 0
 
@@ -72,99 +72,99 @@ c_e__pyomo_gdp_hull_reformulation_disj_xor(B_C_2)_:
 +1 NoClash(B_C_2_1)_binary_indicator_var
 = 1
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)__t(B)_bounds_(ub)_:
 -19 NoClash(A_B_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)__t(A)_bounds_(ub)_:
 -19 NoClash(A_B_3_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_NoClash(A_B_3_0)_c(ub)_:
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(B)
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)__NoClash(A_B_3_0)_c_(ub)_:
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars__t(A)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)__t(B)_bounds_(ub)_:
 -19 NoClash(A_B_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)__t(A)_bounds_(ub)_:
 -19 NoClash(A_B_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_NoClash(A_B_3_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)__NoClash(A_B_3_1)_c_(ub)_:
 +5 NoClash(A_B_3_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)__t(C)_bounds_(ub)_:
 -19 NoClash(A_C_1_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)__t(A)_bounds_(ub)_:
 -19 NoClash(A_C_1_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_NoClash(A_C_1_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)__NoClash(A_C_1_0)_c_(ub)_:
 +2 NoClash(A_C_1_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(A)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars__t(A)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)__t(C)_bounds_(ub)_:
 -19 NoClash(A_C_1_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_t(A)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)__t(A)_bounds_(ub)_:
 -19 NoClash(A_C_1_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(A)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars__t(A)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_NoClash(A_C_1_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)__NoClash(A_C_1_1)_c_(ub)_:
 +5 NoClash(A_C_1_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(A)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars__t(A)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)__t(C)_bounds_(ub)_:
 -19 NoClash(B_C_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)__t(B)_bounds_(ub)_:
 -19 NoClash(B_C_2_0)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_NoClash(B_C_2_0)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)__NoClash(B_C_2_0)_c_(ub)_:
 +6 NoClash(B_C_2_0)_binary_indicator_var
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(B)
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(C)
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars__t(B)_
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(C)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)__t(C)_bounds_(ub)_:
 -19 NoClash(B_C_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars__t(C)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_t(B)_bounds(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)__t(B)_bounds_(ub)_:
 -19 NoClash(B_C_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(B)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars__t(B)_
 <= 0
 
-c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_NoClash(B_C_2_1)_c(ub)_:
+c_u__pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)__NoClash(B_C_2_1)_c_(ub)_:
 +1 NoClash(B_C_2_1)_binary_indicator_var
-+1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(B)
--1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(C)
++1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars__t(B)_
+-1 _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars__t(C)_
 <= 0
 
 c_e_ONE_VAR_CONSTANT: 
@@ -176,23 +176,23 @@ bounds
    0 <= t(B) <= 19
    0 <= t(C) <= 19
    0 <= NoClash(A_B_3_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(B) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars_t(A) <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars__t(B)_ <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(0)_disaggregatedVars__t(A)_ <= 19
    0 <= NoClash(A_B_3_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(B) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars_t(A) <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars__t(B)_ <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(1)_disaggregatedVars__t(A)_ <= 19
    0 <= NoClash(A_C_1_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(C) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars_t(A) <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars__t(C)_ <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(2)_disaggregatedVars__t(A)_ <= 19
    0 <= NoClash(A_C_1_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(C) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars_t(A) <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars__t(C)_ <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(3)_disaggregatedVars__t(A)_ <= 19
    0 <= NoClash(B_C_2_0)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(C) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars_t(B) <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars__t(C)_ <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(4)_disaggregatedVars__t(B)_ <= 19
    0 <= NoClash(B_C_2_1)_binary_indicator_var <= 1
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(C) <= 19
-   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars_t(B) <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars__t(C)_ <= 19
+   0 <= _pyomo_gdp_hull_reformulation_relaxedDisjuncts(5)_disaggregatedVars__t(B)_ <= 19
 binary
   NoClash(A_B_3_0)_binary_indicator_var
   NoClash(A_B_3_1)_binary_indicator_var

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -1707,13 +1707,13 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         # All the outer and inner disjuncts should be on Block:
         self.assertEqual(len(disjBlock), 7)
         pairs = [
-            (0, ["simpledisjunct._pyomo_gdp_bigm_reformulation.simpledisjunct."
-                 "innerdisjunction_xor"]),
+            (0, ["simpledisjunct._pyomo_gdp_bigm_reformulation.'simpledisjunct."
+                 "innerdisjunction_xor'"]),
             (1, ["simpledisjunct.innerdisjunct0.c"]),
             (2, ["simpledisjunct.innerdisjunct1.c"]),
             (3, ["disjunct[0].c"]),
-            (4, ["disjunct[1]._pyomo_gdp_bigm_reformulation.disjunct[1]."
-                 "innerdisjunction_xor",
+            (4, ["disjunct[1]._pyomo_gdp_bigm_reformulation.'disjunct[1]."
+                 "innerdisjunction_xor'",
                  "disjunct[1].c"]),
             (5, ["disjunct[1].innerdisjunct[0].c"]),
             (6, ["disjunct[1].innerdisjunct[1].c"]),
@@ -1908,9 +1908,10 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
 
         # Here we check that the xor constraint from
         # simpledisjunct.innerdisjunction is transformed.
+        m.simpledisjunct.transformation_block().pprint()
         cons5 = m.simpledisjunct.transformation_block().component(
-            "simpledisjunct._pyomo_gdp_bigm_reformulation.simpledisjunct."
-            "innerdisjunction_xor")
+            "simpledisjunct._pyomo_gdp_bigm_reformulation.'simpledisjunct."
+            "innerdisjunction_xor'")
         cons5lb = cons5['lb']
         self.check_xor_relaxation(
             cons5lb,
@@ -1941,8 +1942,8 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         # disjunct[1].innerdisjunction gets transformed alongside the
         # other constraint in disjunct[1].
         cons7 = m.disjunct[1].transformation_block().component(
-            "disjunct[1]._pyomo_gdp_bigm_reformulation.disjunct[1]."
-            "innerdisjunction_xor")
+            "disjunct[1]._pyomo_gdp_bigm_reformulation.'disjunct[1]."
+            "innerdisjunction_xor'")
         cons7lb = cons7[0,'lb']
         self.check_xor_relaxation(
             cons7lb,
@@ -2056,11 +2057,12 @@ class BlocksOnDisjuncts(unittest.TestCase):
         self.assertEqual(len(disjBlock[0].component_map()), 2)
         self.assertEqual(len(disjBlock[1].component_map()), 5)
         self.assertIsInstance(disjBlock[0].component("evil[0].c"), Constraint)
-        self.assertIsInstance(disjBlock[1].component("evil[1].b.c"), Constraint)
+        self.assertIsInstance(disjBlock[1].component("evil[1].'b.c'"),
+                              Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].bb[1].c"),
                               Constraint)
         self.assertIsInstance(
-            disjBlock[1].component("evil[1].b.c_4"), Constraint)
+            disjBlock[1].component("evil[1].'b.c'"), Constraint)
         self.assertIsInstance(
             disjBlock[1].component("evil[1].b.anotherblock.c"),
                                                      Constraint)
@@ -2083,11 +2085,12 @@ class BlocksOnDisjuncts(unittest.TestCase):
         self.assertEqual(len(disjBlock[0].component_map()), 2)
         self.assertEqual(len(disjBlock[1].component_map()), 4)
         self.assertIsInstance(disjBlock[0].component("evil[0].c"), Constraint)
-        self.assertIsInstance(disjBlock[1].component("evil[1].b.c"), Constraint)
+        self.assertIsInstance(disjBlock[1].component("evil[1].'b.c'"),
+                              Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].bb[1].c"),
                               Constraint)
         self.assertIsInstance(
-            disjBlock[1].component("evil[1].b.c_4"), Constraint)
+            disjBlock[1].component("evil[1].'b.c'"), Constraint)
         self.assertIsInstance(disjBlock[0].component("localVarReferences"),
                               Block)
         self.assertIsInstance(disjBlock[1].component("localVarReferences"),
@@ -2107,11 +2110,12 @@ class BlocksOnDisjuncts(unittest.TestCase):
         self.assertEqual(len(disjBlock[0].component_map()), 2)
         self.assertEqual(len(disjBlock[1].component_map()), 4)
         self.assertIsInstance(disjBlock[0].component("evil[0].c"), Constraint)
-        self.assertIsInstance(disjBlock[1].component("evil[1].b.c"), Constraint)
+        self.assertIsInstance(disjBlock[1].component("evil[1].'b.c'"),
+                              Constraint)
         self.assertIsInstance(disjBlock[1].component("evil[1].bb[1].c"),
                               Constraint)
         self.assertIsInstance(
-            disjBlock[1].component("evil[1].b.c_4"), Constraint)
+            disjBlock[1].component("evil[1].'b.c'"), Constraint)
         self.assertIsInstance(disjBlock[0].component("localVarReferences"),
                               Block)
         self.assertIsInstance(disjBlock[1].component("localVarReferences"),
@@ -2286,14 +2290,20 @@ class IndexedDisjunctions(unittest.TestCase):
         self.assertIsInstance(transBlock, Block)
         self.assertIsInstance(transBlock.component("relaxedDisjuncts"), Block)
         self.assertEqual(len(transBlock.relaxedDisjuncts), 4)
+        if model.component('firstTerm') is None:
+            firstTerm = "'firstTerm[1]'.cons"
+            secondTerm = "'secondTerm[1]'.cons"
+        else:
+            firstTerm = "firstTerm[1].cons"
+            secondTerm = "secondTerm[1].cons"
         self.assertIsInstance(transBlock.relaxedDisjuncts[2].component(
-            "firstTerm[1].cons"), Constraint)
+            firstTerm), Constraint)
         self.assertEqual(len(transBlock.relaxedDisjuncts[2].component(
-            "firstTerm[1].cons")), 2)
+            firstTerm)), 2)
         self.assertIsInstance(transBlock.relaxedDisjuncts[3].component(
-            "secondTerm[1].cons"), Constraint)
+            secondTerm), Constraint)
         self.assertEqual(len(transBlock.relaxedDisjuncts[3].component(
-            "secondTerm[1].cons")), 1)
+            secondTerm)), 1)
         self.assertEqual(
             len(model._pyomo_gdp_bigm_reformulation.disjunctionList_xor), 2)
         self.assertFalse(model.disjunctionList[1].active)
@@ -2337,7 +2347,7 @@ class TestErrors(unittest.TestCase):
         # longest constraint name EVER...
         relaxed_xor = disjunct1.component(
             "disjunction_disjuncts[0]._pyomo_gdp_bigm_reformulation."
-            "disjunction_disjuncts[0].nestedDisjunction_xor")
+            "'disjunction_disjuncts[0].nestedDisjunction_xor'")
         self.assertIsInstance(relaxed_xor, Constraint)
         repn = generate_standard_repn(relaxed_xor['lb'].body)
         self.assertEqual(relaxed_xor['lb'].lower, 1)

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -1908,7 +1908,6 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
 
         # Here we check that the xor constraint from
         # simpledisjunct.innerdisjunction is transformed.
-        m.simpledisjunct.transformation_block().pprint()
         cons5 = m.simpledisjunct.transformation_block().component(
             "simpledisjunct._pyomo_gdp_bigm_reformulation.'simpledisjunct."
             "innerdisjunction_xor'")

--- a/pyomo/gdp/tests/test_gdp.py
+++ b/pyomo/gdp/tests/test_gdp.py
@@ -188,7 +188,7 @@ class Reformulate(unittest.TestCase, CommonTests):
         self.assertTrue(cmp(_prob, _solv),
                         msg="Files %s and %s differ" % (_prob, _solv))
         if os.path.exists(join(currdir,self.problem+'_result.lp')):
-            os.remove(join(currdir,self.problem+'_result.lp'))
+           os.remove(join(currdir,self.problem+'_result.lp'))
 
 
 class Solver(unittest.TestCase):
@@ -211,7 +211,7 @@ class Solver(unittest.TestCase):
                 )
         # Clean up test files
         if os.path.exists(join(currdir,self.problem+'_result.lp')):
-            os.remove(join(currdir,self.problem+'_result.lp'))
+           os.remove(join(currdir,self.problem+'_result.lp'))
 
 
 @unittest.skipIf(not yaml_available, "YAML is not available")

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -885,6 +885,13 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertEqual(len(transBlock.disjunctionList_xor), 1)
         self.assertFalse(model.disjunctionList[0].active)
 
+        if model.component('firstTerm') is None:
+            firstTerm = "'firstTerm[0]'.cons"
+            secondTerm = "'secondTerm[0]'.cons"
+        else:
+            firstTerm = "firstTerm[0].cons"
+            secondTerm = "secondTerm[0].cons"
+
         self.assertIsInstance(transBlock.relaxedDisjuncts, Block)
         self.assertEqual(len(transBlock.relaxedDisjuncts), 2)
 
@@ -895,9 +902,9 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertEqual(value(transBlock.relaxedDisjuncts[0].disaggregatedVars.\
                                x), 0)
         self.assertIsInstance(transBlock.relaxedDisjuncts[0].component(
-            "firstTerm[0].cons"), Constraint)
+            firstTerm), Constraint)
         self.assertEqual(len(transBlock.relaxedDisjuncts[0].component(
-            "firstTerm[0].cons")), 0)
+            firstTerm)), 0)
         self.assertIsInstance(transBlock.relaxedDisjuncts[0].x_bounds,
                               Constraint)
         self.assertEqual(len(transBlock.relaxedDisjuncts[0].x_bounds), 2)
@@ -907,9 +914,9 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertFalse(transBlock.relaxedDisjuncts[1].disaggregatedVars.\
                          x.is_fixed())
         self.assertIsInstance(transBlock.relaxedDisjuncts[1].component(
-            "secondTerm[0].cons"), Constraint)
+            secondTerm), Constraint)
         self.assertEqual(len(transBlock.relaxedDisjuncts[1].component(
-            "secondTerm[0].cons")), 1)
+            secondTerm)), 1)
         self.assertIsInstance(transBlock.relaxedDisjuncts[1].x_bounds,
                               Constraint)
         self.assertEqual(len(transBlock.relaxedDisjuncts[1].x_bounds), 2)
@@ -919,14 +926,22 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertIsInstance(transBlock, Block)
         self.assertIsInstance(transBlock.component("relaxedDisjuncts"), Block)
         self.assertEqual(len(transBlock.relaxedDisjuncts), 4)
+
+        if model.component('firstTerm') is None:
+            firstTerm = "'firstTerm[1]'.cons"
+            secondTerm = "'secondTerm[1]'.cons"
+        else:
+            firstTerm = "firstTerm[1].cons"
+            secondTerm = "secondTerm[1].cons"
+
         self.assertIsInstance(transBlock.relaxedDisjuncts[2].component(
-            "firstTerm[1].cons"), Constraint)
+            firstTerm), Constraint)
         self.assertEqual(len(transBlock.relaxedDisjuncts[2].component(
-            "firstTerm[1].cons")), 1)
+            firstTerm)), 1)
         self.assertIsInstance(transBlock.relaxedDisjuncts[3].component(
-            "secondTerm[1].cons"), Constraint)
+            secondTerm), Constraint)
         self.assertEqual(len(transBlock.relaxedDisjuncts[3].component(
-            "secondTerm[1].cons")), 1)
+            secondTerm)), 1)
         self.assertEqual(
             len(transBlock.disjunctionList_xor), 2)
         self.assertFalse(model.disjunctionList[1].active)
@@ -1377,7 +1392,7 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         # check the transformed constraints
 
         # transformed xor
-        xor = disj1.component("d1._pyomo_gdp_hull_reformulation.d1.disj2_xor")
+        xor = disj1.component("d1._pyomo_gdp_hull_reformulation.'d1.disj2_xor'")
         self.assertIsInstance(xor, Constraint)
         self.assertTrue(xor.active)
         self.assertEqual(len(xor), 1)
@@ -1438,7 +1453,7 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
 
         # transformed x >= 1.2
         cons = disj1.component(
-            "d1._pyomo_gdp_hull_reformulation.relaxedDisjuncts[0].d1.d3.c")
+            "d1._pyomo_gdp_hull_reformulation.relaxedDisjuncts[0].'d1.d3.c'")
         first_transformed = m.d1._pyomo_gdp_hull_reformulation.\
                             relaxedDisjuncts[0].component("d1.d3.c")
         original = m.d1.d3.c
@@ -1449,7 +1464,7 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
 
         # transformed x >= 1.3
         cons = disj1.component(
-            "d1._pyomo_gdp_hull_reformulation.relaxedDisjuncts[1].d1.d4.c")
+            "d1._pyomo_gdp_hull_reformulation.relaxedDisjuncts[1].'d1.d4.c'")
         first_transformed = m.d1._pyomo_gdp_hull_reformulation.\
                             relaxedDisjuncts[1].component("d1.d4.c")
         original = m.d1.d4.c
@@ -1801,7 +1816,7 @@ class TestErrors(unittest.TestCase):
 
         relaxed_xor = disjunct1.component(
             "disjunction_disjuncts[0]._pyomo_gdp_hull_reformulation."
-            "disjunction_disjuncts[0].nestedDisjunction_xor")
+            "'disjunction_disjuncts[0].nestedDisjunction_xor'")
         self.assertIsInstance(relaxed_xor, Constraint)
         self.assertEqual(len(relaxed_xor), 1)
         repn = generate_standard_repn(relaxed_xor['eq'].body)
@@ -1962,24 +1977,24 @@ class BlocksOnDisjuncts(unittest.TestCase):
         transBlock = m.disj1.transformation_block()
         self.assertIsInstance(transBlock.component("disj1.b.any_index"),
                               Constraint)
-        self.assertIsInstance(transBlock.component("disj1.b.any_index_4"),
+        self.assertIsInstance(transBlock.component("disj1.'b.any_index'"),
                               Constraint)
         xformed = hull.get_transformed_constraints(
             m.disj1.component("b.any_index"))
         self.assertEqual(len(xformed), 1)
         self.assertIs(xformed[0],
-                      transBlock.component("disj1.b.any_index")['lb'])
+                      transBlock.component("disj1.'b.any_index'")['lb'])
 
         xformed = hull.get_transformed_constraints(m.disj1.b.any_index['local'])
         self.assertEqual(len(xformed), 1)
         self.assertIs(xformed[0],
-                      transBlock.component("disj1.b.any_index_4")[
+                      transBlock.component("disj1.b.any_index")[
                           ('local','ub')])
         xformed = hull.get_transformed_constraints(
             m.disj1.b.any_index['nonlin-ub'])
         self.assertEqual(len(xformed), 1)
         self.assertIs(xformed[0],
-                      transBlock.component("disj1.b.any_index_4")[
+                      transBlock.component("disj1.b.any_index")[
                           ('nonlin-ub','ub')])
 
     def test_local_var_handled_correctly(self):


### PR DESCRIPTION
## Fixes #1857, supersedes #1858

## Summary/Motivation:
This PR makes the generation of string representations of component names and indices more robust by leveraging logic added to ComponentUID for generating the (simplified) string representations.  In particular, this will correctly quote (fully qualified) names containing `.` or other special tokens, and it will correctly report 1-tuples as tuples.

Note that this intentionally only applies the more robust quoting to *fully-qualified* names and not "local names", as we want to preserve the property that
```python
x.parent_block().component(x.local_name) is x
```

## Changes proposed in this PR:
- generalize "safe str" logic from `ComponentUID` into a separate `component_namer` module.
- quote names / indices containing special literals `.\[](),`
- report 1-tuples as tuples (i.e., as `(1,)`)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
