### PR TITLE
Reduce calls to logical_to_linear transformation in bigm and hull transformations

### DIFF
--- a/pyomo/core/plugins/transform/logical_to_linear.py
+++ b/pyomo/core/plugins/transform/logical_to_linear.py
@@ -120,21 +120,24 @@ class LogicalToLinear(IsomorphicTransformation):
         constraint.deactivate()
 
     def _transform_block(self, target_block, model, new_varlists, transBlocks):
-        for logical_constraint in target_block.component_objects(
-                ctype=LogicalConstraint, active=True, descend_into=Block):
-            self._transform_constraint(logical_constraint, new_varlists,
-                                       transBlocks)
+        _blocks = target_block.values() if target_block.is_indexed() else \
+                  (target_block,)
+        for block in _blocks:
+            for logical_constraint in block.component_objects(
+                    ctype=LogicalConstraint, active=True, descend_into=Block):
+                self._transform_constraint(logical_constraint, new_varlists,
+                                           transBlocks)
 
-        # This can go away when we deprecate this transformation transforming
-        # BooleanVars. This just marks the BooleanVars as "seen" so that if
-        # someone asks for their binary var later, we can create it on the fly
-        # and complain.
-        for bool_vardata in target_block.component_data_objects(
-                BooleanVar, descend_into=Block):
-            if bool_vardata._associated_binary is None:
-                bool_vardata._associated_binary = \
-                        _DeprecatedImplicitAssociatedBinaryVariable(
-                            bool_vardata)
+            # This can go away when we deprecate this transformation
+            # transforming BooleanVars. This just marks the BooleanVars as
+            # "seen" so that if someone asks for their binary var later, we can
+            # create it on the fly and complain.
+            for bool_vardata in block.component_data_objects(
+                    BooleanVar, descend_into=Block):
+                if bool_vardata._associated_binary is None:
+                    bool_vardata._associated_binary = \
+                                _DeprecatedImplicitAssociatedBinaryVariable(
+                                    bool_vardata)
 
     def _transform_constraintData(self, logical_constraint, new_varlists,
                                   transBlocks):

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -30,7 +30,7 @@ from pyomo.core.base import Transformation, TransformationFactory, Reference
 import pyomo.core.expr.current as EXPR
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 from pyomo.gdp.util import (
-    is_child_of, get_src_disjunction, get_src_constraint,
+    is_child_of, get_src_disjunction, get_src_constraint, get_root_blocks,
     get_transformed_constraints, _get_constraint_transBlock, get_src_disjunct,
     _warn_for_active_disjunction, _warn_for_active_disjunct, preprocess_targets,
     _to_dict)
@@ -252,9 +252,17 @@ class BigM_Transformation(Transformation):
         # we need to preprocess targets to make sure that if there are any
         # disjunctions in targets that their disjuncts appear before them in
         # the list.
-        targets = preprocess_targets(targets, instance, knownBlocks)
+        preprocessed_targets = preprocess_targets(targets, instance,
+                                                  knownBlocks)
 
-        for t in targets:
+        # transform any logical constraints that might be anywhere on the stuff
+        # we're about to transform.
+        TransformationFactory('core.logical_to_linear').apply_to(
+            instance,
+            targets=get_root_blocks(targets, instance) +
+            [disj for disj in preprocessed_targets if disj.ctype is Disjunct])
+
+        for t in preprocessed_targets:
             if t.ctype is Disjunction:
                 if t.is_indexed():
                     self._transform_disjunction(t, bigM)
@@ -282,10 +290,6 @@ class BigM_Transformation(Transformation):
                         warning_msg += "\t%s\n" % component
                 logger.warning(warning_msg)
 
-        # at the end, transform any logical constraints that might be on
-        # instance
-        TransformationFactory('core.logical_to_linear').apply_to(instance)
-
     def _add_transformation_block(self, instance):
         # make a transformation block on instance to put transformed disjuncts
         # on
@@ -312,8 +316,6 @@ class BigM_Transformation(Transformation):
                 descend_into=(Block, Disjunct),
                 descent_order=TraversalStrategy.PostfixDFS):
             self._transform_disjunction(disjunction, bigM)
-        # transform any logical constraints
-        TransformationFactory('core.logical_to_linear').apply_to(obj)
 
     def _add_xor_constraint(self, disjunction, transBlock):
         # Put the disjunction constraint on the transformation block and
