### PR TITLE
Update PauseGC to work correctly in nested contexts

### DIFF
--- a/pyomo/common/gc_manager.py
+++ b/pyomo/common/gc_manager.py
@@ -33,21 +33,39 @@ import gc
 # if an outer function/method has its own instance of PauseGC.
 class PauseGC(object):
 
-    __slots__ = ("reenable_gc",)
+    __slots__ = ("reenable_gc", "stack_pointer")
+    _stack_depth = 0
 
-    def __init__(self, pause=True):
-        self.reenable_gc = False
-        if pause:
-            self.reenable_gc = gc.isenabled()
-            gc.disable()
+    def __init__(self):
+        self.stack_pointer = None
+        self.reenable_gc = None
 
     def __enter__(self):
+        if self.stack_pointer:
+            raise RuntimeError(
+                "Entering PauseGC context manager that was already entered.")
+        PauseGC._stack_depth += 1
+        self.stack_pointer = PauseGC._stack_depth
+        self.reenable_gc = gc.isenabled()
+        if self.reenable_gc:
+            gc.disable()
         return self
 
     def __exit__(self, type, value, traceback):
         self.close()
 
     def close(self):
+        if not self.stack_pointer:
+            return
+        if self._stack_depth:
+            if self._stack_depth != self.stack_pointer:
+                raise RuntimeError(
+                    "Exiting PauseGC context manager out of order: there "
+                    "are other active PauseGC context managers that were "
+                    "entered after this context manager and have not yet "
+                    "been exited.")
+            PauseGC._stack_depth -= 1
+            self.stack_pointer = None
         if self.reenable_gc:
             gc.enable()
-        self.reenable_gc = False
+        self.reenable_gc = None

--- a/pyomo/common/tests/test_gc.py
+++ b/pyomo/common/tests/test_gc.py
@@ -18,18 +18,55 @@ class TestPauseGC(unittest.TestCase):
     def test_gc_disable(self):
         self.assertTrue(gc.isenabled())
         pgc = PauseGC()
-        self.assertFalse(gc.isenabled())
-        with PauseGC():
-            self.assertFalse(gc.isenabled())
-        self.assertFalse(gc.isenabled())
+        self.assertTrue(gc.isenabled())
+        # pgc hasn't been entered.  Nothing to do
         pgc.close()
         self.assertTrue(gc.isenabled())
 
-        self.assertTrue(gc.isenabled())
-        with PauseGC():
+        with pgc:
             self.assertFalse(gc.isenabled())
-            pgc = PauseGC()
+        self.assertTrue(gc.isenabled())
+
+    def test_gc_early_close(self):
+        pgc = PauseGC()
+        with pgc:
             self.assertFalse(gc.isenabled())
             pgc.close()
+            self.assertTrue(gc.isenabled())
+        self.assertTrue(gc.isenabled())
+
+    def test_gc_nested(self):
+        pgc = PauseGC()
+        with pgc:
+            self.assertFalse(gc.isenabled())
+            with PauseGC():
+                self.assertFalse(gc.isenabled())
+            self.assertFalse(gc.isenabled())
+        self.assertTrue(gc.isenabled())
+
+    def test_gc_errors(self):
+        pgc = PauseGC()
+        self.assertTrue(gc.isenabled())
+
+        with pgc:
+            with self.assertRaisesRegex(
+                    RuntimeError, "Entering PauseGC context manager that "
+                    "was already entered"):
+                with pgc:
+                    pass
+            self.assertFalse(gc.isenabled())
+        self.assertTrue(gc.isenabled())
+
+        with pgc:
+            self.assertFalse(gc.isenabled())
+            with PauseGC():
+                self.assertFalse(gc.isenabled())
+                with self.assertRaisesRegex(
+                        RuntimeError,
+                        "Exiting PauseGC context manager out of order: there "
+                        "are other active PauseGC context managers that were "
+                        "entered after this context manager and have not yet "
+                        "been exited."):
+                    pgc.close()
             self.assertFalse(gc.isenabled())
         self.assertTrue(gc.isenabled())

--- a/pyomo/core/tests/unit/test_symbolic.py
+++ b/pyomo/core/tests/unit/test_symbolic.py
@@ -192,7 +192,11 @@ class SymbolicDerivatives(unittest.TestCase):
 
         e = differentiate(acosh(m.x), wrt=m.x)
         self.assertTrue(e.is_expression_type())
-        self.assertEqual(s(e), s((-1.+m.x**2.)**-.5))
+        # Older versions of sympy:
+        if s(e) == s((-1.+m.x**2.)**-.5):
+            pass
+        else:
+            self.assertEqual(s(e), s((1.+m.x)**-.5)*(-1.+m.x)**-.5))
 
         e = differentiate(atanh(m.x), wrt=m.x)
         self.assertTrue(e.is_expression_type())

--- a/pyomo/core/tests/unit/test_symbolic.py
+++ b/pyomo/core/tests/unit/test_symbolic.py
@@ -196,7 +196,7 @@ class SymbolicDerivatives(unittest.TestCase):
         if s(e) == s((-1.+m.x**2.)**-.5):
             pass
         else:
-            self.assertEqual(s(e), s((1.+m.x)**-.5)*(-1.+m.x)**-.5))
+            self.assertEqual(s(e), s((1.+m.x)**-.5*(-1.+m.x)**-.5))
 
         e = differentiate(atanh(m.x), wrt=m.x)
         self.assertTrue(e.is_expression_type())


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This PR updates the `PauseGC` context manager so that it works correctly in nested contexts.

## Changes proposed in this PR:
- Update `PauseGC` to restore the original state of the garbage collector on context manager exit
- Add a "pseudo stack" for tracking nested instances of the `PauseGC` context manager
- Update tests to verify nested operation

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
