### PR TITLE
Increase timeout when retrieving version from an ASL solver

### DIFF
--- a/pyomo/solvers/plugins/solvers/ASL.py
+++ b/pyomo/solvers/plugins/solvers/ASL.py
@@ -94,7 +94,7 @@ class ASL(SystemCallSolver):
             return _extract_version('')
         try:
             results = subprocess.run([solver_exec, "-v"],
-                                     timeout=2,
+                                     timeout=5,
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT,
                                      universal_newlines=True)


### PR DESCRIPTION
## Fixes #2080

## Summary/Motivation:
Increase the timeout when interrogating an ASL solver for its version.  This resolves #2080, where the current timeout was too short when running slovers through WSL.

## Changes proposed in this PR:
- increase the timeout when interrogating ASL solver version to 5 seconds.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
