### PR TITLE
Account for Variable Domains in PyROS Model Standardization

### DIFF
--- a/pyomo/contrib/pyros/util.py
+++ b/pyomo/contrib/pyros/util.py
@@ -155,15 +155,41 @@ def turn_bounds_to_constraints(variable, model, config=None):
     :param config: solver config
     :return: the list of inequality constraints that are the bounds
     '''
-    if variable.lb is not None:
-        name = variable.name + "_lower_bound_con"
-        model.add_component(name, Constraint(expr=-variable <= -variable.lb))
-        variable.setlb(None)
-    if variable.ub is not None:
-        name = variable.name + "_upper_bound_con"
-        model.add_component(name, Constraint(expr=variable <= variable.ub))
-        variable.setub(None)
-    return
+    lb, ub = variable.lower, variable.upper
+    if variable.domain is not Reals:
+        variable.domain = Reals
+
+    if isinstance(lb, NPV_MaxExpression):
+        lb_args = lb.args
+    else:
+        lb_args = (lb,)
+
+    if isinstance(ub, NPV_MinExpression):
+        ub_args = ub.args
+    else:
+        ub_args = (ub,)
+
+    count = 0
+    for arg in lb_args:
+        if arg is not None:
+            name = unique_component_name(
+                model,
+                variable.name + f"_lower_bound_con_{count}",
+            )
+            model.add_component(name, Constraint(expr=-variable <= -arg))
+            count += 1
+            variable.setlb(None)
+
+    count = 0
+    for arg in ub_args:
+        if arg is not None:
+            name = unique_component_name(
+                model,
+                variable.name + f"_upper_bound_con_{count}",
+            )
+            model.add_component(name, Constraint(expr=variable <= arg))
+            count += 1
+            variable.setub(None)
 
 
 def get_time_from_solver(results):

--- a/pyomo/contrib/pyros/util.py
+++ b/pyomo/contrib/pyros/util.py
@@ -176,7 +176,7 @@ def turn_bounds_to_constraints(variable, model, config=None):
                 model,
                 variable.name + f"_lower_bound_con_{count}",
             )
-            model.add_component(name, Constraint(expr=-variable <= -arg))
+            model.add_component(name, Constraint(expr=arg - variable <= 0))
             count += 1
             variable.setlb(None)
 
@@ -187,7 +187,7 @@ def turn_bounds_to_constraints(variable, model, config=None):
                 model,
                 variable.name + f"_upper_bound_con_{count}",
             )
-            model.add_component(name, Constraint(expr=variable <= arg))
+            model.add_component(name, Constraint(expr=variable - arg <= 0))
             count += 1
             variable.setub(None)
 


### PR DESCRIPTION
## Summary/Motivation:
The method `pyros.util.turn_bounds_to_constraints`, meant to remove the bounds of a model `Var` object and instead impose these bounds through explicit inequality `Constraint`s in the model of interest, does not properly account for variables whose domains are not `Reals`. For a variable whose domain is not `Reals`, setting the bounds to `(None, None)` (through direct assignment or through `setlb`/`setub`) changes the bounds to a value/expression (such as an `NPVMaxExpression` or `NPVMinExpression`) contingent on the variable domain. Consequently, the model(s) generated for the separation phase of a PyROS iteration may be a restriction of the actual separation model(s) to be solved. 

## Changes proposed in this PR:
- Account for variables whose domains are not `Reals` in `pyros.util.turn_bounds_to_constraints`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
