### PR TITLE
Add deprecation path for expression objects moved to `relational_expr`

### DIFF
--- a/pyomo/contrib/parmest/__init__.py
+++ b/pyomo/contrib/parmest/__init__.py
@@ -14,18 +14,18 @@ from pyomo.common.deprecation import relocated_module_attribute
 relocated_module_attribute(
     'create_ef', 
     'pyomo.contrib.parmest.utils.create_ef', 
-    'TBD')
+    version='6.4.2')
 relocated_module_attribute(
     'ipopt_solver_wrapper', 
     'pyomo.contrib.parmest.utils.ipopt_solver_wrapper', 
-    'TBD')
+    version='6.4.2')
 relocated_module_attribute(
     'mpi_utils', 
     'pyomo.contrib.parmest.utils.mpi_utils', 
-    'TBD')
+    version='6.4.2')
 relocated_module_attribute(
     'scenario_tree', 
     'pyomo.contrib.parmest.utils.scenario_tree', 
-    'TBD')
+    version='6.4.2')
 
 

--- a/pyomo/core/expr/logical_expr.py
+++ b/pyomo/core/expr/logical_expr.py
@@ -21,7 +21,9 @@ import traceback
 logger = logging.getLogger('pyomo.core')
 
 from pyomo.common.errors import PyomoException, DeveloperError
-from pyomo.common.deprecation import deprecation_warning, RenamedClass
+from pyomo.common.deprecation import (
+    deprecation_warning, RenamedClass, relocated_module_attribute,
+)
 from .numvalue import (
     native_types,
     native_numeric_types,
@@ -41,6 +43,22 @@ from .expr_common import (
 
 import operator
 
+relocated_module_attribute(
+    'EqualityExpression',
+    'pyomo.core.expr.relational_expr',
+    version='TBD')
+relocated_module_attribute(
+    'InequalityExpression',
+    'pyomo.core.expr.relational_expr',
+    version='TBD')
+relocated_module_attribute(
+    'RangedExpression',
+    'pyomo.core.expr.relational_expr',
+    version='TBD')
+relocated_module_attribute(
+    'inequality',
+    'pyomo.core.expr.relational_expr',
+    version='TBD')
 
 
 def _generate_logical_proposition(etype, lhs, rhs):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
#2499 moved several Expression classes.  This PR adds a deprecation path to the old class locations.

## Changes proposed in this PR:
- Add relocated_module_attribute deprecation paths for `EqualityExpression`, `InequalityExpression`, `RangedExpression`, and `inequality`
- Update version strings for previous parmest deprecations

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
