### PR TITLE
Add support for user-defined Component List starting index

### DIFF
--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -593,9 +593,10 @@ class BooleanVarList(IndexedBooleanVar):
     Variable-length indexed variable objects used to construct Pyomo models.
     """
 
-    def __init__(self, **kwds):
+    def __init__(self, **kwargs):
+        self._starting_index = kwargs.pop('starting_index', 1)
         args = (Set(),)
-        IndexedBooleanVar.__init__(self, *args, **kwds)
+        IndexedBooleanVar.__init__(self, *args, **kwargs)
 
     def construct(self, data=None):
         """Construct this component."""
@@ -609,7 +610,7 @@ class BooleanVarList(IndexedBooleanVar):
         # then let _validate_index complain when we set the value.
         if self._value_init_value.__class__ is dict:
             for i in range(len(self._value_init_value)):
-                self._index.add(i+1)
+                self._index.add(i + self._starting_index)
         super(BooleanVarList,self).construct(data)
         # Note that the current Var initializer silently ignores
         # initialization data that is not in the underlying index set.  To
@@ -622,7 +623,7 @@ class BooleanVarList(IndexedBooleanVar):
 
     def add(self):
         """Add a variable to this list."""
-        next_idx = len(self._index) + 1
+        next_idx = len(self._index) + self._starting_index
         self._index.add(next_idx)
         return self[next_idx]
 

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -973,6 +973,7 @@ class ConstraintList(IndexedConstraint):
             raise ValueError(
                 "ConstraintList does not accept the 'expr' keyword")
         _rule = kwargs.pop('rule', None)
+        self._starting_index = kwargs.pop('starting_index', 1)
 
         args = (Set(dimen=1),)
         super(ConstraintList, self).__init__(*args, **kwargs)
@@ -984,7 +985,9 @@ class ConstraintList(IndexedConstraint):
         # after the base class is set up so that is_indexed() is
         # reliable.
         if self.rule is not None and type(self.rule) is IndexedCallInitializer:
-            self.rule = CountedCallInitializer(self, self.rule)
+            self.rule = CountedCallInitializer(
+                self, self.rule, self._starting_index
+            )
 
 
     def construct(self, data=None):
@@ -1013,7 +1016,7 @@ class ConstraintList(IndexedConstraint):
 
     def add(self, expr):
         """Add a constraint with an implicit index."""
-        next_idx = len(self._index) + 1
+        next_idx = len(self._index) + self._starting_index
         self._index.add(next_idx)
         return self.__setitem__(next_idx, expr)
 

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -546,6 +546,7 @@ class ObjectiveList(IndexedObjective):
             raise ValueError(
                 "ObjectiveList does not accept the 'expr' keyword")
         _rule = kwargs.pop('rule', None)
+        self._starting_index = kwargs.pop('starting_index', 1)
 
         args = (Set(dimen=1),)
         super().__init__(*args, **kwargs)
@@ -555,7 +556,9 @@ class ObjectiveList(IndexedObjective):
         # after the base class is set up so that is_indexed() is
         # reliable.
         if self.rule is not None and type(self.rule) is IndexedCallInitializer:
-            self.rule = CountedCallInitializer(self, self.rule)
+            self.rule = CountedCallInitializer(
+                self, self.rule, self._starting_index
+            )
 
     def construct(self, data=None):
         """
@@ -582,7 +585,7 @@ class ObjectiveList(IndexedObjective):
 
     def add(self, expr, sense=minimize):
         """Add an objective to the list."""
-        next_idx = len(self._index) + 1
+        next_idx = len(self._index) + self._starting_index
         self._index.add(next_idx)
         ans = self.__setitem__(next_idx, expr)
         if ans is not None:

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -924,9 +924,10 @@ class VarList(IndexedVar):
     Variable-length indexed variable objects used to construct Pyomo models.
     """
 
-    def __init__(self, **kwds):
+    def __init__(self, **kwargs):
+        self._starting_index = kwargs.pop('starting_index', 1)
         args = (Set(dimen=1),)
-        IndexedVar.__init__(self, *args, **kwds)
+        IndexedVar.__init__(self, *args, **kwargs)
 
     def construct(self, data=None):
         """Construct this component."""
@@ -947,11 +948,11 @@ class VarList(IndexedVar):
         # then let _validate_index complain when we set the value.
         if self._rule_init is not None and self._rule_init.contains_indices():
             for i, idx in enumerate(self._rule_init.indices()):
-                self._index.add(i+1)
+                self._index.add(i + self._starting_index)
         super(VarList,self).construct(data)
 
     def add(self):
         """Add a variable to this list."""
-        next_idx = len(self._index) + 1
+        next_idx = len(self._index) + self._starting_index
         self._index.add(next_idx)
         return self[next_idx]

--- a/pyomo/core/tests/unit/test_con.py
+++ b/pyomo/core/tests/unit/test_con.py
@@ -1123,6 +1123,14 @@ class TestConList(unittest.TestCase):
 
         self.assertEqual(len(model.c),0)
 
+    def test_0based_add(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.c = ConstraintList(starting_index=0)
+        m.c.add(m.x <= 0)
+        self.assertEqual(list(m.c.keys()), [0])
+        m.c.add(m.x >= 0)
+        self.assertEqual(list(m.c.keys()), [0, 1])
 
 class Test2DArrayCon(unittest.TestCase):
 

--- a/pyomo/core/tests/unit/test_var.py
+++ b/pyomo/core/tests/unit/test_var.py
@@ -938,6 +938,37 @@ class TestVarList(PyomoModel):
         self.assertEqual( type(tmp), int)
         self.assertEqual( tmp, 3 )
 
+    def test_0based_add(self):
+        m = ConcreteModel()
+        m.x = VarList(starting_index=0)
+        m.x.add()
+        self.assertEqual(list(m.x.keys()), [0])
+        m.x.add()
+        self.assertEqual(list(m.x.keys()), [0, 1])
+        m.x.add()
+        self.assertEqual(list(m.x.keys()), [0, 1, 2])
+
+    def test_0based_initialize_with_dict(self):
+        """Test initialize option with a dictionary"""
+        self.model.x = VarList(initialize={1:1.3,2:2.3}, starting_index=0)
+        self.assertRaisesRegex(
+            KeyError, ".*Index '2' is not valid for indexed component 'x'",
+            self.model.create_instance
+        )
+
+    def test_0based_initialize_with_bad_dict(self):
+        """Test initialize option with a dictionary of subkeys"""
+        self.model.x = VarList(initialize={0:1.3, 1:2.3}, starting_index=0)
+        self.instance = self.model.create_instance()
+        self.assertEqual(self.instance.x[0].value, 1.3)
+        self.assertEqual(self.instance.x[1].value, 2.3)
+        self.instance.x[0] = 1
+        self.instance.x[1] = 2
+        self.assertEqual(self.instance.x[0].value, 1)
+        self.assertEqual(self.instance.x[1].value, 2)
+        self.instance.x.add()
+        self.assertEqual(list(self.instance.x.keys()), [0, 1, 2])
+
 
 class Test2DArrayVar(TestSimpleVar):
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This adds support for a `starting_index` option for the Component List classes (`VarList`, `BooleanVarList`, `ConstraintList` and `ObjectiveList`).  For backwards compatibility, the default starting index remains 1.

This was motivated by @mrmundt's TrustRegion work, where we have a `VarList`, but index math would be significantly simpler (and less confusing) if that `VarList` began with 0 instead of 1.

## Changes proposed in this PR:
- Add `starting_index` argument for component List constructors.
- Test the new argument

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
