### PR TITLE
Fix #2475 - Implement "thread safe" proxies for singleton instances (PauseGC, TempFileManager)

### DIFF
--- a/pyomo/common/gc_manager.py
+++ b/pyomo/common/gc_manager.py
@@ -21,7 +21,6 @@ from pyomo.common.multithread import MultiThreadWrapper
 
 class __PauseGCCompanion(object):
     def __init__(self):
-        self.__slots__ = ("reenable_gc", "stack_pointer")
         self._stack_depth = 0
 
 PauseGCCompanion: __PauseGCCompanion = MultiThreadWrapper(__PauseGCCompanion)
@@ -40,6 +39,7 @@ PauseGCCompanion: __PauseGCCompanion = MultiThreadWrapper(__PauseGCCompanion)
 # safe to nest instances of PauseGC That is, you don't have to worry
 # if an outer function/method has its own instance of PauseGC.
 class PauseGC(object):
+    __slots__ = ("reenable_gc", "stack_pointer")
     def __init__(self):
         self.stack_pointer = None
         self.reenable_gc = None

--- a/pyomo/common/gc_manager.py
+++ b/pyomo/common/gc_manager.py
@@ -17,6 +17,14 @@
 #  ___________________________________________________________________________
 
 import gc
+from pyomo.common.multithread import MultiThreadWrapper
+
+class __PauseGCCompanion(object):
+    def __init__(self):
+        self.__slots__ = ("reenable_gc", "stack_pointer")
+        self._stack_depth = 0
+
+PauseGCCompanion: __PauseGCCompanion = MultiThreadWrapper(__PauseGCCompanion)
 
 # PauseGC is a class for clean, scoped management of the Python
 # garbage collector.  To disable the GC for the duration of a
@@ -32,10 +40,6 @@ import gc
 # safe to nest instances of PauseGC That is, you don't have to worry
 # if an outer function/method has its own instance of PauseGC.
 class PauseGC(object):
-
-    __slots__ = ("reenable_gc", "stack_pointer")
-    _stack_depth = 0
-
     def __init__(self):
         self.stack_pointer = None
         self.reenable_gc = None
@@ -44,8 +48,8 @@ class PauseGC(object):
         if self.stack_pointer:
             raise RuntimeError(
                 "Entering PauseGC context manager that was already entered.")
-        PauseGC._stack_depth += 1
-        self.stack_pointer = PauseGC._stack_depth
+        PauseGCCompanion._stack_depth += 1
+        self.stack_pointer = PauseGCCompanion._stack_depth
         self.reenable_gc = gc.isenabled()
         if self.reenable_gc:
             gc.disable()
@@ -57,14 +61,14 @@ class PauseGC(object):
     def close(self):
         if not self.stack_pointer:
             return
-        if self._stack_depth:
-            if self._stack_depth != self.stack_pointer:
+        if PauseGCCompanion._stack_depth:
+            if PauseGCCompanion._stack_depth != self.stack_pointer:
                 raise RuntimeError(
                     "Exiting PauseGC context manager out of order: there "
                     "are other active PauseGC context managers that were "
                     "entered after this context manager and have not yet "
                     "been exited.")
-            PauseGC._stack_depth -= 1
+            PauseGCCompanion._stack_depth -= 1
             self.stack_pointer = None
         if self.reenable_gc:
             gc.enable()

--- a/pyomo/common/multithread.py
+++ b/pyomo/common/multithread.py
@@ -3,6 +3,16 @@ from threading import get_ident, current_thread, main_thread
 
 
 class MultiThreadWrapper():
+    """A python object proxy that wraps different instances for each thread.
+
+    This is useful for handling thread-safe access to singleton objects without
+    having to refactor the code that depends on them.
+
+    Note that instances of the wrapped object are reused if two threads share the same
+    identifier, because identifiers could be reused and are unique only for any given moment.
+    See [get_ident()](https://docs.python.org/3/library/threading.html#threading.get_ident) for more information.
+    """
+
     def __init__(self, base):
         self.__mtdict = defaultdict(base)
 
@@ -27,6 +37,13 @@ class MultiThreadWrapper():
 
 
 class MultiThreadWrapperWithMain(MultiThreadWrapper):
