### PR TITLE
Upgrade action versions

### DIFF
--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -26,7 +26,7 @@ jobs:
           TARGET: manylinux
         python-version: [3.7]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
@@ -51,7 +51,7 @@ jobs:
       run: |
         sudo rm -rfv dist/*-linux_x86_64.whl
     - name: Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: manylinux-wheels
         path: dist
@@ -69,7 +69,7 @@ jobs:
           TARGET: manylinuxaarch64
         python-version: [3.7]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
@@ -96,7 +96,7 @@ jobs:
       run: |
         sudo rm -rfv dist/*-linux_aarch64.whl
     - name: Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: manylinux-aarch64-wheels
         path: dist
@@ -113,7 +113,7 @@ jobs:
           TARGET: generic_tarball
         python-version: [3.7]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
@@ -126,7 +126,7 @@ jobs:
       run: |
         python setup.py --without-cython sdist --format=gztar
     - name: Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: generictarball
         path: dist
@@ -143,7 +143,7 @@ jobs:
           TARGET: osx
         python-version: [ 3.7, 3.8, 3.9, '3.10' ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
@@ -157,7 +157,7 @@ jobs:
         python setup.py  --with-cython --with-distributable-extensions sdist --format=gztar bdist_wheel
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: osx-wheels
         path: dist
@@ -174,7 +174,7 @@ jobs:
           TARGET: win
         python-version: [ 3.7, 3.8, 3.9, '3.10' ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
@@ -191,7 +191,7 @@ jobs:
         $env:PYTHONWARNINGS="ignore::UserWarning"
         Invoke-Expression "python setup.py  --with-cython --with-distributable-extensions sdist --format=gztar bdist_wheel"
     - name: Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: win-wheels
         path: dist

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -129,7 +129,7 @@ jobs:
     #    key: conda-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
     - name: Pip package cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       if: matrix.PYENV == 'pip'
       id: pip-cache
       with:
@@ -137,7 +137,7 @@ jobs:
         key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
     - name: OS package cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       if: matrix.TARGET != 'osx'
       id: os-cache
       with:
@@ -145,7 +145,7 @@ jobs:
         key: pkg-${{env.CACHE_VER}}.0-${{runner.os}}
 
     - name: TPL package download cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: download-cache
       with:
         path: cache/download
@@ -586,7 +586,7 @@ jobs:
         coverage xml -i
 
     - name: Record build artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{github.job}}_${{env.GHA_JOBGROUP}}-${{env.GHA_JOBNAME}}
         path: |
@@ -662,14 +662,14 @@ jobs:
       # We need the source for .codecov.yml and running "coverage xml"
 
     - name: Pip package cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: pip-cache
       with:
         path: cache/pip
         key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.8
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         path: artifacts
 
@@ -769,7 +769,7 @@ jobs:
 
     - name: Upload codecov reports
       if: github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main'
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         files: coverage.xml
         name: ${{ matrix.TARGET }}
@@ -780,7 +780,7 @@ jobs:
       if: |
         hashFiles('coverage-other.xml') != '' &&
         (github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main')
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         files: coverage-other.xml
         name: ${{ matrix.TARGET }}/other

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -121,7 +121,7 @@ jobs:
     # the 5 GB GitHub allows.
     #
     #- name: Conda package cache
-    #  uses: actions/cache@v2
+    #  uses: actions/cache@v3
     #  if: matrix.PYENV == 'conda'
     #  id: conda-cache
     #  with:
@@ -129,7 +129,7 @@ jobs:
     #    key: conda-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
     #- name: Pip package cache
-    #  uses: actions/cache@v2
+    #  uses: actions/cache@v3
     #  if: matrix.PYENV == 'pip'
     #  id: pip-cache
     #  with:
@@ -137,7 +137,7 @@ jobs:
     #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
     #- name: OS package cache
-    #  uses: actions/cache@v2
+    #  uses: actions/cache@v3
     #  if: matrix.TARGET != 'osx'
     #  id: os-cache
     #  with:
@@ -670,7 +670,7 @@ jobs:
       # We need the source for .codecov.yml and running "coverage xml"
 
     #- name: Pip package cache
-    #  uses: actions/cache@v2
+    #  uses: actions/cache@v3
     #  id: pip-cache
     #  with:
     #    path: cache/pip

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -142,7 +142,7 @@ jobs:
     # the 5 GB GitHub allows.
     #
     #- name: Conda package cache
-    #  uses: actions/cache@v2
+    #  uses: actions/cache@v3
     #  if: matrix.PYENV == 'conda'
     #  id: conda-cache
     #  with:
@@ -150,7 +150,7 @@ jobs:
     #    key: conda-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
     #- name: Pip package cache
-    #  uses: actions/cache@v2
+    #  uses: actions/cache@v3
     #  if: matrix.PYENV == 'pip'
     #  id: pip-cache
     #  with:
@@ -158,7 +158,7 @@ jobs:
     #    key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
     #- name: OS package cache
-    #  uses: actions/cache@v2
+    #  uses: actions/cache@v3
     #  if: matrix.TARGET != 'osx'
     #  id: os-cache
     #  with:
@@ -691,7 +691,7 @@ jobs:
       # We need the source for .codecov.yml and running "coverage xml"
 
     #- name: Pip package cache
-    #  uses: actions/cache@v2
+    #  uses: actions/cache@v3
     #  id: pip-cache
     #  with:
     #    path: cache/pip

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -150,7 +150,7 @@ jobs:
     #    key: conda-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
     - name: Pip package cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       if: matrix.PYENV == 'pip'
       id: pip-cache
       with:
@@ -158,7 +158,7 @@ jobs:
         key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-${{matrix.python}}
 
     - name: OS package cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       if: matrix.TARGET != 'osx'
       id: os-cache
       with:
@@ -166,7 +166,7 @@ jobs:
         key: pkg-${{env.CACHE_VER}}.0-${{runner.os}}
 
     - name: TPL package download cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: download-cache
       with:
         path: cache/download
@@ -607,7 +607,7 @@ jobs:
         coverage xml -i
 
     - name: Record build artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{github.job}}_${{env.GHA_JOBGROUP}}-${{env.GHA_JOBNAME}}
         path: |
@@ -683,14 +683,14 @@ jobs:
       # We need the source for .codecov.yml and running "coverage xml"
 
     - name: Pip package cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: pip-cache
       with:
         path: cache/pip
         key: pip-${{env.CACHE_VER}}.0-${{runner.os}}-3.8
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         path: artifacts
 
@@ -790,7 +790,7 @@ jobs:
 
     - name: Upload codecov reports
       if: github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main'
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         files: coverage.xml
         name: ${{ matrix.TARGET }}
@@ -801,7 +801,7 @@ jobs:
       if: |
         hashFiles('coverage-other.xml') != '' &&
         (github.repository_owner == 'Pyomo' || github.ref != 'refs/heads/main')
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         files: coverage-other.xml
         name: ${{ matrix.TARGET }}/other


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
There is a coming upgrade to `Node.js` on GitHub runners, so we need to preemptively update our action versions.

**OUTLIER**: `setup-miniconda` - it hasn't been updated since May 2021, so may need to divorce that dependency.

## Changes proposed in this PR:
- Update lots of actions from v2 to v3

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
