### PR TITLE
Add `remove_nodes` method to IncidenceGraphInterface

### DIFF
--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -353,7 +353,7 @@ class IncidenceGraphInterface(object):
         rows) from the cached incidence matrix. This is a "projection"
         of the variable and constraint vectors, rather than something
         like a vertex elimination.
-        For the puropse of this method, there is not need to distinguish
+        For the puropse of this method, there is no need to distinguish
         between variables and constraints. However, we provide the
         "constraints" argument so a call signature similar to other methods
         in this class is still valid.
@@ -364,8 +364,8 @@ class IncidenceGraphInterface(object):
             VarData or ConData objects whose columns or rows will be
             removed from the incidence matrix.
         constraints: List
-            ConstraintData objects whose rows will be removed from the
-            incidence matrix.
+            VarData or ConData objects whose columns or rows will be
+            removed from the incidence matrix.
 
         """
         if constraints is None:

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -369,7 +369,8 @@ class IncidenceGraphInterface(object):
                 "Attempting to remove variables and constraints from cached "
                 "incidence matrix,\nbut no incidence matrix has been cached."
             )
-        to_exclude = ComponentSet(variables + constraints)
+        to_exclude = ComponentSet(variables)
+        to_exclude.update(constraints)
         vars_to_include = [v for v in self.variables if v not in to_exclude]
         cons_to_include = [c for c in self.constraints if c not in to_exclude]
         incidence_matrix = self._extract_submatrix(

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -350,7 +350,9 @@ class IncidenceGraphInterface(object):
     def remove(self, variables, constraints):
         """
         Removes the specified variables and constraints (columns and
-        rows) from the cached incidence matrix.
+        rows) from the cached incidence matrix. This is a "projection"
+        of the variable and constraint vectors, rather than something
+        like a vertex elimination.
 
         Arguments:
         ----------

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -346,3 +346,42 @@ class IncidenceGraphInterface(object):
         # Switch the order of the maps here to match the method call.
         # Hopefully this does not get too confusing...
         return var_partition, con_partition
+
+    def remove(self, variables, constraints):
+        """
+        Removes the specified variables and constraints (columns and
+        rows) from the cached incidence matrix.
+
+        Arguments:
+        ----------
+        variables: List
+            VarData objects whose columns will be removed from the
+            incidence matrix.
+        constraints: List
+            ConstraintData objects whose rows will be removed from the
+            incidence matrix.
+
+        """
+        if self.cached is IncidenceMatrixType.NONE:
+            raise RuntimeError(
+                "Attempting to remove variables and constraints from cached "
+                "incidence matrix,\nbut no incidence matrix has been cached."
+            )
+        to_exclude = ComponentSet(variables + constraints)
+        vars_to_include = [v for v in self.variables if v not in to_exclude]
+        cons_to_include = [c for c in self.constraints if c not in to_exclude]
+        incidence_matrix = self._extract_submatrix(
+            vars_to_include, cons_to_include
+        )
+        # update attributes
+        self.variables = vars_to_include
+        self.constraints = cons_to_include
+        self.incidence_matrix = incidence_matrix
+        self.var_index_map = ComponentMap(
+            (var, i) for i, var in enumerate(self.variables)
+        )
+        self.con_index_map = ComponentMap(
+            (con, i) for i, con in enumerate(self.constraints)
+        )
+        self.row_block_map = None
+        self.col_block_map = None

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -347,29 +347,35 @@ class IncidenceGraphInterface(object):
         # Hopefully this does not get too confusing...
         return var_partition, con_partition
 
-    def remove(self, variables, constraints):
+    def remove_nodes(self, nodes, constraints=None):
         """
         Removes the specified variables and constraints (columns and
         rows) from the cached incidence matrix. This is a "projection"
         of the variable and constraint vectors, rather than something
         like a vertex elimination.
+        For the puropse of this method, there is not need to distinguish
+        between variables and constraints. However, we provide the
+        "constraints" argument so a call signature similar to other methods
+        in this class is still valid.
 
         Arguments:
         ----------
-        variables: List
-            VarData objects whose columns will be removed from the
-            incidence matrix.
+        nodes: List
+            VarData or ConData objects whose columns or rows will be
+            removed from the incidence matrix.
         constraints: List
             ConstraintData objects whose rows will be removed from the
             incidence matrix.
 
         """
