### PR TITLE
Speed up Book tests; improve import/logging infrastructure

### DIFF
--- a/examples/pyomobook/python-ch/BadIndent.sh
+++ b/examples/pyomobook/python-ch/BadIndent.sh
@@ -1,0 +1,2 @@
+# run python: this will generate a syntax error
+python BadIndent.py

--- a/examples/pyomobook/test_book_examples.py
+++ b/examples/pyomobook/test_book_examples.py
@@ -20,7 +20,8 @@ import sys
 from itertools import zip_longest
 from pyomo.opt import check_available_solvers
 from pyomo.common.dependencies import attempt_import, check_min_version
-from pyomo.common.fileutils import this_file_dir
+from pyomo.common.fileutils import this_file_dir, import_file
+from pyomo.common.log import LoggingIntercept, pyomo_formatter
 from pyomo.common.tee import capture_output
 import pyomo.environ as pyo
 
@@ -238,8 +239,9 @@ def filter(line):
                    'function calls',
                    'List reduced',
                    '.py:',
-                   'built-in method',
-                   '{method'):
+                   '{built-in method',
+                   '{method',
+                   '{pyomo.core.expr.numvalue.as_numeric}'):
         if field in line:
             return True
     return False
@@ -310,19 +312,25 @@ for testdir in glob.glob(os.path.join(currdir,'*')):
         name=os.path.splitext(bname)[0]
         tname = os.path.basename(dir_)+'_'+name
 
+        # If there is both a .py and a .sh, defer to the sh
+        if os.path.exists(os.path.join(dir_, name + '.sh')):
+            continue
+
         suffix = None
         # Look for txt and yml file names matching py file names. Add
         # a test for any found
         for suffix_ in ['.txt', '.yml']:
-            if os.path.exists(os.path.join(dir_,name+suffix_)):
+            if os.path.exists(os.path.join(dir_, name+suffix_)):
                 suffix = suffix_
                 break
-        if not suffix is None:
+        if suffix is not None:
             tname = tname.replace('-','_')
             tname = tname.replace('.','_')
 
             # Create list of tuples with (test_name, test_file, baseline_file)
-            py_test_tuples.append((tname, test_file, os.path.join(dir_,name+suffix)))
+            py_test_tuples.append(
+                (tname, test_file, os.path.join(dir_, name + suffix))
+            )
 
     # Find all .sh files in the test directory
     for file in list(glob.glob(os.path.join(testdir,'*.sh'))) \
@@ -463,11 +471,21 @@ class TestBookExamples(unittest.TestCase):
             raise unittest.SkipTest(skip_msg)
 
         cwd = os.getcwd()
-        os.chdir(dir_)
-        out_file = os.path.splitext(test_file)[0]+'.out'
-        with open(out_file, 'w') as f:
-            subprocess.run([sys.executable, bname], stdout=f, stderr=f, cwd=dir_)
-        os.chdir(cwd)
+        try:
+            os.chdir(dir_)
+            out_file = os.path.splitext(test_file)[0]+'.out'
+            with open(out_file, 'w') as f, capture_output(f, True):
+                # Note: we want LoggingIntercept to log to the
+                # *current* stdout (which is the TeeStream from
+                # capture_output).  This ensures that log messages and
+                # normal output appear in the correct order.
+                with LoggingIntercept(sys.stdout, formatter=pyomo_formatter):
+                    import_file(
+                        bname, infer_package=False, module_name='__main__'
+                    )
+                #subprocess.run([sys.executable, bname], stdout=f, stderr=f, cwd=dir_)
+        finally:
+            os.chdir(cwd)
 
         self.compare_files(out_file, base_file)
         os.remove(out_file)

--- a/examples/pyomobook/test_book_examples.py
+++ b/examples/pyomobook/test_book_examples.py
@@ -474,6 +474,9 @@ class TestBookExamples(unittest.TestCase):
         try:
             os.chdir(dir_)
             out_file = os.path.splitext(test_file)[0]+'.out'
+            # This is roughly equivalent to:
+            #    subprocess.run([sys.executable, bname],
+            #                   stdout=f, stderr=f, cwd=dir_)
             with open(out_file, 'w') as f, capture_output(f, True):
                 # Note: we want LoggingIntercept to log to the
                 # *current* stdout (which is the TeeStream from
