### PR TITLE
Bugfix: ConstructionTimer for component indexed by nonfinite set

### DIFF
--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -23,7 +23,7 @@ from pyomo.common.timing import (
     ConstructionTimer, TransformationTimer, report_timing,
     TicTocTimer, HierarchicalTimer,
 )
-from pyomo.environ import ConcreteModel, RangeSet, Var, TransformationFactory
+from pyomo.environ import ConcreteModel, RangeSet, Var, Any, TransformationFactory
 from pyomo.core.base.var import _VarData
 
 class _pseudo_component(Var):
@@ -79,18 +79,12 @@ class TestTiming(unittest.TestCase):
             str(a))
 
     def test_report_timing(self):
-        # Create a set to ensure that the global sets have already been
-        # constructed (this is an issue until the new set system is
-        # merged in and the GlobalSet objects are not automatically
-        # created by pyomo.core
-        m = ConcreteModel()
-        m.x = Var([1,2])
-
         ref = r"""
            (0(\.\d+)?) seconds to construct Block ConcreteModel; 1 index total
            (0(\.\d+)?) seconds to construct RangeSet FiniteScalarRangeSet; 1 index total
            (0(\.\d+)?) seconds to construct Var x; 2 indices total
-           (0(\.\d+)?) seconds to construct Suffix Suffix; 1 index total
+           (0(\.\d+)?) seconds to construct Var y; 0 indices total
+           (0(\.\d+)?) seconds to construct Suffix Suffix
            (0(\.\d+)?) seconds to apply Transformation RelaxIntegerVars \(in-place\)
            """.strip()
 
@@ -102,6 +96,7 @@ class TestTiming(unittest.TestCase):
                 m = ConcreteModel()
                 m.r = RangeSet(2)
                 m.x = Var(m.r)
+                m.y = Var(Any, dense=False)
                 xfrm.apply_to(m)
             result = out.getvalue().strip()
             self.maxDiff = None
@@ -116,6 +111,7 @@ class TestTiming(unittest.TestCase):
             m = ConcreteModel()
             m.r = RangeSet(2)
             m.x = Var(m.r)
+            m.y = Var(Any, dense=False)
             xfrm.apply_to(m)
             result = os.getvalue().strip()
             self.maxDiff = None
@@ -128,6 +124,7 @@ class TestTiming(unittest.TestCase):
             m = ConcreteModel()
             m.r = RangeSet(2)
             m.x = Var(m.r)
+            m.y = Var(Any, dense=False)
             xfrm.apply_to(m)
             result = os.getvalue().strip()
             self.maxDiff = None

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -105,15 +105,23 @@ class ConstructionTimer(object):
 
     def __str__(self):
         try:
-            idx = len(self.obj.index_set())
-            idx_label = f'{idx} indices' if idx != 1 else '1 index'
+            if self.obj.is_indexed():
+                # indexed component
+                if self.obj.index_set().isfinite():
+                    idx = len(self.obj.index_set())
+                else:
+                    idx = len(self.obj)
+                idx_label = f'{idx} indices' if idx != 1 else '1 index'
+            elif hasattr(self.obj, 'index_set'):
+                # scalar indexed components
+                idx = len(self.obj.index_set())
+                idx_label = f'{idx} indices' if idx != 1 else '1 index'
+            else:
+                # other non-indexed component (e.g., Suffix)
+                idx_label = ''
         except AttributeError:
-            # Unindexed component
+            # unknown component
             idx_label = ''
-        except TypeError:
-            # Component indexed by non-finite set
-            idx = len(self.obj)
-            idx_label = f'{idx} indices' if idx != 1 else '1 index'
         if idx_label:
             idx_label = f'; {idx_label} total'
         try:

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -78,7 +78,7 @@ class GeneralTimer(object):
 
 class ConstructionTimer(object):
     __slots__ = ('obj', 'timer')
-    msg = "%6.*f seconds to construct %s %s; %d %s total"
+    msg = "%6.*f seconds to construct %s %s%s"
     in_progress = "ConstructionTimer object for %s %s; %0.3f elapsed seconds"
 
     def __init__(self, obj):
@@ -106,8 +106,16 @@ class ConstructionTimer(object):
     def __str__(self):
         try:
             idx = len(self.obj.index_set())
+            idx_label = f'{idx} indices' if idx != 1 else '1 index'
         except AttributeError:
-            idx = 1
+            # Unindexed component
+            idx_label = ''
+        except TypeError:
+            # Component indexed by non-finite set
+            idx = len(self.obj)
+            idx_label = f'{idx} indices' if idx != 1 else '1 index'
+        if idx_label:
+            idx_label = f'; {idx_label} total'
         try:
             _type = self.obj.ctype.__name__
         except AttributeError:
@@ -120,8 +128,7 @@ class ConstructionTimer(object):
                             total_time,
                             _type,
                             self.name,
-                            idx,
-                            'indices' if idx > 1 else 'index' )
+                            idx_label )
 
 
 class TransformationTimer(object):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This PR resolves an exception generated when `report_timing()` is on for components indexed by non-finite sets.

## Changes proposed in this PR:
- Catch exception when getting the `len()` of a non-finite set
- Fix some grammar issues in the timing message
- Add / update tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
