### PR TITLE
Do not return duplicate data from `component_data_objects` or `component_data_iterindex`

### DIFF
--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1337,9 +1337,14 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
             return PseudoMap(self, ctype, active, sort)
 
     def _component_data_iteritems(self, ctype=None, active=None, sort=False):
-        """
-        Generator that returns a 3-tuple of (component name, index value,
-        and _ComponentData) for every component data in the block.
+        """return the name, index, and component data for matching ctypes
+
+        Generator that returns a nested 2-tuple of
+
+            ((component name, index value), _ComponentData)
+
+        for every component data in the block matching the specified
+        ctype(s).
         """
         _sort_indices = SortComponents.sort_indices(sort)
         _subcomp = PseudoMap(self, ctype, active, sort)

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -148,6 +148,23 @@ class _DeduplicateInfo(object):
         self.seen_data = set()
 
     def unique(self, comp, items, are_values):
+        """Generator that filters duplicate _ComponentData objects from items
+
+        Parameters
+        ----------
+        comp: ComponentBase
+           The Component (indexed or scalar) that contains all
+           _ComponentData returned by the `items` generator.
+
+        items: generator
+            Generator yielding either the values or the items from the
+            `comp` Component.
+
+        are_values: bool
+            If `True`, `items` yields _ComponentData objects, otherwise,
+            `items` yields `(index, _ComponentData)` tuples.
+
+        """
         if comp.is_reference():
             seen_components_contains = self.seen_components.__contains__
             seen_comp_thru_reference_contains \
@@ -160,7 +177,7 @@ class _DeduplicateInfo(object):
                 _data = _item if are_values else _item[1]
                 # If the data is contained in a component we have
                 # already processed, then it is a duplicate and we can
-                # bypass forther checks.
+                # bypass further checks.
                 _id = id(_data.parent_component())
                 if seen_components_contains(_id):
                     continue
@@ -1366,11 +1383,11 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
             Specifies the component types (`ctypes`) to include in the
             resulting PseudoMap
 
-                =============   ===================
+                =============   ===================================
                 None            All components
                 type            A single component type
                 iterable        All component types in the iterable
-                =============   ===================
+                =============   ===================================
 
         active: None or bool
             Filter components by the active flag
@@ -1382,7 +1399,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
                 =====  ===============================
 
         sort: bool
-            Iterate over the components in a sorted otder
+            Iterate over the components in a sorted order
 
                 =====  ================================================
                 True   Iterate using Block.alphabetizeComponentAndIndex
@@ -1423,6 +1440,20 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
 
         for every component data in the block matching the specified
         ctype(s).
+
+        Parameters
+        ----------
+        ctype:  None or type or iterable
+            Specifies the component types (`ctypes`) to include
+
+        active: None or bool
+            Filter components by the active flag
+
+        sort: None or bool or SortComponents
+            Iterate over the components in a specified sorted order
+
+        dedup: _DeduplicateInfo
+            Deduplicator to prevent returning the same _ComponentData twice
         """
         _sort_indices = SortComponents.sort_indices(sort)
         _subcomp = PseudoMap(self, ctype, active, sort)
@@ -1462,6 +1493,19 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         """Generator that returns the _ComponentData for every component data
         in the block.
 
+        Parameters
+        ----------
+        ctype:  None or type or iterable
+            Specifies the component types (`ctypes`) to include
+
+        active: None or bool
+            Filter components by the active flag
+
+        sort: None or bool or SortComponents
+            Iterate over the components in a specified sorted order
+
+        dedup: _DeduplicateInfo
+            Deduplicator to prevent returning the same _ComponentData twice
         """
         if SortComponents.sort_indices(sort):
             # We need the indices so that we can correctly sort.  Fall
@@ -1592,7 +1636,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
                            sort=False,
                            descend_into=True,
                            descent_order=None):
-        """Generator returning this block and an any matching sub-blocks.
+        """Generator returning this block and any matching sub-blocks.
 
         This is roughly equivalent to
 
@@ -1604,9 +1648,26 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         Notes
         -----
         The `self` block is *always* returned, regardless of the types
