### PR TITLE
Fix generate_standard_repn: tolerate unexpected NPV expressions

### DIFF
--- a/pyomo/repn/standard_repn.py
+++ b/pyomo/repn/standard_repn.py
@@ -914,7 +914,7 @@ def _collect_standard_repn(exp, multiplier, idMap,
     #
     # Catch any known numeric constants
     #
-    if exp.__class__ in native_numeric_types:
+    if exp.__class__ in native_numeric_types or not exp.is_potentially_variable():
         return _collect_const(exp, multiplier, idMap, compute_values,
                               verbose, quadratic)
     #


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This resolves a bug in `generate_standard_repn` reported by @shermanjasonaf where NPV expressions in unexpected locations would lead to an exception about an "`Unexpected expression (type NPV_...)`".  This was occurring when a user was using an expression replacement visitor to replace a Var with a Param, and the "NPV"ness of the subexpression was not being propagated all the way up the new expression tree.

We might also consider resolving this behavior in the expression replacement visitor, but that does not negate the fact that generate_standard_repn should be more tolerant on the expression trees it handles.

## Changes proposed in this PR:
- Add generic handling of NPV expressions within `_collect_standard_repn`
- Add a test for this situation

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
