### PR TITLE
report_scaling should not report zero coefficients

### DIFF
--- a/pyomo/util/report_scaling.py
+++ b/pyomo/util/report_scaling.py
@@ -79,7 +79,7 @@ def _check_coefficents(comp, expr, too_large, too_small, largs_coef_map, small_c
                 if comp not in largs_coef_map:
                     largs_coef_map[comp] = list()
                 largs_coef_map[comp].append((_v, der_lb, der_ub))
-            if abs(der_lb) <= too_small and abs(der_ub) < too_small:
+            if 0 < abs(der_lb) <= too_small and 0 < abs(der_ub) < too_small:
                 if comp not in small_coef_map:
                     small_coef_map[comp] = list()
                 small_coef_map[comp].append((_v, der_lb, der_ub))

--- a/pyomo/util/report_scaling.py
+++ b/pyomo/util/report_scaling.py
@@ -79,10 +79,11 @@ def _check_coefficents(comp, expr, too_large, too_small, largs_coef_map, small_c
                 if comp not in largs_coef_map:
                     largs_coef_map[comp] = list()
                 largs_coef_map[comp].append((_v, der_lb, der_ub))
-            if 0 < abs(der_lb) <= too_small and 0 < abs(der_ub) < too_small:
-                if comp not in small_coef_map:
-                    small_coef_map[comp] = list()
-                small_coef_map[comp].append((_v, der_lb, der_ub))
+            if abs(der_lb) <= too_small and abs(der_ub) < too_small:
+                if der_lb != 0 or der_ub != 0:
+                    if comp not in small_coef_map:
+                        small_coef_map[comp] = list()
+                    small_coef_map[comp].append((_v, der_lb, der_ub))
 
 
 def report_scaling(m: _BlockData, too_large: float = 5e4, too_small: float = 1e-6) -> bool:

--- a/pyomo/util/tests/test_report_scaling.py
+++ b/pyomo/util/tests/test_report_scaling.py
@@ -21,7 +21,8 @@ class TestReportScaling(unittest.TestCase):
     def test_report_scaling(self):
         m = pe.ConcreteModel()
         m.x = pe.Var(list(range(5)))
-        m.c = pe.Constraint(list(range(3)))
+        m.c = pe.Constraint(list(range(4)))
+        m.p = pe.Param(initialize=0, mutable=True)
 
         m.x[0].setlb(-1)
         m.x[0].setub(1)
@@ -38,6 +39,7 @@ class TestReportScaling(unittest.TestCase):
         m.c[0] = m.x[0] + m.x[3] == 0
         m.c[1] = 1 / m.x[1] == 1
         m.c[2] = m.x[1] * m.x[3] == 1
+        m.c[3] = m.x[3] + m.p*m.x[0] == 1
 
         out = StringIO()
         with LoggingIntercept(out, 'pyomo.util.report_scaling', level=logging.INFO):


### PR DESCRIPTION
## Summary/Motivation:
The `report_scaling` function should not report coefficients that are exactly zero.

## Changes proposed in this PR:
- Do not report exactly zero coefficients in `report_scaling`
- Improve the `report_scaling` test

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
