### PR TITLE
Fix `Expression.getitem` when initialized with `Skip`

### DIFF
--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -496,7 +496,7 @@ class _GeneralConstraintData(_ConstraintData):
                     "    Inequality: (lower, expression, upper)"
                     % (self.name, len(expr)))
         #
-        # Ignore an 'empty' constraints
+        # Ignore an 'empty' constraint
         #
         elif _expr_type is type:
             del self.parent_component()[self.index()]

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -569,7 +569,8 @@ class _GeneralConstraintData(_ConstraintData):
                 # Error check: ensure equality does not have infinite RHS
                 raise ValueError(
                     "Equality constraint '%s' defined with "
-                    "non-finite term." % (self.name))
+                    "non-finite term (%sHS == None)." % (
+                        self.name, 'L' if args[0] is None else 'R'))
             if args[0].__class__ in native_numeric_types or \
                not args[0].is_potentially_variable():
                 self._lower = self._upper = args[0]

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -687,25 +687,16 @@ class Constraint(ActiveIndexedComponent):
             return super(Constraint, cls).__new__(IndexedConstraint)
 
     def __init__(self, *args, **kwargs):
-        _init = tuple( _arg for _arg in (
-            kwargs.pop('rule', None),
-            kwargs.pop('expr', None) ) if _arg is not None )
-        if len(_init) == 1:
-            _init = _init[0]
-        elif not _init:
-            _init = None
-        else:
-            raise ValueError("Duplicate initialization: Constraint() only "
-                             "accepts one of 'rule=' and 'expr='")
-
-        kwargs.setdefault('ctype', Constraint)
-        ActiveIndexedComponent.__init__(self, *args, **kwargs)
-
+        _init = self._pop_from_kwargs(
+            'Constraint', kwargs, ('rule', 'expr'), None)
         # Special case: we accept 2- and 3-tuples as constraints
         if type(_init) is tuple:
             self.rule = Initializer(_init, treat_sequences_as_mappings=False)
         else:
             self.rule = Initializer(_init)
+
+        kwargs.setdefault('ctype', Constraint)
+        ActiveIndexedComponent.__init__(self, *args, **kwargs)
 
     def construct(self, data=None):
         """

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -269,27 +269,19 @@ class Expression(IndexedComponent):
             return IndexedExpression.__new__(IndexedExpression)
 
     def __init__(self, *args, **kwds):
-        _init = tuple(
-            arg for arg in
-            (kwds.pop(_arg, None) for _arg in ('rule', 'expr', 'initialize'))
-            if arg is not None
-        )
-        if len(_init) == 1:
-            _init = _init[0]
-        elif not _init:
-            _init = None
-        else:
-            raise ValueError(
-                "Duplicate initialization: Expression() only "
-                "accepts one of 'rule=', 'expr=', and 'initialize='")
-
-        kwds.setdefault('ctype', Expression)
-        IndexedComponent.__init__(self, *args, **kwds)
-
+        _init = self._pop_from_kwargs(
+            'Expression', kwds, ('rule', 'expr', 'initialize'), None)
         # Historically, Expression objects were dense (but None):
         # setting arg_not_specified causes Initializer to recognize
         # _init==None as a constant initializer returning None
+        #
+        # To initialize a completely empty Expression, pass either
+        # initialize={} (to require explicit setitem before a getitem),
+        # or initialize=NOTSET (to allow getitem before setitem)
         self._rule = Initializer(_init, arg_not_specified=NOTSET)
+
+        kwds.setdefault('ctype', Expression)
+        IndexedComponent.__init__(self, *args, **kwds)
 
     def _pprint(self):
         return (

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -351,10 +351,9 @@ class Expression(IndexedComponent):
             #raise KeyError(idx)
         else:
             _init = self._rule(self.parent_block(), idx)
-        obj = self._setitem_when_not_present(idx, _init)
-        #if obj is None:
-        #    raise KeyError(idx)
-        return obj
+            if _init is Expression.Skip:
+                raise KeyError(idx)
+        return self._setitem_when_not_present(idx, _init)
 
     def construct(self, data=None):
         """ Apply the rule to construct values in this set """

--- a/pyomo/core/tests/unit/test_expression.py
+++ b/pyomo/core/tests/unit/test_expression.py
@@ -487,10 +487,29 @@ E : Size=2
     def test_implicit_definition(self):
         model = ConcreteModel()
         model.idx = Set(initialize=[1,2,3])
+        model.E = Expression(model.idx)
+        self.assertEqual(len(model.E), 3)
+        expr = model.E[1]
+        self.assertIs(type(expr), _GeneralExpressionData)
+        model.E[1] = None
+        self.assertIs(expr, model.E[1])
+        self.assertIs(type(expr), _GeneralExpressionData)
+        self.assertIs(expr.value, None)
+        model.E[1] = 5
+        self.assertIs(expr, model.E[1])
+        self.assertEqual(model.E.extract_values(), {1:5, 2:None, 3:None})
+        model.E[2] = 6
+        self.assertIsNot(expr, model.E[2])
+        self.assertEqual(model.E.extract_values(), {1:5, 2:6, 3:None})
+
+    def test_explicit_skip_definition(self):
+        model = ConcreteModel()
+        model.idx = Set(initialize=[1,2,3])
         model.E = Expression(model.idx, rule=lambda m,i: Expression.Skip)
         self.assertEqual(len(model.E), 0)
-        expr = model.E[1]
-        self.assertIsNone(expr)
+        with self.assertRaises(KeyError):
+            expr = model.E[1]
+
         model.E[1] = None
         expr = model.E[1]
         self.assertIs(type(expr), _GeneralExpressionData)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
@andrewlee94 noted that the exception raised when a Constraint was initialized with an `EqualityExpression` where either the RHS or LHS was `None` was unhelpful.  This PR improves that message.  As part of debugging this issue, @andrewlee94 noted that the original problem was that an Equality was being constructed using an indexed Expression where the original rule returned `Expression.Skip`.  In the current behavior, when that happens, `Expression.__getitem__()` ends up returning `None` (not an `ExpressionData` containing, `None`, but an actual `None`).  The real "meat" of this PR is to change the behavior of `Expression._getitem_when_not_present` so that attempting to get an index from an Indexed Expression that was initialized with `Expression.Skip` not raises a KeyError.

Note that it is still allowed to *set* an ExpressionData that was initialized with `Expression.Skip` (it declares a new ExpressionData and initializes it).  That is:

```python
m.e = Expression([1,2], rule=Expression.Skip)
m.e[1] = m.x + m.y
m.c = Constraint(m.x <= m.e[1])
```

works, but the following raises a KeyError:
```python
m.e = Expression([1,2], rule=Expression.Skip)
m.c = Constraint(m.x <= m.e[1])  # KeyError!
m.e[1] = m.x + m.y
```

## Changes proposed in this PR:
- Raise a `KeyError` when attempting to get an Expression index that was initialized with `Expression.Skip`
- Update Expression tests
- Improve the exception message creaking a Constraint with an EqualityExpression where one side is `None`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
