### PR TITLE
Add a `DynamicImplicitDomain` domain validator

### DIFF
--- a/doc/OnlineDocs/library_reference/common/config.rst
+++ b/doc/OnlineDocs/library_reference/common/config.rst
@@ -29,6 +29,7 @@ Domain validators
    InEnum
    Path
    PathList
+   DynamicImplicitDomain
 
 .. autoclass:: ConfigBase
    :members:
@@ -46,6 +47,10 @@ Domain validators
 
 .. autoclass:: ConfigValue
    :show-inheritance:
+   :members:
+   :undoc-members:
+
+.. autoclass:: DynamicImplicitDomain
    :members:
    :undoc-members:
 

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -339,6 +339,62 @@ class PathList(Path):
             return [ super(PathList, self).__call__(data) ]
 
 
+class DynamicImplicitDomain(object):
+    """Implicit domain that can return a custom domain based on the key.
+
+    This provides a mechanism for managing plugin-like systems, where
+    the key specifies a source for additional configuration information.
+    For example, given the plugin module,
+    ``pyomo/common/tests/config_plugin.py``:
+
+    .. literalinclude:: /../../pyomo/common/tests/config_plugin.py
+       :lines: 10-
+
+    .. doctest::
+       :hide:
+
+       >>> import importlib
+       >>> import pyomo.common.fileutils
+       >>> from pyomo.common.config import ConfigDict, DynamicImplicitDomain
+
+    .. doctest::
+
+       >>> def _pluginImporter(name, config):
+       ...     mod = importlib.import_module(name)
+       ...     return mod.get_configuration(config)
+       >>> config = ConfigDict()
+       >>> config.declare('plugins', ConfigDict(
+       ...     implicit=True,
+       ...     implicit_domain=DynamicImplicitDomain(_pluginImporter)))
+       <pyomo.common.config.ConfigDict object at ...>
+       >>> config.plugins['pyomo.common.tests.config_plugin'] = {'key1': 5}
+       >>> config.display()
+       plugins:
+         pyomo.common.tests.config_plugin:
+           key1: 5
+           key2: '5'
+
+    .. note::
+
+       This initializer is only useful for the :py:class:`ConfigDict`
+       ``implicit_domain`` argument (and not for "regular" ``domain``
+       arguments)
+
+    Parameters
+    ----------
+    callback: Callable[[str, object], ConfigBase]
+        A callable (function) that is passed the ConfigDict key and
+        value, and is expected to returnt the appropriate Config object
+        (ConfigValue, ConfigList, or ConfigDict)
+
+    """
+    def __init__(self, callback):
+        self.callback = callback
+
+    def __call__(self, key, value):
+        return self.callback(key, value)
+
+
 def add_docstring_list(docstring, configdict, indent_by=4):
     """Returns the docstring with a formatted configuration arguments listing."""
     return docstring + (" " * indent_by).join(
@@ -1753,7 +1809,9 @@ class ConfigDict(ConfigBase):
         self._decl_order = []
         self._declared = set()
         self._implicit_declaration = implicit
-        if implicit_domain is None or isinstance(implicit_domain, ConfigBase):
+        if ( implicit_domain is None
+             or type(implicit_domain) is DynamicImplicitDomain
+             or isinstance(implicit_domain, ConfigBase) ):
             self._implicit_domain = implicit_domain
         else:
             self._implicit_domain = ConfigValue(None, domain=implicit_domain)
@@ -1791,7 +1849,10 @@ class ConfigDict(ConfigBase):
         if default is NoArgumentGiven:
             return None
         if self._implicit_domain is not None:
-            return self._implicit_domain(default)
+            if type(self._implicit_domain) is DynamicImplicitDomain:
+                return self._implicit_domain(key, default)
+            else:
+                return self._implicit_domain(default)
         else:
             return ConfigValue(default)
 
@@ -1900,10 +1961,6 @@ class ConfigDict(ConfigBase):
             raise ValueError(
                 "duplicate config '%s' defined for ConfigDict '%s'" %
                 (name, self.name(True)))
-        if '.' in name or '[' in name or ']' in name:
-            raise ValueError(
-                "Illegal character in config '%s' for ConfigDict '%s': "
-                "'.[]' are not allowed." % (name, self.name(True)))
         self._data[_name] = config
         self._decl_order.append(_name)
         config._parent = self
@@ -1941,6 +1998,8 @@ class ConfigDict(ConfigBase):
                 ans = self._add(name, config)
             else:
                 ans = self._add(name, ConfigValue(config))
+        elif type(self._implicit_domain) is DynamicImplicitDomain:
+            ans = self._add(name, self._implicit_domain(name, config))
         else:
             ans = self._add(name, self._implicit_domain(config))
         ans._userSet = True

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -384,7 +384,7 @@ class DynamicImplicitDomain(object):
     ----------
     callback: Callable[[str, object], ConfigBase]
         A callable (function) that is passed the ConfigDict key and
-        value, and is expected to returnt the appropriate Config object
+        value, and is expected to return the appropriate Config object
         (ConfigValue, ConfigList, or ConfigDict)
 
     """

--- a/pyomo/common/tests/config_plugin.py
+++ b/pyomo/common/tests/config_plugin.py
@@ -1,0 +1,16 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+from pyomo.common.config import ConfigDict, ConfigValue
+
+def get_configuration(config):
+    ans = ConfigDict()
+    ans.declare('key1', ConfigValue(default=0, domain=int))
+    ans.declare('key2', ConfigValue(default=5, domain=str))
+    return ans(config)

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -465,6 +465,11 @@ class TestConfigDomains(unittest.TestCase):
         self.assertIsNot(test.fast, test2.fast)
         self.assertEqual(test.value(), test2.value())
 
+        self.assertEqual(len(test2), 2)
+        fit = test2.get('fit', {})
+        self.assertEqual(len(test2), 3)
+        self.assertEqual(fit.value(), {'option_f': 2, 'option_i': 1})
+
         with self.assertRaisesRegex(ValueError, "invalid key: fail"):
             test = cfg({'hi': {'option_i': 10},
                         'fast': {'option_f': 20},

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -44,7 +44,7 @@ from pyomo.common.config import (
     ConfigList, MarkImmutable, ImmutableConfigValue,
     PositiveInt, NegativeInt, NonPositiveInt, NonNegativeInt,
     PositiveFloat, NegativeFloat, NonPositiveFloat, NonNegativeFloat,
-    In, Path, PathList, ConfigEnum,
+    In, Path, PathList, ConfigEnum, DynamicImplicitDomain,
     _UnpickleableDomain, _picklable,
 )
 from pyomo.common.log import LoggingIntercept
@@ -438,6 +438,37 @@ class TestConfigDomains(unittest.TestCase):
             cfg.enum = 3
         with self.assertRaisesRegex(ValueError, '.*invalid value'):
             cfg.enum ='ITEM_THREE'
+
+    def test_DynamicImplicitDomain(self):
+        def _rule(key, val):
+            ans = ConfigDict()
+            if 'i' in key:
+                ans.declare('option_i', ConfigValue(domain=int, default=1))
+            if 'f' in key:
+                ans.declare('option_f', ConfigValue(domain=float, default=2))
+            if 's' in key:
+                ans.declare('option_s', ConfigValue(domain=str, default=3))
+            if 'l' in key:
+                raise ValueError('invalid key: %s' % key)
+            return ans(val)
+        cfg = ConfigDict(
+            implicit=True, implicit_domain=DynamicImplicitDomain(_rule))
+        self.assertEqual(len(cfg), 0)
+        test = cfg({'hi': {'option_i': 10},
+                    'fast': {'option_f': 20}})
+        self.assertEqual(len(test), 2)
+        self.assertEqual(test.hi.value(), {'option_i': 10})
+        self.assertEqual(test.fast.value(), {'option_f': 20, 'option_s': '3'})
+
+        test2 = cfg(test)
+        self.assertIsNot(test.hi, test2.hi)
+        self.assertIsNot(test.fast, test2.fast)
+        self.assertEqual(test.value(), test2.value())
+
+        with self.assertRaisesRegex(ValueError, "invalid key: fail"):
+            test = cfg({'hi': {'option_i': 10},
+                        'fast': {'option_f': 20},
+                        'fail': {'option_f': 20}})
 
 
 class TestImmutableConfigValue(unittest.TestCase):
@@ -2337,9 +2368,6 @@ c: 1.0
         with self.assertRaisesRegexp(
                 ValueError, "config 'dd' is already assigned to ConfigDict ''"):
             cfg.declare('dd', cfg.get('b'))
-        with self.assertRaisesRegexp(
-                ValueError, "Illegal character in config 'd\[1\]'"):
-            cfg.declare('d[1]', ConfigValue(1))
 
 
     def test_declare_from(self):

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -467,7 +467,7 @@ class TestConfigDomains(unittest.TestCase):
 
         self.assertEqual(len(test2), 2)
         fit = test2.get('fit', {})
-        self.assertEqual(len(test2), 3)
+        self.assertEqual(len(test2), 2)
         self.assertEqual(fit.value(), {'option_f': 2, 'option_i': 1})
 
         with self.assertRaisesRegex(ValueError, "invalid key: fail"):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This adds a new validator for ConfigDict's `implicit_domain` argument that allows a callback to determine the entry's domain based on the implicit key provided.  This is particularly useful for managing the configurations of plugins, where the plugin itself needs to be able to provide the (sub)`ConfigDict` definition.

This functionality was requested by @darrylmelander for providing cleaner support for configuring plugins in [grid-parity-exchange/Prescient](http://www.github.com/grid-parity-exchange/Prescient)

## Changes proposed in this PR:
- Add `DynamicImplicitDomain` class
- Update tests,
- Add documentation
- Remove prohibition on characters"`.[]`" in ConfigDict entries

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
