### PR TITLE
Improve deprecation context reporting

### DIFF
--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -123,6 +123,17 @@ def _wrap_func(func, msg, logger, version, remove_in):
     wrapper.__doc__ += _deprecation_docstring(func, msg, version, remove_in)
     return wrapper
 
+def _find_calling_frame(module_offset):
+    g = [globals()]
+    calling_frame = inspect.currentframe().f_back
+    while calling_frame is not None:
+        if calling_frame.f_globals is g[-1]:
+            calling_frame = calling_frame.f_back
+        elif len(g) < module_offset:
+            g.append(calling_frame.f_globals)
+        else:
+            break
+    return calling_frame
 
 def deprecation_warning(msg, logger=None, version=None,
                         remove_in=None, calling_frame=None):
@@ -149,28 +160,36 @@ def deprecation_warning(msg, logger=None, version=None,
             the deprecation warning.
 
     """
-    msg = textwrap.fill(
-        'DEPRECATED: %s' % (_default_msg(None, msg, version, remove_in),),
-        width=70)
-    if calling_frame is None:
-        try:
-            g = globals()
-            calling_frame = inspect.currentframe().f_back
-            while calling_frame is not None and calling_frame.f_globals is g:
-                calling_frame = calling_frame.f_back
-        except:
-            pass
-    if calling_frame is not None:
-        info = inspect.getframeinfo(calling_frame)
-        msg += "\n(called from %s:%s)" % (info.filename.strip(), info.lineno)
-
     if logger is None:
         if calling_frame is not None:
-            logger = calling_frame.f_globals['__package__']
+            cf = calling_frame
+        else:
+            # The relevant module is the one that holds the
+            # function/method that called deprecation_warning
+            cf = _find_calling_frame(1)
+        if cf is not None:
+            logger = cf.f_globals['__package__']
             if logger is not None and not logger.startswith('pyomo'):
                 logger = None
         if logger is None:
             logger = 'pyomo'
+
+    msg = textwrap.fill(
+        'DEPRECATED: %s' % (_default_msg(None, msg, version, remove_in),),
+        width=70)
+    if calling_frame is None:
+        # The useful thing to let the user know is what called the
+        # function that generated the deprecation warning.  The current
+        # globals() is *this* module.  Walking up the stack to find the
+        # frame where the globals() changes tells us the module that is
+        # issuing the deprecation warning.  As we assume that *that*
+        # module will not trigger it's own deprecation warnings, we will
+        # walk farther up until the globals changes again.
+        calling_frame = _find_calling_frame(2)
+    if calling_frame is not None:
+        info = inspect.getframeinfo(calling_frame)
+        msg += "\n(called from %s:%s)" % (info.filename.strip(), info.lineno)
+
     logging.getLogger(logger).warning(msg)
 
 
@@ -211,8 +230,8 @@ def _import_object(name, target, version, remove_in):
     from importlib import import_module
     modname, targetname = target.rsplit('.',1)
     deprecation_warning(
-        "the '%s' class has been moved to '%s'" % (name, target),
-        version=version, remove_in=remove_in)
+        "the '%s' class has been moved to '%s'.  Please update your import."
+        % (name, target), version=version, remove_in=remove_in)
     return getattr(import_module(modname), targetname)
 
 class _ModuleGetattrBackport_27(object):
@@ -385,9 +404,10 @@ class RenamedClass(type):
                 version = classdict.get('__renamed__version__')
                 remove_in = classdict.get('__renamed__remove_in__')
                 deprecation_warning(
-                    "%s  The class '%s' has been renamed to '%s'" % (
+                    "%s  The class '%s' has been renamed to '%s'." % (
                         msg, name, new_class.__name__),
-                    version=version, remove_in=remove_in)
+                    version=version, remove_in=remove_in,
+                    calling_frame=_find_calling_frame(1))
             classdict['__renamed__warning__'] = __renamed__warning__
 
             if '__renamed__version__' not in classdict:

--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -183,8 +183,8 @@ def deprecation_warning(msg, logger=None, version=None,
         # globals() is *this* module.  Walking up the stack to find the
         # frame where the globals() changes tells us the module that is
         # issuing the deprecation warning.  As we assume that *that*
-        # module will not trigger it's own deprecation warnings, we will
-        # walk farther up until the globals changes again.
+        # module will not trigger its own deprecation warnings, we will
+        # walk farther up until the globals() changes again.
         calling_frame = _find_calling_frame(2)
     if calling_frame is not None:
         info = inspect.getframeinfo(calling_frame)

--- a/pyomo/common/tests/test_deprecated.py
+++ b/pyomo/common/tests/test_deprecated.py
@@ -410,7 +410,7 @@ class TestRenamedClass(unittest.TestCase):
             out.getvalue().replace("\n", " ").strip(),
             r"^DEPRECATED: Declaring class 'DeprecatedClassSubclass' "
             r"derived from 'DeprecatedClass'.  "
-            r"The class 'DeprecatedClass' has been renamed to 'NewClass'  "
+            r"The class 'DeprecatedClass' has been renamed to 'NewClass'.  "
             r"\(deprecated in X.y\) \(called from [^\)]*\)$",
         )
 
@@ -438,7 +438,7 @@ class TestRenamedClass(unittest.TestCase):
         self.assertRegex(
             out.getvalue().replace("\n", " ").strip(),
             r"^DEPRECATED: Instantiating class 'DeprecatedClass'.  "
-            r"The class 'DeprecatedClass' has been renamed to 'NewClass'  "
+            r"The class 'DeprecatedClass' has been renamed to 'NewClass'.  "
             r"\(deprecated in X.y\) \(called from [^\)]*\)$",
         )
 
@@ -468,8 +468,8 @@ class TestRenamedClass(unittest.TestCase):
             self.assertRegex(
                 out.getvalue().replace("\n", " ").strip(),
                 r"^DEPRECATED: Checking type relative to 'DeprecatedClass'.  "
-                r"The class 'DeprecatedClass' has been renamed to 'NewClass'  "
-                r"\(deprecated in X.y\) \(called from [^\)]*\)$",
+                r"The class 'DeprecatedClass' has been renamed to 'NewClass'."
+                r"  \(deprecated in X.y\) \(called from [^\)]*\)$",
             )
 
         #
@@ -491,8 +491,8 @@ class TestRenamedClass(unittest.TestCase):
             self.assertRegex(
                 out.getvalue().replace("\n", " ").strip(),
                 r"^DEPRECATED: Checking type relative to 'DeprecatedClass'.  "
-                r"The class 'DeprecatedClass' has been renamed to 'NewClass'  "
-                r"\(deprecated in X.y\) \(called from [^\)]*\)$",
+                r"The class 'DeprecatedClass' has been renamed to 'NewClass'."
+                r"  \(deprecated in X.y\) \(called from [^\)]*\)$",
             )
 
         #


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This is a small PR to improve how "`(called from ...)`" is reported for deprecation warnings.  This version does a better job of determining the actual module whose code should be updated:
- for `deprecation_warning()` and `@deprecated` decorators, this is the first frame from the module that calls the module that deprecated the functionality
- for `RenamedClass` it is the module that imported the old class name

## Changes proposed in this PR:
- implement a `_find_calling_frame(module_offset)` method for determining the "calling" module
- Use `_find_calling_frame(2)` for `deprecation_warning()` (and `@deprecated`)
- Use `_find_calling_frame(2)` for `RenamedClass` 
- (add a missing period to the message)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
