### PR TITLE
AMPLExternalFunction: search for the specified library

### DIFF
--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -18,6 +18,7 @@ from ctypes import (
     Structure, POINTER, CFUNCTYPE, cdll, byref,
     c_int, c_long, c_ulong, c_double, c_byte, c_char_p, c_void_p )
 
+from pyomo.common.fileutils import find_library
 from pyomo.core.expr.numvalue import (
     native_types, native_numeric_types, pyomo_constant_types,
     NonNumericValue, NumericConstant,
@@ -325,6 +326,16 @@ class AMPLExternalFunction(ExternalFunction):
         self._function = kwargs.pop('function', None)
         self._known_functions = None
         self._so = None
+        # Convert the specified library name to an absolute path, and
+        # warn the user if we couldn't find it
+        if self._library is not None:
+            _lib = find_library(self._library)
+            if _lib is not None:
+                self._library = _lib
+            else:
+                logger.warning(
+                    'Defining AMPL external function, but cannot locate '
+                    f'specified library "{self._library}"')
         ExternalFunction.__init__(self, *args, **kwargs)
 
     def __getstate__(self):
@@ -359,19 +370,10 @@ class AMPLExternalFunction(ExternalFunction):
         return f, g, h
 
     def load_library(self):
-        try:
-            self._so = cdll.LoadLibrary(self._library)
-        except OSError:
-            # On Linux, it is uncommon for "." to be in the
-            # LD_LIBRARY_PATH, so if things fail to load, attempt to
-            # locate the library via a relative path
-            try:
-                self._so = cdll.LoadLibrary(os.path.join('.',self._library))
-            except OSError:
-                # Re-try with the original library name and allow the
-                # exception to propagate up.
-                self._so = cdll.LoadLibrary(self._library)
-
+        # Note that the library was located in __init__ and converted to
+        # an absolute path (including checking the CWD).  Previous logic
+        # with multiple attempts to load the library is no longer necessary
+        self._so = cdll.LoadLibrary(self._library)
         self._known_functions = {}
         AE = _AMPLEXPORTS()
         AE.ASLdate = 20160307

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -371,8 +371,16 @@ class AMPLExternalFunction(ExternalFunction):
 
     def load_library(self):
         # Note that the library was located in __init__ and converted to
-        # an absolute path (including checking the CWD).  Previous logic
-        # with multiple attempts to load the library is no longer necessary
+        # an absolute path (including checking the CWD).  However, we
+        # previously tested that changing the environment (i.e.,
+        # changing directories) between defining the ExternalFunction
+        # and loading it would cause the library to still be correctly
+        # loaded.  We will re-search for the library here.  If it was
+        # previously found, we will be searching for an absolute path
+        # (and the same path will be found again).
+        _abs_lib = find_library(self._library)
+        if _abs_lib is not None:
+            self._library = _abs_lib
         self._so = cdll.LoadLibrary(self._library)
         self._known_functions = {}
         AE = _AMPLEXPORTS()

--- a/pyomo/core/tests/unit/test_external.py
+++ b/pyomo/core/tests/unit/test_external.py
@@ -16,6 +16,7 @@ from io import StringIO
 import pyomo.common.unittest as unittest
 
 from pyomo.common.getGSL import find_GSL
+from pyomo.common.log import LoggingIntercept
 from pyomo.common.tempfiles import TempfileManager
 from pyomo.environ import (
     ConcreteModel, Block, Var, Objective, Expression, SolverFactory, value,
@@ -449,6 +450,17 @@ class TestAMPLExternalFunction(unittest.TestCase):
                 self.assertAlmostEqual(value(model.o), 2.0, 7)
             finally:
                 os.chdir(orig_dir)
+
+    def test_unknown_library(self):
+        m = ConcreteModel()
+        with LoggingIntercept() as LOG:
+            m.ef = ExternalFunction(
+                library='unknown_pyomo_external_testing_function',
+                function='f')
+        self.assertEqual(
+            LOG.getvalue(),
+            'Defining AMPL external function, but cannot locate '
+            'specified library "unknown_pyomo_external_testing_function"\n')
 
     def test_eval_gsl_function(self):
         DLL = find_GSL()

--- a/pyomo/repn/plugins/ampl/ampl_.py
+++ b/pyomo/repn/plugins/ampl/ampl_.py
@@ -58,6 +58,10 @@ def set_pyomo_amplfunc_env(external_libs):
     env_str = ''
     for _lib in external_libs:
         _lib = _lib.strip()
+        # Convert the library to an absolute path
+        _abs_lib = find_library(_lib)
+        if _abs_lib is not None:
+            _lib = _abs_lib
         if ( ' ' not in _lib
              or ( _lib[0]=='"' and _lib[-1]=='"'
                   and '"' not in _lib[1:-1] )

--- a/pyomo/repn/plugins/ampl/ampl_.py
+++ b/pyomo/repn/plugins/ampl/ampl_.py
@@ -21,6 +21,7 @@ import os
 import time
 from math import isclose
 
+from pyomo.common.fileutils import find_library
 from pyomo.common.gc_manager import PauseGC
 from pyomo.opt import ProblemFormat, AbstractProblemWriter, WriterFactory
 from pyomo.core.expr import current as EXPR


### PR DESCRIPTION
## Fixes #53

## Summary/Motivation:
We previously performed no validation around the external function library location.  This leverages `pyomo.common.fileutils.find_library` to search the filesystem for the specified library (looking in the CWD, plus directories specified the PYOMO_CONFIG_DIR, LD_LIBRARY_PATH, PATH).

## Changes proposed in this PR:
- Search for the external function library, and if found provide the absolute path to to the NL writer
-Add test for warning if the library is not found.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
