### PR TITLE
Update GHA to ubuntu-latest; resolve ampl/mp build error

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -260,20 +260,6 @@ jobs:
     - name: Install Python packages (conda)
       if: matrix.PYENV == 'conda'
       run: |
-        # conda activate puts itself first in the PATH, which overrides
-        # any paths we add through GITHUB_PATH.  We will update .profile
-        # to move the local runner paths back to the front (before conda).
-        for profile in $HOME/.profile $HOME/.bash_profile; do
-            if test ! -e $profile; then
-                continue
-            fi
-            echo '' >> $profile
-            echo 'export PATH=`echo "$PATH" \
-                | tr ":" "\\n" | grep runner | tr "\n" ":"`:`echo "$PATH" \
-                | tr ":" "\\n" | grep -v runner | tr "\n" ":"`' >> $profile
-            cat $profile
-        done
-
         mkdir -p $GITHUB_WORKSPACE/cache/conda
         conda config --set always_yes yes
         conda config --set auto_update_conda false
@@ -298,6 +284,19 @@ jobs:
         python -c 'import sys; print("PYTHON_EXE=%s" \
             % (sys.executable,))' >> $GITHUB_ENV
         echo "NOSETESTS="`which nosetests` >> $GITHUB_ENV
+        #
+        # conda activate puts itself first in the PATH, which overrides
+        # any paths we add through GITHUB_PATH.  We will update .profile
+        # to move the local runner paths back to the front (before conda).
+        for profile in $HOME/.profile $HOME/.bash_profile; do
+            if test ! -e $profile; then
+                continue
+            fi
+            echo '' >> $profile
+            echo 'export PATH=`echo "$PATH" \
+                | tr ":" "\\n" | grep runner | tr "\n" ":"`:`echo "$PATH" \
+                | tr ":" "\\n" | grep -v runner | tr "\n" ":"`' >> $profile
+        done
 
     - name: Setup TPL package directories
       run: |
@@ -510,8 +509,6 @@ jobs:
     - name: Run Pyomo tests
       if: matrix.mpi == 0
       run: |
-        echo PATH="$PATH"
-        cat ~/.profile
         CATEGORY=
         for cat in ${{matrix.category}}; do
             CATEGORY+=" --cat $cat"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -260,6 +260,13 @@ jobs:
     - name: Install Python packages (conda)
       if: matrix.PYENV == 'conda'
       run: |
+        # conda activate puts itself first in the PATH, which overrides
+        # any paths we add through GITHUB_PATH.  We will update .profile
+        # to move the local runner paths back to the front (before conda).
+        echo 'export PATH=`echo "$PATH" \
+            | tr ":" "\n" | grep runner | tr "\n" ":"`:`echo "$PATH" \
+            | tr ":" "\n" | grep -v runner | tr "\n" ":"`' >> $HOME/.profile
+
         mkdir -p $GITHUB_WORKSPACE/cache/conda
         conda config --set always_yes yes
         conda config --set auto_update_conda false

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -496,6 +496,7 @@ jobs:
     - name: Run Pyomo tests
       if: matrix.mpi == 0
       run: |
+        echo PATH="$PATH"
         CATEGORY=
         for cat in ${{matrix.category}}; do
             CATEGORY+=" --cat $cat"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -92,6 +92,11 @@ jobs:
           PYENV: pip
           PACKAGES: cython
 
+        - os: ubuntu-latest
+          python: pypy3
+          TARGET: linux
+          PYENV: pip
+
     steps:
     - name: Checkout Pyomo source
       uses: actions/checkout@v2

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -497,6 +497,7 @@ jobs:
       if: matrix.mpi == 0
       run: |
         echo PATH="$PATH"
+        cat ~/.profile
         CATEGORY=
         for cat in ${{matrix.category}}; do
             CATEGORY+=" --cat $cat"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -267,9 +267,10 @@ jobs:
             if test ! -e $profile; then
                 continue
             fi
