### PR TITLE
Pass AMPLFUNC directly to pynumero_ASL and not through environment

### DIFF
--- a/pyomo/contrib/pynumero/asl.py
+++ b/pyomo/contrib/pynumero/asl.py
@@ -11,14 +11,196 @@
 from pyomo.common.fileutils import find_library
 from pyomo.common.dependencies import numpy as np
 import ctypes
+import logging
 import os
+
+logger = logging.getLogger(__name__)
+
+CURRENT_INTERFACE_VERSION = 2
 
 class _NotSet:
     pass
 
+def _LoadASLInterface(libname):
+    ASLib = ctypes.cdll.LoadLibrary(libname)
+
+    # define 1d array
+    array_1d_double = np.ctypeslib.ndpointer(
+        dtype=np.double, ndim=1, flags='CONTIGUOUS')
+    array_1d_int = np.ctypeslib.ndpointer(
+        dtype=np.intc, ndim=1, flags='CONTIGUOUS')
+
+    # library version
+    try:
+        ASLib.EXTERNAL_AmplInterface_version.argtypes = None
+        ASLib.EXTERNAL_AmplInterface_version.restype = ctypes.c_int
+        interface_version = ASLib.EXTERNAL_AmplInterface_version()
+    except AttributeError:
+        interface_version = 1
+
+    # constructor
+    ASLib.EXTERNAL_AmplInterface_new.argtypes = [ctypes.c_char_p]
+    ASLib.EXTERNAL_AmplInterface_new.restype = ctypes.c_void_p
+
+    if interface_version >= 2:
+        ASLib.EXTERNAL_AmplInterface_new_file.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    else:
+        ASLib.EXTERNAL_AmplInterface_new_file.argtypes = [ctypes.c_char_p]
+    ASLib.EXTERNAL_AmplInterface_new_file.restype = ctypes.c_void_p
+
+    #ASLib.EXTERNAL_AmplInterface_new_str.argtypes = [ctypes.c_char_p]
+    #ASLib.EXTERNAL_AmplInterface_new_str.restype = ctypes.c_void_p
+
+    # number of variables
+    ASLib.EXTERNAL_AmplInterface_n_vars.argtypes = [ctypes.c_void_p]
+    ASLib.EXTERNAL_AmplInterface_n_vars.restype = ctypes.c_int
+
+    # number of constraints
+    ASLib.EXTERNAL_AmplInterface_n_constraints.argtypes = [ctypes.c_void_p]
+    ASLib.EXTERNAL_AmplInterface_n_constraints.restype = ctypes.c_int
+
+    # number of nonzeros in jacobian
+    ASLib.EXTERNAL_AmplInterface_nnz_jac_g.argtypes = [ctypes.c_void_p]
+    ASLib.EXTERNAL_AmplInterface_nnz_jac_g.restype = ctypes.c_int
+
+    # number of nonzeros in hessian of lagrangian
+    ASLib.EXTERNAL_AmplInterface_nnz_hessian_lag.argtypes = [ctypes.c_void_p]
+    ASLib.EXTERNAL_AmplInterface_nnz_hessian_lag.restype = ctypes.c_int
+
+    # lower bounds on x
+    ASLib.EXTERNAL_AmplInterface_x_lower_bounds.argtypes = [ctypes.c_void_p,
+                                                                 array_1d_double,
+                                                                 ctypes.c_int]
+    ASLib.EXTERNAL_AmplInterface_x_lower_bounds.restype = None
+
+    # upper bounds on x
+    ASLib.EXTERNAL_AmplInterface_x_upper_bounds.argtypes = [ctypes.c_void_p,
+                                                                 array_1d_double,
+                                                                 ctypes.c_int]
+    ASLib.EXTERNAL_AmplInterface_x_upper_bounds.restype = None
+
+    # lower bounds on g
+    ASLib.EXTERNAL_AmplInterface_g_lower_bounds.argtypes = [ctypes.c_void_p,
+                                                                 array_1d_double,
+                                                                 ctypes.c_int]
+    ASLib.EXTERNAL_AmplInterface_g_lower_bounds.restype = None
+
+    # upper bounds on g
+    ASLib.EXTERNAL_AmplInterface_g_upper_bounds.argtypes = [ctypes.c_void_p,
+                                                                 array_1d_double,
+                                                                 ctypes.c_int]
+    ASLib.EXTERNAL_AmplInterface_g_upper_bounds.restype = None
+
+    # initial value x
+    ASLib.EXTERNAL_AmplInterface_get_init_x.argtypes = [ctypes.c_void_p,
+                                                             array_1d_double,
+                                                             ctypes.c_int]
+    ASLib.EXTERNAL_AmplInterface_get_init_x.restype = None
+
+    # initial value multipliers
+    ASLib.EXTERNAL_AmplInterface_get_init_multipliers.argtypes = [ctypes.c_void_p,
+                                                                       array_1d_double,
+                                                                       ctypes.c_int]
+    ASLib.EXTERNAL_AmplInterface_get_init_multipliers.restype = None
+
+    # evaluate objective
+    ASLib.EXTERNAL_AmplInterface_eval_f.argtypes = [ctypes.c_void_p,
+                                                         array_1d_double,
+                                                         ctypes.c_int,
+                                                         ctypes.POINTER(ctypes.c_double)]
+    ASLib.EXTERNAL_AmplInterface_eval_f.restype = ctypes.c_bool
+
+    # gradient objective
+    ASLib.EXTERNAL_AmplInterface_eval_deriv_f.argtypes = [ctypes.c_void_p,
+                                                               array_1d_double,
+                                                               array_1d_double,
+                                                               ctypes.c_int]
+    ASLib.EXTERNAL_AmplInterface_eval_deriv_f.restype = ctypes.c_bool
+
+    # structure jacobian of constraints
+    ASLib.EXTERNAL_AmplInterface_struct_jac_g.argtypes = [ctypes.c_void_p,
+                                                               array_1d_int,
+                                                               array_1d_int,
+                                                               ctypes.c_int]
+    ASLib.EXTERNAL_AmplInterface_struct_jac_g.restype = None
+
+    # structure hessian of Lagrangian
+    ASLib.EXTERNAL_AmplInterface_struct_hes_lag.argtypes = [ctypes.c_void_p,
+                                                                 array_1d_int,
+                                                                 array_1d_int,
+                                                                 ctypes.c_int]
+    ASLib.EXTERNAL_AmplInterface_struct_hes_lag.restype = None
+
+    # evaluate constraints
+    ASLib.EXTERNAL_AmplInterface_eval_g.argtypes = [ctypes.c_void_p,
+                                                         array_1d_double,
+                                                         ctypes.c_int,
+                                                         array_1d_double,
+                                                         ctypes.c_int]
+    ASLib.EXTERNAL_AmplInterface_eval_g.restype = ctypes.c_bool
+
+    # evaluate jacobian constraints
+    ASLib.EXTERNAL_AmplInterface_eval_jac_g.argtypes = [ctypes.c_void_p,
+                                                             array_1d_double,
+                                                             ctypes.c_int,
+                                                             array_1d_double,
+                                                             ctypes.c_int]
+    ASLib.EXTERNAL_AmplInterface_eval_jac_g.restype = ctypes.c_bool
+
+    # temporary try/except block while changes get merged in pynumero_libraries
+    try:
+        ASLib.EXTERNAL_AmplInterface_dummy.argtypes = [ctypes.c_void_p]
+        ASLib.EXTERNAL_AmplInterface_dummy.restype = None
+        # evaluate hessian Lagrangian
+        ASLib.EXTERNAL_AmplInterface_eval_hes_lag.argtypes = [ctypes.c_void_p,
+                                                                   array_1d_double,
+                                                                   ctypes.c_int,
+                                                                   array_1d_double,
+                                                                   ctypes.c_int,
+                                                                   array_1d_double,
+                                                                   ctypes.c_int,
+                                                                   ctypes.c_double]
+        ASLib.EXTERNAL_AmplInterface_eval_hes_lag.restype = ctypes.c_bool
+    except Exception:
+        # evaluate hessian Lagrangian
+        ASLib.EXTERNAL_AmplInterface_eval_hes_lag.argtypes = [ctypes.c_void_p,
+                                                                   array_1d_double,
+                                                                   ctypes.c_int,
+                                                                   array_1d_double,
+                                                                   ctypes.c_int,
+                                                                   array_1d_double,
+                                                                   ctypes.c_int]
+        ASLib.EXTERNAL_AmplInterface_eval_hes_lag.restype = ctypes.c_bool
+        interface_version = 0
+
+    # finalize solution
+    ASLib.EXTERNAL_AmplInterface_finalize_solution.argtypes = [ctypes.c_void_p,
+                                                                    ctypes.c_int,
+                                                                    ctypes.c_char_p,
+                                                                    array_1d_double,
+                                                                    ctypes.c_int,
+                                                                    array_1d_double,
+                                                                    ctypes.c_int]
+    ASLib.EXTERNAL_AmplInterface_finalize_solution.restype = None
+
+    # destructor
+    ASLib.EXTERNAL_AmplInterface_free_memory.argtypes = [ctypes.c_void_p]
+    ASLib.EXTERNAL_AmplInterface_free_memory.restype = None
+
+    if CURRENT_INTERFACE_VERSION != interface_version:
+        logger.warning(
+            'The current pynumero_ASL library is version=%s, but found '
+            'version=%s.  Please recompile / update your pynumero_ASL '
+            'library.' % (CURRENT_INTERFACE_VERSION, interface_version))
+
+    return ASLib, interface_version
+
+
 class AmplInterface(object):
 
     libname = _NotSet
