### PR TITLE
Appsi nl writer: better error message when all variables are fixed

### DIFF
--- a/pyomo/contrib/appsi/cmodel/src/nl_writer.cpp
+++ b/pyomo/contrib/appsi/cmodel/src/nl_writer.cpp
@@ -310,6 +310,9 @@ void NLWriter::write(std::string filename) {
   // now write the header
 
   int n_vars = all_vars.size();
+  if (n_vars == 0) {
+    throw py::value_error("there are not any unfixed variables in the problem");
+  }
 
   f << "g3 1 1 0\n";
   f << n_vars << " ";

--- a/pyomo/contrib/appsi/writers/tests/test_nl_writer.py
+++ b/pyomo/contrib/appsi/writers/tests/test_nl_writer.py
@@ -8,6 +8,21 @@ import os
 
 @unittest.skipUnless(cmodel_available, 'appsi extensions are not available')
 class TestNLWriter(unittest.TestCase):
+    def test_all_vars_fixed(self):
+        m = pe.ConcreteModel()
+        m.x = pe.Var()
+        m.y = pe.Var()
+        m.obj = pe.Objective(expr=m.x**2 + m.y**2)
+        m.c1 = pe.Constraint(expr=m.y >= pe.exp(m.x))
+        m.c2 = pe.Constraint(expr=m.y >= (m.x - 1)**2)
+        m.x.fix(1)
+        m.y.fix(2)
+        writer = appsi.writers.NLWriter()
+        with TempfileManager:
+            fname = TempfileManager.create_tempfile(suffix='.appsi.nl')
+            with self.assertRaisesRegex(ValueError, 'there are not any unfixed variables in the problem'):
+                writer.write(m, fname)
+    
     def _write_and_check_header(self, m, correct_lines):
         writer = appsi.writers.NLWriter()
         with TempfileManager:


### PR DESCRIPTION
## Changes proposed in this PR:
- Appsi update: raise a useful error message when writing an nl file for a model where all variables are fixed.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
