### PR TITLE
Use projected NLPs for the inner problem solves in ExternalPyomoModel

### DIFF
--- a/pyomo/contrib/pynumero/interfaces/external_pyomo_model.py
+++ b/pyomo/contrib/pynumero/interfaces/external_pyomo_model.py
@@ -15,6 +15,7 @@ from pyomo.core.base.constraint import Constraint
 from pyomo.core.base.objective import Objective
 from pyomo.core.expr.visitor import identify_variables
 from pyomo.common.collections import ComponentSet
+from pyomo.core.base.suffix import Suffix
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
 from pyomo.util.subsystems import (
     create_subsystem_block,
@@ -23,6 +24,12 @@ from pyomo.util.subsystems import (
 from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP
 from pyomo.contrib.pynumero.interfaces.external_grey_box import (
     ExternalGreyBoxModel,
+)
+from pyomo.contrib.pynumero.interfaces.nlp_projections import ProjectedNLP
+from pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver import (
+    cyipopt_available,
+    CyIpoptNLP,
+    CyIpoptSolver,
 )
 from pyomo.contrib.incidence_analysis.util import (
     generate_strongly_connected_components,
@@ -141,10 +148,24 @@ class ExternalPyomoModel(ExternalGreyBoxModel):
             residual_cons,
             external_cons,
             solver=None,
+            use_cyipopt=True,
             ):
-        if solver is None:
+        if use_cyipopt and not cyipopt_available:
+            raise RuntimeError(
+                "Constructing an ExternalPyomoModel with CyIpopt unavailable. "
+                "Please set the use_cyipopt argument to False."
+            )
+        if solver is not None and use_cyipopt:
+            raise RuntimeError(
+                "Constructing an ExternalPyomoModel with a solver specified "
+                "and use_cyipopt set to True. Please set use_cyipopt to False "
+                "to use the desired solver."
+            )
+        elif solver is None and not use_cyipopt:
             solver = SolverFactory("ipopt")
+        # If use_cyipopt is True, this solver is None and will not be used.
         self._solver = solver
+        self._use_cyipopt = use_cyipopt
 
         # We only need this block to construct the NLP, which wouldn't
         # be necessary if we could compute Hessians of Pyomo constraints.
@@ -158,6 +179,54 @@ class ExternalPyomoModel(ExternalGreyBoxModel):
         self._scc_list = list(generate_strongly_connected_components(
             external_cons, variables=external_vars
         ))
+
+        if use_cyipopt:
+            # Using CyIpopt allows us to solver inner problems without
+            # costly rewriting of the nl file. It requires quite a bit
+            # of preprocessing, however, to construct the ProjectedNLP
+            # for each block of the decomposition.
+
+            # Get "vector-valued" SCCs, those of dimension > 0.
+            # We will solve these with a direct IPOPT interface, which requires
+            # some preprocessing.
+            self._vector_scc_list = [
+                (scc, inputs) for scc, inputs in self._scc_list
+                if len(scc.vars) > 1
+            ]
+
+            # Need a dummy objective to create an NLP
+            for scc, inputs in self._vector_scc_list:
+                scc._obj = Objective(expr=0.0)
+
+                # I need scaling_factor so Pyomo NLPs I create from these blocks
+                # don't break when ProjectedNLP calls get_primals_scaling
+                scc.scaling_factor = Suffix(direction=Suffix.EXPORT)
+                # HACK: scaling_factor just needs to be nonempty.
+                scc.scaling_factor[scc._obj] = 1.0
+
+            # These are the "original NLPs" that will be projected
+            self._vector_scc_nlps = [
+                PyomoNLP(scc) for scc, inputs in self._vector_scc_list
+            ]
+            self._vector_scc_var_names = [
+                [var.name for var in scc.vars.values()]
+                for scc, inputs in self._vector_scc_list
+            ]
+            self._vector_proj_nlps = [
+                ProjectedNLP(nlp, names) for nlp, names in
+                zip(self._vector_scc_nlps, self._vector_scc_var_names)
+            ]
+
+            # We will solve the ProjectedNLPs rather than the original NLPs
+            self._cyipopt_nlps = [CyIpoptNLP(nlp) for nlp in self._vector_proj_nlps]
+            self._cyipopt_solvers = [
+                CyIpoptSolver(nlp) for nlp in self._cyipopt_nlps
+            ]
+            self._vector_scc_input_coords = [
+                nlp.get_primal_indices(inputs)
+                for nlp, (scc, inputs) in
+                zip(self._vector_scc_nlps, self._vector_scc_list)
+            ]
 
         assert len(external_vars) == len(external_cons)
 
@@ -190,14 +259,57 @@ class ExternalPyomoModel(ExternalGreyBoxModel):
         for var, val in zip(input_vars, input_values):
             var.set_value(val)
 
+        vector_scc_idx = 0
         for block, inputs in self._scc_list:
             if len(block.vars) == 1:
                 calculate_variable_from_constraint(
                     block.vars[0], block.cons[0]
                 )
             else:
-                with TemporarySubsystemManager(to_fix=inputs):
-                    solver.solve(block)
+                if self._use_cyipopt:
+                    # Transfer variable values into the projected NLP, solve,
+                    # and extract values.
+
+                    nlp = self._vector_scc_nlps[vector_scc_idx]
+                    proj_nlp = self._vector_proj_nlps[vector_scc_idx]
+                    input_coords = self._vector_scc_input_coords[vector_scc_idx]
+                    cyipopt = self._cyipopt_solvers[vector_scc_idx]
+                    _, local_inputs = self._vector_scc_list[vector_scc_idx]
+
+                    primals = nlp.get_primals()
+                    variables = nlp.get_pyomo_variables()
+
+                    # Set values and bounds from inputs to the SCC.
+                    # This works because values have been set in the original
+                    # pyomo model, either by a previous SCC solve, or from the
+                    # "global inputs"
+                    for i, var in zip(input_coords, local_inputs):
+                        # Set primals (inputs) in the original NLP
+                        primals[i] = var.value
+                    # This affects future evaluations in the ProjectedNLP
+                    nlp.set_primals(primals)
+                    x0 = proj_nlp.get_primals()
+                    sol, _ = cyipopt.solve(x0=x0)
+
+                    # Set primals from solution in projected NLP. This updates
+                    # values in the original NLP
+                    proj_nlp.set_primals(sol)
+                    # I really only need to set new primals for the variables in
+                    # the ProjectedNLP. However, I can only get a list of variables
+                    # from the original Pyomo NLP, so here some of the values I'm
+                    # setting are redundant.
+                    new_primals = nlp.get_primals()
+                    assert len(new_primals) == len(variables)
+                    for var, val in zip(variables, new_primals):
+                        var.set_value(val)
+
+                    vector_scc_idx += 1
+
+                else:
+                    # Use a Pyomo solver to solve this strongly connected
+                    # component.
+                    with TemporarySubsystemManager(to_fix=inputs):
+                        solver.solve(block)
 
         # Send updated variable values to NLP for dervative evaluation
         primals = self._nlp.get_primals()

--- a/pyomo/contrib/pynumero/interfaces/external_pyomo_model.py
+++ b/pyomo/contrib/pynumero/interfaces/external_pyomo_model.py
@@ -205,7 +205,7 @@ class ExternalPyomoModel(ExternalGreyBoxModel):
         ))
 
         if use_cyipopt:
