### PR TITLE
Improved processing of strings passed to `ConfigList`, `ConfigDict`, and `ListOf`

### DIFF
--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -1946,7 +1946,7 @@ class ConfigList(ConfigBase, Sequence):
         self._data = []
         try:
             if isinstance(value, str):
-                value = list(_default_string_list_lexer()(value))
+                value = list(_default_string_list_lexer(value))
             if (type(value) is list) or \
                isinstance(value, ConfigList):
                 for val in value:

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -32,7 +32,7 @@ import types
 from pyomo.common.collections import Sequence, Mapping
 from pyomo.common.deprecation import deprecated, relocated_module_attribute
 from pyomo.common.fileutils import import_file
-from pyomo.common.modeling import NoArgumentGiven
+from pyomo.common.modeling import NOTSET
 
 logger = logging.getLogger('pyomo.common.config')
 
@@ -237,7 +237,6 @@ class In(object):
     def __init__(self, domain, cast=None):
         self._domain = domain
         self._cast = cast
-
 
     def __call__(self, value):
         if self._cast is not None:
@@ -1175,10 +1174,10 @@ class ConfigBase(object):
             # of setting self.__dict__[key] = val.
             object.__setattr__(self, key, val)
 
-    def __call__(self, value=NoArgumentGiven, default=NoArgumentGiven,
-                 domain=NoArgumentGiven,  description=NoArgumentGiven,
-                 doc=NoArgumentGiven, visibility=NoArgumentGiven,
-                 implicit=NoArgumentGiven, implicit_domain=NoArgumentGiven,
+    def __call__(self, value=NOTSET, default=NOTSET,
+                 domain=NOTSET,  description=NOTSET,
+                 doc=NOTSET, visibility=NOTSET,
+                 implicit=NOTSET, implicit_domain=NOTSET,
                  preserve_implicit=False):
         # We will pass through overriding arguments to the constructor.
         # This way if the constructor does special processing of any of
@@ -1190,22 +1189,22 @@ class ConfigBase(object):
         fields = ('description', 'doc', 'visibility')
         if isinstance(self, ConfigDict):
             fields += (('implicit', '_implicit_declaration'), 'implicit_domain')
-            assert domain is NoArgumentGiven
-            assert default is NoArgumentGiven
+            assert domain is NOTSET
+            assert default is NOTSET
         else:
             fields += ('domain',)
             kwds['default'] = (
-                self.value() if default is NoArgumentGiven else default
+                self.value() if default is NOTSET else default
             )
-            assert implicit is NoArgumentGiven
-            assert implicit_domain is NoArgumentGiven
+            assert implicit is NOTSET
+            assert implicit_domain is NOTSET
         for field in fields:
             if type(field) is tuple:
                 field, attr = field
             else:
                 attr = '_'+field
-            if locals()[field] is NoArgumentGiven:
-                kwds[field] = getattr(self, attr, NoArgumentGiven)
+            if locals()[field] is NOTSET:
+                kwds[field] = getattr(self, attr, NOTSET)
             else:
                 kwds[field] = locals()[field]
 
@@ -1227,7 +1226,7 @@ class ConfigBase(object):
                     _tmp._name = v._name
 
         # ... and set the value, if appropriate
-        if value is not NoArgumentGiven:
+        if value is not NOTSET:
             ans.set_value(value)
         return ans
 
@@ -1257,7 +1256,7 @@ class ConfigBase(object):
             return value
         if self._domain is not None:
             try:
-                if value is not NoArgumentGiven:
+                if value is not NOTSET:
                     return self._domain(value)
                 else:
                     return self._domain()
@@ -1771,7 +1770,6 @@ class ConfigList(ConfigBase, Sequence):
             self._domain = ConfigValue(None, domain=self._domain)
         self.reset()
 
-
     def __setstate__(self, state):
         state = super(ConfigList, self).__setstate__(state)
         for x in self._data:
@@ -1785,7 +1783,7 @@ class ConfigList(ConfigBase, Sequence):
         else:
             return val
 
-    def get(self, key, default=NoArgumentGiven):
+    def get(self, key, default=NOTSET):
         # Note: get() is borrowed from ConfigDict for cases where we
         # want the raw stored object (and to aviod the implicit
         # conversion of ConfigValue members to their stored data).
@@ -1794,7 +1792,7 @@ class ConfigList(ConfigBase, Sequence):
             self._userAccessed = True
             return val
         except IndexError:
-            if default is NoArgumentGiven:
+            if default is NOTSET:
                 raise
         # Note: self._domain is ALWAYS derived from ConfigBase
         return self._domain(default)
@@ -1848,7 +1846,7 @@ class ConfigList(ConfigBase, Sequence):
         for val in self.user_values():
             val._userSet = False
 
-    def append(self, value=NoArgumentGiven):
+    def append(self, value=NOTSET):
         val = self._cast(value)
         if val is None:
             return
@@ -1863,7 +1861,7 @@ class ConfigList(ConfigBase, Sequence):
 
     @deprecated("ConfigList.add() has been deprecated.  Use append()",
                 version='5.7.2')
-    def add(self, value=NoArgumentGiven):
+    def add(self, value=NOTSET):
         "Append the specified value to the list, casting as necessary."
         return self.append(value)
 
@@ -1976,12 +1974,12 @@ class ConfigDict(ConfigBase, Mapping):
         else:
             return self._data[_key]
 
-    def get(self, key, default=NoArgumentGiven):
+    def get(self, key, default=NOTSET):
         self._userAccessed = True
         _key = str(key).replace(' ','_')
         if _key in self._data:
             return self._data[_key]
-        if default is NoArgumentGiven:
+        if default is NOTSET:
             return None
         if self._implicit_domain is not None:
             if type(self._implicit_domain) is DynamicImplicitDomain:
@@ -1991,12 +1989,12 @@ class ConfigDict(ConfigBase, Mapping):
         else:
             return ConfigValue(default)
 
-    def setdefault(self, key, default=NoArgumentGiven):
+    def setdefault(self, key, default=NOTSET):
         self._userAccessed = True
         _key = str(key).replace(' ','_')
         if _key in self._data:
             return self._data[_key]
-        if default is NoArgumentGiven:
+        if default is NOTSET:
             return self.add(key, None)
         else:
             return self.add(key, default)

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -2155,6 +2155,9 @@ Scenario definition:
             .declare_as_argument( group=(subp,'Node information') )
         self.config.initialize_argparse(parser)
 
+        # Note that the output for argparse changes in diffeent versions
+        # (in particular, "options:" vs "optional arguments:").  We will
+        # only test for a subset of the output that should stay consistent.
         help = parser.format_help()
         self.assertIn(
             """
@@ -2203,14 +2206,14 @@ Node information:
         parser = argparse.ArgumentParser(prog='tester')
         c.initialize_argparse(parser)
 
-        self.assertEqual("""
-        usage: tester [-h] [--lst INT] [--sub SUB-DICT] [--listof LISTOF[INT]]
-
-optional arguments:
+        # Note that the output for argparse changes in diffeent versions
+        # (in particular, "options:" vs "optional arguments:").  We will
+        # only test for a subset of the output that should stay consistent.
+        self.assertIn("""
   -h, --help            show this help message and exit
   --lst INT
   --sub SUB-DICT
-  --listof LISTOF[INT]""".strip(), parser.format_help().strip())
+  --listof LISTOF[INT]""".strip(), parser.format_help())
 
         args = parser.parse_args([
             '--lst', '42', '--lst', '1',

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -288,6 +288,7 @@ class TestConfigDomains(unittest.TestCase):
     def test_In(self):
         c = ConfigDict()
         c.declare('a', ConfigValue(None, In([1,3,5])))
+        self.assertEqual(c.get('a').domain_name(), 'In[1, 3, 5]')
         self.assertEqual(c.a, None)
         c.a = 3
         self.assertEqual(c.a, 3)
@@ -314,6 +315,23 @@ class TestConfigDomains(unittest.TestCase):
         c.b = '1'
         self.assertEqual(c.b, 1)
 
+        class Container(object):
+            def __init__(self, vals):
+                self._vals = vals
+            def __str__(self):
+                return f'Container{self._vals}'
+            def __contains__(self, val):
+                return val in self._vals
+
+        c.declare('c', ConfigValue(None, In(Container([1,3,5]))))
+        self.assertEqual(c.get('c').domain_name(), 'In(Container[1, 3, 5])')
+        self.assertEqual(c.c, None)
+        c.c = 3
+        self.assertEqual(c.c, 3)
+        with self.assertRaises(ValueError):
+            c.c = 2
+        self.assertEqual(c.c, 3)
+
     def test_In_enum(self):
         class TestEnum(enum.Enum):
             ITEM_ONE = 1
@@ -324,6 +342,7 @@ class TestConfigDomains(unittest.TestCase):
             default=TestEnum.ITEM_TWO,
             domain=In(TestEnum)
         ))
+        self.assertEqual(cfg.get('enum').domain_name(), 'InEnum[TestEnum]')
         self.assertEqual(cfg.enum, TestEnum.ITEM_TWO)
         cfg.enum = 'ITEM_ONE'
         self.assertEqual(cfg.enum, TestEnum.ITEM_ONE)
@@ -474,11 +493,15 @@ class TestConfigDomains(unittest.TestCase):
     def test_ListOf(self):
         c = ConfigDict()
         c.declare('a', ConfigValue(domain=ListOf(int), default=None))
+        self.assertEqual(c.get('a').domain_name(), 'ListOf[int]')
+
         self.assertEqual(c.a, None)
         c.a = 5
         self.assertEqual(c.a, [5])
         c.a = (5, 6.6)
         self.assertEqual(c.a, [5, 6])
+        c.a = '7,8'
+        self.assertEqual(c.a, [7, 8])
 
         ref=(r"(?m)Failed casting a\s+to ListOf\(int\)\s+"
              r"Error: invalid literal for int\(\) with base 10: 'a'")
@@ -486,13 +509,32 @@ class TestConfigDomains(unittest.TestCase):
             c.a = 'a'
 
         c.declare('b', ConfigValue(domain=ListOf(str), default=None))
+        self.assertEqual(c.get('b').domain_name(), 'ListOf[str]')
         self.assertEqual(c.b, None)
-        c.b = "Hello, World"
+        c.b = "'Hello, World'"
         self.assertEqual(c.b, ["Hello, World"])
+        c.b = "Hello, World"
+        self.assertEqual(c.b, ["Hello", "World"])
         c.b = ("A", 6)
         self.assertEqual(c.b, ["A", "6"])
+        with self.assertRaises(ValueError):
+            c.b = "'Hello, World"
+
+        c.declare('b1', ConfigValue(domain=ListOf(
+            str, string_lexer=None), default=None))
+        self.assertEqual(c.get('b1').domain_name(), 'ListOf[str]')
+        self.assertEqual(c.b1, None)
+        c.b1 = "'Hello, World'"
+        self.assertEqual(c.b1, ["'Hello, World'"])
+        c.b1 = "Hello, World"
+        self.assertEqual(c.b1, ["Hello, World"])
+        c.b1 = ("A", 6)
+        self.assertEqual(c.b1, ["A", "6"])
+        c.b1 = "'Hello, World"
+        self.assertEqual(c.b1, ["'Hello, World"])
 
         c.declare('c', ConfigValue(domain=ListOf(int, PositiveInt)))
+        self.assertEqual(c.get('c').domain_name(), 'ListOf[PositiveInt]')
         self.assertEqual(c.c, None)
         c.c = 6
         self.assertEqual(c.c, [6])
@@ -2139,6 +2181,47 @@ Node information:
   --infeasible-nodes STR
                         ALL, NZD, NONE, list or filename
 """, help)
+
+    def test_argparse_lists(self):
+        c = ConfigDict()
+        self.assertEqual(c.domain_name(), '')
+        sub_dict = c.declare('sub_dict', ConfigDict())
+        sub_dict.declare('a', ConfigValue(domain=int))
+        sub_dict.declare('b', ConfigValue())
+        self.assertEqual(c.sub_dict.domain_name(), 'sub-dict')
+        self.assertEqual(c.sub_dict.get('a').domain_name(), 'int')
+        self.assertEqual(c.sub_dict.get('b').domain_name(), '')
+        c.declare(
+            'lst',
+            ConfigList(domain=int)).declare_as_argument(action='append')
+        c.declare(
+            'sub',
+            ConfigList(domain=c.sub_dict)).declare_as_argument(action='append')
+        c.declare('listof', ConfigValue(
+            domain=ListOf(int))).declare_as_argument()
+
+        parser = argparse.ArgumentParser(prog='tester')
+        c.initialize_argparse(parser)
+
+        self.assertEqual("""
+        usage: tester [-h] [--lst INT] [--sub SUB-DICT] [--listof LISTOF[INT]]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --lst INT
+  --sub SUB-DICT
+  --listof LISTOF[INT]""".strip(), parser.format_help().strip())
+
+        args = parser.parse_args([
+            '--lst', '42', '--lst', '1',
+            '--sub', 'a=4', '--sub', 'b=12,a:0',
+            '--listof', '3,2 4'
+        ])
+        leftovers = c.import_argparse(args)
+        self.assertEqual(c.lst.value(), [42, 1])
+        self.assertEqual(c.sub.value(), [{'a':4, 'b':None}, {'a':0, 'b':'12'}])
+        self.assertEqual(c.listof, [3, 2, 4])
+
 
     def test_getattr_setattr(self):
         config = ConfigDict()

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -2225,6 +2225,16 @@ Node information:
         self.assertEqual(c.sub.value(), [{'a':4, 'b':None}, {'a':0, 'b':'12'}])
         self.assertEqual(c.listof, [3, 2, 4])
 
+        args = parser.parse_args([
+            '--lst', '42', '--lst', '1',
+            '--sub', 'a=4', '--sub', 'b=12,a 0',
+            '--listof', '3,2 4'
+        ])
+        with self.assertRaisesRegex(
+                ValueError, r"(?s)invalid value for configuration 'sub':.*"
+                r"Expected ':' or '=' at Line 1 Column 8"):
+            leftovers = c.import_argparse(args)
+
 
     def test_getattr_setattr(self):
         config = ConfigDict()


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
@DLWoodruff pointed out that `ListOf` produces nonintuitive behavior when passed strings: Given a `ListOf(int, PositiveInt)`, passing it the string `'42'` results in the list `[4, 2]`.  This is particularly problematic when using the coupling between the Config system and argparse (where all data comes in as strings).

This PR adds a reasonable parser for interpreting string data: tokens are split using either commas or whitespace, and quotes (single or double) are honored for embedding spaces, quotes, and commas into strings.  An extension of this parser also works for `key=value` (or `key:value`).  

Note that this changes behavior slightly: `ListOf(str)` used to ignore all whitespace or commas and would create a list with a single entry.  After this PR, the string will be parsed and broken up into "words".  The previous behavior can be restored by enclosing the string in quotes.  To my knowledge, no part of Pyomo (apart from one test) relied on the old behavior.

## Changes proposed in this PR:
- Parse string data passed to `ListOf`, `ConfigList`, and `ConfigDict` objects
- Improve reporting of domain names for complex domain validators
- Update testing

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
