### PR TITLE
Fix Var bounds with unitted mutable Params

### DIFF
--- a/pyomo/core/tests/unit/test_var.py
+++ b/pyomo/core/tests/unit/test_var.py
@@ -1405,6 +1405,7 @@ class MiscVarTests(unittest.TestCase):
     def test_set_bounds_units(self):
         m = ConcreteModel()
         m.x = Var(units=units.g)
+        m.p = Param(mutable=True, initialize=1, units=units.kg)
         m.x.setlb(5)
         self.assertEqual(m.x.lb, 5)
         m.x.setlb(6*units.g)
@@ -1413,6 +1414,10 @@ class MiscVarTests(unittest.TestCase):
         self.assertEqual(m.x.lb, 7000)
         with self.assertRaises(UnitsError):
             m.x.setlb(1*units.s)
+        m.x.setlb(m.p)
+        self.assertEqual(m.x.lb, 1000)
+        m.p = 2 * units.kg
+        self.assertEqual(m.x.lb, 2000)
 
         m.x.setub(2)
         self.assertEqual(m.x.ub, 2)
@@ -1421,7 +1426,11 @@ class MiscVarTests(unittest.TestCase):
         m.x.setub(4*units.kg)
         self.assertEqual(m.x.ub, 4000)
         with self.assertRaises(UnitsError):
-            m.x.setlb(1*units.s)
+            m.x.setub(1*units.s)
+        m.x.setub(m.p)
+        self.assertEqual(m.x.ub, 2000)
+        m.p = 3 * units.kg
+        self.assertEqual(m.x.ub, 3000)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fixes #2060

## Summary/Motivation:
Pyomo 6.0's support for automatically converting unitted values when setting Var bounds broke the use of unitted mutable Params (reported in #2060).  This PR causes Var to preserve the expressions when converting incoming unitted values.

## Changes proposed in this PR:
- preserve expressions (use `units.convert()` and not `units.convert_value()`) when setting Var bounds with units
- add test for the expected behavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
