### PR TITLE
Catch non-standard `file.write()` implementations

### DIFF
--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -195,11 +195,12 @@ class _StreamHandle(object):
                 written = 0
             if written and not self.buffering:
                 stream.flush()
-            if written != len(ostring):
+            if written is not None and written != len(ostring):
                 logger.error(
-                    "Output stream closed before all output was "
+                    "Output stream (%s) closed before all output was "
                     "written to it. The following was left in "
-                    "the output buffer:\n\t%r" % (ostring[written:],))
+                    "the output buffer:\n\t%r" % (
+                        stream, ostring[written:],))
 
 
 class TeeStream(object):

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -195,6 +195,10 @@ class _StreamHandle(object):
                 written = 0
             if written and not self.buffering:
                 stream.flush()
+            # Note: some derived file-like objects fail to return the
+            # number of characters written (and implicitly return None).
+            # If we get None, we will just assume that everything was
+            # fine (as opposed to tossing the incomplete write error).
             if written is not None and written != len(ostring):
                 logger.error(
                     "Output stream (%s) closed before all output was "

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -118,10 +118,10 @@ class TestTeeStream(unittest.TestCase):
             with tee.TeeStream(out) as t:
                 out.close()
                 t.STDOUT.write("hi\n")
-        self.assertEqual(
+        self.assertRegex(
             log.getvalue(),
-            "Output stream closed before all output was written to it. "
-            "The following was left in the output buffer:\n\t'hi\\n'\n"
+            r"^Output stream \(<.*?>\) closed before all output was written "
+            r"to it. The following was left in the output buffer:\n\t'hi\\n'\n$"
         )
 
     def test_capture_output(self):

--- a/pyomo/opt/solver/shellcmd.py
+++ b/pyomo/opt/solver/shellcmd.py
@@ -320,6 +320,8 @@ class SystemCallSolver(OptSolver):
                     timeout=timeout,
                     universal_newlines=True,
                 )
+                t.STDOUT.flush()
+                t.STDERR.flush()
 
             rc = results.returncode
             log = ostreams[0].getvalue()


### PR DESCRIPTION
## Fixes #1997

## Summary/Motivation:
Catch non-standard file object implementations that do not return the number of characters written as the result of `write()`.  This resolves an issue with IPython (and hence Jupyter notebooks) where the `OutStream.write()` method returns `None`.  While the bug has been reported upstream (ipython/ipykernel#682), we probably want to still include this workaround to support past / existing IPython releases.


## Changes proposed in this PR:
- Suppress error about not writing output when the file object's `write()` method does not return the number of characters written.
- update test baseline

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