-        indicated by descend_into.
+        indicated by `descend_into`.
 
-        The active flag is enforced on *all* blocks, inclufing self.
+        The active flag is enforced on *all* blocks, including `self`.
+
+        Parameters
+        ----------
+        active: None or bool
+            If not None, filter components by the active flag
+
+        sort: None or bool or SortComponents
+            Iterate over the components in a specified sorted order
+
+        descend_into:  None or type or iterable
+            Specifies the component types (`ctypes`) to return and to
+            descend into.  If `True` or `None`, defaults to `(Block,)`.
+            If `False`, only `self` is returned.
+
+        descent_order: None or TraversalStrategy
+            The stratecy used to walk the block hierarchy.  Defaults to
+            `TraversalStrategy.PrefixDepthFirstSearch`.
 
         """
         # TODO: we should determine if that is desirable behavior(it is

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1666,7 +1666,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
             If `False`, only `self` is returned.
 
         descent_order: None or TraversalStrategy
-            The stratecy used to walk the block hierarchy.  Defaults to
+            The strategy used to walk the block hierarchy.  Defaults to
             `TraversalStrategy.PrefixDepthFirstSearch`.
 
         """

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -368,8 +368,8 @@ class PseudoMap(object):
         # declaration order
         #
         # Ironically, the values are the fundamental thing that we
-        # can (efficiently) iterate over in decl_order.  iterkeys
-        # just wraps itervalues.
+        # can (efficiently) iterate over in decl_order.  keys()
+        # just wraps values().
         for obj in self.values():
             yield obj._name
 
@@ -414,8 +414,8 @@ class PseudoMap(object):
         defined on the Block
         """
         # Ironically, the values are the fundamental thing that we
-        # can (efficiently) iterate over in decl_order.  iteritems
-        # just wraps itervalues.
+        # can (efficiently) iterate over in decl_order.  items()
+        # just wraps values().
         for obj in self.values():
             yield (obj._name, obj)
 
@@ -1388,7 +1388,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
             return
 
         _subcomp = PseudoMap(self, ctype, active, sort)
-        for comp in _subcomp.itervalues():
+        for comp in _subcomp.values():
             # NOTE: Suffix has a dict interface (something other derived
             #   non-indexed Components may do as well), so we don't want
             #   to test the existence of iteritems as a check for
@@ -1397,13 +1397,13 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
             #   processing for the scalar components to catch the case
             #   where there are "sparse scalar components"
             if comp.is_indexed():
-                _values = comp.itervalues()
+                _values = comp.values()
             elif hasattr(comp, '_data'):
                 # This is a Scalar component, which may be empty (e.g.,
                 # from Constraint.Skip on a scalar Constraint).  Only
                 # return a ComponentData if one officially exists.
                 assert len(comp._data) <= 1
-                _values = itervalues(comp._data)
+                _values = comp._data.values()
             else:
                 # This is a non-IndexedComponent Component.  Return it.
                 _values = (comp,)
@@ -1452,7 +1452,6 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         for _block in self.block_data_objects(
                 active, sort, descend_into, descent_order):
             yield from _block.component_map(ctype, active, sort).values()
-                yield x
 
     def component_data_objects(self,
                                ctype=None,
@@ -1468,9 +1467,8 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         """
         for _block in self.block_data_objects(
                 active, sort, descend_into, descent_order):