+    ASLib = None
+    interface_version = None
 
     @classmethod
     def available(cls):
@@ -37,167 +219,26 @@ class AmplInterface(object):
         if nl_buffer is not None:
             raise NotImplementedError("AmplInterface only supported form NL-file for now")
 
-        self.ASLib = ctypes.cdll.LoadLibrary(AmplInterface.libname)
+        # Be sure to remove AMPLFUNC from the environment before loading
+        # the ASL.  This should prevent it from potentially caching an
+        # AMPLFUNC from the initial load and letting it bleed into
+        # (potentially unrelated) subsequent instances
+        b_amplfunc = os.environ.pop('AMPLFUNC', '').encode('utf-8')
 
-        # define 1d array
-        array_1d_double = np.ctypeslib.ndpointer(
-            dtype=np.double, ndim=1, flags='CONTIGUOUS')
-        array_1d_int = np.ctypeslib.ndpointer(
-            dtype=np.intc, ndim=1, flags='CONTIGUOUS')
-
-        # constructor
-        self.ASLib.EXTERNAL_AmplInterface_new.argtypes = [ctypes.c_char_p]
-        self.ASLib.EXTERNAL_AmplInterface_new.restype = ctypes.c_void_p
-
-        self.ASLib.EXTERNAL_AmplInterface_new_file.argtypes = [ctypes.c_char_p]
-        self.ASLib.EXTERNAL_AmplInterface_new_file.restype = ctypes.c_void_p
-
-        #self.ASLib.EXTERNAL_AmplInterface_new_str.argtypes = [ctypes.c_char_p]
-        #self.ASLib.EXTERNAL_AmplInterface_new_str.restype = ctypes.c_void_p
-
-        # number of variables
-        self.ASLib.EXTERNAL_AmplInterface_n_vars.argtypes = [ctypes.c_void_p]
-        self.ASLib.EXTERNAL_AmplInterface_n_vars.restype = ctypes.c_int
-
-        # number of constraints
-        self.ASLib.EXTERNAL_AmplInterface_n_constraints.argtypes = [ctypes.c_void_p]
-        self.ASLib.EXTERNAL_AmplInterface_n_constraints.restype = ctypes.c_int
-
-        # number of nonzeros in jacobian
-        self.ASLib.EXTERNAL_AmplInterface_nnz_jac_g.argtypes = [ctypes.c_void_p]
-        self.ASLib.EXTERNAL_AmplInterface_nnz_jac_g.restype = ctypes.c_int
-
-        # number of nonzeros in hessian of lagrangian
-        self.ASLib.EXTERNAL_AmplInterface_nnz_hessian_lag.argtypes = [ctypes.c_void_p]
-        self.ASLib.EXTERNAL_AmplInterface_nnz_hessian_lag.restype = ctypes.c_int
-
-        # lower bounds on x
-        self.ASLib.EXTERNAL_AmplInterface_x_lower_bounds.argtypes = [ctypes.c_void_p,
-                                                                     array_1d_double,
-                                                                     ctypes.c_int]
-        self.ASLib.EXTERNAL_AmplInterface_x_lower_bounds.restype = None
-
-        # upper bounds on x
-        self.ASLib.EXTERNAL_AmplInterface_x_upper_bounds.argtypes = [ctypes.c_void_p,
-                                                                     array_1d_double,
-                                                                     ctypes.c_int]
-        self.ASLib.EXTERNAL_AmplInterface_x_upper_bounds.restype = None
-
-        # lower bounds on g
-        self.ASLib.EXTERNAL_AmplInterface_g_lower_bounds.argtypes = [ctypes.c_void_p,
-                                                                     array_1d_double,
-                                                                     ctypes.c_int]
-        self.ASLib.EXTERNAL_AmplInterface_g_lower_bounds.restype = None
-
-        # upper bounds on g
-        self.ASLib.EXTERNAL_AmplInterface_g_upper_bounds.argtypes = [ctypes.c_void_p,
-                                                                     array_1d_double,
-                                                                     ctypes.c_int]
-        self.ASLib.EXTERNAL_AmplInterface_g_upper_bounds.restype = None
-
-        # initial value x
-        self.ASLib.EXTERNAL_AmplInterface_get_init_x.argtypes = [ctypes.c_void_p,
-                                                                 array_1d_double,
-                                                                 ctypes.c_int]
-        self.ASLib.EXTERNAL_AmplInterface_get_init_x.restype = None
-
-        # initial value multipliers
-        self.ASLib.EXTERNAL_AmplInterface_get_init_multipliers.argtypes = [ctypes.c_void_p,
-                                                                           array_1d_double,
-                                                                           ctypes.c_int]
-        self.ASLib.EXTERNAL_AmplInterface_get_init_multipliers.restype = None
-
-        # evaluate objective
-        self.ASLib.EXTERNAL_AmplInterface_eval_f.argtypes = [ctypes.c_void_p,
-                                                             array_1d_double,
-                                                             ctypes.c_int,
-                                                             ctypes.POINTER(ctypes.c_double)]
-        self.ASLib.EXTERNAL_AmplInterface_eval_f.restype = ctypes.c_bool
-
-        # gradient objective
-        self.ASLib.EXTERNAL_AmplInterface_eval_deriv_f.argtypes = [ctypes.c_void_p,
-                                                                   array_1d_double,
-                                                                   array_1d_double,
-                                                                   ctypes.c_int]
-        self.ASLib.EXTERNAL_AmplInterface_eval_deriv_f.restype = ctypes.c_bool
-
-        # structure jacobian of constraints
-        self.ASLib.EXTERNAL_AmplInterface_struct_jac_g.argtypes = [ctypes.c_void_p,
-                                                                   array_1d_int,
-                                                                   array_1d_int,
-                                                                   ctypes.c_int]
-        self.ASLib.EXTERNAL_AmplInterface_struct_jac_g.restype = None
-
-        # structure hessian of Lagrangian
-        self.ASLib.EXTERNAL_AmplInterface_struct_hes_lag.argtypes = [ctypes.c_void_p,
-                                                                     array_1d_int,
-                                                                     array_1d_int,
-                                                                     ctypes.c_int]
-        self.ASLib.EXTERNAL_AmplInterface_struct_hes_lag.restype = None
-
-        # evaluate constraints
-        self.ASLib.EXTERNAL_AmplInterface_eval_g.argtypes = [ctypes.c_void_p,
-                                                             array_1d_double,
-                                                             ctypes.c_int,
-                                                             array_1d_double,
-                                                             ctypes.c_int]
-        self.ASLib.EXTERNAL_AmplInterface_eval_g.restype = ctypes.c_bool
-
-        # evaluate jacobian constraints
-        self.ASLib.EXTERNAL_AmplInterface_eval_jac_g.argtypes = [ctypes.c_void_p,
-                                                                 array_1d_double,
-                                                                 ctypes.c_int,
-                                                                 array_1d_double,
-                                                                 ctypes.c_int]
-        self.ASLib.EXTERNAL_AmplInterface_eval_jac_g.restype = ctypes.c_bool
-
-        # temporary try/except block while changes get merged in pynumero_libraries
-        try:
-            self.ASLib.EXTERNAL_AmplInterface_dummy.argtypes = [ctypes.c_void_p]
-            self.ASLib.EXTERNAL_AmplInterface_dummy.restype = None
-            # evaluate hessian Lagrangian
-            self.ASLib.EXTERNAL_AmplInterface_eval_hes_lag.argtypes = [ctypes.c_void_p,
-                                                                       array_1d_double,
-                                                                       ctypes.c_int,
-                                                                       array_1d_double,
-                                                                       ctypes.c_int,
-                                                                       array_1d_double,
-                                                                       ctypes.c_int,
-                                                                       ctypes.c_double]
-            self.ASLib.EXTERNAL_AmplInterface_eval_hes_lag.restype = ctypes.c_bool
-            self.future_libraries = True
-        except Exception:
-            # evaluate hessian Lagrangian
-            self.ASLib.EXTERNAL_AmplInterface_eval_hes_lag.argtypes = [ctypes.c_void_p,
-                                                                       array_1d_double,
-                                                                       ctypes.c_int,
-                                                                       array_1d_double,
-                                                                       ctypes.c_int,
-                                                                       array_1d_double,
-                                                                       ctypes.c_int]
-            self.ASLib.EXTERNAL_AmplInterface_eval_hes_lag.restype = ctypes.c_bool
-            self.future_libraries = False
-
-        # finalize solution
-        self.ASLib.EXTERNAL_AmplInterface_finalize_solution.argtypes = [ctypes.c_void_p,
-                                                                        ctypes.c_int,
-                                                                        ctypes.c_char_p,
-                                                                        array_1d_double,
-                                                                        ctypes.c_int,
-                                                                        array_1d_double,
-                                                                        ctypes.c_int]
-        self.ASLib.EXTERNAL_AmplInterface_finalize_solution.restype = None
-
-        # destructor
-        self.ASLib.EXTERNAL_AmplInterface_free_memory.argtypes = [ctypes.c_void_p]
-        self.ASLib.EXTERNAL_AmplInterface_free_memory.restype = None
+        if AmplInterface.ASLib is None:
+            AmplInterface.ASLib, AmplInterface.interface_version \
+                = _LoadASLInterface(AmplInterface.libname)
 
         if filename is not None:
             if nl_buffer is not None:
                 raise ValueError("Cannot specify both filename= and nl_buffer=")
 
             b_data = filename.encode('utf-8')
