### PR TITLE
appsi - modifying objective with Gurobi interface

### DIFF
--- a/pyomo/contrib/appsi/solvers/gurobi.py
+++ b/pyomo/contrib/appsi/solvers/gurobi.py
@@ -724,6 +724,12 @@ class Gurobi(PersistentBase, PersistentSolver):
                                               mutable_linear_coefficients,
                                               mutable_quadratic_coefficients)
         self._mutable_objective = mutable_objective
+
+        # These two lines are needed as a workaround
+        # see PR #2454
+        self._solver_model.setObjective(0)
+        self._solver_model.update()
+
         self._solver_model.setObjective(gurobi_expr + value(repn_constant), sense=sense)
         self._needs_updated = True
 

--- a/pyomo/contrib/appsi/solvers/tests/test_gurobi_persistent.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_gurobi_persistent.py
@@ -514,7 +514,7 @@ class TestManualModel(unittest.TestCase):
 
         opt = self.opt
         opt.set_instance(m)
-        self.assertEqual(opt._solver_model.getAttr('NumQConstrs'), 0)
+        self.assertEqual(opt._solver_model.getAttr('NumQConstrs'), 1)
 
         opt.remove_constraints([m.c1])
         opt.update()
@@ -536,7 +536,7 @@ class TestManualModel(unittest.TestCase):
         opt = self.opt
         opt.config.symbolic_solver_labels = True
         opt.set_instance(m)
-        self.assertEqual(opt._solver_model.getAttr('NumConstrs'), 0)
+        self.assertEqual(opt._solver_model.getAttr('NumConstrs'), 1)
 
         opt.remove_constraints([m.c2])
         opt.update()
@@ -595,7 +595,7 @@ class TestManualModel(unittest.TestCase):
 
         opt = self.opt
         opt.set_instance(m)
-        self.assertEqual(opt._solver_model.getAttr('NumSOS'), 0)
+        self.assertEqual(opt._solver_model.getAttr('NumSOS'), 1)
 
         opt.remove_sos_constraints([m.c1])
         opt.update()
@@ -632,7 +632,7 @@ class TestManualModel(unittest.TestCase):
 
         opt = self.opt
         opt.set_instance(m)
-        self.assertEqual(opt._solver_model.getAttr('NumVars'), 0)
+        self.assertEqual(opt._solver_model.getAttr('NumVars'), 2)
 
         opt.remove_variables([m.x])
         opt.update()


### PR DESCRIPTION
## Summary/Motivation:
This PR adds a workaround for the issue identified in the following example:
```
import gurobipy


m = gurobipy.Model()
x = m.addVar(name='x')
y = m.addVar(name='y')
m.setObjective(10*x + 10*y + 10, sense=gurobipy.GRB.MAXIMIZE)
m.addConstr(x**2 + y**2 <= 1)
m.setParam('OutputFlag', 0)
m.optimize()
print(m.ObjVal, x.X, y.X) # 24.14  0.707  0.707

m.setObjective(10.0*x + 4.142135687707941*y - 10.0, sense=gurobipy.GRB.MAXIMIZE)
m.optimize()
print(m.ObjVal, x.X, y.X) # 20.82  0.924  0.383

m.setObjective(8.477590668494079*x + 5.664545019213861*y - 10.0, sense=gurobipy.GRB.MAXIMIZE)
m.optimize()
print(m.ObjVal, x.X, y.X) # 20.20  0.831  0.556

m.setObjective(7.767507229274173*x + 6.374628458433767*y - 10.0, sense=gurobipy.GRB.MAXIMIZE)
m.optimize()
print(m.ObjVal, x.X, y.X) # 20.05  0.773  0.634

m.setObjective(0)
m.update()
m.setObjective(7.767507229274173*x + 6.374628458433767*y - 10.0, sense=gurobipy.GRB.MAXIMIZE)
m.optimize()
# the objective value here should match the last one printed (the objectives are the same),
# but it does not; This one is correct
print(m.ObjVal, x.X, y.X) # 0.048  0.773  0.634
```

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
