### PR TITLE
Support IndexComponent_slice to ComponentData

### DIFF
--- a/pyomo/core/base/indexed_component_slice.py
+++ b/pyomo/core/base/indexed_component_slice.py
@@ -15,6 +15,7 @@ import itertools
 from pyomo.common import DeveloperError
 from pyomo.common.collections import Sequence
 
+from pyomo.core.base.global_set import UnindexedComponent_index
 
 class IndexedComponent_slice(object):
     """Special class for slicing through hierarchical component trees
@@ -263,11 +264,13 @@ class IndexedComponent_slice(object):
         for level in self._call_stack:
             if level[0] == IndexedComponent_slice.slice_info:
                 ans += level[1][0].name
-                tmp = dict(level[1][1])
-                tmp.update(level[1][2])
-                if level[1][3] is not None:
-                    tmp[level[1][3]] = Ellipsis
-                ans += self._getitem_args_to_str([tmp[i] for i in sorted(tmp)])
+                if level[1][1] is not None:
+                    tmp = dict(level[1][1])
+                    tmp.update(level[1][2])
+                    if level[1][3] is not None:
+                        tmp[level[1][3]] = Ellipsis
+                    ans += self._getitem_args_to_str(
+                        [tmp[i] for i in sorted(tmp)])
             elif level[0] & IndexedComponent_slice.ITEM_MASK:
                 if isinstance(level[1], Sequence):
                     tmp = list(level[1])
@@ -368,9 +371,24 @@ class _slice_generator(object):
         self.ellipsis = ellipsis
         self.iter_over_index = iter_over_index
 
+        # Cache for the most recent index returned. This is used to
+        # iterate over keys of the slice (for instance, in a
+        # _ReferenceDict).
+        self.last_index = ()
+
         self.tuplize_unflattened_index = (
             self.component._implicit_subsets is None
             or len(self.component._implicit_subsets) == 1 )
+
+        if fixed is None and sliced is None and ellipsis is None:
+            # This is a slice rooted at a concrete component.  This is
+            # unusual (i.e., it is generated programmatically and not
+            # through the normal slice/ellipsis notation).  We will mock
+            # up a "generator" so that the slice can be cleanly iterated
+            # over
+            self.explicit_index_count = 0
+            self.component_iter = _NotIterable
+            return
 
         self.explicit_index_count = len(fixed) + len(sliced)
         if iter_over_index and component.index_set().isfinite():
@@ -381,10 +399,6 @@ class _slice_generator(object):
             # The default behavior is to iterate over the component.
             self.component_iter = component.keys()
 
-        # Cache for the most recent index returned. This is used to
-        # iterate over keys of the slice (for instance, in a
-        # _ReferenceDict).
-        self.last_index = None
 
     def next(self):
         """__next__() iterator for Py2 compatibility"""
@@ -395,6 +409,13 @@ class _slice_generator(object):
         # imports.  Ideally, we would move normalize_index to another
         # module to resolve this.
         from .indexed_component import normalize_index
+
+        if self.component_iter is _NotIterable:
+            # Special case handling for "slices" rooted a concrete
+            # components.  We will replace the iterator with an "empty"
+            # iterator so that the next call will raise StopIteration
+            self.component_iter = iter(())
+            return self.component
 
         while 1:
             # Note: running off the end of the underlying iterator will
@@ -855,6 +876,8 @@ class _IndexedComponent_slice_iter(object):
               for x in self._iter_stack if x is not None ),
             ()
         )
+        if not ans:
+            return UnindexedComponent_index
         if len(ans) == 1:
             return ans[0]
         else:

--- a/pyomo/core/base/indexed_component_slice.py
+++ b/pyomo/core/base/indexed_component_slice.py
@@ -411,7 +411,7 @@ class _slice_generator(object):
         from .indexed_component import normalize_index
 
         if self.component_iter is _NotIterable:
-            # Special case handling for "slices" rooted a concrete
+            # Special case handling for "slices" rooted at concrete
             # components.  We will replace the iterator with an "empty"
             # iterator so that the next call will raise StopIteration
             self.component_iter = iter(())

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -17,7 +17,7 @@ from pyomo.common.collections import (
 from pyomo.core.base.set import SetOf, OrderedSetOf, _SetDataBase
 from pyomo.core.base.component import Component, ComponentData
 from pyomo.core.base.global_set import (
-    UnindexedComponent_set, UnindexedComponent_index,
+    UnindexedComponent_set,
 )
 from pyomo.core.base.indexed_component import (
     IndexedComponent, normalize_index,
@@ -30,8 +30,8 @@ from pyomo.common.deprecation import deprecated
 
 _NotSpecified = object()
 
-_UnindexedComponent_key = [UnindexedComponent_index]
-_UnindexedComponent_base_key = (UnindexedComponent_index,)
+_UnindexedComponent_key = list(UnindexedComponent_set)
+_UnindexedComponent_base_key = tuple(UnindexedComponent_set)
 
 class _fill_in_known_wildcards(object):
     """Variant of "six.advance_iterator" that substitutes wildcard values

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -30,6 +30,8 @@ from pyomo.common.deprecation import deprecated
 
 _NotSpecified = object()
 
