### PR TITLE
Remove Python 3.6 support

### DIFF
--- a/.coin-or/projDesc.xml
+++ b/.coin-or/projDesc.xml
@@ -287,7 +287,7 @@ Carl D. Laird, Chair, Pyomo Management Committee, claird at andrew dot cmu dot e
 
 			<platform>
 				<operatingSystem>Any</operatingSystem>
-				<compiler>Python 3.6, 3.7, 3.8, 3.9, 3.10</compiler>
+				<compiler>Python 3.7, 3.8, 3.9, 3.10</compiler>
 			</platform>
 
 		</testedPlatforms>

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Build manylinux Python wheels
       uses: RalfG/python-wheels-manylinux-build@v0.4.0-manylinux2010_x86_64
       with:
-        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
+        python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
         build-requirements: 'cython pybind11'
         package-path: ''
         pip-wheel-args: ''
@@ -83,7 +83,7 @@ jobs:
     - name: Build manylinux Python wheels
       uses: RalfG/python-wheels-manylinux-build@v0.4.0-manylinux2014_aarch64
       with:
-        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
+        python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39'
         build-requirements: 'cython'
         package-path: ''
         pip-wheel-args: ''
@@ -141,7 +141,7 @@ jobs:
         include:
         - os: macos-latest
           TARGET: osx
-        python-version: [ 3.6, 3.7, 3.8, 3.9, '3.10' ]
+        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -172,7 +172,7 @@ jobs:
         include:
         - os: windows-latest
           TARGET: win
-        python-version: [ 3.6, 3.7, 3.8, 3.9, '3.10' ]
+        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -294,17 +294,6 @@ jobs:
                 | tr ":" "\\n" | grep -v runner | tr "\n" ":"`' >> $profile
         done
 
-    #############################################################
-    # TODO: Delete this once Python 3.6 is deprecated - 12/2021 #
-    #############################################################
-    - name: Windows Python 3.6 Temporary Fix (conda)
-      if: |
-        (matrix.PYENV == 'conda' &&
-        matrix.TARGET == 'win' &&
-        matrix.python == '3.6')
-      run: |
-        conda install tomli==1.2.2 --force-reinstall
-
     - name: Setup TPL package directories
       run: |
         TPL_DIR="${GITHUB_WORKSPACE}/cache/tpl"
@@ -563,17 +552,17 @@ jobs:
 
 
   bare-python-env:
-    name: linux/3.6/bare-env
+    name: linux/3.8/bare-env
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
     - name: Checkout Pyomo source
       uses: actions/checkout@v2
 
-    - name: Set up Python 3.6
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.8
 
     - name: Install Pyomo
       run: |

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.6, 3.7, 3.8, 3.9, '3.10', pypy3]
+        python: [3.7, 3.8, 3.9, '3.10', pypy3]
         other: [""]
         category: [""]
 
@@ -313,17 +313,6 @@ jobs:
                 | tr ":" "\\n" | grep -v runner | tr "\n" ":"`' >> $profile
         done
 
-    #############################################################
-    # TODO: Delete this once Python 3.6 is deprecated - 12/2021 #
-    #############################################################
-    - name: Windows Python 3.6 Temporary Fix (conda)
-      if: |
-        (matrix.PYENV == 'conda' &&
-        matrix.TARGET == 'win' &&
-        matrix.python == '3.6')
-      run: |
-        conda install tomli==1.2.2 --force-reinstall
-
     - name: Setup TPL package directories
       run: |
         TPL_DIR="${GITHUB_WORKSPACE}/cache/tpl"
@@ -582,17 +571,17 @@ jobs:
 
 
   bare-python-env:
-    name: linux/3.6/bare-env
+    name: linux/3.8/bare-env
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
     - name: Checkout Pyomo source
       uses: actions/checkout@v2
 
-    - name: Set up Python 3.6
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.8
 
     - name: Install Pyomo
       run: |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Pyomo is available under the BSD License, see the LICENSE.txt file.
 
 Pyomo is currently tested with the following Python implementations:
 
-* CPython: 3.6, 3.7, 3.8, 3.9, 3.10
+* CPython: 3.7, 3.8, 3.9, 3.10
 * PyPy: 3
 
 ### Installation

--- a/doc/OnlineDocs/contributed_packages/mcpp.rst
+++ b/doc/OnlineDocs/contributed_packages/mcpp.rst
@@ -44,11 +44,11 @@ You will need to compile this file using the following command:
 
 .. code::
 
-    g++ -I $MCPP_PATH/src/3rdparty/fadbad++ -I $MCPP_PATH/src/mc -I /usr/include/python3.6 -fPIC -O2 -c mcppInterface.cpp
+    g++ -I $MCPP_PATH/src/3rdparty/fadbad++ -I $MCPP_PATH/src/mc -I /usr/include/python3.7 -fPIC -O2 -c mcppInterface.cpp
 
 This links the MC++ required library FADBAD++, MC++ itself, and Python to compile the Pyomo-MC++ interface.
 If successful, you will now have a file named ``mcppInterface.o`` in your working directory.
