### PR TITLE
Skip specific MindtPy tests due to failure with Gurobi 9.5.0 on Windows

### DIFF
--- a/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
@@ -161,6 +161,13 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
+                    if mip_solver == 'gurobi_persistent' \
+                       and SolverFactory(mip_solver).version()[:3] == (9,5,0) \
+                       and model.name in {'DuranEx3', 'SimpleMINLP'} \
+                       and sys.platform.startswith('win'):
+                        sys.stderr.write(
+                            "Skipping test due to known solver issue\n")
+                        continue
                     sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
@@ -178,13 +185,6 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
-                    if mip_solver == 'gurobi_persistent' \
-                       and SolverFactory(mip_solver).version()[:3] == (9,5,0) \
-                       and model.name in {'DuranEx3', 'SimpleMINLP'} \
-                       and sys.platform.startswith('win'):
-                        sys.stderr.write(
-                            "Skipping test due to known solver issue\n")
-                        continue
                     sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,

--- a/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
@@ -102,8 +102,10 @@ class TestMindtPy(unittest.TestCase):
                 for mip_solver in available_mip_solvers:
                     if mip_solver == 'gurobi_persistent':
                         if SolverFactory(mip_solver).version()[:3] == (9,5,0) \
-                           and model == 'DuranEx3' \
+                           and model.name == 'DuranEx3' \
                            and sys.platform.startswith('win'):
+                            sys.stderr.write(
+                                "Skipping test due to known solver issue\n")
                             continue
                     sys.stderr.write(
                         f'Solving {model} with {mip_solver} '

--- a/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
@@ -43,7 +43,8 @@ def known_solver_failure(mip_solver, model):
          and sys.platform.startswith('win')
          and SolverFactory(mip_solver).version()[:3] == (9,5,0) ):
         sys.stderr.write(
-            "Skipping test due to known failure in Gurobi 9.5.0 on Windows\n"
+            f"Skipping sub-test {model.name} with {mip_solver} due to known "
+            f"failure when running Gurobi 9.5.0 on Windows\n"
         )
         return True
     return False
