### PR TITLE
appsi: support auto-linked binary vars

### DIFF
--- a/pyomo/contrib/appsi/cmodel/src/expression.hpp
+++ b/pyomo/contrib/appsi/cmodel/src/expression.hpp
@@ -669,6 +669,7 @@ public:
     expr_type_map[np_float64] = py_float;
     expr_type_map[ScalarVar] = var;
     expr_type_map[_GeneralVarData] = var;
+    expr_type_map[AutoLinkedBinaryVar] = var;
     expr_type_map[ScalarParam] = param;
     expr_type_map[_ParamData] = param;
     expr_type_map[MonomialTermExpression] = product;
@@ -721,6 +722,8 @@ public:
       py::module_::import("pyomo.core.base.var").attr("ScalarVar");
   py::object _GeneralVarData =
       py::module_::import("pyomo.core.base.var").attr("_GeneralVarData");
+  py::object AutoLinkedBinaryVar =
+      py::module_::import("pyomo.gdp.disjunct").attr("AutoLinkedBinaryVar");
   py::object numeric_expr = py::module_::import("pyomo.core.expr.numeric_expr");
   py::object NegationExpression = numeric_expr.attr("NegationExpression");
   py::object NPV_NegationExpression =

--- a/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
@@ -2,8 +2,6 @@ import pyomo.environ as pe
 from pyomo.common.dependencies import attempt_import
 import pyomo.common.unittest as unittest
 parameterized, param_available = attempt_import('parameterized')
-if not param_available:
-    raise unittest.SkipTest('Parameterized is not available.')
 parameterized = parameterized.parameterized
 from pyomo.contrib.appsi.base import TerminationCondition, Results, PersistentSolver
 from pyomo.contrib.appsi.cmodel import cmodel_available
@@ -13,7 +11,11 @@ from pyomo.core.expr.numeric_expr import LinearExpression
 import os
 numpy, numpy_available = attempt_import('numpy')
 import random
+from pyomo import gdp
 
+
+if not param_available:
+    raise unittest.SkipTest('Parameterized is not available.')
 
 all_solvers = [('gurobi', Gurobi), ('ipopt', Ipopt), ('cplex', Cplex), ('cbc', Cbc)]
 mip_solvers = [('gurobi', Gurobi), ('cplex', Cplex), ('cbc', Cbc)]
@@ -960,6 +962,37 @@ class TestSolvers(unittest.TestCase):
         m.x.setlb(0.5)
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, 1)
+
+    @parameterized.expand(input=mip_solvers)
+    def test_with_gdp(self, name: str, opt_class: Type[PersistentSolver]):
+        opt: PersistentSolver = opt_class()
+        if not opt.available():
+            raise unittest.SkipTest
+
+        m = pe.ConcreteModel()
+        m.x = pe.Var(bounds=(-10, 10))
+        m.y = pe.Var(bounds=(-10, 10))
+        m.obj = pe.Objective(expr=m.y)
+        m.d1 = gdp.Disjunct()
+        m.d1.c1 = pe.Constraint(expr=m.y >= m.x + 2)
+        m.d1.c2 = pe.Constraint(expr=m.y >= -m.x + 2)
+        m.d2 = gdp.Disjunct()
+        m.d2.c1 = pe.Constraint(expr=m.y >= m.x + 1)
+        m.d2.c2 = pe.Constraint(expr=m.y >= -m.x + 1)
+        m.disjunction = gdp.Disjunction(expr=[m.d2, m.d1])
+        pe.TransformationFactory("gdp.bigm").apply_to(m)
+
+        res = opt.solve(m)
+        self.assertAlmostEqual(res.best_feasible_objective, 1)
+        self.assertAlmostEqual(m.x.value, 0)
+        self.assertAlmostEqual(m.y.value, 1)
+
+        opt: PersistentSolver = opt_class()
+        opt.use_extensions = True
+        res = opt.solve(m)
+        self.assertAlmostEqual(res.best_feasible_objective, 1)
+        self.assertAlmostEqual(m.x.value, 0)
+        self.assertAlmostEqual(m.y.value, 1)
 
 
 @unittest.skipUnless(cmodel_available, 'appsi extensions are not available')


### PR DESCRIPTION
## Fixes #2355.

## Summary/Motivation:
This PR adds support in Appsi for `AutoLinkedBinaryVar`.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
