### PR TITLE
Update xpress, appsi tests to manage CWD

### DIFF
--- a/pyomo/contrib/appsi/writers/tests/test_nl_writer.py
+++ b/pyomo/contrib/appsi/writers/tests/test_nl_writer.py
@@ -1,4 +1,5 @@
 import pyomo.common.unittest as unittest
+from pyomo.common.tempfiles import TempfileManager
 import pyomo.environ as pe
 try:
     from pyomo.contrib.appsi.cmodel import cmodel
@@ -9,14 +10,21 @@ import os
 
 
 class TestNLWriter(unittest.TestCase):
+    def _write_and_check_header(self, m, correct_lines):
+        writer = appsi.writers.NLWriter()
+        with TempfileManager:
+            fname = TempfileManager.create_tempfile(suffix='.appsi.nl')
+            writer.write(m, fname)
+            with open(fname, 'r') as f:
+                for ndx, line in enumerate(list(f.readlines())[:10]):
+                    self.assertTrue(line.startswith(correct_lines[ndx]))
+
     def test_header_1(self):
         m = pe.ConcreteModel()
         m.x = pe.Var()
         m.y = pe.Var()
         m.obj = pe.Objective(expr=m.x + m.y)
         m.c = pe.Constraint(expr=m.x + m.y == 1)
-        writer = appsi.writers.NLWriter()
-        writer.write(m, 'tmp.nl')
         correct_lines = ['g3 1 1 0',
                          '2 1 1 0 1',
                          '0 0',
@@ -27,11 +35,7 @@ class TestNLWriter(unittest.TestCase):
                          '2 2',
                          '0 0',
                          '0 0 0 0 0']
-        f = open('tmp.nl', 'r')
-        for ndx, line in enumerate(list(f.readlines())[:10]):
-            self.assertTrue(line.startswith(correct_lines[ndx]))
-        f.close()
-        os.remove('tmp.nl')
+        self._write_and_check_header(m, correct_lines)
 
     def test_header_2(self):
         m = pe.ConcreteModel()
@@ -39,8 +43,6 @@ class TestNLWriter(unittest.TestCase):
         m.y = pe.Var()
         m.obj = pe.Objective(expr=m.x**2 + m.y)
         m.c = pe.Constraint(expr=m.x + m.y == 1)
-        writer = appsi.writers.NLWriter()
-        writer.write(m, 'tmp.nl')
         correct_lines = ['g3 1 1 0',
                          '2 1 1 0 1',
                          '0 1',
@@ -51,11 +53,7 @@ class TestNLWriter(unittest.TestCase):
                          '2 2',
                          '0 0',
                          '0 0 0 0 0']
-        f = open('tmp.nl', 'r')
-        for ndx, line in enumerate(list(f.readlines())[:10]):
-            self.assertTrue(line.startswith(correct_lines[ndx]))
-        f.close()
-        os.remove('tmp.nl')
+        self._write_and_check_header(m, correct_lines)
 
     def test_header_3(self):
         m = pe.ConcreteModel()
@@ -63,8 +61,6 @@ class TestNLWriter(unittest.TestCase):
         m.y = pe.Var()
         m.obj = pe.Objective(expr=m.x + m.y)
         m.c = pe.Constraint(expr=m.x**2 + m.y == 1)
-        writer = appsi.writers.NLWriter()
-        writer.write(m, 'tmp.nl')
         correct_lines = ['g3 1 1 0',
                          '2 1 1 0 1',
                          '1 0',
@@ -75,11 +71,7 @@ class TestNLWriter(unittest.TestCase):
                          '2 2',
                          '0 0',
                          '0 0 0 0 0']
-        f = open('tmp.nl', 'r')
-        for ndx, line in enumerate(list(f.readlines())[:10]):
-            self.assertTrue(line.startswith(correct_lines[ndx]))
-        f.close()
-        os.remove('tmp.nl')
+        self._write_and_check_header(m, correct_lines)
 
     def test_header_4(self):
         m = pe.ConcreteModel()
@@ -87,8 +79,6 @@ class TestNLWriter(unittest.TestCase):
         m.y = pe.Var()
         m.obj = pe.Objective(expr=m.x**2 + m.y)
         m.c = pe.Constraint(expr=m.x**2 + m.y == 1)
-        writer = appsi.writers.NLWriter()
-        writer.write(m, 'tmp.nl')
         correct_lines = ['g3 1 1 0',
                          '2 1 1 0 1',
                          '1 1',
@@ -99,11 +89,7 @@ class TestNLWriter(unittest.TestCase):
                          '2 2',
                          '0 0',
                          '0 0 0 0 0']
