### PR TITLE
Switch bigm's M value calculation to always use fbbt

### DIFF
--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -891,7 +891,7 @@ class BigM_Transformation(Transformation):
             raise GDP_Error("Cannot estimate M for unbounded "
                             "expressions.\n\t(found while processing "
                             "constraint '%s'). Please specify a value of M " 
-                            " or ensure all variables that appear in the "
+                            "or ensure all variables that appear in the "
                             "constraint are bounded." % name)
         else:
             M = (expr_lb, expr_ub)

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -1423,7 +1423,7 @@ class ScalarDisjIndexedConstraints(unittest.TestCase, CommonTests):
             r"expressions.\n\t\(found while processing "
             r"constraint 'b.simpledisj1.c'\). "
             r"Please specify a value of M "
-            r" or ensure all variables that appear in the "
+            r"or ensure all variables that appear in the "
             r"constraint are bounded.",
             TransformationFactory('gdp.bigm').apply_to,
             m)

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -541,7 +541,7 @@ class TwoTermDisjNonlinear(unittest.TestCase, CommonTests):
         m.y.setlb(None)
         self.assertRaisesRegex(
             GDP_Error,
-            r"Cannot estimate M for unbounded nonlinear "
+            r"Cannot estimate M for unbounded "
             r"expressions.\n\t\(found while processing "
             r"constraint 'd\[0\].c'\)",
             TransformationFactory('gdp.bigm').apply_to,
@@ -1419,9 +1419,12 @@ class ScalarDisjIndexedConstraints(unittest.TestCase, CommonTests):
         m = models.makeTwoTermDisj_IndexedConstraints()
         self.assertRaisesRegex(
             GDP_Error,
-            r"Cannot estimate M for expressions with unbounded variables."
-            r"\n\t\(found unbounded var 'a\[1\]' while processing constraint "
-            r"'b.simpledisj1.c'\)",
+            r"Cannot estimate M for unbounded "
+            r"expressions.\n\t\(found while processing "
+            r"constraint 'b.simpledisj1.c'\). "
+            r"Please specify a value of M "
+            r" or ensure all variables that appear in the "
+            r"constraint are bounded.",
             TransformationFactory('gdp.bigm').apply_to,
             m)
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

The bigm transformation had its own code to calculate M values for linear GDPs, but relies on `contrib.fbbt` for nonlinear expressions. This removes the special handling for the linear case and uses fbbt always.

## Changes proposed in this PR:
- Use `compute_bounds_on_expr` from `contrib.fbbt` for all M value calculations
- Updates tests because I made the unbounded expression error message more general

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
