### PR TITLE
Always include the Pyomo micro version number

### DIFF
--- a/pyomo/version/info.py
+++ b/pyomo/version/info.py
@@ -66,7 +66,7 @@ elif releaselevel == 'invalid':
 
 version_info = (major, minor, micro, releaselevel, serial)
 
-version = '.'.join(str(x) for x in version_info[:(3 if micro else 2)])
+version = '.'.join(str(x) for x in version_info[:3])
 __version__ = version
 if releaselevel != 'final':
     version += ' ('+releaselevel+')'


### PR DESCRIPTION
## Fixes #2255

## Summary/Motivation:
This updates Pyomo to always include the *micro* version number, even when it is 0.

## Changes proposed in this PR:
- Always report version as *major.minor.micro*

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
