### PR TITLE
Remove Component.reconstruct()

### DIFF
--- a/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
@@ -65,7 +65,8 @@ class PyomoNLP(AslNLP):
                     'The ASL interface and PyomoNLP in PyNumero currently '
                     'only support single objective problems. Deactivate '
                     'any extra objectives you may have, or add a dummy '
-                    'objective (f(x)=0) if you have a square problem.')
+                    'objective (f(x)=0) if you have a square problem '
+                    '(found %s objectives).' % (len(objectives),))
             self._objective = objectives[0]
 
             # write the nl file for the Pyomo model and get the symbolMap

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -497,9 +497,23 @@ class Component(_ComponentBase):
         return self._constructed
 
     def reconstruct(self, data=None):
-        """Re-construct model expressions"""
-        self._constructed = False
-        self.construct(data=data)
+        """REMOVED: reconstruct() was removed in Pyomo 6.0.
+
+        Re-constructing model components was fragile and did not
+        correctly update instances of the component used in other
+        components or contexts (this was particularly problemmatic for
+        Var, Param, and Set).  Users who wish to reproduce the old
+        behavior of reconstruct(), are comfortable manipulating
+        non-public interfaces, and who take the time to verify that the
+        correct thing happens to their model can approximate the old
+        behavior of reconstruct with:
+
+            component.clear()
+            component._constructed = False
+            component.construct()
+
+        """
+        raise AttributeError(self.reconstruct.__doc__)
 
     def valid_model_component(self):
         """Return True if this can be used as a model component."""

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -943,6 +943,8 @@ class ScalarConstraint(_GeneralConstraintData, Constraint):
                 "nothing to access." % (self.name))
         return _GeneralConstraintData.strict_upper.fget(self)
 
+    def clear(self):
+        self._data = {}
 
     def set_value(self, expr):
         """Set the expression on this constraint."""

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -750,6 +750,7 @@ class Constraint(ActiveIndexedComponent):
 
         try:
             # We do not (currently) accept data for constructing Constraints
+            index = None
             assert data is None
 
             if self.rule is None:
@@ -762,7 +763,6 @@ class Constraint(ActiveIndexedComponent):
                     "of a constraint with a single expression" %
                     (self.name,) )
 
-            index = None
             block = self.parent_block()
             if self.rule.contains_indices():
                 # The index is coming in externally; we need to validate it

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -458,6 +458,9 @@ class ScalarExpression(_GeneralExpressionData, Expression):
     def value(self, expr):
         self.set_value(expr)
 
+    def clear(self):
+        self._data = {}
+
     def set_value(self, expr):
         """Set the expression on this expression."""
         if self._constructed:

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -546,6 +546,9 @@ class ScalarObjective(_GeneralObjectiveData, Objective):
     # Objective.Skip but expects a valid expression or None
     #
 
+    def clear(self):
+        self._data = {}
+
     def set_value(self, expr):
         """Set the expression of this objective."""
         if not self._constructed:

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -331,13 +331,6 @@ class Objective(ActiveIndexedComponent):
         _init_expr = self._init_expr
         _init_sense = self._init_sense
         _init_rule = self.rule
-        #
-        # We no longer need these
-        #
-        self._init_expr = None
-        self._init_sense = None
-        # Utilities like DAE assume this stays around
-        #self.rule = None
 
         if (_init_rule is None) and \
            (_init_expr is None):

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -956,24 +956,6 @@ This has resulted in the conversion of the source to dense form.
             self.to_dense_data()
         timer.report()
 
-    def reconstruct(self, data=None):
-        """
-        Reconstruct this parameter object.  This is particularly useful
-        for cases where an initialize rule is provided.  An initialize
-        rule can return an expression that is a function of other
-        parameters, so reconstruction can account for changes in dependent
-        parameters.
-
-        Only mutable parameters can be reconstructed.  Otherwise, the
-        changes would not be propagated into expressions in objectives
-        or constraints.
-        """
-        if not self._mutable:
-            raise RuntimeError(
-                "Cannot invoke reconstruct method of immutable Param %s"
-                % (self.name,))
-        IndexedComponent.reconstruct(self, data=data)
-
     def _pprint(self):
         """
         Return data that will be printed for this component.

--- a/pyomo/dae/integral.py
+++ b/pyomo/dae/integral.py
@@ -138,6 +138,9 @@ class ScalarIntegral(ScalarExpression, Integral):
         _GeneralExpressionData.__init__(self, None, component=self)
         Integral.__init__(self, *args, **kwds)
 
+    def clear(self):
+        self._data = {}
+
     def is_fully_discretized(self):
         """
         Checks to see if all ContinuousSets indexing this Integral have been

--- a/pyomo/dae/plugins/colloc.py
+++ b/pyomo/dae/plugins/colloc.py
@@ -499,14 +499,26 @@ class Collocation_Discretization_Transformation(Transformation):
 
             if block.contains_component(Integral):
                 for i in block.component_objects(Integral, descend_into=True):
-                    i.reconstruct()
                     i.parent_block().reclassify_component_type(i, Expression)
+                    # TODO: The following reproduces the old behavior of
+                    # "reconstruct()".  We should come up with an
+                    # implementation that does not rely on manipulating
+                    # private attributes
+                    i.clear()
+                    i._constructed = False
+                    i.construct()
                 # If a model contains integrals they are most likely to appear
                 # in the objective function which will need to be reconstructed
                 # after the model is discretized.
                 for k in block.component_objects(Objective, descend_into=True):
                     # TODO: check this, reconstruct might not work
-                    k.reconstruct()
+                    # TODO: The following reproduces the old behavior of
+                    # "reconstruct()".  We should come up with an
+                    # implementation that does not rely on manipulating
+                    # private attributes
+                    k.clear()
+                    k._constructed = False
+                    k.construct()
 
     def reduce_collocation_points(self, instance, var=None, ncp=None,
                                   contset=None):

--- a/pyomo/dae/plugins/finitedifference.py
+++ b/pyomo/dae/plugins/finitedifference.py
@@ -282,11 +282,24 @@ class Finite_Difference_Transformation(Transformation):
 
             if block.contains_component(Integral):
                 for i in block.component_objects(Integral, descend_into=True):
-                    i.reconstruct()
                     i.parent_block().reclassify_component_type(i, Expression)
+                    # TODO: The following reproduces the old behavior of
+                    # "reconstruct()".  We should come up with an
+                    # implementation that does not rely on manipulating
+                    # private attributes
+                    i.clear()
+                    i._constructed = False
+                    i.construct()
+
                 # If a model contains integrals they are most likely to
                 # appear in the objective function which will need to be
                 # reconstructed after the model is discretized.
                 for k in block.component_objects(Objective, descend_into=True):
                     # TODO: check this, reconstruct might not work
-                    k.reconstruct()
+                    # TODO: The following reproduces the old behavior of
+                    # "reconstruct()".  We should come up with an
+                    # implementation that does not rely on manipulating
+                    # private attributes
+                    k.clear()
+                    k._constructed = False
+                    k.construct()


### PR DESCRIPTION
## Fixes #226, fixes #252

## Summary/Motivation:
`Component.reconstruct()` is fragile and known to not work in numerous cases.  This PR formally removed that method from the Component API and replaces it with an exception directing users away from it.

This also addresses some problems identified in Objective, Constraint, and Expression (failure to define `clear()`).

## Changes proposed in this PR:
- remove `Component.reconstruct()` and replace with exception
- update DAE to not use `reconstruct()`
- define `clear() for scalar Objective, Constraint, and Expression
- resolve error generation initializing IndexedConstraint with a single expression

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
