### PR TITLE
Only emit deprecation warnings once

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -14,7 +14,9 @@ import importlib
 import logging
 import sys
 
-from .deprecation import deprecated, deprecation_warning
+from .deprecation import (
+    deprecated, deprecation_warning, in_testing_environment,
+)
 from . import numeric_types
 
 class DeferredImportError(ImportError):
@@ -581,7 +583,7 @@ def _finalize_matplotlib(module, available):
     # we are in the middle of testing, we need to switch the backend to
     # 'Agg', otherwise attempts to generate plots on CI services without
     # terminal windows will fail.
-    if any(m in sys.modules for m in ('nose', 'nose2', 'sphinx', 'pytest')):
+    if in_testing_environment():
         module.use('Agg')
     import matplotlib.pyplot
 

--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -204,19 +204,12 @@ def deprecation_warning(msg, logger=None, version=None,
         info = inspect.getframeinfo(calling_frame)
         msg += "\n(called from %s:%s)" % (info.filename.strip(), info.lineno)
         if deprecation_warning.emitted_warnings is not None:
-            # In normal operation only emit a deprecation message once
-            # for any context (file/line)
             if msg in deprecation_warning.emitted_warnings:
                 return
             deprecation_warning.emitted_warnings.add(msg)
-        elif deprecation_warning.last_warning == msg:
-            # hide repeated warnings, even when nose/pytest/sphinx are running
-            return
-        deprecation_warning.last_warning = msg
 
     logging.getLogger(logger).warning(msg)
 
-deprecation_warning.last_warning = None
 if in_testing_environment():
     deprecation_warning.emitted_warnings = None
 else:

--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -123,6 +123,7 @@ def _wrap_func(func, msg, logger, version, remove_in):
     wrapper.__doc__ += _deprecation_docstring(func, msg, version, remove_in)
     return wrapper
 
+
 def _find_calling_frame(module_offset):
     g = [globals()]
     calling_frame = inspect.currentframe().f_back
@@ -134,6 +135,19 @@ def _find_calling_frame(module_offset):
         else:
             break
     return calling_frame
+
+
+def in_testing_environment():
+    """Return True if we are currently running in a "testing" environment
+
+    This currently includes if nose, nose2, pytest, or Sphinx are
+    running (imported).
+
+    """
+
+    return any(mod in sys.modules for mod in (
+        'nose', 'nose2', 'pytest', 'sphinx'))
+
 
 def deprecation_warning(msg, logger=None, version=None,
                         remove_in=None, calling_frame=None):

--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -204,12 +204,19 @@ def deprecation_warning(msg, logger=None, version=None,
         info = inspect.getframeinfo(calling_frame)
         msg += "\n(called from %s:%s)" % (info.filename.strip(), info.lineno)
         if deprecation_warning.emitted_warnings is not None:
+            # In normal operation only emit a deprecation message once
+            # for any context (file/line)
             if msg in deprecation_warning.emitted_warnings:
                 return
             deprecation_warning.emitted_warnings.add(msg)
+        elif deprecation_warning.last_warning == msg:
+            # hide repeated warnings, even when nose/pytest/sphinx are running
+            return
+        deprecation_warning.last_warning = msg
 
     logging.getLogger(logger).warning(msg)
 
+deprecation_warning.last_warning = None
 if in_testing_environment():
     deprecation_warning.emitted_warnings = None
 else:

--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -203,8 +203,17 @@ def deprecation_warning(msg, logger=None, version=None,
     if calling_frame is not None:
         info = inspect.getframeinfo(calling_frame)
         msg += "\n(called from %s:%s)" % (info.filename.strip(), info.lineno)
+        if deprecation_warning.emitted_warnings is not None:
+            if msg in deprecation_warning.emitted_warnings:
+                return
+            deprecation_warning.emitted_warnings.add(msg)
 
     logging.getLogger(logger).warning(msg)
+
+if in_testing_environment():
+    deprecation_warning.emitted_warnings = None
+else:
+    deprecation_warning.emitted_warnings = set()
 
 
 def deprecated(msg=None, logger=None, version=None, remove_in=None):

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -2382,7 +2382,7 @@ c: 1.0
         # test that dir is sorted
         self.assertEqual(dir(cfg), sorted(dir(cfg)))
         # check that inconsistent name is flagged
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, "Key 'b' not defined in ConfigDict ''"):
             cfg.b = cfg.declare('bb', ConfigValue(2, int))
 
@@ -2390,10 +2390,10 @@ c: 1.0
     def test_declaration_errors(self):
         cfg = ConfigDict()
         cfg.b = cfg.declare('b', ConfigValue(2, int))
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, "duplicate config 'b' defined for ConfigDict ''"):
             cfg.b = cfg.declare('b', ConfigValue(2, int))
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, "config 'dd' is already assigned to ConfigDict ''"):
             cfg.declare('dd', cfg.get('b'))
 

