### PR TITLE
disable log file in gurobi_direct solver interface when keepfiles=False

### DIFF
--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -205,8 +205,11 @@ class GurobiDirect(DirectSolver):
 
         self._solver_model.optimize(self._callback)
         self._needs_updated = False
-
-        self._solver_model.setParam('LogFile', 'default')
+        
+        if self._keepfiles:
+            # Change LogFile to make Gurobi close the original log file.
+            # May not work for all Gurobi versions, like ver. 9.5.0.
+            self._solver_model.setParam('LogFile', 'default')
 
         # FIXME: can we get a return code indicating if Gurobi had a significant failure?
         return Bunch(rc=None, log=None)

--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -160,9 +160,9 @@ class GurobiDirect(DirectSolver):
         else:
             self._solver_model.setParam('OutputFlag', 0)
 
-        self._solver_model.setParam('LogFile', self._log_file)
-
         if self._keepfiles:
+            # Only save log file when the user wants to keep it.
+            self._solver_model.setParam('LogFile', self._log_file)
             print("Solver log file: "+self._log_file)
 
         # Options accepted by gurobi (case insensitive):


### PR DESCRIPTION
## Fixes #2197 .

## Summary/Motivation:
The gurobi_direct solver interface retrieves results directly from the `gurobipy.Model` object rather than the log file. When the solving parameter `keepfiles = False`, the log file is of no use and will be deleted immediately when the solving finished.  But this will cause `WinError 32` with Gurobi 9.5.0 on Windows when Pyomo tries to deleted the log file (#2197). It's better to disable log file in gurobi_direct solver interface when keepfiles=False.

## Changes proposed in this PR:
- In `GurobiDirect._apply_solver` function,  only set the Gurobi `LogFile` parameter when `keepfiles == True`.


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
