### PR TITLE
Deprecate name_buffer argument to getname

### DIFF
--- a/pyomo/contrib/appsi/fbbt.py
+++ b/pyomo/contrib/appsi/fbbt.py
@@ -133,7 +133,6 @@ class IntervalTightener(PersistentBase):
         if self._symbolic_solver_labels:
             for c in cons:
                 self._symbol_map.removeSymbol(c)
-                self._con_labeler.remove_obj(c)
         for c in cons:
             cc = self._con_map.pop(c)
             self._cmodel.remove_constraint(cc)
@@ -147,7 +146,6 @@ class IntervalTightener(PersistentBase):
         if self._symbolic_solver_labels:
             for v in variables:
                 self._symbol_map.removeSymbol(v)
-                self._var_labeler.remove_obj(v)
         for v in variables:
             cvar = self._var_map.pop(id(v))
             del self._rvar_map[cvar]
@@ -156,7 +154,6 @@ class IntervalTightener(PersistentBase):
         if self._symbolic_solver_labels:
             for p in params:
                 self._symbol_map.removeSymbol(p)
-                self._param_labeler.remove_obj(p)
         for p in params:
             del self._param_map[id(p)]
 
@@ -173,7 +170,6 @@ class IntervalTightener(PersistentBase):
         if self._symbolic_solver_labels:
             if self._objective is not None:
                 self._symbol_map.removeSymbol(self._objective)
-                self._obj_labeler.remove_obj(self._objective)
         super().set_objective(obj)
 
     def _set_objective(self, obj: _GeneralObjectiveData):

--- a/pyomo/contrib/appsi/solvers/gurobi.py
+++ b/pyomo/contrib/appsi/solvers/gurobi.py
@@ -622,7 +622,6 @@ class Gurobi(PersistentBase, PersistentSolver):
             solver_con = self._pyomo_con_to_solver_con_map[con]
             self._solver_model.remove(solver_con)
             self._symbol_map.removeSymbol(con)
-            self._labeler.remove_obj(con)
             del self._pyomo_con_to_solver_con_map[con]
             del self._solver_con_to_pyomo_con_map[id(solver_con)]
             self._range_constraints.discard(con)
@@ -637,7 +636,6 @@ class Gurobi(PersistentBase, PersistentSolver):
             solver_sos_con = self._pyomo_sos_to_solver_sos_map[con]
             self._solver_model.remove(solver_sos_con)
             self._symbol_map.removeSymbol(con)
-            self._labeler.remove_obj(con)
             del self._pyomo_sos_to_solver_sos_map[con]
         self._needs_updated = True
 
@@ -649,7 +647,6 @@ class Gurobi(PersistentBase, PersistentSolver):
             solver_var = self._pyomo_var_to_solver_var_map[v_id]
             self._solver_model.remove(solver_var)
             self._symbol_map.removeSymbol(var)
-            self._labeler.remove_obj(var)
             del self._pyomo_var_to_solver_var_map[v_id]
             self._mutable_bounds.pop(v_id, None)
         self._needs_updated = True

--- a/pyomo/contrib/appsi/writers/lp_writer.py
+++ b/pyomo/contrib/appsi/writers/lp_writer.py
@@ -92,7 +92,6 @@ class LPWriter(PersistentBase):
             cc = self._pyomo_con_to_solver_con_map.pop(c)
             self._writer.remove_constraint(cc)
             self._symbol_map.removeSymbol(c)
-            self._con_labeler.remove_obj(c)
             del self._solver_con_to_pyomo_con_map[cc]
 
     def _remove_sos_constraints(self, cons: List[_SOSConstraintData]):
@@ -104,13 +103,11 @@ class LPWriter(PersistentBase):
             cvar = self._pyomo_var_to_solver_var_map.pop(id(v))
             del self._solver_var_to_pyomo_var_map[cvar]
             self._symbol_map.removeSymbol(v)
-            self._var_labeler.remove_obj(v)
 
     def _remove_params(self, params: List[_ParamData]):
         for p in params:
             del self._pyomo_param_to_solver_param_map[id(p)]
             self._symbol_map.removeSymbol(p)
