### PR TITLE
NPV_SumExpression needs to inherit from NPV_Mixin

### DIFF
--- a/pyomo/core/expr/numeric_expr.py
+++ b/pyomo/core/expr/numeric_expr.py
@@ -1246,11 +1246,8 @@ class UnaryFunctionExpression(ExpressionBase):
         return self._fcn(result[0])
 
 
-class NPV_UnaryFunctionExpression(UnaryFunctionExpression):
+class NPV_UnaryFunctionExpression(NPV_Mixin, UnaryFunctionExpression):
     __slots__ = ()
-
-    def is_potentially_variable(self):
-        return False
 
 
 # NOTE: This should be a special class, since the expression generation relies
@@ -1266,6 +1263,11 @@ class AbsExpression(UnaryFunctionExpression):
 
     def __init__(self, arg):
         super(AbsExpression, self).__init__(arg, 'abs', abs)
+
+    def create_node_with_local_data(self, args, classtype=None):
+        if classtype is None:
+            classtype = self.__class__
+        return classtype(args)
 
 
 class NPV_AbsExpression(NPV_Mixin, AbsExpression):

--- a/pyomo/core/expr/numeric_expr.py
+++ b/pyomo/core/expr/numeric_expr.py
@@ -958,7 +958,7 @@ class SumExpressionBase(_LinearOperatorExpression):
         return 'sum'
 
 
-class NPV_SumExpression(SumExpressionBase):
+class NPV_SumExpression(NPV_Mixin, SumExpressionBase):
     __slots__ = ()
 
     def create_potentially_variable_object(self):
@@ -975,8 +975,22 @@ class NPV_SumExpression(SumExpressionBase):
             return "{0} {1}".format(values[0],values[1])
         return "{0} + {1}".format(values[0],values[1])
 
-    def is_potentially_variable(self):
-        return False
+    def create_node_with_local_data(self, args, classtype=None):
+        assert classtype is None
+        try:
+            npv_args = all(
+                type(arg) in native_types or not arg.is_potentially_variable()
+                for arg in args
+            )
+        except AttributeError:
+            # We can hit this during expression replacement when the new
+            # type is not a PyomoObject type, but is not in the
+            # native_types set.  We will play it safe and clear the NPV flag
+            npv_args = False
+        if npv_args:
+            return NPV_SumExpression(args)
+        else:
+            return SumExpression(args)
 
 
 class SumExpression(SumExpressionBase):