-            # Using CyIpopt allows us to solver inner problems without
+            # Using CyIpopt allows us to solve inner problems without
             # costly rewriting of the nl file. It requires quite a bit
             # of preprocessing, however, to construct the ProjectedNLP
             # for each block of the decomposition.

--- a/pyomo/contrib/pynumero/interfaces/external_pyomo_model.py
+++ b/pyomo/contrib/pynumero/interfaces/external_pyomo_model.py
@@ -147,9 +147,31 @@ class ExternalPyomoModel(ExternalGreyBoxModel):
             external_vars,
             residual_cons,
             external_cons,
-            solver=None,
             use_cyipopt=True,
+            solver=None,
             ):
+        """
+        Arguments:
+        ----------
+        input_vars: list
+            List of variables sent to this system by the outer solver
+        external_vars: list
+            List of variables that are solved for internally by this system
+        residual_cons: list
+            List of equality constraints whose residuals are exposed to
+            the outer solver
+        external_cons: list
+            List of equality constraints used to solve for the external
+            variables
+        use_cyipopt: bool
+            Whether to use CyIpopt to solve strongly connected components of
+            the implicit function that have dimension greater than one.
+        solver: Pyomo solver object
+            Used to solve strongly connected components of the implicit function
+            that have dimension greater than one. Only used if use_cyipopt
+            is False.
+
+        """
         if use_cyipopt and not cyipopt_available:
             raise RuntimeError(
                 "Constructing an ExternalPyomoModel with CyIpopt unavailable. "

--- a/pyomo/contrib/pynumero/interfaces/external_pyomo_model.py
+++ b/pyomo/contrib/pynumero/interfaces/external_pyomo_model.py
@@ -303,13 +303,13 @@ class ExternalPyomoModel(ExternalGreyBoxModel):
                     for var, val in zip(variables, new_primals):
                         var.set_value(val)
 
-                    vector_scc_idx += 1
-
                 else:
                     # Use a Pyomo solver to solve this strongly connected
                     # component.
                     with TemporarySubsystemManager(to_fix=inputs):
                         solver.solve(block)
+
+                vector_scc_idx += 1
 
         # Send updated variable values to NLP for dervative evaluation
         primals = self._nlp.get_primals()

--- a/pyomo/contrib/pynumero/interfaces/external_pyomo_model.py
+++ b/pyomo/contrib/pynumero/interfaces/external_pyomo_model.py
@@ -147,7 +147,7 @@ class ExternalPyomoModel(ExternalGreyBoxModel):
             external_vars,
             residual_cons,
             external_cons,
-            use_cyipopt=True,
+            use_cyipopt=None,
             solver=None,
             ):
         """
@@ -172,6 +172,8 @@ class ExternalPyomoModel(ExternalGreyBoxModel):
             is False.
 
         """