-            self._param_labeler.remove_obj(p)
 
     def _update_variables(self, variables: List[_GeneralVarData]):
         cmodel.process_pyomo_vars(self._expr_types, variables, self._pyomo_var_to_solver_var_map,

--- a/pyomo/contrib/appsi/writers/nl_writer.py
+++ b/pyomo/contrib/appsi/writers/nl_writer.py
@@ -102,7 +102,6 @@ class NLWriter(PersistentBase):
         for c in cons:
             cc = self._pyomo_con_to_solver_con_map.pop(c)
             self._writer.remove_constraint(cc)
-            self._con_labeler.remove_obj(c)
             del self._solver_con_to_pyomo_con_map[cc]
 
     def _remove_sos_constraints(self, cons: List[_SOSConstraintData]):
@@ -114,13 +113,11 @@ class NLWriter(PersistentBase):
             cvar = self._pyomo_var_to_solver_var_map.pop(id(v))
             del self._solver_var_to_pyomo_var_map[cvar]
             # self._symbol_map.removeSymbol(v)
-            self._var_labeler.remove_obj(v)
 
     def _remove_params(self, params: List[_ParamData]):
         for p in params:
             del self._pyomo_param_to_solver_param_map[id(p)]
             self._symbol_map.removeSymbol(p)
-            self._param_labeler.remove_obj(p)
 
     def _update_variables(self, variables: List[_GeneralVarData]):
         cmodel.process_pyomo_vars(self._expr_types, variables, self._pyomo_var_to_solver_var_map,

--- a/pyomo/contrib/fme/fourier_motzkin_elimination.py
+++ b/pyomo/contrib/fme/fourier_motzkin_elimination.py
@@ -22,7 +22,6 @@ from pyomo.opt import TerminationCondition
 import logging
 
 logger = logging.getLogger('pyomo.contrib.fme')
-NAME_BUFFER = {}
 
 def _check_var_bounds_filter(constraint):
     """Check if the constraint is already implied by the variable bounds"""
@@ -189,7 +188,6 @@ class Fourier_Motzkin_Elimination_Transformation(Transformation):
     def _apply_to(self, instance, **kwds):
         log_level = logger.level
         try:
-            assert not NAME_BUFFER
             config = self.CONFIG(kwds.pop('options', {}))
             config.set_value(kwds)
             # lower logging values emit more
@@ -203,8 +201,6 @@ class Fourier_Motzkin_Elimination_Transformation(Transformation):
                 self.verbose = False
             self._apply_to_impl(instance, config)
         finally:
-            # clear the global name buffer
-            NAME_BUFFER.clear()
             # restore logging level
             logger.setLevel(log_level)
 
@@ -399,8 +395,7 @@ class Fourier_Motzkin_Elimination_Transformation(Transformation):
             logger.warning("Projecting out var %s of %s" % (iteration, total))
             if self.verbose:
                 logger.info("Projecting out %s" %
-                            the_var.getname(fully_qualified=True,
-                                            name_buffer=NAME_BUFFER))
+                            the_var.getname(fully_qualified=True))
                 logger.info("New constraints are:")
 
             # we are 'reorganizing' the constraints, we sort based on the sign

--- a/pyomo/contrib/pynumero/interfaces/pyomo_grey_box_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/pyomo_grey_box_nlp.py
@@ -39,7 +39,6 @@ class PyomoNLPWithGreyBoxBlocks(NLP):
         # this is done over *all* variables in active blocks, even
         # if they are not included in this model
         self._pyomo_model_var_names_to_datas = None
-        _name_buffer = {}
         try:
             # We support Pynumero's ExternalGreyBoxBlock modeling
             # objects that are provided through ExternalGreyBoxBlock objects
@@ -59,7 +58,7 @@ class PyomoNLPWithGreyBoxBlocks(NLP):
             self._pyomo_nlp = PyomoNLP(pyomo_model)
             self._pyomo_model_var_names_to_datas = {
                 v.getname(
-                    fully_qualified=True, name_buffer=_name_buffer
+                    fully_qualified=True
                 ): v
                 for v in pyomo_model.component_data_objects(
                     ctype=pyo.Var, descend_into=True
@@ -67,7 +66,7 @@ class PyomoNLPWithGreyBoxBlocks(NLP):
             }
             self._pyomo_model_constraint_names_to_datas = {
                 c.getname(
-                    fully_qualified=True, name_buffer=_name_buffer
+                    fully_qualified=True
                 ): c 
                 for c in pyomo_model.component_data_objects(
                     ctype=pyo.Constraint, descend_into=True
@@ -461,29 +460,28 @@ class _ExternalGreyBoxAsNLP(NLP):
 
         # create the list of primals and constraint names
         # primals will be ordered inputs, followed by outputs
-        _name_buffer = dict()
         self._primals_names = [
             self._block.inputs[k].getname(
-                fully_qualified=True, name_buffer=_name_buffer
+                fully_qualified=True
             ) for k in self._block.inputs
         ]
         self._primals_names.extend(
             self._block.outputs[k].getname(
-                fully_qualified=True, name_buffer=_name_buffer
+                fully_qualified=True
             )
             for k in self._block.outputs
         )
         n_primals = len(self._primals_names)
 
         prefix = self._block.getname(
-            fully_qualified=True, name_buffer=_name_buffer
+            fully_qualified=True
         )
         self._constraint_names = \
             ['{}.{}'.format(prefix, nm) \
              for nm in self._ex_model.equality_constraint_names()]
         output_var_names = [
             self._block.outputs[k].getname(
-                fully_qualified=False, name_buffer=_name_buffer
+                fully_qualified=False
             ) for k in self._block.outputs
         ]
         self._constraint_names.extend(

--- a/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
@@ -180,9 +180,8 @@ class PyomoNLP(AslNLP):
         names in the order corresponding to the primals
         """
         pyomo_variables = self.get_pyomo_variables()
-        name_buffer = {}
         return [
-            v.getname(fully_qualified=True, name_buffer=name_buffer)
+            v.getname(fully_qualified=True)
             for v in pyomo_variables
         ]
 
@@ -192,9 +191,8 @@ class PyomoNLP(AslNLP):
         names in the order corresponding to internal constraint order
         """
         pyomo_constraints = self.get_pyomo_constraints()
-        name_buffer = {}
         return [
-            v.getname(fully_qualified=True, name_buffer=name_buffer)
+            v.getname(fully_qualified=True)
             for v in pyomo_constraints
         ]
 
@@ -204,9 +202,8 @@ class PyomoNLP(AslNLP):
         the order corresponding to the equality constraints.
         """
         equality_constraints = self.get_pyomo_equality_constraints()
-        name_buffer = {}
         return [
-            v.getname(fully_qualified=True, name_buffer=name_buffer)
+            v.getname(fully_qualified=True)
             for v in equality_constraints
         ]
 
@@ -216,9 +213,8 @@ class PyomoNLP(AslNLP):
         the order corresponding to the inequality constraints.
         """
         inequality_constraints = self.get_pyomo_inequality_constraints()
-        name_buffer = {}
         return [
-            v.getname(fully_qualified=True, name_buffer=name_buffer)
+            v.getname(fully_qualified=True)
             for v in inequality_constraints
         ]
 

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -851,31 +851,17 @@ class ComponentData(_ComponentBase):
         to the parent component's index set.
         """
         parent = self.parent_component()
-        if parent is None:
-            return None
-        idx = self._index
-        # ComponentList objects implement _data as a list rather than a dict so
-        # we have to account for both here
-        if isinstance(parent._data, dict):
-            parent_idx = parent._data.get(idx, None)
-        elif isinstance(parent._data, list):
-            try:
-                parent_idx = parent._data[idx]
-            except IndexError:
-                parent_idx = None
-        else:
-            raise DeveloperError("Unrecognized type for '_data' dictionary")
-        if ((idx is NOTSET and parent_idx is not None) or
-            (parent_idx is not self)):
-            parent_idx_name = parent_idx.name if parent_idx is not None \
-                              else 'None'
+        if ( parent is not None and
+             self._index is not NOTSET and
+             parent[self._index] is not self ):
             # This error message is a bit goofy, but we can't call self.name
             # here--it's an infinite loop!
             raise DeveloperError(
                 "The '_data' dictionary and '_index' attribute are out of "
                 "sync for index '%s' on indexed component '%s': The '_data' "
                 "dictionary contains '%s' as the value corresponding to '%s'."
-                % (idx, parent.name, parent_idx_name, idx))
+                % (self._index, parent.name, parent[self._index].name,
+                   self._index))
         return self._index
 
     def __str__(self):

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -853,6 +853,13 @@ class ComponentData(_ComponentBase):
         if parent is None:
             return None
         idx = self._index
+        if idx is NOTSET:
+            # ESJ TODO: I'm not sure if this should be an error, but it's
+            # actually what caught all my bugs... So that makes me think yes.
+            # Problem is, we can't query the name in the error message below--
+            # it would be an infinite loop.
+            raise pyomo.common.DeveloperError(
+                "The '_index' attribute is not yet set.")
         if parent._data[idx] is not self:
             raise pyomo.common.DeveloperError(
                 "The '_data' dictionary and '_index' attribute are out of "

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -849,8 +849,17 @@ class ComponentData(_ComponentBase):
         - for some unknown reason - this instance does not belong
         to the parent component's index set.
         """
-        if self.parent_component() is None:
+        parent = self.parent_component()
+        if parent is None:
             return None
+        idx = self._index
+        if parent._data[idx] is not self:
+            raise pyomo.common.DeveloperError(
+                "The '_data' dictionary and '_index' attribute are out of "
+                "sync for index %s: %s._index is %s, but the '_data' "
+                "dictionary of '%s' contains '%s' as the value corresponding "
+                "to %s." % (idx, self.name, idx, parent.name, 
+                            parent._data[idx].name, idx))
         return self._index
 
     def __str__(self):

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -558,11 +558,6 @@ class Component(_ComponentBase):
         fully_qualified: bool
             Generate full name from nested block names
 
-        name_buffer: dict
-            A dictionary that caches encountered names and indices.
-            Providing a ``name_buffer`` can significantly speed up
-            iterative name generation
-
         relative_to: Block
             Generate fully_qualified names reletive to the specified block.
         """
@@ -874,7 +869,15 @@ class ComponentData(_ComponentBase):
         #
         # Using the buffer, which is a dictionary:  id -> string
         #
-        if name_buffer is not None and id(self) in name_buffer:
+        if name_buffer is not None:
+            deprecation_warning(
+                "The 'name_buffer' argument to getname is deprecated. "
+                "The functionality is no longer necessary since getting names "
+                "is no longer a quadratic operation. Additionally, note that "
+                "use of this argument poses risks if the buffer contains "
+                "names relative to different Blocks in the model hierarchy or "
+                "a mixture of local and fully_qualified names.", version='TODO')
+            if id(self) in name_buffer:
             # Return the name if it is in the buffer
             return name_buffer[id(self)]
 

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -878,8 +878,8 @@ class ComponentData(_ComponentBase):
                 "names relative to different Blocks in the model hierarchy or "
                 "a mixture of local and fully_qualified names.", version='TODO')
             if id(self) in name_buffer:
-            # Return the name if it is in the buffer
-            return name_buffer[id(self)]
+                # Return the name if it is in the buffer
+                return name_buffer[id(self)]
 
         c = self.parent_component()
         if c is self:

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -858,10 +858,9 @@ class ComponentData(_ComponentBase):
             # here--it's an infinite loop!
             raise DeveloperError(
                 "The '_data' dictionary and '_index' attribute are out of "
-                "sync for index '%s' on indexed component '%s': The '_data' "
-                "dictionary contains '%s' as the value corresponding to '%s'."
-                % (self._index, parent.name, parent[self._index].name,
-                   self._index))
+                "sync for indexed %s '%s': The %s entry in the '_data' "
+                "dictionary does not map back to this component data object."
+                % (parent.ctype.__name__, parent.name, self._index))
         return self._index
 
     def __str__(self):

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -15,7 +15,8 @@ from pickle import PickleError
 from weakref import ref as weakref_ref
 
 import pyomo.common
-from pyomo.common.deprecation import deprecated, relocated_module_attribute
+from pyomo.common.deprecation import (
+    deprecated, deprecation_warning, relocated_module_attribute)
 from pyomo.common.factory import Factory
 from pyomo.common.formatting import tabular_writer, StreamIndenter
 from pyomo.common.modeling import NOTSET
@@ -585,6 +586,13 @@ class Component(_ComponentBase):
             # add quotes or otherwise escape the string.
             ans = local_name
         if name_buffer is not None:
+            deprecation_warning(
+                "The 'name_buffer' argument to getname is deprecated. "
+                "The functionality is no longer necessary since getting names "
+                "is no longer a quadratic operation. Additionally, note that "
+                "use of this argument poses risks if the buffer contains "
+                "names relative to different Blocks in the model hierarchy or "
+                "a mixture of local and fully_qualified names.", version='TODO')
             name_buffer[id(self)] = ans
         return ans
 

--- a/pyomo/core/base/label.py
+++ b/pyomo/core/base/label.py
@@ -14,7 +14,7 @@ __all__ = ['CounterLabeler', 'NumericLabeler', 'CNameLabeler', 'TextLabeler',
 
 import re
 
-from pyomo.common.deprecation import deprecation_warning
+from pyomo.common.deprecation import deprecated
 from pyomo.core.base.componentuid import ComponentUID
 
 # This module provides some basic functionality for generating labels
@@ -103,12 +103,11 @@ class NumericLabeler(object):
         self.id += 1
         return self.prefix + str(self.id)
 
+    @deprecated("The 'remove_obj' method is no longer "
+                "necessary now that 'getname' does not "
+                "support the use of a name buffer", version="TODO")
     def remove_obj(self, obj):
-        deprecation_warning("The 'remove_obj' method is no longer "
-                            "necessary now that 'getname' does not "
-                            "support the use of a name buffer",
-                            version="TODO")
-
+        pass
 #
 # TODO: [JDS] I would like to rename TextLabeler to LPLabeler - as it
 # generated LP-file-compliant labels - and make the CNameLabeler the
@@ -127,11 +126,11 @@ class TextLabeler(object):
     def __call__(self, obj):
         return cpxlp_label_from_name(obj.getname(True))
 
+    @deprecated("The 'remove_obj' method is no longer "
+                "necessary now that 'getname' does not "
+                "support the use of a name buffer", version="TODO")
     def remove_obj(self, obj):
-        deprecation_warning("The 'remove_obj' method is no longer "
-                            "necessary now that 'getname' does not "
-                            "support the use of a name buffer",
-                            version="TODO")
+        pass
 
 class AlphaNumericTextLabeler(object):
     def __call__(self, obj):

--- a/pyomo/core/base/label.py
+++ b/pyomo/core/base/label.py
@@ -14,6 +14,7 @@ __all__ = ['CounterLabeler', 'NumericLabeler', 'CNameLabeler', 'TextLabeler',
 
 import re
 
+from pyomo.common.deprecation import deprecation_warning
 from pyomo.core.base.componentuid import ComponentUID
 
 # This module provides some basic functionality for generating labels
@@ -103,7 +104,10 @@ class NumericLabeler(object):
         return self.prefix + str(self.id)
 
     def remove_obj(self, obj):
-        pass
+        deprecation_warning("The 'remove_obj' method is no longer "
+                            "necessary now that 'getname' does not "
+                            "support the use of a name buffer",
+                            version="TODO")
 
 #
 # TODO: [JDS] I would like to rename TextLabeler to LPLabeler - as it
@@ -124,7 +128,10 @@ class TextLabeler(object):
         return cpxlp_label_from_name(obj.getname(True))
 
     def remove_obj(self, obj):
-        pass
+        deprecation_warning("The 'remove_obj' method is no longer "
+                            "necessary now that 'getname' does not "
+                            "support the use of a name buffer",
+                            version="TODO")
 
 class AlphaNumericTextLabeler(object):
     def __call__(self, obj):
@@ -173,7 +180,7 @@ class ShortNameLabeler(object):
                 raise RuntimeError(
                     "Too many identifiers.\n\t"
                     "The ShortNameLabeler cannot generate a guaranteed unique "
-                    "label limited to %d characters" % (self.limit,)) 
+                    "label limited to %d characters" % (self.limit,))
             lbl = self.prefix + lbl[tail:] + suffix
         if self.known_labels is not None:
             self.known_labels.add(lbl.upper() if self.caseInsensitive else lbl)

--- a/pyomo/core/base/label.py
+++ b/pyomo/core/base/label.py
@@ -116,35 +116,23 @@ class NumericLabeler(object):
 # actually being LP-compliant.
 #
 class CNameLabeler(object):
-    def __init__(self):
-        self.name_buffer = {}
-
     def __call__(self, obj):
-        return obj.getname(True, self.name_buffer)
+        return obj.getname(True)
 
 class TextLabeler(object):
-    def __init__(self):
-        self.name_buffer = {}
-
     def __call__(self, obj):
-        return cpxlp_label_from_name(obj.getname(True, self.name_buffer))
+        return cpxlp_label_from_name(obj.getname(True))
 
     def remove_obj(self, obj):
-        self.name_buffer.pop(id(obj))
+        pass
 
 class AlphaNumericTextLabeler(object):
-    def __init__(self):
-        self.name_buffer = {}
-
     def __call__(self, obj):
-        return alphanum_label_from_name(obj.getname(True, self.name_buffer))
+        return alphanum_label_from_name(obj.getname(True))
 
 class NameLabeler(object):
-    def __init__(self):
-        self.name_buffer = {}
-
     def __call__(self, obj):
-        return obj.getname(True, self.name_buffer)
+        return obj.getname(True)
 
 class ShortNameLabeler(object):
     def __init__(self, limit, suffix, start=0, labeler=None,

--- a/pyomo/core/base/label.py
+++ b/pyomo/core/base/label.py
@@ -105,7 +105,7 @@ class NumericLabeler(object):
 
     @deprecated("The 'remove_obj' method is no longer "
                 "necessary now that 'getname' does not "
-                "support the use of a name buffer", version="TODO")
+                "support the use of a name buffer", version="TBD")
     def remove_obj(self, obj):
         pass
 #
@@ -128,7 +128,7 @@ class TextLabeler(object):
 
     @deprecated("The 'remove_obj' method is no longer "
                 "necessary now that 'getname' does not "
-                "support the use of a name buffer", version="TODO")
+                "support the use of a name buffer", version="TBD")
     def remove_obj(self, obj):
         pass
 

--- a/pyomo/core/base/piecewise.py
+++ b/pyomo/core/base/piecewise.py
@@ -1002,6 +1002,8 @@ class Piecewise(Block):
                   not be modified.
     """
 
+    _ComponentDataClass = _PiecewiseData
+
     def __new__(cls, *args, **kwds):
         if cls != Piecewise:
             return super(Piecewise, cls).__new__(cls)
@@ -1198,9 +1200,6 @@ class Piecewise(Block):
                 self.add(index, _is_indexed=is_indexed)
         timer.report()
 
-    def _getitem_when_not_present(self, idx):
-        return self._data.setdefault(idx, _PiecewiseData(self))
-
     def add(self, index, _is_indexed=None):
 
         if _is_indexed is None:
@@ -1367,6 +1366,7 @@ class Piecewise(Block):
         else:
             comp = self
         self._data[index] = comp
+        comp._index = index
         comp.updateBoundType(self._bound_type)
         comp.updatePoints(_self_domain_pts_index,range_pts)
         comp.build_constraints(func,_self_xvar,_self_yvar)

--- a/pyomo/core/base/sos.py
+++ b/pyomo/core/base/sos.py
@@ -303,6 +303,7 @@ class SOSConstraint(ActiveIndexedComponent):
         else:
             soscondata = _SOSConstraintData(self)
         self._data[index] = soscondata
+        soscondata._index = index
 
         soscondata.level = self._sosLevel
 

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -796,6 +796,7 @@ class Var(IndexedComponent, IndexedComponent_NDArrayMixin):
         else:
             obj = self._data[index] = self._ComponentDataClass(component=self)
         parent = self.parent_block()
+        obj._index = index
         # We can directly set the attribute (not the property) because
         # the SetInitializer ensures that the value is a proper Set.
         obj._domain = self._rule_domain(parent, index)
@@ -803,7 +804,6 @@ class Var(IndexedComponent, IndexedComponent_NDArrayMixin):
             obj.lower, obj.upper = self._rule_bounds(parent, index)
         if self._rule_init is not None:
             obj.set_value(self._rule_init(parent, index))
-        obj._index = index
         return obj
 
     #

--- a/pyomo/core/plugins/transform/add_slack_vars.py
+++ b/pyomo/core/plugins/transform/add_slack_vars.py
@@ -17,8 +17,6 @@ from pyomo.core.base import ComponentUID
 from pyomo.core.base.constraint import _ConstraintData
 from pyomo.common.deprecation import deprecation_warning
 
-NAME_BUFFER = {}
-
 def target_list(x):
     deprecation_msg = ("In future releases ComponentUID targets will no "
                        "longer be supported in the core.add_slack_variables "
@@ -84,11 +82,7 @@ class AddSlackVariables(NonIsomorphicTransformation):
         super(AddSlackVariables, self).__init__(**kwds)
 
     def _apply_to(self, instance, **kwds):
-        try:
-            assert not NAME_BUFFER
-            self._apply_to_impl(instance, **kwds)
-        finally:
-            NAME_BUFFER.clear()
+        self._apply_to_impl(instance, **kwds)
 
     def _apply_to_impl(self, instance, **kwds):
         config = self.CONFIG(kwds.pop('options', {}))
@@ -135,8 +129,7 @@ class AddSlackVariables(NonIsomorphicTransformation):
                 raise RuntimeError("Lower bound exceeds upper bound in "
                                    "constraint %s" % cons.name)
             if not cons.active: continue
-            cons_name = cons.getname(fully_qualified=True,
-                                     name_buffer=NAME_BUFFER)
+            cons_name = cons.getname(fully_qualified=True)
             if cons.lower is not None:
                 # we add positive slack variable to body:
                 # declare positive slack

--- a/pyomo/core/plugins/transform/expand_connectors.py
+++ b/pyomo/core/plugins/transform/expand_connectors.py
@@ -37,8 +37,6 @@ class ExpandConnectors(Transformation):
         if is_debug_set(logger):   #pragma:nocover
             logger.debug("   Connectors found!")
 
-        self._name_buffer = {}
-
         #
         # At this point, there are connectors in the model, so we must
         # look for constraints that involve connectors and expand them.
@@ -118,7 +116,7 @@ class ExpandConnectors(Transformation):
             cList = ConstraintList()
             constraint.parent_block().add_component(
                 '%s.expanded' % ( constraint.getname(
-                    fully_qualified=False, name_buffer=self._name_buffer), ),
+                    fully_qualified=False), ),
                 cList )
             connId = next(iter(conn_set))
             ref = known_conn_sets[id(matched_connectors[connId])]
@@ -151,8 +149,7 @@ class ExpandConnectors(Transformation):
                 block.add_component(
                     '%s.%s.aggregate' % (
                         conn.getname(
-                            fully_qualified=True,
-                            name_buffer=self._name_buffer),
+                            fully_qualified=True),
                         var), c )
 
 
@@ -235,7 +232,7 @@ class ExpandConnectors(Transformation):
             # This is expensive (names aren't cheap), but does result in
             # a deterministic ordering
             empty_or_partial.sort(key=lambda x: x.getname(
-                fully_qualified=True, name_buffer=self._name_buffer))
+                fully_qualified=True))
 
         # Fill in any empty connectors
         for c in empty_or_partial:
@@ -260,8 +257,7 @@ class ExpandConnectors(Transformation):
                 new_var = Var( *idx, **var_args )
                 block.add_component(
                     '%s.auto.%s' % (
-                        c.getname(fully_qualified=True,
-                                  name_buffer=self._name_buffer), k ),
+                        c.getname(fully_qualified=True), k ),
                     new_var)
                 if idx:
                     for i in idx[0]:

