### PR TITLE
Fixed examples in working_models.html to Run

### DIFF
--- a/doc/OnlineDocs/tests/scripting/iterative2.py
+++ b/doc/OnlineDocs/tests/scripting/iterative2.py
@@ -14,7 +14,7 @@ model = pyo.AbstractModel()
 model.n = pyo.Param(default=4)
 model.x = pyo.Var(pyo.RangeSet(model.n), within=pyo.Binary)
 def o_rule(model):
-    return summation(model.x)
+    return pyo.summation(model.x)
 model.o = pyo.Objective(rule=o_rule)
 model.c = pyo.ConstraintList()
 

--- a/doc/OnlineDocs/tests/scripting/noiteration1.py
+++ b/doc/OnlineDocs/tests/scripting/noiteration1.py
@@ -14,7 +14,7 @@ model = pyo.ConcreteModel()
 model.n = pyo.Param(default=4)
 model.x = pyo.Var(pyo.RangeSet(model.n), within=pyo.Binary)
 def o_rule(model):
-    return summation(model.x)
+    return pyo.summation(model.x)
 model.o = pyo.Objective(rule=o_rule)
 model.c = pyo.ConstraintList()
 

--- a/doc/OnlineDocs/working_models.rst
+++ b/doc/OnlineDocs/working_models.rst
@@ -340,7 +340,6 @@ of the objective function object. Here is a simple example:
    >>> print ("------------- extend obj --------------") # doctest: +SKIP
    >>> model.obj.expr += 10 * model.y
 
-   >>> opt = SolverFactory('cplex') # doctest: +SKIP
    >>> opt.solve(model) # doctest: +SKIP
    >>> model.pprint() # doctest: +SKIP
 


### PR DESCRIPTION
## Fixes # .
Code examples in docs now run verbatim

## Summary/Motivation:
Two examples from the docs did not run when copy pasted

## Changes proposed in this PR:
In working_models.rst:
 - 'summation' was used instead of 'pyo.summation'
 - An example script instantiated an optimizer twice. First with glpk and then with cplex. Removed the cplex.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
