### PR TITLE
Update book test filter to ignore 'separator lines'

### DIFF
--- a/examples/pyomobook/test_book_examples.py
+++ b/examples/pyomobook/test_book_examples.py
@@ -203,6 +203,8 @@ def filter(line):
                    'Function',
                    'File',
                    'Matplotlib',
+                   '-------',
+                   '=======',
                    '    ^'):
         if line.startswith(field):
             return True


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This resolves Book test failures in Python 3.6.

Gurobi no longer releases updated versions for Python 3.6.  The most recent release's community license will expire on January 13, 2022.  Once that date passes, the Gurobi tests should start being skipped.  However, until that point, Gurobi emits a warning that causes the file diffs to fail.  This updates the Book test filter to ignore the warning.

## Changes proposed in this PR:
- Update Book tests filter to ignore lines beginning with "`-------`" or "`=======`".

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
