### PR TITLE
Resolve numpy deprecation warnings in pynumero

### DIFF
--- a/pyomo/contrib/pynumero/interfaces/utils.py
+++ b/pyomo/contrib/pynumero/interfaces/utils.py
@@ -49,7 +49,7 @@ def build_compression_matrix(compression_mask):
     elif type(compression_mask) is np.ndarray:
         cols = compression_mask.nonzero()[0]
         nnz = len(cols)
-        rows = np.arange(nnz, dtype=np.int)
+        rows = np.arange(nnz, dtype=np.int64)
         data = np.ones(nnz)
         return coo_matrix((data, (rows, cols)), shape=(nnz, len(compression_mask)))
     elif isinstance(compression_mask, mpi_block_vector.MPIBlockVector):

--- a/pyomo/contrib/pynumero/sparse/mpi_block_matrix.py
+++ b/pyomo/contrib/pynumero/sparse/mpi_block_matrix.py
@@ -101,7 +101,7 @@ class MPIBlockMatrix(BaseBlockMatrix):
         self._block_matrix = BlockMatrix(nbrows, nbcols)
         self._mpiw = mpi_comm
         rank = self._mpiw.Get_rank()
-        self._rank_owner = np.asarray(rank_ownership, dtype=np.int)
+        self._rank_owner = np.asarray(rank_ownership, dtype=np.int64)
         self._owned_mask = np.bitwise_or(self._rank_owner == rank, self._rank_owner < 0)
         self._unique_owned_mask = self._rank_owner == rank
 

--- a/pyomo/contrib/pynumero/sparse/tests/test_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_block_vector.py
@@ -120,12 +120,12 @@ class TestBlockVector(unittest.TestCase):
     def test_astype(self):
         v = self.ones
         with self.assertRaises(NotImplementedError) as ctx:
-            vv = v.astype(np.int, copy=False)
+            vv = v.astype(np.int64, copy=False)
 
-        vv = v.astype(np.int)
+        vv = v.astype(np.int64)
         self.assertEqual(vv.nblocks, v.nblocks)
         for blk in vv:
-            self.assertEqual(blk.dtype, np.int)
+            self.assertEqual(blk.dtype, np.int64)
 
     def test_byteswap(self):
         v = self.ones


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
NumPy has deprecated the use of `np.int`.  This PR replaces uses of `np.int` with `np.int64` in PyNumero.

## Changes proposed in this PR:
- Replace `np.int` with `np.int64`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
