### PR TITLE
appsi nl_writer: better handling of fixed binary vars

### DIFF
--- a/pyomo/contrib/appsi/cmodel/src/nl_writer.cpp
+++ b/pyomo/contrib/appsi/cmodel/src/nl_writer.cpp
@@ -407,12 +407,11 @@ void NLWriter::write(std::string filename) {
     v_lb = v->get_lb();
     v_ub = v->get_ub();
     v_domain = v->get_domain();
-    if (v_domain != continuous) {
-      throw py::value_error(
-          "NLWriter currently only supports continuous variables.");
-    }
     if (v->fixed) {
       f << "4 " << v->value << "\n";
+    } else if (v_domain != continuous) {
+      throw py::value_error(
+          "NLWriter currently only supports continuous variables.");
     } else if (v_lb == v_ub) {
       f << "4 " << v_lb << "\n";
     } else if (v_lb > -inf && v_ub < inf) {

--- a/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
@@ -961,6 +961,32 @@ class TestSolvers(unittest.TestCase):
         res = opt.solve(m)
         self.assertAlmostEqual(res.best_feasible_objective, 1)
 
+    @parameterized.expand(input=all_solvers)
+    def test_fixed_binaries(self, name: str, opt_class: Type[PersistentSolver]):
+        opt: PersistentSolver = opt_class()
+        if not opt.available():
+            raise unittest.SkipTest
+        m = pe.ConcreteModel()
+        m.x = pe.Var(domain=pe.Binary)
+        m.y = pe.Var()
+        m.obj = pe.Objective(expr=m.y)
+        m.c = pe.Constraint(expr=m.y >= m.x)
+        m.x.fix(0)
+        res = opt.solve(m)
+        self.assertAlmostEqual(res.best_feasible_objective, 0)
+        m.x.fix(1)
+        res = opt.solve(m)
+        self.assertAlmostEqual(res.best_feasible_objective, 1)
+
+        opt: PersistentSolver = opt_class()
+        opt.update_config.treat_fixed_vars_as_params = False
+        m.x.fix(0)
+        res = opt.solve(m)
+        self.assertAlmostEqual(res.best_feasible_objective, 0)
+        m.x.fix(1)
+        res = opt.solve(m)
+        self.assertAlmostEqual(res.best_feasible_objective, 1)
+
 
 @unittest.skipUnless(cmodel_available, 'appsi extensions are not available')
 class TestLegacySolverInterface(unittest.TestCase):


### PR DESCRIPTION
## Fixes #2375.

## Summary/Motivation:
The Appsi NL writer does not yet support integer variables. However, fixed integer variables should be fine. This PR ensures that fixed integer variables work in the Appsi NL writer.


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
