### PR TITLE
Standardize scalar-valued external function interfaces

### DIFF
--- a/doc/OnlineDocs/library_reference/aml/index.rst
+++ b/doc/OnlineDocs/library_reference/aml/index.rst
@@ -18,6 +18,7 @@ through the `pyomo.environ` namespace.
    Var
    Objective
    Constraint
+   ExternalFunction
    Reference
 
 
@@ -40,6 +41,12 @@ AML Component Documentation
 
 .. autoclass:: Constraint
    :show-inheritance:
+   :members:
+   :inherited-members:
+
+.. autoclass:: ExternalFunction
+   :show-inheritance:
+   :special-members: __init__
    :members:
    :inherited-members:
 

--- a/pyomo/contrib/trustregion/PyomoInterface.py
+++ b/pyomo/contrib/trustregion/PyomoInterface.py
@@ -55,16 +55,16 @@ class ReplaceEFVisitor(EXPR.ExpressionReplacementVisitor):
         # TODO: support more than PythonCallbackFunctions
         assert isinstance(node._fcn, PythonCallbackFunction)
         #
-        # Note: the first argument to PythonCallbackFunction is the
+        # Note: the last argument to PythonCallbackFunction is the
         # function ID.  Since we are going to complain about constant
-        # parameters, we need to skip the first argument when processing
+        # parameters, we need to skip the last argument when processing
         # the argument list.  This is really not good: we should allow
         # for constant arguments to the functions, and we should relax
         # the restriction that the external functions implement the
         # PythonCallbackFunction API (that restriction leads unfortunate
         # things later; i.e., accessing the private _fcn attribute
         # below).
-        for arg in values[1][1:]:
+        for arg in values[1][:-1]:
             if type(arg) in nonpyomo_leaf_types or arg.is_fixed():
                 # We currently do not allow constants or parameters for
                 # the external functions.

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -403,7 +403,8 @@ class PythonCallbackFunction(ExternalFunction):
         # need to add that to the arg_units
         arg_units = kwargs.get('arg_units', None)
         if arg_units is not None:
-            kwargs['arg_units'] = [None] + list(arg_units)
+            kwargs['arg_units'] = list(arg_units)
+            kwargs['arg_units'].append(None)
 
         # TODO: complete/distribute the pyomo_socket_server /
         # pyomo_ampl.so AMPL extension
@@ -471,7 +472,7 @@ class PythonCallbackFunction(ExternalFunction):
         return (
             [ ('function', self._fcn.__qualname__),
               ('units', str(self._units)),
-              ('arg_units', [ str(u) for u in self._arg_units[1:] ]
+              ('arg_units', [ str(u) for u in self._arg_units[:-1] ]
                if self._arg_units is not None else None),
             ],
             (), None, None

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -190,7 +190,7 @@ class ExternalFunction(Component):
                 raise RuntimeError(
                     f"External function '{self.name}' returned an invalid "
                     f"Hessian matrix (expected {n + n*(n+1)//2 + 1}, "
-                    f"received {len(h)}")
+                    f"received {len(h)})")
         else:
             h = None
         if fgh >= 1:
@@ -198,7 +198,7 @@ class ExternalFunction(Component):
                 raise RuntimeError(
                     f"External function '{self.name}' returned an invalid "
                     f"derivative vector (expected {N}, "
-                    f"received {len(g)}")
+                    f"received {len(g)})")
         else:
             g = None
         # Note: the ASL does not require clients to honor the fixed flag
@@ -259,7 +259,7 @@ class AMPLExternalFunction(ExternalFunction):
             self.load_library()
         if self._function not in self._known_functions:
             raise RuntimeError(
-                "Error: external function %s was not registered within "
+                "Error: external function '%s' was not registered within "
                 "external library %s.\n\tAvailable functions: (%s)"
                 % ( self._function, self._library,
                     ', '.join(self._known_functions.keys()) ) )
@@ -445,7 +445,7 @@ class PythonCallbackFunction(ExternalFunction):
             if fgh >= 1:
                 if self._grad is None:
                     raise RuntimeError(
-                        "ExternalFunction '{self.name}' was not defined "
+                        f"ExternalFunction '{self.name}' was not defined "
                         "with a gradient callback.  Cannot evaluate the "
                         "derivative of the function")
                 g = self._grad(args, fixed)
