### PR TITLE
Adding indices to ComponentData objects (take 2)

### DIFF
--- a/pyomo/contrib/pynumero/interfaces/external_grey_box.py
+++ b/pyomo/contrib/pynumero/interfaces/external_grey_box.py
@@ -18,7 +18,7 @@ from pyomo.common.log import is_debug_set
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base import Var, Set, Constraint, value
 from pyomo.core.base.block import _BlockData, Block, declare_custom_block
-from pyomo.core.base.component import UnindexedComponent_index
+from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.initializer import Initializer
 from pyomo.core.base.set import UnindexedComponent_set
 from pyomo.core.base.reference import Reference

--- a/pyomo/contrib/pynumero/interfaces/external_grey_box.py
+++ b/pyomo/contrib/pynumero/interfaces/external_grey_box.py
@@ -408,6 +408,9 @@ class ScalarExternalGreyBoxBlock(ExternalGreyBoxBlockData, ExternalGreyBoxBlock)
     def __init__(self, *args, **kwds):
         ExternalGreyBoxBlockData.__init__(self, component=self)
         ExternalGreyBoxBlock.__init__(self, *args, **kwds)
+        # The above inherit from Block and _BlockData, so it's not until here
+        # that we know it's scalar. So we set the index accordingly.
+        self._index = None
 
     # Pick up the display() from Block and not BlockData
     display = ExternalGreyBoxBlock.display

--- a/pyomo/contrib/pynumero/interfaces/external_grey_box.py
+++ b/pyomo/contrib/pynumero/interfaces/external_grey_box.py
@@ -18,6 +18,7 @@ from pyomo.common.log import is_debug_set
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base import Var, Set, Constraint, value
 from pyomo.core.base.block import _BlockData, Block, declare_custom_block
+from pyomo.core.base.component import UnindexedComponent_index
 from pyomo.core.base.initializer import Initializer
 from pyomo.core.base.set import UnindexedComponent_set
 from pyomo.core.base.reference import Reference
@@ -410,7 +411,7 @@ class ScalarExternalGreyBoxBlock(ExternalGreyBoxBlockData, ExternalGreyBoxBlock)
         ExternalGreyBoxBlock.__init__(self, *args, **kwds)
         # The above inherit from Block and _BlockData, so it's not until here
         # that we know it's scalar. So we set the index accordingly.
-        self._index = None
+        self._index = UnindexedComponent_index
 
     # Pick up the display() from Block and not BlockData
     display = ExternalGreyBoxBlock.display

--- a/pyomo/core/base/action.py
+++ b/pyomo/core/base/action.py
@@ -43,7 +43,7 @@ class BuildAction(IndexedComponent):
 
     def _pprint(self):
         return ([("Size", len(self)),
-                 ("Index", self._index if self.is_indexed() else None),
+                 ("Index", self._index_set if self.is_indexed() else None),
                  ("Active", self.active),]
                  , None, None, None)
 
@@ -62,7 +62,7 @@ class BuildAction(IndexedComponent):
             self._rule(self._parent())
         else:
             # Indexed component
-            for index in self._index:
+            for index in self._index_set:
                 apply_indexed_rule(self, self._rule, self._parent(), index)
         timer.report()
 

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -2039,6 +2039,7 @@ class ScalarBlock(_BlockData, Block):
         # get/setitem_when_not_present so that we do not (implicitly)
         # trigger the Block rule
         self._data[None] = self
+        self._index = None
 
     # We want scalar Blocks to pick up the Block display method
     display = Block.display

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -31,6 +31,7 @@ from pyomo.common.sorting import sorted_robust
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base.component import (
     Component, ActiveComponentData, ModelComponentFactory,
+    UnindexedComponent_index
 )
 from pyomo.core.base.componentuid import ComponentUID
 from pyomo.core.base.set import GlobalSetBase, _SetDataBase
@@ -2039,7 +2040,7 @@ class ScalarBlock(_BlockData, Block):
         # get/setitem_when_not_present so that we do not (implicitly)
         # trigger the Block rule
         self._data[None] = self
-        self._index = None
+        self._index = UnindexedComponent_index
 
     # We want scalar Blocks to pick up the Block display method
     display = Block.display

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -30,9 +30,9 @@ from pyomo.common.log import is_debug_set
 from pyomo.common.sorting import sorted_robust
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base.component import (
-    Component, ActiveComponentData, ModelComponentFactory,
-    UnindexedComponent_index
+    Component, ActiveComponentData, ModelComponentFactory
 )
+from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.componentuid import ComponentUID
 from pyomo.core.base.set import GlobalSetBase, _SetDataBase
 from pyomo.core.base.var import Var

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -799,11 +799,11 @@ class _BlockData(ActiveComponentData):
                 if tset.parent_component().parent_block() is None \
                         and not isinstance(tset.parent_component(), GlobalSetBase):
                     self.add_component("%s_index_%d" % (val.local_name, ctr), tset)
-        if getattr(val, '_index', None) is not None \
-                and isinstance(val._index, _SetDataBase) \
-                and val._index.parent_component().parent_block() is None \
-                and not isinstance(val._index.parent_component(), GlobalSetBase):
-            self.add_component("%s_index" % (val.local_name,), val._index.parent_component())
+        if getattr(val, '_index_set', None) is not None \
+                and isinstance(val._index_set, _SetDataBase) \
+                and val._index_set.parent_component().parent_block() is None \
+                and not isinstance(val._index_set.parent_component(), GlobalSetBase):
+            self.add_component("%s_index" % (val.local_name,), val._index_set.parent_component())
         if getattr(val, 'initialize', None) is not None \
                 and isinstance(val.initialize, _SetDataBase) \
                 and val.initialize.parent_component().parent_block() is None \
@@ -2004,7 +2004,7 @@ class Block(ActiveIndexedComponent):
     def _pprint(self):
         _attrs = [
             ("Size", len(self)),
-            ("Index", self._index if self.is_indexed() else None),
+            ("Index", self._index_set if self.is_indexed() else None),
             ('Active', self.active),
         ]
         # HACK: suppress the top-level block header (for historical reasons)

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -19,8 +19,8 @@ from pyomo.common.deprecation import deprecation_warning
 from pyomo.core.staleflag import StaleFlagManager
 from pyomo.core.expr.boolean_value import BooleanValue
 from pyomo.core.expr.numvalue import value
-from pyomo.core.base.component import (
-    ComponentData, ModelComponentFactory, UnindexedComponent_index)
+from pyomo.core.base.component import ComponentData, ModelComponentFactory
+from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import (IndexedComponent,
                                                UnindexedComponent_set)
 from pyomo.core.base.misc import apply_indexed_rule

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -14,7 +14,7 @@ from weakref import ref as weakref_ref, ReferenceType
 from pyomo.common.deprecation import RenamedClass
 from pyomo.common.log import is_debug_set
 from pyomo.common.timing import ConstructionTimer
-from pyomo.common.modeling import unique_component_name, NOTSET
+from pyomo.common.modeling import unique_component_name, NOTSET, NoArgumentGiven
 from pyomo.common.deprecation import deprecation_warning
 from pyomo.core.staleflag import StaleFlagManager
 from pyomo.core.expr.boolean_value import BooleanValue
@@ -82,6 +82,7 @@ class _BooleanVarData(ComponentData, BooleanValue):
     def __init__(self, component=None):
         self._component = weakref_ref(component) if (component is not None) \
                           else None
+        self._index = NoArgumentGiven
 
     def is_fixed(self):
         """Returns True if this variable is fixed, otherwise returns False."""
@@ -414,7 +415,9 @@ class BooleanVar(IndexedComponent):
         else:
             obj = self._data[index] = self._ComponentDataClass(component=self)
         self._initialize_members((index,))
+        obj._index = index
         return obj
+
     def _setitem_when_not_present(self, index, value):
         """Perform the fundamental component item creation and storage.
 
@@ -494,6 +497,7 @@ class ScalarBooleanVar(_GeneralBooleanVarData, BooleanVar):
     def __init__(self, *args, **kwd):
         _GeneralBooleanVarData.__init__(self, component=self)
         BooleanVar.__init__(self, *args, **kwd)
+        self._index = None
 
     """
     # Since this class derives from Component and Component.__getstate__

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -392,11 +392,11 @@ class BooleanVar(IndexedComponent):
             # Calling dict.update((...) for ...) is roughly
             # 30% slower
             self_weakref = weakref_ref(self)
-            for ndx in self._index:
+            for ndx in self._index_set:
                 cdata = self._ComponentDataClass(component=None)
                 cdata._component = self_weakref
                 self._data[ndx] = cdata
-            self._initialize_members(self._index)
+            self._initialize_members(self._index_set)
         timer.report()
 
     def add(self, index):
@@ -477,7 +477,7 @@ class BooleanVar(IndexedComponent):
             Print component information.
         """
         return ( [("Size", len(self)),
-                  ("Index", self._index if self.is_indexed() else None),
+                  ("Index", self._index_set if self.is_indexed() else None),
                   ],
                  self._data.items(),
                  ( "Value","Fixed","Stale"),
@@ -625,7 +625,7 @@ class BooleanVarList(IndexedBooleanVar):
         # then let _validate_index complain when we set the value.
         if self._value_init_value.__class__ is dict:
             for i in range(len(self._value_init_value)):
-                self._index.add(i + self._starting_index)
+                self._index_set.add(i + self._starting_index)
         super(BooleanVarList,self).construct(data)
         # Note that the current Var initializer silently ignores
         # initialization data that is not in the underlying index set.  To
@@ -638,8 +638,8 @@ class BooleanVarList(IndexedBooleanVar):
 
     def add(self):
         """Add a variable to this list."""
-        next_idx = len(self._index) + self._starting_index
-        self._index.add(next_idx)
+        next_idx = len(self._index_set) + self._starting_index
+        self._index_set.add(next_idx)
         return self[next_idx]
 
 

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -14,12 +14,13 @@ from weakref import ref as weakref_ref, ReferenceType
 from pyomo.common.deprecation import RenamedClass
 from pyomo.common.log import is_debug_set
 from pyomo.common.timing import ConstructionTimer
-from pyomo.common.modeling import unique_component_name, NOTSET, NoArgumentGiven
+from pyomo.common.modeling import unique_component_name, NOTSET
 from pyomo.common.deprecation import deprecation_warning
 from pyomo.core.staleflag import StaleFlagManager
 from pyomo.core.expr.boolean_value import BooleanValue
 from pyomo.core.expr.numvalue import value
-from pyomo.core.base.component import ComponentData, ModelComponentFactory
+from pyomo.core.base.component import (
+    ComponentData, ModelComponentFactory, UnindexedComponent_index)
 from pyomo.core.base.indexed_component import (IndexedComponent,
                                                UnindexedComponent_set)
 from pyomo.core.base.misc import apply_indexed_rule
@@ -82,7 +83,7 @@ class _BooleanVarData(ComponentData, BooleanValue):
     def __init__(self, component=None):
         self._component = weakref_ref(component) if (component is not None) \
                           else None
-        self._index = NoArgumentGiven
+        self._index = NOTSET
 
     def is_fixed(self):
         """Returns True if this variable is fixed, otherwise returns False."""
@@ -205,7 +206,7 @@ class _GeneralBooleanVarData(_BooleanVarData):
         #   - BooleanValue
         self._component = weakref_ref(component) if (component is not None) \
                           else None
-        self._index = NoArgumentGiven
+        self._index = NOTSET
         self._value = None
         self.fixed = False
         self._stale = 0 # True
@@ -503,7 +504,7 @@ class ScalarBooleanVar(_GeneralBooleanVarData, BooleanVar):
     def __init__(self, *args, **kwd):
         _GeneralBooleanVarData.__init__(self, component=self)
         BooleanVar.__init__(self, *args, **kwd)
-        self._index = None
+        self._index = UnindexedComponent_index
 
     """
     # Since this class derives from Component and Component.__getstate__

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -205,6 +205,7 @@ class _GeneralBooleanVarData(_BooleanVarData):
         #   - BooleanValue
         self._component = weakref_ref(component) if (component is not None) \
                           else None
+        self._index = NoArgumentGiven
         self._value = None
         self.fixed = False
         self._stale = 0 # True

--- a/pyomo/core/base/boolean_var.py
+++ b/pyomo/core/base/boolean_var.py
@@ -398,6 +398,11 @@ class BooleanVar(IndexedComponent):
                 cdata = self._ComponentDataClass(component=None)
                 cdata._component = self_weakref
                 self._data[ndx] = cdata