--- a/pyomo/contrib/simplemodel/__init__.py
+++ b/pyomo/contrib/simplemodel/__init__.py
@@ -1,4 +1,16 @@
-from pyomo.common.deprecation import deprecation_warning
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+from pyomo.common.deprecation import (
+    deprecation_warning, in_testing_environment,
+)
 
 try:
     deprecation_warning(
@@ -7,9 +19,9 @@ try:
         "package, which is included in the pyomo_community distribution.",
         version='5.6.9')
     from pyomocontrib_simplemodel import *
-except:
-    # Only raise exception if nose is NOT running
-    import sys
-    if 'nose' not in sys.modules and 'nose2' not in sys.modules:
+except ImportError:
+    # Only raise the exception if nose/pytest/sphinx are NOT running
+    # (otherwise test discovery can result in exceptions)
+    if not in_testing_environment():
         raise RuntimeError(
             "The pyomocontrib_simplemodel package is not installed.")

--- a/pyomo/pysp/__init__.py
+++ b/pyomo/pysp/__init__.py
@@ -10,22 +10,25 @@
 
 import logging
 import sys
-from pyomo.common.deprecation import deprecation_warning
+from pyomo.common.deprecation import (
+    deprecation_warning, in_testing_environment,
+)
 
-# Only implement the deprecation imports nose is NOT running
-if 'nose' not in sys.modules and 'nose2' not in sys.modules:
-    try:
-        from pysp import *
-        # Redirect all (imported) pysp modules into the pyomo.pysp namespace
-        for mod in list(sys.modules):
-            if mod.startswith('pysp.'):
-                sys.modules['pyomo.'+mod] = sys.modules[mod]
-                # Warn the user
-        deprecation_warning(
-            "PySP has been removed from pyomo.pysp namespace.  "
-            "Please import PySP directly from the pysp namespace.",
-            version='6.0')
-    except ImportError:
+try:
+    # Warn the user
+    deprecation_warning(
+        "PySP has been removed from the pyomo.pysp namespace.  "
+        "Please import PySP directly from the pysp namespace.",
+        version='6.0')
+    from pysp import *
+    # Redirect all (imported) pysp modules into the pyomo.pysp namespace
+    for mod in list(sys.modules):
+        if mod.startswith('pysp.'):
+            sys.modules['pyomo.'+mod] = sys.modules[mod]
+except ImportError:
+    # Only raise the exception if nose/pytest/sphinx are NOT running
+    # (otherwise test discovery can result in exceptions)
+    if not in_testing_environment():
         raise ImportError(
             "No module named 'pyomo.pysp'.  "
             "Beginning in Pyomo 6.0, PySP is distributed as a separate "


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Deprecation warnings emitted in certain cases (like in rules) can swamp a user, as the same deprecation warning is emitted many, many times.  This PR adds a cache so that deprecation warnings are only emitted to a user once for any particular context (calling file / line number).

## Changes proposed in this PR:
- add a cache to `deprecation_warning` so repetitive messages are not emitted
- disable deprecation warning cache if nose/pytest/sphinx are running
- standardize the check for detecting if nose / pytest / Sphinx are running
- silence a couple deprecation warnings

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
