### PR TITLE
`TempfileManager` updates (deletion order, add `context()`)

### DIFF
--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -55,3 +55,10 @@ class InfeasibleConstraintException(PyomoException):
 class NondifferentiableError(PyomoException, ValueError):
     """A Pyomo-specific ValueError raised for non-differentiable expressions"""
     pass
+
+class TempfileContextError(PyomoException, IndexError):
+    """A Pyomo-specific IndexError raised when attempting to use the
+    TempfileManager when it does not have a currently active context.
+
+    """
+    pass

--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -411,7 +411,7 @@ class TempfileContext:
             If ``True``, delete all managed files / directories
         """
         if remove:
-            for fd, name in self.tempfiles:
+            for fd, name in reversed(self.tempfiles):
                 if fd is not None:
                     try:
                         os.close(fd)

--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -375,9 +375,7 @@ class TempfileContext:
             The absolute path of the new directory.
 
         """
-        dirname = self.mkdtemp(suffix=suffix, prefix=prefix, dir=dir)
-        self.tempfiles[-1] = (None, dirname)
-        return dirname
+        return self.mkdtemp(suffix=suffix, prefix=prefix, dir=dir)
 
     def add_tempfile(self, filename, exists=True):
         """Declare the specified file/directory to be temporary.

--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -22,6 +22,7 @@ import logging
 import shutil
 import weakref
 from pyomo.common.deprecation import deprecated, deprecation_warning
+from pyomo.common.errors import TempfileContextError
 try:
     from pyutilib.component.config.tempfiles import (
         TempfileManager as pyutilib_mngr
@@ -120,19 +121,32 @@ class TempfileManagerClass(object):
         # exception
         self._context_stack = None
 
+    def context(self):
+        """Return the current active TempfileContext.
+
+        Raises
+        ------
+        TempfileContextError if there is not a current context."""
+        if not self._context_stack:
+            raise TempfileContextError(
+                "TempfileManager has no currently active context.  "
+                "Create a context (with push() or __enter__()) before "
+                "attempting to create temporary objects.")
+        return self._context_stack[-1]
+
     def create_tempfile(self, suffix=None, prefix=None, text=False, dir=None):
         "Call :meth:`TempfileContext.create_tempfile` on the active context"
-        return self._context_stack[-1].create_tempfile(
+        return self.context().create_tempfile(
             suffix=suffix, prefix=prefix, text=text, dir=dir)
 
     def create_tempdir(self, suffix=None, prefix=None, dir=None):
         "Call :meth:`TempfileContext.create_tempdir` on the active context"
-        return self._context_stack[-1].create_tempdir(
+        return self.context().create_tempdir(
             suffix=suffix, prefix=prefix, dir=dir)
 
     def add_tempfile(self, filename, exists=True):
         "Call :meth:`TempfileContext.add_tempfile` on the active context"
-        return self._context_stack[-1].add_tempfile(
+        return self.context().add_tempfile(
             filename=filename, exists=exists)
 
     def clear_tempfiles(self, remove=True):

--- a/pyomo/common/tests/test_tempfile.py
+++ b/pyomo/common/tests/test_tempfile.py
@@ -30,7 +30,9 @@ import pyomo.common.unittest as unittest
 import pyomo.common.tempfiles as tempfiles
 
 from pyomo.common.log import LoggingIntercept
-from pyomo.common.tempfiles import TempfileManager, TempfileManagerClass
+from pyomo.common.tempfiles import (
+    TempfileManager, TempfileManagerClass, TempfileContextError,
+)
 
 try:
     from pyutilib.component.config.tempfiles import (
@@ -547,6 +549,14 @@ class Test_TempfileManager(unittest.TestCase):
         finally:
             self.TM.pop()
             pyutilib_mngr.tempdir = _orig
+
+    def test_context(self):
+        with self.assertRaisesRegex(
+                TempfileContextError,
+                "TempfileManager has no currently active context"):
+            self.TM.context()
+        ctx = self.TM.push()
+        self.assertIs(ctx, self.TM.context())
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
When closing out #1803, it became apparent there were a couple things in the TempfileManager that would be beneficial to clean up:
- temporary objects should be deleted in the opposite order they were created
- we could remove some redundant code
- we should provide a public mechanism to retrieve the current active `TempfileContext`

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
