### PR TITLE
Reduce recursion in model clone / deepcopy

### DIFF
--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1999,6 +1999,16 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
                 str(format))
         return filename, smap_id
 
+    def _create_objects_for_deepcopy(self, memo, component_list):
+        super()._create_objects_for_deepcopy(memo, component_list)
+        # Blocks (and block-like things) need to pre-populate all
+        # Components / ComponentData objects to help prevent deepcopy()
+        # from violating the Python recursion limit.  This step is
+        # recursive; however, we do not expect "super deep" Pyomo block
+        # hierarchies, so should be okay.
+        for comp in self.component_objects(descend_into=False):
+            comp._create_objects_for_deepcopy(memo, component_list)
+
 
 @ModelComponentFactory.register("A component that contains one or more model components.")
 class Block(ActiveIndexedComponent):

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -145,7 +145,7 @@ class _ComponentBase(PyomoObject):
         # cause problems for highly interconnected Pyomo models (for
         # example, a time linked model where each time block has a
         # linking constraint [in the time block] to the next / previous
-        # block).  This would effectively put the entire time hirizon on
+        # block).  This would effectively put the entire time horizon on
         # the stack.  To avoid this, we will leverage the useful
         # knowledge that all component references point to other
         # components / component datas, and NOT to attributes on the

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -171,8 +171,10 @@ class _ComponentBase(PyomoObject):
         return memo[id(self)]
 
     def _create_objects_for_deepcopy(self, memo, component_list):
-        component_list.append(self)
-        memo[id(self)] = self.__class__.__new__(self.__class__)
+        _id = id(self)
+        if _id not in memo:
+            component_list.append(self)
+            memo[_id] = self.__class__.__new__(self.__class__)
 
     def _populate_deepcopied_object(self, memo):
         # We can't do the "obvious", since this is a (partially)

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -441,7 +441,8 @@ class _PythonCallbackFunctionID(NumericConstant):
         return state
 
     def __setstate__(self, state):
-        state['value'] = state['value']._fcn_id
+        state['value'] = PythonCallbackFunction.register_instance(
+            state['value'])
         super().__setstate__(state)
 
 pyomo_constant_types.add(_PythonCallbackFunctionID)

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -331,7 +331,7 @@ class IndexedComponent(Component):
             component_list.append(self)
             memo[_id] = self.__class__.__new__(self.__class__)
         # For indexed components, we need to pre-emptively clone all
-        # component data objects as well (as those are teh objects that
+        # component data objects as well (as those are the objects that
         # will be referenced by things like expressions)
         if self.is_indexed() and not self.is_reference():
             for obj in self._data.values():

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -326,8 +326,10 @@ class IndexedComponent(Component):
         super(IndexedComponent, self).__setstate__(state)
 
     def _create_objects_for_deepcopy(self, memo, component_list):
-        component_list.append(self)
-        memo[id(self)] = self.__class__.__new__(self.__class__)
+        _id = id(self)
+        if _id not in memo:
+            component_list.append(self)
+            memo[_id] = self.__class__.__new__(self.__class__)
         # For indexed components, we need to pre-emptively clone all
         # component data objects as well (as those are teh objects that
         # will be referenced by things like expressions)
@@ -337,9 +339,12 @@ class IndexedComponent(Component):
                 # preemptively clone the data objects.
                 if obj.parent_component() is not self:
                     continue
+                _id = id(obj)
+                if _id in memo:
+                    continue
                 # But everything else should be cloned.
                 component_list.append(obj)
-                memo[id(obj)] = obj.__class__.__new__(obj.__class__)
+                memo[_id] = obj.__class__.__new__(obj.__class__)
 
     def to_dense_data(self):
         """TODO"""

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -903,3 +903,14 @@ class IndexedParam(Param):
             raise TypeError('Cannot compute the value of an indexed Param (%s)'
                             % (self.name,) )
 
+    # Because IndexedParam can use a non-standard data store (i.e., the
+    # values in the _data dict may not be ComponentData objects), we
+    # need to override the normal scheme for pre-allocating
+    # ComponentData objects during deepcopy.
+    def _create_objects_for_deepcopy(self, memo, component_list):
+        component_list.append(self)
+        memo[id(self)] = self.__class__.__new__(self.__class__)
+        if self.mutable and self._data.__class__ is dict:
+            for obj in self._data.values():
+                component_list.append(obj)
+                memo[id(obj)] = obj.__class__.__new__(obj.__class__)

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -908,9 +908,14 @@ class IndexedParam(Param):
     # need to override the normal scheme for pre-allocating
     # ComponentData objects during deepcopy.
     def _create_objects_for_deepcopy(self, memo, component_list):
-        component_list.append(self)
-        memo[id(self)] = self.__class__.__new__(self.__class__)
-        if self.mutable and self._data.__class__ is dict:
+        _id = id(self)
+        if _id not in memo:
+            component_list.append(self)
+            memo[_id] = self.__class__.__new__(self.__class__)
+        if self.mutable:
             for obj in self._data.values():
+                _id = id(obj)
+                if _id in memo:
+                    continue
                 component_list.append(obj)
                 memo[id(obj)] = obj.__class__.__new__(obj.__class__)

--- a/pyomo/core/tests/unit/test_reference.py
+++ b/pyomo/core/tests/unit/test_reference.py
@@ -472,16 +472,25 @@ class TestReference(unittest.TestCase):
         m.b = Block()
         m.b.x = Var([1,2])
         m.c = Block()
-        m.c.r = Reference(m.b.x[2])
+        m.c.r1 = Reference(m.b.x[2])
+        m.c.r2 = Reference(m.b.x)
 
-        self.assertIs(m.c.r[None], m.b.x[2])
+        self.assertIs(m.c.r1[None], m.b.x[2])
         m.d = m.c.clone()
-        self.assertIs(m.d.r[None], m.b.x[2])
+        self.assertIs(m.d.r1[None], m.b.x[2])
+        self.assertIs(m.d.r2[1], m.b.x[1])
+        self.assertIs(m.d.r2[2], m.b.x[2])
 
         i = m.clone()
-        self.assertIs(i.c.r[None], i.b.x[2])
-        self.assertIsNot(i.c.r[None], m.b.x[2])
-        self.assertIs(i.d.r[None], i.b.x[2])
+        self.assertIs(i.c.r1[None], i.b.x[2])
+        self.assertIs(i.c.r2[1], i.b.x[1])
+        self.assertIs(i.c.r2[2], i.b.x[2])
+        self.assertIsNot(i.c.r1[None], m.b.x[2])
+        self.assertIsNot(i.c.r2[1], m.b.x[1])
+        self.assertIsNot(i.c.r2[2], m.b.x[2])
+        self.assertIs(i.d.r1[None], i.b.x[2])
+        self.assertIs(i.d.r2[1], i.b.x[1])
+        self.assertIs(i.d.r2[2], i.b.x[2])
 
 
     def test_reference_var_pprint(self):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
PyROS hit an issue where certain IDAES / DISPATCHES models were not clonable due to deepcopy() hitting a recursion limit.  It turns out that for certain structures of Pyomo models (specifically block-hierarchical models where each block references one of its siblings - think time linking constraints in the time-indexed block).

This PR reworks the model cloning logic to remove the bulk of the opportunity for deep recursion trees when cloning / deepcopying Pyomo models.

## Changes proposed in this PR:
- Remove most (deep) recursion from `model.clone()` / `copy.deepcopy(model)`
- Make the PyomoExternalFunction pickle logic more robust

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
