### PR TITLE
GHA Fixes: Conda+Ubuntu Stalling and IPOPT Naming Update

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -338,12 +338,12 @@ jobs:
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
                 curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-ubuntu2004-64.tar.gz \
+                    -L $URL/idaes-solvers-ubuntu2004-x86_64.tar.gz \
                     > $IPOPT_TAR
             else
                 curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-windows-64.tar.gz \
-                    $URL/idaes-lib-windows-64.tar.gz > $IPOPT_TAR
+                    -L $URL/idaes-solvers-windows-x86_64.tar.gz \
+                    $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
             fi
         fi
         cd $IPOPT_DIR

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -259,6 +259,13 @@ jobs:
         # Note: some pypi packages are not available through conda
         PYOMO_DEPENDENCIES=`python setup.py dependencies \
             --extras "$EXTRAS" | tail -1`
+        # HACK: Remove problem packages on conda+Linux
+        if test "${{matrix.TARGET}}" == linux; then
+            WORDSTOREMOVE="casadi numdifftools pint"
+            for WORD in $WORDSTOREMOVE; do
+                PYOMO_DEPENDENCIES=${PYOMO_DEPENDENCIES//$WORD/}
+            done
+        fi
         CONDA_DEPENDENCIES=`echo $PYOMO_DEPENDENCIES | tr ' ' '\n' \
             | grep -Ev ${PYPI_ONLY} | tr '\n' ' '`
         PYPI_DEPENDENCIES=`echo $PYOMO_DEPENDENCIES | tr ' ' '\n' \

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -278,6 +278,13 @@ jobs:
         # Note: some pypi packages are not available through conda
         PYOMO_DEPENDENCIES=`python setup.py dependencies \
             --extras "$EXTRAS" | tail -1`
+        # HACK: Remove problem packages on conda+Linux
+        if test "${{matrix.TARGET}}" == linux; then
+            WORDSTOREMOVE="casadi numdifftools pint"
+            for WORD in $WORDSTOREMOVE; do
+                PYOMO_DEPENDENCIES=${PYOMO_DEPENDENCIES//$WORD/}
+            done
+        fi
         CONDA_DEPENDENCIES=`echo $PYOMO_DEPENDENCIES | tr ' ' '\n' \
             | grep -Ev ${PYPI_ONLY} | tr '\n' ' '`
         PYPI_DEPENDENCIES=`echo $PYOMO_DEPENDENCIES | tr ' ' '\n' \
@@ -350,12 +357,12 @@ jobs:
             URL=${URL}/releases/download/$VER
             if test "${{matrix.TARGET}}" == linux; then
                 curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-ubuntu2004-64.tar.gz \
+                    -L $URL/idaes-solvers-ubuntu2004-x86_64.tar.gz \
                     > $IPOPT_TAR
             else
                 curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-windows-64.tar.gz \
-                    $URL/idaes-lib-windows-64.tar.gz > $IPOPT_TAR
+                    -L $URL/idaes-solvers-windows-x86_64.tar.gz \
+                    $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
             fi
         fi
         cd $IPOPT_DIR


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
GitHub Actions Runners updated, and the newest version causes issues for Ubuntu+Conda combinations due to the following three packages:

- `casadi`
- `numdifftools`
- `pint`

This PR provides a hack to remove those three packages from the `EXTRAS` so we can get the jobs running again.

Also while finding this fix, it was revealed that IDAES ipopt changed the naming scheme for their tarballs from `platform-64` to `platform-x86_64`, so this also changes that.

## Changes proposed in this PR:
- Remove `casadi`, `numdifftools`, and `pint` from linux/conda jobs
- Update IPOPT URL to `x86_64`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
