### PR TITLE
Move constrained_layout tests to 'expensive' suite

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,6 +14,6 @@ coverage:
 #    - !ci.appveyor.com
 codecov:
   notify:
-    # GHA: 4, Jenkins: 4
-    after_n_builds: 8  # all
+    # GHA: 4, Jenkins: 8
+    after_n_builds: 12  # all
     wait_for_ci: yes

--- a/pyomo/contrib/gdpopt/tests/test_LBB.py
+++ b/pyomo/contrib/gdpopt/tests/test_LBB.py
@@ -87,6 +87,7 @@ class TestGDPopt_LBB(unittest.TestCase):
             fabs(value(strip_pack.total_length.expr) - 11) <= 1E-2)
 
     @unittest.skipUnless(license_available, "Problem is too big for unlicensed BARON.")
+    @unittest.category('expensive')
     def test_LBB_constrained_layout(self):
         """Test LBB with constrained layout."""
         exfile = import_file(
@@ -186,6 +187,7 @@ class TestGDPopt_LBB_Z3(unittest.TestCase):
             fabs(value(strip_pack.total_length.expr) - 11) <= 1E-2)
 
     @unittest.skipUnless(license_available, "Problem is too big for unlicensed BARON.")
+    @unittest.category('expensive')
     def test_LBB_constrained_layout(self):
         """Test LBB with constrained layout."""
         exfile = import_file(

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -257,6 +257,7 @@ class TestGDPopt(unittest.TestCase):
         self.assertTrue(
             fabs(value(strip_pack.total_length.expr) - 11) <= 1E-2)
 
+    @unittest.category('expensive')
     def test_LOA_constrained_layout_default_init(self):
         """Test LOA with constrained layout."""
         exfile = import_file(
@@ -467,6 +468,7 @@ class TestGDPoptRIC(unittest.TestCase):
         self.assertTrue(
             fabs(value(strip_pack.total_length.expr) - 11) <= 1E-2)
 
+    @unittest.category('expensive')
     def test_RIC_constrained_layout_default_init(self):
         """Test RIC with constrained layout."""
         exfile = import_file(
@@ -664,6 +666,7 @@ class TestGLOA(unittest.TestCase):
             fabs(value(strip_pack.total_length.expr) - 11) <= 1E-2)
 
     @unittest.skipUnless(license_available, "Global NLP solver license not available.")
+    @unittest.category('expensive')
     def test_GLOA_constrained_layout_default_init(self):
         """Test LOA with constrained layout."""
         exfile = import_file(


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Thia recategorizes the GDP `constrained_layout` tests as "expensive.  Coverage will be maintained through the Jenkins "expensive" test driver.

## Changes proposed in this PR:
- recategorize `constrained_layout` tests as expensive

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
