### PR TITLE
BUGFIX: GSL and GJH Downloads

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -537,7 +537,7 @@ jobs:
         echo ""
         echo "Pyomo download-extensions"
         echo ""
-        pyomo download-extensions
+        pyomo download-extensions || exit 1
         echo ""
         echo "Pyomo build-extensions"
         echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -558,7 +558,7 @@ jobs:
         echo ""
         echo "Pyomo download-extensions"
         echo ""
-        pyomo download-extensions
+        pyomo download-extensions || exit 1
         echo ""
         echo "Pyomo build-extensions"
         echo ""

--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -301,7 +301,7 @@ class FileDownloader(object):
                 ctx.check_hostname = False
                 ctx.verify_mode = ssl.CERT_NONE
             fetch = request.urlopen(url, context=ctx)
-        except AttributeError:
+        except:
             # This is a fix implemented if we get stuck behind server
             # security features (blocks "bot" agents).
             # We are setting a known user-agent to get around that.

--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -302,8 +302,13 @@ class FileDownloader(object):
                 ctx.verify_mode = ssl.CERT_NONE
             fetch = request.urlopen(url, context=ctx)
         except AttributeError:
-            # Revert to pre-2.7.9 syntax
-            fetch = request.urlopen(url)
+            # This is a fix implemented if we get stuck behind server
+            # security features (blocks "bot" agents).
+            # We are setting a known user-agent to get around that.
+            req = request.Request(
+                url=url,
+                headers={'User-Agent': 'Mozilla/5.0'})
+            fetch = request.urlopen(req)
         ans = fetch.read()
         logger.info("  ...downloaded %s bytes" % (len(ans),))
         return ans

--- a/pyomo/common/getGSL.py
+++ b/pyomo/common/getGSL.py
@@ -35,7 +35,9 @@ def find_GSL():
 
 def get_gsl(downloader):
     system, bits = downloader.get_sysinfo()
-    url = downloader.get_platform_url(urlmap) % (bits,)
+    url = downloader.get_platform_url(urlmap)
+    if '%s' in url:
+        url = url % (bits,)
 
     downloader.set_destination_filename(os.path.join('lib', 'amplgsl.dll'))
 

--- a/pyomo/common/getGSL.py
+++ b/pyomo/common/getGSL.py
@@ -21,10 +21,10 @@ logger = logging.getLogger('pyomo.common')
 # These URLs were retrieved from
 #     https://ampl.com/resources/extended-function-library/
 urlmap = {
-    'linux':   'https://ampl.com/NEW/amplgsl/amplgsl.linux-intel%s.zip',
-    'windows': 'https://ampl.com/NEW/amplgsl/amplgsl.mswin%s.zip',
-    'cygwin':  'https://ampl.com/NEW/amplgsl/amplgsl.mswin%s.zip',
-    'darwin':  'https://ampl.com/NEW/amplgsl/amplgsl.macosx%s.zip'
+    'linux':   'https://old.ampl.com/dl/open/amplgsl/amplgsl-linux%s.zip',
+    'windows': 'https://old.ampl.com/dl/open/amplgsl/amplgsl-mswin%s.zip',
+    'cygwin':  'https://old.ampl.com/dl/open/amplgsl/amplgsl-mswin%s.zip',
+    'darwin':  'https://old.ampl.com/dl/open/amplgsl/amplgsl-osx.zip'
 }
 
 def find_GSL():

--- a/pyomo/common/getGSL.py
+++ b/pyomo/common/getGSL.py
@@ -22,8 +22,8 @@ logger = logging.getLogger('pyomo.common')
 #     https://ampl.com/resources/extended-function-library/
 urlmap = {
     'linux':   'https://old.ampl.com/dl/open/amplgsl/amplgsl-linux%s.zip',
-    'windows': 'https://old.ampl.com/dl/open/amplgsl/amplgsl-mswin%s.zip',
-    'cygwin':  'https://old.ampl.com/dl/open/amplgsl/amplgsl-mswin%s.zip',
+    'windows': 'https://old.ampl.com/dl/open/amplgsl/amplgsl-win%s.zip',
+    'cygwin':  'https://old.ampl.com/dl/open/amplgsl/amplgsl-win%s.zip',
     'darwin':  'https://old.ampl.com/dl/open/amplgsl/amplgsl-osx.zip'
 }
 

--- a/pyomo/contrib/gjh/getGJH.py
+++ b/pyomo/contrib/gjh/getGJH.py
@@ -21,10 +21,10 @@ logger = logging.getLogger('pyomo.common')
 #     https://ampl.com/resources/hooking-your-solver-to-ampl/
 # All 32-bit downloads are used - 64-bit is available only for Linux
 urlmap = {
-    'linux':   'https://ampl.com/netlib/ampl/student/linux/gjh.gz',
-    'windows': 'https://ampl.com/netlib/ampl/student/mswin/gjh.exe.gz',
-    'cygwin':  'https://ampl.com/netlib/ampl/student/mswin/gjh.exe.gz',
-    'darwin':  'https://ampl.com/netlib/ampl/student/macosx/x86_32/gjh.gz',
+    'linux':   'https://netlib.org/ampl/student/linux/gjh.gz',
+    'windows': 'https://netlib.org/ampl/student/mswin/gjh.exe.gz',
+    'cygwin':  'https://netlib.org/ampl/student/mswin/gjh.exe.gz',
+    'darwin':  'https://netlib.org/ampl/student/macosx/x86_32/gjh.gz',
 }
 exemap = {
     'linux':   '',


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
The URLs for GSL and GJH have changed so `pyomo download-extensions` was silently failing on GitHub Actions.

## Changes proposed in this PR:
- Correct the URLs
- If URL fails outright, try doing it again as a recognized user agent
- Explicit failure on `pyomo download-extensions`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
