### PR TITLE
Performance: GDPTree use OrderedSet instead of list

### DIFF
--- a/pyomo/common/collections/orderedset.py
+++ b/pyomo/common/collections/orderedset.py
@@ -17,9 +17,16 @@ class OrderedSet(MutableSet):
     __slots__ = ('_dict')
 
     def __init__(self, iterable=None):
+        # TODO: Starting in Python 3.7, dict is ordered (and is faster
+        # than OrderedDict).  dict began supporting reversed() in 3.8.
+        # We should consider changing the underlying data type here fro
+        # mOrderedDict to dict.
         self._dict = OrderedDict()
         if iterable is not None:
-            self.update(iterable)
+            if iterable.__class__ is OrderedSet:
+                self._dict.update(iterable._dict)
+            else:
+                self.update(iterable)
 
     def __str__(self):
         """String representation of the mapping."""
@@ -55,8 +62,7 @@ class OrderedSet(MutableSet):
 
     def add(self, val):
         """Add an element."""
-        if val not in self._dict:
-            self._dict[val] = None
+        self._dict[val] = None
 
     def discard(self, val):
         """Remove an element. Do not raise an exception if absent."""
@@ -77,10 +83,18 @@ class OrderedSet(MutableSet):
         del self._dict[val]
 
     def intersection(self, other):
-        res = OrderedSet([i for i in self if i in other])
+        other = set(other)
+        res = OrderedSet(filter(other.__contains__, self))
         return res
 
     def union(self, other):
         res = OrderedSet(self)
         res.update(other)
         return res
+
+    #
+    # Not strictly part of MutableSet, but it makes sense that OrderedSet
+    # should be reversible
+    #
+    def __reversed__(self):
+        return reversed(self._dict)

--- a/pyomo/common/collections/orderedset.py
+++ b/pyomo/common/collections/orderedset.py
@@ -19,8 +19,8 @@ class OrderedSet(MutableSet):
     def __init__(self, iterable=None):
         # TODO: Starting in Python 3.7, dict is ordered (and is faster
         # than OrderedDict).  dict began supporting reversed() in 3.8.
-        # We should consider changing the underlying data type here fro
-        # mOrderedDict to dict.
+        # We should consider changing the underlying data type here from
+        # OrderedDict to dict.
         self._dict = OrderedDict()
         if iterable is not None:
             if iterable.__class__ is OrderedSet:

--- a/pyomo/common/tests/test_orderedset.py
+++ b/pyomo/common/tests/test_orderedset.py
@@ -85,3 +85,8 @@ class testOrderedSet(unittest.TestCase):
         self.assertEqual(list(c), [3, 'c'])
         self.assertEqual(list(a), [1, 2, 3, 'a', 'b', 'c'])
         self.assertEqual(list(b), [3, 4, 'c', 'd'])
+
+    def test_reversed(self):
+        a = OrderedSet([1,5,3])
+        self.assertEqual(list(a), [1, 5, 3])
+        self.assertEqual(list(reversed(a)), [3, 5, 1])

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -139,6 +139,8 @@ class GDPTree:
         return self._topological_sort()
 
     def in_degree(self, u):
+        if u not in self._in_degrees:
+            return 0
         return self._in_degrees[u]
 
 def _parent_disjunct(obj):

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -17,7 +17,7 @@ from pyomo.core.base.component import _ComponentBase
 from pyomo.core import (
     Block, TraversalStrategy, SortComponents, LogicalConstraint)
 from pyomo.core.base.block import _BlockData
-from pyomo.common.collections import ComponentMap, ComponentSet
+from pyomo.common.collections import ComponentMap, ComponentSet, OrderedSet
 from pyomo.opt import TerminationCondition, SolverStatus
 
 from weakref import ref as weakref_ref
@@ -85,34 +85,34 @@ def clone_without_expression_components(expr, substitute=None):
                                                 remove_named_expressions=True)
     return visitor.walk_expression(expr)
 
+
 class GDPTree:
     def __init__(self):
         self._adjacency_list = {}
-        self._in_degrees = defaultdict(lambda: 0)
+        self._in_degrees = {}
         # This needs to be ordered so that topological sort is deterministic
-        self._vertices = []
+        self._vertices = OrderedSet()
 
     @property
     def vertices(self):
         return self._vertices
 
     def add_node(self, u):
-        if u not in self._vertices:
-            self._vertices.append(u)
+        self._vertices.add(u)
 
     def _update_in_degree(self, v):
-        self._in_degrees[v] += 1
+        if v not in self._in_degrees:
+            self._in_degrees[v] = 1
+        else:
+            self._in_degrees[v] += 1
 
     def add_edge(self, u, v):
-        if u in self._adjacency_list:
-            self._adjacency_list[u].append(v)
-        else:
-            self._adjacency_list[u] = [v]
+        if u not in self._adjacency_list:
+            self._adjacency_list[u] = OrderedSet()
+        self._adjacency_list[u].add(v)
         self._update_in_degree(v)
-        if u not in self._vertices:
-            self._vertices.append(u)
-        if v not in self._vertices:
-            self._vertices.append(v)
+        self._vertices.add(u)
+        self._vertices.add(v)
 
     def _visit_vertex(self, u, leaf_to_root):
         if u in self._adjacency_list:
@@ -120,12 +120,12 @@ class GDPTree:
                 if v not in leaf_to_root:
                     self._visit_vertex(v, leaf_to_root)
         # we're done--we've been to all its children
-        leaf_to_root.append(u)
+        leaf_to_root.add(u)
 
     def _topological_sort(self):
         # this is reverse of the list we should return (but happens to be what
         # we want for hull and bigm)
-        leaf_to_root = []
+        leaf_to_root = OrderedSet()
         for u in self.vertices:
             if u not in leaf_to_root:
                 self._visit_vertex(u, leaf_to_root)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This resolves a significant performance degradation from the GDP rework.  The GDPTree class (for resolving the order in which disjuncts needed to be processed) used lists internally to ensure determinism.  However, searching for memberships in lists (for deduplication) is O(n).  This PR switched the internal data structures to use `OrderedSet`, reducing membership checks to O(1) without affecting determinish.

## Changes proposed in this PR:
- Switch GDPtree to use `OrderedSet` instead of `list` internally

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
