### PR TITLE
Add Windows `pip` single test

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -87,6 +87,7 @@ jobs:
 
         - os: windows-latest
           python: 3.8
+          other: /pip
           skip_doctest: 1
           TARGET: win
           PYENV: pip
@@ -299,6 +300,15 @@ jobs:
                 | tr ":" "\\n" | grep runner | tr "\n" ":"`:`echo "$PATH" \
                 | tr ":" "\\n" | grep -v runner | tr "\n" ":"`' >> $profile
         done
+
+    - name: Setup TPL package directories
+      run: |
+        TPL_DIR="${GITHUB_WORKSPACE}/cache/tpl"
+        mkdir -p "$TPL_DIR"
+        DOWNLOAD_DIR="${GITHUB_WORKSPACE}/cache/download"
+        mkdir -p "$DOWNLOAD_DIR"
+        echo "TPL_DIR=$TPL_DIR" >> $GITHUB_ENV
+        echo "DOWNLOAD_DIR=$DOWNLOAD_DIR" >> $GITHUB_ENV
 
     - name: Install Ipopt
       if: ${{ ! matrix.slim }}

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -85,6 +85,12 @@ jobs:
           PYENV: pip
           PACKAGES: cython
 
+        - os: windows-latest
+          python: 3.8
+          skip_doctest: 1
+          TARGET: win
+          PYENV: pip
+
     steps:
     - name: Checkout Pyomo source
       uses: actions/checkout@v2
@@ -293,15 +299,6 @@ jobs:
                 | tr ":" "\\n" | grep runner | tr "\n" ":"`:`echo "$PATH" \
                 | tr ":" "\\n" | grep -v runner | tr "\n" ":"`' >> $profile
         done
-
-    - name: Setup TPL package directories
-      run: |
-        TPL_DIR="${GITHUB_WORKSPACE}/cache/tpl"
-        mkdir -p "$TPL_DIR"
-        DOWNLOAD_DIR="${GITHUB_WORKSPACE}/cache/download"
-        mkdir -p "$DOWNLOAD_DIR"
-        echo "TPL_DIR=$TPL_DIR" >> $GITHUB_ENV
-        echo "DOWNLOAD_DIR=$DOWNLOAD_DIR" >> $GITHUB_ENV
 
     - name: Install Ipopt
       if: ${{ ! matrix.slim }}

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -102,6 +102,7 @@ jobs:
 
         - os: windows-latest
           python: 3.8
+          other: /pip
           skip_doctest: 1
           TARGET: win
           PYENV: pip

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -100,6 +100,12 @@ jobs:
           PYENV: pip
           PACKAGES: pyutilib
 
+        - os: windows-latest
+          python: 3.8
+          skip_doctest: 1
+          TARGET: win
+          PYENV: pip
+
         exclude:
         - {os: macos-latest, python: pypy3}
         - {os: windows-latest, python: pypy3}


### PR DESCRIPTION
## Fixes #2310 

## Summary/Motivation:
As noted in the issue, we missed a bug in a PR because we do not test the `win/pip` environment combination. This adds a single test to the test suite so we can make sure to cover that case.

## Changes proposed in this PR:
- Add single test for `win/pip`
- NOTE: Does not run doctests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
