### PR TITLE
Update kernel.constraint to match Constraint (lb/lower, ub/upper) API

### DIFF
--- a/pyomo/core/kernel/conic.py
+++ b/pyomo/core/kernel/conic.py
@@ -97,13 +97,23 @@ class _ConicBase(IConstraint):
         return self._body
 
     @property
+    def lower(self):
+        """The expression for the lower bound of the constraint"""
+        return None
+
+    @property
+    def upper(self):
+        """The expression for the upper bound of the constraint"""
+        return 0.0
+
+    @property
     def lb(self):
-        """The lower bound of the constraint"""
+        """The value of the lower lower bound of the constraint"""
         return None
 
     @property
     def ub(self):
-        """The upper bound of the constraint"""
+        """The value of the lower upper bound of the constraint"""
         return 0.0
 
     @property

--- a/pyomo/core/kernel/conic.py
+++ b/pyomo/core/kernel/conic.py
@@ -108,12 +108,12 @@ class _ConicBase(IConstraint):
 
     @property
     def lb(self):
-        """The value of the lower lower bound of the constraint"""
+        """The value of the lower bound of the constraint"""
         return None
 
     @property
     def ub(self):
-        """The value of the lower upper bound of the constraint"""
+        """The value of the upper bound of the constraint"""
         return 0.0
 
     @property

--- a/pyomo/core/kernel/constraint.py
+++ b/pyomo/core/kernel/constraint.py
@@ -199,7 +199,7 @@ class _MutableBoundsConstraintMixin(object):
     @property
     def lb(self):
         """The value of the lower bound of the constraint"""
-        return None if self._lb is None else value(self._lb)
+        return value(self._lb)
     @lb.setter
     def lb(self, lb):
         self.lower = lb
@@ -207,7 +207,7 @@ class _MutableBoundsConstraintMixin(object):
     @property
     def ub(self):
         """The value of the upper bound of the constraint"""
-        return None if self._ub is None else value(self._ub)
+        return value(self._ub)
     @ub.setter
     def ub(self, ub):
         self.upper = ub

--- a/pyomo/core/kernel/constraint.py
+++ b/pyomo/core/kernel/constraint.py
@@ -34,11 +34,15 @@ class IConstraint(ICategorizedObject):
     #
 
     body = _abstract_readonly_property(
-        doc="The body of the constraint")
+        doc="The expression for the body of the constraint")
+    lower = _abstract_readonly_property(
+        doc="The expression for the lower bound of the constraint")
+    upper = _abstract_readonly_property(
+        doc="The expression for the upper bound of the constraint")
     lb = _abstract_readonly_property(
-        doc="The lower bound of the constraint")
+        doc="The value of the lower bound of the constraint")
     ub = _abstract_readonly_property(
-        doc="The upper bound of the constraint")
+        doc="The value of the upper bound of the constraint")
     rhs = _abstract_readonly_property(
         doc="The right-hand side of the constraint")
     equality = _abstract_readonly_property(
@@ -50,14 +54,6 @@ class IConstraint(ICategorizedObject):
              "instance provides the properties that "
              "define the linear canonical form of a "
              "constraint"))
-
-    # temporary (for backwards compatibility)
-    @property
-    def lower(self):
-        return self.lb
-    @property
-    def upper(self):
-        return self.ub
 
     #
     # Interface
@@ -167,14 +163,14 @@ class _MutableBoundsConstraintMixin(object):
     #
 
     @property
-    def lb(self):
-        """The lower bound of the constraint"""
+    def lower(self):
+        """The expression for the lower bound of the constraint"""
         return self._lb
-    @lb.setter
-    def lb(self, lb):
+    @lower.setter
+    def lower(self, lb):
         if self.equality:
             raise ValueError(
-                "The lb property can not be set "
+                "The lower property can not be set "
                 "when the equality property is True.")
         if (lb is not None) and \
            (not is_numeric_data(lb)):
@@ -184,14 +180,14 @@ class _MutableBoundsConstraintMixin(object):
         self._lb = lb
 
     @property
-    def ub(self):
-        """The upper bound of the constraint"""
+    def upper(self):
+        """The expression for the upper bound of the constraint"""
         return self._ub
-    @ub.setter
-    def ub(self, ub):
+    @upper.setter
+    def upper(self, ub):
         if self.equality:
             raise ValueError(
-                "The ub property can not be set "
+                "The upper property can not be set "
                 "when the equality property is True.")
         if (ub is not None) and \
            (not is_numeric_data(ub)):
@@ -199,6 +195,22 @@ class _MutableBoundsConstraintMixin(object):
                     "Constraint upper bounds must be "
                     "expressions restricted to numeric data.")
         self._ub = ub
