### PR TITLE
gdp.fix_disjuncts transformation should create a fully algebraic model

### DIFF
--- a/pyomo/gdp/plugins/fix_disjuncts.py
+++ b/pyomo/gdp/plugins/fix_disjuncts.py
@@ -20,8 +20,8 @@ logger = logging.getLogger('pyomo.gdp.fix_disjuncts')
 class GDP_Disjunct_Fixer(Transformation):
     """Fix disjuncts to their current Boolean values.
 
-    This reclassifies all disjuncts in the passed model instance as ctype Block and deactivates the
-    constraints and disjunctions within inactive disjuncts.
+    This reclassifies all disjuncts in the passed model instance as ctype Block
+    and deactivates the constraints and disjunctions within inactive disjuncts.
 
     """
 
@@ -38,19 +38,24 @@ class GDP_Disjunct_Fixer(Transformation):
     ))
 
     def _apply_to(self, model, **kwds):
-        """Fix all disjuncts in the given model and reclassify them to Blocks."""
+        """Fix all disjuncts in the given model and reclassify them to 
+        Blocks."""
         config = self.config = self.CONFIG(kwds.pop('options', {}))
         config.set_value(kwds)
 
         self._transformContainer(model)
 
         # Reclassify all disjuncts
-        for disjunct_object in model.component_objects(Disjunct, descend_into=(Block, Disjunct)):
-            disjunct_object.parent_block().reclassify_component_type(disjunct_object, Block)
+        for disjunct_object in model.component_objects(Disjunct,
+                                                       descend_into=(Block,
+                                                                     Disjunct)):
+            disjunct_object.parent_block().reclassify_component_type(
+                disjunct_object, Block)
 
     def _transformContainer(self, obj):
         """Find all disjuncts in the container and transform them."""
-        for disjunct in obj.component_data_objects(ctype=Disjunct, active=True, descend_into=True):
+        for disjunct in obj.component_data_objects(ctype=Disjunct, active=True,
+                                                   descend_into=True):
             _binary = disjunct.binary_indicator_var
             if fabs(value(_binary) - 1) <= self.config.integer_tolerance:
                 disjunct.indicator_var.fix(True)
@@ -62,7 +67,9 @@ class GDP_Disjunct_Fixer(Transformation):
                     'Non-binary indicator variable value %s for disjunct %s'
                     % (disjunct.name, value(_binary)))
 
-        for disjunction in obj.component_data_objects(ctype=Disjunction, active=True, descend_into=True):
+        for disjunction in obj.component_data_objects(ctype=Disjunction,
+                                                      active=True,
+                                                      descend_into=True):
             self._transformDisjunctionData(disjunction)
 
     def _transformDisjunctionData(self, disjunction):

--- a/pyomo/gdp/plugins/fix_disjuncts.py
+++ b/pyomo/gdp/plugins/fix_disjuncts.py
@@ -4,7 +4,7 @@
 import logging
 from math import fabs
 
-from pyomo.common.config import ConfigBlock, ConfigValue, NonNegativeFloat
+from pyomo.common.config import ConfigBlock, NonNegativeFloat
 from pyomo.core.base import Transformation, TransformationFactory
 from pyomo.core.base.block import Block
 from pyomo.core.expr.numvalue import value
@@ -36,12 +36,6 @@ class GDP_Disjunct_Fixer(Transformation):
         super(GDP_Disjunct_Fixer, self).__init__(**kwargs)
 
     CONFIG = ConfigBlock("gdp.fix_disjuncts")
-    CONFIG.declare('integer_tolerance', ConfigValue(
-        default=1E-6,
-        domain=NonNegativeFloat,
-        description="tolerance on binary variable 0, 1 values"
-    ))
-
     def _apply_to(self, model, **kwds):
         """Fix all disjuncts in the given model and reclassify them to 
         Blocks."""

--- a/pyomo/gdp/plugins/fix_disjuncts.py
+++ b/pyomo/gdp/plugins/fix_disjuncts.py
@@ -18,14 +18,16 @@ logger = logging.getLogger('pyomo.gdp.fix_disjuncts')
     'gdp.fix_disjuncts',
     doc="""Fix disjuncts to their current Boolean values and transforms any
     LogicalConstraints and BooleanVars so that the resulting model is a
-    MI(N)LP.""")
+    (MI)(N)LP.""")
 class GDP_Disjunct_Fixer(Transformation):
     """Fix disjuncts to their current Boolean values.
 
     This reclassifies all disjuncts in the passed model instance as ctype Block
     and deactivates the constraints and disjunctions within inactive disjuncts.
     In addition, it transforms relvant LogicalConstraints and BooleanVars so
-    that the resulting model is a MI(N)LP.
+    that the resulting model is a (MI)(N)LP (where it is only mixed-integer
+    if the model contains integer-domain Vars or BooleanVars which were not
+    indicator_vars of Disjuncs.
     """
 
     def __init__(self, **kwargs):

--- a/pyomo/gdp/plugins/fix_disjuncts.py
+++ b/pyomo/gdp/plugins/fix_disjuncts.py
@@ -64,21 +64,18 @@ class GDP_Disjunct_Fixer(Transformation):
         """Find all disjuncts in the container and transform them."""
         for disjunct in obj.component_data_objects(ctype=Disjunct, active=True,
                                                    descend_into=True):
-            _binary = disjunct.binary_indicator_var
-            if _binary.value is None:
-                raise GDP_Error("The value of the binary_indicator_var of "
+            _bool = disjunct.indicator_var
+            if _bool.value is None:
+                raise GDP_Error("The value of the indicator_var of "
                                 "Disjunct '%s' is None. All indicator_vars "
                                 "must have values before calling "
                                 "'fix_disjuncts'." % disjunct.name)
-            if fabs(value(_binary) - 1) <= self.config.integer_tolerance:
+            elif _bool.value:
                 disjunct.indicator_var.fix(True)
                 self._transformContainer(disjunct)
-            elif fabs(value(_binary)) <= self.config.integer_tolerance:
-                disjunct.deactivate()
             else:
-                raise ValueError(
-                    'Non-binary indicator variable value %s for disjunct %s'
-                    % (disjunct.name, value(_binary)))
+                # Deactivating fixes the indicator_var to False
+                disjunct.deactivate()
 
         for disjunction in obj.component_data_objects(ctype=Disjunction,
                                                       active=True,


### PR DESCRIPTION
## Fixes #2261 

## Summary/Motivation:

I think that the `gdp.fix_disjuncts` transformation should be guaranteed to transform a GDP to a fully algebraic model. The cases where this might not happen are:
1) If there are active LogicalConstraints on the model
2) If not all of the Disjuncts' indicator_vars have values.

In the case of 2, the transformation gives a `ValueError` (see #2261). The current behavior for 1 is to ignore the LogicalConstraints. This PR changes that to calling `logical_to_linear` at the end so that they are transformed.

## Changes proposed in this PR:
- Change the error when not all Disjuncts have a value to have a useful message
- Include a call to `logical_to_linear` after the Disjuncts have been reclassified, to transform any global or local-to-a-selected-Disjunct LogicalConstraints

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
