### PR TITLE
Skip appsi tests and Modify slim-build

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -480,14 +480,16 @@ jobs:
 
     - name: Download and install extensions
       run: |
-        echo ""
-        echo "Pyomo download-extensions"
-        echo ""
-        pyomo download-extensions
-        echo ""
-        echo "Pyomo build-extensions"
-        echo ""
-        pyomo build-extensions --parallel 2
+        if ! "${{matrix.slim}}"; then
+            echo ""
+            echo "Pyomo download-extensions"
+            echo ""
+            pyomo download-extensions
+            echo ""
+            echo "Pyomo build-extensions"
+            echo ""
+            pyomo build-extensions --parallel 2
+        fi
 
     - name: Report pyomo plugin information
       run: |

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -480,7 +480,7 @@ jobs:
 
     - name: Download and install extensions
       run: |
-        if ! "${{matrix.slim}}"; then
+        if [[ ! "${{matrix.slim}}" ]]; then
             echo ""
             echo "Pyomo download-extensions"
             echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -493,14 +493,16 @@ jobs:
 
     - name: Download and install extensions
       run: |
-        echo ""
-        echo "Pyomo download-extensions"
-        echo ""
-        pyomo download-extensions
-        echo ""
-        echo "Pyomo build-extensions"
-        echo ""
-        pyomo build-extensions --parallel 2
+        if ! "${{matrix.slim}}"; then
+            echo ""
+            echo "Pyomo download-extensions"
+            echo ""
+            pyomo download-extensions
+            echo ""
+            echo "Pyomo build-extensions"
+            echo ""
+            pyomo build-extensions --parallel 2
+        fi
 
     - name: Report pyomo plugin information
       run: |

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -493,7 +493,7 @@ jobs:
 
     - name: Download and install extensions
       run: |
-        if ! "${{matrix.slim}}"; then
+        if [[ ! "${{matrix.slim}}" ]]; then
             echo ""
             echo "Pyomo download-extensions"
             echo ""

--- a/pyomo/contrib/appsi/examples/tests/test_examples.py
+++ b/pyomo/contrib/appsi/examples/tests/test_examples.py
@@ -1,6 +1,10 @@
 from pyomo.contrib.appsi.examples import getting_started
 import pyomo.common.unittest as unittest
 import pyomo.environ as pe
+try:
+    from pyomo.contrib.appsi.cmodel import cmodel
+except ImportError:
+    raise unittest.SkipTest('appsi extensions are not available')
 
 
 class TestExamples(unittest.TestCase):

--- a/pyomo/contrib/appsi/solvers/tests/test_solvers.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_solvers.py
@@ -1,6 +1,10 @@
 import pyomo.environ as pe
 import pyomo.common.unittest as unittest
 from parameterized import parameterized
+try:
+    from pyomo.contrib.appsi.cmodel import cmodel
+except ImportError:
+    raise unittest.SkipTest('appsi extensions are not available')
 from pyomo.contrib.appsi.base import TerminationCondition, Results, Solver
 from pyomo.contrib.appsi.solvers import Gurobi, Ipopt, Cplex, Cbc
 from typing import Type

--- a/pyomo/contrib/appsi/writers/tests/test_nl_writer.py
+++ b/pyomo/contrib/appsi/writers/tests/test_nl_writer.py
@@ -1,5 +1,9 @@
 import pyomo.common.unittest as unittest
 import pyomo.environ as pe
+try:
+    from pyomo.contrib.appsi.cmodel import cmodel
+except ImportError:
+    raise unittest.SkipTest('appsi extensions are not available')
 from pyomo.contrib import appsi
 import os
 


### PR DESCRIPTION
Fixes #1987 

## Changes proposed in this PR:
- Ensure appsi tests are skipped if appsi extensions are not available
- Don't install extensions on slim build

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
