### PR TITLE
Improve error checking parsing ConfigDict string value

### DIFF
--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -1222,10 +1222,18 @@ def _default_string_dict_lexer(value):
         if not key:
             break
         sep = _lex.token()
+        if not sep:
+            raise ValueError(
+                "Expected ':' or '=' but encountered end of string")
         if sep.type not in ':=':
-            raise ValueError("Expected ':' or '=' at "
-                             f"Line {sep.lineno} Column {sep.lexpos+1}")
+            raise ValueError(
+                f"Expected ':' or '=' but found '{sep.value}' at "
+                f"Line {sep.lineno} Column {sep.lexpos+1}")
         val = _lex.token()
+        if not val:
+            raise ValueError(
+                f"Expected value following '{sep.type}' "
+                f"but encountered end of string")
         yield key.value, val.value
 
 _default_string_dict_lexer._lex = None

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -2226,14 +2226,20 @@ Node information:
         self.assertEqual(c.sub.value(), [{'a':4, 'b':None}, {'a':0, 'b':'12'}])
         self.assertEqual(c.listof, [3, 2, 4])
 
-        args = parser.parse_args([
-            '--lst', '42', '--lst', '1',
-            '--sub', 'a=4', '--sub', 'b=12,a 0',
-            '--listof', '3,2 4'
-        ])
+        args = parser.parse_args(['--sub', 'b=12,a 0'])
         with self.assertRaisesRegex(
                 ValueError, r"(?s)invalid value for configuration 'sub':.*"
-                r"Expected ':' or '=' at Line 1 Column 8"):
+                r"Expected ':' or '=' but found '0' at Line 1 Column 8"):
+            leftovers = c.import_argparse(args)
+        args = parser.parse_args(['--sub', 'b='])
+        with self.assertRaisesRegex(
+                ValueError, r"(?s)Expected value following '=' "
+                "but encountered end of string"):
+            leftovers = c.import_argparse(args)
+        args = parser.parse_args(['--sub', 'b'])
+        with self.assertRaisesRegex(
+                ValueError, r"(?s)Expected ':' or '=' "
+                "but encountered end of string"):
             leftovers = c.import_argparse(args)
 
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Integration checking with IDAES identified a weakness with the `_default_string_dict_lexer` where incomplete records would result in an `AttributeError` instead of a `ValueError`,  This PR crrects that (and adds additional tests for the case identified in IDAES tests).

## Changes proposed in this PR:
- Ensure that incomplete records raise `ValueError` and not `AttributeError`
- Update tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
