### PR TITLE
Updates to `incidence_analysis`

### DIFF
--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -156,6 +156,18 @@ class IncidenceGraphInterface(object):
         if model is None:
             self.cached = IncidenceMatrixType.NONE
         elif isinstance(model, PyomoNLP):
+            if not active:
+                raise ValueError(
+                    "Cannot get the Jacobian of inactive constraints from the "
+                    "nl interface (PyomoNLP).\nPlease set the `active` flag "
+                    "to True."
+                )
+            if include_fixed:
+                raise ValueError(
+                    "Cannot get the Jacobian with respect to fixed variables "
+                    "from the nl interface (PyomoNLP).\nPlease set the "
+                    "`include_fixed` flag to False."
+                )
             nlp = model
             self.cached = IncidenceMatrixType.NUMERIC
             self.variables = nlp.get_pyomo_variables()

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -123,8 +123,8 @@ def get_numeric_incidence_matrix(variables, constraints):
     _check_unindexed(comps)
     block = create_subsystem_block(constraints, variables)
     block._obj = Objective(expr=0)
-    _nlp = PyomoNLP(block)
-    return _nlp.extract_submatrix_jacobian(variables, constraints)
+    nlp = PyomoNLP(block)
+    return nlp.extract_submatrix_jacobian(variables, constraints)
 
 
 class IncidenceGraphInterface(object):

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -23,6 +23,8 @@ from pyomo.contrib.incidence_analysis.matching import maximum_matching
 from pyomo.contrib.incidence_analysis.triangularize import block_triangularize
 from pyomo.contrib.incidence_analysis.dulmage_mendelsohn import (
     dulmage_mendelsohn,
+    RowPartition,
+    ColPartition,
     )
 if scipy_available:
     from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP
@@ -271,11 +273,11 @@ class IncidenceGraphInterface(object):
         matrix = self._extract_submatrix(variables, constraints)
 
         row_partition, col_partition = dulmage_mendelsohn(matrix.tocoo())
