### PR TITLE
Distribute the `ampl_function_demo` C source / cmake files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -247,6 +247,7 @@ setup_kwargs = dict(
     },
     packages = find_packages(exclude=("scripts",)),
     package_data = {
+        "pyomo.contrib.ampl_function_demo": ["src/*"],
         "pyomo.contrib.appsi.cmodel": ["src/*"],
         "pyomo.contrib.mcpp": ["*.cpp"],
         "pyomo.contrib.pynumero": ['src/*', 'src/tests/*'],


### PR DESCRIPTION
## Fixes #2317

## Summary/Motivation:
The new `contrib.ampl_function_demo` module's sources are missing from the `setup.py` `package_data` directive.  This resolves that issue.

## Changes proposed in this PR:
- Include `contrib/ampl_function_demo/src`  in distribution data

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
