### PR TITLE
Appsi: supress cplex output when checking availability

### DIFF
--- a/pyomo/contrib/appsi/solvers/cplex.py
+++ b/pyomo/contrib/appsi/solvers/cplex.py
@@ -94,12 +94,14 @@ class Cplex(PersistentSolver):
             else:
                 try:
                     m = self._cplex.Cplex()
+                    m.set_results_stream(None)
                     m.variables.add(lb=[0]*1001)
                     m.solve()
                     Cplex._available = self.Availability.FullLicense
                 except self._cplex.exceptions.errors.CplexSolverError:
                     try:
                         m = self._cplex.Cplex()
+                        m.set_results_stream(None)
                         m.variables.add(lb=[0])
                         m.solve()
                         Cplex._available = self.Availability.LimitedLicense


### PR DESCRIPTION
## Fixes #2382.

## Summary/Motivation:
Checking the availability of a solver should not produce output.

## Changes proposed in this PR:
- Suppress Cplex output when checking availability

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
