### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -171,6 +171,10 @@ setup_kwargs = dict(
     maintainer = 'Pyomo Developer Team',
     maintainer_email = 'pyomo-developers@googlegroups.com',
     url = 'http://pyomo.org',
+    project_urls = {
+        'Documentation': 'https://pyomo.readthedocs.io/en/stable/',
+        'Source': 'https://github.com/Pyomo/pyomo',
+    },
     license = 'BSD',
     platforms = ["any"],
     description = 'Pyomo: Python Optimization Modeling Objects',


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