--- a/pyomo/core/tests/unit/test_compare.py
+++ b/pyomo/core/tests/unit/test_compare.py
@@ -13,7 +13,7 @@ from pyomo.core.expr.numeric_expr import (
     LinearExpression, MonomialTermExpression, SumExpression,
     ProductExpression, DivisionExpression, PowExpression,
     NegationExpression, UnaryFunctionExpression, ExternalFunctionExpression,
-    Expr_ifExpression
+    Expr_ifExpression, AbsExpression
 )
 from pyomo.core.expr.logical_expr import (
     InequalityExpression, EqualityExpression, RangedExpression
@@ -120,7 +120,7 @@ class TestConvertToPrefixNotation(unittest.TestCase):
         m.x = pe.Var()
         e = abs(m.x)
         pn = convert_expression_to_prefix_notation(e)
-        expected = [(UnaryFunctionExpression, 1, 'abs'),
+        expected = [(AbsExpression, 1, 'abs'),
                     m.x]
         self.assertEqual(pn, expected)
 

--- a/pyomo/core/tests/unit/test_visitor.py
+++ b/pyomo/core/tests/unit/test_visitor.py
@@ -12,17 +12,23 @@
 #
 
 import os
+import pyomo.core.tests.unit.test_visitor
 from os.path import abspath, dirname
 currdir = dirname(abspath(__file__))+os.sep
 
 import pyomo.common.unittest as unittest
 from pyomo.common.unittest import nottest
 
-from pyomo.environ import ConcreteModel, RangeSet, Param, Var, Expression, ExternalFunction, VarList, sum_product, inequality, quicksum, sin, tanh
+from pyomo.environ import ConcreteModel, RangeSet, Param, Var, Expression, ExternalFunction, VarList, sum_product, inequality, quicksum, sin, tanh, value
 from pyomo.core.expr.numvalue import nonpyomo_leaf_types, NumericConstant
 from pyomo.core.expr.numeric_expr import (
     SumExpression, ProductExpression, 
-    MonomialTermExpression, LinearExpression)
+    MonomialTermExpression, LinearExpression,
+    NPV_SumExpression, NPV_ProductExpression, NegationExpression,
+    NPV_NegationExpression, PowExpression, NPV_PowExpression,
+    MaxExpression, NPV_MaxExpression, MinExpression, NPV_MinExpression,
+    DivisionExpression, NPV_DivisionExpression, UnaryFunctionExpression,
+    NPV_UnaryFunctionExpression, AbsExpression, NPV_AbsExpression)
 from pyomo.core.expr.visitor import (
     FixedExpressionError, NonConstantExpressionError,
     StreamBasedExpressionVisitor, ExpressionReplacementVisitor,
@@ -36,6 +42,7 @@ from pyomo.core.expr.expr_errors import TemplateExpressionError
 from pyomo.common.collections import ComponentSet
 from pyomo.common.log import LoggingIntercept
 from io import StringIO
+from pyomo.core.expr.compare import compare_expressions
 
 
 class TestExpressionUtilities(unittest.TestCase):
@@ -296,8 +303,8 @@ class WalkerTests(unittest.TestCase):
         e = sin(M.x) + M.x*M.y + 3
         walker = ReplacementWalkerTest1(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("sin(x) + x*y + 3", str(e))
-        self.assertEqual("sin(w[1]) + w[1]*w[2] + 3", str(f))
+        self.assertTrue(compare_expressions(sin(M.x) + M.x*M.y + 3, e))
+        self.assertTrue(compare_expressions(sin(M.w[1]) + M.w[1]*M.w[2] + 3, f))
 
     def test_replacement_walker2(self):
         M = ConcreteModel()
@@ -307,8 +314,8 @@ class WalkerTests(unittest.TestCase):
         e = M.x
         walker = ReplacementWalkerTest1(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("x", str(e))
-        self.assertEqual("w[1]", str(f))
+        self.assertTrue(compare_expressions(M.x, e))
+        self.assertTrue(compare_expressions(M.w[1], f))
 
     def test_replacement_walker3(self):
         M = ConcreteModel()
@@ -319,8 +326,8 @@ class WalkerTests(unittest.TestCase):
         e = sin(M.x) + M.x*M.y + 3 <= 0
         walker = ReplacementWalkerTest1(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("sin(x) + x*y + 3  <=  0", str(e))
-        self.assertEqual("sin(w[1]) + w[1]*w[2] + 3  <=  0", str(f))
+        self.assertTrue(compare_expressions(sin(M.x) + M.x*M.y + 3  <=  0, e))
+        self.assertTrue(compare_expressions(sin(M.w[1]) + M.w[1]*M.w[2] + 3  <=  0, f))
 
     def test_replacement_walker4(self):
         M = ConcreteModel()
@@ -331,8 +338,8 @@ class WalkerTests(unittest.TestCase):
         e = inequality(0, sin(M.x) + M.x*M.y + 3, 1)
         walker = ReplacementWalkerTest1(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("0  <=  sin(x) + x*y + 3  <=  1", str(e))
-        self.assertEqual("0  <=  sin(w[1]) + w[1]*w[2] + 3  <=  1", str(f))
+        self.assertTrue(compare_expressions(inequality(0, sin(M.x) + M.x*M.y + 3, 1), e))
+        self.assertTrue(compare_expressions(inequality(0, sin(M.w[1]) + M.w[1]*M.w[2] + 3, 1), f))
 
     def test_replacement_walker0(self):
         M = ConcreteModel()
@@ -344,14 +351,21 @@ class WalkerTests(unittest.TestCase):
         self.assertIs(type(e), LinearExpression)
         walker = ReplacementWalkerTest1(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("z[0]*x[0] + z[1]*x[1] + z[2]*x[2]", str(e))
-        self.assertEqual("z[0]*w[1] + z[1]*w[2] + z[2]*w[3]", str(f))
+        self.assertTrue(compare_expressions(LinearExpression(linear_coefs=[i for i in M.z.values()],
+                                                             linear_vars=[i for i in M.x.values()]), e))
+        self.assertTrue(compare_expressions(LinearExpression(linear_coefs=[i for i in M.z.values()],
+                                                             linear_vars=[i for i in M.w.values()]), f))
 
+        del M.w
+        del M.w_index
+        M.w = VarList()
         e = 2*sum_product(M.z, M.x)
         walker = ReplacementWalkerTest1(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("2*(z[0]*x[0] + z[1]*x[1] + z[2]*x[2])", str(e))
-        self.assertEqual("2*(z[0]*w[4] + z[1]*w[5] + z[2]*w[6])", str(f))
+        self.assertTrue(compare_expressions(2*LinearExpression(linear_coefs=[i for i in M.z.values()],
+                                                               linear_vars=[i for i in M.x.values()]), e))
+        self.assertTrue(compare_expressions(2*LinearExpression(linear_coefs=[i for i in M.z.values()],
+                                                               linear_vars=[i for i in M.w.values()]), f))
 
     def test_replace_expressions_with_monomial_term(self):
         M = ConcreteModel()
@@ -443,8 +457,8 @@ class WalkerTests2(unittest.TestCase):
         e = sin(M.x) + M.x*M.y + 3
         walker = ReplacementWalkerTest2(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("sin(x) + x*y + 3", str(e))
-        self.assertEqual("sin(2*w[1]) + 2*w[1]*(2*w[2]) + 3", str(f))
+        self.assertTrue(compare_expressions(sin(M.x) + M.x*M.y + 3, e))
+        self.assertTrue(compare_expressions(sin(2*M.w[1]) + 2*M.w[1]*(2*M.w[2]) + 3, f))
 
     def test_replacement_walker2(self):
         M = ConcreteModel()
@@ -454,8 +468,8 @@ class WalkerTests2(unittest.TestCase):
         e = M.x
         walker = ReplacementWalkerTest2(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("x", str(e))
-        self.assertEqual("2*w[1]", str(f))
+        self.assertTrue(compare_expressions(M.x, e))
+        self.assertTrue(compare_expressions(2*M.w[1], f))
 
     def test_replacement_walker3(self):
         M = ConcreteModel()
@@ -466,8 +480,8 @@ class WalkerTests2(unittest.TestCase):
         e = sin(M.x) + M.x*M.y + 3 <= 0
         walker = ReplacementWalkerTest2(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("sin(x) + x*y + 3  <=  0", str(e))
-        self.assertEqual("sin(2*w[1]) + 2*w[1]*(2*w[2]) + 3  <=  0", str(f))
+        self.assertTrue(compare_expressions(sin(M.x) + M.x*M.y + 3  <=  0, e))
+        self.assertTrue(compare_expressions(sin(2*M.w[1]) + 2*M.w[1]*(2*M.w[2]) + 3  <=  0, f))
 
     def test_replacement_walker4(self):
         M = ConcreteModel()
@@ -478,8 +492,8 @@ class WalkerTests2(unittest.TestCase):
         e = inequality(0, sin(M.x) + M.x*M.y + 3, 1)
         walker = ReplacementWalkerTest2(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("0  <=  sin(x) + x*y + 3  <=  1", str(e))
-        self.assertEqual("0  <=  sin(2*w[1]) + 2*w[1]*(2*w[2]) + 3  <=  1", str(f))
+        self.assertTrue(compare_expressions(inequality(0  ,   sin(M.x) + M.x*M.y + 3  ,   1), e))
+        self.assertTrue(compare_expressions(inequality(0  ,   sin(2*M.w[1]) + 2*M.w[1]*(2*M.w[2]) + 3  ,   1), f))
 
     def test_replacement_walker5(self):
         M = ConcreteModel()
@@ -492,8 +506,8 @@ class WalkerTests2(unittest.TestCase):
         f = walker.dfs_postorder_stack(e)
         self.assertTrue(e.__class__ is MonomialTermExpression)
         self.assertTrue(f.__class__ is ProductExpression)
-        self.assertEqual("z*x", str(e))
-        self.assertEqual("z*(2*w[1])", str(f))
+        self.assertTrue(compare_expressions(M.z*M.x, e))
+        self.assertTrue(compare_expressions(M.z*(2*M.w[1]), f))
 
     def test_replacement_walker0(self):
         M = ConcreteModel()
@@ -505,14 +519,16 @@ class WalkerTests2(unittest.TestCase):
         self.assertIs(type(e), LinearExpression)
         walker = ReplacementWalkerTest2(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("z[0]*x[0] + z[1]*x[1] + z[2]*x[2]", str(e))
-        self.assertEqual("z[0]*(2*w[1]) + z[1]*(2*w[2]) + z[2]*(2*w[3])", str(f))
+        self.assertTrue(compare_expressions(LinearExpression(linear_coefs=[i for i in M.z.values()],
+                                                             linear_vars=[i for i in M.x.values()]), e))
+        self.assertTrue(compare_expressions(M.z[0]*(2*M.w[1]) + M.z[1]*(2*M.w[2]) + M.z[2]*(2*M.w[3]), f))
 
         e = 2*sum_product(M.z, M.x)
         walker = ReplacementWalkerTest2(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("2*(z[0]*x[0] + z[1]*x[1] + z[2]*x[2])", str(e))
-        self.assertEqual("2*(z[0]*(2*w[4]) + z[1]*(2*w[5]) + z[2]*(2*w[6]))", str(f))
+        self.assertTrue(compare_expressions(2*LinearExpression(linear_coefs=[i for i in M.z.values()],
+                                                               linear_vars=[i for i in M.x.values()]), e))
+        self.assertTrue(compare_expressions(2*(M.z[0]*(2*M.w[4]) + M.z[1]*(2*M.w[5]) + M.z[2]*(2*M.w[6])), f))
 
 #
 # Replace all mutable parameters with variables
@@ -549,8 +565,8 @@ class WalkerTests3(unittest.TestCase):
         e = sin(M.x) + M.x*M.y + 3
         walker = ReplacementWalkerTest3(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("sin(x) + x*y + 3", str(e))
-        self.assertEqual("sin(2*w[1]) + 2*w[1]*y + 3", str(f))
+        self.assertTrue(compare_expressions(sin(M.x) + M.x*M.y + 3, e))
+        self.assertTrue(compare_expressions(sin(2*M.w[1]) + 2*M.w[1]*M.y + 3, f))
 
     def test_replacement_walker2(self):
         M = ConcreteModel()
@@ -560,8 +576,8 @@ class WalkerTests3(unittest.TestCase):
         e = M.x
         walker = ReplacementWalkerTest3(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("x", str(e))
-        self.assertEqual("2*w[1]", str(f))
+        self.assertTrue(compare_expressions(M.x, e))
+        self.assertTrue(compare_expressions(2*M.w[1], f))
 
     def test_replacement_walker3(self):
         M = ConcreteModel()
@@ -572,8 +588,8 @@ class WalkerTests3(unittest.TestCase):
         e = sin(M.x) + M.x*M.y + 3 <= 0
         walker = ReplacementWalkerTest3(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("sin(x) + x*y + 3  <=  0", str(e))
-        self.assertEqual("sin(2*w[1]) + 2*w[1]*y + 3  <=  0", str(f))
+        self.assertTrue(compare_expressions(sin(M.x) + M.x*M.y + 3  <=  0, e))
+        self.assertTrue(compare_expressions(sin(2*M.w[1]) + 2*M.w[1]*M.y + 3  <=  0, f))
 
     def test_replacement_walker4(self):
         M = ConcreteModel()
@@ -584,8 +600,8 @@ class WalkerTests3(unittest.TestCase):
         e = inequality(0, sin(M.x) + M.x*M.y + 3, 1)
         walker = ReplacementWalkerTest3(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("0  <=  sin(x) + x*y + 3  <=  1", str(e))
-        self.assertEqual("0  <=  sin(2*w[1]) + 2*w[1]*y + 3  <=  1", str(f))
+        self.assertTrue(compare_expressions(inequality(0, sin(M.x) + M.x*M.y + 3, 1), e))
+        self.assertTrue(compare_expressions(inequality(0, sin(2*M.w[1]) + 2*M.w[1]*M.y + 3, 1), f))
 
     def test_replacement_walker5(self):
         M = ConcreteModel()
@@ -599,8 +615,8 @@ class WalkerTests3(unittest.TestCase):
         self.assertIs(e.__class__, MonomialTermExpression)
         self.assertIs(f.__class__, ProductExpression)
         self.assertTrue(f.arg(0).is_potentially_variable())
-        self.assertEqual("z*x", str(e))
-        self.assertEqual("2*w[1]*x", str(f))
+        self.assertTrue(compare_expressions(M.z*M.x, e))
+        self.assertTrue(compare_expressions(2*M.w[1]*M.x, f))
 
     def test_replacement_walker6(self):
         M = ConcreteModel()
@@ -613,8 +629,8 @@ class WalkerTests3(unittest.TestCase):
         f = walker.dfs_postorder_stack(e)
         self.assertTrue(not e.is_potentially_variable())
         self.assertTrue(f.is_potentially_variable())
-        self.assertEqual("z*2*3", str(e))
-        self.assertEqual("2*w[1]*2*3", str(f))
+        self.assertTrue(compare_expressions(M.z*2*3, e))
+        self.assertTrue(compare_expressions(ProductExpression([ProductExpression([2*M.w[1], 2]), 3]), f))
 
     def test_replacement_walker7(self):
         M = ConcreteModel()
@@ -626,7 +642,7 @@ class WalkerTests3(unittest.TestCase):
         e = M.x*M.e
         self.assertTrue(e.arg(1).is_potentially_variable())
         self.assertTrue(not e.arg(1).arg(0).is_potentially_variable())
-        self.assertEqual("x*(z*2)", str(e))
+        self.assertTrue(compare_expressions(ProductExpression([M.x, (NPV_ProductExpression([M.z, 2]))]), e, include_named_exprs=False))
         walker = ReplacementWalkerTest3(M)
         f = walker.dfs_postorder_stack(e)
         self.assertTrue(e.__class__ is ProductExpression)
@@ -634,7 +650,7 @@ class WalkerTests3(unittest.TestCase):
         self.assertEqual(id(e), id(f))
         self.assertTrue(f.arg(1).is_potentially_variable())
         self.assertTrue(f.arg(1).arg(0).is_potentially_variable())
-        self.assertEqual("x*(2*w[1]*2)", str(f))
+        self.assertTrue(compare_expressions(M.x*ProductExpression([2*M.w[1], 2]), f, include_named_exprs=False))
 
     def test_replacement_walker0(self):
         M = ConcreteModel()
@@ -646,14 +662,16 @@ class WalkerTests3(unittest.TestCase):
         self.assertIs(type(e), LinearExpression)
         walker = ReplacementWalkerTest3(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("z[0]*x[0] + z[1]*x[1] + z[2]*x[2]", str(e))
-        self.assertEqual("2*w[1]*x[0] + 2*w[2]*x[1] + 2*w[3]*x[2]", str(f))
+        self.assertTrue(compare_expressions(LinearExpression(linear_coefs=[i for i in M.z.values()],
+                                                             linear_vars=[i for i in M.x.values()]), e))
+        self.assertTrue(compare_expressions(2*M.w[1]*M.x[0] + 2*M.w[2]*M.x[1] + 2*M.w[3]*M.x[2], f))
 
         e = 2*sum_product(M.z, M.x)
         walker = ReplacementWalkerTest3(M)
         f = walker.dfs_postorder_stack(e)
-        self.assertEqual("2*(z[0]*x[0] + z[1]*x[1] + z[2]*x[2])", str(e))
-        self.assertEqual("2*(2*w[4]*x[0] + 2*w[5]*x[1] + 2*w[6]*x[2])", str(f))
+        self.assertTrue(compare_expressions(2*LinearExpression(linear_coefs=[i for i in M.z.values()],
+                                                               linear_vars=[i for i in M.x.values()]), e))
+        self.assertTrue(compare_expressions(2*(2*M.w[4]*M.x[0] + 2*M.w[5]*M.x[1] + 2*M.w[6]*M.x[2]), f))
 
 
 #
@@ -677,8 +695,8 @@ class WalkerTests_ReplaceInternal(unittest.TestCase):
 
         e = sum(m.y[i] for i in m.y) == 0
         f = ReplacementWalker_ReplaceInternal().dfs_postorder_stack(e)
-        self.assertEqual("y[1] + y[2] + y[3]  ==  0", str(e))
-        self.assertEqual("y[1] + y[2] + y[3]  ==  0", str(f))
+        self.assertTrue(compare_expressions(m.y[1] + m.y[2] + m.y[3]  ==  0, e))
+        self.assertTrue(compare_expressions(m.y[1] + m.y[2] + m.y[3]  ==  0, f))
         self.assertIs(e, f)
 
     def test_replace(self):
@@ -688,8 +706,8 @@ class WalkerTests_ReplaceInternal(unittest.TestCase):
 
         e = m.y[1]*m.y[2] + m.y[2]*m.y[3]  ==  0
         f = ReplacementWalker_ReplaceInternal().dfs_postorder_stack(e)
-        self.assertEqual("y[1]*y[2] + y[2]*y[3]  ==  0", str(e))
-        self.assertEqual("y[1] + y[2] + (y[2] + y[3])  ==  0", str(f))
+        self.assertTrue(compare_expressions(m.y[1]*m.y[2] + m.y[2]*m.y[3]  ==  0, e))
+        self.assertTrue(compare_expressions(SumExpression([SumExpression([m.y[1], m.y[2]]), SumExpression([m.y[2], m.y[3]])])  ==  0, f))
         self.assertIs(type(f.arg(0)), SumExpression)
         self.assertEqual(f.arg(0).nargs(), 2)
         self.assertIs(type(f.arg(0).arg(0)), SumExpression)
@@ -704,10 +722,104 @@ class WalkerTests_ReplaceInternal(unittest.TestCase):
 
         e = m.y[1]*m.y[2]*m.y[2]*m.y[3]  ==  0
         f = ReplacementWalker_ReplaceInternal().dfs_postorder_stack(e)
-        self.assertEqual("y[1]*y[2]*y[2]*y[3]  ==  0", str(e))
-        self.assertEqual("y[1] + y[2] + y[2] + y[3]  ==  0", str(f))
+        self.assertTrue(compare_expressions(m.y[1]*m.y[2]*m.y[2]*m.y[3]  ==  0, e))
+        self.assertTrue(compare_expressions(m.y[1] + m.y[2] + m.y[2] + m.y[3]  ==  0, f))
         self.assertIs(type(f.arg(0)), SumExpression)
         self.assertEqual(f.arg(0).nargs(), 4)
+
+
+class TestReplacementWithNPV(unittest.TestCase):
+
+    def test_npv_sum(self):
+        m = ConcreteModel()
+        m.p1 = Param(mutable=True)
+        m.p2 = Param(mutable=True)
+        m.x = Var()
+
+        e1 = m.p1 + 2
+        e2 = replace_expressions(e1, {id(m.p1): m.p2})
+        e3 = replace_expressions(e1, {id(m.p1): m.x})
+
+        self.assertTrue(compare_expressions(e2, m.p2 + 2))
+        self.assertTrue(compare_expressions(e3, m.x + 2))
+
+    def test_npv_negation(self):
+        m = ConcreteModel()
+        m.p1 = Param(mutable=True)
+        m.p2 = Param(mutable=True)
+        m.x = Var()
+
+        e1 = -m.p1
+        e2 = replace_expressions(e1, {id(m.p1): m.p2})
+        e3 = replace_expressions(e1, {id(m.p1): m.x})
+
+        self.assertTrue(compare_expressions(e2, -m.p2))
+        self.assertTrue(compare_expressions(e3, NegationExpression([m.x])))
+
+    def test_npv_pow(self):
+        m = ConcreteModel()
+        m.p1 = Param(mutable=True)
+        m.p2 = Param(mutable=True)
+        m.x = Var()
+
+        e1 = m.p1**3
+        e2 = replace_expressions(e1, {id(m.p1): m.p2})
+        e3 = replace_expressions(e1, {id(m.p1): m.x})
+
+        self.assertTrue(compare_expressions(e2, m.p2**3))
+        self.assertTrue(compare_expressions(e3, m.x**3))
+
+    def test_npv_product(self):
+        m = ConcreteModel()
+        m.p1 = Param(mutable=True)
+        m.p2 = Param(mutable=True)
+        m.x = Var()
+
+        e1 = m.p1*3
+        e2 = replace_expressions(e1, {id(m.p1): m.p2})
+        e3 = replace_expressions(e1, {id(m.p1): m.x})
+
+        self.assertTrue(compare_expressions(e2, m.p2*3))
+        self.assertTrue(compare_expressions(e3, ProductExpression([m.x, 3])))
+
+    def test_npv_div(self):
+        m = ConcreteModel()
+        m.p1 = Param(mutable=True)
+        m.p2 = Param(mutable=True)
+        m.x = Var()
+
+        e1 = m.p1/3
+        e2 = replace_expressions(e1, {id(m.p1): m.p2})
+        e3 = replace_expressions(e1, {id(m.p1): m.x})
+
+        self.assertTrue(compare_expressions(e2, m.p2/3))
+        self.assertTrue(compare_expressions(e3, DivisionExpression([m.x, 3])))
+
+    def test_npv_unary(self):
+        m = ConcreteModel()
+        m.p1 = Param(mutable=True)
+        m.p2 = Param(mutable=True)
+        m.x = Var(initialize=0)
+
+        e1 = sin(m.p1)
+        e2 = replace_expressions(e1, {id(m.p1): m.p2})
+        e3 = replace_expressions(e1, {id(m.p1): m.x})
+
+        self.assertTrue(compare_expressions(e2, sin(m.p2)))
+        self.assertTrue(compare_expressions(e3, sin(m.x)))
+
+    def test_npv_abs(self):
+        m = ConcreteModel()
+        m.p1 = Param(mutable=True)
+        m.p2 = Param(mutable=True)
+        m.x = Var()
+
+        e1 = abs(m.p1)
+        e2 = replace_expressions(e1, {id(m.p1): m.p2})
+        e3 = replace_expressions(e1, {id(m.p1): m.x})
+
+        self.assertTrue(compare_expressions(e2, abs(m.p2)))
+        self.assertTrue(compare_expressions(e3, abs(m.x)))
 
 
 class TestStreamBasedExpressionVisitor(unittest.TestCase):


### PR DESCRIPTION
## Fixes #2208 .

## Changes proposed in this PR:
- `NPV_SumExpression` inherits from `NPV_Mixin`
- Unfortunately, the implementation of `create_node_with_local_data` in `NPV_Mixin` does not work for `NPV_SumExpression`. You end up with an instance of `SumExpressionBase` instead of `SumExpression` when some of `args` are potentially variable. Therefore, I reimplemented `create_node_with_local_data` for `NPV_SumExpression`. Maybe there is a way to make the `NPV_Mixin` implementation work?

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
