### PR TITLE
Fixing issue with APPSI CBC options

### DIFF
--- a/pyomo/contrib/appsi/solvers/cbc.py
+++ b/pyomo/contrib/appsi/solvers/cbc.py
@@ -341,7 +341,7 @@ class Cbc(PersistentSolver):
             cmd.extend(['-timeMode', 'elapsed'])
         for key, val in _check_and_escape_options():
             if val.strip() != '':
-                cmd.append('-'+key, val)
+                cmd.extend(['-'+key, val])
             else:
                 action_options.append('-'+key)
         cmd.extend(['-printingOptions', 'all'])


### PR DESCRIPTION
## Fixes N/A .

## Summary/Motivation:
I found a small bug when attempting to use solver options with the APPSI CBC interface. Code to reproduce:
```
>>> from pyomo.environ import *
>>> m = ConcreteModel(); m.x=Var(); m.c=Constraint(expr=(0,m.x,1)); m.o=Objective(expr=m.x)
>>> s = SolverFactory('appsi_cbc')
>>> s.options['feas'] = 'off'
>>> s.solve(m)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/bknueven/Software/pyomo/pyomo/contrib/appsi/base.py", line 1116, in solve
    results: Results = super(LegacySolverInterface, self).solve(model)
  File "/Users/bknueven/Software/pyomo/pyomo/contrib/appsi/solvers/cbc.py", line 191, in solve
    res = self._apply_solver(timer)
  File "/Users/bknueven/Software/pyomo/pyomo/contrib/appsi/solvers/cbc.py", line 344, in _apply_solver
    cmd.append('-'+key, val)
TypeError: append() takes exactly one argument (2 given)
```

## Changes proposed in this PR:
- replace mistaken `append` with `extend`.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
