### PR TITLE
Allow `find_component` to work with `ComponentUID`

### DIFF
--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -901,7 +901,11 @@ class _BlockData(ActiveComponentData):
         """
         Return a block component given a name.
         """
-        return ComponentUID(label_or_component).find_component_on(self)
+        if type(label_or_component) is ComponentUID:
+            cuid = label_or_component
+        else:
+            cuid = ComponentUID(label_or_component)
+        return cuid.find_component_on(self)
 
     def add_component(self, name, val):
         """

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -899,7 +899,20 @@ class _BlockData(ActiveComponentData):
 
     def find_component(self, label_or_component):
         """
-        Return a block component given a name.
+        Returns a component in the block given a name.
+
+        Parameters
+        ----------
+        label_or_component : str, Component, or ComponentUID
+            The name of the component to find in this block. String or
+            Component arguments are first converted to ComponentUID.
+
+        Returns
+        -------
+        Component
+            Component on the block identified by the ComponentUID. If
+            a matching component is not found, None is returned.
+
         """
         if type(label_or_component) is ComponentUID:
             cuid = label_or_component


### PR DESCRIPTION
## Fixes:
The following code did not work:
```python
import pyomo.environ as pyo
m = pyo.ConcreteModel()
m.v = pyo.Var()
cuid = pyo.ComponentUID("v")
m.find_component(cuid)
```
Of course, `cuid.find_component_on(m)` would still work in this example.

## Summary/Motivation:
It's convenient to use the same syntax for finding a component from either a string or CUID.

## Changes proposed in this PR:
- `find_component` checks if its argument is a CUID and calls `find_component_on` appropriately
- Tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
