### PR TITLE
Add ListOf domain validator for ConfigValue

### DIFF
--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -237,7 +237,40 @@ class InEnum(object):
             value, self._domain.__name__))
 
 
-class Module:
+class ListOf(object):
+    """Domain validator for lists of a specified type
+
+    Parameters
+    ----------
+    itemtype: type
+        The type for each element in the list
+
+    domain: Callable
+        A domain validator (callable that takes the incoming value,
+        validates it, and returns the appropriate domain type) for each
+        element in the list.  If not specified, defaults to the
+        `itemtype`.
+
+    """
+    def __init__(self, itemtype, domain=None):
+        self.itemtype = itemtype
+        if domain is None:
+            self.domain = self.itemtype
+        else:
+            self.domain = domain
+        self.__name__ = 'ListOf(%s)' % (
+            getattr(self.domain, '__name__', self.domain),)
+
+    def __call__(self, value):
+        if hasattr(value, '__iter__') and not isinstance(value, self.itemtype):
+            return [self.domain(v) for v in value]
+        else:
+            return [self.domain(value)]
+
+    def __repr__(self):
+        return "ListOf(%s)" % domain.__name__
+
+class Module(object):
     """ Domain validator for modules.
 
     Modules can be specified as module objects, by module name,

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -270,6 +270,7 @@ class ListOf(object):
     def __repr__(self):
         return "ListOf(%s)" % domain.__name__
 
+
 class Module(object):
     """ Domain validator for modules.
 
@@ -628,6 +629,8 @@ validators for common use cases:
    NonNegativeFloat
    In
    InEnum
+   ListOf
+   Module
    Path
    PathList
 

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -267,9 +267,6 @@ class ListOf(object):
         else:
             return [self.domain(value)]
 
-    def __repr__(self):
-        return "ListOf(%s)" % domain.__name__
-
 
 class Module(object):
     """ Domain validator for modules.

--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -133,7 +133,6 @@ class RunAllNEOSSolvers(object):
     def test_mosek(self):
         self._run('mosek')
 
-    @unittest.expectedFailure
     def test_octeract(self):
         self._run('octeract')
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
There are several derivative projects that all declare their own `ConfigValue` domain validators for a "list of" values of a single type.  This provides a common `ListOf` domain validator that takes as it's construction argument the class of the target item type and an optional domain validator (if not provided, the domain validator falls back to using the item type)

## Changes proposed in this PR:
- Add `ListOf` domain validator class
- Add `ListOf` and `Module` to the module developer documentation
- It appears that oceract is working on NEOS again, so this removes the `expectedFailure` so that tests pass

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
