### PR TITLE
GHA: add retry / timeout to powershell downloads

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -361,7 +361,8 @@ jobs:
         }
         if (-not (Test-Path "$INSTALLER" -PathType Leaf)) {
             echo "...downloading GAMS"
-            Invoke-WebRequest -Uri "$URL" -OutFile "$INSTALLER"
+            Invoke-WebRequest -Uri "$URL" -OutFile "$INSTALLER" `
+                -RetryIntervalSec 30 -MaximumRetryCount 8 -TimeoutSec 150
         }
         echo "...installing GAMS"
         if ( "${{matrix.TARGET}}" -eq "win" ) {
@@ -411,7 +412,8 @@ jobs:
         }
         if (-not (Test-Path "$INSTALLER" -PathType Leaf)) {
             echo "...downloading BARON ($URL)"
-            Invoke-WebRequest -Uri "$URL" -OutFile "$INSTALLER"
+            Invoke-WebRequest -Uri "$URL" -OutFile "$INSTALLER" `
+                -RetryIntervalSec 30 -MaximumRetryCount 8 -TimeoutSec 150
         }
         echo "...installing BARON"
         if ( "${{matrix.TARGET}}" -eq "win" ) {

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -18,7 +18,7 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
-  CACHE_VER: v210630.0
+  CACHE_VER: v210812.0
   NEOS_EMAIL: tests@pyomo.org
 
 jobs:

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -380,7 +380,8 @@ jobs:
         }
         if (-not (Test-Path "$INSTALLER" -PathType Leaf)) {
             echo "...downloading GAMS"
-            Invoke-WebRequest -Uri "$URL" -OutFile "$INSTALLER"
+            Invoke-WebRequest -Uri "$URL" -OutFile "$INSTALLER" `
+                -RetryIntervalSec 30 -MaximumRetryCount 8 -TimeoutSec 150
         }
         echo "...installing GAMS"
         if ( "${{matrix.TARGET}}" -eq "win" ) {
@@ -430,7 +431,8 @@ jobs:
         }
         if (-not (Test-Path "$INSTALLER" -PathType Leaf)) {
             echo "...downloading BARON ($URL)"
-            Invoke-WebRequest -Uri "$URL" -OutFile "$INSTALLER"
+            Invoke-WebRequest -Uri "$URL" -OutFile "$INSTALLER" `
+                -RetryIntervalSec 30 -MaximumRetryCount 8 -TimeoutSec 150
         }
         echo "...installing BARON"
         if ( "${{matrix.TARGET}}" -eq "win" ) {

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -21,7 +21,7 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
-  CACHE_VER: v210630.0
+  CACHE_VER: v210812.0
   NEOS_EMAIL: tests@pyomo.org
 
 jobs:


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
We have recently noticed intermittent failures downloading Baron.  This PR adds a retry to the download request, and forces a rebuild of the GHA caches.

## Changes proposed in this PR:
- retry downloads through Invoke-Webrequest
- rebuild GHA caches

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
