### PR TITLE
Resolve regressions in `assertStructuredAlmostEqual` and `Initializer`

### DIFF
--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -54,7 +54,7 @@ jobs:
         path: dist
 
   manylinuxaarch64:
-  if: ${{ false }}
+    if: ${{ false }}
     name: ${{ matrix.TARGET }}/wheel_creation
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -54,6 +54,7 @@ jobs:
         path: dist
 
   manylinuxaarch64:
+  if: ${{ false }}
     name: ${{ matrix.TARGET }}/wheel_creation
     runs-on: ${{ matrix.os }}
     strategy:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,6 +34,7 @@ Pyomo 6.2    17 Nov 2021
   - Fix bugs with open NumericRanges (#2170, #2179)
   - Fix bugs with References (#2158)
   - Fix Initializer by treating pandas.Series as sequences (#2151)
+  - Fix Initializer support for ConfigList/ConfigDict (#2200)
   - Add a DataFrameInitializer (#2150)
   - Add a public API for retrieving variable bound expressions (#2172)
   - Rework Var component to leverage Initializer (#2184)
@@ -48,6 +49,7 @@ Pyomo 6.2    17 Nov 2021
   - Improve GAMS writer performance (#2191)
 - Testing
   - Resolve test failures when no solvers are available (#2146)
+  - Resolve NumericValue support in assertStructuredAlmostEqual (#2200)
   - Fix typo in booktest skip declaration (#2186)
 - DAE Updates
   - Utility function to slice individual components in flatten module (#2141)

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -29,6 +29,7 @@ import sys
 from textwrap import wrap
 import types
 
+from pyomo.common.collections import Sequence, Mapping
 from pyomo.common.deprecation import deprecated, relocated_module_attribute
 from pyomo.common.fileutils import import_file
 from pyomo.common.modeling import NoArgumentGiven
@@ -1158,10 +1159,11 @@ class ConfigBase(object):
         # can allocate the state dictionary.  If it is not, then we call
         # the super-class's __getstate__ (since that class is NOT
         # 'object').
-        if self.__class__.__mro__[-2] is ConfigBase:
-            state = {}
+        _base = super(ConfigBase, self)
+        if hasattr(_base, '__getstate__'):
+            state = _base.__getstate__()
         else:
-            state = super(ConfigBase, self).__getstate__()
+            state = {}
         state.update((key, getattr(self, key)) for key in ConfigBase.__slots__)
         state['_domain'] = _picklable(state['_domain'], self)
         state['_parent'] = None
@@ -1721,7 +1723,7 @@ class MarkImmutable(object):
         self.release_lock()
 
 
-class ConfigList(ConfigBase):
+class ConfigList(ConfigBase, Sequence):
     """Store and manipulate a list of configuration values.
 
     Parameters
@@ -1896,7 +1898,7 @@ class ConfigList(ConfigBase):
                 yield v
 
 
-class ConfigDict(ConfigBase):
+class ConfigDict(ConfigBase, Mapping):
     """Store and manipulate a dictionary of configuration values.
 
     Parameters

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -1151,7 +1151,7 @@ class ConfigBase(object):
         #    state[i] = getattr(self,i)
         # return state
         #
-        # Hoewever, in this case, the (nominal) parent class is
+        # However, in this case, the (nominal) parent class is
         # 'object', and object does not implement __getstate__.  Since
         # super() doesn't actually return a class, we are going to check
         # the *derived class*'s MRO and see if this is the second to
@@ -1159,7 +1159,7 @@ class ConfigBase(object):
         # can allocate the state dictionary.  If it is not, then we call
         # the super-class's __getstate__ (since that class is NOT
         # 'object').
-        _base = super(ConfigBase, self)
+        _base = super()
         if hasattr(_base, '__getstate__'):
             state = _base.__getstate__()
         else:

--- a/pyomo/common/tests/test_unittest.py
+++ b/pyomo/common/tests/test_unittest.py
@@ -15,6 +15,7 @@ import time
 
 import pyomo.common.unittest as unittest
 from pyomo.common.log import LoggingIntercept
+from pyomo.environ import ConcreteModel, Var, Param
 
 @unittest.timeout(10)
 def short_sleep():
@@ -148,6 +149,20 @@ class TestPyomoUnittest(unittest.TestCase):
         b[1.1][2] -= 1.999e-7
         with self.assertRaisesRegex(self.failureException,
                                     '3 !~= 2.999'):
+            self.assertStructuredAlmostEqual(a, b)
+
+    def test_assertStructuredAlmostEqual_numericvalue(self):
+        m = ConcreteModel()
+        m.v = Var(initialize=2.)
+        m.p = Param(initialize=2.)
+        a = {1.1: [1,m.p,3], 'a': 'hi', 3: {1:2, 3:4}}
+        b = {1.1: [1,m.v,3], 'a': 'hi', 3: {1:2, 3:4}}
+        self.assertStructuredAlmostEqual(a, b)
+        m.v.set_value(m.v.value - 1.999e-7)
+        self.assertStructuredAlmostEqual(a, b)
+        m.v.set_value(m.v.value - 1.999e-7)
+        with self.assertRaisesRegex(self.failureException,
+                                    '2.0 !~= 1.999'):
             self.assertStructuredAlmostEqual(a, b)
 
     def test_timeout_fcn_call(self):

--- a/pyomo/core/tests/unit/test_initializer.py
+++ b/pyomo/core/tests/unit/test_initializer.py
@@ -11,6 +11,7 @@
 import pickle
 
 import pyomo.common.unittest as unittest
+from pyomo.common.config import ConfigValue, ConfigList, ConfigDict
 from pyomo.common.dependencies import pandas as pd, pandas_available
 
 from pyomo.core.base.util import flatten_tuple
@@ -534,3 +535,28 @@ class Test_Initializer(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, 'type'):
             d(None, 2)
         self.assertEqual(d(None, 3), 100)
+
+    def test_config_integration(self):
+        c = ConfigList()
+        c.add(1)
+        c.add(3)
+        c.add(5)
+        a = Initializer(c)
+        self.assertIs(type(a), ItemInitializer)
+        self.assertTrue(a.contains_indices())
+        self.assertEqual(list(a.indices()), [0, 1, 2])
+        self.assertEqual(a(None, 0), 1)
+        self.assertEqual(a(None, 1), 3)
+        self.assertEqual(a(None, 2), 5)
+
+        c = ConfigDict()
+        c.declare('opt_1', ConfigValue(default=1))
+        c.declare('opt_3', ConfigValue(default=3))
+        c.declare('opt_5', ConfigValue(default=5))
+        a = Initializer(c)
+        self.assertIs(type(a), ItemInitializer)
+        self.assertTrue(a.contains_indices())
+        self.assertEqual(list(a.indices()), ['opt_1', 'opt_3', 'opt_5'])
+        self.assertEqual(a(None, 'opt_1'), 1)
+        self.assertEqual(a(None, 'opt_3'), 3)
+        self.assertEqual(a(None, 'opt_5'), 5)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This resolves two regressions in previously supported behavior (identified through testing with IDAES):
- `assertStructuredAlmostEqual()` should support structures containing `NumericValue` objects.  As we are now more strict in only converting *constant* `NumericValue` objects to floats, the default `item_callback` needed to be augmented to also `__call__` the value if the cast to `float()` failed.
- `Initializer` used to recognize `ConfigList` as a `Sequence` object.  This restores that behavior.

## Changes proposed in this PR:
- Support `NumericValue` objects in the default `assertStructuredAlmostEqual` implementation
- Support passing `ConfigList` and `ConfigDict` to `Initializer()`
- Add tests verifying these behaviors

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
