### PR TITLE
Move PYOMO_CONFIG_DIR into pyomo.common.envvar

### DIFF
--- a/pyomo/common/__init__.py
+++ b/pyomo/common/__init__.py
@@ -11,6 +11,7 @@
 # The log should be imported first so that the Pyomo LogHandler can be
 # set up as soon as possible
 from . import log
+from . import envvar
 
 from .factory import Factory
 

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -23,33 +23,19 @@ import io
 import logging
 import os
 import pickle
-import platform
 import re
 import sys
 from textwrap import wrap
 import types
 
-from pyomo.common.deprecation import deprecated
+from pyomo.common.deprecation import deprecated, relocated_module_attribute
 from pyomo.common.modeling import NoArgumentGiven
 
 logger = logging.getLogger('pyomo.common.config')
 
-if 'PYOMO_CONFIG_DIR' in os.environ:
-    PYOMO_CONFIG_DIR = os.path.abspath(os.environ['PYOMO_CONFIG_DIR'])
-elif platform.system().lower().startswith(('windows','cygwin')):
-    PYOMO_CONFIG_DIR = os.path.abspath(
-        os.path.join(os.environ.get('LOCALAPPDATA', ''), 'Pyomo'))
-else:
-    PYOMO_CONFIG_DIR = os.path.abspath(
-        os.path.join(os.environ.get('HOME', ''), '.pyomo'))
-
-# Note that alternative platform-independent implementation of the above
-# could be to use:
-#
-#   PYOMO_CONFIG_DIR = os.path.abspath(appdirs.user_data_dir('pyomo'))
-#
-# But would require re-adding the hard dependency on appdirs.  For now
-# (13 Jul 20), the above appears to be sufficiently robust.
+relocated_module_attribute(
+    'PYOMO_CONFIG_DIR', 'pyomo.common.envvar.PYOMO_CONFIG_DIR',
+    version='TBD')
 
 USER_OPTION = 0
 ADVANCED_OPTION = 1

--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -17,7 +17,7 @@ import re
 import sys
 import subprocess
 
-from .config import PYOMO_CONFIG_DIR
+from . import envvar
 from .deprecation import deprecated
 from .errors import DeveloperError
 import pyomo.common
@@ -261,7 +261,7 @@ class FileDownloader(object):
         if self.target is not None:
             self._fname = self.target
         else:
-            self._fname = PYOMO_CONFIG_DIR
+            self._fname = envvar.PYOMO_CONFIG_DIR
             if not os.path.isdir(self._fname):
                 os.makedirs(self._fname)
         if os.path.isdir(self._fname):

--- a/pyomo/common/envvar.py
+++ b/pyomo/common/envvar.py
@@ -1,0 +1,29 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import os
+import platform
+
+if 'PYOMO_CONFIG_DIR' in os.environ:
+    PYOMO_CONFIG_DIR = os.path.abspath(os.environ['PYOMO_CONFIG_DIR'])
+elif platform.system().lower().startswith(('windows','cygwin')):
+    PYOMO_CONFIG_DIR = os.path.abspath(
+        os.path.join(os.environ.get('LOCALAPPDATA', ''), 'Pyomo'))
+else:
+    PYOMO_CONFIG_DIR = os.path.abspath(
+        os.path.join(os.environ.get('HOME', ''), '.pyomo'))
+
+# Note that alternative platform-independent implementation of the above
+# could be to use:
+#
+#   PYOMO_CONFIG_DIR = os.path.abspath(appdirs.user_data_dir('pyomo'))
+#
+# But would require re-adding the hard dependency on appdirs.  For now
+# (13 Jul 20), the above appears to be sufficiently robust.

--- a/pyomo/common/fileutils.py
+++ b/pyomo/common/fileutils.py
@@ -25,8 +25,8 @@ import platform
 import importlib.util
 import sys
 
+from . import envvar
 from .deprecation import deprecated
