### PR TITLE
Clean up dependencies and `solver.available()` IO

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -560,6 +560,13 @@ jobs:
         echo ""
         echo "PYOMO_CONFIG_DIR=${GITHUB_WORKSPACE}/config" >> $GITHUB_ENV
 
+    - name: Report pyomo plugin information
+      run: |
+        echo "$PATH"
+        pyomo help --solvers || exit 1
+        pyomo help --transformations || exit 1
+        pyomo help --writers || exit 1
+
     - name: Run Pyomo standalone test
       run: |
         echo ""
@@ -567,13 +574,6 @@ jobs:
         echo ""
         python `pwd`/pyomo/environ/tests/standalone_minimal_pyomo_driver.py \
             || exit 1
-
-    - name: Report pyomo plugin information
-      run: |
-        echo "$PATH"
-        pyomo help --solvers || exit 1
-        pyomo help --transformations || exit 1
-        pyomo help --writers || exit 1
 
 
   cover:

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -570,7 +570,7 @@ jobs:
     - name: Run Pyomo standalone test
       run: |
         echo ""
-        echo "Running standalone Pyomo test
+        echo "Running standalone Pyomo test"
         echo ""
         python `pwd`/pyomo/environ/tests/standalone_minimal_pyomo_driver.py \
             || exit 1

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -542,12 +542,53 @@ jobs:
           #   manage total artifact storage
           # TEST-*.xml
 
+
+  bare-python-env:
+    name: linux/3.7/bare-env
+    runs-on: ubuntu-18.04
+    timeout-minutes: 20
+    steps:
+    - name: Checkout Pyomo source
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install Pyomo
+      run: |
+        echo ""
+        echo "Install Pyomo..."
+        echo ""
+        python setup.py develop
+        echo ""
+        echo "Set custom PYOMO_CONFIG_DIR"
+        echo ""
+        echo "PYOMO_CONFIG_DIR=${GITHUB_WORKSPACE}/config" >> $GITHUB_ENV
+
+    - name: Run Pyomo standalone test
+      run: |
+        echo ""
+        echo "Running standalone Pyomo test
+        echo ""
+        python `pwd`/pyomo/environ/tests/standalone_minimal_pyomo_driver.py \
+            || exit 1
+
+    - name: Report pyomo plugin information
+      run: |
+        echo "$PATH"
+        pyomo help --solvers || exit 1
+        pyomo help --transformations || exit 1
+        pyomo help --writers || exit 1
+
+
   cover:
     name: process-coverage-${{ matrix.TARGET }}
     needs: build
     if: always() # run even if a build job fails
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -25,7 +25,7 @@ env:
       python-louvain sphinx-copybutton
   PYTHON_NUMPY_PKGS: >
       numpy scipy pyodbc pandas matplotlib seaborn numdifftools 
-      parameterized casadi
+      casadi
   CACHE_VER: v210415.0
   NEOS_EMAIL: tests@pyomo.org
 
@@ -94,13 +94,6 @@ jobs:
           TARGET: linux
           PYENV: pip
           PACKAGES: cython
-
-        - os: ubuntu-18.04
-          python: 3.7
-          other: /pyutilib
-          TARGET: linux
-          PYENV: pip
-          PACKAGES: pyutilib
 
     steps:
     - name: Checkout Pyomo source
@@ -544,17 +537,17 @@ jobs:
 
 
   bare-python-env:
-    name: linux/3.7/bare-env
+    name: linux/3.6/bare-env
     runs-on: ubuntu-18.04
-    timeout-minutes: 20
+    timeout-minutes: 10
     steps:
     - name: Checkout Pyomo source
       uses: actions/checkout@v2
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.6
 
     - name: Install Pyomo
       run: |
@@ -588,7 +581,7 @@ jobs:
     needs: build
     if: always() # run even if a build job fails
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -519,7 +519,7 @@ jobs:
         done
         $PYTHON_EXE -m pyomo.common.unittest \
             pyomo `pwd`/pyomo-model-libraries \
-             `pwd`/examples/pyomobook -v $CATEGORY
+            `pwd`/examples/pyomobook -v $CATEGORY
 
     - name: Run Pyomo MPI tests
       if: matrix.mpi != 0

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -580,6 +580,13 @@ jobs:
         echo ""
         echo "PYOMO_CONFIG_DIR=${GITHUB_WORKSPACE}/config" >> $GITHUB_ENV
 
+    - name: Report pyomo plugin information
+      run: |
+        echo "$PATH"
+        pyomo help --solvers || exit 1
+        pyomo help --transformations || exit 1
+        pyomo help --writers || exit 1
+
     - name: Run Pyomo standalone test
       run: |
         echo ""
@@ -587,13 +594,6 @@ jobs:
         echo ""
         python `pwd`/pyomo/environ/tests/standalone_minimal_pyomo_driver.py \
             || exit 1
-
-    - name: Report pyomo plugin information
-      run: |
-        echo "$PATH"
-        pyomo help --solvers || exit 1
-        pyomo help --transformations || exit 1
-        pyomo help --writers || exit 1
 
 
   cover:

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -28,7 +28,7 @@ env:
       python-louvain sphinx-copybutton
   PYTHON_NUMPY_PKGS: >
       numpy scipy pyodbc pandas matplotlib seaborn numdifftools 
-      parameterized casadi
+      casadi
   CACHE_VER: v210415.0
   NEOS_EMAIL: tests@pyomo.org
 
@@ -554,6 +554,47 @@ jobs:
           # In general, do not record test results as artifacts to
           #   manage total artifact storage
           # TEST-*.xml
+
+
+  bare-python-env:
+    name: linux/3.6/bare-env
+    runs-on: ubuntu-18.04
+    timeout-minutes: 10
+    steps:
+    - name: Checkout Pyomo source
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+
+    - name: Install Pyomo
+      run: |
+        echo ""
+        echo "Install Pyomo..."
+        echo ""
+        python setup.py develop
+        echo ""
+        echo "Set custom PYOMO_CONFIG_DIR"
+        echo ""
+        echo "PYOMO_CONFIG_DIR=${GITHUB_WORKSPACE}/config" >> $GITHUB_ENV
+
+    - name: Run Pyomo standalone test
+      run: |
+        echo ""
+        echo "Running standalone Pyomo test"
+        echo ""
+        python `pwd`/pyomo/environ/tests/standalone_minimal_pyomo_driver.py \
+            || exit 1
+
+    - name: Report pyomo plugin information
+      run: |
+        echo "$PATH"
+        pyomo help --solvers || exit 1
+        pyomo help --transformations || exit 1
+        pyomo help --writers || exit 1
+
 
   cover:
     name: process-coverage-${{ matrix.TARGET }}

--- a/pyomo/common/backports.py
+++ b/pyomo/common/backports.py
@@ -1,0 +1,20 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+# backport of contextlib.nullcontext for supporting Python < 3.7
+class nullcontext(object):
+    def __init__(self, enter_result=None):
+        self.result = enter_result
+
+    def __enter__(self):
+        return self.result
+
+    def __exit__(self, et, ev, tb):
+        return

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -65,7 +65,7 @@ class ModuleUnavailable(object):
         if msg is None:
             msg = _err
         if _imp:
-            if not str(msg):
+            if not msg or not str(msg):
                 msg = (
                     "The %s module (an optional Pyomo dependency) " \
                     "failed to import: %s" % (self.__name__, _imp)
@@ -73,7 +73,7 @@ class ModuleUnavailable(object):
             else:
                 msg = "%s (import raised %s)" % (msg, _imp,)
         if _ver:
-            if not str(msg):
+            if not msg or not str(msg):
                 msg = "The %s module %s" % (self.__name__, _ver)
             else:
                 msg = "%s (%s)" % (msg, _ver,)

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -65,18 +65,18 @@ class ModuleUnavailable(object):
         if msg is None:
             msg = _err
         if _imp:
-            if not msg:
+            if not str(msg):
                 msg = (
                     "The %s module (an optional Pyomo dependency) " \
                     "failed to import: %s" % (self.__name__, _imp)
                 )
             else:
-                msg += " (import raised %s)" % (_imp,)
+                msg = "%s (import raised %s)" % (msg, _imp,)
         if _ver:
-            if not msg:
+            if not str(msg):
                 msg = "The %s module %s" % (self.__name__, _ver)
             else:
-                msg += " (%s)" % (_ver,)
+                msg = "%s (%s)" % (msg, _ver,)
         return msg
 
     def log_import_warning(self, logger='pyomo', msg=None):

--- a/pyomo/common/log.py
+++ b/pyomo/common/log.py
@@ -17,12 +17,11 @@
 #
 # Utility classes for working with the logger
 #
-
+import io
 import logging
 import re
 import sys
 import textwrap
-from io import TextIOBase
 
 from pyomo.common.deprecation import deprecated
 from pyomo.common.fileutils import PYOMO_ROOT_DIR
@@ -294,7 +293,10 @@ class LoggingIntercept(object):
         >>> buf.getvalue()
     """
 
-    def __init__(self, output, module=None, level=logging.WARNING):
+    def __init__(self, output=None, module=None, level=logging.WARNING):
+        if output is None:
+            output = io.StringIO()
+        self.output = output
         self.handler = logging.StreamHandler(output)
         self.handler.setFormatter(logging.Formatter('%(message)s'))
         self.handler.setLevel(level)
@@ -308,6 +310,7 @@ class LoggingIntercept(object):
         logger.propagate = 0
         logger.setLevel(self.handler.level)
         logger.addHandler(self.handler)
+        return self.output
 
     def __exit__(self, et, ev, tb):
         logger = logging.getLogger(self.module)
@@ -318,7 +321,7 @@ class LoggingIntercept(object):
             logger.handlers.append(h)
 
 
-class LogStream(TextIOBase):
+class LogStream(io.TextIOBase):
     """
     This class logs whatever gets sent to the write method.
     This is useful for logging solver output (a LogStream

--- a/pyomo/contrib/appsi/solvers/gurobi.py
+++ b/pyomo/contrib/appsi/solvers/gurobi.py
@@ -7,6 +7,7 @@ from typing import List, Dict
 from pyomo.common.collections import ComponentSet, ComponentMap, OrderedSet
 from pyomo.common.dependencies import attempt_import
 from pyomo.common.errors import PyomoException
+from pyomo.common.tee import capture_output
 from pyomo.common.timing import HierarchicalTimer
 from pyomo.core.kernel.objective import minimize, maximize
 from pyomo.core.base import SymbolMap, NumericLabeler, TextLabeler
@@ -201,7 +202,10 @@ class Gurobi(PersistentBase, PersistentSolver):
     @classmethod
     def _check_license(cls):
         try:
-            m = gurobipy.Model()
+            # Gurobipy writes out license file information when creating
+            # the environment
+            with capture_output(capture_fd=True):
+                m = gurobipy.Model()
         except ImportError:
             # Triggered if this is the first time the deferred import of
             # gurobipy is resolved. _import_gurobipy will have already
@@ -210,6 +214,7 @@ class Gurobi(PersistentBase, PersistentSolver):
         except gurobipy.GurobiError:
             cls._available = Gurobi.Availability.BadLicense
             return
+        m.setParam('OutputFlag', 0)
         try:
             # As of 3/2021, the limited-size Gurobi license was limited
             # to 2000 variables.

--- a/pyomo/contrib/appsi/solvers/tests/test_solvers.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_solvers.py
@@ -4,6 +4,7 @@ import pyomo.common.unittest as unittest
 parameterized, param_available = attempt_import('parameterized')
 if not param_available:
     raise unittest.SkipTest('Parameterized is not available.')
+parameterized = parameterized.parameterized
 try:
     from pyomo.contrib.appsi.cmodel import cmodel
 except ImportError:

--- a/pyomo/contrib/appsi/solvers/tests/test_solvers.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_solvers.py
@@ -1,6 +1,9 @@
 import pyomo.environ as pe
+from pyomo.common.dependencies import attempt_import
 import pyomo.common.unittest as unittest
-from parameterized import parameterized
+parameterized, param_available = attempt_import('parameterized')
+if not param_available:
+    raise unittest.SkipTest('Parameterized is not available.')
 try:
     from pyomo.contrib.appsi.cmodel import cmodel
 except ImportError:

--- a/pyomo/contrib/gdpbb/GDPbb.py
+++ b/pyomo/contrib/gdpbb/GDPbb.py
@@ -30,7 +30,8 @@ class GDPbbSolveData(object):
     pass
 
 
-@SolverFactory.register('gdpbb', doc='Branch and Bound based GDP Solver')
+@SolverFactory.register(
+    'gdpbb', doc='[DEPRECATED] Branch and Bound based GDP Solver')
 @deprecated("GDPbb has been merged into GDPopt. "
             "You can use the algorithm using GDPopt with strategy='LBB'.",
             logger="pyomo.solvers",

--- a/pyomo/contrib/preprocessing/plugins/constraint_tightener.py
+++ b/pyomo/contrib/preprocessing/plugins/constraint_tightener.py
@@ -10,7 +10,7 @@ logger = logging.getLogger('pyomo.contrib.preprocessing')
 
 @TransformationFactory.register(
     'core.tighten_constraints_from_vars',
-    doc="Tightens upper and lower bound on linear constraints.")
+    doc="[DEPRECATED] Tightens upper and lower bound on linear constraints.")
 @deprecated(
     "Use of the constraint tightener transformation is deprecated. "
     "Its functionality may be partially replicated using "

--- a/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
@@ -523,7 +523,7 @@ class PyomoCyIpoptSolver(object):
         self._model = model
 
     def available(self, exception_flag=False):
-        return numpy_available and cyipopt_available
+        return bool(numpy_available and cyipopt_available)
 
     def license_is_valid(self):
         return True

--- a/pyomo/core/tests/diet/test_diet.py
+++ b/pyomo/core/tests/diet/test_diet.py
@@ -10,7 +10,6 @@
 
 import json
 import os
-from nose.tools import nottest
 
 import pyomo.common.unittest as unittest
 
@@ -47,7 +46,7 @@ class Test(unittest.TestCase):
         import pyomo.environ
         solvers = check_available_solvers('glpk')
 
-    @nottest
+    @unittest.nottest
     def run_pyomo(self, *args, **kwargs):
         """
         Run Pyomo with the given arguments. `args` should be a list with

--- a/pyomo/duality/plugins.py
+++ b/pyomo/duality/plugins.py
@@ -37,7 +37,8 @@ logger = logging.getLogger('pyomo.core')
 # specified, then the entire model is dualized.
 # This returns a new Block object.
 #
-@TransformationFactory.register('duality.linear_dual', doc="Dualize a linear model")
+@TransformationFactory.register(
+    'duality.linear_dual', doc="[DEPRECATED] Dualize a linear model")
 @deprecated(
     "Use of the pyomo.duality package is deprecated. There are known bugs "
     "in pyomo.duality, and we do not recommend the use of this code. "

--- a/pyomo/environ/tests/standalone_minimal_pyomo_driver.py
+++ b/pyomo/environ/tests/standalone_minimal_pyomo_driver.py
@@ -1,3 +1,13 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
 import sys
 from io import StringIO
 from pyomo.common.log import LoggingIntercept
@@ -137,7 +147,7 @@ def run_transformationfactory_test():
 
     if not isinstance(bigm, pyo.Transformation):
         print("TransformationFactory(gdp.bigm) did not return a "
-              "transfomation")
+              "transformation")
         sys.exit(4)
 
     _check_log_and_out(LOG, OUT, 30)

--- a/pyomo/environ/tests/standalone_minimal_pyomo_driver.py
+++ b/pyomo/environ/tests/standalone_minimal_pyomo_driver.py
@@ -1,0 +1,159 @@
+import sys
+from io import StringIO
+from pyomo.common.log import LoggingIntercept
+from pyomo.common.tee import capture_output
+
+_baseline = """
+\\* Source Pyomo model name=unknown *\\
+
+min
+x2:
++ [
++2 x1 ^ 2
+] / 2
+
+s.t.
+
+c_l_x3_:
++1 x1
+>= 1
+
+c_e_ONE_VAR_CONSTANT:
+ONE_VAR_CONSTANT = 1.0
+
+bounds
+    -inf <= x1 <= +inf
+end
+"""
+
+def _check_log_and_out(LOG, OUT, offset, msg=None):
+    sys.stdout.flush()
+    sys.stderr.flush()
+    msg = str(msg) + ': ' if msg else ''
+    if LOG.getvalue():
+        raise RuntimeError(
+            "FAIL: %sMessage logged to the Logger:\n>>>\n%s<<<" % (
+                msg, LOG.getvalue(),))
+
+    if OUT.getvalue():
+        raise RuntimeError(
+            "FAIL: %sMessage sent to stdout/stderr:\n>>>\n%s<<<" % (
+                msg, OUT.getvalue(),))
+
+
+def import_pyomo_environ():
+    with LoggingIntercept() as LOG, capture_output(capture_fd=True) as OUT:
+        import pyomo.environ as pyo
+        globals()['pyo'] = pyo
+    _check_log_and_out(LOG, OUT, 0)
+
+def run_writer_test():
+    with LoggingIntercept() as LOG, capture_output(capture_fd=True) as OUT:
+        # Enumerate the writers...
+        from pyomo.opt import WriterFactory
+        info = []
+        for writer in sorted(WriterFactory):
+            info.append("  %s: %s" % (writer, WriterFactory.doc(writer)))
+            _check_log_and_out(LOG, OUT, 10, writer)
+
+    print("Pyomo Problem Writers")
+    print("---------------------")
+    print('\n'.join(info))
+
+    with LoggingIntercept() as LOG, capture_output(capture_fd=True) as OUT:
+        # Test a writer
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.c = pyo.Constraint(expr=m.x >= 1)
+        m.o = pyo.Objective(expr=m.x**2)
+
+        from pyomo.common.tempfiles import TempfileManager
+        with TempfileManager:
+            fname = TempfileManager.create_tempfile(suffix='pyomo.lp')
+            m.write(fname)
+            with open(fname, 'r') as FILE:
+                data = FILE.read()
+
+    if not all(d.strip() == b.strip() for d,b in zip(
+            data.strip().splitlines(), _baseline.strip().splitlines())):
+        print("Result did not match baseline.\nRESULT:\n%s\nBASELINE:\n%s"
+              % (data, _baseline))
+        print(data.strip().splitlines())
+        print(_baseline.strip().splitlines())
+        sys.exit(2)
+
+    _check_log_and_out(LOG, OUT, 10)
+
+
+def run_solverfactory_test():
+    skip_solvers = {
+        'py',
+    }
+
+    with LoggingIntercept() as LOG, capture_output(capture_fd=True) as OUT:
+        info = []
+        for solver in sorted(pyo.SolverFactory):
+            _doc = pyo.SolverFactory.doc(solver)
+            if _doc is not None and 'DEPRECATED' in _doc:
+                _avail = 'DEPR'
+            elif solver in skip_solvers:
+                _avail = 'SKIP'
+            else:
+                _avail = str(pyo.SolverFactory(solver).available(False))
+            info.append("   %s(%s): %s" % (solver, _avail, _doc))
+            #_check_log_and_out(LOG, OUT, 20, solver)
+
+        glpk = pyo.SolverFactory('glpk')
+
+    print("")
+    print("Pyomo Solvers")
+    print("-------------")
+    print("\n".join(info))
+
+    if type(glpk.available(False)) != bool:
+        print("Solver glpk.available() did not return bool")
+        sys.exit(3)
+
+    _check_log_and_out(LOG, OUT, 20)
+
+
+def run_transformationfactory_test():
+    with LoggingIntercept() as LOG, capture_output(capture_fd=True) as OUT:
+        info = []
+        for t in sorted(pyo.TransformationFactory):
+            _doc = pyo.TransformationFactory.doc(t)
+            info.append("   %s: %s" % (t, _doc))
+            if 'DEPRECATED' not in _doc:
+                pyo.TransformationFactory(t)
+            _check_log_and_out(LOG, OUT, 30, t)
+
+        bigm = pyo.TransformationFactory('gdp.bigm')
+
+
+    print("")
+    print("Pyomo Transformations")
+    print("---------------------")
+    print('\n'.join(info))
+
+    if not isinstance(bigm, pyo.Transformation):
+        print("TransformationFactory(gdp.bigm) did not return a "
+              "transfomation")
+        sys.exit(4)
+
+    _check_log_and_out(LOG, OUT, 30)
+
+
+if __name__ == '__main__':
+    # Run some basic tests: map all errors / warnings / exceptions to a
+    # non-zero process return code, so that these tests can be run
+    # outside of any test harness
+    try:
+        import_pyomo_environ()
+        run_writer_test()
+        run_solverfactory_test()
+        run_transformationfactory_test()
+    except:
+        et, e, tb = sys.exc_info()
+        print(str(e))
+        sys.exit(1)
+    sys.exit(0)

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -1089,7 +1089,7 @@ class Hull_Reformulation(Transformation):
 
 @TransformationFactory.register(
     'gdp.chull',
-    doc="Deprecated name for the hull reformulation. Please use 'gdp.hull'.")
+    doc="[DEPRECATED] please use 'gdp.hull' to get the Hull transformation.")
 @deprecated("The 'gdp.chull' name is deprecated. "
             "Please use the more apt 'gdp.hull' instead.",
             logger='pyomo.gdp',

--- a/pyomo/opt/solver/shellcmd.py
+++ b/pyomo/opt/solver/shellcmd.py
@@ -2,8 +2,8 @@
 #
 #  Pyomo: Python Optimization Modeling Objects
 #  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
-#  Under the terms of Contract DE-NA0003525 with National Technology and 
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
@@ -17,9 +17,10 @@ import logging
 import subprocess
 from io import StringIO
 
+from pyomo.common.backports import nullcontext
 from pyomo.common.errors import ApplicationError
 from pyomo.common.collections import Bunch
-from pyomo.common.log import is_debug_set
+from pyomo.common.log import is_debug_set, LoggingIntercept
 from pyomo.common.tempfiles import TempfileManager
 from pyomo.common.tee import TeeStream
 
@@ -111,7 +112,11 @@ class SystemCallSolver(OptSolver):
         if not OptSolver.available(self,exception_flag):
             return False
         try:
-            ans = self.executable()
+            # HACK: Suppress logged warnings about the executable not
+            # being found
+            cm = nullcontext() if exception_flag else LoggingIntercept()
+            with cm:
+                ans = self.executable()
         except NotImplementedError:
             ans = None
         if ans is None:

--- a/pyomo/repn/tests/ampl/test_ampl_comparison.py
+++ b/pyomo/repn/tests/ampl/test_ampl_comparison.py
@@ -21,11 +21,11 @@ from os.path import abspath, dirname, join
 currdir = dirname(abspath(__file__))+os.sep
 
 import pyomo.common.unittest as unittest
-import pyomo.common
+from pyomo.common.dependencies import attempt_import
 
 import pyomo.scripting.pyomo_main as main
 
-parameterized, param_available = pyomo.common.dependencies.attempt_import('parameterized')
+parameterized, param_available = attempt_import('parameterized')
 if not param_available:
     raise unittest.SkipTest('Parameterized is not available.')
 

--- a/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
@@ -296,7 +296,7 @@ class DirectOrPersistentSolver(OptSolver):
             raise ApplicationError(
                 "No Python bindings available for %s solver plugin"
                 % (type(self),))
-        return _api
+        return bool(_api)
 
     def _get_version(self):
         if self._version is None:

--- a/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
@@ -95,9 +95,6 @@ class DirectOrPersistentSolver(OptSolver):
         self._version = None
         """The version of the solver."""
 
-        self._version_major = None
-        """The major version of the solver. For example, if using Gurobi 7.0.2, then _version_major is 7."""
-
         self._symbolic_solver_labels = False
         """A bool. If true then the solver components will be given names corresponding to the pyomo component names."""
 

--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -111,9 +111,10 @@ class GurobiDirect(DirectSolver):
             self._max_constraint_degree = 1
             self._capabilities.quadratic_constraint = False
 
-        # Note that the base OptSolver class declares a _version
-        # attribute (hiding the class attribute).  We will fix that here.
-        self._version = GurobiDirect._version
+        # remove the instance-level definiton of the gurobi version:
+        # because the version comes from an imported module, only one
+        # version of gurobi is supported (and stored as a class attribute)
+        del self._version
 
     def available(self, exception_flag=True):
         if not gurobipy_available:

--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -111,7 +111,7 @@ class GurobiDirect(DirectSolver):
             self._max_constraint_degree = 1
             self._capabilities.quadratic_constraint = False
 
-        # remove the instance-level definiton of the gurobi version:
+        # remove the instance-level definition of the gurobi version:
         # because the version comes from an imported module, only one
         # version of gurobi is supported (and stored as a class attribute)
         del self._version

--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -12,8 +12,11 @@ import logging
 import re
 import sys
 
-from pyomo.common.tempfiles import TempfileManager
 from pyomo.common.collections import ComponentSet, ComponentMap, Bunch
+from pyomo.common.dependencies import attempt_import
+from pyomo.common.errors import ApplicationError
+from pyomo.common.tempfiles import TempfileManager
+from pyomo.common.tee import capture_output
 from pyomo.core.expr.numvalue import is_fixed
 from pyomo.core.expr.numvalue import value
 from pyomo.repn import generate_standard_repn
@@ -41,10 +44,38 @@ def _is_numeric(x):
         return False
     return True
 
+
+def _parse_gurobi_version(gurobipy, avail):
+    if not avail:
+        return
+    GurobiDirect._version = gurobipy.gurobi.version()
+    GurobiDirect._name = "Gurobi %s.%s%s" % GurobiDirect._version
+    while len(GurobiDirect._version) < 4:
+        GurobiDirect._version += (0,)
+    GurobiDirect._version = GurobiDirect._version[:4]
+    GurobiDirect._version_major = GurobiDirect._version[0]
+
+gurobipy, gurobipy_available = attempt_import(
+    'gurobipy',
+    # Other forms of exceptions can be thrown by the gurobi python
+    # import.  For example, a gurobipy.GurobiError exception is thrown
+    # if all tokens for Gurobi are already in use; assuming, of course,
+    # the license is a token license.  Unfortunately, you can't import
+    # without a license, which means we can't explicitly test for that
+    # exception!
+    catch_exceptions=(Exception,),
+    callback=_parse_gurobi_version,
+)
+
+
 @SolverFactory.register('gurobi_direct', doc='Direct python interface to Gurobi')
 class GurobiDirect(DirectSolver):
 
     _verified_license = None
+    _import_messages = ''
+    _name = None
+    _version = None
+    _version_major = 0
 
     def __init__(self, **kwds):
         if 'type' not in kwds:
@@ -58,30 +89,7 @@ class GurobiDirect(DirectSolver):
         self._callback = None
         self._callback_func = None
 
-        self._name = None
-        try:
-            import gurobipy
-            self._gurobipy = gurobipy
-            self._python_api_exists = True
-            self._version = self._gurobipy.gurobi.version()
-            self._name = "Gurobi %s.%s%s" % self._version
-            while len(self._version) < 4:
-                self._version += (0,)
-            self._version = self._version[:4]
-            self._version_major = self._version[0]
-        except ImportError:
-            self._python_api_exists = False
-        except Exception as e:
-            # other forms of exceptions can be thrown by the gurobi python
-            # import. for example, a gurobipy.GurobiError exception is thrown
-            # if all tokens for Gurobi are already in use. assuming, of
-            # course, the license is a token license. unfortunately, you can't
-            # import without a license, which means we can't test for the
-            # exception above!
-            logger.error(
-                "Import of gurobipy failed - gurobi message=%s\n" % (e,))
-            self._python_api_exists = False
-
+        self._python_api_exists = gurobipy_available
         self._range_constraints = set()
 
         self._max_obj_degree = 2
@@ -96,24 +104,41 @@ class GurobiDirect(DirectSolver):
         self._capabilities.sos2 = True
 
         # fix for compatibility with pre-5.0 Gurobi
-        if self._python_api_exists and \
-           (self._version_major < 5):
+        #
+        # Note: Unfortunately, this will trigger the immediate import
+        #    of the gurobipy module
+        if gurobipy_available and GurobiDirect._version_major < 5:
             self._max_constraint_degree = 1
             self._capabilities.quadratic_constraint = False
 
     def available(self, exception_flag=True):
-        if not super().available(exception_flag):
+        if not gurobipy_available:
+            if exception_flag:
+                gurobipy.log_import_warning(logger=__name__)
+                raise ApplicationError(
+                    "No Python bindings available for %s solver plugin"
+                    % (type(self),))
             return False
         if self._verified_license is None:
-            try:
-                # verify that we can get a Gurobi license
-                m = self._gurobipy.Model()
-                m.dispose()
-                GurobiDirect._verified_license = True
-            except Exception as e:
-                logger.error(
-                    "Could not create Model - gurobi message=%s\n" % (e,))
-                GurobiDirect._verified_license = False
+            with capture_output(capture_fd=True) as OUT:
+                try:
+                    # verify that we can get a Gurobi license
+                    # Gurobipy writes out license file information when creating
+                    # the environment
+                    m = gurobipy.Model()
+                    m.dispose()
+                    GurobiDirect._verified_license = True
+                except Exception as e:
+                    GurobiDirect._import_messages += \
+                        "\nCould not create Model - gurobi message=%s\n" % (e,)
+                    GurobiDirect._verified_license = False
+            if OUT.getvalue():
+                GurobiDirect._import_messages += "\n" + OUT.getvalue()
+        if exception_flag and not self._verified_license:
+            logger.warning(GurobiDirect._import_messages)
+            raise ApplicationError(
+                "Could not create a gurobipy Model for %s solver plugin"
+                % (type(self),))
         return self._verified_license
 
     def _apply_solver(self):
@@ -171,7 +196,7 @@ class GurobiDirect(DirectSolver):
         if self._version_major >= 5:
             for suffix in self._suffixes:
                 if re.match(suffix, "dual"):
-                    self._solver_model.setParam(self._gurobipy.GRB.Param.QCPDual, 1)
+                    self._solver_model.setParam(gurobipy.GRB.Param.QCPDual, 1)
 
         self._solver_model.optimize(self._callback)
         self._needs_updated = False
@@ -190,7 +215,7 @@ class GurobiDirect(DirectSolver):
 
         if len(repn.linear_vars) > 0:
             referenced_vars.update(repn.linear_vars)
-            new_expr = self._gurobipy.LinExpr(repn.linear_coefs, [self._pyomo_var_to_solver_var_map[i] for i in repn.linear_vars])
+            new_expr = gurobipy.LinExpr(repn.linear_coefs, [self._pyomo_var_to_solver_var_map[i] for i in repn.linear_vars])
         else:
             new_expr = 0.0
 
@@ -226,11 +251,11 @@ class GurobiDirect(DirectSolver):
         if var.has_lb():
             lb = value(var.lb)
         else:
-            lb = -self._gurobipy.GRB.INFINITY
+            lb = -gurobipy.GRB.INFINITY
         if var.has_ub():
             ub = value(var.ub)
         else:
-            ub = self._gurobipy.GRB.INFINITY
+            ub = gurobipy.GRB.INFINITY
         return lb, ub
 
     def _add_var(self, var):
@@ -255,9 +280,9 @@ class GurobiDirect(DirectSolver):
         self._solver_var_to_pyomo_var_map = ComponentMap()
         try:
             if model.name is not None:
-                self._solver_model = self._gurobipy.Model(model.name)
+                self._solver_model = gurobipy.Model(model.name)
             else:
-                self._solver_model = self._gurobipy.Model()
+                self._solver_model = gurobipy.Model()
         except Exception:
             e = sys.exc_info()[1]
             msg = ("Unable to create Gurobi model. "
@@ -319,7 +344,7 @@ class GurobiDirect(DirectSolver):
 
         if con.equality:
             gurobipy_con = self._solver_model.addConstr(lhs=gurobi_expr,
-                                                        sense=self._gurobipy.GRB.EQUAL,
+                                                        sense=gurobipy.GRB.EQUAL,
                                                         rhs=value(con.lower),
                                                         name=conname)
         elif con.has_lb() and con.has_ub():
@@ -330,12 +355,12 @@ class GurobiDirect(DirectSolver):
             self._range_constraints.add(con)
         elif con.has_lb():
             gurobipy_con = self._solver_model.addConstr(lhs=gurobi_expr,
-                                                        sense=self._gurobipy.GRB.GREATER_EQUAL,
+                                                        sense=gurobipy.GRB.GREATER_EQUAL,
                                                         rhs=value(con.lower),
                                                         name=conname)
         elif con.has_ub():
             gurobipy_con = self._solver_model.addConstr(lhs=gurobi_expr,
-                                                        sense=self._gurobipy.GRB.LESS_EQUAL,
+                                                        sense=gurobipy.GRB.LESS_EQUAL,
                                                         rhs=value(con.upper),
                                                         name=conname)
         else:
@@ -357,9 +382,9 @@ class GurobiDirect(DirectSolver):
         conname = self._symbol_map.getSymbol(con, self._labeler)
         level = con.level
         if level == 1:
-            sos_type = self._gurobipy.GRB.SOS_TYPE1
+            sos_type = gurobipy.GRB.SOS_TYPE1
         elif level == 2:
-            sos_type = self._gurobipy.GRB.SOS_TYPE2
+            sos_type = gurobipy.GRB.SOS_TYPE2
         else:
             raise ValueError("Solver does not support SOS "
                              "level {0} constraints".format(level))
@@ -395,11 +420,11 @@ class GurobiDirect(DirectSolver):
         :return: gurobipy.GRB.CONTINUOUS or gurobipy.GRB.BINARY or gurobipy.GRB.INTEGER
         """
         if var.is_binary():
-            vtype = self._gurobipy.GRB.BINARY
+            vtype = gurobipy.GRB.BINARY
         elif var.is_integer():
-            vtype = self._gurobipy.GRB.INTEGER
+            vtype = gurobipy.GRB.INTEGER
         elif var.is_continuous():
-            vtype = self._gurobipy.GRB.CONTINUOUS
+            vtype = gurobipy.GRB.CONTINUOUS
         else:
             raise ValueError('Variable domain type is not recognized for {0}'.format(var.domain))
         return vtype
@@ -415,9 +440,9 @@ class GurobiDirect(DirectSolver):
             raise ValueError('Cannot add inactive objective to solver.')
 
         if obj.sense == minimize:
-            sense = self._gurobipy.GRB.MINIMIZE
+            sense = gurobipy.GRB.MINIMIZE
         elif obj.sense == maximize:
-            sense = self._gurobipy.GRB.MAXIMIZE
+            sense = gurobipy.GRB.MAXIMIZE
         else:
             raise ValueError('Objective sense is not recognized: {0}'.format(obj.sense))
 
@@ -456,10 +481,10 @@ class GurobiDirect(DirectSolver):
                 raise RuntimeError("***The gurobi_direct solver plugin cannot extract solution suffix="+suffix)
 
         gprob = self._solver_model
-        grb = self._gurobipy.GRB
+        grb = gurobipy.GRB
         status = gprob.Status
 
-        if gprob.getAttr(self._gurobipy.GRB.Attr.IsMIP):
+        if gprob.getAttr(gurobipy.GRB.Attr.IsMIP):
             if extract_reduced_costs:
                 logger.warning("Cannot get reduced costs for MIP.")
             if extract_duals:
@@ -470,7 +495,7 @@ class GurobiDirect(DirectSolver):
         self.results = SolverResults()
         soln = Solution()
 
-        self.results.solver.name = self._name
+        self.results.solver.name = GurobiDirect._name
         self.results.solver.wallclock_time = gprob.Runtime
 
         if status == grb.LOADED:  # problem is loaded, but no solution
@@ -582,25 +607,25 @@ class GurobiDirect(DirectSolver):
             try:
                 self.results.problem.upper_bound = gprob.ObjVal
                 self.results.problem.lower_bound = gprob.ObjVal
-            except (self._gurobipy.GurobiError, AttributeError):
+            except (gurobipy.GurobiError, AttributeError):
                 pass
         elif gprob.ModelSense == 1:  # minimizing
             try:
                 self.results.problem.upper_bound = gprob.ObjVal
-            except (self._gurobipy.GurobiError, AttributeError):
+            except (gurobipy.GurobiError, AttributeError):
                 pass
             try:
                 self.results.problem.lower_bound = gprob.ObjBound
-            except (self._gurobipy.GurobiError, AttributeError):
+            except (gurobipy.GurobiError, AttributeError):
                 pass
         elif gprob.ModelSense == -1:  # maximizing
             try:
                 self.results.problem.upper_bound = gprob.ObjBound
-            except (self._gurobipy.GurobiError, AttributeError):
+            except (gurobipy.GurobiError, AttributeError):
                 pass
             try:
                 self.results.problem.lower_bound = gprob.ObjVal
-            except (self._gurobipy.GurobiError, AttributeError):
+            except (gurobipy.GurobiError, AttributeError):
                 pass
         else:
             raise RuntimeError('Unrecognized gurobi objective sense: {0}'.format(gprob.ModelSense))
@@ -719,7 +744,7 @@ class GurobiDirect(DirectSolver):
     def _warm_start(self):
         for pyomo_var, gurobipy_var in self._pyomo_var_to_solver_var_map.items():
             if pyomo_var.value is not None:
-                gurobipy_var.setAttr(self._gurobipy.GRB.Attr.Start, value(pyomo_var))
+                gurobipy_var.setAttr(gurobipy.GRB.Attr.Start, value(pyomo_var))
         self._needs_updated = True
 
     def _load_vars(self, vars_to_load=None):

--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -74,7 +74,7 @@ class GurobiDirect(DirectSolver):
     _verified_license = None
     _import_messages = ''
     _name = None
-    _version = None
+    _version = 0
     _version_major = 0
 
     def __init__(self, **kwds):
@@ -110,6 +110,10 @@ class GurobiDirect(DirectSolver):
         if gurobipy_available and GurobiDirect._version_major < 5:
             self._max_constraint_degree = 1
             self._capabilities.quadratic_constraint = False
+
+        # Note that the base OptSolver class declares a _version
+        # attribute (hiding the class attribute).  We will fix that here.
+        self._version = GurobiDirect._version
 
     def available(self, exception_flag=True):
         if not gurobipy_available:

--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -14,8 +14,11 @@ import re
 import sys
 import time
 
-from pyomo.common.tempfiles import TempfileManager
 from pyomo.common.collections import ComponentSet, ComponentMap, Bunch
+from pyomo.common.dependencies import attempt_import
+from pyomo.common.errors import ApplicationError
+from pyomo.common.tee import capture_output
+from pyomo.common.tempfiles import TempfileManager
 from pyomo.core.expr.numvalue import is_fixed
 from pyomo.core.expr.numvalue import value
 from pyomo.repn import generate_standard_repn
@@ -47,8 +50,67 @@ def _print_message(xp_prob, _, msg, *args):
         sys.stdout.write(msg+'\n')
         sys.stdout.flush()
 
+def _finalize_xpress_import(xpress, avail):
+    if not avail:
+        return
+    XpressDirect._version = tuple(
+        int(k) for k in xpress.getversion().split('.'))
+    XpressDirect._name = "Xpress %s.%s.%s" % XpressDirect._version
+    # in versions prior to 34, xpress raised a RuntimeError, but
+    # in more recent versions it raises a
+    # xpress.ModelError. We'll cache the appropriate one here
+    if XpressDirect._version[0] < 34:
+        XpressDirect.XpressException = RuntimeError
+    else:
+        XpressDirect.XpressException = xpress.ModelError
+
+class _xpress_importer_class(object):
+    # We want to be able to *update* the message that the deferred
+    # import generates using the stdout recorded during the actual
+    # import.  As strings are immutable in Python, we will give this
+    # *class* as the error message, so that we can update the embedded
+    # string later.
+    def __init__(self):
+        self.import_message = ""
+
+    def __str__(self):
+        return str(self.import_message)
+
+    def __call__(self):
+        _cwd = os.getcwd()
+        try:
+            with capture_output() as OUT:
+                import xpress
+        finally:
+            # In some versions of XPRESS (notably 8.9.0), `import
+            # xpress` temporarily changes the CWD.  If the import fails
+            # (e.g., due to an expired license), the CWD is not always
+            # restored.  This block ensures that the CWD is preserved.
+            os.chdir(_cwd)
+            self.import_message += OUT.getvalue()
+        return xpress
+
+_xpress_importer = _xpress_importer_class()
+xpress, xpress_available = attempt_import(
+    'xpress',
+    error_message=_xpress_importer,
+    # Other forms of exceptions can be thrown by the xpress python
+    # import.  For example, an xpress.InterfaceError exception is thrown
+    # if the Xpress license is not valid.  Unfortunately, you can't
+    # import without a license, which means we can't test for that
+    # explicit exception!
+    catch_exceptions=(Exception,),
+    importer=_xpress_importer,
+    callback=_finalize_xpress_import,
+)
+
+
 @SolverFactory.register('xpress_direct', doc='Direct python interface to XPRESS')
 class XpressDirect(DirectSolver):
+
+    _name = None
+    _version = None
+    XpressException = RuntimeError
 
     def __init__(self, **kwds):
         if 'type' not in kwds:
@@ -59,41 +121,9 @@ class XpressDirect(DirectSolver):
         self._pyomo_con_to_solver_con_map = dict()
         self._solver_con_to_pyomo_con_map = ComponentMap()
 
-        self._name = None
-        _cwd = os.getcwd()
-        try:
-            import xpress 
-            self._xpress = xpress
-            self._python_api_exists = True
-            self._version = tuple(
-                    int(k) for k in self._xpress.getversion().split('.'))
-            self._name = "Xpress %s.%s.%s" % self._version
-            self._version_major = self._version[0]
-            # in versions prior to 34, xpress raised a RuntimeError, but in more
-            # recent versions it raises a xpress.ModelError. We'll cache the appropriate
-            # one here
-            if self._version_major < 34:
-                self._XpressException = RuntimeError
-            else:
-                self._XpressException = xpress.ModelError
-        except ImportError:
-            self._python_api_exists = False
-        except Exception as e:
-            # other forms of exceptions can be thrown by the xpress python
-            # import. for example, a xpress.InterfaceError exception is thrown
-            # if the Xpress license is not valid. Unfortunately, you can't
-            # import without a license, which means we can't test for the
-            # exception above!
-            print("Import of xpress failed - xpress message=" + str(e) + "\n")
-            self._python_api_exists = False
-        finally:
-            # In some versions of XPRESS (notably 8.9.0), `import
-            # xpress` temporarily changes the CWD.  If the import fails
-            # (e.g., due to an expired license), the CWD is not always
-            # restored.  This block ensures that the CWD is preserved.
-            os.chdir(_cwd)
-
         self._range_constraints = set()
+
+        self._python_api_exists = xpress_available
 
         # TODO: this isn't a limit of XPRESS, which implements an SLP
         #       method for NLPs. But it is a limit of *this* interface
@@ -112,6 +142,16 @@ class XpressDirect(DirectSolver):
         self._capabilities.integer = True
         self._capabilities.sos1 = True
         self._capabilities.sos2 = True
+
+    def available(self, exception_flag=True):
+        """True if the solver is available."""
+
+        if exception_flag and not xpress_available:
+            xpress.log_import_warning(logger=__name__)
+            raise ApplicationError(
+                "No Python bindings available for %s solver plugin"
+                % (type(self),))
+        return bool(xpress_available)
 
     def _apply_solver(self):
         if not self._save_results:
@@ -142,13 +182,13 @@ class XpressDirect(DirectSolver):
         # xpress is picky about the type which is passed
         # into a control. So we will infer and cast
         # get the xpress valid controls
-        xp_controls = self._xpress.controls
+        xp_controls = xpress.controls
         for key, option in self.options.items():
             if key == 'mipgap': # handled above
                 continue
-            try: 
+            try:
                 self._solver_model.setControl(key, option)
-            except self._XpressException:
+            except XpressDirect.XpressException:
                 # take another try, converting to its type
                 # we'll wrap this in a function to raise the
                 # xpress error
@@ -180,7 +220,7 @@ class XpressDirect(DirectSolver):
         #       will cause an exception when constructing expressions
         if len(repn.linear_vars) > 0:
             referenced_vars.update(repn.linear_vars)
-            new_expr = self._xpress.Sum(float(coef)*self._pyomo_var_to_solver_var_map[var] for coef,var in zip(repn.linear_coefs, repn.linear_vars))
+            new_expr = xpress.Sum(float(coef)*self._pyomo_var_to_solver_var_map[var] for coef,var in zip(repn.linear_coefs, repn.linear_vars))
         else:
             new_expr = 0.0
 
@@ -215,24 +255,24 @@ class XpressDirect(DirectSolver):
         if var.has_lb():
             lb = value(var.lb)
         else:
-            lb = -self._xpress.infinity
+            lb = -xpress.infinity
         if var.has_ub():
             ub = value(var.ub)
         else:
-            ub = self._xpress.infinity
+            ub = xpress.infinity
         return lb, ub
 
     def _add_var(self, var):
         varname = self._symbol_map.getSymbol(var, self._labeler)
-        vartype = self._xpress_vartype_from_var(var)
-        lb, ub = self._xpress_lb_ub_from_var(var)
+        vartype = xpress_vartype_from_var(var)
+        lb, ub = xpress_lb_ub_from_var(var)
 
-        xpress_var = self._xpress.var(name=varname, lb=lb, ub=ub, vartype=vartype)
+        xpress_var = xpress.var(name=varname, lb=lb, ub=ub, vartype=vartype)
         self._solver_model.addVariable(xpress_var)
 
         ## bounds on binary variables don't seem to be set correctly
         ## by the method above
-        if vartype == self._xpress.binary:
+        if vartype == xpress.binary:
             if lb == ub:
                 self._solver_model.chgbounds([xpress_var], ['B'], [lb])
             else:
@@ -251,9 +291,9 @@ class XpressDirect(DirectSolver):
         self._solver_var_to_pyomo_var_map = ComponentMap()
         try:
             if model.name is not None:
-                self._solver_model = self._xpress.problem(name=model.name)
+                self._solver_model = xpress.problem(name=model.name)
             else:
-                self._solver_model = self._xpress.problem()
+                self._solver_model = xpress.problem()
         except Exception:
             e = sys.exc_info()[1]
             msg = ("Unable to create Xpress model. "
@@ -283,7 +323,7 @@ class XpressDirect(DirectSolver):
         else:
             xpress_expr, referenced_vars = self._get_expr_from_pyomo_expr(
                 con.body,
-                self._max_constraint_degree) 
+                self._max_constraint_degree)
 
         if con.has_lb():
             if not is_fixed(con.lower):
@@ -295,27 +335,27 @@ class XpressDirect(DirectSolver):
                                  "is not constant.".format(con))
 
         if con.equality:
-            xpress_con = self._xpress.constraint(body=xpress_expr,
-                                                 sense=self._xpress.eq,
-                                                 rhs=value(con.lower),
-                                                 name=conname)
+            xpress_con = xpress.constraint(body=xpress_expr,
+                                           sense=xpress.eq,
+                                           rhs=value(con.lower),
+                                           name=conname)
         elif con.has_lb() and con.has_ub():
-            xpress_con = self._xpress.constraint(body=xpress_expr,
-                                                 sense=self._xpress.range,
-                                                 lb=value(con.lower),
-                                                 ub=value(con.upper),
-                                                 name=conname)
+            xpress_con = xpress.constraint(body=xpress_expr,
+                                           sense=xpress.range,
+                                           lb=value(con.lower),
+                                           ub=value(con.upper),
+                                           name=conname)
             self._range_constraints.add(xpress_con)
         elif con.has_lb():
-            xpress_con = self._xpress.constraint(body=xpress_expr,
-                                                 sense=self._xpress.geq,
-                                                 rhs=value(con.lower),
-                                                 name=conname)
+            xpress_con = xpress.constraint(body=xpress_expr,
+                                           sense=xpress.geq,
+                                           rhs=value(con.lower),
+                                           name=conname)
         elif con.has_ub():
-            xpress_con = self._xpress.constraint(body=xpress_expr,
-                                                 sense=self._xpress.leq,
-                                                 rhs=value(con.upper),
-                                                 name=conname)
+            xpress_con = xpress.constraint(body=xpress_expr,
+                                           sense=xpress.leq,
+                                           rhs=value(con.upper),
+                                           name=conname)
         else:
             raise ValueError("Constraint does not have a lower "
                              "or an upper bound: {0} \n".format(con))
@@ -356,7 +396,7 @@ class XpressDirect(DirectSolver):
             self._referenced_variables[v] += 1
             weights.append(w)
 
-        xpress_con = self._xpress.sos(xpress_vars, weights, level, conname)
+        xpress_con = xpress.sos(xpress_vars, weights, level, conname)
         self._solver_model.addSOS(xpress_con)
         self._pyomo_con_to_solver_con_map[con] = xpress_con
         self._solver_con_to_pyomo_con_map[xpress_con] = con
@@ -368,15 +408,15 @@ class XpressDirect(DirectSolver):
         :return: xpress.continuous or xpress.binary or xpress.integer
         """
         if var.is_binary():
-            vartype = self._xpress.binary
+            vartype = xpress.binary
         elif var.is_integer():
-            vartype = self._xpress.integer
+            vartype = xpress.integer
         elif var.is_continuous():
-            vartype = self._xpress.continuous
+            vartype = xpress.continuous
         else:
             raise ValueError('Variable domain type is not recognized for {0}'.format(var.domain))
         return vartype
-    
+
     def _set_objective(self, obj):
         if self._objective is not None:
             for var in self._vars_referenced_by_obj:
@@ -388,9 +428,9 @@ class XpressDirect(DirectSolver):
             raise ValueError('Cannot add inactive objective to solver.')
 
         if obj.sense == minimize:
-            sense = self._xpress.minimize
+            sense = xpress.minimize
         elif obj.sense == maximize:
-            sense = self._xpress.maximize
+            sense = xpress.maximize
         else:
             raise ValueError('Objective sense is not recognized: {0}'.format(obj.sense))
 
@@ -427,7 +467,7 @@ class XpressDirect(DirectSolver):
                 raise RuntimeError("***The xpress_direct solver plugin cannot extract solution suffix="+suffix)
 
         xprob = self._solver_model
-        xp = self._xpress
+        xp = xpress
         xprob_attrs = xprob.attributes
 
         ## XPRESS's status codes depend on this
@@ -445,7 +485,7 @@ class XpressDirect(DirectSolver):
         self.results = SolverResults()
         soln = Solution()
 
-        self.results.solver.name = self._name
+        self.results.solver.name = XpressDirect._name
         self.results.solver.wallclock_time = self._opt_time
 
         if is_mip:
@@ -574,25 +614,25 @@ class XpressDirect(DirectSolver):
             try:
                 self.results.problem.upper_bound = xprob_attrs.lpobjval
                 self.results.problem.lower_bound = xprob_attrs.lpobjval
-            except (self._XpressException, AttributeError):
+            except (XpressDirect.XpressException, AttributeError):
                 pass
         elif xprob_attrs.objsense == 1.0:  # minimizing MIP
             try:
                 self.results.problem.upper_bound = xprob_attrs.mipbestobjval
-            except (self._XpressException, AttributeError):
+            except (XpressDirect.XpressException, AttributeError):
                 pass
             try:
                 self.results.problem.lower_bound = xprob_attrs.bestbound
-            except (self._XpressException, AttributeError):
+            except (XpressDirect.XpressException, AttributeError):
                 pass
         elif xprob_attrs.objsense == -1.0:  # maximizing MIP
             try:
                 self.results.problem.upper_bound = xprob_attrs.bestbound
-            except (self._XpressException, AttributeError):
+            except (XpressDirect.XpressException, AttributeError):
                 pass
             try:
                 self.results.problem.lower_bound = xprob_attrs.mipbestobjval
-            except (self._XpressException, AttributeError):
+            except (XpressDirect.XpressException, AttributeError):
                 pass
         else:
             raise RuntimeError('Unrecognized xpress objective sense: {0}'.format(xprob_attrs.objsense))
@@ -608,7 +648,7 @@ class XpressDirect(DirectSolver):
         self.results.problem.number_of_integer_variables = xprob_attrs.mipents
         self.results.problem.number_of_continuous_variables = xprob_attrs.cols - xprob_attrs.mipents
         self.results.problem.number_of_objectives = 1
-        self.results.problem.number_of_solutions = xprob_attrs.mipsols if is_mip else 1 
+        self.results.problem.number_of_solutions = xprob_attrs.mipsols if is_mip else 1
 
         # if a solve was stopped by a limit, we still need to check to
         # see if there is a solution available - this may not always

--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -269,8 +269,8 @@ class XpressDirect(DirectSolver):
 
     def _add_var(self, var):
         varname = self._symbol_map.getSymbol(var, self._labeler)
-        vartype = xpress_vartype_from_var(var)
-        lb, ub = xpress_lb_ub_from_var(var)
+        vartype = self._xpress_vartype_from_var(var)
+        lb, ub = self._xpress_lb_ub_from_var(var)
 
         xpress_var = xpress.var(name=varname, lb=lb, ub=ub, vartype=vartype)
         self._solver_model.addVariable(xpress_var)

--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -143,7 +143,7 @@ class XpressDirect(DirectSolver):
         self._capabilities.sos1 = True
         self._capabilities.sos2 = True
 
-        # remove the instance-level definiton of the xpress version:
+        # remove the instance-level definition of the xpress version:
         # because the version comes from an imported module, only one
         # version of xpress is supported (and stored as a class attribute)
         del self._version

--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -143,6 +143,11 @@ class XpressDirect(DirectSolver):
         self._capabilities.sos1 = True
         self._capabilities.sos2 = True
 
+        # remove the instance-level definiton of the xpress version:
+        # because the version comes from an imported module, only one
+        # version of xpress is supported (and stored as a class attribute)
+        del self._version
+
     def available(self, exception_flag=True):
         """True if the solver is available."""
 


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
A question on StackOverflow about if `nose` was required prompted a review of strict dependencies within Pyomo.  This PR removes a few strict dependencies that had snuck in (notably, the last import of `nose`, and an unconditional import of `parameterized`).

As part of testing, this PR creates a new "bare environment" test: that is, `pip install pyomo` into a completely empty Python environment, and then test that minimal functionality works:
- create a simple model
- write the model to a NL file
- test that you can query `.available(False)` on all (non-deprecated) solvers
- test that you can create instances of all (non-deprecated) transformations

The test checks that no output is sent to STDOUT/STDERR, and that no messages are logged.  This led to updates of several solvers to suppress output when querying `.available()`, and to marking several deprecated transformations as deprecated in their registration documentation.

## Changes proposed in this PR:
- remove explicit dependencies on `nose`, and `parameterized`
- Suppress messages from `SystemCallSolver.availalbe()` when the executable cannot be found
- Update Gurobi and Xpress direct interfaces:
  - Suppress messages when testing availability
  - Update interface to leverage `attempt_import`
- Update APPSI Gurobi interface to suppress output when checking the license
- Update deprecation notices on several deprecated transformations
- Add a "bare environment" test that verifies the basic functionality of Pyomo with only the required dependencies.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