+        if constraints is None:
+            constraints = []
         if self.cached is IncidenceMatrixType.NONE:
             raise RuntimeError(
                 "Attempting to remove variables and constraints from cached "
                 "incidence matrix,\nbut no incidence matrix has been cached."
             )
-        to_exclude = ComponentSet(variables)
+        to_exclude = ComponentSet(nodes)
         to_exclude.update(constraints)
         vars_to_include = [v for v in self.variables if v not in to_exclude]
         cons_to_include = [c for c in self.constraints if c not in to_exclude]

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -1051,7 +1051,7 @@ class TestDulmageMendelsohnInterface(unittest.TestCase):
         # matrix.
         vars_to_remove = [m.flow_comp[1]]
         cons_to_remove = [m.flow_eqn[1]]
-        igraph.remove_nodes(vars_to_remove, cons_to_remove)
+        igraph.remove_nodes(vars_to_remove + cons_to_remove)
         var_dmp, con_dmp = igraph.dulmage_mendelsohn()
         var_con_set = ComponentSet(igraph.variables + igraph.constraints)
         underconstrained_set = ComponentSet(

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -675,6 +675,47 @@ class TestGasExpansionModelInterfaceClassStructural(unittest.TestCase):
             igraph.block_triangularize(variables, constraints)
         self.assertIn('must be unindexed', str(exc.exception))
 
+    def test_remove(self):
+        model = make_gas_expansion_model()
+        igraph = IncidenceGraphInterface(model)
+
+        n_eqn = len(list(model.component_data_objects(pyo.Constraint)))
+        matching = igraph.maximum_matching()
+        values = ComponentSet(matching.values())
+        self.assertEqual(len(matching), n_eqn)
+        self.assertEqual(len(values), n_eqn)
+
+        variable_set = ComponentSet(igraph.variables)
+        self.assertIn(model.F[0], variable_set)
+        self.assertIn(model.F[2], variable_set)
+        var_dmp, con_dmp = igraph.dulmage_mendelsohn()
+        underconstrained_set = ComponentSet(
+            var_dmp.unmatched + var_dmp.underconstrained
+        )
+        self.assertIn(model.F[0], underconstrained_set)
+        self.assertIn(model.F[2], underconstrained_set)
+
+        N, M = igraph.incidence_matrix.shape
+
+        # Say we know that these variables and constraints should
+        # be matched...
+        vars_to_remove = [model.F[0], model.F[2]]
+        cons_to_remove = [model.mbal[1], model.mbal[2]]
+        igraph.remove(vars_to_remove, cons_to_remove)
+        variable_set = ComponentSet(igraph.variables)
+        self.assertNotIn(model.F[0], variable_set)
+        self.assertNotIn(model.F[2], variable_set)
+        var_dmp, con_dmp = igraph.dulmage_mendelsohn()
+        underconstrained_set = ComponentSet(
+            var_dmp.unmatched + var_dmp.underconstrained
+        )
+        self.assertNotIn(model.F[0], underconstrained_set)
+        self.assertNotIn(model.F[2], underconstrained_set)
+
+        N_new, M_new = igraph.incidence_matrix.shape
+        self.assertEqual(N_new, N - len(cons_to_remove))
+        self.assertEqual(M_new, M - len(vars_to_remove))
+
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
 @unittest.skipUnless(scipy_available, "scipy is not available.")
@@ -987,6 +1028,42 @@ class TestDulmageMendelsohnInterface(unittest.TestCase):
         self.assertEqual(len(con_dmp[0]+con_dmp[1]), len(overconstrained_cons))
         for con in con_dmp[0]+con_dmp[1]:
             self.assertIn(con, overconstrained_cons)
+
+    def test_remove(self):
+        m = make_degenerate_solid_phase_model()
+        variables = list(m.component_data_objects(pyo.Var))
+        constraints = list(m.component_data_objects(pyo.Constraint))
+
+        igraph = IncidenceGraphInterface(m)
+        var_dmp, con_dmp = igraph.dulmage_mendelsohn()
+        var_con_set = ComponentSet(igraph.variables + igraph.constraints)
+        underconstrained_set = ComponentSet(
+            var_dmp.unmatched + var_dmp.underconstrained
+        )
+        self.assertIn(m.flow_comp[1], var_con_set)
+        self.assertIn(m.flow_eqn[1], var_con_set)
+        self.assertIn(m.flow_comp[1], underconstrained_set)
+
+        N, M = igraph.incidence_matrix.shape
+
+        # flow_comp[1] is underconstrained, but we think it should be
+        # specified by flow_eqn[1], so we remove these from the incidence
+        # matrix.
+        vars_to_remove = [m.flow_comp[1]]
+        cons_to_remove = [m.flow_eqn[1]]
+        igraph.remove(vars_to_remove, cons_to_remove)
+        var_dmp, con_dmp = igraph.dulmage_mendelsohn()
+        var_con_set = ComponentSet(igraph.variables + igraph.constraints)
+        underconstrained_set = ComponentSet(
+            var_dmp.unmatched + var_dmp.underconstrained
+        )
+        self.assertNotIn(m.flow_comp[1], var_con_set)
+        self.assertNotIn(m.flow_eqn[1], var_con_set)
+        self.assertNotIn(m.flow_comp[1], underconstrained_set)
+
+        N_new, M_new = igraph.incidence_matrix.shape
+        self.assertEqual(N_new, N - len(cons_to_remove))
+        self.assertEqual(M_new, M - len(vars_to_remove))
 
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -701,7 +701,7 @@ class TestGasExpansionModelInterfaceClassStructural(unittest.TestCase):
         # be matched...
         vars_to_remove = [model.F[0], model.F[2]]
         cons_to_remove = (model.mbal[1], model.mbal[2])
-        igraph.remove(vars_to_remove, cons_to_remove)
+        igraph.remove_nodes(vars_to_remove, cons_to_remove)
         variable_set = ComponentSet(igraph.variables)
         self.assertNotIn(model.F[0], variable_set)
         self.assertNotIn(model.F[2], variable_set)
@@ -1051,7 +1051,7 @@ class TestDulmageMendelsohnInterface(unittest.TestCase):
         # matrix.
         vars_to_remove = [m.flow_comp[1]]
         cons_to_remove = [m.flow_eqn[1]]
-        igraph.remove(vars_to_remove, cons_to_remove)
+        igraph.remove_nodes(vars_to_remove, cons_to_remove)
         var_dmp, con_dmp = igraph.dulmage_mendelsohn()
         var_con_set = ComponentSet(igraph.variables + igraph.constraints)
         underconstrained_set = ComponentSet(

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -700,7 +700,7 @@ class TestGasExpansionModelInterfaceClassStructural(unittest.TestCase):
         # Say we know that these variables and constraints should
         # be matched...
         vars_to_remove = [model.F[0], model.F[2]]
-        cons_to_remove = [model.mbal[1], model.mbal[2]]
+        cons_to_remove = (model.mbal[1], model.mbal[2])
         igraph.remove(vars_to_remove, cons_to_remove)
         variable_set = ComponentSet(igraph.variables)
         self.assertNotIn(model.F[0], variable_set)

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -1113,6 +1113,13 @@ class TestExceptions(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "inactive constraints"):
             igraph = IncidenceGraphInterface(nlp, active=False)
 
+    def test_remove_no_matrix(self):
+        m = pyo.ConcreteModel()
+        m.v1 = pyo.Var()
+        igraph = IncidenceGraphInterface()
+        with self.assertRaisesRegex(RuntimeError, "no incidence matrix"):
+            igraph.remove_nodes([m.v1])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary/Motivation:
When debugging a model that has an unexpected overconstrained or underconstrained subsystem, a common task we want to do is remove a particular variable and constraint from the incidence graph/matrix, the equivalent of fixing a variable and deactivating a constraint. This can help narrow down the "cause" of the unexpected overconstrained/underconstrained system. This is currently possible by fixing/deactivating, then re-constructing the incidence graph, but would be nice to do this without altering the Pyomo model. This motivates the addition of a method on `IncidenceGraphInterface` for removing nodes from an incidence graph. Note this is "projecting" variables and constraints out of the model, rather than doing some sort of vertex elimination (where new edges/nonzeros would be added to the graph). 

## Changes proposed in this PR:
- Add a `remove` method to `IncidenceGraphInterface` that removes columns and rows corresponding to provided variables and constraints from the cached incidence matrix
- Basic tests for the new method

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
