### PR TITLE
Fixing bug in GLPK solver plugin

### DIFF
--- a/pyomo/solvers/plugins/solvers/GLPK.py
+++ b/pyomo/solvers/plugins/solvers/GLPK.py
@@ -143,7 +143,7 @@ class GLPKSHELL(SystemCallSolver):
             raise RuntimeError(
                 "Pyomo only supports versions of GLPK since 4.58; "
                 "found version %s.  Please upgrade your installation "
-                "of GLPK" % ('.'.join(map(str, _glpk_version)),)
+                "of GLPK" % ('.'.join(map(str, _ver)),)
             )
 
         #


### PR DESCRIPTION
## Summary/Motivation:
This fixes a small bug reported by a user where an incorrect local variable name was used in an error message in the GLPK solver plugin.

## Changes proposed in this PR:
- Rename `_glpk_version` to `_ver` in error message

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
