### PR TITLE
APPSI: resolve build errors in MSVC

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -67,6 +67,7 @@ ADVANCE CHANGE NOTICE
   - APPSI: Correctly identify changes to constraints (#2299)
   - APPSI: Improvements to persistent interface (#2246)
   - APPSI: Implement FBBT in C++ module (#2248)
+  - APPSI: Resolve build errors on Windows (#2309)
   - GDPopt: Fix bugs in preprocessing (#2211)
   - GDPopt: Switch preprocessing to use FBBT (#2264)
   - incidence_analysis: General improvements (#2239, #2240)

--- a/pyomo/contrib/appsi/build.py
+++ b/pyomo/contrib/appsi/build.py
@@ -49,8 +49,8 @@ def get_appsi_extension(in_setup=False, appsi_root=None):
         package_name = 'appsi_cmodel'
     if sys.platform.startswith('win'):
         # Assume that builds on Windows will use MSVC
-        # MSVC doesn't have a flag for c++11, use c++14
-        extra_args = ['/std:c++14']
+        # MSVC doesn't have a flag for c++11, use c++latest
+        extra_args = ['/std:c++latest']
     else:
         # Assume all other platforms are GCC-like
         extra_args = ['-std=c++11']

--- a/pyomo/contrib/appsi/build.py
+++ b/pyomo/contrib/appsi/build.py
@@ -49,8 +49,8 @@ def get_appsi_extension(in_setup=False, appsi_root=None):
         package_name = 'appsi_cmodel'
     if sys.platform.startswith('win'):
         # Assume that builds on Windows will use MSVC
-        # MSVC doesn't have a flag for c++11, use c++latest
-        extra_args = ['/std:c++latest']
+        # MSVC doesn't have a flag for c++11, use c++14
+        extra_args = ['/std:c++14']
     else:
         # Assume all other platforms are GCC-like
         extra_args = ['-std=c++11']

--- a/pyomo/contrib/appsi/build.py
+++ b/pyomo/contrib/appsi/build.py
@@ -47,7 +47,14 @@ def get_appsi_extension(in_setup=False, appsi_root=None):
         package_name = 'pyomo.contrib.appsi.cmodel.appsi_cmodel'
     else:
         package_name = 'appsi_cmodel'
-    return Pybind11Extension(package_name, sources, extra_compile_args=['-std=c++11'])
+    if sys.platform.startswith('win'):
+        # Assume that builds on Windows will use MSVC
+        # MSVC doesn't have a flag for c++11, use c++14
+        extra_args = ['/std:c++14']
+    else:
+        # Assume all other platforms are GCC-like
+        extra_args = ['-std=c++11']
+    return Pybind11Extension(package_name, sources, extra_compile_args=extra_args)
 
 def build_appsi(args=[]):
     print('\n\n**** Building APPSI ****')

--- a/pyomo/contrib/appsi/cmodel/src/interval.cpp
+++ b/pyomo/contrib/appsi/cmodel/src/interval.cpp
@@ -489,7 +489,7 @@ void _inverse_power1(double zl, double zu, double yl, double yu, double orig_xl,
   interval_exp(*xl, *xu, xl, xu);
 
   // if y is an integer, then x can be negative
-  if (yl == yu and yl == round(yl)) // y is a fixed integer
+  if ((yl == yu) and (yl == round(yl))) // y is a fixed integer
   {
     int y = static_cast<int>(yl);
     if (y == 0) {

--- a/pyomo/contrib/appsi/cmodel/src/interval.cpp
+++ b/pyomo/contrib/appsi/cmodel/src/interval.cpp
@@ -489,7 +489,7 @@ void _inverse_power1(double zl, double zu, double yl, double yu, double orig_xl,
   interval_exp(*xl, *xu, xl, xu);
 
   // if y is an integer, then x can be negative
-  if ((yl == yu) and (yl == round(yl))) // y is a fixed integer
+  if ((yl == yu) && (yl == round(yl))) // y is a fixed integer
   {
     int y = static_cast<int>(yl);
     if (y == 0) {

--- a/pyomo/contrib/appsi/cmodel/src/interval.cpp
+++ b/pyomo/contrib/appsi/cmodel/src/interval.cpp
@@ -706,7 +706,7 @@ void interval_tan(double xl, double xu, double *res_lb, double *res_ub) {
   // minimum value of i such that pi*i + pi/2 >= xl. Then round i up. If pi*i +
   // pi/2 is still less than or equal to xu, then there is an undefined point
   // between xl and xu.
-  if (xl <= -inf or xu >= inf) {
+  if ((xl <= -inf) || (xu >= inf)) {
     *res_lb = -inf;
     *res_ub = inf;
   } else if (_is_inf(xl) || _is_inf(xu))


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This resolves APPSI build errors identified during the Pyomo 6.3.0 release process.

## Changes proposed in this PR:
- Replace logical `and` and `or` with `&&` and `||`
- Force inclusion of `/std:c++14` on Windows build

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
