### PR TITLE
Deprecate the `Alias` component

### DIFF
--- a/pyomo/core/base/alias.py
+++ b/pyomo/core/base/alias.py
@@ -11,6 +11,7 @@
 import weakref
 import logging
 
+from pyomo.common.deprecation import deprecated
 from pyomo.common.log import is_debug_set
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base.component import Component, ComponentData
@@ -48,6 +49,9 @@ __all__ = ['Alias']
 #     could possibly never encounter Aliases (if we're
 #     careful).
 
+@deprecated("The Alias component was never completed/tested and will "
+            "be removed.  Consider using Reference()",
+            version='6.3', remove_in='6.3.1')
 class Alias(Component):
 
     __slots__ = ('_aliased_object')


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This deprecates the (untested/undocumented) `Alias` component.  It is a first step for #2284, which will be merged after the 6.3 release.

## Changes proposed in this PR:
- Deprecate `pyomo.core.base.alias.Alias`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
