### PR TITLE
appsi: dont require c++ extensions if they are not needed

### DIFF
--- a/pyomo/contrib/appsi/solvers/gurobi.py
+++ b/pyomo/contrib/appsi/solvers/gurobi.py
@@ -1,9 +1,7 @@
 from collections.abc import Iterable
-import enum
 import logging
 import math
 from typing import List, Dict, Optional
-
 from pyomo.common.collections import ComponentSet, ComponentMap, OrderedSet
 from pyomo.common.dependencies import attempt_import
 from pyomo.common.errors import PyomoException
@@ -20,9 +18,6 @@ from pyomo.core.expr.numvalue import (
     value, is_constant, is_fixed, native_numeric_types,
 )
 from pyomo.repn import generate_standard_repn
-from pyomo.core.base.set import (Reals, NonNegativeReals, NonPositiveReals,
-                                 Integers, NonNegativeIntegers, NonPositiveIntegers,
-                                 Binary, PercentFraction, UnitInterval)
 from pyomo.core.expr.numeric_expr import NPV_MaxExpression, NPV_MinExpression
 from pyomo.contrib.appsi.base import (
     PersistentSolver, Results, TerminationCondition, MIPSolverConfig,
@@ -254,22 +249,19 @@ class Gurobi(PersistentBase, PersistentSolver):
         except gurobipy.GurobiError:
             cls._available = Gurobi.Availability.BadLicense
             return
-        if not cmodel_available:
-            cls._available = Gurobi.Availability.NeedsCompiledExtension
-        else:
-            m = gurobipy.Model()
+        m = gurobipy.Model()
+        m.setParam('OutputFlag', 0)
+        try:
+            # As of 3/2021, the limited-size Gurobi license was limited
+            # to 2000 variables.
+            m.addVars(range(2001))
             m.setParam('OutputFlag', 0)
-            try:
-                # As of 3/2021, the limited-size Gurobi license was limited
-                # to 2000 variables.
-                m.addVars(range(2001))
-                m.setParam('OutputFlag', 0)
-                m.optimize()
-                cls._available = Gurobi.Availability.FullLicense
-            except gurobipy.GurobiError:
-                cls._available = Gurobi.Availability.LimitedLicense
-            finally:
-                m.dispose()
+            m.optimize()
+            cls._available = Gurobi.Availability.FullLicense
+        except gurobipy.GurobiError:
+            cls._available = Gurobi.Availability.LimitedLicense
+        finally:
+            m.dispose()
 
     def version(self):
         version = (gurobipy.GRB.VERSION_MAJOR,
@@ -436,7 +428,8 @@ class Gurobi(PersistentBase, PersistentSolver):
         self.gurobi_options = saved_options
         self.update_config = saved_update_config
         self._model = model
-        self._expr_types = cmodel.PyomoExprTypes()
+        if self.use_extensions and cmodel_available:
+            self._expr_types = cmodel.PyomoExprTypes()
 
         if self.config.symbolic_solver_labels:
             self._labeler = TextLabeler()
@@ -837,6 +830,7 @@ class Gurobi(PersistentBase, PersistentSolver):
     def get_primals(self, vars_to_load=None, solution_number=0):
         if self._needs_updated:
             self._update_gurobi_model()  # this is needed to ensure that solutions cannot be loaded after the model has been changed
+
         var_map = self._pyomo_var_to_solver_var_map
         ref_vars = self._referenced_variables
         if vars_to_load is None:

--- a/pyomo/contrib/appsi/solvers/tests/test_gurobi_persistent.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_gurobi_persistent.py
@@ -105,7 +105,6 @@ def create_pmedian_model():
     return model
 
 
-@unittest.skipUnless(cmodel_available, 'appsi extensions are not available')
 class TestGurobiPersistentSimpleLPUpdates(unittest.TestCase):
     def setUp(self):
         self.m = pe.ConcreteModel()
@@ -180,7 +179,7 @@ class TestGurobiPersistentSimpleLPUpdates(unittest.TestCase):
         finally:
             Gurobi._available = _avail
 
-@unittest.skipUnless(cmodel_available, 'appsi extensions are not available')
+
 class TestGurobiPersistent(unittest.TestCase):
     def test_range_constraints(self):
         m = pe.ConcreteModel()
@@ -408,7 +407,6 @@ class TestGurobiPersistent(unittest.TestCase):
         self.assertAlmostEqual(pe.value(m.obj.expr), 6.592304628123309)
 
 
-@unittest.skipUnless(cmodel_available, 'appsi extensions are not available')
 class TestManualModel(unittest.TestCase):
     def setUp(self):
         opt = Gurobi()

--- a/pyomo/contrib/appsi/utils/__init__.py
+++ b/pyomo/contrib/appsi/utils/__init__.py
@@ -1,2 +1,2 @@
 from .get_objective import get_objective
-from .identify_named_expressions import identify_named_expressions
+from .collect_vars_and_named_exprs import collect_vars_and_named_exprs

--- a/pyomo/contrib/appsi/utils/collect_vars_and_named_exprs.py
+++ b/pyomo/contrib/appsi/utils/collect_vars_and_named_exprs.py
@@ -1,9 +1,8 @@
 from pyomo.core.expr.visitor import ExpressionValueVisitor, nonpyomo_leaf_types
-from pyomo.common.collections import ComponentSet
 from pyomo.core.expr import current as _expr
 
 
-class _NamedExpressionVisitor(ExpressionValueVisitor):
+class _VarAndNamedExprCollector(ExpressionValueVisitor):
     def __init__(self):
         self.named_expressions = dict()
         self.variables = dict()
@@ -37,10 +36,10 @@ class _NamedExpressionVisitor(ExpressionValueVisitor):
         return True, None
 
 
-_visitor = _NamedExpressionVisitor()
+_visitor = _VarAndNamedExprCollector()
 
 
-def identify_named_expressions(expr):
+def collect_vars_and_named_exprs(expr):
     _visitor.__init__()
     _visitor.dfs_postorder_stack(expr)
     return (list(_visitor.named_expressions.values()),

--- a/pyomo/contrib/appsi/utils/tests/test_collect_vars_and_named_exprs.py
+++ b/pyomo/contrib/appsi/utils/tests/test_collect_vars_and_named_exprs.py
@@ -1,0 +1,56 @@
+from pyomo.common import unittest
+import pyomo.environ as pe
+from pyomo.contrib.appsi.utils import collect_vars_and_named_exprs
+from pyomo.contrib.appsi.cmodel import cmodel, cmodel_available
+from typing import Callable
+from pyomo.common.getGSL import find_GSL
+
+
+class TestCollectVarsAndNamedExpressions(unittest.TestCase):
+    def basics_helper(self, collector: Callable, *args):
+        m = pe.ConcreteModel()
+        m.x = pe.Var()
+        m.y = pe.Var()
+        m.z = pe.Var()
+        m.E = pe.Expression(expr=2*m.z + 1)
+        m.y.fix(3)
+        e = m.x*m.y + m.x*m.E
+        named_exprs, var_list, fixed_vars, external_funcs = collector(e, *args)
+        self.assertEqual([m.E], named_exprs)
+        self.assertEqual([m.x, m.y, m.z], var_list)
+        self.assertEqual([m.y], fixed_vars)
+        self.assertEqual([], external_funcs)
+
+    def test_basics(self):
+        self.basics_helper(collect_vars_and_named_exprs)
+
+    @unittest.skipUnless(cmodel_available, 'appsi extensions are not available')
+    def test_basics_cmodel(self):
+        self.basics_helper(cmodel.prep_for_repn, cmodel.PyomoExprTypes())
+
+    def external_func_helper(self, collector: Callable, *args):
+        DLL = find_GSL()
+        if not DLL:
+            self.skipTest('Could not find amplgsl.dll library')
+
+        m = pe.ConcreteModel()
+        m.x = pe.Var()
+        m.y = pe.Var()
+        m.z = pe.Var()
+        m.hypot = pe.ExternalFunction(library=DLL, function='gsl_hypot')
+        func = m.hypot(m.x, m.x*m.y)
+        m.E = pe.Expression(expr=2*func)
+        m.y.fix(3)
+        e = m.z + m.x*m.E
+        named_exprs, var_list, fixed_vars, external_funcs = collector(e, *args)
+        self.assertEqual([m.E], named_exprs)
+        self.assertEqual([m.z, m.x, m.y], var_list)
+        self.assertEqual([m.y], fixed_vars)
+        self.assertEqual([func], external_funcs)
+
+    def test_external(self):
+        self.external_func_helper(collect_vars_and_named_exprs)
+
+    @unittest.skipUnless(cmodel_available, 'appsi extensions are not available')
+    def test_external_cmodel(self):
+        self.basics_helper(cmodel.prep_for_repn, cmodel.PyomoExprTypes())


### PR DESCRIPTION
## Summary/Motivation:
This removes the requirement for c++ extensions when they are not needed.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