-            echo 'export PATH=`echo "$PATH" \
-                | tr ":" "\n" | grep runner | tr "\n" ":"`:`echo "$PATH" \
-                | tr ":" "\n" | grep -v runner | tr "\n" ":"`' >> $profile
+            echo 'export PATH=`echo "$PATH" \\
+                | tr ":" "\\n" | grep runner | tr "\n" ":"`:`echo "$PATH" \\
+                | tr ":" "\\n" | grep -v runner | tr "\n" ":"`' >> $profile
+            cat $profile
         done
 
         mkdir -p $GITHUB_WORKSPACE/cache/conda

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -37,16 +37,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
-        python: [3.9]
+        os: [ubuntu-latest]
         other: [""]
         category: ["nightly"]
-        # Ubuntu-18.04 should be replaced with ubuntu-latest once PyNumero
-        # build error is resolved:
-        # https://github.com/Pyomo/pyomo/issues/1710
 
         include:
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
+          python: 3.9
           TARGET: linux
           PYENV: pip
 
@@ -61,7 +58,7 @@ jobs:
           PYENV: conda
           PACKAGES: glpk
 
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
           python: 3.8
           other: /mpi
           mpi: 3
@@ -70,7 +67,7 @@ jobs:
           PYENV: conda
           PACKAGES: mpi4py openmpi
 
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
           python: 3.7
           other: /conda
           skip_doctest: 1
@@ -78,7 +75,7 @@ jobs:
           PYENV: conda
           PACKAGES: mpi4py openmpi
 
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
           python: 3.9
           other: /slim
           slim: 1
@@ -86,7 +83,7 @@ jobs:
           TARGET: linux
           PYENV: pip
 
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
           python: 3.6
           other: /cython
           setup_options: --with-cython
@@ -312,7 +309,7 @@ jobs:
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
                 curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-ubuntu1804-64.tar.gz \
+                    -L $URL/idaes-solvers-ubuntu2004-64.tar.gz \
                     > $IPOPT_TAR
             else
                 curl --max-time 150 --retry 8 \
@@ -538,7 +535,7 @@ jobs:
 
   bare-python-env:
     name: linux/3.6/bare-env
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
     - name: Checkout Pyomo source
@@ -585,10 +582,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
         include:
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
           TARGET: linux
         - os: macos-latest
           TARGET: osx

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -263,9 +263,14 @@ jobs:
         # conda activate puts itself first in the PATH, which overrides
         # any paths we add through GITHUB_PATH.  We will update .profile
         # to move the local runner paths back to the front (before conda).
-        echo 'export PATH=`echo "$PATH" \
-            | tr ":" "\n" | grep runner | tr "\n" ":"`:`echo "$PATH" \
-            | tr ":" "\n" | grep -v runner | tr "\n" ":"`' >> $HOME/.profile
+        for profile in $HOME/.profile $HOME/.bash_profile; do
+            if test ! -e $profile; then
+                continue
+            fi
+            echo 'export PATH=`echo "$PATH" \
+                | tr ":" "\n" | grep runner | tr "\n" ":"`:`echo "$PATH" \
+                | tr ":" "\n" | grep -v runner | tr "\n" ":"`' >> $profile
+        done
 
         mkdir -p $GITHUB_WORKSPACE/cache/conda
         conda config --set always_yes yes

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -38,6 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        python: [3.9]
         other: [""]
         category: ["nightly"]
 

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -93,11 +93,6 @@ jobs:
           PYENV: pip
           PACKAGES: cython
 
-        - os: ubuntu-latest
-          python: pypy3
-          TARGET: linux
-          PYENV: pip
-
     steps:
     - name: Checkout Pyomo source
       uses: actions/checkout@v2

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -267,8 +267,9 @@ jobs:
             if test ! -e $profile; then
                 continue
             fi
-            echo 'export PATH=`echo "$PATH" \\
-                | tr ":" "\\n" | grep runner | tr "\n" ":"`:`echo "$PATH" \\
+            echo '' >> $profile
+            echo 'export PATH=`echo "$PATH" \
+                | tr ":" "\\n" | grep runner | tr "\n" ":"`:`echo "$PATH" \
                 | tr ":" "\\n" | grep -v runner | tr "\n" ":"`' >> $profile
             cat $profile
         done

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -40,16 +40,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python: [3.6, 3.7, 3.8, 3.9, pypy3]
         other: [""]
         category: ["nightly"]
-        # Ubuntu-18.04 should be replaced with ubuntu-latest once PyNumero
-        # build error is resolved:
-        # https://github.com/Pyomo/pyomo/issues/1710
 
         include:
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
           TARGET: linux
           PYENV: pip
 
@@ -62,7 +59,7 @@ jobs:
           PYENV: conda
           PACKAGES: glpk
 
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
           python: 3.8
           other: /mpi
           mpi: 3
@@ -71,7 +68,7 @@ jobs:
           PYENV: conda
           PACKAGES: mpi4py openmpi
 
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
           python: 3.7
           other: /conda
           skip_doctest: 1
@@ -79,7 +76,7 @@ jobs:
           PYENV: conda
           PACKAGES: mpi4py openmpi
 
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
           python: 3.9
           other: /slim
           slim: 1
@@ -87,7 +84,7 @@ jobs:
           TARGET: linux
           PYENV: pip
 
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
           python: 3.6
           other: /cython
           setup_options: --with-cython
@@ -96,7 +93,7 @@ jobs:
           PYENV: pip
           PACKAGES: cython
 
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
           python: 3.7
           other: /singletest
           category: neos
@@ -104,7 +101,7 @@ jobs:
           TARGET: linux
           PYENV: pip
 
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
           python: 3.7
           other: /pyutilib
           TARGET: linux
@@ -332,7 +329,7 @@ jobs:
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
                 curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-ubuntu1804-64.tar.gz \
+                    -L $URL/idaes-solvers-ubuntu2004-64.tar.gz \
                     > $IPOPT_TAR
             else
                 curl --max-time 150 --retry 8 \
@@ -558,7 +555,7 @@ jobs:
 
   bare-python-env:
     name: linux/3.6/bare-env
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
     - name: Checkout Pyomo source
