### PR TITLE
Remove use of `OrderedSet.__getitem__` from contset.py

### DIFF
--- a/pyomo/dae/contset.py
+++ b/pyomo/dae/contset.py
@@ -265,19 +265,20 @@ class ContinuousSet(SortedScalarSet):
         -------
         `float` or `None` 
         """
-        lo = 1
-        hi = len(self) + 1
-        i = bisect.bisect_right(self, target, lo=lo, hi=hi)
+        lo = 0
+        hi = len(self)
+        arr = list(self)
+        i = bisect.bisect_right(arr, target, lo=lo, hi=hi)
         # i is the index at which target should be inserted if it is to be
         # right of any equal components. 
 
         if i == lo:
             # target is less than every entry of the set
-            nearest_index = i
+            nearest_index = i + 1
             delta = self.card(nearest_index) - target
         elif i == hi:
             # target is greater than or equal to every entry of the set
-            nearest_index = i-1
+            nearest_index = i
             delta = target - self.card(nearest_index)
         else:
             # p_le <= target < p_g
@@ -286,7 +287,7 @@ class ContinuousSet(SortedScalarSet):
             # delta = min(delta_left, delta_right)
             # Tie goes to the index on the left.
             delta, nearest_index = min(
-                (abs(target - self.card(j)), j) for j in [i-1, i]
+                (abs(target - self.card(j)), j) for j in [i, i+1]
             )
 
         if tolerance is not None:

--- a/pyomo/dae/contset.py
+++ b/pyomo/dae/contset.py
@@ -274,18 +274,20 @@ class ContinuousSet(SortedScalarSet):
         if i == lo:
             # target is less than every entry of the set
             nearest_index = i
-            delta = self[nearest_index] - target
+            delta = self.card(nearest_index) - target
         elif i == hi:
             # target is greater than or equal to every entry of the set
             nearest_index = i-1
-            delta = target - self[nearest_index]
+            delta = target - self.card(nearest_index)
         else:
             # p_le <= target < p_g
             # delta_left = target - p_le
             # delta_right = p_g - target
             # delta = min(delta_left, delta_right)
             # Tie goes to the index on the left.
-            delta, nearest_index = min((abs(target - self[j]), j) for j in [i-1, i])
+            delta, nearest_index = min(
+                (abs(target - self.card(j)), j) for j in [i-1, i]
+            )
 
         if tolerance is not None:
             if delta > tolerance:


### PR DESCRIPTION
## Summary/Motivation:
Several methods of `ContinuousSet` use `OrderedSet.__getitem__`, including `find_nearest_index`, which does so implicitly through the `bisect` module. This PR updates these methods to not use the deprecated `__getitem__` method.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
