### PR TITLE
NFC: Correct typos and incorrect link

### DIFF
--- a/doc/OnlineDocs/contributed_packages/trustregion.rst
+++ b/doc/OnlineDocs/contributed_packages/trustregion.rst
@@ -23,7 +23,7 @@ Simulation-Based Engineering, Crosscutting Research Program within the U.S.
 Department of Energy’s Office of Fossil Energy and Carbon Management.
 
 .. _Eason & Biegler, 2018: https://doi.org/10.1002/aic.16364
-.. _Yoshio & Biegler, 2021: https://doi.org/10.1016/j.compchemeng.2021.107447
+.. _Yoshio & Biegler, 2021: https://doi.org/10.1002/aic.17054
 
 Methodology Overview
 ---------------------

--- a/pyomo/common/tests/test_dependencies.py
+++ b/pyomo/common/tests/test_dependencies.py
@@ -34,11 +34,11 @@ class TestDependencies(unittest.TestCase):
     def test_import_error(self):
         module_obj, module_available = attempt_import(
             '__there_is_no_module_named_this__',
-            'Testing import of a non-existant module',
+            'Testing import of a non-existent module',
             defer_check=False)
         self.assertFalse(module_available)
         with self.assertRaisesRegex(
-                DeferredImportError, 'Testing import of a non-existant module'):
+                DeferredImportError, 'Testing import of a non-existent module'):
             module_obj.try_to_call_a_method()
 
         # Note that some attribute will intentionally raise

--- a/pyomo/common/tests/test_download.py
+++ b/pyomo/common/tests/test_download.py
@@ -50,9 +50,9 @@ class Test_FileDownloader(unittest.TestCase):
         self.assertIsNone(f._fname)
 
         with self.assertRaisesRegex(
-                RuntimeError, "cacert='nonexistant_file_name' does not "
+                RuntimeError, "cacert='nonexistent_file_name' does not "
                 "refer to a valid file."):
-            FileDownloader(True, 'nonexistant_file_name')
+            FileDownloader(True, 'nonexistent_file_name')
 
     def test_parse(self):
         f = FileDownloader()
@@ -95,9 +95,9 @@ class Test_FileDownloader(unittest.TestCase):
 
         f = FileDownloader()
         with self.assertRaisesRegex(
-                RuntimeError, "--cacert='nonexistant_file_name' does "
+                RuntimeError, "--cacert='nonexistent_file_name' does "
                 "not refer to a valid file"):
-            f.parse_args(['--cacert', 'nonexistant_file_name'])
+            f.parse_args(['--cacert', 'nonexistent_file_name'])
 
         f = FileDownloader()
         with capture_output() as io:

--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -450,7 +450,7 @@ class TestFileUtils(unittest.TestCase):
         self._check_file( Executable(f_in_path).executable,
                           os.path.join(pathdir, f_in_path) )
 
-        # Test the above for a nonexistant file
+        # Test the above for a nonexistent file
         self.assertFalse( Executable(f_in_tmp).available() )
         if Executable(f_in_tmp):
             self.fail("Expected casting Executable(f_in_tmp) to bool=False")

--- a/pyomo/contrib/trustregion/README.md
+++ b/pyomo/contrib/trustregion/README.md
@@ -4,9 +4,9 @@ The trust region filter algorithm was initially introduced into Pyomo
 based on the work by Eason/Biegler in their 2016 and 2018 papers in AIChE.
 
 The algorithm has been updated to match work by Yoshio/Biegler in their
-2020 paper in AIChE.
+2021 paper in AIChE.
 
-The algorith, at its core, takes a model and makes incremental steps towards
+The algorithm, at its core, takes a model and makes incremental steps towards
 an optimal solution using a surrogate model.
 
 Full details on the algorithm can be found in:

--- a/pyomo/contrib/trustregion/examples/example2.py
+++ b/pyomo/contrib/trustregion/examples/example2.py
@@ -17,7 +17,7 @@
 
 """
 This model is adapted from Noriyuki Yoshio's model for his and Biegler's
-2020 publication in AIChE.
+2021 publication in AIChE.
 
 
 Yoshio, N, Biegler, L.T. Demand-based optimization of a chlorobenzene process


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
While doing something entirely unrelated, I found a few NFC typos and an incorrect link in one of the OnlineDocs. This PR corrects these errors and introduces no functional changes.

## Changes proposed in this PR:
- Correct all instances of `existant`
- Correct Yoshio/Biegler citation link
- Correct year for Yoshio/Biegler citation
- Fix typo in TRF `README`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
