### PR TITLE
Add explicit space to GAMS put statements

### DIFF
--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -813,9 +813,9 @@ class ProblemWriter_gams(AbstractProblemWriter):
                 output_file.write("\nput results;")
                 output_file.write("\nput 'SYMBOL  :  LEVEL  :  MARGINAL' /;")
                 for var in var_list:
-                    output_file.write("\nput %s %s.l %s.m /;" % (var, var, var))
+                    output_file.write("\nput %s ' ' %s.l ' ' %s.m /;" % (var, var, var))
                 for con in constraint_names:
-                    output_file.write("\nput %s %s.l %s.m /;" % (con, con, con))
+                    output_file.write("\nput %s ' ' %s.l ' ' %s.m /;" % (con, con, con))
                 output_file.write("\nput GAMS_OBJECTIVE GAMS_OBJECTIVE.l "
                                   "GAMS_OBJECTIVE.m;\n")
 

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -826,7 +826,7 @@ class ProblemWriter_gams(AbstractProblemWriter):
                 output_file.write("\nput statresults;")
                 output_file.write("\nput 'SYMBOL   :   VALUE' /;")
                 for stat in stat_vars:
-                    output_file.write("\nput '%s' %s /;\n" % (stat, stat))
+                    output_file.write("\nput '%s' ' ' %s /;\n" % (stat, stat))
 
 valid_solvers = {
 'ALPHAECP': {'MINLP','MIQCP'},


### PR DESCRIPTION
## Fixes #2440 

## Summary/Motivation:
We received a report that our writer interface is problematic for GAMS 39+. This resolves that issue.

## Changes proposed in this PR:
- Add explicit space in `put` statements

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