--- a/pyomo/core/tests/unit/test_indexed.py
+++ b/pyomo/core/tests/unit/test_indexed.py
@@ -212,9 +212,8 @@ class TestIndexedComponent(unittest.TestCase):
         with self.assertRaisesRegex(
                 DeveloperError,
                 ".*The '_data' dictionary and '_index' attribute are out of "
-                "sync for index '2' on indexed component 'x': The '_data' "
-                "dictionary contains 'x\[2\]' as the value corresponding to "
-                "'2'"):
+                "sync for indexed Var 'x': The 2 entry in the '_data' "
+                "dictionary does not map back to this component data object."):
             m.x[3].index()
 
 if __name__ == "__main__":

--- a/pyomo/core/tests/unit/test_indexed.py
+++ b/pyomo/core/tests/unit/test_indexed.py
@@ -15,6 +15,7 @@ import os
 from os.path import abspath, dirname
 currdir = dirname(abspath(__file__))+os.sep
 
+from pyomo.common import DeveloperError
 import pyomo.common.unittest as unittest
 
 from pyomo.environ import ConcreteModel, Var, Param, Set, value
@@ -200,6 +201,21 @@ class TestIndexedComponent(unittest.TestCase):
         self.assertEqual(list(zip(ordered_keys, [10, 20, 1, 30, 1])),
                          list(m.P.items(True)))
 
