### PR TITLE
Quick Fix: Only Uninstall Qt if it exists

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -286,6 +286,9 @@ jobs:
                 conda install -q -y -c conda-forge $PKG \
                     || echo "WARNING: $PKG is not available"
             done
+            # TODO: This is a hack to stop test_qt.py from running until we
+            # can better troubleshoot why it fails on GHA
+            conda remove qt pyqt || echo "PyQt not in this environment"
         fi
         # Re-try Pyomo (optional) dependencies with pip
         if test -n "$PYPI_DEPENDENCIES"; then

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -1,4 +1,4 @@
- I doname: GitHub Branch CI
+name: GitHub Branch CI
 
 on:
   push:

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -1,4 +1,4 @@
-name: GitHub Branch CI
+ I doname: GitHub Branch CI
 
 on:
   push:
@@ -286,9 +286,6 @@ jobs:
                 conda install -q -y -c conda-forge $PKG \
                     || echo "WARNING: $PKG is not available"
             done
-            # TODO: This is a hack to stop test_qt.py from running until we
-            # can better troubleshoot why it fails on GHA
-            conda remove qt pyqt
         fi
         # Re-try Pyomo (optional) dependencies with pip
         if test -n "$PYPI_DEPENDENCIES"; then

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -307,7 +307,7 @@ jobs:
             done
             # TODO: This is a hack to stop test_qt.py from running until we
             # can better troubleshoot why it fails on GHA
-            conda remove qt pyqt
+            conda remove qt pyqt || echo "PyQt not in this environment"
         fi
         # Re-try Pyomo (optional) dependencies with pip
         if test -n "$PYPI_DEPENDENCIES"; then


### PR DESCRIPTION
## Fixes N/A

## Summary/Motivation:
The `mpi` environment no longer has `qt` and `pyqt`, so the hack to uninstall them is causing failures. This adds a simple `OR` statement to keep going if those packages don't exist

## Changes proposed in this PR:
- Update statement to `conda remove qt pyqt || echo "PyQt not in this environment"`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
