### PR TITLE
Provide a way to release license from persistent interface

### DIFF
--- a/pyomo/contrib/appsi/solvers/gurobi.py
+++ b/pyomo/contrib/appsi/solvers/gurobi.py
@@ -263,11 +263,14 @@ class Gurobi(PersistentBase, PersistentSolver):
         finally:
             m.dispose()
             del m
-            gurobipy.disposeDefaultEnv()
+            with capture_output(capture_fd=True):
+                gurobipy.disposeDefaultEnv()
 
     def release_license(self):
         self._reinit()
-        gurobipy.disposeDefaultEnv()
+        if gurobipy_available:
+            with capture_output(capture_fd=True):
+                gurobipy.disposeDefaultEnv()
 
     def __del__(self):
         self.release_license()

--- a/pyomo/contrib/appsi/solvers/gurobi.py
+++ b/pyomo/contrib/appsi/solvers/gurobi.py
@@ -262,6 +262,16 @@ class Gurobi(PersistentBase, PersistentSolver):
             cls._available = Gurobi.Availability.LimitedLicense
         finally:
             m.dispose()
+            del m
+            gurobipy.disposeDefaultEnv()
+
+    def release_license(self):
+        del self._solver_model
+        gurobipy.disposeDefaultEnv()
+        self._model = None
+
+    def __del__(self):
+        self.release_license()
 
     def version(self):
         version = (gurobipy.GRB.VERSION_MAJOR,


### PR DESCRIPTION
## Summary/Motivation:
This PR adds a method to the Appsi Gurobi interface to delete the Gurobi model and release the license.


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