+    """An extension of `MultiThreadWrapper` that exposes the wrapped instance
+    corresponding to the [main_thread()](https://docs.python.org/3/library/threading.html#threading.main_thread)
+    under the `.main_thread` field.
+
+    This is useful for a falling back to a main instance when needed, but results
+    in race conditions if used improperly.
+    """
     def __init__(self, base):
         super().__init__(base)
         self.main_thread = base()

--- a/pyomo/common/multithread.py
+++ b/pyomo/common/multithread.py
@@ -1,0 +1,14 @@
+from collections import defaultdict
+from threading import get_ident
+
+
+class MultiThreadWrapper(object):
+    def __init__(self, base):
+        self.__mtdict = defaultdict(base)
+
+    def __getattr__(self, attr):
+        try:
+            return super(MultiThreadWrapper, self).__getattr__(attr)
+        except AttributeError:
+            id = get_ident()
+            return getattr(self.__mtdict[id], attr)

--- a/pyomo/common/multithread.py
+++ b/pyomo/common/multithread.py
@@ -39,6 +39,8 @@ class MultiThreadWrapper():
     def __str__(self):
         return self.mtdict[get_ident()].__str__()
 
+    def __new__(cls, wrapped):
+        return super().__new__(type('MultiThreadMeta' + wrapped.__name__, (cls,), {'__doc__': wrapped.__doc__}))
 
 
 class MultiThreadWrapperWithMain(MultiThreadWrapper):
@@ -49,6 +51,7 @@ class MultiThreadWrapperWithMain(MultiThreadWrapper):
     This is useful for a falling back to a main instance when needed, but results
     in race conditions if used improperly.
     """
+
     def __init__(self, base):
         super().__init__(base)
 

--- a/pyomo/common/multithread.py
+++ b/pyomo/common/multithread.py
@@ -13,31 +13,31 @@ class MultiThreadWrapper():
     See [get_ident()](https://docs.python.org/3/library/threading.html#threading.get_ident) for more information.
     """
 
-    __slots__ = 'mtdict'
+    __slots__ = '_mtdict'
 
     def __init__(self, base):
-        object.__setattr__(self, 'mtdict', defaultdict(base))
+        object.__setattr__(self, '_mtdict', defaultdict(base))
 
     def __getattr__(self, attr):
-        return getattr(self.mtdict[get_ident()], attr)
+        return getattr(self._mtdict[get_ident()], attr)
     
     def __setattr__(self, attr, value):
-        setattr(self.mtdict[get_ident()], attr, value)
+        setattr(self._mtdict[get_ident()], attr, value)
     
     def __delattr__(self, attr):
-        delattr(self.mtdict[get_ident()], attr)
+        delattr(self._mtdict[get_ident()], attr)
     
     def __enter__(self):
-        return self.mtdict[get_ident()].__enter__()
+        return self._mtdict[get_ident()].__enter__()
     
     def __exit__(self, exc_type, exc_value, traceback):
-        return self.mtdict[get_ident()].__exit__(exc_type, exc_value, traceback)
+        return self._mtdict[get_ident()].__exit__(exc_type, exc_value, traceback)
     
     def __dir__(self):
-        return list(object.__dir__(self)) + list(self.mtdict[get_ident()].__dir__())
+        return list(object.__dir__(self)) + list(self._mtdict[get_ident()].__dir__())
     
     def __str__(self):
-        return self.mtdict[get_ident()].__str__()
+        return self._mtdict[get_ident()].__str__()
 
     def __new__(cls, wrapped):
         return super().__new__(type('MultiThreadMeta' + wrapped.__name__, (cls,), {'__doc__': wrapped.__doc__}))
@@ -57,7 +57,7 @@ class MultiThreadWrapperWithMain(MultiThreadWrapper):
 
     def __getattr__(self, attr):
         if attr == 'main_thread':
-            return self.mtdict[main_thread().ident]
+            return self._mtdict[main_thread().ident]
         return super().__getattr__(attr)
 
     def __setattr__(self, attr, value):

--- a/pyomo/common/multithread.py
+++ b/pyomo/common/multithread.py
@@ -29,29 +29,29 @@ class MultiThreadWrapper():
 class MultiThreadWrapperWithMain(MultiThreadWrapper):
     def __init__(self, base):
         super().__init__(base)
-        self.main = base()
+        self.main_thread = base()
 
     def __getattr__(self, attr):
         if current_thread() is main_thread():
