### PR TITLE
Redesign `Var.stale` handling to use a global state flag

### DIFF
--- a/examples/pyomobook/test_book_examples.py
+++ b/examples/pyomobook/test_book_examples.py
@@ -203,6 +203,8 @@ def filter(line):
                    'Function',
                    'File',
                    'Matplotlib',
+                   '-------',
+                   '=======',
                    '    ^'):
         if line.startswith(field):
             return True

--- a/pyomo/contrib/appsi/base.py
+++ b/pyomo/contrib/appsi/base.py
@@ -25,6 +25,7 @@ from pyomo.core.kernel.objective import minimize, maximize
 from pyomo.core.base import SymbolMap
 import weakref
 from io import StringIO
+from pyomo.core.staleflag import StaleFlagManager
 
 
 class TerminationCondition(enum.Enum):
@@ -154,6 +155,8 @@ class SolutionLoaderBase(abc.ABC):
         """
         for v, val in self.get_primals(vars_to_load=vars_to_load).items():
             v.set_value(val, skip_validation=True)
+        StaleFlagManager.mark_all_as_stale(delayed=True)
+        
 
     @abc.abstractmethod
     def get_primals(self, vars_to_load: Optional[Sequence[_GeneralVarData]] = None) -> Mapping[_GeneralVarData, float]:
@@ -486,6 +489,7 @@ class PersistentSolver(Solver):
         """
         for v, val in self.get_primals(vars_to_load=vars_to_load).items():
             v.set_value(val, skip_validation=True)
+        StaleFlagManager.mark_all_as_stale(delayed=True)
 
     @abc.abstractmethod
     def get_primals(self, vars_to_load: Optional[Sequence[_GeneralVarData]] = None) -> Mapping[_GeneralVarData, float]:

--- a/pyomo/contrib/appsi/solvers/cbc.py
+++ b/pyomo/contrib/appsi/solvers/cbc.py
@@ -20,6 +20,7 @@ import sys
 from typing import Dict
 from pyomo.common.config import ConfigValue, NonNegativeInt
 from pyomo.common.errors import PyomoException
+from pyomo.core.staleflag import StaleFlagManager
 
 
 logger = logging.getLogger(__name__)
@@ -169,6 +170,7 @@ class Cbc(PersistentSolver):
         self._writer.update_params()
 
     def solve(self, model, timer: HierarchicalTimer = None):
+        StaleFlagManager.mark_all_as_stale()
         avail = self.available()
         if not avail:
             raise PyomoException(f'Solver {self.__class__} is not available ({avail}).')

--- a/pyomo/contrib/appsi/solvers/gurobi.py
+++ b/pyomo/contrib/appsi/solvers/gurobi.py
@@ -25,6 +25,7 @@ from pyomo.contrib.appsi.base import (
     PersistentSolver, Results, TerminationCondition, MIPSolverConfig,
     PersistentBase, PersistentSolutionLoader
 )
+from pyomo.core.staleflag import StaleFlagManager
 
 logger = logging.getLogger(__name__)
 
@@ -298,6 +299,7 @@ class Gurobi(PersistentBase, PersistentSolver):
         return self._postsolve(timer)
 
     def solve(self, model, timer: HierarchicalTimer = None) -> Results:
+        StaleFlagManager.mark_all_as_stale()
         avail = self.available()
         if not avail:
             raise PyomoException(f'Solver {self.__class__} is not available ({avail}).')
@@ -782,6 +784,7 @@ class Gurobi(PersistentBase, PersistentSolver):
     def load_vars(self, vars_to_load=None, solution_number=0):
         for v, val in self.get_primals(vars_to_load=vars_to_load, solution_number=solution_number).items():
             v.set_value(val, skip_validation=True)
+        StaleFlagManager.mark_all_as_stale(delayed=True)
 
     def get_primals(self, vars_to_load=None, solution_number=0):
         if self._needs_updated:

--- a/pyomo/contrib/appsi/solvers/ipopt.py
+++ b/pyomo/contrib/appsi/solvers/ipopt.py
@@ -23,6 +23,7 @@ from typing import Dict
 from pyomo.common.config import ConfigValue, NonNegativeInt
 from pyomo.common.errors import PyomoException
 import os
+from pyomo.core.staleflag import StaleFlagManager
 
 
 logger = logging.getLogger(__name__)
@@ -237,6 +238,7 @@ class Ipopt(PersistentSolver):
         f.close()
 
     def solve(self, model, timer: HierarchicalTimer = None):
+        StaleFlagManager.mark_all_as_stale()
         avail = self.available()
         if not avail:
             raise PyomoException(f'Solver {self.__class__} is not available ({avail}).')

--- a/pyomo/contrib/fbbt/tests/test_interval.py
+++ b/pyomo/contrib/fbbt/tests/test_interval.py
@@ -236,8 +236,8 @@ class TestInterval(unittest.TestCase):
                     zl, zu = interval.cos(xl, xu)
                     x = np.linspace(xl, xu, 100)
                     _z = np.cos(x)
-                    self.assertTrue(np.all(zl <= _z))
-                    self.assertTrue(np.all(zu >= _z))
+                    self.assertTrue(np.all(zl <= _z + 1e-14))
+                    self.assertTrue(np.all(zu >= _z - 1e-14))
 
     @unittest.skipIf(not numpy_available, 'Numpy is not available.')
     def test_sin(self):
@@ -249,8 +249,8 @@ class TestInterval(unittest.TestCase):
                     zl, zu = interval.sin(xl, xu)
                     x = np.linspace(xl, xu, 100)
                     _z = np.sin(x)
-                    self.assertTrue(np.all(zl <= _z))
-                    self.assertTrue(np.all(zu >= _z))
+                    self.assertTrue(np.all(zl <= _z + 1e-14))
+                    self.assertTrue(np.all(zu >= _z - 1e-14))
 
     @unittest.skipIf(not numpy_available, 'Numpy is not available.')
     def test_tan(self):
@@ -262,8 +262,8 @@ class TestInterval(unittest.TestCase):
                     zl, zu = interval.tan(xl, xu)
                     x = np.linspace(xl, xu, 100)
                     _z = np.tan(x)
-                    self.assertTrue(np.all(zl <= _z))
-                    self.assertTrue(np.all(zu >= _z))
+                    self.assertTrue(np.all(zl <= _z + 1e-14))
+                    self.assertTrue(np.all(zu >= _z - 1e-14))
 
     @unittest.skipIf(not numpy_available, 'Numpy is not available.')
     def test_asin(self):