+    def test_index_attribute_out_of_sync(self):
+        m = ConcreteModel()
+        m.x = Var([1,2,3])
+        # make sure everything is right to begin with
+        for i in [1, 2, 3]:
+            self.assertEqual(m.x[i].index(), i)
+        # now mess it up
+        m.x[3]._index = 2
+        with self.assertRaisesRegex(
+                DeveloperError,
+                ".*The '_data' dictionary and '_index' attribute are out of "
+                "sync for index '2' on indexed component 'x': The '_data' "
+                "dictionary contains 'x\[2\]' as the value corresponding to "
+                "'2'"):
+            m.x[3].index()
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/gdp/basic_step.py
+++ b/pyomo/gdp/basic_step.py
@@ -104,7 +104,6 @@ def apply_basic_step(disjunctions_or_constraints):
     # Link the new disjunct indicator_var's to the original
     # indicator_var's.  Since only one of the new
     #
-    NAME_BUFFER = {}
     ans.indicator_links = ConstraintList()
     for i in ans.DISJUNCTIONS:
         for j in range(len(disjunctions[i].disjuncts)):
@@ -117,8 +116,7 @@ def apply_basic_step(disjunctions_or_constraints):
                      if (idx[i] if isinstance(idx, tuple) else idx) == j ))
             # and throw on a Reference to original on the block
             for v in (orig_var, orig_binary_var):
-                name_base = v.getname(
-                    fully_qualified=True, name_buffer=NAME_BUFFER)
+                name_base = v.getname(fully_qualified=True)
                 ans.add_component(unique_component_name( ans, name_base),
                                   Reference(v))
 

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -19,7 +19,7 @@ from pyomo.common.modeling import unique_component_name
 from pyomo.common.deprecation import deprecated, deprecation_warning
 from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
 from pyomo.core import (
-    Block, BooleanVar, Connector, Constraint, Param, Set, SetOf, Suffix, Var, 
+    Block, BooleanVar, Connector, Constraint, Param, Set, SetOf, Suffix, Var,
     Expression, SortComponents, TraversalStrategy, value, RangeSet,
     NonNegativeIntegers, LogicalConstraint, Binary, )
 from pyomo.core.base.boolean_var import (
@@ -29,7 +29,7 @@ from pyomo.core.base import Transformation, TransformationFactory, Reference
 import pyomo.core.expr.current as EXPR
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 from pyomo.gdp.util import (
-    is_child_of, get_src_disjunction, get_src_constraint, 
+    is_child_of, get_src_disjunction, get_src_constraint,
     get_transformed_constraints, _get_constraint_transBlock, get_src_disjunct,
     _warn_for_active_disjunction, _warn_for_active_disjunct, preprocess_targets,
     _to_dict)
@@ -40,8 +40,6 @@ from functools import wraps
 from weakref import ref as weakref_ref, ReferenceType
 
 logger = logging.getLogger('pyomo.gdp.bigm')
-
-NAME_BUFFER = {}
 
 @TransformationFactory.register('gdp.bigm', doc="Relax disjunctive model using "
                                 "big-M terms.")
@@ -194,7 +192,6 @@ class BigM_Transformation(Transformation):
         return arg_list
 
     def _apply_to(self, instance, **kwds):
-        assert not NAME_BUFFER
         self._generate_debug_messages = is_debug_set(logger)
         self.used_args = ComponentMap() # If everything was sure to go well,
                                         # this could be a dictionary. But if
@@ -205,8 +202,6 @@ class BigM_Transformation(Transformation):
         try:
             self._apply_to_impl(instance, **kwds)
         finally:
-            # Clear the global name buffer now that we are done
-            NAME_BUFFER.clear()
             # same for our bookkeeping about what we used from bigM arg dict
             self.used_args.clear()
 
@@ -324,7 +319,7 @@ class BigM_Transformation(Transformation):
         #    nm = '_xor' if xor else '_or'
         nm = '_xor'
         orCname = unique_component_name( transBlock, disjunction.getname(
-            fully_qualified=True, name_buffer=NAME_BUFFER) + nm)
+            fully_qualified=True) + nm)
         transBlock.add_component(orCname, orC)
         disjunction._algebraic_constraint = weakref_ref(orC)
 
@@ -376,8 +371,7 @@ class BigM_Transformation(Transformation):
         if len(obj.disjuncts) == 0:
             raise GDP_Error("Disjunction '%s' is empty. This is "
                             "likely indicative of a modeling error."  %
-                            obj.getname(fully_qualified=True,
-                                        name_buffer=NAME_BUFFER))
+                            obj.getname(fully_qualified=True))
         for disjunct in obj.disjuncts:
             or_expr += disjunct.binary_indicator_var
             # make suffix list. (We don't need it until we are
@@ -519,8 +513,7 @@ class BigM_Transformation(Transformation):
         varRefBlock = disjunctBlock.localVarReferences
         for v in block.component_objects(Var, descend_into=Block, active=None):
             varRefBlock.add_component(unique_component_name(
-                varRefBlock, v.getname(fully_qualified=True,
-                                       name_buffer=NAME_BUFFER)), Reference(v))
+                varRefBlock, v.getname(fully_qualified=True)), Reference(v))
 
         # Now look through the component map of block and transform everything
         # we have a handler for. Yell if we don't know how to handle it. (Note
@@ -570,16 +563,15 @@ class BigM_Transformation(Transformation):
 
     def _warn_for_active_disjunction(self, disjunction, disjunct, bigMargs,
                                      arg_list, suffix_list):
-        _warn_for_active_disjunction(disjunction, disjunct, NAME_BUFFER)
+        _warn_for_active_disjunction(disjunction, disjunct)
 
     def _warn_for_active_disjunct(self, innerdisjunct, outerdisjunct, bigMargs,
                                   arg_list, suffix_list):
-        _warn_for_active_disjunct(innerdisjunct, outerdisjunct, NAME_BUFFER)
+        _warn_for_active_disjunct(innerdisjunct, outerdisjunct)
 
     def _warn_for_active_logical_statement(
             self, logical_statment, disjunct, infodict, bigMargs, suffix_list):
-        _warn_for_active_logical_constraint(logical_statment, disjunct,
-                                            NAME_BUFFER)
+        _warn_for_active_logical_constraint(logical_statment, disjunct)
 
     def _transform_block_on_disjunct(self, block, disjunct, bigMargs, arg_list,
                                      suffix_list):
@@ -631,7 +623,7 @@ class BigM_Transformation(Transformation):
         # Though rare, it is possible to get naming conflicts here
         # since constraints from all blocks are getting moved onto the
         # same block. So we get a unique name
-        cons_name = obj.getname(fully_qualified=True, name_buffer=NAME_BUFFER)
+        cons_name = obj.getname(fully_qualified=True)
         name = unique_component_name(transBlock, cons_name)
 
         if obj.is_indexed():
@@ -663,8 +655,7 @@ class BigM_Transformation(Transformation):
             M = (lower[0], upper[0])
 
             if self._generate_debug_messages:
-                _name = obj.getname(
-                    fully_qualified=True, name_buffer=NAME_BUFFER)
+                _name = obj.getname(fully_qualified=True)
                 logger.debug("GDP(BigM): The value for M for constraint '%s' "
                              "from the BigM argument is %s." % (cons_name,
                                                                 str(M)))
@@ -683,8 +674,7 @@ class BigM_Transformation(Transformation):
                 M = (lower[0], upper[0])
 
             if self._generate_debug_messages:
-                _name = obj.getname(
-                    fully_qualified=True, name_buffer=NAME_BUFFER)
+                _name = obj.getname(fully_qualified=True)
                 logger.debug("GDP(BigM): The value for M for constraint '%s' "
                              "after checking suffixes is %s." % (cons_name,
                                                                  str(M)))
@@ -697,8 +687,7 @@ class BigM_Transformation(Transformation):
                 upper = (M[1], None, None)
 
             if self._generate_debug_messages:
-                _name = obj.getname(
-                    fully_qualified=True, name_buffer=NAME_BUFFER)
+                _name = obj.getname(fully_qualified=True)
                 logger.debug("GDP(BigM): The value for M for constraint '%s' "
                              "after estimating (if needed) is %s." %
                              (cons_name, str(M)))
@@ -770,8 +759,7 @@ class BigM_Transformation(Transformation):
         # None
         need_lower = constraint.lower is not None
         need_upper = constraint.upper is not None
-        constraint_name = constraint.getname(fully_qualified=True,
-                                             name_buffer=NAME_BUFFER)
+        constraint_name = constraint.getname(fully_qualified=True)
 
         # check for the constraint itself and its container
         parent = constraint.parent_component()
@@ -832,8 +820,7 @@ class BigM_Transformation(Transformation):
         # looking for half the answer.
         need_lower = constraint.lower is not None and lower[0] is None
         need_upper = constraint.upper is not None and upper[0] is None
-        constraint_name = constraint.getname(fully_qualified=True,
-                                             name_buffer=NAME_BUFFER)
+        constraint_name = constraint.getname(fully_qualified=True)
         M = None
         # first we check if the constraint or its parent is a key in any of the
         # suffix lists

--- a/pyomo/gdp/plugins/cuttingplane.py
+++ b/pyomo/gdp/plugins/cuttingplane.py
@@ -39,8 +39,6 @@ import logging
 
 logger = logging.getLogger('pyomo.gdp.cuttingplane')
 
-NAME_BUFFER = {}
-
 def do_not_tighten(m):
     return m
 
@@ -690,7 +688,6 @@ class CuttingPlane_Transformation(Transformation):
         original_log_level = logger.level
         log_level = logger.getEffectiveLevel()
         try:
-            assert not NAME_BUFFER
             self._config = self.CONFIG(kwds.pop('options', {}))
             self._config.set_value(kwds)
 
@@ -717,8 +714,6 @@ class CuttingPlane_Transformation(Transformation):
         finally:
             del self._config
             del self.verbose
-            # clear the global name buffer
-            NAME_BUFFER.clear()
             # restore logging level
             logger.setLevel(original_log_level)
 
