### PR TITLE
Remove hard-coded project name from default `attempt_import()` message

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -293,17 +293,23 @@ def check_min_version(module, min_version):
             module = indicator._module
         else:
             return False
-    try:
-        from packaging import version as _version
-        _parser = _version.parse
-    except ImportError:
-        # pkg_resources is an order of magnitude slower to import than
-        # packaging.  Only use it if the preferred (but optional)
-        # packaging library is not present
-        from pkg_resources import parse_version as _parser
+    if check_min_version._parser is None:
+        try:
+            from packaging import version as _version
+            _parser = _version.parse
+        except ImportError:
+            # pkg_resources is an order of magnitude slower to import than
+            # packaging.  Only use it if the preferred (but optional)
+            # packaging library is not present
+            from pkg_resources import parse_version as _parser
+        check_min_version._parser = _parser
+    else:
+        _parser = check_min_version._parser
 
     version = getattr(module, '__version__', '0.0.0')
     return _parser(min_version) <= _parser(version)
+
+check_min_version._parser = None
 
 
 def attempt_import(name, error_message=None, only_catch_importerror=None,

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -405,7 +405,7 @@ def attempt_import(name, error_message=None, only_catch_importerror=None,
         ``deferred_submodules=['pyplot', 'pylab']`` for ``matplotlib``.
 
     catch_exceptions: Iterable[Exception], optional
-        If provide, this is the list of exceptions that will be caught
+        If provided, this is the list of exceptions that will be caught
         when importing the target module, resulting in
         ``attempt_import`` returning a :py:class:`ModuleUnavailable`
         instance.  The default is to only catch :py:class:`ImportError`.
@@ -455,8 +455,8 @@ def attempt_import(name, error_message=None, only_catch_importerror=None,
             # Ensures all names begin with '.'
             #
             # Fill in any missing submodules.  For example, if a user
-            # provides {'foo.bar.baz': ['bz']}, then expand the dict to
-            # {'.foo': None, '.foo.bar': None, '.foo.bar.baz': ['bz']}
+            # provides ['foo.bar.baz'], then expand the list to
+            # ['.foo', '.foo.bar', '.foo.bar.baz']
             deferred = []
             for _submod in deferred_submodules:
                 if _submod[0] != '.':

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -73,13 +73,12 @@ class ModuleUnavailable(object):
             msg = _err
         if _imp:
             if not msg or not str(msg):
+                _pkg_str = _package.split('.')[0].capitalize()
+                if _pkg_str:
+                    _pkg_str += ' '
                 msg = (
-                    "The %s module (an optional %s dependency) " \
-                    "failed to import: %s" % (
-                        self.__name__,
-                        _package.split('.')[0].capitalize(),
-                        _imp,
-                    )
+                    "The %s module (an optional %sdependency) "
+                    "failed to import: %s" % (self.__name__, _pkg_str, _imp)
                 )
             else:
                 msg = "%s (import raised %s)" % (msg, _imp,)
@@ -202,7 +201,7 @@ class DeferredImportIndicator(_DeferredImportIndicatorBase):
     def resolve(self):
         # Only attempt the import once, then cache some form of result
         if self._module is None:
-            package = self._original_globals['__name__']
+            package = self._original_globals.get('__name__', '')
             try:
                 self._module, self._available = _perform_import(
                     name=self._names[0],
@@ -487,8 +486,13 @@ def attempt_import(name, error_message=None, only_catch_importerror=None,
             "deferred_submodules is only valid if defer_check==True")
 
     return _perform_import(
-        name, error_message, minimum_version, callback, importer,
-        catch_exceptions, inspect.currentframe().f_back.f_globals['__name__']
+        name=name,
+        error_message=error_message,
+        minimum_version=minimum_version,
+        callback=callback,
+        importer=importer,
+        catch_exceptions=catch_exceptions,
+        package=inspect.currentframe().f_back.f_globals.get('__name__', ''),
     )
 
 

--- a/pyomo/common/tests/test_dependencies.py
+++ b/pyomo/common/tests/test_dependencies.py
@@ -221,7 +221,8 @@ class TestDependencies(unittest.TestCase):
 
     def test_import_exceptions(self):
         mod, avail = attempt_import('pyomo.common.tests.dep_mod_except',
-                                    defer_check=True)
+                                    defer_check=True,
+                                    only_catch_importerror=True)
         with self.assertRaisesRegex(ValueError, "cannot import module"):
             bool(avail)
         # second test will not re-trigger the exception
@@ -232,6 +233,20 @@ class TestDependencies(unittest.TestCase):
                                     only_catch_importerror=False)
         self.assertFalse(avail)
         self.assertFalse(avail)
+
+        mod, avail = attempt_import('pyomo.common.tests.dep_mod_except',
+                                    defer_check=True,
+                                    catch_exceptions=(ImportError, ValueError))
+        self.assertFalse(avail)
+        self.assertFalse(avail)
+
+        with self.assertRaisesRegex(
+                ValueError, 'Cannot specify both only_catch_importerror '
+                'and catch_exceptions'):
+            mod, avail = attempt_import('pyomo.common.tests.dep_mod_except',
+                                        defer_check=True,
+                                        only_catch_importerror=True,
+                                        catch_exceptions=(ImportError,))
 
     def test_generate_warning(self):
         mod, avail = attempt_import('pyomo.common.tests.dep_mod_except',


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This removes a hard-coded package name (`Pyomo`) from the error message generated by unavailable modules imported through `attempt_import()`.  The package name is now automatically generated.  This produces more informative user messages when projects outside of Pyomo leverage `attempt_import()` (like IDAES).

## Changes proposed in this PR:
- calculate package name from `attempt_import()` calling frame 
- Cache the import of the version parser (performance improvement)
- Expand test coverage

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
