### PR TITLE
Make typing overloads available at runtime

### DIFF
--- a/pyomo/common/pyomo_typing.py
+++ b/pyomo/common/pyomo_typing.py
@@ -1,0 +1,31 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import typing
+
+_overloads = {}
+
+def _get_fullqual_name(func: typing.Callable) -> str:
+    return f"{func.__module__}.{func.__qualname__}"
+
+def overload(func: typing.Callable):
+    """Wrap typing.overload that remembers the overloaded signatures
+
+    This provides a custom implementation of typing.overload that
+    remembers the overloaded signitures so that they are available for
+    runtime inspection.
+
+    """
+    _overloads.setdefault(_get_fullqual_name(func), []).append(func)
+    return typing.overload(func)
+
+def get_overloads_for(func: typing.Callable):
+    return _overloads.get(_get_fullqual_name(func), [])

--- a/pyomo/common/pyomo_typing.py
+++ b/pyomo/common/pyomo_typing.py
@@ -20,7 +20,7 @@ def overload(func: typing.Callable):
     """Wrap typing.overload that remembers the overloaded signatures
 
     This provides a custom implementation of typing.overload that
-    remembers the overloaded signitures so that they are available for
+    remembers the overloaded signatures so that they are available for
     runtime inspection.
 
     """

--- a/pyomo/common/tests/test_typing.py
+++ b/pyomo/common/tests/test_typing.py
@@ -1,0 +1,24 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import pyomo.common.unittest as unittest
+
+import inspect
+
+from pyomo.common.pyomo_typing import get_overloads_for
+from pyomo.environ import Block
+
+class TestTyping(unittest.TestCase):
+    def test_get_overloads_for(self):
+        func_list = get_overloads_for(Block.__init__)
+        self.assertEqual(len(func_list), 1)
+        kwds = inspect.getfullargspec(func_list[0]).kwonlyargs
+        self.assertEqual(kwds, ['rule', 'concrete', 'dense', 'name', 'doc'])

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -22,7 +22,7 @@ import textwrap
 from inspect import isclass
 from operator import itemgetter
 from io import StringIO
-from typing import overload
+from pyomo.common.pyomo_typing import overload
 
 from pyomo.common.collections import Mapping
 from pyomo.common.deprecation import deprecated, deprecation_warning, RenamedClass

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -18,7 +18,7 @@ import sys
 import logging
 import math
 from weakref import ref as weakref_ref
-from typing import overload
+from pyomo.common.pyomo_typing import overload
 
 from pyomo.common.deprecation import RenamedClass
 from pyomo.common.errors import DeveloperError

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -14,7 +14,7 @@ __all__ = ['Expression', '_ExpressionData']
 import sys
 import logging
 from weakref import ref as weakref_ref
-from typing import overload
+from pyomo.common.pyomo_typing import overload
 
 from pyomo.common.log import is_debug_set
 from pyomo.common.deprecation import deprecated, RenamedClass

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -13,7 +13,7 @@ import logging
 import os
 import types
 import weakref
-from typing import overload
+from pyomo.common.pyomo_typing import overload
 
 from ctypes import (
     Structure, POINTER, CFUNCTYPE, cdll, byref,

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -20,7 +20,7 @@ __all__ = ('Objective',
 import sys
 import logging
 from weakref import ref as weakref_ref
-from typing import overload
+from pyomo.common.pyomo_typing import overload
 
 from pyomo.common.log import is_debug_set
 from pyomo.common.modeling import NOTSET

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -15,7 +15,7 @@ import sys
 import types
 import logging
 from weakref import ref as weakref_ref
-from typing import overload
+from pyomo.common.pyomo_typing import overload
 
 from pyomo.common.deprecation import deprecation_warning, RenamedClass
 from pyomo.common.log import is_debug_set

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -15,7 +15,7 @@ import logging
 import math
 import sys
 import weakref
-from typing import overload
+from pyomo.common.pyomo_typing import overload
 
 from pyomo.common.deprecation import (
     deprecated, deprecation_warning, RenamedClass,

--- a/pyomo/core/base/suffix.py
+++ b/pyomo/core/base/suffix.py
@@ -14,7 +14,7 @@ __all__ = ('Suffix',
            'active_import_suffix_generator')
 
 import logging
-from typing import overload
+from pyomo.common.pyomo_typing import overload
 
 from pyomo.common.collections import ComponentMap
 from pyomo.common.log import is_debug_set

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -14,7 +14,7 @@ __all__ = ['Var', '_VarData', '_GeneralVarData', 'VarList', 'SimpleVar',
 
 import logging
 import sys
-from typing import overload
+from pyomo.common.pyomo_typing import overload
 from weakref import ref as weakref_ref
 
 from pyomo.common.collections import Sequence


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
We currently use `typing.overload` to provide type hints for the component constructors.  Unfortunately, the implementation in the standard library throws the overloaded functions away so they are unavailable for dynamic inspection.  This PR wraps the standard `typing.overload` to maintain a dictionary of the overloaded functions so that they can be retrieved / inspected at runtime.

This PR is needed by IDAES to remove the `default=` dict from all the ProcessBlock definitions (for IDAES 2.0, https://github.com/IDAES/idaes-pse/issues/729)

## Changes proposed in this PR:
- add custom implementation of `typing.overload` and `get_overloads_for`
- add a test

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
