### PR TITLE
Fix for Xpress when stopped due to MAXTIME or MAXNODES

### DIFF
--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -205,7 +205,7 @@ class XpressDirect(DirectSolver):
 
         start_time = time.time()
         if self._tee:
-            self._solver_model.solve()
+            self._solve_model()
         else:
             # In xpress versions greater than or equal 36,
             # it seems difficult to completely suppress console
@@ -213,7 +213,7 @@ class XpressDirect(DirectSolver):
             # As a work around, we capature all screen output
             # when tee is False.
             with capture_output() as OUT:
-                self._solver_model.solve()
+                self._solve_model()
         self._opt_time = time.time() - start_time
 
         self._solver_model.setlogfile('')
@@ -222,6 +222,10 @@ class XpressDirect(DirectSolver):
 
         # FIXME: can we get a return code indicating if XPRESS had a significant failure?
         return Bunch(rc=None, log=None)
+
+    def _solve_model(self):
+        self._solver_model.solve()
+        self._solver_model.postsolve()
 
     def _get_expr_from_pyomo_repn(self, repn, max_degree=2):
         referenced_vars = ComponentSet()


### PR DESCRIPTION
## Fixes # N/A

## Summary/Motivation:
If Xpress stops due to some limit, e.g., a time limit set by the user, it leaves the model in a presolved state. Explicitly calling `postsolve` enables the user to set a time limit or node limit while using Pyomo and get a result back.

## Changes proposed in this PR:
- Add postsolve to whenever Xpress calls `solve`

## Questions:
- It would be nice to test this -- are there any existing problems in Pyomo's test suite that might fail on `main` when a time or node limit is set?

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
