### PR TITLE
Remove APPSI Distributables from Windows

### DIFF
--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -168,9 +168,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
+        os: [windows-2019]
         include:
-        - os: windows-latest
+        - os: windows-2019
           TARGET: win
         python-version: [ 3.7, 3.8, 3.9, '3.10' ]
     steps:

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -168,9 +168,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019]
+        os: [windows-latest]
         include:
-        - os: windows-2019
+        - os: windows-latest
           TARGET: win
         python-version: [ 3.7, 3.8, 3.9, '3.10' ]
     steps:

--- a/setup.py
+++ b/setup.py
@@ -104,12 +104,14 @@ if (('--with-distributable-extensions' in sys.argv)
         pass
     #
     # Import the APPSI extension builder
-    #
-    appsi_extension = import_pyomo_module(
-        'pyomo', 'contrib', 'appsi', 'build.py')['get_appsi_extension'](
-            in_setup=True, appsi_root=os.path.join(
-                os.path.dirname(__file__), 'pyomo', 'contrib', 'appsi'))
-    ext_modules.append(appsi_extension)
+    # NOTE: There is inconsistent behavior in Windows for APPSI.
+    # As a result, we will NOT include these extensions in Windows.
+    if not sys.platform.startswith('win'):
+        appsi_extension = import_pyomo_module(
+            'pyomo', 'contrib', 'appsi', 'build.py')['get_appsi_extension'](
+                in_setup=True, appsi_root=os.path.join(
+                    os.path.dirname(__file__), 'pyomo', 'contrib', 'appsi'))
+        ext_modules.append(appsi_extension)
 
 
 class DependenciesCommand(Command):


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
The APPSI distributables are inconsistent in behavior on Windows. They would consistently with `conda` on 3.7 and 3.8, but not on 3.9+; with `pip`, it seems to depend on machine. As a result, rather than try to chase down the issue, we are going to remove APPSI distributables from the release.

## Changes proposed in this PR:
- Remove APPSI distributables for Windows

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