-            return getattr(self.main, attr)
+            return getattr(self.main_thread, attr)
         return super().__getattr__(attr)
     
     def __setattr__(self, attr, value):
         if attr == '_MultiThreadWrapper__mtdict':
             super().__setattr__(attr, value)
-        elif attr == 'main':
+        elif attr == 'main_thread':
             object.__setattr__(self, attr, value)
         elif current_thread() is main_thread():
-            setattr(self.main, attr, value)
+            setattr(self.main_thread, attr, value)
         else:
             super().__setattr__(attr, value)
     
     def __enter__(self):
         if current_thread() is main_thread():
-            return self.main.__enter__()
+            return self.main_thread.__enter__()
         return super().__enter__()
     
     def __exit__(self, exc_type, exc_value, traceback):
         if current_thread() is main_thread():
-            return self.main.__exit__(exc_type, exc_value, traceback)
+            return self.main_thread.__exit__(exc_type, exc_value, traceback)
         return super().__exit__(exc_type, exc_value, traceback)

--- a/pyomo/common/multithread.py
+++ b/pyomo/common/multithread.py
@@ -2,16 +2,13 @@ from collections import defaultdict
 from threading import get_ident, current_thread, main_thread
 
 
-class MultiThreadWrapper(object):
+class MultiThreadWrapper():
     def __init__(self, base):
         self.__mtdict = defaultdict(base)
 
     def __getattr__(self, attr):
-        try:
-            return super(MultiThreadWrapper, self).__getattr__(attr)
-        except AttributeError:
-            id = get_ident()
-            return getattr(self.__mtdict[id], attr)
+        id = get_ident()
+        return getattr(self.__mtdict[id], attr)
 
 
 class MultiThreadWrapperWithMain(MultiThreadWrapper):

--- a/pyomo/common/multithread.py
+++ b/pyomo/common/multithread.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from threading import get_ident
+from threading import get_ident, current_thread, main_thread
 
 
 class MultiThreadWrapper(object):
@@ -12,3 +12,14 @@ class MultiThreadWrapper(object):
         except AttributeError:
             id = get_ident()
             return getattr(self.__mtdict[id], attr)
+
+
+class MultiThreadWrapperWithMain(MultiThreadWrapper):
+    def __init__(self, base):
+        super().__init__(base)
+        self.main = base()
+
+    def __getattr__(self, attr):
+        if current_thread() is main_thread():
+            return getattr(self.main, attr)
+        return super().__getattr__(attr)

--- a/pyomo/common/multithread.py
+++ b/pyomo/common/multithread.py
@@ -16,6 +16,14 @@ class MultiThreadWrapper():
         else:
             id = get_ident()
             setattr(self.__mtdict[id], attr, value)
+    
+    def __enter__(self):
+        id = get_ident()
+        return self.__mtdict[id].__enter__()
+    
+    def __exit__(self, exc_type, exc_value, traceback):
+        id = get_ident()
+        return self.__mtdict[id].__exit__(exc_type, exc_value, traceback)
 
 
 class MultiThreadWrapperWithMain(MultiThreadWrapper):
@@ -37,3 +45,13 @@ class MultiThreadWrapperWithMain(MultiThreadWrapper):
             setattr(self.main, attr, value)
         else:
             super().__setattr__(attr, value)
+    
+    def __enter__(self):
+        if current_thread() is main_thread():
+            return self.main.__enter__()
+        return super().__enter__()
+    
+    def __exit__(self, exc_type, exc_value, traceback):
+        if current_thread() is main_thread():
+            return self.main.__exit__(exc_type, exc_value, traceback)
+        return super().__exit__(exc_type, exc_value, traceback)

--- a/pyomo/common/multithread.py
+++ b/pyomo/common/multithread.py
@@ -17,23 +17,19 @@ class MultiThreadWrapper():
         self.__mtdict = defaultdict(base)
 
     def __getattr__(self, attr):
-        id = get_ident()
-        return getattr(self.__mtdict[id], attr)
+        return getattr(self.__mtdict[get_ident()], attr)
     
     def __setattr__(self, attr, value):
         if attr == '_MultiThreadWrapper__mtdict':
             object.__setattr__(self, attr, value)
         else:
-            id = get_ident()
-            setattr(self.__mtdict[id], attr, value)
+            setattr(self.__mtdict[get_ident()], attr, value)
     
     def __enter__(self):
