### PR TITLE
Add linux aarch64 wheel build support

### DIFF
--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -53,6 +53,50 @@ jobs:
         name: manylinux-wheels
         path: dist
 
+  manylinuxaarch64:
+    name: ${{ matrix.TARGET }}/wheel_creation
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        include:
+        - os: ubuntu-latest
+          TARGET: manylinuxaarch64
+        python-version: [3.7]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - uses: docker/setup-qemu-action@v1
+      name: Set up QEMU
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install twine wheel setuptools
+    - name: Build manylinux Python wheels
+      uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2014_aarch64
+      with:
+        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
+        build-requirements: 'cython'
+        package-path: ''
+        pip-wheel-args: ''
+        # When locally testing, --no-deps flag is necessary (PyUtilib dependency will trigger an error otherwise)
+    - name: Consolidate wheels
+      run: |
+        sudo test -d dist || mkdir -v dist
+        sudo find . -name \*.whl | grep -v /dist/ | xargs -n1 -i mv -v "{}" dist/
+    - name: Delete linux wheels
+      run: |
+        sudo rm -rfv dist/*-linux_aarch64.whl
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: manylinux-aarch64-wheels
+        path: dist
+
   generictarball:
     name: ${{ matrix.TARGET }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -77,7 +77,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install twine wheel setuptools
     - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2014_aarch64
+      uses: RalfG/python-wheels-manylinux-build@v0.4.0-manylinux2014_aarch64
       with:
         python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
         build-requirements: 'cython'


### PR DESCRIPTION
## Fixes https://github.com/Pyomo/pyomo/issues/2075

## Summary/Motivation: 
Add linux aarch64 wheel support

## Changes proposed in this PR:
- In **.github/workflows/release_wheel_creation.yml** file did the changes to add linux aarch64 wheel support.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
