### PR TITLE
Add support for custom pint registries

### DIFF
--- a/pyomo/core/base/units_container.py
+++ b/pyomo/core/base/units_container.py
@@ -111,7 +111,11 @@ import logging
 import sys
 
 from pyomo.common.dependencies import attempt_import
-from pyomo.core.expr.numvalue import NumericValue, nonpyomo_leaf_types, value, native_types, native_numeric_types, pyomo_constant_types
+from pyomo.common.modeling import NOTSET
+from pyomo.core.expr.numvalue import (
+    NumericValue, nonpyomo_leaf_types, value, native_types,
+    native_numeric_types, pyomo_constant_types,
+)
 from pyomo.core.expr.template_expr import IndexTemplate
 from pyomo.core.expr import current as EXPR
 
@@ -965,8 +969,10 @@ class PyomoUnitsContainer(object):
         on the class until they are requested.
 
     """
-    def __init__(self, pint_registry):
+    def __init__(self, pint_registry=NOTSET):
         """Create a PyomoUnitsContainer instance."""
+        if pint_registry is NOTSET:
+            pint_registry = pint_module.UnitRegistry()
         self._pint_registry = pint_registry
         if pint_registry is None:
             self._pint_dimensionless = None
@@ -992,11 +998,10 @@ class PyomoUnitsContainer(object):
             :skipif: not pint_available
             :hide:
 
-            # get a local units object (to avoid duplicate registration
+            # Get a local units object (to avoid duplicate registration
             # with the example in load_definitions_from_strings)
-            >>> import pint
             >>> import pyomo.core.base.units_container as _units
-            >>> u = _units.PyomoUnitsContainer(pint.UnitRegistry())
+            >>> u = _units.PyomoUnitsContainer()
             >>> with open('my_additional_units.txt', 'w') as FILE:
             ...     tmp = FILE.write("USD = [currency]\\n")
 
@@ -1011,6 +1016,7 @@ class PyomoUnitsContainer(object):
             :skipif: not pint_available
             :hide:
 
+            # Clean up the file we just created
             >>> import os
             >>> os.remove('my_additional_units.txt')
 
@@ -1037,7 +1043,7 @@ class PyomoUnitsContainer(object):
             # with the example in load_definitions_from_strings)
             >>> import pint
             >>> import pyomo.core.base.units_container as _units
-            >>> u = _units.PyomoUnitsContainer(pint.UnitRegistry())
+            >>> u = _units.PyomoUnitsContainer()
 
         .. doctest::
             :skipif: not pint_available

--- a/pyomo/core/tests/unit/test_units.py
+++ b/pyomo/core/tests/unit/test_units.py
@@ -37,6 +37,33 @@ def python_callback_function(arg1, arg2):
 @unittest.skipIf(not pint_available, 'Testing units requires pint')
 class TestPyomoUnit(unittest.TestCase):
 
+    def test_container_constructor(self):
+        # Custom pint registry:
+        um0 = PyomoUnitsContainer(None)
+        self.assertIsNone(um0.pint_registry)
+        self.assertIsNone(um0._pint_dimensionless)
+        um1 = PyomoUnitsContainer()
+        self.assertIsNotNone(um1.pint_registry)
+        self.assertIsNotNone(um1._pint_dimensionless)
+        with self.assertRaisesRegex(
+                ValueError,
+                'Cannot operate with Unit and Unit of different registries'):
+            self.assertEqual(um1._pint_dimensionless, units._pint_dimensionless)
+        self.assertIsNot(um1.pint_registry, units.pint_registry)
+        um2 = PyomoUnitsContainer(pint_module.UnitRegistry())
+        self.assertIsNotNone(um2.pint_registry)
+        self.assertIsNotNone(um2._pint_dimensionless)
+        with self.assertRaisesRegex(
+                ValueError,
+                'Cannot operate with Unit and Unit of different registries'):
+            self.assertEqual(um2._pint_dimensionless, units._pint_dimensionless)
+        self.assertIsNot(um2.pint_registry, units.pint_registry)
+        self.assertIsNot(um2.pint_registry, um1.pint_registry)
+
+        um3 = PyomoUnitsContainer(units.pint_registry)
+        self.assertIs(um3.pint_registry, units.pint_registry)
+        self.assertEqual(um3._pint_dimensionless, units._pint_dimensionless)
+
     def test_PyomoUnit_NumericValueMethods(self):
         m = ConcreteModel()
         uc = units


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
#2140 requested a mechanism for supporting custom Pint `UnitRegistry` instances in the Pyomo units system.  This PR adds a mechanism for setting the Pint `UnitRegistry` instance used by Pyomo.  The basic idea is that a user can call:

```python
>>> import pint
>>> my_ureg = pint.UnitRegistry()
>>> 
>>> import pyomo.environ as pyo
>>> pyo.units.set_pint_registry(my_ureg)
>>> pyo.units.pint_registry is my_ureg
True
```

If `set_pint_registry` is called after `pyo.units` has been accessed in another context (e.g., to declare a unit), the internal pint registry is changed and a warning is emitted (and the user is likely to get later exceptions from pint, as pint does not support comparing units across `pint.UnitRegistry` instances).

Note that this updates `PyomoUnitsContainer.__init__()` to require a single argument (the Pint `UnitRegistry` instance).

## Changes proposed in this PR:
- Add `set_pint_registry()` method to set a custom Pint registry
- Add public `pint_registry` property to get the current Pint registry
- Add tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
