### PR TITLE
Skip some fileutils tests on OSX Big Sur and Python<3.8

### DIFF
--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -133,6 +133,7 @@ class TestFileUtils(unittest.TestCase):
         subdir_name = 'aaa'
         subdir = os.path.join(self.tmpdir, subdir_name)
         os.mkdir(subdir)
+        # CWD restored in tearDown
         os.chdir(self.tmpdir)
 
         fname = 'foo.py'
@@ -205,10 +206,10 @@ class TestFileUtils(unittest.TestCase):
             os.path.join(subdir,subdir_name)
         )
 
-    def test_find_library(self):
-        self.tmpdir = os.path.abspath(tempfile.mkdtemp())
-        os.chdir(self.tmpdir)
-
+    @unittest.skipIf(sys.version_info[:2] < (3, 8)
+                     and platform.mac_ver()[0].startswith('11.'),
+                     "find_library has known bugs in Big Sur for Python<3.8")
+    def test_find_library_system(self):
         # Find a system library (before we muck with the PATH)
         _args = {'cwd':False, 'include_PATH':False, 'pathlist':[]}
         if FileDownloader.get_sysinfo()[0] == 'windows':
@@ -229,6 +230,11 @@ class TestFileUtils(unittest.TestCase):
         # file, so only check one)
         _lib = ctypes.cdll.LoadLibrary(a)
         self.assertIsNotNone(_lib)
+
+    def test_find_library_user(self):
+        self.tmpdir = os.path.abspath(tempfile.mkdtemp())
+        # CWD restored in tearDown
+        os.chdir(self.tmpdir)
 
         envvar.PYOMO_CONFIG_DIR = self.tmpdir
         config_libdir = os.path.join(self.tmpdir, 'lib')
@@ -325,6 +331,7 @@ class TestFileUtils(unittest.TestCase):
 
     def test_find_executable(self):
         self.tmpdir = os.path.abspath(tempfile.mkdtemp())
+        # CWD restored in tearDown
         os.chdir(self.tmpdir)
 
         envvar.PYOMO_CONFIG_DIR = self.tmpdir

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -207,10 +207,9 @@ class TestFileUtils(unittest.TestCase):
         )
 
     @unittest.skipIf(sys.version_info[:2] < (3, 8)
-                     and platform.mac_ver()[0].startswith('11.'),
+                     and platform.mac_ver()[0] == 10.16,
                      "find_library has known bugs in Big Sur for Python<3.8")
     def test_find_library_system(self):
-        print(sys.version_info, platform.mac_ver())
         # Find a system library (before we muck with the PATH)
         _args = {'cwd':False, 'include_PATH':False, 'pathlist':[]}
         if FileDownloader.get_sysinfo()[0] == 'windows':

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -207,7 +207,7 @@ class TestFileUtils(unittest.TestCase):
         )
 
     @unittest.skipIf(sys.version_info[:2] < (3, 8)
-                     and platform.mac_ver()[0] == 10.16,
+                     and platform.mac_ver()[0].startswith('10.16'),
                      "find_library has known bugs in Big Sur for Python<3.8")
     def test_find_library_system(self):
         # Find a system library (before we muck with the PATH)

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -210,6 +210,7 @@ class TestFileUtils(unittest.TestCase):
                      and platform.mac_ver()[0].startswith('11.'),
                      "find_library has known bugs in Big Sur for Python<3.8")
     def test_find_library_system(self):
+        print(sys.version_info, platform.mac_ver())
         # Find a system library (before we muck with the PATH)
         _args = {'cwd':False, 'include_PATH':False, 'pathlist':[]}
         if FileDownloader.get_sysinfo()[0] == 'windows':


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Big Sur changes how libraries are stored on the filesystem (they have been moved into a cache).  This broke `find_library` for Python versions before 3.8.  This PR skips the `find_library tests for those specific versions.  This is a reasonable approach, as there appears to not be a clean workaround, and only affects old distributions (Python 3.6 is about to hit EOL, and 3.7 will EOL in 18 months).

It is important to note that this does not affect Pyomo functionality: `find_library` will still locate non-system libraries, as they should be installed on the file system - it only affects locating system libraries, which is not something that we expect Pyomo users to be using that utility for.

## Changes proposed in this PR:
- Skip test that does not with on OSX Big Sur and Python < 3.8

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
