### PR TITLE
update check to see if gurobipy is available in doctests

### DIFF
--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -264,11 +264,7 @@ dot_sens_available = bool(pyomo.opt.check_available_solvers('dot_sens'))
 baron_available = bool(pyomo.opt.check_available_solvers('baron'))
 glpk_available = bool(pyomo.opt.check_available_solvers('glpk'))
 baron = pyomo.opt.SolverFactory('baron')
-try:
-    import gurobipy
-    gurobipy_available = True
-except ImportError:
-    gurobipy_available = False
+gurobipy_available = bool(pyomo.opt.check_available_solvers('gurobi_direct'))
 if numpy_available and scipy_available:
     from pyomo.contrib.pynumero.asl import AmplInterface
     asl_available = AmplInterface.available()


### PR DESCRIPTION
## Summary/Motivation:
The doctests on Python 3.6 started failing today because the check in `conf.py` only checks to see if gurobipy is installed, not whether there is a valid license (and it looks like the community edition license has expired). This PR updates that check.


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
