### PR TITLE
Improve `@disable_methods` decorator, fix `str(FlagType)`

### DIFF
--- a/pyomo/common/modeling.py
+++ b/pyomo/common/modeling.py
@@ -57,7 +57,7 @@ class FlagType(type):
             return cls.__module__ + "." + cls.__qualname__
 
     def __str__(cls):
-        return __name__
+        return cls.__name__
 
 
 class NOTSET(object, metaclass=FlagType):

--- a/pyomo/common/tests/test_modeling.py
+++ b/pyomo/common/tests/test_modeling.py
@@ -8,10 +8,12 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import sys
+
 import pyomo.common.unittest as unittest
 
 from pyomo.environ import ConcreteModel, Var
-from pyomo.common.modeling import unique_component_name
+from pyomo.common.modeling import unique_component_name, NOTSET
 
 class TestModeling(unittest.TestCase):
     def test_unique_component_name(self):
@@ -45,3 +47,7 @@ class TestModeling(unittest.TestCase):
         self.assertIn(name[2], '0123456789')
         self.assertIn(name[3], '0123456789')
 
+    def test_NOTSET(self):
+        self.assertEqual(str(NOTSET), 'NOTSET')
+        assert 'sphinx' not in sys.modules
+        self.assertEqual(repr(NOTSET), 'pyomo.common.modeling.NOTSET')

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -584,7 +584,7 @@ class Component(_ComponentBase):
             else:
                 ans = name_repr(local_name)
         else:
-            # Note: we want "getattr(x.parent_block(), x.localname) == x"
+            # Note: we want "getattr(x.parent_block(), x.local_name) == x"
             # so we do not want to call _safe_name_str, as that could
             # add quotes or otherwise escape the string.
             ans = local_name


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This improves the `@disable_methods` decorator's handling of methods with optional positional arguments (particularly the case where the default value is a type or a local class instance), as well as correctly wrapping read-only properties (as read-only properties).  

While debugging errors surrounding using `NOTSET` as a default argument value for a disabled method, we also noticed that `FlagType` incorrectly implemented `__str__`.  This PR resolves that error and adds tests for the expected behavior.

## Changes proposed in this PR:
- Resolve errors when disabling methods with optional arguments whose default values are types or local class instances
- Resolve error where disabling read-only properties made them look like they were read/write
- add tests of expected behavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
