### PR TITLE
Update name generator/parser to better handle special_characters

### DIFF
--- a/pyomo/core/base/componentuid.py
+++ b/pyomo/core/base/componentuid.py
@@ -75,7 +75,7 @@ class ComponentUID(object):
                                  "ComponentUID object from a string type")
             try:
                 self._cids = tuple(self._parse_cuid_v2(component))
-            except (OSError, IOError, AssertionError):
+            except (OSError, IOError):
                 self._cids = tuple(self._parse_cuid_v1(component))
 
         elif type(component) is IndexedComponent_slice:

--- a/pyomo/core/tests/unit/test_componentuid.py
+++ b/pyomo/core/tests/unit/test_componentuid.py
@@ -123,6 +123,27 @@ class TestComponentUID(unittest.TestCase):
             cuid._cids,
             (('b',(_star, _star)), ('c',tuple()), ('a',(_star,))) )
 
+    def test_parseFromString_spaces(self):
+        cuid = ComponentUID('x[a b,c d]')
+        self.assertEqual(
+            cuid._cids,
+            (('x',('a b', 'c d')), ))
+
+        cuid = ComponentUID("x['a b',\"c d\"]")
+        self.assertEqual(
+            cuid._cids,
+            (('x',('a b', 'c d')), ))
+
+        cuid = ComponentUID('x[a b, c d]')
+        self.assertEqual(
+            cuid._cids,
+            (('x',('a b', 'c d')), ))
+
+        cuid = ComponentUID("x[ a b , 'c d' ]")
+        self.assertEqual(
+            cuid._cids,
+            (('x',('a b', 'c d')), ))
+
     def test_parseFromRepr1(self):
         cuid = ComponentUID('b:1,2.c.a:2')
         self.assertEqual(


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This resolves some problems with the updated component name generator, particularly around the appearance of "ignored" whitespace in the component string name, and the need to quote names containing special characters (like quotes and colons).

## Changes proposed in this PR:
- define an additional list of "special characters" that require quotation
- add tests
- add some inline documentation for the parser

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