@@ -483,7 +486,6 @@ class TestBookExamples(unittest.TestCase):
                     import_file(
                         bname, infer_package=False, module_name='__main__'
                     )
-                #subprocess.run([sys.executable, bname], stdout=f, stderr=f, cwd=dir_)
         finally:
             os.chdir(cwd)
 

--- a/pyomo/common/fileutils.py
+++ b/pyomo/common/fileutils.py
@@ -417,7 +417,7 @@ def find_executable(exename, cwd=True, include_PATH=True, pathlist=None):
                      pathlist=pathlist, allow_pathlist_deep_references=False)
 
 
-def import_file(path, clear_cache=False, infer_package=True):
+def import_file(path, clear_cache=False, infer_package=True, module_name=None):
     """
     Import a module given the full path/filename of the file.
     Replaces import_file from pyutilib (Pyomo 6.0.0).
@@ -436,7 +436,8 @@ def import_file(path, clear_cache=False, infer_package=True):
     if not os.path.exists(path):
         raise FileNotFoundError('File does not exist. Check path.')
     module_dir, module_file = os.path.split(path)
-    module_name, module_ext = os.path.splitext(module_file)
+    if module_name is None:
+        module_name, module_ext = os.path.splitext(module_file)
     if infer_package:
         while module_dir and os.path.exists(
                 os.path.join(module_dir, '__init__.py')):

--- a/pyomo/common/log.py
+++ b/pyomo/common/log.py
@@ -262,14 +262,15 @@ class _GlobalLogFilter(object):
 # different formatter based on if the main pyomo logger is enabled for
 # debugging.  It has been updated to suppress output if any handlers
 # have been defined at the root level.
-_pyomoLogger = logging.getLogger('pyomo')
-_handler = StdoutHandler()
-_handler.setFormatter(LegacyPyomoFormatter(
+pyomo_logger = logging.getLogger('pyomo')
+pyomo_handler = StdoutHandler()
+pyomo_formatter = LegacyPyomoFormatter(
     base=PYOMO_ROOT_DIR,
-    verbosity=lambda: _pyomoLogger.isEnabledFor(logging.DEBUG),
-))
-_handler.addFilter(_GlobalLogFilter())
-_pyomoLogger.addHandler(_handler)
+    verbosity=lambda: pyomo_logger.isEnabledFor(logging.DEBUG),
+)
+pyomo_handler.setFormatter(pyomo_formatter)
+pyomo_handler.addFilter(_GlobalLogFilter())
+pyomo_logger.addHandler(pyomo_handler)
 
 
 @deprecated('The pyomo.common.log.LogHandler class has been deprecated '

--- a/pyomo/common/log.py
+++ b/pyomo/common/log.py
@@ -371,10 +371,18 @@ class LogStream(io.TextIOBase):
     def __init__(self, level, logger):
         self._level = level
         self._logger = logger
+        self._buffer = ''
 
     def write(self, s: str) -> int:
         res = len(s)
-        s = s.rstrip('\n')
-        for line in s.split('\n'):
+        if self._buffer:
+            s = self._buffer + s
+        lines = s.split('\n')
+        for line in lines[:-1]:
             self._logger.log(self._level, line)
+        self._buffer = lines[-1]
         return res
+
+    def flush(self):
+        if self._buffer:
+            self.write('\n')


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This speeds up the Pyomo Book tests by reducing the number of subprocess calls.  Python files are now tested using `import_file()`.  In order to testing these files as if they were "scripts", This PR adds a new option to `import_file()` to support setting the new module's `__name__` (in this case, so that it can be set to `"__main__").

This also improves part of the logging system:
- `LoggingIntercept` can now be passed a designated formatter (to that the book tests can re-use the main Pyomo formatter)
- `LogStream` object now has better support for handling EOL in the text stream: lines are buffered until encountering an EOL, then the whole line is sent to the logger as a single record.

## Changes proposed in this PR:
- buffer lines in `LogStream` and only forward to the logger when EOL is received.
- support passing a formatter to `LoggingIntercept`
- support re-using the `LoggingIntercept` context manager
- support passing the module `__name__` to `import_file()`
- reduce the number of subprocess calls in the Book Tests driver

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
