### PR TITLE
Adding support for abs in numeric differentiation

### DIFF
--- a/pyomo/core/expr/calculus/diff_with_pyomo.py
+++ b/pyomo/core/expr/calculus/diff_with_pyomo.py
@@ -11,7 +11,7 @@
 from pyomo.common.collections import ComponentMap, ComponentSet
 from pyomo.core.expr import current as _expr
 from pyomo.core.expr.visitor import ExpressionValueVisitor, nonpyomo_leaf_types
-from pyomo.core.expr.numvalue import value
+from pyomo.core.expr.numvalue import value, is_constant
 from pyomo.core.expr.current import exp, log, sin, cos
 import math
 
@@ -266,6 +266,31 @@ def _diff_sqrt(node, val_dict, der_dict):
     der_dict[arg] += der * 0.5 * val_dict[arg]**(-0.5)
 
 
+def _diff_abs(node, val_dict, der_dict):
+    """
+    Reverse automatic differentiation on the abs function.
+    This will raise an exception at 0.
+
+    Parameters
+    ----------
+    node: pyomo.core.expr.numeric_expr.UnaryFunctionExpression
+    val_dict: ComponentMap
+    der_dict: ComponentMap
+    """
+    assert len(node.args) == 1
+    arg = node.args[0]
+    der = der_dict[node]
+    val = val_dict[arg]
+    if not is_constant(val):
+        raise DifferentiationException('Cannot perform symbolic differentiation of abs(x). Please use numeric differentiation')
+    if val == 0:
+        raise DifferentiationException('Cannot differentiate abs(x) at x=0')
+    elif val < 0:
+        der_dict[arg] -= der
+    else:
+        der_dict[arg] += der
+
+
 _unary_map = dict()
 _unary_map['exp'] = _diff_exp
 _unary_map['log'] = _diff_log
@@ -277,6 +302,7 @@ _unary_map['asin'] = _diff_asin
 _unary_map['acos'] = _diff_acos
 _unary_map['atan'] = _diff_atan
 _unary_map['sqrt'] = _diff_sqrt
+_unary_map['abs'] = _diff_abs
 
 
 def _diff_UnaryFunctionExpression(node, val_dict, der_dict):
@@ -333,6 +359,7 @@ _diff_map[_expr.NegationExpression] = _diff_NegationExpression
 _diff_map[_expr.UnaryFunctionExpression] = _diff_UnaryFunctionExpression
 _diff_map[_expr.ExternalFunctionExpression] = _diff_ExternalFunctionExpression
 _diff_map[_expr.LinearExpression] = _diff_SumExpression
+_diff_map[_expr.AbsExpression] = _diff_abs
 
 _diff_map[_expr.NPV_ProductExpression] = _diff_ProductExpression
 _diff_map[_expr.NPV_DivisionExpression] = _diff_DivisionExpression
@@ -341,6 +368,7 @@ _diff_map[_expr.NPV_SumExpression] = _diff_SumExpression
 _diff_map[_expr.NPV_NegationExpression] = _diff_NegationExpression
 _diff_map[_expr.NPV_UnaryFunctionExpression] = _diff_UnaryFunctionExpression
 _diff_map[_expr.NPV_ExternalFunctionExpression] = _diff_ExternalFunctionExpression
+_diff_map[_expr.NPV_AbsExpression] = _diff_abs
 
 
 def _symbolic_value(x):


### PR DESCRIPTION
## Summary/Motivation:
This PR adds support for `abs` in Pyomo's numeric differentiation. Attempting symbolic differentiation on an `abs` expression with a non-constant argument will still raise an exception.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
