### PR TITLE
Extend linux distribution map logic

### DIFF
--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -81,7 +81,7 @@ class FileDownloader(object):
                     dist = val
                 elif key == 'version_id':
                     ver = val
-        return cls._map_dist(dist), ver
+        return cls._map_linux_dist(dist), ver
 
     @classmethod
     def _get_distver_from_redhat_release(cls):
@@ -93,7 +93,7 @@ class FileDownloader(object):
                 if re.match(r'^[0-9\.]+', word):
                     ver = word
                     break
-        return cls._map_dist(dist), ver
+        return cls._map_linux_dist(dist), ver
 
     @classmethod
     def _get_distver_from_lsb_release(cls):
@@ -101,26 +101,37 @@ class FileDownloader(object):
                               stderr=subprocess.STDOUT, universal_newlines=True)
         ver = subprocess.run(['lsb_release', '-sr'], stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT, universal_newlines=True)
-        return cls._map_dist(dist.stdout.lower().strip()), ver.stdout.strip()
+        return cls._map_linux_dist(dist.stdout), ver.stdout.strip()
 
     @classmethod
     def _get_distver_from_distro(cls):
         return distro.id(), distro.version(best=True)
 
     @classmethod
-    def _map_dist(cls, dist):
-        dist = dist.lower()
-        _map = {
-            'centos': 'centos',
-            'redhat': 'rhel',
-            'red hat': 'rhel', # RHEL6 reports 'red hat enterprise'
-            'fedora': 'fedora',
-            'debian': 'debian',
-            'ubuntu': 'ubuntu',
+    def _map_linux_dist(cls, dist):
+        # Some distributions end up reporting longer strings or strings
+        # with spaces (e.g., RHEL6 reports 'red hat enterprise')
+        dist = dist.lower().strip().replace(' ', '')
+        _map = [
+            'redhat',
+            'fedora',
+            'ubuntu', # implicitly maps kubuntu / xubuntu
+            'debian',
+            # Additional RHEL (Fedora) spins
+            'centos',
+            'rocky',
+            'almalinux',
+            'scientific',
+            # Additional Ubuntu (Debian) spins
+            'linuxmint',
         }
         for key in _map:
+            if key.__class__ is tuple:
+                key, val = key
+            else:
+                val = key
             if key in dist:
-                return _map[key]
+                return val
         return dist
 
     @classmethod
@@ -176,7 +187,13 @@ class FileDownloader(object):
 
         _os, _ver = FileDownloader._os_version
         _map = {
+            'almalinux': 'rhel',
             'centos': 'rhel',
+            'rocky': 'rhel',
+            'scientific': 'rhel',
+            'kubuntu': 'ubuntu',
+            'linuxmint': 'ubuntu',
+            'xubuntu': 'ubuntu',
         }
         if _os in _map:
             _os = _map[_os]

--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -124,7 +124,7 @@ class FileDownloader(object):
             'scientific',
             # Additional Ubuntu (Debian) spins
             'linuxmint',
-        }
+        ]
         for key in _map:
             if key.__class__ is tuple:
                 key, val = key

--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -113,7 +113,7 @@ class FileDownloader(object):
         # with spaces (e.g., RHEL6 reports 'red hat enterprise')
         dist = dist.lower().strip().replace(' ', '')
         _map = [
-            'redhat',
+            ('redhat', 'rhel'),
             'fedora',
             'ubuntu', # implicitly maps kubuntu / xubuntu
             'debian',


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Working with IDAES, there were some Linux distributions that were generating meaningless OS versions.  This updates /simplifies some of the logic and adds handling for additional distributions.

## Changes proposed in this PR:
- update Linux distribution mapping logic
- add additional known linux distributions

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