-from . import config
 
 def this_file(stack_offset=1):
     """Returns the file name for the module that calls this function.
@@ -316,10 +316,10 @@ def find_library(libname, cwd=True, include_PATH=True, pathlist=None):
     if pathlist is None:
         # Note: PYOMO_CONFIG_DIR/lib comes before LD_LIBRARY_PATH, and
         # PYOMO_CONFIG_DIR/bin comes immediately before PATH
-        pathlist = [ os.path.join(config.PYOMO_CONFIG_DIR, 'lib') ]
+        pathlist = [ os.path.join(envvar.PYOMO_CONFIG_DIR, 'lib') ]
         pathlist.extend(os.environ.get('LD_LIBRARY_PATH','').split(os.pathsep))
         if include_PATH:
-            pathlist.append( os.path.join(config.PYOMO_CONFIG_DIR, 'bin') )
+            pathlist.append( os.path.join(envvar.PYOMO_CONFIG_DIR, 'bin') )
     elif isinstance(pathlist, str):
         pathlist = pathlist.split(os.pathsep)
     else:
@@ -386,7 +386,7 @@ def find_executable(exename, cwd=True, include_PATH=True, pathlist=None):
 
     """
     if pathlist is None:
-        pathlist = [ os.path.join(config.PYOMO_CONFIG_DIR, 'bin') ]
+        pathlist = [ os.path.join(envvar.PYOMO_CONFIG_DIR, 'bin') ]
     elif isinstance(pathlist, str):
         pathlist = pathlist.split(os.pathsep)
     else:
@@ -608,7 +608,7 @@ class PathManager(object):
         >>> import os
         >>> from stat import S_IXUSR, S_IXGRP, S_IXOTH
         >>> _testfile = os.path.join(
-        ...    pyomo.common.config.PYOMO_CONFIG_DIR, 'bin', 'demo_exec_file')
+        ...    pyomo.common.envvar.PYOMO_CONFIG_DIR, 'bin', 'demo_exec_file')
         >>> _del_testfile = not os.path.exists(_testfile)
         >>> if _del_testfile:
         ...     open(_testfile,'w').close()
@@ -654,13 +654,13 @@ class PathManager(object):
     The ``Executable`` singleton looks for executables in the system
     ``PATH`` and in the list of directories specified by the ``pathlist``
     attribute.  ``Executable.pathlist`` defaults to a list containing the
-    ``os.path.join(pyomo.common.config.PYOMO_CONFIG_DIR, 'bin')``.
+    ``os.path.join(pyomo.common.envvar.PYOMO_CONFIG_DIR, 'bin')``.
 
     The ``Library`` singleton looks for executables in the system
     ``LD_LIBRARY_PATH``, ``PATH`` and in the list of directories
     specified by the ``pathlist`` attribute.  ``Library.pathlist``
     defaults to a list containing the
-    ``os.path.join(pyomo.common.config.PYOMO_CONFIG_DIR, 'lib')``.
+    ``os.path.join(pyomo.common.envvar.PYOMO_CONFIG_DIR, 'lib')``.
 
     Users may also override the normal file resolution by explicitly
     setting the location using :py:meth:`set_path`:
@@ -668,7 +668,7 @@ class PathManager(object):
     .. doctest::
 
         >>> Executable('demo_exec_file').set_path(os.path.join(
-        ...     pyomo.common.config.PYOMO_CONFIG_DIR, 'bin', 'demo_exec_file'))
+        ...     pyomo.common.envvar.PYOMO_CONFIG_DIR, 'bin', 'demo_exec_file'))
 
     Explicitly setting the path is an absolute operation and will
     set the location whether or not that location points to an actual
@@ -690,7 +690,7 @@ class PathManager(object):
         >>> loc = Executable('demo_exec_file').executable
         >>> print(os.path.isfile(loc))
         >>> Executable('demo_exec_file').executable = os.path.join(
-        ...     pyomo.common.config.PYOMO_CONFIG_DIR, 'bin', 'demo_exec_file')
+        ...     pyomo.common.envvar.PYOMO_CONFIG_DIR, 'bin', 'demo_exec_file')
         >>> Executable('demo_exec_file').executable = None
 
     .. doctest::

--- a/pyomo/common/tests/test_download.py
+++ b/pyomo/common/tests/test_download.py
@@ -16,10 +16,9 @@ import tempfile
 import subprocess
 
 import pyomo.common.unittest as unittest
-
+import pyomo.common.envvar as envvar
 
 from pyomo.common import DeveloperError