-        con_partition = tuple(
-                [constraints[i] for i in subset] for subset in row_partition
+        con_partition = RowPartition(
+                *[[constraints[i] for i in subset] for subset in row_partition]
                 )
-        var_partition = tuple(
-                [variables[i] for i in subset] for subset in col_partition
+        var_partition = ColPartition(
+                *[[variables[i] for i in subset] for subset in col_partition]
                 )
         # Switch the order of the maps here to match the method call.
         # Hopefully this does not get too confusing...

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -15,6 +15,7 @@ from pyomo.core.base.constraint import Constraint
 from pyomo.core.base.objective import Objective
 from pyomo.core.base.reference import Reference
 from pyomo.core.expr.visitor import identify_variables
+from pyomo.util.subsystems import create_subsystem_block
 from pyomo.common.collections import ComponentSet, ComponentMap
 from pyomo.common.dependencies import scipy_available
 from pyomo.common.dependencies import networkx as nx
@@ -116,38 +117,13 @@ def get_numeric_incidence_matrix(variables, constraints):
     constraints with respect to variables.
     """
     # NOTE: There are several ways to get a numeric incidence matrix
-    # from a Pyomo model. This function implements a somewhat roundabout
-    # method, which is to construct a dummy Block with the necessary
-    # variables and constraints, then construct a PyNumero PyomoNLP
-    # from the block and have PyNumero evaluate the desired Jacobian
-    # via ASL.
+    # from a Pyomo model. Here we get the numeric incidence matrix by
+    # creating a temporary block and using the PyNumero ASL interface.
     comps = list(variables) + list(constraints)
     _check_unindexed(comps)
-    M, N = len(constraints), len(variables)
-    _block = Block()
-    _block.construct()
-    _block.obj = Objective(expr=0)
-    _block.vars = Reference(variables)
-    _block.cons = Reference(constraints)
-    var_set = ComponentSet(variables)
-    other_vars = []
-    for con in constraints:
-        for var in identify_variables(con.body, include_fixed=False):
-            # Fixed vars will be ignored by the nl file write, so
-            # there is no point to including them here.
-            # A different method of assembling this matrix, e.g.
-            # Pyomo's automatic differentiation, could support taking
-            # derivatives with respect to fixed variables.
-            if var not in var_set:
-                other_vars.append(var)
-                var_set.add(var)
-    # These variables are necessary due to the nl writer's philosophy
-    # about what constitutes a model. Note that we take derivatives with
-    # respect to them even though this is not necessary. We could fix them
-    # here to avoid doing this extra work, but that would alter the user's
-    # model, which we would rather not do.
-    _block.other_vars = Reference(other_vars)
-    _nlp = PyomoNLP(_block)
+    block = create_subsystem_block(constraints, variables)
+    block._obj = Objective(expr=0)
+    _nlp = PyomoNLP(block)
     return _nlp.extract_submatrix_jacobian(variables, constraints)
 
 

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -295,6 +295,16 @@ class IncidenceGraphInterface(object):
 
     def get_diagonal_blocks(self, variables=None, constraints=None):
         """
+        Returns the diagonal blocks in a block triangularization of the
+        incidence matrix of the provided constraints with respect to the
+        provided variables.
+
+        Returns
+        -------
+        tuple of lists
+        The first list contains lists that partition the variables,
+        the second lists contains lists that partition the constraints.
+
         """
         variables, constraints = self._validate_input(variables, constraints)
         matrix = self._extract_submatrix(variables, constraints)

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -800,6 +800,45 @@ class TestDulmageMendelsohnInterface(unittest.TestCase):
         for con in con_dmp[0]+con_dmp[1]:
             self.assertIn(con, overconstrained_cons)
 
+    def test_named_tuple(self):
+        m = make_degenerate_solid_phase_model()
+        variables = list(m.component_data_objects(pyo.Var))
+        constraints = list(m.component_data_objects(pyo.Constraint))
+
+        igraph = IncidenceGraphInterface()
+        var_dmp, con_dmp = igraph.dulmage_mendelsohn(variables, constraints)
+
+        underconstrained_vars = ComponentSet(m.flow_comp.values())
+        underconstrained_vars.add(m.flow)
+        underconstrained_cons = ComponentSet(m.flow_eqn.values())
+
+        dmp_vars_under = var_dmp.unmatched + var_dmp.underconstrained
+        dmp_vars_over = var_dmp.overconstrained
+        dmp_cons_under = con_dmp.underconstrained
+        dmp_cons_over = con_dmp.unmatched + con_dmp.overconstrained
+
+        self.assertEqual(len(dmp_vars_under), len(underconstrained_vars))
+        for var in dmp_vars_under:
+            self.assertIn(var, underconstrained_vars)
+
+        self.assertEqual(len(dmp_cons_under), len(underconstrained_cons))
+        for con in dmp_cons_under:
+            self.assertIn(con, underconstrained_cons)
+
+        overconstrained_cons = ComponentSet(m.holdup_eqn.values())
+        overconstrained_cons.add(m.density_eqn)
+        overconstrained_cons.add(m.sum_eqn)
+        overconstrained_vars = ComponentSet(m.x.values())
+        overconstrained_vars.add(m.rho)
+
+        self.assertEqual(len(dmp_vars_over), len(overconstrained_vars))
+        for var in dmp_vars_over:
+            self.assertIn(var, overconstrained_vars)
+
+        self.assertEqual(len(dmp_cons_over), len(overconstrained_cons))
+        for con in dmp_cons_over:
+            self.assertIn(con, overconstrained_cons)
+
     def test_incidence_graph(self):
         m = make_degenerate_solid_phase_model()
         variables = list(m.component_data_objects(pyo.Var))

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -782,6 +782,58 @@ class TestGasExpansionModelInterfaceClassNoCache(unittest.TestCase):
         var_blocks, con_blocks = igraph.get_diagonal_blocks(
             variables, constraints
         )
+        self.assertIs(igraph.row_block_map, None)
+        self.assertIs(igraph.col_block_map, None)
+        self.assertEqual(len(var_blocks), N+1)
+        self.assertEqual(len(con_blocks), N+1)
+
+        for i, (vars, cons) in enumerate(zip(var_blocks, con_blocks)):
+            var_set = ComponentSet(vars)
+            con_set = ComponentSet(cons)
+
+            if i == 0:
+                pred_var_set = ComponentSet([model.P[0]])
+                self.assertEqual(pred_var_set, var_set)
+                pred_con_set = ComponentSet([model.ideal_gas[0]])
+                self.assertEqual(pred_con_set, con_set)
+
+            else:
+                pred_var_set = ComponentSet([
+                    model.rho[i], model.T[i], model.P[i], model.F[i]
+                ])
+                pred_con_set = ComponentSet([
+                    model.ideal_gas[i],
+                    model.expansion[i],
+                    model.mbal[i],
+                    model.ebal[i],
+                ])
+                self.assertEqual(pred_var_set, var_set)
+                self.assertEqual(pred_con_set, con_set)
+
+    def test_diagonal_blocks_with_cached_maps(self):
+        N = 5
+        model = make_gas_expansion_model(N)
+        igraph = IncidenceGraphInterface()
+
+        # These are the variables and constraints of the square,
+        # nonsingular subsystem
+        variables = []
+        variables.extend(model.P.values())
+        variables.extend(model.T[i] for i in model.streams
+                if i != model.streams.first())
+        variables.extend(model.rho[i] for i in model.streams
+                if i != model.streams.first())
+        variables.extend(model.F[i] for i in model.streams
+                if i != model.streams.first())
+
+        constraints = list(model.component_data_objects(pyo.Constraint))
+
+        igraph.block_triangularize(variables, constraints)
+        var_blocks, con_blocks = igraph.get_diagonal_blocks(
+            variables, constraints
+        )
+        self.assertIsNot(igraph.row_block_map, None)
+        self.assertIsNot(igraph.col_block_map, None)
         self.assertEqual(len(var_blocks), N+1)
         self.assertEqual(len(con_blocks), N+1)
 

--- a/pyomo/contrib/incidence_analysis/tests/test_triangularize.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_triangularize.py
@@ -10,7 +10,10 @@
 
 import random
 from pyomo.contrib.incidence_analysis.matching import maximum_matching
-from pyomo.contrib.incidence_analysis.triangularize import block_triangularize
+from pyomo.contrib.incidence_analysis.triangularize import (
+        block_triangularize,
+        get_diagonal_blocks,
+        )
 from pyomo.common.dependencies import (
         scipy,
         scipy_available,
@@ -347,6 +350,54 @@ class TestTriangularize(unittest.TestCase):
                 col_idx = col_perm[2*i+1]
                 self.assertEqual(row_block_map[row_idx], i)
                 self.assertEqual(col_block_map[col_idx], i)
+
+    def test_decomposable_tridiagonal_diagonal_blocks(self):
+        """
+        This matrix decomposes into 2x2 blocks
+        |x x      |
+        |x x      |
+        |  x x x  |
+        |    x x  |
+        |      x x|
+        """
+        N = 5
+        row = []
+        col = []
+        data = []
+
+        # Diagonal
+        row.extend(range(N))
+        col.extend(range(N))
+        data.extend(1 for _ in range(N))
+
+        # Below diagonal
+        row.extend(range(1, N))
+        col.extend(range(N-1))
+        data.extend(1 for _ in range(N-1))
+
+        # Above diagonal
+        row.extend(i for i in range(N-1) if not i%2)
+        col.extend(i+1 for i in range(N-1) if not i%2)
+        data.extend(1 for i in range(N-1) if not i%2)
+
+        matrix = sps.coo_matrix((data, (row, col)), shape=(N, N))
+
+        row_blocks, col_blocks = get_diagonal_blocks(matrix)
+
+        self.assertEqual(len(row_blocks), (N+1)//2)
+        self.assertEqual(len(col_blocks), (N+1)//2)
+
+        for i in range((N+1)//2):
+            rows = row_blocks[i]
+            cols = col_blocks[i]
+            
+            if 2*i+1 < N:
+                self.assertEqual(set(rows), {2*i, 2*i+1})
+                self.assertEqual(set(cols), {2*i, 2*i+1})
+            else:
+                self.assertEqual(set(rows), {2*i})
+                self.assertEqual(set(cols), {2*i})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/contrib/incidence_analysis/triangularize.py
+++ b/pyomo/contrib/incidence_analysis/triangularize.py
@@ -97,3 +97,52 @@ def block_triangularize(matrix, matching=None):
     col_block_map = {c: row_block_map[col_row_map[c]] for c in range(N)}
 
     return row_block_map, col_block_map
+
+
+def get_blocks_from_maps(row_block_map, col_block_map):
+    """
+    Gets the row and column coordinates of each diagonal block in a
+    block triangularization from maps of row/column coordiates to
+    block indices.
+
+    """
+    blocks = set(row_block_map.values())
+    assert blocks == set(col_block_map.values())
+    n_blocks = len(blocks)
+    block_rows = [[] for _ in range(n_blocks)]
+    block_cols = [[] for _ in range(n_blocks)]
+    for r, b in row_block_map.items():
+        block_rows[b].append(r)
+    for c, b in col_block_map.items():
+        block_cols[b].append(c)
+    return block_rows, block_cols
+
+
+def get_diagonal_blocks(matrix, matching=None):
+    """
+    Gets the diagonal blocks of a block triangularization of the provided
+    matrix.
+
+    Arguments
+    ---------
+    coo_matrix
+        Matrix to get the diagonal blocks of
+
+    matching
+        Dict mapping row indices to column indices in the perfect matching
+        to be used by the block triangularization.
+
+    Returns
+    -------
+    tuple of lists
+        The first list is a list-of-lists of row indices that partitions
+        the indices into diagonal blocks. The second list is a
+        list-of-lists of column indices that partitions the indices into
+        diagonal blocks.
+
+    """
+    row_block_map, col_block_map = block_triangularize(
+        matrix, matching=matching
+    )
+    block_rows, block_cols = get_blocks_from_maps(row_block_map, col_block_map)
+    return block_rows, block_cols

--- a/pyomo/contrib/incidence_analysis/triangularize.py
+++ b/pyomo/contrib/incidence_analysis/triangularize.py
@@ -105,6 +105,24 @@ def get_blocks_from_maps(row_block_map, col_block_map):
     block triangularization from maps of row/column coordiates to
     block indices.
 
+    Arguments
+    ---------
+    row_block_map: dict
+        Dict mapping each row coordinate to the coordinate of the 
+        block it belongs to
+
+    col_block_map: dict
+        Dict mapping each column coordinate to the coordinate of the
+        block it belongs to
+
+    Returns
+    -------
+    tuple of lists
+        The first list is a list-of-lists of row indices that partitions
+        the indices into diagonal blocks. The second list is a
+        list-of-lists of column indices that partitions the indices into
+        diagonal blocks.
+
     """
     blocks = set(row_block_map.values())
     assert blocks == set(col_block_map.values())


### PR DESCRIPTION
## Summary/Motivation:
Some small updates to `incidence_analysis`. The main motivation is to more easily get the diagonal blocks from a block triangularization (as opposed to a map from variables and constraints to their block index).

## Changes proposed in this PR:
- Add `get_diagonal_blocks` function to **block_triangularize.py**, and corresponding `get_diagonal_blocks` method in `IncidenceGraphInterface` 
- use named tuples as returned objects from `dulmage_mendelsohn` in `IncidenceGraphInterface` (as opposed to just in the incidence matrix interface).
- Use `get_subsystem_block` where applicable
- In the Pyomo interface, when a model is passed as an argument, only use variables that appear in constraints

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