-            for x in _block._component_data_itervalues(
-                    ctype=ctype, active=active, sort=sort):
-                yield x
+            yield from _block._component_data_itervalues(
+                    ctype=ctype, active=active, sort=sort)
 
     def component_data_iterindex(self,
                                  ctype=None,
@@ -1490,7 +1488,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         for _block in self.block_data_objects(
                 active, sort, descend_into, descent_order):
             yield from _block._component_data_iteritems(
-                    ctype=ctype, active=active, sort=sort):
+                    ctype=ctype, active=active, sort=sort)
 
     @deprecated("The all_blocks method is deprecated.  "
                 "Use the Block.block_data_objects() method.",

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -147,14 +147,6 @@ class _DeduplicateInfo(object):
         self.seen_comp_thru_reference = set()
         self.seen_data = set()
 
-    @staticmethod
-    def item(item):
-        return item[0]
-
-    @staticmethod
-    def value(item):
-        return item
-
     def unique(self, comp, items, are_values):
         if comp.is_reference():
             seen_components_contains = self.seen_components.__contains__
@@ -189,7 +181,7 @@ class _DeduplicateInfo(object):
             self.seen_components.add(_id)
             if _id not in self.seen_comp_thru_reference:
                 # No data in this component has yet been emitted
-                # (through a Referenec), so we can just yield all the
+                # (through a Reference), so we can just yield all the
                 # values.
                 yield from items
             else:

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1383,8 +1383,10 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         if SortComponents.sort_indices(sort):
             # We need the indices so that we can correctly sort.  Fall
             # back on _component_data_iteritems.
-            for k,v in self._component_data_iteritems(ctype, active, sort):
-                yield v
+            yield from map(
+                itemgetter(1),
+                self._component_data_iteritems(ctype, active, sort)
+            )
             return
 
         _subcomp = PseudoMap(self, ctype, active, sort)
@@ -1409,12 +1411,9 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
                 _values = (comp,)
 
             if active is None or not isinstance(comp, ActiveIndexedComponent):
-                for compData in _values:
-                    yield compData
+                yield from _values
             else:
-                for compData in _values:
-                    if compData.active == active:
-                        yield compData
+                yield from filter(lambda cDat: cDat.active == active, _values)
 
     @deprecated("The all_components method is deprecated.  "
                 "Use the Block.component_objects() method.",

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1602,14 +1602,28 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
                            descent_order=None):
         """Generator returning this block and an any matching sub-blocks.
 
-        This is semantically equivalent to
+        This is roughly equivalent to
 
-            iter([self, list(self.component_data_objects(Block, ...))])
+            iter(block for block in itertools.chain(
+                [self], self.component_data_objects(descend_into, ...))
+                if block.active == active
+            )
 
-        Note that the `self` block is *always* returned, regardless of
-        the active flag.
+        Notes
+        -----
+        The `self` block is *always* returned, regardless of the types
+        indicated by descend_into.
+
+        The active flag is enforced on *all* blocks, inclufing self.
 
         """
+        # TODO: we should determine if that is desirable behavior(it is
+        # historical, so there are backwards compatibility arguments to
+        # not change it, but because of block_data_objects() use in
+        # component_data_objects, it might be desirable to always return
+        # self.
+        if active is not None and self.active != active:
+            return
         if not descend_into:
             yield self
             return

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -842,7 +842,7 @@ class _BlockData(ActiveComponentData):
                                              descend_into=descend_into,
                                              sort=SortComponents.unsorted):
             if active is None:
-                ctypes.update(ctype for ctype in block._ctypes)
+                ctypes.update(block._ctypes)
             else:
                 assert active is True
                 for ctype in block._ctypes:
@@ -851,8 +851,10 @@ class _BlockData(ActiveComponentData):
                             active=True,
                             descend_into=False,
                             sort=SortComponents.unsorted):
+                        # We only need to verify that there is at least
+                        # one active data member
                         ctypes.add(ctype)
-                        break  # just need 1 or more
+                        break
         return ctypes
 
     def model(self):

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -403,7 +403,7 @@ class IndexedComponent(Component):
 
         """
         sort_needed = ordered
-        if not self._index.isordered():
+        if not self._index_set.isordered():
             #
             # If the index set is not ordered, then return the
             # data iterator.  This is in an arbitrary order, which is

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -403,8 +403,14 @@ class IndexedComponent(Component):
 
         """
         sort_needed = ordered
