### PR TITLE
Skip parmest tests when seaborn, matplotlib are missing

### DIFF
--- a/pyomo/contrib/parmest/examples/reactor_design/reactor_design.py
+++ b/pyomo/contrib/parmest/examples/reactor_design/reactor_design.py
@@ -10,10 +10,13 @@
 #  ___________________________________________________________________________
 """
 Continuously stirred tank reactor model, based on
-pyomo\examples\doc\pyomobook\nonlinear-ch\react_design\ReactorDesign.py
+pyomo/examples/doc/pyomobook/nonlinear-ch/react_design/ReactorDesign.py
 """
 import pandas as pd
-from pyomo.environ import ConcreteModel, Var, PositiveReals, Objective, Constraint, maximize, SolverFactory
+from pyomo.environ import (
+    ConcreteModel, Var, PositiveReals, Objective, Constraint, maximize,
+    SolverFactory
+)
 
 def reactor_design_model(data):
     

--- a/pyomo/contrib/parmest/tests/test_examples.py
+++ b/pyomo/contrib/parmest/tests/test_examples.py
@@ -11,7 +11,11 @@
 
 import pyomo.common.unittest as unittest
 import pyomo.contrib.parmest.parmest as parmest
+from pyomo.contrib.parmest.graphics import (
+    matplotlib_available, seaborn_available
+)
 from pyomo.opt import SolverFactory
+
 ipopt_available = SolverFactory('ipopt').available()
 
 
@@ -32,14 +36,17 @@ class TestRooneyBieglerExamples(unittest.TestCase):
         from pyomo.contrib.parmest.examples.rooney_biegler import rooney_biegler
         rooney_biegler.main()
 
+    @unittest.skipUnless(seaborn_available, "test requires seaborn")
     def test_parameter_estimation_example(self):
         from pyomo.contrib.parmest.examples.rooney_biegler import parameter_estimation_example
         parameter_estimation_example.main()
 
+    @unittest.skipUnless(seaborn_available, "test requires seaborn")
     def test_bootstrap_example(self):
         from pyomo.contrib.parmest.examples.rooney_biegler import bootstrap_example
         bootstrap_example.main()
 
+    @unittest.skipUnless(seaborn_available, "test requires seaborn")
     def test_likelihood_ratio_example(self):
         from pyomo.contrib.parmest.examples.rooney_biegler import likelihood_ratio_example
         likelihood_ratio_example.main()
@@ -111,6 +118,7 @@ class TestReactorDesignExamples(unittest.TestCase):
         from pyomo.contrib.parmest.examples.reactor_design import parameter_estimation_example
         parameter_estimation_example.main()
 
+    @unittest.skipUnless(seaborn_available, "test requires seaborn")
     def test_bootstrap_example(self):
         from pyomo.contrib.parmest.examples.reactor_design import bootstrap_example
         bootstrap_example.main()
@@ -133,6 +141,7 @@ class TestReactorDesignExamples(unittest.TestCase):
         from pyomo.contrib.parmest.examples.reactor_design import multisensor_data_example
         multisensor_data_example.main()
 
+    @unittest.skipUnless(matplotlib_available, "test requires matplotlib")
     def test_datarec_example(self):
         from pyomo.contrib.parmest.examples.reactor_design import datarec_example
         datarec_example.main()


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This partially addresses #2390: it will skip the failing tests when `seaborn` and `matplotlib` are not present.  However, it does not resolve the issue (installing `cyipopt` / `pymumps` uninstall `seaborn` / `matplotlib`).

## Changes proposed in this PR:
- Skip `parmest` tests requiring `matplotlib` / `seaborn` when not installed
- Silence a warning raised by parmest test file

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