+
+    @property
+    def lb(self):
+        """The value of the lower bound of the constraint"""
+        return None if self._lb is None else value(self._lb)
+    @lb.setter
+    def lb(self, lb):
+        self.lower = lb
+
+    @property
+    def ub(self):
+        """The value of the upper bound of the constraint"""
+        return None if self._ub is None else value(self._ub)
+    @ub.setter
+    def ub(self, ub):
+        self.upper = ub
 
     @property
     def rhs(self):
@@ -578,8 +590,8 @@ class constraint(_MutableBoundsConstraintMixin,
         # Error check, to ensure that we don't have an equality
         # constraint with 'infinite' RHS
         #
-        assert not (self.equality and (self.lb is None))
-        assert (not self.equality) or (self.lb is self.ub)
+        assert not (self.equality and (self.lower is None))
+        assert (not self.equality) or (self.lower is self.upper)
 
 #
 # Note: This class is experimental. The implementation may

--- a/pyomo/core/kernel/matrix_constraint.py
+++ b/pyomo/core/kernel/matrix_constraint.py
@@ -12,7 +12,7 @@ from pyomo.common.dependencies import (
     numpy, numpy_available as has_numpy,
     scipy, scipy_available as has_scipy,
 )
-from pyomo.core.expr.numvalue import NumericValue
+from pyomo.core.expr.numvalue import NumericValue, value
 from pyomo.core.kernel.constraint import \
     (IConstraint,
      constraint_tuple)

--- a/pyomo/core/kernel/matrix_constraint.py
+++ b/pyomo/core/kernel/matrix_constraint.py
@@ -94,14 +94,14 @@ class _MatrixConstraintData(IConstraint):
         return sum(c * v for v, c in self.terms)
 
     @property
-    def lb(self):
-        """The lower bound of the constraint"""
+    def lower(self):
+        """The expression for the lower bound of the constraint"""
         return self.parent.lb[self._storage_key]
-    @lb.setter
-    def lb(self, lb):
+    @lower.setter
+    def lower(self, lb):
         if self.equality:
             raise ValueError(
-                "The lb property can not be set "
+                "The lower property can not be set "
                 "when the equality property is True.")
         if lb is None:
             lb = -numpy.inf
@@ -112,14 +112,14 @@ class _MatrixConstraintData(IConstraint):
         self.parent.lb[self._storage_key] = lb
 
     @property
-    def ub(self):
-        """The upper bound of the constraint"""
+    def upper(self):
+        """The expression for the upper bound of the constraint"""
         return self.parent.ub[self._storage_key]
-    @ub.setter
-    def ub(self, ub):
+    @upper.setter
+    def upper(self, ub):
         if self.equality:
             raise ValueError(
-                "The ub property can not be set "
+                "The upper property can not be set "
                 "when the equality property is True.")
         if ub is None:
             ub = numpy.inf
@@ -128,6 +128,22 @@ class _MatrixConstraintData(IConstraint):
                              "a simple numeric type "
                              "or None")
         self.parent.ub[self._storage_key] = ub
+
+    @property
+    def lb(self):
+        """The value of the lower bound of the constraint"""
+        return value(self.lower)
+    @lb.setter
+    def lb(self, lb):
+        self.lower = lb
+
+    @property
+    def ub(self):
+        """The value of the upper bound of the constraint"""
+        return value(self.upper)
+    @ub.setter
+    def ub(self, ub):
+        self.upper = ub
 
     @property
     def rhs(self):

--- a/pyomo/core/tests/unit/kernel/test_constraint.py
+++ b/pyomo/core/tests/unit/kernel/test_constraint.py
@@ -170,68 +170,68 @@ class Test_constraint(unittest.TestCase):
         c.equality = False
         pL = parameter()
         c.lb = pL
-        self.assertIs(c.lb, pL)
+        self.assertIs(c.lower, pL)
         pU = parameter()
         c.ub = pU
-        self.assertIs(c.ub, pU)
+        self.assertIs(c.upper, pU)
 
         with self.assertRaises(ValueError):
             self.assertEqual(c.has_lb(), False)
-        self.assertIs(c.lb, pL)
+        self.assertIs(c.lower, pL)
         with self.assertRaises(ValueError):
             self.assertEqual(c.has_ub(), False)
-        self.assertIs(c.ub, pU)
+        self.assertIs(c.upper, pU)
 
         pL.value = float('-inf')
         self.assertEqual(c.has_lb(), False)
-        self.assertEqual(c.lb(), float('-inf'))
+        self.assertEqual(c.lb, float('-inf'))
         with self.assertRaises(ValueError):
             self.assertEqual(c.has_ub(), False)
-        self.assertIs(c.ub, pU)
+        self.assertIs(c.upper, pU)
 
         pU.value = float('inf')
         self.assertEqual(c.has_lb(), False)
-        self.assertEqual(c.lb(), float('-inf'))
+        self.assertEqual(c.lb, float('-inf'))
         self.assertEqual(c.has_ub(), False)
