### PR TITLE
Fixing symbol names in Initializer deprecation layer

### DIFF
--- a/pyomo/core/base/util.py
+++ b/pyomo/core/base/util.py
@@ -20,13 +20,13 @@ relocated_module_attribute(
     'disable_methods', 'pyomo.core.base.disable_methods.disable_methods',
     version='TBD')
 relocated_module_attribute(
-    'Initialzer', 'pyomo.core.base.initialzer.Initialzer',
+    'Initializer', 'pyomo.core.base.initializer.Initializer',
     version='TBD')
 relocated_module_attribute(
-    'IndexedCallInitialzer', 'pyomo.core.base.initialzer.Initialzer',
+    'IndexedCallInitializer', 'pyomo.core.base.initializer.Initializer',
     version='TBD')
 relocated_module_attribute(
-    'CountedCallInitialzer', 'pyomo.core.base.initialzer.Initialzer',
+    'CountedCallInitializer', 'pyomo.core.base.initializer.Initializer',
     version='TBD')
 
 def is_functor(obj):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This is a simple PR fixing symbol name spelling in the deprecation layer for moving the Initializer methods to their own module.

## Changes proposed in this PR:
- fix the spelling of "Initializer"

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
