### PR TITLE
Add option to force variables into nl file (for DAEs)

### DIFF
--- a/pyomo/repn/plugins/ampl/ampl_.py
+++ b/pyomo/repn/plugins/ampl/ampl_.py
@@ -1145,7 +1145,8 @@ class ProblemWriter_nl(AbstractProblemWriter):
 
         if export_nonlinear_variables:
             for v in export_nonlinear_variables:
-                for vi in v.values():
+                v_iter = v.values() if v.is_indexed() else iter((v,))
+                for vi in v_iter:
                     if self_varID_map[id(vi)] not in UsedVars:
                         Vars_dict[id(vi)] = vi
                         ConNonlinearVars.update([self_varID_map[id(vi)]])

--- a/pyomo/repn/tests/ampl/test_ampl_nl.py
+++ b/pyomo/repn/tests/ampl/test_ampl_nl.py
@@ -100,6 +100,25 @@ class TestNLWriter(unittest.TestCase):
 
         self._cleanup(test_fname)
 
+        model.write(
+            test_fname,
+            format='nl',
+            io_options={
+                'symbolic_solver_labels':True,
+                'export_nonlinear_variables':[model.z, model.w[2]]
+            }
+        )
+        with open(test_fname + '.col') as f:
+            names = list(map(str.strip, f.readlines()))
+        assert "z" in names
+        assert "y" not in names
+        assert "x" in names
+        assert "w[1]" not in names
+        assert "w[2]" in names
+        assert "w[3]" not in names
+
+        self._cleanup(test_fname)
+
     def test_var_on_other_model(self):
         other = ConcreteModel()
         other.a = Var()


### PR DESCRIPTION
## Fixes #855

## Summary/Motivation:

For the PETSc DAE solver, differential variables may not appear in constraints, but they need to be in the NL file.  The ASL seems ok with having the extra variables.  I guess this would lead to empty columns in the Jacobian for variables that don't appear in constraints.  The empty columns get filled in when I put together the Jacobian for the DAE.  I tested this with the DAE solver and it seems to work correctly.  I'm not really sure if there is a use for this outside the DAE solver.

## Changes proposed in this PR:
- Add the force_in_nonlinear_constraint_vars option for AMPL type solvers to force variable into an nl-file even when they do not appear in constraints.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