-        id = get_ident()
-        return self.__mtdict[id].__enter__()
+        return self.__mtdict[get_ident()].__enter__()
     
     def __exit__(self, exc_type, exc_value, traceback):
-        id = get_ident()
-        return self.__mtdict[id].__exit__(exc_type, exc_value, traceback)
+        return self.__mtdict[get_ident()].__exit__(exc_type, exc_value, traceback)
 
 
 class MultiThreadWrapperWithMain(MultiThreadWrapper):

--- a/pyomo/common/multithread.py
+++ b/pyomo/common/multithread.py
@@ -14,22 +14,19 @@ class MultiThreadWrapper():
     """
 
     def __init__(self, base):
-        self.__mtdict = defaultdict(base)
+        object.__setattr__(self, 'mtdict', defaultdict(base))
 
     def __getattr__(self, attr):
-        return getattr(self.__mtdict[get_ident()], attr)
+        return getattr(self.mtdict[get_ident()], attr)
     
     def __setattr__(self, attr, value):
-        if attr == '_MultiThreadWrapper__mtdict':
-            object.__setattr__(self, attr, value)
-        else:
-            setattr(self.__mtdict[get_ident()], attr, value)
+        setattr(self.mtdict[get_ident()], attr, value)
     
     def __enter__(self):
-        return self.__mtdict[get_ident()].__enter__()
+        return self.mtdict[get_ident()].__enter__()
     
     def __exit__(self, exc_type, exc_value, traceback):
-        return self.__mtdict[get_ident()].__exit__(exc_type, exc_value, traceback)
+        return self.mtdict[get_ident()].__exit__(exc_type, exc_value, traceback)
 
 
 class MultiThreadWrapperWithMain(MultiThreadWrapper):
@@ -44,10 +41,8 @@ class MultiThreadWrapperWithMain(MultiThreadWrapper):
         super().__init__(base)
 
     def __getattr__(self, attr):
-        if attr == '_MultiThreadWrapperWithMain__mtdict':
-            return object.__getattribute__(self, '_MultiThreadWrapper__mtdict')
-        elif attr == 'main_thread':
-            return self.__mtdict[main_thread().ident]
+        if attr == 'main_thread':
+            return self.mtdict[main_thread().ident]
         return super().__getattr__(attr)
 
     def __setattr__(self, attr, value):

--- a/pyomo/common/multithread.py
+++ b/pyomo/common/multithread.py
@@ -13,6 +13,8 @@ class MultiThreadWrapper():
     See [get_ident()](https://docs.python.org/3/library/threading.html#threading.get_ident) for more information.
     """
 
+    __slots__ = 'mtdict'
+
     def __init__(self, base):
         object.__setattr__(self, 'mtdict', defaultdict(base))
 
@@ -22,11 +24,21 @@ class MultiThreadWrapper():
     def __setattr__(self, attr, value):
         setattr(self.mtdict[get_ident()], attr, value)
     
+    def __delattr__(self, attr):
+        delattr(self.mtdict[get_ident()], attr)
+    
     def __enter__(self):
         return self.mtdict[get_ident()].__enter__()
     
     def __exit__(self, exc_type, exc_value, traceback):
         return self.mtdict[get_ident()].__exit__(exc_type, exc_value, traceback)
+    
+    def __dir__(self):
+        return list(object.__dir__(self)) + list(self.mtdict[get_ident()].__dir__())
+    
+    def __str__(self):
+        return self.mtdict[get_ident()].__str__()
+
 
 
 class MultiThreadWrapperWithMain(MultiThreadWrapper):
@@ -50,3 +62,6 @@ class MultiThreadWrapperWithMain(MultiThreadWrapper):
             raise ValueError('Setting `main_thread` attribute is not allowed')
         else:
             super().__setattr__(attr, value)
+    
+    def __dir__(self):
+        return super().__dir__() + ['main_thread']

--- a/pyomo/common/multithread.py
+++ b/pyomo/common/multithread.py
@@ -9,6 +9,13 @@ class MultiThreadWrapper():
     def __getattr__(self, attr):
         id = get_ident()
         return getattr(self.__mtdict[id], attr)
