### PR TITLE
Improve handling of restricted words on Blocks

### DIFF
--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1062,7 +1062,7 @@ class _BlockData(ActiveComponentData):
         if not val.valid_model_component():
             raise RuntimeError(
                 "Cannot add '%s' as a component to a block" % str(type(val)))
-        if name in self._Block_reserved_words:# and hasattr(self, name):
+        if name in self._Block_reserved_words:
             raise ValueError("Attempting to declare a block component using "
                              "the name of a reserved attribute:\n\t%s"
                              % (name,))

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1046,6 +1046,8 @@ class _BlockData(ActiveComponentData):
 
     @contextmanager
     def _declare_reserved_components(self):
+        # Temporarily mask the class reserved words like with a local
+        # instance attribute
         self._Block_reserved_words = ()
         yield
         del self._Block_reserved_words

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -18,6 +18,7 @@ import logging
 import sys
 import weakref
 import textwrap
+from contextlib import contextmanager
 
 from inspect import isclass
 from itertools import filterfalse
@@ -882,30 +883,45 @@ class _BlockData(ActiveComponentData):
                 p_block = p_block.parent_block()
             # record the components and the non-component objects added
             # to the block
-            src_comp_map = src.component_map()
-            src_raw_dict = {k:v for k,v in src.__dict__.items()
-                            if k not in src_comp_map}
+            src_comp_map = dict(src.component_map().items())
+            src_raw_dict = src.__dict__
+            del_src_comp = src.del_component
         elif isinstance(src, Mapping):
-            src_comp_map = {}
+            src_comp_map = {k: v for k, v in src.items()
+                            if isinstance(v, Component)}
             src_raw_dict = src
+            del_src_comp = lambda x: None
         else:
             raise ValueError(
                 "_BlockData.transfer_attributes_from(): expected a "
                 "Block or dict; received %s" % (type(src).__name__,))
 
+        if src_comp_map:
+            # Filter out any components from src
+            src_raw_dict = {k: v for k, v in src_raw_dict.items()
+                            if k not in src_comp_map}
+
         # Use component_map for the components to preserve decl_order
-        for k,v in src_comp_map.items():
-            if k in self._decl:
-                self.del_component(k)
-            src.del_component(k)
-            self.add_component(k,v)
+        # Note that we will move any reserved components over as well as
+        # any user-defined components.  There is a bit of trust here
+        # that the user knows what they are doing.
+        with self._declare_reserved_components():
+            for k,v in src_comp_map.items():
+                if k in self._decl:
+                    self.del_component(k)
+                del_src_comp(k)
+                self.add_component(k,v)
         # Because Blocks are not slotized and we allow the
         # assignment of arbitrary data to Blocks, we will move over
         # any other unrecognized entries in the object's __dict__:
-        for k in sorted(src_raw_dict.keys()):
-            if k not in self._Block_reserved_words or not hasattr(self, k) \
-               or k in self._decl:
-                setattr(self, k, src_raw_dict[k])
+        for k, v in src_raw_dict.items():
+            if ( k not in self._Block_reserved_words # user-defined
+                 or not hasattr(self, k) # reserved, but not present
+                 or k in self._decl # reserved, but a component and the
+                                    # incoming thing is data (attempt to
+                                    # set the value)
+            ):
+                setattr(self, k, v)
 
     def _add_implicit_sets(self, val):
         """TODO: This method has known issues (see tickets) and needs to be
@@ -1028,6 +1044,12 @@ class _BlockData(ActiveComponentData):
             cuid = ComponentUID(label_or_component)
         return cuid.find_component_on(self)
 
+    @contextmanager
+    def _declare_reserved_components(self):
+        self._Block_reserved_words = ()
+        yield
+        del self._Block_reserved_words
+
     def add_component(self, name, val):
         """
         Add a component 'name' to the block.
@@ -1040,7 +1062,7 @@ class _BlockData(ActiveComponentData):
         if not val.valid_model_component():
             raise RuntimeError(
                 "Cannot add '%s' as a component to a block" % str(type(val)))
-        if name in self._Block_reserved_words and hasattr(self, name):
+        if name in self._Block_reserved_words:# and hasattr(self, name):
             raise ValueError("Attempting to declare a block component using "
                              "the name of a reserved attribute:\n\t%s"
                              % (name,))
@@ -1240,6 +1262,10 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
         #    return
 
         name = obj.local_name
+        if name in self._Block_reserved_words:
+            raise ValueError(
+                "Attempting to delete a reserved block component:\n\t%s"
+                % (obj.name,))
 
         # Replace the component in the master list with a None placeholder
         idx = self._decl[name]
