### PR TITLE
Define an `as_quantity()` to evaluate a Pyomo expression to a pint `Quantity`

### DIFF
--- a/pyomo/core/base/units_container.py
+++ b/pyomo/core/base/units_container.py
@@ -117,6 +117,7 @@ from pyomo.core.expr.numvalue import (
     native_numeric_types, pyomo_constant_types,
 )
 from pyomo.core.expr.template_expr import IndexTemplate
+from pyomo.core.expr.visitor import ExpressionValueVisitor
 from pyomo.core.expr import current as EXPR
 
 pint_module, pint_available = attempt_import(
@@ -1298,6 +1299,87 @@ external
     @property
     def pint_registry(self):
         return self._pint_registry
+
+
+class _QuantityVisitor(ExpressionValueVisitor):
+
+    def __init__(self):
+        self.native_types = set(nonpyomo_leaf_types)
+        self.native_types.add(units._pint_registry.Quantity)
+        self._unary_inverse_trig = {
+            'asin', 'acos', 'atan', 'asinh', 'acosh', 'atanh',
+        }
+
+    def visit(self, node, values):
+        """ Visit nodes that have been expanded """
+        if node.__class__ in self.handlers:
+            return self.handlers[node.__class__](self, node, values)
+        return node._apply_operation(values)
+
+    def visiting_potential_leaf(self, node):
+        """
+        Visiting a potential leaf.
+
+        Return True if the node is not expanded.
+        """
+        if node.__class__ in self.native_types:
+            return True, node
+
+        if node.is_expression_type():
+            return False, None
+
+        if node.is_numeric_type():
+            if hasattr(node, 'get_units'):
+                unit = node.get_units()
+                if unit is not None:
+                    return True, value(node) * unit._pint_unit
+                else:
+                    return True, value(node)
+            elif node.__class__ is _PyomoUnit:
+                return True, node._pint_unit
+            else:
+                return True, value(node)
+        elif node.is_logical_type():
+            return True, value(node)
+        else:
+            return True, node
+
+    def finalize(self, val):
+        if val.__class__ is units._pint_registry.Quantity:
+            return val
+        elif val.__class__ is units._pint_registry.Unit:
+            return 1. * val
+        # else
+        try:
+            return val * units._pint_dimensionless
+        except:
+            return val
+
+    def _handle_unary_function(self, node, values):
+        ans = node._apply_operation(values)
+        if node.getname() in self._unary_inverse_trig:
+            ans = ans * units._pint_registry.radian
+        return ans
+
+    def _handle_external(self, node, values):
+        # External functions are units-unaware
+        ans = node._apply_operation([
+            val.magnitude if val.__class__ is units._pint_registry.Quantity
+            else val for val in values])
+        unit = node.get_units()
+        if unit is not None:
+            ans = ans * unit._pint_unit
+        return ans
+
+_QuantityVisitor.handlers = {
+    EXPR.UnaryFunctionExpression: _QuantityVisitor._handle_unary_function,
+    EXPR.NPV_UnaryFunctionExpression: _QuantityVisitor._handle_unary_function,
+    EXPR.ExternalFunctionExpression: _QuantityVisitor._handle_external,
+    EXPR.NPV_ExternalFunctionExpression: _QuantityVisitor._handle_external,
+}
+
+def as_quantity(expr):
+    return _QuantityVisitor().dfs_postorder_stack(expr)
 
 
 class _DeferredUnitsSingleton(PyomoUnitsContainer):

--- a/pyomo/core/base/units_container.py
+++ b/pyomo/core/base/units_container.py
@@ -360,11 +360,11 @@ class _PyomoUnit(NumericValue):
         : bool
            A string representation for the expression tree.
         """
-        if len(self._pint_unit.dimensionality) > 1 or any(
-                i < 0 for i in self._pint_unit.dimensionality.values()):
-            return "("+str(self)+")"
+        _str = str(self)
+        if any(map(_str.__contains__, ' */')):
+            return "(" + _str + ")"
         else:
-            return str(self)
+            return _str
 
     def __call__(self, exception=True):
         """Unit is treated as a constant value, and this method always returns 1.0

--- a/pyomo/core/tests/unit/test_units.py
+++ b/pyomo/core/tests/unit/test_units.py
@@ -160,8 +160,12 @@ class TestPyomoUnit(unittest.TestCase):
         self.assertEqual(kg.to_string(), 'kg')
         # ToDo: is this really the correct behavior for verbose?
         self.assertEqual(kg.to_string(verbose=True), 'kg')
-        self.assertEqual(kg.to_string(), 'kg')
-        self.assertEqual(kg.to_string(), 'kg')
+        self.assertEqual((kg/uc.s).to_string(), 'kg/s')
+        self.assertEqual((kg*uc.m**2/uc.s).to_string(), 'kg*m**2/s')
+
+        m.v = Var(initialize=3, units=uc.J)
+        e = uc.convert(m.v, uc.g*uc.m**2/uc.s**2)
+        self.assertEqual(e.to_string(), '1000.0*(g*m**2/J/s**2)*v')
 
         # check __nonzero__ / __bool__
         with self.assertRaisesRegex(

--- a/pyomo/core/tests/unit/test_units.py
+++ b/pyomo/core/tests/unit/test_units.py
@@ -10,6 +10,7 @@
 #  ___________________________________________________________________________
 #
 #
+import math
 import pickle
 
 from pyomo.common.errors import PyomoException
@@ -19,16 +20,18 @@ from pyomo.environ import (
     ExternalFunction, value, sum_product, maximize, units,
     log, log10, exp, sqrt, cos, sin, tan, asin, acos, atan, cosh, sinh,
     tanh, asinh, acosh, atanh, ceil, floor,
+    BooleanVar
 )
 from pyomo.common.log import LoggingIntercept
 from pyomo.util.check_units import (
     assert_units_consistent, check_units_equivalent,
 )
 from pyomo.core.expr import inequality
+from pyomo.core.expr.numvalue import NumericConstant
 import pyomo.core.expr.current as EXPR
 from pyomo.core.base.units_container import (
     pint_available, pint_module, _DeferredUnitsSingleton,
-    InconsistentUnitsError, UnitsError, PyomoUnitsContainer,
+    InconsistentUnitsError, UnitsError, PyomoUnitsContainer, as_quantity
 )
 from io import StringIO
 
@@ -665,6 +668,147 @@ class TestPyomoUnit(unittest.TestCase):
             "system after the PyomoUnitsContainer was constructed",
             LOG.getvalue()
         )
+
+    def test_as_quantity_scalar(self):
+        _pint = units._pint_registry
+        Quantity = _pint.Quantity
+        m = ConcreteModel()
+        m.x = Var(initialize=1)
+        m.y = Var(initialize=2, units=units.g)
+        m.p = Param(initialize=3)
+        m.q = Param(initialize=4, units=1/units.s)
+        m.b = BooleanVar(initialize=True)
+
+        q = as_quantity(0)
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q, 0 * _pint.dimensionless)
+
+        q = as_quantity(None)
+        self.assertIs(q.__class__, None.__class__)
+        self.assertEqual(q, None)
+
+        q = as_quantity(str('aaa'))
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q, 'aaa' * _pint.dimensionless)
+
+        q = as_quantity(True)
+        self.assertIs(q.__class__, bool)
+        self.assertEqual(q, True)
+
+        q = as_quantity(units.kg)
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q, 1 * _pint.kg)
+
+        q = as_quantity(NumericConstant(5))
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q, 5 * _pint.dimensionless)
+
+        q = as_quantity(m.x)
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q, 1 * _pint.dimensionless)
+
+        q = as_quantity(m.y)
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q, 2 * _pint.g)
+
+        q = as_quantity(m.p)
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q, 3 * _pint.dimensionless)
+
+        q = as_quantity(m.q)
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q, 4 / _pint.s)
+
+        q = as_quantity(m.b)
+        self.assertIs(q.__class__, bool)
+        self.assertEqual(q, True)
+
+        class UnknownPyomoType(object):
+            def is_expression_type(self):
+                return False
+
+            def is_numeric_type(self):
+                return False
+
+            def is_logical_type(self):
+                return False
+
+        other = UnknownPyomoType()
+        q = as_quantity(other)
+        self.assertIs(q.__class__, UnknownPyomoType)
+        self.assertIs(q, other)
+
+    def test_as_quantity_expression(self):
+        _pint = units._pint_registry
+        Quantity = _pint.Quantity
+        m = ConcreteModel()
+        m.x = Var(initialize=1)
+        m.y = Var(initialize=2, units=units.g)
+        m.p = Param(initialize=3)
+        m.q = Param(initialize=4, units=1/units.s)
+
+        q = as_quantity(m.x * m.p)
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q, 3 * _pint.dimensionless)
+
+        q = as_quantity(m.x * m.q)
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q, 4 / _pint.s)
+
+        q = as_quantity(m.y * m.p)
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q, 6 * _pint.g)
+
+        q = as_quantity(m.y * m.q)
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q, 8 * _pint.g / _pint.s)
+
+        q = as_quantity(m.y <= 2*m.y)
+        self.assertIs(q.__class__, bool)
+        self.assertEqual(q, True)
+
+        q = as_quantity(m.y >= 2*m.y)
+        self.assertIs(q.__class__, bool)
+        self.assertEqual(q, False)
+
+        q = as_quantity(EXPR.Expr_if(IF=m.y <= 2*m.y, THEN=m.x, ELSE=m.p))
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q, 1 * _pint.dimensionless)
+
+        q = as_quantity(EXPR.Expr_if(IF=m.y >= 2*m.y, THEN=m.x, ELSE=m.p))
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q, 3 * _pint.dimensionless)
+
+        # NOTE: The following two tests are not unit consistent (but can
+        # be evaluated)
+
+        q = as_quantity(EXPR.Expr_if(IF=m.x <= 2*m.x, THEN=m.y, ELSE=m.q))
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q, 2 * _pint.g)
+
+        q = as_quantity(EXPR.Expr_if(IF=m.x >= 2*m.x, THEN=m.y, ELSE=m.q))
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q, 4 / _pint.s)
+
+        # Note: check the units explicitly, as
+        #   Quantity(x, radian) == Quantity(x, dimensionless)
+        q = as_quantity(acos(m.x))
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q.units, _pint.radian)
+        self.assertEqual(q, 0 * _pint.radian)
+
+        q = as_quantity(cos(m.x*math.pi))
+        self.assertIs(q.__class__, Quantity)
+        self.assertEqual(q.units, _pint.dimensionless)
+        self.assertAlmostEqual(q, -1 * _pint.dimensionless)
+
+        def MyAdder(x, y):
+            return x + y
+        m.EF = ExternalFunction(MyAdder, units=units.kg)
+        ef = m.EF(m.x, m.y)
+        q = as_quantity(ef)
+        self.assertIs(q.__class__, Quantity)
+        self.assertAlmostEqual(q, 3 * _pint.kg)
 
 
 if __name__ == "__main__":

--- a/pyomo/environ/__init__.py
+++ b/pyomo/environ/__init__.py
@@ -142,7 +142,7 @@ from pyomo.opt import (
     TerminationCondition, SolverStatus, check_optimal_termination,
     assert_optimal_termination
     )
-from pyomo.core.base.units_container import units
+from pyomo.core.base.units_container import units, as_quantity
 
 # These APIs are deprecated and should be removed in the near future
 from pyomo.common.deprecation import relocated_module_attribute


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This PR adds a `as_quantity()` function that will accept numeric-like objects (int / float / None / Var / Param / expression / etc) and return the value as a native `pint` `Quantity` (value + units).

This is useful for applications like user interfaces, and was requested by IDAES (@andrewlee94 and @dangunter)

## Changes proposed in this PR:
- add `as_quantity()` function to evaluate an expression to a pint Quantity
- add tests (including expanded coverage of `units_container`)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
