### PR TITLE
Improve Reference() performance

### DIFF
--- a/pyomo/core/base/global_set.py
+++ b/pyomo/core/base/global_set.py
@@ -73,6 +73,10 @@ class _UnindexedComponent_set(GlobalSetBase):
         return [ self ]
     def construct(self):
         pass
+    def bounds(self):
+        return (None, None)
+    def get_interval(self):
+        return (None, None, None)
     def __len__(self):
         return 1
     def __eq__(self, other):

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -708,14 +708,6 @@ def Reference(reference, ctype=NOTSET):
             # Note that this is redundant for Component and ComponentData
             # inputs, as _iter was already empty.
             _iter = ()
-        else:
-            # If the caller specified a ctype, then we will prepopulate
-            # the list to improve our chances of avoiding a scan of the
-            # entire Reference (by simulating multiple ctypes having
-            # been found, we can break out as soon as we know that there
-            # are not common subsets by forcing the len(ctypes) > 1 check
-            # to return True).
-            ctypes = set((1,2))
 
     for obj in _iter:
         #
@@ -724,16 +716,17 @@ def Reference(reference, ctype=NOTSET):
         # objects to attempt to infer both the ctype and, if a slice
         # was provided, the index_set (determined by slice_index).
         #
-        ctypes.add(obj.ctype)
-        if not isinstance(obj, ComponentData):
-            # This object is not a ComponentData (likely it is a pure
-            # IndexedComponent container).  As the Reference will treat
-            # it as if it *were* a ComponentData, we will skip ctype
-            # identification and return a base IndexedComponent, thereby
-            # preventing strange exceptions in the writers and with
-            # things like pprint().  Of course, all of this logic is
-            # skipped if the User knows better and forced a ctype on us.
-            ctypes.add(0)
+        if ctype is NOTSET:
+            ctypes.add(obj.ctype)
+            if not isinstance(obj, ComponentData):
+                # This object is not a ComponentData (likely it is a pure
+                # IndexedComponent container).  As the Reference will treat
+                # it as if it *were* a ComponentData, we will skip ctype
+                # identification and return a base IndexedComponent, thereby
+                # preventing strange exceptions in the writers and with
+                # things like pprint().  Of course, all of this logic is
+                # skipped if the User knows better and forced a ctype on us.
+                ctypes.add(0)
         # Note that we want to walk the entire slice, unless we can
         # prove that BOTH there aren't common indexing sets (i.e., index
         # is None) AND there is more than one ctype.
@@ -743,7 +736,7 @@ def Reference(reference, ctype=NOTSET):
             # identify the wilcards for this obj and check compatibility
             # of the wildcards with any previously-identified wildcards.
             slice_idx = _identify_wildcard_sets(_iter._iter_stack, slice_idx)
-        elif len(ctypes) > 1:
+        elif ctype is not NOTSET or len(ctypes) > 1:
             break
 
     if index is None:

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -14,7 +14,10 @@ from pyomo.common.collections import (
     UserDict, OrderedDict, Mapping, MutableMapping,
     Set as collections_Set, Sequence,
 )
