### PR TITLE
Deprecate OrderedSet.__getitem__ in favor of OrderedSet.card()

### DIFF
--- a/examples/pyomobook/test_book_examples.py
+++ b/examples/pyomobook/test_book_examples.py
@@ -13,6 +13,7 @@ import filecmp
 import glob
 import os
 import os.path
+import re
 import subprocess
 import sys
 from itertools import zip_longest
@@ -228,7 +229,17 @@ def filter(line):
 
 def filter_file_contents(lines):
     filtered = []
+    deprecated = None
     for line in lines:
+        # Ignore all deprecation warnings
+        if line.startswith('WARNING: DEPRECATED:'):
+            deprecated = ''
+        if deprecated is not None:
+            deprecated += line
+            if re.search(r'\(called\s+from[^)]+\)', deprecated):
+                deprecated = None
+            continue
+
         if not line or filter(line):
             continue
 

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -1366,13 +1366,22 @@ class _ScalarOrderedSetMixin(object):
 class _OrderedSetMixin(object):
     __slots__ = ()
 
-    def __getitem__(self, index):
+    def card(self, index):
         raise DeveloperError("Derived ordered set class (%s) failed to "
-                             "implement __getitem__" % (type(self).__name__,))
+                             "implement card" % (type(self).__name__,))
 
     def ord(self, val):
         raise DeveloperError("Derived ordered set class (%s) failed to "
                              "implement ord" % (type(self).__name__,))
+
+    def __getitem__(self, key):
+        if key is None and not self.is_indexed():
+            return self
+        deprecation_warning(
+            "Using __getitem__ to return a set value from its (ordered) "
+            "position is deprecated.  Please use card()",
+            version='TBD', remove_in='7.0')
+        return self.card(key)
 
     def isordered(self):
         """Returns True if this is an ordered finite discrete (iterable) Set"""
@@ -1382,10 +1391,10 @@ class _OrderedSetMixin(object):
         return self.data()
 
     def first(self):
-        return self[1]
+        return self.card(1)
 
     def last(self):
-        return self[len(self)]
+        return self.card(len(self))
 
     def next(self, item, step=1):
         """
@@ -1402,7 +1411,7 @@ class _OrderedSetMixin(object):
             raise IndexError("Cannot advance before the beginning of the Set")
         if position > len(self):
             raise IndexError("Cannot advance past the end of the Set")
-        return self[position]
+        return self.card(position)
 
     def nextw(self, item, step=1):
         """
@@ -1416,7 +1425,7 @@ class _OrderedSetMixin(object):
         If the search item is not in the Set an IndexError is raised.
         """
         position = self.ord(item)
-        return self[(position+step-1) % len(self) + 1]
+        return self.card((position+step-1) % len(self) + 1)
 
     def prev(self, item, step=1):
         """Return the previous item in the set.
@@ -1546,7 +1555,7 @@ class _OrderedSetData(_OrderedSetMixin, _FiniteSetData):
         self.discard(ans)
         return ans
 
-    def __getitem__(self, index):
+    def card(self, index):
         """
         Return the specified member of the set.
 
@@ -1678,7 +1687,7 @@ class _SortedSetData(_SortedSetMixin, _OrderedSetData):
         super(_SortedSetData, self).clear()
         self._is_sorted = True
 
-    def __getitem__(self, index):
+    def card(self, index):
         """
         Return the specified member of the set.
 
@@ -1687,7 +1696,7 @@ class _SortedSetData(_SortedSetMixin, _OrderedSetData):
         """
         if not self._is_sorted:
             self._sort()
-        return super(_SortedSetData, self).__getitem__(index)
+        return super(_SortedSetData, self).card(index)
 
     def ord(self, item):
         """
