### PR TITLE
[WIP] Appsi-Windows Fix

### DIFF
--- a/pyomo/contrib/appsi/cmodel/src/cmodel_bindings.cpp
+++ b/pyomo/contrib/appsi/cmodel/src/cmodel_bindings.cpp
@@ -18,7 +18,10 @@
 #include "nl_writer.hpp"
 //#include "profiler.h"
 
+extern double inf;
+
 PYBIND11_MODULE(appsi_cmodel, m) {
+  inf = py::module_::import("math").attr("inf").cast<double>();
   m.attr("inf") = inf;
   // m.def("ProfilerStart", &ProfilerStart);
   // m.def("ProfilerStop", &ProfilerStop);

--- a/pyomo/contrib/appsi/cmodel/src/common.cpp
+++ b/pyomo/contrib/appsi/cmodel/src/common.cpp
@@ -1,3 +1,3 @@
 #include "common.hpp"
 
-double inf = py::module_::import("math").attr("inf").cast<double>();
+double inf;

--- a/pyomo/contrib/appsi/cmodel/tests/test_import.py
+++ b/pyomo/contrib/appsi/cmodel/tests/test_import.py
@@ -1,0 +1,23 @@
+from pyomo.common import unittest
+from pyomo.common.fileutils import find_library, this_file_dir
+import os
+from pyomo.common.envvar import PYOMO_CONFIG_DIR
+import sys
+from pyomo.contrib.appsi.cmodel import cmodel_available
+
+
+class TestCmodelImport(unittest.TestCase):
+    def test_import(self):
+        pyomo_config_dir = os.path.join(
+            PYOMO_CONFIG_DIR, "lib", "python%s.%s" % sys.version_info[:2],
+            "site-packages"
+        )
+        cmodel_dir = this_file_dir()
+        cmodel_dir = os.path.join(cmodel_dir, os.pardir)
+        lib = find_library("appsi_cmodel.*", pathlist=pyomo_config_dir)
+        if lib is None:
+            lib = find_library("appsi_cmodel.*", pathlist=cmodel_dir)
+        if lib is not None:
+            self.assertTrue(cmodel_available)
+        else:
+            raise unittest.SkipTest('appsi library file not found')


### PR DESCRIPTION
## Fixes #2316.

## Summary/Motivation:
This PR ensures that appsi cmodel `inf` does not get initialized until the module gets imported.

## Changes proposed in this PR:
- Move initialization of `inf`
- Add a test to ensure `cmodel` can be imported if the library exists

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
