### PR TITLE
Improve comparison of Book examples to baselines

### DIFF
--- a/examples/pyomobook/test_book_examples.py
+++ b/examples/pyomobook/test_book_examples.py
@@ -2,13 +2,14 @@
 #
 #  Pyomo: Python Optimization Modeling Objects
 #  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
-#  Under the terms of Contract DE-NA0003525 with National Technology and 
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
 import pyomo.common.unittest as unittest
+import filecmp
 import glob
 import os
 import os.path
@@ -17,13 +18,15 @@ import sys
 from itertools import zip_longest
 from pyomo.opt import check_available_solvers
 from pyomo.common.dependencies import attempt_import, check_min_version
-from filecmp import cmp
+from pyomo.common.fileutils import this_file_dir
+from pyomo.common.tee import capture_output
+
 parameterized, param_available = attempt_import('parameterized')
 if not param_available:
     raise unittest.SkipTest('Parameterized is not available.')
 
 # Find all *.txt files, and use them to define baseline tests
-currdir = os.path.dirname(os.path.abspath(__file__))
+currdir = this_file_dir()
 datadir = currdir
 
 solver_dependencies =   {
@@ -45,25 +48,25 @@ solver_dependencies =   {
     'test_abstract_ch_pyomo_AbstractH': ['ipopt'],
     'test_abstract_ch_AbstHLinScript': ['glpk'],
     'test_abstract_ch_pyomo_AbstractHLinear': ['glpk'],
-    
+
     # blocks_ch
     'test_blocks_ch_lotsizing': ['glpk'],
     'test_blocks_ch_blocks_lotsizing': ['glpk'],
-    
+
     # dae_ch
     'test_dae_ch_run_path_constraint_tester': ['ipopt'],
-    
+
     # gdp_ch
     'test_gdp_ch_pyomo_scont': ['glpk'],
     'test_gdp_ch_pyomo_scont2': ['glpk'],
     'test_gdp_ch_scont_script': ['glpk'],
-    
+
     # intro_ch'
     'test_intro_ch_pyomo_concrete1_generic': ['glpk'],
     'test_intro_ch_pyomo_concrete1': ['glpk'],
     'test_intro_ch_pyomo_coloring_concrete': ['glpk'],
     'test_intro_ch_pyomo_abstract5': ['glpk'],
-    
+
     # mpec_ch
     'test_mpec_ch_path1': ['path'],
     'test_mpec_ch_nlp_ex1b': ['ipopt'],
@@ -75,7 +78,7 @@ solver_dependencies =   {
     'test_mpec_ch_nlp2': ['ipopt'],
     'test_mpec_ch_nlp3': ['ipopt'],
     'test_mpec_ch_mip1': ['glpk'],
-    
+
     # nonlinear_ch
     'test_rosen_rosenbrock': ['ipopt'],
     'test_react_design_ReactorDesign': ['ipopt'],
@@ -84,7 +87,7 @@ solver_dependencies =   {
     'test_multimodal_multimodal_init2': ['ipopt'],
     'test_disease_est_disease_estimation': ['ipopt'],
     'test_deer_DeerProblem': ['ipopt'],
-    
+
     # scripts_ch
     'test_sudoku_sudoku_run': ['glpk'],
     'test_scripts_ch_warehouse_script': ['glpk'],
@@ -92,17 +95,17 @@ solver_dependencies =   {
     'test_scripts_ch_warehouse_cuts': ['glpk'],
     'test_scripts_ch_prob_mod_ex': ['glpk'],
     'test_scripts_ch_attributes': ['glpk'],
-    
+
     # optimization_ch
     'test_optimization_ch_ConcHLinScript': ['glpk'],
-    
+
     # overview_ch
     'test_overview_ch_wl_mutable_excel': ['glpk'],
     'test_overview_ch_wl_excel': ['glpk'],
     'test_overview_ch_wl_concrete_script': ['glpk'],
     'test_overview_ch_wl_abstract_script': ['glpk'],
     'test_overview_ch_pyomo_wl_abstract': ['glpk'],
-    
+
     # performance_ch
     'test_performance_ch_wl': ['gurobi', 'gurobi_persistent'],
     'test_performance_ch_persistent': ['gurobi_persistent'],
@@ -120,10 +123,10 @@ package_dependencies =  {
     # overview_ch'
     'test_overview_ch_wl_excel': ['pandas', 'xlrd'],
     'test_overview_ch_wl_mutable_excel': ['pandas', 'xlrd'],
-    
+
     # scripts_ch'
     'test_scripts_ch_warehouse_cuts': ['matplotlib'],
-    
+
     # performance_ch'
     'test_performance_ch_wl': ['numpy','matplotlib'],
 }
@@ -137,7 +140,7 @@ available_solvers = check_available_solvers(*solvers_used)
 solver_available = {solver_:solver_ in available_solvers for solver_ in solvers_used}
 
 package_available = {}
-package_modules = {}        
+package_modules = {}
 packages_used = set(sum(list(package_dependencies.values()), []))
 for package_ in packages_used:
     pack, pack_avail = attempt_import(package_)
@@ -196,7 +199,7 @@ def filter(line):
                    'Job ',
                    'Importing module',
                    'Function',
-                   'File', 
+                   'File',
                    'Matplotlib',
                    '    ^'):
         if line.startswith(field):
@@ -228,7 +231,7 @@ def filter_file_contents(lines):
     for line in lines:
         if not line or filter(line):
             continue
-            
+
         # Strip off beginning of lines giving time in seconds
         # Needed for the performance chapter tests
         if "seconds" in line:
@@ -267,17 +270,17 @@ for testdir in glob.glob(os.path.join(currdir,'*')):
     # each chapter in the book.
     if '-ch' not in testdir:
         continue
-   
+
     # Find all .py files in the test directory
     for file in list(glob.glob(os.path.join(testdir,'*.py'))) \
         + list(glob.glob(os.path.join(testdir,'*','*.py'))):
-    
+
         test_file = os.path.abspath(file)
         bname = os.path.basename(test_file)
         dir_ = os.path.dirname(test_file)
         name=os.path.splitext(bname)[0]
         tname = os.path.basename(dir_)+'_'+name
-    
+
         suffix = None
         # Look for txt and yml file names matching py file names. Add
         # a test for any found
@@ -288,7 +291,7 @@ for testdir in glob.glob(os.path.join(currdir,'*')):
         if not suffix is None:
             tname = tname.replace('-','_')
             tname = tname.replace('.','_')
-        
+
             # Create list of tuples with (test_name, test_file, baseline_file)
             py_test_tuples.append((tname, test_file, os.path.join(dir_,name+suffix)))
 
@@ -320,94 +323,109 @@ def custom_name_func(test_func, test_num, test_params):
     return "test_%s_%s" %(test_params.args[0], func_name[-2:])
 
 
+def compare_files(out_file, base_file, abstol, reltol,
+                  exception, formatter):
+    try:
+        if filecmp.cmp(out_file, base_file):
+            return True
+    except:
+        pass
+
+    with open(out_file, 'r') as f1, open(base_file, 'r') as f2:
+        out_file_contents = f1.read()
+        base_file_contents = f2.read()
+
+    # Filter files independently and then compare filtered contents
+    out_filtered = filter_file_contents(
+        out_file_contents.strip().split('\n'))
+    base_filtered = filter_file_contents(
+        base_file_contents.strip().split('\n'))
+
+    if len(out_filtered) != len(base_filtered):
+        # it is likely that a solver returned a (slightly) nonzero
+        # value for a variable that is normally 0.  Try to look for
+        # sequences like "['varname:', 'Value:', 1e-9]" that appear
+        # in one result but not the other and remove them.
+        i = 0
+        while i < len(base_filtered):
+            try:
+                unittest.assertStructuredAlmostEqual(
+                    out_filtered[i], base_filtered[i],
+                    abstol=abstol, reltol=reltol,
+                    allow_second_superset=False,
+                    exception=exception)
+                i += 1
+                continue
+            except exception:
+                pass
+
+            try:
+                index_of_out_i_in_base = base_filtered.index(
+                    out_filtered[i], i)
+            except ValueError:
+                index_of_out_i_in_base = float('inf')
+            try:
+                index_of_base_i_in_out = out_filtered.index(
+                    base_filtered[i], i)
+            except ValueError:
+                index_of_base_i_in_out = float('inf')
+            if index_of_out_i_in_base < index_of_base_i_in_out:
+                extra = base_filtered
+                n = index_of_out_i_in_base
+            else:
+                extra = out_filtered
+                n = index_of_base_i_in_out
+            extra_terms = extra[i:n]
+            try:
+                assert len(extra_terms) % 3 == 0
+                assert all(str(_)[-1] == ":" for _ in extra_terms[0::3])
+                assert all(str(_) == "Value:" for _ in extra_terms[1::3])
+                assert all(abs(_) < abstol for _ in extra_terms[2::3])
+            except:
+                # This does not match the pattern we are looking
+                # for: quit processing, and let the next
+                # assertStructuredAlmostEqual raise the appropriate
+                # failureException
+                break
+            extra[i:n] = []
+
+    try:
+        unittest.assertStructuredAlmostEqual(out_filtered, base_filtered,
+                                             abstol=abstol, reltol=reltol,
+                                             allow_second_superset=False,
+                                             exception=exception,
+                                             formatter=formatter)
+    except exception:
+        # Print helpful information when file comparison fails
+        print('---------------------------------')
+        print('BASELINE FILE')
+        print('---------------------------------')
+        print(base_file_contents)
+        print('=================================')
+        print('---------------------------------')
+        print('TEST OUTPUT FILE')
+        print('---------------------------------')
+        print(out_file_contents)
+        raise
+    return True
+
+
 class TestBookExamples(unittest.TestCase):
 
-    def compare_files(self, out_file, base_file):
-        try:
-            self.assertTrue(
-                cmp(out_file, base_file),
-                msg="Files %s and %s differ" % (out_file, base_file))
-            return
-        except self.failureException:
-            pass
-
-        with open(out_file, 'r') as f1, open(base_file, 'r') as f2:
-            out_file_contents = f1.read()
-            base_file_contents = f2.read()
-                
-        # Filter files independently and then compare filtered contents
-        out_filtered = filter_file_contents(
-            out_file_contents.strip().split('\n'))
-        base_filtered = filter_file_contents(
-            base_file_contents.strip().split('\n'))
-
-        if len(out_filtered) != len(base_filtered):
-            # it is likely that a solver returned a (slightly) nonzero
-            # value for a variable that is normally 0.  Try to look for
-            # sequences like "['varname:', 'Value:', 1e-9]" that appear
-            # in one result but not the other and remove them.
-            i = 0
-            while i < len(base_filtered):
-                try:
-                    self.assertStructuredAlmostEqual(
-                        out_filtered[i], base_filtered[i],
-                        abstol=1e-6, allow_second_superset=False)
-                    i += 1
-                    continue
-                except self.failureException:
-                    pass
-
-                try:
-                    index_of_out_i_in_base = base_filtered.index(
-                        out_filtered[i], i)
-                except ValueError:
-                    index_of_out_i_in_base = float('inf')
-                try:
-                    index_of_base_i_in_out = out_filtered.index(
-                        base_filtered[i], i)
-                except ValueError:
-                    index_of_base_i_in_out = float('inf')
-                if index_of_out_i_in_base < index_of_base_i_in_out:
-                    extra = base_filtered
-                    n = index_of_out_i_in_base
-                else:
-                    extra = out_filtered
-                    n = index_of_base_i_in_out
-                extra_terms = extra[i:n]
-                try:
-                    assert len(extra_terms) % 3 == 0
-                    assert all(str(_)[-1] == ":" for _ in extra_terms[0::3])
-                    assert all(str(_) == "Value:" for _ in extra_terms[1::3])
-                    assert all(abs(_) < 1e-7 for _ in extra_terms[2::3])
-                except:
-                    # This does not match the pattern we are looking
-                    # for: quit processing, and let the next
-                    # assertStructuredAlmostEqual raise the appropriate
-                    # failureException
-                    break
-                extra[i:n] = []
-
-        try:
-            self.assertStructuredAlmostEqual(out_filtered, base_filtered,
-                                             abstol=1e-6,
-                                             allow_second_superset=False)
-        except self.failureException:
-            # Print helpful information when file comparison fails
-            print('---------------------------------')
-            print('BASELINE FILE')
-            print('---------------------------------')
-            print(base_file_contents)
-            print('=================================')
-            print('---------------------------------')
-            print('TEST OUTPUT FILE')
-            print('---------------------------------')
-            print(out_file_contents)
-            raise
+    def compare_files(self, out_file, base_file, abstol=1e-6):
+        return compare_files(
+            out_file,
+            base_file,
+            abstol=abstol,
+            reltol=None,
+            exception=self.failureException,
+            formatter=self._formatMessage,
+        )
 
     @parameterized.parameterized.expand(py_test_tuples, name_func=custom_name_func)
     def test_book_py(self, tname, test_file, base_file):
         bname = os.path.basename(test_file)
-        dir_ = os.path.dirname(test_file)      
+        dir_ = os.path.dirname(test_file)
 
         skip_msg = check_skip('test_'+tname)
         if skip_msg:
@@ -435,7 +453,7 @@ class TestBookExamples(unittest.TestCase):
         # Skip all shell tests on Windows.
         if os.name == 'nt':
            raise unittest.SkipTest("Shell tests are not runnable on Windows")
-    
+
         cwd = os.getcwd()
         os.chdir(dir_)
         out_file = os.path.splitext(test_file)[0]+'.out'
@@ -448,6 +466,27 @@ class TestBookExamples(unittest.TestCase):
         self.compare_files(out_file, base_file)
         os.remove(out_file)
 
+    def test_test_functions(self):
+        with capture_output() as OUT:
+            self.assertTrue(self.compare_files(
+                os.path.join(currdir,'tests','ref1.txt'),
+                os.path.join(currdir,'tests','ref2.txt'),
+            ))
+            self.assertTrue(self.compare_files(
+                os.path.join(currdir,'tests','ref2.txt'),
+                os.path.join(currdir,'tests','ref1.txt'),
+            ))
+        self.assertEqual(OUT.getvalue(), "")
+
+        with self.assertRaises(self.failureException):
+            with capture_output() as OUT:
+                self.compare_files(
+                    os.path.join(currdir,'tests','ref1.txt'),
+                    os.path.join(currdir,'tests','ref2.txt'),
+                    abstol=1e-10,
+                )
+        self.assertIn('BASELINE FILE', OUT.getvalue())
+        self.assertIn('TEST OUTPUT FILE', OUT.getvalue())
 
 if __name__ == "__main__":
     unittest.main()

--- a/examples/pyomobook/tests/ref1.txt
+++ b/examples/pyomobook/tests/ref1.txt
@@ -1,0 +1,62 @@
+[    0.00] Setting up Pyomo environment
+[    0.00] Applying Pyomo preprocessing actions
+[    0.00] Creating model
+[    0.00] Applying solver
+[    0.05] Processing results
+    Number of solutions: 1
+    Solution Information
+      Gap: None
+      Status: optimal
+      Function Value: 5.99999868365
+    Solver results file: results.yml
+[    0.05] Applying Pyomo postprocessing actions
+[    0.05] Pyomo Finished
+# ==========================================================
+# = Solver Results                                         =
+# ==========================================================
+# ----------------------------------------------------------
+#   Problem Information
+# ----------------------------------------------------------
+Problem: 
+- Name: unknown
+  Lower bound: -inf
+  Upper bound: inf
+  Number of objectives: 1
+  Number of constraints: 0
+  Number of variables: 5
+  Number of binary variables: None
+  Number of integer variables: None
+  Number of continuous variables: None
+  Sense: unknown
+# ----------------------------------------------------------
+#   Solver Information
+# ----------------------------------------------------------
+Solver: 
+- Name: None
+  Status: ok
+  Wallclock time: 0.0448701381683
+  Termination condition: unknown
+# ----------------------------------------------------------
+#   Solution Information
+# ----------------------------------------------------------
+Solution: 
+- number of solutions: 1
+  number of solutions displayed: 1
+- Gap: None
+  Status: optimal
+  Message: Ipopt 3.12.3\x3a Optimal Solution Found
+  Objective:
+    f:
+      Value: 5.99999868365
+  Variable:
+    x[1]:
+      Value: 0.99999989051
+    x[2]:
+      Value: 1.09542744934e-07
+    x[3]:
+      Value: 0.999999890145
+    x[4]:
+      Value: 1.097718383e-07
+    x[5]:
+      Value: 0.999999956206
+  Constraint: No values

--- a/examples/pyomobook/tests/ref2.txt
+++ b/examples/pyomobook/tests/ref2.txt
@@ -1,0 +1,58 @@
+[    0.00] Setting up Pyomo environment
+[    0.00] Applying Pyomo preprocessing actions
+[    0.00] Creating model
+[    0.00] Applying solver
+[    0.05] Processing results
+    Number of solutions: 1
+    Solution Information
+      Gap: None
+      Status: optimal
+      Function Value: 5.99999868365
+    Solver results file: results.yml
+[    0.05] Applying Pyomo postprocessing actions
+[    0.05] Pyomo Finished
+# ==========================================================
+# = Solver Results                                         =
+# ==========================================================
+# ----------------------------------------------------------
+#   Problem Information
+# ----------------------------------------------------------
+Problem: 
+- Name: unknown
+  Lower bound: -inf
+  Upper bound: inf
+  Number of objectives: 1
+  Number of constraints: 0
+  Number of variables: 5
+  Number of binary variables: None
+  Number of integer variables: None
+  Number of continuous variables: None
+  Sense: unknown
+# ----------------------------------------------------------
+#   Solver Information
+# ----------------------------------------------------------
+Solver: 
+- Name: None
+  Status: ok
+  Wallclock time: 0.0448701381683
+  Termination condition: unknown
+# ----------------------------------------------------------
+#   Solution Information
+# ----------------------------------------------------------
+Solution: 
+- number of solutions: 1
+  number of solutions displayed: 1
+- Gap: None
+  Status: optimal
+  Message: Ipopt 3.12.3\x3a Optimal Solution Found
+  Objective:
+    f:
+      Value: 5.99999868365
+  Variable:
+    x[1]:
+      Value: 0.99999989051
+    x[3]:
+      Value: 0.999999890145
+    x[5]:
+      Value: 0.999999956206
+  Constraint: No values


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This reworks `test_book_examples:compare_files` to ignore extra entries in the output that look like values that are very close to zero.  This fixes an issue where different versions of solvers occasionally return slightly nonzero values for variables that are nominally zero (within tolerance) in the reference solution.

In particular, this resolves an intermittent test failure in `pyomobook.test_book_examples:TestBookExamples.test_mpec_ch_nlp_ex2_sh` (see, e.g. [here](https://github.com/Pyomo/pyomo/pull/2043/checks?check_run_id=3021511846) on #2043)

## Changes proposed in this PR:
- Allow file comparisons to pass with extra entries that look like slightly nonzero variable values.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
