### PR TITLE
Update Wheel Creation GHA Version

### DIFF
--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -33,7 +33,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install twine wheel setuptools
     - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.4.3-manylinux2010_x86_64
+      uses: RalfG/python-wheels-manylinux-build@v0.4.0-manylinux2010_x86_64
       with:
         python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
         build-requirements: 'cython'

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -33,7 +33,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install twine wheel setuptools
     - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.4.0
+      uses: RalfG/python-wheels-manylinux-build@v0.4.3-manylinux2010_x86_64
       with:
         python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
         build-requirements: 'cython'

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -33,7 +33,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install twine wheel setuptools
     - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
+      uses: RalfG/python-wheels-manylinux-build@v0.4.0
       with:
         python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
         build-requirements: 'cython'


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
There was a bump from `0.3.3` to `0.4.0` for the `python-wheels-manylinux-build` GitHub Action. Tested action here: https://github.com/mrmundt/pyomo/actions/runs/1463697825 

NOTE: This also introduces Python 3.10 support, for when we eventually want to integrate that.

## Changes proposed in this PR:
- Bump version from `0.3.3` to `0.4.0`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
