### PR TITLE
Correct calculation of Constraint.equality for RangedExpression with constant bounds

### DIFF
--- a/pyomo/core/tests/unit/test_con.py
+++ b/pyomo/core/tests/unit/test_con.py
@@ -170,10 +170,105 @@ class TestConstraintCreation(unittest.TestCase):
             return (0, model.y, 1)
         model.c = Constraint(rule=rule)
 
-        self.assertEqual(model.c.equality,         False)
-        self.assertEqual(model.c.lower,             0)
-        self.assertIs   (model.c.body,              model.y)
-        self.assertEqual(model.c.upper,             1)
+        self.assertEqual(model.c.equality, False)
+        self.assertEqual(model.c.lower, 0)
+        self.assertIs   (model.c.body, model.y)
+        self.assertEqual(model.c.upper, 1)
+
+        model = self.create_model()
+        def rule(model):
+            return (0, model.y, 0)
+        model.c = Constraint(rule=rule)
+
+        self.assertEqual(model.c.equality, True)
+        self.assertEqual(model.c.lower, 0)
+        self.assertIs   (model.c.body, model.y)
+        self.assertEqual(model.c.upper, 0)
+
+        # Test mixed bound types (int / float)
+        model = self.create_model()
+        def rule(model):
+            return (0, model.y, 0.)
+        model.c = Constraint(rule=rule)
+
+        self.assertEqual(model.c.equality, True)
+        self.assertEqual(model.c.lower, 0)
+        self.assertIs   (model.c.body, model.y)
+        self.assertEqual(model.c.upper, 0)
+
+    def test_tuple_construct_2sided_mutable_inequality(self):
+        model = self.create_model()
+        model.p = Param(initialize=0, mutable=True)
+        model.q = Param(initialize=0., mutable=True)
+        def rule(model):
+            return (0, model.y, model.q)
+        model.c = Constraint(rule=rule)
+
+        self.assertEqual(model.c.equality, False)
+        self.assertEqual(model.c.lower, 0)
+        self.assertIs(model.c.body, model.y)
+        self.assertIs(model.c.upper, model.q)
+        self.assertEqual(model.c.lb, 0)
+        self.assertEqual(model.c.ub, 0)
+
+        def rule(model):
+            return (model.p, model.y, 0)
+        model.d = Constraint(rule=rule)
+
+        self.assertEqual(model.d.equality, False)
+        self.assertIs(model.d.lower, model.p)
+        self.assertIs(model.d.body, model.y)
+        self.assertEqual(model.d.upper, 0)
+        self.assertEqual(model.d.lb, 0)
+        self.assertEqual(model.d.ub, 0)
+
+        def rule(model):
+            return (model.p, model.y, model.q)
+        model.e = Constraint(rule=rule)
+
+        self.assertEqual(model.e.equality, False)
+        self.assertIs(model.e.lower, model.p)
+        self.assertIs(model.e.body, model.y)
+        self.assertIs(model.e.upper, model.q)
+        self.assertEqual(model.e.lb, 0)
+        self.assertEqual(model.e.ub, 0)
+
+    def test_tuple_construct_2sided_immutable_inequality(self):
+        model = self.create_model()
+        model.p = Param(initialize=0, mutable=False)
+        model.q = Param(initialize=0., mutable=False)
+        def rule(model):
+            return (0, model.y, model.q)
+        model.c = Constraint(rule=rule)
+
+        self.assertEqual(model.c.equality, True)
+        self.assertEqual(model.c.lower, 0)
+        self.assertIs(model.c.body, model.y)
+        self.assertIs(model.c.upper, model.q)
+        self.assertEqual(model.c.lb, 0)
+        self.assertEqual(model.c.ub, 0)
+
+        def rule(model):
+            return (model.p, model.y, 0)
+        model.d = Constraint(rule=rule)
+
+        self.assertEqual(model.d.equality, True)
+        self.assertIs(model.d.lower, model.p)
+        self.assertIs(model.d.body, model.y)
+        self.assertEqual(model.d.upper, 0)
+        self.assertEqual(model.d.lb, 0)
+        self.assertEqual(model.d.ub, 0)
+
+        def rule(model):
+            return (model.p, model.y, model.q)
+        model.e = Constraint(rule=rule)
+
+        self.assertEqual(model.e.equality, True)
+        self.assertIs(model.e.lower, model.p)
+        self.assertIs(model.e.body, model.y)
+        self.assertIs(model.e.upper, model.q)
+        self.assertEqual(model.e.lb, 0)
+        self.assertEqual(model.e.ub, 0)
 
     def test_tuple_construct_invalid_2sided_inequality(self):
         model = self.create_model(abstract=True)


### PR DESCRIPTION
## Fixes #2093 

## Summary/Motivation:
As was documented in #2093, the new implementation of `ConstraintData.equality` would occasionally fail to identify equality constraints for `RangedExpression` objects where the bounds were constants.  This resolves that issue by using `==` instead of `is` when both bounds are constants (native types or constant expressions).

## Changes proposed in this PR:
- Use `==` instead of `is` to compare constraint bounds and determine `equality` when both bounds are constants.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