-from pyomo.core.base.set import SetOf, OrderedSetOf, _SetDataBase
+from pyomo.common.modeling import NOTSET
+from pyomo.core.base.set import (
+    SetOf, OrderedSetOf, _SetDataBase,
+)
 from pyomo.core.base.component import Component, ComponentData
 from pyomo.core.base.global_set import (
     UnindexedComponent_set,
@@ -27,8 +30,6 @@ from pyomo.core.base.indexed_component_slice import (
 )
 from pyomo.core.base.util import flatten_tuple
 from pyomo.common.deprecation import deprecated
-
-_NotSpecified = object()
 
 _UnindexedComponent_key = list(UnindexedComponent_set)
 _UnindexedComponent_base_key = tuple(UnindexedComponent_set)
@@ -539,7 +540,7 @@ def _identify_wildcard_sets(iter_stack, index):
         #     Reference(m.c[:].v)
     return index
 
-def Reference(reference, ctype=_NotSpecified):
+def Reference(reference, ctype=NOTSET):
     """Creates a component that references other components
 
     ``Reference`` generates a *reference component*; that is, an indexed
@@ -673,7 +674,7 @@ def Reference(reference, ctype=_NotSpecified):
             "component, component slice, Sequence, or Mapping (received %s)"
             % (type(reference).__name__,))
 
-    if ctype is _NotSpecified:
+    if ctype is NOTSET:
         ctypes = set()
     else:
         # If the caller specified a ctype, then we will prepopulate the
@@ -724,7 +725,7 @@ def Reference(reference, ctype=_NotSpecified):
                 index = index * idx
             # index is now either a single Set, or a SetProduct of the
             # wildcard sets.
-    if ctype is _NotSpecified:
+    if ctype is NOTSET:
         if len(ctypes) == 1:
             ctype = ctypes.pop()
         else:

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -621,7 +621,11 @@ class _SetData(_SetDataBase):
         # but problemmatic for code coverage.
         ranges = list(self.ranges())
         if len(ranges) == 1:
-            start, end, c = ranges[0].normalize_bounds()
+            try:
+                start, end, c = ranges[0].normalize_bounds()
+            except AttributeError:
+                # Catching Any, NonNumericRange, etc...
+                return (None, None, None,)
             return (
                 None if start == -_inf else start,
                 None if end == _inf else end,

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -625,7 +625,7 @@ class _SetData(_SetDataBase):
                 start, end, c = ranges[0].normalize_bounds()
             except AttributeError:
                 # Catching Any, NonNumericRange, etc...
-                return (None, None, None,)
+                return self.bounds() + (None,)
             return (
                 None if start == -_inf else start,
                 None if end == _inf else end,

--- a/pyomo/core/tests/unit/test_reference.py
+++ b/pyomo/core/tests/unit/test_reference.py
@@ -33,7 +33,7 @@ from pyomo.core.base.indexed_component import (
 )
 from pyomo.core.base.indexed_component_slice import IndexedComponent_slice
 from pyomo.core.base.reference import (
-    _ReferenceDict, _ReferenceSet, Reference
+    _ReferenceDict, _ReferenceSet, Reference, UnindexedComponent_ReferenceSet,
 )
 
 
@@ -413,7 +413,7 @@ class TestReference(unittest.TestCase):
         self.assertIs(m.r.ctype, Var)
         self.assertIsNot(m.r.index_set(), m.x.index_set())
         self.assertIs(m.x.index_set(), UnindexedComponent_set)
-        self.assertIs(type(m.r.index_set()), OrderedSetOf)
+        self.assertIs(m.r.index_set(), UnindexedComponent_ReferenceSet)
         self.assertEqual(len(m.r), 1)
         self.assertTrue(m.r.is_indexed())
         self.assertIn(None, m.r)
@@ -458,7 +458,7 @@ class TestReference(unittest.TestCase):
         self.assertIs(m.r.ctype, Var)
         self.assertIsNot(m.r.index_set(), m.y.index_set())
         self.assertIs(m.y.index_set(), m.y_index)
-        self.assertIs(type(m.r.index_set()), OrderedSetOf)
+        self.assertIs(m.r.index_set(), UnindexedComponent_ReferenceSet)
         self.assertEqual(len(m.r), 1)
         self.assertTrue(m.r.is_reference())
         self.assertTrue(m.r.is_indexed())
@@ -997,11 +997,46 @@ class TestReference(unittest.TestCase):
             normalize_index.flatten = _old_flatten
 
     def test_pprint_nonfinite_sets(self):
-        # test issue #2039
         self.maxDiff = None
         m = ConcreteModel()
         m.v = Var(NonNegativeIntegers, dense=False)
         m.ref = Reference(m.v)
+        buf = StringIO()
+        m.pprint(ostream=buf)
+        self.assertEqual(buf.getvalue().strip(), """
+2 Var Declarations
+    ref : Size=0, Index=NonNegativeIntegers, ReferenceTo=v
+        Key : Lower : Value : Upper : Fixed : Stale : Domain
+    v : Size=0, Index=NonNegativeIntegers
+        Key : Lower : Value : Upper : Fixed : Stale : Domain
+
+2 Declarations: v ref
+""".strip())
+
+        m.v[3]
+        m.ref[5]
+        buf = StringIO()
+        m.pprint(ostream=buf)
+        self.assertEqual(buf.getvalue().strip(), """
+2 Var Declarations
+    ref : Size=2, Index=NonNegativeIntegers, ReferenceTo=v
+        Key : Lower : Value : Upper : Fixed : Stale : Domain
+          3 :  None :  None :  None : False :  True :  Reals
+          5 :  None :  None :  None : False :  True :  Reals
+    v : Size=2, Index=NonNegativeIntegers
+        Key : Lower : Value : Upper : Fixed : Stale : Domain
+          3 :  None :  None :  None : False :  True :  Reals
+          5 :  None :  None :  None : False :  True :  Reals
+
+2 Declarations: v ref
+""".strip())
+
+    def test_pprint_nonfinite_sets_ctypeNone(self):
+        # test issue #2039
+        self.maxDiff = None
+        m = ConcreteModel()
+        m.v = Var(NonNegativeIntegers, dense=False)
+        m.ref = Reference(m.v, ctype=None)
         buf = StringIO()
         m.pprint(ostream=buf)
         self.assertEqual(buf.getvalue().strip(), """
@@ -1010,15 +1045,10 @@ class TestReference(unittest.TestCase):
         Key : Lower : Value : Upper : Fixed : Stale : Domain
 
 1 IndexedComponent Declarations
-    ref : Size=0, Index=ref_index, ReferenceTo=v
+    ref : Size=0, Index=NonNegativeIntegers, ReferenceTo=v
         Key : Object
 
-1 SetOf Declarations
-    ref_index : Dimen=0, Size=0, Bounds=(None, None)
-        Key  : Ordered : Members
-        None :   False : ReferenceSet(v[...])
-
-3 Declarations: v ref_index ref
+2 Declarations: v ref
 """.strip())
 
         m.v[3]
@@ -1033,17 +1063,12 @@ class TestReference(unittest.TestCase):
           5 :  None :  None :  None : False :  True :  Reals
 
 1 IndexedComponent Declarations
-    ref : Size=2, Index=ref_index, ReferenceTo=v
+    ref : Size=2, Index=NonNegativeIntegers, ReferenceTo=v
         Key : Object
           3 : <class 'pyomo.core.base.var._GeneralVarData'>
           5 : <class 'pyomo.core.base.var._GeneralVarData'>
 
-1 SetOf Declarations
-    ref_index : Dimen=1, Size=2, Bounds=(3, 5)
-        Key  : Ordered : Members
-        None :   False : ReferenceSet(v[...])
-
-3 Declarations: v ref_index ref
+2 Declarations: v ref
 """.strip())
 
     def test_pprint_nested(self):

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -5468,6 +5468,17 @@ class TestSetUtils(unittest.TestCase):
         a = RangeSet(ranges=(NR(0,10,3), NR(1,10,3), NR(2,10,3)))
         self.assertEqual(a.get_interval(), (0, 10, None))
 
+    def test_get_interval(self):
+        self.assertEqual(Any.get_interval(), (None, None, None))
+        a = UnindexedComponent_set
+        self.assertEqual(a.get_interval(), (None, None, None))
+        a = Set(initialize=['a'])
+        a.construct()
+        self.assertEqual(a.get_interval(), ('a', 'a', None))
+        a = Set(initialize=[1])
+        a.construct()
+        self.assertEqual(a.get_interval(), (1, 1, 0))
+
 
 class TestDeprecation(unittest.TestCase):
     def test_filter(self):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This (significantly) speeds up `Reference()` construction by avoiding iterating over the referent if the Reference `ctype` and indexing sets can be easily inferred by looking at referent.

## Changes proposed in this PR:
- Avoid iterating over the referent to determine indexing set / ctype for `Component` and `ComponentData` referents
- Cache a special-purpose GlobalSet that mimics the `UnindexedComponent_set` 
- Update testing

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
