### PR TITLE
BUGFIX: Restrict `conda` to use `conda-forge` channel

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -66,7 +66,7 @@ jobs:
           skip_doctest: 1
           TARGET: linux
           PYENV: conda
-          PACKAGES: mpi4py 'openmpi>4,!=4.1.3,!=4.1.4'
+          PACKAGES: mpi4py openmpi
 
         - os: ubuntu-latest
           python: 3.7
@@ -259,6 +259,7 @@ jobs:
         conda config --show channels
         conda config --remove channels defaults
         conda config --add channels conda-forge
+        conda config --set channel_priority strict
         conda info
         conda config --show-sources
         conda config --show channels

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -66,7 +66,7 @@ jobs:
           skip_doctest: 1
           TARGET: linux
           PYENV: conda
-          PACKAGES: mpi4py 'openmpi>4,!=4.1.3'
+          PACKAGES: mpi4py 'openmpi>4,!=4.1.3,!=4.1.4'
 
         - os: ubuntu-latest
           python: 3.7

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -256,8 +256,12 @@ jobs:
         conda config --set always_yes yes
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
+        conda config --show channels
+        conda config --remove channels defaults
+        conda config --add channels conda-forge
         conda info
         conda config --show-sources
+        conda config --show channels
         conda list --show-channel-urls
         # Note: some pypi packages are not available through conda
         PYOMO_DEPENDENCIES=`python setup.py dependencies \

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -275,8 +275,12 @@ jobs:
         conda config --set always_yes yes
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
+        conda config --show channels
+        conda config --remove channels defaults
+        conda config --add channels conda-forge
         conda info
         conda config --show-sources
+        conda config --show channels
         conda list --show-channel-urls
         # Note: some pypi packages are not available through conda
         PYOMO_DEPENDENCIES=`python setup.py dependencies \

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -66,7 +66,7 @@ jobs:
           skip_doctest: 1
           TARGET: linux
           PYENV: conda
-          PACKAGES: mpi4py 'openmpi>4,!=4.1.3'
+          PACKAGES: mpi4py 'openmpi>4,!=4.1.3,!=4.1.4'
 
         - os: ubuntu-latest
           python: 3.7

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -66,7 +66,7 @@ jobs:
           skip_doctest: 1
           TARGET: linux
           PYENV: conda
-          PACKAGES: mpi4py 'openmpi>4,!=4.1.3,!=4.1.4'
+          PACKAGES: mpi4py openmpi
 
         - os: ubuntu-latest
           python: 3.7


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
We have an issue in Linux+Conda `mpi` tests where the `bin` gets blown away when `cyipopt` is installed (starting in version 4.1.3). Upon suggestion in https://github.com/conda-forge/openmpi-feedstock#installing-openmpi-mpi , we restricted the channel to `conda-forge` and removed `defaults`.

## Changes proposed in this PR:
- Disallow `defaults` conda channel

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
