### PR TITLE
More edge cases for FBBT

### DIFF
--- a/pyomo/contrib/fbbt/interval.py
+++ b/pyomo/contrib/fbbt/interval.py
@@ -74,7 +74,7 @@ def inv(xl, xu, feasibility_tol):
 
 
 def div(xl, xu, yl, yu, feasibility_tol):
-    if xl <= 0 <= xu and yl <= 0 <= yu:
+    if xl - feasibility_tol <= 0 <= xu + feasibility_tol and yl - feasibility_tol <= 0 <= yu + feasibility_tol:
         lb = -inf
         ub = inf
     else:

--- a/pyomo/contrib/fbbt/interval.py
+++ b/pyomo/contrib/fbbt/interval.py
@@ -29,12 +29,13 @@ def sub(xl, xu, yl, yu):
 
 
 def mul(xl, xu, yl, yu):
-    lb = min(xl*yl, xl*yu, xu*yl, xu*yu)
-    ub = max(xl*yl, xl*yu, xu*yl, xu*yu)
-    if math.isnan(lb):
+    options = [xl*yl, xl*yu, xu*yl, xu*yu]
+    if any(math.isnan(i) for i in options):
         lb = -inf
-    if math.isnan(ub):
         ub = inf
+    else:
+        lb = min(options)
+        ub = max(options)
     return lb, ub
 
 
@@ -49,7 +50,12 @@ def inv(xl, xu, feasibility_tol):
     if xu - xl <= -feasibility_tol:
         raise InfeasibleConstraintException(f'lower bound is greater than upper bound in inv; xl: {xl}; xu: {xu}')
     elif xu <= 0 <= xl:
-        raise IntervalException(f'Division by zero in inv; xl: {xl}; xu: {xu}')
+        # This has to return -inf to inf because it could later be multiplied by 0
+        lb = -inf
+        ub = inf
+    elif xl < 0 < xu:
+        lb = -inf
+        ub = inf
     elif 0 <= xl <= feasibility_tol:
         # xu must be strictly positive
         ub = inf
@@ -74,11 +80,7 @@ def inv(xl, xu, feasibility_tol):
 
 
 def div(xl, xu, yl, yu, feasibility_tol):
-    if xl - feasibility_tol <= 0 <= xu + feasibility_tol and yl - feasibility_tol <= 0 <= yu + feasibility_tol:
-        lb = -inf
-        ub = inf
-    else:
-        lb, ub = mul(xl, xu, *inv(yl, yu, feasibility_tol))
+    lb, ub = mul(xl, xu, *inv(yl, yu, feasibility_tol))
     return lb, ub
 
 

--- a/pyomo/contrib/fbbt/tests/test_interval.py
+++ b/pyomo/contrib/fbbt/tests/test_interval.py
@@ -67,8 +67,9 @@ class TestInterval(unittest.TestCase):
         self.assertEqual(lb, 10)
         self.assertEqual(ub, interval.inf)
 
-        with self.assertRaises(interval.IntervalException):
-            lb, ub = interval.inv(0, 0, feasibility_tol=1e-8)
+        lb, ub = interval.inv(0, 0, feasibility_tol=1e-8)
+        self.assertEqual(lb, -interval.inf)
+        self.assertEqual(ub, interval.inf)
 
         lb, ub = interval.inv(-0.1, 0, feasibility_tol=1e-8)
         self.assertEqual(lb, -interval.inf)
@@ -78,11 +79,13 @@ class TestInterval(unittest.TestCase):
         self.assertAlmostEqual(lb, -10)
         self.assertAlmostEqual(ub, -5)
 
-        with self.assertRaises(interval.IntervalException):
-            lb, ub = interval.inv(0, -1e-16, feasibility_tol=1e-8)
+        lb, ub = interval.inv(0, -1e-16, feasibility_tol=1e-8)
+        self.assertEqual(lb, -interval.inf)
+        self.assertEqual(ub, interval.inf)
 
-        with self.assertRaises(interval.IntervalException):
-            lb, ub = interval.inv(1e-16, 0, feasibility_tol=1e-8)
+        lb, ub = interval.inv(1e-16, 0, feasibility_tol=1e-8)
+        self.assertEqual(lb, -interval.inf)
+        self.assertEqual(ub, interval.inf)
 
         lb, ub = interval.inv(-1, 1, feasibility_tol=1e-8)
         self.assertAlmostEqual(lb, -interval.inf)
