### PR TITLE
 `calculate_variable_from_constraint()` should ignore bounds/domain when updating variable value

### DIFF
--- a/pyomo/util/calc_var_value.py
+++ b/pyomo/util/calc_var_value.py
@@ -28,6 +28,12 @@ def calculate_variable_from_constraint(variable, constraint,
     residual, it falls back on Newton's method using exact (symbolic)
     derivatives.
 
+    Notes
+    -----
+    This is an unconstrained solver and is NOT guaranteed to respect the
+    variable bounds or domain.  The solver may leave the variable value
+    in an infeasible state (outside the declared bounds or domain bounds).
+
     Parameters:
     -----------
     variable: :py:class:`_VarData`
@@ -52,9 +58,6 @@ def calculate_variable_from_constraint(variable, constraint,
     Returns:
     --------
     None
-
-    Note: this is an unconstrained solver and is NOT guaranteed to
-    respect the variable bounds.
 
     """
     # Leverage all the Constraint logic to process the incoming tuple/expression

--- a/pyomo/util/calc_var_value.py
+++ b/pyomo/util/calc_var_value.py
@@ -73,27 +73,30 @@ def calculate_variable_from_constraint(variable, constraint,
         raise ValueError("Constraint must be an equality constraint")
 
     if variable.value is None:
+        # Note that we use "valid=True" here as well, as the variable
+        # domain may not admit the calculated initial guesses, and we
+        # want to bypass that check.
         if variable.lb is None:
             if variable.ub is None:
                 # no variable values, and no lower or upper bound - set
                 # initial value to 0.0
-                variable.set_value(0)
+                variable.set_value(0, valid=True)
             else:
                 # no variable value or lower bound - set to 0 or upper
                 # bound whichever is lower
-                variable.set_value(min(0, variable.ub))
+                variable.set_value(min(0, variable.ub), valid=True)
         elif variable.ub is None:
             # no variable value or upper bound - set to 0 or lower
             # bound, whichever is higher
-            variable.set_value(max(0, variable.lb))
+            variable.set_value(max(0, variable.lb), valid=True)
         else:
             # we have upper and lower bounds
             if variable.lb <= 0 and variable.ub >= 0:
                 # set the initial value to 0 if bounds bracket 0
-                variable.set_value(0)
+                variable.set_value(0, valid=True)
             else:
                 # set the initial value to the midpoint of the bounds
-                variable.set_value((variable.lb+variable.ub)/2.0)
+                variable.set_value((variable.lb+variable.ub)/2.0, valid=True)
 
     # store the initial value to use later if necessary
     orig_initial_value = variable.value
@@ -113,7 +116,7 @@ def calculate_variable_from_constraint(variable, constraint,
             "initial guess.\n\tPlease provide a different initial guess.")
         raise
 
-    variable.set_value(x1 - (residual_1-upper))
+    variable.set_value(x1 - (residual_1-upper), valid=True)
     residual_2 = value(body, exception=False)
 
     # If we encounter an error while evaluating the expression at the
@@ -134,13 +137,13 @@ def calculate_variable_from_constraint(variable, constraint,
         slope = float(residual_1 - residual_2) / (x1 - x2)
         intercept = (residual_1-upper) - slope*x1
         if slope:
-            variable.set_value(-intercept/slope)
+            variable.set_value(-intercept/slope, valid=True)
             body_val = value(body, exception=False)
             if body_val is not None and abs(body_val-upper) < eps:
                 return
 
     # Variable appears nonlinearly; solve using Newton's method
-    variable.set_value(orig_initial_value) # restore initial value
+    variable.set_value(orig_initial_value, valid=True) # restore initial value
     expr = body - upper
     expr_deriv = differentiate(expr, wrt=variable,
                                mode=differentiate.Modes.sympy)
@@ -186,7 +189,7 @@ def calculate_variable_from_constraint(variable, constraint,
         pk = -fk/fpk
         alpha = 1.0
         xkp1 = xk + alpha * pk
-        variable.set_value(xkp1)
+        variable.set_value(xkp1, valid=True)
 
         # perform line search
         if linesearch:
@@ -208,7 +211,7 @@ def calculate_variable_from_constraint(variable, constraint,
                     break
                 alpha /= 2.0
                 xkp1 = xk + alpha * pk
-                variable.set_value(xkp1)
+                variable.set_value(xkp1, valid=True)
 
             if alpha <= alpha_min:
                 residual = value(expr, exception=False)

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -253,6 +253,8 @@ class Test_calc_var(unittest.TestCase):
         calculate_variable_from_constraint(m.v1, m.c3)
         self.assertEqual(value(m.v1), -0.1)
 
+    @unittest.skipUnless(differentiate_available, "this test requires sympy")
+    def test_nonlinear_bound_violation(self):
         # Test nonlinear solution falling outside bounds
         m.c4 = Constraint(expr=m.v1**3 == -8)
         m.v1.set_value(1)

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -255,6 +255,10 @@ class Test_calc_var(unittest.TestCase):
 
     @unittest.skipUnless(differentiate_available, "this test requires sympy")
     def test_nonlinear_bound_violation(self):
+        m = ConcreteModel()
+        m.v1 = Var(initialize=1, domain=NonNegativeReals)
+        m.c1 = Constraint(expr=m.v1 == 0)
+
         # Test nonlinear solution falling outside bounds
         m.c4 = Constraint(expr=m.v1**3 == -8)
         m.v1.set_value(1)


### PR DESCRIPTION
## Fixes #2176 .

## Summary/Motivation:
@andrewlee94 noted that `calculate_variable_from_constraint()` would raise exceptions if the intermediate values encountered by the solver fell outside the variable bounds (or were not admitted by the variable domain).  This PR updates the solver to avoid bounds/domain checking when setting the variable value.  As the method implements an unconstrined solver (which is documented in the function docstring), it should not surprise the user if the resulting variable values is outside the variable domain.

## Changes proposed in this PR:
- Ignore variable domain/bound when setting the variable value in `calculate_variable_from_constraint()`
- Add tests for behavior reported in #2176

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