-            self._obj = self.ASLib.EXTERNAL_AmplInterface_new_file(b_data)
+            if self.interface_version >= 2:
+                args = (b_data, b_amplfunc)
+            else:
+                args = (b_data,)
+            self._obj = self.ASLib.EXTERNAL_AmplInterface_new_file(*args)
         elif nl_buffer is not None:
             b_data = nl_buffer.encode('utf-8')
             if os.name in ['nt', 'dos']:
@@ -328,7 +369,7 @@ class AmplInterface(object):
         assert x.dtype == np.double, "Error: array type. Function eval_hes_lag expects an array of type double"
         assert lam.dtype == np.double, "Error: array type. Function eval_hes_lag expects an array of type double"
         assert hes_lag.dtype == np.double, "Error: array type. Function eval_hes_lag expects an array of type double"
-        if self.future_libraries:
+        if self.interface_version >= 1:
             res = self.ASLib.EXTERNAL_AmplInterface_eval_hes_lag(self._obj,
                                                                  x,
                                                                  self._nx,

--- a/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
@@ -93,12 +93,7 @@ class PyomoNLP(AslNLP):
                 os.environ.get('AMPLFUNC', None),
                 os.environ.get('PYOMO_AMPLFUNC', None),
             )))
-            # Use the CtypesEnviron to clear the AMPLFUNC variable
-            # everywhere (python, dlls, etc).
-            with CtypesEnviron(AMPLFUNC=''):
-                # Now just set the AMPLFUNC in the python env (for
-                # AmplInterface to see)
-                os.environ['AMPLFUNC'] = amplfunc
+            with CtypesEnviron(AMPLFUNC=amplfunc):
                 super(PyomoNLP, self).__init__(nl_file)
 
             # keep pyomo model in cache

