### PR TITLE
Fixes to GDPopt and examples to avoid implicit conversion warnings

### DIFF
--- a/examples/gdp/eight_process/eight_proc_logical.py
+++ b/examples/gdp/eight_process/eight_proc_logical.py
@@ -128,7 +128,7 @@ def build_eight_process_flowsheet():
     m.specs3 = Constraint(expr=m.flow[12] <= 5 * m.flow[14])
     m.specs4 = Constraint(expr=m.flow[12] >= 2 * m.flow[14])
 
-    m.Y = Reference(m.use_unit[:].indicator_bool)
+    m.Y = Reference(m.use_unit[:].indicator_var)
 
     # logical propositions
     m.use1or2 = LogicalConstraint(expr=m.Y[1].xor(m.Y[2]))
@@ -150,7 +150,7 @@ def build_eight_process_flowsheet():
     """Bound definitions"""
     # x (flow) upper bounds
     x_ubs = {3: 2, 5: 2, 9: 2, 10: 1, 14: 1, 17: 2, 19: 2, 21: 2, 25: 3}
-    for i, x_ub in x_ubs.item():
+    for i, x_ub in x_ubs.items():
         m.flow[i].setub(x_ub)
 
     # Optimal solution uses units 2, 4, 6, 8 with objective value 68.
@@ -162,7 +162,7 @@ if __name__ == "__main__":
     m = build_eight_process_flowsheet()
     from pyomo.environ import TransformationFactory
     TransformationFactory('core.logical_to_linear').apply_to(m)
-    SolverFactory('gdpopt').solve(m, tee=True)
+    SolverFactory('gdpopt').solve(m, tee=True, strategy='LOA')
     update_boolean_vars_from_binary(m)
     m.Y.display()
     m.flow.display()

--- a/examples/gdp/small_lit/ex1_Lee.py
+++ b/examples/gdp/small_lit/ex1_Lee.py
@@ -34,6 +34,6 @@ def build_model():
 
 if __name__ == "__main__":
     model = build_model()
-    results = SolverFactory('gdpopt').solve(model, tee=True)
+    results = SolverFactory('gdpopt').solve(model, tee=True, strategy='LOA')
     print(results)
 

--- a/examples/gdp/stickies.py
+++ b/examples/gdp/stickies.py
@@ -342,50 +342,53 @@ def build_model():
     # Boolean Constraints
     ######################
 
+    # TODO: convert the logical constraints below to use proper
+    # LogicalConstraint expressions
+
     # These are the GAMS versions of the logical constraints, which is not
     # what appears in the formulation:
     def log1_rule(model, s):
