### PR TITLE
BUGFIX: Import `value` in `pyomo.core.base.external`

### DIFF
--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -10,7 +10,6 @@
 #  ___________________________________________________________________________
 
 import logging
-import os
 import types
 import weakref
 from pyomo.common.pyomo_typing import overload
@@ -22,7 +21,7 @@ from ctypes import (
 from pyomo.common.fileutils import find_library
 from pyomo.core.expr.numvalue import (
     native_types, native_numeric_types, pyomo_constant_types,
-    NonNumericValue, NumericConstant,
+    NonNumericValue, NumericConstant, value
 )
 from pyomo.core.expr import current as EXPR
 from pyomo.core.base.component import Component


### PR DESCRIPTION
## Fixes #2524 

## Summary/Motivation:
`value` was not imported in `pyomo.core.base.external` - this fixes that issue.

## Changes proposed in this PR:
- Add `value` to import statements
- Remove `os` import (as it was unused)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
