### PR TITLE
Resolving tee issues with Xpress 8.9+

### DIFF
--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -213,11 +213,8 @@ class XpressDirect(DirectSolver):
             # output without disabling logging altogether.
             # As a work around, we capature all screen output
             # when tee is False.
-            try:
-                with capture_output() as OUT:
-                    self._solver_model.solve()
-            except:
-                raise
+            with capture_output() as OUT:
+                self._solver_model.solve()
         self._opt_time = time.time() - start_time
 
         self._solver_model.setlogfile('')


### PR DESCRIPTION
## Fixes # N/A

## Summary/Motivation:
Starting with Xpress 8.9 / 36, then behavior of console logging changed in Xpress. This PR keeps xpress_direct / xpress_persistent current with this change.

## Changes proposed in this PR:
- Only create a "cbmessage" callback when tee is True for Xpress <8.9
- Capture the solver output in any case when tee is False

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
