### PR TITLE
Add Python 3.10 as an officially-supported interpreter

### DIFF
--- a/.coin-or/projDesc.xml
+++ b/.coin-or/projDesc.xml
@@ -287,7 +287,7 @@ Carl D. Laird, Chair, Pyomo Management Committee, claird at andrew dot cmu dot e
 
 			<platform>
 				<operatingSystem>Any</operatingSystem>
-				<compiler>Python 3.6, 3.7, 3.8, 3.9</compiler>
+				<compiler>Python 3.6, 3.7, 3.8, 3.9, 3.10</compiler>
 			</platform>
 
 		</testedPlatforms>

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -52,6 +52,14 @@ jobs:
           PACKAGES: glpk
 
         - os: ubuntu-latest
+          python: 3.9
+          other: /conda
+          skip_doctest: 1
+          TARGET: linux
+          PYENV: conda
+          PACKAGES: mpi4py openmpi
+
+        - os: ubuntu-latest
           python: 3.8
           other: /mpi
           mpi: 3
@@ -62,14 +70,6 @@ jobs:
 
         - os: ubuntu-latest
           python: 3.7
-          other: /conda
-          skip_doctest: 1
-          TARGET: linux
-          PYENV: conda
-          PACKAGES: mpi4py openmpi
-
-        - os: ubuntu-latest
-          python: 3.9
           other: /slim
           slim: 1
           skip_doctest: 1
@@ -77,7 +77,7 @@ jobs:
           PYENV: pip
 
         - os: ubuntu-latest
-          python: 3.7
+          python: 3.8
           other: /cython
           setup_options: --with-cython
           skip_doctest: 1

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -53,6 +53,14 @@ jobs:
 
         - os: ubuntu-latest
           python: 3.9
+          other: /conda
+          skip_doctest: 1
+          TARGET: linux
+          PYENV: conda
+          PACKAGES: mpi4py openmpi
+
+        - os: ubuntu-latest
+          python: 3.8
           other: /mpi
           mpi: 3
           skip_doctest: 1
@@ -62,14 +70,6 @@ jobs:
 
         - os: ubuntu-latest
           python: 3.7
-          other: /conda
-          skip_doctest: 1
-          TARGET: linux
-          PYENV: conda
-          PACKAGES: mpi4py openmpi
-
-        - os: ubuntu-latest
-          python: 3.9
           other: /slim
           slim: 1
           skip_doctest: 1
@@ -77,7 +77,7 @@ jobs:
           PYENV: pip
 
         - os: ubuntu-latest
-          python: 3.7
+          python: 3.8
           other: /cython
           setup_options: --with-cython
           skip_doctest: 1

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Pyomo is available under the BSD License, see the LICENSE.txt file.
 
 Pyomo is currently tested with the following Python implementations:
 
-* CPython: 3.6, 3.7, 3.8, 3.9
+* CPython: 3.6, 3.7, 3.8, 3.9, 3.10
 * PyPy: 3
 
 ### Installation

--- a/doc/OnlineDocs/installation.rst
+++ b/doc/OnlineDocs/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 Pyomo currently supports the following versions of Python:
 
-* CPython: 3.6, 3.7, 3.8, 3.9
+* CPython: 3.6, 3.7, 3.8, 3.9, 3.10
 * PyPy: 3
 
 

--- a/setup.py
+++ b/setup.py
@@ -192,6 +192,7 @@ setup_kwargs = dict(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Scientific/Engineering :: Mathematics',


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Add Python 3.10 as an officially-supported interpreter.

## Changes proposed in this PR:
- Add python 3.10 to setup.py, documentation

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
