### PR TITLE
Issue warning when using the Xpress LP/MPS interface

### DIFF
--- a/pyomo/environ/tests/standalone_minimal_pyomo_driver.py
+++ b/pyomo/environ/tests/standalone_minimal_pyomo_driver.py
@@ -98,6 +98,9 @@ def run_writer_test():
 def run_solverfactory_test():
     skip_solvers = {
         'py',
+        'xpress',
+        '_xpress_shell',
+        '_mock_xpress',
     }
 
     with LoggingIntercept() as LOG, capture_output(capture_fd=True) as OUT:

--- a/pyomo/solvers/plugins/solvers/XPRESS.py
+++ b/pyomo/solvers/plugins/solvers/XPRESS.py
@@ -75,6 +75,12 @@ class XPRESS_shell(ILMLicensedSystemCallSolver):
     """
 
     def __init__(self, **kwds):
+        logger.warning(
+                "The shell interface for Xpress is broken for recent versions "\
+                "of Xpress. Please use xpress_direct or xpress_persistent, "\
+                "which require the Xpress Python API. Python bindings "\
+                "for recent versions of Xpress can be installed via `pip`: "\
+                "<https://pypi.org/project/xpress/>.")
         #
         # Call base class constructor
         #


### PR DESCRIPTION
## Fixes:
There are lots of open issues around the Xpress LP/MPS interface (#58, #59, #69, #1429, #1601).

## Summary/Motivation:
The Xpress LP/MPS interface only partially works with current versions of Xpress. This PR would add a warning directing users to the direct or persistent interface.

## Changes proposed in this PR:
- Add warning when `_xpress_shell` is created
- Remove `xpress` from solver factory tests as the new warning causes this test to fail

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
