### PR TITLE
Overhaul of Pyomo TempfileManager

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,7 +7,9 @@ omit =
 # The [run] section must be at the end, as the build harness will add a
 # "data_file" directive to the end of this file.
 [run]
-concurrency = multiprocessing,thread
+concurrency =
+    multiprocessing
+    thread
 parallel = True
 source =
     pyomo

--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -39,6 +39,7 @@ finally:
 # -- Options for intersphinx ---------------------------------------------
 
 intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
     'matplotlib': ('https://matplotlib.org/stable/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'pandas': ('https://pandas.pydata.org/docs/', None),

--- a/doc/OnlineDocs/library_reference/common/index.rst
+++ b/doc/OnlineDocs/library_reference/common/index.rst
@@ -13,4 +13,5 @@ or rely on any other parts of Pyomo.
    deprecation.rst
    fileutils.rst
    formatting.rst
+   tempfiles.rst
    timing.rst

--- a/doc/OnlineDocs/library_reference/common/tempfiles.rst
+++ b/doc/OnlineDocs/library_reference/common/tempfiles.rst
@@ -1,0 +1,7 @@
+
+pyomo.common.tempfiles
+======================
+
+.. automodule:: pyomo.common.tempfiles
+   :members:
+   :member-order: bysource

--- a/pyomo/common/formatting.py
+++ b/pyomo/common/formatting.py
@@ -102,7 +102,7 @@ def tabular_writer(ostream, prefix, data, header, row_generator):
 
     Parameters
     ----------
-    ostream: RawIOBase
+    ostream: io.TextIOBase
         the stream to write to
     prefix: str
         prefix each generated line with this string

--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -40,11 +40,6 @@ class TempfileManagerClass(object):
     Pyomo declares a global instance of this class as ``TempfileManager``:
 
     .. doctest::
-       :hide:
-
-       >>> import os
-
-    .. doctest::
 
        >>> from pyomo.common.tempfiles import TempfileManager
 
@@ -59,6 +54,7 @@ class TempfileManagerClass(object):
 
     .. doctest::
 
+       >>> import os
        >>> with TempfileManager.new_context() as tempfile:
        ...     fd, fname = tempfile.mkstemp()
        ...     dname = tempfile.mkdtemp()

--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -264,6 +264,7 @@ class TempfileContext:
 
         """
         dir = self._resolve_tempdir(dir)
+        # Note: ans == (fd, fname)
         ans = tempfile.mkstemp(suffix=suffix, prefix=prefix, dir=dir, text=text)
         self.tempfiles.append(ans)
         return ans
@@ -336,10 +337,7 @@ class TempfileContext:
     def create_tempfile(self, suffix=None, prefix=None, text=False, dir=None):
         """Create a unique temporary file.
 
-        If this context is generating sequential files (see
-        :meth:`sequential_files()`), the directory name will be
-        generated as ``prefix + counter + suffix``; otherwise, the name
-        is generated as in :func:`tempfile.mkstemp()`.
+        The file name is generated as in :func:`tempfile.mkstemp()`.
 
         Any file handles to the new file (e.g., from :meth:`mkstemp`)
         are closed.
@@ -359,10 +357,7 @@ class TempfileContext:
     def create_tempdir(self, suffix=None, prefix=None, dir=None):
         """Create a unique temporary directory.
 
-        If this context is generating sequential files (see
-        :meth:`sequential_files()`), the directory name will be
-        generated as ``prefix + counter + suffix``; otherwise, the name
-        is generated as in :func:`fileutil.mkdtemp()`.
+        The file name is generated as in :func:`tempfile.mkdtemp()`.
 
         Returns
         -------

--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -86,6 +86,7 @@ class TempfileManagerClass(object):
        True
 
        >>> TempfileManager.pop()
+       <pyomo.common.tempfiles.TempfileContext object ...>
        >>> os.path.exists(fname)
        False
        >>> os.path.exists(dname)

--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -52,8 +52,8 @@ class TempfileManagerClass(object):
     :class:`TempfileContext` contexts.  It implements a basic stack,
     where users can :meth:`push()` a new context (causing it to become
     the current "active" context) and :meth:`pop()` contexts off
-    (optionally deleting all files associated with the context.  In
-    general usage, users will either use the this class to create new
+    (optionally deleting all files associated with the context).  In
+    general usage, users will either use this class to create new
     tempfile contexts and use them explicitly (i.e., through a context
     manager):
 

--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -125,17 +125,17 @@ class TempfileManagerClass(object):
         self._context_stack = None
 
     def create_tempfile(self, suffix=None, prefix=None, text=False, dir=None):
-        """:meth:`TempfileContext.create_tempfile` for the active context"""
+        "Call :meth:`TempfileContext.create_tempfile` on the active context"
         return self._context_stack[-1].create_tempfile(
             suffix=suffix, prefix=prefix, text=text, dir=dir)
 
     def create_tempdir(self, suffix=None, prefix=None, dir=None):
-        """:meth:`TempfileContext.create_tempdir` for the active context"""
+        "Call :meth:`TempfileContext.create_tempdir` on the active context"
         return self._context_stack[-1].create_tempdir(
             suffix=suffix, prefix=prefix, dir=dir)
 
     def add_tempfile(self, filename, exists=True):
-        """:meth:`TempfileContext.add_tempfile` for the active context"""
+        "Call :meth:`TempfileContext.add_tempfile` on the active context"
         return self._context_stack[-1].add_tempfile(
             filename=filename, exists=exists)
 
@@ -403,7 +403,7 @@ class TempfileContext:
     def add_tempfile(self, filename, exists=True):
         """Declare the specified file/directory to be temporary.
 
-        This adds the doecified path as a "temporary" object to this
+        This adds the specified path as a "temporary" object to this
         context's list of managed temporary paths (i.e., it will be
         potentially be deleted when the context is released (see
         :meth:`release`).

--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -20,6 +20,7 @@ import time
 import tempfile
 import logging
 import shutil
+import weakref
 from pyomo.common.deprecation import deprecation_warning
 try:
     from pyutilib.component.config.tempfiles import (
@@ -29,174 +30,496 @@ except ImportError:
     pyutilib_mngr = None
 
 deletion_errors_are_fatal = True
+DELETE_COUNTED_CONFLICTS = True
 
-class _TempfileContext(object):
+logger = logging.getLogger(__name__)
+
+
+class TempfileManagerClass(object):
+    """A class for managing tempfile contexts
+
+    Pyomo declares a global instance of this class as ``TempfileManager``:
+
+    .. doctest::
+       :hide:
+
+       >>> import os
+
+    .. doctest::
+
+       >>> from pyomo.common.tempfiles import TempfileManager
+
+    This class provides an interface for managing
+    :class:`TempfileContext` contexts.  It implements a basic stack,
+    where users can :meth:`push()` a new context (causing it to become
+    the current "active" context) and :meth:`pop()` contexts off
+    (optionally deleting all files associated with the context.  In
+    general usage, users will either use the this class to create new
+    tempfile contexts and use them explicitly (i.e., through a context
+    manager):
+
+    .. doctest::
+
+       >>> with TempfileManager.new_context() as tempfile:
+       ...     fd, fname = tempfile.mkstemp()
+       ...     dname = tempfile.mkdtemp()
+       ...     os.path.isfile(fname)
+       ...     os.path.isdir(dname)
+       True
+       True
+       >>> os.path.exists(fname)
+       False
+       >>> os.path.exists(dname)
+       False
+
+    or through an implicit active context accessed through the manager
+    class:
+
+    .. doctest::
+
+       >>> TempfileManager.push()
+       <pyomo.common.tempfiles.TempfileContext object ...>
+       >>> fname = TempfileManager.create_tempfile()
+       >>> dname = TempfileManager.create_tempdir()
+       >>> os.path.isfile(fname)
+       True
+       >>> os.path.isdir(dname)
+       True
+
+       >>> TempfileManager.pop()
+       >>> os.path.exists(fname)
+       False
+       >>> os.path.exists(dname)
+       False
+
+    """
+
     def __init__(self):
-        self.ctr = -1
-        self.files = []
-
-    def append(self, filename):
-        self.files.append(filename)
-
-    def __iter__(self):
-        return iter(self.files)
-
-class TempfileManagerClass:
-    """A class that manages temporary files."""
-
-    def __init__(self, **kwds):
+        self._context_stack = []
+        self._context_manager_stack = []
         self.tempdir = None
-        self._tempfiles = []
-        self.push()
+
+    def __del__(self):
+        self.shutdown()
+
+    def shutdown(self, remove=True):
+        if not self._context_stack:
+            return
+        if any(ctx.tempfiles for ctx in self._context_stack):
+            logger.error(
+                "Temporary files created through TempfileManager "
+                "contexts have not been deleted (observed during "
+                "TempfileManager instance shutdown).\n"
+                "Undeleted entries:\n\t"+ "\n\t".join(
+                    fname if isinstance(fname, str) else fname.decode()
+                    for ctx in self._context_stack
+                    for fd, fname in ctx.tempfiles))
+        if self._context_stack:
+            logger.warning(
+                "TempfileManagerClass instance: un-popped tempfile "
+                "contexts still exist during TempfileManager instance "
+                "shutdown")
+        self.clear_tempfiles(remove)
+        # Delete the stack so that subsequent operations generate an
+        # exception
+        self._context_stack = None
 
     def create_tempfile(self, suffix=None, prefix=None, text=False, dir=None):
-        """Create a unique temporary file
+        """:meth:`TempfileContext.create_tempfile` for the active context"""
+        return self._context_stack[-1].create_tempfile(
+            suffix=suffix, prefix=prefix, text=text, dir=dir)
 
-        Returns the absolute path of a temporary filename that is
-        guaranteed to be unique.  This function generates the file and
-        returns the filename.
+    def create_tempdir(self, suffix=None, prefix=None, dir=None):
+        """:meth:`TempfileContext.create_tempdir` for the active context"""
+        return self._context_stack[-1].create_tempdir(
+            suffix=suffix, prefix=prefix, dir=dir)
+
+    def add_tempfile(self, filename, exists=True):
+        """:meth:`TempfileContext.add_tempfile` for the active context"""
+        return self._context_stack[-1].add_tempfile(
+            filename=filename, exists=exists)
+
+    def clear_tempfiles(self, remove=True):
+        """Delete all temporary files and remove all contexts."""
+        while self._context_stack:
+            self.pop(remove)
+
+    def sequential_files(self, ctr=0):
+        """:meth:`TempfileContext.sequential_files` for the active context"""
+        self._context_stack[-1].sequential_files(ctr)
+
+    def unique_files(self):
+        """:meth:`TempfileContext.unique_files` for the active context"""
+        self._context_stack[-1].unique_files()
+
+    def new_context(self):
+        """Create and return an new tempfile context
+
+        Returns
+        -------
+        TempfileContext
+            the newly-created tempfile context
 
         """
-        if suffix is None:
-            suffix = ''
-        if prefix is None:
-            prefix = 'tmp'
-        if dir is None:
-            dir = self.tempdir
-            if dir is None and pyutilib_mngr is not None:
-                dir = pyutilib_mngr.tempdir
-                if dir is not None:
-                    deprecation_warning(
-                        "The use of the PyUtilib TempfileManager.tempdir "
-                        "to specify the default location for Pyomo "
-                        "temporary files has been deprecated.  "
-                        "Please set TempfileManager.tempdir in "
-                        "pyomo.common.tempfiles", version='5.7.2')
+        return TempfileContext(self)
 
-        ans = tempfile.mkstemp(suffix=suffix, prefix=prefix, text=text, dir=dir)
-        ans = list(ans)
-        fname = os.path.abspath(ans[1])
-        os.close(ans[0])
-        if self._tempfiles[-1].ctr >= 0:
-            new_fname = os.path.join(
-                os.path.dirname(fname),
-                prefix + str(self._tempfiles[-1].ctr) + suffix
-            )
-            # Delete any file having the sequential name and then
-            # rename
-            if os.path.exists(new_fname):
-                os.remove(new_fname)
-            shutil.move(fname, new_fname)
-            fname = new_fname
-            self._tempfiles[-1].ctr += 1
-        self._tempfiles[-1].append(fname)
+    def push(self):
+        """Create a new tempfile context and set it as the active context.
+
+        Returns
+        -------
+        TempfileContext
+            the newly-created tempfile context
+
+        """
+        context = self.new_context()
+        self._context_stack.append(context)
+        return context
+
+    def pop(self, remove=True):
+        """Remove and release the active context
+
+        Parameters
+        ----------
+        remove: bool
+            If ``True``, delete all managed files / directories
+
+        """
+        ctx = self._context_stack.pop()
+        ctx.release(remove)
+        return ctx
+
+    def __enter__(self):
+        ctx = self.push()
+        self._context_manager_stack.append(ctx)
+        return ctx
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        ctx = self._context_manager_stack.pop()
+        while True:
+            if ctx is self.pop():
+                break
+            logger.warning(
+                "TempfileManager: tempfile context was pushed onto "
+                "the TempfileManager stack within a context manager "
+                "(i.e., `with TempfileManager:`) but was not popped "
+                "before the context manager exited.  Popping the "
+                "context to preserve the stack integrity.")
+
+
+class TempfileContext:
+    """A `context` for managing collections of temporary files
+
+    Instances of this class hold a "temporary file context".  That is,
+    this records a collection of temporary file system objects that are
+    all managed as a group.  The most common use of the context is to
+    ensure that all files are deleted when the context is released.
+
+    This class replicates a significant portion of the :mod:`tempfile`
+    module interface.
+
+    Instances of this class may be used as context managers (with the
+    temporary files / directories getting automatically deleted when the
+    context manager exits).
+
+    Instances will also attempt to delete any temporary objects from the
+    filesystem when the context falls out of scope (although this
+    behavior is not guaranteed for instances existing when the
+    interpreter is shutting down).
+
+    """
+
+    def __init__(self, manager):
+        self.manager = weakref.ref(manager)
+        self.ctr = None
+        self.tempfiles = []
+        self.tempdir = None
+
+    def __del__(self):
+        self.release()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.release()
+
+    def mkstemp(self, suffix=None, prefix=None, dir=None, text=False):
+        """Create a unique temporary file using :func:`tempfile.mkstemp`
+
+        Parameters are handled as in :func:`tempfile.mkstemp`, with
+        the exception that the new file is created in the directory
+        returned by :meth:`gettempdir`
+
+        Returns
+        -------
+        fd: int
+            the opened file descriptor
+
+        fname: str or bytes
+            the absolute path to the new temporary file
+
+        """
+        dir = self._resolve_tempdir(dir)
+        ans = tempfile.mkstemp(suffix=suffix, prefix=prefix, dir=dir, text=text)
+        self.tempfiles.append(ans)
+        return ans
+
+    def mkdtemp(self, suffix=None, prefix=None, dir=None):
+        """Create a unique temporary directory using :func:`tempfile.mkdtemp`
+
+        Parameters are handled as in :func:`tempfile.mkdtemp`, with
+        the exception that the new file is created in the directory
+        returned by :meth:`gettempdir`
+
+        Returns
+        -------
+        dname: str or bytes
+            the absolute path to the new temporary directory
+
+        """
+        dir = self._resolve_tempdir(dir)
+        dname = tempfile.mkdtemp(suffix=suffix, prefix=prefix, dir=dir)
+        self.tempfiles.append((None, dname))
+        return dname
+
+    def gettempdir(self):
+        """Return the default name of the directory used for temporary files.
+
+        This method returns the first non-null location returned from:
+
+         - This context's ``tempdir`` (i.e., ``self.tempdir``)
+         - This context's manager's ``tempdir`` (i.e.,
+           ``self.manager().tempdir``)
+         - :func:`tempfile.gettempdir()`
+
+        Returns
+        -------
+        dir: str
+            The default directory to use for creating temporary objects
+        """
+        dir = self._resolve_tempdir()
+        if dir is None:
+            return tempfile.gettempdir()
+        if isinstance(dir, bytes):
+            return dir.decode()
+        return dir
+
+    def gettempdirb(self):
+        """Same as :meth:`gettempdir()`, but the return value is ``bytes``
+
+        """
+        dir = self._resolve_tempdir()
+        if dir is None:
+            return tempfile.gettempdirb()
+        if not isinstance(dir, bytes):
+            return dir.encode()
+        return dir
+
+    def gettempprefix(self):
+        """Return the filename prefix used to create temporary files.
+
+        See :func:`tempfile.gettempprefix()`
+
+        """
+        return tempfile.gettempprefix()
+
+    def gettempprefixb(self):
+        """Same as :meth:`gettempprefix()`, but the return value is ``bytes``
+
+        """
+        return tempfile.gettempprefixb()
+
+    def sequential_files(self, ctr=0):
+        """Start generating sequential files, using the specified counter.
+
+        The sequential files are named using ``prefix + counter +
+        suffix``.  While the ``counter`` defaults to an integer
+        beginning at 0, any object that supports ``__str__`` and
+        ``__iadd__`` may be used.
+
+        Parameters
+        ----------
+        ctr:
+            "Counter" used to generate the name sequence
+
+        """
+        self.ctr = ctr
+
+    def unique_files(self):
+        """Stop generating sequential files
+
+        This returns the name generator to the default one used in
+        :func:`tempfile.mkstemp()`.
+
+        """
+        self.ctr = None
+
+    def create_tempfile(self, suffix=None, prefix=None, text=False, dir=None):
+        """Create a unique temporary file.
+
+        If this context is generating sequential files (see
+        :meth:`sequential_files()`), the directory name will be
+        generated as ``prefix + counter + suffix``; otherwise, the name
+        is generated as in :func:`tempfile.mkstemp()`.
+
+        Any file handles to the new file (e.g., from :meth:`mkstemp`)
+        are closed.
+
+        Returns
+        -------
+        fname: str or bytes
+            The absolute path of the new file.
+
+        """
+        fd, fname = self.mkstemp(suffix=suffix, prefix=prefix,
+                                 dir=dir, text=text)
+        os.close(fd)
+        if self.ctr is not None:
+            fname = self._make_counted_object(fname, prefix, suffix)
+        self.tempfiles[-1] = (None, fname)
         return fname
 
     def create_tempdir(self, suffix=None, prefix=None, dir=None):
-        """Create a unique temporary directory
+        """Create a unique temporary directory.
 
-        Returns the absolute path of a temporary directory that is
-        guaranteed to be unique.  This function generates the directory
-        and returns the directory name.
+        If this context is generating sequential files (see
+        :meth:`sequential_files()`), the directory name will be
+        generated as ``prefix + counter + suffix``; otherwise, the name
+        is generated as in :func:`fileutil.mkdtemp()`.
+
+        Returns
+        -------
+        dname: str or bytes
+            The absolute path of the new directory.
 
         """
-        if suffix is None:
-            suffix = ''
-        if prefix is None:
-            prefix = 'tmp'
-        if dir is None:
-            dir = self.tempdir
-            if dir is None and pyutilib_mngr is not None:
-                dir = pyutilib_mngr.tempdir
-                if dir is not None:
-                    deprecation_warning(
-                        "The use of the PyUtilib TempfileManager.tempdir "
-                        "to specify the default location for Pyomo "
-                        "temporary directories has been deprecated.  "
-                        "Please set TempfileManager.tempdir in "
-                        "pyomo.common.tempfiles", version='5.7.2')
-
-        dirname = tempfile.mkdtemp(suffix=suffix, prefix=prefix, dir=dir)
-        if self._tempfiles[-1].ctr >= 0:
-            new_dirname = os.path.join(
-                os.path.dirname(dirname),
-                prefix + str(self._tempfiles[-1].ctr) + suffix
-            )
-            # Delete any directory having the sequential name and then
-            # rename
-            if os.path.exists(new_dirname):
-                shutil.rmtree(new_dirname)
-            shutil.move(dirname, new_dirname)
-            dirname = new_dirname
-            self._tempfiles[-1].ctr += 1
-
-        self._tempfiles[-1].append(dirname)
+        dirname = self.mkdtemp(suffix=suffix, prefix=prefix, dir=dir)
+        if self.ctr is not None:
+            dirname = self._make_counted_object(dirname, prefix, suffix)
+        self.tempfiles[-1] = (None, dirname)
         return dirname
 
     def add_tempfile(self, filename, exists=True):
-        """Declare this file to be temporary."""
+        """Declare the specified file/directory to be temporary.
+
+        This adds the doecified path as a "temporary" object to this
+        context's list of managed temporary paths (i.e., it will be
+        potentially be deleted when the context is released (see
+        :meth:`release`).
+
+        Parameters
+        ----------
+        filename: str
+            the file / directory name to be treated as temporary
+        exists: bool
+            if ``True``, the file / directory must already exist.
+
+        """
         tmp = os.path.abspath(filename)
         if exists and not os.path.exists(tmp):
             raise IOError("Temporary file does not exist: " + tmp)
-        self._tempfiles[-1].append(tmp)
+        self.tempfiles.append((None, tmp))
 
-    def clear_tempfiles(self, remove=True):
-        """Delete all temporary files."""
-        while self._tempfiles:
-            self.pop(remove)
-        self.push()
+    def release(self, remove=True):
+        """Release this context
 
-    def sequential_files(self, ctr=0):
-        """Start generating sequential files, using the specified counter"""
-        self._tempfiles[-1].ctr = ctr
+        This releases the current context, potentially deleting all
+        managed temporary objects (files and directories), and resetting
+        the context to generate unique names.
 
-    def unique_files(self):
-        """Stop generating sequential files, using the specified counter"""
-        self._tempfiles[-1].ctr = -1
-
-    #
-    # Support "with" statements, where the pop automatically
-    # takes place on exit.
-    #
-    def push(self):
-        self._tempfiles.append(_TempfileContext())
-        return self
-
-    def __enter__(self):
-        self.push()
-
-    def __exit__(self, type, value, traceback):
-        self.pop(remove=True)
-
-    def pop(self, remove=True):
-        files = self._tempfiles.pop()
+        Parameters
+        ----------
+        remove: bool
+            If ``True``, delete all managed files / directories
+        """
         if remove:
-            for filename in files:
-                if os.path.exists(filename):
-                    if os.path.isdir(filename):
-                        shutil.rmtree(
-                            filename,
-                            ignore_errors=not deletion_errors_are_fatal)
+            for fd, name in self.tempfiles:
+                if fd is not None:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
+                self._remove_filesystem_object(name)
+        self.ctr = None
+        self.tempfiles.clear()
+
+    def _resolve_tempdir(self, dir=None):
+        if dir is not None:
+            return dir
+        elif self.tempdir is not None:
+            return self.tempdir
+        elif self.manager().tempdir is not None:
+            return self.manager().tempdir
+        elif pyutilib_mngr is not None and pyutilib_mngr.tempdir is not None:
+            deprecation_warning(
+                "The use of the PyUtilib TempfileManager.tempdir "
+                "to specify the default location for Pyomo "
+                "temporary files has been deprecated.  "
+                "Please set TempfileManager.tempdir in "
+                "pyomo.common.tempfiles", version='5.7.2')
+            return pyutilib_mngr.tempdir
+        return None
+
+    def _make_counted_object(self, target, prefix, suffix):
+        if suffix is None:
+            suffix = target.__class__()
+        if prefix is None:
+            if isinstance(target, bytes):
+                prefix = self.gettempprefixb()
+            else:
+                prefix = self.gettempprefix()
+        while True:
+            next_id = str(self.ctr)
+            self.ctr += 1
+            if isinstance(target, bytes):
+                next_id = next_id.encode()
+            new_target = os.path.join(
+                os.path.dirname(target),
+                prefix + next_id + suffix
+            )
+            if not os.path.exists(new_target):
+                break
+            if DELETE_COUNTED_CONFLICTS:
+                # Delete any file having the sequential name and then rename
+                logger.warning("Deleting a pre-existing (sequential) "
+                               "temporary file: %s" % new_target)
+                self._remove_filesystem_object(new_target)
+                break
+            # Fall through to incrementing the counter until we find an
+            # available name
+
+        shutil.move(target, new_target)
+        return new_target
+
+    def _remove_filesystem_object(self, name):
+        if not os.path.exists(name):
+            return
+        if os.path.isfile(name) or os.path.islink(name):
+            try:
+                os.remove(name)
+            except WindowsError:
+                # Sometimes Windows doesn't release the
+                # file lock immediately when the process
+                # terminates.  If we get an error, wait a
+                # second and try again.
+                try:
+                    time.sleep(1)
+                    os.remove(name)
+                except WindowsError:
+                    if deletion_errors_are_fatal:
+                        raise
                     else:
-                        try:
-                            os.remove(filename)
-                        except WindowsError:
-                            # Sometimes Windows doesn't release the
-                            # file lock immediately when the process
-                            # terminates.  If we get an error, wait a
-                            # second and try again.
-                            try:
-                                time.sleep(1)
-                                os.remove(filename)
-                            except WindowsError:
-                                if deletion_errors_are_fatal:
-                                    raise
-                                else:
-                                    # Failure to delete a tempfile
-                                    # should NOT be fatal
-                                    logger = logging.getLogger(__name__)
-                                    logger.warning("Unable to delete temporary "
-                                                   "file %s" % (filename,))
+                        # Failure to delete a tempfile
+                        # should NOT be fatal
+                        logger = logging.getLogger(__name__)
+                        logger.warning("Unable to delete temporary "
+                                       "file %s" % (name,))
+            return
+        assert os.path.isdir(name)
+        shutil.rmtree(
+            name,
+            ignore_errors=not deletion_errors_are_fatal)
 
-
+# The global Pyomo TempfileManager instance
 TempfileManager = TempfileManagerClass()

--- a/pyomo/common/tests/test_tee.py
+++ b/pyomo/common/tests/test_tee.py
@@ -141,16 +141,14 @@ class TestTeeStream(unittest.TestCase):
             capture.reset()
 
     def test_capture_output_logfile_string(self):
-        logfile = TempfileManager.create_tempfile()
-        self.assertTrue(isinstance(logfile, str))
-        try: 
+        with TempfileManager.new_context() as tempfile:
+            logfile = tempfile.create_tempfile()
+            self.assertTrue(isinstance(logfile, str))
             with tee.capture_output(logfile):
                 print('HELLO WORLD')
             with open(logfile, 'r') as f:
                 result = f.read()
             self.assertEqual('HELLO WORLD\n', result)
-        finally:
-            TempfileManager.clear_tempfiles()
 
     def test_capture_output_stack_error(self):
         OUT1 = StringIO()

--- a/pyomo/common/tests/test_tempfile.py
+++ b/pyomo/common/tests/test_tempfile.py
@@ -305,7 +305,8 @@ class Test_TempfileManager(unittest.TestCase):
         sub_fname = os.path.join(dname, "testfile")
         self.TM.add_tempfile(fname)
         with self.assertRaisesRegex(
-                IOError, "Temporary file does not exist: %s" % sub_fname):
+                IOError, "Temporary file does not exist: %s"
+                % sub_fname.replace('\\', '\\\\')):
             self.TM.add_tempfile(sub_fname)
         self.TM.add_tempfile(sub_fname, exists=False)
         with open(sub_fname, "w") as FILE:

--- a/pyomo/common/tests/test_tempfile.py
+++ b/pyomo/common/tests/test_tempfile.py
@@ -15,23 +15,22 @@
 #  the U.S. Government retains certain rights in this software.
 #  ___________________________________________________________________________
 
-
+import gc
 import glob
 import os
 import shutil
 import sys
+import tempfile
 from io import StringIO
 
 from os.path import abspath, dirname
-currdir = dirname(abspath(__file__)) + os.sep
-tempdir = dirname(abspath(__file__)) + os.sep + 'tempdir' + os.sep
 
 import pyomo.common.unittest as unittest
 
 import pyomo.common.tempfiles as tempfiles
 
 from pyomo.common.log import LoggingIntercept
-from pyomo.common.tempfiles import TempfileManager
+from pyomo.common.tempfiles import TempfileManager, TempfileManagerClass
 
 try:
     from pyutilib.component.config.tempfiles import (
@@ -41,21 +40,23 @@ except ImportError:
     pyutilib_mngr = None
 
 old_tempdir = TempfileManager.tempdir
+tempdir = None
 
-class Test(unittest.TestCase):
+class Test_LegacyTestSuite(unittest.TestCase):
 
     def setUp(self):
+        global tempdir
+        tempdir = tempfile.mkdtemp() + os.sep
         TempfileManager.tempdir = tempdir
         TempfileManager.push()
-        if os.path.exists(tempdir):
-            shutil.rmtree(tempdir)
-        os.mkdir(tempdir)
 
     def tearDown(self):
+        global tempdir
         TempfileManager.pop()
         TempfileManager.tempdir = old_tempdir
         if os.path.exists(tempdir):
-            shutil.rmtree(tempdir)
+           shutil.rmtree(tempdir)
+        tempdir = None
 
     def test_add1(self):
         """Test explicit adding of a file that is missing"""
@@ -65,21 +66,8 @@ class Test(unittest.TestCase):
         except IOError:
             pass
 
-    def test_add1_dir(self):
-        """Test explicit adding of a directory that is missing"""
-        try:
-            TempfileManager.add_tempfile(tempdir + 'add1')
-            self.fail(
-                "Expected IOError because directory 'add1' does not exist")
-        except IOError:
-            pass
-
     def test_add2(self):
         """Test explicit adding of a file that is missing"""
-        TempfileManager.add_tempfile(tempdir + 'add2', False)
-
-    def test_add2_dir(self):
-        """Test explicit adding of a directory that is missing"""
         TempfileManager.add_tempfile(tempdir + 'add2', False)
 
     def test_add3(self):
@@ -175,6 +163,8 @@ class Test(unittest.TestCase):
         TempfileManager.add_tempfile(tempdir + 'pushpopdir2a')
 
         TempfileManager.clear_tempfiles()
+        # Push a new context onto the stack so that the tearDown succeeds
+        TempfileManager.push()
 
         if os.path.exists(tempdir + 'pushpop2a'):
             self.fail("clear_tempfiles() failed to clean out files")
@@ -289,33 +279,313 @@ class Test(unittest.TestCase):
         self.assertNotEqual(fname, 'tmp3')
         self.assertTrue(fname.startswith('tmp'))
 
+
+class Test_TempfileManager(unittest.TestCase):
+
+    def setUp(self):
+        self.TM = TempfileManagerClass()
+
+    def tearDown(self):
+        self.TM.shutdown()
+
+    def test_create_tempfile(self):
+        context = self.TM.push()
+        fname = self.TM.create_tempfile("suffix", "prefix")
+        self.assertRegex(os.path.basename(fname), '^prefix')
+        self.assertRegex(os.path.basename(fname), 'suffix$')
+        self.assertGreater(len(os.path.basename(fname)), len('prefixsuffix'))
+        self.assertTrue(os.path.exists(fname))
+        self.assertTrue(os.path.isfile(fname))
+        context.release()
+        self.assertFalse(os.path.exists(fname))
+
+    def test_mkstemp(self):
+        context = self.TM.new_context()
+        fd, fname = context.mkstemp("suffix", "prefix")
+        self.assertRegex(os.path.basename(fname), '^prefix')
+        self.assertRegex(os.path.basename(fname), 'suffix$')
+        self.assertGreater(len(os.path.basename(fname)), len('prefixsuffix'))
+        self.assertTrue(os.path.exists(fname))
+        self.assertTrue(os.path.isfile(fname))
+        # calling fsync should run without error
+        os.fsync(fd)
+        context.release()
+        self.assertFalse(os.path.exists(fname))
+        # calling fsync should error, as the file descriptor was closed
+        with self.assertRaises(OSError):
+            os.fsync(fd)
+
+        context = self.TM.new_context()
+        fd, fname = context.mkstemp("suffix", "prefix")
+        # closing the fd should not result in an error when the context
+        # is released
+        os.close(fd)
+        context.release()
+
+    def test_create_tempdir(self):
+        context = self.TM.push()
+        fname = self.TM.create_tempdir("suffix", "prefix")
+        self.assertRegex(os.path.basename(fname), '^prefix')
+        self.assertRegex(os.path.basename(fname), 'suffix$')
+        self.assertGreater(len(os.path.basename(fname)), len('prefixsuffix'))
+        self.assertTrue(os.path.exists(fname))
+        self.assertTrue(os.path.isdir(fname))
+        context.release()
+        self.assertFalse(os.path.exists(fname))
+
+    def test_add_tempfile(self):
+        context1 = self.TM.push()
+        context2 = self.TM.push()
+        fname = context1.create_tempfile()
+        dname = context1.create_tempdir()
+        sub_fname = os.path.join(dname, "testfile")
+        self.TM.add_tempfile(fname)
+        with self.assertRaisesRegex(
+                IOError, "Temporary file does not exist: %s" % sub_fname):
+            self.TM.add_tempfile(sub_fname)
+        self.TM.add_tempfile(sub_fname, exists=False)
+        with open(sub_fname, "w") as FILE:
+            FILE.write("\n")
+
+        self.assertTrue(os.path.exists(fname))
+        self.assertTrue(os.path.exists(dname))
+        self.assertTrue(os.path.exists(sub_fname))
+        self.TM.pop()
+        self.assertFalse(os.path.exists(fname))
+        self.assertTrue(os.path.exists(dname))
+        self.assertFalse(os.path.exists(sub_fname))
+
+        # Releasing a context that is missing files should be OK (no error)
+        self.TM.pop()
+        self.assertFalse(os.path.exists(fname))
+        self.assertFalse(os.path.exists(dname))
+        self.assertFalse(os.path.exists(sub_fname))
+
+    def test_sequential_files(self):
+        ctx1 = self.TM.push()
+        ctx2 = self.TM.push()
+        tempdir = ctx1.mkdtemp()
+        self.TM.sequential_files(10)
+        fname10 = self.TM.create_tempfile(".txt", "test", dir=tempdir)
+        with open(fname10, 'w') as FILE:
+            FILE.write("original\n")
+        self.assertEqual(fname10, os.path.join(tempdir, "test10.txt"))
+        fname11 = self.TM.create_tempfile(".txt", "test", dir=tempdir)
+        self.assertEqual(fname11, os.path.join(tempdir, "test11.txt"))
+        dname = self.TM.create_tempdir(".txt", "test", dir=tempdir)
+        self.assertEqual(dname, os.path.join(tempdir, "test12.txt"))
+
+        fname = self.TM.create_tempfile(dir=tempdir)
+        self.assertEqual(os.path.basename(fname),
+                         tempfile.gettempprefix() + "13")
+        fname = self.TM.create_tempfile(dir=tempdir.encode())
+        self.assertEqual(os.path.basename(fname),
+                         tempfile.gettempprefixb() + b"14")
+
+        self.TM.unique_files()
+        fname = self.TM.create_tempfile(".txt", "test", dir=tempdir)
+        self.assertNotEqual(os.path.basename(fname), "test14.txt")
+
+        _orig_del = tempfiles.DELETE_COUNTED_CONFLICTS
+        try:
+            tempfiles.DELETE_COUNTED_CONFLICTS = False
+            self.TM.sequential_files(10)
+            fname = self.TM.create_tempfile(".txt", "test", dir=tempdir)
+            self.assertEqual(fname, os.path.join(tempdir, "test13.txt"))
+
+            tempfiles.DELETE_COUNTED_CONFLICTS = True
+            self.TM.sequential_files(10)
+            fname = self.TM.create_tempfile(".txt", "test", dir=tempdir)
+            self.assertEqual(fname, os.path.join(tempdir, "test10.txt"))
+            with open(fname, 'r') as FILE:
+                self.assertEqual(FILE.read(), "")
+        finally:
+            tempfiles.DELETE_COUNTED_CONFLICTS = _orig_del
+        ctx1 = self.TM.pop()
+        ctx2 = self.TM.pop()
+
+    def test_gettempprefix(self):
+        ctx = self.TM.new_context()
+        pre = ctx.gettempprefix()
+        self.assertIsInstance(pre, str)
+        self.assertEqual(pre, tempfile.gettempprefix())
+
+        preb = ctx.gettempprefixb()
+        self.assertIsInstance(preb, bytes)
+        self.assertEqual(preb, tempfile.gettempprefixb())
+
+    def test_gettempdir(self):
+        context = self.TM.push()
+        # Creating in the system TMP
+        fname = context.create_tempfile()
+        self.assertIsInstance(fname, str)
+        system_tmpdir = os.path.dirname(fname)
+        self.assertEqual(system_tmpdir, tempfile.gettempdir())
+        tmpdir = context.gettempdir()
+        self.assertIsInstance(tmpdir, str)
+        self.assertEqual(tmpdir, system_tmpdir)
+        tmpdirb = context.gettempdirb()
+        self.assertIsInstance(tmpdirb, bytes)
+        self.assertEqual(tmpdirb.decode(), tmpdir)
+
+        # Creating in a TMP specified on the TempfileManager
+        manager_tmpdir = context.create_tempdir()
+        self.assertNotEqual(manager_tmpdir, system_tmpdir)
+        self.TM.tempdir = manager_tmpdir
+        fname = context.create_tempfile()
+        self.assertIsInstance(fname, str)
+        tmpdir = context.gettempdir()
+        self.assertIsInstance(tmpdir, str)
+        self.assertEqual(tmpdir, manager_tmpdir)
+        tmpdirb = context.gettempdirb()
+        self.assertIsInstance(tmpdirb, bytes)
+        self.assertEqual(tmpdirb.decode(), tmpdir)
+
+        # Creating in a TMP specified on the context
+        context_tmpdir = context.create_tempdir()
+        self.assertNotEqual(context_tmpdir, system_tmpdir)
+        self.assertNotEqual(context_tmpdir, manager_tmpdir)
+        context.tempdir = context_tmpdir
+        fname = context.create_tempfile()
+        self.assertIsInstance(fname, str)
+        tmpdir = context.gettempdir()
+        self.assertIsInstance(tmpdir, str)
+        self.assertEqual(tmpdir, context_tmpdir)
+        tmpdirb = context.gettempdirb()
+        self.assertIsInstance(tmpdirb, bytes)
+        self.assertEqual(tmpdirb.decode(), tmpdir)
+
+        # Creating in a TMP specified on the context ... but in bytes
+        context.tempdir = context_tmpdir.encode()
+        fname = context.create_tempfile()
+        self.assertIsInstance(fname, bytes)
+        tmpdir = context.gettempdir()
+        self.assertIsInstance(tmpdir, str)
+        self.assertEqual(tmpdir, context_tmpdir)
+        tmpdirb = context.gettempdirb()
+        self.assertIsInstance(tmpdirb, bytes)
+        self.assertEqual(tmpdirb.decode(), tmpdir)
+        # Cleanup
+        self.TM.pop()
+
+    def test_shutdown(self):
+        with LoggingIntercept() as LOG:
+            self.TM.shutdown()
+        self.assertEqual(LOG.getvalue(), "")
+
+        self.TM = TempfileManagerClass()
+        ctx = self.TM.push()
+        with LoggingIntercept() as LOG:
+            self.TM.shutdown()
+        self.assertEqual(
+            LOG.getvalue().strip(),
+            "TempfileManagerClass instance: un-popped tempfile "
+            "contexts still exist during TempfileManager instance "
+            "shutdown"
+        )
+
+        self.TM = TempfileManagerClass()
+        ctx = self.TM.push()
+        fname = ctx.create_tempfile()
+        self.assertTrue(os.path.exists(fname))
+        with LoggingIntercept() as LOG:
+            self.TM.shutdown()
+        self.assertFalse(os.path.exists(fname))
+        self.assertEqual(
+            LOG.getvalue().strip(),
+            "Temporary files created through TempfileManager "
+            "contexts have not been deleted (observed during "
+            "TempfileManager instance shutdown).\n"
+            "Undeleted entries:\n\t%s\n"
+            "TempfileManagerClass instance: un-popped tempfile "
+            "contexts still exist during TempfileManager instance "
+            "shutdown" % fname
+        )
+
+        # The TM is already shut down, so this should be a noop
+        with LoggingIntercept() as LOG:
+            self.TM.shutdown()
+        self.assertEqual(LOG.getvalue(), "")
+
+    def test_del_clears_contexts(self):
+        TM = TempfileManagerClass()
+        ctx = TM.push()
+        fname = ctx.create_tempfile()
+        self.assertTrue(os.path.exists(fname))
+        with LoggingIntercept() as LOG:
+            TM = None
+            gc.collect()
+            gc.collect()
+            gc.collect()
+        self.assertFalse(os.path.exists(fname))
+        self.assertEqual(
+            LOG.getvalue().strip(),
+            "Temporary files created through TempfileManager "
+            "contexts have not been deleted (observed during "
+            "TempfileManager instance shutdown).\n"
+            "Undeleted entries:\n\t%s\n"
+            "TempfileManagerClass instance: un-popped tempfile "
+            "contexts still exist during TempfileManager instance "
+            "shutdown" % fname
+        )
+
+    def test_tempfilemanager_as_context_manager(self):
+        with LoggingIntercept() as LOG:
+            with self.TM:
+                fname = self.TM.create_tempfile()
+                self.assertTrue(os.path.exists(fname))
+            self.assertFalse(os.path.exists(fname))
+            self.assertEqual(LOG.getvalue(), "")
+
+            with self.TM:
+                self.TM.push()
+                fname = self.TM.create_tempfile()
+                self.assertTrue(os.path.exists(fname))
+            self.assertFalse(os.path.exists(fname))
+            self.assertEqual(
+                LOG.getvalue().strip(),
+                "TempfileManager: tempfile context was pushed onto "
+                "the TempfileManager stack within a context manager "
+                "(i.e., `with TempfileManager:`) but was not popped "
+                "before the context manager exited.  Popping the "
+                "context to preserve the stack integrity."
+            )
+
+    def test_tempfilecontext_as_context_manager(self):
+        with LoggingIntercept() as LOG:
+            ctx = self.TM.new_context()
+            with ctx:
+                fname = ctx.create_tempfile()
+                self.assertTrue(os.path.exists(fname))
+            self.assertFalse(os.path.exists(fname))
+            self.assertEqual(LOG.getvalue(), "")
+
     @unittest.skipIf(not sys.platform.lower().startswith('win'),
                      "test only applies to Windows platforms")
     def test_open_tempfile_windows(self):
-        TempfileManager.push()
-        fname = TempfileManager.create_tempfile()
+        self.TM.push()
+        fname = self.TM.create_tempfile()
         f = open(fname)
         try:
             _orig = tempfiles.deletion_errors_are_fatal
             tempfiles.deletion_errors_are_fatal = True
             with self.assertRaisesRegex(
                     WindowsError, ".*process cannot access the file"):
-                TempfileManager.pop()
+                self.TM.pop()
         finally:
             tempfiles.deletion_errors_are_fatal = _orig
             f.close()
             os.remove(fname)
 
-        TempfileManager.push()
-        fname = TempfileManager.create_tempfile()
+        self.TM.push()
+        fname = self.TM.create_tempfile()
         f = open(fname)
-        log = StringIO()
         try:
             _orig = tempfiles.deletion_errors_are_fatal
             tempfiles.deletion_errors_are_fatal = False
-            with LoggingIntercept(log, 'pyomo.common'):
-                TempfileManager.pop()
-            self.assertIn("Unable to delete temporary file", log.getvalue())
+            with LoggingIntercept(None, 'pyomo.common') as LOG:
+                self.TM.pop()
+            self.assertIn("Unable to delete temporary file", LOG.getvalue())
         finally:
             tempfiles.deletion_errors_are_fatal = _orig
             f.close()
@@ -324,30 +594,28 @@ class Test(unittest.TestCase):
     @unittest.skipIf(pyutilib_mngr is None,
                      "deprecation test requires pyutilib")
     def test_deprecated_tempdir(self):
-        TempfileManager.push()
+        self.TM.push()
         try:
-            tmpdir = TempfileManager.create_tempdir()
+            tmpdir = self.TM.create_tempdir()
             _orig = pyutilib_mngr.tempdir
             pyutilib_mngr.tempdir = tmpdir
-            TempfileManager.tempdir = None
+            self.TM.tempdir = None
 
-            log = StringIO()
-            with LoggingIntercept(log, 'pyomo'):
-                fname = TempfileManager.create_tempfile()
+            with LoggingIntercept() as LOG:
+                fname = self.TM.create_tempfile()
             self.assertIn(
                 "The use of the PyUtilib TempfileManager.tempdir "
                 "to specify the default location for Pyomo "
-                "temporary files", log.getvalue().replace("\n", " "))
+                "temporary files", LOG.getvalue().replace("\n", " "))
 
-            log = StringIO()
-            with LoggingIntercept(log, 'pyomo'):
-                dname = TempfileManager.create_tempdir()
+            with LoggingIntercept() as LOG:
+                dname = self.TM.create_tempdir()
             self.assertIn(
                 "The use of the PyUtilib TempfileManager.tempdir "
                 "to specify the default location for Pyomo "
-                "temporary directories", log.getvalue().replace("\n", " "))
+                "temporary files", LOG.getvalue().replace("\n", " "))
         finally:
-            TempfileManager.pop()
+            self.TM.pop()
             pyutilib_mngr.tempdir = _orig
 
 if __name__ == "__main__":

--- a/pyomo/common/tests/test_tempfile.py
+++ b/pyomo/common/tests/test_tempfile.py
@@ -243,42 +243,6 @@ class Test_LegacyTestSuite(unittest.TestCase):
         fname = os.path.basename(fname)
         self.assertTrue(fname.endswith('bar'))
 
-    def test_create4(self):
-        """Test create logic - no options"""
-        TempfileManager.sequential_files(2)
-        fname = TempfileManager.create_tempfile()
-        OUTPUT = open(fname, 'w')
-        OUTPUT.write('tempfile\n')
-        OUTPUT.close()
-        self.assertEqual(len(list(glob.glob(tempdir + '*'))), 1)
-        fname = os.path.basename(fname)
-        self.assertEqual(fname, 'tmp2')
-        #
-        TempfileManager.unique_files()
-        fname = TempfileManager.create_tempfile()
-        OUTPUT = open(fname, 'w')
-        OUTPUT.write('tempfile\n')
-        OUTPUT.close()
-        self.assertEqual(len(list(glob.glob(tempdir + '*'))), 2)
-        fname = os.path.basename(fname)
-        self.assertNotEqual(fname, 'tmp3')
-        self.assertTrue(fname.startswith('tmp'))
-
-    def test_create4_dir(self):
-        """Test create logic - no options"""
-        TempfileManager.sequential_files(2)
-        fname = TempfileManager.create_tempdir()
-        self.assertEqual(len(list(glob.glob(tempdir + '*'))), 1)
-        fname = os.path.basename(fname)
-        self.assertEqual(fname, 'tmp2')
-        #
-        TempfileManager.unique_files()
-        fname = TempfileManager.create_tempdir()
-        self.assertEqual(len(list(glob.glob(tempdir + '*'))), 2)
-        fname = os.path.basename(fname)
-        self.assertNotEqual(fname, 'tmp3')
-        self.assertTrue(fname.startswith('tmp'))
-
 
 class Test_TempfileManager(unittest.TestCase):
 
