### PR TITLE
Windows/Python 3.6 Testing Dependency Fix

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -46,7 +46,7 @@ jobs:
           PYENV: pip
 
         - os: windows-latest
-          python: 3.7
+          python: 3.6
           TARGET: win
           PYENV: conda
           PACKAGES: glpk
@@ -292,6 +292,17 @@ jobs:
                 | tr ":" "\\n" | grep runner | tr "\n" ":"`:`echo "$PATH" \
                 | tr ":" "\\n" | grep -v runner | tr "\n" ":"`' >> $profile
         done
+
+    #############################################################
+    # TODO: Delete this once Python 3.6 is deprecated - 12/2021 #
+    #############################################################
+    - name: Windows Python 3.6 Temporary Fix (conda)
+      if: |
+        (matrix.PYENV == 'conda' &&
+        matrix.TARGET == 'win' &&
+        matrix.python == '3.6')
+      run: |
+        conda install tomli==1.2.2 --force-reinstall
 
     - name: Setup TPL package directories
       run: |

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -46,7 +46,7 @@ jobs:
           PYENV: pip
 
         - os: windows-latest
-          python: 3.6
+          python: 3.7
           TARGET: win
           PYENV: conda
           PACKAGES: glpk

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -312,6 +312,17 @@ jobs:
                 | tr ":" "\\n" | grep -v runner | tr "\n" ":"`' >> $profile
         done
 
+    #############################################################
+    # TODO: Delete this once Python 3.6 is deprecated - 12/2021 #
+    #############################################################
+    - name: Windows Python 3.6 Temporary Fix (conda)
+      if: |
+        (matrix.PYENV == 'conda' &&
+        matrix.TARGET == 'win' &&
+        matrix.python == '3.6')
+      run: |
+        conda install tomli==1.2.2 --force-reinstall
+
     - name: Setup TPL package directories
       run: |
         TPL_DIR="${GITHUB_WORKSPACE}/cache/tpl"


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
We currently are experiencing testing failures for Windows/Python 3.6 due to an update in `coverage`. This adds a check with a big note to replace the problem version of the dependency.

## Changes proposed in this PR:
- Add step to install older version of `tomli`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
