### PR TITLE
GDPopt deletes the dummy objective if it has to make one

### DIFF
--- a/pyomo/contrib/gdpopt/algorithm_base_class.py
+++ b/pyomo/contrib/gdpopt/algorithm_base_class.py
@@ -56,6 +56,7 @@ class _GDPoptAlgorithm():
         self.incumbent_continuous_soln = None
 
         self.original_obj = None
+        self._dummy_obj = None
         self.original_util_block = None
 
         self.log_formatter = ('{:>9}   {:>15}   {:>11.5f}   {:>11.5f}   '
@@ -412,7 +413,7 @@ class _GDPoptAlgorithm():
         if number_of_objectives == 0:
             config.logger.warning(
                 'Model has no active objectives. Adding dummy objective.')
-            discrete_obj = Objective(expr=1)
+            self._dummy_obj = discrete_obj = Objective(expr=1)
             original_model.add_component(unique_component_name(original_model,
                                                                'dummy_obj'),
                                          discrete_obj)
@@ -456,6 +457,9 @@ class _GDPoptAlgorithm():
         # prior one.
         if self.original_obj is not None:
             self.original_obj.activate()
+        if self._dummy_obj is not None:
+            self._dummy_obj.parent_block().del_component(self._dummy_obj)
+            self._dummy_obj = None
 
     def _get_final_pyomo_results_object(self):
         """

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -156,6 +156,11 @@ class TestGDPoptUnit(unittest.TestCase):
             self.assertIn("Model has no active objectives. Adding dummy "
                           "objective.", output.getvalue().strip())
 
+        # check that the dummy objective is removed after the solve (else
+        # repeated solves result in the error about multiple active objectives
+        # on the model)
+        self.assertIsNone(m.component("dummy_obj"))
+
     def test_multiple_objectives(self):
         m = ConcreteModel()
         m.x = Var()


### PR DESCRIPTION
## Fixes #2526 

## Summary/Motivation:

Fixing a silly bug where when GDPopt yells at you about not having an objective, and when you add one, then it yells at you for having two because it never deleted its own.

## Changes proposed in this PR:
- Fixes the bug
- Adds a check in the tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
