### PR TITLE
Utility function to slice individual components in flatten module

### DIFF
--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -123,16 +123,10 @@ def _fill_indices_from_product(partial_index_list, product):
 
 
 def slice_component_along_sets(component, sets, context_slice=None):
-    # TODO: Any optional args I need?
-    # Might be useful to pass in a slice if I'm intending to continue
-    # an existing slice.
-    # Could also just take the slices yielded by this function and
-    # "concatenate" them with the parent slice after the fact somehow.
     set_set = ComponentSet(sets)
     subsets = list(component.index_set().subsets())
     temp_idx = [get_slice_for_set(s) if s in set_set else _NotAnIndex
             for s in subsets]
-    sliced_sets = [s for s in subsets if s in set_set]
     other_sets = [s for s in subsets if s not in set_set]
 
     if context_slice is None:

--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -139,6 +139,13 @@ def slice_component_along_sets(component, sets, context_slice=None):
         If provided, instead of creating a new slice, we will extend this
         one with appropriate getattr and getitem calls.
 
+    Yields
+    ------
+    tuple
+        The first entry is the index in the product of "other sets"
+        corresponding to the slice, and the second entry is the slice
+        at that index.
+
     """
     set_set = ComponentSet(sets)
     subsets = list(component.index_set().subsets())

--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -38,6 +38,7 @@ def get_slice_for_set(s):
         # Should this be None or tuple()? RBP 202110
         return None
 
+
 class _NotAnIndex(object):
     """ 
     `None` is a valid index, so we use a dummy class to 
@@ -45,6 +46,7 @@ class _NotAnIndex(object):
     from our product.
     """
     pass
+
 
 def _fill_indices(filled_index, index):
     """
@@ -66,6 +68,7 @@ def _fill_indices(filled_index, index):
         return filled_index[0]
     else:
         return filled_index
+
 
 def _fill_indices_from_product(partial_index_list, product):
     """ 
@@ -274,6 +277,7 @@ def generate_sliced_components(b, index_stack, slice_, sets, ctype, index_map):
         for _ in new_sets:
             index_stack.pop()
 
+
 def flatten_components_along_sets(m, sets, ctype, indices=None):
     """
     This function iterates over components (recursively) contained
@@ -342,6 +346,7 @@ def flatten_components_along_sets(m, sets, ctype, indices=None):
     #      )                            ^ These components are indexed by time
     #            ^ These components are indexed by time and space
     return sets_list, comps_list
+
 
 def flatten_dae_components(model, time, ctype, indices=None):
     target = ComponentSet((time,))

--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -211,10 +211,7 @@ def generate_sliced_components(b, index_stack, slice_, sets, ctype, index_map):
 
     for c in b.component_objects(ctype, descend_into=False):
         subsets = list(c.index_set().subsets())
-        temp_idx = [get_slice_for_set(s) if s in sets else _NotAnIndex
-                for s in subsets]
         new_sets = [s for s in subsets if s in sets]
-        other_sets = [s for s in subsets if s not in sets]
         sliced_sets = index_stack + new_sets
 
         # We have extended our "index stack;" now we must extend

--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -109,7 +109,7 @@ def _fill_indices_from_product(partial_index_list, product):
             # because `comp` was created with two set arguments, the first
             # of which was already a product.
 
-            yield _fill_indices(filled_index, index)
+            yield (index, _fill_indices(filled_index, index))
 
             normalize_index.flatten = False
             # Want to get the unflattened factors when we advance the
@@ -167,8 +167,8 @@ def slice_component_along_sets(component, *sets):
         # will be valid.
         try:
             if component.is_indexed():
-                # TODO: This should probably not be an ellipsis...
-                c_slice = component[...]
+                slice_idx = tuple(get_slice_for_set(s) for s in new_sets)
+                c_slice = component[slice_idx]
                 # Make sure this slice is not empty...
                 next(iter(c_slice.duplicate()))
             else:
@@ -222,7 +222,7 @@ def generate_sliced_components(b, index_stack, slice_, sets, ctype, index_map):
             # This implementation avoids issues about selecting an arbitrary
             # index, but requires duplicating some of the slice-iter logic below
 
-            for new_index in _fill_indices_from_product(temp_idx, cross_prod):
+            for _, new_index in _fill_indices_from_product(temp_idx, cross_prod):
                 try:
                     c_slice = getattr(slice_, c.local_name)[new_index]
                     if type(c_slice) is IndexedComponent_slice:
@@ -277,7 +277,7 @@ def generate_sliced_components(b, index_stack, slice_, sets, ctype, index_map):
         if other_sets and sub.is_indexed():
             cross_prod = other_sets[0].cross(*other_sets[1:])
 
-            for new_index in _fill_indices_from_product(temp_idx, cross_prod):
+            for _, new_index in _fill_indices_from_product(temp_idx, cross_prod):
                 try:
                     sub_slice = getattr(slice_, sub.local_name)[new_index]
 

--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -123,6 +123,23 @@ def _fill_indices_from_product(partial_index_list, product):
 
 
 def slice_component_along_sets(component, sets, context_slice=None):
+    """
+    This function generates all possible slices of the provided component
+    along the provided sets. That is, it will iterate over the component's
+    other indexing sets and, for each index, yield a slice along the
+    sets specified in the call signature.
+
+    Arguments
+    ---------
+    component: Component
+        The component whose slices will be yielded
+    sets: ComponentSet
+        ComponentSet of Pyomo sets that will be sliced along
+    context_slice: IndexedComponent_slice
+        If provided, instead of creating a new slice, we will extend this
+        one with appropriate getattr and getitem calls.
+
+    """
     set_set = ComponentSet(sets)
     subsets = list(component.index_set().subsets())
     temp_idx = [get_slice_for_set(s) if s in set_set else _NotAnIndex

--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -222,7 +222,9 @@ def generate_sliced_components(b, index_stack, slice_, sets, ctype, index_map):
         sliced_sets = index_stack + new_sets
 
         # Extend our slice with this component
-        for idx, new_slice in slice_component_along_sets(c, sets, context_slice=context_slice):
+        for idx, new_slice in slice_component_along_sets(
+                c, sets, context_slice=context_slice
+                ):
             yield sliced_sets, new_slice
 
     # We now descend into subblocks

--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -35,6 +35,7 @@ def get_slice_for_set(s):
                 return (Ellipsis,)
     else:
         # Case for e.g. UnindexedComponent_set
+        # Should this be None or tuple()? RBP 202110
         return None
 
 class _NotAnIndex(object):

--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -156,6 +156,8 @@ def slice_component_along_sets(component, sets, context_slice=None):
                 cross_prod,
                 ):
             try:
+                if normalize_index.flatten:
+                    new_index = normalize_index(new_index)
                 c_slice = base_component[new_index]
                 if type(c_slice) is IndexedComponent_slice:
                     # This is just to make sure we do not have an

--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -186,8 +186,7 @@ def generate_sliced_components(b, index_stack, slice_, sets, ctype, index_map):
             # will be valid.
             try:
                 if c.is_indexed():
-                    slice_idx = tuple(get_slice_for_set(s) for s
-                            in new_sets)
+                    slice_idx = tuple(get_slice_for_set(s) for s in new_sets)
                     c_slice = getattr(slice_, c.local_name)[slice_idx]
                     # Make sure this slice is not empty...
                     next(iter(c_slice.duplicate()))
@@ -269,7 +268,8 @@ def generate_sliced_components(b, index_stack, slice_, sets, ctype, index_map):
             # to iterate over "other sets."
             try:
                 if sub.is_indexed():
-                    sub_slice = getattr(slice_, sub.local_name)[...]
+                    slice_index = tuple(get_slice_for_set(s) for s in new_sets)
+                    sub_slice = getattr(slice_, sub.local_name)[slice_index]
                     # We have to get the block data object.
                     descend_slice = sub[descend_index_sliced_sets]
                     data = descend_slice if type(descend_slice) is not \

--- a/pyomo/dae/flatten.py
+++ b/pyomo/dae/flatten.py
@@ -186,7 +186,9 @@ def generate_sliced_components(b, index_stack, slice_, sets, ctype, index_map):
             # will be valid.
             try:
                 if c.is_indexed():
-                    c_slice = getattr(slice_, c.local_name)[...]
+                    slice_idx = tuple(get_slice_for_set(s) for s
+                            in new_sets)
+                    c_slice = getattr(slice_, c.local_name)[slice_idx]
                     # Make sure this slice is not empty...
                     next(iter(c_slice.duplicate()))
                 else:

--- a/pyomo/dae/tests/test_flatten.py
+++ b/pyomo/dae/tests/test_flatten.py
@@ -1389,19 +1389,69 @@ class TestCUID(unittest.TestCase):
                 raise RuntimeError()
 
 