@@ -936,8 +931,7 @@ class CuttingPlane_Transformation(Transformation):
                     x_hull.set_value(x_rbigm.value, skip_validation=True)
                 if self.verbose:
                     logger.info("\t%s = %s" % 
-                                (x_rbigm.getname(fully_qualified=True,
-                                                 name_buffer=NAME_BUFFER),
+                                (x_rbigm.getname(fully_qualified=True),
                                  x_rbigm.value))
 
             # compare objectives: check absolute difference close to 0, relative
@@ -968,8 +962,7 @@ class CuttingPlane_Transformation(Transformation):
                 xhat[x_rbigm] = value(x_hull)
                 if self.verbose:
                     logger.info("\t%s = %s" % 
-                                (x_hull.getname(fully_qualified=True,
-                                                name_buffer=NAME_BUFFER), 
+                                (x_hull.getname(fully_qualified=True), 
                                  x_hull.value))
 
             # [JDS 19 Dec 18] Note: we check that the separation objective was
@@ -1063,8 +1056,7 @@ class CuttingPlane_Transformation(Transformation):
                         logger.info("The variable %s will not be included in "
                                     "the separation problem: It was stale in "
                                     "the rBigM solve." % x_rbigm.getname(
-                                        fully_qualified=True,
-                                        name_buffer=NAME_BUFFER))
+                                        fully_qualified=True))
                     to_delete.append(i)
         elif norm == float('inf'):
             u = transBlock_rHull.u = Var(domain=NonNegativeReals)
@@ -1083,8 +1075,7 @@ class CuttingPlane_Transformation(Transformation):
                         logger.info("The variable %s will not be included in "
                                     "the separation problem: It was stale in "
                                     "the rBigM solve." % x_rbigm.getname(
-                                        fully_qualified=True,
-                                        name_buffer=NAME_BUFFER))
+                                        fully_qualified=True))
                     to_delete.append(j)
             # we'll need the duals of these to get the subgradient
             self._add_dual_suffix(transBlock_rHull.model())

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -19,14 +19,14 @@ from pyomo.core.expr.numvalue import ZeroConstant
 import pyomo.core.expr.current as EXPR
 from pyomo.core.base import Transformation, TransformationFactory, Reference
 from pyomo.core import (
-    Block, BooleanVar, Connector, Constraint, Param, Set, SetOf, Suffix, Var, 
+    Block, BooleanVar, Connector, Constraint, Param, Set, SetOf, Suffix, Var,
     Expression, SortComponents, TraversalStrategy, Any, RangeSet, Reals, value,
     NonNegativeIntegers, LogicalConstraint, Binary )
 from pyomo.core.base.boolean_var import (
     _DeprecatedImplicitAssociatedBinaryVariable)
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 from pyomo.gdp.util import (
-    clone_without_expression_components, is_child_of, get_src_disjunction, 
+    clone_without_expression_components, is_child_of, get_src_disjunction,
     get_src_constraint, get_transformed_constraints, get_src_disjunct,
     _warn_for_active_disjunction, _warn_for_active_disjunct, preprocess_targets)
 from pyomo.core.util import target_list
@@ -35,8 +35,6 @@ from functools import wraps
 from weakref import ref as weakref_ref
 
 logger = logging.getLogger('pyomo.gdp.hull')
-
-NAME_BUFFER = {}
 
 @TransformationFactory.register(
     'gdp.hull',
@@ -224,12 +222,7 @@ class Hull_Reformulation(Transformation):
         return local_var_dict
 
     def _apply_to(self, instance, **kwds):
-        assert not NAME_BUFFER
-        try:
-            self._apply_to_impl(instance, **kwds)
-        finally:
-            # Clear the global name buffer now that we are done
-            NAME_BUFFER.clear()
+        self._apply_to_impl(instance, **kwds)
 
     def _apply_to_impl(self, instance, **kwds):
         if not instance.ctype in (Block, Disjunct):
@@ -337,8 +330,7 @@ class Hull_Reformulation(Transformation):
         transBlock.add_component(
             unique_component_name(transBlock,
                                   disjunction.getname(
-                                      fully_qualified=True,
-                                      name_buffer=NAME_BUFFER) + '_xor'), orC)
+                                      fully_qualified=True) + '_xor'), orC)
         disjunction._algebraic_constraint = weakref_ref(orC)
 
         return orC
@@ -402,8 +394,7 @@ class Hull_Reformulation(Transformation):
         if len(obj.disjuncts) == 0:
             raise GDP_Error("Disjunction '%s' is empty. This is "
                             "likely indicative of a modeling error."  %
-                            obj.getname(fully_qualified=True,
-                                        name_buffer=NAME_BUFFER))
+                            obj.getname(fully_qualified=True))
 
         # We first go through and collect all the variables that we
         # are going to disaggregate.
@@ -468,8 +459,7 @@ class Hull_Reformulation(Transformation):
                 if self._generate_debug_messages:
                     logger.debug("Assuming '%s' is not a local var since it is"
                                  "used in multiple disjuncts." %
-                                 var.getname(fully_qualified=True,
-                                             name_buffer=NAME_BUFFER))
+                                 var.getname(fully_qualified=True))
                 for disj in disjuncts:
                     varSet[disj].append(var)
                 varsToDisaggregate.append(var)
@@ -637,7 +627,7 @@ class Hull_Reformulation(Transformation):
             # get a unique name
             disaggregatedVarName = unique_component_name(
                 relaxationBlock.disaggregatedVars,
-                var.getname(fully_qualified=False, name_buffer=NAME_BUFFER))
+                var.getname(fully_qualified=True))
             relaxationBlock.disaggregatedVars.add_component(
                 disaggregatedVarName, disaggregatedVar)
             # mark this as local because we won't re-disaggregate if this is a
@@ -664,8 +654,7 @@ class Hull_Reformulation(Transformation):
             # get a unique name
             conName = unique_component_name(
                 relaxationBlock,
-                var.getname(fully_qualified=False, name_buffer=NAME_BUFFER) + \
-                "_bounds")
+                var.getname(fully_qualified=False) + "_bounds")
             bigmConstraint = Constraint(transBlock.lbub)
             relaxationBlock.add_component(conName, bigmConstraint)
 
@@ -744,8 +733,7 @@ class Hull_Reformulation(Transformation):
         for v in block.component_objects(Var, descend_into=Block, active=None):
             if len(v) > 0:
                 varRefBlock.add_component(unique_component_name(
-                    varRefBlock, v.getname(fully_qualified=True,
-                                           name_buffer=NAME_BUFFER)),
+                    varRefBlock, v.getname(fully_qualified=True)),
                                           Reference(v))
 
         # Look through the component map of block and transform everything we
@@ -834,17 +822,16 @@ class Hull_Reformulation(Transformation):
 
     def _warn_for_active_disjunction( self, disjunction, disjunct,
                                       var_substitute_map, zero_substitute_map):
-        _warn_for_active_disjunction(disjunction, disjunct, NAME_BUFFER)
+        _warn_for_active_disjunction(disjunction, disjunct)
 
     def _warn_for_active_disjunct( self, innerdisjunct, outerdisjunct,
                                    var_substitute_map, zero_substitute_map):
-        _warn_for_active_disjunct(innerdisjunct, outerdisjunct, NAME_BUFFER)
+        _warn_for_active_disjunct(innerdisjunct, outerdisjunct)
 
     def _warn_for_active_logical_statement(
             self, logical_statment, disjunct, var_substitute_map,
             zero_substitute_map):
-        _warn_for_active_logical_constraint(logical_statment, disjunct,
-                                            NAME_BUFFER)
+        _warn_for_active_logical_constraint(logical_statment, disjunct)
 
     def _transform_block_on_disjunct( self, block, disjunct, var_substitute_map,
                                       zero_substitute_map):
@@ -869,7 +856,7 @@ class Hull_Reformulation(Transformation):
         # since constraints from all blocks are getting moved onto the
         # same block. So we get a unique name
         name = unique_component_name(relaxationBlock, obj.getname(
-            fully_qualified=True, name_buffer=NAME_BUFFER))
+            fully_qualified=True))
 
         if obj.is_indexed():
             newConstraint = Constraint(obj.index_set(), transBlock.lbub)
@@ -980,8 +967,7 @@ class Hull_Reformulation(Transformation):
 
             if c.lower is not None:
                 if self._generate_debug_messages:
-                    _name = c.getname(
-                        fully_qualified=True, name_buffer=NAME_BUFFER)
+                    _name = c.getname(fully_qualified=True)
                     logger.debug("GDP(Hull): Transforming constraint " +
                                  "'%s'", _name)
                 if NL:
@@ -1002,8 +988,7 @@ class Hull_Reformulation(Transformation):
 
             if c.upper is not None:
                 if self._generate_debug_messages:
-                    _name = c.getname(
-                        fully_qualified=True, name_buffer=NAME_BUFFER)
+                    _name = c.getname(fully_qualified=True)
                     logger.debug("GDP(Hull): Transforming constraint " +
                                  "'%s'", _name)
                 if NL:
@@ -1046,8 +1031,7 @@ class Hull_Reformulation(Transformation):
                 return
             raise GDP_Error("A component called 'LocalVars' is declared on "
                             "Disjunct %s, but it is of type %s, not Suffix."
-                            % (disjunct.getname(fully_qualified=True,
-                                                name_buffer=NAME_BUFFER),
+                            % (disjunct.getname(fully_qualified=True),
                                localSuffix.ctype))
 
     # These are all functions to retrieve transformed components from

--- a/pyomo/gdp/plugins/partition_disjuncts.py
+++ b/pyomo/gdp/plugins/partition_disjuncts.py
@@ -45,8 +45,6 @@ from math import floor
 import logging
 logger = logging.getLogger('pyomo.gdp.partition_disjuncts')
 
-NAME_BUFFER = {}
-
 def _generate_additively_separable_repn(nonlinear_part):
     if nonlinear_part.__class__ is not EXPR.SumExpression:
         # This isn't separable, so we just have the one expression
@@ -334,7 +332,6 @@ class PartitionDisjuncts_Transformation(Transformation):
                             "the case of nested disjunctions)." %
                             (instance.name, instance.ctype))
         try:
-            assert not NAME_BUFFER
             self._config = self.CONFIG(kwds.pop('options', {}))
             self._config.set_value(kwds)
             self._transformation_blocks = {}
@@ -360,8 +357,6 @@ class PartitionDisjuncts_Transformation(Transformation):
 
             del self._config
             del self._transformation_blocks
-            # clear the global name buffer
-            NAME_BUFFER.clear()
 
     def _apply_to_impl(self, instance):
         self.variable_partitions = self._config.variable_partitions if \
@@ -377,15 +372,13 @@ class PartitionDisjuncts_Transformation(Transformation):
                 Constraint, active=True, descend_into=Block,
                 sort=SortComponents.deterministic):
             global_constraints.add_component(unique_component_name(
-                global_constraints, cons.getname(fully_qualified=True,
-                                                 name_buffer=NAME_BUFFER)),
+                global_constraints, cons.getname(fully_qualified=True)),
                                              Reference(cons))
         for var in instance.component_objects(
                 Var, descend_into=(Block, Disjunct),
                 sort=SortComponents.deterministic):
             global_constraints.add_component(unique_component_name(
-                global_constraints, var.getname(fully_qualified=True,
-                                                name_buffer=NAME_BUFFER)),
+                global_constraints, var.getname(fully_qualified=True)),
                                              Reference(var))
         self._global_constraints = global_constraints
 
@@ -464,8 +457,7 @@ class PartitionDisjuncts_Transformation(Transformation):
         if len(obj.disjuncts) == 0:
             raise GDP_Error("Disjunction '%s' is empty. This is "
                             "likely indicative of a modeling error."  %
-                            obj.getname(fully_qualified=True,
-                                        name_buffer=NAME_BUFFER))
+                            obj.getname(fully_qualified=True))
 
         if transBlock is None and transformed_parent_disjunct is not None:
             transBlock = self._get_transformation_block(
@@ -531,8 +523,7 @@ class PartitionDisjuncts_Transformation(Transformation):
                                                     transformed_disjuncts])
         transBlock.add_component(
             unique_component_name(transBlock,
-                                  obj.getname(fully_qualified=True,
-                                              name_buffer=NAME_BUFFER)),
+                                  obj.getname(fully_qualified=True)),
             transformed_disjunction)
         obj._algebraic_constraint = weakref_ref(transformed_disjunction)
 
@@ -578,10 +569,9 @@ class PartitionDisjuncts_Transformation(Transformation):
 
         transformed_disjunct = Disjunct()
         disjunct._transformation_block = weakref_ref(transformed_disjunct)
-        transBlock.add_component(unique_component_name(
-            transBlock,
-            disjunct.getname(fully_qualified=True, name_buffer=NAME_BUFFER)),
-                                 transformed_disjunct)
+        transBlock.add_component(
+            unique_component_name(transBlock, disjunct.getname(
+                fully_qualified=True)), transformed_disjunct)
         # If the original has an indicator_var fixed to something, fix this one
         # too.
         if disjunct.indicator_var.fixed:
@@ -606,8 +596,7 @@ class PartitionDisjuncts_Transformation(Transformation):
         for var in disjunct.component_objects(Var, descend_into=Block,
                                               active=None):
             transformed_disjunct.add_component(unique_component_name(
-                transformed_disjunct, var.getname(fully_qualified=True,
-                                                  name_buffer=NAME_BUFFER)),
+                transformed_disjunct, var.getname(fully_qualified=True)),
                                            Reference(var))
 
         # Since this transformation is GDP -> GDP and it is based on
@@ -658,8 +647,7 @@ class PartitionDisjuncts_Transformation(Transformation):
     def _transform_constraint(self, cons, disjunct, transformed_disjunct,
                               transBlock, partition):
         instance = disjunct.model()
-        cons_name = cons.getname(fully_qualified=True,
-                                 name_buffer=NAME_BUFFER)
+        cons_name = cons.getname(fully_qualified=True)
 
         # create place on transformed Disjunct for the new constraint and
         # for the auxiliary variables
@@ -799,7 +787,7 @@ class PartitionDisjuncts_Transformation(Transformation):
     def _warn_for_active_disjunct(self, disjunct, parent_disjunct,
                                   transformed_parent_disjunct, transBlock,
                                   partition):
-        _warn_for_active_disjunct(disjunct, parent_disjunct, NAME_BUFFER)
+        _warn_for_active_disjunct(disjunct, parent_disjunct)
 
 # Add the CONFIG arguments to the transformation's docstring
 PartitionDisjuncts_Transformation.__doc__ = add_docstring_list(

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -22,6 +22,7 @@ from pyomo.repn import generate_standard_repn
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 import pyomo.gdp.tests.models as models
 import pyomo.gdp.tests.common_tests as ct
+from pytest import set_trace
 
 import random
 from io import StringIO
@@ -77,7 +78,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
                 w = relaxationBlock.disaggregatedVars.w
                 y = transBlock._disaggregatedVars[0]
             elif i == 0: # this disjunct as x, y, and no w
-                y = relaxationBlock.disaggregatedVars.y                
+                y = relaxationBlock.disaggregatedVars.y
                 w = transBlock._disaggregatedVars[1]
             # variables created (w and y can be Vars or VarDatas depending on
             # the disjunct)
@@ -196,7 +197,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         ct.check_linear_coef(self, repn, m.d[1].indicator_var, -3)
         self.assertEqual(repn.constant, 0)
 
-    def check_bound_constraints_on_disjBlock(self, cons, disvar, indvar, lb, 
+    def check_bound_constraints_on_disjBlock(self, cons, disvar, indvar, lb,
                                              ub):
         self.assertIsInstance(cons, Constraint)
 
@@ -245,7 +246,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
     def test_disaggregatedVar_bounds(self):
         m = models.makeTwoTermDisj_Nonlinear()
         TransformationFactory('gdp.hull').apply_to(m)
-        
+
         transBlock = m._pyomo_gdp_hull_reformulation
         disjBlock = transBlock.relaxedDisjuncts
         for i in [0,1]:
@@ -400,7 +401,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         hull = TransformationFactory('gdp.hull')
         hull.apply_to(m)
 
-        transBlock = m._pyomo_gdp_hull_reformulation 
+        transBlock = m._pyomo_gdp_hull_reformulation
         disjBlock = transBlock.relaxedDisjuncts
 
         for i in [0,1]:
@@ -441,7 +442,8 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
         # check that we used the bounds on the local variable as if they are
         # global. Which means checking the bounds constraints...
-        y_disagg = m.disj2.transformation_block().disaggregatedVars.y
+        y_disagg = m.disj2.transformation_block().disaggregatedVars.component(
+            "disj2.y")
         cons = hull.get_var_bounds_constraint(y_disagg)
         lb = cons['lb']
         self.assertIsNone(lb.lower)
@@ -472,7 +474,8 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
                       m.disj1._transformation_block().parent_block().\
                       _disaggregatedVars[0])
         self.assertIs(disj2y,
-                      m.disj2._transformation_block().disaggregatedVars.y)
+                      m.disj2._transformation_block().disaggregatedVars.\
+                      component("disj2.y"))
         self.assertIs(hull.get_src_var(disj1y), m.disj2.y)
         self.assertIs(hull.get_src_var(disj2y), m.disj2.y)
 
@@ -514,8 +517,8 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         varBlock = transBlock.disaggregatedVars
         self.assertEqual(len([v for v in
                               varBlock.component_data_objects(Var)]), 2)
-        x = varBlock.component("x")
-        y = varBlock.component("y")
+        x = varBlock.component("disj1.x")
+        y = varBlock.component("disj1.y")
         self.assertIsInstance(x, Var)
         self.assertIsInstance(y, Var)
         self.assertIs(hull.get_disaggregated_var(m.disj1.x, disj), x)
@@ -528,7 +531,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
             varBlock = transBlock.disaggregatedVars
             self.assertEqual(len([v for v in
                                   varBlock.component_data_objects(Var)]), 1)
-            y = varBlock.component("y")
+            y = varBlock.component("disj1.y")
             self.assertIsInstance(y, Var)
             self.assertIs(hull.get_disaggregated_var(m.disj1.y, disj), y)
             self.assertIs(hull.get_src_var(y), m.disj1.y)
@@ -538,7 +541,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         varBlock = transBlock.disaggregatedVars
         self.assertEqual(len([v for v in
                               varBlock.component_data_objects(Var)]), 1)
-        x = varBlock.component("x")
+        x = varBlock.component("disj1.x")
         self.assertIsInstance(x, Var)
         self.assertIs(hull.get_disaggregated_var(m.disj1.x, disj), x)
         self.assertIs(hull.get_src_var(x), m.disj1.x)
@@ -559,48 +562,52 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         self.assertIs(hull.get_disaggregated_var(m.disj1.y, m.disj3), y1)
         self.assertIs(hull.get_src_var(y1), m.disj1.y)
 
-    def check_name_collision_disaggregated_vars(self, m, disj, name):
+    def check_name_collision_disaggregated_vars(self, m, disj):
         hull = TransformationFactory('gdp.hull')
         transBlock = disj.transformation_block()
         varBlock = transBlock.disaggregatedVars
         self.assertEqual(len([v for v in
                               varBlock.component_data_objects(Var)]), 2)
-        x = varBlock.component("x")
-        x2 = varBlock.component(name)
+        # ESJ: This is not what I expected. *Can* we still get name collisions,
+        # if we're using a fully qualified name here?
+        x2 = varBlock.component("'disj1.x'")
+        x = varBlock.component("disj1.x")
+        x_orig = m.component("disj1.x")
         self.assertIsInstance(x, Var)
         self.assertIsInstance(x2, Var)
         self.assertIs(hull.get_disaggregated_var(m.disj1.x, disj), x)
         self.assertIs(hull.get_src_var(x), m.disj1.x)
