### PR TITLE
Bugfix for `sum_product(Var, Param, Param)`

### DIFF
--- a/pyomo/core/tests/unit/test_expr_misc.py
+++ b/pyomo/core/tests/unit/test_expr_misc.py
@@ -96,6 +96,28 @@ class Test(unittest.TestCase):
         baseline = "1/(y[1]*x[1]) + 1/(y[2]*x[2]) + 1/(y[3]*x[3])"
         self.assertEqual( str(expr), baseline )
 
+    def test_sum_product_ParamVarVar(self):
+        model = AbstractModel()
+        model.A = Set(initialize=[1,2,3])
+        model.B = Param(model.A,initialize={1:100,2:200,3:300}, mutable=True)
+        model.x = Var(model.A)
+        model.y = Var(model.A)
+        instance=model.create_instance()
+        expr = sum_product(instance.B, instance.y, instance.x)
+        baseline = "B[1]*y[1]*x[1] + B[2]*y[2]*x[2] + B[3]*y[3]*x[3]"
+        self.assertEqual( str(expr), baseline )
+
+    def test_sum_product_ParamParamVar(self):
+        model = AbstractModel()
+        model.A = Set(initialize=[1,2,3])
+        model.B = Param(model.A,initialize={1:100,2:200,3:300}, mutable=True)
+        model.x = Var(model.A)
+        model.y = Param(model.A, mutable=True)
+        instance=model.create_instance()
+        expr = sum_product(instance.B, instance.y, instance.x)
+        baseline = "B[1]*y[1]*x[1] + B[2]*y[2]*x[2] + B[3]*y[3]*x[3]"
+        self.assertEqual( str(expr), baseline )
+
     def test_expr5(self):
         model = ConcreteModel()
         model.A = Set(initialize=[1,2,3], doc='set A')

--- a/pyomo/core/util.py
+++ b/pyomo/core/util.py
@@ -200,7 +200,6 @@ def sum_product(*args, **kwds):
             params_.append(arg)
     nvars = len(vars_)
 
-    num_index = range(0,nargs)
     if ndenom == 0:
         #
         # Sum of polynomial terms
@@ -224,8 +223,8 @@ def sum_product(*args, **kwds):
                         expr += start
                         for i in index:
                             term = 1
-                            for j in params_:
-                                term *= params_[j][i]
+                            for p in params_:
+                                term *= p[i]
                             expr += term * v[i]
                 return expr
             #
@@ -233,24 +232,24 @@ def sum_product(*args, **kwds):
                 expr += start
                 for i in index:
                     term = 1
-                    for j in num_index:
-                        term *= args[j][i]
+                    for arg in args:
+                        term *= arg[i]
                     expr += term
             return expr
         #
-        return quicksum((prod(args[j][i] for j in num_index) for i in index), start)
+        return quicksum((prod(arg[i] for arg in args) for i in index), start)
     elif nargs == 0:
         #
         # Sum of reciprocals
         #
-        denom_index = range(0,ndenom)
-        return quicksum((1/prod(denom[j][i] for j in denom_index) for i in index), start)
+        return quicksum((1/prod(den[i] for den in denom) for i in index), start)
     else:
         #
         # Sum of fractions
         #
-        denom_index = range(0,ndenom)
-        return quicksum((prod(args[j][i] for j in num_index)/prod(denom[j][i] for j in denom_index) for i in index), start)
+        return quicksum((
+            prod(arg[i] for arg in args) / prod(den[i] for den in denom)
+            for i in index), start)
 
 
 #: An alias for :func:`sum_product <pyomo.core.expr.util>`


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This resolves a longstanding bug (undefined variable) in `sum_product` uncovered while generating a larger expression test suite.

## Changes proposed in this PR:
- Resolve sum_product bug for `sum_product(Param, Param, Var)`
- Expand `sum_product` testing

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