@@ -60,7 +61,6 @@ class TestMindtPy(unittest.TestCase):
         """Test the LP/NLP decomposition algorithm."""
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
-                sys.stderr.write(f'Solving {model}\n')
                 results = opt.solve(model, strategy='OA',
                                     mip_solver='cplex_persistent',
                                     nlp_solver=required_nlp_solvers,
@@ -77,7 +77,6 @@ class TestMindtPy(unittest.TestCase):
         """Test the LP/NLP decomposition algorithm."""
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
-                sys.stderr.write(f'Solving {model}\n')
                 results = opt.solve(model, strategy='OA',
                                     mip_solver='gurobi_persistent',
                                     nlp_solver=required_nlp_solvers,
@@ -93,7 +92,6 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
-                    sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -112,10 +110,6 @@ class TestMindtPy(unittest.TestCase):
                 for mip_solver in available_mip_solvers:
                     if known_solver_failure(mip_solver, model):
                         continue
-                    sys.stderr.write(
-                        f'Solving {model} with {mip_solver} '
-                        f'{SolverFactory(mip_solver).version()[:3]}'
-                        f' on {sys.platform}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -132,7 +126,6 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
-                    sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -149,7 +142,6 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
-                    sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -168,7 +160,6 @@ class TestMindtPy(unittest.TestCase):
                 for mip_solver in available_mip_solvers:
                     if known_solver_failure(mip_solver, model):
                         continue
-                    sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -187,7 +178,6 @@ class TestMindtPy(unittest.TestCase):
                 for mip_solver in available_mip_solvers:
                     if known_solver_failure(mip_solver, model):
                         continue
-                    sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -206,7 +196,6 @@ class TestMindtPy(unittest.TestCase):
                 for mip_solver in available_mip_solvers:
                     if known_solver_failure(mip_solver, model):
                         continue
-                    sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,

--- a/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
@@ -46,6 +46,7 @@ class TestMindtPy(unittest.TestCase):
         """Test the LP/NLP decomposition algorithm."""
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
+                print(f'Solving {model}')
                 results = opt.solve(model, strategy='OA',
                                     mip_solver='cplex_persistent',
                                     nlp_solver=required_nlp_solvers,
@@ -62,6 +63,7 @@ class TestMindtPy(unittest.TestCase):
         """Test the LP/NLP decomposition algorithm."""
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
+                print(f'Solving {model}')
                 results = opt.solve(model, strategy='OA',
                                     mip_solver='gurobi_persistent',
                                     nlp_solver=required_nlp_solvers,
@@ -77,6 +79,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
+                    print(f'Solving {model} with {mip_solver}')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -93,6 +96,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
+                    print(f'Solving {model} with {mip_solver}')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -109,6 +113,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
+                    print(f'Solving {model} with {mip_solver}')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -125,6 +130,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
+                    print(f'Solving {model} with {mip_solver}')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -141,6 +147,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
+                    print(f'Solving {model} with {mip_solver}')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -157,6 +164,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
+                    print(f'Solving {model} with {mip_solver}')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -173,6 +181,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
+                    print(f'Solving {model} with {mip_solver}')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,

--- a/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
@@ -100,6 +100,11 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
+                    if mip_solver == 'gurobi_persistent':
+                        if SolverFactory(mip_solver).version()[:3] == (9,5,0) \
+                           and model == 'DuranEx3' \
+                           and sys.platform.startswith('win'):
+                            continue
                     sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,

--- a/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
@@ -37,6 +37,16 @@ model_list = [EightProcessFlowsheet(convex=True),
               SimpleMINLP()
               ]
 
+def known_solver_failure(mip_solver, model):
+    if ( mip_solver == 'gurobi_persistent'
+         and model.name in {'DuranEx3', 'SimpleMINLP'}
+         and sys.platform.startswith('win')
+         and SolverFactory(mip_solver).version()[:3] == (9,5,0) ):
+        sys.stderr.write(
+            "Skipping test due to known failure in Gurobi 9.5.0 on Windows\n"
+        )
+        return True
+    return False
 
 @unittest.skipIf(not subsolvers_available,
                  'Required subsolvers %s are not available'
@@ -100,12 +110,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
-                    if mip_solver == 'gurobi_persistent' \
-                       and SolverFactory(mip_solver).version()[:3] == (9,5,0) \
-                       and model.name in {'DuranEx3', 'SimpleMINLP'} \
-                       and sys.platform.startswith('win'):
-                        sys.stderr.write(
-                            "Skipping test due to known solver issue\n")
+                    if known_solver_failure(mip_solver, model):
                         continue
                     sys.stderr.write(
                         f'Solving {model} with {mip_solver} '
@@ -161,12 +166,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
-                    if mip_solver == 'gurobi_persistent' \
-                       and SolverFactory(mip_solver).version()[:3] == (9,5,0) \
-                       and model.name in {'DuranEx3', 'SimpleMINLP'} \
-                       and sys.platform.startswith('win'):
-                        sys.stderr.write(
-                            "Skipping test due to known solver issue\n")
+                    if known_solver_failure(mip_solver, model):
                         continue
                     sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
@@ -185,12 +185,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
-                    if mip_solver == 'gurobi_persistent' \
-                       and SolverFactory(mip_solver).version()[:3] == (9,5,0) \
-                       and model.name in {'DuranEx3', 'SimpleMINLP'} \
-                       and sys.platform.startswith('win'):
-                        sys.stderr.write(
-                            "Skipping test due to known solver issue\n")
+                    if known_solver_failure(mip_solver, model):
                         continue
                     sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
@@ -209,6 +204,8 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
+                    if known_solver_failure(mip_solver, model):
+                        continue
                     sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,

--- a/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
@@ -107,8 +107,8 @@ class TestMindtPy(unittest.TestCase):
                             continue
                     sys.stderr.write(
                         f'Solving {model} with {mip_solver} '
-                        '{SolverFactory(mip_solver).version()[:3]}'
-                        ' on {sys.platform}\n')
+                        f'{SolverFactory(mip_solver).version()[:3]}'
+                        f' on {sys.platform}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,

--- a/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
@@ -9,11 +9,15 @@
 #  ___________________________________________________________________________
 
 """Tests for the MindtPy solver."""
+import sys
 import pyomo.common.unittest as unittest
-from pyomo.contrib.mindtpy.tests.eight_process_problem import \
-    EightProcessFlowsheet
+from pyomo.contrib.mindtpy.tests.eight_process_problem import (
+    EightProcessFlowsheet,
+)
 from pyomo.contrib.mindtpy.tests.MINLP_simple import SimpleMINLP as SimpleMINLP
-from pyomo.contrib.mindtpy.tests.constraint_qualification_example import ConstraintQualificationExample
+from pyomo.contrib.mindtpy.tests.constraint_qualification_example import (
+    ConstraintQualificationExample,
+)
 from pyomo.environ import SolverFactory, value
 from pyomo.opt import TerminationCondition
 
@@ -46,7 +50,7 @@ class TestMindtPy(unittest.TestCase):
         """Test the LP/NLP decomposition algorithm."""
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
-                print(f'Solving {model}')
+                sys.stderr.write(f'Solving {model}\n')
                 results = opt.solve(model, strategy='OA',
                                     mip_solver='cplex_persistent',
                                     nlp_solver=required_nlp_solvers,
@@ -63,7 +67,7 @@ class TestMindtPy(unittest.TestCase):
         """Test the LP/NLP decomposition algorithm."""
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
-                print(f'Solving {model}')
+                sys.stderr.write(f'Solving {model}\n')
                 results = opt.solve(model, strategy='OA',
                                     mip_solver='gurobi_persistent',
                                     nlp_solver=required_nlp_solvers,
@@ -79,7 +83,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
-                    print(f'Solving {model} with {mip_solver}')
+                    sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -96,7 +100,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
-                    print(f'Solving {model} with {mip_solver}')
+                    sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -113,7 +117,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
-                    print(f'Solving {model} with {mip_solver}')
+                    sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -130,7 +134,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
-                    print(f'Solving {model} with {mip_solver}')
+                    sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -147,7 +151,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
-                    print(f'Solving {model} with {mip_solver}')
+                    sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -164,7 +168,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
-                    print(f'Solving {model} with {mip_solver}')
+                    sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,
@@ -181,7 +185,7 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
-                    print(f'Solving {model} with {mip_solver}')
+                    sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,

--- a/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
@@ -100,13 +100,13 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
-                    if mip_solver == 'gurobi_persistent':
-                        if SolverFactory(mip_solver).version()[:3] == (9,5,0) \
-                           and model.name == 'DuranEx3' \
-                           and sys.platform.startswith('win'):
-                            sys.stderr.write(
-                                "Skipping test due to known solver issue\n")
-                            continue
+                    if mip_solver == 'gurobi_persistent' \
+                       and SolverFactory(mip_solver).version()[:3] == (9,5,0) \
+                       and model.name in {'DuranEx3', 'SimpleMINLP'} \
+                       and sys.platform.startswith('win'):
+                        sys.stderr.write(
+                            "Skipping test due to known solver issue\n")
+                        continue
                     sys.stderr.write(
                         f'Solving {model} with {mip_solver} '
                         f'{SolverFactory(mip_solver).version()[:3]}'

--- a/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
@@ -105,7 +105,10 @@ class TestMindtPy(unittest.TestCase):
                            and model == 'DuranEx3' \
                            and sys.platform.startswith('win'):
                             continue
-                    sys.stderr.write(f'Solving {model} with {mip_solver}\n')
+                    sys.stderr.write(
+                        f'Solving {model} with {mip_solver} '
+                        '{SolverFactory(mip_solver).version()[:3]}'
+                        ' on {sys.platform}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,
                                         nlp_solver=required_nlp_solvers,

--- a/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
@@ -185,6 +185,13 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
+                    if mip_solver == 'gurobi_persistent' \
+                       and SolverFactory(mip_solver).version()[:3] == (9,5,0) \
+                       and model.name in {'DuranEx3', 'SimpleMINLP'} \
+                       and sys.platform.startswith('win'):
+                        sys.stderr.write(
+                            "Skipping test due to known solver issue\n")
+                        continue
                     sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,

--- a/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
+++ b/pyomo/contrib/mindtpy/tests/test_mindtpy_lp_nlp.py
@@ -178,6 +178,13 @@ class TestMindtPy(unittest.TestCase):
         with SolverFactory('mindtpy') as opt:
             for model in model_list:
                 for mip_solver in available_mip_solvers:
+                    if mip_solver == 'gurobi_persistent' \
+                       and SolverFactory(mip_solver).version()[:3] == (9,5,0) \
+                       and model.name in {'DuranEx3', 'SimpleMINLP'} \
+                       and sys.platform.startswith('win'):
+                        sys.stderr.write(
+                            "Skipping test due to known solver issue\n")
+                        continue
                     sys.stderr.write(f'Solving {model} with {mip_solver}\n')
                     results = opt.solve(model, strategy='OA',
                                         mip_solver=mip_solver,


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

Specific MindtPy tests cause the test suite to fail catastrophically when run using Gurobi 9.5.0 (from conda) under Windows.  The same tests do not fail on Linux, nor do they fail with other versions of Gurobi.  Instead of removing / reworking those tests, this PR skips those specific sub-tests (2 tests, only on Windows, and only when running with Gurobi 9.5.0) so that CI builds resume passing.

## Changes proposed in this PR:
- skip specific MindtPy tests in very specific situations

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
