### PR TITLE
Check Var bounds when setting values

### DIFF
--- a/doc/OnlineDocs/working_models.rst
+++ b/doc/OnlineDocs/working_models.rst
@@ -297,11 +297,11 @@ this document on ``Var`` access :ref:`VarAccess`.
 
 Note that
 
-   >>> instance.x.fix(2)
+   >>> instance.x.fix(1)
 
 is equivalent to
 
-   >>> instance.x.value = 2
+   >>> instance.x.value = 1
    >>> instance.x.fixed = True
 
 and

--- a/examples/dae/stochpdegas_automatic.py
+++ b/examples/dae/stochpdegas_automatic.py
@@ -157,7 +157,9 @@ model.stochd = Param(model.SCEN,model.DEM,model.TIME,within=PositiveReals,mutabl
 # define temporal variables
 def p_bounds_rule(m,k,j,t):
     return (value(m.pmin[j]),value(m.pmax[j]))
-model.p = Var(model.SCEN, model.NODE, model.TIME, bounds=p_bounds_rule, initialize=50.0)
+def p_init(m,k,j,t):
+    return (value(m.pmax[j]) + value(m.pmin[j])) / 2
+model.p = Var(model.SCEN, model.NODE, model.TIME, bounds=p_bounds_rule, initialize=p_init)
 model.dp = Var(model.SCEN,model.LINK_A,model.TIME,bounds=(0.0,100.0), initialize=10.0)
 model.fin = Var(model.SCEN,model.LINK,model.TIME,bounds=(1.0,500.0),initialize=100.0)
 model.fout = Var(model.SCEN,model.LINK,model.TIME,bounds=(1.0,500.0),initialize=100.0)

--- a/examples/dae/stochpdegas_automatic.py
+++ b/examples/dae/stochpdegas_automatic.py
@@ -11,7 +11,7 @@ model = AbstractModel()
 # sets
 model.TF = Param(within=NonNegativeReals)
 def _tinit(m):
-    return [0.5,value(m.TF)]    
+    return [0.5,value(m.TF)]
     # What it should be to match description in paper
     #return [0,value(m.TF)]
 model.TIME = ContinuousSet(initialize=_tinit)
@@ -93,9 +93,9 @@ model.rand_d = Param(model.SCEN,model.DEM,within=NonNegativeReals,mutable=True)
 
 # convert units for input data
 def rescale_rule(m):
-    
+
     for i in m.LINK:
-        m.ldiam[i] = m.ldiam[i]*m.dfac         
+        m.ldiam[i] = m.ldiam[i]*m.dfac
         m.llength[i] = m.llength[i]*m.lfac
         # m.dx[i] = m.llength[i]/float(m.DIS.last())
 
@@ -112,11 +112,11 @@ def rescale_rule(m):
 model.rescale = BuildAction(rule=rescale_rule)
 
 def compute_constants(m):
-    
+
     for i in m.LINK:
         m.lam[i] = (2.0*log10(3.7*m.ldiam[i]/(m.eps*m.dfac)))**(-2.0)
         m.A[i] = (1.0/4.0)*m.pi*m.ldiam[i]*m.ldiam[i]
-        m.nu2 = m.gam*m.z*m.R*m.Tgas/m.M   
+        m.nu2 = m.gam*m.z*m.R*m.Tgas/m.M
         m.c1[i] = (m.pfac2/m.ffac2)*(m.nu2/m.A[i])
         m.c2[i] = m.A[i]*(m.ffac2/m.pfac2)
         m.c3[i] = m.A[i]*(m.pfac2/m.ffac2)*(8.0*m.lam[i]*m.nu2)/(m.pi*m.pi*(m.ldiam[i]**5.0))
@@ -126,7 +126,7 @@ model.compute_constants = BuildAction(rule=compute_constants)
 
 # set stochastic demands
 def compute_demands_rule(m):
-    
+
     for k in m.SCEN:
         for j in m.DEM:
             if k == 2:
@@ -134,7 +134,7 @@ def compute_demands_rule(m):
             elif k == 1:
                 m.rand_d[k,j] =  1.2*m.d[j]
             else:
-                m.rand_d[k,j] =  1.3*m.d[j]        
+                m.rand_d[k,j] =  1.3*m.d[j]
 model.compute_demands = BuildAction(rule=compute_demands_rule)
 
 def stochd_init(m,k,j,t):
@@ -144,13 +144,13 @@ def stochd_init(m,k,j,t):
     # if t >= m.TDEC and t < m.TDEC+5:
     #     return m.rand_d[k,j]
     # if t >= m.TDEC+5:
-    #     return m.d[j]                         
+    #     return m.d[j]
     if t < m.TDEC+1:
         return m.d[j]
     if t >= m.TDEC+1 and t < m.TDEC+1+4.5:
         return m.rand_d[k,j]
     if t >= m.TDEC+1+4.5:
-        return m.d[j]                         
+        return m.d[j]
 
 model.stochd = Param(model.SCEN,model.DEM,model.TIME,within=PositiveReals,mutable=True,default=stochd_init)
 
@@ -168,7 +168,7 @@ model.s = Var(model.SCEN,model.SUP,model.TIME,bounds=s_bounds_rule,initialize=10
 model.dem = Var(model.SCEN,model.DEM,model.TIME,initialize=100.0)
 model.pow = Var(model.SCEN,model.LINK_A,model.TIME,bounds=(0.0,3000.0),initialize=1000.0)
 model.slack = Var(model.SCEN,model.LINK,model.TIME,model.DIS,bounds=(0.0,None),initialize=10.0)
-  
+
 # define spatio-temporal variables
 model.px = Var(model.SCEN,model.LINK,model.TIME,model.DIS,bounds=(10.0,100.0),initialize=50.0)
 model.fx = Var(model.SCEN,model.LINK,model.TIME,model.DIS,bounds=(1.0,100.0),initialize=100.0)
@@ -183,10 +183,10 @@ model.dfxdx = DerivativeVar(model.fx,wrt=model.DIS,initialize=0)
 
 # compressor equations
 def powereq_rule(m,j,i,t):
-    return m.pow[j,i,t] == m.c4*m.fin[j,i,t]*(((m.p[j,m.lstartloc[i],t]+m.dp[j,i,t])/m.p[j,m.lstartloc[i],t])**m.om - 1.0) 
+    return m.pow[j,i,t] == m.c4*m.fin[j,i,t]*(((m.p[j,m.lstartloc[i],t]+m.dp[j,i,t])/m.p[j,m.lstartloc[i],t])**m.om - 1.0)
 model.powereq = Constraint(model.SCEN,model.LINK_A,model.TIME,rule=powereq_rule)
 
-# cvar model 
+# cvar model
 model.cvar_lambda = Param(within=NonNegativeReals)
 model.nu = Var(initialize=100.0)
 model.phi = Var(model.SCEN,bounds=(0.0,None),initialize=100.0)
@@ -203,10 +203,10 @@ def nodeeq_rule(m,k,i,t):
            sum(m.fin[k,j,t] for j in m.LINK if m.lstartloc[j]==i) - \
            sum(m.dem[k,j,t] for j in m.DEM if m.dloc[j]==i) == 0.0
 model.nodeeq = Constraint(model.SCEN,model.NODE,model.TIME,rule=nodeeq_rule)
-                    
+
 # boundary conditions flow
 def flow_start_rule(m,j,i,t):
-    return m.fx[j,i,t,m.DIS.first()] == m.fin[j,i,t]    
+    return m.fx[j,i,t,m.DIS.first()] == m.fin[j,i,t]
 model.flow_start = Constraint(model.SCEN,model.LINK,model.TIME,rule=flow_start_rule)
 
 def flow_end_rule(m,j,i,t):
@@ -215,22 +215,22 @@ model.flow_end = Constraint(model.SCEN,model.LINK,model.TIME,rule=flow_end_rule)
 
 # First PDE for gas network model
 def flow_rule(m,j,i,t,k):
-    if t == m.TIME.first() or k == m.DIS.last(): 
+    if t == m.TIME.first() or k == m.DIS.last():
         return Constraint.Skip # Do not apply pde at initial time or final location
-    return m.dpxdt[j,i,t,k]/3600 + m.c1[i]/m.llength[i]*m.dfxdx[j,i,t,k] == 0 
+    return m.dpxdt[j,i,t,k]/3600 + m.c1[i]/m.llength[i]*m.dfxdx[j,i,t,k] == 0
 model.flow = Constraint(model.SCEN,model.LINK,model.TIME,model.DIS,rule=flow_rule)
 
 # Second PDE for gas network model
 def press_rule(m,j,i,t,k):
     if t == m.TIME.first() or k == m.DIS.last():
-        return Constraint.Skip # Do not apply pde at initial time or final location    
+        return Constraint.Skip # Do not apply pde at initial time or final location
     return m.dfxdt[j,i,t,k]/3600 == -m.c2[i]/m.llength[i]*m.dpxdx[j,i,t,k] - m.slack[j,i,t,k]
 model.press = Constraint(model.SCEN,model.LINK,model.TIME,model.DIS,rule=press_rule)
 
 def slackeq_rule(m,j,i,t,k):
     if t == m.TIME.last():
         return Constraint.Skip
-    return m.slack[j,i,t,k]*m.px[j,i,t,k] == m.c3[i]*m.fx[j,i,t,k]*m.fx[j,i,t,k] 
+    return m.slack[j,i,t,k]*m.px[j,i,t,k] == m.c3[i]*m.fx[j,i,t,k]*m.fx[j,i,t,k]
 model.slackeq = Constraint(model.SCEN,model.LINK,model.TIME,model.DIS,rule=slackeq_rule)
 
 # boundary conditions pressure, passive links
@@ -244,21 +244,21 @@ model.presspas_end = Constraint(model.SCEN,model.LINK_P,model.TIME,rule=presspas
 
 # boundary conditions pressure, active links
 def pressact_start_rule(m,j,i,t):
-    return m.px[j,i,t,m.DIS.first()] == m.p[j,m.lstartloc[i],t]+m.dp[j,i,t]	
+    return m.px[j,i,t,m.DIS.first()] == m.p[j,m.lstartloc[i],t]+m.dp[j,i,t]
 model.pressact_start = Constraint(model.SCEN,model.LINK_A,model.TIME,rule=pressact_start_rule)
 
 def pressact_end_rule(m,j,i,t):
     return m.px[j,i,t,m.DIS.last()] == m.p[j,m.lendloc[i],t]
 model.pressact_end = Constraint(model.SCEN,model.LINK_A,model.TIME,rule=pressact_end_rule)
-     
+
 # fix pressure at supply nodes
 def suppres_rule(m,k,j,t):
-    return m.p[k,m.sloc[j],t] == m.pmin[m.sloc[j]]    
+    return m.p[k,m.sloc[j],t] == m.pmin[m.sloc[j]]
 model.suppres = Constraint(model.SCEN,model.SUP,model.TIME,rule=suppres_rule)
 
 # discharge pressure for compressors
 def dispress_rule(m,j,i,t):
-    return m.p[j,m.lstartloc[i],t]+m.dp[j,i,t] <= m.pmax[m.lstartloc[i]]    
+    return m.p[j,m.lstartloc[i],t]+m.dp[j,i,t] <= m.pmax[m.lstartloc[i]]
 model.dispress = Constraint(model.SCEN,model.LINK_A,model.TIME,rule=dispress_rule)
 
 # ss constraints
@@ -271,7 +271,7 @@ model.flow_ss = Constraint(model.SCEN,model.LINK,model.DIS,rule=flow_ss_rule)
 def pres_ss_rule(m,j,i,k):
     if k == m.DIS.last():
         return Constraint.Skip
-    return 0.0 == - m.c2[i]/m.llength[i]*m.dpxdx[j,i,m.TIME.first(),k] - m.slack[j,i,m.TIME.first(),k]; 
+    return 0.0 == - m.c2[i]/m.llength[i]*m.dpxdx[j,i,m.TIME.first(),k] - m.slack[j,i,m.TIME.first(),k];
 model.pres_ss = Constraint(model.SCEN,model.LINK,model.DIS,rule=pres_ss_rule)
 
 # non-anticipativity constraints

--- a/pyomo/contrib/preprocessing/plugins/bounds_to_vars.py
+++ b/pyomo/contrib/preprocessing/plugins/bounds_to_vars.py
@@ -122,11 +122,12 @@ def _adjust_var_value_if_not_feasible(var):
     # within its implied bounds, as the constraint we are
     # deactivating is not an invalid constraint, but rather we
     # are moving its implied bound directly onto the variable.
+    var_value = var.value
     if var.has_lb():
-        var_value = max(var.value, var.lb)
+        var_value = max(var_value, var.lb)
     if var.has_ub():
-        var_value = min(var.value, var.ub)
-    if var.is_integer() or var.is_binary():
+        var_value = min(var_value, var.ub)
+    if var.is_integer():
         var.set_value(int(var_value))
     else:
         var.set_value(var_value)

--- a/pyomo/contrib/preprocessing/plugins/bounds_to_vars.py
+++ b/pyomo/contrib/preprocessing/plugins/bounds_to_vars.py
@@ -72,25 +72,26 @@ class ConstraintToVarBoundTransform(IsomorphicTransformation):
                 continue
             elif coef > 0:
                 if constr.has_ub():
-                    new_ub = (value(constr.upper) - const) / coef
+                    new_ub = (constr.ub - const) / coef
                     var_ub = float('inf') if var.ub is None else var.ub
                     var.setub(min(var_ub, new_ub))
                 if constr.has_lb():
-                    new_lb = (value(constr.lower) - const) / coef
+                    new_lb = (constr.lb - const) / coef
                     var_lb = float('-inf') if var.lb is None else var.lb
                     var.setlb(max(var_lb, new_lb))
             elif coef < 0:
                 if constr.has_ub():
-                    new_lb = (value(constr.upper) - const) / coef
+                    new_lb = (constr.ub - const) / coef
                     var_lb = float('-inf') if var.lb is None else var.lb
                     var.setlb(max(var_lb, new_lb))
                 if constr.has_lb():
-                    new_ub = (value(constr.lower) - const) / coef
+                    new_ub = (constr.lb - const) / coef
                     var_ub = float('inf') if var.ub is None else var.ub
                     var.setub(min(var_ub, new_ub))
 
-            if var.is_integer() or var.is_binary():
-                # Make sure that the lb and ub are integral. Use safe construction if near to integer.
+            if var.is_integer():
+                # Make sure that the lb and ub are integral. Use safe
+                # construction if near to integer.
                 if var.has_lb():
                     var.setlb(int(min(math.ceil(var.lb - config.tolerance),
                                       math.ceil(var.lb))))
@@ -101,9 +102,14 @@ class ConstraintToVarBoundTransform(IsomorphicTransformation):
             if var is not None and var.value is not None:
                 _adjust_var_value_if_not_feasible(var)
 
-            if (config.detect_fixed and var.has_lb() and var.has_ub() and
-                    fabs(value(var.lb) - value(var.ub)) <= config.tolerance):
-                var.fix(var.lb)
+            if config.detect_fixed and var.has_lb() and var.has_ub():
+                lb, ub = var.bounds
+                if lb == ub:
+                    var.fix(lb)
+                elif fabs(lb - ub) <= config.tolerance:
+                    # If the bounds are note exactly equal, set the
+                    # value to the midpoint
+                    var.fix((lb + ub) / 2)
 
             constr.deactivate()
 

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -109,8 +109,9 @@ class _BooleanVarData(ComponentData, BooleanValue):
         # the flag to always be False, we will just ignore it in the
         # name of efficiency.
         if val.__class__ not in _logical_var_types:
-            logger.warning("implicitly casting '%s' value %s to bool"
-                           % (self.name, val))
+            if not skip_validation:
+                logger.warning("implicitly casting '%s' value %s to bool"
+                               % (self.name, val))
             val = bool(val)
         self._value = val
         self.stale = False

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -143,7 +143,7 @@ class _BooleanVarData(ComponentData, BooleanValue):
         """Return the stale indicator for this variable."""
         raise NotImplementedError
 
-    def fix(self, val=NOTSET, skip_validation=False):
+    def fix(self, value=NOTSET, skip_validation=False):
         """
         Set the fixed indicator to True. Value argument is optional,
         indicating the variable should be fixed at its current value.
@@ -237,14 +237,14 @@ class _GeneralBooleanVarData(_BooleanVarData):
         """Return the domain for this variable."""
         return BooleanSet
 
-    def fix(self, val=NOTSET, skip_validation=False):
+    def fix(self, value=NOTSET, skip_validation=False):
         """
         Set the fixed indicator to True. Value argument is optional,
         indicating the variable should be fixed at its current value.
         """
         self.fixed = True
-        if val is not NOTSET:
-            self.set_value(val, skip_validation)
+        if value is not NOTSET:
+            self.set_value(value, skip_validation)
 
     def unfix(self):
         """Sets the fixed indicator to False."""
@@ -527,13 +527,13 @@ class ScalarBooleanVar(_GeneralBooleanVarData, BooleanVar):
     def domain(self):
         return _GeneralBooleanVarData.domain.fget(self)
 
-    def fix(self, val=NOTSET, skip_validation=False):
+    def fix(self, value=NOTSET, skip_validation=False):
         """
         Set the fixed indicator to True. Value argument is optional,
         indicating the variable should be fixed at its current value.
         """
         if self._constructed:
-            return _GeneralBooleanVarData.fix(self, val, skip_validation)
+            return _GeneralBooleanVarData.fix(self, value, skip_validation)
         raise ValueError(
             "Fixing variable '%s' "
             "before the Var has been constructed (there "
@@ -561,13 +561,13 @@ class SimpleBooleanVar(metaclass=RenamedClass):
 class IndexedBooleanVar(BooleanVar):
     """An array of variables."""
 
-    def fix(self, val=NOTSET, skip_validation=False):
+    def fix(self, value=NOTSET, skip_validation=False):
         """
         Set the fixed indicator to True. Value argument is optional,
         indicating the variable should be fixed at its current value.
         """
         for boolean_vardata in self.values():
-            boolean_vardata.fix(val, skip_validation)
+            boolean_vardata.fix(value, skip_validation)
 
     def unfix(self):
         """Sets the fixed indicator to False."""

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -144,17 +144,28 @@ class _BooleanVarData(ComponentData, BooleanValue):
         raise NotImplementedError
 
     def fix(self, value=NOTSET, skip_validation=False):
+        """Fix the value of this variable (treat as nonvariable)
+
+        This sets the `fixed` indicator to True.  If ``value`` is
+        provided, the value (and the ``skip_validation`` flag) are first
+        passed to :py:meth:`set_value()`.
+
         """
-        Set the fixed indicator to True. Value argument is optional,
-        indicating the variable should be fixed at its current value.
-        """
-        raise NotImplementedError
+        self.fixed = True
+        if value is not NOTSET:
+            self.set_value(value, skip_validation)
 
     def unfix(self):
-        """Sets the fixed indicator to False."""
-        raise NotImplementedError
+        """Unfix this varaible (treat as variable)
 
-    free=unfix
+        This sets the `fixed` indicator to False.
+
+        """
+        self.fixed = False
+
+    def free(self):
+        """Alias for :py:meth:`unfix`"""
+        return self.unfix()
 
 
 class _GeneralBooleanVarData(_BooleanVarData):
@@ -236,21 +247,6 @@ class _GeneralBooleanVarData(_BooleanVarData):
     def domain(self):
         """Return the domain for this variable."""
         return BooleanSet
-
-    def fix(self, value=NOTSET, skip_validation=False):
-        """
-        Set the fixed indicator to True. Value argument is optional,
-        indicating the variable should be fixed at its current value.
-        """
-        self.fixed = True
-        if value is not NOTSET:
-            self.set_value(value, skip_validation)
-
-    def unfix(self):
-        """Sets the fixed indicator to False."""
-        self.fixed = False
-
-    free = unfix
 
     def get_associated_binary(self):
         """Get the binary _VarData associated with this 
@@ -550,8 +546,6 @@ class ScalarBooleanVar(_GeneralBooleanVarData, BooleanVar):
             "is currently nothing to set)."
             % (self.name))
 
-    free=unfix
-
 
 class SimpleBooleanVar(metaclass=RenamedClass):
     __renamed__new_class__ = ScalarBooleanVar
@@ -562,23 +556,34 @@ class IndexedBooleanVar(BooleanVar):
     """An array of variables."""
 
     def fix(self, value=NOTSET, skip_validation=False):
-        """
-        Set the fixed indicator to True. Value argument is optional,
-        indicating the variable should be fixed at its current value.
+        """Fix all variables in this IndexedBooleanVar (treat as nonvariable)
+
+        This sets the `fixed` indicator to True for every variable in
+        this IndexedBooleanVar.  If ``value`` is provided, the value
+        (and the ``skip_validation`` flag) are first passed to
+        :py:meth:`set_value()`.
+
         """
         for boolean_vardata in self.values():
             boolean_vardata.fix(value, skip_validation)
 
     def unfix(self):
-        """Sets the fixed indicator to False."""
+        """Unfix all varaibles in this IndexedBooleanVar (treat as variable)
+
+        This sets the `fixed` indicator to False for every variable in
+        this IndexedBooleanVar.
+
+        """
         for boolean_vardata in self.values():
             boolean_vardata.unfix()
+
+    def free(self):
+        """Alias for :py:meth:`unfix`"""
+        return self.unfix()
 
     @property
     def domain(self):
         return BooleanSet
-
-    free=unfix
     
 
 @ModelComponentFactory.register("List of logical decision variables.")

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -255,18 +255,28 @@ class _VarData(ComponentData, NumericValue):
         """Return the stale indicator for this variable."""
         raise NotImplementedError
 
-    def fix(self, value=NOTSET, valid=False):
+    def fix(self, value=NOTSET, skip_validation=False):
+        """Fix the value of this variable (treat as nonvariable)
+
+        This sets the `fixed` indicator to True.  If ``value`` is
+        provided, the value (and the ``skip_validation`` flag) are first
+        passed to :py:meth:`set_value()`.
+
         """
-        Set the fixed indicator to True. Value argument is optional,
-        indicating the variable should be fixed at its current value.
-        """
-        raise NotImplementedError
+        self.fixed = True
+        if value is not NOTSET:
+            self.set_value(value, skip_validation)
 
     def unfix(self):
-        """Sets the fixed indicator to False."""
-        raise NotImplementedError
+        """Unfix this varaible (treat as variable)
+
+        This sets the `fixed` indicator to False.
+
+        """
+        self.fixed = False
 
     def free(self):
+        """Alias for :py:meth:`unfix`"""
         return self.unfix()
 
 
@@ -520,22 +530,6 @@ class _GeneralVarData(_VarData):
     # fixed is an attribute
 
     # stale is an attribute
-
-    def fix(self, value=NOTSET, skip_validation=False):
-        """Fix the value of this variable (treat as nonvariable)
-
-        This sets the `fixed` indicator to True.  If ``value`` is
-        provided, the value (and the ``valid`` flag) are first passed to
-        :py:meth:`set_value()`.
-
-        """
-        self.fixed = True
-        if value is not NOTSET:
-            self.set_value(value, skip_validation)
-
-    def unfix(self):
-        """Sets the fixed indicator to False."""
-        self.fixed = False
 
     def _process_bound(self, val, bound_type):
         if type(val) in native_numeric_types or val is None:
@@ -865,19 +859,29 @@ class IndexedVar(Var):
             vardata.upper = val
 
     def fix(self, value=NOTSET, skip_validation=False):
-        """
-        Set the fixed indicator to True. Value argument is optional,
-        indicating the variable should be fixed at its current value.
+        """Fix all variables in this IndexedVar (treat as nonvariable)
+
+        This sets the `fixed` indicator to True for every variable in
+        this IndexedVar.  If ``value`` is provided, the value (and the
+        ``skip_validation`` flag) are first passed to
+        :py:meth:`set_value()`.
+
         """
         for vardata in self.values():
             vardata.fix(value, skip_validation)
 
     def unfix(self):
-        """Sets the fixed indicator to False."""
+        """Unfix all varaibles in this IndexedVar (treat as variable)
+
+        This sets the `fixed` indicator to False for every variable in
+        this IndexedVar.
+
+        """
         for vardata in self.values():
             vardata.unfix()
 
     def free(self):
+        """Alias for :py:meth:`unfix`"""
         return self.unfix()
 
     @property

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -18,7 +18,7 @@ from weakref import ref as weakref_ref
 from pyomo.common.collections import Sequence
 from pyomo.common.deprecation import RenamedClass
 from pyomo.common.log import is_debug_set
-from pyomo.common.modeling import NoArgumentGiven
+from pyomo.common.modeling import NOTSET
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.expr.numeric_expr import NPV_MaxExpression, NPV_MinExpression
 from pyomo.core.expr.numvalue import (
@@ -255,7 +255,7 @@ class _VarData(ComponentData, NumericValue):
         """Return the stale indicator for this variable."""
         raise NotImplementedError
 
-    def fix(self, value=NoArgumentGiven, valid=False):
+    def fix(self, value=NOTSET, valid=False):
         """
         Set the fixed indicator to True. Value argument is optional,
         indicating the variable should be fixed at its current value.
@@ -521,7 +521,7 @@ class _GeneralVarData(_VarData):
 
     # stale is an attribute
 
-    def fix(self, value=NoArgumentGiven, skip_validation=False):
+    def fix(self, value=NOTSET, skip_validation=False):
         """Fix the value of this variable (treat as nonvariable)
 
         This sets the `fixed` indicator to True.  If ``value`` is
@@ -530,7 +530,7 @@ class _GeneralVarData(_VarData):
 
         """
         self.fixed = True
-        if value is not NoArgumentGiven:
+        if value is not NOTSET:
             self.set_value(value, skip_validation)
 
     def unfix(self):
@@ -864,13 +864,13 @@ class IndexedVar(Var):
         for vardata in self.values():
             vardata.upper = val
 
-    def fix(self, value=NoArgumentGiven):
+    def fix(self, value=NOTSET, skip_validation=False):
         """
         Set the fixed indicator to True. Value argument is optional,
         indicating the variable should be fixed at its current value.
         """
         for vardata in self.values():
-            vardata.fix(value=value)
+            vardata.fix(value, skip_validation)
 
     def unfix(self):
         """Sets the fixed indicator to False."""

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -384,17 +384,14 @@ class _GeneralVarData(_VarData):
 
         if not skip_validation:
             if val not in self.domain:
-                # logger.warning(
-                raise ValueError("Numeric value `%s` (%s) is not in "
-                                 "domain %s for Var %s" %
-                                 (val, type(val).__name__,
-                                  self.domain, self.name))
+                logger.warning(
+                    "Setting Var '%s' to a value `%s` (%s) not in domain %s." %
+                    (self.name, val, type(val).__name__, self.domain))
             elif (self._lb is not None and val < value(self._lb)) or (
                     self._ub is not None and val > value(self._ub)):
-                pass
-                # logger.warning(
-                #     "Setting Var '%s' to a numeric value `%s` "
-                #     "outside the bounds %s." % (self.name, val, self.bounds))
+                logger.warning(
+                    "Setting Var '%s' to a numeric value `%s` "
+                    "outside the bounds %s." % (self.name, val, self.bounds))
 
         self._value = val
         self.stale = False

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -221,7 +221,7 @@ class _VarData(ComponentData, NumericValue):
     # Abstract Interface
     #
 
-    def set_value(self, val, valid=False):
+    def set_value(self, val, skip_validation=False):
         """Set the current variable value."""
         raise NotImplementedError
 
@@ -350,7 +350,7 @@ class _GeneralVarData(_VarData):
     # Abstract Interface
     #
 
-    def set_value(self, val, valid=False):
+    def set_value(self, val, skip_validation=False):
         """Set the current variable value.
 
         Set the value of this variable.  The incoming value is converted
@@ -382,7 +382,7 @@ class _GeneralVarData(_VarData):
             else:
                 val = value(val)
 
-        if not valid:
+        if not skip_validation:
             if val not in self.domain:
                 # logger.warning(
                 raise ValueError("Numeric value `%s` (%s) is not in "
@@ -524,7 +524,7 @@ class _GeneralVarData(_VarData):
 
     # stale is an attribute
 
-    def fix(self, value=NoArgumentGiven, valid=False):
+    def fix(self, value=NoArgumentGiven, skip_validation=False):
         """Fix the value of this variable (treat as nonvariable)
 
         This sets the `fixed` indicator to True.  If ``value`` is
@@ -534,7 +534,7 @@ class _GeneralVarData(_VarData):
         """
         self.fixed = True
         if value is not NoArgumentGiven:
-            self.set_value(value, valid)
+            self.set_value(value, skip_validation)
 
     def unfix(self):
         """Sets the fixed indicator to False."""
@@ -653,7 +653,7 @@ class Var(IndexedComponent, IndexedComponent_NDArrayMixin):
 
     extract_values = get_values
 
-    def set_values(self, new_values, valid=False):
+    def set_values(self, new_values, skip_validation=False):
         """
         Set the values of a dictionary.
 
@@ -661,7 +661,7 @@ class Var(IndexedComponent, IndexedComponent_NDArrayMixin):
         dictionary.
         """
         for index, new_value in new_values.items():
-            self[index].set_value(new_value, valid)
+            self[index].set_value(new_value, skip_validation)
 
     def get_units(self):
         """Return the units expression for this Var."""

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -692,7 +692,7 @@ class Var(IndexedComponent, IndexedComponent_NDArrayMixin):
                     "with 'dense=True'.  Reverting to 'dense=False' as "
                     "it is not possible to make this variable dense.  "
                     "This warning can be suppressed by specifying "
-                    "'dense=False'")
+                    "'dense=False'" % (self.name,))
                 self._dense = False
 
             if ( self._rule_init is not None and

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -3579,7 +3579,7 @@ class TestSet(unittest.TestCase):
         self.assertEqual(m.I.dimen, 1)
 
         m = ConcreteModel()
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, 'Set rule or initializer returned None'):
             m.I = Set(initialize=lambda m: None, dimen=2)
         self.assertTrue(m.I._init_values.constant())

--- a/pyomo/core/tests/unit/test_sets.py
+++ b/pyomo/core/tests/unit/test_sets.py
@@ -2978,8 +2978,8 @@ class TestSetErrors(PyomoModel):
         b=Set(a)
         with self.assertRaisesRegex(
                 #TypeError, "Cannot apply a Set operator to an indexed"):
-                ValueError, "Error retrieving component IndexedSet\[None\]: "
-                "The component has not been constructed."):
+                ValueError, r"Error retrieving component IndexedSet\[None\]: "
+                r"The component has not been constructed."):
             c=Set(within=b, dimen=2)
             c.construct()
 

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -68,8 +68,8 @@ class AutoLinkedBinaryVar(ScalarVar):
     def get_associated_boolean(self):
         return self._associated_boolean()
 
-    def set_value(self, val, valid=False):
-        super().set_value(val, valid)
+    def set_value(self, val, skip_validation=False):
+        super().set_value(val, skip_validation)
         bool_var = self.get_associated_boolean()
         # Only update the associated Boolean value if it is needed
         # to match the current (potentially fractional) binary value.
@@ -147,15 +147,10 @@ class AutoLinkedBooleanVar(ScalarBooleanVar):
             % (self.name,), version='6.0')
         return self.get_associated_binary()
 
-    @property
-    def value(self):
-        return self._value
-
-    @value.setter
-    def value(self, val):
+    def set_value(self, val, skip_validation=False):
         # super() does not work as expected for properties; we will call
         # the property setter explicitly.
-        ScalarBooleanVar.value.fset(self, val)
+        super().set_value(val, skip_validation)
         bin_var = self.get_associated_binary()
         bin_val = bin_var.value
         if bin_val is None:

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -18,7 +18,7 @@ from weakref import ref as weakref_ref
 from pyomo.common.deprecation import RenamedClass,  deprecation_warning
 from pyomo.common.errors import PyomoException
 from pyomo.common.log import is_debug_set
-from pyomo.common.modeling import unique_component_name
+from pyomo.common.modeling import unique_component_name, NOTSET
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core import (
     ModelComponentFactory, Binary, Block, ConstraintList, Any,
@@ -83,11 +83,11 @@ class AutoLinkedBinaryVar(ScalarVar):
         if bool_val != bool_var.value:
             bool_var.set_value(bool_val)
 
-    def fix(self, *val):
-        super().fix(*val)
+    def fix(self, val=NOTSET, skip_validation=False):
+        super().fix(val, skip_validation)
         bool_var = self.get_associated_boolean()
         if not bool_var.is_fixed():
-            bool_var.fix()
+            bool_var.fix(skip_validation=skip_validation)
 
     def unfix(self):
         super().unfix()
@@ -169,18 +169,11 @@ class AutoLinkedBooleanVar(ScalarBooleanVar):
                 val = int(val)
             bin_var.set_value(val)
 
-    def fix(self, *val):
-        super().fix(*val)
+    def fix(self, val=NOTSET, skip_validation=False):
+        super().fix(val, skip_validation)
         bin_var = self.get_associated_binary()
-
-        val = self.value
-        if val is not None:
-            val = int(val)
-        if not bin_var.is_fixed() or bin_var.value != val:
-            # Note: if someone fixes the Boolean to True/False then we
-            # need to snap the binary to 1/0 (and not leave it at the
-            # potentially fractional value)
-            bin_var.fix(val)
+        if not bin_var.is_fixed():
+            bin_var.fix(skip_validation=skip_validation)
 
     def unfix(self):
         super().unfix()

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -72,23 +72,22 @@ class AutoLinkedBinaryVar(ScalarVar):
         super().set_value(val, skip_validation)
         if not _propagate_value:
             return
-        bool_var = self.get_associated_boolean()
-        # Only update the associated Boolean value if it is needed
-        # to match the current (potentially fractional) binary value.
-        # (This prevents infinite recursion.)
+        # Map the incoming (numeric) value to bool/None
         if val is None:
             bool_val = None
         elif fabs(val - 0.5) < 0.5 - AutoLinkedBinaryVar.INTEGER_TOLERANCE:
             bool_val = None
         else:
             bool_val = bool(int(val + 0.5))
-        bool_var.set_value(bool_val, skip_validation, _propagate_value=False)
+        # (Setting _propagate_value prevents infinite recursion.)
+        self.get_associated_boolean().set_value(
+            bool_val, skip_validation, _propagate_value=False)
 
     def fix(self, val=NOTSET, skip_validation=False):
         super().fix(val, skip_validation)
         bool_var = self.get_associated_boolean()
         if not bool_var.is_fixed():
-            bool_var.fix(skip_validation=skip_validation)
+            bool_var.fix()
 
     def unfix(self):
         super().unfix()
@@ -154,19 +153,20 @@ class AutoLinkedBooleanVar(ScalarBooleanVar):
         super().set_value(val, skip_validation)
         if not _propagate_value:
             return
-        bin_var = self.get_associated_binary()
-        # Fetch the current value (so that it is cast to None/bool)
+        # Fetch the current value (so we know it has already been cast
+        # to None/bool)
         val = self.value
-        # (Settring _propagate_value prevents infinite recursion.)
         if val is not None:
             val = int(val)
-        bin_var.set_value(val, skip_validation, _propagate_value=False)
+        # (Setting _propagate_value prevents infinite recursion.)
+        self.get_associated_binary().set_value(
+            val, skip_validation, _propagate_value=False)
 
     def fix(self, val=NOTSET, skip_validation=False):
         super().fix(val, skip_validation)
         bin_var = self.get_associated_binary()
         if not bin_var.is_fixed():
-            bin_var.fix(skip_validation=skip_validation)
+            bin_var.fix()
 
     def unfix(self):
         super().unfix()

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -83,8 +83,8 @@ class AutoLinkedBinaryVar(ScalarVar):
         self.get_associated_boolean().set_value(
             bool_val, skip_validation, _propagate_value=False)
 
-    def fix(self, val=NOTSET, skip_validation=False):
-        super().fix(val, skip_validation)
+    def fix(self, value=NOTSET, skip_validation=False):
+        super().fix(value, skip_validation)
         bool_var = self.get_associated_boolean()
         if not bool_var.is_fixed():
             bool_var.fix()
@@ -162,8 +162,8 @@ class AutoLinkedBooleanVar(ScalarBooleanVar):
         self.get_associated_binary().set_value(
             val, skip_validation, _propagate_value=False)
 
-    def fix(self, val=NOTSET, skip_validation=False):
-        super().fix(val, skip_validation)
+    def fix(self, value=NOTSET, skip_validation=False):
+        super().fix(value, skip_validation)
         bin_var = self.get_associated_binary()
         if not bin_var.is_fixed():
             bin_var.fix()

--- a/pyomo/gdp/tests/test_disjunct.py
+++ b/pyomo/gdp/tests/test_disjunct.py
@@ -376,16 +376,18 @@ class TestAutoVars(unittest.TestCase):
         self.assertEqual(m.iv.value, True)
         self.assertEqual(m.biv.value, 1)
 
-        with self.assertRaisesRegex(
-                ValueError, r"Numeric value `0.5` \(float\) is not in "
-                r"domain Binary for Var biv"):
+        with LoggingIntercept() as LOG:
             m.biv.fix(0.5)
-        self.assertEqual(m.iv.value, True)
-        self.assertEqual(m.biv.value, 1)
-
-        m.biv.fix(0.5, True)
+        self.assertEqual(LOG.getvalue().strip(), "Setting Var 'biv' to a "
+                         "value `0.5` (float) not in domain Binary.")
         self.assertEqual(m.iv.value, None)
         self.assertEqual(m.biv.value, 0.5)
+
+        with LoggingIntercept() as LOG:
+            m.biv.fix(0.55, True)
+        self.assertEqual(LOG.getvalue().strip(), "")
+        self.assertEqual(m.iv.value, None)
+        self.assertEqual(m.biv.value, 0.55)
 
         m.biv.fix(0)
         self.assertEqual(m.iv.value, False)
@@ -394,16 +396,18 @@ class TestAutoVars(unittest.TestCase):
         eps = AutoLinkedBinaryVar.INTEGER_TOLERANCE / 10
 
         # Note that fixing to a near-True value will toggle the iv
-        with self.assertRaisesRegex(
-                ValueError, r"Numeric value `0.9+` \(float\) is not in "
-                r"domain Binary for Var biv"):
+        with LoggingIntercept() as LOG:
             m.biv.fix(1-eps)
-        self.assertEqual(m.iv.value, False)
-        self.assertEqual(m.biv.value, 0)
-
-        m.biv.fix(1-eps, True)
+        self.assertEqual(LOG.getvalue().strip(), "Setting Var 'biv' to a "
+                         "value `%s` (float) not in domain Binary." % (1-eps))
         self.assertEqual(m.iv.value, True)
         self.assertEqual(m.biv.value, 1-eps)
+
+        with LoggingIntercept() as LOG:
+            m.biv.fix(eps, True)
+        self.assertEqual(LOG.getvalue().strip(), "")
+        self.assertEqual(m.iv.value, False)
+        self.assertEqual(m.biv.value, eps)
 
         m.iv.fix(True)
         self.assertEqual(m.iv.value, True)

--- a/pyomo/util/calc_var_value.py
+++ b/pyomo/util/calc_var_value.py
@@ -73,30 +73,31 @@ def calculate_variable_from_constraint(variable, constraint,
         raise ValueError("Constraint must be an equality constraint")
 
     if variable.value is None:
-        # Note that we use "valid=True" here as well, as the variable
-        # domain may not admit the calculated initial guesses, and we
-        # want to bypass that check.
+        # Note that we use "skip_validation=True" here as well, as the
+        # variable domain may not admit the calculated initial guesses,
+        # and we want to bypass that check.
         if variable.lb is None:
             if variable.ub is None:
                 # no variable values, and no lower or upper bound - set
                 # initial value to 0.0
-                variable.set_value(0, valid=True)
+                variable.set_value(0, skip_validation=True)
             else:
                 # no variable value or lower bound - set to 0 or upper
                 # bound whichever is lower
-                variable.set_value(min(0, variable.ub), valid=True)
+                variable.set_value(min(0, variable.ub), skip_validation=True)
         elif variable.ub is None:
             # no variable value or upper bound - set to 0 or lower
             # bound, whichever is higher
-            variable.set_value(max(0, variable.lb), valid=True)
+            variable.set_value(max(0, variable.lb), skip_validation=True)
         else:
             # we have upper and lower bounds
             if variable.lb <= 0 and variable.ub >= 0:
                 # set the initial value to 0 if bounds bracket 0
-                variable.set_value(0, valid=True)
+                variable.set_value(0, skip_validation=True)
             else:
                 # set the initial value to the midpoint of the bounds
-                variable.set_value((variable.lb+variable.ub)/2.0, valid=True)
+                variable.set_value(
+                    (variable.lb+variable.ub)/2.0, skip_validation=True)
 
     # store the initial value to use later if necessary
     orig_initial_value = variable.value
@@ -116,7 +117,7 @@ def calculate_variable_from_constraint(variable, constraint,
             "initial guess.\n\tPlease provide a different initial guess.")
         raise
 
-    variable.set_value(x1 - (residual_1-upper), valid=True)
+    variable.set_value(x1 - (residual_1 - upper), skip_validation=True)
     residual_2 = value(body, exception=False)
 
     # If we encounter an error while evaluating the expression at the
@@ -137,13 +138,15 @@ def calculate_variable_from_constraint(variable, constraint,
         slope = float(residual_1 - residual_2) / (x1 - x2)
         intercept = (residual_1-upper) - slope*x1
         if slope:
-            variable.set_value(-intercept/slope, valid=True)
+            variable.set_value(-intercept/slope, skip_validation=True)
             body_val = value(body, exception=False)
             if body_val is not None and abs(body_val-upper) < eps:
                 return
 
     # Variable appears nonlinearly; solve using Newton's method
-    variable.set_value(orig_initial_value, valid=True) # restore initial value
+    #
+    # restore initial value
+    variable.set_value(orig_initial_value, skip_validation=True)
     expr = body - upper
     expr_deriv = differentiate(expr, wrt=variable,
                                mode=differentiate.Modes.sympy)
@@ -189,7 +192,7 @@ def calculate_variable_from_constraint(variable, constraint,
         pk = -fk/fpk
         alpha = 1.0
         xkp1 = xk + alpha * pk
-        variable.set_value(xkp1, valid=True)
+        variable.set_value(xkp1, skip_validation=True)
 
         # perform line search
         if linesearch:
@@ -211,7 +214,7 @@ def calculate_variable_from_constraint(variable, constraint,
                     break
                 alpha /= 2.0
                 xkp1 = xk + alpha * pk
-                variable.set_value(xkp1, valid=True)
+                variable.set_value(xkp1, skip_validation=True)
 
             if alpha <= alpha_min:
                 residual = value(expr, exception=False)

--- a/pyomo/util/calc_var_value.py
+++ b/pyomo/util/calc_var_value.py
@@ -130,17 +130,23 @@ def calculate_variable_from_constraint(variable, constraint,
     if residual_2 is not None and type(residual_2) is not complex:
         # if the variable appears linearly with a coefficient of 1, then we
         # are done
-        if abs(residual_2-upper) < eps:
+        if abs(residual_2 - upper) < eps:
+            # Re-set the variable value to trigger any warnings WRT the
+            # final variable state
+            variable.set_value(variable.value)
             return
 
         # Assume the variable appears linearly and calculate the coefficient
         x2 = value(variable)
         slope = float(residual_1 - residual_2) / (x1 - x2)
-        intercept = (residual_1-upper) - slope*x1
+        intercept = (residual_1 - upper) - slope*x1
         if slope:
             variable.set_value(-intercept/slope, skip_validation=True)
             body_val = value(body, exception=False)
-            if body_val is not None and abs(body_val-upper) < eps:
+            if body_val is not None and abs(body_val - upper) < eps:
+                # Re-set the variable value to trigger any warnings WRT
+                # the final variable state
+                variable.set_value(variable.value)
                 return
 
     # Variable appears nonlinearly; solve using Newton's method
@@ -223,3 +229,7 @@ def calculate_variable_from_constraint(variable, constraint,
                 raise RuntimeError(
                     "Linesearch iteration limit reached; remaining "
                     "residual = %s." % (residual,))
+    #
+    # Re-set the variable value to trigger any warnings WRT the final
+    # variable state
+    variable.set_value(variable.value)

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -90,7 +90,7 @@ class Test_calc_var(unittest.TestCase):
                 ValueError, "Constraint 'tuple' is a Ranged Inequality "
                 "with a variable upper bound."):
             calculate_variable_from_constraint(m.x, (15, 5*m.x, m.x))
-            
+
 
     @unittest.skipIf(not differentiate_available, "this test requires sympy")
     def test_nonlinear(self):
@@ -266,12 +266,11 @@ class Test_calc_var(unittest.TestCase):
         calculate_variable_from_constraint(m.v1, m.c4)
         self.assertEqual(value(m.v1), -2)
 
-    def test_warn_final_value(self):
+    def test_warn_final_value_linear(self):
         m = ConcreteModel()
         m.x = Var(bounds=(0,1))
         m.c1 = Constraint(expr=m.x == 10)
         m.c2 = Constraint(expr=5*m.x == 10)
-        m.c3 = Constraint(expr=(m.x - 3.5)**2 == 0)
 
         with LoggingIntercept() as LOG:
             calculate_variable_from_constraint(m.x, m.c1)
@@ -288,6 +287,12 @@ class Test_calc_var(unittest.TestCase):
             "Setting Var 'x' to a numeric value `2.0` outside the "
             "bounds (0, 1).")
         self.assertEqual(value(m.x), 2)
+
+    @unittest.skipUnless(differentiate_available, "this test requires sympy")
+    def test_warn_final_value_nonlinear(self):
+        m = ConcreteModel()
+        m.x = Var(bounds=(0,1))
+        m.c3 = Constraint(expr=(m.x - 3.5)**2 == 0)
 
         with LoggingIntercept() as LOG:
             calculate_variable_from_constraint(m.x, m.c3)

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -15,7 +15,8 @@ import pyomo.common.unittest as unittest
 
 from pyomo.common.log import LoggingIntercept
 from pyomo.environ import (
-    ConcreteModel, Var, Constraint, Param, value, exp, NonNegativeReals
+    ConcreteModel, Var, Constraint, Param, value, exp, NonNegativeReals,
+    Binary,
 )
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 from pyomo.core.expr.calculus.diff_with_sympy import differentiate_available
@@ -264,3 +265,43 @@ class Test_calc_var(unittest.TestCase):
         m.v1.set_value(1)
         calculate_variable_from_constraint(m.v1, m.c4)
         self.assertEqual(value(m.v1), -2)
+
+    def test_warn_final_value(self):
+        m = ConcreteModel()
+        m.x = Var(bounds=(0,1))
+        m.c1 = Constraint(expr=m.x == 10)
+        m.c2 = Constraint(expr=5*m.x == 10)
+        m.c3 = Constraint(expr=(m.x - 3.5)**2 == 0)
+
+        with LoggingIntercept() as LOG:
+            calculate_variable_from_constraint(m.x, m.c1)
+        self.assertEqual(
+            LOG.getvalue().strip(),
+            "Setting Var 'x' to a numeric value `10` outside the "
+            "bounds (0, 1).")
+        self.assertEqual(value(m.x), 10)
+
+        with LoggingIntercept() as LOG:
+            calculate_variable_from_constraint(m.x, m.c2)
+        self.assertEqual(
+            LOG.getvalue().strip(),
+            "Setting Var 'x' to a numeric value `2.0` outside the "
+            "bounds (0, 1).")
+        self.assertEqual(value(m.x), 2)
+
+        with LoggingIntercept() as LOG:
+            calculate_variable_from_constraint(m.x, m.c3)
+        self.assertRegex(
+            LOG.getvalue().strip(),
+            r"Setting Var 'x' to a numeric value `[0-9\.]+` outside the "
+            r"bounds \(0, 1\).")
+        self.assertAlmostEqual(value(m.x), 3.5, 3)
+
+        m.x.domain = Binary
+        with LoggingIntercept() as LOG:
+            calculate_variable_from_constraint(m.x, m.c3)
+        self.assertRegex(
+            LOG.getvalue().strip(),
+            r"Setting Var 'x' to a value `[0-9\.]+` \(float\) not in "
+            "domain Binary.")
+        self.assertAlmostEqual(value(m.x), 3.5, 3)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This implements the first 2 proposals from #2180:
 - Var values are checked against both the domain and the bounds
 - Values failing the domain or bounds checks generate a warning and not an exception

## Changes proposed in this PR:
- Emit warnings when setting a Var value outside the domain or bounds
- Make `set_value()` and `fix()` implementations consistent across `Var`, `BooleanVar`, `AutoLinkedBinaryVar` and `AutoLinkedBooleanVar`
- Resolve bug in `contrib.constraints_to_var_bounds` that could move a var value outside its bounds
- Update examples to avoid initializing outside domain
- Update documentation to not set Var values outside bounds

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