@@ -362,47 +326,12 @@ class Test_TempfileManager(unittest.TestCase):
         self.assertFalse(os.path.exists(sub_fname))
 
     def test_sequential_files(self):
-        ctx1 = self.TM.push()
-        ctx2 = self.TM.push()
-        tempdir = ctx1.mkdtemp()
-        self.TM.sequential_files(10)
-        fname10 = self.TM.create_tempfile(".txt", "test", dir=tempdir)
-        with open(fname10, 'w') as FILE:
-            FILE.write("original\n")
-        self.assertEqual(fname10, os.path.join(tempdir, "test10.txt"))
-        fname11 = self.TM.create_tempfile(".txt", "test", dir=tempdir)
-        self.assertEqual(fname11, os.path.join(tempdir, "test11.txt"))
-        dname = self.TM.create_tempdir(".txt", "test", dir=tempdir)
-        self.assertEqual(dname, os.path.join(tempdir, "test12.txt"))
-
-        fname = self.TM.create_tempfile(dir=tempdir)
-        self.assertEqual(os.path.basename(fname),
-                         tempfile.gettempprefix() + "13")
-        fname = self.TM.create_tempfile(dir=tempdir.encode())
-        self.assertEqual(os.path.basename(fname),
-                         tempfile.gettempprefixb() + b"14")
-
-        self.TM.unique_files()
-        fname = self.TM.create_tempfile(".txt", "test", dir=tempdir)
-        self.assertNotEqual(os.path.basename(fname), "test14.txt")
-
-        _orig_del = tempfiles.DELETE_COUNTED_CONFLICTS
-        try:
-            tempfiles.DELETE_COUNTED_CONFLICTS = False
-            self.TM.sequential_files(10)
-            fname = self.TM.create_tempfile(".txt", "test", dir=tempdir)
-            self.assertEqual(fname, os.path.join(tempdir, "test13.txt"))
-
-            tempfiles.DELETE_COUNTED_CONFLICTS = True
-            self.TM.sequential_files(10)
-            fname = self.TM.create_tempfile(".txt", "test", dir=tempdir)
-            self.assertEqual(fname, os.path.join(tempdir, "test10.txt"))
-            with open(fname, 'r') as FILE:
-                self.assertEqual(FILE.read(), "")
-        finally:
-            tempfiles.DELETE_COUNTED_CONFLICTS = _orig_del
-        ctx1 = self.TM.pop()
-        ctx2 = self.TM.pop()
+        with LoggingIntercept() as LOG:
+            self.assertIsNone(self.TM.sequential_files())
+        self.assertIn(
+            "The TempfileManager.sequential_files() method has been removed",
+            LOG.getvalue().replace('\n',' '))
+        self.assertIsNone(self.TM.unique_files())
 
     def test_gettempprefix(self):
         ctx = self.TM.new_context()

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -1562,7 +1562,6 @@ class MiscNonIndexedParamBehaviorTests(unittest.TestCase):
 
     # Test that display actually displays the correct param value
     def test_mutable_display(self):