-class TestSliceComponent(unittest.TestCase):
+class TestSliceComponent(TestFlatten):
+
+    def make_model(self):
+        m = ConcreteModel()
+        m.s1 = Set(initialize=[1, 2, 3])
+        m.s2 = Set(initialize=["a", "b"])
+        m.s3 = Set(initialize=[4, 5, 6])
+        m.s4 = Set(initialize=["c", "d"])
+        m.v12 = Var(m.s1, m.s2)
+        m.v124 = Var(m.s1, m.s2, m.s4)
+        return m
     
     def test_no_sets(self):
-        pass
+        m = self.make_model()
+        var = m.v12
+        sets = (m.s3, m.s4)
+        ref_data = {self._hashRef(v) for v in m.v12.values()}
+
+        slices = [slice_ for _, slice_ in slice_component_along_sets(var, sets)]
+        self.assertEqual(len(slices), len(ref_data))
+        self.assertEqual(len(slices), len(m.s1)*len(m.s2))
+        for slice_ in slices:
+            self.assertIn(self._hashRef(slice_), ref_data)
 
     def test_one_set(self):
-        pass
+        m = self.make_model()
+        var = m.v124
+        sets = (m.s1, m.s3)
+        ref_data = {
+            self._hashRef(Reference(m.v124[:, i, j])) for i, j in m.s2*m.s4
+        }
+
+        slices = [s for _, s in slice_component_along_sets(var, sets)]
+        self.assertEqual(len(slices), len(ref_data))
+        self.assertEqual(len(slices), len(m.s2)*len(m.s4))
+        for slice_ in slices:
+            self.assertIn(self._hashRef(Reference(slice_)), ref_data)
 
     def test_some_sets(self):
-        pass
+        m = self.make_model()
+        var = m.v124
+        sets = (m.s1, m.s3)
+        ref_data = {
+            self._hashRef(Reference(m.v124[:, i, j])) for i, j in m.s2*m.s4
+        }
+
+        slices = [s for _, s in slice_component_along_sets(var, sets)]
+        self.assertEqual(len(slices), len(ref_data))
+        self.assertEqual(len(slices), len(m.s2)*len(m.s4))
+        for slice_ in slices:
+            self.assertIn(self._hashRef(Reference(slice_)), ref_data)
 
     def test_all_sets(self):
-        pass
+        m = self.make_model()
+        var = m.v12
+        sets = (m.s1, m.s2)
+        ref_data = {self._hashRef(Reference(m.v12[:, :]))}
+
+        slices = [s for _, s in slice_component_along_sets(var, sets)]
+        self.assertEqual(len(slices), len(ref_data))
+        self.assertEqual(len(slices), 1)
+        for slice_ in slices:
+            self.assertIn(self._hashRef(Reference(slice_)), ref_data)
 
 
 class TestExceptional(unittest.TestCase):

--- a/pyomo/dae/tests/test_flatten.py
+++ b/pyomo/dae/tests/test_flatten.py
@@ -1217,7 +1217,7 @@ class TestCUID(unittest.TestCase):
 
         sets = (m.s1, m.s2)
         ctype = Var
-        sets_list, comps_list = flatten_components_along_sets(m, sets, Var)
+        sets_list, comps_list = flatten_components_along_sets(m, sets, ctype)
         for sets, comps in zip(sets_list, comps_list):
             if len(sets) == 1 and sets[0] is UnindexedComponent_set:
                 self.assertEqual(len(comps), len(m.s1)*len(m.s2))
@@ -1242,7 +1242,7 @@ class TestCUID(unittest.TestCase):
 
         sets = (m.s3, m.s4)
         ctype = Var
-        sets_list, comps_list = flatten_components_along_sets(m, sets, Var)
+        sets_list, comps_list = flatten_components_along_sets(m, sets, ctype)
         for sets, comps in zip(sets_list, comps_list):
             if len(sets) == 1 and sets[0] is m.s4:
                 self.assertEqual(len(comps), len(m.s1))
@@ -1266,7 +1266,7 @@ class TestCUID(unittest.TestCase):
 
         sets = (m.s3, m.s4)
         ctype = Var
-        sets_list, comps_list = flatten_components_along_sets(m, sets, Var)
+        sets_list, comps_list = flatten_components_along_sets(m, sets, ctype)
         for sets, comps in zip(sets_list, comps_list):
             if len(sets) == 2 and sets[0] is m.s3 and sets[1] is m.s4:
                 self.assertEqual(len(comps), 1)
@@ -1287,7 +1287,7 @@ class TestCUID(unittest.TestCase):
 
         sets = (m.s1,)
         ctype = Var
