### PR TITLE
Logical_to_linear on hierarchical models

### DIFF
--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -17,7 +17,8 @@ from pyomo.common.timing import ConstructionTimer
 from pyomo.core.expr.boolean_value import BooleanValue
 from pyomo.core.expr.numvalue import value
 from pyomo.core.base.component import ComponentData, ModelComponentFactory
-from pyomo.core.base.indexed_component import IndexedComponent, UnindexedComponent_set
+from pyomo.core.base.indexed_component import (IndexedComponent,
+                                               UnindexedComponent_set)
 from pyomo.core.base.misc import apply_indexed_rule
 from pyomo.core.base.set import Set, BooleanSet
 from pyomo.core.base.util import is_functor
@@ -126,7 +127,8 @@ class _BooleanVarData(ComponentData, BooleanValue):
 
     free=unfix
 
-    def to_string(self, verbose=None, labeler=None, smap=None, compute_values=False):
+    def to_string(self, verbose=None, labeler=None, smap=None,
+                  compute_values=False):
         """Return the component name"""
         if self.fixed and compute_values:
             try:
@@ -229,7 +231,8 @@ class _GeneralBooleanVarData(_BooleanVarData):
         if len(val) == 1:
             self.value = val[0]
         elif len(val) > 1:
-            raise TypeError("fix expected at most 1 arguments, got %d" % (len(val)))
+            raise TypeError("fix expected at most 1 arguments, got %d" %
+                            (len(val)))
 
     def unfix(self):
         """Sets the fixed indicator to False."""
@@ -239,7 +242,8 @@ class _GeneralBooleanVarData(_BooleanVarData):
 
     def get_associated_binary(self):
         """Get the binary _VarData associated with this _GeneralBooleanVarData"""
-        return self._associated_binary() if self._associated_binary is not None else None
+        return self._associated_binary() if self._associated_binary \
+            is not None else None
 
     def associate_binary_var(self, binary_var):
         """Associate a binary _VarData to this _GeneralBooleanVarData"""

--- a/pyomo/core/plugins/transform/logical_to_linear.py
+++ b/pyomo/core/plugins/transform/logical_to_linear.py
@@ -1,20 +1,27 @@
-"""Transformation from BooleanVar and LogicalConstraint to Binary and Constraints."""
+"""Transformation from BooleanVar and LogicalConstraint to Binary and
+Constraints."""
 from pyomo.common.collections import ComponentMap
 from pyomo.common.modeling import unique_component_name
 from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
-from pyomo.core import TransformationFactory, BooleanVar, VarList, Binary, LogicalConstraint, Block, ConstraintList, \
-    native_types, BooleanVarList
+from pyomo.core import (TransformationFactory, BooleanVar, VarList, Binary,
+                        LogicalConstraint, Block, ConstraintList, native_types,
+                        BooleanVarList)
 from pyomo.core.expr.cnf_walker import to_cnf
-from pyomo.core.expr.logical_expr import AndExpression, OrExpression, NotExpression, AtLeastExpression, \
-    AtMostExpression, ExactlyExpression, special_boolean_atom_types, EqualityExpression, InequalityExpression, \
-    RangedExpression
+from pyomo.core.expr.logical_expr import (AndExpression, OrExpression,
+                                          NotExpression, AtLeastExpression,
+                                          AtMostExpression, ExactlyExpression,
+                                          special_boolean_atom_types,
+                                          EqualityExpression,
+                                          InequalityExpression,
+                                          RangedExpression)
 from pyomo.core.expr.numvalue import native_logical_types, value
 from pyomo.core.expr.visitor import StreamBasedExpressionVisitor
 from pyomo.core.plugins.transform.hierarchy import IsomorphicTransformation
 from pyomo.gdp import Disjunct
 
 
-@TransformationFactory.register("core.logical_to_linear", doc="Convert logic to linear constraints")
+@TransformationFactory.register("core.logical_to_linear", 
+                                doc="Convert logic to linear constraints")
 class LogicalToLinear(IsomorphicTransformation):
     """
     Re-encode logical constraints as linear constraints,
@@ -22,11 +29,16 @@ class LogicalToLinear(IsomorphicTransformation):
     """
 
     def _apply_to(self, model, **kwds):
