### PR TITLE
Abort the Jenkins build if virtualenv creation fails

### DIFF
--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -73,7 +73,7 @@ if test -z "$MODE" -o "$MODE" == setup; then
     echo "#"
     echo "# Setting up virtual environment"
     echo "#"
-    virtualenv python $VENV_SYSTEM_PACKAGES --clear
+    virtualenv python $VENV_SYSTEM_PACKAGES --clear || exit 1
     source python/bin/activate
     # Because modules set the PYTHONPATH, we need to make sure that the
     # virtualenv appears first


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This traps if the virtualenv creation on Jenkins failed and prevents the build from proceeding.  This will help prevent Jenkins builds from attempting to write to the global python environment.

## Changes proposed in this PR:
- catch and exit if virtualenv setup fails

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