-        sets_list, comps_list = flatten_components_along_sets(m, sets, Var)
+        sets_list, comps_list = flatten_components_along_sets(m, sets, ctype)
         self.assertEqual(len(sets_list), 1)
         self.assertEqual(len(comps_list), 1)
         for sets, comps in zip(sets_list, comps_list):
@@ -1320,7 +1320,7 @@ class TestCUID(unittest.TestCase):
 
         sets = (m.s3, m.s4)
         ctype = Var
-        sets_list, comps_list = flatten_components_along_sets(m, sets, Var)
+        sets_list, comps_list = flatten_components_along_sets(m, sets, ctype)
         self.assertEqual(len(sets_list), 1)
         self.assertEqual(len(comps_list), 1)
         for sets, comps in zip(sets_list, comps_list):
@@ -1348,7 +1348,7 @@ class TestCUID(unittest.TestCase):
 
         sets = (m.s1, m.s4)
         ctype = Var
-        sets_list, comps_list = flatten_components_along_sets(m, sets, Var)
+        sets_list, comps_list = flatten_components_along_sets(m, sets, ctype)
         self.assertEqual(len(sets_list), 1)
         self.assertEqual(len(comps_list), 1)
         for sets, comps in zip(sets_list, comps_list):
@@ -1376,11 +1376,33 @@ class TestCUID(unittest.TestCase):
 
         sets = (m.s1, m.s2)
         ctype = Var
-        sets_list, comps_list = flatten_components_along_sets(m, sets, Var)
+        sets_list, comps_list = flatten_components_along_sets(m, sets, ctype)
         self.assertEqual(len(sets_list), 1)
         self.assertEqual(len(comps_list), 1)
         for sets, comps in zip(sets_list, comps_list):
             if len(sets) == 2 and sets[0] is m.s1 and sets[1] is m.s2:
+                self.assertEqual(len(comps), 1)
+                cuid_set = set(str(ComponentUID(comp.referent))
+                        for comp in comps)
+                self.assertEqual(cuid_set, pred_cuid_set)
+            else:
+                raise RuntimeError()
+
+    def test_cuids_multiple_slices(self):
+        m = ConcreteModel()
+        m.s1 = Set(initialize=[1, 2, 3])
+        def block_rule(b, i):
+            b.v = Var(m.s1)
+        m.b = Block(m.s1, rule=block_rule)
+
+        pred_cuid_set = {"b[*].v[*]"}
+        sets = (m.s1,)
+        ctype = Var
+        sets_list, comps_list = flatten_components_along_sets(m, sets, ctype)
+        self.assertEqual(len(sets_list), 1)
+        self.assertEqual(len(comps_list), 1)
+        for sets, comps in zip(sets_list, comps_list):
+            if len(sets) == 2 and sets[0] is m.s1 and sets[1] is m.s1:
                 self.assertEqual(len(comps), 1)
                 cuid_set = set(str(ComponentUID(comp.referent))
                         for comp in comps)