-        f = open('tmp.nl', 'r')
-        for ndx, line in enumerate(list(f.readlines())[:10]):
-            self.assertTrue(line.startswith(correct_lines[ndx]))
-        f.close()
-        os.remove('tmp.nl')
+        self._write_and_check_header(m, correct_lines)
 
     def test_header_5(self):
         m = pe.ConcreteModel()
@@ -111,8 +97,6 @@ class TestNLWriter(unittest.TestCase):
         m.y = pe.Var()
         m.obj = pe.Objective(expr=m.x**2 + m.y**2)
         m.c = pe.Constraint(expr=m.x**2 + m.y == 1)
-        writer = appsi.writers.NLWriter()
-        writer.write(m, 'tmp.nl')
         correct_lines = ['g3 1 1 0',
                          '2 1 1 0 1',
                          '1 1',
@@ -123,11 +107,7 @@ class TestNLWriter(unittest.TestCase):
                          '2 2',
                          '0 0',
                          '0 0 0 0 0']
-        f = open('tmp.nl', 'r')
-        for ndx, line in enumerate(list(f.readlines())[:10]):
-            self.assertTrue(line.startswith(correct_lines[ndx]))
-        f.close()
-        os.remove('tmp.nl')
+        self._write_and_check_header(m, correct_lines)
 
     def test_header_6(self):
         m = pe.ConcreteModel()
@@ -135,8 +115,6 @@ class TestNLWriter(unittest.TestCase):
         m.y = pe.Var()
         m.obj = pe.Objective(expr=m.x**2 + m.y)
         m.c = pe.Constraint(expr=m.x**2 + m.y**2 == 1)
-        writer = appsi.writers.NLWriter()
-        writer.write(m, 'tmp.nl')
         correct_lines = ['g3 1 1 0',
                          '2 1 1 0 1',
                          '1 1',
@@ -147,11 +125,7 @@ class TestNLWriter(unittest.TestCase):
                          '2 2',
                          '0 0',
                          '0 0 0 0 0']
-        f = open('tmp.nl', 'r')
-        for ndx, line in enumerate(list(f.readlines())[:10]):
-            self.assertTrue(line.startswith(correct_lines[ndx]))
-        f.close()
-        os.remove('tmp.nl')
+        self._write_and_check_header(m, correct_lines)
 
     def test_header_7(self):
         m = pe.ConcreteModel()
@@ -159,8 +133,6 @@ class TestNLWriter(unittest.TestCase):
         m.y = pe.Var()
         m.obj = pe.Objective(expr=m.x + m.y)
         m.c = pe.Constraint(expr=m.x + m.y**2 == 1)
-        writer = appsi.writers.NLWriter()
-        writer.write(m, 'tmp.nl')
         correct_lines = ['g3 1 1 0',
                          '2 1 1 0 1',
                          '1 0',
@@ -171,11 +143,7 @@ class TestNLWriter(unittest.TestCase):
                          '2 2',
                          '0 0',
                          '0 0 0 0 0']
-        f = open('tmp.nl', 'r')
-        for ndx, line in enumerate(list(f.readlines())[:10]):
-            self.assertTrue(line.startswith(correct_lines[ndx]))
-        f.close()
-        os.remove('tmp.nl')
+        self._write_and_check_header(m, correct_lines)
 
     def test_header_8(self):
         m = pe.ConcreteModel()
@@ -183,8 +151,6 @@ class TestNLWriter(unittest.TestCase):
         m.y = pe.Var()
         m.obj = pe.Objective(expr=m.x + m.y)
         m.c = pe.Constraint(expr=m.x**2 + m.y**2 == 1)
-        writer = appsi.writers.NLWriter()
-        writer.write(m, 'tmp.nl')
         correct_lines = ['g3 1 1 0',
                          '2 1 1 0 1',
                          '1 0',
@@ -195,11 +161,7 @@ class TestNLWriter(unittest.TestCase):
                          '2 2',
                          '0 0',
                          '0 0 0 0 0']
-        f = open('tmp.nl', 'r')
-        for ndx, line in enumerate(list(f.readlines())[:10]):
-            self.assertTrue(line.startswith(correct_lines[ndx]))
-        f.close()
-        os.remove('tmp.nl')
+        self._write_and_check_header(m, correct_lines)
 
     def test_header_9(self):
         m = pe.ConcreteModel()