-        if hasattr(self._index_set, 'isfinite') and not \
-           self._index_set.isfinite():
+        if not self._index.isordered():
+            #
+            # If the index set is not ordered, then return the
+            # data iterator.  This is in an arbitrary order, which is
+            # fine because the data is unordered.
+            #
+            # As non-finite sets are unordered by definition (only
+            # finite sets are be ordered), this will also catch them.
             #
             # If the index set is virtual (e.g., Any) then return the
             # data iterator.  Note that since we cannot check the length

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -403,14 +403,7 @@ class IndexedComponent(Component):
 
         """
         sort_needed = ordered
-        if not self._index_set.isordered():
-            #
-            # If the index set is not ordered, then return the
-            # data iterator.  This is in an arbitrary order, which is
-            # fine because the data is unordered.
-            #
-            # As non-finite sets are unordered by definition (only
-            # finite sets are be ordered), this will also catch them.
+        if not self._index_set.isfinite():
             #
             # If the index set is virtual (e.g., Any) then return the
             # data iterator.  Note that since we cannot check the length
@@ -451,8 +444,7 @@ You can silence this warning by one of three ways:
        where it is empty.
 """ % (self.name,) )
 
-            if not hasattr(self._index_set, 'isordered') or \
-               not self._index_set.isordered():
+            if not self._index_set.isordered():
                 #
                 # If the index set is not ordered, then return the
                 # data iterator.  This is in an arbitrary order, which is

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -593,11 +593,11 @@ class TestBlock(unittest.TestCase):
                          set([]))
         del b.y
 
-        # a block DOES NOT check its own .active flag
+        # a block DOES check its own .active flag
         self.assertEqual(b.collect_ctypes(),
                          set([Var]))
         self.assertEqual(b.collect_ctypes(active=True),
-                         set([Var]))
+                         set([]))
         b.activate()
         self.assertEqual(b.collect_ctypes(),
                          set([Var]))

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -593,11 +593,11 @@ class TestBlock(unittest.TestCase):
                          set([]))
         del b.y
 
-        # a block DOES check its own .active flag apparently
+        # a block DOES NOT check its own .active flag
         self.assertEqual(b.collect_ctypes(),
                          set([Var]))
         self.assertEqual(b.collect_ctypes(active=True),
-                         set([]))
+                         set([Var]))
         b.activate()
         self.assertEqual(b.collect_ctypes(),
                          set([Var]))

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -239,12 +239,15 @@ class BigM_Transformation(Transformation):
         # means for the target to be deactivated: is it just the
         # target itself [historical implementation] or any block in
         # the hierarchy?
-        def _filter_inactive(t):
-            if not t.active:
-                logger.warn('GDP.BigM transformation passed a deactivated '
-                            'target (%s). Skipping.' % (t.name,))
-            return t.active
-        targets = list(filter(_filter_inactive, targets))
+        def _filter_inactive(targets):
+            for t in targets:
+                if not t.active:
+                    logger.warning(
+                        'GDP.BigM transformation passed a deactivated '
+                        f'target ({t.name}). Skipping.')
+                else:
+                    yield t
+        targets = list(_filter_inactive(targets))
 
         # we need to preprocess targets to make sure that if there are any
         # disjunctions in targets that their disjuncts appear before them in

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -230,6 +230,22 @@ class BigM_Transformation(Transformation):
         knownBlocks = {}
         if targets is None:
             targets = (instance, )
+
+        # FIXME: For historical reasons, BigM would silently skip
+        # any targets that were explicitly deactivated.  This
+        # preserves that behavior (although adds a warning).  We
+        # should revisit that design decision and probably remove
+        # this filter, as it is slightly ambiguous as to what it
+        # means for the target to be deactivated: is it just the
+        # target itself [historical implementation] or any block in
+        # the hierarchy?
+        def _filter_inactive(t):
+            if not t.active:
+                logger.warn('GDP.BigM transformation passed a deactivated '
+                            'target (%s). Skipping.' % (t.name,))
+            return t.active
+        targets = list(filter(_filter_inactive, targets))
+
         # we need to preprocess targets to make sure that if there are any
         # disjunctions in targets that their disjuncts appear before them in
         # the list.

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -249,12 +249,15 @@ class Hull_Reformulation(Transformation):
         # means for the target to be deactivated: is it just the
         # target itself [historical implementation] or any block in
         # the hierarchy?
