### PR TITLE
Add `--with-distributable-extensions` option to `setup.py`

### DIFF
--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -39,7 +39,7 @@ jobs:
       uses: RalfG/python-wheels-manylinux-build@v0.4.0-manylinux2010_x86_64
       with:
         python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
-        build-requirements: 'cython'
+        build-requirements: 'cython pybind11'
         package-path: ''
         pip-wheel-args: ''
         # When locally testing, --no-deps flag is necessary (PyUtilib dependency will trigger an error otherwise)

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -51,7 +51,7 @@ jobs:
       run: |
         sudo rm -rfv dist/*-linux_x86_64.whl
     - name: Upload artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: manylinux-wheels
         path: dist
@@ -71,7 +71,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - uses: docker/setup-qemu-action@v1
@@ -96,7 +96,7 @@ jobs:
       run: |
         sudo rm -rfv dist/*-linux_aarch64.whl
     - name: Upload artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: manylinux-aarch64-wheels
         path: dist
@@ -115,7 +115,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -126,7 +126,7 @@ jobs:
       run: |
         python setup.py --without-cython sdist --format=gztar
     - name: Upload artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: generictarball
         path: dist
@@ -145,7 +145,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -157,7 +157,7 @@ jobs:
         python setup.py  --with-cython --with-distributable-extensions sdist --format=gztar bdist_wheel
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: osx-wheels
         path: dist
@@ -176,7 +176,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -191,7 +191,7 @@ jobs:
         $env:PYTHONWARNINGS="ignore::UserWarning"
         Invoke-Expression "python setup.py  --with-cython --with-distributable-extensions sdist --format=gztar bdist_wheel"
     - name: Upload artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: win-wheels
         path: dist

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -10,6 +10,9 @@ on:
         description: Git Hash (Optional)
         required: false
 
+env:
+  PYOMO_SETUP_ARGS: --with-distributable-extensions
+
 jobs:
   manylinux:
     name: ${{ matrix.TARGET }}/wheel_creation
@@ -151,7 +154,7 @@ jobs:
         pip install twine wheel setuptools cython
     - name: Build OSX Python wheels
       run: |
-        python setup.py  --with-cython sdist --format=gztar bdist_wheel
+        python setup.py  --with-cython --with-distributable-extensions sdist --format=gztar bdist_wheel
 
     - name: Upload artifact
       uses: actions/upload-artifact@v1
@@ -186,7 +189,7 @@ jobs:
       shell: pwsh
       run: |
         $env:PYTHONWARNINGS="ignore::UserWarning"
-        Invoke-Expression "python setup.py  --with-cython sdist --format=gztar bdist_wheel"
+        Invoke-Expression "python setup.py  --with-cython --with-distributable-extensions sdist --format=gztar bdist_wheel"
     - name: Upload artifact
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install twine wheel setuptools
+        pip install twine wheel setuptools pybind11
     - name: Build manylinux Python wheels
       uses: RalfG/python-wheels-manylinux-build@v0.4.0-manylinux2010_x86_64
       with:
@@ -79,7 +79,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install twine wheel setuptools
+        pip install twine wheel setuptools pybind11
     - name: Build manylinux Python wheels
       uses: RalfG/python-wheels-manylinux-build@v0.4.0-manylinux2014_aarch64
       with:
@@ -121,7 +121,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install twine wheel setuptools
+        pip install twine wheel setuptools pybind11
     - name: Build generic tarball
       run: |
         python setup.py --without-cython sdist --format=gztar
@@ -151,7 +151,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install twine wheel setuptools cython
+        pip install twine wheel setuptools cython pybind11
     - name: Build OSX Python wheels
       run: |
         python setup.py  --with-cython --with-distributable-extensions sdist --format=gztar bdist_wheel
@@ -184,7 +184,7 @@ jobs:
       run: |
         $env:PYTHONWARNINGS="ignore::UserWarning"
         Invoke-Expression "python -m pip install --upgrade pip"
-        Invoke-Expression "pip install setuptools twine wheel cython"
+        Invoke-Expression "pip install setuptools twine wheel cython pybind11"
     - name: Build Windows Python wheels
       shell: pwsh
       run: |

--- a/pyomo/contrib/appsi/build.py
+++ b/pyomo/contrib/appsi/build.py
@@ -44,7 +44,7 @@ def get_appsi_extension(in_setup=False, appsi_root=None):
         package_name = 'pyomo.contrib.appsi.cmodel.appsi_cmodel'
     else:
         package_name = 'appsi_cmodel'
-    return Pybind11Extension(package_name, sources)
+    return Pybind11Extension(package_name, sources, extra_compile_args=['-std=c++11'])
 
 def build_appsi(args=[]):
     print('\n\n**** Building APPSI ****')

--- a/pyomo/contrib/appsi/build.py
+++ b/pyomo/contrib/appsi/build.py
@@ -14,10 +14,6 @@ import os
 import sys
 import tempfile
 
-from pyomo.common.envvar import PYOMO_CONFIG_DIR
-from pyomo.common.fileutils import this_file_dir
-
-
 def handleReadonly(function, path, excinfo):
     excvalue = excinfo[1]
     if excvalue.errno == errno.EACCES:
@@ -26,15 +22,13 @@ def handleReadonly(function, path, excinfo):
     else:
         raise
 
+def get_appsi_extension(in_setup=False, appsi_root=None):
+    from pybind11.setup_helpers import Pybind11Extension
 
-def build_appsi(args=[]):
-    print('\n\n**** Building APPSI ****')
-    import setuptools
-    from distutils.dist import Distribution
-    from pybind11.setup_helpers import Pybind11Extension, build_ext
-    import pybind11.setup_helpers
+    if appsi_root is None:
+        from pyomo.common.fileutils import this_file_dir
+        appsi_root = this_file_dir()
 
-    appsi_root = this_file_dir()
     sources = [
         os.path.join(appsi_root, 'cmodel', 'src', file_)
         for file_ in (
@@ -45,6 +39,21 @@ def build_appsi(args=[]):
                 'cmodel_bindings.cpp',
         )
     ]
+
+    if in_setup:
+        package_name = 'pyomo.contrib.appsi.cmodel.appsi_cmodel'
+    else:
+        package_name = 'appsi_cmodel'
+    return Pybind11Extension(package_name, sources)
+
+def build_appsi(args=[]):
+    print('\n\n**** Building APPSI ****')
+    import setuptools
+    from distutils.dist import Distribution
+    from pybind11.setup_helpers import build_ext
+    import pybind11.setup_helpers
+    from pyomo.common.envvar import PYOMO_CONFIG_DIR
+    from pyomo.common.fileutils import this_file_dir
 
     class appsi_build_ext(build_ext):
         def run(self):
@@ -78,9 +87,7 @@ def build_appsi(args=[]):
         package_config = {
             'name': 'appsi_cmodel',
             'packages': [],
-            'ext_modules': [
-                Pybind11Extension("appsi_cmodel", sources)
-            ],
+            'ext_modules': [ get_appsi_extension(False) ],
             'cmdclass': {
                 "build_ext": appsi_build_ext,
             },

--- a/setup.py
+++ b/setup.py
@@ -95,8 +95,12 @@ ERROR: Cython was explicitly requested with --with-cython, but cythonization
             raise
         using_cython = False
 
-if '--with-distributable-extensions' in sys.argv:
-    sys.argv.remove('--with-distributable-extensions')
+if ('--with-distributable-extensions' in sys.argv
+    or os.environ['PYOMO_SETUP_ARGS']):
+    try:
+        sys.argv.remove('--with-distributable-extensions')
+    except:
+        pass
     #
     # Import the APPSI extension builder
     #

--- a/setup.py
+++ b/setup.py
@@ -95,8 +95,8 @@ ERROR: Cython was explicitly requested with --with-cython, but cythonization
             raise
         using_cython = False
 
-if ('--with-distributable-extensions' in sys.argv
-    or os.environ['PYOMO_SETUP_ARGS']):
+if (('--with-distributable-extensions' in sys.argv)
+    or ('--with-distributable-extensions' in os.getenv('PYOMO_SETUP_ARGS'))):
     try:
         sys.argv.remove('--with-distributable-extensions')
     except:

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ def read(*rnames):
 
 def import_pyomo_module(*path):
     _module_globals = dict(globals())
+    _module_globals['__name__'] = None
     _source = os.path.join(os.path.dirname(__file__), *path)
     with open(_source) as _FILE:
         exec(_FILE.read(), _module_globals)

--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,8 @@ if using_cython:
         ]
         for f in files:
             shutil.copyfile(f[:-1], f)
-        ext_modules = cythonize(files, compiler_directives={
-            "language_level": 3 if sys.version_info >= (3, ) else 2})
+        ext_modules = cythonize(files,
+                                compiler_directives={"language_level": 3})
     except:
         if using_cython == CYTHON_REQUIRED:
             print("""
@@ -96,7 +96,8 @@ ERROR: Cython was explicitly requested with --with-cython, but cythonization
         using_cython = False
 
 if (('--with-distributable-extensions' in sys.argv)
-    or ('--with-distributable-extensions' in os.getenv('PYOMO_SETUP_ARGS'))):
+    or (os.getenv('PYOMO_SETUP_ARGS') is not None and
+        '--with-distributable-extensions' in os.getenv('PYOMO_SETUP_ARGS'))):
     try:
         sys.argv.remove('--with-distributable-extensions')
     except:


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This PR updates `setup.py` to add an `--with-distributable-extensions` option that will build the subset of `pyomo build_extensions` that can be distributed as part of Pyomo (currently the APPSI extensions).  It also updates the wheel creation process to build and include the distributable extensions.

## Changes proposed in this PR:
- add `--with-distributable-extensions` to `setup.py`
- Update wheel builder to include the compiled distributable extensions.
- Update APPSI builder to work with the new framework.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
