### PR TITLE
Adding option to test driver for turning off log capture

### DIFF
--- a/pyomo/common/tests/test_unittest.py
+++ b/pyomo/common/tests/test_unittest.py
@@ -10,6 +10,7 @@
 
 import datetime
 import multiprocessing
+import os
 from io import StringIO
 import time
 
@@ -233,6 +234,30 @@ class TestPyomoUnittest(unittest.TestCase):
         cmd_opts.extend(['--show-log'])
         arguments = parser.parse_args(cmd_opts)
         self.assertTrue(arguments.showlog)
+
+    def test_build_cmd(self):
+        cmd_opts = 'bogus target names'.split()
+        parser = unittest.buildParser()
+        options, unknown = parser.parse_known_args(cmd_opts)
+        self.assertEqual(unknown, [])
+        env = os.environ.copy()
+        cmd = unittest.build_cmd(options, unknown, env)
+        self.assertIn('--eval-attr=smoke and (not fragile)', cmd)
+        self.assertIn('bogus', cmd)
+        cmd_opts.extend(['--nocapture'])
+        parser = unittest.buildParser()
+        options, unknown = parser.parse_known_args(cmd_opts)
+        self.assertEqual(unknown, ['--nocapture'])
+        env = os.environ.copy()
+        cmd = unittest.build_cmd(options, unknown, env)
+        self.assertIn('--nocapture', cmd)
+        cmd_opts.extend('--cat not-real --cat whatever'.split(' '))
+        parser = unittest.buildParser()
+        options, unknown = parser.parse_known_args(cmd_opts)
+        env = os.environ.copy()
+        cmd = unittest.build_cmd(options, unknown, env)
+        self.assertIn('--eval-attr=whatever and (not fragile)', cmd)
+
 
 
 if __name__ == '__main__':

--- a/pyomo/common/tests/test_unittest.py
+++ b/pyomo/common/tests/test_unittest.py
@@ -230,6 +230,9 @@ class TestPyomoUnittest(unittest.TestCase):
         arguments = parser.parse_args(cmd_opts)
         self.assertTrue(arguments.verbose)
         self.assertTrue(arguments.xunit)
+        cmd_opts.extend(['--show-log'])
+        arguments = parser.parse_args(cmd_opts)
+        self.assertTrue(arguments.showlog)
 
 
 if __name__ == '__main__':

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -567,14 +567,8 @@ def buildParser():
         help='Turn off log capture and allow warnings/deprecations to show.')
     return parser
 
-
-def runtests(options):
-
-    from pyomo.common.fileutils import PYOMO_ROOT_DIR as basedir, Executable
-    env = os.environ.copy()
-    os.chdir(basedir)
-
-    print("Running tests in directory %s" % (basedir,))
+def build_cmd(options, unknown, env):
+    from pyomo.common.fileutils import Executable
 
     if sys.platform.startswith('win'):
         binDir = os.path.join(sys.exec_prefix, 'Scripts')
@@ -612,6 +606,8 @@ def runtests(options):
     if options.showlog:
         cmd.append('--nologcapture')
         cmd.append('--nocapture')
+    if unknown:
+        cmd.extend(unknown)
 
     attr = []
     _with_performance = False
@@ -664,6 +660,19 @@ def runtests(options):
         env['NOSE_WITH_FORCED_GC'] = '1'
 
     cmd.extend(options.targets)
+
+    return cmd
+
+def runtests(parser):
+
+    from pyomo.common.fileutils import PYOMO_ROOT_DIR as basedir
+    env = os.environ.copy()
+    os.chdir(basedir)
+
+    options, unknown = parser.parse_known_args()
+
+    print("Running tests in directory %s" % (basedir,))
+    cmd = build_cmd(options, unknown, env)
     print(cmd)
     print("Running...\n    %s\n" % (
             ' '.join( (x if ' ' not in x else '"'+x+'"') for x in cmd ), ))
@@ -675,5 +684,4 @@ def runtests(options):
 
 if __name__ == '__main__':
     parser = buildParser()
-    options = parser.parse_args()
-    sys.exit(runtests(options))
+    sys.exit(runtests(parser))

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -561,6 +561,10 @@ def buildParser():
         action='store_true',
         dest='dryrun',
         help='Dry run: collect but do not execute the tests')
+    parser.add_argument('--show-log',
+        action='store_true',
+        dest='showlog',
+        help='Turn off log capture and allow warnings/deprecations to show.')
     return parser
 
 
@@ -602,10 +606,12 @@ def runtests(options):
         cmd.append('-x')
     if options.dryrun:
         cmd.append('--collect-only')
-
     if options.xunit:
         cmd.append('--with-xunit')
         cmd.append('--xunit-file=TEST-pyomo.xml')
+    if options.showlog:
+        cmd.append('--nologcapture')
+        cmd.append('--nocapture')
 
     attr = []
     _with_performance = False


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
As part of the release process, we now check the logs to make sure that deprecation warnings are not being thrown in the core. This adds the option to show all logs rather than the default where they are swallowed.

This PR also enables any extra values that are passed to be tacked on directly to the nosetests call.

## Changes proposed in this PR:
- Add `--show-log` option for Pyomo test driver
- Allow unknown arguments to be passed and added onto nosetests call

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
