### PR TITLE
Remove scipy from GHA puppy builds

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -277,7 +277,7 @@ jobs:
         # Note: some pypi packages are not available through conda
         PYOMO_DEPENDENCIES=`python setup.py dependencies \
             --extras "$EXTRAS" | tail -1`
-        PACKAGES="${PYTHON_CORE_PKGS} ${PYTHON_PACKAGES} ${CONDA_DEPENDENCIES} "
+        PACKAGES="${PYTHON_CORE_PKGS} ${PYTHON_PACKAGES} ${PYOMO_DEPENDENCIES} "
         if [[ ${{matrix.python}} == pypy* ]]; then
             EXCLUDE="$PYPY_EXCLUDE $EXCLUDE"
         fi

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -18,6 +18,7 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
+  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
   CACHE_VER: v210812.0
   NEOS_EMAIL: tests@pyomo.org
 
@@ -232,8 +233,17 @@ jobs:
         python -m pip install --cache-dir cache/pip --upgrade pip
         PYOMO_DEPENDENCIES=`python setup.py dependencies \
             --extras "$EXTRAS" | tail -1`
-        python -m pip install --cache-dir cache/pip \
-            ${PYTHON_CORE_PKGS} ${PYTHON_PACKAGES} ${PYOMO_DEPENDENCIES}
+        PACKAGES="${PYTHON_CORE_PKGS} ${PYTHON_PACKAGES} ${PYOMO_DEPENDENCIES} "
+        if [[ ${{matrix.python}} == pypy* ]]; then
+            EXCLUDE="$PYPY_EXCLUDE $EXCLUDE"
+        fi
+        EXCLUDE=`echo "$EXCLUDE" | xargs`
+        if test -n "$EXCLUDE"; then
+            for WORD in $EXCLUDE; do
+                PACKAGES=${PACKAGES//$WORD / }
+            done
+        fi
+        python -m pip install --cache-dir cache/pip ${PACKAGES}
         python -m pip install --cache-dir cache/pip pymysql || \
             python -m pip install --cache-dir cache/pip pymysql
         if test -z "${{matrix.slim}}"; then
@@ -267,19 +277,28 @@ jobs:
         # Note: some pypi packages are not available through conda
         PYOMO_DEPENDENCIES=`python setup.py dependencies \
             --extras "$EXTRAS" | tail -1`
+        PACKAGES="${PYTHON_CORE_PKGS} ${PYTHON_PACKAGES} ${CONDA_DEPENDENCIES} "
+        if [[ ${{matrix.python}} == pypy* ]]; then
+            EXCLUDE="$PYPY_EXCLUDE $EXCLUDE"
+        fi
         # HACK: Remove problem packages on conda+Linux
         if test "${{matrix.TARGET}}" == linux; then
-            WORDSTOREMOVE="casadi numdifftools pint"
-            for WORD in $WORDSTOREMOVE; do
-                PYOMO_DEPENDENCIES=${PYOMO_DEPENDENCIES//$WORD/}
+            EXCLUDE="casadi numdifftools pint $EXCLUDE"
+        fi
+        EXCLUDE=`echo "$EXCLUDE" | xargs`
+        if test -n "$EXCLUDE"; then
+            for WORD in $EXCLUDE; do
+                PACKAGES=${PACKAGES//$WORD / }
             done
         fi
-        CONDA_DEPENDENCIES=`echo $PYOMO_DEPENDENCIES | tr ' ' '\n' \
-            | grep -Ev ${PYPI_ONLY} | tr '\n' ' '`
-        PYPI_DEPENDENCIES=`echo $PYOMO_DEPENDENCIES | tr ' ' '\n' \
-            | grep -E ${PYPI_ONLY} | tr '\n' ' '`
-        conda install -q -y -c conda-forge \
-            ${PYTHON_CORE_PKGS} ${PYTHON_PACKAGES} ${CONDA_DEPENDENCIES}
+        for PKG in $PACKAGES; do
+            if [[ " $PYPI_ONLY " == *" $PKG "* ]]; then
+                PYPI_DEPENDENCIES="$PYPI_DEPENDENCIES $PKG"
+            else
+                CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $PKG"
+            fi
+        done
+        conda install -q -y -c conda-forge $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
             conda install -q -y -c ibmdecisionoptimization 'cplex>=12.10' \
                 || echo "WARNING: CPLEX Community Edition is not available"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -298,7 +298,7 @@ jobs:
         # Note: some pypi packages are not available through conda
         PYOMO_DEPENDENCIES=`python setup.py dependencies \
             --extras "$EXTRAS" | tail -1`
-        PACKAGES="${PYTHON_CORE_PKGS} ${PYTHON_PACKAGES} ${CONDA_DEPENDENCIES} "
+        PACKAGES="${PYTHON_CORE_PKGS} ${PYTHON_PACKAGES} ${PYOMO_DEPENDENCIES} "
         if [[ ${{matrix.python}} == pypy* ]]; then
             EXCLUDE="$PYPY_EXCLUDE $EXCLUDE"
         fi

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -21,6 +21,7 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
+  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
   CACHE_VER: v210812.0
   NEOS_EMAIL: tests@pyomo.org
 
@@ -253,8 +254,17 @@ jobs:
         python -m pip install --cache-dir cache/pip --upgrade pip
         PYOMO_DEPENDENCIES=`python setup.py dependencies \
             --extras "$EXTRAS" | tail -1`
-        python -m pip install --cache-dir cache/pip \
-            ${PYTHON_CORE_PKGS} ${PYTHON_PACKAGES} ${PYOMO_DEPENDENCIES}
+        PACKAGES="${PYTHON_CORE_PKGS} ${PYTHON_PACKAGES} ${PYOMO_DEPENDENCIES} "
+        if [[ ${{matrix.python}} == pypy* ]]; then
+            EXCLUDE="$PYPY_EXCLUDE $EXCLUDE"
+        fi
+        EXCLUDE=`echo "$EXCLUDE" | xargs`
+        if test -n "$EXCLUDE"; then
+            for WORD in $EXCLUDE; do
+                PACKAGES=${PACKAGES//$WORD / }
+            done
+        fi
+        python -m pip install --cache-dir cache/pip ${PACKAGES}
         python -m pip install --cache-dir cache/pip pymysql || \
             python -m pip install --cache-dir cache/pip pymysql
         if test -z "${{matrix.slim}}"; then
@@ -288,19 +298,28 @@ jobs:
         # Note: some pypi packages are not available through conda
         PYOMO_DEPENDENCIES=`python setup.py dependencies \
             --extras "$EXTRAS" | tail -1`
+        PACKAGES="${PYTHON_CORE_PKGS} ${PYTHON_PACKAGES} ${CONDA_DEPENDENCIES} "
+        if [[ ${{matrix.python}} == pypy* ]]; then
+            EXCLUDE="$PYPY_EXCLUDE $EXCLUDE"
+        fi
         # HACK: Remove problem packages on conda+Linux
         if test "${{matrix.TARGET}}" == linux; then
-            WORDSTOREMOVE="casadi numdifftools pint"
-            for WORD in $WORDSTOREMOVE; do
-                PYOMO_DEPENDENCIES=${PYOMO_DEPENDENCIES//$WORD/}
+            EXCLUDE="casadi numdifftools pint $EXCLUDE"
+        fi
+        EXCLUDE=`echo "$EXCLUDE" | xargs`
+        if test -n "$EXCLUDE"; then
+            for WORD in $EXCLUDE; do
+                PACKAGES=${PACKAGES//$WORD / }
             done
         fi
-        CONDA_DEPENDENCIES=`echo $PYOMO_DEPENDENCIES | tr ' ' '\n' \
-            | grep -Ev ${PYPI_ONLY} | tr '\n' ' '`
-        PYPI_DEPENDENCIES=`echo $PYOMO_DEPENDENCIES | tr ' ' '\n' \
-            | grep -E ${PYPI_ONLY} | tr '\n' ' '`
-        conda install -q -y -c conda-forge \
-            ${PYTHON_CORE_PKGS} ${PYTHON_PACKAGES} ${CONDA_DEPENDENCIES}
+        for PKG in $PACKAGES; do
+            if [[ " $PYPI_ONLY " == *" $PKG "* ]]; then
+                PYPI_DEPENDENCIES="$PYPI_DEPENDENCIES $PKG"
+            else
+                CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $PKG"
+            fi
+        done
+        conda install -q -y -c conda-forge $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
             conda install -q -y -c ibmdecisionoptimization 'cplex>=12.10' \
                 || echo "WARNING: CPLEX Community Edition is not available"
@@ -559,7 +578,7 @@ jobs:
         for cat in ${{matrix.category}}; do
             CATEGORY+=" -m $cat"
         done
-        $PYTHON_EXE -m pytest -v  \
+        $PYTHON_EXE -m pytest -v \
             -W ignore::Warning $CATEGORY \
             pyomo `pwd`/pyomo-model-libraries \
             `pwd`/examples/pyomobook --junitxml="TEST-pyomo.xml"


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Currently installing scipy under pypy on GHA fails. This updates the GHA drivers to not install scipy on GHA under pypy. 

## Changes proposed in this PR:
- improved mechanism for specifying packages to exclude from environment setup

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