@@ -605,10 +602,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
         include:
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
           TARGET: linux
         - os: macos-latest
           TARGET: osx

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -298,6 +298,19 @@ jobs:
         python -c 'import sys; print("PYTHON_EXE=%s" \
             % (sys.executable,))' >> $GITHUB_ENV
         echo "NOSETESTS="`which nosetests` >> $GITHUB_ENV
+        #
+        # conda activate puts itself first in the PATH, which overrides
+        # any paths we add through GITHUB_PATH.  We will update .profile
+        # to move the local runner paths back to the front (before conda).
+        for profile in $HOME/.profile $HOME/.bash_profile; do
+            if test ! -e $profile; then
+                continue
+            fi
+            echo '' >> $profile
+            echo 'export PATH=`echo "$PATH" \
+                | tr ":" "\\n" | grep runner | tr "\n" ":"`:`echo "$PATH" \
+                | tr ":" "\\n" | grep -v runner | tr "\n" ":"`' >> $profile
+        done
 
     - name: Setup TPL package directories
       run: |

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -99,9 +99,9 @@ class TestTiming(unittest.TestCase):
         RES = 0.02 # resolution (seconds): 1/5 the sleep
 
         # Note: pypy on GHA occasionally has timing
-        # differences of >0.03s
+        # differences of >0.04s
         if 'pypy_version_info' in dir(sys):
-            RES *= 2
+            RES *= 2.5
         # Note: previously, OSX on GHA also had significantly nosier tests
         # if sys.platform == 'darwin':
         #     RES *= 2

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -441,7 +441,7 @@ class Estimator(object):
                     for key in self.solver_options:
                         solver.options[key] = self.solver_options[key]
 
-                solve_result = solver.solve(ef, tee = True)#self.tee)
+                solve_result = solver.solve(ef, tee = self.tee)
 
             # The import error will be raised when we attempt to use
             # inv_reduced_hessian_barrier below.

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -441,7 +441,7 @@ class Estimator(object):
                     for key in self.solver_options:
                         solver.options[key] = self.solver_options[key]
 
-                solve_result = solver.solve(ef, tee = self.tee)
+                solve_result = solver.solve(ef, tee = True)#self.tee)
 
             # The import error will be raised when we attempt to use
             # inv_reduced_hessian_barrier below.

--- a/pyomo/contrib/pynumero/src/amplmp-3.1.0.patch
+++ b/pyomo/contrib/pynumero/src/amplmp-3.1.0.patch
@@ -2,8 +2,21 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 523faa7..2523b22 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -388,9 +388,6 @@  ** Disable AMPL testing
-   enable_cxx11(benchmark)
+@@ -336,8 +336,6 @@ check_cxx_source_compiles("
+   int main() {}" MP_VARIADIC_TEMPLATES)
+
+ if (MP_VARIADIC_TEMPLATES)
+-  add_executable(nl-example src/nl-example.cc)
+-  target_link_libraries(nl-example mp)
+ endif ()
+
+ add_subdirectory(doc)
+@@ -384,13 +384,8 @@ endforeach ()
+ if (MP_VARIADIC_TEMPLATES AND HAVE_ATOMIC)
+   option(BENCHMARK_ENABLE_TESTING
+          "Enable testing of the benchmark library." OFF)
+-  add_subdirectory(thirdparty/benchmark)
+-  enable_cxx11(benchmark)
  endif ()
  
 -enable_testing()

--- a/pyomo/contrib/pynumero/src/amplmp-3.1.0.patch
+++ b/pyomo/contrib/pynumero/src/amplmp-3.1.0.patch
@@ -4,12 +4,12 @@ index 523faa7..2523b22 100644
 +++ b/CMakeLists.txt
 @@ -336,8 +336,6 @@ check_cxx_source_compiles("
    int main() {}" MP_VARIADIC_TEMPLATES)
-
+ 
  if (MP_VARIADIC_TEMPLATES)
 -  add_executable(nl-example src/nl-example.cc)
 -  target_link_libraries(nl-example mp)
  endif ()
-
+ 
  add_subdirectory(doc)
 @@ -384,13 +384,8 @@ endforeach ()
  if (MP_VARIADIC_TEMPLATES AND HAVE_ATOMIC)


### PR DESCRIPTION
## Fixes #1710

## Summary/Motivation:
GHA was pinned back at `ubuntu-18.04` because our build of ampl/mp failed on the newer `ubuntu-20.04` (aka `ubuntu-latest`) platform.  `ubuntu-18.04` is deprecated by GHA and will be removed in September.

This PR "resolves" that build error by excluding the portions of ampl/mp that were failing from the build (none were needed to produce the `libasl.a` library).  This allows us to update to `ubuntu-latest`.

As part of the move, the pypy3 build will now build with pypy3.7 (instead of pypy3.6).

## Changes proposed in this PR:
- update ampl/mp patch to remove builds of problematic code.
- update GHA to use `ubuntu-latest`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
