### PR TITLE
Fix typo in booktest skip declaration

### DIFF
--- a/examples/pyomobook/test_book_examples.py
+++ b/examples/pyomobook/test_book_examples.py
@@ -58,7 +58,7 @@ solver_dependencies =   {
     'test_dae_ch_run_path_constraint_tester': ['ipopt'],
 
     # gdp_ch
-    'test_gdp_ch_pyomo_gdp_uc_sh': ['glpk'],
+    'test_gdp_ch_pyomo_gdp_uc': ['glpk'],
     'test_gdp_ch_pyomo_scont': ['glpk'],
     'test_gdp_ch_pyomo_scont2': ['glpk'],
     'test_gdp_ch_scont_script': ['glpk'],


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This fixes the last failing test in the Jenkins "no solvers" test suite.  The test should be skipped when GLPK is not available, but the declaration was skipping the wrong test name.

## Changes proposed in this PR:
- Resolve error skipping Book test when GLPK is not available.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
