### PR TITLE
Remove calls to `warnings.warning`

### DIFF
--- a/pyomo/contrib/pynumero/sparse/block_matrix.py
+++ b/pyomo/contrib/pynumero/sparse/block_matrix.py
@@ -804,7 +804,7 @@ class BlockMatrix(BaseBlockMatrix):
                     raise ValueError(msg)
                 msg = 'blocks need to be sparse matrices or BlockMatrices; a numpy array was given; copying the numpy array to a coo_matrix'
                 logger.warning(msg)
-                warnings.warning(msg)
+                warnings.warn(msg)
                 value = coo_matrix(value)
             else:
                 assert isspmatrix(value), 'blocks need to be sparse matrices or BlockMatrices'

--- a/pyomo/solvers/tests/checks/test_writers.py
+++ b/pyomo/solvers/tests/checks/test_writers.py
@@ -10,7 +10,6 @@
 
 import os
 from os.path import join, dirname, abspath
-import warnings
 import types
 try:
     import new
@@ -29,7 +28,6 @@ thisDir = dirname(abspath( __file__ ))
 
 # Cleanup Expected Failure Results Files
 _cleanup_expected_failures = True
-
 
 #
 # A function that returns a function that gets
@@ -89,14 +87,16 @@ def create_test_method(model,
 
         if is_expected_failure:
             if rc[0]:
-                warnings.warning("\nTest model '%s' was marked as an expected "
-                              "failure but no failure occured. The "
-                              "reason given for the expected failure "
-                              "is:\n\n****\n%s\n****\n\n"
-                              "Please remove this case as an expected "
-                              "failure if the above issue has been "
-                              "corrected in the latest version of the "
-                              "solver." % (model_class.description, test_case.msg))
+                self.fail(
+                    "\nTest model '%s' was marked as an expected "
+                    "failure but no failure occured. The "
+                    "reason given for the expected failure "
+                    "is:\n\n****\n%s\n****\n\n"
+                    "Please remove this case as an expected "
+                    "failure if the above issue has been "
+                    "corrected in the latest version of the "
+                    "solver." % (model_class.description, test_case.msg)
+                )
             if _cleanup_expected_failures:
                 os.remove(save_filename)
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
@joshua-cogliati-inl reported incorrect use of the warnings module (introduced when removing logger deprecation warnings in #1935).  This removes (invalid) calls to `warnings.warning()`

## Changes proposed in this PR:
- remove calls to `warning.warning`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