--- a/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
@@ -89,12 +89,16 @@ class PyomoNLP(AslNLP):
             # The NL writer advertises the external function libraries
             # through the PYOMO_AMPLFUNC environment variable; merge it
             # with any preexisting AMPLFUNC definitions
-            amplfunc = "\n".join(
-                val for val in (
-                    os.environ.get('AMPLFUNC', ''),
-                    os.environ.get('PYOMO_AMPLFUNC', ''),
-                ) if val)
-            with CtypesEnviron(AMPLFUNC=amplfunc):
+            amplfunc = "\n".join(filter(None, (
+                os.environ.get('AMPLFUNC', None),
+                os.environ.get('PYOMO_AMPLFUNC', None),
+            )))
+            # Use the CtypesEnviron to clear the AMPLFUNC variable
+            # everywhere (python, dlls, etc).
+            with CtypesEnviron(AMPLFUNC=''):
+                # Now just set the AMPLFUNC in the python env (for
+                # AmplInterface to see)
+                os.environ['AMPLFUNC'] = amplfunc
                 super(PyomoNLP, self).__init__(nl_file)
 
             # keep pyomo model in cache

--- a/pyomo/contrib/pynumero/src/AmplInterface.cpp
+++ b/pyomo/contrib/pynumero/src/AmplInterface.cpp
@@ -33,7 +33,7 @@ char* new_char_p_from_std_str(std::string str)
    //return const_cast<char*>(str.c_str());
 }
 
