### PR TITLE
Improve `common.timing` test robustness

### DIFF
--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -168,7 +168,7 @@ class TestTiming(unittest.TestCase):
         with capture_output() as out:
             ref = time.perf_counter()
             total = timer.toc(delta=False)
-        self.assertAlmostEqual(ref - abs_time, total, delta=RES)
+        self.assertAlmostEqual(ref - start_time, total, delta=RES)
         self.assertRegex(
             out.getvalue(),
             r'\[    [.0-9]+\] .* in test_TicTocTimer_tictoc'

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -150,8 +150,8 @@ class TestTiming(unittest.TestCase):
 
         time.sleep(SLEEP)
 
-        ref = time.perf_counter()
         with capture_output() as out:
+            ref = time.perf_counter()
             delta = timer.toc()
         self.assertAlmostEqual(ref - start_time, delta, delta=RES)
         # entering / leaving the context manager can take non-trivial
@@ -161,8 +161,8 @@ class TestTiming(unittest.TestCase):
             out.getvalue(),
             r'\[\+   [.0-9]+\] .* in test_TicTocTimer_tictoc'
         )
-        ref = time.perf_counter()
         with capture_output() as out:
+            ref = time.perf_counter()
             total = timer.toc(delta=False)
         self.assertAlmostEqual(ref - abs_time, total, delta=RES)
         self.assertRegex(

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -154,13 +154,17 @@ class TestTiming(unittest.TestCase):
             ref = time.perf_counter()
             delta = timer.toc()
         self.assertAlmostEqual(ref - start_time, delta, delta=RES)
-        # entering / leaving the context manager can take non-trivial
-        # time on some platforms (up to 0.02 on Windows)
-        self.assertAlmostEqual(0.01, timer.toc(None), delta=RES)
         self.assertRegex(
             out.getvalue(),
             r'\[\+   [.0-9]+\] .* in test_TicTocTimer_tictoc'
         )
+        with capture_output() as out:
+            # entering / leaving the context manager can take non-trivial
+            # time on some platforms (up to 0.03 on Windows / Python 3.10)
+            self.assertAlmostEqual(
+                time.perf_counter() - ref, timer.toc(None), delta=RES)
+        self.assertEqual(out.getvalue(), '')
+
         with capture_output() as out:
             ref = time.perf_counter()
             total = timer.toc(delta=False)

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -205,7 +205,7 @@ class TicTocTimer(object):
                 class was constructed). Note: timing logged using logger.info
 
         """
-        self._lastTime = default_timer()
+        self._lastTime = self._loadTime = default_timer()
         if msg is _NotSpecified:
             msg = "Resetting the tic/toc delta timer"
         if msg is not None:
@@ -225,9 +225,9 @@ class TicTocTimer(object):
                 called this method; if msg is None, then no message is
                 printed.
             delta (bool): print out the elapsed wall clock time since
-                the last call to :meth:`tic` or :meth:`toc`
-                (``True`` (default)) or since the module was first
-                loaded (``False``).
+                the last call to :meth:`tic` (``False``) or since the
+                most recent call to either :meth:`tic` or :meth:`toc`
+                (``True`` (default)).
             ostream (FILE): an optional output stream (overrides the ostream
                 provided when the class was constructed).
             logger (Logger): an optional output stream using the python
@@ -254,6 +254,9 @@ class TicTocTimer(object):
                 msg = "[+%7.2f] %s\n" % (ans, msg)
         else:
             ans = now - self._loadTime
+            # Even though we are reporting the cumulative time, we will
+            # still reset the delta timer.
+            self._lastTime = now
             if msg is not None:
                 msg = "[%8.2f] %s\n" % (ans, msg)
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
We are noticing an increased number of timer test failures (especially on win/python3.10).  This PR updates the tests to hopefully reduce the variance between the reference timer and the tic/toc timer.

## Changes proposed in this PR:
- move reference timer into context manager to remove variance introduced by entering the context manager

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
