### PR TITLE
Ensure UnindexedComponent_set is properly global when pickled

### DIFF
--- a/pyomo/core/base/global_set.py
+++ b/pyomo/core/base/global_set.py
@@ -58,6 +58,7 @@ class GlobalSetBase(object):
 #
 #UnindexedComponent_set = set([None])
 class _UnindexedComponent_set(GlobalSetBase):
+    local_name = 'UnindexedComponent_set'
     def __init__(self, name):
         self.name = name
     def __contains__(self, val):
@@ -89,5 +90,6 @@ class _UnindexedComponent_set(GlobalSetBase):
         # As this set only has a single element, it is implicitly "ordered"
         return True
 UnindexedComponent_set = _UnindexedComponent_set('UnindexedComponent_set')
+GlobalSets[UnindexedComponent_set.local_name] = UnindexedComponent_set
 
 UnindexedComponent_index = next(iter(UnindexedComponent_set))


### PR DESCRIPTION
## Fixes #2411 

## Summary/Motivation:
Resolve pickle errors for the global `UnindexedComponent_set`.

This will enable pickling transformed models using `dill`; however, transformed GDP models still are not picklable using `pickle`, as the transformation adds weakrefs to the model (that `pickle` cannot pickle).  A separate issue (#2417) will track resolving that issue.

## Changes proposed in this PR:
- Ensure that `UnindexedComponent_set` is correctly pickled / restored

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
