### PR TITLE
Resolve exception cloning empty LinearExpression objects

### DIFF
--- a/pyomo/core/expr/numeric_expr.py
+++ b/pyomo/core/expr/numeric_expr.py
@@ -1352,6 +1352,11 @@ class LinearExpression(ExpressionBase):
     @_args_.setter
     def _args_(self, value):
         self._args_cache_ = list(value)
+        if not self._args_cache_:
+            self.constant = 0
+            self.linear_coefs = []
+            self.linear_vars = []
+            return
         if self._args_cache_[0].__class__ is not MonomialTermExpression:
             self.constant = value[0]
             first_var = 1

--- a/pyomo/core/tests/unit/test_numeric_expr.py
+++ b/pyomo/core/tests/unit/test_numeric_expr.py
@@ -4053,6 +4053,35 @@ class TestCloneExpression(unittest.TestCase):
             total = counter.count - start
             self.assertEqual(total, 1)
 
+    def test_LinearExpression(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var([1,2])
+        e = LinearExpression()
+        f = e.clone()
+        self.assertIsNot(e, f)
+        self.assertIsNot(e.linear_coefs, f.linear_coefs)
+        self.assertIsNot(e.linear_vars, f.linear_vars)
+        self.assertEqual(e.constant, f.constant)
+        self.assertEqual(e.linear_coefs, f.linear_coefs)
+        self.assertEqual(e.linear_vars, f.linear_vars)
+        self.assertEqual(f.constant, 0)
+        self.assertEqual(f.linear_coefs, [])
+        self.assertEqual(f.linear_vars, [])
+
+        e = LinearExpression(
+            constant=5, linear_vars=[m.x, m.y[1]], linear_coefs=[10, 20])
+        f = e.clone()
+        self.assertIsNot(e, f)
+        self.assertIsNot(e.linear_coefs, f.linear_coefs)
+        self.assertIsNot(e.linear_vars, f.linear_vars)
+        self.assertEqual(e.constant, f.constant)
+        self.assertEqual(e.linear_coefs, f.linear_coefs)
+        self.assertEqual(e.linear_vars, f.linear_vars)
+        self.assertEqual(f.constant, 5)
+        self.assertEqual(f.linear_coefs, [10, 20])
+        self.assertEqual(f.linear_vars, [m.x, m.y[1]])
+
     def test_getitem(self):
         # Testing cloning of the abs() function
         with clone_counter() as counter:


### PR DESCRIPTION
## Fixes #2455

## Summary/Motivation:
The root problem in #2455 turned out to be that recent changes to the storage model for LinearExpression broke cloning empty LinearExpression objects.  This PR resolves that bug and introduces tests for the original behavior.

## Changes proposed in this PR:
- Resolve exception when cloning empty LinearExpression
- Add clone tests for LinearExpression

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
