### PR TITLE
BUGFIX: `win/3.10` `_ctypes` import failure

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -45,6 +45,20 @@ jobs:
           TARGET: osx
           PYENV: pip
 
+        - os: windows-latest
+          python: '3.10'
+          TARGET: win
+          PYENV: conda
+          PACKAGES: glpk
+
+        - os: ubuntu-latest
+          python: 3.9
+          other: /conda
+          skip_doctest: 1
+          TARGET: linux
+          PYENV: conda
+          PACKAGES:
+
         - os: ubuntu-latest
           python: 3.8
           other: /mpi
@@ -54,17 +68,29 @@ jobs:
           PYENV: conda
           PACKAGES: mpi4py openmpi
 
-        - os: windows-latest
+        - os: ubuntu-latest
+          python: 3.7
+          other: /slim
+          slim: 1
+          skip_doctest: 1
+          TARGET: linux
+          PYENV: pip
+
+        - os: ubuntu-latest
           python: 3.8
-          TARGET: win
-          PYENV: conda
-          PACKAGES: glpk
+          other: /cython
+          setup_options: --with-cython
+          skip_doctest: 1
+          TARGET: linux
+          PYENV: pip
+          PACKAGES: cython
 
         - os: windows-latest
-          python: '3.10'
+          python: 3.8
+          other: /pip
+          skip_doctest: 1
           TARGET: win
-          PYENV: conda
-          PACKAGES: glpk
+          PYENV: pip
 
 
     steps:

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -206,6 +206,8 @@ jobs:
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python }}
+        channels: conda-forge
+        channel-priority: strict
 
     # GitHub actions is very fragile when it comes to setting up various
     # Python interpreters, expecially the setup-miniconda interface.
@@ -257,10 +259,6 @@ jobs:
         conda config --set always_yes yes
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
-        conda config --show channels
-        conda config --remove channels defaults
-        conda config --add channels conda-forge
-        conda config --set channel_priority strict
         conda info
         conda config --show-sources
         conda config --show channels
@@ -296,8 +294,6 @@ jobs:
             done
             # TODO: This is a hack to stop test_qt.py from running until we
             # can better troubleshoot why it fails on GHA
-            which python
-            python --version
             for QTPACKAGE in qt pyqt; do
                 conda remove $QTPACKAGE || echo "$QTPACKAGE not in this environment"
             done

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -92,7 +92,6 @@ jobs:
           TARGET: win
           PYENV: pip
 
-
     steps:
     - name: Checkout Pyomo source
       uses: actions/checkout@v3

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -61,7 +61,7 @@ jobs:
           PACKAGES: glpk
 
         - os: windows-latest
-          python: 3.10
+          python: '3.10'
           TARGET: win
           PYENV: conda
           PACKAGES: glpk

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -45,20 +45,6 @@ jobs:
           TARGET: osx
           PYENV: pip
 
-        - os: windows-latest
-          python: 3.7
-          TARGET: win
-          PYENV: conda
-          PACKAGES: glpk
-
-        - os: ubuntu-latest
-          python: 3.9
-          other: /conda
-          skip_doctest: 1
-          TARGET: linux
-          PYENV: conda
-          PACKAGES:
-
         - os: ubuntu-latest
           python: 3.8
           other: /mpi
@@ -68,29 +54,18 @@ jobs:
           PYENV: conda
           PACKAGES: mpi4py openmpi
 
-        - os: ubuntu-latest
-          python: 3.7
-          other: /slim
-          slim: 1
-          skip_doctest: 1
-          TARGET: linux
-          PYENV: pip
-
-        - os: ubuntu-latest
-          python: 3.8
-          other: /cython
-          setup_options: --with-cython
-          skip_doctest: 1
-          TARGET: linux
-          PYENV: pip
-          PACKAGES: cython
-
         - os: windows-latest
           python: 3.8
-          other: /pip
-          skip_doctest: 1
           TARGET: win
-          PYENV: pip
+          PYENV: conda
+          PACKAGES: glpk
+
+        - os: windows-latest
+          python: 3.10
+          TARGET: win
+          PYENV: conda
+          PACKAGES: glpk
+
 
     steps:
     - name: Checkout Pyomo source
@@ -264,6 +239,8 @@ jobs:
         conda config --show-sources
         conda config --show channels
         conda list --show-channel-urls
+        which python
+        python --version
         # Note: some pypi packages are not available through conda
         PYOMO_DEPENDENCIES=`python setup.py dependencies \
             --extras "$EXTRAS" | tail -1`
@@ -293,6 +270,8 @@ jobs:
             done
             # TODO: This is a hack to stop test_qt.py from running until we
             # can better troubleshoot why it fails on GHA
+            which python
+            python --version
             for QTPACKAGE in qt pyqt; do
                 conda remove $QTPACKAGE || echo "$QTPACKAGE not in this environment"
             done

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -46,7 +46,7 @@ jobs:
           PYENV: pip
 
         - os: windows-latest
-          python: '3.10'
+          python: 3.7
           TARGET: win
           PYENV: conda
           PACKAGES: glpk

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -282,6 +282,8 @@ jobs:
         conda config --show-sources
         conda config --show channels
         conda list --show-channel-urls
+        which python
+        python --version
         # Note: some pypi packages are not available through conda
         PYOMO_DEPENDENCIES=`python setup.py dependencies \
             --extras "$EXTRAS" | tail -1`
@@ -311,6 +313,8 @@ jobs:
             done
             # TODO: This is a hack to stop test_qt.py from running until we
             # can better troubleshoot why it fails on GHA
+            which python
+            python --version
             for QTPACKAGE in qt pyqt; do
                 conda remove $QTPACKAGE || echo "$QTPACKAGE not in this environment"
             done

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -224,6 +224,9 @@ jobs:
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python }}
+        channels: conda-forge
+        channel-priority: strict
+
 
     # GitHub actions is very fragile when it comes to setting up various
     # Python interpreters, expecially the setup-miniconda interface.
@@ -275,9 +278,6 @@ jobs:
         conda config --set always_yes yes
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
-        conda config --show channels
-        conda config --remove channels defaults
-        conda config --add channels conda-forge
         conda info
         conda config --show-sources
         conda config --show channels
@@ -313,8 +313,6 @@ jobs:
             done
             # TODO: This is a hack to stop test_qt.py from running until we
             # can better troubleshoot why it fails on GHA
-            which python
-            python --version
             for QTPACKAGE in qt pyqt; do
                 conda remove $QTPACKAGE || echo "$QTPACKAGE not in this environment"
             done

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -227,7 +227,6 @@ jobs:
         channels: conda-forge
         channel-priority: strict
 
-
     # GitHub actions is very fragile when it comes to setting up various
     # Python interpreters, expecially the setup-miniconda interface.
     # Per the setup-miniconda documentation, it is important to always


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
`win/3.10` has a failure due to a Python version inconsistency. This moves the channel and priority assertion to the `miniconda` step to avoid the inconsistency.

## Changes proposed in this PR:
- Set channel and channel-strict values in `setup-miniconda` action
- Print out python version for sanity

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
