### PR TITLE
Generate a useful warning when LP writer raises KeyError

### DIFF
--- a/pyomo/repn/plugins/cpxlp.py
+++ b/pyomo/repn/plugins/cpxlp.py
@@ -454,7 +454,10 @@ class ProblemWriter_cpxlp(AbstractProblemWriter):
         object_symbol_dictionary = symbol_map.byObject
         variable_symbol_dictionary = variable_symbol_map.byObject
 
-        # cache - these are called all the time.
+        # TODO: this is a quick wrapper to map a very unintuitive
+        # exception to a more meaningful error.  Future versions of the
+        # LP writer may be more accepting in what expressions/variables
+        # they accept.
         def print_expr_canonical(
                 obj,
                 x,
@@ -486,11 +489,12 @@ class ProblemWriter_cpxlp(AbstractProblemWriter):
                         if id(v) == _id:
                             _var = v
                             break
-                logger.error(
-                    "Model contained expression (%s) that contains "
-                    "a variable (%s) that is not attached to an active "
-                    "block on the submodel being solved"
-                    % (obj.name, _var.name))
+                if _var is not None:
+                    logger.error(
+                        "Model contained an expression (%s) that contains "
+                        "a variable (%s) that is not attached to an active "
+                        "block on the submodel being written"
+                        % (obj.name, _var.name))
                 raise
 
         # print the model name and the source, so we know roughly where

--- a/pyomo/repn/plugins/cpxlp.py
+++ b/pyomo/repn/plugins/cpxlp.py
@@ -486,8 +486,9 @@ class ProblemWriter_cpxlp(AbstractProblemWriter):
                             break
                 if _var is None and x.quadratic_vars:
                     for v in x.quadratic_vars:
-                        if id(v) == _id:
-                            _var = v
+                        v = [_v for _v in v if id(_v) == _id]
+                        if v:
+                            _var = v[0]
                             break
                 if _var is not None:
                     logger.error(

--- a/pyomo/repn/plugins/cpxlp.py
+++ b/pyomo/repn/plugins/cpxlp.py
@@ -491,7 +491,7 @@ class ProblemWriter_cpxlp(AbstractProblemWriter):
                             break
                 if _var is not None:
                     logger.error(
-                        "Model contained an expression (%s) that contains "
+                        "Model contains an expression (%s) that contains "
                         "a variable (%s) that is not attached to an active "
                         "block on the submodel being written"
                         % (obj.name, _var.name))

--- a/pyomo/repn/tests/cpxlp/test_cpxlp.py
+++ b/pyomo/repn/tests/cpxlp/test_cpxlp.py
@@ -18,6 +18,7 @@ import random
 from filecmp import cmp
 import pyomo.common.unittest as unittest
 
+from pyomo.common.log import LoggingIntercept
 from pyomo.common.tempfiles import TempfileManager
 from pyomo.environ import (
     ConcreteModel, Var, Constraint, Objective, Block, ComponentMap,
@@ -197,9 +198,15 @@ class TestCPXLP_writer(unittest.TestCase):
 
         baseline_fname, test_fname = self._get_fnames()
         self._cleanup(test_fname)
-        self.assertRaises(
-            KeyError,
-            model.write, test_fname, format='lp')
+        with LoggingIntercept() as LOG:
+            self.assertRaises(
+                KeyError,
+                model.write, test_fname, format='lp')
+        self.assertEqual(
+            LOG.getvalue().replace('\n', ' ').strip(),
+            'Model contained expression (c) that contains a variable '
+            '(a) that is not attached to an active block on the '
+            'submodel being solved')
         self._cleanup(test_fname)
 
     def test_var_on_deactivated_block(self):

--- a/pyomo/repn/tests/cpxlp/test_cpxlp.py
+++ b/pyomo/repn/tests/cpxlp/test_cpxlp.py
@@ -204,7 +204,7 @@ class TestCPXLP_writer(unittest.TestCase):
                 model.write, test_fname, format='lp')
         self.assertEqual(
             LOG.getvalue().replace('\n', ' ').strip(),
-            'Model contained an expression (c) that contains a variable '
+            'Model contains an expression (c) that contains a variable '
             '(a) that is not attached to an active block on the '
             'submodel being written')
         self._cleanup(test_fname)

--- a/pyomo/repn/tests/cpxlp/test_cpxlp.py
+++ b/pyomo/repn/tests/cpxlp/test_cpxlp.py
@@ -204,9 +204,9 @@ class TestCPXLP_writer(unittest.TestCase):
                 model.write, test_fname, format='lp')
         self.assertEqual(
             LOG.getvalue().replace('\n', ' ').strip(),
-            'Model contained expression (c) that contains a variable '
+            'Model contained an expression (c) that contains a variable '
             '(a) that is not attached to an active block on the '
-            'submodel being solved')
+            'submodel being written')
         self._cleanup(test_fname)
 
     def test_var_on_deactivated_block(self):

--- a/pyomo/repn/tests/cpxlp/test_cpxlp.py
+++ b/pyomo/repn/tests/cpxlp/test_cpxlp.py
@@ -188,16 +188,32 @@ class TestCPXLP_writer(unittest.TestCase):
         return prefix+".lp.baseline", prefix+".lp.out"
 
     def test_var_on_other_model(self):
+        baseline_fname, test_fname = self._get_fnames()
+        self._cleanup(test_fname)
+
         other = ConcreteModel()
         other.a = Var()
 
         model = ConcreteModel()
         model.x = Var()
-        model.c = Constraint(expr=other.a + 2*model.x <= 0)
         model.obj = Objective(expr=model.x)
 
-        baseline_fname, test_fname = self._get_fnames()
+        # Test var in linear expression
+        model.c = Constraint(expr=other.a + 2*model.x <= 0)
+        with LoggingIntercept() as LOG:
+            self.assertRaises(
+                KeyError,
+                model.write, test_fname, format='lp')
+        self.assertEqual(
+            LOG.getvalue().replace('\n', ' ').strip(),
+            'Model contains an expression (c) that contains a variable '
+            '(a) that is not attached to an active block on the '
+            'submodel being written')
         self._cleanup(test_fname)
+
+        # Test var in quadratic expression
+        del model.c
+        model.c = Constraint(expr=other.a * model.x <= 0)
         with LoggingIntercept() as LOG:
             self.assertRaises(
                 KeyError,


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
There has been a longstanding issue where the LP writer generates a very uninformative `KeyError` when writing models (or subblocks) to LP format that contain expressions (Constraints / Objectives) that reference Vars outside the scope of that (sub)model.  While future versions of the LP writer may relax this restriction (see #1032), this PR at least catches the `KeyError` and logs a more useful error.

## Changes proposed in this PR:
- catch `KeyError` in LP writer and log a meaningful message
- update test to verify logged messsage

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
