### PR TITLE
Fix MindtPy Feasibility Pump standalone bug

### DIFF
--- a/pyomo/contrib/mindtpy/initialization.py
+++ b/pyomo/contrib/mindtpy/initialization.py
@@ -157,7 +157,7 @@ def init_rNLP(solve_data, config):
                 copy_var_list_values(m.MindtPy_utils.variable_list,
                                      solve_data.working_model.MindtPy_utils.variable_list,
                                      config, ignore_integrality=True)
-            if config.strategy == 'OA':
+            if config.strategy in {'OA', 'FP'}:
                 add_oa_cuts(solve_data.mip, dual_values, solve_data, config)
             elif config.strategy == 'GOA':
                 add_affine_cuts(solve_data, config)


### PR DESCRIPTION
## Fixes # .


## Summary/Motivation:
MindtPy provides feasibility pump implementation both as an initialization strategy and a standalone decomposition strategy (like OA). In the previous Feasibility Pump standalone implementation, no OA cuts are added after solving the relaxed NLP problem. This PR fixes this bug.

## Changes proposed in this PR:
- initialization.py

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
