### PR TITLE
Update Exception Handling Parsing BARON lower/upper bounds

### DIFF
--- a/pyomo/solvers/plugins/solvers/BARON.py
+++ b/pyomo/solvers/plugins/solvers/BARON.py
@@ -369,11 +369,11 @@ class BARONSHELL(SystemCallSolver):
             try:
                 results.problem.lower_bound = float(line[5])
             except ValueError:
-                results.problem.lower_bound = None
+                results.problem.lower_bound = float("-inf")
             try:
                 results.problem.upper_bound = float(line[6])
             except ValueError:
-                results.problem.upper_bound = None
+                results.problem.upper_bound = float("inf")
             results.problem.missing_bounds = line[9]
             results.problem.iterations = line[10]
             results.problem.node_opt = line[11]


### PR DESCRIPTION
## Summary/Motivation:
Follow-up on #2467 in conversation with @jsiirola to handle exceptional cases in which the BARON solver outputs (to the results time file parsed at postsolve) a string `'*****'` in place of a numerical value for the objective lower and/or upper bound. PR #2467 handles these exceptional cases by mapping the `'*****'` to `None`, but this may result in a `TypeError` when attempting to assign `soln.gap = results.problem.upper_bound - results.problem.lower_bound` in the `_process_soln_file` method afterwards. This PR maps `'*****'` to `float('-inf')` for the lower bound and to `float('inf')` for the upper bound in the exceptional cases instead.

Note that the `'*****'` string may also be written to the time file in the event the model written to BARON was solved to global optimality (within tolerances).

## Changes proposed in this PR:
- catch errors converting the lower / upper objective bounds to `float` (mapping `ValueError` to `float("-inf")` / `float("inf")`)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
