### PR TITLE
Update `differentiate()` to accept string mode identifiers

### DIFF
--- a/pyomo/core/expr/calculus/derivatives.py
+++ b/pyomo/core/expr/calculus/derivatives.py
@@ -14,9 +14,9 @@ from .diff_with_pyomo import reverse_sd, reverse_ad
 
 
 class Modes(str, enum.Enum):
-    sympy='sympy'
-    reverse_symbolic='reverse_symbolic'
-    reverse_numeric='reverse_numeric'
+    sympy = 'sympy'
+    reverse_symbolic = 'reverse_symbolic'
+    reverse_numeric = 'reverse_numeric'
 
     # Overloading __str__ is needed to match the behavior of the old
     # pyutilib.enum class (removed June 2020). There are spots in the
@@ -81,6 +81,13 @@ def differentiate(expr, wrt=None, wrt_list=None, mode=Modes.reverse_numeric):
 
     """
 
+    try:
+        mode = Modes(mode)
+    except:
+        raise ValueError(
+            f'differentiate(): Unrecognized differentiation mode: {mode}\n'
+            f'Expected one of {list(map(str, Modes))}.'
+        )
     if mode == Modes.reverse_numeric or mode == Modes.reverse_symbolic:
         if mode == Modes.reverse_numeric:
             res = reverse_ad(expr=expr)
@@ -103,12 +110,9 @@ def differentiate(expr, wrt=None, wrt_list=None, mode=Modes.reverse_numeric):
                 else:
                     _res.append(0)
             res = _res
-    elif mode is Modes.sympy:
-        res = sympy_diff(expr=expr, wrt=wrt, wrt_list=wrt_list)
     else:
-        raise ValueError(
-            'differentiate(): Unrecognized differentiation mode: {0}'.format(
-                mode))
+        assert mode == Modes.sympy
+        res = sympy_diff(expr=expr, wrt=wrt, wrt_list=wrt_list)
 
     return res
 

--- a/pyomo/core/tests/unit/test_derivs.py
+++ b/pyomo/core/tests/unit/test_derivs.py
@@ -18,6 +18,7 @@ from pyomo.core.expr.calculus.diff_with_pyomo import (
 from pyomo.core.expr.numeric_expr import (
     LinearExpression, MonomialTermExpression,
 )
+from pyomo.core.expr.compare import compare_expressions
 from pyomo.core.expr.sympy_tools import sympy_available
 
 tol = 6
@@ -314,7 +315,7 @@ class TestDifferentiate(unittest.TestCase):
         m.y = pyo.Var(initialize=0.88)
         ddx = differentiate(m.x**2, wrt=m.x, mode='sympy')
         self.assertIsInstance(ddx, MonomialTermExpression)
-        self.assertEqual(str(ddx), '2.0*x')
+        self.assertTrue(compare_expressions(ddx, 2*m.x))
         self.assertAlmostEqual(ddx(), 0.46)
         ddy = differentiate(m.x**2, wrt=m.y, mode='sympy')
         self.assertEqual(ddy, 0)
@@ -323,7 +324,7 @@ class TestDifferentiate(unittest.TestCase):
         self.assertIsInstance(ddx, list)
         self.assertEqual(len(ddx), 2)
         self.assertIsInstance(ddx[0], MonomialTermExpression)
-        self.assertEqual(str(ddx[0]), '2.0*x')
+        self.assertTrue(compare_expressions(ddx[0], 2*m.x))
         self.assertAlmostEqual(ddx[0](), 0.46)
         self.assertEqual(ddx[1], 0)
 
@@ -333,7 +334,7 @@ class TestDifferentiate(unittest.TestCase):
         m.y = pyo.Var(initialize=0.88)
         ddx = differentiate(m.x**2, wrt=m.x, mode='reverse_symbolic')
         self.assertIsInstance(ddx, MonomialTermExpression)
-        self.assertEqual(str(ddx), '2*x')
+        self.assertTrue(compare_expressions(ddx, 2*m.x))
         self.assertAlmostEqual(ddx(), 0.46)
         ddy = differentiate(m.x**2, wrt=m.y, mode='reverse_symbolic')
         self.assertEqual(ddy, 0)
@@ -343,7 +344,7 @@ class TestDifferentiate(unittest.TestCase):
         self.assertIsInstance(ddx, list)
         self.assertEqual(len(ddx), 2)
         self.assertIsInstance(ddx[0], MonomialTermExpression)
-        self.assertEqual(str(ddx[0]), '2*x')
+        self.assertTrue(compare_expressions(ddx[0], 2*m.x))
         self.assertAlmostEqual(ddx[0](), 0.46)
         self.assertEqual(ddx[1], 0)
 

--- a/pyomo/core/tests/unit/test_derivs.py
+++ b/pyomo/core/tests/unit/test_derivs.py
@@ -2,18 +2,23 @@
 #
 #  Pyomo: Python Optimization Modeling Objects
 #  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
-#  Under the terms of Contract DE-NA0003525 with National Technology and 
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
 import pyomo.common.unittest as unittest
 import pyomo.environ as pyo
-from pyomo.core.expr.calculus.diff_with_pyomo import reverse_ad, reverse_sd, DifferentiationException
 from pyomo.common.getGSL import find_GSL
-from pyomo.core.expr.numeric_expr import LinearExpression
-
+from pyomo.core.expr.calculus.derivatives import differentiate, Modes
+from pyomo.core.expr.calculus.diff_with_pyomo import (
+    reverse_ad, reverse_sd, DifferentiationException,
+)
+from pyomo.core.expr.numeric_expr import (
+    LinearExpression, MonomialTermExpression,
+)
+from pyomo.core.expr.sympy_tools import sympy_available
 
 tol = 6
 
@@ -300,3 +305,78 @@ class TestDerivs(unittest.TestCase):
         self.assertAlmostEqual(derivs[m.x], approx_deriv(e, m.x), tol)
         self.assertAlmostEqual(derivs[m.y], pyo.value(symbolic[m.y]), tol+3)
         self.assertAlmostEqual(derivs[m.y], approx_deriv(e, m.y), tol)
+
+class TestDifferentiate(unittest.TestCase):
+    @unittest.skipUnless(sympy_available, "test requires sympy")
+    def test_sympy(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(initialize=0.23)
+        m.y = pyo.Var(initialize=0.88)
+        ddx = differentiate(m.x**2, wrt=m.x, mode='sympy')
+        self.assertIsInstance(ddx, MonomialTermExpression)
+        self.assertEqual(str(ddx), '2.0*x')
+        self.assertAlmostEqual(ddx(), 0.46)
+        ddy = differentiate(m.x**2, wrt=m.y, mode='sympy')
+        self.assertEqual(ddy, 0)
+
+        ddx = differentiate(m.x**2, wrt_list=[m.x, m.y], mode='sympy')
+        self.assertIsInstance(ddx, list)
+        self.assertEqual(len(ddx), 2)
+        self.assertIsInstance(ddx[0], MonomialTermExpression)
+        self.assertEqual(str(ddx[0]), '2.0*x')
+        self.assertAlmostEqual(ddx[0](), 0.46)
+        self.assertEqual(ddx[1], 0)
+
+    def test_reverse_symbolic(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(initialize=0.23)
+        m.y = pyo.Var(initialize=0.88)
+        ddx = differentiate(m.x**2, wrt=m.x, mode='reverse_symbolic')
+        self.assertIsInstance(ddx, MonomialTermExpression)
+        self.assertEqual(str(ddx), '2*x')
+        self.assertAlmostEqual(ddx(), 0.46)
+        ddy = differentiate(m.x**2, wrt=m.y, mode='reverse_symbolic')
+        self.assertEqual(ddy, 0)
+
+        ddx = differentiate(m.x**2, wrt_list=[m.x, m.y],
+                            mode='reverse_symbolic')
+        self.assertIsInstance(ddx, list)
+        self.assertEqual(len(ddx), 2)
+        self.assertIsInstance(ddx[0], MonomialTermExpression)
+        self.assertEqual(str(ddx[0]), '2*x')
+        self.assertAlmostEqual(ddx[0](), 0.46)
+        self.assertEqual(ddx[1], 0)
+
+    def test_reverse_numeric(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(initialize=0.23)
+        m.y = pyo.Var(initialize=0.88)
+        ddx = differentiate(m.x**2, wrt=m.x, mode='reverse_numeric')
+        self.assertIsInstance(ddx, float)
+        self.assertAlmostEqual(ddx, 0.46)
+        ddy = differentiate(m.x**2, wrt=m.y, mode='reverse_numeric')
+        self.assertEqual(ddy, 0)
+
+        ddx = differentiate(m.x**2, wrt_list=[m.x, m.y],
+                            mode='reverse_numeric')
+        self.assertIsInstance(ddx, list)
+        self.assertEqual(len(ddx), 2)
+        self.assertIsInstance(ddx[0], float)
+        self.assertAlmostEqual(ddx[0], 0.46)
+        self.assertEqual(ddx[1], 0)
+
+    def test_bad_mode(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(initialize=0.23)
+        with self.assertRaisesRegex(
+                ValueError, r'Unrecognized differentiation mode: foo\n'
+                r"Expected one of \['sympy', 'reverse_symbolic', "
+                r"'reverse_numeric'\]"):
+            ddx = differentiate(m.x**2, m.x, mode='foo')
+
+    def test_bad_wrt(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(initialize=0.23)
+        with self.assertRaisesRegex(
+                ValueError, r'Cannot specify both wrt and wrt_list'):
+            ddx = differentiate(m.x**2, wrt=m.x, wrt_list=[m.x])

--- a/pyomo/core/tests/unit/test_derivs.py
+++ b/pyomo/core/tests/unit/test_derivs.py
@@ -15,9 +15,7 @@ from pyomo.core.expr.calculus.derivatives import differentiate, Modes
 from pyomo.core.expr.calculus.diff_with_pyomo import (
     reverse_ad, reverse_sd, DifferentiationException,
 )
-from pyomo.core.expr.numeric_expr import (
-    LinearExpression, MonomialTermExpression,
-)
+from pyomo.core.expr.numeric_expr import LinearExpression
 from pyomo.core.expr.compare import compare_expressions
 from pyomo.core.expr.sympy_tools import sympy_available
 
@@ -314,7 +312,6 @@ class TestDifferentiate(unittest.TestCase):
         m.x = pyo.Var(initialize=0.23)
         m.y = pyo.Var(initialize=0.88)
         ddx = differentiate(m.x**2, wrt=m.x, mode='sympy')
-        self.assertIsInstance(ddx, MonomialTermExpression)
         self.assertTrue(compare_expressions(ddx, 2*m.x))
         self.assertAlmostEqual(ddx(), 0.46)
         ddy = differentiate(m.x**2, wrt=m.y, mode='sympy')
@@ -323,7 +320,6 @@ class TestDifferentiate(unittest.TestCase):
         ddx = differentiate(m.x**2, wrt_list=[m.x, m.y], mode='sympy')
         self.assertIsInstance(ddx, list)
         self.assertEqual(len(ddx), 2)
-        self.assertIsInstance(ddx[0], MonomialTermExpression)
         self.assertTrue(compare_expressions(ddx[0], 2*m.x))
         self.assertAlmostEqual(ddx[0](), 0.46)
         self.assertEqual(ddx[1], 0)
@@ -333,7 +329,6 @@ class TestDifferentiate(unittest.TestCase):
         m.x = pyo.Var(initialize=0.23)
         m.y = pyo.Var(initialize=0.88)
         ddx = differentiate(m.x**2, wrt=m.x, mode='reverse_symbolic')
-        self.assertIsInstance(ddx, MonomialTermExpression)
         self.assertTrue(compare_expressions(ddx, 2*m.x))
         self.assertAlmostEqual(ddx(), 0.46)
         ddy = differentiate(m.x**2, wrt=m.y, mode='reverse_symbolic')
@@ -343,7 +338,6 @@ class TestDifferentiate(unittest.TestCase):
                             mode='reverse_symbolic')
         self.assertIsInstance(ddx, list)
         self.assertEqual(len(ddx), 2)
-        self.assertIsInstance(ddx[0], MonomialTermExpression)
         self.assertTrue(compare_expressions(ddx[0], 2*m.x))
         self.assertAlmostEqual(ddx[0](), 0.46)
         self.assertEqual(ddx[1], 0)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
The original implementation of `pyomo.core.expr.calculus.derivatives.differentiate` accepted string modes for `reverse_symbolic` and `reverse_numeric`, but not `sympy`.  This updates `differentiate()` to always accept either Modes Enum values or strings.  It also increases (slightly) unit test coverage of `differentiate()`

## Changes proposed in this PR:
- Accept string identifiers for all `differentiate()` `Modes`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
