### PR TITLE
Yield Iterator in `IndexedComponent`

### DIFF
--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -360,15 +360,17 @@ You can silence this warning by one of three ways:
 
     def keys(self):
         """Return an iterator of the keys in the dictionary"""
-        return iter([ x for x in self ])
+        return iter(self)
 
     def values(self):
         """Return an iterator of the component data objects in the dictionary"""
-        return iter([ self[x] for x in self ])
+        for s in self:
+            yield self[s]
 
     def items(self):
         """Return an iterator of (index,data) tuples from the dictionary"""
-        return iter([ (x, self[x]) for x in self ])
+        for s in self:
+            yield s, self[s]
 
     def __getitem__(self, index):
         """

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -360,17 +360,15 @@ You can silence this warning by one of three ways:
 
     def keys(self):
         """Return an iterator of the keys in the dictionary"""
-        return iter(self)
+        return iter([ x for x in self ])
 
     def values(self):
         """Return an iterator of the component data objects in the dictionary"""
-        for s in self:
-            yield self[s]
+        return iter([ self[x] for x in self ])
 
     def items(self):
         """Return an iterator of (index,data) tuples from the dictionary"""
-        for s in self:
-            yield s, self[s]
+        return iter([ (x, self[x]) for x in self ])
 
     def __getitem__(self, index):
         """

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -360,15 +360,17 @@ You can silence this warning by one of three ways:
 
     def keys(self):
         """Return an iterator of the keys in the dictionary"""
-        return [ x for x in self ]
+        return iter(self)
 
     def values(self):
         """Return an iterator of the component data objects in the dictionary"""
-        return [ self[x] for x in self ]
+        for s in self:
+            yield self[s]
 
     def items(self):
         """Return an iterator of (index,data) tuples from the dictionary"""
-        return [ (x, self[x]) for x in self ]
+        for s in self:
+            yield s, self[s]
 
     def __getitem__(self, index):
         """

--- a/pyomo/core/tests/unit/test_compare.py
+++ b/pyomo/core/tests/unit/test_compare.py
@@ -28,7 +28,7 @@ class TestConvertToPrefixNotation(unittest.TestCase):
     def test_linear_expression(self):
         m = pe.ConcreteModel()
         m.x = pe.Var([1, 2, 3, 4])
-        e = LinearExpression(constant=3, linear_coefs=m.x.keys(), linear_vars=m.x.values())
+        e = LinearExpression(constant=3, linear_coefs=m.x.keys(), linear_vars=[m.x.values()])
         expected = [(LinearExpression, 9), 3, 1, 2, 3, 4, m.x[1], m.x[2], m.x[3], m.x[4]]
         pn = convert_expression_to_prefix_notation(e)
         self.assertEqual(pn, expected)

--- a/pyomo/core/tests/unit/test_compare.py
+++ b/pyomo/core/tests/unit/test_compare.py
@@ -28,7 +28,7 @@ class TestConvertToPrefixNotation(unittest.TestCase):
     def test_linear_expression(self):
         m = pe.ConcreteModel()
         m.x = pe.Var([1, 2, 3, 4])
-        e = LinearExpression(constant=3, linear_coefs=m.x.keys(), linear_vars=[m.x.values()])
+        e = LinearExpression(constant=3, linear_coefs=m.x.keys(), linear_vars=list(m.x.values()))
         expected = [(LinearExpression, 9), 3, 1, 2, 3, 4, m.x[1], m.x[2], m.x[3], m.x[4]]
         pn = convert_expression_to_prefix_notation(e)
         self.assertEqual(pn, expected)

--- a/pyomo/core/tests/unit/test_compare.py
+++ b/pyomo/core/tests/unit/test_compare.py
@@ -28,7 +28,7 @@ class TestConvertToPrefixNotation(unittest.TestCase):
     def test_linear_expression(self):
         m = pe.ConcreteModel()
         m.x = pe.Var([1, 2, 3, 4])
-        e = LinearExpression(constant=3, linear_coefs=m.x.keys(), linear_vars=list(m.x.values()))
+        e = LinearExpression(constant=3, linear_coefs=list(m.x.keys()), linear_vars=list(m.x.values()))
         expected = [(LinearExpression, 9), 3, 1, 2, 3, 4, m.x[1], m.x[2], m.x[3], m.x[4]]
         pn = convert_expression_to_prefix_notation(e)
         self.assertEqual(pn, expected)


### PR DESCRIPTION
## Fixes #1995 

## Summary/Motivation:
`IndexedComponent` methods `keys`, `values`, and `items` returned lists instead of iterators. This addresses that issue.

## Changes proposed in this PR:
- Yield iterators instead of lists

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
