### PR TITLE
bugfix for gurobi work limit

### DIFF
--- a/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
@@ -167,6 +167,11 @@ def gurobi_run(model_file, warmstart_file, soln_file, mipgap, options, suffixes)
         message = 'Optimization terminated because the time expended exceeded the value specified in the TimeLimit parameter.'
         term_cond = 'maxTimeLimit'
         solution_status = 'stoppedByLimit'
+    elif (solver_status == GRB.WORK_LIMIT):
+        status = 'aborted'
+        message = 'Optimization terminated because the work expended exceeded the value specified in the WorkLimit parameter.'
+        term_cond = 'maxTimeLimit'
+        solution_status = 'stoppedByLimit'
     elif (solver_status == GRB.SOLUTION_LIMIT):
         status = 'aborted'
         message = 'Optimization terminated because the number of solutions found reached the value specified in the SolutionLimit parameter.'

--- a/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI_RUN.py
@@ -167,7 +167,7 @@ def gurobi_run(model_file, warmstart_file, soln_file, mipgap, options, suffixes)
         message = 'Optimization terminated because the time expended exceeded the value specified in the TimeLimit parameter.'
         term_cond = 'maxTimeLimit'
         solution_status = 'stoppedByLimit'
-    elif (solver_status == GRB.WORK_LIMIT):
+    elif hasattr(GRB, "WORK_LIMIT") and (solver_status == GRB.WORK_LIMIT):
         status = 'aborted'
         message = 'Optimization terminated because the work expended exceeded the value specified in the WorkLimit parameter.'
         term_cond = 'maxTimeLimit'

--- a/pyomo/solvers/tests/checks/test_gurobi.py
+++ b/pyomo/solvers/tests/checks/test_gurobi.py
@@ -5,15 +5,16 @@ try:
     from pyomo.solvers.plugins.solvers.GUROBI_RUN import gurobi_run
     from gurobipy import GRB
     gurobipy_available = True
+    has_worklimit = hasattr(GRB, "WORK_LIMIT")
 except:
     gurobipy_available = False
-
+    has_worklimit = False
 @unittest.skipIf(not gurobipy_available,
                      "gurobipy is not available")
 class GurobiTest(unittest.TestCase):
 
 
-    @unittest.skipIf(not hasattr(GRB, "WORK_LIMIT"),
+    @unittest.skipIf(not has_worklimit,
                      "gurobi < 9.5")
     @patch("builtins.open")
     @patch("pyomo.solvers.plugins.solvers.GUROBI_RUN.read")
@@ -37,7 +38,7 @@ class GurobiTest(unittest.TestCase):
             return None
         model.getAttr = getAttr
         gurobi_run(None, None, None, None, {}, [])
-        self.assertTrue("WorkLimit" in file.write.call_args.args[0])
+        self.assertTrue("WorkLimit" in file.write.call_args[0][0])
 
 
 if __name__ == '__main__':

--- a/pyomo/solvers/tests/checks/test_gurobi.py
+++ b/pyomo/solvers/tests/checks/test_gurobi.py
@@ -8,10 +8,11 @@ try:
 except:
     gurobipy_available = False
 
+@unittest.skipIf(not gurobipy_available,
+                     "gurobipy is not available")
 class GurobiTest(unittest.TestCase):
 
-    @unittest.skipIf(not gurobipy_available,
-                     "gurobipy is not available")
+
     @unittest.skipIf(not hasattr(GRB, "WORK_LIMIT"),
                      "gurobi < 9.5")
     @patch("builtins.open")

--- a/pyomo/solvers/tests/checks/test_gurobi.py
+++ b/pyomo/solvers/tests/checks/test_gurobi.py
@@ -1,0 +1,46 @@
+import unittest
+from unittest.mock import MagicMock
+from pyomo.solvers.plugins.solvers.GUROBI_RUN import gurobi_run
+from unittest.mock import patch, MagicMock
+
+try:
+    from gurobipy import GRB
+    gurobipy_available = True
+except:
+    gurobipy_available = False
+
+class GurobiTest(unittest.TestCase):
+
+
+
+    @unittest.skipIf(not gurobipy_available,
+                     "gurobipy is not available")
+    @unittest.skipIf(not hasattr(GRB, "WORK_LIMIT"),
+                     "gurobi < 9.5")
+    @patch("builtins.open")
+    @patch("pyomo.solvers.plugins.solvers.GUROBI_RUN.read")
+    def test_work_limit(self, read:MagicMock, open: MagicMock):
+        file = MagicMock()
+        open.return_value = file
+        model = MagicMock()
+        read.return_value = model
+        def getAttr(attr):
+            if attr == GRB.Attr.Status:
+                return GRB.WORK_LIMIT
+            elif attr == GRB.Attr.ModelSense:
+                return 1
+            elif attr == GRB.Attr.ModelName:
+                return ""
+            elif attr.startswith("Num"):
+                return 1
+            elif attr == GRB.Attr.SolCount:
+                return 0
+
+            return None
+        model.getAttr = getAttr
+        gurobi_run(None, None, None, None, {}, [])
+        self.assertEqual(file.write.call_args.args[0], 'termination_message: Optimization terminated because the work expended exceeded the value specified in the WorkLimit parameter.\n')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pyomo/solvers/tests/checks/test_gurobi.py
+++ b/pyomo/solvers/tests/checks/test_gurobi.py
@@ -1,4 +1,4 @@
-import unittest
+import pyomo.common.unittest as unittest
 from unittest.mock import patch, MagicMock
 
 try:

--- a/pyomo/solvers/tests/checks/test_gurobi.py
+++ b/pyomo/solvers/tests/checks/test_gurobi.py
@@ -1,17 +1,14 @@
 import unittest
-from unittest.mock import MagicMock
-from pyomo.solvers.plugins.solvers.GUROBI_RUN import gurobi_run
 from unittest.mock import patch, MagicMock
 
 try:
+    from pyomo.solvers.plugins.solvers.GUROBI_RUN import gurobi_run
     from gurobipy import GRB
     gurobipy_available = True
 except:
     gurobipy_available = False
 
 class GurobiTest(unittest.TestCase):
-
-
 
     @unittest.skipIf(not gurobipy_available,
                      "gurobipy is not available")
@@ -39,7 +36,7 @@ class GurobiTest(unittest.TestCase):
             return None
         model.getAttr = getAttr
         gurobi_run(None, None, None, None, {}, [])
-        self.assertEqual(file.write.call_args.args[0], 'termination_message: Optimization terminated because the work expended exceeded the value specified in the WorkLimit parameter.\n')
+        self.assertTrue("WorkLimit" in file.write.call_args.args[0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Fixes # 

If the WorkLimit is set in gurobi and the optimisation is stoped because the limit is reached pyomo does not detect the feasible solution.

## Summary/Motivation:

Gurobi 9.5 introduced a deterministic [work limit](https://www.gurobi.com/documentation/9.5/refman/worklimit.html) as alternative to a time limit. Pyomo does not detect this correctly if the optimisation is stopped because of WORK_LIMIT.

Work limit would be very useful for us and we would love to see a quick bugfix release including this fix.

## Changes proposed in this PR:
- handle a stop due to work limit the same as time limit


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