@@ -503,10 +505,6 @@ class BigM_Transformation(Transformation):
             self._transfer_transBlock_data(transBlock, destinationBlock)
             # we leave the transformation block because it still has the XOR
             # constraints, which we want to be on the parent disjunct.
-
-        # Transform any logical constraints here. We need to do this before we
-        # create the variable references!
-        TransformationFactory('core.logical_to_linear').apply_to(block)
 
         # We don't know where all the BooleanVars are used, so if there are any
         # that the above transformation didn't transform, we need to do it now,

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -22,7 +22,7 @@ from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
 from pyomo.core import (
     Block, BooleanVar, Connector, Constraint, Param, Set, SetOf, Suffix, Var,
     Expression, SortComponents, TraversalStrategy, value, RangeSet,
-    NonNegativeIntegers, LogicalConstraint, Binary, )
+    NonNegativeIntegers, Binary, )
 from pyomo.core.base.boolean_var import (
     _DeprecatedImplicitAssociatedBinaryVariable)
 from pyomo.core.base.external import ExternalFunction

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -30,7 +30,7 @@ from pyomo.core.base import Transformation, TransformationFactory, Reference
 import pyomo.core.expr.current as EXPR
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 from pyomo.gdp.util import (
-    is_child_of, get_src_disjunction, get_src_constraint, get_root_blocks,
+    is_child_of, get_src_disjunction, get_src_constraint,
     get_transformed_constraints, _get_constraint_transBlock, get_src_disjunct,
     _warn_for_active_disjunction, _warn_for_active_disjunct, preprocess_targets,
     _to_dict)
@@ -259,7 +259,7 @@ class BigM_Transformation(Transformation):
         # we're about to transform.
         TransformationFactory('core.logical_to_linear').apply_to(
             instance,
-            targets=get_root_blocks(targets, instance) +
+            targets=[blk for blk in targets if blk.ctype is Block] +
             [disj for disj in preprocessed_targets if disj.ctype is Disjunct])
 
         for t in preprocessed_targets:

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -28,7 +28,7 @@ from pyomo.core.base.boolean_var import (
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 from pyomo.gdp.util import (
     clone_without_expression_components, is_child_of, get_src_disjunction,
-    get_src_constraint, get_root_blocks, get_transformed_constraints,
+    get_src_constraint, get_transformed_constraints,
     get_src_disjunct, _warn_for_active_disjunction, _warn_for_active_disjunct,
     preprocess_targets)
 from pyomo.core.util import target_list
@@ -269,7 +269,7 @@ class Hull_Reformulation(Transformation):
         # we're about to transform.
         TransformationFactory('core.logical_to_linear').apply_to(
             instance,
-            targets=get_root_blocks(targets, instance) +
+            targets=[blk for blk in targets if blk.ctype is Block] +
             [disj for disj in preprocessed_targets if disj.ctype is Disjunct])
 
         for t in preprocessed_targets:

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -22,14 +22,15 @@ from pyomo.core.base import Transformation, TransformationFactory, Reference
 from pyomo.core import (
     Block, BooleanVar, Connector, Constraint, Param, Set, SetOf, Suffix, Var,
     Expression, SortComponents, TraversalStrategy, Any, RangeSet, Reals, value,
-    NonNegativeIntegers, LogicalConstraint, Binary )
+    NonNegativeIntegers, Binary )
 from pyomo.core.base.boolean_var import (
     _DeprecatedImplicitAssociatedBinaryVariable)
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 from pyomo.gdp.util import (
     clone_without_expression_components, is_child_of, get_src_disjunction,
-    get_src_constraint, get_transformed_constraints, get_src_disjunct,
-    _warn_for_active_disjunction, _warn_for_active_disjunct, preprocess_targets)
+    get_src_constraint, get_root_blocks, get_transformed_constraints,
+    get_src_disjunct, _warn_for_active_disjunction, _warn_for_active_disjunct,
+    preprocess_targets)
 from pyomo.core.util import target_list
 from pyomo.network import Port
 from functools import wraps
@@ -262,8 +263,16 @@ class Hull_Reformulation(Transformation):
         # we need to preprocess targets to make sure that if there are any
         # disjunctions in targets that their disjuncts appear before them in
         # the list.