+                # NOTE: This is a special case where a key, value pair is added
+                # to the _data dictionary without calling
+                # _getitem_when_not_present, which is why we need to set the
+                # index here.
+                cdata._index = ndx
             self._initialize_members(self._index_set)
         timer.report()
 

--- a/pyomo/core/base/check.py
+++ b/pyomo/core/base/check.py
@@ -63,7 +63,7 @@ class BuildCheck(IndexedComponent):
                 raise ValueError("BuildCheck %r identified error" % self.name)
         else:
             # Indexed component
-            for index in self._index:
+            for index in self._index_set:
                 res = apply_indexed_rule(self, self._rule, self._parent(), index)
                 if not res:
                     raise ValueError("BuildCheck %r identified error with index %r" % (self.name, str(index)))

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -18,7 +18,7 @@ import pyomo.common
 from pyomo.common.deprecation import deprecated, relocated_module_attribute
 from pyomo.common.factory import Factory
 from pyomo.common.formatting import tabular_writer, StreamIndenter
-from pyomo.common.modeling import NOTSET, NoArgumentGiven
+from pyomo.common.modeling import NOTSET
 from pyomo.common.sorting import sorted_robust
 from pyomo.core.pyomoobject import PyomoObject
 from pyomo.core.base.component_namer import name_repr, index_repr
@@ -713,7 +713,7 @@ class ComponentData(_ComponentBase):
         # this assumption is significantly faster.
         #
         self._component = weakref_ref(component)
