### PR TITLE
Appsi: better handling of immutable parameters

### DIFF
--- a/pyomo/contrib/appsi/base.py
+++ b/pyomo/contrib/appsi/base.py
@@ -774,7 +774,12 @@ class PersistentBase(abc.ABC):
 
     def add_block(self, block):
         self.add_variables(list(OrderedDict((id(var), var) for var in block.component_data_objects(Var, descend_into=True, sort=False)).values()))
-        self.add_params(list(OrderedDict((id(p), p) for p in block.component_data_objects(Param, descend_into=True, sort=False)).values()))
+        param_dict = OrderedDict()
+        for p in block.component_objects(Param, descend_into=True, sort=False):
+            if p.mutable:
+                for _p in p.values():
+                    param_dict[id(_p)] = _p
+        self.add_params(list(param_dict.values()))
         self.add_constraints([con for con in block.component_data_objects(Constraint, descend_into=True,
                                                                           active=True, sort=False)])
         self.add_sos_constraints([con for con in block.component_data_objects(SOSConstraint, descend_into=True,
@@ -888,7 +893,11 @@ class PersistentBase(abc.ABC):
         timer.stop('vars')
         timer.start('params')
         if config.check_for_new_or_removed_params:
-            current_params_dict = {id(p): p for p in self._model.component_data_objects(Param, descend_into=True, sort=False)}
+            current_params_dict = dict()
+            for p in self._model.component_objects(Param, descend_into=True, sort=False):
+                if p.mutable:
+                    for _p in p.values():
+                        current_params_dict[id(_p)] = _p
             for p_id, p in current_params_dict.items():
                 if p_id not in self._params:
                     new_params.append(p)

--- a/pyomo/contrib/appsi/base.py
+++ b/pyomo/contrib/appsi/base.py
@@ -346,8 +346,17 @@ class UpdateConfig(ConfigDict):
     update_params: bool
     update_named_expressions: bool
     """
-    def __init__(self):
-        super(UpdateConfig, self).__init__()
+    def __init__(self,
+                 description=None,
+                 doc=None,
+                 implicit=False,
+                 implicit_domain=None,
+                 visibility=0):
+        super(UpdateConfig, self).__init__(description=description,
+                                           doc=doc,
+                                           implicit=implicit,
+                                           implicit_domain=implicit_domain,
+                                           visibility=visibility)
 
         self.declare('check_for_new_or_removed_constraints', ConfigValue(domain=bool))
         self.declare('check_for_new_or_removed_vars', ConfigValue(domain=bool))

--- a/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
@@ -146,6 +146,42 @@ class TestSolvers(unittest.TestCase):
             self.assertAlmostEqual(duals[m.c2], a1 / (a2 - a1))
 
     @parameterized.expand(input=all_solvers)
+    def test_immutable_param(self, name: str, opt_class: Type[PersistentSolver]):
+        """
+        This test is important because component_data_objects returns immutable params as floats.
+        We want to make sure we process these correctly.
+        """
+        opt: PersistentSolver = opt_class()
+        if not opt.available():
+            raise unittest.SkipTest
+        m = pe.ConcreteModel()
+        m.x = pe.Var()
+        m.y = pe.Var()
+        m.a1 = pe.Param(mutable=True)
+        m.a2 = pe.Param(initialize=-1)
+        m.b1 = pe.Param(mutable=True)
+        m.b2 = pe.Param(mutable=True)
+        m.obj = pe.Objective(expr=m.y)
+        m.c1 = pe.Constraint(expr=(0, m.y - m.a1*m.x - m.b1, None))
+        m.c2 = pe.Constraint(expr=(None, -m.y + m.a2*m.x + m.b2, 0))
+
+        params_to_test = [(1, 2, 1), (1, 2, 1), (1, 3, 1)]
+        for (a1, b1, b2) in params_to_test:
+            a2 = m.a2.value
+            m.a1.value = a1
+            m.b1.value = b1
+            m.b2.value = b2
+            res: Results = opt.solve(m)
+            self.assertEqual(res.termination_condition, TerminationCondition.optimal)
+            self.assertAlmostEqual(m.x.value, (b2 - b1) / (a1 - a2))
+            self.assertAlmostEqual(m.y.value, a1 * (b2 - b1) / (a1 - a2) + b1)
+            self.assertAlmostEqual(res.best_feasible_objective, m.y.value)
+            self.assertTrue(res.best_objective_bound <= m.y.value)
+            duals = opt.get_duals()
+            self.assertAlmostEqual(duals[m.c1], (1 + a1 / (a2 - a1)))
+            self.assertAlmostEqual(duals[m.c2], a1 / (a2 - a1))
+
+    @parameterized.expand(input=all_solvers)
     def test_equality(self, name: str, opt_class: Type[PersistentSolver]):
         opt: PersistentSolver = opt_class()
         if not opt.available():


### PR DESCRIPTION
## Summary/Motivation:
- I was so focused on mutable parameters that I forgot to test immutable parameters! This fixes an appsi bug when using immutable parameters.
- This PR also has a minor fix to `UpdateConfig` to ensure arguments of the base class are passed through the `__init__`


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
