### PR TITLE
Fix PyROS Variable Default Initialization

### DIFF
--- a/pyomo/contrib/pyros/pyros_algorithm_methods.py
+++ b/pyomo/contrib/pyros/pyros_algorithm_methods.py
@@ -101,8 +101,12 @@ def ROSolver_iterative_solve(model_data, config):
         )
     elif config.objective_focus is ObjectiveType.worst_case:
         # === Worst-case cost objective
-        master_data.master_model.zeta = Var(initialize=value(master_data.master_model.scenarios[0, 0].first_stage_objective +
-                                                            master_data.master_model.scenarios[0, 0].second_stage_objective))
+        master_data.master_model.zeta = Var(
+                initialize=value(
+                    master_data.master_model.scenarios[0, 0].first_stage_objective +
+                    master_data.master_model.scenarios[0, 0].second_stage_objective,
+                    exception=False)
+        )
         master_data.master_model.obj = Objective(expr=master_data.master_model.zeta)
         master_data.master_model.scenarios[0,0].epigraph_constr = Constraint(expr=
                         master_data.master_model.scenarios[0, 0].first_stage_objective +

--- a/pyomo/contrib/pyros/tests/test_grcs.py
+++ b/pyomo/contrib/pyros/tests/test_grcs.py
@@ -2175,5 +2175,83 @@ class testBypassingSeparation(unittest.TestCase):
                          msg="Returned termination condition is not return robust_optimal.")
 
 