-        # def _filter_inactive(t):
-        #     if not t.active:
-        #         logger.warn('GDP.Hull transformation passed a deactivated '
-        #                     'target (%s). Skipping.' % (t.name,))
-        #     return t.active
-        # targets = list(filter(_filter_inactive, targets))
+        def _filter_inactive(targets):
+            for t in targets:
+                if not t.active:
+                    logger.warning(
+                        'GDP.Hull transformation passed a deactivated '
+                        f'target ({t.name}). Skipping.')
+                else:
+                    yield t
+        targets = list(_filter_inactive(targets))
 
         # we need to preprocess targets to make sure that if there are any
         # disjunctions in targets that their disjuncts appear before them in

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -240,6 +240,22 @@ class Hull_Reformulation(Transformation):
         knownBlocks = {}
         if targets is None:
             targets = ( instance, )
+
+        # FIXME: For historical reasons, Hull would silently skip
+        # any targets that were explicitly deactivated.  This
+        # preserves that behavior (although adds a warning).  We
+        # should revisit that design decision and probably remove
+        # this filter, as it is slightly ambiguous as to what it
+        # means for the target to be deactivated: is it just the
+        # target itself [historical implementation] or any block in
+        # the hierarchy?
+        def _filter_inactive(t):
+            if not t.active:
+                logger.warn('GDP.Hull transformation passed a deactivated '
+                            'target (%s). Skipping.' % (t.name,))
+            return t.active
+        targets = list(filter(_filter_inactive, targets))
+
         # we need to preprocess targets to make sure that if there are any
         # disjunctions in targets that their disjuncts appear before them in
         # the list.

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -249,12 +249,12 @@ class Hull_Reformulation(Transformation):
         # means for the target to be deactivated: is it just the
         # target itself [historical implementation] or any block in
         # the hierarchy?
-        def _filter_inactive(t):
-            if not t.active:
-                logger.warn('GDP.Hull transformation passed a deactivated '
-                            'target (%s). Skipping.' % (t.name,))
-            return t.active
-        targets = list(filter(_filter_inactive, targets))
+        # def _filter_inactive(t):
+        #     if not t.active:
+        #         logger.warn('GDP.Hull transformation passed a deactivated '
+        #                     'target (%s). Skipping.' % (t.name,))
+        #     return t.active
+        # targets = list(filter(_filter_inactive, targets))
 
         # we need to preprocess targets to make sure that if there are any
         # disjunctions in targets that their disjuncts appear before them in
@@ -421,6 +421,8 @@ class Hull_Reformulation(Transformation):
         localVarsByDisjunct = ComponentMap()
         include_fixed_vars = not self._config.assume_fixed_vars_permanent
         for disjunct in obj.disjuncts:
+            if not disjunct.active:
+                continue
             disjunctVars = varsByDisjunct[disjunct] = ComponentSet()
             # create the key for each disjunct now
             transBlock._disaggregatedVarMap['disaggregatedVar'][

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -23,7 +23,6 @@ from pyomo.repn import generate_standard_repn
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 import pyomo.gdp.tests.models as models
 import pyomo.gdp.tests.common_tests as ct
-from pytest import set_trace
 
 import random
 from io import StringIO

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -182,15 +182,14 @@ def get_gdp_tree(targets, instance, knownBlocks):
                            knownBlocks=knownBlocks):
             raise GDP_Error("Target '%s' is not a component on instance "
                             "'%s'!" % (t.name, instance.name))
+        if not t.active:
+            continue
         if t.ctype is Block or isinstance(t, _BlockData):
             if t.is_indexed():
                 for block in t.values():
-                    if not t.active:
-                        continue
-                    gdp_tree = _gather_disjunctions(block, gdp_tree)
+                    if block.active:
+                        gdp_tree = _gather_disjunctions(block, gdp_tree)
             else:
-                if not t.active:
-                    continue
                 gdp_tree = _gather_disjunctions(t, gdp_tree)
         elif t.ctype is Disjunction:
             parent = _parent_disjunct(t)

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -182,33 +182,23 @@ def get_gdp_tree(targets, instance, knownBlocks):
                            knownBlocks=knownBlocks):
             raise GDP_Error("Target '%s' is not a component on instance "
                             "'%s'!" % (t.name, instance.name))
