### PR TITLE
fix(contrib/mindtpy): Replace is not by !=

### DIFF
--- a/pyomo/contrib/mindtpy/iterate.py
+++ b/pyomo/contrib/mindtpy/iterate.py
@@ -155,7 +155,7 @@ def MindtPy_iteration_loop(solve_data, config):
 
     # if add_no_good_cuts is True, the bound obtained in the last iteration is no reliable.
     # we correct it after the iteration.
-    if (config.add_no_good_cuts or config.use_tabu_list) and config.strategy is not 'FP' and not solve_data.should_terminate and config.add_regularization is None:
+    if (config.add_no_good_cuts or config.use_tabu_list) and config.strategy != 'FP' and not solve_data.should_terminate and config.add_regularization is None:
         bound_fix(solve_data, config, last_iter_cuts)
 
 


### PR DESCRIPTION
## Fixes # .
The SyntaxWarning of pyomo.
## Summary/Motivation:
To eliminate the SyntaxWarning of pyomo.
While installing pyomo, I found the warning shown below:
```
/usr/local/lib/python3.8/dist-packages/Pyomo-6.0.2.dev0-py3.8.egg/pyomo/contrib/mindtpy/iterate.py:158: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if (config.add_no_good_cuts or config.use_tabu_list) and config.strategy is not 'FP' and not solve_data.should_terminate and config.add_regularization is None:
```
According to the second subsection of this [document](https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior), it advises replacing the keyword `is not` to `!=` to avoid possible accident in CPython.

Hope this pr help! Thanks for your great works.

## Changes proposed in this PR:
- Replace is not by !=
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
