### PR TITLE
Fix missing parameter in the overload of `Objective` initializer

### DIFF
--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -261,7 +261,7 @@ class Objective(ActiveIndexedComponent):
             return IndexedObjective.__new__(IndexedObjective)
 
     @overload
-    def __init__(self, expr=None, rule=None, sense=minimize,
+    def __init__(self, *indexes, expr=None, rule=None, sense=minimize,
                  name=None, doc=None): ...
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Fixes # .
In PR #2212, the `*args` is missing in the overload of `Objective` initializer
## Summary/Motivation:
Fix missing parameter in the overload of `Objective` initializer.

## Changes proposed in this PR:
- Before
```python
class Objective(ActiveIndexedComponent):
    @overload
    def __init__(self, expr=None, rule=None, sense=minimize,
                 name=None, doc=None): ...

    def __init__(self, *args, **kwargs):
```
- Now
```python
class Objective(ActiveIndexedComponent):
    @overload
    def __init__(self, *indexes, expr=None, rule=None, sense=minimize,
                 name=None, doc=None): ...

    def __init__(self, *args, **kwargs):
```

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
