### PR TITLE
Rework coverage uploads to use GitHub Action

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -697,17 +697,15 @@ jobs:
             cp -v $ARTIFACT/.coverage .coverage-$NAME
         done
         rm -vf .coverage coverage.xml
-        if [ ${{ matrix.TARGET }} == 'linux' ]; then
-          echo "Build: linux/other"
-          echo ""
-          FILES=.coverage-*_other-*
-          coverage combine --debug=dataio $FILES
-          if test ! -e .coverage; then
-              echo "No coverage to upload."
-          else
-              coverage xml || coverage xml -i
-              mv -v coverage.xml coverage-other.xml
-          fi
+        echo "Build: ${{ matrix.TARGET }}/other"
+        echo ""
+        FILES=.coverage-*_other-*
+        coverage combine --debug=dataio $FILES
+        if test ! -e .coverage; then
+            echo "No coverage to upload."
+        else
+            coverage xml || coverage xml -i
+            mv -v coverage.xml coverage-other.xml
         fi
         echo ""
         echo "Build: ${{ matrix.TARGET }}"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -729,7 +729,7 @@ jobs:
 
     - name: Upload other coverage reports
       if: |
-        matrix.TARGET  == 'linux' &&
+        hashFiles('coverage-other.xml') != '' &&
         (github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main')
       uses: codecov/codecov-action@v2
       with:

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -683,7 +683,7 @@ jobs:
             exit 1
         fi
 
-    - name: Upload codecov reports
+    - name: Combine coverage reports
       if: github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main'
       run: |
         set +e
@@ -692,71 +692,49 @@ jobs:
         else
             SHA=$GITHUB_SHA
         fi
-        function upload {
-            echo ""
-            echo "Build group: $1"
-            export CODECOV_NAME=$1
-            export TAG=$1
-            export GHA_OS_NAME=${{matrix.TARGET}}
-            shift
-            rm -vf .coverage coverage.xml
-            echo "    $@" | sed 's/ /\n    /'
-            coverage combine --debug=dataio $@
-            if test ! -e .coverage; then
-                echo "No coverage to upload."
-                return
-            fi
-            coverage xml || coverage xml -i
-            i=0
-            while : ; do
-                ((i+=1))
-                rm -f codecov.log
-                echo "Uploading coverage to codecov (attempt ${i})"
-                bash $CODECOV -Z -e TAG,GHA_OS_NAME -X gcov -X s3 \
-                    -f coverage.xml -C $SHA | tee codecov.log
-                if test $? == 0; then
-                    echo "PASS $CODECOV_NAME" >> codecov.result
-                    break
-                elif test $i -ge 2; then
-                    if test `grep successfully codecov.log | wc -l` -gt 0; then
-                        echo "PASS $CODECOV_NAME (implied)" >> codecov.result
-                    else
-                        # Do not fail the build (yet) just because the
-                        # codecov upload fails
-                        echo "FAIL $CODECOV_NAME" >> codecov.result
-                        break
-                    fi
-                fi
-                DELAY=$(( RANDOM % 30 + 30))
-                echo "Pausing $DELAY seconds before re-attempting upload"
-                sleep $DELAY
-            done
-        }
         for ARTIFACT in artifacts/*_*${{matrix.TARGET}}_*; do
             NAME=`echo $ARTIFACT | cut -d/ -f2`
             cp -v $ARTIFACT/.coverage .coverage-$NAME
         done
-        upload ${{matrix.TARGET}} .coverage-*_${{matrix.TARGET}}-*
-        if compgen -G ".coverage-*" > /dev/null; then
-            upload ${{matrix.TARGET}}/other .coverage-*
+        rm -vf .coverage coverage.xml
+        if [ ${{ matrix.TARGET }} == 'linux' ]; then
+          echo "Build: linux/other"
+          echo ""
+          FILES=.coverage-*_other-*
+          coverage combine --debug=dataio $FILES
+          if test ! -e .coverage; then
+              echo "No coverage to upload."
+          else
+              coverage xml || coverage xml -i
+              mv -v coverage.xml coverage-other.xml
+          fi
         fi
-        # Legacy builds that don't support coverage 5.x
-        if compgen -G ".coverage-*" > /dev/null; then
-            echo ""
-            echo "Installing coverage 4.x for legacy builds"
-            pip install --cache-dir cache/pip 'coverage<5'
-            upload ${{matrix.TARGET}}/legacy .coverage-*
+        echo ""
+        echo "Build: ${{ matrix.TARGET }}"
+        echo ""
+        FILES=.coverage-*_${{matrix.TARGET}}-*
+        coverage combine --debug=dataio $FILES
+        rm -vf artifacts/*/*.xml
+        if test ! -e .coverage; then
+            echo "No coverage to upload."
+        else
+            coverage xml || coverage xml -i
         fi
 
-    - name: Check codecov upload success
-      run: |
-        FAIL=`grep FAIL codecov.result | wc -l`
-        ALL=`cat codecov.result | wc -l`
-        echo "$FAIL of $ALL codecov uploads failed"
-        if test $FAIL -gt 0; then
-            grep FAIL codecov.result | sed 's/^/    /'
-            if test $FAIL -gt 1; then
-                echo "More than 1 codecov upload failed."
-                exit 1
-            fi
-        fi
+    - name: Upload codecov reports
+      if: github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main'
+      uses: codecov/codecov-action@v2
+      with:
+        files: coverage.xml
+        name: ${{ matrix.TARGET }}
+        flags: ${{ matrix.TARGET }}
+
+    - name: Upload other coverage reports
+      if: |
+        matrix.TARGET  == 'linux' &&
+        (github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main')
+      uses: codecov/codecov-action@v2
+      with:
+        files: coverage-other.xml
+        name: ${{ matrix.TARGET }}/other
+        flags: ${{ matrix.TARGET }},other

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -702,7 +702,7 @@ jobs:
             exit 1
         fi
 
-    - name: Upload codecov reports
+    - name: Combine coverage reports
       if: github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main'
       run: |
         set +e
@@ -711,71 +711,49 @@ jobs:
         else
             SHA=$GITHUB_SHA
         fi
-        function upload {
-            echo ""
-            echo "Build group: $1"
-            export CODECOV_NAME=$1
-            export TAG=$1
-            export GHA_OS_NAME=${{matrix.TARGET}}
-            shift
-            rm -vf .coverage coverage.xml
-            echo "    $@" | sed 's/ /\n    /'
-            coverage combine --debug=dataio $@
-            if test ! -e .coverage; then
-                echo "No coverage to upload."
-                return
-            fi
-            coverage xml || coverage xml -i
-            i=0
-            while : ; do
-                ((i+=1))
-                rm -f codecov.log
-                echo "Uploading coverage to codecov (attempt ${i})"
-                bash $CODECOV -Z -e TAG,GHA_OS_NAME -X gcov -X s3 \
-                    -f coverage.xml -C $SHA | tee codecov.log
-                if test $? == 0; then
-                    echo "PASS $CODECOV_NAME" >> codecov.result
-                    break
-                elif test $i -ge 2; then
-                    if test `grep successfully codecov.log | wc -l` -gt 0; then
-                        echo "PASS $CODECOV_NAME (implied)" >> codecov.result
-                    else
-                        # Do not fail the build (yet) just because the
-                        # codecov upload fails
-                        echo "FAIL $CODECOV_NAME" >> codecov.result
-                        break
-                    fi
-                fi
-                DELAY=$(( RANDOM % 30 + 30))
-                echo "Pausing $DELAY seconds before re-attempting upload"
-                sleep $DELAY
-            done
-        }
         for ARTIFACT in artifacts/*_*${{matrix.TARGET}}_*; do
             NAME=`echo $ARTIFACT | cut -d/ -f2`
             cp -v $ARTIFACT/.coverage .coverage-$NAME
         done
-        upload ${{matrix.TARGET}} .coverage-*_${{matrix.TARGET}}-*
-        if compgen -G ".coverage-*" > /dev/null; then
-            upload ${{matrix.TARGET}}/other .coverage-*
+        rm -vf .coverage coverage.xml
+        if [ ${{ matrix.TARGET }} == 'linux' ]; then
+          echo "Build: linux/other"
+          echo ""
+          FILES=.coverage-*_other-*
+          coverage combine --debug=dataio $FILES
+          if test ! -e .coverage; then
+              echo "No coverage to upload."
+          else
+              coverage xml || coverage xml -i
+              mv -v coverage.xml coverage-other.xml
+          fi
         fi
-        # Legacy builds that don't support coverage 5.x
-        if compgen -G ".coverage-*" > /dev/null; then
-            echo ""
-            echo "Installing coverage 4.x for legacy builds"
-            pip install --cache-dir cache/pip 'coverage<5'
-            upload ${{matrix.TARGET}}/legacy .coverage-*
+        echo ""
+        echo "Build: ${{ matrix.TARGET }}"
+        echo ""
+        FILES=.coverage-*_${{matrix.TARGET}}-*
+        coverage combine --debug=dataio $FILES
+        rm -vf artifacts/*/*.xml
+        if test ! -e .coverage; then
+            echo "No coverage to upload."
+        else
+            coverage xml || coverage xml -i
         fi
 
-    - name: Check codecov upload success
-      run: |
-        FAIL=`grep FAIL codecov.result | wc -l`
-        ALL=`cat codecov.result | wc -l`
-        echo "$FAIL of $ALL codecov uploads failed"
-        if test $FAIL -gt 0; then
-            grep FAIL codecov.result | sed 's/^/    /'
-            if test $FAIL -gt 1; then
-                echo "More than 1 codecov upload failed."
-                exit 1
-            fi
-        fi
+    - name: Upload codecov reports
+      if: github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main'
+      uses: codecov/codecov-action@v2
+      with:
+        files: coverage.xml
+        name: ${{ matrix.TARGET }}
+        flags: ${{ matrix.TARGET }}
+
+    - name: Upload other coverage reports
+      if: |
+        matrix.TARGET  == 'linux' &&
+        (github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main')
+      uses: codecov/codecov-action@v2
+      with:
+        files: coverage-other.xml
+        name: ${{ matrix.TARGET }}/other
+        flags: ${{ matrix.TARGET }},other

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -716,17 +716,15 @@ jobs:
             cp -v $ARTIFACT/.coverage .coverage-$NAME
         done
         rm -vf .coverage coverage.xml
-        if [ ${{ matrix.TARGET }} == 'linux' ]; then
-          echo "Build: linux/other"
-          echo ""
-          FILES=.coverage-*_other-*
-          coverage combine --debug=dataio $FILES
-          if test ! -e .coverage; then
-              echo "No coverage to upload."
-          else
-              coverage xml || coverage xml -i
-              mv -v coverage.xml coverage-other.xml
-          fi
+        echo "Build: ${{ matrix.TARGET }}/other"
+        echo ""
+        FILES=.coverage-*_other-*
+        coverage combine --debug=dataio $FILES
+        if test ! -e .coverage; then
+            echo "No coverage to upload."
+        else
+            coverage xml || coverage xml -i
+            mv -v coverage.xml coverage-other.xml
         fi
         echo ""
         echo "Build: ${{ matrix.TARGET }}"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -747,7 +747,9 @@ jobs:
         flags: ${{ matrix.TARGET }}
 
     - name: Upload other coverage reports
-      if: github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main'
+      if: |
+        hashFiles('coverage-other.xml') != '' &&
+        (github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main')
       uses: codecov/codecov-action@v2
       with:
         files: coverage-other.xml

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -747,9 +747,7 @@ jobs:
         flags: ${{ matrix.TARGET }}
 
     - name: Upload other coverage reports
-      if: |
-        matrix.TARGET  == 'linux' &&
-        (github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main')
+      if: github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main'
       uses: codecov/codecov-action@v2
       with:
         files: coverage-other.xml


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
The bash uploaded for coverage reports is deprecated. After a break in the system yesterday, we resolved to switch to using the better supposed GitHub action `codecov-action`.

## Changes proposed in this PR:
- Switch from codecov bash uploaded to `codecov-action` uploader

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
