### PR TITLE
Resolve failing FBBT tests

### DIFF
--- a/pyomo/contrib/fbbt/tests/test_interval.py
+++ b/pyomo/contrib/fbbt/tests/test_interval.py
@@ -236,8 +236,8 @@ class TestInterval(unittest.TestCase):
                     zl, zu = interval.cos(xl, xu)
                     x = np.linspace(xl, xu, 100)
                     _z = np.cos(x)
-                    self.assertTrue(np.all(zl <= _z))
-                    self.assertTrue(np.all(zu >= _z))
+                    self.assertTrue(np.all(zl <= _z + 1e-14))
+                    self.assertTrue(np.all(zu >= _z - 1e-14))
 
     @unittest.skipIf(not numpy_available, 'Numpy is not available.')
     def test_sin(self):
@@ -249,8 +249,8 @@ class TestInterval(unittest.TestCase):
                     zl, zu = interval.sin(xl, xu)
                     x = np.linspace(xl, xu, 100)
                     _z = np.sin(x)
-                    self.assertTrue(np.all(zl <= _z))
-                    self.assertTrue(np.all(zu >= _z))
+                    self.assertTrue(np.all(zl <= _z + 1e-14))
+                    self.assertTrue(np.all(zu >= _z - 1e-14))
 
     @unittest.skipIf(not numpy_available, 'Numpy is not available.')
     def test_tan(self):
@@ -262,16 +262,8 @@ class TestInterval(unittest.TestCase):
                     zl, zu = interval.tan(xl, xu)
                     x = np.linspace(xl, xu, 100)
                     _z = np.tan(x)
-                    if np.any(zl > _z) or np.any(zu < _z):
-                        print('failed test_tan')
-                        print(f'    xl: {xl}')
-                        print(f'    xu: {xu}')
-                        print(f'    zl: {zl}')
-                        print(f'    zu: {zu}')
-                        print(f'    minimum of _z: {np.min(_z)}')
-                        print(f'    maximum of _z: {np.max(_z)}')
-                    self.assertTrue(np.all(zl <= _z))
-                    self.assertTrue(np.all(zu >= _z))
+                    self.assertTrue(np.all(zl <= _z + 1e-14))
+                    self.assertTrue(np.all(zu >= _z - 1e-14))
 
     @unittest.skipIf(not numpy_available, 'Numpy is not available.')
     def test_asin(self):

--- a/pyomo/contrib/fbbt/tests/test_interval.py
+++ b/pyomo/contrib/fbbt/tests/test_interval.py
@@ -262,6 +262,14 @@ class TestInterval(unittest.TestCase):
                     zl, zu = interval.tan(xl, xu)
                     x = np.linspace(xl, xu, 100)
                     _z = np.tan(x)
+                    if np.any(zl > _z) or np.any(zu < _z):
+                        print('failed test_tan')
+                        print(f'    xl: {xl}')
+                        print(f'    xu: {xu}')
+                        print(f'    zl: {zl}')
+                        print(f'    zu: {zu}')
+                        print(f'    minimum of _z: {np.min(_z)}')
+                        print(f'    maximum of _z: {np.max(_z)}')
                     self.assertTrue(np.all(zl <= _z))
                     self.assertTrue(np.all(zu >= _z))
 


### PR DESCRIPTION
## Summary/Motivation:
A few of the FBBT tests are failing due to floating point comparisons. They are off in the 16th digit. This PR adds a small tolerance to make the tests more robust.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