--- a/pyomo/dae/tests/test_flatten.py
+++ b/pyomo/dae/tests/test_flatten.py
@@ -27,6 +27,7 @@ from pyomo.core.base.indexed_component import (
 from pyomo.dae.flatten import (
         flatten_dae_components,
         flatten_components_along_sets,
+        slice_component_along_sets,
         )
 
 class TestAssumedBehavior(unittest.TestCase):
@@ -1386,6 +1387,21 @@ class TestCUID(unittest.TestCase):
                 self.assertEqual(cuid_set, pred_cuid_set)
             else:
                 raise RuntimeError()
+
+
+class TestSliceComponent(unittest.TestCase):
+    
+    def test_no_sets(self):
+        pass
+
+    def test_one_set(self):
+        pass
+
+    def test_some_sets(self):
+        pass
+
+    def test_all_sets(self):
+        pass
 
 
 class TestExceptional(unittest.TestCase):

--- a/pyomo/dae/tests/test_flatten.py
+++ b/pyomo/dae/tests/test_flatten.py
@@ -1275,6 +1275,29 @@ class TestCUID(unittest.TestCase):
             else:
                 raise RuntimeError()
 
+    def test_cuid_one_set_no_subblocks(self):
+        m = ConcreteModel()
+        m.s1 = Set(initialize=[1, 2, 3])
+        m.v = Var(m.s1)
+
+        pred_cuid_set = {
+            "v[*]",
+        }
+
+        sets = (m.s1,)
+        ctype = Var
+        sets_list, comps_list = flatten_components_along_sets(m, sets, Var)
+        self.assertEqual(len(sets_list), 1)
+        self.assertEqual(len(comps_list), 1)
+        for sets, comps in zip(sets_list, comps_list):
+            if len(sets) == 1 and sets[0] is m.s1:
+                self.assertEqual(len(comps), 1)
+                cuid_set = set(str(ComponentUID(comp.referent))
+                        for comp in comps)
+                self.assertEqual(cuid_set, pred_cuid_set)
+            else:
+                raise RuntimeError()
+
     def test_cuids_no_sets_with_subblocks(self):
         m = ConcreteModel()
         m.s1 = Set(initialize=[1, 2, 3])


### PR DESCRIPTION
## Summary/Motivation:
`flatten_components_along_sets` basically does two things. One is that it "reshapes" components into other components indexed only by some "subset" of their indexing sets. The other is that it flattens the block hierarchy, so that all indices in parent blocks may be applied to a single component. The first piece of functionality is equally useful applied to a single component as to all components in a model or block. This PR adds a utility function, `slice_component_along_sets`, that generates slices of the given component along the sets specified, and uses this utility function to cut down some duplicated code in the `generate_sliced_components` function. An example use case is generating all "derivative variables" from a single `DerivativeVar`, where a "derivative variable" is something indexed only by time. It is sometimes useful to assume that "derivative variables" are indexed only by time, so they may all be accessed in a consistent manner.
```python
import pyomo.environ as pyo 
import pyomo.dae as dae 
from pyomo.dae.flatten import slice_component_along_sets


def main():
    m = pyo.ConcreteModel()
    m.s = pyo.Set(initialize=["a", "b"])
    m.time = dae.ContinuousSet(initialize=[0, 10])
    m.v = pyo.Var(m.s, m.time)
    m.dv = dae.DerivativeVar(m.v, wrt=m.time)

    for idx, slice_ in slice_component_along_sets(m.dv, (m.time,)):
        print(str(pyo.ComponentUID(slice_)))


if __name__ == "__main__":
    main()
```
Output:
```
dv[a,*]
dv[b,*]
```


This PR also addresses an inconsistency where CUIDs from slices from the flattener would contain a double asterisk even if they were constructed from a constant-dimension slice. This made it hard to use these CUIDs as keys in a dict that stored data related to sliced components. The old behavior was:
```python
import pyomo.environ as pyo 
from pyomo.dae.flatten import (
    flatten_dae_components,
    flatten_components_along_sets,
    )   


def main():
    m = pyo.ConcreteModel()
    m.time = pyo.Set(initialize=[1,2,3])
    m.v = pyo.Var(m.time)
    m.b = pyo.Block(m.time)
    for t in m.time:
        m.b[t].v = pyo.Var()
        m.b[t].vt = pyo.Var(m.time)

    comps_cuid_list = []
    sets_list, comps_list = flatten_components_along_sets(m, (m.time,), pyo.Var) 
    for comps in comps_list:
        for comp in comps:
            cuid = pyo.ComponentUID(comp.referent)
            comps_cuid_list.append(str(cuid))
            print(cuid)

    # This is a problem, we would expect only a single asterisk
    # here.
    assert comps_cuid_list == ['v[**]', 'b[**].v', 'b[**].vt[**]']


if __name__ == "__main__":
    main()
```
and the new behavior is:
```python
import pyomo.environ as pyo
from pyomo.dae.flatten import (
    flatten_dae_components,
    flatten_components_along_sets,
    )


def main():
    m = pyo.ConcreteModel()
    m.time = pyo.Set(initialize=[1,2,3])
    m.v = pyo.Var(m.time)
    m.b = pyo.Block(m.time)
    for t in m.time:
        m.b[t].v = pyo.Var()
        m.b[t].vt = pyo.Var(m.time)

    comps_cuid_list = []
    sets_list, comps_list = flatten_components_along_sets(m, (m.time,), pyo.Var)
    for comps in comps_list:
        for comp in comps:
            cuid = pyo.ComponentUID(comp.referent)
            comps_cuid_list.append(str(cuid))
            print(cuid)

    # This is what we expect
    assert comps_cuid_list == ['v[*]', 'b[*].v', 'b[*].vt[*]']


if __name__ == "__main__":
    main()
```

## Changes proposed in this PR:
- Add `slice_component_along_sets` generator
- Change slice creation in `flatten` module to make CUIDs more consistent

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
