### PR TITLE
Resolve TeeStream deadlock / libgcc_s.so.1 loader issues

### DIFF
--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -419,7 +419,9 @@ class TeeStream(object):
 
     def __del__(self):
         # Implement __del__ to guarantee that file descriptors are closed
-        self.close()
+        # ... but only if we are not called by the GC in the handler thread
+        if threading.current_thread() not in self._threads:
+            self.close()
 
     def _start(self, handle):
         if not _peek_available:

--- a/pyomo/common/tee.py
+++ b/pyomo/common/tee.py
@@ -360,7 +360,7 @@ class TeeStream(object):
         # and a peculiar error ("libgcc_s.so.1 must be installed for
         # pthread_cancel to work"; see https://bugs.python.org/issue18748)
         #
-        # To accomplish this, er will keep two handle lists: one is the
+        # To accomplish this, we will keep two handle lists: one is the
         # set of "active" handles that the (merged reader) thread is
         # using, and the other the list of all handles so the original
         # thread can close them after the reader thread terminates.

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -168,6 +168,29 @@ class TestTeeStream(unittest.TestCase):
         finally:
             sys.stdout, sys.stderr = old
 
+    def test_deadlock(self):
+        class MockStream(object):
+            def write(self, data):
+                time.sleep(0.1)
+
+        _save = tee._poll_timeout, tee._poll_timeout_deadlock
+        tee._poll_timeout = tee._poll_interval * 2**5  # 0.0032
+        tee._poll_timeout_deadlock = tee._poll_interval * 2**7 # 0.0128
+
+        try:
+            with LoggingIntercept() as LOG, self.assertRaisesRegex(
+                    RuntimeError, 'deadlock'):
+                with tee.TeeStream(MockStream()) as t:
+                    err = t.STDERR
+                    err.write('*')
+            self.assertEqual(
+                'Significant delay observed waiting to join reader '
+                'threads, possible output stream deadlock\n',
+                LOG.getvalue()
+            )
+        finally:
+            tee._poll_timeout, tee._poll_timeout_deadlock = _save
+
 class TestFileDescriptor(unittest.TestCase):
     def setUp(self):
         self.out = sys.stdout
@@ -176,6 +199,7 @@ class TestFileDescriptor(unittest.TestCase):
     def tearDown(self):
         sys.stdout = self.out
         os.dup2(self.out_fd, 1)
+        os.close(self.out_fd)
 
     def _generate_output(self, redirector):
         with redirector:
@@ -289,6 +313,9 @@ class TestFileDescriptor(unittest.TestCase):
 
         self.assertEqual(OUT.getvalue(), "to_stdout_1\nto_fd1_1\n")
         with os.fdopen(r, 'r') as FILE:
-            os.close(w)
             os.close(1)
+            os.close(w)
             self.assertEqual(FILE.read(), "to_stdout_2\nto_fd1_2\n")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -53,7 +53,7 @@ class TestTeeStream(unittest.TestCase):
             # flush() and short pause should help
             t.STDOUT.write("Hello\nWorld")
             t.STDOUT.flush()
-            time.sleep(tee._poll_interval*10)
+            time.sleep(tee._poll_interval*100)
             t.STDERR.write("interrupting\ncow")
             t.STDERR.flush()
             # For determinism, it is important that the STDERR message
@@ -171,7 +171,7 @@ class TestTeeStream(unittest.TestCase):
     def test_deadlock(self):
         class MockStream(object):
             def write(self, data):
-                time.sleep(0.1)
+                time.sleep(0.2)
 
         _save = tee._poll_timeout, tee._poll_timeout_deadlock
         tee._poll_timeout = tee._poll_interval * 2**5  # 0.0032

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -137,6 +137,8 @@ class TestPyomoEnviron(unittest.TestCase):
             'tempfile',
             'textwrap',
             'typing',
+            'win32file',
+            'win32pipe',
         }
         # Non-standard-library TPLs that Pyomo will load unconditionally
         ref.add('ply')

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,7 @@ class DependenciesCommand(Command):
 
     def _print_deps(self, deplist):
         implementation_name = sys.implementation.name
+        platform_system = platform.system()
         python_version = '.'.join(platform.python_version_tuple()[:2])
         for entry in deplist:
             dep, _, condition = (_.strip() for _ in entry.partition(';'))
@@ -212,7 +213,7 @@ setup_kwargs = dict(
             #
             # subprocess output is merged more reliably if
             # 'PeekNamedPipe' is available from pywin32
-            'pywin32;platform_system=="Windows"',
+            'pywin32; platform_system=="Windows"',
             #
             # The following optional dependencies are difficult to
             # install on PyPy (binary wheels are not available), so we

--- a/setup.py
+++ b/setup.py
@@ -209,6 +209,11 @@ setup_kwargs = dict(
             'sympy',     # differentiation
             'xlrd',      # dataportals
             'z3-solver', # community_detection
+            #
+            # subprocess output is merged more reliably if
+            # 'PeekNamedPipe' is available from pywin32
+            'pywin32;platform_system=="Windows"',
+            #
             # The following optional dependencies are difficult to
             # install on PyPy (binary wheels are not available), so we
             # will only "require" them on other (CPython) platforms:


### PR DESCRIPTION
## Fixes #2054 .

## Summary/Motivation:
@eslickj noted that the recent rework of `TeeStream` introduced deadlock errors on Windows.  As part of debugging that issue, we ran across errors where `TeeStream` would cease working and abort with the error:
```
libgcc_s.so.1 must be installed for pthread_cancel to work
```

This appears to all be due to closing files in different threads from the thread that opened them.  This PR resolves that issue and adds a test that the deadlock error is correctly generated.  It also lengthens the timeout before we quit trying to wait for reader threads to terminate (to roughly 200 seconds) and introduces a separate timeout where we issue a warning about possible deadlock (after ~3 seconds).

## Changes proposed in this PR:
- Resolve `TeeStream` handle errors where files were closed by a thread that didn't open them
- Lengthen `TeeStream` timeouts (and issue a warning before the deadlock triggers an exception)
- Add tests exercising the deadlock logic
- (unrelated) resolve a test that would fail if the user's HOME directory was accessed through a symlink

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
