### PR TITLE
Resolve dill incompatibility with `attempt_import`.

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -80,6 +80,11 @@ class ModuleUnavailable(object):
     def __setstate__(self, state):
         self.__name__, self._moduleunavailable_info_ = state
 
+    # Included because recent dill picklers look for the mro() when
+    # detecting numpy types
+    def mro(self):
+        return [DeferredImportModule, object]
+
     def _moduleunavailable_message(self, msg=None):
         _err, _ver, _imp, _package = self._moduleunavailable_info_
         if msg is None:
@@ -163,6 +168,12 @@ class DeferredImportModule(object):
     def __setstate__(self, state):
         for k, v in state.items():
             super().__setattr__(k, v)
+
+    # Included because recent dill picklers look for the mro() when
+    # detecting numpy types
+    def mro(self):
+        return [DeferredImportModule, object]
+
 
 class _DeferredImportIndicatorBase(object):
     def __and__(self, other):

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -74,6 +74,12 @@ class ModuleUnavailable(object):
                                  % (type(self).__name__, attr))
         raise DeferredImportError(self._moduleunavailable_message())
 
+    def __getstate__(self):
+        return (self.__name__, self._moduleunavailable_info_)
+
+    def __setstate__(self, state):
+        self.__name__, self._moduleunavailable_info_ = state
+
     def _moduleunavailable_message(self, msg=None):
         _err, _ver, _imp, _package = self._moduleunavailable_info_
         if msg is None:
@@ -151,6 +157,12 @@ class DeferredImportModule(object):
                 _mod = getattr(_mod, _sub)
         return getattr(_mod, attr)
 
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, state):
+        for k, v in state.items():
+            super().__setattr__(k, v)
 
 class _DeferredImportIndicatorBase(object):
     def __and__(self, other):

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -51,10 +51,16 @@ class ModuleUnavailable(object):
         The module name that originally attempted the import
     """
 
-    # We need special handling for Sphinx here, as it will look for the
-    # __sphinx_mock__ attribute on all module-level objects, and we need
-    # that to raise an AttributeError and not a DeferredImportError
-    _getattr_raises_attributeerror = {'__sphinx_mock__',}
+    _getattr_raises_attributeerror = {
+        # We need special handling for Sphinx here, as it will look for the
+        # __sphinx_mock__ attribute on all module-level objects, and we need
+        # that to raise an AttributeError and not a DeferredImportError
+        '__sphinx_mock__',
+        # We need special handling for dill as well, as dill's attempts
+        # to pickle module gobals look for the '_dill' attribute on all
+        # global objects.
+        '_dill',
+    }
 
     def __init__(self, name, message, version_error, import_error, package):
         self.__name__ = name

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -83,7 +83,7 @@ class ModuleUnavailable(object):
     # Included because recent dill picklers look for the mro() when
     # detecting numpy types
     def mro(self):
-        return [DeferredImportModule, object]
+        return [ModuleUnavailable, object]
 
     def _moduleunavailable_message(self, msg=None):
         _err, _ver, _imp, _package = self._moduleunavailable_info_

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -56,9 +56,9 @@ class ModuleUnavailable(object):
         # __sphinx_mock__ attribute on all module-level objects, and we need
         # that to raise an AttributeError and not a DeferredImportError
         '__sphinx_mock__',
-        # We need special handling for dill as well, as dill's attempts
-        # to pickle module gobals look for the '_dill' attribute on all
-        # global objects.
+        # We need special handling for dill as well, as dill attempts to
+        # pickle module globals by looking for the '_dill' attribute on
+        # all global objects.
         '_dill',
     }
 

--- a/pyomo/common/tests/deps.py
+++ b/pyomo/common/tests/deps.py
@@ -26,6 +26,11 @@ from pyomo.common.tests.dep_mod import (
 bogus, bogus_available \
     = attempt_import('nonexisting.module.bogus', defer_check=True)
 
+pkl_test, pkl_available = attempt_import(
+    'nonexisting.module.pickle_test',
+    deferred_submodules=['submod'], defer_check=True
+)
+
 pyo, pyo_available = attempt_import(
     'pyomo', alt_names=['pyo'],
     deferred_submodules={'version': None,

--- a/pyomo/common/tests/test_dependencies.py
+++ b/pyomo/common/tests/test_dependencies.py
@@ -18,7 +18,8 @@ from pyomo.common.log import LoggingIntercept
 from pyomo.common.dependencies import (
     attempt_import, ModuleUnavailable, DeferredImportModule,
     DeferredImportIndicator, DeferredImportError,
-    _DeferredAnd, _DeferredOr, check_min_version
+    _DeferredAnd, _DeferredOr, check_min_version,
+    dill, dill_available
 )
 
 import pyomo.common.tests.dep_mod as dep_mod
@@ -48,6 +49,26 @@ class TestDependencies(unittest.TestCase):
                 "attribute '__sphinx_mock__'"):
             module_obj.__sphinx_mock__
 
+    @unittest.skipUnless(dill_available, "Test requires dill module")
+    def test_pickle(self):
+        self.assertIs(deps.pkl_test.__class__, DeferredImportModule)
+        # Pickle the DeferredImportModule class
+        pkl = dill.dumps(deps.pkl_test)
+        deps.new_pkl_test = dill.loads(pkl)
+        self.assertIs(deps.pkl_test.__class__, deps.new_pkl_test.__class__)
+        self.assertIs(deps.new_pkl_test.__class__, DeferredImportModule)
+        self.assertIsNot(deps.pkl_test, deps.new_pkl_test)
+        self.assertIn('submod', deps.new_pkl_test.__dict__)
+        with self.assertRaisesRegex(
+                DeferredImportError, 'nonexisting.module.pickle_test module'):
+            deps.new_pkl_test.try_to_call_a_method()
+        # Pickle the ModuleUnavailable class
+        self.assertIs(deps.new_pkl_test.__class__, ModuleUnavailable)
+        pkl = dill.dumps(deps.new_pkl_test)
+        new_pkl_test_2 = dill.loads(pkl)
+        self.assertIs(deps.new_pkl_test.__class__, new_pkl_test_2.__class__)
+        self.assertIsNot(deps.new_pkl_test, new_pkl_test_2)
+        self.assertIs(new_pkl_test_2.__class__, ModuleUnavailable)
 
     def test_import_success(self):
         module_obj, module_available = attempt_import(


### PR DESCRIPTION
## Fixes #2414

## Summary/Motivation:
Current `dill` implementations look for the `dill` module by looking for the `_dill` attribute on all objects in the `globals()`.  This was causing missing modules (`ModuleUnavailable` objects) to raise a `DeferredImportError`.  This adds a special case to that this behavior does not trigger the  `DeferredImportError` (and instead raises the "expected" `AttributeError`.

This also makes the `ModuleUnavailable` and `DeferredImportModule` classes picklable.

## Changes proposed in this PR:
- Do not trigger a `DeferredImportError` when attempting to retrieve a `_dill` attribute
- Make `ModuleUnavailable` and `DeferredImportModule` classes picklable.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
