### PR TITLE
Add deprecation path for relocated classes and methods

### DIFF
--- a/pyomo/core/__init__.py
+++ b/pyomo/core/__init__.py
@@ -123,12 +123,21 @@ from pyomo.core.base import util
 
 from pyomo.core.base.instance2dat import instance2dat
 
+from pyomo.core.util import (prod, quicksum, sum_product, dot_product,
+                             summation, sequence)
+
 # These APIs are deprecated and should be removed in the near future
 from pyomo.core.base.set import (
     set_options, RealSet, IntegerSet, BooleanSet,
 )
 
-from pyomo.core.util import (prod, quicksum, sum_product, dot_product,
-                             summation, sequence)
-
-from weakref import ref as weakref_ref
+from pyomo.common.deprecation import relocated_module_attribute
+relocated_module_attribute(
+    'SimpleBlock', 'pyomo.core.base.block.SimpleBlock', version='6.0')
+relocated_module_attribute(
+    'SimpleVar', 'pyomo.core.base.var.SimpleVar', version='6.0')
+relocated_module_attribute(
+    'SimpleBooleanVar', 'pyomo.core.base.boolean_var.SimpleBooleanVar',
+    version='6.0'
+)
+del relocated_module_attribute

--- a/pyomo/core/base/__init__.py
+++ b/pyomo/core/base/__init__.py
@@ -10,32 +10,9 @@
 
 # TODO: this import is for historical backwards compatibility and should
 # probably be removed
-
-import pyomo.core.expr.numvalue
-import pyomo.core.expr.logical_expr
 from pyomo.common.collections import ComponentMap
-from pyomo.core.expr.symbol_map import SymbolMap
-import pyomo.core.base.action
-import pyomo.core.base.boolean_var
-import pyomo.core.base.check
-import pyomo.core.base.component
-import pyomo.core.base.config
-import pyomo.core.base.constraint
-import pyomo.core.base.expression
-import pyomo.core.base.global_set
-import pyomo.core.base.indexed_component
-import pyomo.core.base.indexed_component_slice
-import pyomo.core.base.label
-import pyomo.core.base.logical_constraint
-import pyomo.core.base.misc
-import pyomo.core.base.param
-import pyomo.core.base.range
-import pyomo.core.base.set_types
-import pyomo.core.base.set
-import pyomo.core.base.units_container
-import pyomo.core.base.util
-import pyomo.core.base.var
 
