### PR TITLE
Remove deprecated NumPy bool from PyNumero

### DIFF
--- a/pyomo/contrib/pynumero/sparse/block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/block_vector.py
@@ -347,7 +347,7 @@ class BlockVector(np.ndarray, BaseBlockVector):
         """
         assert_block_structure(self)
         results = np.array([self.get_block(i).all() for i in range(self.nblocks)],
-                            dtype=np.bool)
+                            dtype=bool)
         return results.all(axis=axis, out=out, keepdims=keepdims)
 
     def any(self, axis=None, out=None, keepdims=False):
@@ -356,7 +356,7 @@ class BlockVector(np.ndarray, BaseBlockVector):
         """
         assert_block_structure(self)
         results = np.array([self.get_block(i).any() for i in range(self.nblocks)],
-                            dtype=np.bool)
+                            dtype=bool)
         return results.any(axis=axis, out=out, keepdims=keepdims)
 
     def max(self, axis=None, out=None, keepdims=False):

--- a/pyomo/contrib/pynumero/sparse/mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/mpi_block_vector.py
@@ -1229,11 +1229,11 @@ class MPIBlockVector(np.ndarray, BaseBlockVector):
         num_processors = self._mpiw.Get_size()
         local_mask = self._owned_mask.flatten()
         receive_data = np.empty(num_processors * self.nblocks,
-                                dtype=np.bool)
+                                dtype=bool)
         self._mpiw.Allgather(local_mask, receive_data)
         processor_to_mask = np.split(receive_data, num_processors)
 
-        global_mask = np.zeros(self.nblocks, dtype=np.bool)
+        global_mask = np.zeros(self.nblocks, dtype=bool)
 
         for bid in range(self.nblocks):
             owner = self._rank_owner[bid]


### PR DESCRIPTION
## Fixes # .
Deprecation warning when using PyNumero with recent NumPy:
```consolve
DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

## Changes proposed in this PR:
- Replace `numpy.bool` with `bool` to avoid Deprecation warnings

Local tests passed after this change with `numpy==1.19` and `numpy==1.18`.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
