### PR TITLE
[WIP] Add a QuadraticExpression node

### DIFF
--- a/pyomo/core/expr/compare.py
+++ b/pyomo/core/expr/compare.py
@@ -16,7 +16,7 @@ from .numeric_expr import (
     NPV_ProductExpression, NPV_DivisionExpression, NPV_PowExpression,
     NPV_SumExpression, NPV_NegationExpression, NPV_UnaryFunctionExpression,
     NPV_ExternalFunctionExpression, Expr_ifExpression, AbsExpression,
-    NPV_AbsExpression, NumericValue)
+    NPV_AbsExpression, NumericValue, QuadraticExpression)
 from pyomo.core.expr.logical_expr import (
     RangedExpression, InequalityExpression, EqualityExpression
 )
@@ -29,6 +29,14 @@ def handle_linear_expression(node: LinearExpression, pn: List):
     pn.append(node.constant)
     pn.extend(node.linear_coefs)
     pn.extend(node.linear_vars)
+    return tuple()
+
+
+def handle_quadratic_expression(node: QuadraticExpression, pn: List):
+    pn.append((type(node), 3*node.nargs()))
+    pn.extend(node.coefs)
+    pn.extend(node.vars_1)
+    pn.extend(node.vars_2)
     return tuple()
 
 
@@ -76,6 +84,7 @@ handler[NPV_AbsExpression] = handle_unary_expression
 handler[RangedExpression] = handle_expression
 handler[InequalityExpression] = handle_expression
 handler[EqualityExpression] = handle_expression
+handler[QuadraticExpression] = handle_quadratic_expression
 
 
 class PrefixVisitor(StreamBasedExpressionVisitor):

--- a/pyomo/core/expr/current.py
+++ b/pyomo/core/expr/current.py
@@ -66,6 +66,7 @@ if _mode == Mode.pyomo5_trees:
                                               NPV_UnaryFunctionExpression,
                                               AbsExpression, NPV_AbsExpression,
                                               LinearExpression,
+                                              QuadraticExpression,
                                               _MutableLinearExpression,
                                               decompose_term,
                                               LinearDecompositionError,

--- a/pyomo/repn/standard_repn.py
+++ b/pyomo/repn/standard_repn.py
@@ -877,6 +877,7 @@ _repn_collectors = {
     EXPR.AbsExpression                          : _collect_nonl,
     EXPR.NegationExpression                     : _collect_negation,
     EXPR.LinearExpression                       : _collect_linear,
+    EXPR.QuadraticExpression                    : _collect_sum,
     EXPR.InequalityExpression                   : _collect_comparison,
     EXPR.RangedExpression                       : _collect_comparison,
     EXPR.EqualityExpression                     : _collect_comparison,


### PR DESCRIPTION
## Fixes #1761, #230.

## Summary/Motivation:
This PR adds a `QuadraticExpression` node to the expression system. This PR does not add any special handling of `QuadraticExpression` (that can be added later as needed). 

This can reduce the construction time for quadratic constraints and it allows Pyomo-based algorithms to add special handling of quadratic constraints.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
