### PR TITLE
Improve management of stdout in cyipopt solver

### DIFF
--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -46,7 +46,7 @@ class redirect_fd(object):
     a specified new output target (either file name or file descriptor).
     For the special case of file descriptors 1 (stdout) and 2 (stderr),
     we will also make sure that the Python `sys.stdout` or `sys.stderr`
-    reamin usable: in the case of synchronize=True, the `sys.stdout` /
+    remain usable: in the case of synchronize=True, the `sys.stdout` /
     `sys.stderr` file handles point to the new file descriptor.  When
     synchronize=False, we preserve the behavior of the Python file
     object (retargeting it to the original file descriptor if necessary).

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -90,7 +90,7 @@ class redirect_fd(object):
                 # descriptor that we just redirected, then we want to
                 # retarget the std file to the original (duplicated)
                 # target file descriptor.  This allows, e.g. Python to
-                # still write to stdout when re redirect fd=1 to
+                # still write to stdout when we redirect fd=1 to
                 # /dev/null
                 try:
                     old_std_fd = getattr(sys, self.std).fileno()

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -291,28 +291,6 @@ class TestFileDescriptor(unittest.TestCase):
             os.close(1)
             self.assertEqual(FILE.read(), "to_fd1_2\n")
 
-    def test_redirect_disable(self):
-        r,w = os.pipe()
-        os.dup2(w, 1)
-        try:
-            sys.stdout, out = StringIO(), sys.stdout
-            rd = tee.redirect_fd(synchronize=True, enable=False)
-            with rd:
-                sys.stdout.write("to_stdout_1\n")
-                os.fdopen(1, 'w', closefd=False).write("to_fd1_1\n")
-
-            sys.stdout.write("to_stdout_2\n")
-            sys.stdout.flush()
-            os.fdopen(1, 'w', closefd=False).write("to_fd1_2\n")
-        finally:
-            sys.stdout, out = out, sys.stdout
-
-        self.assertEqual(out.getvalue(), "to_stdout_1\nto_stdout_2\n")
-        with os.fdopen(r, 'r') as FILE:
-            os.close(w)
-            os.close(1)
-            self.assertEqual(FILE.read(), "to_fd1_1\nto_fd1_2\n")
-
     def test_caputure_output_fd(self):
         r,w = os.pipe()
         os.dup2(w, 1)

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -166,3 +166,168 @@ class TestTeeStream(unittest.TestCase):
             b.tee = None
         finally:
             sys.stdout, sys.stderr = old