-from pyomo.common.config import PYOMO_CONFIG_DIR
 from pyomo.common.fileutils import this_file
 from pyomo.common.download import FileDownloader, distro_available
 from pyomo.common.tee import capture_output
@@ -112,9 +111,10 @@ class Test_FileDownloader(unittest.TestCase):
         f = FileDownloader()
         self.assertIsNone(f._fname)
         f.set_destination_filename('foo')
-        self.assertEqual(f._fname, os.path.join(PYOMO_CONFIG_DIR, 'foo'))
+        self.assertEqual(f._fname,
+                         os.path.join(envvar.PYOMO_CONFIG_DIR, 'foo'))
         # By this point, the CONFIG_DIR is guaranteed to have been created
-        self.assertTrue(os.path.isdir(PYOMO_CONFIG_DIR))
+        self.assertTrue(os.path.isdir(envvar.PYOMO_CONFIG_DIR))
 
         f.target = self.tmpdir
         f.set_destination_filename('foo')

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -22,7 +22,7 @@ from io import StringIO
 
 import pyomo.common.unittest as unittest
 
-import pyomo.common.config as config
+import pyomo.common.envvar as envvar
 from pyomo.common.log import LoggingIntercept
 from pyomo.common.fileutils import (
     this_file, this_file_dir, find_file, find_library, find_executable, 
@@ -46,12 +46,12 @@ class TestFileUtils(unittest.TestCase):
     def setUp(self):
         self.tmpdir = None
         self.basedir = os.path.abspath(os.path.curdir)
-        self.config = config.PYOMO_CONFIG_DIR
+        self.config = envvar.PYOMO_CONFIG_DIR
         self.ld_library_path = os.environ.get('LD_LIBRARY_PATH', None)
         self.path = os.environ.get('PATH', None)
 
     def tearDown(self):
-        config.PYOMO_CONFIG_DIR = self.config
+        envvar.PYOMO_CONFIG_DIR = self.config
         os.chdir(self.basedir)
         if self.tmpdir:
             shutil.rmtree(self.tmpdir)
@@ -244,7 +244,7 @@ class TestFileUtils(unittest.TestCase):
         _lib = ctypes.cdll.LoadLibrary(a)
         self.assertIsNotNone(_lib)
 
-        config.PYOMO_CONFIG_DIR = self.tmpdir
+        envvar.PYOMO_CONFIG_DIR = self.tmpdir
         config_libdir = os.path.join(self.tmpdir, 'lib')
         os.mkdir(config_libdir)
         config_bindir = os.path.join(self.tmpdir, 'bin')
@@ -341,7 +341,7 @@ class TestFileUtils(unittest.TestCase):
         self.tmpdir = os.path.abspath(tempfile.mkdtemp())
         os.chdir(self.tmpdir)
 
-        config.PYOMO_CONFIG_DIR = self.tmpdir
+        envvar.PYOMO_CONFIG_DIR = self.tmpdir
         config_libdir = os.path.join(self.tmpdir, 'lib')
         os.mkdir(config_libdir)
         config_bindir = os.path.join(self.tmpdir, 'bin')
@@ -427,7 +427,7 @@ class TestFileUtils(unittest.TestCase):
         Executable = PathManager(find_executable, _ExecutableData)
         self.tmpdir = os.path.abspath(tempfile.mkdtemp())
 
-        config.PYOMO_CONFIG_DIR = self.tmpdir
+        envvar.PYOMO_CONFIG_DIR = self.tmpdir
         config_bindir = os.path.join(self.tmpdir, 'bin')
         os.mkdir(config_bindir)
 

--- a/pyomo/contrib/mcpp/build.py
+++ b/pyomo/contrib/mcpp/build.py
@@ -12,7 +12,7 @@ import os
 import shutil
 import tempfile
 
-import pyomo.common.envars as envvar
+import pyomo.common.envvar as envvar
 
 from pyomo.common.fileutils import this_file_dir, find_dir
 from pyomo.common.download import FileDownloader

--- a/pyomo/contrib/mcpp/build.py
+++ b/pyomo/contrib/mcpp/build.py
@@ -12,7 +12,8 @@ import os
 import shutil
 import tempfile
 
-from pyomo.common.config import PYOMO_CONFIG_DIR
+import pyomo.common.envars as envvar
+
 from pyomo.common.fileutils import this_file_dir, find_dir
 from pyomo.common.download import FileDownloader
 
@@ -24,7 +25,7 @@ def _generate_configuration():
     # Try and find MC++.  Defer to the MCPP_ROOT if it is set;
     # otherwise, look in common locations for a mcpp directory.
     pathlist=[
-        os.path.join(PYOMO_CONFIG_DIR, 'src'),
+        os.path.join(envvar.PYOMO_CONFIG_DIR, 'src'),
         this_file_dir(),
     ]
     if 'MCPP_ROOT' in os.environ:
@@ -90,7 +91,7 @@ def build_mcpp():
     package_config = _generate_configuration()
     package_config['cmdclass'] = {'build_ext': _BuildWithoutPlatformInfo}
     dist = distutils.core.Distribution(package_config)
-    install_dir = os.path.join(PYOMO_CONFIG_DIR, 'lib')
+    install_dir = os.path.join(envvar.PYOMO_CONFIG_DIR, 'lib')
     dist.get_command_obj('install_lib').install_dir = install_dir
     try:
         basedir = os.path.abspath(os.path.curdir)

--- a/pyomo/contrib/pynumero/build.py
+++ b/pyomo/contrib/pynumero/build.py
@@ -15,7 +15,7 @@ import stat
 import sys
 import tempfile
 
-from pyomo.common import config
+import pyomo.common.envvar as envvar
 from pyomo.common.fileutils import this_file_dir, find_executable
 
 def handleReadonly(function, path, excinfo):
@@ -37,7 +37,7 @@ def build_pynumero(user_args=[], parallel=None):
 
             cmake_config = 'Debug' if self.debug else 'Release'
             cmake_args = [
-                '-DCMAKE_INSTALL_PREFIX=' + config.PYOMO_CONFIG_DIR,
+                '-DCMAKE_INSTALL_PREFIX=' + envvar.PYOMO_CONFIG_DIR,
                 '-DBUILD_AMPLMP_IF_NEEDED=ON',
                 #'-DCMAKE_BUILD_TYPE=' + cmake_config,
             ] + user_args
@@ -96,7 +96,7 @@ def build_pynumero(user_args=[], parallel=None):
         tmpdir = os.path.abspath(tempfile.mkdtemp())
         os.chdir(tmpdir)
         dist.run_command('build_ext')
-        install_dir = os.path.join(config.PYOMO_CONFIG_DIR, 'lib')
+        install_dir = os.path.join(envvar.PYOMO_CONFIG_DIR, 'lib')
     finally:
         os.chdir(basedir)
         shutil.rmtree(tmpdir, onerror=handleReadonly)

--- a/pyomo/core/base/config.py
+++ b/pyomo/core/base/config.py
@@ -11,8 +11,9 @@
 import os
 import json
 
+import pyomo.common.envvar as envvar
 from pyomo.common.config import (
-    ConfigBase, ConfigBlock, ConfigValue, ADVANCED_OPTION, PYOMO_CONFIG_DIR,
+    ConfigBase, ConfigBlock, ConfigValue, ADVANCED_OPTION,
 )
 from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 import logging
@@ -30,7 +31,7 @@ class _PyomoOptions(object):
         sources.append((yaml, 'yml', yaml_available, 'yaml', yaml_load_args))
         sources.append((yaml, 'yaml', yaml_available, 'yaml', yaml_load_args))
         for parser, suffix, available, library, parser_args in sources:
-            cfg_file = os.path.join( PYOMO_CONFIG_DIR, 'config.'+suffix)
+            cfg_file = os.path.join(envvar.PYOMO_CONFIG_DIR, 'config.'+suffix)
             if not os.path.exists(cfg_file):
                 continue
             if not available:


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This moves the `PYOMO_CONFIG_DIR` into `pyomo.common.envvar`.  The move helps resolve potential circular references between `pyomo.common.config` and `pyomo.common.fileutils` and allows for a cleaner implementation of the Config `Module` domain in #2062

## Changes proposed in this PR:
- move `PYOMO_CONFIG_DIR` to `pyomo.common.envvar` 
- add a deprecation path for `pyomo.common.config.PYOMO_CONFIG_DIR`
- update references throughout Pyomo

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