-If you are not using Python 3.6, you will need to link to the appropriate Python version.
+If you are not using Python 3.7, you will need to link to the appropriate Python version.
 You now need to create a shared object file with the following command:
 
 .. code::

--- a/doc/OnlineDocs/installation.rst
+++ b/doc/OnlineDocs/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 Pyomo currently supports the following versions of Python:
 
-* CPython: 3.6, 3.7, 3.8, 3.9, 3.10
+* CPython: 3.7, 3.8, 3.9, 3.10
 * PyPy: 3
 
 

--- a/pyomo/core/kernel/block.py
+++ b/pyomo/core/kernel/block.py
@@ -8,16 +8,8 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import sys
 import logging
 import math
-
-if sys.version_info[:2] >= (3,7):
-    # dict became ordered in CPython 3.6 and added to the standard in 3.7
-    _ordered_dict_ = dict
-else:
-    import collections
-    _ordered_dict_ = collections.OrderedDict
 
 from pyomo.core.staleflag import StaleFlagManager
 from pyomo.core.expr.symbol_map import SymbolMap
@@ -98,16 +90,16 @@ class block(IBlock):
         d['_storage_key'] = None
         d['_active'] = True
         d['_block__byctype'] = None
-        d['_block__order'] = _ordered_dict_()
+        d['_block__order'] = dict()
 
     def _activate_large_storage_mode(self):
-        if self.__byctype.__class__ is not _ordered_dict_:
+        if self.__byctype.__class__ is not dict:
             self_byctype = \
-                self.__dict__['_block__byctype'] = _ordered_dict_()
+                self.__dict__['_block__byctype'] = dict()
             for key, obj in self.__order.items():
                 ctype = obj.ctype
                 if ctype not in self_byctype:
-                    self_byctype[ctype] = _ordered_dict_()
+                    self_byctype[ctype] = dict()
                 self_byctype[ctype][key] = obj
 
     #
@@ -132,7 +124,7 @@ class block(IBlock):
                     ctypes_set.add(child_ctype)
                     ctypes.append(child_ctype)
             return tuple(ctypes)
-        elif self_byctype.__class__ is _ordered_dict_:
+        elif self_byctype.__class__ is dict:
             # large-block storage
             return tuple(self_byctype)
         else:
@@ -165,7 +157,7 @@ class block(IBlock):
 
         if ctype is _no_ctype:
             yield from self.__order.values()
-        elif self_byctype.__class__ is _ordered_dict_:
+        elif self_byctype.__class__ is dict:
             # large-block storage
             if ctype in self_byctype:
                 yield from self_byctype[ctype].values()
@@ -227,10 +219,10 @@ class block(IBlock):
                 if self_byctype is None:
                     # storing a single ctype
                     self.__dict__['_block__byctype'] = ctype
-                elif self_byctype.__class__ is _ordered_dict_:
+                elif self_byctype.__class__ is dict:
                     # large-block storage
                     if ctype not in self_byctype:
-                        self_byctype[ctype] = _ordered_dict_()
+                        self_byctype[ctype] = dict()
                     self_byctype[ctype][name] = obj
                 elif self_byctype.__class__ is int:
                     # small-block storage
@@ -269,7 +261,7 @@ class block(IBlock):
             del self_order[name]
             obj._clear_parent_and_storage_key()
             self_byctype = self.__byctype
-            if self_byctype.__class__ is _ordered_dict_:
+            if self_byctype.__class__ is dict:
                 # large-block storage
                 ctype = obj.ctype
                 del self_byctype[ctype][name]

--- a/pyomo/core/kernel/dict_container.py
+++ b/pyomo/core/kernel/dict_container.py
@@ -8,18 +8,11 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import sys
 import logging
 import collections.abc
 
 from pyomo.core.kernel.homogeneous_container import \
     IHomogeneousContainer
-
-if sys.version_info[:2] >= (3,7):
-    # dict became ordered in CPython 3.6 and added to the standard in 3.7
-    _ordered_dict_ = dict
-else:
-    _ordered_dict_ = collections.OrderedDict
 
 logger = logging.getLogger('pyomo.core')
 
@@ -44,7 +37,7 @@ class DictContainer(IHomogeneousContainer,
     _child_storage_entry_string = "[%s]"
 
     def __init__(self, *args, **kwds):
-        self._data = _ordered_dict_()
+        self._data = dict()
         if len(args) > 0:
             if len(args) > 1:
                 raise TypeError(

--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,6 @@ setup_kwargs = dict(
         'Operating System :: Unix',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -197,7 +196,7 @@ setup_kwargs = dict(
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Software Development :: Libraries :: Python Modules' ],
-    python_requires = '>=3.6',
+    python_requires = '>=3.7',
     install_requires = [
         'ply',
     ],


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:

Pyomo 6.3.0 was the last release to support Python 3.6. This PR removes all support for 3.6.

## Changes proposed in this PR:
- Remove Python 3.6 support
- Fix "hacks" that were necessary for Python 3.6

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