-void AmplInterface::initialize(const char *nlfilename)
+void AmplInterface::initialize(const char *nlfilename, const char *amplfunc)
 {
    // The includes from the Ampl Solver Library
    // have a number of macros that expand to include
@@ -49,10 +49,15 @@ void AmplInterface::initialize(const char *nlfilename)
    typedef std::vector<std::string>::iterator iter;
 
    std::string cp_nlfilename(nlfilename);
+   std::string cp_amplfunc(amplfunc);
 
    // translate options to command input
    std::vector <std::string> arguments;
    arguments.push_back("pynumero");
+   if (cp_amplfunc.length() > 0) {
+      arguments.push_back("-i");
+      arguments.push_back(cp_amplfunc);
+   }
    arguments.push_back(cp_nlfilename);
    for (iter it=options.begin(); it != options.end(); ++it) {
       arguments.push_back(*it);
@@ -447,23 +452,34 @@ FILE* AmplInterfaceStr::open_nl(ASL_pfgh *asl, char* stub)
 }
 
 extern "C" {
+   PYNUMERO_ASL_EXPORT int
+   EXTERNAL_AmplInterface_version() {
+      /** 0: original implementation
+          1: added EXTERNAL_AmplInterface_dummy
+             updated EXTERNAL_AmplInterface_eval_hes_lag arguments
+          2: added EXTERNAL_AmplInterface_version
+             added amplfunc argument to EXTERNAL_AmplInterface_new_file
+       **/
+      return 2;
+   }
+
    PYNUMERO_ASL_EXPORT AmplInterface*
-   EXTERNAL_AmplInterface_new_file(char *nlfilename) {
+   EXTERNAL_AmplInterface_new_file(char *nlfilename, char *amplfunc) {
       AmplInterface* ans = new AmplInterfaceFile();
-      ans->initialize(nlfilename);
+      ans->initialize(nlfilename, amplfunc);
       return ans;
    }
 
    PYNUMERO_ASL_EXPORT AmplInterface*
-   EXTERNAL_AmplInterface_new_str(char *nl, size_t size) {
+   EXTERNAL_AmplInterface_new_str(char *nl, size_t size, char *amplfunc) {
       AmplInterface* ans = new AmplInterfaceStr(nl, size);
-      ans->initialize("membuf.nl");
+      ans->initialize("membuf.nl", amplfunc);
       return ans;
    }
 
    PYNUMERO_ASL_EXPORT AmplInterface*
-   EXTERNAL_AmplInterface_new(char *nlfilename) {
-      return EXTERNAL_AmplInterface_new_file(nlfilename);
+   EXTERNAL_AmplInterface_new(char *nlfilename, char *amplfunc) {
+      return EXTERNAL_AmplInterface_new_file(nlfilename, amplfunc);
    }
 
    PYNUMERO_ASL_EXPORT

--- a/pyomo/contrib/pynumero/src/AmplInterface.hpp
+++ b/pyomo/contrib/pynumero/src/AmplInterface.hpp
@@ -34,7 +34,7 @@ public:
    AmplInterface();
    virtual ~AmplInterface();
 
-   void initialize(const char *nlfilename); 
+   void initialize(const char *nlfilename, const char *amplfunc="");
 
    virtual FILE* open_nl(ASL_pfgh *asl, char *stub) = 0;
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
We have gotten reports of users having trouble solving multiple models with different AMPL external functions through the PyNumero interface.  It appears that the interface sees the AMPLFUNC environment variable when the `pynumero_ASL` library is first loaded, then never sees subsequent updates.  This PR attempts to resolve this by explicitly passing the AMPLFUNC string through the `ctypes` interface and not rely on environment variables.

This PR also adds a version identifier to the `pynumero_ASL` compiled library so that the Python client code can easily determine the API that the compiled library supports.  It also simplifies the load of the library so work is not unnecessarily repeated during sequential solves.

## Changes proposed in this PR:
- Pass the `AMPLFUNC` library paths through the `ctypes` interface and not rely on environment variables.
- Add a version number to the compiled library
- general cleanup of the library interface declaration

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
