### PR TITLE
Don't use polynomial_degree to check for linear and constant expressions in preprocessing transformations

### DIFF
--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -279,6 +279,28 @@ class TestGDPopt(unittest.TestCase):
         self.assertFalse(value(m.disj.disjuncts[0].indicator_var))
         self.assertTrue(value(m.disj.disjuncts[1].indicator_var))
 
+    def test_subproblem_preprocessing_encounters_trivial_constraints(self):
+        m = ConcreteModel()
+        m.x = Var(bounds=(0, 10))
+        m.z = Var(bounds=(-10, 10))
+        m.disjunction = Disjunction(expr=[[m.x == 0, m.z >= 4], 
+                                          [m.x + m.z <= 0]])
+        m.cons = Constraint(expr=m.x*m.z <= 0)
+        m.obj = Objective(expr=-m.z)
+        m.disjunction.disjuncts[0].indicator_var.fix(True)
+        m.disjunction.disjuncts[1].indicator_var.fix(False)
+        SolverFactory('gdpopt').solve(m, strategy='RIC', mip_solver=mip_solver,
+                                      nlp_solver=nlp_solver,
+                                      init_strategy='fix_disjuncts')
+        # The real test is that this doesn't throw an error when we preprocess
+        # to solve the first subproblem (in the initialization). The nonlinear
+        # constraint becomes trivial, which we need to make sure is handled
+        # correctly.
+        self.assertEqual(value(m.x), 0)
+        self.assertEqual(value(m.z), 10)
+        self.assertTrue(value(m.disjunction.disjuncts[0].indicator_var))
+        self.assertFalse(value(m.disjunction.disjuncts[1].indicator_var))
+
     @unittest.skipUnless(sympy_available, "Sympy not available")
     def test_logical_constraints_on_disjuncts(self):
         m = models.makeLogicalConstraintsOnDisjuncts()

--- a/pyomo/contrib/preprocessing/plugins/remove_zero_terms.py
+++ b/pyomo/contrib/preprocessing/plugins/remove_zero_terms.py
@@ -39,9 +39,11 @@ class RemoveZeroTerms(IsomorphicTransformation):
 
         for constr in m.component_data_objects(
                 ctype=Constraint, active=True, descend_into=True):
-            if not constr.body.polynomial_degree() == 1:
-                continue  # we currently only process linear constraints
             repn = generate_standard_repn(constr.body)
+            if not repn.is_linear() or repn.is_constant():
+                continue  # we currently only process linear constraints, and we
+                          # assume that trivial constraints have already been
+                          # deactivated
 
             # get the index of all nonzero coefficient variables
             nonzero_vars_indx = [

--- a/pyomo/contrib/preprocessing/plugins/remove_zero_terms.py
+++ b/pyomo/contrib/preprocessing/plugins/remove_zero_terms.py
@@ -43,7 +43,8 @@ class RemoveZeroTerms(IsomorphicTransformation):
             if not repn.is_linear() or repn.is_constant():
                 continue  # we currently only process linear constraints, and we
                           # assume that trivial constraints have already been
-                          # deactivated
+                          # deactivated or will be deactivated in a different
+                          # step
 
             # get the index of all nonzero coefficient variables
             nonzero_vars_indx = [

--- a/pyomo/contrib/preprocessing/tests/test_deactivate_trivial_constraints.py
+++ b/pyomo/contrib/preprocessing/tests/test_deactivate_trivial_constraints.py
@@ -110,6 +110,17 @@ class TestTrivialConstraintDeactivator(unittest.TestCase):
 
         self.assertFalse(m.c.active)
 
+    def test_higher_degree_trivial_constraint(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var()
+        m.z = Var()
+        m.c = Constraint(expr=(m.x**2 + m.y)*m.z >= -8)
+        m.z.fix(0)
+        TransformationFactory(
+            'contrib.deactivate_trivial_constraints').apply_to(m)
+        self.assertFalse(m.c.active)
+
     def test_trivial_linear_constraint_due_to_cancellation(self):
         m = ConcreteModel()
         m.x = Var()

--- a/pyomo/contrib/preprocessing/tests/test_deactivate_trivial_constraints.py
+++ b/pyomo/contrib/preprocessing/tests/test_deactivate_trivial_constraints.py
@@ -98,6 +98,28 @@ class TestTrivialConstraintDeactivator(unittest.TestCase):
         TransformationFactory(
             'contrib.deactivate_trivial_constraints').apply_to(m)
 
+    def test_trivial_constraint_due_to_0_coefficient(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var()
+        m.y.fix(0)
+        m.c = Constraint(expr=m.x*m.y >= 0)
+
+        TransformationFactory(
+            'contrib.deactivate_trivial_constraints').apply_to(m)
+
+        self.assertFalse(m.c.active)
+
+    def test_trivial_linear_constraint_due_to_cancellation(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.c = Constraint(expr=m.x - m.x <= 0)
+
+        TransformationFactory(
+            'contrib.deactivate_trivial_constraints').apply_to(m)
+
+        self.assertFalse(m.c.active)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyomo/contrib/preprocessing/tests/test_zero_term_removal.py
+++ b/pyomo/contrib/preprocessing/tests/test_zero_term_removal.py
@@ -3,6 +3,7 @@ import pyomo.common.unittest as unittest
 from pyomo.environ import (ConcreteModel, Constraint, TransformationFactory,
                            Var)
 from pyomo.core.expr import current as EXPR
+from pyomo.repn import generate_standard_repn
 
 
 class TestRemoveZeroTerms(unittest.TestCase):
@@ -33,6 +34,27 @@ class TestRemoveZeroTerms(unittest.TestCase):
         self.assertFalse(any(id(m.v1) == id(v)
                              for v in EXPR.identify_variables(m.c4.body)))
 
+    def test_trivial_constraints_skipped(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var()
+        m.z = Var()
+        m.c = Constraint(expr=(m.x + m.y)*m.z >= 8)
+        m.z.fix(0)
+        TransformationFactory('contrib.remove_zero_terms').apply_to(m)
+        m.z.unfix()
+        # check constraint is unchanged
+        self.assertEqual(m.c.lower, 8)
+        self.assertIsNone(m.c.upper)
+        repn = generate_standard_repn(m.c.body)
+        self.assertTrue(repn.is_quadratic())
+        self.assertEqual(repn.quadratic_coefs[0], 1)
+        self.assertEqual(repn.quadratic_coefs[1], 1)
+        self.assertIs(repn.quadratic_vars[0][0], m.x)
+        self.assertIs(repn.quadratic_vars[0][1], m.z)
+        self.assertIs(repn.quadratic_vars[1][0], m.y)
+        self.assertIs(repn.quadratic_vars[1][1], m.z)
+        self.assertEqual(repn.constant, 0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Fixes #2271 

## Summary/Motivation:

Due to the behaviors in #2301, there are several cases where the contrib.preprocessing transformations should rely on `generate_standard_repn` and not `polynomial_degree` to determine linear and constant expressions. This has implications for GDPopt, since it can lead to errors in the preprocessing of the NLP subproblems due to trivial constraints.

## Changes proposed in this PR:
- `deactivate_trivial_constraints` uses standard_repn to determine if constraint bodies are constant
- `remove_zero_terms` does not do anything with trivial constraints: It assumes `deactivate_trivial_constraints` will be called before or after if trivial constraints are a problem.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