-        self.assertEqual(c.ub(), float('inf'))
+        self.assertEqual(c.ub, float('inf'))
 
         pL.value = 0
         self.assertEqual(c.has_lb(), True)
-        self.assertEqual(c.lb(), 0)
+        self.assertEqual(c.lb, 0)
         self.assertEqual(c.has_ub(), False)
-        self.assertEqual(c.ub(), float('inf'))
+        self.assertEqual(c.ub, float('inf'))
 
         pU.value = 0
         self.assertEqual(c.has_lb(), True)
-        self.assertEqual(c.lb(), 0)
+        self.assertEqual(c.lb, 0)
         self.assertEqual(c.has_ub(), True)
-        self.assertEqual(c.ub(), 0)
+        self.assertEqual(c.ub, 0)
 
         pL.value = float('inf')
         self.assertEqual(c.has_lb(), True)
-        self.assertEqual(c.lb(), float('inf'))
+        self.assertEqual(c.lb, float('inf'))
         self.assertEqual(c.has_ub(), True)
-        self.assertEqual(c.ub(), 0)
+        self.assertEqual(c.ub, 0)
 
         pU.value = float('-inf')
         self.assertEqual(c.has_lb(), True)
-        self.assertEqual(c.lb(), float('inf'))
+        self.assertEqual(c.lb, float('inf'))
         self.assertEqual(c.has_ub(), True)
-        self.assertEqual(c.ub(), float('-inf'))
+        self.assertEqual(c.ub, float('-inf'))
 
         pL.value = float('inf')
         c.rhs = pL
         self.assertEqual(c.has_lb(), True)
-        self.assertEqual(c.lb(), float('inf'))
+        self.assertEqual(c.lb, float('inf'))
         self.assertEqual(c.has_ub(), False)
-        self.assertEqual(c.ub(), float('inf'))
+        self.assertEqual(c.ub, float('inf'))
 
         pL.value = float('-inf')
         c.rhs = pL
         self.assertEqual(c.has_lb(), False)
-        self.assertEqual(c.lb(), float('-inf'))
+        self.assertEqual(c.lb, float('-inf'))
         self.assertEqual(c.has_ub(), True)
-        self.assertEqual(c.ub(), float('-inf'))
+        self.assertEqual(c.ub, float('-inf'))
 
     def test_bounds_getter_setter(self):
         c = constraint()
@@ -567,32 +567,32 @@ class Test_constraint(unittest.TestCase):
         pU = parameter()
         c.expr = (pL, e, pU)
         self.assertIs(c.body, e)
-        self.assertIs(c.lb, pL)
-        self.assertIs(c.ub, pU)
+        self.assertIs(c.lower, pL)
+        self.assertIs(c.upper, pU)
         e.expr = None
         self.assertIs(c.body, e)
-        self.assertIs(c.lb, pL)
-        self.assertIs(c.ub, pU)
+        self.assertIs(c.lower, pL)
+        self.assertIs(c.upper, pU)
         c.expr = (pL, e, pU)
         self.assertIs(c.body, e)
-        self.assertIs(c.lb, pL)
-        self.assertIs(c.ub, pU)
+        self.assertIs(c.lower, pL)
+        self.assertIs(c.upper, pU)
 
         e.expr = 1.0
         eL = data_expression()
         eU = data_expression()
         c.expr = (eL, e, eU)
         self.assertIs(c.body, e)
-        self.assertIs(c.lb, eL)
-        self.assertIs(c.ub, eU)
+        self.assertIs(c.lower, eL)
+        self.assertIs(c.upper, eU)
         e.expr = None
         self.assertIs(c.body, e)
-        self.assertIs(c.lb, eL)
-        self.assertIs(c.ub, eU)
+        self.assertIs(c.lower, eL)
+        self.assertIs(c.upper, eU)
         c.expr = (eL, e, eU)
         self.assertIs(c.body, e)
-        self.assertIs(c.lb, eL)
-        self.assertIs(c.ub, eU)
+        self.assertIs(c.lower, eL)
+        self.assertIs(c.upper, eU)
 
     # make sure we can use a mutable param that
     # has not been given a value in the upper bound
@@ -606,7 +606,7 @@ class Test_constraint(unittest.TestCase):
         self.assertEqual(c.equality, False)
 
         c = constraint(expr=p <= x)
-        self.assertTrue(c.lb is p)
+        self.assertIs(c.lower, p)
         self.assertEqual(c.equality, False)
 
         c = constraint(expr=p <= x + 1)
@@ -625,7 +625,7 @@ class Test_constraint(unittest.TestCase):
         self.assertEqual(c.equality, False)
 
         c = constraint(expr=x >= p)
-        self.assertTrue(c.lb is p)
+        self.assertIs(c.lower, p)
         self.assertEqual(c.equality, False)
 
         c = constraint(expr=x + 1 >= p)