+        if use_cyipopt is None:
+            use_cyipopt = cyipopt_available
         if use_cyipopt and not cyipopt_available:
             raise RuntimeError(
                 "Constructing an ExternalPyomoModel with CyIpopt unavailable. "

--- a/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_block.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_block.py
@@ -1233,7 +1233,7 @@ class TestExceptions(unittest.TestCase):
                         )
         finally:
             # HACK: Reset the global flag
-            epm_module.cyipopt_available = True
+            epm_module.cyipopt_available = cyipopt_available
 
 
 if __name__ == '__main__':

--- a/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_block.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_block.py
@@ -1200,12 +1200,12 @@ class TestExceptions(unittest.TestCase):
         msg = "Please set use_cyipopt to False"
         with self.assertRaisesRegex(RuntimeError, msg):
             ex_model = ExternalPyomoModel(
-                    input_vars,
-                    external_vars,
-                    residual_cons,
-                    external_cons,
-                    solver=inner_solver,
-                    )
+                input_vars,
+                external_vars,
+                residual_cons,
+                external_cons,
+                solver=inner_solver,
+            )
 
     def test_cyipopt_unavailable(self):
         try:
@@ -1226,11 +1226,12 @@ class TestExceptions(unittest.TestCase):
             msg = "Constructing an ExternalPyomoModel with CyIpopt unavailable"
             with self.assertRaisesRegex(RuntimeError, msg):
                 ex_model = ExternalPyomoModel(
-                        input_vars,
-                        external_vars,
-                        residual_cons,
-                        external_cons,
-                        )
+                    input_vars,
+                    external_vars,
+                    residual_cons,
+                    external_cons,
+                    use_cyipopt=True,
+                )
         finally:
             # HACK: Reset the global flag
             epm_module.cyipopt_available = cyipopt_available

--- a/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_block.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_block.py
@@ -1205,6 +1205,7 @@ class TestExceptions(unittest.TestCase):
                 residual_cons,
                 external_cons,
                 solver=inner_solver,
+                use_cyipopt=True,
             )
 
     def test_cyipopt_unavailable(self):

