### PR TITLE
Expand documentation of `pyomo.common`

### DIFF
--- a/doc/OnlineDocs/library_reference/common/deprecation.rst
+++ b/doc/OnlineDocs/library_reference/common/deprecation.rst
@@ -1,0 +1,6 @@
+pyomo.common.deprecation
+========================
+
+.. automodule:: pyomo.common.deprecation
+   :members:
+   :member-order: bysource

--- a/doc/OnlineDocs/library_reference/common/fileutils.rst
+++ b/doc/OnlineDocs/library_reference/common/fileutils.rst
@@ -1,0 +1,6 @@
+pyomo.common.fileutils
+======================
+
+.. automodule:: pyomo.common.fileutils
+   :members:
+   :member-order: bysource

--- a/doc/OnlineDocs/library_reference/common/formatting.rst
+++ b/doc/OnlineDocs/library_reference/common/formatting.rst
@@ -1,0 +1,6 @@
+pyomo.common.formatting
+=======================
+
+.. automodule:: pyomo.common.formatting
+   :members:
+   :member-order: bysource

--- a/doc/OnlineDocs/library_reference/common/index.rst
+++ b/doc/OnlineDocs/library_reference/common/index.rst
@@ -11,4 +11,6 @@ or rely on any other parts of Pyomo.
    config.rst
    dependencies.rst
    deprecation.rst
+   fileutils.rst
+   formatting.rst
    timing.rst

--- a/pyomo/common/fileutils.py
+++ b/pyomo/common/fileutils.py
@@ -15,6 +15,21 @@
 #  the U.S. Government retains certain rights in this software.
 #  ___________________________________________________________________________
 
+"""This module provides general utilities for working with the file system
+
+.. autosummary::
+
+   this_file
+   this_file_dir
+   find_path
+   find_file
+   find_dir
+   find_library
+   find_executable
+   import_file
+   PathManager
+   PathData
+"""
 
 import ctypes.util
 import glob
@@ -407,9 +422,10 @@ def import_file(path, clear_cache=False, infer_package=True):
     Replaces import_file from pyutilib (Pyomo 6.0.0).
     
     This function returns the module object that is created.
+
     Parameters
     ----------
-    path : str
+    path: str
         Full path to .py file.
     clear_cache: bool
         Remove module if already loaded. The default is False.
@@ -436,8 +452,10 @@ def import_file(path, clear_cache=False, infer_package=True):
     return module
 
 
+class PathData(object):
+    """An object for storing and managing a :py:class:`PathManager` path
 
-class _PathData(object):
+    """
     def __init__(self, manager, name):
         self._mngr = manager
         self._registered_name = name
@@ -525,9 +543,13 @@ class _PathData(object):
         return ans
 
 
-class _ExecutableData(_PathData):
+class ExecutableData(PathData):
+    """A :py:class:`PathData` class specifically for executables.
+
+    """
     @property
     def executable(self):
+        """Get (or set) the path to the executable"""
         return self.path()
 
     @executable.setter
@@ -541,9 +563,9 @@ class PathManager(object):
     The :py:class:`PathManager` defines a class very similar to the
     :py:class:`CachedFactory` class; however it does not register type
     constructors.  Instead, it registers instances of
-    :py:class:`_PathData` (or :py:class:`_ExecutableData`).  These
+    :py:class:`PathData` (or :py:class:`ExecutableData`).  These
     contain the resolved path to the directory object under which the
-    :py:class:`_PathData` object was registered.  We do not use
+    :py:class:`PathData` object was registered.  We do not use
     the PyUtilib ``register_executable`` and ``registered_executable``
     functions so that we can automatically include Pyomo-specific
     locations in the search path (namely the ``PYOMO_CONFIG_DIR``).
@@ -582,7 +604,7 @@ class PathManager(object):
         True
 
     For convenience, :py:meth:`available()` and :py:meth:`path()` are
