### PR TITLE
Miscellaneous testing fixes

### DIFF
--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -248,8 +248,6 @@ doctest_default_flags = (
     doctest.ELLIPSIS + doctest.NORMALIZE_WHITESPACE +
     doctest.IGNORE_EXCEPTION_DETAIL + doctest.DONT_ACCEPT_TRUE_FOR_1
 )
-doctest_global_setup = '''
-import doctest
 class IgnoreResultOutputChecker(doctest.OutputChecker):
     IGNORE_RESULT = doctest.register_optionflag('IGNORE_RESULT')
     def check_output(self, want, got, optionflags):
@@ -258,6 +256,7 @@ class IgnoreResultOutputChecker(doctest.OutputChecker):
         return super().check_output(want, got, optionflags)
 doctest.OutputChecker = IgnoreResultOutputChecker
 
+doctest_global_setup = '''
 from pyomo.common.dependencies import (
     attempt_import, numpy_available, scipy_available, pandas_available,
     yaml_available, networkx_available, matplotlib_available,

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -182,7 +182,6 @@ class TestTiming(unittest.TestCase):
             r'\[    [.0-9]+\|   1\] .* in test_TicTocTimer_tictoc'
         )
 
-
     def test_TicTocTimer_context_manager(self):
         SLEEP = 0.1
         RES = 0.05 # resolution (seconds): 1/2 the sleep
@@ -196,7 +195,7 @@ class TestTiming(unittest.TestCase):
         with timer:
             time.sleep(SLEEP)
         abs_time = time.perf_counter() - abs_time
-        self.assertGreater(abs_time, SLEEP*3)
+        self.assertGreater(abs_time, SLEEP*3 - RES/10)
         self.assertAlmostEqual(timer.toc(None), abs_time - exclude, delta=RES)
 
     def test_HierarchicalTimer(self):

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -116,6 +116,7 @@ class TestPyomoEnviron(unittest.TestCase):
         # modules from the "standard" library.  Their order in the list
         # of slow-loading TPLs can vary from platform to platform.
         ref = {
+            '__future__',
             'argparse',
             'cPickle',
             'copy',

--- a/pyomo/scripting/util.py
+++ b/pyomo/scripting/util.py
@@ -71,7 +71,7 @@ def setup_environment(data):
     #
     postsolve = getattr(data.options, 'postsolve', None)
     if postsolve:
-        if not yaml_available and data.options.postsolve.results_format == 'yaml':
+        if data.options.postsolve.results_format == 'yaml' and not yaml_available:
             raise ValueError("Configuration specifies a yaml file, but pyyaml is not installed!")
     #
     global start_time

--- a/pyomo/solvers/tests/models/LP_trivial_constraints.py
+++ b/pyomo/solvers/tests/models/LP_trivial_constraints.py
@@ -9,7 +9,9 @@
 #  ___________________________________________________________________________
 
 import pyomo.kernel as pmo
-from pyomo.core import ConcreteModel, Var, Objective, Constraint, RealInterval, ConstraintList
+from pyomo.core import (
+    ConcreteModel, Var, Objective, Constraint, RangeSet, ConstraintList
+)
 from pyomo.solvers.tests.models.base import _BaseTestModel, register_model
 
 @register_model
@@ -32,7 +34,7 @@ class LP_trivial_constraints(_BaseTestModel):
         model = self.model
         model._name = self.description
 
-        model.x = Var(domain=RealInterval(bounds=(float('-inf'), None)))
+        model.x = Var(domain=RangeSet(float('-inf'), None, 0))
         model.y = Var(bounds=(None, float('inf')))
         model.obj = Objective(expr=model.x - model.y)
         model.c = ConstraintList()
@@ -92,7 +94,7 @@ class LP_trivial_constraints_kernel(LP_trivial_constraints):
         model = self.model
         model._name = self.description
 
-        model.x = pmo.variable(domain=RealInterval(bounds=(float('-inf'), None)))
+        model.x = pmo.variable(domain=RangeSet(float('-inf'), None, 0))
         model.y = pmo.variable(ub=float('inf'))
         model.obj = pmo.objective(model.x - model.y)
         model.c = pmo.constraint_dict()


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This resolves several intermittent testing failures observed over the past weeks:

## Changes proposed in this PR:
- update how we override `doctest.OutputChecker` (resolve intermittent failure on Windows)
- relax some timing comparisons
- remove use of deprecated functionality in tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
