### PR TITLE
Un-indenting a DAE test that looks like it wasn't run by accident?

### DIFF
--- a/pyomo/dae/tests/test_integral.py
+++ b/pyomo/dae/tests/test_integral.py
@@ -141,63 +141,62 @@ class TestIntegral(unittest.TestCase):
         with self.assertRaises(ValueError):
             m.int = Integral(m.t, wrt=m.t)
 
-            # test DerivativeVar reclassification after discretization
+    # test DerivativeVar reclassification after discretization
+    def test_reclassification_finite_difference(self):
+        m = ConcreteModel()
+        m.t = ContinuousSet(bounds=(0, 1))
+        m.x = ContinuousSet(bounds=(5, 10))
+        m.s = Set(initialize=[1, 2, 3])
+        m.v = Var(m.t)
+        m.v2 = Var(m.s, m.t)
+        m.v3 = Var(m.t, m.x)
 
-        def test_reclassification_finite_difference(self):
-            m = ConcreteModel()
-            m.t = ContinuousSet(bounds=(0, 1))
-            m.x = ContinuousSet(bounds=(5, 10))
-            m.s = Set(initialize=[1, 2, 3])
-            m.v = Var(m.t)
-            m.v2 = Var(m.s, m.t)
-            m.v3 = Var(m.t, m.x)
+        def _int1(m, t):
+            return m.v[t]
 
-            def _int1(m, t):
-                return m.v[t]
+        m.int1 = Integral(m.t, rule=_int1)
 
-            m.int1 = Integral(m.t, rule=_int1)
+        def _int2(m, s, t):
+            return m.v2[s, t]
 
-            def _int2(m, s, t):
-                return m.v2[s, t]
+        m.int2 = Integral(m.s, m.t, wrt=m.t, rule=_int2)
 
-            m.int2 = Integral(m.s, m.t, wrt=m.t, rule=_int2)
+        def _int3(m, t, x):
+            return m.v3[t, x]
 
-            def _int3(m, t, x):
-                return m.v3[t, x]
+        m.int3 = Integral(m.t, m.x, wrt=m.t, rule=_int3)
 
-            m.int3 = Integral(m.t, m.x, wrt=m.t, rule=_int3)
+        def _int4(m, x):
+            return m.int3[x]
 
-            def _int4(m, x):
-                return m.int3[x]
+        m.int4 = Integral(m.x, wrt=m.x, rule=_int4)
 
-            m.int4 = Integral(m.x, wrt=m.x, rule=_int4)
+        self.assertFalse(m.int1.is_fully_discretized())
+        self.assertFalse(m.int2.is_fully_discretized())
+        self.assertFalse(m.int3.is_fully_discretized())
+        self.assertFalse(m.int4.is_fully_discretized())
 
-            self.assertFalse(m.int1.is_fully_discretized())
-            self.assertFalse(m.int2.is_fully_discretized())
-            self.assertFalse(m.int3.is_fully_discretized())
-            self.assertFalse(m.int4.is_fully_discretized())
+        TransformationFactory('dae.finite_difference').apply_to(m, wrt=m.t)
 
-            TransformationFactory('dae.finite_difference').apply_to(m, wrt=m.t)
+        self.assertTrue(m.int1.is_fully_discretized())
+        self.assertTrue(m.int2.is_fully_discretized())
+        self.assertFalse(m.int3.is_fully_discretized())
+        self.assertFalse(m.int4.is_fully_discretized())
 
-            self.assertTrue(m.int1.is_fully_discretized())
-            self.assertTrue(m.int2.is_fully_discretized())
-            self.assertFalse(m.int3.is_fully_discretized())
-            self.assertFalse(m.int4.is_fully_discretized())
+        self.assertTrue(m.int1.ctype is Integral)
+        self.assertTrue(m.int2.ctype is Integral)
+        self.assertTrue(m.int3.ctype is Integral)
+        self.assertTrue(m.int4.ctype is Integral)
 
-            self.assertTrue(m.int1.ctype is Integral)
-            self.assertTrue(m.int2.ctype is Integral)
-            self.assertTrue(m.int3.ctype is Integral)
-            self.assertTrue(m.int4.ctype is Integral)
+        TransformationFactory('dae.finite_difference').apply_to(m, wrt=m.x)
 
-            TransformationFactory('dae.finite_difference').apply_to(m, wrt=m.x)
+        self.assertTrue(m.int3.is_fully_discretized())
+        self.assertTrue(m.int4.is_fully_discretized())
 
-            self.assertTrue(m.int3.is_fully_discretized())
-            self.assertTrue(m.int4.is_fully_discretized())
-
-            self.assertTrue(m.int1.ctype is Expression)
-            self.assertTrue(m.int2.ctype is Expression)
-            self.assertTrue(m.int3.ctype is Expression)
-            self.assertTrue(m.int4.ctype is Expression)
+        self.assertTrue(m.int1.ctype is Expression)
+        self.assertTrue(m.int2.ctype is Expression)
+        self.assertTrue(m.int3.ctype is Expression)
+        self.assertTrue(m.int4.ctype is Expression)
 
     # test DerivativeVar reclassification after discretization
     def test_reclassification_collocation(self):


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:

While I was mucking around with ComponentData indices, I ran across a test in DAE which was defined inside of another test, but never run. I expect this was an indentation typo at some point? If I'm right, then this un-indents it and makes it run again. If I'm not right, we can just close this.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
