### PR TITLE
Expression.set_value: raise exception for non-numeric expressions

### DIFF
--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -191,7 +191,7 @@ class _GeneralExpressionDataImpl(_ExpressionData):
             raise ValueError(
                 f"Cannot assign {expr.__class__.__name__} to "
                 f"'{self.name}': {self.__class__.__name__} components only "
-                "allows numeric expression types.")
+                "allow numeric expression types.")
         # In-place operators will leave self as an argument.  We need to
         # replace that with the current expression in order to avoid
         # loops in the expression tree.

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -187,6 +187,11 @@ class _GeneralExpressionDataImpl(_ExpressionData):
             self._expr = None
             return
         expr = as_numeric(expr)
+        if not expr.is_numeric_type():
+            raise ValueError(
+                f"Cannot assign {expr.__class__.__name__} to "
+                f"'{self.name}': {self.__class__.__name__} components only "
+                "allows numeric expression types.")
         # In-place operators will leave self as an argument.  We need to
         # replace that with the current expression in order to avoid
         # loops in the expression tree.

--- a/pyomo/core/tests/unit/test_obj.py
+++ b/pyomo/core/tests/unit/test_obj.py
@@ -50,7 +50,7 @@ class TestScalarObj(unittest.TestCase):
         m.x = Var()
         with self.assertRaisesRegex(
                 ValueError, "Cannot assign InequalityExpression to 'obj': "
-                "ScalarObjective components only allows numeric expression "
+                "ScalarObjective components only allow numeric expression "
                 "types."):
             m.obj = Objective(expr=m.x <= 0)
 

--- a/pyomo/core/tests/unit/test_obj.py
+++ b/pyomo/core/tests/unit/test_obj.py
@@ -45,6 +45,15 @@ class TestScalarObj(unittest.TestCase):
         model.o.expr += 2
         self.assertEqual(model.o.expr(), 4)
 
+    def test_scalar_invalid_expr(self):
+        m = ConcreteModel()
+        m.x = Var()
+        with self.assertRaisesRegex(
+                ValueError, "Cannot assign InequalityExpression to 'obj': "
+                "ScalarObjective components only allows numeric expression "
+                "types."):
+            m.obj = Objective(expr=m.x <= 0)
+
     def test_empty_singleton(self):
         a = Objective()
         a.construct()

--- a/pyomo/core/tests/unit/test_pickle.py
+++ b/pyomo/core/tests/unit/test_pickle.py
@@ -227,7 +227,7 @@ class Test(unittest.TestCase):
     def test_pickle_concrete_model_objective(self):
         model = ConcreteModel()
         model.x = Var()
-        model.A = Objective(expr=model.x <= 0)
+        model.A = Objective(expr=model.x**2)
         str = pickle.dumps(model)
         tmodel = pickle.loads(str)
         self.verifyModel(model, tmodel)


### PR DESCRIPTION
## Fixes #378.

## Summary/Motivation:
The root cause of #2562 was that the user was setting the value of an `Expression` component (in this case, the `Objective`) to a relational expression and not a numeric expression.  Now that Pyomo is supporting multiple expression "systems", we should be more careful about what we accept for `Expression`/ `Objective` values.

This PR raises an exception when setting an `Expression`/ `Objective` to anything other than a valid numeric expression.

## Changes proposed in this PR:
- `ExpressionData.set_value()` raise exception for non-numeric expressions 
- Update test to exercise exception

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