@@ -207,8 +169,6 @@ class TestNLWriter(unittest.TestCase):
         m.y = pe.Var()
         m.obj = pe.Objective(expr=m.x + m.y**2)
         m.c = pe.Constraint(expr=m.x + m.y == 1)
-        writer = appsi.writers.NLWriter()
-        writer.write(m, 'tmp.nl')
         correct_lines = ['g3 1 1 0',
                          '2 1 1 0 1',
                          '0 1',
@@ -219,11 +179,7 @@ class TestNLWriter(unittest.TestCase):
                          '2 2',
                          '0 0',
                          '0 0 0 0 0']
-        f = open('tmp.nl', 'r')
-        for ndx, line in enumerate(list(f.readlines())[:10]):
-            self.assertTrue(line.startswith(correct_lines[ndx]))
-        f.close()
-        os.remove('tmp.nl')
+        self._write_and_check_header(m, correct_lines)
 
     def test_header_10(self):
         m = pe.ConcreteModel()
@@ -231,8 +187,6 @@ class TestNLWriter(unittest.TestCase):
         m.y = pe.Var()
         m.obj = pe.Objective(expr=m.x + m.y**2)
         m.c = pe.Constraint(expr=m.x + m.y**2 == 1)
-        writer = appsi.writers.NLWriter()
-        writer.write(m, 'tmp.nl')
         correct_lines = ['g3 1 1 0',
                          '2 1 1 0 1',
                          '1 1',
@@ -243,11 +197,7 @@ class TestNLWriter(unittest.TestCase):
                          '2 2',
                          '0 0',
                          '0 0 0 0 0']
-        f = open('tmp.nl', 'r')
-        for ndx, line in enumerate(list(f.readlines())[:10]):
-            self.assertTrue(line.startswith(correct_lines[ndx]))
-        f.close()
-        os.remove('tmp.nl')
+        self._write_and_check_header(m, correct_lines)
 
     def test_header_11(self):
         m = pe.ConcreteModel()
@@ -255,8 +205,6 @@ class TestNLWriter(unittest.TestCase):
         m.y = pe.Var()
         m.obj = pe.Objective(expr=m.x + m.y**2)
         m.c = pe.Constraint(expr=m.x**2 + m.y == 1)
-        writer = appsi.writers.NLWriter()
-        writer.write(m, 'tmp.nl')
         correct_lines = ['g3 1 1 0',
                          '2 1 1 0 1',
                          '1 1',
@@ -267,11 +215,7 @@ class TestNLWriter(unittest.TestCase):
                          '2 2',
                          '0 0',
                          '0 0 0 0 0']
-        f = open('tmp.nl', 'r')
-        for ndx, line in enumerate(list(f.readlines())[:10]):
-            self.assertTrue(line.startswith(correct_lines[ndx]))
-        f.close()
-        os.remove('tmp.nl')
+        self._write_and_check_header(m, correct_lines)
 
     def test_header_12(self):
         m = pe.ConcreteModel()
@@ -279,8 +223,6 @@ class TestNLWriter(unittest.TestCase):
         m.y = pe.Var()
         m.obj = pe.Objective(expr=m.x + m.y**2)
         m.c = pe.Constraint(expr=m.x**2 + m.y**2 == 1)
-        writer = appsi.writers.NLWriter()
-        writer.write(m, 'tmp.nl')
         correct_lines = ['g3 1 1 0',
                          '2 1 1 0 1',
                          '1 1',
@@ -291,11 +233,7 @@ class TestNLWriter(unittest.TestCase):
                          '2 2',
                          '0 0',
                          '0 0 0 0 0']
-        f = open('tmp.nl', 'r')
-        for ndx, line in enumerate(list(f.readlines())[:10]):
-            self.assertTrue(line.startswith(correct_lines[ndx]))
-        f.close()
-        os.remove('tmp.nl')
+        self._write_and_check_header(m, correct_lines)
 
     def test_header_13(self):
         m = pe.ConcreteModel()
@@ -303,8 +241,6 @@ class TestNLWriter(unittest.TestCase):
         m.y = pe.Var()
         m.obj = pe.Objective(expr=m.x**2 + m.y)
         m.c = pe.Constraint(expr=m.x + m.y**2 == 1)
-        writer = appsi.writers.NLWriter()
-        writer.write(m, 'tmp.nl')
         correct_lines = ['g3 1 1 0',
                          '2 1 1 0 1',
                          '1 1',
@@ -315,11 +251,7 @@ class TestNLWriter(unittest.TestCase):
                          '2 2',
                          '0 0',
                          '0 0 0 0 0']