+
+class TestFileDescriptor(unittest.TestCase):
+    def setUp(self):
+        self.out = sys.stdout
+        self.out_fd = os.dup(1)
+
+    def tearDown(self):
+        sys.stdout = self.out
+        os.dup2(self.out_fd, 1)
+
+    def test_redirect_synchronize_stdout(self):
+        r,w = os.pipe()
+        os.dup2(w, 1)
+        sys.stdout = os.fdopen(1, 'w', closefd=False)
+        rd = tee.redirect_fd(synchronize=True)
+        with rd:
+            sys.stdout.write("to_stdout_1\n")
+            os.fdopen(1, 'w', closefd=False).write("to_fd1_1\n")
+
+        sys.stdout.write("to_stdout_2\n")
+        sys.stdout.flush()
+        os.fdopen(1, 'w', closefd=False).write("to_fd1_2\n")
+
+        with os.fdopen(r, 'r') as FILE:
+            os.close(w)
+            os.close(1)
+            self.assertEqual(FILE.read(), "to_stdout_2\nto_fd1_2\n")
+
+    def test_redirect_no_synchronize_stdout(self):
+        r,w = os.pipe()
+        os.dup2(w, 1)
+        sys.stdout = os.fdopen(1, 'w', closefd=False)
+        rd = tee.redirect_fd(synchronize=False)
+        with rd:
+            sys.stdout.write("to_stdout_1\n")
+            os.fdopen(1, 'w', closefd=False).write("to_fd1_1\n")
+
+        sys.stdout.write("to_stdout_2\n")
+        sys.stdout.flush()
+        os.fdopen(1, 'w', closefd=False).write("to_fd1_2\n")
+
+        with os.fdopen(r, 'r') as FILE:
+            os.close(w)
+            os.close(1)
+            self.assertEqual(FILE.read(),
+                             "to_stdout_1\nto_stdout_2\nto_fd1_2\n")
+
+    def test_redirect_synchronize_stdout_not_fd1(self):
+        r,w = os.pipe()
+        os.dup2(w, 1)
+        rd = tee.redirect_fd(synchronize=True)
+        with rd:
+            sys.stdout.write("to_stdout_1\n")
+            os.fdopen(1, 'w', closefd=False).write("to_fd1_1\n")
+
+        sys.stdout.write("to_stdout_2\n")
+        sys.stdout.flush()
+        os.fdopen(1, 'w', closefd=False).write("to_fd1_2\n")
+
+        with os.fdopen(r, 'r') as FILE:
+            os.close(w)
+            os.close(1)
+            self.assertEqual(FILE.read(), "to_fd1_2\n")
+
+    def test_redirect_no_synchronize_stdout_not_fd1(self):
+        r,w = os.pipe()
+        os.dup2(w, 1)
+        rd = tee.redirect_fd(synchronize=False)
+        with rd:
+            sys.stdout.write("to_stdout_1\n")
+            os.fdopen(1, 'w', closefd=False).write("to_fd1_1\n")
+
+        sys.stdout.write("to_stdout_2\n")
+        sys.stdout.flush()
+        os.fdopen(1, 'w', closefd=False).write("to_fd1_2\n")
+
+        with os.fdopen(r, 'r') as FILE:
+            os.close(w)
+            os.close(1)
+            self.assertEqual(FILE.read(), "to_fd1_2\n")
+
+    def test_redirect_synchronize_stringio(self):
+        r,w = os.pipe()
+        os.dup2(w, 1)
+        try:
+            sys.stdout, out = StringIO(), sys.stdout
+            rd = tee.redirect_fd(synchronize=True)
+            with rd:
+                sys.stdout.write("to_stdout_1\n")
+                os.fdopen(1, 'w', closefd=False).write("to_fd1_1\n")
+
+            sys.stdout.write("to_stdout_2\n")
+            sys.stdout.flush()
+            os.fdopen(1, 'w', closefd=False).write("to_fd1_2\n")
+        finally:
+            sys.stdout, out = out, sys.stdout
+
+        self.assertEqual(out.getvalue(), "to_stdout_2\n")
+        with os.fdopen(r, 'r') as FILE:
+            os.close(w)
+            os.close(1)
+            self.assertEqual(FILE.read(), "to_fd1_2\n")
+
+    def test_redirect_no_synchronize_stringio(self):
+        r,w = os.pipe()
+        os.dup2(w, 1)
+        try:
+            sys.stdout, out = StringIO(), sys.stdout
+            rd = tee.redirect_fd(synchronize=False)
+            with rd:
+                sys.stdout.write("to_stdout_1\n")
+                os.fdopen(1, 'w', closefd=False).write("to_fd1_1\n")
+
+            sys.stdout.write("to_stdout_2\n")
+            sys.stdout.flush()
+            os.fdopen(1, 'w', closefd=False).write("to_fd1_2\n")
+        finally:
+            sys.stdout, out = out, sys.stdout
+
+        self.assertEqual(out.getvalue(), "to_stdout_1\nto_stdout_2\n")
+        with os.fdopen(r, 'r') as FILE:
+            os.close(w)
+            os.close(1)
+            self.assertEqual(FILE.read(), "to_fd1_2\n")
+
+    def test_redirect_disable(self):
+        r,w = os.pipe()
+        os.dup2(w, 1)
+        try:
+            sys.stdout, out = StringIO(), sys.stdout
+            rd = tee.redirect_fd(synchronize=True, enable=False)
+            with rd:
+                sys.stdout.write("to_stdout_1\n")
+                os.fdopen(1, 'w', closefd=False).write("to_fd1_1\n")
+
+            sys.stdout.write("to_stdout_2\n")
+            sys.stdout.flush()
+            os.fdopen(1, 'w', closefd=False).write("to_fd1_2\n")
+        finally:
+            sys.stdout, out = out, sys.stdout
+
+        self.assertEqual(out.getvalue(), "to_stdout_1\nto_stdout_2\n")
+        with os.fdopen(r, 'r') as FILE:
+            os.close(w)
+            os.close(1)
+            self.assertEqual(FILE.read(), "to_fd1_1\nto_fd1_2\n")
+
+    def test_caputure_output_fd(self):
+        r,w = os.pipe()
+        os.dup2(w, 1)
+        sys.stdout = os.fdopen(1, 'w', closefd=False)
+        with tee.capture_output(capture_fd=True) as OUT:
+            sys.stdout.write("to_stdout_1\n")
+            sys.stdout.flush()
+            os.fdopen(1, 'w', closefd=False).write("to_fd1_1\n")
+
+        sys.stdout.write("to_stdout_2\n")
+        sys.stdout.flush()
+        os.fdopen(1, 'w', closefd=False).write("to_fd1_2\n")
+
+        self.assertEqual(OUT.getvalue(), "to_stdout_1\nto_fd1_1\n")
+        with os.fdopen(r, 'r') as FILE:
+            os.close(w)
+            os.close(1)
+            self.assertEqual(FILE.read(), "to_stdout_2\nto_fd1_2\n")

--- a/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
@@ -438,11 +438,21 @@ class CyIpoptSolver(object):
                 x_scaling = np.ones(nx)
             if g_scaling is None:
                 g_scaling = np.ones(ng)
-            cyipopt_solver.setProblemScaling(obj_scaling, x_scaling, g_scaling)
+            try:
+                set_scaling = cyipopt_solver.set_problem_scaling
+            except AttributeError:
+                # Fall back to pre-1.0.0 API
+                set_scaling = cyipopt_solver.setProblemScaling
+            set_scaling(obj_scaling, x_scaling, g_scaling)
 
         # add options
