### PR TITLE
Increase CBC timeout when getting version/asl compatibility

### DIFF
--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -297,7 +297,7 @@ class CBCSHELL(SystemCallSolver):
         """
         results = subprocess.run(
             [self.executable(), "-stop"],
-            timeout=1,
+            timeout=5,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True
@@ -310,7 +310,7 @@ class CBCSHELL(SystemCallSolver):
     def _compiled_with_asl(self):
         results = subprocess.run(
             [self.executable(), "dummy", "-AMPL", "-stop"],
-            timeout=1,
+            timeout=5,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True


### PR DESCRIPTION
## Fixes #2102

## Summary/Motivation:
While previous PRs (#2250) removed the CBC version check and ASL compatibility check from the setup for most CBC (LP/MIP) workflows, this PR bumps the timeout to match the one used for the ASL.

## Changes proposed in this PR:
- increase CBC subprocess timeout to 5 seconds

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