-        f = open('tmp.nl', 'r')
-        for ndx, line in enumerate(list(f.readlines())[:10]):
-            self.assertTrue(line.startswith(correct_lines[ndx]))
-        f.close()
-        os.remove('tmp.nl')
+        self._write_and_check_header(m, correct_lines)
 
     def test_header_14(self):
         m = pe.ConcreteModel()
@@ -327,8 +259,6 @@ class TestNLWriter(unittest.TestCase):
         m.y = pe.Var()
         m.obj = pe.Objective(expr=m.x**2 + m.y**2)
         m.c = pe.Constraint(expr=m.x + m.y == 1)
-        writer = appsi.writers.NLWriter()
-        writer.write(m, 'tmp.nl')
         correct_lines = ['g3 1 1 0',
                          '2 1 1 0 1',
                          '0 1',
@@ -339,11 +269,7 @@ class TestNLWriter(unittest.TestCase):
                          '2 2',
                          '0 0',
                          '0 0 0 0 0']
-        f = open('tmp.nl', 'r')
-        for ndx, line in enumerate(list(f.readlines())[:10]):
-            self.assertTrue(line.startswith(correct_lines[ndx]))
-        f.close()
-        os.remove('tmp.nl')
+        self._write_and_check_header(m, correct_lines)
 
     def test_header_15(self):
         m = pe.ConcreteModel()
@@ -351,8 +277,6 @@ class TestNLWriter(unittest.TestCase):
         m.y = pe.Var()
         m.obj = pe.Objective(expr=m.x**2 + m.y**2)
         m.c = pe.Constraint(expr=m.x + m.y**2 == 1)
-        writer = appsi.writers.NLWriter()
-        writer.write(m, 'tmp.nl')
         correct_lines = ['g3 1 1 0',
                          '2 1 1 0 1',
                          '1 1',
@@ -363,11 +287,7 @@ class TestNLWriter(unittest.TestCase):
                          '2 2',
                          '0 0',
                          '0 0 0 0 0']
-        f = open('tmp.nl', 'r')
-        for ndx, line in enumerate(list(f.readlines())[:10]):
-            self.assertTrue(line.startswith(correct_lines[ndx]))
-        f.close()
-        os.remove('tmp.nl')
+        self._write_and_check_header(m, correct_lines)
 
     def test_header_16(self):
         m = pe.ConcreteModel()
@@ -375,8 +295,6 @@ class TestNLWriter(unittest.TestCase):
         m.y = pe.Var()
         m.obj = pe.Objective(expr=m.x**2 + m.y**2)
         m.c = pe.Constraint(expr=m.x**2 + m.y**2 == 1)
-        writer = appsi.writers.NLWriter()
-        writer.write(m, 'tmp.nl')
         correct_lines = ['g3 1 1 0',
                          '2 1 1 0 1',
                          '1 1',
@@ -387,8 +305,4 @@ class TestNLWriter(unittest.TestCase):
                          '2 2',
                          '0 0',
                          '0 0 0 0 0']
-        f = open('tmp.nl', 'r')
-        for ndx, line in enumerate(list(f.readlines())[:10]):
-            self.assertTrue(line.startswith(correct_lines[ndx]))
-        f.close()
-        os.remove('tmp.nl')
+        self._write_and_check_header(m, correct_lines)

--- a/pyomo/solvers/tests/checks/test_xpress_persistent.py
+++ b/pyomo/solvers/tests/checks/test_xpress_persistent.py
@@ -1,13 +1,7 @@
 import pyomo.common.unittest as unittest
 import pyomo.environ as pe
 from pyomo.core.expr.taylor_series import taylor_series_expansion
-try:
-    import xpress
-    p = xpress.problem()
-    del p
-    xpress_available = True
-except:
-    xpress_available = False
+from pyomo.solvers.plugins.solvers.xpress_direct import xpress_available
 
 class TestXpressPersistent(unittest.TestCase):
     @unittest.skipIf(not xpress_available, "xpress is not available")


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Importing `xpress` when the bindings are present but not licensed causes the CWD to change.  This fixes a test that was directly importing `xpress` instead of using `xpress_direct.xpress_available` (which manages the CWD).

The bug also highlighted that the APPSI NL writer tests assumed that the CWD was writable.  This switches those tests to use the TempfileManager to create (and remove) temporary files.

## Changes proposed in this PR:
- Use  `xpress_direct.xpress_available` to detect xpress python API availability
- Use TempfileManager in APPSI NL writer tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
