### PR TITLE
Add Bool, Integer domain validators

### DIFF
--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -657,6 +657,8 @@ validators for common use cases:
 
 .. autosummary::
 
+   Bool
+   Integer
    PositiveInt
    NegativeInt
    NonNegativeInt

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -43,6 +43,47 @@ USER_OPTION = 0
 ADVANCED_OPTION = 1
 DEVELOPER_OPTION = 2
 
+def Bool(val):
+    """Domain validator for bool-like objects.
+
+    This is a more strict domain than ``bool``, as it will error on
+    values that do not "look" like a Boolean value (i.e., it accepts
+    ``True``, ``False``, 0, 1, and the case insensitive strings
+    ``'true'``, ``'false'``, ``'yes'``, ``'no'``, ``'t'``, ``'f'``,
+    ``'y'``, and ``'n'``)
+
+    """
+    if type(val) is bool:
+        return val
+    if isinstance(val, str):
+        v = val.upper()
+        if v in {'TRUE', 'YES', 'T', 'Y', '1'}:
+            return True
+        if v in {'FALSE', 'NO', 'F', 'N', '0'}:
+            return False
+    elif int(val) == float(val):
+        v = int(val)
+        if v in {0, 1}:
+            return bool(v)
+    raise ValueError(
+        "Expected Boolean, but received %s" % (val,))
+
+def Integer(val):
+    """Domain validation function admitting integers
+
+    This domain will admit integers, as well as any values that are
+    "reasonably exactly" convertible to integers.  This is more strict
+    than ``int``, as it will generate errors for floating point values
+    that are not integer.
+
+    """
+    ans = int(val)
+    # We want to give an error for floating point numbers...
+    if ans != float(val):
+        raise ValueError(
+            "Expected integer, but received %s" % (val,))
+    return ans
+
 def PositiveInt(val):
     """Domain validation function admitting strictly positive integers
 

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -42,7 +42,7 @@ def yaml_load(arg):
 from pyomo.common.config import (
     ConfigDict, ConfigValue,
     ConfigList, MarkImmutable, ImmutableConfigValue,
-    PositiveInt, NegativeInt, NonPositiveInt, NonNegativeInt,
+    Bool, Integer, PositiveInt, NegativeInt, NonPositiveInt, NonNegativeInt,
     PositiveFloat, NegativeFloat, NonPositiveFloat, NonNegativeFloat,
     In, ListOf, Module, Path, PathList, ConfigEnum, DynamicImplicitDomain,
     _UnpickleableDomain, _picklable,
@@ -62,6 +62,69 @@ class GlobalClass(object):
 
 
 class TestConfigDomains(unittest.TestCase):
+    def test_Bool(self):
+        c = ConfigDict()
+        c.declare('a', ConfigValue(True, Bool))
+        self.assertEqual(c.a, True)
+        c.a = False
+        self.assertEqual(c.a, False)
+        c.a = 1
+        self.assertEqual(c.a, True)
+        c.a = 'n'
+        self.assertEqual(c.a, False)
+        c.a = 'T'
+        self.assertEqual(c.a, True)
+        c.a = 'no'
+        self.assertEqual(c.a, False)
+        c.a = '1'
+        self.assertEqual(c.a, True)
+        c.a = 0.
+        self.assertEqual(c.a, False)
+        c.a = True
+        self.assertEqual(c.a, True)
+        c.a = 0
+        self.assertEqual(c.a, False)
+        c.a = 'y'
+        self.assertEqual(c.a, True)
+        c.a = 'F'
+        self.assertEqual(c.a, False)
+        c.a = 'yes'
+        self.assertEqual(c.a, True)
+        c.a = '0'
+        self.assertEqual(c.a, False)
+        c.a = 1.
+        self.assertEqual(c.a, True)
+
+        with self.assertRaises(ValueError):
+            c.a = 2
+        self.assertEqual(c.a, True)
+        with self.assertRaises(ValueError):
+            c.a = 'a'
+        self.assertEqual(c.a, True)
+        with self.assertRaises(ValueError):
+            c.a = 0.5
+        self.assertEqual(c.a, True)
+
+    def test_Integer(self):
+        c = ConfigDict()
+        c.declare('a', ConfigValue(5, Integer))
+        self.assertEqual(c.a, 5)
+        c.a = 4.
+        self.assertEqual(c.a, 4)
+        c.a = -6
+        self.assertEqual(c.a, -6)
+        c.a = '10'
+        self.assertEqual(c.a, 10)
+        with self.assertRaises(ValueError):
+            c.a = 2.6
+        self.assertEqual(c.a, 10)
+        with self.assertRaises(ValueError):
+            c.a = 'a'
+        self.assertEqual(c.a, 10)
+        with self.assertRaises(ValueError):
+            c.a = '1.1'
+        self.assertEqual(c.a, 10)
+
     def test_PositiveInt(self):
         c = ConfigDict()
         c.declare('a', ConfigValue(5, PositiveInt))


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Discussions with IDAES developers (notably @andrewlee94) highlighted the need for `Integer` and `Bool` domain validators that were more strict than just `int` and `bool` (in that they required the argument to "look" like an integer).

## Changes proposed in this PR:
- Add `Integer`, `Bool` domain validators

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
