### PR TITLE
Bugfix: implicit `Var` construction and `Ellipsis` in `Any`

### DIFF
--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -3965,7 +3965,7 @@ class _AnySet(_SetData, Set):
         Set.__init__(self, **kwds)
 
     def get(self, val, default=None):
-        return val
+        return val if val is not Ellipsis else default
 
     def ranges(self):
         yield AnyRange()

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -18,7 +18,7 @@ from weakref import ref as weakref_ref
 from pyomo.common.collections import Sequence
 from pyomo.common.deprecation import RenamedClass
 from pyomo.common.log import is_debug_set
-from pyomo.common.modeling import NoArgumentGiven
+from pyomo.common.modeling import NoArgumentGiven, NOTSET
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.expr.numeric_expr import NPV_MaxExpression, NPV_MinExpression
 from pyomo.core.expr.numvalue import (
@@ -802,6 +802,22 @@ class Var(IndexedComponent, IndexedComponent_NDArrayMixin):
             obj.lower, obj.upper = self._rule_bounds(parent, index)
         if self._rule_init is not None:
             obj.set_value(self._rule_init(parent, index))
+        return obj
+
+    #
+    # Because we need to do more initialization than simply calling
+    # set_value(), we need to override _setitem_when_not_present
+    #
+    def _setitem_when_not_present(self, index, value=NOTSET):
+        if value is self.Skip:
+            return None
+        try:
+            obj = self._getitem_when_not_present(index)
+            if value is not NOTSET:
+                obj.set_value(value)
+        except:
+            self._data.pop(index, None)
+            raise
         return obj
 
     def _pprint(self):

--- a/pyomo/core/tests/unit/test_indexed_slice.py
+++ b/pyomo/core/tests/unit/test_indexed_slice.py
@@ -15,7 +15,7 @@ import pickle
 
 import pyomo.common.unittest as unittest
 
-from pyomo.environ import Var, Block, ConcreteModel, RangeSet, Set
+from pyomo.environ import Var, Block, ConcreteModel, RangeSet, Set, Any
 from pyomo.core.base.block import _BlockData
 from pyomo.core.base.indexed_component_slice import IndexedComponent_slice
 from pyomo.core.base.set import normalize_index
@@ -156,6 +156,16 @@ class TestComponentSlices(unittest.TestCase):
         self.assertRaisesRegex(
             IndexError, 'wildcard slice .* can only appear once',
             self.m.b.__getitem__, (Ellipsis,Ellipsis) )
+
+    def test_any_slice(self):
+        m = ConcreteModel()
+        m.x = Var(Any, dense=False)
+        m.x[1] = 1
+        m.x[1,1] = 2
+        m.x[2] = 3
+        self.assertEqual(list(str(_) for _ in m.x[:]), ['x[1]', 'x[2]'])
+        self.assertEqual(list(str(_) for _ in m.x[:,:]), ['x[1,1]'])
+        self.assertEqual(list(str(_) for _ in m.x[...]), ['x[1]', 'x[1,1]', 'x[2]'])
 
 
     def test_nonterminal_slice(self):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
The rework of the Var initialization broke "implicit" variable construction, like:
```python
m.x = Var(Integers, domain=Binary)
m.x[1] = 1
```

This resolves that bug and adds tests to ensure the behavior is preserved.

As part of this PR, it became apparent that `Any` cannot admit `Ellipsis`, otherwise component slicing over Components indexed by `Any` will not work correctly.  This PR also resolves (and tests) that bug.

## Changes proposed in this PR:
- Ensure implicitly instantiated variables are correctly initialized
- the `Any` set should not admit `Ellipsis`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