-        tmp_stream = TempfileManager.create_tempfile(suffix = '.param_display.test')
         model = ConcreteModel()
         model.Q = Param(initialize=0.0, mutable=True)
         self.assertEqual(model.Q.value, 0.0)
@@ -1731,7 +1730,6 @@ class MiscIndexedParamBehaviorTests(unittest.TestCase):
 
     # Test that display actually displays the correct param value
     def test_mutable_display(self):
-        tmp_stream = TempfileManager.create_tempfile(suffix = '.param_display.test')
         model = ConcreteModel()
         model.P = Param([1,2],default=0.0, mutable=True)
         model.Q = Param([1,2],initialize=0.0, mutable=True)
@@ -1794,7 +1792,6 @@ class MiscIndexedParamBehaviorTests(unittest.TestCase):
 
     # Test that pprint actually displays the correct param value
     def test_mutable_pprint(self):
-        tmp_stream = TempfileManager.create_tempfile(suffix = '.param_display.test')
         model = ConcreteModel()
         model.P = Param([1,2],default=0.0, mutable=True)
         model.Q = Param([1,2],initialize=0.0, mutable=True)

--- a/pyomo/opt/tests/base/test_convert.py
+++ b/pyomo/opt/tests/base/test_convert.py
@@ -71,6 +71,7 @@ class MockArg4(MockArg):
 class OptConvertDebug(unittest.TestCase):
 
     def setUp(self):
