### PR TITLE
Restore AMPLFUNC environment variable for old pynumero_ASL versions

### DIFF
--- a/pyomo/contrib/pynumero/asl.py
+++ b/pyomo/contrib/pynumero/asl.py
@@ -223,7 +223,7 @@ class AmplInterface(object):
         # the ASL.  This should prevent it from potentially caching an
         # AMPLFUNC from the initial load and letting it bleed into
         # (potentially unrelated) subsequent instances
-        b_amplfunc = os.environ.pop('AMPLFUNC', '').encode('utf-8')
+        amplfunc = os.environ.pop('AMPLFUNC', '')
 
         if AmplInterface.ASLib is None:
             AmplInterface.ASLib, AmplInterface.interface_version \
@@ -235,8 +235,15 @@ class AmplInterface(object):
 
             b_data = filename.encode('utf-8')
             if self.interface_version >= 2:
-                args = (b_data, b_amplfunc)
+                args = (b_data, amplfunc.encode('utf-8'))
             else:
+                # Old ASL interface library.
+                if amplfunc:
+                    # we need to put AMPLFUNC back into the environment,
+                    # as old versions of the library rely on ONLY the
+                    # environment variable for passing the library(ies)
+                    # locations to the ASL
+                    os.environ['AMPLFUNC'] = amplfunc
                 args = (b_data,)
             self._obj = self.ASLib.EXTERNAL_AmplInterface_new_file(*args)
         elif nl_buffer is not None:


### PR DESCRIPTION
## Fixes #2126

## Summary/Motivation:
There is a flaw in the backwards compatibility layer for pynumero working with old (v1) versions of `pynumero_ASL`.  This patch fixes the backwards compatibility layer so that `AMPLFUNC` is left in the environment when using old versions of the compiled library.

## Changes proposed in this PR:
- Leave `AMPLFUNC` in the environment when using old versions (< 2) of the `pynumero_ASL` library

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