-        if not t.active:
-            continue
         if t.ctype is Block or isinstance(t, _BlockData):
-            if t.is_indexed():
-                for block in t.values():
-                    if block.active:
-                        gdp_tree = _gather_disjunctions(block, gdp_tree)
-            else:
-                gdp_tree = _gather_disjunctions(t, gdp_tree)
+            _blocks = t.values() if t.is_indexed() else (t,)
+            for block in _blocks:
+                if not block.active:
+                    continue
+                gdp_tree = _gather_disjunctions(block, gdp_tree)
         elif t.ctype is Disjunction:
             parent = _parent_disjunct(t)
             if parent is not None and parent in targets:
                 gdp_tree.add_edge(parent, t)
-            if t.is_indexed():
-                for disjunction in t.values():
-                    gdp_tree.add_node(disjunction)
-                    for disjunct in disjunction.disjuncts:
-                        if not disjunct.active:
-                            continue
-                        gdp_tree.add_edge(disjunction, disjunct)
-                        gdp_tree = _gather_disjunctions(disjunct, gdp_tree)
-            else:
-                gdp_tree.add_node(t)
-                for disjunct in t.disjuncts:
+            _disjunctions = t.values() if t.is_indexed() else (t,)
+            for disjunction in _disjunctions:
+                gdp_tree.add_node(disjunction)
+                for disjunct in disjunction.disjuncts:
                     if not disjunct.active:
                         continue
-                    gdp_tree.add_edge(t, disjunct)
+                    gdp_tree.add_edge(disjunction, disjunct)
                     gdp_tree = _gather_disjunctions(disjunct, gdp_tree)
         else:
             # There's nothing else we care about, so we don't know how to

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -165,6 +165,8 @@ def _gather_disjunctions(block, gdp_tree):
             # might be a Block, in case it wouldn't get added below.)
             gdp_tree.add_node(disjunction)
             for disjunct in disjunction.disjuncts:
+                if not disjunct.active:
+                    continue
                 gdp_tree.add_edge(disjunction, disjunct)
                 to_explore.append(disjunct)
             if block.ctype is Disjunct:
@@ -183,8 +185,12 @@ def get_gdp_tree(targets, instance, knownBlocks):
         if t.ctype is Block or isinstance(t, _BlockData):
             if t.is_indexed():
                 for block in t.values():
+                    if not t.active:
+                        continue
                     gdp_tree = _gather_disjunctions(block, gdp_tree)
             else:
+                if not t.active:
+                    continue
                 gdp_tree = _gather_disjunctions(t, gdp_tree)
         elif t.ctype is Disjunction:
             parent = _parent_disjunct(t)
@@ -194,11 +200,15 @@ def get_gdp_tree(targets, instance, knownBlocks):
                 for disjunction in t.values():
                     gdp_tree.add_node(disjunction)
                     for disjunct in disjunction.disjuncts:
+                        if not disjunct.active:
+                            continue
                         gdp_tree.add_edge(disjunction, disjunct)
                         gdp_tree = _gather_disjunctions(disjunct, gdp_tree)
             else:
                 gdp_tree.add_node(t)
                 for disjunct in t.disjuncts:
+                    if not disjunct.active:
+                        continue
                     gdp_tree.add_edge(t, disjunct)
                     gdp_tree = _gather_disjunctions(disjunct, gdp_tree)
         else:


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This is the first step toward resolving issues with references where the model component iterators can return the same data multiple times.  The implementation is aware that the only way to see the same component twice is through `Reference`s, and makes use of this to minimize the overhead of deduplication (in particular, `id()`s are only cached for component containers, _unless_ a `Reference` is encountered).

This implementation has only minimal impact on performance (<1% overhead):
![image](https://user-images.githubusercontent.com/356359/177866703-fbe31d0e-9907-4e94-aa7b-aa5cb9cc1a4f.png)

Note that this does NOT resolve the issues in the writers, etc.  That will be implemented in a subsequent PR

## Changes proposed in this PR:
- `component_data_objects()` and `component_data_iterindex()` will not yield the same data object more than once
- clean up GDP handling of deactivated blocks / disjuncts 
- updated documentation

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
