### PR TITLE
Improve management of tempfiles in tests

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -18,7 +18,7 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
-  CACHE_VER: v210618.0
+  CACHE_VER: v210630.0
   NEOS_EMAIL: tests@pyomo.org
 
 jobs:

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -21,7 +21,7 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
-  CACHE_VER: v210618.0
+  CACHE_VER: v210630.0
   NEOS_EMAIL: tests@pyomo.org
 
 jobs:

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -500,6 +500,11 @@ class TestCase(_unittest.TestCase):
         # Disable nose's use of test docstrings for the test description.
         return None
 
+    def currentTestPassed(self):
+        # Note: this only works for Python 3.4+
+        return not (self._outcome and any(
+            test is self and err for test, err in self._outcome.errors))
+
     def assertStructuredAlmostEqual(self, first, second,
                                     places=None, msg=None, delta=None,
                                     reltol=None, abstol=None,

--- a/pyomo/contrib/community_detection/tests/test_detection.py
+++ b/pyomo/contrib/community_detection/tests/test_detection.py
@@ -20,12 +20,18 @@ from io import StringIO
 
 from pyomo.common.dependencies import networkx_available, matplotlib_available
 from pyomo.common.log import LoggingIntercept
-from pyomo.environ import ConcreteModel, Constraint, Objective, Var, Integers, minimize, RangeSet, Block, ConstraintList
+from pyomo.common.tempfiles import TempfileManager
+from pyomo.environ import (
+    ConcreteModel, Constraint, Objective, Var, Integers, minimize,
+    RangeSet, Block, ConstraintList,
+)
 from pyomo.contrib.community_detection.detection import (
     detect_communities, CommunityMap,
     community_louvain_available, community_louvain
 )
-from pyomo.contrib.community_detection.community_graph import generate_model_graph
+from pyomo.contrib.community_detection.community_graph import (
+    generate_model_graph,
+)
 
 from pyomo.solvers.tests.models.LP_unbounded import LP_unbounded
 from pyomo.solvers.tests.models.QP_simple import QP_simple
@@ -619,7 +625,10 @@ class TestDecomposition(unittest.TestCase):
         model = decode_model_1()
         community_map_object = detect_communities(model)
 
-        fig, pos = community_map_object.visualize_model_graph(filename='test_visualize_model_graph_1')
+        with TempfileManager:
+            fig, pos = community_map_object.visualize_model_graph(
+                filename=TempfileManager.create_tempfile(
+                    'test_visualize_model_graph_1.png'))
         correct_pos_dict_length = 5
 
         self.assertTrue(isinstance(pos, dict))
@@ -630,8 +639,11 @@ class TestDecomposition(unittest.TestCase):
         model = decode_model_2()
         community_map_object = detect_communities(model)
 
-        fig, pos = community_map_object.visualize_model_graph(type_of_graph='bipartite',
-                                                              filename='test_visualize_model_graph_2')
+        with TempfileManager:
+            fig, pos = community_map_object.visualize_model_graph(
+                type_of_graph='bipartite',
+                filename=TempfileManager.create_tempfile(
+                    'test_visualize_model_graph_2.png'))
         correct_pos_dict_length = 13
 
         self.assertTrue(isinstance(pos, dict))

--- a/pyomo/core/tests/examples/test_pyomo.py
+++ b/pyomo/core/tests/examples/test_pyomo.py
@@ -24,6 +24,7 @@ import pyomo.common.unittest as unittest
 from pyomo.common.dependencies import yaml_available
 from pyomo.common.fileutils import this_file_dir
 from pyomo.common.tee import capture_output
+from pyomo.common.tempfiles import TempfileManager
 import pyomo.core
 import pyomo.scripting.pyomo_main as main
 from pyomo.opt import check_available_solvers
@@ -32,17 +33,9 @@ from io import StringIO
 
 currdir = this_file_dir()
 
-if os.path.exists(sys.exec_prefix+os.sep+'bin'+os.sep+'coverage'):
-    executable=sys.exec_prefix+os.sep+'bin'+os.sep+'coverage -x '
-else:
-    executable=sys.executable
-
-def filter_fn(line):
-    tmp = line.strip()
-    return tmp.startswith('Disjunct') or tmp.startswith('DEPRECATION') or tmp.startswith('DiffSet') or line.startswith('    ') or tmp.startswith("Differential") or tmp.startswith("DerivativeVar") or tmp.startswith("InputVar") or tmp.startswith('StateVar') or tmp.startswith('Complementarity')
-
-
 _diff_tol = 1e-6
+
+deleteFiles = True
 
 solvers = None
 class BaseTester(unittest.TestCase):
@@ -55,12 +48,14 @@ class BaseTester(unittest.TestCase):
 
     def pyomo(self, cmd, **kwds):
         if 'root' in kwds:
-            OUTPUT=kwds['root']+'.out'
-            results=kwds['root']+'.jsn'
-            self.ofile = OUTPUT
+            OUTPUT = kwds['root'] + '.out'
+            results = kwds['root'] + '.jsn'
+            TempfileManager.add_tempfile(OUTPUT, exists=False)
+            TempfileManager.add_tempfile(results, exists=False)
         else:
-            OUTPUT=StringIO()
-            results='results.jsn'
+            OUTPUT = StringIO()
+            results = 'results.jsn'
+            TempfileManager.create_tempfile(suffix='results.jsn')
         with capture_output(OUTPUT):
             try:
                 _dir = os.getcwd()
@@ -81,23 +76,21 @@ class BaseTester(unittest.TestCase):
         return output
 
     def setUp(self):
-        self.ofile = None
         if not 'glpk' in solvers:
             self.skipTest("GLPK is not installed")
+        TempfileManager.push()
 
     def tearDown(self):
-        return
-        if self.ofile and os.path.exists(self.ofile):
-            return
-            os.remove(self.ofile)
-        if os.path.exists(join(currdir, 'results.jsn')):
-            return
-            os.remove(join(currdir, 'results.jsn'))
+        TempfileManager.pop(remove=deleteFiles or self.currentTestPassed())
 
-    def run_pyomo(self, cmd, root=None):
-        cmd = ('pyomo solve --solver=glpk --results-format=json ' \
-              '--save-results=%s.jsn %s' % (root, cmd)).split(' ')
-        with open(root+'.out', 'w') as f:
+    def run_pyomo(self, cmd, root):
+        results = root + '.jsn'
+        TempfileManager.add_tempfile(results, exists=False)
+        output = root + '.out'
+        TempfileManager.add_tempfile(output, exists=False)
+        cmd = ['pyomo', 'solve', '--solver=glpk', '--results-format=json',
+               '--save-results=%s' % results] + cmd
+        with open(output, 'w') as f:
             result = subprocess.run(cmd, stdout=f, stderr=f)
         return result
 
@@ -146,11 +139,11 @@ class TestJson(BaseTester):
         # Simple execution of 'pyomo'
         self.pyomo([join(currdir, 'pmedian.py'),join(currdir, 'pmedian.dat')], root=join(currdir, 'test1'))
         self.compare_json(join(currdir, 'test1.jsn'), join(currdir, 'test1.txt'))
-        os.remove(os.path.join(currdir, 'test1.out'))
 
     def test1a_simple_pyomo_execution(self):
         # Simple execution of 'pyomo' in a subprocess
-        files = os.path.join(currdir, 'pmedian.py') + ' ' + os.path.join(currdir, 'pmedian.dat')
+        files = [ os.path.join(currdir, 'pmedian.py'),
+                  os.path.join(currdir, 'pmedian.dat') ]
         self.run_pyomo(files, root=os.path.join(currdir, 'test1a'))
         self.compare_json(join(currdir, 'test1a.jsn'), join(currdir, 'test1.txt'))
 
@@ -158,7 +151,6 @@ class TestJson(BaseTester):
         # Simple execution of 'pyomo' with a configuration file
         self.pyomo(join(currdir, 'test1b.json'), root=join(currdir, 'test1'))
         self.compare_json(join(currdir, 'test1.jsn'), join(currdir, 'test1.txt'))
-        os.remove(os.path.join(currdir, 'test1.out'))
 
     def test2_bad_model_name(self):
         # Run pyomo with bad --model-name option value
@@ -174,105 +166,89 @@ class TestJson(BaseTester):
         # Run pyomo with model that does not define model object
         self.pyomo('pmedian1.py pmedian.dat', root=join(currdir, 'test3'))
         self.compare_json(join(currdir, "test3.jsn"), join(currdir, "test1.txt"))
-        os.remove(os.path.join(currdir, 'test3.out'))
 
     def test4_valid_modelname_option(self):
         # Run pyomo with good --model-name option value
         self.pyomo('--model-name=MODEL '+join(currdir, 'pmedian1.py pmedian.dat'), root=join(currdir, 'test4'))
         self.compare_json(join(currdir, "test4.jsn"), join(currdir, "test1.txt"))
-        os.remove(os.path.join(currdir, 'test4.out'))
 
     def test4b_valid_modelname_option(self):
         # Run pyomo with good 'object name' option value (configfile)
         self.pyomo(join(currdir, 'test4b.json'), root=join(currdir, 'test4b'))
         self.compare_json(join(currdir, "test4b.jsn"), join(currdir, "test1.txt"))
-        os.remove(os.path.join(currdir, 'test4b.out'))
 
     def test5_create_model_fcn(self):
         #"""Run pyomo with create_model function"""
         self.pyomo('pmedian2.py pmedian.dat', root=join(currdir, 'test5'))
         self.compare_files(join(currdir, "test5.out"), join(currdir, "test5.txt"))
-        os.remove(os.path.join(currdir, 'test5.jsn'))
 
     def test5b_create_model_fcn(self):
         # Run pyomo with create_model function (configfile)
         self.pyomo(join(currdir, 'test5b.json'), root=join(currdir, 'test5'))
         self.compare_files(join(currdir, "test5.out"), join(currdir, "test5.txt"))
-        os.remove(os.path.join(currdir, 'test5.jsn'))
 
     def test8_instanceonly_option(self):
         #"""Run pyomo with --instance-only option"""
         output = self.pyomo('--instance-only pmedian.py pmedian.dat', root=join(currdir, 'test8'))
         self.assertEqual(type(output.retval.instance), pyomo.core.ConcreteModel)
         # Check that the results file was NOT created
-        self.assertRaises(OSError, lambda: os.remove(join(currdir, 'test8.jsn')))
-        os.remove(os.path.join(currdir, 'test8.out'))
+        self.assertFalse(os.path.exists(join(currdir, 'test8.jsn')))
 
     def test8b_instanceonly_option(self):
         # Run pyomo with --instance-only option (configfile)
         output = self.pyomo(join(currdir, 'test8b.json'), root=join(currdir, 'test8'))
         self.assertEqual(type(output.retval.instance), pyomo.core.ConcreteModel)
         # Check that the results file was NOT created
-        self.assertRaises(OSError, lambda: os.remove(join(currdir, 'test8.jsn')))
-        os.remove(os.path.join(currdir, 'test8.out'))
+        self.assertFalse(os.path.exists(join(currdir, 'test8.jsn')))
 
     def test9_disablegc_option(self):
         #"""Run pyomo with --disable-gc option"""
         output = self.pyomo('--disable-gc pmedian.py pmedian.dat', root=join(currdir, 'test9'))
         self.assertEqual(type(output.retval.instance), pyomo.core.ConcreteModel)
-        os.remove(os.path.join(currdir, 'test9.jsn'))
-        os.remove(os.path.join(currdir, 'test9.out'))
 
     def test9b_disablegc_option(self):
         # Run pyomo with --disable-gc option (configfile)
         output = self.pyomo(join(currdir, 'test9b.json'), root=join(currdir, 'test9'))
         self.assertEqual(type(output.retval.instance), pyomo.core.ConcreteModel)
-        os.remove(os.path.join(currdir, 'test9.jsn'))
-        os.remove(os.path.join(currdir, 'test9.out'))
 
     def test12_output_option(self):
         #"""Run pyomo with --output option"""
-        self.pyomo('--logfile=%s pmedian.py pmedian.dat' % (join(currdir, 'test12.log')), root=join(currdir, 'test12'))
+        log = join(currdir, 'test12.log')
+        TempfileManager.add_tempfile(log, exists=False)
+        self.pyomo('--logfile=%s pmedian.py pmedian.dat' % (log,), root=join(currdir, 'test12'))
         self.compare_json(join(currdir, "test12.jsn"), join(currdir, "test12.txt"))
-        os.remove(os.path.join(currdir, 'test12.log'))
-        os.remove(os.path.join(currdir, 'test12.out'))
 
     def test12b_output_option(self):
         # Run pyomo with --output option (configfile)
+        log = join(currdir, 'test12b.log')
+        TempfileManager.add_tempfile(log, exists=False)
         self.pyomo(join(currdir, 'test12b.json'), root=join(currdir, 'test12'))
         self.compare_json(join(currdir, "test12.jsn"), join(currdir, "test12.txt"))
-        os.remove(os.path.join(currdir, 'test12b.log'))
-        os.remove(os.path.join(currdir, 'test12.out'))
 
     def test14_concrete_model_with_constraintlist(self):
         # Simple execution of 'pyomo' with a concrete model and constraint lists
         self.pyomo('pmedian4.py', root=join(currdir, 'test14'))
         self.compare_json(join(currdir, "test14.jsn"), join(currdir, "test14.txt"))
-        os.remove(os.path.join(currdir, 'test14.out'))
 
     def test14b_concrete_model_with_constraintlist(self):
         # Simple execution of 'pyomo' with a concrete model and constraint lists (configfile)
         self.pyomo('pmedian4.py', root=join(currdir, 'test14'))
         self.compare_json(join(currdir, "test14.jsn"), join(currdir, "test14.txt"))
-        os.remove(os.path.join(currdir, 'test14.out'))
 
     def test15_simple_pyomo_execution(self):
         # Simple execution of 'pyomo' with options
         self.pyomo(['--solver-options="mipgap=0.02 cuts="', join(currdir, 'pmedian.py'), 'pmedian.dat'], root=join(currdir, 'test15'))
         self.compare_json(join(currdir, "test15.jsn"), join(currdir, "test1.txt"))
-        os.remove(os.path.join(currdir, 'test15.out'))
 
     def test15b_simple_pyomo_execution(self):
         # Simple execution of 'pyomo' with options
         self.pyomo(join(currdir, 'test15b.json'), root=join(currdir, 'test15b'))
         self.compare_json(join(currdir, "test15b.jsn"), join(currdir, "test1.txt"))
-        os.remove(os.path.join(currdir, 'test15b.out'))
 
     def test15c_simple_pyomo_execution(self):
         # Simple execution of 'pyomo' with options
         self.pyomo(join(currdir, 'test15c.json'), root=join(currdir, 'test15c'))
         self.compare_json(join(currdir, "test15c.jsn"), join(currdir, "test1.txt"))
-        os.remove(os.path.join(currdir, 'test15c.out'))
 
 
 @unittest.skipIf(not yaml_available, "YAML not available available")
@@ -291,14 +267,13 @@ class TestWithYaml(BaseTester):
         # Simple execution of 'pyomo' with options
         self.pyomo(join(currdir, 'test15b.yaml'), root=join(currdir, 'test15b'))
         self.compare_json(join(currdir, "test15b.jsn"), join(currdir, "test1.txt"))
-        os.remove(os.path.join(currdir, 'test15b.out'))
 
     def test15c_simple_pyomo_execution(self):
         # Simple execution of 'pyomo' with options
         self.pyomo(join(currdir, 'test15c.yaml'), root=join(currdir, 'test15c'))
         self.compare_json(join(currdir, "test15c.jsn"), join(currdir, "test1.txt"))
-        os.remove(os.path.join(currdir, 'test15c.out'))
 
 
 if __name__ == "__main__":
+    deleteFiles = False
     unittest.main()

--- a/pyomo/opt/problem/ampl.py
+++ b/pyomo/opt/problem/ampl.py
@@ -63,5 +63,7 @@ class AmplModel(object):
             args = (self.modfile, self.datfile)
         res = convert_problem(args, format, [format], solver_capability)
         if filename is not None and res[0][0] != filename:
+            if os.path.exists(filename):
+                os.remove(filename)
             os.rename(res[0][0], filename)
 

--- a/pyomo/opt/problem/ampl.py
+++ b/pyomo/opt/problem/ampl.py
@@ -62,6 +62,6 @@ class AmplModel(object):
         else:
             args = (self.modfile, self.datfile)
         res = convert_problem(args, format, [format], solver_capability)
-        if not filename is None:
+        if filename is not None and res[0][0] != filename:
             os.rename(res[0][0], filename)
 

--- a/pyomo/opt/tests/base/test_ampl.py
+++ b/pyomo/opt/tests/base/test_ampl.py
@@ -15,19 +15,20 @@ from itertools import zip_longest
 import json
 import os
 import sys
-from os.path import abspath, dirname, join
-currdir = dirname(abspath(__file__))+os.sep
-
+from os.path import join
 from filecmp import cmp
+
 import pyomo.common.unittest as unittest
-from pyomo.common.tempfiles import TempfileManager
+
 from pyomo.common.errors import ApplicationError
+from pyomo.common.fileutils import this_file_dir
+from pyomo.common.tempfiles import TempfileManager
 
 import pyomo.opt
 
-old_tempdir = TempfileManager.tempdir
+currdir = this_file_dir()
+deleteFiles = True
 
-solver = None
 class Test(unittest.TestCase):
 
     @classmethod
@@ -37,18 +38,18 @@ class Test(unittest.TestCase):
         solvers = pyomo.opt.check_available_solvers('glpk')
 
     def setUp(self):
-        TempfileManager.tempdir = currdir
+        TempfileManager.push()
 
     def tearDown(self):
-        TempfileManager.clear_tempfiles()
-        TempfileManager.tempdir = old_tempdir
+        TempfileManager.pop(remove=deleteFiles or self.currentTestPassed())
 
     def test3_write_nl(self):
         """ Convert from AMPL to NL """
         self.model = pyomo.opt.AmplModel(join(currdir, 'test3.mod'))
         """ Convert from MOD+DAT to NL """
+        _test = TempfileManager.create_tempfile(suffix='test3.nl')
         try:
-            self.model.write(join(currdir, 'test3.nl'))
+            self.model.write(_test)
         except ApplicationError:
             err = sys.exc_info()[1]
             if pyomo.common.Executable("ampl"):
@@ -61,7 +62,6 @@ class Test(unittest.TestCase):
                 self.fail("Unexpected ConverterError - ampl is enabled "
                           "but not available: '%s'" % str(err))
             return
-        _test = join(currdir, 'test3.nl')
         _base = join(currdir, 'test3.baseline.nl')
         with open(_test, 'r') as run, open(_base, 'r') as baseline:
             for line1, line2 in zip_longest(run, baseline):
@@ -77,8 +77,9 @@ class Test(unittest.TestCase):
     def test3_write_lp(self):
         """ Convert from AMPL to LP """
         self.model = pyomo.opt.AmplModel(join(currdir, 'test3.mod'))
+        _test = TempfileManager.create_tempfile(suffix='test3.lp')
         try:
-            self.model.write(join(currdir, 'test3.lp'))
+            self.model.write(_test)
         except ApplicationError:
             err = sys.exc_info()[1]
             if pyomo.common.Executable("glpsol"):
@@ -91,7 +92,6 @@ class Test(unittest.TestCase):
                 self.fail("Unexpected ConverterError - glpsol is enabled "
                           "but not available: '%s'" % str(err))
             return
-        _test = join(currdir, 'test3.lp')
         _base = join(currdir, 'test3.baseline.lp')
         with open(_test, 'r') as run, open(_base, 'r') as baseline:
             for line1, line2 in zip_longest(run, baseline):
@@ -109,8 +109,9 @@ class Test(unittest.TestCase):
         if not pyomo.common.Executable("ampl"):
             self.skipTest("The ampl executable is not available")
         self.model = pyomo.opt.AmplModel(join(currdir, 'test3.mod'))
+        _test = TempfileManager.create_tempfile(suffix='test3.mps')
         try:
-            self.model.write(join(currdir, 'test3.mps'))
+            self.model.write(_test)
         except ApplicationError:
             err = sys.exc_info()[1]
             if pyomo.common.Executable("ampl"):
@@ -123,7 +124,6 @@ class Test(unittest.TestCase):
                 self.fail("Unexpected ConverterError - ampl is enabled "
                           "but not available: '%s'" % str(err))
             return
-        _test = join(currdir, 'test3.mps')
         _base = join(currdir, 'test3.baseline.mps')
         with open(_test, 'r') as run, open(_base, 'r') as baseline:
             for line1, line2 in zip_longest(run, baseline):
@@ -138,9 +138,11 @@ class Test(unittest.TestCase):
 
     def test3a_write_nl(self):
         """ Convert from AMPL to NL """
-        self.model = pyomo.opt.AmplModel(join(currdir, 'test3a.mod'), join(currdir, 'test3a.dat'))
+        self.model = pyomo.opt.AmplModel(
+            join(currdir, 'test3a.mod'), join(currdir, 'test3a.dat'))
+        _test = TempfileManager.create_tempfile(suffix='test3a.nl')
         try:
-            self.model.write(join(currdir, 'test3a.nl'))
+            self.model.write(_test)
         except ApplicationError:
             err = sys.exc_info()[1]
             if pyomo.common.Executable("ampl"):
@@ -153,7 +155,6 @@ class Test(unittest.TestCase):
                 self.fail("Unexpected ConverterError - ampl is enabled "
                           "but not available: '%s'" % str(err))
             return
-        _test = join(currdir, 'test3a.nl')
         _base = join(currdir, 'test3.baseline.nl')
         with open(_test, 'r') as run, open(_base, 'r') as baseline:
             for line1, line2 in zip_longest(run, baseline):
@@ -168,9 +169,11 @@ class Test(unittest.TestCase):
 
     def test3a_write_lp(self):
         """ Convert from AMPL to LP """
-        self.model = pyomo.opt.AmplModel(join(currdir, 'test3a.mod'), join(currdir, 'test3a.dat'))
+        self.model = pyomo.opt.AmplModel(
+            join(currdir, 'test3a.mod'), join(currdir, 'test3a.dat'))
+        _test = TempfileManager.create_tempfile(suffix='test3a.lp')
         try:
-            self.model.write(join(currdir, 'test3a.lp'))
+            self.model.write(_test)
         except ApplicationError:
             err = sys.exc_info()[1]
             if pyomo.common.Executable("glpsol"):
@@ -183,7 +186,6 @@ class Test(unittest.TestCase):
                 self.fail("Unexpected ConverterError - glpsol is enabled "
                           "but not available: '%s'" % str(err))
             return
-        _test = join(currdir, 'test3a.lp')
         _base = join(currdir, 'test3.baseline.lp')
         with open(_test, 'r') as run, open(_base, 'r') as baseline:
             for line1, line2 in zip_longest(run, baseline):
@@ -200,9 +202,11 @@ class Test(unittest.TestCase):
         """ Convert from AMPL to MPS """
         if not pyomo.common.Executable("ampl"):
             self.skipTest("The ampl executable is not available")
-        self.model = pyomo.opt.AmplModel(join(currdir, 'test3a.mod'), join(currdir, 'test3a.dat'))
+        self.model = pyomo.opt.AmplModel(
+            join(currdir, 'test3a.mod'), join(currdir, 'test3a.dat'))
+        _test = TempfileManager.create_tempfile(suffix='test3a.mps')
         try:
-            self.model.write(join(currdir, 'test3a.mps'))
+            self.model.write(_test)
         except ApplicationError:
             err = sys.exc_info()[1]
             if pyomo.common.Executable("ampl"):
@@ -215,7 +219,6 @@ class Test(unittest.TestCase):
                 self.fail("Unexpected ConverterError - ampl is enabled "
                           "but not available: '%s'" % str(err))
             return
-        _test = join(currdir, 'test3a.mps')
         _base = join(currdir, 'test3.baseline.mps')
         with open(_test, 'r') as run, open(_base, 'r') as baseline:
             for line1, line2 in zip_longest(run, baseline):
@@ -233,9 +236,10 @@ class Test(unittest.TestCase):
             self.skipTest("glpk solver is not available")
         self.model = pyomo.opt.AmplModel(join(currdir, 'test3.mod'))
         opt = pyomo.opt.SolverFactory('glpk')
+        _test = TempfileManager.create_tempfile(suffix='test3.out')
         results = opt.solve(self.model, keepfiles=False)
-        results.write(filename=join(currdir, 'test3.out'), format='json')
-        with open(join(currdir,"test3.out"), 'r') as out, \
+        results.write(filename=_test, format='json')
+        with open(_test, 'r') as out, \
             open(join(currdir,"test3.baseline.out"), 'r') as txt:
             self.assertStructuredAlmostEqual(json.load(txt), json.load(out),
                                              abstol=1e-6,
@@ -244,11 +248,13 @@ class Test(unittest.TestCase):
     def test3a_solve(self):
         if not 'glpk' in solvers:
             self.skipTest("glpk solver is not available")
-        self.model = pyomo.opt.AmplModel(join(currdir, 'test3a.mod'), join(currdir, 'test3a.dat'))
+        self.model = pyomo.opt.AmplModel(
+            join(currdir, 'test3a.mod'), join(currdir, 'test3a.dat'))
         opt = pyomo.opt.SolverFactory('glpk')
         results = opt.solve(self.model, keepfiles=False)
-        results.write(filename=join(currdir, 'test3a.out'), format='json')
-        with open(join(currdir,"test3a.out"), 'r') as out, \
+        _test = TempfileManager.create_tempfile(suffix='test3a.out')
+        results.write(filename=_test, format='json')
+        with open(_test, 'r') as out, \
             open(join(currdir,"test3.baseline.out"), 'r') as txt:
             self.assertStructuredAlmostEqual(json.load(txt), json.load(out),
                                              abstol=1e-6,
@@ -256,5 +262,6 @@ class Test(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    deleteFiles = False
     unittest.main()
 

--- a/pyomo/repn/tests/ampl/test_ampl_comparison.py
+++ b/pyomo/repn/tests/ampl/test_ampl_comparison.py
@@ -17,17 +17,21 @@ import re
 import glob
 import subprocess
 import os
-from os.path import abspath, dirname, join
-currdir = dirname(abspath(__file__))+os.sep
+from os.path import join
 
 import pyomo.common.unittest as unittest
 from pyomo.common.dependencies import attempt_import
+from pyomo.common.fileutils import this_file_dir
+from pyomo.common.tempfiles import TempfileManager
 
 import pyomo.scripting.pyomo_main as main
 
 parameterized, param_available = attempt_import('parameterized')
 if not param_available:
     raise unittest.SkipTest('Parameterized is not available.')
+
+currdir = this_file_dir()
+deleteFiles = True
 
 # https://github.com/ghackebeil/gjh_asl_json
 has_gjh_asl_json = False
@@ -47,42 +51,46 @@ class Tests(unittest.TestCase):
         output = main.main(['convert', '--logging=quiet', '-c']+cmd)
         return output
 
+    def setUp(self):
+        TempfileManager.push()
+
+    def tearDown(self):
+        TempfileManager.pop(remove=deleteFiles or self.currentTestPassed())
+
 
 class BaselineTests(Tests):
-    def __init__(self, *args, **kwds):
-        Tests.__init__(self, *args, **kwds)
+    #
+    # The following test generates an nl file for the test case
+    # and checks that it matches the current pyomo baseline nl file
+    #
 
-    #
-    #The following test generates an nl file for the test case
-    #and checks that it matches the current pyomo baseline nl file
-    #
     @parameterized.parameterized.expand(input=names)
     def nlwriter_baseline_test(self, name):
-        if os.path.exists(join(currdir, name+'.dat')):
-            self.pyomo(['--output='+join(currdir, name+'.test.nl'),
-                        join(currdir, name+'_testCase.py'),
-                        join(currdir, name+'.dat')])
-        else:
-            self.pyomo(['--output='+join(currdir, name+'.test.nl'),
-                        join(currdir, name+'_testCase.py')])
+        baseline = join(currdir, name+'.pyomo.nl')
+        testFile = TempfileManager.create_tempfile(
+            suffix=name + '.test.nl')
+        cmd = ['--output=' + testFile,
+               join(currdir, name+'_testCase.py')]
+        if os.path.exists(join(currdir, name + '.dat')):
+            cmd.append(join(currdir, name + '.dat'))
+        self.pyomo(cmd)
 
         # Check that the pyomo nl file matches its own baseline
-        with open(join(currdir, name+'.test.nl'), 'r') as f1, \
-                open(join(currdir, name+'.pyomo.nl'), 'r') as f2:
-                    f1_contents = list(filter(None, f1.read().replace('n', 'n ').split()))
-                    f2_contents = list(filter(None, f2.read().replace('n', 'n ').split()))
-                    for item1, item2 in zip_longest(f1_contents, f2_contents):
-                        try:
-                            self.assertEqual(float(item1), float(item2))
-                        except:
-                            self.assertEqual(item1, item2)
-        os.remove(join(currdir, name+'.test.nl'))
+        with open(testFile, 'r') as f1, open(baseline, 'r') as f2:
+            f1_contents = list(filter(
+                None, f1.read().replace('n', 'n ').split()))
+            f2_contents = list(filter(
+                None, f2.read().replace('n', 'n ').split()))
+            for item1, item2 in zip_longest(f1_contents, f2_contents):
+                try:
+                    self.assertEqual(float(item1), float(item2))
+                except:
+                    self.assertEqual(item1, item2)
 
 
-class ASLTests(Tests):
-
-    def __init__(self, *args, **kwds):
-        Tests.__init__(self, *args, **kwds)
+@unittest.skipUnless(
+    has_gjh_asl_json, "'gjh_asl_json' executable not available")
+class ASLJSONTests(Tests):
 
     #
     # The following test calls the gjh_asl_json executable to
@@ -93,62 +101,52 @@ class ASLTests(Tests):
     #
     @parameterized.parameterized.expand(input=names)
     def nlwriter_asl_test(self, name):
-        if not has_gjh_asl_json:
-            self.skipTest("'gjh_asl_json' executable not available")
-            return
-        if os.path.exists(join(currdir, name+'.dat')):
-            self.pyomo(['--output='+join(currdir, name+'.test.nl'),
-                        '--file-determinism=3',
-                        '--symbolic-solver-labels',
-                        join(currdir, name+'_testCase.py'),
-                        join(currdir, name+'.dat')])
-        else:
-            self.pyomo(['--output='+join(currdir, name+'.test.nl'),
-                        '--file-determinism=3',
-                        '--symbolic-solver-labels',
-                        join(currdir, name+'_testCase.py')])
+        testFile = TempfileManager.create_tempfile(suffix=name+'.test.nl')
+        testFile_row = testFile[:-2] + 'row'
+        TempfileManager.add_tempfile(testFile_row, exists=False)
+        testFile_col = testFile[:-2] + 'col'
+        TempfileManager.add_tempfile(testFile_col, exists=False)
 
+        cmd = ['--output='+testFile,
+               '--file-determinism=3',
+               '--symbolic-solver-labels',
+               join(currdir, name+'_testCase.py')]
+        if os.path.exists(join(currdir, name + '.dat')):
+               cmd.append(join(currdir, name + '.dat'))
+
+        self.pyomo(cmd)
+
+        #
         # compare AMPL and Pyomo nl file structure
-        try:
-            os.remove(join(currdir, name+'.ampl.json'))
-        except Exception:
-            pass
-        try:
-            os.remove(join(currdir, name+'.test.json'))
-        except Exception:
-            pass
-
+        #
+        testFile_json = testFile[:-2]+'json'
+        TempfileManager.add_tempfile(testFile_json, exists=False)
         # obtain the nl file summary information for comparison with ampl
-        p = subprocess.run(['gjh_asl_json',
-                            join(currdir, name+'.test.nl'),
-                            'rows='+join(currdir, name+'.test.row'),
-                            'cols='+join(currdir, name+'.test.col')],
-                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                           universal_newlines=True)
+        p = subprocess.run(
+            ['gjh_asl_json', testFile,
+             'rows=' + testFile_row,
+             'cols=' + testFile_col,
+             'json=' + testFile_json],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            universal_newlines=True)
         self.assertTrue(p.returncode == 0, msg=p.stdout)
 
-        # obtain the nl file summary information for comparison with pyomo
-        p = subprocess.run(['gjh_asl_json',
-                            join(currdir, name+'.ampl.nl'),
-                            'rows='+join(currdir, name+'.ampl.row'),
-                            'cols='+join(currdir, name+'.ampl.col')],
-                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                           universal_newlines=True)
+        baseFile = join(currdir, name+'.ampl.nl')
+        amplFile = TempfileManager.create_tempfile(suffix=name+'.ampl.json')
+        # obtain the nl file summary information for comparison with ampl
+        p = subprocess.run(
+            ['gjh_asl_json', baseFile,
+             'rows=' + baseFile[:-2] + 'row',
+             'cols=' + baseFile[:-2] + 'col',
+             'json=' + amplFile],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            universal_newlines=True)
         self.assertTrue(p.returncode == 0, msg=p.stdout)
 
-        with open(join(currdir, name+'.test.json'), 'r') as f1, \
-            open(join(currdir, name+'.ampl.json'), 'r') as f2:
-                self.assertStructuredAlmostEqual(json.load(f1),
-                                                 json.load(f2),
-                                                 abstol=1e-8)
-
-        os.remove(join(currdir, name+'.ampl.json'))
-
-        # delete temporary test files
-        os.remove(join(currdir, name+'.test.col'))
-        os.remove(join(currdir, name+'.test.row'))
-        os.remove(join(currdir, name+'.test.nl'))
-
+        with open(testFile_json, 'r') as f1, open(amplFile, 'r') as f2:
+            self.assertStructuredAlmostEqual(
+                json.load(f1), json.load(f2), abstol=1e-8)
 
 if __name__ == "__main__":
+    deleteFiles = False
     unittest.main()

--- a/pyomo/repn/tests/gams/test_gams_comparison.py
+++ b/pyomo/repn/tests/gams/test_gams_comparison.py
@@ -15,25 +15,29 @@ import re
 import glob
 import os
 from os.path import abspath, dirname, join
-currdir = dirname(abspath(__file__))+os.sep
-datadir = abspath(join(currdir, "..", "ampl"))+os.sep
 
 from filecmp import cmp
 import pyomo.common.unittest as unittest
-import pyomo.common
+from pyomo.common.dependencies import attempt_import
+from pyomo.common.fileutils import this_file_dir
+from pyomo.common.tempfiles import TempfileManager
 
 import pyomo.scripting.pyomo_main as main
 
-parameterized, param_available = pyomo.common.dependencies.attempt_import('parameterized')
+parameterized, param_available = attempt_import('parameterized')
 if not param_available:
     raise unittest.SkipTest('Parameterized is not available.')
+
+currdir = this_file_dir()
+datadir = abspath(join(currdir, "..", "ampl"))
+deleteFiles = True
 
 # add test methods to classes
 invalidlist = []
 validlist = []
 
 invalid_tests = {'small14',}
-for f in glob.glob(datadir+'*_testCase.py'):
+for f in glob.glob(join(datadir, '*_testCase.py')):
     name = re.split('[._]',os.path.basename(f))[0]
     if name in invalid_tests:
         # Create some list
@@ -41,7 +45,7 @@ for f in glob.glob(datadir+'*_testCase.py'):
     else:
         validlist.append((name, datadir))
 
-for f in glob.glob(currdir+'*_testCase.py'):
+for f in glob.glob(join(currdir, '*_testCase.py')):
     name = re.split('[._]',os.path.basename(f))[0]
     validlist.append((name, currdir))
 
@@ -53,11 +57,14 @@ class Tests(unittest.TestCase):
         output = main.main(['convert', '--logging=quiet', '-c']+cmd)
         return output
 
+    def setUp(self):
+        TempfileManager.push()
+
+    def tearDown(self):
+        TempfileManager.pop(remove=deleteFiles or self.currentTestPassed())
+
 
 class BaselineTests(Tests):
-    def __init__(self, *args, **kwds):
-        Tests.__init__(self, *args, **kwds)
-
     #
     # The following test generates a GMS file for the test case
     # and checks that it matches the current pyomo baseline GMS file
@@ -65,39 +72,37 @@ class BaselineTests(Tests):
 
     @parameterized.parameterized.expand(input=validlist)
     def gams_writer_baseline_test(self, name, targetdir):
-        if os.path.exists(targetdir+name+'.dat'):
-            self.pyomo(['--output='+currdir+name+'.test.gms',
-                        targetdir+name+'_testCase.py',
-                        targetdir+name+'.dat'])
-        else:
-            self.pyomo(['--output='+currdir+name+'.test.gms',
-                        targetdir+name+'_testCase.py'])
+        baseline = join(currdir, name+'.pyomo.gms')
+        testFile = TempfileManager.create_tempfile(
+            suffix=name + '.test.gms')
+        cmd = ['--output=' + testFile,
+               join(targetdir, name + '_testCase.py')]
+        if os.path.exists(join(targetdir, name + '.dat')):
+            cmd.append(join(targetdir, name + '.dat'))
+        self.pyomo(cmd)
 
         # Check that the pyomo nl file matches its own baseline
         try:
-            self.assertTrue(cmp(currdir+name+'.test.gms',
-                               currdir+name+'.pyomo.gms'))
+            self.assertTrue(cmp(testFile, baseline))
         except:
-            with open(currdir+name+'.test.gms', 'r') as f1, \
-                open(currdir+name+'.pyomo.gms', 'r') as f2:
-                    f1_contents = list(filter(None, f1.read().split()))
-                    f2_contents = list(filter(None, f2.read().split()))
-                    self.assertEqual(f1_contents, f2_contents)
+            with open(testFile, 'r') as f1, open(baseline, 'r') as f2:
+                f1_contents = list(filter(None, f1.read().split()))
+                f2_contents = list(filter(None, f2.read().split()))
+                self.assertEqual(f1_contents, f2_contents)
 
 
     @parameterized.parameterized.expand(input=invalidlist)
     def gams_writer_test_invalid(self, name, targetdir):
-        with self.assertRaisesRegex(
+        with TempfileManager, self.assertRaisesRegex(
                 RuntimeError, "GAMS files cannot represent the unary function"):
-            if os.path.exists(targetdir+name+'.dat'):
-                self.pyomo(['--output='+currdir+name+'.test.gms',
-                            targetdir+name+'_testCase.py',
-                            targetdir+name+'.dat'])
-            else:
-                self.pyomo(['--output='+currdir+name+'.test.gms',
-                            targetdir+name+'_testCase.py'])
-
+            testFile = join(currdir, name + '.test.gms')
+            cmd = ['--output=' + testFile,
+                   join(targetdir, name + '_testCase.py')]
+            if os.path.exists(join(targetdir, name + '.dat')):
+                cmd.append(join(targetdir, name + '.dat'))
+            self.pyomo(cmd)
 
 
 if __name__ == "__main__":
+    deleteFiles = False
     unittest.main()

--- a/pyomo/solvers/tests/mip/test_asl.py
+++ b/pyomo/solvers/tests/mip/test_asl.py
@@ -10,30 +10,28 @@
 
 import json
 import os
-from os.path import abspath, dirname, join
-pyomodir = dirname(abspath(__file__))+os.sep+".."+os.sep+".."+os.sep
-currdir = dirname(abspath(__file__))+os.sep
-
+from os.path import join
 from filecmp import cmp
+
 import pyomo.common.unittest as unittest
+
 import pyomo.common
+from pyomo.common.fileutils import this_file_dir
 from pyomo.common.tempfiles import TempfileManager
 
 from pyomo.core import ConcreteModel
 from pyomo.opt import ResultsFormat, SolverResults, SolverFactory
 
+currdir = this_file_dir()
+deleteFiles = True
+
 old_ignore_time = None
-old_tempdir = None
 def setUpModule():
-    global old_tempdir
     global old_ignore_time
-    old_tempdir = TempfileManager.tempdir
     old_ignore_time = SolverResults.default_print_options.ignore_time
     SolverResults.default_print_options.ignore_time = True
-    TempfileManager.tempdir = currdir
 
 def tearDownModule():
-    TempfileManager.tempdir = old_tempdir
     SolverResults.default_print_options.ignore_time = old_ignore_time
 
 cplexamp_available = False
@@ -50,10 +48,7 @@ class mock_all(unittest.TestCase):
         self.do_setup(False)
 
     def do_setup(self,flag):
-        global tmpdir
-        tmpdir = os.getcwd()
-        os.chdir(currdir)
-        TempfileManager.sequential_files(0)
+        TempfileManager.push()
         if flag:
             if not cplexamp_available:
                 self.skipTest("The 'cplexamp' command is not available")
@@ -62,10 +57,7 @@ class mock_all(unittest.TestCase):
             self.asl = SolverFactory('_mock_asl:cplexamp')
 
     def tearDown(self):
-        global tmpdir
-        TempfileManager.clear_tempfiles()
-        TempfileManager.unique_files()
-        os.chdir(tmpdir)
+        TempfileManager.pop(remove=deleteFiles or self.currentTestPassed())
         self.asl = None
 
     def test_path(self):
@@ -76,21 +68,18 @@ class mock_all(unittest.TestCase):
 
     def test_solve4(self):
         """ Test ASL - test4.nl """
-        results = self.asl.solve(currdir+"test4.nl",
-                                 logfile=currdir+"test_solve4.log",
+        _log = TempfileManager.create_tempfile(".test_solve4.log")
+        _out = TempfileManager.create_tempfile(".test_solve4.txt")
+
+        results = self.asl.solve(join(currdir, "test4.nl"),
+                                 logfile=_log,
                                  suffixes=['.*'])
-        results.write(filename=currdir+"test_solve4.txt",
-                      times=False,
-                      format='json')
-        with open(join(currdir, "test_solve4.txt"), 'r') as out, \
-            open(join(currdir, "test4_asl.txt"), 'r') as txt:
+        results.write(filename=_out, times=False, format='json')
+        _baseline = join(currdir, "test4_asl.txt")
+        with open(_out, 'r') as out, open(_baseline, 'r') as txt:
             self.assertStructuredAlmostEqual(json.load(txt), json.load(out),
                                              abstol=1e-4,
                                              allow_second_superset=True)
-
-        os.remove(currdir+"test_solve4.log")
-        if os.path.exists(currdir+"test4.soln"):
-            os.remove(currdir+"test4.soln")
 
     #
     # This test is disabled, but it's useful for interactively exercising
@@ -147,4 +136,5 @@ class mip_all(mock_all):
 
 
 if __name__ == "__main__":
+    deleteFiles = False
     unittest.main()

--- a/pyomo/solvers/tests/mip/test_factory.py
+++ b/pyomo/solvers/tests/mip/test_factory.py
@@ -12,12 +12,8 @@
 #
 
 import os
-from os.path import abspath, dirname
-pyomodir = dirname(abspath(__file__))+"/../.."
-currdir = dirname(abspath(__file__))+os.sep
 
 import pyomo.common.unittest as unittest
-from pyomo.common.tempfiles import TempfileManager
 
 from pyomo.opt import (AbstractProblemWriter, AbstractResultsReader,
                        OptSolver, ReaderFactory,
@@ -26,15 +22,6 @@ from pyomo.opt.base.solvers import UnknownSolver
 from pyomo.opt.plugins.sol import ResultsReader_sol
 from pyomo.solvers.plugins.solvers import PICO
 
-
-old_tempdir = None
-def setUpModule():
-    global old_tempdir
-    old_tempdir = TempfileManager.tempdir
-    TempfileManager.tempdir = currdir
-
-def tearDownModule():
-    TempfileManager.tempdir = old_tempdir
 
 class MockWriter(AbstractProblemWriter):
 
@@ -63,7 +50,6 @@ class OptFactoryDebug(unittest.TestCase):
         import pyomo.environ
 
     def tearDown(self):
-        TempfileManager.clear_tempfiles()
         ReaderFactory.unregister('rtest3')
         ReaderFactory.unregister('stest3')
         ReaderFactory.unregister('wtest3')

--- a/pyomo/solvers/tests/mip/test_ipopt.py
+++ b/pyomo/solvers/tests/mip/test_ipopt.py
@@ -11,22 +11,21 @@
 import json
 import os
 from os.path import abspath, dirname, join
-currdir = dirname(abspath(__file__))
 
 import pyomo.common.unittest as unittest
+
+from pyomo.common.fileutils import this_file_dir
+from pyomo.common.log import LoggingIntercept
 from pyomo.common.tempfiles import TempfileManager
 
 import pyomo.opt
-from pyomo.core import ConcreteModel, RangeSet, Var, Param, Objective, ConstraintList, value, minimize
+from pyomo.core import (
+    ConcreteModel, RangeSet, Var, Param, Objective, ConstraintList,
+    value, minimize,
+)
 
-old_tempdir = None
-def setUpModule():
-    global old_tempdir
-    old_tempdir = TempfileManager.tempdir
-    TempfileManager.tempdir = currdir
-
-def tearDownModule():
-    TempfileManager.tempdir = old_tempdir
+currdir = this_file_dir()
+deleteFiles = True
 
 ipopt_available = False
 class Test(unittest.TestCase):
@@ -41,19 +40,14 @@ class Test(unittest.TestCase):
     def setUp(self):
         if not ipopt_available:
             self.skipTest("The 'ipopt' command is not available")
-        self.do_setup()
-
-    def do_setup(self):
-        global tmpdir
-        tmpdir = os.getcwd()
-        os.chdir(currdir)
-        TempfileManager.sequential_files(0)
+        TempfileManager.push()
 
         self.asl = pyomo.opt.SolverFactory('asl:ipopt', keepfiles=True)
         self.ipopt = pyomo.opt.SolverFactory('ipopt', keepfiles=True)
 
         # The sisser CUTEr instance
-        # Formulated in Pyomo by Carl D. Laird, Daniel P. Word, Brandon C. Barrera and Saumyajyoti Chaudhuri
+        # Formulated in Pyomo by Carl D. Laird, Daniel P. Word, Brandon
+        #     C. Barrera and Saumyajyoti Chaudhuri
         # Taken from:
 
         #   Source:
@@ -71,7 +65,8 @@ class Test(unittest.TestCase):
         sisser_instance = ConcreteModel()
 
         sisser_instance.N = RangeSet(1,2)
-        sisser_instance.xinit = Param(sisser_instance.N, initialize={ 1 : 1.0, 2 : 0.1})
+        sisser_instance.xinit = Param(
+            sisser_instance.N, initialize={ 1 : 1.0, 2 : 0.1})
 
         def fa(model, i):
             return value(model.xinit[i])
@@ -83,18 +78,16 @@ class Test(unittest.TestCase):
 
         self.sisser_instance = sisser_instance
 
+
+    def tearDown(self):
+        TempfileManager.pop(remove=deleteFiles or self.currentTestPassed())
+
     def compare_json(self, file1, file2):
         with open(file1, 'r') as out, \
             open(file2, 'r') as txt:
             self.assertStructuredAlmostEqual(json.load(txt), json.load(out),
                                              abstol=1e-7,
                                              allow_second_superset=True)
-
-    def tearDown(self):
-        global tmpdir
-        TempfileManager.clear_tempfiles()
-        TempfileManager.unique_files()
-        os.chdir(tmpdir)
 
     def test_version_asl(self):
         self.assertTrue(self.asl.version() is not None)
@@ -108,33 +101,35 @@ class Test(unittest.TestCase):
 
     def test_asl_solve_from_nl(self):
         # Test ipopt solve from nl file
+        _log = TempfileManager.create_tempfile(".test_ipopt.log")
         results = self.asl.solve(join(currdir, "sisser.pyomo.nl"),
-                                 logfile=join(currdir, "test_asl_solve_from_nl.log"),
+                                 logfile=_log,
                                  suffixes=['.*'])
         # We don't want the test to care about which Ipopt version we are using
         results.Solution(0).Message = "Ipopt"
         results.Solver.Message = "Ipopt"
-        results.write(filename=join(currdir, "test_asl_solve_from_nl.txt"),
+        _out = TempfileManager.create_tempfile(".test_ipopt.txt")
+        results.write(filename=_out,
                       times=False,
                       format='json')
-        self.compare_json(join(currdir, "test_asl_solve_from_nl.txt"),
-                          join(currdir, "test_solve_from_nl.baseline"))
-        os.remove(join(currdir, "test_asl_solve_from_nl.log"))
+        self.compare_json(
+            _out, join(currdir, "test_solve_from_nl.baseline"))
 
     def test_ipopt_solve_from_nl(self):
         # Test ipopt solve from nl file
+        _log = TempfileManager.create_tempfile(".test_ipopt.log")
         results = self.ipopt.solve(join(currdir, "sisser.pyomo.nl"),
-                                   logfile=join(currdir, "test_ipopt_solve_from_nl.log"),
+                                   logfile=_log,
                                    suffixes=['.*'])
         # We don't want the test to care about which Ipopt version we are using
         results.Solution(0).Message = "Ipopt"
         results.Solver.Message = "Ipopt"
-        results.write(filename=join(currdir, "test_ipopt_solve_from_nl.txt"),
+        _out = TempfileManager.create_tempfile(".test_ipopt.txt")
+        results.write(filename=_out,
                       times=False,
                       format='json')
-        self.compare_json(join(currdir, "test_ipopt_solve_from_nl.txt"),
-                          join(currdir, "test_solve_from_nl.baseline"))
-        os.remove(join(currdir, "test_ipopt_solve_from_nl.log"))
+        self.compare_json(
+            _out, join(currdir, "test_solve_from_nl.baseline"))
 
     def test_asl_solve_from_instance(self):
         # Test ipopt solve from a pyomo instance and load the solution
@@ -144,11 +139,12 @@ class Test(unittest.TestCase):
         self.sisser_instance.solutions.store_to(results)
         results.Solution(0).Message = "Ipopt"
         results.Solver.Message = "Ipopt"
-        results.write(filename=join(currdir, "test_asl_solve_from_instance.txt"),
+        _out = TempfileManager.create_tempfile(".test_ipopt.txt")
+        results.write(filename=_out,
                       times=False,
                       format='json')
-        self.compare_json(join(currdir, "test_asl_solve_from_instance.txt"),
-                          join(currdir, "test_solve_from_instance.baseline"))
+        self.compare_json(
+            _out, join(currdir, "test_solve_from_instance.baseline"))
         #self.sisser_instance.load_solutions(results)
 
     def test_ipopt_solve_from_instance(self):
@@ -159,11 +155,12 @@ class Test(unittest.TestCase):
         self.sisser_instance.solutions.store_to(results)
         results.Solution(0).Message = "Ipopt"
         results.Solver.Message = "Ipopt"
-        results.write(filename=join(currdir, "test_ipopt_solve_from_instance.txt"),
+        _out = TempfileManager.create_tempfile(".test_ipopt.txt")
+        results.write(filename=_out,
                       times=False,
                       format='json')
-        self.compare_json(join(currdir, "test_ipopt_solve_from_instance.txt"),
-                          join(currdir, "test_solve_from_instance.baseline"))
+        self.compare_json(
+            _out, join(currdir, "test_solve_from_instance.baseline"))
         #self.sisser_instance.load_solutions(results)
 
     def test_ipopt_solve_from_instance_OF_options(self):
@@ -177,23 +174,36 @@ class Test(unittest.TestCase):
                                       "option_file_name": "junk.opt"})
         # Creating a dummy ipopt.opt file in the cwd
         # will cover the code that prints a warning
-        assert os.getcwd() == currdir, str(os.getcwd())+" "+currdir
-        with open(join(currdir, 'ipopt.opt'), "w") as f:
-            pass
-        # Test ipopt solve from a pyomo instance and load the solution
-        results = self.ipopt.solve(self.sisser_instance,
-                                   suffixes=['.*'],
-                                   options={"OF_mu_init": 0.1})
-        os.remove(join(currdir, 'ipopt.opt'))
+        _cwd = os.getcwd()
+        tmpdir = TempfileManager.create_tempdir()
+        try:
+            os.chdir(tmpdir)
+            # create an empty ipopt.opt file
+            open(join(tmpdir, 'ipopt.opt'), "w").close()
+            # Test ipopt solve from a pyomo instance and load the solution
+            with LoggingIntercept() as LOG:
+                results = self.ipopt.solve(self.sisser_instance,
+                                           suffixes=['.*'],
+                                           options={"OF_mu_init": 0.1})
+            self.assertRegex(
+                LOG.getvalue().replace("\n", " "),
+                r"A file named (.*) exists in the current working "
+                r"directory, but Ipopt options file options \(i.e., "
+                r"options that start with 'OF_'\) were provided. The "
+                r"options file \1 will be ignored.")
+        finally:
+            os.chdir(_cwd)
+
         # We don't want the test to care about which Ipopt version we are using
         self.sisser_instance.solutions.store_to(results)
         results.Solution(0).Message = "Ipopt"
         results.Solver.Message = "Ipopt"
-        results.write(filename=join(currdir, "test_ipopt_solve_from_instance.txt"),
+        _out = TempfileManager.create_tempfile(".test_ipopt.txt")
+        results.write(filename=_out,
                       times=False,
                       format='json')
-        self.compare_json(join(currdir, "test_ipopt_solve_from_instance.txt"),
-                          join(currdir, "test_solve_from_instance.baseline"))
+        self.compare_json(
+            _out, join(currdir, "test_solve_from_instance.baseline"))
         #self.sisser_instance.load_solutions(results)
 
     def test_bad_dof(self):
@@ -204,11 +214,12 @@ class Test(unittest.TestCase):
         m.c.add(m.x + m.y == 1)
         m.c.add(m.x - m.y == 0)
         m.c.add(2*m.x - 3*m.y == 1)
-        m.write('j.nl')
+        #m.write('j.nl')
         res = self.ipopt.solve(m)
         self.assertEqual(str(res.solver.status), "warning")
         self.assertEqual(str(res.solver.termination_condition), "other")
         self.assertTrue("Too few degrees of freedom" in res.solver.message)
 
 if __name__ == "__main__":
+    deleteFiles = False
     unittest.main()

--- a/pyomo/solvers/tests/mip/test_ipopt.py
+++ b/pyomo/solvers/tests/mip/test_ipopt.py
@@ -214,7 +214,6 @@ class Test(unittest.TestCase):
         m.c.add(m.x + m.y == 1)
         m.c.add(m.x - m.y == 0)
         m.c.add(2*m.x - 3*m.y == 1)
-        #m.write('j.nl')
         res = self.ipopt.solve(m)
         self.assertEqual(str(res.solver.status), "warning")
         self.assertEqual(str(res.solver.termination_condition), "other")

--- a/pyomo/solvers/tests/mip/test_scip.py
+++ b/pyomo/solvers/tests/mip/test_scip.py
@@ -78,14 +78,17 @@ class Test(unittest.TestCase):
 
         # Creating a dummy scip.set file in the cwd
         # will cover the code that prints a warning
-        assert os.getcwd() == currdir, str(os.getcwd())+" "+currdir
-        with open(join(currdir, 'scip.set'), "w") as f:
-            pass
-        # Test scip solve from a pyomo instance and load the solution
-        results = self.scip.solve(self.model,
-                                  suffixes=['.*'],
-                                  options={"limits/softtime": 100})
-        os.remove(join(currdir, 'scip.set'))
+        _cwd = os.getcwd()
+        tmpdir = TempfileManager.create_tempdir()
+        try:
+            os.chdir(tmpdir)
+            open(join(tmpdir, 'scip.set'), "w").close()
+            # Test scip solve from a pyomo instance and load the solution
+            results = self.scip.solve(self.model,
+                                      suffixes=['.*'],
+                                      options={"limits/softtime": 100})
+        finally:
+            os.chdir(_cwd)
         # We don't want the test to care about which Scip version we are using
         self.model.solutions.store_to(results)
         results.Solution(0).Message = "Scip"

--- a/pyomo/solvers/tests/mip/test_solver.py
+++ b/pyomo/solvers/tests/mip/test_solver.py
@@ -12,25 +12,11 @@
 #
 
 import os
-from os.path import abspath, dirname
-pyomodir = dirname(abspath(__file__))+"/../.."
-currdir = dirname(abspath(__file__))+os.sep
 
 import pyomo.common.unittest as unittest
-from pyomo.common.tempfiles import TempfileManager
 
 import pyomo.opt
 import pyomo.solvers.plugins.solvers
-
-old_tempdir = None
-def setUpModule():
-    global old_tempdir
-    old_tempdir = TempfileManager.tempdir
-    TempfileManager.tempdir = currdir
-
-def tearDownModule():
-    TempfileManager.tempdir = old_tempdir
-
 
 class MockSolver2(pyomo.opt.OptSolver):
 
@@ -49,7 +35,6 @@ class OptSolverDebug(unittest.TestCase):
 
     def tearDown(self):
         pyomo.opt.SolverFactory.unregister('stest2')
-        TempfileManager.clear_tempfiles()
 
     def test_solver_init1(self):
         """


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Recently infrastructure changes caused a number of tests to no longer clean up temporary files that they created.  This PR is the first step toward cleaning up the management of temporary files within tests

## Changes proposed in this PR:
- remove use of the `sequential_files()` mode (make that mode a flag local to the current "tempfile context")
- create test files in the tempdir (and not the current working directory or the test file directory)
- improve management of some written files to ensure that they are registered to (and deleted by) a TempfileManager
- only keep temporary files for failed tests when the test module is run directly (i.e., by `python` and not through `nosetests` or `pytests`)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
