### PR TITLE
Fix typo in pyomo.core.base.initializer.py

### DIFF
--- a/pyomo/core/base/initializer.py
+++ b/pyomo/core/base/initializer.py
@@ -85,7 +85,7 @@ def Initializer(init,
             if pandas_available and isinstance(init, pandas.Series):
                 initializer_map[init.__class__] = ItemInitializer
         elif any(c.__name__ == 'DataFrame' for c in init.__class__.__mro__):
-            if pandas_available and isinstance(init, pandas.DataFrams):
+            if pandas_available and isinstance(init, pandas.DataFrame):
                 initializer_map[init.__class__] = DataFrameInitializer
         else:
             # Note: this picks up (among other things) all string instances


### PR DESCRIPTION
When initializing with a `pandas.DataFrame`, the following exception is thrown: `AttributeError: module 'pandas' has no attribute 'DataFrams'` 

Fix: `pandas.DataFrams` -> `pandas.DataFrame`

## Fixes # .

## Summary/Motivation:

## Changes proposed in this PR:
- Small typo fix in pyomo.core.base.initializer.py

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
