### PR TITLE
Ignore `SetOf`, `BuildAction`, and `BuildCheck` components when checking units

### DIFF
--- a/pyomo/util/check_units.py
+++ b/pyomo/util/check_units.py
@@ -15,9 +15,9 @@ module objects.
 """
 from pyomo.core.base.units_container import units, UnitsError
 from pyomo.core.base import (Objective, Constraint, Var, Param,
-                             Suffix, Set, RangeSet, Block,
+                             Suffix, Set, SetOf, RangeSet, Block,
                              ExternalFunction, Expression,
-                             value, BooleanVar)
+                             value, BooleanVar, BuildAction, BuildCheck)
 from pyomo.dae import ContinuousSet, DerivativeVar
 from pyomo.network import Port, Arc
 from pyomo.mpec import Complementarity
@@ -173,17 +173,24 @@ _component_data_handlers = {
     Expression: _assert_units_consistent_property_expr,
     Suffix: None,
     Param: _assert_units_consistent_expression,
-    Set: None,
-    RangeSet: None,
     Disjunct: _assert_units_consistent_block,
     Disjunction: None,
     BooleanVar: None,
     Block: _assert_units_consistent_block,
     ExternalFunction: None,
-    ContinuousSet: None, # ToDo: change this when continuous sets have units assigned
+    # TODO: change this when Sets / ContinuousSets sets have units:
+    ContinuousSet: None,
+    Set: None,
+    SetOf: None,
+    RangeSet: None,
+    # TODO: Piecewise: _assert_units_consistent_piecewise,
+    # TODO: SOSConstraint: _assert_units_consistent_sos,
+    # TODO: LogicalConstriant: _assert_units_consistent_logical,
+    BuildAction: None,
+    BuildCheck: None,
     # complementarities that are not in normal form are not working yet
     # see comment in test_check_units
-    # Complementarity: _assert_units_complementarity
+    # TODO: Complementarity: _assert_units_complementarity
     }
 
 def assert_units_consistent(obj):


### PR DESCRIPTION
## Fixes #2365 

## Summary/Motivation:
`assert_units_consistent()` failed on models containing the following (unitless) components:
- `SetOf`
- `BuildAction`
- `BuildCheck`

This PR adds those components to the list of components to ignore when checking units for a block / model.

## Changes proposed in this PR:
- Ignore `SetOf`, `BuildAction`, and `BuildCheck` in `assert_units_consistent()`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