-        self.assertIs(hull.get_disaggregated_var(m.x, disj), x2)
-        self.assertIs(hull.get_src_var(x2), m.x)
+        self.assertIs(hull.get_disaggregated_var(x_orig, disj), x2)
+        self.assertIs(hull.get_src_var(x2), x_orig)
 
     def test_disaggregated_var_name_collision(self):
         # same model as the test above, but now I am putting what was disj1.y as
-        # m.x, just to invite disaster, and adding constraints that involve all
-        # the variables so they will all be disaggregated on the Disjunct
+        # m.'disj1.x', just to invite disaster, and adding constraints that
+        # involve all the variables so they will all be disaggregated on the
+        # Disjunct
         m = ConcreteModel()
-        m.x = Var(bounds=(2, 11))
+        x = Var(bounds=(2, 11))
+        m.add_component("disj1.x", x)
         m.disj1 = Disjunct()
         m.disj1.x = Var(bounds=(1, 10))
-        m.disj1.cons1 = Constraint(expr=m.disj1.x + m.x <= 5)
+        m.disj1.cons1 = Constraint(expr=m.disj1.x + x <= 5)
         m.disj2 = Disjunct()
-        m.disj2.cons = Constraint(expr=m.x >= 8)
+        m.disj2.cons = Constraint(expr=x >= 8)
         m.disj2.cons1 = Constraint(expr=m.disj1.x == 3)
         m.disjunction1 = Disjunction(expr=[m.disj1, m.disj2])
 
         m.disj3 = Disjunct()
         m.disj3.cons = Constraint(expr=m.disj1.x >= 7)
-        m.disj3.cons1 = Constraint(expr=m.x >= 10)
+        m.disj3.cons1 = Constraint(expr=x >= 10)
         m.disj4 = Disjunct()
-        m.disj4.cons = Constraint(expr=m.x == 3)
+        m.disj4.cons = Constraint(expr=x == 3)
         m.disj4.cons1 = Constraint(expr=m.disj1.x == 4)
         m.disjunction2 = Disjunction(expr=[m.disj3, m.disj4])
 
         hull = TransformationFactory('gdp.hull')
         hull.apply_to(m)
-        for disj, nm in ((m.disj1, "x_4"), (m.disj2, "x_9"),
-                         (m.disj3, "x_5"), (m.disj4, "x_8")):
-            self.check_name_collision_disaggregated_vars(m, disj, nm)
+        for disj in (m.disj1, m.disj2, m.disj3, m.disj4):
+            self.check_name_collision_disaggregated_vars(m, disj)
 
     def test_do_not_transform_user_deactivated_disjuncts(self):
         ct.check_user_deactivated_disjuncts(self, 'hull')
@@ -687,7 +694,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         # as are the XOR, reaggregation and their bounds constraints
         self.assertEqual(len(list(transBlock.component_objects(
             Constraint, descend_into=False))), 3)
-        
+
         if lb == 0:
             # 3 reaggregation + 2 bounds + 1 xor (because one bounds constraint
             # is on the parent transformation block, and we don't need lb
@@ -875,16 +882,16 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         relaxedDisjuncts = m._pyomo_gdp_hull_reformulation.relaxedDisjuncts
 
         disaggregatedVars = {
-            (1,'A'): 
+            (1,'A'):
             [relaxedDisjuncts[0].disaggregatedVars.component('a[1,A]'),
              relaxedDisjuncts[1].disaggregatedVars.component('a[1,A]')],
-            (1,'B'): 
+            (1,'B'):
             [relaxedDisjuncts[2].disaggregatedVars.component('a[1,B]'),
              relaxedDisjuncts[3].disaggregatedVars.component('a[1,B]')],
-            (2,'A'): 
+            (2,'A'):
             [relaxedDisjuncts[4].disaggregatedVars.component('a[2,A]'),
              relaxedDisjuncts[5].disaggregatedVars.component('a[2,A]')],
-            (2,'B'): 
+            (2,'B'):
             [relaxedDisjuncts[6].disaggregatedVars.component('a[2,B]'),
              relaxedDisjuncts[7].disaggregatedVars.component('a[2,B]')],
         }
@@ -1875,45 +1882,49 @@ class TestSpecialCases(unittest.TestCase):
         # z should be disaggregated because we can't be sure it's not somewhere
         # else on the model. (Note however that the copy of x corresponding to
         # this disjunct is on the disjunction block)
-        self.assertEqual(sorted(varBlock.component_map(Var)), ['y','z'])
+        self.assertEqual(sorted(varBlock.component_map(Var)), ['d2.z','y'])
         # constraint on the disjunction block
         self.assertEqual(len(rd.component_map(Constraint)), 3)
         # bounds haven't changed on original
         self.assertEqual(i.d2.z.bounds, (7,9))
         # check disaggregated variable
-        self.assertIsInstance(varBlock.component("z"), Var)
-        self.assertEqual(varBlock.z.bounds, (0,9))
-        self.assertEqual(len(rd.z_bounds), 2)
-        self.assertEqual(rd.z_bounds['lb'].lower, None)
-        self.assertEqual(rd.z_bounds['lb'].upper, 0)
-        self.assertEqual(rd.z_bounds['ub'].lower, None)
-        self.assertEqual(rd.z_bounds['ub'].upper, 0)
-        i.d2.indicator_var = 1
-        varBlock.z = 2
-        self.assertEqual(rd.z_bounds['lb'].body(), 5)
-        self.assertEqual(rd.z_bounds['ub'].body(), -7)
+        z = varBlock.component('d2.z')
+        self.assertIsInstance(z, Var)
+        self.assertEqual(z.bounds, (0,9))
+        z_bounds = rd.component("d2.z_bounds")
+        self.assertEqual(len(z_bounds), 2)
+        self.assertEqual(z_bounds['lb'].lower, None)
+        self.assertEqual(z_bounds['lb'].upper, 0)
+        self.assertEqual(z_bounds['ub'].lower, None)
+        self.assertEqual(z_bounds['ub'].upper, 0)
+        i.d2.indicator_var = True
+        z.set_value(2)
+        self.assertEqual(z_bounds['lb'].body(), 5)
+        self.assertEqual(z_bounds['ub'].body(), -7)
 
         m.d2.z.setlb(-9)
         m.d2.z.setub(-7)
         i = TransformationFactory('gdp.hull').create_using(m)
         rd = i._pyomo_gdp_hull_reformulation.relaxedDisjuncts[1]
         varBlock = rd.disaggregatedVars
-        self.assertEqual(sorted(varBlock.component_map(Var)), ['y','z'])
+        self.assertEqual(sorted(varBlock.component_map(Var)), ['d2.z','y'])
         self.assertEqual(len(rd.component_map(Constraint)), 3)
         # original bounds unchanged
         self.assertEqual(i.d2.z.bounds, (-9,-7))
         # check disaggregated variable
-        self.assertIsInstance(varBlock.component("z"), Var)
-        self.assertEqual(varBlock.z.bounds, (-9,0))
-        self.assertEqual(len(rd.z_bounds), 2)
-        self.assertEqual(rd.z_bounds['lb'].lower, None)
-        self.assertEqual(rd.z_bounds['lb'].upper, 0)
-        self.assertEqual(rd.z_bounds['ub'].lower, None)
-        self.assertEqual(rd.z_bounds['ub'].upper, 0)
-        i.d2.indicator_var = 1
-        varBlock.z = 2
-        self.assertEqual(rd.z_bounds['lb'].body(), -11)
-        self.assertEqual(rd.z_bounds['ub'].body(), 9)
+        z = varBlock.component("d2.z")
+        self.assertIsInstance(z, Var)
+        self.assertEqual(z.bounds, (-9,0))
+        z_bounds = rd.component("d2.z_bounds")
+        self.assertEqual(len(z_bounds), 2)
+        self.assertEqual(z_bounds['lb'].lower, None)
+        self.assertEqual(z_bounds['lb'].upper, 0)
+        self.assertEqual(z_bounds['ub'].lower, None)
+        self.assertEqual(z_bounds['ub'].upper, 0)
+        i.d2.indicator_var = True
+        z.set_value(2)
+        self.assertEqual(z_bounds['lb'].body(), -11)
+        self.assertEqual(z_bounds['ub'].body(), 9)
 
     def test_local_var_suffix(self):
         hull = TransformationFactory('gdp.hull')
@@ -1933,7 +1944,7 @@ class TestSpecialCases(unittest.TestCase):
         self.assertEqual(m.d2.z.lb, -9)
         self.assertEqual(m.d2.z.ub, -7)
         z_disaggregated = m.d2.transformation_block().disaggregatedVars.\
-                          component("z")
+                          component("d2.z")
         self.assertIsInstance(z_disaggregated, Var)
         self.assertIs(z_disaggregated,
                       hull.get_disaggregated_var(m.d2.z, m.d2))
@@ -2037,16 +2048,20 @@ class TestErrors(unittest.TestCase):
                  binary_indicator_var
         d4_ind = m.disjunction_disjuncts[0].nestedDisjunction_disjuncts[1].\
                  binary_indicator_var
+        d3_ind_dis = disjunct1.disaggregatedVars.component(
+            "disjunction_disjuncts[0].nestedDisjunction_"
+            "disjuncts[0].binary_indicator_var")
         self.assertIs(hull.get_disaggregated_var(d3_ind,
                                                  m.disjunction_disjuncts[0]),
-                      disjunct1.disaggregatedVars.binary_indicator_var)
-        self.assertIs(hull.get_src_var(
-            disjunct1.disaggregatedVars.binary_indicator_var), d3_ind)
+                      d3_ind_dis)
+        self.assertIs(hull.get_src_var(d3_ind_dis), d3_ind)
+        d4_ind_dis = disjunct1.disaggregatedVars.component(
+            "disjunction_disjuncts[0].nestedDisjunction_"
+            "disjuncts[1].binary_indicator_var")
         self.assertIs(hull.get_disaggregated_var(d4_ind,
-                                                  m.disjunction_disjuncts[0]),
-                      disjunct1.disaggregatedVars.binary_indicator_var_4)
-        self.assertIs(hull.get_src_var(
-            disjunct1.disaggregatedVars.binary_indicator_var_4), d4_ind)
+                                                 m.disjunction_disjuncts[0]),
+                      d4_ind_dis)
+        self.assertIs(hull.get_src_var(d4_ind_dis), d4_ind)
 
         relaxed_xor = disjunct1.component(
             "disjunction_disjuncts[0]._pyomo_gdp_hull_reformulation."
@@ -2063,34 +2078,31 @@ class TestErrors(unittest.TestCase):
         ct.check_linear_coef(
             self, repn, m.disjunction.disjuncts[0].indicator_var, -1)
         ct.check_linear_coef(
-            self, repn, disjunct1.disaggregatedVars.binary_indicator_var, 1)
+            self, repn, d3_ind_dis, 1)
         ct.check_linear_coef(
-            self, repn, disjunct1.disaggregatedVars.binary_indicator_var_4, 1)
+            self, repn, d4_ind_dis, 1)
         self.assertEqual(repn.constant, 0)
 
         # but the disaggregation constraints are going to force them to 0 (which
         # will in turn force the outer disjunct indicator variable to 0, which
         # is what we want)