--- a/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_block.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_block.py
@@ -1179,6 +1179,7 @@ class TestExternalGreyBoxBlockWithReferences(unittest.TestCase):
         for i, j in zip(jac.row, jac.col):
             self.assertIn((i, j), expected_nonzeros)
 
+
 class TestExceptions(unittest.TestCase):
 
     def test_solver_with_cyipopt(self):

--- a/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_block.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_block.py
@@ -720,6 +720,7 @@ class TestPyomoNLPWithGreyBoxBLocks(unittest.TestCase):
                 external_vars,
                 residual_cons,
                 external_cons,
+                use_cyipopt=False,
                 )
         block.set_external_model(ex_model)
 
@@ -808,6 +809,7 @@ class TestPyomoNLPWithGreyBoxBLocks(unittest.TestCase):
                 external_vars,
                 residual_cons,
                 external_cons,
+                use_cyipopt=False,
                 )
         block.set_external_model(ex_model)
 
@@ -890,6 +892,7 @@ class TestPyomoNLPWithGreyBoxBLocks(unittest.TestCase):
                 external_vars,
                 residual_cons,
                 external_cons,
+                use_cyipopt=False,
                 )
         block.set_external_model(ex_model)
 
@@ -981,6 +984,7 @@ class TestPyomoNLPWithGreyBoxBLocks(unittest.TestCase):
                 external_vars,
                 residual_cons,
                 external_cons,
+                use_cyipopt=False,
                 )
         block.set_external_model(ex_model)
 

--- a/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_block.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_block.py
@@ -1186,7 +1186,10 @@ class TestExternalGreyBoxBlockWithReferences(unittest.TestCase):
 
 class TestExceptions(unittest.TestCase):
 
+    @unittest.skipUnless(cyipopt_available, "cyipopt is not available")
     def test_solver_with_cyipopt(self):
+        # CyIpopt is required here just because we get a different error
+        # (see test below) if CyIpopt is unavailable.
         m = pyo.ConcreteModel()
         m.ex_block = ExternalGreyBoxBlock(concrete=True)
         block = m.ex_block

--- a/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_block.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_block.py
@@ -31,6 +31,7 @@ if not AmplInterface.available():
 from pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver import (
     cyipopt_available,
 )
