### PR TITLE
Resolve errors when creating Reference to a scalar Set

### DIFF
--- a/pyomo/core/base/indexed_component_slice.py
+++ b/pyomo/core/base/indexed_component_slice.py
@@ -378,7 +378,7 @@ class _slice_generator(object):
             self.component_iter = component.index_set().__iter__()
         else:
             # The default behavior is to iterate over the component.
-            self.component_iter = component.__iter__()
+            self.component_iter = component.keys()
 
         # Cache for the most recent index returned. This is used to
         # iterate over keys of the slice (for instance, in a

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -367,7 +367,7 @@ class _ReferenceDict_mapping(UserDict):
 class _ReferenceSet(collections_Set):
     """A set-like object whose values are defined by a slice.
 
-    This implements a dict-like object whose members are defined by a
+    This implements a set-like object whose members are defined by a
     component slice (:py:class:`IndexedComponent_slice`).
     :py:class:`_ReferenceSet` differs from the
     :py:class:`_ReferenceDict` above in that it looks in the underlying

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -2296,7 +2296,7 @@ class SetOf(_SetData, Component):
         if cls is not SetOf:
             return super(SetOf, cls).__new__(cls)
         reference, = args
-        if isinstance(reference, _SetData):
+        if isinstance(reference, (_SetData, GlobalSetBase)):
             if reference.isfinite():
                 if reference.isordered():
                     return super(SetOf, cls).__new__(OrderedSetOf)

--- a/pyomo/core/tests/unit/test_reference.py
+++ b/pyomo/core/tests/unit/test_reference.py
@@ -25,7 +25,7 @@ from pyomo.environ import (
 from pyomo.common.collections import ComponentSet
 from pyomo.core.base.var import IndexedVar
 from pyomo.core.base.set import (
-    SetProduct, FiniteSetOf, UnknownSetDimen, normalize_index,
+    SetProduct, FiniteSetOf, OrderedSetOf, UnknownSetDimen, normalize_index,
 )
 from pyomo.core.base.indexed_component import (
     UnindexedComponent_set, IndexedComponent
@@ -412,7 +412,7 @@ class TestReference(unittest.TestCase):
         self.assertIs(m.r.ctype, Var)
         self.assertIsNot(m.r.index_set(), m.x.index_set())
         self.assertIs(m.x.index_set(), UnindexedComponent_set)
-        self.assertIs(type(m.r.index_set()), FiniteSetOf)
+        self.assertIs(type(m.r.index_set()), OrderedSetOf)
         self.assertEqual(len(m.r), 1)
         self.assertTrue(m.r.is_indexed())
         self.assertIn(None, m.r)
@@ -426,7 +426,7 @@ class TestReference(unittest.TestCase):
         self.assertIs(m.s.ctype, Var)
         self.assertIsNot(m.s.index_set(), m.x.index_set())
         self.assertIs(m.x.index_set(), UnindexedComponent_set)
-        self.assertIs(type(m.s.index_set()), FiniteSetOf)
+        self.assertIs(type(m.s.index_set()), OrderedSetOf)
         self.assertEqual(len(m.s), 1)
         self.assertTrue(m.s.is_indexed())
         self.assertIn(None, m.s)
@@ -457,7 +457,7 @@ class TestReference(unittest.TestCase):
         self.assertIs(m.r.ctype, Var)
         self.assertIsNot(m.r.index_set(), m.y.index_set())
         self.assertIs(m.y.index_set(), m.y_index)
-        self.assertIs(type(m.r.index_set()), FiniteSetOf)
+        self.assertIs(type(m.r.index_set()), OrderedSetOf)
         self.assertEqual(len(m.r), 1)
         self.assertTrue(m.r.is_indexed())
         self.assertIn(None, m.r)
@@ -698,8 +698,8 @@ class TestReference(unittest.TestCase):
         self.assertEqual(m.r.index_set().dimen, 2)
         base_sets = list(m.r.index_set().subsets())
         self.assertEqual(len(base_sets), 2)
-        self.assertIs(type(base_sets[0]), FiniteSetOf)
-        self.assertIs(type(base_sets[1]), FiniteSetOf)
+        self.assertIs(type(base_sets[0]), OrderedSetOf)
+        self.assertIs(type(base_sets[1]), OrderedSetOf)
 
     def test_ctype_detection(self):
         m = ConcreteModel()

--- a/pyomo/core/tests/unit/test_reference.py
+++ b/pyomo/core/tests/unit/test_reference.py
@@ -883,6 +883,25 @@ class TestReference(unittest.TestCase):
                 KeyError, "Index '1' is not valid for indexed component 'r'"):
             m.r[1] = m.x
 
+    def test_reference_to_set(self):
+        m = ConcreteModel()
+        m.I = Set(initialize=[1,3,5])
+        m.r = Reference(m.I)
+        self.assertEqual(len(m.r), 1)
+        self.assertEqual(list(m.r.keys()), [None])
+        self.assertEqual(list(m.r.values()), [m.I])
+        self.assertIs(m.r[None], m.I)
+
+        # Test that a referent Set containing None doesn't break the
+        # None index
+        m = ConcreteModel()
+        m.I = Set(initialize=[1,3,None,5])
+        m.r = Reference(m.I)
+        self.assertEqual(len(m.r), 1)
+        self.assertEqual(list(m.r.keys()), [None])
+        self.assertEqual(list(m.r.values()), [m.I])
+        self.assertIs(m.r[None], m.I)
+
     def test_is_reference(self):
         m = ConcreteModel()
         m.v0 = Var()


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
@anyacastillo pointed out that creating a Reference to a scalar Set resulted in an exception.  This PR resolves that bug.  

As part of resolving that bug, this PR also resolves an issue where `SetOf(UnindexedComponent_set)` was creating an unordered `FiniteSetOf` instead of an `OrderedSetOf`.

## Changes proposed in this PR:
- Resolve exception for `Reference(ScalarSet)`
- `SetOf(UnindexedCOmponent_set)` should be ordered

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
