### PR TITLE
Trap exception raised by new versions of networkx

### DIFF
--- a/pyomo/contrib/community_detection/community_graph.py
+++ b/pyomo/contrib/community_detection/community_graph.py
@@ -140,10 +140,16 @@ def generate_model_graph(model, type_of_graph, with_objective=True, weighted_gra
         variable_nodes = set(number_component_map) - constraint_nodes
         graph_nodes = variable_nodes
 
-    if weighted_graph:
-        projected_model_graph = nx.bipartite.weighted_projected_graph(bipartite_model_graph, graph_nodes)
-    else:
-        projected_model_graph = nx.bipartite.projected_graph(bipartite_model_graph, graph_nodes)
+    try:
+        if weighted_graph:
+            projected_model_graph = nx.bipartite.weighted_projected_graph(bipartite_model_graph, graph_nodes)
+        else:
+            projected_model_graph = nx.bipartite.projected_graph(bipartite_model_graph, graph_nodes)
+    except nx.exception.NetworkXAlgorithmError:
+        # See Pyomo #2413: networkx now raises exceptions for invalid
+        # projections.  This restores the (probably invalid) previous
+        # behavior in community_detection
+        projected_model_graph = nx.Graph()
 
     # Log important information with the following logger function
     _event_log(model, projected_model_graph, set(constraint_variable_map), type_of_graph, with_objective)


### PR DESCRIPTION
## Fixes #2413

## Summary/Motivation:
Recent versions of networkx raise exceptions for invalid projections.  This PR traps those exceptions and maps hem back to the empty graphs that community_detection originally expected.

## Changes proposed in this PR:
- trap exceptions from networkx

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
