### PR TITLE
appsi: fix bug in update_variables

### DIFF
--- a/pyomo/contrib/appsi/base.py
+++ b/pyomo/contrib/appsi/base.py
@@ -839,8 +839,13 @@ class PersistentBase(abc.ABC):
         self.remove_params([p for p in block.component_data_objects(ctype=Param, descend_into=True, sort=False)])
 
     @abc.abstractmethod
-    def update_variables(self, variables: List[_GeneralVarData]):
+    def _update_variables(self, variables: List[_GeneralVarData]):
         pass
+
+    def update_variables(self, variables: List[_GeneralVarData]):
+        for v in variables:
+            self._vars[id(v)] = (v, v.lb, v.ub, v.is_fixed(), v.domain, v.value)
+        self._update_variables(variables)
 
     @abc.abstractmethod
     def update_params(self):

--- a/pyomo/contrib/appsi/solvers/gurobi.py
+++ b/pyomo/contrib/appsi/solvers/gurobi.py
@@ -581,7 +581,7 @@ class Gurobi(PersistentBase, PersistentSolver):
     def _remove_params(self, params: List[_ParamData]):
         pass
 
-    def update_variables(self, variables: List[_GeneralVarData]):
+    def _update_variables(self, variables: List[_GeneralVarData]):
         for var in variables:
             var_id = id(var)
             if var_id not in self._pyomo_var_to_solver_var_map:

--- a/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
@@ -412,6 +412,18 @@ class TestSolvers(unittest.TestCase):
         res = opt.solve(m)
         self.assertAlmostEqual(m.x.value, (b2 - b1) / (a1 - a2))
         self.assertAlmostEqual(m.y.value, a1 * (b2 - b1) / (a1 - a2) + b1)
+        m.x.fix(0)
+        res = opt.solve(m)
+        self.assertAlmostEqual(m.x.value, 0)
+        self.assertAlmostEqual(m.y.value, 2)
+        m.x.value = 2
+        res = opt.solve(m)
+        self.assertAlmostEqual(m.x.value, 2)
+        self.assertAlmostEqual(m.y.value, 3)
+        m.x.value = 0
+        res = opt.solve(m)
+        self.assertAlmostEqual(m.x.value, 0)
+        self.assertAlmostEqual(m.y.value, 2)
 
     @parameterized.expand(input=all_solvers)
     def test_mutable_param_with_range(self, name: str, opt_class: Type[PersistentSolver]):

--- a/pyomo/contrib/appsi/writers/lp_writer.py
+++ b/pyomo/contrib/appsi/writers/lp_writer.py
@@ -138,7 +138,7 @@ class LPWriter(PersistentBase):
             self._symbol_map.removeSymbol(p)
             self._param_labeler.remove_obj(p)
 
-    def update_variables(self, variables: List[_GeneralVarData]):
+    def _update_variables(self, variables: List[_GeneralVarData]):
         for v in variables:
             cv = self._pyomo_var_to_solver_var_map[id(v)]
             if v.is_binary():

--- a/pyomo/contrib/appsi/writers/nl_writer.py
+++ b/pyomo/contrib/appsi/writers/nl_writer.py
@@ -151,7 +151,7 @@ class NLWriter(PersistentBase):
             self._symbol_map.removeSymbol(p)
             self._param_labeler.remove_obj(p)
 
-    def update_variables(self, variables: List[_GeneralVarData]):
+    def _update_variables(self, variables: List[_GeneralVarData]):
         for v in variables:
             cv = self._pyomo_var_to_solver_var_map[id(v)]
             if not v.is_continuous():


### PR DESCRIPTION
## Summary/Motivation:
This PR fixes a bug in APPSI where variables do not get updated properly if they are modified more than once (the change detection broke).

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