+_UnindexedComponent_key = [UnindexedComponent_index]
+_UnindexedComponent_base_key = (UnindexedComponent_index,)
 
 class _fill_in_known_wildcards(object):
     """Variant of "six.advance_iterator" that substitutes wildcard values
@@ -162,8 +164,8 @@ class _fill_in_known_wildcards(object):
     def check_complete(self):
         if not self.key:
             return
-        if (self.key == [UnindexedComponent_index] and
-            self.base_key == (UnindexedComponent_index,)):
+        if (self.key == _UnindexedComponent_key and
+            self.base_key == _UnindexedComponent_base_key):
             return
         raise KeyError("Extra (unused) values for slice index %s"
                        % ( self.base_key, ))

--- a/pyomo/core/tests/unit/test_indexed_slice.py
+++ b/pyomo/core/tests/unit/test_indexed_slice.py
@@ -736,5 +736,11 @@ class TestComponentSlices(unittest.TestCase):
                 s, (IndexedComponent_slice.set_attribute, 'bogus', 10))),
             'b[...].bogus = 10')
 
+    def test_slice_to_componentdata(self):
+        m = ConcreteModel()
+        m.x = Var([1,2])
+        i = IndexedComponent_slice(m.x, None, None, None)[2]
+        self.assertEqual(list(i), [m.x[2]])
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/core/tests/unit/test_reference.py
+++ b/pyomo/core/tests/unit/test_reference.py
@@ -460,6 +460,7 @@ class TestReference(unittest.TestCase):
         self.assertIs(m.y.index_set(), m.y_index)
         self.assertIs(type(m.r.index_set()), OrderedSetOf)
         self.assertEqual(len(m.r), 1)
+        self.assertTrue(m.r.is_reference())
         self.assertTrue(m.r.is_indexed())
         self.assertIn(None, m.r)
         self.assertNotIn(1, m.r)
@@ -919,12 +920,15 @@ class TestReference(unittest.TestCase):
 
         m.ref0 = Reference(m.v0)
         m.ref1 = Reference(m.v1)
+        m.ref2 = Reference(m.v1[2])
 
         self.assertFalse(m.v0.is_reference())
         self.assertFalse(m.v1.is_reference())
+        self.assertFalse(m.v1[2].is_reference())
 
         self.assertTrue(m.ref0.is_reference())
         self.assertTrue(m.ref1.is_reference())
+        self.assertTrue(m.ref2.is_reference())
 
         unique_vars = list(
                 v for v in m.component_objects(Var) if not v.is_reference())


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This supports the creation of `IndexedComponent_slice` objects that point to a single object (without any slice or ellipsis).  This supports, e.g. creating a slice to a specific `ComponentData` object.

Using this, the PR simplifies the construction of references to single `ComponentData` objects (this now leverages `IndexedComponent_slice` like other References instead of creating a hidden "floating" Component).

## Changes proposed in this PR:
- Support creating `IndexedComponent_slice` with no Slice / Ellipsis at the initial component
- Update `Reference(ComponentData)` to use `IndexedComponent_slice` objects directly (and not through a hidden floating Component)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
