### PR TITLE
Support cloning individual indexed blocks

### DIFF
--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1329,7 +1329,6 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         # NonNegativeReals, etc) that are not "owned" by any blocks and
         # should be preserved as singletons.
         #
-        save_parent, self._parent = self._parent, None
         try:
             new_block = copy.deepcopy(
                 self, {
@@ -1342,8 +1341,13 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
                     '__block_scope__': {id(self): True, id(None): False},
                     '__paranoid__': True,
                     })
-        finally:
-            self._parent = save_parent
+
+        # We need to "detangle" the new block from the original block
+        # hierarchy
+        if self.parent_component() is self:
+            new_block._parent = None
+        else:
+            new_block._component = None
 
         return new_block
 

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -2070,6 +2070,18 @@ class TestBlock(unittest.TestCase):
         self.assertIs(m.c.parent_component(), m.c)
         self.assertIs(m.c.parent_block(), m)
 
+        m.c1 = Block()
+        m.c1.transfer_attributes_from(m.blk[3].clone())
+
+        self.assertEqual([1, 2, 3], list(m.c1.IDX))
+        self.assertEqual(list(m.blk[3].IDX), list(m.c1.IDX))
+        self.assertIsNot(m.blk[3].IDX, m.c1.IDX)
+        self.assertIsNot(m.blk[3].x, m.c1.x)
+        self.assertIsNot(m.blk[3].IDX, m.c1.x.index_set())
+        self.assertIs(m.c1.IDX, m.c1.x.index_set())
+        self.assertIs(m.c1.parent_component(), m.c1)
+        self.assertIs(m.c1.parent_block(), m)
+
         @m.Block([1,2,3])
         def d(b, i):
             return b.model().blk[i].clone()

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -2053,6 +2053,37 @@ class TestBlock(unittest.TestCase):
             sorted(id(x) for x in (m.x, m.y[1], nb.x, nb.y[1])),
         )
 
+    def test_clone_indexed_subblock(self):
+        m = ConcreteModel()
+        @m.Block([1,2,3])
+        def blk(b, i):
+            b.IDX = RangeSet(i)
+            b.x = Var(b.IDX)
+        m.c = Block(rule=m.blk[2].clone())
+
+        self.assertEqual([1, 2], list(m.c.IDX))
+        self.assertEqual(list(m.blk[2].IDX), list(m.c.IDX))
+        self.assertIsNot(m.blk[2].IDX, m.c.IDX)
+        self.assertIsNot(m.blk[2].x, m.c.x)
+        self.assertIsNot(m.blk[2].IDX, m.c.x.index_set())
+        self.assertIs(m.c.IDX, m.c.x.index_set())
+        self.assertIs(m.c.parent_component(), m.c)
+        self.assertIs(m.c.parent_block(), m)
+
+        @m.Block([1,2,3])
+        def d(b, i):
+            return b.model().blk[i].clone()
+
+        for i in [1, 2, 3]:
+            self.assertEqual(list(range(1, i+1)), list(m.d[i].IDX))
+            self.assertEqual(list(m.blk[i].IDX), list(m.d[i].IDX))
+            self.assertIsNot(m.blk[i].IDX, m.d[i].IDX)
+            self.assertIsNot(m.blk[i].x, m.d[i].x)
+            self.assertIsNot(m.blk[i].IDX, m.d[i].x.index_set())
+            self.assertIs(m.d[i].IDX, m.d[i].x.index_set())
+            self.assertIs(m.d[i].parent_component(), m.d)
+            self.assertIs(m.d[i].parent_block(), m)
+
     def test_clone_unclonable_attribute(self):
         class foo(object):
             def __deepcopy__(bogus):


### PR DESCRIPTION
## Fixes #2008 .

## Summary/Motivation:
This resolves #2008 and allows individual `_BlockData` to be `cloned()`.  Note that the result is itself a `_BlockData` and should not be directly attached to a model.  Instead, the result should be passed to another block initializer / rule.  For example:

```python
m = ConcreteModel()
@m.Block([1,2,3])
def blk(b, i):
    b.IDX = RangeSet(i)
    b.x = Var(b.IDX)

m.c = Block(rule=m.blk[2].clone())

@m.Block([1,2,3])
def d(b, i):
    return b.model().blk[i].clone()
```

## Changes proposed in this PR:
- Resolve exception when cloning individual `_BlockData`
- Add tests for expected behavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
