### PR TITLE
Modify PyROS Subproblem Initialization and Solver Call Routines

### DIFF
--- a/pyomo/contrib/pyros/CHANGELOG.txt
+++ b/pyomo/contrib/pyros/CHANGELOG.txt
@@ -2,6 +2,18 @@
 PyROS CHANGELOG
 ===============
 
+-------------------------------------------------------------------------------
+PyROS 1.2.0    09 Sep 2022
+-------------------------------------------------------------------------------
+- Ensure master feasibility problems initialized to a feasible point.
+- Initialize master problems to master feasibility solution (if solved
+  successfully), or to initial point (otherwise)
+- Initialize separation problems to nominal polished master solution (if
+  nominal objective focus), or to solution from most recently added block
+  (if worst case focus).
+- Extend documentation and handling of Exceptions and non-optimal subsolver
+  terminations.
+
 
 -------------------------------------------------------------------------------
 PyROS 1.1.4    27 Jul 2022
@@ -9,10 +21,12 @@ PyROS 1.1.4    27 Jul 2022
 - Ensure `DiscreteScenarioSet` problems terminate successfully if there
   are no remaining scenarios to separate.
 
+
 -------------------------------------------------------------------------------
 PyROS 1.1.3    12 Jul 2022
 -------------------------------------------------------------------------------
 - Avoid master feasibiliity problem unit consistency checks.
+
 
 -------------------------------------------------------------------------------
 PyROS 1.1.2    31 May 2022
@@ -28,7 +42,7 @@ PyROS 1.1.1    25 Apr 2022
 
 
 -------------------------------------------------------------------------------
-PyROS 1.1.0    04 Apr 2021
+PyROS 1.1.0    04 Apr 2022
 -------------------------------------------------------------------------------
 - Change master feasibility problem formulation, initialization, and scaling
 

--- a/pyomo/contrib/pyros/master_problem_methods.py
+++ b/pyomo/contrib/pyros/master_problem_methods.py
@@ -512,7 +512,7 @@ def solver_call_master(model_data, config, solver, solve_data):
 
     higher_order_decision_rule_efficiency(config, model_data)
 
-    for idx, opt in enumerate(backup_solvers):
+    for opt in backup_solvers:
         try:
             results = opt.solve(
                 nlp_model,

--- a/pyomo/contrib/pyros/master_problem_methods.py
+++ b/pyomo/contrib/pyros/master_problem_methods.py
@@ -443,7 +443,7 @@ def minimize_dr_vars(model_data, config):
         )
         for master_dr, polish_dr in dr_var_zip:
             for mvar, pvar in zip(master_dr.values(), polish_dr.values()):
-                mvar.set_value(value(pvar))
+                mvar.set_value(value(pvar), skip_validation=True)
 
     return results
 

--- a/pyomo/contrib/pyros/master_problem_methods.py
+++ b/pyomo/contrib/pyros/master_problem_methods.py
@@ -234,7 +234,10 @@ def solve_master_feasibility_problem(model_data, config):
         )
         raise
 
-    if check_optimal_termination(results):
+    feasible_terminations = {
+        tc.optimal, tc.locallyOptimal, tc.globallyOptimal, tc.feasible
+    }
+    if results.solver.termination_condition in feasible_terminations:
         model.solutions.load_from(results)
 
     # load master feasibility point to master model

--- a/pyomo/contrib/pyros/master_problem_methods.py
+++ b/pyomo/contrib/pyros/master_problem_methods.py
@@ -145,7 +145,7 @@ def construct_master_feasibility_problem(model_data, config):
 
     # retain original constraint exprs (for slack initialization and scaling)
     pre_slack_con_exprs = ComponentMap(
-        [(con, con.body - con.upper) for con in targets]
+        (con, con.body - con.upper) for con in targets
     )
 
     # add slack variables and objective

--- a/pyomo/contrib/pyros/master_problem_methods.py
+++ b/pyomo/contrib/pyros/master_problem_methods.py
@@ -144,7 +144,9 @@ def construct_master_feasibility_problem(model_data, config):
             if con not in dr_eqs])
 
     # retain original constraint exprs (for slack initialization and scaling)