@@ -454,7 +454,7 @@ class PythonCallbackFunction(ExternalFunction):
             if fgh == 2:
                 if self._hess is None:
                     raise RuntimeError(
-                        "ExternalFunction '{self.name}' was not defined "
+                        f"ExternalFunction '{self.name}' was not defined "
                         "with a Hessian callback.  Cannot evaluate the "
                         "second derivative of the function")
                 h = self._hess(args, fixed)

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -91,7 +91,7 @@ class ExternalFunction(Component):
         args_ = []
         for arg in args:
             if type(arg) is types.GeneratorType:
-                args_.extend(val for val in arg)
+                args_.extend(arg)
             else:
                 args_.append(arg)
         #

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -538,7 +538,7 @@ class PythonCallbackFunction(ExternalFunction):
                 h = self._hess(args, fixed)
             else:
                 h = None
-        # Update g,h to reflect the function id (which by defiition is
+        # Update g,h to reflect the function id (which by definition is
         # always fixed)
         if g is not None:
             g.append(0)

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -31,10 +31,10 @@ logger = logging.getLogger('pyomo.core')
 
 
 class ExternalFunction(Component):
-    """Interface to an external (non-algrbraic) function.
+    """Interface to an external (non-algebraic) function.
 
     :class:`ExternalFunction` provides an interface for declaring
-    general user-provided functiona, and then embedding calls to the
+    general user-provided functions, and then embedding calls to the
     external functions within Pyomo expressions.
 
     .. note::
@@ -50,14 +50,14 @@ class ExternalFunction(Component):
     """
     def __new__(cls, *args, **kwargs):
         if cls is not ExternalFunction:
-            return super(ExternalFunction, cls).__new__(cls)
+            return super().__new__(cls)
         elif args:
-            return super(ExternalFunction, cls).__new__(PythonCallbackFunction)
+            return super().__new__(PythonCallbackFunction)
         elif 'library' not in kwargs and any(
                 kw in kwargs for kw in ('function', 'fgh')):
-            return super(ExternalFunction, cls).__new__(PythonCallbackFunction)
+            return super().__new__(PythonCallbackFunction)
         else:
-            return super(ExternalFunction, cls).__new__(AMPLExternalFunction)
+            return super().__new__(AMPLExternalFunction)
 
     @overload
     def __init__(self, function=None, gradient=None, hessian=None,
@@ -88,14 +88,14 @@ class ExternalFunction(Component):
           One to three functions that can evaluate the function value,
           gradient of the function [partial derivatives] with respect to
           its inputs, and the Hessian of the function [partial second
-          dericatives].  The ``function`` interface expects a function
+          derivatives].  The ``function`` interface expects a function
           matching the prototype:
 
           .. code::
 
              def function(*args): float
 
-          The ``gradient`` amd ``hessian`` interface expect functions
+          The ``gradient`` and ``hessian`` interface expect functions
           matching the prototype:
 
           .. code::
@@ -109,7 +109,7 @@ class ExternalFunction(Component):
 
         **ASL function libraries** (:class:`AMPLExternalFunction` interface)
 
-        Pyomo can also call functions compiles as part of an AMPL
+        Pyomo can also call functions compiled as part of an AMPL
         External Function library (see the `User-defined functions
         <https://www.ampl.com/REFS/HOOKING/#userdefinedfuncs>`_ section
         in the `Hooking your solver to AMPL
@@ -327,7 +327,7 @@ class AMPLExternalFunction(ExternalFunction):
         ExternalFunction.__init__(self, *args, **kwargs)
 
     def __getstate__(self):
-        state = super(AMPLExternalFunction, self).__getstate__()
+        state = super().__getstate__()
         # Remove reference to loaded library (they are not copyable or
         # picklable)
         state['_so'] = state['_known_functions'] = None
@@ -413,7 +413,7 @@ class _PythonCallbackFunctionID(NumericConstant):
     Function IDs are effectively pointers back to the
     PythonCallbackFunction.  As such, we need special handling to
     maintain / preserve the correct linkages through deepcopy (and
-    model.clone().
+    model.clone()).
 
     """
     __slots__ = ()
