### PR TITLE
Update list of known TPLs to reflect Python 3.10

### DIFF
--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -121,30 +121,34 @@ class TestPyomoEnviron(unittest.TestCase):
         ref = {
             '__future__',
             'argparse',
+            'ast',       # Imported on Windows
+            'base64',    # Imported on Windows
             'cPickle',
-            'copy',
             'csv',
             'ctypes',
             'decimal',
-            'gc',
+            'gc',        # Imported on MacOS, Windows; Linux in 3.10
             'glob',
+            'heapq',     # Added in Python 3.10
+            'importlib', # Imported on Windows
             'inspect',
-            'json',
+            'json',      # Imported on Windows
+            'locale',    # Added in Python 3.9
             'logging',
             'pickle',
             'platform',
-            'pyutilib',
-            'random',
+            'random',    # Imported on MacOS, Windows
             'shlex',
-            'socket',
-            'tempfile',
+            'socket',    # Imported on MacOS, Windows; Linux in 3.10
+            'tempfile',  # Imported on MacOS, Windows
             'textwrap',
             'typing',
-            'win32file',
-            'win32pipe',
+            'win32file', # Imported on Windows
+            'win32pipe', # Imported on Windows
         }
         # Non-standard-library TPLs that Pyomo will load unconditionally
         ref.add('ply')
+        ref.add('pyutilib')
         if numpy_available:
             ref.add('numpy')
         diff = set(_[0] for _ in tpl_by_time[-5:]).difference(ref)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This updates the list of TPLs that get loaded through pyomo.environ to reflect new modules required by Python 3.10 (heapq) and several loaded by Windows that were never included.

## Changes proposed in this PR:
- Update the list of known TPLs for testing `import pyomo.environ` time

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
