### PR TITLE
Fix deprecation warning in Pyomo.dae

### DIFF
--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -452,7 +452,7 @@ def get_index_information(var, ds):
 
     if var.dim() != 1:
         indCount = 0
-        for index in var.index_set().set_tuple:
+        for index in var.index_set().subsets():
             if isinstance(index, ContinuousSet):
                 if index is ds:
                     dsindex = indCount

--- a/pyomo/dae/plugins/colloc.py
+++ b/pyomo/dae/plugins/colloc.py
@@ -593,11 +593,11 @@ class Collocation_Discretization_Transformation(Transformation):
             raise IndexError("ContinuousSet '%s' is not an indexing set of"
                              " the variable '%s'" % (ds.name, var.name))
         varidx = var.index_set()
-        if not hasattr(varidx, 'set_tuple'):
+        if not varidx.subsets():
             if ds is not varidx:
                 raise IndexError("ContinuousSet '%s' is not an indexing set of"
                                  " the variable '%s'" % (ds.name, var.name))
-        elif ds not in varidx.set_tuple:
+        elif ds not in varidx.subsets():
             raise IndexError("ContinuousSet '%s' is not an indexing set of the"
                              " variable '%s'" % (ds.name, var.name))
 


### PR DESCRIPTION
## Fixes # .
Fixes deprecation warnings in Pyomo.dae

## Summary/Motivation:
Attribute .set_tuple was deprecated in 5.7 and using .subsets() is recommended instead.

## Changes proposed in this PR:
- Modify two files in Pyomo.dae that use the deprecated attribute. All tests included in the package are working normally.
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
