### PR TITLE
Updates to the performance test driver

### DIFF
--- a/scripts/performance/main.py
+++ b/scripts/performance/main.py
@@ -212,12 +212,14 @@ def main(argv):
     )
 
     options, argv = parser.parse_known_args(argv)
-    if not options.projects:
+    if options.projects:
+        # Pytest really, really wants the initial script to belong to the
+        # "main" project being tested.  Just re-assign it to the main
+        # project module (which seems to be enough for pytest)
+        argv[0] = options.projects[0]
+    else:
         options.projects.append('pyomo')
-    # Pytest really, really wants the initial script to belong to the
-    # "main" project being tested.  Just re-assign it to the main
-    # project module (which seems to be enough for pytest)
-    argv[0] = options.projects[0]
+
     argv.append('-W ignore::Warning')
 
     results = tuple(run_tests(options, argv) for i in range(options.replicates))

--- a/scripts/performance/main.py
+++ b/scripts/performance/main.py
@@ -62,7 +62,7 @@ class TimingHandler(logging.Handler):
             name = record.msg.name
             val = record.msg.timer
         except AttributeError:
-            name = None
+            name = ''
             val = str(record.msg)
         if name in cat_data:
             try:

--- a/scripts/performance/main.py
+++ b/scripts/performance/main.py
@@ -251,6 +251,7 @@ def main(argv):
         if close_ostream:
             ostream.close()
     print("Performance run complete.")
+    return results
 
 if __name__ == '__main__':
-    main(sys.argv)
+    results = main(sys.argv)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This PR resolves issues recording performance data when a test logs `GeneralTimer` data.  It also updates the driver so that it does not run the entire pyomo test suite when a project is not specified.

## Changes proposed in this PR:
- Do not generate an un-JSON-able result when GeneralTimer data is recorded
- Do not automatically reassign the script name when the project is not set

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