-        targets = preprocess_targets(targets, instance, knownBlocks)
-        for t in targets:
+        preprocessed_targets = preprocess_targets(targets, instance,
+                                                  knownBlocks)
+        # transform any logical constraints that might be anywhere on the stuff
+        # we're about to transform.
+        TransformationFactory('core.logical_to_linear').apply_to(
+            instance,
+            targets=get_root_blocks(targets, instance) +
+            [disj for disj in preprocessed_targets if disj.ctype is Disjunct])
+
+        for t in preprocessed_targets:
             if t.ctype is Disjunction:
                 if t.is_indexed():
                     self._transform_disjunction(t)
@@ -274,10 +283,6 @@ class Hull_Reformulation(Transformation):
                     self._transform_block(t)
                 else:
                     self._transform_blockData(t)
-
-        # at the end, transform any logical constraints that might be on
-        # instance
-        TransformationFactory('core.logical_to_linear').apply_to(instance)
 
     def _add_transformation_block(self, instance):
         # make a transformation block on instance where we will store
@@ -328,8 +333,6 @@ class Hull_Reformulation(Transformation):
                 descend_into=(Block,Disjunct),
                 descent_order=TraversalStrategy.PostfixDFS):
             self._transform_disjunction(disjunction)
-        # transform any logical constraints
-        TransformationFactory('core.logical_to_linear').apply_to(obj)
 
     def _add_xor_constraint(self, disjunction, transBlock):
         # Put XOR constraint on the transformation block
@@ -725,10 +728,6 @@ class Hull_Reformulation(Transformation):
             transBlock = obj.algebraic_constraint().parent_block()
 
             self._transfer_var_references(transBlock, destinationBlock)
-
-        # Transform any logical constraints here. We need to do this before we
-        # create the variable references!
-        TransformationFactory('core.logical_to_linear').apply_to(block)
 
         # We don't know where all the BooleanVars are used, so if there are any
         # that the above transformation didn't transform, we need to do it now,

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -211,11 +211,46 @@ def get_gdp_tree(targets, instance, knownBlocks):
                 % (t.name, type(t)) )
     return gdp_tree
 
+def _gather_blocks(block, tree):
+    to_explore = [block]
+    while to_explore:
+        parent = to_explore.pop()
+        for child in parent.component_data_objects(
+                (Block, Disjunct),
+                active=True,
+                sort=SortComponents.deterministic,
+                descend_into=False):
+            tree.add_edge(block, child)
+            to_explore.append(child)
+    return tree
+
+def get_block_tree(targets, instance):
+    tree = GDPTree()
+    for t in targets:
+        if t.ctype in (Block, Disjunct) or isinstance(t, _BlockData):
+            _blocks = t.values() if t.is_indexed() else (t,)
+            for block in _blocks:
+                if not block.active:
+                    continue
+                tree.add_node(block)
+                tree = _gather_blocks(block, tree)
+    return tree
+
 def preprocess_targets(targets, instance, knownBlocks):
     gdp_tree = get_gdp_tree(targets, instance, knownBlocks)
     # this is for bigm and hull: We need to transform from the leaves up, so we
     # want a reverse of a topological sort: no parent can come before its child.
     return gdp_tree.reverse_topological_sort()
+
+def get_root_blocks(targets, instance):
+    tree = get_block_tree(targets, instance)
+    # when we call logical_to_linear as part of the GDP transformations, we need
+    # to transform all the logical constraints first. We will use the
+    # preprocessed targets to find the Disjuncts we need to transform, and this
+    # finds the block(s) at the root(s) of the component tree being
+    # transformed. It would be more efficient to build this tree simultaneously,
+    # but I'm not sure it's worth the chaos?
+    return [blk for blk in tree.topological_sort() if tree.in_degree(blk) == 0]
 
 # [ESJ 07/09/2019 Should this be a more general utility function elsewhere?  I'm
 #  putting it here for now so that all the gdp transformations can use it.


### PR DESCRIPTION
## Fixes # NA

## Summary/Motivation:

Previously we were calling logical_to_linear as if we added `LogicalConstraint`s to the model, but we didn't actually do that... This modifies the bigm and hull transformations to only call it once, before they execute any of their own logic. Note that the call itself is slightly interesting because it needs to both specify every `Disjunct` that will be transformed as a target (else `logical_to_linear` will ignore them) and every `Block` as well.

## Changes proposed in this PR:
- Modifies 'logical_to_linear' to accept `IndexedBlocks` as targets
- Consolidates down to one call to `logical_to_linear` in both bigm and hull

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
