### PR TITLE
Add test for missing / extra __init__.py files

### DIFF
--- a/pyomo/environ/tests/test_package_layout.py
+++ b/pyomo/environ/tests/test_package_layout.py
@@ -23,7 +23,6 @@ import pyomo.common.unittest as unittest
 # contain Python files that are only used in testing and explicitly NOT
 # part of the "Pyomo package")
 _NON_MODULE_DIRS = {
-    join('contrib', 'appsi', 'build'),
     join('checker', 'doc'),
     join('checker', 'tests', 'examples'),
     join('contrib', 'appsi', 'cmodel', 'src'),

--- a/pyomo/environ/tests/test_package_layout.py
+++ b/pyomo/environ/tests/test_package_layout.py
@@ -11,6 +11,7 @@
 # Unit Tests for pyomo.base.misc
 #
 import os
+from os.path import join
 
 from pyomo.common.fileutils import PYOMO_ROOT_DIR
 
@@ -22,24 +23,24 @@ import pyomo.common.unittest as unittest
 # contain Python files that are only used in testing and explicitly NOT
 # part of the "Pyomo package")
 _NON_MODULE_DIRS = {
-    'contrib/appsi/build',
-    'checker/doc',
-    'checker/tests/examples',
-    'contrib/appsi/cmodel/src',
-    'contrib/pynumero/src',
-    'core/tests/data/baselines',
-    'core/tests/diet/baselines',
-    'opt/tests/solver/exe_dir',
-    'solvers/tests/checks/data',
-    'solvers/tests/mip/asl',
-    'solvers/tests/mip/cbc',
-    'solvers/tests/mip/cplex',
-    'solvers/tests/mip/glpk',
-    'solvers/tests/mip/pico',
-    'solvers/tests/piecewise_linear/baselines',
-    'solvers/tests/piecewise_linear/kernel_baselines',
-    'solvers/tests/piecewise_linear/kernel_problems',
-    'solvers/tests/piecewise_linear/problems',
+    join('contrib', 'appsi', 'build'),
+    join('checker', 'doc'),
+    join('checker', 'tests', 'examples')
+    join('contrib', 'appsi', 'cmodel', 'src')
+    join('contrib', 'pynumero', 'src')
+    join('core', 'tests', 'data', 'baselines')
+    join('core', 'tests', 'diet', 'baselines')
+    join('opt', 'tests', 'solver', 'exe_dir')
+    join('solvers', 'tests', 'checks', 'data')
+    join('solvers', 'tests', 'mip', 'asl')
+    join('solvers', 'tests', 'mip', 'cbc')
+    join('solvers', 'tests', 'mip', 'cplex')
+    join('solvers', 'tests', 'mip', 'glpk')
+    join('solvers', 'tests', 'mip', 'pico')
+    join('solvers', 'tests', 'piecewise_linear', 'baselines')
+    join('solvers', 'tests', 'piecewise_linear', 'kernel_baselines')
+    join('solvers', 'tests', 'piecewise_linear', 'kernel_problems')
+    join('solvers', 'tests', 'piecewise_linear', 'problems')
 }
 
 class TestPackageLayout(unittest.TestCase):

--- a/pyomo/environ/tests/test_package_layout.py
+++ b/pyomo/environ/tests/test_package_layout.py
@@ -25,22 +25,22 @@ import pyomo.common.unittest as unittest
 _NON_MODULE_DIRS = {
     join('contrib', 'appsi', 'build'),
     join('checker', 'doc'),
-    join('checker', 'tests', 'examples')
-    join('contrib', 'appsi', 'cmodel', 'src')
-    join('contrib', 'pynumero', 'src')
-    join('core', 'tests', 'data', 'baselines')
-    join('core', 'tests', 'diet', 'baselines')
-    join('opt', 'tests', 'solver', 'exe_dir')
-    join('solvers', 'tests', 'checks', 'data')
-    join('solvers', 'tests', 'mip', 'asl')
-    join('solvers', 'tests', 'mip', 'cbc')
-    join('solvers', 'tests', 'mip', 'cplex')
-    join('solvers', 'tests', 'mip', 'glpk')
-    join('solvers', 'tests', 'mip', 'pico')
-    join('solvers', 'tests', 'piecewise_linear', 'baselines')
-    join('solvers', 'tests', 'piecewise_linear', 'kernel_baselines')
-    join('solvers', 'tests', 'piecewise_linear', 'kernel_problems')
-    join('solvers', 'tests', 'piecewise_linear', 'problems')
+    join('checker', 'tests', 'examples'),
+    join('contrib', 'appsi', 'cmodel', 'src'),
+    join('contrib', 'pynumero', 'src'),
+    join('core', 'tests', 'data', 'baselines'),
+    join('core', 'tests', 'diet', 'baselines'),
+    join('opt', 'tests', 'solver', 'exe_dir'),
+    join('solvers', 'tests', 'checks', 'data'),
+    join('solvers', 'tests', 'mip', 'asl'),
+    join('solvers', 'tests', 'mip', 'cbc'),
+    join('solvers', 'tests', 'mip', 'cplex'),
+    join('solvers', 'tests', 'mip', 'glpk'),
+    join('solvers', 'tests', 'mip', 'pico'),
+    join('solvers', 'tests', 'piecewise_linear', 'baselines'),
+    join('solvers', 'tests', 'piecewise_linear', 'kernel_baselines'),
+    join('solvers', 'tests', 'piecewise_linear', 'kernel_problems'),
+    join('solvers', 'tests', 'piecewise_linear', 'problems'),
 }
 
 class TestPackageLayout(unittest.TestCase):

--- a/pyomo/environ/tests/test_package_layout.py
+++ b/pyomo/environ/tests/test_package_layout.py
@@ -18,8 +18,9 @@ import pyomo.common.unittest as unittest
 
 
 # List of directories under `pyomo` that intentionally do NOT have
-# __init__.py files (because they contain no Python files - or Python
-# files used in testing and explicitly NOT part of the "Pyomo package"
+# __init__.py files (because they either contain no Python files - or
+# contain Python files that are only used in testing and explicitly NOT
+# part of the "Pyomo package")
 _NON_MODULE_DIRS = {
     'contrib/appsi/build',
     'checker/doc',

--- a/pyomo/environ/tests/test_package_layout.py
+++ b/pyomo/environ/tests/test_package_layout.py
@@ -17,6 +17,9 @@ from pyomo.common.fileutils import PYOMO_ROOT_DIR
 import pyomo.common.unittest as unittest
 
 
+# List of directories under `pyomo` that intentionally do NOT have
+# __init__.py files (because they contain no Python files - or Python
+# files used in testing and explicitly NOT part of the "Pyomo package"
 _NON_MODULE_DIRS = {
     'contrib/appsi/build',
     'checker/doc',

--- a/pyomo/environ/tests/test_package_layout.py
+++ b/pyomo/environ/tests/test_package_layout.py
@@ -1,0 +1,78 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Unit Tests for pyomo.base.misc
+#
+import os
+
+from pyomo.common.fileutils import PYOMO_ROOT_DIR
+
+import pyomo.common.unittest as unittest
+
+
+_NON_MODULE_DIRS = {
+    'contrib/appsi/build',
+    'checker/doc',
+    'checker/tests/examples',
+    'contrib/appsi/cmodel/src',
+    'contrib/pynumero/src',
+    'core/tests/data/baselines',
+    'core/tests/diet/baselines',
+    'opt/tests/solver/exe_dir',
+    'solvers/tests/checks/data',
+    'solvers/tests/mip/asl',
+    'solvers/tests/mip/cbc',
+    'solvers/tests/mip/cplex',
+    'solvers/tests/mip/glpk',
+    'solvers/tests/mip/pico',
+    'solvers/tests/piecewise_linear/baselines',
+    'solvers/tests/piecewise_linear/kernel_baselines',
+    'solvers/tests/piecewise_linear/kernel_problems',
+    'solvers/tests/piecewise_linear/problems',
+}
+
+class TestPackageLayout(unittest.TestCase):
+    def test_for_init_files(self):
+        _NMD = set(_NON_MODULE_DIRS)
+        fail = []
+        module_dir = os.path.join(PYOMO_ROOT_DIR, 'pyomo')
+        for path, subdirs, files in os.walk(module_dir):
+            assert path.startswith(module_dir)
+            relpath = path[1+len(module_dir):]
+            # Skip all __pycache__ directories
+            try:
+                subdirs.remove('__pycache__')
+            except ValueError:
+                pass
+
+            if '__init__.py' in files:
+                continue
+
+            if relpath in _NMD:
+                _NMD.remove(relpath)
+                # Skip checking all subdirectories
+                subdirs[:] = []
+                continue
+
+            fail.append(relpath)
+
+        if fail:
+            self.fail(
+                "Directories are missing __init__.py files:\n\t"
+                + "\n\t".join(sorted(fail))
+            )
+        if _NMD:
+            self.fail(
+                "_NON_MODULE_DIRS contains entries not found in package "
+                "or unexpectedly contain a __init__.py file:\n\t"
+                + "\n\t".join(sorted(_NMD))
+            )
+
+


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
The 6.1 release hit an issue in the last steps of release where the Conda build caught that directories were missing `__init__.py` files.  This PR adds a test that will identify this situation during development and not in the release process.

## Changes proposed in this PR:
- Add a test that checks for `__init__.py` files in all the module subdirectories.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
