### PR TITLE
Fix sorted_robust whith nested tuples and user `key` function

### DIFF
--- a/pyomo/core/base/misc.py
+++ b/pyomo/core/base/misc.py
@@ -127,7 +127,7 @@ class _robust_sort_keyfcn(object):
         argument of the sort key.
 
         """
-        if use_key and self._key is not None:
+        if self._key is not None:
             val = self._key(val)
 
         return self._generate_sort_key(val)

--- a/pyomo/core/base/misc.py
+++ b/pyomo/core/base/misc.py
@@ -118,7 +118,7 @@ class _robust_sort_keyfcn(object):
         self._typemap[tuple] =(3, tuple.__name__)
         self._key = key
 
-    def __call__(self, val):
+    def __call__(self, val, use_key=True):
         """Generate a tuple ( str(type_name), val ) for sorting the value.
 
         `key=` expects a function.  We are generating a functor so we
@@ -127,7 +127,7 @@ class _robust_sort_keyfcn(object):
         argument of the sort key.
 
         """
-        if self._key is not None:
+        if use_key and self._key is not None:
             val = self._key(val)
 
         try:
@@ -156,7 +156,7 @@ class _robust_sort_keyfcn(object):
         if i == 1:
             return _typename, val
         elif i == 3:
-            return _typename, tuple(self(v) for v in val)
+            return _typename, tuple(self(v, use_key=False) for v in val)
         elif i == 2:
             return _typename, str(val)
         else:

--- a/pyomo/core/base/misc.py
+++ b/pyomo/core/base/misc.py
@@ -115,10 +115,10 @@ class _robust_sort_keyfcn(object):
     def __init__(self, key=None):
         # sort all native numeric types as if they were floats
         self._typemap = {t: (1, float.__name__) for t in native_numeric_types}
-        self._typemap[tuple] =(3, tuple.__name__)
+        self._typemap[tuple] =(4, tuple.__name__)
         self._key = key
 
-    def __call__(self, val, use_key=True):
+    def __call__(self, val):
         """Generate a tuple ( str(type_name), val ) for sorting the value.
 
         `key=` expects a function.  We are generating a functor so we
@@ -130,6 +130,9 @@ class _robust_sort_keyfcn(object):
         if use_key and self._key is not None:
             val = self._key(val)
 
+        return self._generate_sort_key(val)
+
+    def _generate_sort_key(self, val):
         try:
             i, _typename = self._typemap[val.__class__]
         except KeyError:
@@ -154,12 +157,16 @@ class _robust_sort_keyfcn(object):
                     i = 3
             self._typemap[_type] = i, _typename
         if i == 1:
+            # value type is directly comparable
             return _typename, val
-        elif i == 3:
-            return _typename, tuple(self(v, use_key=False) for v in val)
+        elif i == 4:
+            # nested tuple: recurse into it (so that the tuple is comparable)
+            return _typename, tuple(self._generate_sort_key(v) for v in val)
         elif i == 2:
+            # value type is convertible to string
             return _typename, str(val)
         else:
+            # everything else (incuding i==3), fall back on id()
             return _typename, id(val)
 
 

--- a/pyomo/core/tests/unit/test_base_misc.py
+++ b/pyomo/core/tests/unit/test_base_misc.py
@@ -54,6 +54,16 @@ class TestSortedRobust(unittest.TestCase):
         a = sorted_robust([('str1', 'str1'), ((1,), 'str2')])
         self.assertEqual(a, [('str1', 'str1'), ((1,), 'str2')])
 
+        # ensure it doesn't throw an error
+        # Test for issue https://github.com/Pyomo/pyomo/issues/2019
+        sorted_robust(
+            [
+                (("10_1", 2), None),
+                ((10, 2), None)
+            ],
+            key=lambda x: x[0]
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Fixes #2019

## Summary/Motivation:

See Issue

## Important note

Please see my note in the issue on finding a workaround while I'm waiting for the patch. Help would be much appreciated!

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
