### PR TITLE
Resolve mapping gradient/hessian for external function with string args

### DIFF
--- a/pyomo/contrib/ampl_function_demo/tests/test_ampl_function_demo.py
+++ b/pyomo/contrib/ampl_function_demo/tests/test_ampl_function_demo.py
@@ -14,6 +14,7 @@ import pyomo.environ as pyo
 import pyomo.common.unittest as unittest
 from pyomo.common.fileutils import find_library
 from pyomo.opt import check_available_solvers
+from pyomo.core.base.external import nan
 
 flib = find_library("asl_external_demo")
 is_pypy = platform.python_implementation().lower().startswith('pypy')
@@ -41,13 +42,13 @@ class TestAMPLExternalFunction(unittest.TestCase):
 
         f, g, h = m.tf.evaluate_fgh(("sum", 1, 2, 3))
         self.assertEqual(f, 6)
-        self.assertEqual(g, [0, 1, 1, 1])
-        self.assertEqual(h, [0]*10)
+        self.assertEqual(g, [nan, 1, 1, 1])
+        self.assertEqual(h, [nan, nan, 0, nan, 0, 0, nan, 0, 0, 0])
 
         f, g, h = m.tf.evaluate_fgh(("inv", 1, 2, 3))
         self.assertAlmostEqual(f, 1.8333333, 4)
-        self.assertStructuredAlmostEqual(g, [0, -1, -1/4, -1/9])
-        self.assertStructuredAlmostEqual(h, [0, 0, 2, 0, 0, 1/4, 0, 0, 0, 2/27])
+        self.assertStructuredAlmostEqual(g, [nan, -1, -1/4, -1/9])
+        self.assertStructuredAlmostEqual(h, [nan, nan, 2, nan, 0, 1/4, nan, 0, 0, 2/27])
 
     @unittest.skipUnless(check_available_solvers('ipopt'),
                          "The 'ipopt' solver is not available")

--- a/pyomo/contrib/ampl_function_demo/tests/test_ampl_function_demo.py
+++ b/pyomo/contrib/ampl_function_demo/tests/test_ampl_function_demo.py
@@ -34,6 +34,21 @@ class TestAMPLExternalFunction(unittest.TestCase):
             reltol=1e-5
         )
 
+    @unittest.skipIf(is_pypy, 'Cannot evaluate external functions under pypy')
+    def test_eval_function_fgh(self):
+        m = pyo.ConcreteModel()
+        m.tf = pyo.ExternalFunction(library=flib, function="demo_function")
+
+        f, g, h = m.tf.evaluate_fgh(("sum", 1, 2, 3))
+        self.assertEqual(f, 6)
+        self.assertEqual(g, [0, 1, 1, 1])
+        self.assertEqual(h, [0]*10)
+
+        f, g, h = m.tf.evaluate_fgh(("inv", 1, 2, 3))
+        self.assertAlmostEqual(f, 1.8333333, 4)
+        self.assertStructuredAlmostEqual(g, [0, -1, -1/4, -1/9])
+        self.assertStructuredAlmostEqual(h, [0, 0, 2, 0, 0, 1/4, 0, 0, 0, 2/27])
+
     @unittest.skipUnless(check_available_solvers('ipopt'),
                          "The 'ipopt' solver is not available")
     def test_solve_function(self):

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -360,11 +360,24 @@ class AMPLExternalFunction(ExternalFunction):
         fcn = self._known_functions[self._function][0]
         f = fcn(byref(arglist))
         if fgh >= 1:
-            g = [arglist.derivs[i] for i in range(N)]
+            g = [0]*N
+            for i in range(N):
+                if arglist.at[i] < 0:
+                    continue
+                g[i] = arglist.derivs[arglist.at[i]]
         else:
             g = None
         if fgh >= 2:
-            h = [arglist.hes[i] for i in range((N + N**2)//2)]
+            h = [0]*((N + N**2)//2)
+            for j in range(N):
+                j_r = arglist.at[j]
+                if j_r < 0:
+                    continue
+                for i in range(j+1):
+                    i_r = arglist.at[i]
+                    if i_r < 0:
+                        continue
+                    h[i + j*(j + 1)//2] = arglist.hes[i_r + j_r*(j_r + 1)//2]
         else:
             h = None
         return f, g, h

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -30,7 +30,7 @@ from pyomo.core.base.units_container import units
 __all__  = ( 'ExternalFunction', )
 
 logger = logging.getLogger('pyomo.core')
-
+nan = float('nan')
 
 class ExternalFunction(Component):
     """Interface to an external (non-algebraic) function.
@@ -360,7 +360,7 @@ class AMPLExternalFunction(ExternalFunction):
         fcn = self._known_functions[self._function][0]
         f = fcn(byref(arglist))
         if fgh >= 1:
-            g = [0]*N
+            g = [nan]*N
             for i in range(N):
                 if arglist.at[i] < 0:
                     continue
@@ -368,7 +368,7 @@ class AMPLExternalFunction(ExternalFunction):
         else:
             g = None
         if fgh >= 2:
-            h = [0]*((N + N**2)//2)
+            h = [nan]*((N + N**2)//2)
             for j in range(N):
                 j_r = arglist.at[j]
                 if j_r < 0:


### PR DESCRIPTION
## Fixes #2528 .

## Summary/Motivation:
The `AmplExternalFunction` interface did not correctly map the gradient / Hessian for external functions with string arguments.  This PR resolves that mapping, inserting 0's in the corresponding locations.

Question for reviewers (and @eslickj): is it correct to insert `0`s, or should this put `nan`s in locations corresponding to string arguments?

## Changes proposed in this PR:
- correct mapping of gradient / Hessian information for external functions with string arguments
- update test to exercise this behavior.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
