### PR TITLE
Resolve exception raised by appsi_gurobi during python shutdown

### DIFF
--- a/pyomo/common/__init__.py
+++ b/pyomo/common/__init__.py
@@ -21,7 +21,7 @@ from .fileutils import (
     # The following will be deprecated soon
     register_executable, registered_executable, unregister_executable
 )
-from . import config, dependencies, timing
+from . import config, dependencies, shutdown, timing
 from .deprecation import deprecated
 from .errors import DeveloperError
 from ._command import pyomo_command, get_pyomo_commands

--- a/pyomo/common/shutdown.py
+++ b/pyomo/common/shutdown.py
@@ -1,0 +1,17 @@
+import atexit
+
+def python_is_shutting_down():
+    """Returns `True` if the interpreter is in the process of shutting down.
+
+    This uses a function attribute to flag when the interpreter begins
+    to shut down.  Note that we invert the sense of the flag: that way
+    if the interpreter happens to have already cleared / released the
+    flag and left it `None`, the correct answer is still returned.
+    """
+    return not python_is_shutting_down.isalive
+
+python_is_shutting_down.isalive = [True]
+
+@atexit.register
+def _flag_shutting_down():
+    python_is_shutting_down.isalive.clear()

--- a/pyomo/contrib/appsi/solvers/gurobi.py
+++ b/pyomo/contrib/appsi/solvers/gurobi.py
@@ -7,6 +7,7 @@ from pyomo.common.dependencies import attempt_import
 from pyomo.common.errors import PyomoException
 from pyomo.common.tee import capture_output
 from pyomo.common.timing import HierarchicalTimer
+from pyomo.common.shutdown import python_is_shutting_down
 from pyomo.common.config import ConfigValue
 from pyomo.core.kernel.objective import minimize, maximize
 from pyomo.core.base import SymbolMap, NumericLabeler, TextLabeler
@@ -273,7 +274,8 @@ class Gurobi(PersistentBase, PersistentSolver):
                 gurobipy.disposeDefaultEnv()
 
     def __del__(self):
-        self.release_license()
+        if not python_is_shutting_down():
+            self.release_license()
 
     def version(self):
         version = (gurobipy.GRB.VERSION_MAJOR,


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
#2480 provided a more robust way to release Gurobi licenses from the `appsi_gurobi` solver.  However, this led to issues where Python was raising exceptions during the interpreter shutdown (due to the precarious and inconsistent state in which `__del__` gets called when the interpreter shuts down).

This PR resolves that issue by NOT attempting to explicitly free the Gurobi license during the interpreter shutdown

## Changes proposed in this PR:
- Add `pyomo.common.shutdown.python_is_shutting_down()`
- Bypass call to `release_license()` during python shutdown.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