@@ -441,7 +441,7 @@ class PythonCallbackFunction(ExternalFunction):
 
     @classmethod
     def register_instance(cls, instance):
-        # Ideally, we would just use the id() as the finction id, but
+        # Ideally, we would just use the id() as the function id, but
         # Python id() is more than 32-bits, which can cause problems for
         # the ASL.  We will map id() to a "small" integer and use that
         # small integer as the "function id".
@@ -506,8 +506,7 @@ class PythonCallbackFunction(ExternalFunction):
         # NOTE: we append the Function ID to the END of the argument
         # list because it is easier to update the gradient / hessian
         # results
-        return super(PythonCallbackFunction, self).__call__(
-            *args, _PythonCallbackFunctionID(self._fcn_id))
+        return super().__call__(*args, _PythonCallbackFunctionID(self._fcn_id))
 
     def _evaluate(self, args, fixed, fgh):
         # Remove the fcn_id
@@ -604,7 +603,7 @@ class _ARGLIST(Structure):
         ]
 
     def __init__(self, args, fgh=0, fixed=None):
-        super(_ARGLIST, self).__init__()
+        super().__init__()
         N = len(args)
         self.n = self.nr = N
         self.at = (c_int*N)()

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -268,11 +268,11 @@ class AMPLExternalFunction(ExternalFunction):
         arglist = _ARGLIST(args, fgh, fixed)
         fcn = self._known_functions[self._function][0]
         f = fcn(byref(arglist))
-        if fgh > 0:
+        if fgh >= 1:
             g = [arglist.derivs[i] for i in range(N)]
         else:
             g = None
