### PR TITLE
GHA: Remove caching of OS/python packages; rebuild all caches; pin matplotlib!=3.6.1

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -19,7 +19,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
-  CACHE_VER: v210812.0
+  CACHE_VER: v221013.0
   NEOS_EMAIL: tests@pyomo.org
 
 jobs:
@@ -128,21 +128,21 @@ jobs:
     #    path: cache/conda
     #    key: conda-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
-    - name: Pip package cache
-      uses: actions/cache@v2
-      if: matrix.PYENV == 'pip'
-      id: pip-cache
-      with:
-        path: cache/pip
-        key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
+    #- name: Pip package cache
+    #  uses: actions/cache@v2
+    #  if: matrix.PYENV == 'pip'
+    #  id: pip-cache
+    #  with:
+    #    path: cache/pip
+    #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
-    - name: OS package cache
-      uses: actions/cache@v2
-      if: matrix.TARGET != 'osx'
-      id: os-cache
-      with:
-        path: cache/os
-        key: pkg-${{env.CACHE_VER}}.0-${{runner.os}}
+    #- name: OS package cache
+    #  uses: actions/cache@v2
+    #  if: matrix.TARGET != 'osx'
+    #  id: os-cache
+    #  with:
+    #    path: cache/os
+    #    key: pkg-${{env.CACHE_VER}}.0-${{runner.os}}
 
     - name: TPL package download cache
       uses: actions/cache@v2
@@ -661,12 +661,12 @@ jobs:
       uses: actions/checkout@v3
       # We need the source for .codecov.yml and running "coverage xml"
 
-    - name: Pip package cache
-      uses: actions/cache@v2
-      id: pip-cache
-      with:
-        path: cache/pip
-        key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.8
+    #- name: Pip package cache
+    #  uses: actions/cache@v2
+    #  id: pip-cache
+    #  with:
+    #    path: cache/pip
+    #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.8
 
     - name: Download build artifacts
       uses: actions/download-artifact@v2

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -19,7 +19,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
-  CACHE_VER: v221013.0
+  CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
 
 jobs:
@@ -146,6 +146,7 @@ jobs:
 
     - name: TPL package download cache
       uses: actions/cache@v2
+      if: ${{ ! matrix.slim }}
       id: download-cache
       with:
         path: cache/download

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -314,7 +314,14 @@ jobs:
             # TODO: This is a hack to stop test_qt.py from running until we
             # can better troubleshoot why it fails on GHA
             for QTPACKAGE in qt pyqt; do
-                conda remove $QTPACKAGE || echo "$QTPACKAGE not in this environment"
+                # Because conda is insane, removing packages can cause
+                # unrelated packages to be updated (breaking version
+                # specifications specified previously, e.g., in
+                # setup.py).  There doesn't appear to be a good
+                # workaround, so we will just force-remove (recognizing
+                # that it may break other conda cruft).
+                conda remove --force-remove $QTPACKAGE \
+                    || echo "$QTPACKAGE not in this environment"
             done
         fi
         # Re-try Pyomo (optional) dependencies with pip

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -335,7 +335,14 @@ jobs:
             # TODO: This is a hack to stop test_qt.py from running until we
             # can better troubleshoot why it fails on GHA
             for QTPACKAGE in qt pyqt; do
-                conda remove $QTPACKAGE || echo "$QTPACKAGE not in this environment"
+                # Because conda is insane, removing packages can cause
+                # unrelated packages to be updated (breaking version
+                # specifications specified previously, e.g., in
+                # setup.py).  There doesn't appear to be a good
+                # workaround, so we will just force-remove (recognizing
+                # that it may break other conda cruft).
+                conda remove --force-remove $QTPACKAGE \
+                    || echo "$QTPACKAGE not in this environment"
             done
         fi
         # Re-try Pyomo (optional) dependencies with pip

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -22,7 +22,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
-  CACHE_VER: v221013.0
+  CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
 
 jobs:
@@ -167,6 +167,7 @@ jobs:
 
     - name: TPL package download cache
       uses: actions/cache@v2
+      if: ${{ ! matrix.slim }}
       id: download-cache
       with:
         path: cache/download

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -22,7 +22,7 @@ env:
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
-  CACHE_VER: v210812.0
+  CACHE_VER: v221013.0
   NEOS_EMAIL: tests@pyomo.org
 
 jobs:
@@ -149,21 +149,21 @@ jobs:
     #    path: cache/conda
     #    key: conda-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
-    - name: Pip package cache
-      uses: actions/cache@v2
-      if: matrix.PYENV == 'pip'
-      id: pip-cache
-      with:
-        path: cache/pip
-        key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
+    #- name: Pip package cache
+    #  uses: actions/cache@v2
+    #  if: matrix.PYENV == 'pip'
+    #  id: pip-cache
+    #  with:
+    #    path: cache/pip
+    #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
-    - name: OS package cache
-      uses: actions/cache@v2
-      if: matrix.TARGET != 'osx'
-      id: os-cache
-      with:
-        path: cache/os
-        key: pkg-${{env.CACHE_VER}}.0-${{runner.os}}
+    #- name: OS package cache
+    #  uses: actions/cache@v2
+    #  if: matrix.TARGET != 'osx'
+    #  id: os-cache
+    #  with:
+    #    path: cache/os
+    #    key: pkg-${{env.CACHE_VER}}.0-${{runner.os}}
 
     - name: TPL package download cache
       uses: actions/cache@v2
@@ -682,12 +682,12 @@ jobs:
       uses: actions/checkout@v3
       # We need the source for .codecov.yml and running "coverage xml"
 
-    - name: Pip package cache
-      uses: actions/cache@v2
-      id: pip-cache
-      with:
-        path: cache/pip
-        key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.8
+    #- name: Pip package cache
+    #  uses: actions/cache@v2
+    #  id: pip-cache
+    #  with:
+    #    path: cache/pip
+    #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.8
 
     - name: Download build artifacts
       uses: actions/download-artifact@v2

--- a/setup.py
+++ b/setup.py
@@ -228,7 +228,9 @@ setup_kwargs = dict(
         'optional': [
             'dill',      # No direct use, but improves lambda pickle
             'ipython',   # contrib.viewer
-            'matplotlib',
+            # Note: matplotlib 3.6.1 has bug #24127, which breaks
+            # seaborn's histplot (triggering parmest failures)
+            'matplotlib!=3.6.1',
             'networkx',  # network, incidence_analysis, community_detection
             'numpy',
             'openpyxl',  # dataportals


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This reduces the amount of environment code that we cache by removing the pip and os caches.  It also updates the cache id (forcing all caches to be rebuilt).

## Changes proposed in this PR:
- remove caching of pip and os packages from GHA workflows
- Update the GHA cache ID to trigger rebuild of all caches
- Exclude broken matplotlib release

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
