### PR TITLE
Add `deprecation.relocated_module()` utility

### DIFF
--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -386,40 +386,40 @@ class RenamedClass(type):
     This metaclass provides a mechanism for renaming old classes while
     still preserving isinstance / issubclass relationships.
 
-    Example
-    -------
-        >>> from pyomo.common.deprecation import RenamedClass
-        >>> class NewClass(object):
-        ...     pass
-        >>> class OldClass(metaclass=RenamedClass):
-        ...     __renamed__new_class__ = NewClass
-        ...     __renamed__version__ = '6.0'
+    Examples
+    --------
+    >>> from pyomo.common.deprecation import RenamedClass
+    >>> class NewClass(object):
+    ...     pass
+    >>> class OldClass(metaclass=RenamedClass):
+    ...     __renamed__new_class__ = NewClass
+    ...     __renamed__version__ = '6.0'
 
-        Deriving from the old class generates a warning:
+    Deriving from the old class generates a warning:
 
-        >>> class DerivedOldClass(OldClass):
-        ...     pass
-        WARNING: DEPRECATED: Declaring class 'DerivedOldClass' derived from
-            'OldClass'. The class 'OldClass' has been renamed to 'NewClass'.
-            (deprecated in 6.0) ...
+    >>> class DerivedOldClass(OldClass):
+    ...     pass
+    WARNING: DEPRECATED: Declaring class 'DerivedOldClass' derived from
+        'OldClass'. The class 'OldClass' has been renamed to 'NewClass'.
+        (deprecated in 6.0) ...
 
-        As does instantiating the old class:
+    As does instantiating the old class:
 
-        >>> old = OldClass()
-        WARNING: DEPRECATED: Instantiating class 'OldClass'.  The class
-            'OldClass' has been renamed to 'NewClass'.  (deprecated in 6.0) ...
+    >>> old = OldClass()
+    WARNING: DEPRECATED: Instantiating class 'OldClass'.  The class
+        'OldClass' has been renamed to 'NewClass'.  (deprecated in 6.0) ...
 
-        Finally, isinstance and issubclass still work, for example:
+    Finally, `isinstance` and `issubclass` still work, for example:
 
-        >>> isinstance(old, NewClass)
-        True
-        >>> class NewSubclass(NewClass):
-        ...     pass
-        >>> new = NewSubclass()
-        >>> isinstance(new, OldClass)
-        WARNING: DEPRECATED: Checking type relative to 'OldClass'.  The class
-            'OldClass' has been renamed to 'NewClass'.  (deprecated in 6.0) ...
-        True
+    >>> isinstance(old, NewClass)
+    True
+    >>> class NewSubclass(NewClass):
+    ...     pass
+    >>> new = NewSubclass()
+    >>> isinstance(new, OldClass)
+    WARNING: DEPRECATED: Checking type relative to 'OldClass'.  The class
+        'OldClass' has been renamed to 'NewClass'.  (deprecated in 6.0) ...
+    True
 
     """
     def __new__(cls, name, bases, classdict, *args, **kwargs):

--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -358,8 +358,8 @@ def relocated_module(new_name, msg=None, logger=None,
     -------
     >>> from pyomo.common.deprecation import relocated_module
     >>> relocated_module('pyomo.common.deprecation', version='1.2.3')
-    WARNING: DEPRECATED: The ... module has been moved to
-        pyomo.common.deprecation. Please update your import.
+    WARNING: DEPRECATED: The '...' module has been moved to
+        'pyomo.common.deprecation'. Please update your import.
         (deprecated in 1.2.3) ...
 
     """

--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -15,6 +15,7 @@
 
    deprecated
    deprecation_warning
