### PR TITLE
Adding utility for gathering BigM values after transformation

### DIFF
--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -1004,3 +1004,33 @@ class BigM_Transformation(Transformation):
         # fails... (That is, it's a bug in the mapping.)
         lower, upper = transBlock.bigm_src[constraint]
         return (lower[0], upper[0])
+
+    def get_all_M_values_by_constraint(self, model):
+        """Returns a dictionary mapping each constraint to a tuple:
+        (lower_M_value, upper_M_value), where either can be None if the
+        constraint does not have a lower or upper bound (respectively).
+
+        Parameters
+        ----------
+        model: A GDP model that has been transformed with BigM
+        """
+        m_values = {}
+        for disj in model.component_data_objects(
+                Disjunct,
+                active=None,
+                descend_into=(Block, Disjunct)):
+            if disj.transformation_block is not None:
+                transBlock = disj.transformation_block()
+                for cons, (lower, upper) in transBlock.bigm_src.items():
+                    m_values[cons] = self.get_M_value(cons)
+        return m_values
+
+    def get_largest_M_value(self, model):
+        """Returns the largest M value for any constraint on the model.
+
+        Parameters
+        ----------
+        model: A GDP model that has been transformed with BigM
+        """
+        return max(max(abs(m) for m in m_values if m is not None) for m_values
+                   in self.get_all_M_values_by_constraint(model).values())

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -1024,7 +1024,7 @@ class BigM_Transformation(Transformation):
                 transBlock = disj.transformation_block()
                 # If it was transformed with BigM, we get the M values.
                 if hasattr(transBlock, 'bigm_src'):
-                    for cons, (lower, upper) in transBlock.bigm_src.items():
+                    for cons in transBlock.bigm_src:
                         m_values[cons] = self.get_M_value(cons)
         return m_values
 

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -1019,10 +1019,13 @@ class BigM_Transformation(Transformation):
                 Disjunct,
                 active=None,
                 descend_into=(Block, Disjunct)):
+            # First check if it was transformed at all.
             if disj.transformation_block is not None:
                 transBlock = disj.transformation_block()
-                for cons, (lower, upper) in transBlock.bigm_src.items():
-                    m_values[cons] = self.get_M_value(cons)
+                # If it was transformed with BigM, we get the M values.
+                if hasattr(transBlock, 'bigm_src'):
+                    for cons, (lower, upper) in transBlock.bigm_src.items():
+                        m_values[cons] = self.get_M_value(cons)
         return m_values
 
     def get_largest_M_value(self, model):

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -1342,6 +1342,8 @@ class ScalarDisjIndexedConstraints(unittest.TestCase, CommonTests):
     def checkMs(self, m, disj1c1lb, disj1c1ub, disj1c2lb, disj1c2ub, disj2c1ub,
                 disj2c2ub):
         bigm = TransformationFactory('gdp.bigm')
+        m_values = bigm.get_all_M_values_by_constraint(m)
+
         c = bigm.get_transformed_constraints(m.b.simpledisj1.c[1])
         self.assertEqual(len(c), 2)
         lb = c[0]
@@ -1356,6 +1358,10 @@ class ScalarDisjIndexedConstraints(unittest.TestCase, CommonTests):
         self.assertEqual(repn.constant, -disj1c1ub)
         ct.check_linear_coef(
             self, repn, m.b.simpledisj1.indicator_var, disj1c1ub)
+        self.assertIn(m.b.simpledisj1.c[1], m_values.keys())
+        self.assertEqual(m_values[m.b.simpledisj1.c[1]][0], disj1c1lb)
+        self.assertEqual(m_values[m.b.simpledisj1.c[1]][1], disj1c1ub)
+
         c = bigm.get_transformed_constraints(m.b.simpledisj1.c[2])
         self.assertEqual(len(c), 2)
         lb = c[0]
@@ -1370,6 +1376,9 @@ class ScalarDisjIndexedConstraints(unittest.TestCase, CommonTests):
         self.assertEqual(repn.constant, -disj1c2ub)
         ct.check_linear_coef(
             self, repn, m.b.simpledisj1.indicator_var, disj1c2ub)
+        self.assertIn(m.b.simpledisj1.c[2], m_values.keys())
+        self.assertEqual(m_values[m.b.simpledisj1.c[2]][0], disj1c2lb)
+        self.assertEqual(m_values[m.b.simpledisj1.c[2]][1], disj1c2ub)
 
         c = bigm.get_transformed_constraints(m.b.simpledisj2.c[1])
         self.assertEqual(len(c), 1)
@@ -1379,6 +1388,10 @@ class ScalarDisjIndexedConstraints(unittest.TestCase, CommonTests):
         self.assertEqual(repn.constant, -disj2c1ub)
         ct.check_linear_coef(
             self, repn, m.b.simpledisj2.indicator_var, disj2c1ub)
+        self.assertIn(m.b.simpledisj2.c[1], m_values.keys())
+        self.assertEqual(m_values[m.b.simpledisj2.c[1]][1], disj2c1ub)
+        self.assertIsNone(m_values[m.b.simpledisj2.c[1]][0])
+
         c = bigm.get_transformed_constraints(m.b.simpledisj2.c[2])
         self.assertEqual(len(c), 1)
         ub = c[0]
@@ -1387,6 +1400,12 @@ class ScalarDisjIndexedConstraints(unittest.TestCase, CommonTests):
         self.assertEqual(repn.constant, -disj2c2ub)
         ct.check_linear_coef(
             self, repn, m.b.simpledisj2.indicator_var, disj2c2ub)
+        self.assertIn(m.b.simpledisj2.c[2], m_values.keys())
+        self.assertEqual(m_values[m.b.simpledisj2.c[2]][1], disj2c2ub)
+        self.assertIsNone(m_values[m.b.simpledisj2.c[2]][0])
+
+        # verify that we don't have anything extra in this dictionary either.
+        self.assertEqual(len(m_values), 4)
 
     def test_suffix_M_constraintData_on_block(self):
         m = models.makeTwoTermDisj_IndexedConstraints()

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -1284,6 +1284,15 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertIs(src, bigms)
         self.assertIs(key, m.b.disjunct[1])
 
+    def test_largest_M_value(self):
+        m = models.makeTwoTermDisjOnBlock()
+        m = models.add_disj_not_on_block(m)
+        bigm = TransformationFactory('gdp.bigm')
+        bigms = {m.b: 100, m.b.disjunct[1]: 13}
+        bigm.apply_to(m, bigM=bigms)
+
+        self.assertEqual(bigm.get_largest_M_value(m), 100)
+
     def test_block_targets_inactive(self):
         ct.check_block_targets_inactive(self, 'bigm')
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

Calculating M values can be time-consuming, so it may make sense to run the model once, allowing for automatic calculating, and then pull out the calculated values and specify either all of them or the largest one to the transformation thereafter. This adds a couple utility methods to the bigm transformation to ease that process.

## Changes proposed in this PR:
- Adds two methods to the bigm transformation: `get_all_M_values_by_constraint` to get M values from a transformed model in a dictionary with the original constraints as the keys and `get_largest_M_value` to grab the largest (in absolute value) of these

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
