### PR TITLE
Skip new `SCIP` tests on `pypy`

### DIFF
--- a/pyomo/solvers/tests/mip/test_scip_version.py
+++ b/pyomo/solvers/tests/mip/test_scip_version.py
@@ -10,11 +10,12 @@
 #  ___________________________________________________________________________
 
 import subprocess
+import sys
 from os.path import join, exists, splitext
 
 import pyomo.common.unittest as unittest
 
-from pyomo.common.fileutils import this_file_dir, ExecutableData
+from pyomo.common.fileutils import this_file_dir
 from pyomo.common.tempfiles import TempfileManager
 
 import pyomo.environ
@@ -26,7 +27,8 @@ import pyomo.solvers.plugins.solvers.SCIPAMPL
 currdir = this_file_dir()
 deleteFiles = True
 
-
+@unittest.skipIf('pypy_version_info' in dir(sys),
+                 "Skip SCIPAMPL tests on Pypy due to performance")
 class Test(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
The new SCIP 8 tests cause consistent timeouts for `pypy` tests. The rest of the SCIP tests do not run on `pypy` normally anyway - so this just skips those tests.

## Changes proposed in this PR:
- Skip `SCIPAMPL` tests on `pypy`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
