### PR TITLE
Ensure numpy.float64 values don't end up in a ContinuousSet

### DIFF
--- a/pyomo/dae/plugins/colloc.py
+++ b/pyomo/dae/plugins/colloc.py
@@ -159,7 +159,7 @@ def calc_cp(alpha, beta, k):
             poly = [sum(pair) for pair in zip(poly, prod)]
 
     cp = numpy.roots(poly)
-    return cp
+    return numpy.sort(cp).tolist()
 
 # BLN: This is a legacy function that was used to calculate the collocation
 # constants for an alternative form of the collocation equations described
@@ -229,7 +229,7 @@ def calc_afinal(cp):
         p = [1]
         for j in range(len(cp) - 1):
             p = conv(p, ptmp[j])
-        afinal.append(numpy.polyval(p, 1.0))
+        afinal.append(float(numpy.polyval(p, 1.0)))
     return afinal
 
 
@@ -301,7 +301,7 @@ class Collocation_Discretization_Transformation(Transformation):
             alpha = 1
             beta = 0
             k = self._ncp[currentds] - 1
-            cp = sorted(list(calc_cp(alpha, beta, k)))
+            cp = calc_cp(alpha, beta, k)
             cp.insert(0, 0.0)
             cp.append(1.0)
             adot = calc_adot(cp, 1)
@@ -336,7 +336,7 @@ class Collocation_Discretization_Transformation(Transformation):
             alpha = 0
             beta = 0
             k = self._ncp[currentds]
-            cp = sorted(list(calc_cp(alpha, beta, k)))
+            cp = calc_cp(alpha, beta, k)
             cp.insert(0, 0.0)
             adot = calc_adot(cp, 1)
             adotdot = calc_adot(cp, 2)

--- a/pyomo/dae/tests/test_colloc.py
+++ b/pyomo/dae/tests/test_colloc.py
@@ -75,6 +75,7 @@ class TestCollocation(unittest.TestCase):
 
         for idx, val in enumerate(list(m.t)):
             self.assertAlmostEqual(val, expected_disc_points[idx])
+            self.assertTrue(type(val) in [float, int])
 
         self.assertTrue(hasattr(m, '_pyomo_dae_reclassified_derivativevars'))
         self.assertTrue(m._pyomo_dae_reclassified_derivativevars[0] is m.dv1)
@@ -174,6 +175,7 @@ class TestCollocation(unittest.TestCase):
 
         for idx, val in enumerate(list(m.t)):
             self.assertAlmostEqual(val, expected_disc_points[idx])
+            self.assertTrue(type(val) in [float, int])
 
         self.assertTrue(hasattr(m, '_pyomo_dae_reclassified_derivativevars'))
         self.assertTrue(m.dv1 in m._pyomo_dae_reclassified_derivativevars)


### PR DESCRIPTION
## Fixes #1941

## Summary/Motivation:
This is a minor change in the collocation discretization in Pyomo.DAE to ensure numpy.float64 values don't end up in a `ContinuousSet` (and therefore as component indices). This is mainly for consistency, there weren't any known issues with the previous implementation but it was observed that a ContinuousSet could contain both numpy values and native Python values which could be confusing. 

## Changes proposed in this PR:
- Convert numpy.float64 values to floats before adding them to a ContinuousSet

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
