### PR TITLE
Update GDP references

### DIFF
--- a/doc/OnlineDocs/modeling_extensions/gdp/index.rst
+++ b/doc/OnlineDocs/modeling_extensions/gdp/index.rst
@@ -9,7 +9,7 @@ Generalized Disjunctive Programming
    :align: right
    :class: no-scaled-link
 
-The Pyomo.GDP modeling extension provides support for Generalized Disjunctive Programming (GDP)\ [#gdp]_, an extension of Disjunctive Programming\ [#dp]_ from the operations research community to include nonlinear relationships. The classic form for a GDP is given by:
+The Pyomo.GDP modeling extension\ [#gdp-main-paper]_ provides support for Generalized Disjunctive Programming (GDP)\ [#gdp]_, an extension of Disjunctive Programming\ [#dp]_ from the operations research community to include nonlinear relationships. The classic form for a GDP is given by:
 
 .. math::
 
@@ -70,6 +70,7 @@ The following sections describe the key concepts, modeling, and solution approac
 
 Literature References
 =====================
+.. [#gdp-main-paper] Chen, Q., Johnson, E. S., Bernal, D. E., Valentin, R., Kale, S., Bates, J., Siirola, J. D. and Grossmann, I. E. (2021). Pyomo.GDP: an ecosystem for logic based modeling and optimization development, *Optimization and Engineering* (pp. 1-36).https://doi.org/10.1007/s11081-021-09601-7 
 
 .. [#gdp] Raman, R., & Grossmann, I. E. (1994). Modelling and computational techniques for logic based integer programming. *Computers & Chemical Engineering*, 18(7), 563–578. https://doi.org/10.1016/0098-1354(93)E0010-7
 

--- a/doc/OnlineDocs/modeling_extensions/gdp/solving.rst
+++ b/doc/OnlineDocs/modeling_extensions/gdp/solving.rst
@@ -133,6 +133,8 @@ References
 
 .. [#gdp-pse-paper] Chen, Q., Johnson, E. S., Siirola, J. D., & Grossmann, I. E. (2018). Pyomo.GDP: Disjunctive Models in Python. In M. R. Eden, M. G. Ierapetritou, & G. P. Towler (Eds.), *Proceedings of the 13th International Symposium on Process Systems Engineering* (pp. 889–894). San Diego: Elsevier B.V. https://doi.org/10.1016/B978-0-444-64241-7.50143-9
 
+.. [#gdp-main-paper] Chen, Q., Johnson, E. S., Bernal, D. E., Valentin, R., Kale, S., Bates, J., Siirola, J. D. and Grossmann, I. E. (2021). Pyomo.GDP: an ecosystem for logic based modeling and optimization development, *Optimization and Engineering* (pp. 1-36).https://doi.org/10.1007/s11081-021-09601-7 
+
 .. [#gdp-review-2013] Grossmann, I. E., & Trespalacios, F. (2013). Systematic modeling of discrete-continuous optimization models through generalized disjunctive programming. *AIChE Journal*, 59(9), 3276–3295. https://doi.org/10.1002/aic.14088
 
 .. [#gdp-mbm] Trespalacios, F., & Grossmann, I. E. (2015). Improved Big-M reformulation for generalized disjunctive programs. *Computers and Chemical Engineering*, 76, 98–103. https://doi.org/10.1016/j.compchemeng.2015.02.013

--- a/pyomo/contrib/gdpopt/GDPopt.py
+++ b/pyomo/contrib/gdpopt/GDPopt.py
@@ -78,13 +78,14 @@ class GDPoptSolver(object):
     For nonconvex problems, LOA may not report rigorous lower/upper bounds.
 
     Questions: Please make a post at StackOverflow and/or contact Qi Chen
-    <https://github.com/qtothec>.
+    <https://github.com/qtothec> or David Bernal <https://github.com/bernalde>.
 
     Several key GDPopt components were prototyped by BS and MS students:
 
     - Logic-based branch and bound: Sunjeev Kale
     - MC++ interface: Johnny Bates
     - LOA set-covering initialization: Eloy Fernandez
+    - Logic-to-linear transformation: Romeo Valentin
 
     """
 
@@ -217,10 +218,10 @@ Subsolvers:
         to_cite_text = """
 If you use this software, you may cite the following:
 - Implementation:
-Chen, Q; Johnson, ES; Siirola, JD; Grossmann, IE.
-Pyomo.GDP: Disjunctive Models in Python.
-Proc. of the 13th Intl. Symposium on Process Systems Eng.
-San Diego, 2018.
+Chen, Q; Johnson, ES; Bernal, DE; Valentin, R; Kale, S;
+Bates, J; Siirola, JD; Grossmann, IE.
+Pyomo.GDP: an ecosystem for logic based modeling and optimization development.
+Optimization and Engineering, 2021. 
         """.strip()
         if config.strategy == "LOA":
             to_cite_text += "\n"


### PR DESCRIPTION
## Fixes # .

- Updates the previous reference of Pyomo.GDP (conference paper PSE 2018) to the full-length paper.
- Adds reference for questions to @bernalde as @qtothec is no longer actively involved with Pyomo.
- Mention contribution of @RomeoV in GDPOpt

## Summary/Motivation:
When looking at the logs of GDPOpt the older reference appears, which has been superseded by the most recent paper.

## Changes proposed in this PR:
- Changes in docs and logs of Pyomo.GDP and GDPOpt to include the reference 
Chen, Qi, et al. "Pyomo. GDP: an ecosystem for logic based modeling and optimization development." Optimization and Engineering (2021): 1-36.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