-        for boolean_var in model.component_objects(ctype=BooleanVar, descend_into=(Block, Disjunct)):
+        for boolean_var in model.component_objects(ctype=BooleanVar,
+                                                   descend_into=(Block,
+                                                                 Disjunct)):
             new_varlist = None
             for bool_vardata in boolean_var.values():
-                if new_varlist is None and bool_vardata.get_associated_binary() is None:
-                    new_var_list_name = unique_component_name(model, boolean_var.local_name + '_asbinary')
+                if new_varlist is None and \
+                   bool_vardata.get_associated_binary() is None:
+                    new_var_list_name = unique_component_name(
+                        model,
+                        boolean_var.local_name + '_asbinary')
                     new_varlist = VarList(domain=Binary)
                     setattr(model, new_var_list_name, new_varlist)
 
@@ -41,13 +53,19 @@ class LogicalToLinear(IsomorphicTransformation):
         # Process statements in global (entire model) context
         _process_logical_constraints_in_logical_context(model)
         # Process statements that appear in disjuncts
-        for disjunct in model.component_data_objects(Disjunct, descend_into=(Block, Disjunct), active=True):
+        for disjunct in model.component_data_objects(Disjunct,
+                                                     descend_into=(Block,
+                                                                   Disjunct), 
+                                                     active=True):
             _process_logical_constraints_in_logical_context(disjunct)
 
 
 def update_boolean_vars_from_binary(model, integer_tolerance=1e-5):
-    """Updates all Boolean variables based on the value of their linked binary variables."""
-    for boolean_var in model.component_data_objects(BooleanVar, descend_into=(Block, Disjunct)):
+    """Updates all Boolean variables based on the value of their linked binary
+variables."""
+    for boolean_var in model.component_data_objects(BooleanVar,
+                                                    descend_into=(Block,
+                                                                  Disjunct)):
         binary_var = boolean_var.get_associated_binary()
         if binary_var is not None and binary_var.value is not None:
             if abs(binary_var.value - 1) <= integer_tolerance:
@@ -55,7 +73,8 @@ def update_boolean_vars_from_binary(model, integer_tolerance=1e-5):
             elif abs(binary_var.value) <= integer_tolerance:
                 boolean_var.value = False
             else:
-                raise ValueError("Binary variable has non-{0,1} value: %s = %s" % (binary_var.name, binary_var.value))
+                raise ValueError("Binary variable has non-{0,1} value: "
+                                 "%s = %s" % (binary_var.name, binary_var.value))
             boolean_var.stale = binary_var.stale
 
 
@@ -71,8 +90,10 @@ def _process_logical_constraints_in_logical_context(context):
     indicator_map = ComponentMap()
     cnf_statements = []
     # Convert all logical constraints to CNF
-    for logical_constraint in context.component_data_objects(ctype=LogicalConstraint, active=True):
-        cnf_statements.extend(to_cnf(logical_constraint.body, new_boolvarlist, indicator_map))
+    for logical_constraint in context.component_data_objects(
+            ctype=LogicalConstraint, active=True):
+        cnf_statements.extend(to_cnf(logical_constraint.body, new_boolvarlist,
+                                     indicator_map))
         logical_constraint.deactivate()
 
     # Associate new Boolean vars to new binary variables
@@ -85,14 +106,18 @@ def _process_logical_constraints_in_logical_context(context):
         for linear_constraint in _cnf_to_linear_constraint_list(cnf_statement):
             new_constrlist.add(expr=linear_constraint)
 
-    # Add bigM associated with special atoms
-    # Note: this ad-hoc reformulation may be revisited for tightness in the future.
+    # Add bigM associated with special atoms 
+    # Note: this ad-hoc reformulation may be revisited for tightness in the 
+    # future.
     old_varlist_length = len(new_varlist)
     for indicator_var, special_atom in indicator_map.items():
-        for linear_constraint in _cnf_to_linear_constraint_list(special_atom, indicator_var, new_varlist):
+        for linear_constraint in _cnf_to_linear_constraint_list(special_atom,
+                                                                indicator_var,
+                                                                new_varlist):
             new_constrlist.add(expr=linear_constraint)
 
-    # Previous step may have added auxiliary binaries. Associate augmented Booleans to them.
+    # Previous step may have added auxiliary binaries. Associate augmented
+    # Booleans to them.
     num_new = len(new_varlist) - old_varlist_length
     list_o_vars = list(new_varlist.values())
     if num_new:
@@ -100,9 +125,9 @@ def _process_logical_constraints_in_logical_context(context):
             new_bool_vardata = new_boolvarlist.add()
             new_bool_vardata.associate_binary_var(binary_vardata)
 
-    # If added components were not used, remove them.
-    # Note: it is ok to simply delete the index_set for these components, because by
-    # default, a new set object is generated for each [Thing]List.
+    # If added components were not used, remove them.  
+    # Note: it is ok to simply delete the index_set for these components,
+    # because by default, a new set object is generated for each [Thing]List.
     if len(new_constrlist) == 0:
         new_xfrm_block.del_component(new_constrlist.index_set())
         new_xfrm_block.del_component(new_constrlist)
@@ -118,22 +143,27 @@ def _process_logical_constraints_in_logical_context(context):
         context.del_component(new_xfrm_block)
 
 
-def _cnf_to_linear_constraint_list(cnf_expr, indicator_var=None, binary_varlist=None):
+def _cnf_to_linear_constraint_list(cnf_expr, indicator_var=None,
+                                   binary_varlist=None):
     # Screen for constants
     if type(cnf_expr) in native_types or cnf_expr.is_constant():
         if value(cnf_expr) is True:
             return []
         else:
             raise ValueError(
-                "Cannot build linear constraint for logical expression with constant value False: %s"
+                "Cannot build linear constraint for logical expression with "
+                "constant value False: %s"
                 % cnf_expr)
     if cnf_expr.is_expression_type():
-        return CnfToLinearVisitor(indicator_var, binary_varlist).walk_expression(cnf_expr)
+        return CnfToLinearVisitor(indicator_var, binary_varlist).walk_expression(
+            cnf_expr)
     else:
-        return [cnf_expr.get_associated_binary() == 1]  # Assume that cnf_expr is a BooleanVar
+        return [cnf_expr.get_associated_binary() == 1]  # Assume that cnf_expr
+                                                        # is a BooleanVar
 
 
-_numeric_relational_types = {InequalityExpression, EqualityExpression, RangedExpression}
+_numeric_relational_types = {InequalityExpression, EqualityExpression,
+                             RangedExpression}
 
 
 class CnfToLinearVisitor(StreamBasedExpressionVisitor):
@@ -150,13 +180,14 @@ class CnfToLinearVisitor(StreamBasedExpressionVisitor):
 
     def exitNode(self, node, values):
         if type(node) == AndExpression:
-            return list((v if type(v) in _numeric_relational_types else v == 1) for v in values)
+            return list((v if type(v) in _numeric_relational_types else v == 1)
+                        for v in values)
         elif type(node) == OrExpression:
             return sum(values) >= 1
         elif type(node) == NotExpression:
             return 1 - values[0]
-        # Note: the following special atoms should only be encountered as root nodes.
-        # If they are encountered otherwise, something went wrong.
+        # Note: the following special atoms should only be encountered as root
+        # nodes.  If they are encountered otherwise, something went wrong.
         sum_values = sum(values[1:])
         num_args = node.nargs() - 1  # number of logical arguments
         if self._indicator is None:
@@ -169,30 +200,36 @@ class CnfToLinearVisitor(StreamBasedExpressionVisitor):
         else:
             rhs_lb, rhs_ub = compute_bounds_on_expr(values[0])
             if rhs_lb == float('-inf') or rhs_ub == float('inf'):
