### PR TITLE
Generate standard repn misidentifies nonlinear expr

### DIFF
--- a/pyomo/repn/standard_repn.py
+++ b/pyomo/repn/standard_repn.py
@@ -613,6 +613,13 @@ def _collect_prod(exp, multiplier, idMap, compute_values, verbose, quadratic):
                     ans.quadratic[ndx] += multiplier*lcoef*rcoef
                 else:
                     ans.quadratic[ndx] = multiplier*lcoef*rcoef
+
+        # If there are a product of quadratic terms, return a none linear expression
+        if len(lhs.quadratic) > 0 and len(rhs.quadratic) > 0 and len(lhs.linear) == 0 and len(rhs.linear) == 0:
+            # TODO raise an error ?
+            logging.getLogger('pyomo.core').warning("The problem is not quadratic")
+            return _collect_prod(exp, multiplier, idMap, compute_values, verbose, quadratic=False)
+
         # TODO - Use quicksum here?
         el_linear = multiplier*sum(coef*idMap[key] for key, coef in lhs.linear.items())
         er_linear = multiplier*sum(coef*idMap[key] for key, coef in rhs.linear.items())

--- a/pyomo/repn/tests/test_standard.py
+++ b/pyomo/repn/tests/test_standard.py
@@ -2661,16 +2661,15 @@ class Test(unittest.TestCase):
         #
         self.assertTrue(len(rep.linear_vars) == 0)
         self.assertTrue(len(rep.linear_coefs) == 0)
-        self.assertTrue(len(rep.quadratic_vars) == 1)
-        self.assertTrue(len(rep.quadratic_coefs) == 1)
+        self.assertTrue(len(rep.quadratic_vars) == 0)
+        self.assertTrue(len(rep.quadratic_coefs) == 0)
         self.assertFalse(rep.nonlinear_expr is None)
         self.assertEqual(len(rep.nonlinear_vars), 3)
-        baseline = { bc_key:5 }
+        baseline = {}
         self.assertEqual(baseline, repn_to_dict(rep))
         s = pickle.dumps(rep)
         rep = pickle.loads(s)
-        bc_key_ = (id(rep.quadratic_vars[0][0]),id(rep.quadratic_vars[0][1])) if id(rep.quadratic_vars[0][0]) <= id(rep.quadratic_vars[0][1]) else (id(rep.quadratic_vars[0][1]),id(rep.quadratic_vars[0][0]))
-        baseline = { bc_key_:5 }
+        baseline = {}
         self.assertEqual(baseline, repn_to_dict(rep))
 
         # Do not collect quadratics

--- a/pyomo/repn/tests/test_standard.py
+++ b/pyomo/repn/tests/test_standard.py
@@ -3955,6 +3955,17 @@ class Test(unittest.TestCase):
         rep = generate_standard_repn(e, compute_values=True, quadratic=False)
         self.assertEqual(str(rep.to_expression()), "(1 + v)*(1 + v)")
 
+    def test_product6(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var()
+
+        e = (m.x + m.y) * (m.x - m.y) * (m.x ** 2 + m.y ** 2)
+        rep = generate_standard_repn(e)
+        self.assertEqual(str(rep.to_expression()), "(x + y)*(x - y)*(x**2 + y**2)")
+        self.assertTrue(rep.is_nonlinear())
+        self.assertFalse(rep.is_quadratic())
+
     def test_vars(self): 
         m = ConcreteModel()
         m.v = Var(initialize=2)

--- a/pyomo/repn/tests/test_standard.py
+++ b/pyomo/repn/tests/test_standard.py
@@ -3927,19 +3927,19 @@ class Test(unittest.TestCase):
 
         e = (1 + m.v + m.w + m.v**2)*(m.v + m.w + m.v**2)
         rep = generate_standard_repn(e, compute_values=True)
-        self.assertEqual(str(rep.to_expression()), "v + w + 2*v**2 + 2*(v*w) + w**2 + (v + w)*(v*v) + v*v*(v + w)")
+        self.assertEqual(str(rep.to_expression()), "(1 + v + w + v**2)*(v + w + v**2)")
         rep = generate_standard_repn(e, compute_values=True, quadratic=False)
         self.assertEqual(str(rep.to_expression()), "(1 + v + w + v**2)*(v + w + v**2)")
 
         e = (m.v + m.w + m.v**2)*(1 + m.v + m.w + m.v**2)
         rep = generate_standard_repn(e, compute_values=True)
-        self.assertEqual(str(rep.to_expression()), "v + w + 2*v**2 + 2*(v*w) + w**2 + (v + w)*(v*v) + v*v*(v + w)")
+        self.assertEqual(str(rep.to_expression()), "(v + w + v**2)*(1 + v + w + v**2)")
         rep = generate_standard_repn(e, compute_values=True, quadratic=False)
         self.assertEqual(str(rep.to_expression()), "(v + w + v**2)*(1 + v + w + v**2)")
 
         e = (1 + m.v + m.w + m.v**2)*(1 + m.v + m.w + m.v**2)
         rep = generate_standard_repn(e, compute_values=True)
-        self.assertEqual(str(rep.to_expression()), "1 + 2*v + 2*w + 3*v**2 + 2*(v*w) + w**2 + (v + w)*(v*v) + v*v*(v + w)")
+        self.assertEqual(str(rep.to_expression()), "(1 + v + w + v**2)*(1 + v + w + v**2)")
         rep = generate_standard_repn(e, compute_values=True, quadratic=False)
         self.assertEqual(str(rep.to_expression()), "(1 + v + w + v**2)*(1 + v + w + v**2)")
 


### PR DESCRIPTION
## Fixes #2046 .

## Summary/Motivation:
This PR detects that a product of quadric terms is not quadratic and is non linear. Add a warning to the user.

## Changes proposed in this PR:
- In `_collect_prod`, when it detects that there is a product between quadratic terms, method `_collect_prod` is run with parameter `quadratic` set to False
- Warning in order to tell the user that the problem is not quadratic whereas the parameter `quadratic` is set to `True`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
