### PR TITLE
Updates to the BARON solution parser

### DIFF
--- a/pyomo/solvers/plugins/solvers/BARON.py
+++ b/pyomo/solvers/plugins/solvers/BARON.py
@@ -285,22 +285,20 @@ class BARONSHELL(SystemCallSolver):
         #
         # Process logfile
         #
-        OUTPUT = open(self._log_file)
+        cuts = ['Bilinear', 'LD-Envelopes', 'Multilinears',
+                'Convexity', 'Integrality']
 
         # Collect cut-generation statistics from the log file
-        for line in OUTPUT:
-            if 'Bilinear' in line:
-                results.solver.statistics['Bilinear_cuts'] = int(line.split()[1])
-            elif 'LD-Envelopes' in line:
-                results.solver.statistics['LD-Envelopes_cuts'] = int(line.split()[1])
-            elif 'Multilinears' in line:
-                results.solver.statistics['Multilinears_cuts'] = int(line.split()[1])
-            elif 'Convexity' in line:
-                results.solver.statistics['Convexity_cuts'] = int(line.split()[1])
-            elif 'Integrality' in line:
-                results.solver.statistics['Integrality_cuts'] = int(line.split()[1])
+        with open(self._log_file) as OUTPUT:
+            for line in OUTPUT:
+                for field in cuts:
+                    if field in line:
+                        try:
+                            results.solver.statistics[field+'_cuts'] = int(
+                                line.split()[1])
+                        except:
+                            pass
 
-        OUTPUT.close()
         return results
 
 

--- a/pyomo/solvers/plugins/solvers/BARON.py
+++ b/pyomo/solvers/plugins/solvers/BARON.py
@@ -356,11 +356,25 @@ class BARONSHELL(SystemCallSolver):
         # Process model and solver status from the Baron tim file
         #
         line = TimFile.readline().split()
-        results.problem.name = line[0]
-        results.problem.number_of_constraints = int(line[1])
-        results.problem.number_of_variables = int(line[2])
-        results.problem.lower_bound = float(line[5])
-        results.problem.upper_bound = float(line[6])
+        try:
+            # The list of information in the tim file depends on the
+            # BARON version.  As we extract things in order, older
+            # versions of BARON will just result in an IndexError AFTER
+            # we have grabbed all the data that it returns - and we can
+            # safely silently ignore the exception.
+            results.problem.name = line[0]
+            results.problem.number_of_constraints = int(line[1])
+            results.problem.number_of_variables = int(line[2])
+            results.problem.lower_bound = float(line[5])
+            results.problem.upper_bound = float(line[6])
+            results.problem.missing_bounds = line[9]
+            results.problem.iterations = line[10]
+            results.problem.node_opt = line[11]
+            results.problem.node_memmax = line[12]
+            results.problem.cpu_time = float(line[13])
+            results.problem.wall_time = float(line[14])
+        except IndexError:
+            pass
         soln.gap = results.problem.upper_bound - results.problem.lower_bound
         solver_status = line[7]
         model_status = line[8]


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This incorporates minor fixes to the BARON result parsers suggested by @niksah:
- Do not fail when attempting to parse the cut information returned by older versions of BARON
- Parse additional information from the TIM file

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