-                raise ValueError(
-                    "Cannnot generate linear constraints for %s([N, *logical_args]) with unbounded N. "
-                    "Detected %s <= N <= %s." % (type(node).__name__, rhs_lb, rhs_ub)
-                )
+                raise ValueError( "Cannnot generate linear constraints for %s"
+                                  "([N, *logical_args]) with unbounded N. "
+                                  "Detected %s <= N <= %s." %
+                                  (type(node).__name__, rhs_lb, rhs_ub) )
             indicator_binary = self._indicator.get_associated_binary()
             if type(node) == AtLeastExpression:
                 return [
                     sum_values >= values[0] - rhs_ub * (1 - indicator_binary),
-                    sum_values <= values[0] - 1 + (-(rhs_lb - 1) + num_args) * indicator_binary
+                    sum_values <= values[0] - 1 + (-(rhs_lb - 1) + num_args) * \
+                    indicator_binary
                 ]
             elif type(node) == AtMostExpression:
                 return [
-                    sum_values <= values[0] + (-rhs_lb + num_args) * (1 - indicator_binary),
-                    sum_values >= (values[0] + 1) - (rhs_ub + 1) * indicator_binary
+                    sum_values <= values[0] + (-rhs_lb + num_args) * \
+                    (1 - indicator_binary),
+                    sum_values >= (values[0] + 1) - (rhs_ub + 1) * \
+                    indicator_binary
                 ]
             elif type(node) == ExactlyExpression:
                 less_than_binary = self._binary_varlist.add()
                 more_than_binary = self._binary_varlist.add()
                 return [
-                    sum_values <= values[0] + (-rhs_lb + num_args) * (1 - indicator_binary),
+                    sum_values <= values[0] + (-rhs_lb + num_args) * \
+                    (1 - indicator_binary),
                     sum_values >= values[0] - rhs_ub * (1 - indicator_binary),
                     indicator_binary + less_than_binary + more_than_binary >= 1,
-                    sum_values <= values[0] - 1 + (-(rhs_lb - 1) + num_args) * (1 - less_than_binary),
-                    sum_values >= values[0] + 1 - (rhs_ub + 1) * (1 - more_than_binary),
+                    sum_values <= values[0] - 1 + (-(rhs_lb - 1) + num_args) * \
+                    (1 - less_than_binary),
+                    sum_values >= values[0] + 1 - (rhs_ub + 1) * \
+                    (1 - more_than_binary),
                 ]
             pass
 

--- a/pyomo/core/tests/unit/test_logical_to_linear.py
+++ b/pyomo/core/tests/unit/test_logical_to_linear.py
@@ -401,7 +401,7 @@ class TestLogicalToLinearBackmap(unittest.TestCase):
         TransformationFactory('core.logical_to_linear').apply_to(m)
         m.Y_asbinary[1].value = 1
         m.Y_asbinary[2].value = 0
-        m.b.Y_asbinary.value = 1
+        m.b.Y.get_associated_binary().value = 1
         update_boolean_vars_from_binary(m)
         self.assertTrue(m.Y[1].value)
         self.assertFalse(m.Y[2].value)

--- a/pyomo/core/tests/unit/test_logical_to_linear.py
+++ b/pyomo/core/tests/unit/test_logical_to_linear.py
@@ -362,6 +362,11 @@ class TestLogicalToLinearTransformation(unittest.TestCase):
                                                             m.b.Y[3])))
         TransformationFactory('core.logical_to_linear').apply_to(m)
 
+        boolean_var = m.b.component("Y_asbinary")
+        self.assertIsInstance(boolean_var, Var)
+        notAVar = m.component("Y_asbinary")
+        self.assertIsNone(notAVar)
+
         transBlock = m.b.component("logic_to_linear")
         self.assertIsInstance(transBlock, Block)
         notAThing = m.component("logic_to_linear")
@@ -388,6 +393,20 @@ class TestLogicalToLinearBackmap(unittest.TestCase):
         self.assertTrue(m.Y[1].value)
         self.assertFalse(m.Y[2].value)
         self.assertIsNone(m.Y[3].value)
+
+    def test_backmap_hierarchical_model(self):
+        m = _generate_boolean_model(3)
+        m.b = Block()
+        m.b.Y = BooleanVar()
+        TransformationFactory('core.logical_to_linear').apply_to(m)
+        m.Y_asbinary[1].value = 1
+        m.Y_asbinary[2].value = 0
+        m.b.Y_asbinary.value = 1
+        update_boolean_vars_from_binary(m)
+        self.assertTrue(m.Y[1].value)
+        self.assertFalse(m.Y[2].value)
+        self.assertIsNone(m.Y[3].value)
+        self.assertTrue(m.b.Y.value)
 
     def test_backmap_noninteger(self):
         m = _generate_boolean_model(2)


### PR DESCRIPTION
## Fixes #2134 

## Summary/Motivation:

The `core.logical_to_linear` transformation put everything it transformed on the parent model (except for stuff on Disjuncts), which results in incorrect solutions if you then solve sub-blocks.

## Changes proposed in this PR:
- Declare the `logical_to_linear` transformation block on the parent block of the constraints being transformed
- Declare the associated binary variables on the parent block of the BooleanVars they correspond to
- PEP-8ing line lengths a little because I can't help myself

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