+        TempfileManager.push()
         TempfileManager.tempdir = currdir
 
     def tearDown(self):

--- a/pyomo/repn/tests/gams/test_gams_comparison.py
+++ b/pyomo/repn/tests/gams/test_gams_comparison.py
@@ -93,9 +93,10 @@ class BaselineTests(Tests):
 
     @parameterized.parameterized.expand(input=invalidlist)
     def gams_writer_test_invalid(self, name, targetdir):
-        with TempfileManager, self.assertRaisesRegex(
+        with self.assertRaisesRegex(
                 RuntimeError, "GAMS files cannot represent the unary function"):
-            testFile = join(currdir, name + '.test.gms')
+            testFile = TempfileManager.create_tempfile(
+                suffix=name + '.test.gms')
             cmd = ['--output=' + testFile,
                    join(targetdir, name + '_testCase.py')]
             if os.path.exists(join(targetdir, name + '.dat')):

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -66,6 +66,7 @@ class CPLEXShellWritePrioritiesFile(unittest.TestCase):
     suffix_cls = Suffix
 
     def setUp(self):
+        TempfileManager.push()
         self.mock_model = self.get_mock_model()
         self.mock_cplex_shell = self.get_mock_cplex_shell(self.mock_model)
         self.mock_cplex_shell._priorities_file_name = TempfileManager.create_tempfile(


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Discussions with DISPATCHES / IDAES developers (notably, @andrewlee94) highlighted several shortcomings and weaknesses in the `TempfileManager` class (originally developed for PyUtilib)

This PR overhauls the internal implementation of the `TempfileManager` class.  This update is backwards compatible with the previous implementation, but adds several features:
- handles both `str` and `bytes`, using the same logic as the Python `tempfile` module
- adds several new methods for consistency with the `tempfile` module (`mkstemp`, `mkdtemp`, `gettemptdir`, `gettemptdirb`, `gettemptprefix`, `gettemptprefixb`)
- defines a proper "context" object that can be used to create / remove temporary files.  This allows users to create and manipulate temporary file contexts independently of the normal `TempfileManager` "context stack"
- improved robustness for deleting temporary files when either the context or a local `TempfileManager` instance fall out of scope.
- incorporate documentation into Pyomo online docs

## Changes proposed in this PR:
- (see above)


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
