### PR TITLE
Avoid exception parsing BARON objective lower/upper bounds

### DIFF
--- a/pyomo/solvers/plugins/solvers/BARON.py
+++ b/pyomo/solvers/plugins/solvers/BARON.py
@@ -366,8 +366,14 @@ class BARONSHELL(SystemCallSolver):
             results.problem.name = line[0]
             results.problem.number_of_constraints = int(line[1])
             results.problem.number_of_variables = int(line[2])
-            results.problem.lower_bound = float(line[5])
-            results.problem.upper_bound = float(line[6])
+            try:
+                results.problem.lower_bound = float(line[5])
+            except ValueError:
+                results.problem.lower_bound = None
+            try:
+                results.problem.upper_bound = float(line[6])
+            except ValueError:
+                results.problem.upper_bound = None
             results.problem.missing_bounds = line[9]
             results.problem.iterations = line[10]
             results.problem.node_opt = line[11]


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
@shermanjasonaf reported that the BARON interface could raise an exception when BARON failed to identify either an upper or lower bound within the time limit.  This PR catches those errors and maps the "`*****`" returned by Baron to `None`.

## Changes proposed in this PR:
- catch errors converting the upper / lower objective bounds to `float` (mapping `ValueError` to `None`)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
