### PR TITLE
Relax timing target for Windows on GHA

### DIFF
--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -130,7 +130,9 @@ class TestTiming(unittest.TestCase):
         with capture_output() as out:
             delta = timer.toc()
         self.assertAlmostEqual(ref - start_time, delta, delta=RES)
-        self.assertAlmostEqual(0, timer.toc(None), delta=RES)
+        # entering / leavin the context manager can take non-trivial
+        # time on some platforms (up to 0.02 on Windows)
+        self.assertAlmostEqual(0.01, timer.toc(None), delta=RES)
         self.assertRegex(
             out.getvalue(),
             r'\[\+   [.0-9]+\] .* in test_TicTocTimer_tictoc'
@@ -168,7 +170,7 @@ class TestTiming(unittest.TestCase):
             timer.stop()
             delta = timer.toc()
         self.assertAlmostEqual(ref, delta, delta=RES)
-        #self.assertAlmostEqual(0, timer.toc(None), delta=RES)
+        #self.assertAlmostEqual(0.01, timer.toc(None), delta=RES)
         self.assertRegex(
             out.getvalue(),
             r'\[    [.0-9]+\|   1\] .* in test_TicTocTimer_tictoc'


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This relaxes a timing target to accommodate observed timing variability on Windows in GHA.

## Changes proposed in this PR:
- relax timing target

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