+   relocated_module
    relocated_module_attribute
    RenamedClass
 """
@@ -321,6 +322,71 @@ class _ModuleGetattrBackport_35(types.ModuleType):
             return target_obj
         raise AttributeError("module '%s' has no attribute '%s'"
                              % (self.__name__, name))
+
+def relocated_module(new_name, msg=None, logger=None,
+                     version=None, remove_in=None):
+    """Provide a deprecation path for moved / renamed modules
+
+    Upon import, the old module (that called `relocated_module()`) will
+    be replaced in `sys.modules` by an alias that points directly to the
+    new module.  As a result, the old module should have only two lines
+    of executable Python code (the import of `relocated_module` and the
+    call to it).
+
+    Parameters
+    ----------
+    new_name: str
+        The new (fully-qualified) module name
+
+    msg: str
+        A custom deprecation message.
+
+    logger: str
+        The logger to use for emitting the warning (default: the calling
+        pyomo package, or "pyomo")
+
+    version: str [required]
+        The version in which the module was renamed or moved.
+        General practice is to set version to '' or 'TBD' during
+        development and update it to the actual release as part of the
+        release process.
+
+    remove_in: str
+        The version in which the module will be removed from the code.
+
+    Example
+    -------
+    >>> from pyomo.common.deprecation import relocated_module
+    >>> relocated_module('pyomo.common.deprecation', version='1.2.3')
+    WARNING: DEPRECATED: The ... module has been moved to
+        pyomo.common.deprecation. Please update your import.
+        (deprecated in 1.2.3) ...
+
+    """
+    from importlib import import_module
+    new_module = import_module(new_name)
+
+    # The relevant module (the one being deprecated) is the one that
+    # holds the function/method that called deprecated_module().  The
+    # relevant calling frame for the deprecation warning is the first
+    # frame in the stack that doesn't look like the importer (i.e., the
+    # thing that imported the deprecated module).
+    cf = _find_calling_frame(1)
+    old_name = cf.f_globals.get('__name__', '<stdin>')
+    cf = cf.f_back
+    if cf is not None:
+        importer = cf.f_back.f_globals['__name__'].split('.')[0]
+        while cf is not None and \
+              cf.f_globals['__name__'].split('.')[0] == importer:
+            cf = cf.f_back
+    if cf is None:
+        cf = _find_calling_frame(1)
+
+    sys.modules[old_name] = new_module
+    if msg is None:
+        msg = f"The '{old_name}' module has been moved to '{new_name}'. " \
+              'Please update your import.'
+    deprecation_warning(msg, logger, version, remove_in, cf)
 
 def relocated_module_attribute(local, target, version, remove_in=None):
     """Provide a deprecation path for moved / renamed module attributes

--- a/pyomo/common/tests/relo_mod.py
+++ b/pyomo/common/tests/relo_mod.py
@@ -1,0 +1,14 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+from pyomo.common.deprecation import relocated_module
+
+relocated_module('pyomo.common.tests.relo_mod_new', version='1.2')

--- a/pyomo/common/tests/relo_mod_new.py
+++ b/pyomo/common/tests/relo_mod_new.py
@@ -1,0 +1,14 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+RELO_ATTR = 42
+
+class ReloClass(object): pass

--- a/pyomo/common/tests/test_deprecated.py
+++ b/pyomo/common/tests/test_deprecated.py
@@ -434,7 +434,7 @@ class TestRelocated(unittest.TestCase):
             r"DEPRECATED: The 'pyomo\.common\.tests\.relo_mod' module has "
             r"been moved to 'pyomo\.common\.tests\.relo_mod_new'. Please "
             r"update your import. \(deprecated in 1\.2\) \(called from "
-            r".*/pyomo/common/tests/test_deprecated\.py")
+            r".*test_deprecated\.py")
         with LoggingIntercept() as LOG:
             # Second import: no warning
             import pyomo.common.tests.relo_mod as relo

--- a/pyomo/common/tests/test_deprecated.py
+++ b/pyomo/common/tests/test_deprecated.py
@@ -425,6 +425,25 @@ class TestRelocated(unittest.TestCase):
             "DEPRECATED: the 'oldName' class has been moved to "
             "'pyomo.common.tests.test_deprecated.TestRelocated'")
 
+    def test_relocated_module(self):
+        with LoggingIntercept() as LOG:
+            # Can import attributes defined only in the new module
+            from pyomo.common.tests.relo_mod import ReloClass
+        self.assertRegex(
+            LOG.getvalue().replace('\n', ' '),
+            r"DEPRECATED: The 'pyomo\.common\.tests\.relo_mod' module has "
+            r"been moved to 'pyomo\.common\.tests\.relo_mod_new'. Please "
+            r"update your import. \(deprecated in 1\.2\) \(called from "
+            r".*/pyomo/common/tests/test_deprecated\.py")
+        with LoggingIntercept() as LOG:
+            # Second import: no warning
+            import pyomo.common.tests.relo_mod as relo
+        self.assertEqual(LOG.getvalue(), '')
+        import pyomo.common.tests.relo_mod_new as relo_new
+        self.assertIs(relo, relo_new)
+        self.assertEqual(relo.RELO_ATTR, 42)
+        self.assertIs(ReloClass, relo_new.ReloClass)
+
 
 class TestRenamedClass(unittest.TestCase):
     def test_renamed(self):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This PR adds a `relocated_module()` method that we can use to reliably generate deprecation paths for renamed / moved modules.

## Changes proposed in this PR:
- Add `pyomo.common.deprecation.relocated_module()`
- Update documentation and tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
