### PR TITLE
HierarchicalTimer: use constant indentation for very long lines

### DIFF
--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -242,3 +242,53 @@ all                    1     [0-9.]+ +[0-9.]+ +100.0
         self.assertEqual(100., timer.get_relative_percent_time('all'))
         self.assertTrue(100. > timer.get_relative_percent_time('all.a'))
         self.assertTrue(50. < timer.get_relative_percent_time('all.a'))
+
+    def test_HierarchicalTimer_longNames(self):
+        RES = 0.01 # resolution (seconds)
+
+        timer = HierarchicalTimer()
+        start_time = time.perf_counter()
+        timer.start('all'*25)
+        time.sleep(0.02)
+        for i in range(10):
+            timer.start('a'*75)
+            time.sleep(0.01)
+            for j in range(5):
+                timer.start('aa'*20)
+                time.sleep(0.001)
+                timer.stop('aa'*20)
+            timer.start('ab'*20)
+            timer.stop('ab'*20)
+            timer.stop('a'*75)
+        end_time = time.perf_counter()
+        timer.stop('all'*25)
+        ref = (
+"""Identifier%s   ncalls   cumtime   percall      %%
+%s------------------------------------
+%s%s        1     [0-9.]+ +[0-9.]+ +100.0
+    %s------------------------------------
+    %s%s       10     [0-9.]+ +[0-9.]+ +[0-9.]+
+        %s------------------------------------
+        %s%s       50     [0-9.]+ +[0-9.]+ +[0-9.]+
+        %s%s       10     [0-9.]+ +[0-9.]+ +[0-9.]+
+        other%s      n/a     [0-9.]+ +n/a +[0-9.]+
+        %s====================================
+    other%s      n/a     [0-9.]+ +n/a +[0-9.]+
+    %s====================================
+%s====================================
+""" % (
+    ' '*69,
+    '-'*79,
+    'all'*25, ' '*4,
+    '-'*75,
+    'a'*75, '',
+    '-'*71,
+    'aa'*20, ' '*31,
+    'ab'*20, ' '*31,
+    ' '*66,
+    '='*71,
+    ' '*70,
+    '='*75,
+    '='*79)).splitlines()
+        for l, r in zip(str(timer).splitlines(), ref):
+            self.assertRegex(l, r)

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -540,8 +540,23 @@ class HierarchicalTimer(object):
         return stage_lengths
 
     def __str__(self):
+        const_indent = 4
+        max_name_length = 200 - 36
         stage_identifier_lengths = self._get_identifier_len()
-        name_formatter = '{name:<' + str(sum(stage_identifier_lengths)) + '}'
+        name_field_width = sum(stage_identifier_lengths)
+        if name_field_width > max_name_length:
+            # switch to a constant indentation of const_indent spaces
+            # (to hopefully shorten the line lengths
+            name_field_width = max(
+                const_indent*i + l
+                for i, l in enumerate(stage_identifier_lengths)
+            )
+            for i in range(len(stage_identifier_lengths) - 1):
+                stage_identifier_lengths[i] = const_indent
+            stage_identifier_lengths[-1] = (
+                name_field_width -
+                const_indent*(len(stage_identifier_lengths) - 1) )
+        name_formatter = '{name:<' + str(name_field_width) + '}'
         s = ( name_formatter + '{ncalls:>9} {cumtime:>9} '
               '{percall:>9} {percent:>6}\n').format(
                   name='Identifier',
@@ -549,7 +564,7 @@ class HierarchicalTimer(object):
                   cumtime='cumtime',
                   percall='percall',
                   percent='%')
-        underline = '-' * (sum(stage_identifier_lengths) + 36) + '\n'
+        underline = '-' * (name_field_width + 36) + '\n'
         s += underline
         sub_stage_identifier_lengths = stage_identifier_lengths[1:]
         for name, timer in sorted(self.timers.items()):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This updates the hierarchical timer to use constant indentation (instead of the total field width) when using the total field width would result in lines longer than 200 characters.  This provides more readable output (e.g., when outputting timing information for models with deep block hierarchies).  For example:

```
Identifier                                                                        ncalls   cumtime   percall      %
-------------------------------------------------------------------------------------------------------------------
allallallallallallallallallallallallallallallallallallallallallallallallall            1     0.187     0.187  100.0
    ---------------------------------------------------------------------------------------------------------------
    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa       10     0.167     0.017   89.2
        -----------------------------------------------------------------------------------------------------------
        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa                                      50     0.064     0.001   38.3
        abababababababababababababababababababab                                      10     0.000     0.000    0.0
        other                                                                        n/a     0.103       n/a   61.7
        ===========================================================================================================
    other                                                                            n/a     0.020       n/a   10.8
    ===============================================================================================================
===================================================================================================================
```

## Changes proposed in this PR:
- switch the HierarchicalTimer string report to indent by 4 spaces when not doing so would result in lines longer than 200 characters.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