@@ -1722,7 +1731,7 @@ _FINITESET_API = _SET_API + (
     '__reversed__', '__len__', 'data', 'sorted_data', 'ordered_data',
 )
 _ORDEREDSET_API = _FINITESET_API + (
-    '__getitem__', 'ord',
+    'card', 'ord',
 )
 _SETDATA_API = (
     'set_value', 'add', 'remove', 'discard', 'clear', 'update', 'pop',
@@ -2349,7 +2358,7 @@ class UnorderedSetOf(SetOf):
     pass
 
 class OrderedSetOf(_ScalarOrderedSetMixin, _OrderedSetMixin, SetOf):
-    def __getitem__(self, index):
+    def card(self, index):
         i = self._to_0_based_index(index)
         try:
             return self._ref[i]
@@ -2495,7 +2504,7 @@ class _FiniteRangeSetData( _SortedSetMixin,
         else:
             return sum(1 for _ in self)
 
-    def __getitem__(self, index):
+    def card(self, index):
         assert int(index) == index
         idx = self._to_0_based_index(index)
         if len(self._ranges) == 1:
@@ -3228,11 +3237,11 @@ class SetUnion_OrderedSet(_ScalarOrderedSetMixin, _OrderedSetMixin,
                           SetUnion_FiniteSet):
     __slots__ = tuple()
 
-    def __getitem__(self, index):
+    def card(self, index):
         idx = self._to_0_based_index(index)
         set0_len = len(self._sets[0])
         if idx < set0_len:
-            return self._sets[0][idx+1]
+            return self._sets[0].card(idx+1)
         else:
             idx -= set0_len - 1
             set1_iter = iter(self._sets[1])
@@ -3367,7 +3376,7 @@ class SetIntersection_OrderedSet(_ScalarOrderedSetMixin, _OrderedSetMixin,
                                  SetIntersection_FiniteSet):
     __slots__ = tuple()
 
-    def __getitem__(self, index):
+    def card(self, index):
         idx = self._to_0_based_index(index)
         _iter = iter(self)
         try:
@@ -3456,7 +3465,7 @@ class SetDifference_OrderedSet(_ScalarOrderedSetMixin, _OrderedSetMixin,
                                SetDifference_FiniteSet):
     __slots__ = tuple()
 
-    def __getitem__(self, index):
+    def card(self, index):
         idx = self._to_0_based_index(index)
         _iter = iter(self)
         try:
@@ -3564,7 +3573,7 @@ class SetSymmetricDifference_OrderedSet(_ScalarOrderedSetMixin,
                                         SetSymmetricDifference_FiniteSet):
     __slots__ = tuple()
 
-    def __getitem__(self, index):
+    def card(self, index):
         idx = self._to_0_based_index(index)
         _iter = iter(self)
         try:
@@ -3842,7 +3851,7 @@ class SetProduct_OrderedSet(_ScalarOrderedSetMixin, _OrderedSetMixin,
                             SetProduct_FiniteSet):
     __slots__ = tuple()
 
-    def __getitem__(self, index):
+    def card(self, index):
         _idx = self._to_0_based_index(index)
         _ord = list(len(_) for _ in self._sets)
         i = len(_ord)
@@ -3851,7 +3860,7 @@ class SetProduct_OrderedSet(_ScalarOrderedSetMixin, _OrderedSetMixin,
             _ord[i], _idx = _idx % _ord[i], _idx // _ord[i]
         if _idx:
             raise IndexError("%s index out of range" % (self.name,))
-        ans = tuple(s[i+1] for s,i in zip(self._sets, _ord))
+        ans = tuple(s.card(i+1) for s,i in zip(self._sets, _ord))
         if FLATTEN_CROSS_PRODUCT and normalize_index.flatten \
            and self.dimen != len(ans):
             return self._flatten_product(ans)

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -3618,18 +3618,18 @@ class TestSet(unittest.TestCase):
             self.assertTrue(_s.isordered())
             self.assertTrue(_s.isfinite())
             for i,v in enumerate(_l):
-                self.assertEqual(_s[i+1], v)
+                self.assertEqual(_s.card(i+1), v)
             with self.assertRaisesRegex(IndexError, "I index out of range"):
-                _s[len(_l)+1]
+                _s.card(len(_l)+1)
             with self.assertRaisesRegex(IndexError, "I index out of range"):
-                _s[len(_l)+2]
+                _s.card(len(_l)+2)
 
             for i,v in enumerate(reversed(_l)):
-                self.assertEqual(_s[-(i+1)], v)
+                self.assertEqual(_s.card(-(i+1)), v)
             with self.assertRaisesRegex(IndexError, "I index out of range"):
-                _s[-len(_l)-1]
+                _s.card(-len(_l)-1)
             with self.assertRaisesRegex(IndexError, "I index out of range"):
-                _s[-len(_l)-2]
+                _s.card(-len(_l)-2)
 
             for i,v in enumerate(_l):
                 self.assertEqual(_s.ord(v), i+1)
@@ -5575,6 +5575,21 @@ class TestDeprecation(unittest.TestCase):
             output.getvalue(),
             r"^DEPRECATED: check_values\(\) is deprecated: Sets only "
             r"contain valid")
+
+    def test_getitem(self):
+        m = ConcreteModel()
+        m.I = Set(initialize=['a','b'])
+        with LoggingIntercept() as OUT:
+            self.assertIs(m.I[None], m.I)
+        self.assertEqual(OUT.getvalue(), "")
+
+        with LoggingIntercept() as OUT:
+            self.assertEqual(m.I[2], 'b')
+        self.assertRegex(
+            OUT.getvalue().replace('\n', ' '),
+            r"^DEPRECATED: Using __getitem__ to return a set value from "
+            r"its \(ordered\) position is deprecated.  Please use card\(\)")
+
 
 
 class TestIssues(unittest.TestCase):


### PR DESCRIPTION
## Summary/Motivation:
This is an implementation of PEP #2049.

## Changes proposed in this PR:
- Add `OrderedSerMixin.card()` (by renaming implementations of `__getitem__()` to `card()`)
- Add an implementation of `__getitem__()` that returns `self` for scalar sets when the key is `None` (mimicking the `__getitem__` behavior of other scalar indexed components), otherwise it emits a deprecation warning and returns the result from `card()`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