-    available by casting the :py:class:`_PathData` object requrned
+    available by casting the :py:class:`PathData` object requrned
     from ``Executable`` or ``Library`` to either a ``bool`` or ``str``:
 
     .. doctest::
@@ -596,7 +618,7 @@ class PathManager(object):
     time a client queried the location or availability, the
     PathManager will return incorrect information.  You can cause
     the :py:class:`PathManager` to refresh its cache by calling
-    ``rehash()`` on either the :py:class:`_PathData` (for the
+    ``rehash()`` on either the :py:class:`PathData` (for the
     single file) or the :py:class:`PathManager` to refresh the
     cache for all files:
 
@@ -636,8 +658,8 @@ class PathManager(object):
 
         >>> Executable('demo_exec_file').set_path(None)
 
-    The ``Executable`` singleton uses :py:class:`_ExecutableData`, an
-    extended form of the :py:class:`_PathData` class, which provides the
+    The ``Executable`` singleton uses :py:class:`ExecutableData`, an
+    extended form of the :py:class:`PathData` class, which provides the
     ``executable`` property as an alais for :py:meth:`path()` and
     :py:meth:`set_path()`:
 
@@ -681,8 +703,8 @@ class PathManager(object):
 #
 # Define singleton objects for Pyomo / Users to interact with
 #
-Executable = PathManager(find_executable, _ExecutableData)
-Library = PathManager(find_library, _PathData)
+Executable = PathManager(find_executable, ExecutableData)
+Library = PathManager(find_library, PathData)
 
 
 @deprecated("pyomo.common.register_executable(name) has been deprecated; "

--- a/pyomo/common/fileutils.py
+++ b/pyomo/common/fileutils.py
@@ -26,7 +26,10 @@ import importlib.util
 import sys
 
 from . import envvar
-from .deprecation import deprecated
+from .deprecation import deprecated, relocated_module_attribute
+
+relocated_module_attribute(
+    'StreamIndenter', 'pyomo.common.formatting', version='TBD')
 
 def this_file(stack_offset=1):
     """Returns the file name for the module that calls this function.
@@ -432,53 +435,6 @@ def import_file(path, clear_cache=False, infer_package=True):
         sys.path.pop(0)
     return module
 
-
-class StreamIndenter(object):
-    """
-    Mock-up of a file-like object that wraps another file-like object
-    and indents all data using the specified string before passing it to
-    the underlying file.  Since this presents a full file interface,
-    StreamIndenter objects may be arbitrarily nested.
-    """
-
-    def __init__(self, ostream, indent=' '*4):
-        self.os = ostream
-        self.indent = indent
-        self.stripped_indent = indent.rstrip()
-        self.newline = True
-
-    def __getattr__(self, name):
-        return getattr(self.os, name)
-
-    def write(self, data):
-        if not len(data):
-            return
-        lines = data.split('\n')
-        if self.newline:
-            if lines[0]:
-                self.os.write(self.indent+lines[0])
-            else:
-                self.os.write(self.stripped_indent)
-        else:
-            self.os.write(lines[0])
-        if len(lines) < 2:
-            self.newline = False
-            return
-        for line in lines[1:-1]:
-            if line:
-                self.os.write("\n"+self.indent+line)
-            else:
-                self.os.write("\n"+self.stripped_indent)
-        if lines[-1]:
-            self.os.write("\n"+self.indent+lines[-1])
-            self.newline = False
-        else:
-            self.os.write("\n")
-            self.newline = True
-
-    def writelines(self, sequence):
-        for x in sequence:
-            self.write(x)
 
 
 class _PathData(object):

--- a/pyomo/common/formatting.py
+++ b/pyomo/common/formatting.py
@@ -182,3 +182,50 @@ def tabular_writer(ostream, prefix, data, header, row_generator):
                 + " : ".join( _width[i] % x for i,x in enumerate(_data) )
                 + "\n")
 
+
+class StreamIndenter(object):
+    """
+    Mock-up of a file-like object that wraps another file-like object
+    and indents all data using the specified string before passing it to
+    the underlying file.  Since this presents a full file interface,
+    StreamIndenter objects may be arbitrarily nested.
+    """
+
+    def __init__(self, ostream, indent=' '*4):
+        self.os = ostream
+        self.indent = indent
+        self.stripped_indent = indent.rstrip()
+        self.newline = True
+
+    def __getattr__(self, name):
+        return getattr(self.os, name)
+
+    def write(self, data):
+        if not len(data):
+            return
+        lines = data.split('\n')
+        if self.newline:
+            if lines[0]:
+                self.os.write(self.indent+lines[0])
+            else:
+                self.os.write(self.stripped_indent)
+        else:
+            self.os.write(lines[0])
+        if len(lines) < 2:
+            self.newline = False
+            return
+        for line in lines[1:-1]:
+            if line:
+                self.os.write("\n"+self.indent+line)
+            else:
+                self.os.write("\n"+self.stripped_indent)
+        if lines[-1]:
+            self.os.write("\n"+self.indent+lines[-1])
+            self.newline = False
+        else:
+            self.os.write("\n")
+            self.newline = True
+
+    def writelines(self, sequence):
+        for x in sequence:
+            self.write(x)

--- a/pyomo/common/formatting.py
+++ b/pyomo/common/formatting.py
@@ -7,6 +7,14 @@
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
+"""This module provides general utilities for producing formated I/O
+
+.. autosummary::
+
+   tostr
+   tabular_writer
+   StreamIndenter
+"""
 
 import types
 from pyomo.common.sorting import sorted_robust
@@ -87,6 +95,7 @@ tostr.handlers = {
     ),
     None: lambda value, quote_str: str(value),
 }
+
 
 def tabular_writer(ostream, prefix, data, header, row_generator):
     """Output data in tabular form

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -26,7 +26,7 @@ import pyomo.common.envvar as envvar
 from pyomo.common.log import LoggingIntercept
 from pyomo.common.fileutils import (
     this_file, this_file_dir, find_file, find_library, find_executable, 
-    PathManager, _system, _path, _exeExt, _libExt, _ExecutableData,
+    PathManager, _system, _path, _exeExt, _libExt, ExecutableData,
     import_file,
 )
 from pyomo.common.download import FileDownloader
@@ -410,7 +410,7 @@ class TestFileUtils(unittest.TestCase):
 
 
     def test_PathManager(self):
-        Executable = PathManager(find_executable, _ExecutableData)
+        Executable = PathManager(find_executable, ExecutableData)
         self.tmpdir = os.path.abspath(tempfile.mkdtemp())
 
         envvar.PYOMO_CONFIG_DIR = self.tmpdir

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -27,7 +27,7 @@ from pyomo.common.log import LoggingIntercept
 from pyomo.common.fileutils import (
     this_file, this_file_dir, find_file, find_library, find_executable, 
     PathManager, _system, _path, _exeExt, _libExt, _ExecutableData,
-    import_file, StreamIndenter
+    import_file,
 )
 from pyomo.common.download import FileDownloader
 
@@ -113,20 +113,6 @@ class TestFileUtils(unittest.TestCase):
         with self.assertRaises(FileNotFoundError) as context:
             import_file(os.path.join(_this_file_dir, 'import_ex'))
         self.assertTrue('File does not exist' in str(context.exception))
-
-    def test_StreamIndenter_noprefix(self):
-        OUT1 = StringIO()
-        OUT2 = StreamIndenter(OUT1)
-        OUT2.write('Hello?\nHello, world!')
-        self.assertEqual('    Hello?\n    Hello, world!',
-                         OUT2.getvalue())
-
-    def test_StreamIndenter_prefix(self):
-        prefix = 'foo:'
-        OUT1 = StringIO()
-        OUT2 = StreamIndenter(OUT1, prefix)
-        OUT2.write('Hello?\nHello, world!')
-        self.assertEqual('foo:Hello?\nfoo:Hello, world!', OUT2.getvalue())
 
     def test_system(self):
         self.assertTrue(platform.system().lower().startswith(_system()))

--- a/pyomo/common/tests/test_formatting.py
+++ b/pyomo/common/tests/test_formatting.py
@@ -13,7 +13,7 @@ from io import StringIO
 
 import pyomo.common.unittest as unittest
 
-from pyomo.common.formatting import tostr, tabular_writer
+from pyomo.common.formatting import tostr, tabular_writer, StreamIndenter
 
 class DerivedList(list): pass
 class DerivedTuple(tuple): pass
@@ -168,4 +168,20 @@ Key : i : j
     : 2 : cccc
 """
         self.assertEqual(ref.strip(), os.getvalue().strip())
+
+
+class TestStreamIndenter(unittest.TestCase):
+    def test_StreamIndenter_noprefix(self):
+        OUT1 = StringIO()
+        OUT2 = StreamIndenter(OUT1)
+        OUT2.write('Hello?\nHello, world!')
+        self.assertEqual('    Hello?\n    Hello, world!',
+                         OUT2.getvalue())
+
+    def test_StreamIndenter_prefix(self):
+        prefix = 'foo:'
+        OUT1 = StringIO()
+        OUT2 = StreamIndenter(OUT1, prefix)
+        OUT2.write('Hello?\nHello, world!')
+        self.assertEqual('foo:Hello?\nfoo:Hello, world!', OUT2.getvalue())
 

--- a/pyomo/common/tests/test_formatting.py
+++ b/pyomo/common/tests/test_formatting.py
@@ -21,6 +21,7 @@ class DerivedDict(dict): pass
 class DerivedStr(str): pass
 NamedTuple = namedtuple('NamedTuple', ['x', 'y'])
 
+
 class TestToStr(unittest.TestCase):
     def test_new_type_float(self):
         self.assertEqual(tostr(0.5), '0.5')
@@ -49,6 +50,7 @@ class TestToStr(unittest.TestCase):
     def test_new_type_namedtuple(self):
         self.assertEqual(tostr(NamedTuple(1, 2)), 'NamedTuple(x=1, y=2)')
         self.assertIs(tostr.handlers[NamedTuple], tostr.handlers[None])
+
 
 class TestTabularWriter(unittest.TestCase):
     def test_unicode_table(self):

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -24,7 +24,7 @@ from io import StringIO
 
 from pyomo.common.collections import Mapping
 from pyomo.common.deprecation import deprecated, deprecation_warning, RenamedClass
-from pyomo.common.fileutils import StreamIndenter
+from pyomo.common.formatting import StreamIndenter
 from pyomo.common.log import is_debug_set
 from pyomo.common.sorting import sorted_robust
 from pyomo.common.timing import ConstructionTimer

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -17,8 +17,7 @@ from weakref import ref as weakref_ref
 import pyomo.common
 from pyomo.common.deprecation import deprecated, relocated_module_attribute
 from pyomo.common.factory import Factory
-from pyomo.common.fileutils import StreamIndenter
-from pyomo.common.formatting import tabular_writer
+from pyomo.common.formatting import tabular_writer, StreamIndenter
 from pyomo.common.modeling import NOTSET
 from pyomo.common.sorting import sorted_robust
 from pyomo.core.pyomoobject import PyomoObject


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This adds additional documentation to the `pyomo.common` section of the library reference.

As part of documentation, this PR makes `_PathData` and `_ExecutableData` classes "public" (no leading underscore).  It also moves the `StreamIndenter` class from `pyomo.common.fileutils` into `pyomo.common.formatting`.

## Changes proposed in this PR:
- expand documentation to include library references for `formatting`, `fileutils`, and `deprecation`.
- Rename `_PathData` and `_ExecutableData` to `PathData` and `ExecutableData`
- Move `StreamIndenter` from `pyomo.common.fileutils` to `pyomo.common.formatting`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
