### PR TITLE
appsi fbbt: add tests for named expressions

### DIFF
--- a/pyomo/contrib/appsi/cmodel/src/fbbt_model.cpp
+++ b/pyomo/contrib/appsi/cmodel/src/fbbt_model.cpp
@@ -50,7 +50,7 @@ void FBBTConstraint::perform_fbbt(double feasibility_tol, double integer_tol,
   if (body_lb > con_ub + feasibility_tol ||
       body_ub < con_lb - feasibility_tol) {
     throw InfeasibleConstraintException(
-        "Infeasible constraint; the bounds computed on the body of the "
+        "Infeasible constraint (" + name + "); the bounds computed on the body of the "
         "constraint violate the constraint bounds:\n  con LB: " +
         std::to_string(con_lb) + "\n  con UB: " + std::to_string(con_ub) +
         "\n  body LB: " + std::to_string(body_lb) +

--- a/pyomo/contrib/appsi/tests/test_fbbt.py
+++ b/pyomo/contrib/appsi/tests/test_fbbt.py
@@ -125,3 +125,17 @@ class TestFBBTPersistent(unittest.TestCase):
         self.assertTrue(m.c2.active)
         self.assertAlmostEqual(m.y.lb, 0)
         self.assertAlmostEqual(m.y.ub, 2)
+
+    def test_named_exprs(self):
+        m = pe.ConcreteModel()
+        m.a = pe.Set(initialize=[1,2,3])
+        m.x = pe.Var(m.a, bounds=(0, None))
+        m.e = pe.Expression(m.a)
+        for i in m.a:
+            m.e[i].expr = i*m.x[i]
+        m.c = pe.Constraint(expr=sum(m.e.values()) == 0)
+        it = appsi.fbbt.IntervalTightener()
+        it.perform_fbbt(m)
+        for x in m.x.values():
+            self.assertAlmostEqual(x.lb, 0)
+            self.assertAlmostEqual(x.ub, 0)


### PR DESCRIPTION
## Changes proposed in this PR:
- Add a test for performing FBBT with named expressions
- Improve error messages in FBBT when a constraint is found to be infeasible

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