-        return model.screen_selection_disjunct[1, s].indicator_var == \
-            sum(model.flow_acceptance_disjunct[s, n, 1].indicator_var \
+        return model.screen_selection_disjunct[1, s].binary_indicator_var == \
+            sum(model.flow_acceptance_disjunct[s, n, 1].binary_indicator_var \
                 for n in model.Nodes if s != n)
     model.log1 = Constraint(model.Screens, rule=log1_rule)
 
     def log2_rule(model, s):
-        return model.screen_selection_disjunct[1, s].indicator_var == \
-            sum(model.flow_rejection_disjunct[s, n, 1].indicator_var \
+        return model.screen_selection_disjunct[1, s].binary_indicator_var == \
+            sum(model.flow_rejection_disjunct[s, n, 1].binary_indicator_var \
                 for n in model.Nodes if s != n)
     model.log2 = Constraint(model.Screens, rule=log2_rule)
 
     def log3_rule(model, s):
-        return model.screen_selection_disjunct[1, s].indicator_var >= \
-            sum(model.flow_acceptance_disjunct[s, sprime, 1].indicator_var \
+        return model.screen_selection_disjunct[1, s].binary_indicator_var >= \
+            sum(model.flow_acceptance_disjunct[s, sprime, 1].binary_indicator_var \
                 for sprime in model.Screens if s != sprime)
     model.log3 = Constraint(model.Screens, rule=log3_rule)
 
     def log4_rule(model, s):
-        return model.screen_selection_disjunct[1, s].indicator_var >= \
-            sum(model.flow_rejection_disjunct[s, sprime, 1].indicator_var \
+        return model.screen_selection_disjunct[1, s].binary_indicator_var >= \
+            sum(model.flow_rejection_disjunct[s, sprime, 1].binary_indicator_var \
                 for sprime in model.Screens if s != sprime)
     model.log4 = Constraint(model.Screens, rule=log4_rule)
 
     def log6_rule(model, s, sprime):
-        return model.flow_acceptance_disjunct[s, sprime, 1].indicator_var + \
-            model.flow_acceptance_disjunct[sprime, s, 1].indicator_var <= 1
+        return model.flow_acceptance_disjunct[s, sprime, 1].binary_indicator_var + \
+            model.flow_acceptance_disjunct[sprime, s, 1].binary_indicator_var <= 1
     model.log6 = Constraint(model.ScreenPairs, rule=log6_rule)
 
     def log7_rule(model, s, sprime):
-        return model.flow_rejection_disjunct[s, sprime, 1].indicator_var + \
-            model.flow_rejection_disjunct[sprime, s, 1].indicator_var <= 1
+        return model.flow_rejection_disjunct[s, sprime, 1].binary_indicator_var + \
+            model.flow_rejection_disjunct[sprime, s, 1].binary_indicator_var <= 1
     model.log7 = Constraint(model.ScreenPairs, rule=log7_rule)
 
     def log8_rule(model, s, n):
-        return model.flow_acceptance_disjunct[s, n, 1].indicator_var + \
-            model.flow_rejection_disjunct[s, n, 1].indicator_var <= 1
+        return model.flow_acceptance_disjunct[s, n, 1].binary_indicator_var + \
+            model.flow_rejection_disjunct[s, n, 1].binary_indicator_var <= 1
     model.log8 = Constraint(model.ScreenNodePairs, rule=log8_rule)
 
     def log9_rule(model, s, sprime):
-        return model.flow_acceptance_disjunct[s, sprime, 1].indicator_var + \
-            model.flow_rejection_disjunct[sprime, s, 1].indicator_var <= 1
+        return model.flow_acceptance_disjunct[s, sprime, 1].binary_indicator_var + \
+            model.flow_rejection_disjunct[sprime, s, 1].binary_indicator_var <= 1
     model.log9 = Constraint(model.ScreenPairs, rule=log9_rule)
 
     # These are the above logical constraints implemented correctly (I think)
@@ -493,8 +496,8 @@ def build_model():
 
     # fix the variables they fix in GAMS
     for s in instance.Screens:
-        instance.flow_acceptance_disjunct[s,'SNK',1].indicator_var.fix(0)
-        instance.flow_rejection_disjunct[s,'PRD',1].indicator_var.fix(0)
+        instance.flow_acceptance_disjunct[s,'SNK',1].indicator_var.fix(False)
+        instance.flow_rejection_disjunct[s,'PRD',1].indicator_var.fix(False)
 
     ##################################################################################
     ## for validation: Fix all the indicator variables to see if we get same objective

--- a/pyomo/contrib/gdpopt/nlp_solve.py
+++ b/pyomo/contrib/gdpopt/nlp_solve.py
@@ -423,9 +423,9 @@ def solve_local_subproblem(mip_result, solve_data, config):
             )
         else:
             if config.round_discrete_vars:
-                disj.indicator_var.fix(rounded_val)
+                disj.indicator_var.fix(bool(rounded_val))
             else:
-                disj.indicator_var.fix(val)
+                disj.indicator_var.fix(bool(val))
 
     if config.force_subproblem_nlp:
         # We also need to copy over the discrete variable values
@@ -492,9 +492,9 @@ def solve_global_subproblem(mip_result, solve_data, config):
             )
         else:
             if config.round_discrete_vars:
-                disj.indicator_var.fix(rounded_val)
+                disj.indicator_var.fix(bool(rounded_val))
             else:
-                disj.indicator_var.fix(val)
+                disj.indicator_var.fix(bool(val))
 
     if config.force_subproblem_nlp:
         # We also need to copy over the discrete variable values


### PR DESCRIPTION
## Summary/Motivation:
Following PR #1960 I noticed that there were a few GDPopt examples throwing warnings about "implicit conversion of Boolean to Binary". I also found a couple GDPopt examples that didn't run at all. This PR makes a few small fixes to get the examples running without any warnings. Ideally these examples would be run by the GDPopt tests but that is left as a future exercise.

## Changes proposed in this PR:
- Fixed spot in GDPopt relying on implicit conversion of Binary to Boolean
- Fixed a few GDPopt examples that were broken

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