+    
+    def __setattr__(self, attr, value):
+        if attr == '_MultiThreadWrapper__mtdict':
+            object.__setattr__(self, attr, value)
+        else:
+            id = get_ident()
+            setattr(self.__mtdict[id], attr, value)
 
 
 class MultiThreadWrapperWithMain(MultiThreadWrapper):
@@ -20,3 +27,13 @@ class MultiThreadWrapperWithMain(MultiThreadWrapper):
         if current_thread() is main_thread():
             return getattr(self.main, attr)
         return super().__getattr__(attr)
+    
+    def __setattr__(self, attr, value):
+        if attr == '_MultiThreadWrapper__mtdict':
+            super().__setattr__(attr, value)
+        elif attr == 'main':
+            object.__setattr__(self, attr, value)
+        elif current_thread() is main_thread():
+            setattr(self.main, attr, value)
+        else:
+            super().__setattr__(attr, value)

--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -429,7 +429,7 @@ class TempfileContext:
             return self.tempdir
         elif self.manager().tempdir is not None:
             return self.manager().tempdir
-        elif TempfileManager is not None and TempfileManager.main.tempdir is not None:
+        elif TempfileManager.main.tempdir is not None:
             return TempfileManager.main.tempdir
         elif pyutilib_mngr is not None and pyutilib_mngr.tempdir is not None:
             deprecation_warning(

--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -17,7 +17,6 @@
 #  ___________________________________________________________________________
 
 import os
-import threading
 import time
 import tempfile
 import logging
@@ -25,7 +24,7 @@ import shutil
 import weakref
 from pyomo.common.deprecation import deprecated, deprecation_warning
 from pyomo.common.errors import TempfileContextError
-from pyomo.common.multithread import MultiThreadWrapper
+from pyomo.common.multithread import MultiThreadWrapperWithMain
 try:
     from pyutilib.component.config.tempfiles import (
         TempfileManager as pyutilib_mngr
@@ -472,16 +471,5 @@ class TempfileContext:
             ignore_errors=not deletion_errors_are_fatal)
 
 
-class MultiThreadTempfileManager(MultiThreadWrapper):
-    def __init__(self):
-        super().__init__(TempfileManagerClass)
-        self.main = TempfileManagerClass()
-
-    def __getattr__(self, attr):
-        if threading.current_thread() is threading.main_thread():
-            return getattr(self.main, attr)
-        return super().__getattr__(attr)
-
-
 # The global Pyomo TempfileManager instance
-TempfileManager = MultiThreadTempfileManager()
+TempfileManager = MultiThreadWrapperWithMain(TempfileManagerClass)

--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -472,4 +472,4 @@ class TempfileContext:
 
 
 # The global Pyomo TempfileManager instance
-TempfileManager = MultiThreadWrapperWithMain(TempfileManagerClass)
+TempfileManager: TempfileManagerClass = MultiThreadWrapperWithMain(TempfileManagerClass)

--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -429,8 +429,8 @@ class TempfileContext:
             return self.tempdir
         elif self.manager().tempdir is not None:
             return self.manager().tempdir
-        elif TempfileManager.main.tempdir is not None:
-            return TempfileManager.main.tempdir
+        elif TempfileManager.main_thread.tempdir is not None:
+            return TempfileManager.main_thread.tempdir
         elif pyutilib_mngr is not None and pyutilib_mngr.tempdir is not None:
             deprecation_warning(
                 "The use of the PyUtilib TempfileManager.tempdir "

--- a/pyomo/common/tests/test_multithread.py
+++ b/pyomo/common/tests/test_multithread.py
@@ -87,7 +87,7 @@ class TestMultithreading(unittest.TestCase):
             opt.solve(model) 
 
             # Iterate, adding a cut to exclude the previously found solution
-            for i in range(5):
+            for _ in range(5):
                 expr = 0
                 for j in model.x:
                     if pyo.value(model.x[j]) < 0.5:
@@ -96,7 +96,7 @@ class TestMultithreading(unittest.TestCase):
                         expr += (1 - model.x[j])
                 model.cuts.add( expr >= 1 )
                 results = opt.solve(model)
-                return results
+            return results
 
         tp = ThreadPool(4)
         results = tp.map(test, [model.clone() for i in range(4)])

--- a/pyomo/common/tests/test_multithread.py
+++ b/pyomo/common/tests/test_multithread.py
@@ -9,16 +9,21 @@ class Dummy():
     def __init__(self):
         self.number = 1
         self.rnd = threading.get_ident()
+
     def __str__(self):
         return 'asd'
 
+
 class TestMultithreading(unittest.TestCase):
+
     def test_wrapper_docs(self):
         sut = MultiThreadWrapper(Dummy)
         self.assertEqual(sut.__class__.__doc__, Dummy.__doc__)
+
     def test_wrapper_field(self):
         sut = MultiThreadWrapper(Dummy)
         self.assertEqual(sut.number, 1)
+
     def test_independent_writes(self):
         sut = MultiThreadWrapper(Dummy)
         sut.number = 2
@@ -27,6 +32,7 @@ class TestMultithreading(unittest.TestCase):
         t = Thread(target=thread_func)
         t.start()
         t.join()
+
     def test_independent_writes2(self):
         sut = MultiThreadWrapper(Dummy)
         def thread_func():
@@ -35,6 +41,7 @@ class TestMultithreading(unittest.TestCase):
         t.start()
         t.join()
         self.assertEqual(sut.number, 1)
+
     def test_independent_del(self):
         sut = MultiThreadWrapper(Dummy)
         del sut.number
@@ -43,6 +50,7 @@ class TestMultithreading(unittest.TestCase):
         t = Thread(target=thread_func)
         t.start()
         t.join()
+
     def test_independent_del2(self):
         sut = MultiThreadWrapper(Dummy)
         def thread_func():
@@ -51,10 +59,12 @@ class TestMultithreading(unittest.TestCase):
         t.start()
         t.join()
         self.assertEqual(sut.number, 1)
+
     def test_special_methods(self):
         sut = MultiThreadWrapper(Dummy)
         self.assertTrue(set(Dummy().__dir__()).issubset(set(sut.__dir__())))
         self.assertEqual(str(sut), str(Dummy()))
+
     def test_main(self):
         sut = MultiThreadWrapperWithMain(Dummy)
         self.assertIs(sut.main_thread.rnd, sut.rnd)
@@ -96,10 +106,13 @@ class TestMultithreading(unittest.TestCase):
                         expr += (1 - model.x[j])
                 model.cuts.add( expr >= 1 )
                 results = opt.solve(model)
-            return results
+            return results, [v for v in model.x]
 
         tp = ThreadPool(4)
         results = tp.map(test, [model.clone() for i in range(4)])
         tp.close()
-        for result in results:
+        for result, _ in results:
             self.assertEqual(result.solver.termination_condition, pyo.TerminationCondition.optimal)
+        results = list(results)
+        for _, values in results[1:]:
+            self.assertEqual(values, results[0][1])

--- a/pyomo/common/tests/test_multithread.py
+++ b/pyomo/common/tests/test_multithread.py
@@ -2,6 +2,7 @@ import threading
 import pyomo.common.unittest as unittest
 from pyomo.common.multithread import *
 from threading import Thread
+from pyomo.opt.base.solvers import check_available_solvers
 
 class Dummy():
     """asdfg"""
@@ -66,6 +67,8 @@ class TestMultithreading(unittest.TestCase):
         t.start()
         t.join()
         self.assertEqual(sut.number, 5)
+    
+    @unittest.skipIf(len(check_available_solvers('glpk')) < 1, "glpk solver not available")
     def test_solve(self):
         # Based on the minimal example in https://github.com/Pyomo/pyomo/issues/2475
         import pyomo.environ as pyo

--- a/pyomo/common/tests/test_multithread.py
+++ b/pyomo/common/tests/test_multithread.py
@@ -1,0 +1,98 @@
+from random import random
+import pyomo.common.unittest as unittest
+from pyomo.common.multithread import *
+from threading import Thread
+
+class Dummy():
+    """asdfg"""
+    def __init__(self):
+        self.id = 1
+        self.rnd = random()
+    def __str__(self):
+        return 'asd'
+
+class TestMultithreading(unittest.TestCase):
+    def test_wrapper_docs(self):
+        sut = MultiThreadWrapper(Dummy)
+        self.assertEqual(sut.__class__.__doc__, Dummy.__doc__)
+    def test_wrapper_field(self):
+        sut = MultiThreadWrapper(Dummy)
+        self.assertEqual(sut.id, 1)
+    def test_independent_writes(self):
+        sut = MultiThreadWrapper(Dummy)
+        sut.id = 2
+        def thread_func():
+            self.assertEqual(sut.id, 1)
+        t = Thread(target=thread_func)
+        t.start()
+        t.join()
+    def test_independent_writes2(self):
+        sut = MultiThreadWrapper(Dummy)
+        def thread_func():
+            sut.id = 2
+        t = Thread(target=thread_func)
+        t.start()
+        t.join()
+        self.assertEqual(sut.id, 1)
+    def test_independent_del(self):
+        sut = MultiThreadWrapper(Dummy)
+        del sut.id
+        def thread_func():
+            self.assertEqual(sut.id, 1)
+        t = Thread(target=thread_func)
+        t.start()
+        t.join()
+    def test_independent_del2(self):
+        sut = MultiThreadWrapper(Dummy)
+        def thread_func():
+            del sut.id
+        t = Thread(target=thread_func)
+        t.start()
+        t.join()
+        self.assertEqual(sut.id, 1)
+    def test_special_methods(self):
+        sut = MultiThreadWrapper(Dummy)
+        self.assertTrue(set(Dummy().__dir__()).issubset(set(sut.__dir__())))
+        self.assertEqual(str(sut), str(Dummy()))
+    def test_main(self):
+        sut = MultiThreadWrapperWithMain(Dummy)
+        self.assertIs(sut.main_thread.rnd, sut.rnd)
+        def thread_func():
+            self.assertIsNot(sut.main_thread.rnd, sut.rnd)
+        t = Thread(target=thread_func)
+        t.start()
+        t.join()
+    def test_solve(self):
+        # Based on the minimal example in https://github.com/Pyomo/pyomo/issues/2475
+        import pyomo.environ as pyo
+        from pyomo.opt import SolverFactory
+        from multiprocessing.dummy import Pool as ThreadPool
+
+        model = pyo.ConcreteModel()
+        model.nVars = pyo.Param(initialize=4)
+        model.N = pyo.RangeSet(model.nVars)
+        model.x = pyo.Var(model.N, within=pyo.Binary)
+        model.obj = pyo.Objective(expr=pyo.summation(model.x))
+        model.cuts = pyo.ConstraintList()
+
+        def test(model):
+            opt = SolverFactory('glpk')
+            opt.solve(model) 
+
+            # Iterate, adding a cut to exclude the previously found solution
+            for i in range(5):
+                expr = 0
+                for j in model.x:
+                    if pyo.value(model.x[j]) < 0.5:
+                        expr += model.x[j]
+                    else:
+                        expr += (1 - model.x[j])
+                model.cuts.add( expr >= 1 )
+                results = opt.solve(model)
+                return results
+
+        tp = ThreadPool(4)
+        results = tp.map(test, [model.clone() for i in range(4)])
+        tp.close()
+        for result in results:
+            self.assertEqual(result.solver.termination_condition, pyo.TerminationCondition.optimal)


### PR DESCRIPTION
# Fixes #2475
# Fixes #1125
## Summary/Motivation:
The purpose is to support thread based parallelism of solve calls in python. This is possible despite the GIL because the solve calls wait for the solver child processes to end, and this is a I/O blocking operation.

In order to avoid major code refactors and problems, I implemented a proxy that turns global instances (aka singletons) into thread-specific objects. For the usual use-case, this change should be almost unnoticeable, while for a multithreaded use of these singletons, now each of them is a different and totally independent instance of the same type for each thread. This avoids race conditions. The idea is inspired by process oriented parallelism, which is already supported with MPI.

## Changes proposed in this PR:
- Added a new file in pyomo.common: multithread.py.  
  This file contains the boilerplate code that is common to all proxies for singletons.
- Replaced these singletons with refactored+proxied versions of themselves:
  - PauseGC class fields, using the Companion pattern
  - TempFileManager
  
The changes pass the tests and should solve the [issue above](https://github.com/Pyomo/pyomo/issues/2475): I tested in local, and I have created unit tests.


As asked in the [issue](https://github.com/Pyomo/pyomo/issues/2475), I implemented a version of the MultiThread proxy that considers the main thread instance of the singleton as special, exposing it in a ".main" field. This could create problems if any proxied class has its own "main" field definition: I'm open for suggestions for an improvement of this, but I think it's an unavoidable issue.

I used type hints for proxied singletons otherwise autocompletion would not work anymore on those.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