+import pyomo.contrib.pynumero.interfaces.external_pyomo_model as epm_module
 from pyomo.contrib.pynumero.interfaces.external_pyomo_model import (
     ExternalPyomoModel,
     get_hessian_of_constraint,
@@ -244,6 +245,122 @@ class TestExternalGreyBoxBlock(unittest.TestCase):
 
     @unittest.skipUnless(cyipopt_available, "cyipopt is not available")
     def test_optimize(self):
+        m = pyo.ConcreteModel()
+        m.ex_block = ExternalGreyBoxBlock(concrete=True)
+        block = m.ex_block
+
+        m_ex = _make_external_model()
+        input_vars = [m_ex.a, m_ex.b, m_ex.r, m_ex.x_out, m_ex.y_out]
+        external_vars = [m_ex.x, m_ex.y]
+        residual_cons = [m_ex.c_out_1, m_ex.c_out_2]
+        external_cons = [m_ex.c_ex_1, m_ex.c_ex_2]
+        ex_model = ExternalPyomoModel(
+                input_vars,
+                external_vars,
+                residual_cons,
+                external_cons,
+                )
+        block.set_external_model(ex_model)
+
+        a = m.ex_block.inputs["input_0"]
+        b = m.ex_block.inputs["input_1"]
+        r = m.ex_block.inputs["input_2"]
+        x = m.ex_block.inputs["input_3"]
+        y = m.ex_block.inputs["input_4"]
+        m.obj = pyo.Objective(expr=
+                (x-2.0)**2 + (y-2.0)**2 + (a-2.0)**2 + (b-2.0)**2 + (r-2.0)**2
+                )
+
+        # Solve with external model embedded
+        solver = pyo.SolverFactory("cyipopt")
+        solver.solve(m)
+
+        m_ex.obj = pyo.Objective(expr=
+                (m_ex.x-2.0)**2 + (m_ex.y-2.0)**2 + (m_ex.a-2.0)**2 +
+                (m_ex.b-2.0)**2 + (m_ex.r-2.0)**2
+                )
+        m_ex.a.set_value(0.0)
+        m_ex.b.set_value(0.0)
+        m_ex.r.set_value(0.0)
+        m_ex.y.set_value(0.0)
+        m_ex.x.set_value(0.0)
+
+        # Solve external model, now with same objective function
+        ipopt = pyo.SolverFactory("ipopt")
+        ipopt.solve(m_ex)
+
+        # Make sure full space and reduced space solves give same
+        # answers.
+        self.assertAlmostEqual(m_ex.a.value, a.value, delta=1e-8)
+        self.assertAlmostEqual(m_ex.b.value, b.value, delta=1e-8)
+        self.assertAlmostEqual(m_ex.r.value, r.value, delta=1e-8)
+        self.assertAlmostEqual(m_ex.x.value, x.value, delta=1e-8)
+        self.assertAlmostEqual(m_ex.y.value, y.value, delta=1e-8)
+
+    @unittest.skipUnless(cyipopt_available, "cyipopt is not available")
+    def test_optimize_with_ipopt_for_inner_problem(self):
+        # Use Ipopt, rather than the default CyIpopt, for the inner problem
+        m = pyo.ConcreteModel()
+        m.ex_block = ExternalGreyBoxBlock(concrete=True)
+        block = m.ex_block
+
+        m_ex = _make_external_model()
+        input_vars = [m_ex.a, m_ex.b, m_ex.r, m_ex.x_out, m_ex.y_out]
+        external_vars = [m_ex.x, m_ex.y]
+        residual_cons = [m_ex.c_out_1, m_ex.c_out_2]
+        external_cons = [m_ex.c_ex_1, m_ex.c_ex_2]
+        inner_solver = pyo.SolverFactory("ipopt")
+        ex_model = ExternalPyomoModel(
+                input_vars,
+                external_vars,
+                residual_cons,
+                external_cons,
+                solver=inner_solver,
+                use_cyipopt=False,
+                )
+        block.set_external_model(ex_model)
+
+        a = m.ex_block.inputs["input_0"]
+        b = m.ex_block.inputs["input_1"]
+        r = m.ex_block.inputs["input_2"]
+        x = m.ex_block.inputs["input_3"]
+        y = m.ex_block.inputs["input_4"]
+        m.obj = pyo.Objective(expr=
+                (x-2.0)**2 + (y-2.0)**2 + (a-2.0)**2 + (b-2.0)**2 + (r-2.0)**2
+                )
+
+        # Solve with external model embedded
+        solver = pyo.SolverFactory("cyipopt")
+        solver.solve(m)
+
+        m_ex.obj = pyo.Objective(expr=
+                (m_ex.x-2.0)**2 + (m_ex.y-2.0)**2 + (m_ex.a-2.0)**2 +
+                (m_ex.b-2.0)**2 + (m_ex.r-2.0)**2
+                )
+        m_ex.a.set_value(0.0)
+        m_ex.b.set_value(0.0)
+        m_ex.r.set_value(0.0)
+        m_ex.y.set_value(0.0)
+        m_ex.x.set_value(0.0)
+
+        # Solve external model, now with same objective function
+        ipopt = pyo.SolverFactory("ipopt")
+        ipopt.solve(m_ex)
+
+        # Make sure full space and reduced space solves give same
+        # answers.
+        self.assertAlmostEqual(m_ex.a.value, a.value, delta=1e-8)
+        self.assertAlmostEqual(m_ex.b.value, b.value, delta=1e-8)
+        self.assertAlmostEqual(m_ex.r.value, r.value, delta=1e-8)
+        self.assertAlmostEqual(m_ex.x.value, x.value, delta=1e-8)
+        self.assertAlmostEqual(m_ex.y.value, y.value, delta=1e-8)
+
+    @unittest.skipUnless(cyipopt_available, "cyipopt is not available")
+    def test_optimize_no_cyipopt_for_inner_problem(self):
+        # Here we don't specify a solver for the inner problem.
+        # This is contrived, as clearly CyIpopt is available for the outer
+        # solve. This test exercises the part of the ExternalPyomoModel
+        # constructor that sets a default solver if CyIpopt is not available.
         m = pyo.ConcreteModel()
         m.ex_block = ExternalGreyBoxBlock(concrete=True)
         block = m.ex_block
@@ -1061,6 +1178,57 @@ class TestExternalGreyBoxBlockWithReferences(unittest.TestCase):
         jac = nlp.evaluate_jacobian()
         for i, j in zip(jac.row, jac.col):
             self.assertIn((i, j), expected_nonzeros)
+
+class TestExceptions(unittest.TestCase):
+
+    def test_solver_with_cyipopt(self):
+        m = pyo.ConcreteModel()
+        m.ex_block = ExternalGreyBoxBlock(concrete=True)
+        block = m.ex_block
+
+        m_ex = _make_external_model()
+        input_vars = [m_ex.a, m_ex.b, m_ex.r, m_ex.x_out, m_ex.y_out]
+        external_vars = [m_ex.x, m_ex.y]
+        residual_cons = [m_ex.c_out_1, m_ex.c_out_2]
+        external_cons = [m_ex.c_ex_1, m_ex.c_ex_2]
+        inner_solver = pyo.SolverFactory("ipopt")
+        msg = "Please set use_cyipopt to False"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            ex_model = ExternalPyomoModel(
+                    input_vars,
+                    external_vars,
+                    residual_cons,
+                    external_cons,
+                    solver=inner_solver,
+                    )
+
+    def test_cyipopt_unavailable(self):
+        try:
+            # HACK: Make external_pyomo_model.py think that cyipopt is not
+            # available.
+            epm_module.cyipopt_available = False
+
+            m = pyo.ConcreteModel()
+            m.ex_block = ExternalGreyBoxBlock(concrete=True)
+            block = m.ex_block
+
+            m_ex = _make_external_model()
+            input_vars = [m_ex.a, m_ex.b, m_ex.r, m_ex.x_out, m_ex.y_out]
+            external_vars = [m_ex.x, m_ex.y]
+            residual_cons = [m_ex.c_out_1, m_ex.c_out_2]
+            external_cons = [m_ex.c_ex_1, m_ex.c_ex_2]
+            inner_solver = pyo.SolverFactory("ipopt")
+            msg = "Constructing an ExternalPyomoModel with CyIpopt unavailable"
+            with self.assertRaisesRegex(RuntimeError, msg):
+                ex_model = ExternalPyomoModel(
+                        input_vars,
+                        external_vars,
+                        residual_cons,
+                        external_cons,
+                        )
+        finally:
+            # HACK: Reset the global flag
+            epm_module.cyipopt_available = True
 
 
 if __name__ == '__main__':

--- a/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_model.py
+++ b/pyomo/contrib/pynumero/interfaces/tests/test_external_pyomo_model.py
@@ -1086,6 +1086,7 @@ class TestScaling(unittest.TestCase):
             [m.x, m.y],
             [m.con_3, m.con_4],
             [m.con_1, m.con_2],
+            use_cyipopt=False,
         )
         epm_model.obj = pyo.Objective(
             expr=m.x**2 + m.y**2 + m.u**2 + m.v**2


### PR DESCRIPTION
## Summary/Motivation:
There is a significant performance improvement for some problems if we create ProjectedNLPs that we solve repeatedly with CyIpopt, rather than solve Pyomo blocks with Ipopt, for the inner problems in the implicit function formulation.

## Changes proposed in this PR:
- Add the data structures necessary to repeatedly solve a sequence of square problems as PyomoNLPs, where variables are updated before each solve
- Change the default behavior of ExternalPyomoModel to solve ProjectedNLPs with CyIpopt, and only use Ipopt (or another Pyomo solver) if specified, or if CyIpopt is unavailable.

### A comparison comparison on a chemical looping steady state optimization problem:
- Current main:
![2022-02-08_before_patch](https://user-images.githubusercontent.com/8885032/153121920-59e4568f-ded9-4630-830b-56fbffb65660.png)
- This branch
![2022-02-08_after_patch](https://user-images.githubusercontent.com/8885032/153122011-e416131f-af3c-43d8-b56f-cd6e88cd4f14.png)


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