-        if fgh > 1:
+        if fgh >= 2:
             h = [arglist.hes[i] for i in range((N + N**2)//2)]
         else:
             h = None
@@ -531,9 +531,9 @@ class _ARGLIST(Structure):
         self.at = (c_int*N)()
         self.ra = (c_double*N)()
         self.sa = None
-        if fgh > 0:
+        if fgh >= 1:
             self.derivs = (c_double*N)(0.)
-        if fgh > 1:
+        if fgh >= 2:
             self.hes = (c_double*((N+N*N)//2))(0.)
 
         for i,v in enumerate(args):

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -83,7 +83,7 @@ class ExternalFunction(Component):
             try:
                 # Q: Is there a better way to test if a value is an object
                 #    not in native_types and not a standard expression type?
-                if arg.__class__ in native_types or arg.is_expression_type():
+                if arg.__class__ in native_types:
                     continue
                 if arg.is_potentially_variable():
                     pv = True

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -73,7 +73,8 @@ class ExternalFunction(Component):
         :class:`ExternalFunction`: Python callback functions and AMPL
         external functions.
 
-        **Python callback functions**
+        **Python callback functions** (:class:`PythonCallbackFunction`
+        interface)
 
         Python callback functions can be specified one of two ways:
 
@@ -106,7 +107,7 @@ class ExternalFunction(Component):
           indicating which arguments are currently fixed (``True``) or
           variable (``False``).
 
-        **ASL function libraries**
+        **ASL function libraries** (:class:`AMPLExternalFunction` interface)
 
         Pyomo can also call functions compiles as part of an AMPL
         External Function library (see the `User-defined functions

--- a/pyomo/core/expr/calculus/diff_with_pyomo.py
+++ b/pyomo/core/expr/calculus/diff_with_pyomo.py
@@ -312,13 +312,13 @@ def _diff_ExternalFunctionExpression(node, val_dict, der_dict):
 
     Parameters
     ----------
-    node: pyomo.core.expr.numeric_expr.ProductExpression
+    node: pyomo.core.expr.numeric_expr.ExternalFunctionExpression
     val_dict: ComponentMap
     der_dict: ComponentMap
     """
     der = der_dict[node]
     vals = tuple(val_dict[i] for i in node.args)
-    derivs = node._fcn.evaluate_fgh(vals)[1]
+    derivs = node._fcn.evaluate_fgh(vals, fgh=1)[1]
     for ndx, arg in enumerate(node.args):
         der_dict[arg] += der * derivs[ndx]
 

--- a/pyomo/core/tests/unit/test_external.py
+++ b/pyomo/core/tests/unit/test_external.py
@@ -140,17 +140,66 @@ class TestAMPLExternalFunction(unittest.TestCase):
         model = ConcreteModel()
         model.gamma = ExternalFunction(
             library=DLL, function="gsl_sf_gamma")
+        model.beta = ExternalFunction(
+            library=DLL, function="gsl_sf_beta")
         model.bessel = ExternalFunction(
             library=DLL, function="gsl_sf_bessel_Jnu")
+
         f,g,h = model.gamma.evaluate_fgh((2.0,))
         self.assertAlmostEqual(f, 1.0, 7)
         self.assertListsAlmostEqual(g, [0.422784335098467], 7)
         self.assertListsAlmostEqual(h, [0.8236806608528794], 7)
 
+        f,g,h = model.beta.evaluate_fgh((2.5, 2.0,), fixed=[1,1])
+        self.assertAlmostEqual(f, 0.11428571428571432, 7)
+        self.assertListsAlmostEqual(g, [0.0, 0.0], 7)
+        self.assertListsAlmostEqual(h, [0.0, 0.0, 0.0], 7)
+
+        f,g,h = model.beta.evaluate_fgh((2.5, 2.0,), fixed=[0,1])
+        self.assertAlmostEqual(f, 0.11428571428571432, 7)
+        self.assertListsAlmostEqual(
+            g, [-0.07836734693877555, 0.0], 7)
+        self.assertListsAlmostEqual(
+            h, [0.08135276967930034, 0.0, 0.0], 7)
+
+        f,g,h = model.beta.evaluate_fgh((2.5, 2.0,))
+        self.assertAlmostEqual(f, 0.11428571428571432, 7)
+        self.assertListsAlmostEqual(
+            g, [-0.07836734693877555, -0.11040989614412142], 7)
+        self.assertListsAlmostEqual(
+            h, [0.08135276967930034, 0.0472839170086535, 0.15194654464270113],
+            7)
+
+        f,g,h = model.beta.evaluate_fgh((2.5, 2.0,), fgh=1)
+        self.assertAlmostEqual(f, 0.11428571428571432, 7)
+        self.assertListsAlmostEqual(
+            g, [-0.07836734693877555, -0.11040989614412142], 7)
+        self.assertIsNone(h)
+
+        f,g,h = model.beta.evaluate_fgh((2.5, 2.0,), fgh=0)
+        self.assertAlmostEqual(f, 0.11428571428571432, 7)
+        self.assertIsNone(g)
+        self.assertIsNone(h)
+
         f,g,h = model.bessel.evaluate_fgh((2.5, 2.0,), fixed=[1,0])
         self.assertAlmostEqual(f, 0.223924531469, 7)
         self.assertListsAlmostEqual(g, [0.0, 0.21138811435101745], 7)
         self.assertListsAlmostEqual(h, [0.0, 0.0, 0.02026349177575621], 7)
+
+        # Note: Not all AMPL-GSL functions honor the fixed flag
+        # (notably, gamma and bessel do not as of 12/2021).  We will
+        # test that our interface corrects that
+
+        f,g,h = model.gamma.evaluate_fgh((2.0,), fixed=[1])
+        self.assertAlmostEqual(f, 1.0, 7)
+        self.assertListsAlmostEqual(g, [0.0], 7)
+        self.assertListsAlmostEqual(h, [0.0], 7)
+
+        f,g,h = model.bessel.evaluate_fgh((2.5, 2.0,), fixed=[1,1])
+        self.assertAlmostEqual(f, 0.223924531469, 7)
+        self.assertListsAlmostEqual(g, [0.0, 0.0], 7)
+        self.assertListsAlmostEqual(h, [0.0, 0.0, 0.0], 7)
+
 
     @unittest.skipIf(not check_available_solvers('ipopt'),
                      "The 'ipopt' solver is not available")

--- a/pyomo/core/tests/unit/test_external.py
+++ b/pyomo/core/tests/unit/test_external.py
@@ -23,16 +23,16 @@ from pyomo.core.base.external import (PythonCallbackFunction,
 from pyomo.core.base.units_container import pint_available, units
 from pyomo.opt import check_available_solvers
 
-def _g(*args):
+def _count(*args):
     return len(args)
 
-def _h(*args):
+def _sum(*args):
     return 2 + sum(args)
 
 class TestPythonCallbackFunction(unittest.TestCase):
     def test_call_countArgs(self):
         m = ConcreteModel()
-        m.f = ExternalFunction(_g)
+        m.f = ExternalFunction(_count)
         self.assertIsInstance(m.f, PythonCallbackFunction)
         self.assertEqual(value(m.f()), 0)
         self.assertEqual(value(m.f(2)), 1)
@@ -40,7 +40,7 @@ class TestPythonCallbackFunction(unittest.TestCase):
 
     def test_call_sumfcn(self):
         m = ConcreteModel()
-        m.f = ExternalFunction(_h)
+        m.f = ExternalFunction(_sum)
         self.assertIsInstance(m.f, PythonCallbackFunction)
         self.assertEqual(value(m.f()), 2.0)
         self.assertEqual(value(m.f(1)), 3.0)
@@ -48,7 +48,7 @@ class TestPythonCallbackFunction(unittest.TestCase):
 
     def test_getname(self):
         m = ConcreteModel()
-        m.f = ExternalFunction(_h)
+        m.f = ExternalFunction(_sum)
         self.assertIsInstance(m.f, PythonCallbackFunction)
         self.assertEqual(m.f.name, "f")
         self.assertEqual(m.f.local_name, "f")
@@ -65,31 +65,31 @@ class TestPythonCallbackFunction(unittest.TestCase):
     def test_extra_kwargs(self):
         m = ConcreteModel()
         with self.assertRaises(ValueError):
-            m.f = ExternalFunction(_g, this_should_raise_error='foo')
+            m.f = ExternalFunction(_count, this_should_raise_error='foo')
 
     def test_pprint(self):
         m = ConcreteModel()
-        m.h = ExternalFunction(_g)
+        m.h = ExternalFunction(_count)
 
         out = StringIO()
         m.pprint(ostream=out)
         self.assertEqual(out.getvalue().strip(), """
 1 ExternalFunction Declarations
-    h : function=_g, units=None, arg_units=None
+    h : function=_count, units=None, arg_units=None
 
 1 Declarations: h
         """.strip())
 
         if not pint_available:
             return
-        m.i = ExternalFunction(function=_h,
+        m.i = ExternalFunction(function=_sum,
                                units=units.kg, arg_units=[units.m, units.s])
         out = StringIO()
         m.pprint(ostream=out)
         self.assertEqual(out.getvalue().strip(), """
 2 ExternalFunction Declarations
-    h : function=_g, units=None, arg_units=None
-    i : function=_h, units=kg, arg_units=['m', 's']
+    h : function=_count, units=None, arg_units=None
+    i : function=_sum, units=kg, arg_units=['m', 's']
 
 2 Declarations: h i
         """.strip())


### PR DESCRIPTION
## Fixes #2157 

## Summary/Motivation:
The Python and ASL external function interfaces have drifted apart over time.  When we added `evaluate_fgh` to the ASL interface, we did not also add it to the Python callback interface.  This PR reworks the Scalar-values ExternalFunction interface so that `evaluate()` and `evaluate_fgh()` are cleanly supported through both ASL and PythonCallback interfaces.

In addition, there are numerous code cleanups:
- G, and H entries are now zeroed out based on the fixed flag (i.e., the gradient and Hessian values are now guaranteed to be correct when specifying that argument indices are fixed).
- improved handling of the global "function id" in the PythonCallbackFunction interface, including special handling so that `clone()` / `deepcopy()` work correctly.
- Improved documentation

## Changes proposed in this PR:
- Add `evaluate_fgh` as a formal part of the `ExternalFunction` API
- Resolve pickling issues with the PythonCallbackFunction
- Improve test coverage
- Add documentation

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