+        try:
+            add_option = cyipopt_solver.add_option
+        except AttributeError:
+            # Fall back to pre-1.0.0 API
+            add_option = cyipopt_solver.addOption
         for k, v in self._options.items():
-            cyipopt_solver.addOption(k, v)
+            add_option(k, v)
 
         # We preemptively set up the TeeStream, even if we aren't
         # going to use it: the implementation is such that the
@@ -568,11 +578,21 @@ class PyomoCyIpoptSolver(object):
                 x_scaling = np.ones(nx)
             if g_scaling is None:
                 g_scaling = np.ones(ng)
-            cyipopt_solver.setProblemScaling(obj_scaling, x_scaling, g_scaling)
+            try:
+                set_scaling = cyipopt_solver.set_problem_scaling
+            except AttributeError:
+                # Fall back to pre-1.0.0 API
+                set_scaling = cyipopt_solver.setProblemScaling
+            set_scaling(obj_scaling, x_scaling, g_scaling)
 
         # add options
+        try:
+            add_option = cyipopt_solver.add_option
+        except AttributeError:
+            # Fall back to pre-1.0.0 API
+            add_option = cyipopt_solver.addOption
         for k, v in config.options.items():
-            cyipopt_solver.addOption(k, v)
+            add_option(k, v)
 
         timer = TicTocTimer()
         try:

--- a/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
@@ -560,7 +560,7 @@ class PyomoCyIpoptSolver(object):
 
         timer = TicTocTimer()
         try:
-            with redirect_fd(fd=1, enable=not tee, synchronize=False):
+            with redirect_fd(fd=1, enable=not config.tee, synchronize=False):
                 x, info = cyipopt_solver.solve(problem.x_init())
             solverStatus = SolverStatus.ok
         except:

--- a/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
@@ -450,7 +450,7 @@ class CyIpoptSolver(object):
         # processing threads) until afer a client accesses
         # STDOUT/STDERR
         with TeeStream(sys.stdout) as _teeStream:
-            if config.tee:
+            if tee:
                 try:
                     fd = sys.stdout.fileno()
                 except (io.UnsupportedOperation, AttributeError):

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_cyipopt_interfaces.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_cyipopt_interfaces.py
@@ -26,9 +26,10 @@ if not AmplInterface.available():
 
 from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP
 
-try:
-    import ipopt
-except ImportError:
+from pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver import (
+    cyipopt_available
+)
+if not cyipopt_available:
     raise unittest.SkipTest("Pynumero needs cyipopt to run CyIpoptSolver tests")
 
 from pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver import CyIpoptNLP

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_cyipopt_solver.py
@@ -27,9 +27,10 @@ if not AmplInterface.available():
 
 from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP
 
-try:
-    import ipopt
-except ImportError:
+from pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver import (
+    cyipopt_available
+)
+if not cyipopt_available:
     raise unittest.SkipTest("Pynumero needs cyipopt to run CyIpoptSolver tests")
 
 from pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver import (

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_pyomo_ext_cyipopt.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_pyomo_ext_cyipopt.py
@@ -25,9 +25,10 @@ if not AmplInterface.available():
     raise unittest.SkipTest(
         "Pynumero needs the ASL extension to run CyIpoptSolver tests")
 
-try:
-    import ipopt
-except ImportError:
+from pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver import (
+    cyipopt_available
+)
+if not cyipopt_available:
     raise unittest.SkipTest("Pynumero needs cyipopt to run CyIpoptSolver tests")
 
 from pyomo.contrib.pynumero.algorithms.solvers.pyomo_ext_cyipopt import ExternalInputOutputModel, PyomoExternalCyIpoptProblem


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Cyipopt sends its output directly to file descriptor 1 (and not `sys.stdout`).  This forced users to resort to tools like `wurlitzer` to get proper IO redirection for cyipopt with `tee=True`.  This PR refines how the cyipopt solver interface manages output redirection, including cases where `sys.stdout` does not have a proper `fileno()`.

As part of this PR, the original file descriptor redirection logic in the cyipopt solver interface has been abstracted and refined into the `pyomo.common.tee.redirect_fd` context manager.  In the future we can use this with other C-bindings (like MC++) to prevent the unconditional output of those tools to the stdout / stderr file descriptors.

## Changes proposed in this PR:
- Cyipopt solver: redirect the stdout file descriptor (fd=1) to `sys.stdout` when `tee=True` and to `os.devnull` when `tee=False`
- Implement a general `redirect_fd` context manager in `pyomo.common.tee`
- add a `capture_fd` boolean argument to `capture_output` to also capture output to the raw file descriptors
- remove the (deprecated) use of `import ipopt` to test for cyipopt availability
- remove the (deprecated) use of `setProblemScaling` and `addOption`
- Add tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
