### PR TITLE
Fix errors and deprecation warnings in some DAE examples

### DIFF
--- a/examples/dae/distill_DAE.py
+++ b/examples/dae/distill_DAE.py
@@ -21,7 +21,7 @@ model.atray = Param(initialize = 0.25)
 model.acond = Param(initialize = 0.5)
 model.areb = Param(initialize = 1.0)
 
-model.S_TRAYS = Set()  
+model.S_TRAYS = Set(dimen=1)
 model.S_RECTIFICATION = Set(within = model.S_TRAYS)  
 model.S_STRIPPING = Set(within = model.S_TRAYS)  
 model.x0 = Param(model.S_TRAYS)

--- a/examples/dae/run_stochpdegas_automatic.py
+++ b/examples/dae/run_stochpdegas_automatic.py
@@ -15,7 +15,7 @@ discretizer.apply_to(instance,nfe=47,wrt=instance.TIME,scheme='BACKWARD')
 # What it should be to match description in paper
 #discretizer.apply_to(instance,nfe=48,wrt=instance.TIME,scheme='BACKWARD')
 
-TimeStep = instance.TIME[2]-instance.TIME[1]
+TimeStep = instance.TIME.at(2) - instance.TIME.at(1)
 
 def supcost_rule(m,k):
     return sum(m.cs*m.s[k,j,t]*(TimeStep) for j in m.SUP for t in m.TIME.get_finite_elements())

--- a/examples/dae/stochpdegas_automatic.py
+++ b/examples/dae/stochpdegas_automatic.py
@@ -21,11 +21,11 @@ model.SCEN = RangeSet(1,model.S)
 
 # links
 model.LINK = Set(dimen=1)
-model.lstartloc = Param(model.LINK)
-model.lendloc = Param(model.LINK)
+model.lstartloc = Param(model.LINK, within=Any)
+model.lendloc = Param(model.LINK, within=Any)
 model.ldiam = Param(model.LINK,within=PositiveReals,mutable=True)
 model.llength = Param(model.LINK,within=PositiveReals,mutable=True)
-model.ltype = Param(model.LINK)
+model.ltype = Param(model.LINK, within=Any)
 
 def link_a_init_rule(m):
     return (l for l in m.LINK if m.ltype[l] == "a")
@@ -42,14 +42,14 @@ model.pmax = Param(model.NODE,within=PositiveReals,mutable=True)
 
 # supply
 model.SUP = Set()
-model.sloc = Param(model.SUP)
+model.sloc = Param(model.SUP, within=Any)
 model.smin = Param(model.SUP,within=NonNegativeReals,mutable=True)
 model.smax = Param(model.SUP,within=NonNegativeReals,mutable=True)
 model.scost = Param(model.SUP,within=NonNegativeReals)
 
 # demand
 model.DEM = Set()
-model.dloc = Param(model.DEM)
+model.dloc = Param(model.DEM, within=Any)
 model.d = Param(model.DEM, within=PositiveReals,mutable=True)
 
 # physical data

--- a/examples/dae/stochpdegas_automatic.py
+++ b/examples/dae/stochpdegas_automatic.py
@@ -20,7 +20,7 @@ model.S = Param(within=PositiveIntegers)
 model.SCEN = RangeSet(1,model.S)
 
 # links
-model.LINK = Set()
+model.LINK = Set(dimen=1)
 model.lstartloc = Param(model.LINK)
 model.lendloc = Param(model.LINK)
 model.ldiam = Param(model.LINK,within=PositiveReals,mutable=True)


### PR DESCRIPTION
## Fixes:
- Errors in **distill.py** and **stochpdegas_automatic.py** due to creating a derivative involving a set with no dimension (due to the model being abstract)
- Deprecation warnings in **stochpdegas_automatic.py** due to using `Set.__getitem__` and implicitly creating a `Param` with domain `Any`.

This PR fixes the above. I did not test all the DAE examples, but I believe I tested all whose filenames start with "run_". The real fix, obviously, would be to add tests for these examples, which I did not do.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