--- a/pyomo/contrib/gdpopt/util.py
+++ b/pyomo/contrib/gdpopt/util.py
@@ -224,8 +224,6 @@ def copy_var_list_values(from_list, to_list, config,
             # instead log warnings).  This means that the following will
             # always succeed and the ValueError should never be raised.
             v_to.set_value(value(v_from, exception=False))
-            if skip_stale:
-                v_to.stale = False
         except ValueError as err:
             err_msg = getattr(err, 'message', str(err))
             var_val = value(v_from)

--- a/pyomo/contrib/gdpopt/util.py
+++ b/pyomo/contrib/gdpopt/util.py
@@ -219,6 +219,11 @@ def copy_var_list_values(from_list, to_list, config,
         if skip_fixed and v_to.is_fixed():
             continue  # Skip fixed variables.
         try:
+            # We don't want to trigger the reset of the global stale
+            # indicator, so we will set this variable to be "stale",
+            # knowing that set_value will switch it back to "not
+            # stale"
+            v_to.stale = True
             # NOTE: PEP 2180 changes the var behavior so that domain /
             # bounds violations no longer generate exceptions (and
             # instead log warnings).  This means that the following will

--- a/pyomo/contrib/mindtpy/initialization.py
+++ b/pyomo/contrib/mindtpy/initialization.py
@@ -163,6 +163,11 @@ def init_rNLP(solve_data, config):
                 add_affine_cuts(solve_data, config)
             # TODO check if value of the binary or integer varibles is 0/1 or integer value.
             for var in solve_data.mip.MindtPy_utils.discrete_variable_list:
+                # We don't want to trigger the reset of the global stale
+                # indicator, so we will set this variable to be "stale",
+                # knowing that set_value will switch it back to "not
+                # stale"
+                var.stale = True
                 var.set_value(int(round(var.value)), skip_validation=True)
     elif subprob_terminate_cond in {tc.infeasible, tc.noSolution}:
         # TODO fail? try something else?

--- a/pyomo/contrib/mindtpy/single_tree.py
+++ b/pyomo/contrib/mindtpy/single_tree.py
@@ -59,9 +59,17 @@ class LazyOACallback_cplex(cplex.callbacks.LazyConstraintCallback if cplex_avail
             v_val = self.get_values(
                 opt._pyomo_var_to_solver_var_map[v_from])
             try:
+                # We don't want to trigger the reset of the global stale
+                # indicator, so we will set this variable to be "stale",
+                # knowing that set_value will switch it back to "not
+                # stale"
+                v_to.stale = True
+                # NOTE: PEP 2180 changes the var behavior so that domain
+                # / bounds violations no longer generate exceptions (and
+                # instead log warnings).  This means that the following
+                # will always succeed and the ValueError should never be
+                # raised.
                 v_to.set_value(v_val)
-                if skip_stale:
-                    v_to.stale = False
             except ValueError:
                 # Snap the value to the bounds
                 if v_to.has_lb() and v_val < v_to.lb and v_to.lb - v_val <= config.variable_tolerance:

--- a/pyomo/contrib/mindtpy/single_tree.py
+++ b/pyomo/contrib/mindtpy/single_tree.py
@@ -284,6 +284,11 @@ class LazyOACallback_cplex(cplex.callbacks.LazyConstraintCallback if cplex_avail
             for var, val in zip(MindtPy.variable_list, var_values):
                 if not var.is_binary():
                     continue
+                # We don't want to trigger the reset of the global stale
+                # indicator, so we will set this variable to be "stale",
+                # knowing that set_value will switch it back to "not
+                # stale"
+                var.stale = True
                 var.set_value(val, skip_validation=True)
 
             # check to make sure that binary variables are all 0 or 1

--- a/pyomo/contrib/mindtpy/util.py
+++ b/pyomo/contrib/mindtpy/util.py
@@ -647,6 +647,11 @@ def copy_var_list_values_from_solution_pool(from_list, to_list, config, solver_m
                 solver_model.setParam(
                     gurobipy.GRB.Param.SolutionNumber, solution_name)
                 var_val = var_map[v_from].Xn
+            # We don't want to trigger the reset of the global stale
+            # indicator, so we will set this variable to be "stale",
+            # knowing that set_value will switch it back to "not
+            # stale"
+            v_to.stale = True
             # NOTE: PEP 2180 changes the var behavior so that domain /
             # bounds violations no longer generate exceptions (and
             # instead log warnings).  This means that the following will

--- a/pyomo/contrib/preprocessing/plugins/var_aggregator.py
+++ b/pyomo/contrib/preprocessing/plugins/var_aggregator.py
@@ -310,5 +310,11 @@ class VariableAggregator(IsomorphicTransformation):
         for agg_var in datablock.z.itervalues():
             if not agg_var.stale:
                 for var in datablock.z_to_vars[agg_var]:
-                    var.set_value(agg_var.value,skip_validation=True)
-                    var.stale = False
+                    # We don't want to accidentally trigger the reset of
+                    # the global stale indicator, so we will set this
+                    # variable to be "stale", knowing that set_value
+                    # will switch it back to "not stale".  In normal
+                    # situations, we would expect var to already be
+                    # stale.
+                    var.stale = True
+                    var.set_value(agg_var.value, skip_validation=True)

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -541,9 +541,9 @@ class ModelSolutions(object):
                 if attr_key in valid_import_suffixes:
                     valid_import_suffixes[attr_key][cdata] = attr_value
 
-        # Advance the stale flag again so that any subsequent variable
-        # updates will "set" the stale flag for these variables
-        StaleFlagManager.advance_flag()
+        # Set the state flag to "delayed advance": it will auto-advance
+        # if a non-stale variable is updated.
+        StaleFlagManager.advance_flag(delayed=True)
 
 @ModelComponentFactory.register('Model objects can be used as a component of other models.')
 class Model(ScalarBlock):

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -463,7 +463,7 @@ class ModelSolutions(object):
         # loading the solution, so you known which variables have "real"
         # values and which ones don't.
         #
-        StaleFlagManager.advance_flag()
+        StaleFlagManager.mark_all_as_stale()
 
         if index is not None:
             self.index = index
@@ -542,8 +542,9 @@ class ModelSolutions(object):
                     valid_import_suffixes[attr_key][cdata] = attr_value
 
         # Set the state flag to "delayed advance": it will auto-advance
-        # if a non-stale variable is updated.
-        StaleFlagManager.advance_flag(delayed=True)
+        # if a non-stale variable is updated (causing all non-stale
+        # variables to be marked as stale).
+        StaleFlagManager.mark_all_as_stale(delayed=True)
 
 @ModelComponentFactory.register('Model objects can be used as a component of other models.')
 class Model(ScalarBlock):

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -22,6 +22,7 @@ from pyomo.common.dependencies import pympler, pympler_available
 from pyomo.common.deprecation import deprecated, deprecation_warning
 from pyomo.common.gc_manager import PauseGC
 from pyomo.common.log import is_debug_set
+from pyomo.core.staleflag import StaleFlagManager
 from pyomo.core.expr.symbol_map import SymbolMap
 from pyomo.core.base.component import ModelComponentFactory
 from pyomo.core.base.var import Var
@@ -458,11 +459,13 @@ class ModelSolutions(object):
         """
         instance = self._instance()
         #
-        # Set the "stale" flag of each variable in the model prior to loading the
-        # solution, so you known which variables have "real" values and which ones don't.
+        # Set the "stale" flag of each variable in the model prior to
+        # loading the solution, so you known which variables have "real"
+        # values and which ones don't.
         #
-        instance._flag_vars_as_stale()
-        if not index is None:
+        StaleFlagManager.advance_flag()
+
+        if index is not None:
             self.index = index
         soln = self.solutions[self.index]
 
@@ -521,7 +524,6 @@ class ModelSolutions(object):
                                        str(vdata.value)))
 
             vdata.set_value(val, skip_validation=True)
-            vdata.stale = False
 
             for _attr_key, attr_value in entry.items():
                 attr_key = _attr_key[0].lower() + _attr_key[1:]
@@ -539,6 +541,9 @@ class ModelSolutions(object):
                 if attr_key in valid_import_suffixes:
                     valid_import_suffixes[attr_key][cdata] = attr_value
 
+        # Advance the stale flag again so that any subsequent variable
+        # updates will "set" the stale flag for these variables
+        StaleFlagManager.advance_flag()
 
 @ModelComponentFactory.register('Model objects can be used as a component of other models.')
 class Model(ScalarBlock):

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -815,23 +815,6 @@ class _BlockData(ActiveComponentData):
                 and not isinstance(val.domain, GlobalSetBase):
             self.add_component("%s_domain" % (val.local_name,), val.domain)
 
-    def _flag_vars_as_stale(self):
-        """
-        Configure *all* variables (on active blocks) and
-        their composite _VarData objects as stale. This
-        method is used prior to loading solver
-        results. Variable that did not particpate in the
-        solution are flagged as stale.  E.g., it most cases
-        fixed variables will be flagged as stale since they
-        are compiled out of expressions; however, many
-        solver plugins support including fixed variables in
-        the output problem by overriding bounds in order to
-        minimize preprocessing requirements, meaning fixed
-        variables are not necessarily always stale.
-        """
-        for variable in self.component_objects(Var, active=True):
-            variable.flag_as_stale()
-
     def collect_ctypes(self,
                        active=None,
                        descend_into=True):

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -266,7 +266,7 @@ class _GeneralBooleanVarData(_BooleanVarData):
         if val:
             self._stale = 0
         else:
-            self._stale = StaleFlagManager.get_flag(self._stale)
+            self._stale = StaleFlagManager.get_flag(0)
 
     def get_associated_binary(self):
         """Get the binary _VarData associated with this 

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -114,8 +114,12 @@ class _BooleanVarData(ComponentData, BooleanValue):
                 logger.warning("implicitly casting '%s' value %s to bool"
                                % (self.name, val))
             val = bool(val)
+        if self._value == val and not self.stale:
+            # do not update the value / set the stale flag if we are not
+            # changing the value and the variable is currently not stale
+            return
         self._value = val
-        self._stale = StaleFlagManager.get_flag()
+        self._stale = StaleFlagManager.get_flag(self._stale)
 
     def clear(self):
         self.value = None
@@ -257,7 +261,7 @@ class _GeneralBooleanVarData(_BooleanVarData):
         if val:
             self._stale = 0
         else:
-            self._stale = StaleFlagManager.get_flag()
+            self._stale = StaleFlagManager.get_flag(self._stale)
 
     def get_associated_binary(self):
         """Get the binary _VarData associated with this 

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -16,6 +16,7 @@ from pyomo.common.log import is_debug_set
 from pyomo.common.timing import ConstructionTimer
 from pyomo.common.modeling import unique_component_name, NOTSET
 from pyomo.common.deprecation import deprecation_warning
+from pyomo.core.staleflag import StaleFlagManager
 from pyomo.core.expr.boolean_value import BooleanValue
 from pyomo.core.expr.numvalue import value
 from pyomo.core.base.component import ComponentData, ModelComponentFactory
@@ -114,7 +115,7 @@ class _BooleanVarData(ComponentData, BooleanValue):
                                % (self.name, val))
             val = bool(val)
         self._value = val
-        self.stale = False
+        self._stale = StaleFlagManager.get_flag()
 
     def clear(self):
         self.value = None
@@ -192,7 +193,7 @@ class _GeneralBooleanVarData(_BooleanVarData):
     these attributes in certain cases.
     """
 
-    __slots__ = ('_value', 'fixed', 'stale', '_associated_binary')
+    __slots__ = ('_value', 'fixed', '_stale', '_associated_binary')
 
     def __init__(self, component=None):
         #
@@ -205,7 +206,7 @@ class _GeneralBooleanVarData(_BooleanVarData):
                           else None
         self._value = None
         self.fixed = False
-        self.stale = True
+        self._stale = 0 # True
 
         self._associated_binary = None
 
@@ -247,6 +248,16 @@ class _GeneralBooleanVarData(_BooleanVarData):
     def domain(self):
         """Return the domain for this variable."""
         return BooleanSet
+
+    @property
+    def stale(self):
+        return StaleFlagManager.is_stale(self._stale)
+    @stale.setter
+    def stale(self, val):
+        if val:
+            self._stale = 0
+        else:
+            self._stale = StaleFlagManager.get_flag()
 
     def get_associated_binary(self):
         """Get the binary _VarData associated with this 
@@ -323,7 +334,7 @@ class BooleanVar(IndexedComponent):
         Set the 'stale' attribute of every variable data object to True.
         """
         for boolvar_data in self._data.values():
-            boolvar_data.stale = True
+            boolvar_data._stale = 0
 
     def get_values(self, include_fixed_values=True):
         """

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -114,10 +114,6 @@ class _BooleanVarData(ComponentData, BooleanValue):
                 logger.warning("implicitly casting '%s' value %s to bool"
                                % (self.name, val))
             val = bool(val)
-        if self._value == val and not self.stale:
-            # do not update the value / set the stale flag if we are not
-            # changing the value and the variable is currently not stale
-            return
         self._value = val
         self._stale = StaleFlagManager.get_flag(self._stale)
 

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -220,6 +220,7 @@ class _GeneralBooleanVarData(_BooleanVarData):
             state[i] = getattr(self, i)
         if isinstance(self._associated_binary, ReferenceType):
             state['_associated_binary'] = self._associated_binary()
+        state['_stale'] = self.stale
         return state
 
     def __setstate__(self, state):
@@ -228,6 +229,10 @@ class _GeneralBooleanVarData(_BooleanVarData):
         Note: adapted from class ComponentData in pyomo.core.base.component
 
         """
+        if state.pop('_stale', True):
+            state['_stale'] = 0
+        else:
+            state['_stale'] = StaleFlagManager.get_flag(0)
         super().__setstate__(state)
         if self._associated_binary is not None and \
            type(self._associated_binary) is not \

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -220,7 +220,7 @@ class _GeneralBooleanVarData(_BooleanVarData):
             state[i] = getattr(self, i)
         if isinstance(self._associated_binary, ReferenceType):
             state['_associated_binary'] = self._associated_binary()
-        state['_stale'] = self.stale
+        state['_stale'] = StaleFlagManager.is_stale(self._stale)
         return state
 
     def __setstate__(self, state):

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -324,11 +324,15 @@ class _GeneralVarData(_VarData):
         state = super(_GeneralVarData, self).__getstate__()
         for i in _GeneralVarData.__slots__:
             state[i] = getattr(self, i)
+        state['_stale'] = self.stale
         return state
 
-    # Note: None of the slots on this class need to be edited, so we
-    # don't need to implement a specialized __setstate__ method, and
-    # can quietly rely on the super() class's implementation.
+    def __setstate__(self, state):
+        if state.pop('_stale', True):
+            state['_stale'] = 0
+        else:
+            state['_stale'] = StaleFlagManager.get_flag(0)
+        super().__setstate__(state)
 
     #
     # Abstract Interface

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -56,8 +56,7 @@ _VARDATA_API = (
     'bounds', 'lower', 'upper', 'lb', 'ub', 'has_lb', 'has_ub',
     'setlb', 'setub', 'get_units',
     'is_integer', 'is_binary', 'is_continuous', 'is_fixed',
-    'fix', 'unfix', 'free', 'set_value', 'value',
-    # Note: we can't disable fixed / stale as they are public attributes
+    'fix', 'unfix', 'free', 'set_value', 'value', 'stale', 'fixed',
 )
 
 

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -312,7 +312,7 @@ class _GeneralVarData(_VarData):
     these attributes in certain cases.
     """
 
-    __slots__ = ('_value', '_lb', '_ub', '_domain', 'fixed', '_stale')
+    __slots__ = ('_value', '_lb', '_ub', '_domain', '_fixed', '_stale')
 
     def __init__(self, component=None):
         #
@@ -333,7 +333,7 @@ class _GeneralVarData(_VarData):
         self._lb = None
         self._ub = None
         self._domain = None
-        self.fixed = False
+        self._fixed = False
         self._stale = 0 # True
 
     @classmethod
@@ -344,7 +344,7 @@ class _GeneralVarData(_VarData):
         self._lb = src._lb
         self._ub = src._ub
         self._domain = src._domain
-        self.fixed = src.fixed
+        self._fixed = src._fixed
         self._stale = src._stale
         return self
 
@@ -533,7 +533,12 @@ class _GeneralVarData(_VarData):
         # component if not scalar
         return self.parent_component()._units
 
-    # fixed is an attribute
+    @property
+    def fixed(self):
+        return self._fixed
+    @fixed.setter
+    def fixed(self, val):
+        self._fixed = bool(val)
 
     @property
     def stale(self):

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -528,7 +528,7 @@ class _GeneralVarData(_VarData):
         if val:
             self._stale = 0 # True
         else:
-            self._stale = StaleFlagManager.get_flag(self._stale)
+            self._stale = StaleFlagManager.get_flag(0)
 
     def _process_bound(self, val, bound_type):
         if type(val) in native_numeric_types or val is None:

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -324,7 +324,7 @@ class _GeneralVarData(_VarData):
         state = super(_GeneralVarData, self).__getstate__()
         for i in _GeneralVarData.__slots__:
             state[i] = getattr(self, i)
-        state['_stale'] = self.stale
+        state['_stale'] = StaleFlagManager.is_stale(self._stale)
         return state
 
     def __setstate__(self, state):

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -88,15 +88,6 @@ class _VarData(ComponentData, NumericValue):
 
     __slots__ = ()
 
-    def __init__(self, component=None):
-        #
-        # These lines represent in-lining of the
-        # following constructors:
-        #   - ComponentData
-        #   - NumericValue
-        self._component = weakref_ref(component) if (component is not None) \
-                          else None
-
     #
     # Interface
     #

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -385,10 +385,6 @@ class _GeneralVarData(_VarData):
                     extra={'id':'W1002'},
                 )
 
-        if self._value == val and not self.stale:
-            # do not update the value / set the stale flag if we are not
-            # changing the value and the variable is currently not stale
-            return
         self._value = val
         self._stale = StaleFlagManager.get_flag(self._stale)
 

--- a/pyomo/core/kernel/block.py
+++ b/pyomo/core/kernel/block.py
@@ -19,6 +19,7 @@ else:
     import collections
     _ordered_dict_ = collections.OrderedDict
 
+from pyomo.core.staleflag import StaleFlagManager
 from pyomo.core.expr.symbol_map import SymbolMap
 from pyomo.core.kernel.base import \
     (_no_ctype,
@@ -381,11 +382,15 @@ class block(IBlock):
                 valid_import_suffixes[attr_key][self] = attr_value
 
         #
+        # Set the "stale" flag of each variable in the model prior to
+        # loading the solution, so you known which variables have "real"
+        # values and which ones don't.
+        #
+        StaleFlagManager.advance_flag()
+         #
         # Load variable data
         #
         from pyomo.core.kernel.variable import IVariable
-        for var in self.components(ctype=IVariable):
-            var.stale = True
         var_skip_attrs = ['id','canonical_label']
         seen_var_ids = set()
         for label, entry in solution.variable.items():
@@ -430,7 +435,6 @@ class block(IBlock):
                                comparison_tolerance_for_fixed_vars,
                                var.value))
                     var.set_value(attr_value, skip_validation=True)
-                    var.stale = False
                 elif attr_key in valid_import_suffixes:
                     valid_import_suffixes[attr_key][var] = attr_value
 
@@ -511,7 +515,10 @@ class block(IBlock):
                            comparison_tolerance_for_fixed_vars,
                            var.value))
                 var.set_value(default_variable_value, skip_validation=True)
-                var.stale = False
+
+        # Advance the stale flag again so that any subsequent variable
+        # updates will "set" the stale flag for these variables
+        StaleFlagManager.advance_flag()
 
 # inserts class definitions for simple _tuple, _list, and
 # _dict containers into this module

--- a/pyomo/core/kernel/block.py
+++ b/pyomo/core/kernel/block.py
@@ -386,7 +386,7 @@ class block(IBlock):
         # loading the solution, so you known which variables have "real"
         # values and which ones don't.
         #
-        StaleFlagManager.advance_flag()
+        StaleFlagManager.mark_all_as_stale()
          #
         # Load variable data
         #
@@ -517,8 +517,9 @@ class block(IBlock):
                 var.set_value(default_variable_value, skip_validation=True)
 
         # Set the state flag to "delayed advance": it will auto-advance
-        # if a non-stale variable is updated.
-        StaleFlagManager.advance_flag(delayed=True)
+        # if a non-stale variable is updated (causing all non-stale
+        # variables to be marked as stale).
+        StaleFlagManager.mark_all_as_stale(delayed=True)
 
 # inserts class definitions for simple _tuple, _list, and
 # _dict containers into this module

--- a/pyomo/core/kernel/block.py
+++ b/pyomo/core/kernel/block.py
@@ -516,9 +516,9 @@ class block(IBlock):
                            var.value))
                 var.set_value(default_variable_value, skip_validation=True)
 
-        # Advance the stale flag again so that any subsequent variable
-        # updates will "set" the stale flag for these variables
-        StaleFlagManager.advance_flag()
+        # Set the state flag to "delayed advance": it will auto-advance
+        # if a non-stale variable is updated.
+        StaleFlagManager.advance_flag(delayed=True)
 
 # inserts class definitions for simple _tuple, _list, and
 # _dict containers into this module

--- a/pyomo/core/kernel/variable.py
+++ b/pyomo/core/kernel/variable.py
@@ -8,6 +8,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 from pyomo.common.modeling import NoArgumentGiven
+from pyomo.core.staleflag import StaleFlagManager
 from pyomo.core.expr.numvalue import (NumericValue,
                                       is_numeric_data,
                                       value)
@@ -343,7 +344,7 @@ class variable(IVariable):
         self._ub = ub
         self._value = value
         self._fixed = fixed
-        self._stale = True
+        self._stale = 0 # True
         if (domain_type is not None) or \
            (domain is not None):
             self._domain_type, self._lb, self._ub = \
@@ -384,6 +385,7 @@ class variable(IVariable):
     @value.setter
     def value(self, value):
         self._value = value
+        self._stale = StaleFlagManager.get_flag()
 
     def set_value(self, value, skip_validation=True):
         self.value = value
@@ -399,10 +401,13 @@ class variable(IVariable):
     @property
     def stale(self):
         """The stale status of the variable"""
-        return self._stale
+        return StaleFlagManager.is_stale(self._stale)
     @stale.setter
     def stale(self, stale):
-        self._stale = stale
+        if stale:
+            self._stale = 0
+        else:
+            self._stale = StaleFlagManager.get_flag()
 
     @property
     def domain_type(self):

--- a/pyomo/core/kernel/variable.py
+++ b/pyomo/core/kernel/variable.py
@@ -385,7 +385,7 @@ class variable(IVariable):
     @value.setter
     def value(self, value):
         self._value = value
-        self._stale = StaleFlagManager.get_flag()
+        self._stale = StaleFlagManager.get_flag(self._stale)
 
     def set_value(self, value, skip_validation=True):
         self.value = value
@@ -407,7 +407,7 @@ class variable(IVariable):
         if stale:
             self._stale = 0
         else:
-            self._stale = StaleFlagManager.get_flag()
+            self._stale = StaleFlagManager.get_flag(0)
 
     @property
     def domain_type(self):

--- a/pyomo/core/staleflag.py
+++ b/pyomo/core/staleflag.py
@@ -10,24 +10,53 @@
 
 class _StaleFlagManager(object):
     def __init__(self):
-        self._current = 1
-        self._next = 1
+        self._current = 0
         self.advance_flag()
 
-    def _get_flag(self):
+    def _get_flag(self, current_flag):
+        """Return the current global stale flag value"""
         return self._current
 
-    def _get_flag_first(self):
-        self._current = self._next
+    def _get_flag_delayed(self, current_flag):
+        """Implement the "delayed" advancement of the global stale flag value
+
+        This will continue to return the current value of the state flag
+        until the first non-stale variable is updated (that it, it is
+        passed the current stale flag when called).  This allows for
+        updating stale variable values without incrementing the global
+        stale flag, but will mark everything as stale as soon as a
+        non-stale variable value is changed.
+
+        """
+        if current_flag < self._current:
+            return self._current
+        self._current += 1
         setattr(self, 'get_flag', getattr(self, '_get_flag'))
         return self._current
 
     def is_stale(self, val):
+        """Return ``True`` if the passed value indicated a stale variable"""
         return val != self._current
 
-    def advance_flag(self):
-        setattr(self, 'get_flag', getattr(self, '_get_flag_first'))
-        self._current = self._next
-        self._next += 1
+    def advance_flag(self, delayed=False):
+        """Advance the global stale flag, marking all variables as stale
+
+        This is generally called immediately before and after a batch
+        variable update (i.e. loading values from a solver result or
+        stored solution).  Before the batch update :meth:`advance_flag`
+        is called with ``delayed=False``, which immediately marks all
+        variables as stale.  After the batch update,
+        :meth:`advance_flag` is typically called with ``delayed=True``.
+        This allows additional stale variables to be updated without
+        advancing the global flag, but as soon as any non-stale variable
+        has its value changed, then the flag is advanced and all other
+        variables become stale.
+
+        """
+        if delayed:
+            setattr(self, 'get_flag', getattr(self, '_get_flag_delayed'))
+        else:
+            setattr(self, 'get_flag', getattr(self, '_get_flag'))
+            self._current += 1
 
 StaleFlagManager = _StaleFlagManager()

--- a/pyomo/core/staleflag.py
+++ b/pyomo/core/staleflag.py
@@ -11,7 +11,7 @@
 class _StaleFlagManager(object):
     def __init__(self):
         self._current = 0
-        self.advance_flag()
+        self.mark_all_as_stale()
 
     def _get_flag(self, current_flag):
         """Return the current global stale flag value"""
@@ -38,19 +38,19 @@ class _StaleFlagManager(object):
         """Return ``True`` if the passed value indicated a stale variable"""
         return val != self._current
 
-    def advance_flag(self, delayed=False):
+    def mark_all_as_stale(self, delayed=False):
         """Advance the global stale flag, marking all variables as stale
 
         This is generally called immediately before and after a batch
         variable update (i.e. loading values from a solver result or
-        stored solution).  Before the batch update :meth:`advance_flag`
-        is called with ``delayed=False``, which immediately marks all
-        variables as stale.  After the batch update,
-        :meth:`advance_flag` is typically called with ``delayed=True``.
-        This allows additional stale variables to be updated without
-        advancing the global flag, but as soon as any non-stale variable
-        has its value changed, then the flag is advanced and all other
-        variables become stale.
+        stored solution).  Before the batch update
+        :meth:`mark_all_as_stale` is called with ``delayed=False``,
+        which immediately marks all variables as stale.  After the batch
+        update, :meth:`mark_all_as_stale` is typically called with
+        ``delayed=True``.  This allows additional stale variables to be
+        updated without advancing the global flag, but as soon as any
+        non-stale variable has its value changed, then the flag is
+        advanced and all other variables become stale.
 
         """
         if delayed:

--- a/pyomo/core/staleflag.py
+++ b/pyomo/core/staleflag.py
@@ -28,10 +28,9 @@ class _StaleFlagManager(object):
         non-stale variable value is changed.
 
         """
-        if current_flag < self._current:
-            return self._current
-        self._current += 1
-        setattr(self, 'get_flag', getattr(self, '_get_flag'))
+        if current_flag == self._current:
+            self._current += 1
+            setattr(self, 'get_flag', getattr(self, '_get_flag'))
         return self._current
 
     def is_stale(self, val):

--- a/pyomo/core/staleflag.py
+++ b/pyomo/core/staleflag.py
@@ -1,0 +1,33 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+class _StaleFlagManager(object):
+    def __init__(self):
+        self._current = 1
+        self._next = 1
+        self.advance_flag()
+
+    def _get_flag(self):
+        return self._current
+
+    def _get_flag_first(self):
+        self._current = self._next
+        setattr(self, 'get_flag', getattr(self, '_get_flag'))
+        return self._current
+
+    def is_stale(self, val):
+        return val != self._current
+
+    def advance_flag(self):
+        setattr(self, 'get_flag', getattr(self, '_get_flag_first'))
+        self._current = self._next
+        self._next += 1
+
+StaleFlagManager = _StaleFlagManager()

--- a/pyomo/core/tests/unit/test_var.py
+++ b/pyomo/core/tests/unit/test_var.py
@@ -27,6 +27,7 @@ from pyomo.core.base import IntegerSet
 from pyomo.core.expr.numeric_expr import (
     NPV_ProductExpression, NPV_MaxExpression, NPV_MinExpression,
 )
+from pyomo.core.staleflag import StaleFlagManager
 from pyomo.environ import (
     AbstractModel, ConcreteModel, Set, Param, Var, VarList, RangeSet,
     Suffix, Expression, NonPositiveReals, PositiveReals, Reals, RealSet,
@@ -1569,6 +1570,32 @@ class MiscVarTests(unittest.TestCase):
         m.p = 3 * units.kg
         self.assertEqual(m.x.ub, 3000)
 
+    def test_stale(self):
+        m = ConcreteModel()
+        m.x = Var(initialize=0)
+        self.assertFalse(m.x.stale)
+        m.y = Var()
+        self.assertTrue(m.y.stale)
+
+        StaleFlagManager.mark_all_as_stale(delayed=False)
+        self.assertTrue(m.x.stale)
+        self.assertTrue(m.y.stale)
+        m.x = 1
+        self.assertFalse(m.x.stale)
+        self.assertTrue(m.y.stale)
+        m.y = 2
+        self.assertFalse(m.x.stale)
+        self.assertFalse(m.y.stale)
+
+        StaleFlagManager.mark_all_as_stale(delayed=True)
+        self.assertFalse(m.x.stale)
+        self.assertFalse(m.y.stale)
+        m.x = 1
+        self.assertFalse(m.x.stale)
+        self.assertTrue(m.y.stale)
+        m.y = 2
+        self.assertFalse(m.x.stale)
+        self.assertFalse(m.y.stale)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/repn/tests/test_standard.py
+++ b/pyomo/repn/tests/test_standard.py
@@ -176,7 +176,7 @@ class Test(unittest.TestCase):
 
     def test_simplesum(self):
         # a + b
-        m = AbstractModel()
+        m = ConcreteModel()
         m.a = Var()
         m.b = Var()
         e = m.a + m.b
@@ -205,7 +205,7 @@ class Test(unittest.TestCase):
 
     def test_constsum(self):
         # a + 5
-        m = AbstractModel()
+        m = ConcreteModel()
         m.a = Var()
         e = m.a + 5
  
@@ -232,7 +232,7 @@ class Test(unittest.TestCase):
         self.assertEqual(baseline, repn_to_dict(rep))
 
         # 5 + a
-        m = AbstractModel()
+        m = ConcreteModel()
         m.a = Var()
         e = 5 + m.a
  
@@ -857,7 +857,7 @@ class Test(unittest.TestCase):
         #
         # Check the structure of nested sums
         #
-        m = AbstractModel()
+        m = ConcreteModel()
         m.a = Var()
         m.b = Var()
         m.c = Var()
@@ -1018,7 +1018,7 @@ class Test(unittest.TestCase):
         #
         # Check sums with nested products
         #
-        m = AbstractModel()
+        m = ConcreteModel()
         m.a = Var()
         m.b = Var()
         m.c = Var()
@@ -1176,7 +1176,7 @@ class Test(unittest.TestCase):
         #    -
         #     \
         #      a
-        m = AbstractModel()
+        m = ConcreteModel()
         m.a = Var()
         e = - m.a
 
@@ -1206,7 +1206,7 @@ class Test(unittest.TestCase):
         #    -
         #   / \
         #  a   b
-        m = AbstractModel()
+        m = ConcreteModel()
         m.a = Var()
         m.b = Var()
         e = m.a - m.b
@@ -1263,7 +1263,7 @@ class Test(unittest.TestCase):
         #    -
         #   / \
         #  a   5
-        m = AbstractModel()
+        m = ConcreteModel()
         m.a = Var()
         e = m.a - 5
 
@@ -1320,7 +1320,7 @@ class Test(unittest.TestCase):
         #
         # Check the structure of nested differences
         #
-        m = AbstractModel()
+        m = ConcreteModel()
         m.a = Var()
         m.b = Var()
         m.c = Var()
@@ -1512,7 +1512,7 @@ class Test(unittest.TestCase):
         #
         # Check the structure of sum of products
         #
-        m = AbstractModel()
+        m = ConcreteModel()
         m.a = Var()
         m.b = Var()
         m.c = Var()
@@ -1722,7 +1722,7 @@ class Test(unittest.TestCase):
         #    *
         #   / \
         #  a   5
-        m = AbstractModel()
+        m = ConcreteModel()
         m.a = Var()
         e = m.a * 5
 
@@ -2057,7 +2057,7 @@ class Test(unittest.TestCase):
         #     +   5
         #    / \
         #   a   b
-        m = AbstractModel()
+        m = ConcreteModel()
         m.a = Var()
         m.b = Var()
         m.c = Var()
@@ -2176,7 +2176,7 @@ class Test(unittest.TestCase):
         self.assertEqual(baseline, repn_to_dict(rep))
 
     def test_quadratic1(self):
-        m = AbstractModel()
+        m = ConcreteModel()
         m.a = Var()
         m.b = Var()
         m.c = Var()

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -17,6 +17,7 @@ from pyomo.common.collections import ComponentSet, ComponentMap, Bunch
 from pyomo.core.base import Suffix, Var, Constraint, SOSConstraint, Objective
 from pyomo.core.expr.numvalue import is_fixed
 from pyomo.core.expr.numvalue import value
+from pyomo.core.staleflag import StaleFlagManager
 from pyomo.repn import generate_standard_repn
 from pyomo.solvers.plugins.solvers.direct_solver import DirectSolver
 from pyomo.solvers.plugins.solvers.direct_or_persistent_solver import DirectOrPersistentSolver
@@ -155,10 +156,8 @@ class CPLEXDirect(DirectSolver):
         self._capabilities.sos2 = True
 
     def _apply_solver(self):
-        if not self._save_results:
-            for block in self._pyomo_model.block_data_objects(descend_into=True, active=True):
-                for var in block.component_data_objects(ctype=Var, descend_into=False, active=True, sort=False):
-                    var.stale = True
+        StaleFlagManager.mark_all_as_stale()
+
         # In recent versions of CPLEX it is helpful to manually open the
         # log file and then explicitly close it after CPLEX is finished.
         # This ensures that the file is closed (and unlocked) on Windows
@@ -742,7 +741,6 @@ class CPLEXDirect(DirectSolver):
                 for name, val in zip(var_names, var_vals):
                     pyomo_var = self._solver_var_to_pyomo_var_map[name]
                     if self._referenced_variables[pyomo_var] > 0:
-                        pyomo_var.stale = False
                         soln_variables[name] = {"Value": val}
 
                 if extract_reduced_costs:
@@ -841,7 +839,6 @@ class CPLEXDirect(DirectSolver):
 
         for pyomo_var, val in zip(vars_to_load, vals):
             if self._referenced_variables[pyomo_var] > 0:
-                pyomo_var.stale = False
                 pyomo_var.set_value(val, skip_validation=True)
 
     def _load_rc(self, vars_to_load=None):

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -787,7 +787,7 @@ class CPLEXDirect(DirectSolver):
                         soln_constraints[con_name]["Slack"] = qudratic_slacks[i]
         elif self._load_solutions:
             if cpxprob.solution.get_solution_type() > 0:
-                self._load_vars()
+                self.load_vars()
 
                 if extract_reduced_costs:
                     self._load_rc()

--- a/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
@@ -19,6 +19,7 @@ from pyomo.common.collections import ComponentMap, ComponentSet, Bunch
 from pyomo.common.tempfiles import TempfileManager
 import pyomo.opt.base.solvers
 from pyomo.opt.base.formats import ResultsFormat
+from pyomo.core.staleflag import StaleFlagManager
 
 
 class DirectOrPersistentSolver(OptSolver):
@@ -277,6 +278,7 @@ class DirectOrPersistentSolver(OptSolver):
         vars_to_load: list of Var
         """
         self._load_vars(vars_to_load)
+        StaleFlagManager.mark_all_as_stale(delayed=True)
 
     """ This method should be implemented by subclasses."""
     def warm_start_capable(self):

--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -721,7 +721,7 @@ class GurobiDirect(DirectSolver):
         elif self._load_solutions:
             if gprob.SolCount > 0:
 
-                self._load_vars()
+                self.load_vars()
 
                 if extract_reduced_costs:
                     self._load_rc()

--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -19,6 +19,7 @@ from pyomo.common.tempfiles import TempfileManager
 from pyomo.common.tee import capture_output
 from pyomo.core.expr.numvalue import is_fixed
 from pyomo.core.expr.numvalue import value
+from pyomo.core.staleflag import StaleFlagManager
 from pyomo.repn import generate_standard_repn
 from pyomo.solvers.plugins.solvers.direct_solver import DirectSolver
 from pyomo.solvers.plugins.solvers.direct_or_persistent_solver import DirectOrPersistentSolver
@@ -147,14 +148,8 @@ class GurobiDirect(DirectSolver):
         return self._verified_license
 
     def _apply_solver(self):
-        if not self._save_results:
-            for block in self._pyomo_model.block_data_objects(descend_into=True,
-                                                              active=True):
-                for var in block.component_data_objects(ctype=pyomo.core.base.var.Var,
-                                                        descend_into=False,
-                                                        active=True,
-                                                        sort=False):
-                    var.stale = True
+        StaleFlagManager.mark_all_as_stale()
+
         if self._tee:
             self._solver_model.setParam('OutputFlag', 1)
         else:
@@ -671,7 +666,6 @@ class GurobiDirect(DirectSolver):
                 for gurobi_var, val, name in zip(gurobi_vars, var_vals, names):
                     pyomo_var = self._solver_var_to_pyomo_var_map[gurobi_var]
                     if self._referenced_variables[pyomo_var] > 0:
-                        pyomo_var.stale = False
                         soln_variables[name] = {"Value": val}
 
                 if extract_reduced_costs:
@@ -766,7 +760,6 @@ class GurobiDirect(DirectSolver):
 
         for var, val in zip(vars_to_load, vals):
             if ref_vars[var] > 0:
-                var.stale = False
                 var.set_value(val, skip_validation=True)
 
     def _load_rc(self, vars_to_load=None):

--- a/pyomo/solvers/plugins/solvers/gurobi_persistent.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_persistent.py
@@ -12,6 +12,7 @@ from collections.abc import Iterable
 
 from pyomo.solvers.plugins.solvers.gurobi_direct import GurobiDirect, gurobipy
 from pyomo.solvers.plugins.solvers.persistent_solver import PersistentSolver
+from pyomo.core.staleflag import StaleFlagManager
 from pyomo.core.expr.numvalue import value, is_fixed
 from pyomo.opt.base import SolverFactory
 
@@ -583,6 +584,7 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
         ----------
         vars: Var or iterable of Var
         """
+        StaleFlagManager.mark_all_as_stale()
         if not isinstance(vars, Iterable):
             vars = [vars]
         gurobi_vars = [self._pyomo_var_to_solver_var_map[i] for i in vars]
@@ -596,6 +598,7 @@ class GurobiPersistent(PersistentSolver, GurobiDirect):
         ----------
         vars: iterable of vars
         """
+        StaleFlagManager.mark_all_as_stale()
         if not isinstance(vars, Iterable):
             vars = [vars]
         gurobi_vars = [self._pyomo_var_to_solver_var_map[i] for i in vars]

--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -17,9 +17,10 @@ import pyomo.core.base.var
 import pyomo.core.base.constraint
 from pyomo.common.tempfiles import TempfileManager
 from pyomo.core import is_fixed, value, minimize, maximize
-from pyomo.repn import generate_standard_repn
 from pyomo.core.base.suffix import Suffix
+from pyomo.core.staleflag import StaleFlagManager
 from pyomo.opt.base.solvers import OptSolver
+from pyomo.repn import generate_standard_repn
 from pyomo.solvers.plugins.solvers.direct_solver import DirectSolver
 from pyomo.solvers.plugins.solvers.direct_or_persistent_solver import \
     DirectOrPersistentSolver
@@ -133,13 +134,7 @@ class MOSEKDirect(DirectSolver):
         return True
 
     def _apply_solver(self):
-        if not self._save_results:
-            for block in self._pyomo_model.block_data_objects(
-                    descend_into=True, active=True):
-                for var in block.component_data_objects(
-                        ctype=pyomo.core.base.var.Var, descend_into=False,
-                        active=True, sort=False):
-                    var.stale = True
+        StaleFlagManager.mark_all_as_stale()
 
         if self._tee:
             def _process_stream(msg):
@@ -764,7 +759,6 @@ class MOSEKDirect(DirectSolver):
                 for mosek_var, val, name in zip(mosek_vars, var_vals, names):
                     pyomo_var = self._solver_var_to_pyomo_var_map[mosek_var]
                     if self._referenced_variables[pyomo_var] > 0:
-                        pyomo_var.stale = False
                         soln_variables[name] = {"Value": val}
 
                 if extract_reduced_costs:
@@ -868,7 +862,6 @@ class MOSEKDirect(DirectSolver):
 
         for var, val in zip(vars_to_load, var_vals):
             if ref_vars[var] > 0:
-                var.stale = False
                 var.set_value(val, skip_validation=True)
 
     def _load_rc(self, vars_to_load=None):

--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -821,7 +821,7 @@ class MOSEKDirect(DirectSolver):
         elif self._load_solutions:
             if self.results.problem.number_of_solutions > 0:
 
-                self._load_vars()
+                self.load_vars()
 
                 if extract_reduced_costs:
                     self._load_rc()

--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -724,7 +724,7 @@ class XpressDirect(DirectSolver):
             if xprob_attrs.lpstatus == xp.lp_optimal and \
                     ((not is_mip) or (xprob_attrs.mipsols > 0)):
 
-                self._load_vars()
+                self.load_vars()
 
                 if extract_reduced_costs:
                     self._load_rc()

--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -21,6 +21,7 @@ from pyomo.common.tee import capture_output
 from pyomo.common.tempfiles import TempfileManager
 from pyomo.core.expr.numvalue import is_fixed
 from pyomo.core.expr.numvalue import value
+from pyomo.core.staleflag import StaleFlagManager
 from pyomo.repn import generate_standard_repn
 from pyomo.solvers.plugins.solvers.direct_solver import DirectSolver
 from pyomo.solvers.plugins.solvers.direct_or_persistent_solver import DirectOrPersistentSolver
@@ -163,14 +164,7 @@ class XpressDirect(DirectSolver):
         return bool(xpress_available)
 
     def _apply_solver(self):
-        if not self._save_results:
-            for block in self._pyomo_model.block_data_objects(descend_into=True,
-                                                              active=True):
-                for var in block.component_data_objects(ctype=pyomo.core.base.var.Var,
-                                                        descend_into=False,
-                                                        active=True,
-                                                        sort=False):
-                    var.stale = True
+        StaleFlagManager.mark_all_as_stale()
 
         self._solver_model.setlogfile(self._log_file)
         if self._keepfiles:
@@ -689,7 +683,6 @@ class XpressDirect(DirectSolver):
                 for xpress_var, val in zip(xpress_vars, var_vals):
                     pyomo_var = self._solver_var_to_pyomo_var_map[xpress_var]
                     if self._referenced_variables[pyomo_var] > 0:
-                        pyomo_var.stale = False
                         soln_variables[xpress_var.name] = {"Value": val}
 
                 if extract_reduced_costs:
@@ -772,7 +765,6 @@ class XpressDirect(DirectSolver):
 
         for var, val in zip(vars_to_load, vals):
             if ref_vars[var] > 0:
-                var.stale = False
                 var.set_value(val, skip_validation=True)
 
     def _load_rc(self, vars_to_load=None):

--- a/pyomo/solvers/tests/models/LP_unused_vars.json
+++ b/pyomo/solvers/tests/models/LP_unused_vars.json
@@ -2,35 +2,35 @@
   "B[1]": {}, 
   "B[1].b": {}, 
   "B[1].b.X[1]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.X[2]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.X_initialy_stale[1]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.X_initialy_stale[2]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.X_unused[1]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.X_unused[2]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.X_unused_initialy_stale[1]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.X_unused_initialy_stale[2]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.c[1]": {
@@ -55,53 +55,53 @@
     "value": null
   }, 
   "B[1].b.x": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.x_initialy_stale": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.x_unused": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.x_unused_initialy_stale": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[2]": {}, 
   "B[2].b": {}, 
   "B[2].b.X[1]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.X[2]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.X_initialy_stale[1]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.X_initialy_stale[2]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.X_unused[1]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.X_unused[2]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.X_unused_initialy_stale[1]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.X_unused_initialy_stale[2]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.c[1]": {
@@ -126,19 +126,19 @@
     "value": null
   }, 
   "B[2].b.x": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.x_initialy_stale": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.x_unused": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.x_unused_initialy_stale": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "X[1]": {
@@ -162,53 +162,53 @@
     "value": 1.0
   }, 
   "X_unused[1]": {
-    "stale": true, 
+    "stale": true,
     "value": -1.0
   }, 
   "X_unused[2]": {
-    "stale": true, 
+    "stale": true,
     "value": -1.0
   }, 
   "X_unused_initialy_stale[1]": {
-    "stale": true, 
+    "stale": true,
     "value": -1.0
   }, 
   "X_unused_initialy_stale[2]": {
-    "stale": true, 
+    "stale": true,
     "value": -1.0
   }, 
   "b": {}, 
   "b.b": {}, 
   "b.b.X[1]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "b.b.X[2]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "b.b.X_initialy_stale[1]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "b.b.X_initialy_stale[2]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "b.b.X_unused[1]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "b.b.X_unused[2]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "b.b.X_unused_initialy_stale[1]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "b.b.X_unused_initialy_stale[2]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "b.b.c[1]": {
@@ -233,19 +233,19 @@
     "value": null
   }, 
   "b.b.x": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "b.b.x_initialy_stale": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "b.b.x_unused": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "b.b.x_unused_initialy_stale": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "c[1]": {
@@ -307,11 +307,11 @@
     "value": 1.0
   }, 
   "x_unused": {
-    "stale": true, 
+    "stale": true,
     "value": -1.0
   }, 
   "x_unused_initialy_stale": {
-    "stale": true, 
+    "stale": true,
     "value": -1.0
   }
 }

--- a/pyomo/solvers/tests/models/LP_unused_vars.py
+++ b/pyomo/solvers/tests/models/LP_unused_vars.py
@@ -72,7 +72,7 @@ class LP_unused_vars(_BaseTestModel):
         model.c.add( model.X_initialy_stale[1] >= 0 )
         model.c.add( model.X_initialy_stale[2] >= 1 )
 
-        # Test that stale flags do not get updated
+        # Test that stale flags get set
         # on inactive blocks (where "inactive blocks" mean blocks
         # that do NOT follow a path of all active parent blocks
         # up to the top-level model)
@@ -100,15 +100,19 @@ class LP_unused_vars(_BaseTestModel):
         model = self.model
         model.x_unused.value = -1.0
         model.x_unused_initialy_stale.value = -1.0
+        model.x_unused_initialy_stale.stale = True
         for i in model.s:
             model.X_unused[i].value = -1.0
             model.X_unused_initialy_stale[i].value = -1.0
+            model.X_unused_initialy_stale[i].stale = True
 
         model.x.value = -1.0
         model.x_initialy_stale.value = -1.0
+        model.x_initialy_stale.stale = True
         for i in model.s:
             model.X[i].value = -1.0
             model.X_initialy_stale[i].value = -1.0
+            model.X_initialy_stale[i].stale = True
 
 @register_model
 class LP_unused_vars_kernel(LP_unused_vars):

--- a/pyomo/solvers/tests/models/MILP_unused_vars.json
+++ b/pyomo/solvers/tests/models/MILP_unused_vars.json
@@ -2,35 +2,35 @@
   "B[1]": {}, 
   "B[1].b": {}, 
   "B[1].b.X[1]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.X[2]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.X_initialy_stale[1]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.X_initialy_stale[2]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.X_unused[1]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.X_unused[2]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.X_unused_initialy_stale[1]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.X_unused_initialy_stale[2]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.c[1]": {
@@ -55,53 +55,53 @@
     "value": null
   }, 
   "B[1].b.x": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.x_initialy_stale": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.x_unused": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[1].b.x_unused_initialy_stale": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[2]": {}, 
   "B[2].b": {}, 
   "B[2].b.X[1]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.X[2]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.X_initialy_stale[1]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.X_initialy_stale[2]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.X_unused[1]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.X_unused[2]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.X_unused_initialy_stale[1]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.X_unused_initialy_stale[2]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.c[1]": {
@@ -126,19 +126,19 @@
     "value": null
   }, 
   "B[2].b.x": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.x_initialy_stale": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.x_unused": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "B[2].b.x_unused_initialy_stale": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "X[1]": {
@@ -162,53 +162,53 @@
     "value": 1.0
   }, 
   "X_unused[1]": {
-    "stale": true, 
+    "stale": true,
     "value": -1.0
   }, 
   "X_unused[2]": {
-    "stale": true, 
+    "stale": true,
     "value": -1.0
   }, 
   "X_unused_initialy_stale[1]": {
-    "stale": true, 
+    "stale": true,
     "value": -1.0
   }, 
   "X_unused_initialy_stale[2]": {
-    "stale": true, 
+    "stale": true,
     "value": -1.0
   }, 
   "b": {}, 
   "b.b": {}, 
   "b.b.X[1]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "b.b.X[2]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "b.b.X_initialy_stale[1]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "b.b.X_initialy_stale[2]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "b.b.X_unused[1]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "b.b.X_unused[2]": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "b.b.X_unused_initialy_stale[1]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "b.b.X_unused_initialy_stale[2]": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "b.b.c[1]": {
@@ -233,19 +233,19 @@
     "value": null
   }, 
   "b.b.x": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "b.b.x_initialy_stale": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "b.b.x_unused": {
-    "stale": false, 
+    "stale": true,
     "value": null
   }, 
   "b.b.x_unused_initialy_stale": {
-    "stale": true, 
+    "stale": true,
     "value": null
   }, 
   "c[1]": {
@@ -307,11 +307,11 @@
     "value": 1.0
   }, 
   "x_unused": {
-    "stale": true, 
+    "stale": true,
     "value": -1.0
   }, 
   "x_unused_initialy_stale": {
-    "stale": true, 
+    "stale": true,
     "value": -1.0
   }
 }

--- a/pyomo/solvers/tests/models/MILP_unused_vars.py
+++ b/pyomo/solvers/tests/models/MILP_unused_vars.py
@@ -71,7 +71,7 @@ class MILP_unused_vars(_BaseTestModel):
         model.c.add( model.X_initialy_stale[1] >= 0 )
         model.c.add( model.X_initialy_stale[2] >= 1 )
 
-        # Test that stale flags do not get updated
+        # Test that stale flags get set
         # on inactive blocks (where "inactive blocks" mean blocks
         # that do NOT follow a path of all active parent blocks
         # up to the top-level model)
@@ -99,15 +99,19 @@ class MILP_unused_vars(_BaseTestModel):
         model = self.model
         model.x_unused.value = -1
         model.x_unused_initialy_stale.value = -1
+        model.x_unused_initialy_stale.stale = True
         for i in model.s:
             model.X_unused[i].value = -1
             model.X_unused_initialy_stale[i].value = -1
+            model.X_unused_initialy_stale[i].stale = True
 
         model.x.value = -1
         model.x_initialy_stale.value = -1
+        model.x_initialy_stale.stale = True
         for i in model.s:
             model.X[i].value = -1
             model.X_initialy_stale[i].value = -1
+            model.X_initialy_stale[i].stale = True
 
 @register_model
 class MILP_unused_vars_kernel(MILP_unused_vars):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
The current implementation of the `Var.stale` indicator results in inconsistent updates to the "staleness" of a VarData when solving sub-trees in a block-hierarchical model.  Consider a model with a sub-block with variables and constraints on both the outer and inner blocks.  Constraints only reference variables within their current sub-tree: constraints on the sub-block only reference variables on the sub-block, and constraints on the model reference variables on both the model and the sub-block.

If I solve the model, then all variable `stale` flags will be `False`.  If I then go and solve just the sub-block, then the variables on the sub-block will still have their "stale" flags set to `False`, but then the variables on the model will also still be `False`, even though those variables are very much stale.

This issue arises because the `stale` flag is a simple `bool`, and updating the flag is the responsibility of the solution loader.  As the solution loader only works in the context of the sub-block being solved, it does not know about the larger model and does not set the `stale` flag on the upper-level model:
```python
>>> from pyomo.environ import *
>>> m = ConcreteModel()
>>> m.x = Var()
>>> m.b = Block()
>>> m.b.y = Var()
>>> m.b.o = Objective(expr=m.b.y**2)
>>> m.o = Objective(expr=(m.x-1)**2 + (m.b.y-3)**2)
>>> m.b.o.deactivate()
>>> s = SolverFactory('ipopt')
>>> s.solve(m)
{'Problem': [{'Lower bound': -inf, 'Upper bound': inf, 'Number of objectives': 1, 'Number of constraints': 0, 'Number of variables': 2, 'Sense': 'unknown'}], 'Solver': [{'Status': 'ok', 'Message': 'Ipopt 3.13.2\\x3a Optimal Solution Found', 'Termination condition': 'optimal', 'Id': 0, 'Error rc': 0, 'Time': 0.01160120964050293}], 'Solution': [OrderedDict([('number of solutions', 0), ('number of solutions displayed', 0)])]}
>>> m.pprint()
1 Var Declarations
    x : Size=1, Index=None
        Key  : Lower : Value : Upper : Fixed : Stale : Domain
        None :  None :   1.0 :  None : False : False :  Reals

1 Objective Declarations
    o : Size=1, Index=None, Active=True
        Key  : Active : Sense    : Expression
        None :   True : minimize : (x - 1)**2 + (b.y - 3)**2

1 Block Declarations
    b : Size=1, Index=None, Active=True
        1 Var Declarations
            y : Size=1, Index=None
                Key  : Lower : Value : Upper : Fixed : Stale : Domain
                None :  None :   3.0 :  None : False : False :  Reals

        1 Objective Declarations
            o : Size=1, Index=None, Active=False
                Key  : Active : Sense    : Expression
                None :  False : minimize :     b.y**2

        2 Declarations: y o

3 Declarations: x b o
>>> m.b.o.activate()
>>> s.solve(m.b)
{'Problem': [{'Lower bound': -inf, 'Upper bound': inf, 'Number of objectives': 1, 'Number of constraints': 0, 'Number of variables': 1, 'Sense': 'unknown'}], 'Solver': [{'Status': 'ok', 'Message': 'Ipopt 3.13.2\\x3a Optimal Solution Found', 'Termination condition': 'optimal', 'Id': 0, 'Error rc': 0, 'Time': 0.012385129928588867}], 'Solution': [OrderedDict([('number of solutions', 0), ('number of solutions displayed', 0)])]}
>>> m.pprint()
1 Var Declarations
    x : Size=1, Index=None
        Key  : Lower : Value : Upper : Fixed : Stale : Domain
        None :  None :   1.0 :  None : False : False :  Reals

1 Objective Declarations
    o : Size=1, Index=None, Active=True
        Key  : Active : Sense    : Expression
        None :   True : minimize : (x - 1)**2 + (b.y - 3)**2

1 Block Declarations
    b : Size=1, Index=None, Active=True
        1 Var Declarations
            y : Size=1, Index=None
                Key  : Lower : Value : Upper : Fixed : Stale : Domain
                None :  None :   0.0 :  None : False : False :  Reals

        1 Objective Declarations
            o : Size=1, Index=None, Active=True
                Key  : Active : Sense    : Expression
                None :   True : minimize :     b.y**2

        2 Declarations: y o

3 Declarations: x b o
```

This PR proposes to change how we calculate "staleness" to use a global, monotonically increasing "stale flag".  The Var's stale attribute is no longer a bool, and is instead the value of the global stale flag at the last time the Var value was updated.  A stale variable is then a variable whose stale flag is older than the current global stale flag.  This makes "updating" staleness simpler and more well-defined: incrementing the global stale flag marks all variables as stale.  At present, we only need to update the stale flag when loading a solution (either from a solver or from a solutions database), and whenever a non-stale variable's value is changed.

One consequence of this change is that if there are multiple models, solving any one model will mark the variables in all other models as stale.  While this can initially appear to be inconvenient and a strange side effect, the behavior is more deterministic (and defensible) compared to the current behavior of having to "find" all variables that have been declared anywhere.

This PR is compatible with the concept of allowing models to reference variables outside the current subblock (PEP #1032)

## Changes proposed in this PR:
- switch `stale` attributes from `bool` to properties that calculate the current staleness by comparing a local integer to a global integer.
- switch Var `fixed` from attribute to property and disable in AbstractVars

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