@@ -2303,7 +2329,7 @@ def components_data(block, ctype,
 
 #
 # Create a Block and record all the default attributes, methods, etc.
-# These will be assumes to be the set of illegal component names.
+# These will be assumed to be the set of illegal component names.
 #
 _BlockData._Block_reserved_words = set(dir(Block()))
 

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -30,7 +30,7 @@ from pyomo.environ import (AbstractModel, ConcreteModel, Var, Set,
                            Objective, Expression, SOSConstraint,
                            SortComponents, NonNegativeIntegers,
                            TraversalStrategy, RangeSet, SolverFactory,
-                           value, sum_product, ComponentUID)
+                           value, sum_product, ComponentUID, Any)
 from pyomo.common.log import LoggingIntercept
 from pyomo.common.tempfiles import TempfileManager
 from pyomo.core.base.block import ScalarBlock, SubclassOf, _BlockData, declare_custom_block
@@ -708,12 +708,13 @@ class TestBlock(unittest.TestCase):
         self.assertEqual(m._decl_order, [])
 
         m.b = DerivedBlock()
-        m.b.a = a = Param()
-        m.b.x = Var()
-        m.b.b = b = Var()
-        m.b.y = Var()
-        m.b.z = Param()
-        m.b.c = c = Param()
+        with m.b._declare_reserved_components():
+            m.b.a = a = Param()
+            m.b.x = Var()
+            m.b.b = b = Var()
+            m.b.y = Var()
+            m.b.z = Param()
+            m.b.c = c = Param()
         m.b.clear()
         self.assertEqual(m.b._ctypes, {Var: [1, 1, 1], Param:[0,2,2]})
         self.assertEqual(m.b._decl, {'a':0, 'b':1, 'c':2})
@@ -745,8 +746,9 @@ class TestBlock(unittest.TestCase):
             _Block_reserved_words = set()
             def __init__(self, *args, **kwds):
                 super(DerivedBlock, self).__init__(*args, **kwds)
-                self.x = Var()
-                self.y = Var()
+                with self._declare_reserved_components():
+                    self.x = Var()
+                    self.y = Var()
         DerivedBlock._Block_reserved_words = set(dir(DerivedBlock()))
 
         b = DerivedBlock(concrete=True)
@@ -776,7 +778,7 @@ class TestBlock(unittest.TestCase):
 
         b.clear()
         b.transfer_attributes_from(c)
-        self.assertEqual(list(b.component_map()), ['y','x','z'])
+        self.assertEqual(list(b.component_map()), ['y','z','x'])
         self.assertEqual(sorted(list(c.keys())), ['x','y','z'])
         self.assertIs(b.x, c['x'])
         self.assertIsNot(b.y, c['y'])
@@ -2472,6 +2474,35 @@ class TestBlock(unittest.TestCase):
         with self.assertRaisesRegex(
                 ValueError, ".*using the name of a reserved attribute"):
             m.b.foo = Var()
+
+        class DerivedBlockReservedComp(DerivedBlock):
+            def __init__(self, *args, **kwargs):
+                """Constructor"""
+                super(DerivedBlock, self).__init__(*args, **kwargs)
+                with self._declare_reserved_components():
+                    self.x = Var()
+        DerivedBlockReservedComp._Block_reserved_words = set(
+            dir(DerivedBlockReservedComp()))
+
+        m.c = DerivedBlockReservedComp()
+
+        with self.assertRaisesRegex(
+                ValueError, "Attempting to delete a reserved block component"):
+            m.c.del_component('x')
+
+        with self.assertRaisesRegex(
+                ValueError, "Attempting to delete a reserved block component"):
+            m.c.x = Var()
+
+        class RestrictedBlock(ScalarBlock):
+            _Block_reserved_words = Any - {'start', 'end',}
+
+        m.d = RestrictedBlock()
+        m.d.start = v = Var()
+        self.assertIs(m.d.start, v)
+        with self.assertRaisesRegex(
+                ValueError, "using the name of a reserved attribute"):
+            m.d.step = Var()
 
         #
         # Overriding attributes with non-components is (currently) allowed

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -329,8 +329,9 @@ class _DisjunctData(_BlockData):
 
     def __init__(self, component):
         _BlockData.__init__(self, component)
-        self.indicator_var = AutoLinkedBooleanVar()
-        self.binary_indicator_var = AutoLinkedBinaryVar(self.indicator_var)
+        with self._declare_reserved_components():
+            self.indicator_var = AutoLinkedBooleanVar()
+            self.binary_indicator_var = AutoLinkedBinaryVar(self.indicator_var)
         self.indicator_var.associate_binary_var(self.binary_indicator_var)
         # pointer to transformation block if this disjunct has been
         # transformed. None indicates it hasn't been transformed.


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This PR improves handling of reserved words on Blocks:
- prevent deleting or replacing components that are declared as reserved words
- add a (private) context manager to simplify declaring "reserved" components
- improve preservation of declaration order (remove `sorted()` that is unnecessary in Python 3.7+)
- update and expand testing

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