@@ -135,12 +138,10 @@ class TestInterval(unittest.TestCase):
                     (np.random.uniform(-5, -2), np.random.uniform(-2, 0))]
         for xl, xu in x_bounds:
             for yl, yu in y_bounds:
+                zl, zu = interval.power(xl, xu, yl, yu, feasibility_tol=1e-8)
                 if xl == 0 and xu == 0 and yu < 0:
-                    with self.assertRaises(interval.IntervalException):
-                        zl, zu = interval.power(xl, xu, yl, yu, feasibility_tol=1e-8)
-                    continue
-                else:
-                    zl, zu = interval.power(xl, xu, yl, yu, feasibility_tol=1e-8)
+                    self.assertEqual(zl, -interval.inf)
+                    self.assertEqual(zu, interval.inf)
                 x = np.linspace(xl, xu, 100)
                 y = np.linspace(yl, yu, 100)
                 for _x in x:
@@ -177,9 +178,10 @@ class TestInterval(unittest.TestCase):
                         if _yl > _yu:
                             continue
                         if _xl == 0 and _xu == 0 and _yu < 0:
-                            with self.assertRaises(interval.IntervalException):
-                                lb, ub = interval.power(_xl, _xu, _yl, _yu, feasibility_tol=1e-8)
-                        elif _yl == _yu and _yl != round(_yl) and (_xu < 0 or (_xu <= 0 and _yu < 0)):
+                            lb, ub = interval.power(_xl, _xu, _yl, _yu, feasibility_tol=1e-8)
+                            self.assertEqual(lb, -interval.inf)
+                            self.assertEqual(ub, interval.inf)
+                        elif _yl == _yu and _yl != round(_yl) and (_xu < 0 or (_xu < 0 and _yu < 0)):
                             with self.assertRaises((InfeasibleConstraintException, interval.IntervalException)):
                                 lb, ub = interval.power(_xl, _xu, _yl, _yu, feasibility_tol=1e-8)
                         else:
@@ -344,3 +346,7 @@ class TestInterval(unittest.TestCase):
         lb, ub = interval._inverse_power1(-1, -1e-12, 2, 2, -interval.inf, interval.inf, feasibility_tol=1e-8)
         self.assertAlmostEqual(lb, 0)
         self.assertAlmostEqual(ub, 0)
+
+        lb, ub = interval.mul(0, 0, -interval.inf, interval.inf)
+        self.assertEqual(lb, -interval.inf)
+        self.assertEqual(ub, interval.inf)

--- a/pyomo/contrib/fbbt/tests/test_interval.py
+++ b/pyomo/contrib/fbbt/tests/test_interval.py
@@ -106,6 +106,23 @@ class TestInterval(unittest.TestCase):
                     self.assertTrue(np.all(zl <= _z))
                     self.assertTrue(np.all(zu >= _z))
 
+    def test_div_edge_cases(self):
+        lb, ub = interval.div(0, -1e-16, 0, 0, 1e-8)
+        self.assertEqual(lb, -interval.inf)
+        self.assertEqual(ub, interval.inf)
+
+        lb, ub = interval.div(0, 1e-16, 0, 0, 1e-8)
+        self.assertEqual(lb, -interval.inf)
+        self.assertEqual(ub, interval.inf)
+
+        lb, ub = interval.div(-1e-16, 0, 0, 0, 1e-8)
+        self.assertEqual(lb, -interval.inf)
+        self.assertEqual(ub, interval.inf)
+
+        lb, ub = interval.div(1e-16, 0, 0, 0, 1e-8)
+        self.assertEqual(lb, -interval.inf)
+        self.assertEqual(ub, interval.inf)
+
     @unittest.skipIf(not numpy_available, 'Numpy is not available.')
     def test_pow(self):
         x_bounds = [(np.random.uniform(0, 2), np.random.uniform(2, 5)),


### PR DESCRIPTION
## Changes proposed in this PR:
This PR handles some more edge cases in the interval arithmetic in the FBBT module. In particular, 

```
div(0, -1e-16, 0, 0, 1e-8)
```

currently raises an exception. In reality, this should return `(-inf, inf)`.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