-    pre_slack_con_exprs = ComponentMap([(con, con.body) for con in targets])
+    pre_slack_con_exprs = ComponentMap(
+        [(con, con.body - con.upper) for con in targets]
+    )
 
     # add slack variables and objective
     # inequalities g(v) <= b become g(v) -- s^-<= b

--- a/pyomo/contrib/pyros/pyros.py
+++ b/pyomo/contrib/pyros/pyros.py
@@ -45,7 +45,9 @@ from pyomo.contrib.pyros.pyros_algorithm_methods import ROSolver_iterative_solve
 from pyomo.contrib.pyros.uncertainty_sets import uncertainty_sets
 from pyomo.core.base import Constraint
 
-__version__ =  "1.1.4"
+
+__version__ = "1.2.0"
+
 
 def NonNegIntOrMinusOne(obj):
     '''

--- a/pyomo/contrib/pyros/separation_problem_methods.py
+++ b/pyomo/contrib/pyros/separation_problem_methods.py
@@ -19,6 +19,7 @@ from pyomo.core.expr.current import (replace_expressions,
 from pyomo.contrib.pyros.util import get_main_elapsed_time, is_certain_parameter
 from pyomo.contrib.pyros.uncertainty_sets import Geometry
 from pyomo.common.errors import ApplicationError
+from pyomo.contrib.pyros.util import ABS_CON_CHECK_FEAS_TOL
 import os
 from copy import deepcopy
 
@@ -507,8 +508,12 @@ def initialize_separation(model_data, config):
     # check: initial point feasible?
     for con in sep_model.component_data_objects(Constraint, active=True):
         lb, val, ub = value(con.lb), value(con.body), value(con.ub)
-        lb_viol = val < lb - 1e-5 if lb is not None else False
-        ub_viol = val > ub + 1e-5 if ub is not None else False
+        lb_viol = (
+            val < lb - ABS_CON_CHECK_FEAS_TOL if lb is not None else False
+        )
+        ub_viol = (
+            val > ub + ABS_CON_CHECK_FEAS_TOL if ub is not None else False
+        )
         if lb_viol or ub_viol:
             config.progress_logger.debug(con.name, lb, val, ub)
 

--- a/pyomo/contrib/pyros/separation_problem_methods.py
+++ b/pyomo/contrib/pyros/separation_problem_methods.py
@@ -586,6 +586,7 @@ def solver_call_separation(model_data, config, solver, solve_data, is_global):
         elapsed = get_main_elapsed_time(model_data.timing)
         if config.time_limit:
             if elapsed >= config.time_limit:
+                solve_data.found_violation = False
                 return True
 
         # if separation problem solved to optimality, record results

--- a/pyomo/contrib/pyros/separation_problem_methods.py
+++ b/pyomo/contrib/pyros/separation_problem_methods.py
@@ -517,8 +517,8 @@ def solver_call_separation(model_data, config, solver, solve_data, is_global):
     -------
     : bool
         True if separation problem was not solved to an appropriate
-        optimality status and the time limit is not exceeded,
-        False otherwise.
+        optimality status by any of the solvers available or the
+        PyROS elapsed time limit is exceeded, False otherwise.
     """
     if is_global:
         backup_solvers = deepcopy(config.backup_global_solvers)

--- a/pyomo/contrib/pyros/separation_problem_methods.py
+++ b/pyomo/contrib/pyros/separation_problem_methods.py
@@ -577,7 +577,8 @@ def solver_call_separation(model_data, config, solver, solve_data, is_global):
     # All subordinate solvers failed to optimize model to appropriate
     # termination condition. PyROS will terminate with subsolver
     # error. At this point, export model if desired
-    if (save_dir := config.subproblem_file_directory) and config.keepfiles:
+    save_dir = config.subproblem_file_directory
+    if save_dir and config.keepfiles:
         objective = str(
             list(nlp_model.component_data_objects(Objective, active=True))[0].name
         )

--- a/pyomo/contrib/pyros/tests/test_grcs.py
+++ b/pyomo/contrib/pyros/tests/test_grcs.py
@@ -2129,6 +2129,8 @@ class RegressionTest(unittest.TestCase):
         self.assertEqual(results.pyros_termination_condition, pyrosTerminationCondition.time_out,
                          msg="Returned termination condition is not return time_out.")
 
+    @unittest.skipUnless(SolverFactory('baron').license_is_valid(),
+                         "Global NLP solver is not available and licensed.")
     def test_terminate_with_application_error(self):
         """
         Check that PyROS correctly raises ApplicationError

--- a/pyomo/contrib/pyros/tests/test_grcs.py
+++ b/pyomo/contrib/pyros/tests/test_grcs.py
@@ -2153,13 +2153,13 @@ class RegressionTest(unittest.TestCase):
                 r"Solver \(ipopt\) did not exit normally",
                 ):
             pyros_solver.solve(
-                m,
-                [m.x1],
-                [],
-                [m.p],
-                box_set,
-                solver,
-                baron,
+                model=m,
+                first_stage_variables=[m.x1],
+                second_stage_variables=[],
+                uncertain_params=[m.p],
+                uncertainty_set=box_set,
+                local_solver=solver,
+                global_solver=baron,
                 objective_focus=ObjectiveType.nominal,
             )
 

--- a/pyomo/contrib/pyros/tests/test_grcs.py
+++ b/pyomo/contrib/pyros/tests/test_grcs.py
@@ -1980,6 +1980,7 @@ class RegressionTest(unittest.TestCase):
         config.global_solver = SolverFactory('baron')
         config.uncertain_params = m.working_model.util.uncertain_params
         config.tee = False
+        config.solve_master_globally = True
 
         add_decision_rule_variables(model_data=m, config=config)
         add_decision_rule_constraints(model_data=m, config=config)

--- a/pyomo/contrib/pyros/util.py
+++ b/pyomo/contrib/pyros/util.py
@@ -27,11 +27,14 @@ import logging
 from pprint import pprint
 import math
 
+
 # Tolerances used in the code
 PARAM_IS_CERTAIN_REL_TOL = 1e-4
 PARAM_IS_CERTAIN_ABS_TOL = 0
 COEFF_MATCH_REL_TOL = 1e-6
 COEFF_MATCH_ABS_TOL = 0
+ABS_CON_CHECK_FEAS_TOL = 1e-5
+
 
 '''Code borrowed from gdpopt: time_code, get_main_ellapsed_time, a_logger.'''
 @contextmanager


### PR DESCRIPTION
## Summary/Motivation:
Modify subproblem initialization and solver call routines such that:
- subproblem models are initialized to a feasible point, where possible
- non-optimal or exceptional solver termination statuses are handled more gracefully
- solutions returned by the appropriate solver(s) are properly loaded to the appropriate model(s) where appropriate.

## Changes proposed in this PR:
**General**
- More comprehensive documentation for all subproblem solver call routines
- alter exception handling for subordinate optimizer `solve()` calls

**Master Feasibility Problem**
- ensure initialized to feasible point
- if solver does not succesfully converge to at least a feasible solution, load the initial point to the master model

**Master Problem**
- ensure initial point provided to each backup solver (if used) is the same, and not the final iterate returned by the previous backup solver

**DR Polishing Problem**
- use local subsolver if `solve_master_globally=False`, and global subsolver otherwise.
- load second-stage variable and state variable values from polished DR problem (to ensure polished master solution is feasible for the master model, and separation problems may therefore be initialized to a feasible point).
- ensure polished DR solution is loaded in event of `globallyOptimal` solver termination (resolve bug)

**Separation Problem**
- initialize to feasible point from either the nominal or most recently added master block (depending on the objective focus)
- ensure initial point provided to each backup solver (if used) is the same, and not final iterate returned by previous backup solver
- check for PyROS timeout before checking for optimality

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