-        self._index = NoArgumentGiven
+        self._index = NOTSET
 
     def __getstate__(self):
         """Prepare a picklable state of this instance for pickling.
@@ -1006,3 +1006,5 @@ class ActiveComponentData(ComponentData):
         """Set the active attribute to False"""
         self._active = False
 
+# ESJ TODO
+UnindexedComponent_index = None

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -701,7 +701,8 @@ class ComponentData(_ComponentBase):
     # _GeneralExpressionData, _LogicalConstraintData,
     # _GeneralLogicalConstraintData, _GeneralObjectiveData,
     # _ParamData,_GeneralVarData, _GeneralBooleanVarData, _DisjunctionData,
-    # _ArcData, and _PortData. Changes made here need to be made in those
+    # _ArcData, _PortData, _LinearConstraintData, and
+    # _LinearMatrixConstraintData. Changes made here need to be made in those
     # constructors as well!
     def __init__(self, component):
         #
@@ -854,6 +855,13 @@ class ComponentData(_ComponentBase):
 
     def getname(self, fully_qualified=False, name_buffer=None, relative_to=None):
         """Return a string with the component name and index"""
+        # NOTE: There are bugs with name buffers if a user always gives the same
+        # dictionary but switches from fully-qualified to local names or changes
+        # the component the name is relative to. We will simply deprecate the
+        # buffer in a future PR, but for now we will leave this method so it
+        # behaves the same when a buffer is given, and, in the absence of a
+        # buffer it will construct the name using the index (woohoo!)
+
         #
         # Using the buffer, which is a dictionary:  id -> string
         #
@@ -893,13 +901,10 @@ class ComponentData(_ComponentBase):
                 return name_buffer[id(self)]
         else:
             #
-            # No buffer, so we iterate through the component _data
-            # dictionary until we find this object.  This can be much
-            # more expensive than if a buffer is provided.
+            # No buffer, we can do what we are going to do all the time after we
+            # deprecate the buffer.
             #
-            for idx, obj in c.items():
-                if obj is self:
-                    return base + index_repr(idx)
+            return base + index_repr(self.index())
         #
         raise RuntimeError("Fatal error: cannot find the component data in "
                            "the owning component's _data dictionary.")

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -697,7 +697,11 @@ class ComponentData(_ComponentBase):
     __slots__ = __pickle_slots__ + ('__weakref__',)
 
     # NOTE: This constructor is in-lined in the constructors for the following
-    # classes: _BooleanVarData, _ConnectorData, _ConstraintData, _GeneralExpressionData, _LogicalConstraintData, _GeneralLogicalConstraintData, _GeneralObjectiveData, _ParamData,_GeneralVarData Changes made here need to be made in those
+    # classes: _BooleanVarData, _ConnectorData, _ConstraintData,
+    # _GeneralExpressionData, _LogicalConstraintData,
+    # _GeneralLogicalConstraintData, _GeneralObjectiveData,
+    # _ParamData,_GeneralVarData, _GeneralBooleanVarData, _DisjunctionData,
+    # _ArcData, and _PortData. Changes made here need to be made in those
     # constructors as well!
     def __init__(self, component):
         #

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -22,6 +22,7 @@ from pyomo.common.modeling import NOTSET
 from pyomo.common.sorting import sorted_robust
 from pyomo.core.pyomoobject import PyomoObject
 from pyomo.core.base.component_namer import name_repr, index_repr
+from pyomo.core.base.global_set import UnindexedComponent_index
 
 logger = logging.getLogger('pyomo.core')
 
@@ -1005,6 +1006,3 @@ class ActiveComponentData(ComponentData):
     def deactivate(self):
         """Set the active attribute to False"""
         self._active = False
-
-# ESJ TODO
-UnindexedComponent_index = None

--- a/pyomo/core/base/connector.py
+++ b/pyomo/core/base/connector.py
@@ -20,8 +20,8 @@ from pyomo.common.log import is_debug_set
 from pyomo.common.modeling import NOTSET
 from pyomo.common.timing import ConstructionTimer
 
-from pyomo.core.base.component import (
-    ComponentData, ModelComponentFactory, UnindexedComponent_index)
+from pyomo.core.base.component import ComponentData, ModelComponentFactory
+from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import IndexedComponent
 from pyomo.core.base.misc import apply_indexed_rule
 from pyomo.core.base.numvalue import NumericValue, value

--- a/pyomo/core/base/connector.py
+++ b/pyomo/core/base/connector.py
@@ -181,7 +181,7 @@ class Connector(IndexedComponent):
         # Construct _ConnectorData objects for all index values
         #
         if self.is_indexed():
-            self._initialize_members(self._index)
+            self._initialize_members(self._index_set)
         else:
             self._data[None] = self
             self._initialize_members([None])
@@ -218,7 +218,7 @@ class Connector(IndexedComponent):
                     _len = 1
                 yield _k, _len, str(_v)
         return ( [("Size", len(self)),
-                  ("Index", self._index if self.is_indexed() else None),
+                  ("Index", self._index_set if self.is_indexed() else None),
                   ],
                  self._data.items(),
                  ( "Name","Size", "Variable", ),

--- a/pyomo/core/base/connector.py
+++ b/pyomo/core/base/connector.py
@@ -17,6 +17,7 @@ from weakref import ref as weakref_ref
 from pyomo.common.deprecation import deprecated, RenamedClass
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.log import is_debug_set
+from pyomo.common.modeling import NoArgumentGiven
 from pyomo.common.timing import ConstructionTimer
 
 from pyomo.core.base.component import ComponentData, ModelComponentFactory
@@ -42,6 +43,7 @@ class _ConnectorData(ComponentData, NumericValue):
         #   - NumericValue
         self._component = weakref_ref(component) if (component is not None) \
                           else None
+        self._index = NoArgumentGiven
 
         self.vars = {}
         self.aggregators = {}
@@ -261,6 +263,7 @@ class ScalarConnector(Connector, _ConnectorData):
     def __init__(self, *args, **kwd):
         _ConnectorData.__init__(self, component=self)
         Connector.__init__(self, *args, **kwd)
+        self._index = None
 
     #
     # Since this class derives from Component and Component.__getstate__

--- a/pyomo/core/base/connector.py
+++ b/pyomo/core/base/connector.py
@@ -17,10 +17,11 @@ from weakref import ref as weakref_ref
 from pyomo.common.deprecation import deprecated, RenamedClass
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.log import is_debug_set
-from pyomo.common.modeling import NoArgumentGiven
+from pyomo.common.modeling import NOTSET
 from pyomo.common.timing import ConstructionTimer
 
-from pyomo.core.base.component import ComponentData, ModelComponentFactory
+from pyomo.core.base.component import (
+    ComponentData, ModelComponentFactory, UnindexedComponent_index)
 from pyomo.core.base.indexed_component import IndexedComponent
 from pyomo.core.base.misc import apply_indexed_rule
 from pyomo.core.base.numvalue import NumericValue, value
@@ -43,7 +44,7 @@ class _ConnectorData(ComponentData, NumericValue):
         #   - NumericValue
         self._component = weakref_ref(component) if (component is not None) \
                           else None
-        self._index = NoArgumentGiven
+        self._index = NOTSET
 
         self.vars = {}
         self.aggregators = {}
@@ -263,7 +264,7 @@ class ScalarConnector(Connector, _ConnectorData):
     def __init__(self, *args, **kwd):
         _ConnectorData.__init__(self, component=self)
         Connector.__init__(self, *args, **kwd)
-        self._index = None
+        self._index = UnindexedComponent_index
 
     #
     # Since this class derives from Component and Component.__getstate__

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -1,3 +1,4 @@
+
 #  ___________________________________________________________________________
 #
 #  Pyomo: Python Optimization Modeling Objects
@@ -22,14 +23,14 @@ from pyomo.common.deprecation import RenamedClass
 from pyomo.common.errors import DeveloperError
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.log import is_debug_set
-from pyomo.common.modeling import NoArgumentGiven
+from pyomo.common.modeling import NOTSET
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.expr import logical_expr
 from pyomo.core.expr.numvalue import (
     NumericValue, value, as_numeric, is_fixed, native_numeric_types,
 )
 from pyomo.core.base.component import (
-    ActiveComponentData, ModelComponentFactory,
+    ActiveComponentData, ModelComponentFactory, UnindexedComponent_index
 )
 from pyomo.core.base.indexed_component import (
     ActiveIndexedComponent, UnindexedComponent_set, rule_wrapper,
@@ -138,7 +139,7 @@ class _ConstraintData(ActiveComponentData):
         #   - ComponentData
         self._component = weakref_ref(component) if (component is not None) \
                           else None
-        self._index = NoArgumentGiven
+        self._index = NOTSET
         self._active = True
 
     #
@@ -822,7 +823,7 @@ class ScalarConstraint(_GeneralConstraintData, Constraint):
     def __init__(self, *args, **kwds):
         _GeneralConstraintData.__init__(self, component=self, expr=None)
         Constraint.__init__(self, *args, **kwds)
-        self._index = None
+        self._index = UnindexedComponent_index
 
     #
     # Since this class derives from Component and

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -774,7 +774,7 @@ class Constraint(ActiveIndexedComponent):
         """
         return (
             [("Size", len(self)),
-             ("Index", self._index if self.is_indexed() else None),
+             ("Index", self._index_set if self.is_indexed() else None),
              ("Active", self.active),
              ],
             self.items(),
@@ -1020,7 +1020,7 @@ class ConstraintList(IndexedConstraint):
 
     def add(self, expr):
         """Add a constraint with an implicit index."""
-        next_idx = len(self._index) + self._starting_index
-        self._index.add(next_idx)
+        next_idx = len(self._index_set) + self._starting_index
+        self._index_set.add(next_idx)
         return self.__setitem__(next_idx, expr)
 

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -22,6 +22,7 @@ from pyomo.common.deprecation import RenamedClass
 from pyomo.common.errors import DeveloperError
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.log import is_debug_set
+from pyomo.common.modeling import NoArgumentGiven
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.expr import logical_expr
 from pyomo.core.expr.numvalue import (
@@ -137,6 +138,7 @@ class _ConstraintData(ActiveComponentData):
         #   - ComponentData
         self._component = weakref_ref(component) if (component is not None) \
                           else None
+        self._index = NoArgumentGiven
         self._active = True
 
     #
@@ -820,6 +822,7 @@ class ScalarConstraint(_GeneralConstraintData, Constraint):
     def __init__(self, *args, **kwds):
         _GeneralConstraintData.__init__(self, component=self, expr=None)
         Constraint.__init__(self, *args, **kwds)
+        self._index = None
 
     #
     # Since this class derives from Component and

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -29,9 +29,8 @@ from pyomo.core.expr import logical_expr
 from pyomo.core.expr.numvalue import (
     NumericValue, value, as_numeric, is_fixed, native_numeric_types,
 )
-from pyomo.core.base.component import (
-    ActiveComponentData, ModelComponentFactory, UnindexedComponent_index
-)
+from pyomo.core.base.component import ActiveComponentData, ModelComponentFactory
+from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import (
     ActiveIndexedComponent, UnindexedComponent_set, rule_wrapper,
 )

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -21,8 +21,8 @@ from pyomo.common.modeling import NOTSET
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.timing import ConstructionTimer
 
-from pyomo.core.base.component import (
-    ComponentData, ModelComponentFactory, UnindexedComponent_index)
+from pyomo.core.base.component import ComponentData, ModelComponentFactory
+from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import (
     IndexedComponent,
     UnindexedComponent_set, )

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -17,11 +17,12 @@ from typing import overload
 
 from pyomo.common.log import is_debug_set
 from pyomo.common.deprecation import deprecated, RenamedClass
-from pyomo.common.modeling import NOTSET, NoArgumentGiven
+from pyomo.common.modeling import NOTSET
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.timing import ConstructionTimer
 
-from pyomo.core.base.component import ComponentData, ModelComponentFactory
+from pyomo.core.base.component import (
+    ComponentData, ModelComponentFactory, UnindexedComponent_index)
 from pyomo.core.base.indexed_component import (
     IndexedComponent,
     UnindexedComponent_set, )
@@ -228,7 +229,7 @@ class _GeneralExpressionData(_GeneralExpressionDataImpl,
         # Inlining ComponentData.__init__
         self._component = weakref_ref(component) if (component is not None) \
                           else None
-        self._index = NoArgumentGiven
+        self._index = NOTSET
 
 
 @ModelComponentFactory.register(
@@ -374,7 +375,7 @@ class ScalarExpression(_GeneralExpressionData, Expression):
     def __init__(self, *args, **kwds):
         _GeneralExpressionData.__init__(self, expr=None, component=self)
         Expression.__init__(self, *args, **kwds)
-        self._index = None
+        self._index = UnindexedComponent_index
 
     #
     # Since this class derives from Component and

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -280,7 +280,7 @@ class Expression(IndexedComponent):
         return (
             [('Size', len(self)),
              ('Index', None if (not self.is_indexed())
-                  else self._index)
+                  else self._index_set)
              ],
             self.items(),
             ("Expression",),
@@ -467,7 +467,7 @@ class IndexedExpression(Expression):
 
     #
     # Leaving this method for backward compatibility reasons
-    # Note: It allows adding members outside of self._index.
+    # Note: It allows adding members outside of self._index_set.
     #       This has always been the case. Not sure there is
     #       any reason to maintain a reference to a separate
     #       index set if we allow this.

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -17,7 +17,7 @@ from typing import overload
 
 from pyomo.common.log import is_debug_set
 from pyomo.common.deprecation import deprecated, RenamedClass
-from pyomo.common.modeling import NOTSET
+from pyomo.common.modeling import NOTSET, NoArgumentGiven
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.timing import ConstructionTimer
 
@@ -228,6 +228,7 @@ class _GeneralExpressionData(_GeneralExpressionDataImpl,
         # Inlining ComponentData.__init__
         self._component = weakref_ref(component) if (component is not None) \
                           else None
+        self._index = NoArgumentGiven
 
 
 @ModelComponentFactory.register(
@@ -373,6 +374,7 @@ class ScalarExpression(_GeneralExpressionData, Expression):
     def __init__(self, *args, **kwds):
         _GeneralExpressionData.__init__(self, expr=None, component=self)
         Expression.__init__(self, *args, **kwds)
+        self._index = None
 
     #
     # Since this class derives from Component and

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -135,7 +135,7 @@ class ExternalFunction(Component):
         # FIXME: We must declare an _index attribute because
         # block._add_temporary_set assumes ALL components define an
         # index.  Sigh.
-        self._index = None
+        self._index_set = None
 
     def get_units(self):
         """Return the units for this ExternalFunction"""

--- a/pyomo/core/base/global_set.py
+++ b/pyomo/core/base/global_set.py
@@ -88,3 +88,5 @@ class _UnindexedComponent_set(GlobalSetBase):
         # As this set only has a single element, it is implicitly "ordered"
         return True
 UnindexedComponent_set = _UnindexedComponent_set('UnindexedComponent_set')
+
+UnindexedComponent_index = next(iter(UnindexedComponent_set))

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -230,7 +230,7 @@ class IndexedComponent(Component):
     """
     This is the base class for all indexed modeling components.
     This class stores a dictionary, self._data, that maps indices
-    to component data objects.  The object self._index defines valid
+    to component data objects.  The object self._index_set defines valid
     keys for this dictionary, and the dictionary keys may be a
     strict subset.
 
@@ -252,7 +252,7 @@ class IndexedComponent(Component):
     Private class attributes:
         _data               A dictionary from the index set to
                                 component data objects
-        _index              The set of valid indices
+        _index_set              The set of valid indices
         _implicit_subsets   A temporary data element that stores
                                 sets that are transfered to the model
     """
@@ -263,7 +263,7 @@ class IndexedComponent(Component):
     # If an index is supplied for which there is not a _data entry
     # (specifically, in a get call), then this flag determines whether
     # a check is performed to see if the input index is in the
-    # index set _index. This is extremely expensive, and so this flag
+    # index set _index_set. This is extremely expensive, and so this flag
     # is provided to disable that feature globally.
     #
     _DEFAULT_INDEX_CHECKING_ENABLED = True
@@ -282,13 +282,13 @@ class IndexedComponent(Component):
             # If no indexing sets are provided, generate a dummy index
             #
             self._implicit_subsets = None
-            self._index = UnindexedComponent_set
+            self._index_set = UnindexedComponent_set
         elif len(args) == 1:
             #
             # If a single indexing set is provided, just process it.
             #
             self._implicit_subsets = None
-            self._index = process_setarg(args[0])
+            self._index_set = process_setarg(args[0])
         else:
             #
             # If multiple indexing sets are provided, process them all,
@@ -307,26 +307,26 @@ class IndexedComponent(Component):
             #
             tmp = [process_setarg(x) for x in args]
             self._implicit_subsets = tmp
-            self._index = tmp[0].cross(*tmp[1:])
+            self._index_set = tmp[0].cross(*tmp[1:])
 
     def __getstate__(self):
         # Special processing of getstate so that we never copy the
         # UnindexedComponent_set set
         state = super(IndexedComponent, self).__getstate__()
         if not self.is_indexed():
-            state['_index'] = None
+            state['_index_set'] = None
         return state
 
     def __setstate__(self, state):
         # Special processing of setstate so that we never copy the
         # UnindexedComponent_set set
-        if state['_index'] is None:
-            state['_index'] = UnindexedComponent_set
+        if state['_index_set'] is None:
+            state['_index_set'] = UnindexedComponent_set
         super(IndexedComponent, self).__setstate__(state)
 
     def to_dense_data(self):
         """TODO"""
-        for idx in self._index:
+        for idx in self._index_set:
             if idx in self._data:
                 continue
             try:
@@ -346,11 +346,11 @@ class IndexedComponent(Component):
 
     def index_set(self):
         """Return the index set"""
-        return self._index
+        return self._index_set
 
     def is_indexed(self):
         """Return true if this component is indexed"""
-        return self._index is not UnindexedComponent_set
+        return self._index_set is not UnindexedComponent_set
 
     def is_reference(self):
         """Return True if this component is a reference, where
@@ -363,7 +363,7 @@ class IndexedComponent(Component):
         """Return the dimension of the index"""
         if not self.is_indexed():
             return 0
-        return self._index.dimen
+        return self._index_set.dimen
 
     def __len__(self):
         """
@@ -402,7 +402,8 @@ class IndexedComponent(Component):
 
         """
         sort_needed = ordered
-        if hasattr(self._index, 'isfinite') and not self._index.isfinite():
+        if hasattr(self._index_set, 'isfinite') and not \
+           self._index_set.isfinite():
             #
             # If the index set is virtual (e.g., Any) then return the
             # data iterator.  Note that since we cannot check the length
@@ -412,16 +413,17 @@ class IndexedComponent(Component):
             ans = self._data.__iter__()
         elif self.is_reference():
             ans = self._data.__iter__()
-        elif len(self) == len(self._index):
+        elif len(self) == len(self._index_set):
             #
             # If the data is dense then return the index iterator.
             #
-            ans = self._index.__iter__()
-            if ordered and self._index.isordered():
+            ans = self._index_set.__iter__()
+            if ordered and self._index_set.isordered():
                 # As this iterator is ordered, we do not need to sort it
                 sort_needed = False
         else:
-            if not self._data and self._index and PyomoOptions.paranoia_level:
+            if not self._data and self._index_set and \
+               PyomoOptions.paranoia_level:
                 logger.warning(
 """Iterating over a Component (%s)
 defined by a non-empty concrete set before any data objects have
@@ -442,8 +444,8 @@ You can silence this warning by one of three ways:
        where it is empty.
 """ % (self.name,) )
 
-            if not hasattr(self._index, 'isordered') or \
-               not self._index.isordered():
+            if not hasattr(self._index_set, 'isordered') or \
+               not self._index_set.isordered():
                 #
                 # If the index set is not ordered, then return the
                 # data iterator.  This is in an arbitrary order, which is
@@ -459,7 +461,7 @@ You can silence this warning by one of three ways:
                 # small number of indices.  However, this provides a
                 # consistent ordering that the user expects.
                 #
-                ans = filter(self._data.__contains__, self._index)
+                ans = filter(self._data.__contains__, self._index_set)
                 # As the iterator is ordered, we do not need to sort it
                 sort_needed = False
         if sort_needed:
@@ -739,7 +741,7 @@ You can silence this warning by one of three ways:
 
         # This is only called through __{get,set,del}item__, which has
         # already trapped unhashable objects.
-        validated_idx = self._index.get(idx, _NotFound)
+        validated_idx = self._index_set.get(idx, _NotFound)
         if validated_idx is not _NotFound:
             # If the index is in the underlying index set, then return it
             #  Note: This check is potentially expensive (e.g., when the
@@ -759,7 +761,7 @@ You can silence this warning by one of three ways:
                 idx = normalized_idx
                 if idx in self._data:
                     return idx
-                if idx in self._index:
+                if idx in self._index_set:
                     return idx
         # There is the chance that the index contains an Ellipsis,
         # so we should generate a slicer
@@ -1016,7 +1018,7 @@ value() function.""" % ( self.name, i ))
     def _pprint(self):
         """Print component information."""
         return ( [("Size", len(self)),
-                  ("Index", self._index if self.is_indexed() else None),
+                  ("Index", self._index_set if self.is_indexed() else None),
                   ],
                  self._data.items(),
                  ( "Object",),

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -981,7 +981,7 @@ value() function.""" % ( self.name, i ))
         should override this method.
 
         Implementations may assume that the index has already been
-        validated and is a legitimate entry in the _data dict.
+        validated and is a legitimate entry to add to the _data dict.
         """
         # If the value is "Skip" do not add anything
         if value is IndexedComponent.Skip:
@@ -993,6 +993,7 @@ value() function.""" % ( self.name, i ))
             obj = self._data[index] = self
         else:
             obj = self._data[index] = self._ComponentDataClass(component=self)
+        obj._index = index
         try:
             if value is not _NotSpecified:
                 obj.set_value(value)

--- a/pyomo/core/base/instance2dat.py
+++ b/pyomo/core/base/instance2dat.py
@@ -24,7 +24,7 @@ def instance2dat(instance, output_filename):
         if (set_object.initialize is not None) and (type(set_object.initialize) is types.FunctionType):
             continue
 
-        if (set_name.find("_index") == -1) and (set_name.find("_domain") == -1):
+        if (set_name.find("_index_set") == -1) and (set_name.find("_domain") == -1):
             if set_object.dim() == 0:
                 if len(set_object) == 0:
                     continue

--- a/pyomo/core/base/logical_constraint.py
+++ b/pyomo/core/base/logical_constraint.py
@@ -18,6 +18,7 @@ from weakref import ref as weakref_ref
 from pyomo.common.deprecation import RenamedClass
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.log import is_debug_set
+from pyomo.common.modeling import NoArgumentGiven
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base.constraint import Constraint
 from pyomo.core.expr.boolean_value import as_boolean, BooleanConstant
@@ -71,6 +72,7 @@ class _LogicalConstraintData(ActiveComponentData):
         #   - ComponentData
         self._component = weakref_ref(component) if (component is not None) \
             else None
+        self._index = NoArgumentGiven
         self._active = True
 
     #
@@ -123,11 +125,12 @@ class _GeneralLogicalConstraintData(_LogicalConstraintData):
         #
         # These lines represent in-lining of the
         # following constructors:
-        #   - _LogicalStatmentData,
+        #   - _LogicalConstraintData,
         #   - ActiveComponentData
         #   - ComponentData
         self._component = weakref_ref(component) if (component is not None) \
             else None
+        self._index = NoArgumentGiven
         self._active = True
 
         self._expr = None
@@ -217,7 +220,7 @@ class LogicalConstraint(ActiveIndexedComponent):
             A boolean that is true if this component has been constructed
         _data
             A dictionary from the index set to component data objects
-        _index
+        _index_set
             The set of valid indices
         _implicit_subsets
             A tuple of set objects that represents the index set
@@ -424,6 +427,7 @@ class ScalarLogicalConstraint(_GeneralLogicalConstraintData, LogicalConstraint):
         _GeneralLogicalConstraintData.__init__(
             self, component=self, expr=None)
         LogicalConstraint.__init__(self, *args, **kwds)
+        self._index = None
 
     #
     # Since this class derives from Component and

--- a/pyomo/core/base/logical_constraint.py
+++ b/pyomo/core/base/logical_constraint.py
@@ -18,13 +18,13 @@ from weakref import ref as weakref_ref
 from pyomo.common.deprecation import RenamedClass
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.log import is_debug_set
-from pyomo.common.modeling import NoArgumentGiven
+from pyomo.common.modeling import NOTSET
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base.constraint import Constraint
 from pyomo.core.expr.boolean_value import as_boolean, BooleanConstant
 from pyomo.core.expr.numvalue import native_types, native_logical_types
 from pyomo.core.base.component import (
-    ActiveComponentData, ModelComponentFactory,
+    ActiveComponentData, ModelComponentFactory, UnindexedComponent_index
 )
 from pyomo.core.base.indexed_component import \
     (ActiveIndexedComponent,
@@ -72,7 +72,7 @@ class _LogicalConstraintData(ActiveComponentData):
         #   - ComponentData
         self._component = weakref_ref(component) if (component is not None) \
             else None
-        self._index = NoArgumentGiven
+        self._index = NOTSET
         self._active = True
 
     #
@@ -130,7 +130,7 @@ class _GeneralLogicalConstraintData(_LogicalConstraintData):
         #   - ComponentData
         self._component = weakref_ref(component) if (component is not None) \
             else None
-        self._index = NoArgumentGiven
+        self._index = NOTSET
         self._active = True
 
         self._expr = None
@@ -427,7 +427,7 @@ class ScalarLogicalConstraint(_GeneralLogicalConstraintData, LogicalConstraint):
         _GeneralLogicalConstraintData.__init__(
             self, component=self, expr=None)
         LogicalConstraint.__init__(self, *args, **kwds)
-        self._index = None
+        self._index = UnindexedComponent_index
 
     #
     # Since this class derives from Component and

--- a/pyomo/core/base/logical_constraint.py
+++ b/pyomo/core/base/logical_constraint.py
@@ -327,7 +327,7 @@ class LogicalConstraint(ActiveIndexedComponent):
                     "of a logical constraint with a single expression" %
                     (self.name,))
 
-            for ndx in self._index:
+            for ndx in self._index_set:
                 try:
                     tmp = apply_indexed_rule(self,
                                              _init_rule,
@@ -352,7 +352,7 @@ class LogicalConstraint(ActiveIndexedComponent):
         """
         return (
             [("Size", len(self)),
-             ("Index", self._index if self.is_indexed() else None),
+             ("Index", self._index_set if self.is_indexed() else None),
              ("Active", self.active),
              ],
             self.items(),
@@ -570,7 +570,7 @@ class LogicalConstraintList(IndexedLogicalConstraint):
             _generator = _init_rule
         if _generator is None:
             while True:
-                val = len(self._index) + 1
+                val = len(self._index_set) + 1
                 if generate_debug_messages:
                     logger.debug(
                         "   Constructing logical constraint index " + str(val))
@@ -601,7 +601,7 @@ class LogicalConstraintList(IndexedLogicalConstraint):
 
     def add(self, expr):
         """Add a logical constraint with an implicit index."""
-        next_idx = len(self._index) + 1
-        self._index.add(next_idx)
+        next_idx = len(self._index_set) + 1
+        self._index_set.add(next_idx)
         return self.__setitem__(next_idx, expr)
 

--- a/pyomo/core/base/logical_constraint.py
+++ b/pyomo/core/base/logical_constraint.py
@@ -23,9 +23,8 @@ from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base.constraint import Constraint
 from pyomo.core.expr.boolean_value import as_boolean, BooleanConstant
 from pyomo.core.expr.numvalue import native_types, native_logical_types
-from pyomo.core.base.component import (
-    ActiveComponentData, ModelComponentFactory, UnindexedComponent_index
-)
+from pyomo.core.base.component import ActiveComponentData, ModelComponentFactory
+from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import \
     (ActiveIndexedComponent,
      UnindexedComponent_set,

--- a/pyomo/core/base/matrix_constraint.py
+++ b/pyomo/core/base/matrix_constraint.py
@@ -55,7 +55,7 @@ class _MatrixConstraintData(_ConstraintData):
         _index          The row index into the main coefficient matrix
     """
 
-    __slots__ = ('_index',)
+    __slots__ = ()
 
     # the super secret flag that makes the writers
     # handle _MatrixConstraintData objects more efficiently
@@ -119,7 +119,6 @@ class _MatrixConstraintData(_ConstraintData):
         This method must be defined because this class uses slots.
         """
         result = super(_MatrixConstraintData, self).__getstate__()
-        result['_index'] = self._index
         return result
 
     # Since this class requires no special processing of the state

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -22,13 +22,13 @@ from weakref import ref as weakref_ref
 from typing import overload
 
 from pyomo.common.log import is_debug_set
-from pyomo.common.modeling import NoArgumentGiven
+from pyomo.common.modeling import NOTSET
 from pyomo.common.deprecation import RenamedClass
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.expr.numvalue import value
 from pyomo.core.base.component import (
-    ActiveComponentData, ModelComponentFactory,
+    ActiveComponentData, ModelComponentFactory, UnindexedComponent_index
 )
 from pyomo.core.base.indexed_component import (
     ActiveIndexedComponent, UnindexedComponent_set, rule_wrapper,
@@ -151,7 +151,7 @@ class _GeneralObjectiveData(_GeneralExpressionDataImpl,
         # Inlining ActiveComponentData.__init__
         self._component = weakref_ref(component) if (component is not None) \
                           else None
-        self._index = NoArgumentGiven
+        self._index = NOTSET
         self._active = True
         self._sense = sense
 
@@ -407,7 +407,7 @@ class ScalarObjective(_GeneralObjectiveData, Objective):
     def __init__(self, *args, **kwd):
         _GeneralObjectiveData.__init__(self, expr=None, component=self)
         Objective.__init__(self, *args, **kwd)
-        self._index = None
+        self._index = UnindexedComponent_index
 
     #
     # Since this class derives from Component and

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -22,6 +22,7 @@ from weakref import ref as weakref_ref
 from typing import overload
 
 from pyomo.common.log import is_debug_set
+from pyomo.common.modeling import NoArgumentGiven
 from pyomo.common.deprecation import RenamedClass
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.timing import ConstructionTimer
@@ -150,6 +151,7 @@ class _GeneralObjectiveData(_GeneralExpressionDataImpl,
         # Inlining ActiveComponentData.__init__
         self._component = weakref_ref(component) if (component is not None) \
                           else None
+        self._index = NoArgumentGiven
         self._active = True
         self._sense = sense
 
@@ -405,6 +407,7 @@ class ScalarObjective(_GeneralObjectiveData, Objective):
     def __init__(self, *args, **kwd):
         _GeneralObjectiveData.__init__(self, expr=None, component=self)
         Objective.__init__(self, *args, **kwd)
+        self._index = None
 
     #
     # Since this class derives from Component and

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -27,9 +27,8 @@ from pyomo.common.deprecation import RenamedClass
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.expr.numvalue import value
-from pyomo.core.base.component import (
-    ActiveComponentData, ModelComponentFactory, UnindexedComponent_index
-)
+from pyomo.core.base.component import ActiveComponentData, ModelComponentFactory
+from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import (
     ActiveIndexedComponent, UnindexedComponent_set, rule_wrapper,
 )

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -364,7 +364,7 @@ class Objective(ActiveIndexedComponent):
         """
         return (
             [("Size", len(self)),
-             ("Index", self._index if self.is_indexed() else None),
+             ("Index", self._index_set if self.is_indexed() else None),
              ("Active", self.active)
              ],
             self._data.items(),
@@ -385,7 +385,7 @@ class Objective(ActiveIndexedComponent):
         ostream.write(prefix+self.local_name+" : ")
         ostream.write(", ".join("%s=%s" % (k,v) for k,v in [
                     ("Size", len(self)),
-                    ("Index", self._index if self.is_indexed() else None),
+                    ("Index", self._index_set if self.is_indexed() else None),
                     ("Active", self.active),
                     ] ))
 
@@ -590,8 +590,8 @@ class ObjectiveList(IndexedObjective):
 
     def add(self, expr, sense=minimize):
         """Add an objective to the list."""
-        next_idx = len(self._index) + self._starting_index
-        self._index.add(next_idx)
+        next_idx = len(self._index_set) + self._starting_index
+        self._index_set.add(next_idx)
         ans = self.__setitem__(next_idx, expr)
         if ans is not None:
             if sense not in {minimize, maximize}:

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -20,8 +20,8 @@ from pyomo.common.deprecation import deprecation_warning, RenamedClass
 from pyomo.common.log import is_debug_set
 from pyomo.common.modeling import NOTSET
 from pyomo.common.timing import ConstructionTimer
-from pyomo.core.base.component import (
-    ComponentData, ModelComponentFactory, UnindexedComponent_index)
+from pyomo.core.base.component import ComponentData, ModelComponentFactory
+from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import (
     IndexedComponent, UnindexedComponent_set, IndexedComponent_NDArrayMixin
 )

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -18,9 +18,10 @@ from typing import overload
 
 from pyomo.common.deprecation import deprecation_warning, RenamedClass
 from pyomo.common.log import is_debug_set
-from pyomo.common.modeling import NOTSET, NoArgumentGiven
+from pyomo.common.modeling import NOTSET
 from pyomo.common.timing import ConstructionTimer
-from pyomo.core.base.component import ComponentData, ModelComponentFactory
+from pyomo.core.base.component import (
+    ComponentData, ModelComponentFactory, UnindexedComponent_index)
 from pyomo.core.base.indexed_component import (
     IndexedComponent, UnindexedComponent_set, IndexedComponent_NDArrayMixin
 )
@@ -135,7 +136,7 @@ class _ParamData(ComponentData, NumericValue):
         # the base ComponentData constructor.
         #
         self._component = weakref_ref(component)
-        self._index = NoArgumentGiven
+        self._index = NOTSET
         #
         # The following is equivalent to calling the
         # base NumericValue constructor.
@@ -679,7 +680,7 @@ class Param(IndexedComponent, IndexedComponent_NDArrayMixin):
             if index is None and not self.is_indexed():
                 self._data[None] = self
                 self.set_value(value, index)
-                self._index = None
+                self._index = UnindexedComponent_index
                 return self
             elif self._mutable:
                 obj = self._data[index] = _ParamData(self)
@@ -837,7 +838,7 @@ class ScalarParam(_ParamData, Param):
     def __init__(self, *args, **kwds):
         Param.__init__(self, *args, **kwds)
         _ParamData.__init__(self, component=self)
-        self._index = None
+        self._index = UnindexedComponent_index
 
     #
     # Since this class derives from Component and Component.__getstate__

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -322,7 +322,7 @@ class Param(IndexedComponent, IndexedComponent_NDArrayMixin):
         """
         if self._default_val is Param.NoValue:
             return len(self._data)
-        return len(self._index)
+        return len(self._index_set)
 
     def __contains__(self, idx):
         """
@@ -331,7 +331,7 @@ class Param(IndexedComponent, IndexedComponent_NDArrayMixin):
         """
         if self._default_val is Param.NoValue:
             return idx in self._data
-        return idx in self._index
+        return idx in self._index_set
 
     # We do not need to override keys(), as the __len__ override will
     # cause the base class keys() to correctly correctly handle default
@@ -457,7 +457,7 @@ class Param(IndexedComponent, IndexedComponent_NDArrayMixin):
                 for index, new_value in new_values.items():
                     self[index] = new_value
             else:
-                for index in self._index:
+                for index in self._index_set:
                     self[index] = new_values
             return
         #
@@ -478,14 +478,14 @@ class Param(IndexedComponent, IndexedComponent_NDArrayMixin):
                 # For scalars, we will choose an approach based on
                 # how "dense" the Param is
                 if not self._data: # empty
-                    for index in self._index:
+                    for index in self._index_set:
                         p = self._data[index] = _ParamData(self)
                         p._value = new_values
-                elif len(self._data) == len(self._index):
-                    for index in self._index:
+                elif len(self._data) == len(self._index_set):
+                    for index in self._index_set:
                         self._data[index]._value = new_values
                 else:
-                    for index in self._index:
+                    for index in self._index_set:
                         if index not in self._data:
                             self._data[index] = _ParamData(self)
                         self._data[index]._value = new_values
@@ -792,7 +792,7 @@ class Param(IndexedComponent, IndexedComponent_NDArrayMixin):
             self._constructed = True
 
             # populate all other indices with default data
-            # (avoids calling _set_contains on self._index at runtime)
+            # (avoids calling _set_contains on self._index_set at runtime)
             if self._dense_initialize:
                 self.to_dense_data()
         finally:
@@ -814,7 +814,7 @@ class Param(IndexedComponent, IndexedComponent_NDArrayMixin):
             dataGen = lambda k, v: [ v, ]
         headers = [
             ("Size", len(self)),
-            ("Index", self._index if self.is_indexed() else None),
+            ("Index", self._index_set if self.is_indexed() else None),
             ("Domain", self.domain.name),
             ("Default", default),
             ("Mutable", self._mutable),

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -18,7 +18,7 @@ from typing import overload
 
 from pyomo.common.deprecation import deprecation_warning, RenamedClass
 from pyomo.common.log import is_debug_set
-from pyomo.common.modeling import NOTSET
+from pyomo.common.modeling import NOTSET, NoArgumentGiven
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base.component import ComponentData, ModelComponentFactory
 from pyomo.core.base.indexed_component import (
@@ -135,6 +135,7 @@ class _ParamData(ComponentData, NumericValue):
         # the base ComponentData constructor.
         #
         self._component = weakref_ref(component)
+        self._index = NoArgumentGiven
         #
         # The following is equivalent to calling the
         # base NumericValue constructor.
@@ -552,6 +553,7 @@ class Param(IndexedComponent, IndexedComponent_NDArrayMixin):
                     ans = self._data[index] = _ParamData(self)
                 else:
                     ans = self._data[index] = self
+                ans._index = index
                 return ans
             if self.is_indexed():
                 idx_str = '%s[%s]' % (self.name, index,)
@@ -677,10 +679,12 @@ class Param(IndexedComponent, IndexedComponent_NDArrayMixin):
             if index is None and not self.is_indexed():
                 self._data[None] = self
                 self.set_value(value, index)
+                self._index = None
                 return self
             elif self._mutable:
                 obj = self._data[index] = _ParamData(self)
                 obj.set_value(value, index)
+                obj._index = index
                 return obj
             else:
                 self._data[index] = value
@@ -833,6 +837,7 @@ class ScalarParam(_ParamData, Param):
     def __init__(self, *args, **kwds):
         Param.__init__(self, *args, **kwds)
         _ParamData.__init__(self, component=self)
+        self._index = None
 
     #
     # Since this class derives from Component and Component.__getstate__

--- a/pyomo/core/base/piecewise.py
+++ b/pyomo/core/base/piecewise.py
@@ -1192,7 +1192,7 @@ class Piecewise(Block):
                 logger.debug("  Constructing single Piecewise component (index=None)")
             self.add(None, _is_indexed=is_indexed)
         else:
-            for index in self._index:
+            for index in self._index_set:
                 if generate_debug_messages:
                     logger.debug("  Constructing Piecewise index "+str(index))
                 self.add(index, _is_indexed=is_indexed)

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -2078,6 +2078,7 @@ class Set(IndexedComponent):
             obj = self._data[index] = self
         else:
             obj = self._data[index] = self._ComponentDataClass(component=self)
+        obj._index = index
         if _d is not UnknownSetDimen:
             obj._dimen = _d
         if domain is not None:
@@ -2235,6 +2236,7 @@ class FiniteScalarSet(_FiniteSetData, Set):
     def __init__(self, **kwds):
         _FiniteSetData.__init__(self, component=self)
         Set.__init__(self, **kwds)
+        self._index = None
 
 
 class FiniteSimpleSet(metaclass=RenamedClass):
@@ -2265,6 +2267,7 @@ class SortedScalarSet(_ScalarOrderedSetMixin, _SortedSetData, Set):
 
         _SortedSetData.__init__(self, component=self)
         Set.__init__(self, **kwds)
+        self._index = None
 
 
 class SortedSimpleSet(metaclass=RenamedClass):
@@ -3012,6 +3015,7 @@ class InfiniteScalarRangeSet(_InfiniteRangeSetData, RangeSet):
     def __init__(self, *args, **kwds):
         _InfiniteRangeSetData.__init__(self, component=self)
         RangeSet.__init__(self, *args, **kwds)
+        self._index = None
 
     # We want the RangeSet.__str__ to override the one in _FiniteSetMixin
     __str__ = RangeSet.__str__
@@ -3027,6 +3031,7 @@ class FiniteScalarRangeSet(_ScalarOrderedSetMixin,
     def __init__(self, *args, **kwds):
         _FiniteRangeSetData.__init__(self, component=self)
         RangeSet.__init__(self, *args, **kwds)
+        self._index = None
 
     # We want the RangeSet.__str__ to override the one in _FiniteSetMixin
     __str__ = RangeSet.__str__

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -38,6 +38,7 @@ from pyomo.core.base.range import (
 )
 from pyomo.core.base.component import (
     _ComponentBase, Component, ComponentData, ModelComponentFactory,
+    UnindexedComponent_index
 )
 from pyomo.core.base.indexed_component import (
     IndexedComponent, UnindexedComponent_set, normalize_index,
@@ -2236,7 +2237,8 @@ class FiniteScalarSet(_FiniteSetData, Set):
     def __init__(self, **kwds):
         _FiniteSetData.__init__(self, component=self)
         Set.__init__(self, **kwds)
-        self._index = None
+        self._index = UnindexedComponent_index
+
 
 
 class FiniteSimpleSet(metaclass=RenamedClass):
@@ -2267,7 +2269,7 @@ class SortedScalarSet(_ScalarOrderedSetMixin, _SortedSetData, Set):
 
         _SortedSetData.__init__(self, component=self)
         Set.__init__(self, **kwds)
-        self._index = None
+        self._index = UnindexedComponent_index
 
 
 class SortedSimpleSet(metaclass=RenamedClass):
@@ -3015,7 +3017,7 @@ class InfiniteScalarRangeSet(_InfiniteRangeSetData, RangeSet):
     def __init__(self, *args, **kwds):
         _InfiniteRangeSetData.__init__(self, component=self)
         RangeSet.__init__(self, *args, **kwds)
-        self._index = None
+        self._index = UnindexedComponent_index
 
     # We want the RangeSet.__str__ to override the one in _FiniteSetMixin
     __str__ = RangeSet.__str__
@@ -3031,7 +3033,7 @@ class FiniteScalarRangeSet(_ScalarOrderedSetMixin,
     def __init__(self, *args, **kwds):
         _FiniteRangeSetData.__init__(self, component=self)
         RangeSet.__init__(self, *args, **kwds)
-        self._index = None
+        self._index = UnindexedComponent_index
 
     # We want the RangeSet.__str__ to override the one in _FiniteSetMixin
     __str__ = RangeSet.__str__

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -38,14 +38,13 @@ from pyomo.core.base.range import (
 )
 from pyomo.core.base.component import (
     _ComponentBase, Component, ComponentData, ModelComponentFactory,
-    UnindexedComponent_index
 )
 from pyomo.core.base.indexed_component import (
     IndexedComponent, UnindexedComponent_set, normalize_index,
     rule_wrapper,
 )
 from pyomo.core.base.global_set import (
-    GlobalSets, GlobalSetBase,
+    GlobalSets, GlobalSetBase, UnindexedComponent_index
 )
 
 from collections.abc import Sequence

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -2213,7 +2213,7 @@ class Set(IndexedComponent):
                 _ordered = "Insertion"
         return (
             [("Size", len(self._data)),
-             ("Index", self._index if self.is_indexed() else None),
+             ("Index", self._index_set if self.is_indexed() else None),
              ("Ordered", _ordered),],
             self._data.items(),
             ("Dimen","Domain","Size","Members",),

--- a/pyomo/core/base/sos.py
+++ b/pyomo/core/base/sos.py
@@ -272,7 +272,7 @@ class SOSConstraint(ActiveIndexedComponent):
         else:
             _self_rule = self._rule
             _self_parent = self._parent()
-            for index in self._index:
+            for index in self._index_set:
                 try:
                     tmp = apply_indexed_rule(self, _self_rule, _self_parent, index)
                 except Exception:
@@ -323,7 +323,7 @@ class SOSConstraint(ActiveIndexedComponent):
             ostream.write("  ")
         ostream.write("\tSize="+str(len(self._data.keys()))+' ')
         if self.is_indexed():
-            ostream.write("\tIndex= "+self._index.name+'\n')
+            ostream.write("\tIndex= "+self._index_set.name+'\n')
         else:
             ostream.write("\n")
         for val in self._data:

--- a/pyomo/core/base/sos.py
+++ b/pyomo/core/base/sos.py
@@ -18,7 +18,7 @@ from pyomo.common.log import is_debug_set
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base.misc import apply_indexed_rule
 from pyomo.core.base.component import (
-    ActiveComponentData, ModelComponentFactory
+    ActiveComponentData, ModelComponentFactory, UnindexedComponent_index
 )
 from pyomo.core.base.indexed_component import (
     ActiveIndexedComponent, UnindexedComponent_set
@@ -347,7 +347,7 @@ class ScalarSOSConstraint(SOSConstraint, _SOSConstraintData):
     def __init__(self, *args, **kwd):
         _SOSConstraintData.__init__(self, self)
         SOSConstraint.__init__(self, *args, **kwd)
-        self._index = None
+        self._index = UnindexedComponent_index
 
 
 class SimpleSOSConstraint(metaclass=RenamedClass):

--- a/pyomo/core/base/sos.py
+++ b/pyomo/core/base/sos.py
@@ -17,9 +17,8 @@ from pyomo.common.deprecation import RenamedClass
 from pyomo.common.log import is_debug_set
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base.misc import apply_indexed_rule
-from pyomo.core.base.component import (
-    ActiveComponentData, ModelComponentFactory, UnindexedComponent_index
-)
+from pyomo.core.base.component import ActiveComponentData, ModelComponentFactory
+from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import (
     ActiveIndexedComponent, UnindexedComponent_set
 )

--- a/pyomo/core/base/sos.py
+++ b/pyomo/core/base/sos.py
@@ -347,6 +347,7 @@ class ScalarSOSConstraint(SOSConstraint, _SOSConstraintData):
     def __init__(self, *args, **kwd):
         _SOSConstraintData.__init__(self, self)
         SOSConstraint.__init__(self, *args, **kwd)
+        self._index = None
 
 
 class SimpleSOSConstraint(metaclass=RenamedClass):

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -817,7 +817,7 @@ class Var(IndexedComponent, IndexedComponent_NDArrayMixin):
         """Print component information."""
         headers = [
             ("Size", len(self)),
-            ("Index", self._index if self.is_indexed() else None),
+            ("Index", self._index_set if self.is_indexed() else None),
         ]
         if self._units is not None:
             headers.append(('Units', str(self._units)))
@@ -950,11 +950,11 @@ class VarList(IndexedVar):
         # then let _validate_index complain when we set the value.
         if self._rule_init is not None and self._rule_init.contains_indices():
             for i, idx in enumerate(self._rule_init.indices()):
-                self._index.add(i + self._starting_index)
+                self._index_set.add(i + self._starting_index)
         super(VarList,self).construct(data)
 
     def add(self):
         """Add a variable to this list."""
-        next_idx = len(self._index) + self._starting_index
-        self._index.add(next_idx)
+        next_idx = len(self._index_set) + self._starting_index
+        self._index_set.add(next_idx)
         return self[next_idx]

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -19,14 +19,15 @@ from weakref import ref as weakref_ref
 from pyomo.common.collections import Sequence
 from pyomo.common.deprecation import RenamedClass
 from pyomo.common.log import is_debug_set
-from pyomo.common.modeling import NoArgumentGiven, NOTSET
+from pyomo.common.modeling import NOTSET
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.staleflag import StaleFlagManager
 from pyomo.core.expr.numeric_expr import NPV_MaxExpression, NPV_MinExpression
 from pyomo.core.expr.numvalue import (
     NumericValue, value, is_potentially_variable, native_numeric_types,
 )
-from pyomo.core.base.component import ComponentData, ModelComponentFactory
+from pyomo.core.base.component import (
+    ComponentData, ModelComponentFactory, UnindexedComponent_index)
 from pyomo.core.base.disable_methods import disable_methods
 from pyomo.core.base.indexed_component import (
     IndexedComponent, UnindexedComponent_set, IndexedComponent_NDArrayMixin
@@ -295,7 +296,7 @@ class _GeneralVarData(_VarData):
         #   - NumericValue
         self._component = weakref_ref(component) if (component is not None) \
                           else None
-        self._index = NoArgumentGiven
+        self._index = NOTSET
         self._value = None
         #
         # The type of the lower and upper bound attributes can either be
@@ -848,7 +849,7 @@ class ScalarVar(_GeneralVarData, Var):
     def __init__(self, *args, **kwd):
         _GeneralVarData.__init__(self, component=self)
         Var.__init__(self, *args, **kwd)
-        self._index = None
+        self._index = UnindexedComponent_index
 
     # Since this class derives from Component and Component.__getstate__
     # just packs up the entire __dict__ into the state dict, we do not

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -26,8 +26,8 @@ from pyomo.core.expr.numeric_expr import NPV_MaxExpression, NPV_MinExpression
 from pyomo.core.expr.numvalue import (
     NumericValue, value, is_potentially_variable, native_numeric_types,
 )
-from pyomo.core.base.component import (
-    ComponentData, ModelComponentFactory, UnindexedComponent_index)
+from pyomo.core.base.component import ComponentData, ModelComponentFactory
+from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.disable_methods import disable_methods
 from pyomo.core.base.indexed_component import (
     IndexedComponent, UnindexedComponent_set, IndexedComponent_NDArrayMixin

--- a/pyomo/core/beta/dict_objects.py
+++ b/pyomo/core/beta/dict_objects.py
@@ -109,6 +109,7 @@ class ComponentDict(MutableMapping):
                     # * see __delitem__ for explanation
                     self._data[key]._component = None
                 self._data[key] = val
+                self._data[key]._index = key
                 return
             elif (key in self._data) and (self._data[key] is val):
                 # a very special case that makes sense to handle

--- a/pyomo/core/beta/list_objects.py
+++ b/pyomo/core/beta/list_objects.py
@@ -98,6 +98,7 @@ class ComponentList(MutableSequence):
                     self._active |= getattr(item, '_active', True)
                 self._data[i]._component = None
                 self._data[i] = item
+                item._index = i
                 return
             elif self._data[i] is item:
                 # a very special case that makes sense to handle
@@ -133,6 +134,7 @@ class ComponentList(MutableSequence):
                 if hasattr(self, "_active"):
                     self._active |= getattr(item, '_active', True)
                 self._data.insert(i, item)
+                item._index = i
                 return
             # see note about allowing components to live in more than
             # one container

--- a/pyomo/core/plugins/transform/util.py
+++ b/pyomo/core/plugins/transform/util.py
@@ -176,9 +176,9 @@ def _getAbstractIndices(comp):
     """
     Returns the index or index set of this component
     """
-    if type(comp._index_set) != type({}):
+    if type(comp.index_set()) != type({}):
         # Singly indexed component
-        return comp._index_set
+        return comp.index_set()
     else:
         # Unindexed constraint
         return {None: None}

--- a/pyomo/core/plugins/transform/util.py
+++ b/pyomo/core/plugins/transform/util.py
@@ -176,9 +176,9 @@ def _getAbstractIndices(comp):
     """
     Returns the index or index set of this component
     """
-    if type(comp._index) != type({}):
+    if type(comp._index_set) != type({}):
         # Singly indexed component
-        return comp._index
+        return comp._index_set
     else:
         # Unindexed constraint
         return {None: None}

--- a/pyomo/core/tests/transform/test_transform.py
+++ b/pyomo/core/tests/transform/test_transform.py
@@ -327,7 +327,7 @@ class Test(unittest.TestCase):
         for c in ('x', 'y', 'z'):
             for n in ('1', '2', '3', '4'):
                 var = transformed.__getattribute__(c+n)
-                for ndx in var._index:
+                for ndx in var._index_set:
                     self.assertTrue(self.nonnegativeBounds(var[ndx]))
 
     @unittest.skipIf(not 'glpk' in solvers, "glpk solver is not available")

--- a/pyomo/core/tests/transform/test_transform.py
+++ b/pyomo/core/tests/transform/test_transform.py
@@ -327,7 +327,7 @@ class Test(unittest.TestCase):
         for c in ('x', 'y', 'z'):
             for n in ('1', '2', '3', '4'):
                 var = transformed.__getattribute__(c+n)
-                for ndx in var._index_set:
+                for ndx in var.index_set():
                     self.assertTrue(self.nonnegativeBounds(var[ndx]))
 
     @unittest.skipIf(not 'glpk' in solvers, "glpk solver is not available")

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -787,7 +787,6 @@ class ArrayParam6(unittest.TestCase):
         model.b = Set(initialize=['a','b','c'])
         model.c = model.b * model.b
         model.p = Param(model.a, model.c, within=NonNegativeIntegers, default=0, mutable=True)
-        #print(model.p._index_set.keys())
         model.p[1,'a','b'] = 1
         model.p[1,('a','b')] = 1
         model.p[(1,'b'),'b'] = 1

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -787,7 +787,7 @@ class ArrayParam6(unittest.TestCase):
         model.b = Set(initialize=['a','b','c'])
         model.c = model.b * model.b
         model.p = Param(model.a, model.c, within=NonNegativeIntegers, default=0, mutable=True)
-        #print(model.p._index.keys())
+        #print(model.p._index_set.keys())
         model.p[1,'a','b'] = 1
         model.p[1,('a','b')] = 1
         model.p[(1,'b'),'b'] = 1

--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -119,7 +119,7 @@ def expand_components(block):
     # BlockData will be added to the indexed Block but will not be
     # constructed correctly.
     for blk in block.component_objects(Block, descend_into=True):
-        missing_idx = set(blk._index) - set(blk._data.keys())
+        missing_idx = set(blk._index_set) - set(blk._data.keys())
         if missing_idx:
             blk._dae_missing_idx = missing_idx
 
@@ -259,7 +259,7 @@ def _update_var(v):
     #       Var (which is now a IndexedComponent). However, it
     #       would be much slower to rely on that method to generate new
     #       _VarData for a large number of new indices.
-    new_indices = set(v._index) - set(v._data.keys())
+    new_indices = set(v._index_set) - set(v._data.keys())
     for index in new_indices:
         v.add(index)
 

--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -119,7 +119,7 @@ def expand_components(block):
     # BlockData will be added to the indexed Block but will not be
     # constructed correctly.
     for blk in block.component_objects(Block, descend_into=True):
-        missing_idx = set(blk._index_set) - set(blk._data.keys())
+        missing_idx = set(blk.index_set()) - set(blk._data.keys())
         if missing_idx:
             blk._dae_missing_idx = missing_idx
 
@@ -259,7 +259,7 @@ def _update_var(v):
     #       Var (which is now a IndexedComponent). However, it
     #       would be much slower to rely on that method to generate new
     #       _VarData for a large number of new indices.
-    new_indices = set(v._index_set) - set(v._data.keys())
+    new_indices = set(v.index_set()) - set(v._data.keys())
     for index in new_indices:
         v.add(index)
 

--- a/pyomo/dae/tests/test_diffvar.py
+++ b/pyomo/dae/tests/test_diffvar.py
@@ -42,7 +42,7 @@ class TestDerivativeVar(unittest.TestCase):
         self.assertTrue(m.dv._sVar is m.v)
         self.assertTrue(m.v._derivative[('t',)]() is m.dv)
         self.assertTrue(m.dv.ctype is DerivativeVar)
-        self.assertTrue(m.dv._index is m.t)
+        self.assertTrue(m.dv._index_set is m.t)
         self.assertTrue(m.dv2._wrt[0] is m.t)
         self.assertTrue(m.dv2._wrt[1] is m.t)
         self.assertTrue(m.v._derivative[('t', 't')]() is m.dv2)

--- a/pyomo/dae/tests/test_diffvar.py
+++ b/pyomo/dae/tests/test_diffvar.py
@@ -42,7 +42,7 @@ class TestDerivativeVar(unittest.TestCase):
         self.assertTrue(m.dv._sVar is m.v)
         self.assertTrue(m.v._derivative[('t',)]() is m.dv)
         self.assertTrue(m.dv.ctype is DerivativeVar)
-        self.assertTrue(m.dv._index_set is m.t)
+        self.assertTrue(m.dv.index_set() is m.t)
         self.assertTrue(m.dv2._wrt[0] is m.t)
         self.assertTrue(m.dv2._wrt[1] is m.t)
         self.assertTrue(m.v._derivative[('t', 't')]() is m.dv2)

--- a/pyomo/dae/tests/test_flatten.py
+++ b/pyomo/dae/tests/test_flatten.py
@@ -586,13 +586,13 @@ class TestFlatten(TestCategorize):
 
         ref1 = Reference(m.v_2n[:,('c',3)])
 
-        ref_set = ref1._index_set._ref # _index is a _ReferenceSet
+        ref_set = ref1.index_set()._ref # _index is a _ReferenceSet
 
         #next(ref_set._get_iter(ref_set._slice, ('a',1)))
         # ^ This raises a somewhat cryptic error message.
         # _ReferenceSet.__contains__ seems to be the culprit,
         # which is called in validate_index for every __getitem__.
-        self.assertNotIn(('a',1), ref1._index_set._ref)
+        self.assertNotIn(('a',1), ref_set)
         # ^ This does not seem to behave as expected...
         # Reason is incompatibility with flatten==False.
 

--- a/pyomo/dae/tests/test_flatten.py
+++ b/pyomo/dae/tests/test_flatten.py
@@ -586,13 +586,13 @@ class TestFlatten(TestCategorize):
 
         ref1 = Reference(m.v_2n[:,('c',3)])
 
-        ref_set = ref1._index._ref # _index is a _ReferenceSet
+        ref_set = ref1._index_set._ref # _index is a _ReferenceSet
 
         #next(ref_set._get_iter(ref_set._slice, ('a',1)))
         # ^ This raises a somewhat cryptic error message.
         # _ReferenceSet.__contains__ seems to be the culprit,
         # which is called in validate_index for every __getitem__.
-        self.assertNotIn(('a',1), ref1._index._ref)
+        self.assertNotIn(('a',1), ref1._index_set._ref)
         # ^ This does not seem to behave as expected...
         # Reason is incompatibility with flatten==False.
 

--- a/pyomo/dae/tests/test_misc.py
+++ b/pyomo/dae/tests/test_misc.py
@@ -484,7 +484,7 @@ class TestDaeMisc(unittest.TestCase):
 
         generate_finite_elements(model.t, 5)
 
-        missing_idx = set(model.blk._index) - set(model.blk._data.keys())
+        missing_idx = set(model.blk._index_set) - set(model.blk._data.keys())
         model.blk._dae_missing_idx = missing_idx
 
         update_contset_indexed_component(model.blk, expansion_map)
@@ -537,7 +537,7 @@ class TestDaeMisc(unittest.TestCase):
 
         generate_finite_elements(model.t, 5)
 
-        missing_idx = set(model.blk._index) - set(model.blk._data.keys())
+        missing_idx = set(model.blk._index_set) - set(model.blk._data.keys())
         model.blk._dae_missing_idx = missing_idx
 
         update_contset_indexed_component(model.blk, expansion_map)
@@ -592,7 +592,7 @@ class TestDaeMisc(unittest.TestCase):
 
         generate_finite_elements(model.t, 5)
 
-        missing_idx = set(model.blk._index) - set(model.blk._data.keys())
+        missing_idx = set(model.blk._index_set) - set(model.blk._data.keys())
         model.blk._dae_missing_idx = missing_idx
 
         update_contset_indexed_component(model.blk, expansion_map)
@@ -647,7 +647,7 @@ class TestDaeMisc(unittest.TestCase):
 
         generate_finite_elements(model.t, 5)
 
-        missing_idx = set(model.blk._index) - set(model.blk._data.keys())
+        missing_idx = set(model.blk._index_set) - set(model.blk._data.keys())
         model.blk._dae_missing_idx = missing_idx
 
         update_contset_indexed_component(model.blk, expansion_map)

--- a/pyomo/dae/tests/test_misc.py
+++ b/pyomo/dae/tests/test_misc.py
@@ -484,7 +484,7 @@ class TestDaeMisc(unittest.TestCase):
 
         generate_finite_elements(model.t, 5)
 
-        missing_idx = set(model.blk._index_set) - set(model.blk._data.keys())
+        missing_idx = set(model.blk.index_set()) - set(model.blk._data.keys())
         model.blk._dae_missing_idx = missing_idx
 
         update_contset_indexed_component(model.blk, expansion_map)
@@ -537,7 +537,7 @@ class TestDaeMisc(unittest.TestCase):
 
         generate_finite_elements(model.t, 5)
 
-        missing_idx = set(model.blk._index_set) - set(model.blk._data.keys())
+        missing_idx = set(model.blk.index_set()) - set(model.blk._data.keys())
         model.blk._dae_missing_idx = missing_idx
 
         update_contset_indexed_component(model.blk, expansion_map)
@@ -592,7 +592,7 @@ class TestDaeMisc(unittest.TestCase):
 
         generate_finite_elements(model.t, 5)
 
-        missing_idx = set(model.blk._index_set) - set(model.blk._data.keys())
+        missing_idx = set(model.blk.index_set()) - set(model.blk._data.keys())
         model.blk._dae_missing_idx = missing_idx
 
         update_contset_indexed_component(model.blk, expansion_map)
@@ -647,7 +647,7 @@ class TestDaeMisc(unittest.TestCase):
 
         generate_finite_elements(model.t, 5)
 
-        missing_idx = set(model.blk._index_set) - set(model.blk._data.keys())
+        missing_idx = set(model.blk.index_set()) - set(model.blk._data.keys())
         model.blk._dae_missing_idx = missing_idx
 
         update_contset_indexed_component(model.blk, expansion_map)

--- a/pyomo/duality/lagrangian_dual.py
+++ b/pyomo/duality/lagrangian_dual.py
@@ -89,7 +89,7 @@ class DualTransformation(IsomorphicTransformation):
 
         # Walk constaints
         for (con_name, con_array) in sf.component_map(Constraint, active=True).items():
-            for con in (con_array[ndx] for ndx in con_array._index_set):
+            for con in (con_array[ndx] for ndx in con_array.index_set()):
                 # The qualified constraint name
                 cname = "%s%s" % (variable_prefix, con.local_name)
 
@@ -123,7 +123,7 @@ class DualTransformation(IsomorphicTransformation):
         # Walk objectives. Multiply all coefficients by the objective's 'sense'
         # to convert maximizing objectives to minimizing ones.
         for (obj_name, obj_array) in sf.component_map(Objective, active=True).items():
-            for obj in (obj_array[ndx] for ndx in obj_array._index_set):
+            for obj in (obj_array[ndx] for ndx in obj_array.index_set()):
                 # The qualified objective name
 
                 # Process the objective
@@ -140,7 +140,7 @@ class DualTransformation(IsomorphicTransformation):
         # Make constraint index set
         constraint_set_init = []
         for (var_name, var_array) in sf.component_map(Var, active=True).items():
-            for var in (var_array[ndx] for ndx in var_array._index_set):
+            for var in (var_array[ndx] for ndx in var_array.index_set()):
                 constraint_set_init.append("%s%s" %
                                            (var.local_name, constraint_suffix))
 
@@ -148,7 +148,7 @@ class DualTransformation(IsomorphicTransformation):
         variable_set_init = []
         dual_variable_roots = []
         for (con_name, con_array) in sf.component_map(Constraint, active=True).items():
-            for con in (con_array[ndx] for ndx in con_array._index_set):
+            for con in (con_array[ndx] for ndx in con_array.index_set()):
                 dual_variable_roots.append(con.local_name)
                 variable_set_init.append("%s%s" % (variable_prefix, con.local_name))
 

--- a/pyomo/duality/lagrangian_dual.py
+++ b/pyomo/duality/lagrangian_dual.py
@@ -89,7 +89,7 @@ class DualTransformation(IsomorphicTransformation):
 
         # Walk constaints
         for (con_name, con_array) in sf.component_map(Constraint, active=True).items():
-            for con in (con_array[ndx] for ndx in con_array._index):
+            for con in (con_array[ndx] for ndx in con_array._index_set):
                 # The qualified constraint name
                 cname = "%s%s" % (variable_prefix, con.local_name)
 
@@ -123,7 +123,7 @@ class DualTransformation(IsomorphicTransformation):
         # Walk objectives. Multiply all coefficients by the objective's 'sense'
         # to convert maximizing objectives to minimizing ones.
         for (obj_name, obj_array) in sf.component_map(Objective, active=True).items():
-            for obj in (obj_array[ndx] for ndx in obj_array._index):
+            for obj in (obj_array[ndx] for ndx in obj_array._index_set):
                 # The qualified objective name
 
                 # Process the objective
@@ -140,7 +140,7 @@ class DualTransformation(IsomorphicTransformation):
         # Make constraint index set
         constraint_set_init = []
         for (var_name, var_array) in sf.component_map(Var, active=True).items():
-            for var in (var_array[ndx] for ndx in var_array._index):
+            for var in (var_array[ndx] for ndx in var_array._index_set):
                 constraint_set_init.append("%s%s" %
                                            (var.local_name, constraint_suffix))
 
@@ -148,7 +148,7 @@ class DualTransformation(IsomorphicTransformation):
         variable_set_init = []
         dual_variable_roots = []
         for (con_name, con_array) in sf.component_map(Constraint, active=True).items():
-            for con in (con_array[ndx] for ndx in con_array._index):
+            for con in (con_array[ndx] for ndx in con_array._index_set):
                 dual_variable_roots.append(con.local_name)
                 variable_set_init.append("%s%s" % (variable_prefix, con.local_name))
 

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -637,7 +637,7 @@ class Disjunction(ActiveIndexedComponent):
                 (self.name,) )
         elif self._init_rule is not None:
             _init_rule = self._init_rule
-            for ndx in self._index:
+            for ndx in self._index_set:
                 try:
                     expr = apply_indexed_rule(self,
                                              _init_rule,
@@ -667,7 +667,7 @@ class Disjunction(ActiveIndexedComponent):
         """
         return (
             [("Size", len(self)),
-             ("Index", self._index if self.is_indexed() else None),
+             ("Index", self._index_set if self.is_indexed() else None),
              ("Active", self.active),
              ],
             self.items(),

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -18,14 +18,15 @@ from weakref import ref as weakref_ref
 from pyomo.common.deprecation import RenamedClass,  deprecation_warning
 from pyomo.common.errors import PyomoException
 from pyomo.common.log import is_debug_set
-from pyomo.common.modeling import unique_component_name, NOTSET, NoArgumentGiven
+from pyomo.common.modeling import unique_component_name, NOTSET
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core import (
     ModelComponentFactory, Binary, Block, ConstraintList, Any,
     LogicalConstraintList, BooleanValue, ScalarBooleanVar, ScalarVar,
     value)
 from pyomo.core.base.component import (
-    ActiveComponent, ActiveComponentData, ComponentData
+    ActiveComponent, ActiveComponentData, ComponentData, 
+    UnindexedComponent_index
 )
 from pyomo.core.base.numvalue import native_types
 from pyomo.core.base.block import _BlockData
@@ -447,7 +448,7 @@ class _DisjunctionData(ActiveComponentData):
         #   - ComponentData
         self._component = weakref_ref(component) if (component is not None) \
                           else None
-        self._index = NoArgumentGiven
+        self._index = NOTSET
         self._active = True
         self.disjuncts = []
         self.xor = True
@@ -683,7 +684,7 @@ class ScalarDisjunction(_DisjunctionData, Disjunction):
     def __init__(self, *args, **kwds):
         _DisjunctionData.__init__(self, component=self)
         Disjunction.__init__(self, *args, **kwds)
-        self._index = None
+        self._index = UnindexedComponent_index
 
     #
     # Singleton disjunctions are strange in that we want them to be

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -410,7 +410,7 @@ class ScalarDisjunct(_DisjunctData, Disjunct):
         _DisjunctData.__init__(self, self)
         Disjunct.__init__(self, *args, **kwds)
         self._data[None] = self
-        self._index = None
+        self._index = UnindexedComponent_index
 
 
 class SimpleDisjunct(metaclass=RenamedClass):

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -18,7 +18,7 @@ from weakref import ref as weakref_ref
 from pyomo.common.deprecation import RenamedClass,  deprecation_warning
 from pyomo.common.errors import PyomoException
 from pyomo.common.log import is_debug_set
-from pyomo.common.modeling import unique_component_name, NOTSET
+from pyomo.common.modeling import unique_component_name, NOTSET, NoArgumentGiven
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core import (
     ModelComponentFactory, Binary, Block, ConstraintList, Any,
@@ -409,6 +409,7 @@ class ScalarDisjunct(_DisjunctData, Disjunct):
         _DisjunctData.__init__(self, self)
         Disjunct.__init__(self, *args, **kwds)
         self._data[None] = self
+        self._index = None
 
 
 class SimpleDisjunct(metaclass=RenamedClass):
@@ -446,6 +447,7 @@ class _DisjunctionData(ActiveComponentData):
         #   - ComponentData
         self._component = weakref_ref(component) if (component is not None) \
                           else None
+        self._index = NoArgumentGiven
         self._active = True
         self.disjuncts = []
         self.xor = True
@@ -681,6 +683,7 @@ class ScalarDisjunction(_DisjunctionData, Disjunction):
     def __init__(self, *args, **kwds):
         _DisjunctionData.__init__(self, component=self)
         Disjunction.__init__(self, *args, **kwds)
+        self._index = None
 
     #
     # Singleton disjunctions are strange in that we want them to be

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -25,9 +25,9 @@ from pyomo.core import (
     LogicalConstraintList, BooleanValue, ScalarBooleanVar, ScalarVar,
     value)
 from pyomo.core.base.component import (
-    ActiveComponent, ActiveComponentData, ComponentData, 
-    UnindexedComponent_index
+    ActiveComponent, ActiveComponentData, ComponentData
 )
+from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.numvalue import native_types
 from pyomo.core.base.block import _BlockData
 from pyomo.core.base.misc import apply_indexed_rule

--- a/pyomo/mpec/complementarity.py
+++ b/pyomo/mpec/complementarity.py
@@ -16,8 +16,8 @@ from pyomo.common.timing import ConstructionTimer
 from pyomo.core.expr import current as EXPR
 from pyomo.core.expr.numvalue import ZeroConstant, native_numeric_types, as_numeric
 from pyomo.core import Constraint, Var, Block, Set
-from pyomo.core.base.component import (
-    ModelComponentFactory, UnindexedComponent_index)
+from pyomo.core.base.component import ModelComponentFactory
+from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.block import _BlockData
 from pyomo.core.base.disable_methods import disable_methods
 from pyomo.core.base.initializer import (

--- a/pyomo/mpec/complementarity.py
+++ b/pyomo/mpec/complementarity.py
@@ -265,7 +265,7 @@ Error thrown for Complementarity "%s".""" % ( b.name, ) )
 
         return (
             [("Size", len(self)),
-             ("Index", self._index if self.is_indexed() else None),
+             ("Index", self._index_set if self.is_indexed() else None),
              ("Active", self.active),
              ],
             self._data.items(),
@@ -326,7 +326,7 @@ class ComplementarityList(IndexedComplementarity):
         Add a complementarity condition with an implicit index.
         """
         self._nconditions += 1
-        self._index.add(self._nconditions)
+        self._index_set.add(self._nconditions)
         return Complementarity.add(self, self._nconditions, expr)
 
     def construct(self, data=None):

--- a/pyomo/mpec/complementarity.py
+++ b/pyomo/mpec/complementarity.py
@@ -280,6 +280,7 @@ class ScalarComplementarity(_ComplementarityData, Complementarity):
         _ComplementarityData.__init__(self, self)
         Complementarity.__init__(self, *args, **kwds)
         self._data[None] = self
+        self._index = None
 
 
 class SimpleComplementarity(metaclass=RenamedClass):

--- a/pyomo/mpec/complementarity.py
+++ b/pyomo/mpec/complementarity.py
@@ -16,7 +16,8 @@ from pyomo.common.timing import ConstructionTimer
 from pyomo.core.expr import current as EXPR
 from pyomo.core.expr.numvalue import ZeroConstant, native_numeric_types, as_numeric
 from pyomo.core import Constraint, Var, Block, Set
-from pyomo.core.base.component import ModelComponentFactory
+from pyomo.core.base.component import (
+    ModelComponentFactory, UnindexedComponent_index)
 from pyomo.core.base.block import _BlockData
 from pyomo.core.base.disable_methods import disable_methods
 from pyomo.core.base.initializer import (
@@ -280,7 +281,7 @@ class ScalarComplementarity(_ComplementarityData, Complementarity):
         _ComplementarityData.__init__(self, self)
         Complementarity.__init__(self, *args, **kwds)
         self._data[None] = self
-        self._index = None
+        self._index = UnindexedComponent_index
 
 
 class SimpleComplementarity(metaclass=RenamedClass):

--- a/pyomo/network/arc.py
+++ b/pyomo/network/arc.py
@@ -330,7 +330,7 @@ class Arc(ActiveIndexedComponent):
                 raise IndexError(
                     "Arc '%s': Cannot initialize multiple indices "
                     "of an arc with single ports" % self.name)
-            for idx in self._index:
+            for idx in self._index_set:
                 try:
                     tmp = apply_indexed_rule(self, self._rule, self_parent, idx)
                 except Exception:
@@ -348,7 +348,7 @@ class Arc(ActiveIndexedComponent):
         """Return data that will be printed for this component."""
         return (
             [("Size", len(self)),
-             ("Index", self._index if self.is_indexed() else None),
+             ("Index", self._index_set if self.is_indexed() else None),
              ("Active", self.active)],
             self.items(),
             ("Ports", "Directed", "Active"),

--- a/pyomo/network/arc.py
+++ b/pyomo/network/arc.py
@@ -17,6 +17,7 @@ from pyomo.core.base.indexed_component import (ActiveIndexedComponent,
 from pyomo.core.base.misc import apply_indexed_rule
 from pyomo.common.deprecation import RenamedClass
 from pyomo.common.log import is_debug_set
+from pyomo.common.modeling import NoArgumentGiven
 from pyomo.common.timing import ConstructionTimer
 from weakref import ref as weakref_ref
 import logging, sys
@@ -77,6 +78,7 @@ class _ArcData(ActiveComponentData):
         #   - ComponentData
         self._component = weakref_ref(component) if (component is not None) \
                           else None
+        self._index = NoArgumentGiven
         self._active = True
 
         self._ports = None
@@ -362,6 +364,7 @@ class ScalarArc(_ArcData, Arc):
     def __init__(self, *args, **kwds):
         _ArcData.__init__(self, self)
         Arc.__init__(self, *args, **kwds)
+        self._index = None
 
     def set_value(self, vals):
         """

--- a/pyomo/network/arc.py
+++ b/pyomo/network/arc.py
@@ -11,10 +11,10 @@
 __all__ = [ 'Arc' ]
 
 from pyomo.network.port import Port
-from pyomo.core.base.component import (
-    ActiveComponentData, ModelComponentFactory, UnindexedComponent_index)
-from pyomo.core.base.indexed_component import (ActiveIndexedComponent,
-    UnindexedComponent_set)
+from pyomo.core.base.component import ActiveComponentData, ModelComponentFactory
+from pyomo.core.base.indexed_component import (
+    ActiveIndexedComponent, UnindexedComponent_set)
+from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.misc import apply_indexed_rule
 from pyomo.common.deprecation import RenamedClass
 from pyomo.common.log import is_debug_set

--- a/pyomo/network/arc.py
+++ b/pyomo/network/arc.py
@@ -11,13 +11,14 @@
 __all__ = [ 'Arc' ]
 
 from pyomo.network.port import Port
-from pyomo.core.base.component import ActiveComponentData, ModelComponentFactory
+from pyomo.core.base.component import (
+    ActiveComponentData, ModelComponentFactory, UnindexedComponent_index)
 from pyomo.core.base.indexed_component import (ActiveIndexedComponent,
     UnindexedComponent_set)
 from pyomo.core.base.misc import apply_indexed_rule
 from pyomo.common.deprecation import RenamedClass
 from pyomo.common.log import is_debug_set
-from pyomo.common.modeling import NoArgumentGiven
+from pyomo.common.modeling import NOTSET
 from pyomo.common.timing import ConstructionTimer
 from weakref import ref as weakref_ref
 import logging, sys
@@ -78,7 +79,7 @@ class _ArcData(ActiveComponentData):
         #   - ComponentData
         self._component = weakref_ref(component) if (component is not None) \
                           else None
-        self._index = NoArgumentGiven
+        self._index = NOTSET
         self._active = True
 
         self._ports = None
@@ -364,7 +365,7 @@ class ScalarArc(_ArcData, Arc):
     def __init__(self, *args, **kwds):
         _ArcData.__init__(self, self)
         Arc.__init__(self, *args, **kwds)
-        self._index = None
+        self.index = UnindexedComponent_index
 
     def set_value(self, vals):
         """

--- a/pyomo/network/port.py
+++ b/pyomo/network/port.py
@@ -17,12 +17,13 @@ from pyomo.common.collections import ComponentMap
 from pyomo.common.deprecation import RenamedClass
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.log import is_debug_set
-from pyomo.common.modeling import unique_component_name, NoArgumentGiven
+from pyomo.common.modeling import unique_component_name, NOTSET
 from pyomo.common.timing import ConstructionTimer
 
 from pyomo.core.base.var import Var
 from pyomo.core.base.constraint import Constraint
-from pyomo.core.base.component import ComponentData, ModelComponentFactory
+from pyomo.core.base.component import (
+    ComponentData, ModelComponentFactory, UnindexedComponent_index)
 from pyomo.core.base.indexed_component import \
     IndexedComponent, UnindexedComponent_set
 from pyomo.core.base.misc import apply_indexed_rule
@@ -55,7 +56,7 @@ class _PortData(ComponentData):
         #   - NumericValue
         self._component = weakref_ref(component) if (component is not None) \
                           else None
-        self._index = NoArgumentGiven
+        self._index = NOTSET
 
         self.vars = {}
         self._arcs = []
@@ -731,7 +732,7 @@ class ScalarPort(Port, _PortData):
     def __init__(self, *args, **kwd):
         _PortData.__init__(self, component=self)
         Port.__init__(self, *args, **kwd)
-        self._index = None
+        self._index = UnindexedComponent_index
 
 
 class SimplePort(metaclass=RenamedClass):

--- a/pyomo/network/port.py
+++ b/pyomo/network/port.py
@@ -17,7 +17,7 @@ from pyomo.common.collections import ComponentMap
 from pyomo.common.deprecation import RenamedClass
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.log import is_debug_set
-from pyomo.common.modeling import unique_component_name
+from pyomo.common.modeling import unique_component_name, NoArgumentGiven
 from pyomo.common.timing import ConstructionTimer
 
 from pyomo.core.base.var import Var
@@ -55,6 +55,7 @@ class _PortData(ComponentData):
         #   - NumericValue
         self._component = weakref_ref(component) if (component is not None) \
                           else None
+        self._index = NoArgumentGiven
 
         self.vars = {}
         self._arcs = []
@@ -344,6 +345,7 @@ class Port(IndexedComponent):
     def _getitem_when_not_present(self, idx):
         """Returns the default component data value."""
         tmp = self._data[idx] = _PortData(component=self)
+        tmp._index = idx
         return tmp
 
     def construct(self, data=None):
@@ -729,6 +731,7 @@ class ScalarPort(Port, _PortData):
     def __init__(self, *args, **kwd):
         _PortData.__init__(self, component=self)
         Port.__init__(self, *args, **kwd)
+        self._index = None
 
 
 class SimplePort(metaclass=RenamedClass):

--- a/pyomo/network/port.py
+++ b/pyomo/network/port.py
@@ -359,7 +359,7 @@ class Port(IndexedComponent):
 
         # Construct _PortData objects for all index values
         if self.is_indexed():
-            self._initialize_members(self._index)
+            self._initialize_members(self._index_set)
         else:
             self._data[None] = self
             self._initialize_members([None])
@@ -424,7 +424,7 @@ class Port(IndexedComponent):
                 yield _k, _len, str(_v)
         return (
             [("Size", len(self)),
-             ("Index", self._index if self.is_indexed() else None)],
+             ("Index", self._index_set if self.is_indexed() else None)],
              self._data.items(),
              ( "Name", "Size", "Variable"),
              _line_generator)

--- a/pyomo/network/port.py
+++ b/pyomo/network/port.py
@@ -22,8 +22,8 @@ from pyomo.common.timing import ConstructionTimer
 
 from pyomo.core.base.var import Var
 from pyomo.core.base.constraint import Constraint
-from pyomo.core.base.component import (
-    ComponentData, ModelComponentFactory, UnindexedComponent_index)
+from pyomo.core.base.component import ComponentData, ModelComponentFactory
+from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import \
     IndexedComponent, UnindexedComponent_set
 from pyomo.core.base.misc import apply_indexed_rule

--- a/pyomo/repn/beta/matrix.py
+++ b/pyomo/repn/beta/matrix.py
@@ -407,7 +407,7 @@ class _LinearMatrixConstraintData(_LinearConstraintData):
         _active         A boolean that indicates whether this data is active
     """
 
-    __slots__ = ('_index')
+    __slots__ = ()
 
     def __init__(self, index, component=None):
         #
@@ -430,7 +430,6 @@ class _LinearMatrixConstraintData(_LinearConstraintData):
         This method must be defined because this class uses slots.
         """
         result = super(_LinearMatrixConstraintData, self).__getstate__()
-        result['_index'] = self._index
         return result
 
     # Since this class requires no special processing of the state
@@ -697,4 +696,3 @@ class MatrixConstraint(Mapping, IndexedConstraint):
 
     def __delitem__(self):
         raise NotImplementedError
-

--- a/pyomo/repn/beta/matrix.py
+++ b/pyomo/repn/beta/matrix.py
@@ -370,6 +370,7 @@ class _LinearConstraintData(_ConstraintData):
         #   - ComponentData
         self._component = weakref_ref(component) if (component is not None) \
                           else None
+        self._index = index
         self._active = True
 
 class _LinearMatrixConstraintData(_LinearConstraintData):


### PR DESCRIPTION
## Fixes #1130

## Summary/Motivation:

This supersedes #1228--it turned out to be easier to make the changes starting from the modern era than it was to revive the original PR.

## Changes proposed in this PR:
- Renames `_index` to `_index_set` on all indexed components
- Adds `_index` to `_ComponentData` to store the ComponentData's key in its parent's `_data` dictionary
- Sets `_index=None` in the `__init__` methods of all ScalarComponents
- `getname` no longer means a linear scan *in the absence of a name buffer.* However, the behavior is the same as before when a name buffer is provided. This is because there are bugs with the `name_buffer` arg if the user uses the same dictionary but switches between fully-qualified and local names or switches what component the name is relative to. I will address this in a subsequent PR.

Things to look for when reviewing:
- Keeping the `_index` in sync with the parent's `_data` dictionary relies on the assumption that the only time key-value pairs are updated in this dictionary is in `_getitem_when_not_present` and `_setitem_when_not_present`. It turns out that's not true for `Var` and `BooleanVar`, and if there are other places where the assumption doesn't hold, the `_index` needs to be updated when the value is changed or when a key-value pair is added.
- `_ComponentData.__init__` is in-lined in *many* classes... Any `__init__` method that in-lines it needs to set `_index = NoArgumentGiven`.

## Performance impact

Performance results comparing main and this branch with 10 replicate each are here:
![image](https://user-images.githubusercontent.com/12833636/160669867-80b0a908-954d-4049-93e1-2180c8890a7b.png)
I'm not completely sure what's happening with the last test or if we should be concerned, but overall it looks like this is okay.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
