### PR TITLE
APPSI: update Gurobi solver unavailable message

### DIFF
--- a/pyomo/contrib/appsi/base.py
+++ b/pyomo/contrib/appsi/base.py
@@ -464,6 +464,12 @@ class Solver(abc.ABC):
         def __bool__(self):
             return self._value_ > 0
 
+        def __format__(self, format_spec):
+            # We want general formatting of this Enum to return the
+            # formatted string value and not the int (which is the
+            # default implementation from IntEnum)
+            return format(str(self).split('.')[-1], format_spec)
+
     @abc.abstractmethod
     def solve(self, model: _BlockData, timer: HierarchicalTimer = None) -> Results:
         """

--- a/pyomo/contrib/appsi/solvers/tests/test_gurobi_persistent.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_gurobi_persistent.py
@@ -1,3 +1,4 @@
+from pyomo.common.errors import PyomoException
 import pyomo.common.unittest as unittest
 import pyomo.environ as pe
 from pyomo.contrib.appsi.solvers.gurobi import Gurobi
@@ -76,6 +77,17 @@ class TestGurobiPersistentSimpleLPUpdates(unittest.TestCase):
         self.assertAlmostEqual(x, self.m.x.value)
         self.assertAlmostEqual(y, self.m.y.value)
 
+    def test_set_instance_not_available(self):
+        _avail = Gurobi._available
+        try:
+            Gurobi._available = Gurobi.Availability.NeedsCompiledExtension
+            with self.assertRaisesRegex(
+                    PyomoException,
+                    r'Solver pyomo.contrib.appsi.solvers.gurobi.Gurobi '
+                    r'is not available \(NeedsCompiledExtension\).'):
+                opt.set_instance(pe.ConcreteModel())
+        finally:
+            Gurobi._available = _avail
 
 @unittest.skipUnless(cmodel_available, 'appsi extensions are not available')
 class TestGurobiPersistent(unittest.TestCase):


### PR DESCRIPTION
## Fixes #N/A .

## Summary/Motivation:

#2316 noted that the error raised when the APPSI Gurobi interface was not available was not at all helpful in identifying *why* the solver was unavailable.  This resolves that to produce a more informative (and consistent) error message.

## Changes proposed in this PR:
- Always raise a `PyomoException` when APPSI's Gurobi solver is not available.
- Update `Solver.Availability` to print a straing (and not a number) when printed using a f-string

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