+@unittest.skipUnless(SolverFactory('baron').available(exception_flag=False)
+                     and SolverFactory('baron').license_is_valid(),
+                     "Global NLP solver is not available and licensed.")
+class testUninitializedVars(unittest.TestCase):
+    def test_uninitialized_vars(self):
+        """
+        Test a simple PyROS model instance with uninitialized
+        first-stage and second-stage variables.
+        """
+        m = ConcreteModel()
+
+        # parameters
+        m.ell0 = Param(initialize=1)
+        m.u0 = Param(initialize=3)
+        m.ell = Param(initialize=1)
+        m.u = Param(initialize=5)
+        m.p = Param(initialize=m.u0, mutable=True)
+        m.r = Param(initialize=0.1)
+
+        # variables
+        m.x = Var(bounds=(m.ell0, m.u0))
+        m.z = Var(bounds=(m.ell0, m.p))
+        m.t = Var(initialize=1, bounds=(0, m.r))
+
+        # objectives
+        m.obj = Objective(expr=-m.x ** 2 + m.z ** 2)
+
+        # auxiliary constraints
+        m.t_lb_con = Constraint(expr=m.x - m.z <= m.t)
+        m.t_ub_con = Constraint(expr=-m.t <= m.x - m.z)
+
+        # other constraints
+        m.con1 = Constraint(expr=m.x - m.z >= 0.1)
+
+        box_set = BoxSet(
+                bounds=((value(m.ell), value(m.u)),)
+        )
+
+        # solvers
+        local_solver = SolverFactory("ipopt")
+        global_solver = SolverFactory("baron")
+
+        # pyros setup
+        pyros_solver = SolverFactory("pyros")
+
+        # solve for different decision rule orders
+        for dr_order in [0, 1, 2]:
+            model = m.clone()
+
+            # degree of freedom partitioning
+            fsv = [model.x]
+            ssv = [model.z, model.t]
+
+            # uncertainty
+            uncertain_params = [model.p]
+
+            res = pyros_solver.solve(
+                    model=model,
+                    first_stage_variables=fsv,
+                    second_stage_variables=ssv,
+                    uncertain_params=uncertain_params,
+                    uncertainty_set=box_set,
+                    local_solver=local_solver,
+                    global_solver=global_solver,
+                    objective_focus=ObjectiveType.worst_case,
+                    decision_rule_order=2,
+                    solve_master_globally=True
+            )
+
+            self.assertEqual(
+                    res.pyros_termination_condition,
+                    pyrosTerminationCondition.robust_optimal,
+                    msg=("Returned termination condition for solve with"
+                         f"decision rule order {dr_order} is not return "
+                         "robust_optimal.")
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/contrib/pyros/tests/test_grcs.py
+++ b/pyomo/contrib/pyros/tests/test_grcs.py
@@ -2198,6 +2198,7 @@ class testUninitializedVars(unittest.TestCase):
         m.x = Var(bounds=(m.ell0, m.u0))
         m.z = Var(bounds=(m.ell0, m.p))
         m.t = Var(initialize=1, bounds=(0, m.r))
+        m.w = Var(bounds=(0, 1))
 
         # objectives
         m.obj = Objective(expr=-m.x ** 2 + m.z ** 2)
@@ -2208,6 +2209,7 @@ class testUninitializedVars(unittest.TestCase):
 
         # other constraints
         m.con1 = Constraint(expr=m.x - m.z >= 0.1)
+        m.eq_con = Constraint(expr=m.w == 0.5 * m.t)
 
         box_set = BoxSet(
                 bounds=((value(m.ell), value(m.u)),)
@@ -2227,8 +2229,6 @@ class testUninitializedVars(unittest.TestCase):
             # degree of freedom partitioning
             fsv = [model.x]
             ssv = [model.z, model.t]
-
-            # uncertainty
             uncertain_params = [model.p]
 
             res = pyros_solver.solve(

--- a/pyomo/contrib/pyros/util.py
+++ b/pyomo/contrib/pyros/util.py
@@ -707,8 +707,11 @@ def add_decision_rule_variables(model_data, config):
     bounds = (None, None)
     if degree == 0:
         for i in range(len(second_stage_variables)):
-            model_data.working_model.add_component("decision_rule_var_" + str(i),
-                                                   Var(initialize=value(second_stage_variables[i]),bounds=bounds,domain=Reals))#bounds=(second_stage_variables[i].lb, second_stage_variables[i].ub)))
+            model_data.working_model.add_component(
+                    "decision_rule_var_" + str(i),
+                    Var(initialize=value(second_stage_variables[i], exception=False),
+                        bounds=bounds,domain=Reals)
+            )#bounds=(second_stage_variables[i].lb, second_stage_variables[i].ub)))
             first_stage_variables.extend(getattr(model_data.working_model, "decision_rule_var_" + str(i)).values())
             decision_rule_vars.append(getattr(model_data.working_model, "decision_rule_var_" + str(i)))
     elif degree == 1:
@@ -729,7 +732,7 @@ def add_decision_rule_variables(model_data, config):
             dict_init = {}
             for r in range(num_vars):
                 if r == 0:
-                    dict_init.update({r: value(second_stage_variables[i])})
+                    dict_init.update({r: value(second_stage_variables[i], exception=False)})
                 else:
                     dict_init.update({r: 0})
             model_data.working_model.add_component("decision_rule_var_" + str(i),

--- a/pyomo/contrib/pyros/util.py
+++ b/pyomo/contrib/pyros/util.py
@@ -723,7 +723,7 @@ def add_decision_rule_variables(model_data, config):
                         bounds=bounds,
                         domain=Reals))#bounds=(second_stage_variables[i].lb, second_stage_variables[i].ub)))
             # === For affine drs, the [0]th constant term is initialized to the control variable values, all other terms are initialized to 0
-            getattr(model_data.working_model, "decision_rule_var_" + str(i))[0].set_value(value(second_stage_variables[i]), skip_validation=True)
+            getattr(model_data.working_model, "decision_rule_var_" + str(i))[0].set_value(value(second_stage_variables[i], exception=False), skip_validation=True)
             first_stage_variables.extend(list(getattr(model_data.working_model, "decision_rule_var_" + str(i)).values()))
             decision_rule_vars.append(getattr(model_data.working_model, "decision_rule_var_" + str(i)))
     elif degree == 2 or degree == 3 or degree == 4:
@@ -746,7 +746,6 @@ def add_decision_rule_variables(model_data, config):
             "Decision rule order " + str(config.decision_rule_order) +
             " is not yet supported. PyROS supports polynomials of degree 0 (static approximation), 1, 2.")
     model_data.working_model.util.decision_rule_vars = decision_rule_vars
-    return
 
 
 def partition_powers(n, v):
@@ -830,7 +829,6 @@ def add_decision_rule_constraints(model_data, config):
                 raise RuntimeError("Construction of the decision rule functions did not work correctly! "
                                    "Did not use all coefficient terms.")
     model_data.working_model.util.decision_rule_eqns = decision_rule_eqns
-    return
 
 
 def identify_objective_functions(model, config):

--- a/pyomo/contrib/pyros/util.py
+++ b/pyomo/contrib/pyros/util.py
@@ -711,7 +711,7 @@ def add_decision_rule_variables(model_data, config):
                     "decision_rule_var_" + str(i),
                     Var(initialize=value(second_stage_variables[i], exception=False),
                         bounds=bounds,domain=Reals)
-            )#bounds=(second_stage_variables[i].lb, second_stage_variables[i].ub)))
+            )
             first_stage_variables.extend(getattr(model_data.working_model, "decision_rule_var_" + str(i)).values())
             decision_rule_vars.append(getattr(model_data.working_model, "decision_rule_var_" + str(i)))
     elif degree == 1:
@@ -721,7 +721,7 @@ def add_decision_rule_variables(model_data, config):
                     Var(index_set,
                         initialize=0,
                         bounds=bounds,
-                        domain=Reals))#bounds=(second_stage_variables[i].lb, second_stage_variables[i].ub)))
+                        domain=Reals))
             # === For affine drs, the [0]th constant term is initialized to the control variable values, all other terms are initialized to 0
             getattr(model_data.working_model, "decision_rule_var_" + str(i))[0].set_value(value(second_stage_variables[i], exception=False), skip_validation=True)
             first_stage_variables.extend(list(getattr(model_data.working_model, "decision_rule_var_" + str(i)).values()))


### PR DESCRIPTION
## Summary/Motivation:
PyROS does not gracefully handle models with:
- uninitialized variables on which the objective function is contingent
- uninitialized second stage variables

as auxiliary variables are initialized to values using the `value()` method. In either case, an exception is raised by the `value()` method.

## Changes proposed in this PR:
- add `exception=False` option to the `value()` method calls used for initializing epigraph and decision rule variables. Consequently, by default, auxiliary variables are not initialized if any of the variables used to
initialize the auxiliary variables are not initialized.
- add a corresponding unit test

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
