### PR TITLE
Correct scalar mutable param getitem implementation

### DIFF
--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -522,7 +522,10 @@ class Param(IndexedComponent, IndexedComponent_NDArrayMixin):
             # reasonable values produces an informative error.
             if self._mutable:
                 # Note: _ParamData defaults to Param.NoValue
-                ans = self._data[index] = _ParamData(self)
+                if self.is_indexed():
+                    ans = self._data[index] = _ParamData(self)
+                else:
+                    ans = self._data[index] = self
                 return ans
             if self.is_indexed():
                 idx_str = '%s[%s]' % (self.name, index,)

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -1405,6 +1405,32 @@ q : Size=3, Index=Any, Domain=Any, Default=None, Mutable=True
 1 Declarations: p
         """.strip())
 
+    def test_scalar_get_mutable_when_not_present(self):
+        m = ConcreteModel()
+        m.p = Param(mutable=True)
+        self.assertEqual(m.p._data, {})
+        m.x_p = Var(bounds=(0, m.p))
+        self.assertEqual(m.p._data, {})
+        self.assertIs(m.p[None], m.p)
+        self.assertEqual(len(m.p._data), 1)
+        self.assertIs(m.p._data[None], m.p)
+        m.p = 10
+        self.assertEqual(m.x_p.bounds, (0, 10))
+        m.p = 20
+        self.assertEqual(m.x_p.bounds, (0, 20))
+
+    def test_scalar_set_mutable_when_not_present(self):
+        m = ConcreteModel()
+        m.p = Param(mutable=True)
+        self.assertEqual(m.p._data, {})
+        m.p = 10
+        self.assertEqual(len(m.p._data), 1)
+        self.assertIs(m.p._data[None], m.p)
+        m.x_p = Var(bounds=(0, m.p))
+        self.assertEqual(m.x_p.bounds, (0, 10))
+        m.p = 20
+        self.assertEqual(m.x_p.bounds, (0, 20))
+
 
 def createNonIndexedParamMethod(func, init_xy, new_xy, tol=1e-10):
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Mutable Scalar Params that were first instantiated using getitem were being initialized as if they were indexed params.  This PR corrects that behavior, including a test that verifies the expected behavior.

## Changes proposed in this PR:
- fix `_getitem_when_not_present` for scalar mutable params
- add tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
