### PR TITLE
Support using TicTocTimer as a context manager

### DIFF
--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -184,15 +184,7 @@ class TestTiming(unittest.TestCase):
 
     def test_TicTocTimer_context_manager(self):
         SLEEP = 0.1
-        RES = 0.02 # resolution (seconds): 1/5 the sleep
-
-        # Note: pypy on GHA occasionally has timing
-        # differences of >0.03s
-        if 'pypy_version_info' in dir(sys):
-            RES *= 2
-        # Note: previously, OSX on GHA also had significantly nosier tests
-        # if sys.platform == 'darwin':
-        #     RES *= 2
+        RES = 0.05 # resolution (seconds): 1/2 the sleep
 
         abs_time = time.time()
         with TicTocTimer() as timer:

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -180,6 +180,28 @@ class TestTiming(unittest.TestCase):
             r'\[    [.0-9]+\|   1\] .* in test_TicTocTimer_tictoc'
         )
 
+
+    def test_TicTocTimer_context_manager(self):
+        SLEEP = 0.1
+        RES = 0.02 # resolution (seconds): 1/5 the sleep
+
+        # Note: pypy on GHA occasionally has timing
+        # differences of >0.03s
+        if 'pypy_version_info' in dir(sys):
+            RES *= 2
+        # Note: previously, OSX on GHA also had significantly nosier tests
+        # if sys.platform == 'darwin':
+        #     RES *= 2
+
+        abs_time = time.time()
+        with TicTocTimer() as timer:
+            time.sleep(SLEEP)
+        time.sleep(SLEEP)
+        with timer:
+            time.sleep(SLEEP)
+        self.assertAlmostEqual(time.time() - abs_time, SLEEP*3, delta=RES)
+        self.assertAlmostEqual(timer.toc(None), SLEEP*2, delta=RES)
+
     def test_HierarchicalTimer(self):
         RES = 0.01 # resolution (seconds)
 

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -187,15 +187,17 @@ class TestTiming(unittest.TestCase):
         SLEEP = 0.1
         RES = 0.05 # resolution (seconds): 1/2 the sleep
 
+        abs_time = time.perf_counter()
         with TicTocTimer() as timer:
-            abs_time = time.perf_counter()
             time.sleep(SLEEP)
+        exclude = -time.perf_counter()
         time.sleep(SLEEP)
+        exclude += time.perf_counter()
         with timer:
             time.sleep(SLEEP)
-        self.assertAlmostEqual(time.perf_counter() - abs_time,
-                               SLEEP*3, delta=RES)
-        self.assertAlmostEqual(timer.toc(None), SLEEP*2, delta=RES)
+        abs_time = time.perf_counter() - abs_time
+        self.assertGreater(abs_time, SLEEP*3)
+        self.assertAlmostEqual(timer.toc(None), abs_time - exclude, delta=RES)
 
     def test_HierarchicalTimer(self):
         RES = 0.01 # resolution (seconds)

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -96,6 +96,15 @@ class TestTiming(unittest.TestCase):
     def test_TicTocTimer_tictoc(self):
         SLEEP = 0.1
         RES = 0.02 # resolution (seconds): 1/5 the sleep
+
+        # Note: pypy on GHA occasionally has timing
+        # differences of >0.03s
+        if 'pypy_version_info' in dir(sys):
+            RES *= 2
+        # Note: previously, OSX on GHA also had significantly nosier tests
+        # if sys.platform == 'darwin':
+        #     RES *= 2
+
         abs_time = time.time()
         timer = TicTocTimer()
 
@@ -152,14 +161,6 @@ class TestTiming(unittest.TestCase):
         ref -= time.time()
         timer.start()
         time.sleep(SLEEP)
-
-        # Note: pypy and osx (py3.8) on GHA occasionally have timing
-        # differences of >0.01s for the following tests
-        #
-        # Update: we relaxed the resolution for all tests to 0.2
-        #
-        # if 'pypy_version_info' in dir(sys) or sys.platform == 'darwin':
-        #     RES *= 2
 
         with capture_output() as out:
             ref += time.time()

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -279,6 +279,14 @@ class TicTocTimer(object):
         self._start_count += 1
         self._lastTime = default_timer()
 
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, et, ev, tb):
+        self.stop()
+
+
 _globalTimer = TicTocTimer()
 tic = functools.partial(TicTocTimer.tic, _globalTimer)
 tic.__doc__ = """


### PR DESCRIPTION
## Fixes # N/A

## Summary/Motivation:
This is a small update to support using the TicTocTimer as a context manager.  That is, instead of explicitly managing the timer with `timer.start()` and `timer.stop()`, users can simply:

```python
timer = TicTocTimer()
timer.stop()
while iterating:
   # Do some set up
   with timer:
        # time (the cumulative time in) this subroutine
        subroutine()
    # do some clean up
```

## Changes proposed in this PR:
- Add support for using the `TicTocTimer` as a context manager
- Relax the timing test resolution under pypy (reduce false negatives)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