+from pyomo.core.expr.symbol_map import SymbolMap
 from pyomo.core.expr.numvalue import (nonpyomo_leaf_types,
                                       native_types,
                                       native_numeric_types,
@@ -115,8 +92,6 @@ from pyomo.core.base.transformation import (
     Transformation,
     TransformationFactory,
 )
-#
-import pyomo.core.base.util
 
 from pyomo.core.base.instance2dat import instance2dat
 
@@ -125,12 +100,13 @@ from pyomo.core.base.set import (
     set_options, RealSet, IntegerSet, BooleanSet,
 )
 
-from weakref import ref as weakref_ref
-
-#
-# This is a hack to strip out modules, which shouldn't have been included in these imports
-#
-import types
-_locals = locals()
-__all__ = [__name for __name in _locals.keys() if (not __name.startswith('_') and not isinstance(_locals[__name],types.ModuleType)) or __name == '_' ]
-__all__.append('pyomo')
+from pyomo.common.deprecation import relocated_module_attribute
+relocated_module_attribute(
+    'SimpleBlock', 'pyomo.core.base.block.SimpleBlock', version='6.0')
+relocated_module_attribute(
+    'SimpleVar', 'pyomo.core.base.var.SimpleVar', version='6.0')
+relocated_module_attribute(
+    'SimpleBooleanVar', 'pyomo.core.base.boolean_var.SimpleBooleanVar',
+    version='6.0'
+)
+del relocated_module_attribute

--- a/pyomo/core/base/util.py
+++ b/pyomo/core/base/util.py
@@ -13,8 +13,21 @@
 #
 import inspect
 
+from pyomo.common.deprecation import relocated_module_attribute
 from pyomo.core.base.indexed_component import normalize_index
 
+relocated_module_attribute(
+    'disable_methods', 'pyomo.core.base.disable_methods.disable_methods',
+    version='TBD')
+relocated_module_attribute(
+    'Initialzer', 'pyomo.core.base.initialzer.Initialzer',
+    version='TBD')
+relocated_module_attribute(
+    'IndexedCallInitialzer', 'pyomo.core.base.initialzer.Initialzer',
+    version='TBD')
+relocated_module_attribute(
+    'CountedCallInitialzer', 'pyomo.core.base.initialzer.Initialzer',
+    version='TBD')
 
 def is_functor(obj):
     """

--- a/pyomo/environ/__init__.py
+++ b/pyomo/environ/__init__.py
@@ -114,7 +114,7 @@ from pyomo.core import expr, base, beta, kernel, plugins
 from pyomo.core.base import util
 
 from pyomo.core import (numvalue, numeric_expr, boolean_value,
-                             current, symbol_map, sympy_tools, 
+                             current, symbol_map, sympy_tools,
                              taylor_series, visitor, expr_common, expr_errors,
                              calculus, native_types,
                              linear_expression, nonlinear_expression,
@@ -132,20 +132,20 @@ from pyomo.core import (numvalue, numeric_expr, boolean_value,
                              maximize, PyomoOptions, Expression, CuidLabeler,
                              CounterLabeler, NumericLabeler,
                              CNameLabeler, TextLabeler,
-                             AlphaNumericTextLabeler, NameLabeler, ShortNameLabeler, 
-                             name, Component, ComponentUID, BuildAction, 
+                             AlphaNumericTextLabeler, NameLabeler, ShortNameLabeler,
+                             name, Component, ComponentUID, BuildAction,
                              BuildCheck, Set, SetOf, simple_set_rule, RangeSet,
                              Param, Var, VarList, ScalarVar,
                              BooleanVar, BooleanVarList, ScalarBooleanVar,
                              logical_expr, simple_constraint_rule,
                              simple_constraintlist_rule, ConstraintList,
-                             Constraint, LogicalConstraint, 
+                             Constraint, LogicalConstraint,
                              LogicalConstraintList, simple_objective_rule,
                              simple_objectivelist_rule, Objective,
                              ObjectiveList, Connector, SOSConstraint,
                              Piecewise, active_export_suffix_generator,
-                             active_import_suffix_generator, Suffix, 
-                             ExternalFunction, symbol_map_from_instance, 
+                             active_import_suffix_generator, Suffix,
+                             ExternalFunction, symbol_map_from_instance,
                              Reference, Reals, PositiveReals, NonPositiveReals,
                              NegativeReals, NonNegativeReals, Integers,
                              PositiveIntegers, NonPositiveIntegers,
@@ -154,12 +154,12 @@ from pyomo.core import (numvalue, numeric_expr, boolean_value,
                              UnitInterval, PercentFraction, RealInterval,
                              IntegerInterval, display, SortComponents,
                              TraversalStrategy, Block, ScalarBlock,
-                             active_components, components, 
-                             active_components_data, components_data, 
+                             active_components, components,
+                             active_components_data, components_data,
                              global_option, Model, ConcreteModel,
                              AbstractModel,
                              ModelComponentFactory, Transformation,
-                             TransformationFactory, instance2dat, 
+                             TransformationFactory, instance2dat,
                              set_options, RealSet, IntegerSet, BooleanSet,
                              prod, quicksum, sum_product, dot_product,
                              summation, sequence)
@@ -170,4 +170,15 @@ from pyomo.opt import (
     assert_optimal_termination
     )
 from pyomo.core.base.units_container import units
-from weakref import ref as weakref_ref
+
+# These APIs are deprecated and should be removed in the near future
+from pyomo.common.deprecation import relocated_module_attribute
+relocated_module_attribute(
+    'SimpleBlock', 'pyomo.core.base.block.SimpleBlock', version='6.0')
+relocated_module_attribute(
+    'SimpleVar', 'pyomo.core.base.var.SimpleVar', version='6.0')
+relocated_module_attribute(
+    'SimpleBooleanVar', 'pyomo.core.base.boolean_var.SimpleBooleanVar',
+    version='6.0'
+)
+del relocated_module_attribute


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Pyomo 6.0 renamed `SimpleBlock`, `SimpleVar`, and `SimpleBooleanVar`, but did not provide deprecation paths for users who import it from `pyomo.core`, `pyomo.core.base`, or `pyomo.environ`.  This PR adds that deprecation path.  We also recently moved `disabled_methods` and `Initializer` out of `pyomo.core.base.util`, and this PR adds the deprecation path for those imports as well.

## Changes proposed in this PR:
- `relocated_module_attribute` calls for `SimpleBlock`, `SimpleVar`, and `SimpleBooleanVar` in `pyomo.core`, `pyomo.core.base`, or `pyomo.environ`.
- `relocated_module_attribute` calls for `disabled_methods` and `Initializer` in `pyomo.core.base.util`
- clean up imports in `pyomo.core.base.__init__.py`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