-        d3_ind_dis = transBlock.disaggregationConstraints[1, None]
-        self.assertEqual(d3_ind_dis.lower, 0)
-        self.assertEqual(d3_ind_dis.upper, 0)
-        repn = generate_standard_repn(d3_ind_dis.body)
+        d3_ind_dis_cons = transBlock.disaggregationConstraints[1, None]
+        self.assertEqual(d3_ind_dis_cons.lower, 0)
+        self.assertEqual(d3_ind_dis_cons.upper, 0)
+        repn = generate_standard_repn(d3_ind_dis_cons.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(len(repn.linear_vars), 2)
         self.assertEqual(repn.constant, 0)
-        ct.check_linear_coef(
-            self, repn, disjunct1.disaggregatedVars.binary_indicator_var, -1)
+        ct.check_linear_coef(self, repn, d3_ind_dis, -1)
         ct.check_linear_coef(self, repn, transBlock._disaggregatedVars[0], -1)
-        d4_ind_dis = transBlock.disaggregationConstraints[2, None]
-        self.assertEqual(d4_ind_dis.lower, 0)
-        self.assertEqual(d4_ind_dis.upper, 0)
-        repn = generate_standard_repn(d4_ind_dis.body)
+        d4_ind_dis_cons = transBlock.disaggregationConstraints[2, None]
+        self.assertEqual(d4_ind_dis_cons.lower, 0)
+        self.assertEqual(d4_ind_dis_cons.upper, 0)
+        repn = generate_standard_repn(d4_ind_dis_cons.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(len(repn.linear_vars), 2)
         self.assertEqual(repn.constant, 0)
-        ct.check_linear_coef(
-            self, repn,
-            disjunct1.disaggregatedVars.binary_indicator_var_4, -1)
+        ct.check_linear_coef( self, repn, d4_ind_dis, -1)
         ct.check_linear_coef( self, repn, transBlock._disaggregatedVars[1], -1)
 
     def test_mapping_method_errors(self):

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -367,7 +367,7 @@ def get_transformed_constraints(srcConstraint):
                      % srcConstraint.name)
         raise
 
-def _warn_for_active_disjunction(disjunction, disjunct, NAME_BUFFER):
+def _warn_for_active_disjunction(disjunction, disjunct):
     # this should only have gotten called if the disjunction is active
     assert disjunction.active
     problemdisj = disjunction
@@ -382,16 +382,15 @@ def _warn_for_active_disjunction(disjunction, disjunct, NAME_BUFFER):
     parentblock = problemdisj.parent_block()
     # the disjunction should only have been active if it wasn't transformed
     assert problemdisj.algebraic_constraint is None
-    _probDisjName = problemdisj.getname(
-        fully_qualified=True, name_buffer=NAME_BUFFER)
-    _disjName = disjunct.getname(fully_qualified=True, name_buffer=NAME_BUFFER)
+    _probDisjName = problemdisj.getname(fully_qualified=True)
+    _disjName = disjunct.getname(fully_qualified=True)
     raise GDP_Error("Found untransformed disjunction '%s' in disjunct '%s'! "
                     "The disjunction must be transformed before the "
                     "disjunct. If you are using targets, put the "
                     "disjunction before the disjunct in the list."
                     % (_probDisjName, _disjName))
 
-def _warn_for_active_disjunct(innerdisjunct, outerdisjunct, NAME_BUFFER):
+def _warn_for_active_disjunct(innerdisjunct, outerdisjunct):
     assert innerdisjunct.active
     problemdisj = innerdisjunct
     if innerdisjunct.is_indexed():
@@ -406,11 +405,8 @@ def _warn_for_active_disjunct(innerdisjunct, outerdisjunct, NAME_BUFFER):
                     "has not been transformed. {0} needs to be deactivated "
                     "or its disjunction transformed before {1} can be "
                     "transformed.".format(
-                        problemdisj.getname(
-                            fully_qualified=True, name_buffer = NAME_BUFFER),
-                        outerdisjunct.getname(
-                            fully_qualified=True,
-                            name_buffer=NAME_BUFFER)))
+                        problemdisj.getname(fully_qualified=True),
+                        outerdisjunct.getname(fully_qualified=True)))
 
 def check_model_algebraic(instance):
     """Checks if there are any active Disjuncts or Disjunctions reachable via

--- a/pyomo/network/plugins/expand_arcs.py
+++ b/pyomo/network/plugins/expand_arcs.py
@@ -59,7 +59,6 @@ class ExpandArcs(Transformation):
             arc.deactivate()
 
     def _collect_ports(self, instance):
-        self._name_buffer = {}
         # List of the ports in the order in which we found them
         # (this should be deterministic, provided that the user's model
         # is deterministic)
@@ -199,8 +198,7 @@ class ExpandArcs(Transformation):
         if len(empty_or_partial) > 1:
             # This is expensive (names aren't cheap), but does result in
             # a deterministic ordering
-            empty_or_partial.sort(key=lambda x: x.getname(
-                fully_qualified=True, name_buffer=self._name_buffer))
+            empty_or_partial.sort(key=lambda x: x.getname(fully_qualified=True))
 
         # Fill in any empty ports
         for p in empty_or_partial:
@@ -210,8 +208,7 @@ class ExpandArcs(Transformation):
                     continue
 
                 vname = unique_component_name(
-                    block, '%s_auto_%s' % (p.getname(
-                        fully_qualified=True, name_buffer=self._name_buffer),k))
+                    block, '%s_auto_%s' % (p.getname(fully_qualified=True),k))
 
                 new_var = replicate_var(v[0], vname, block)
 

--- a/pyomo/solvers/plugins/solvers/mosek_persistent.py
+++ b/pyomo/solvers/plugins/solvers/mosek_persistent.py
@@ -111,7 +111,6 @@ class MOSEKPersistent(PersistentSolver, MOSEKDirect):
             for v in solver_vars:
                 var_ids.append(self._pyomo_var_to_solver_var_map[v])
                 self._symbol_map.removeSymbol(v)
-                self._labeler.remove_obj(v)
                 del self._referenced_variables[v]
                 del self._pyomo_var_to_solver_var_map[v]
             self._solver_model.removevars(var_ids)
@@ -160,12 +159,10 @@ class MOSEKPersistent(PersistentSolver, MOSEKDirect):
             for c in lq_cons:
                 lq.append(self._pyomo_con_to_solver_con_map[c])
                 self._symbol_map.removeSymbol(c)
-                self._labeler.remove_obj(c)
                 del self._pyomo_con_to_solver_con_map[c]
             for c in cone_cons:
                 cones.append(self._pyomo_cone_to_solver_cone_map[c])
                 self._symbol_map.removeSymbol(c)
-                self._labeler.remove_obj(c)
                 del self._pyomo_cone_to_solver_cone_map[c]
             self._solver_model.removecons(lq)
             self._solver_model.removecones(cones)

--- a/pyomo/solvers/plugins/solvers/persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/persistent_solver.py
@@ -314,7 +314,6 @@ class PersistentSolver(DirectOrPersistentSolver):
         solver_con = self._pyomo_con_to_solver_con_map[con]
         self._remove_constraint(solver_con)
         self._symbol_map.removeSymbol(con)
-        self._labeler.remove_obj(con)
         for var in self._vars_referenced_by_con[con]:
             self._referenced_variables[var] -= 1
         del self._vars_referenced_by_con[con]
@@ -341,7 +340,6 @@ class PersistentSolver(DirectOrPersistentSolver):
         solver_con = self._pyomo_con_to_solver_con_map[con]
         self._remove_sos_constraint(solver_con)
         self._symbol_map.removeSymbol(con)
-        self._labeler.remove_obj(con)
         for var in self._vars_referenced_by_con[con]:
             self._referenced_variables[var] -= 1
         del self._vars_referenced_by_con[con]
@@ -371,7 +369,6 @@ class PersistentSolver(DirectOrPersistentSolver):
         solver_var = self._pyomo_var_to_solver_var_map[var]
         self._remove_var(solver_var)
         self._symbol_map.removeSymbol(var)
-        self._labeler.remove_obj(var)
         del self._referenced_variables[var]
         del self._pyomo_var_to_solver_var_map[var]
         del self._solver_var_to_pyomo_var_map[solver_var]


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

Now that ComponentData objects know their own indices, the name_buffer argument to getname is no longer necessary to get good performance. In addition, it returns the wrong name if the same dictionary was specified as the name_buffer in queries that switched where the the model the names where relative to or switched between local and fully-qualified names.

## Changes proposed in this PR:
- Deprecates the `name_buffer` argument to `getname`
- Deprecates the `remove_obj` function in the Labeler classes since all it did was update the name_buffer
- Adds a check in the `index` method that the `_index` attribute and the `_data` dictionary are in sync and raises an error if not
- Fixes bugs that the addition above exposed
- Fixes tests that wrongly relied on the bugs in name_buffer, mainly in the `hull` transformation in pyomo.gdp

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