@@ -638,7 +638,7 @@ class Test_constraint(unittest.TestCase):
         self.assertEqual(c.equality, False)
 
         c = constraint(expr=(p, x, None))
-        self.assertTrue(c.lb is p)
+        self.assertIs(c.lower, p)
         self.assertEqual(c.equality, False)
 
         c = constraint(expr=(p, x + 1, None))
@@ -662,7 +662,7 @@ class Test_constraint(unittest.TestCase):
         self.assertEqual(c.equality, False)
 
         c = constraint(expr=x <= p)
-        self.assertTrue(c.ub is p)
+        self.assertIs(c.upper, p)
         self.assertEqual(c.equality, False)
 
         c = constraint(expr=x + 1 <= p)
@@ -681,7 +681,7 @@ class Test_constraint(unittest.TestCase):
         self.assertEqual(c.equality, False)
 
         c = constraint(expr=p >= x)
-        self.assertTrue(c.ub is p)
+        self.assertIs(c.upper, p)
         self.assertEqual(c.equality, False)
 
         c = constraint(expr=p >= x + 1)
@@ -694,7 +694,7 @@ class Test_constraint(unittest.TestCase):
         self.assertEqual(c.equality, False)
 
         c = constraint(expr=(None, x, p))
-        self.assertTrue(c.ub is p)
+        self.assertIs(c.upper, p)
         self.assertEqual(c.equality, False)
 
         c = constraint(expr=(None, x + 1, p))
@@ -718,7 +718,7 @@ class Test_constraint(unittest.TestCase):
         self.assertEqual(c.equality, True)
 
         c = constraint(expr=x == p)
-        self.assertTrue(c.ub is p)
+        self.assertIs(c.upper, p)
         self.assertEqual(c.equality, True)
 
         c = constraint(expr=x + 1 == p)
@@ -731,30 +731,30 @@ class Test_constraint(unittest.TestCase):
         self.assertEqual(c.equality, True)
 
         c = constraint(expr=(x, p))
-        self.assertTrue(c.ub is p)
-        self.assertTrue(c.lb is p)
-        self.assertTrue(c.rhs is p)
+        self.assertIs(c.upper, p)
+        self.assertIs(c.lower, p)
+        self.assertIs(c.rhs, p)
         self.assertIs(c.body, x)
         self.assertEqual(c.equality, True)
 
         c = constraint(expr=(p, x))
-        self.assertTrue(c.ub is p)
-        self.assertTrue(c.lb is p)
-        self.assertTrue(c.rhs is p)
+        self.assertIs(c.upper, p)
+        self.assertIs(c.lower, p)
+        self.assertIs(c.rhs, p)
         self.assertIs(c.body, x)
         self.assertEqual(c.equality, True)
 
         c = constraint(expr=logical_expr.EqualityExpression((p, x)))
-        self.assertTrue(c.ub is p)
-        self.assertTrue(c.lb is p)
-        self.assertTrue(c.rhs is p)
+        self.assertIs(c.upper, p)
+        self.assertIs(c.lower, p)
+        self.assertIs(c.rhs, p)
         self.assertIs(c.body, x)
         self.assertEqual(c.equality, True)
 
         c = constraint(expr=logical_expr.EqualityExpression((x, p)))
-        self.assertTrue(c.ub is p)
-        self.assertTrue(c.lb is p)
-        self.assertTrue(c.rhs is p)
+        self.assertIs(c.upper, p)
+        self.assertIs(c.lower, p)
+        self.assertIs(c.rhs, p)
         self.assertIs(c.body, x)
         self.assertEqual(c.equality, True)
 
@@ -1940,17 +1940,17 @@ class Test_linear_constraint(unittest.TestCase):
         pL = parameter()
         pU = parameter()
         c.lb = pL
-        self.assertIs(c.lb, pL)
+        self.assertIs(c.lower, pL)
         c.ub = pU
-        self.assertIs(c.ub, pU)
+        self.assertIs(c.upper, pU)
 
         e.expr = 1.0
         eL = data_expression()
         eU = data_expression()
         c.lb = eL
-        self.assertIs(c.lb, eL)
+        self.assertIs(c.lower, eL)
         c.ub = eU
-        self.assertIs(c.ub, eU)
+        self.assertIs(c.upper, eU)
 
     def test_call(self):
         c = linear_constraint([],[])


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
#2073 updates the `Constraint` API to provide two sets of methods to retrieve constraint bounds:
- `lb`, `ub` to retrieve the numeric value of the bound
- `lower`, `upper` to retrieve the bound expression

This PR updates kernel's `constraint` to match this API

## Changes proposed in this PR:
- add `lower` and `upper` attributes
- switch `lb` and `ub` to return the current numeric value of the bound
- update tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
