### PR TITLE
NLv2: update tracking of used named subexpressions

### DIFF
--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -1382,7 +1382,11 @@ class _NLWriter_impl(object):
             if info[2]:
                 pass
             elif info[1] is None:
-                n_subexpressions[3 if info[0] else 1] += 1
+                if info[0] is None:
+                    # Unused subexpression
+                    pass
+                else:
+                    n_subexpressions[3 if info[0] else 1] += 1
             elif info[0] is None:
                 n_subexpressions[4 if info[1] else 2] += 1
             else:

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -1581,6 +1581,9 @@ class AMPLRepn(object):
             return prefix + (template.const % 0), [], named_exprs
 
     def compile_nonlinear_fragment(self, visitor):
+        if not self.nonlinear:
+            self.nonlinear = None
+            return
         args = []
         nterms = len(self.nonlinear)
         nl_sum = ''.join(map(itemgetter(0), self.nonlinear))
@@ -1591,10 +1594,8 @@ class AMPLRepn(object):
             self.nonlinear = (visitor.template.nary_sum % nterms) + nl_sum, args
         elif nterms == 2:
             self.nonlinear = visitor.template.binary_sum + nl_sum, args
-        elif nterms == 1:
+        else: # nterms == 1:
             self.nonlinear = nl_sum, args
-        else: # nterms == 0
-            self.nonlinear = None
 
     def append(self, other):
         """Append a child result from acceptChildResult
@@ -2018,7 +2019,7 @@ def handle_named_expression_node(visitor, node, arg1):
     if mult != 1:
         repn.const *= mult
         if repn.linear:
-            repn.linear = [(v, c*mult) for v, c in repn.linear if c]
+            repn.linear = [(v, c*mult) for v, c in repn.linear]
         if repn.nonlinear:
             if mult == -1:
                 prefix = visitor.template.negation

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -1515,6 +1515,7 @@ class AMPLRepn(object):
                 prefix += template.negation
             else:
                 prefix += template.multiplier % self.mult
+            self.mult = 1
         if self.named_exprs is not None:
             if named_exprs is None:
                 named_exprs = set(self.named_exprs)

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -2247,8 +2247,6 @@ class AMPLRepnVisitor(StreamBasedExpressionVisitor):
         self.used_named_expressions = used_named_expressions
         self.symbolic_solver_labels = symbolic_solver_labels
         #self.value_cache = {}
-        self._before_child_handlers = _before_child_handlers
-        self._operator_handles = _operator_handles
 
     def initializeWalker(self, expr):
         expr, src, src_idx = expr
@@ -2260,10 +2258,10 @@ class AMPLRepnVisitor(StreamBasedExpressionVisitor):
 
     def beforeChild(self, node, child, child_idx):
         try:
-            return self._before_child_handlers[child.__class__](self, child)
+            return _before_child_handlers[child.__class__](self, child)
         except KeyError:
             self._register_new_before_child_processor(child)
-        return self._before_child_handlers[child.__class__](self, child)
+        return _before_child_handlers[child.__class__](self, child)
 
     def enterNode(self, node):
         # SumExpression are potentially large nary operators.  Directly
@@ -2285,7 +2283,7 @@ class AMPLRepnVisitor(StreamBasedExpressionVisitor):
         #
         # General expressions...
         #
-        return self._operator_handles[node.__class__](self, node, *data)
+        return _operator_handles[node.__class__](self, node, *data)
 
     def finalizeResult(self, result):
         # We need to make a copy of the AMPLRepn as we will be modifying

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -2345,10 +2345,8 @@ class AMPLRepnVisitor(StreamBasedExpressionVisitor):
             ans.nl = None
 
         if ans.nonlinear.__class__ is list:
-            if ans.nonlinear:
-                ans.compile_nonlinear_fragment(self)
-            else:
-                ans.nonlinear = None
+            ans.compile_nonlinear_fragment(self)
+
         linear = {}
         if ans.mult != 1:
             mult, ans.mult = ans.mult, 1
@@ -2365,7 +2363,6 @@ class AMPLRepnVisitor(StreamBasedExpressionVisitor):
                 else:
                     prefix = self.template.multiplier % mult
                 ans.nonlinear = prefix + ans.nonlinear[0], ans.nonlinear[1]
-
         elif ans.linear:
             for v, c in ans.linear:
                 if v in linear:

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -2298,7 +2298,7 @@ class AMPLRepnVisitor(StreamBasedExpressionVisitor):
                 # This named expression has both a linear and a
                 # nonlinear component, and possibly a multiplier and
                 # constant.  We will not include this named expression
-                # and instead will expost the components so that linear
+                # and instead will expose the components so that linear
                 # variables are not accidentally re-characterized as
                 # nonlinear.
                 pass

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -1353,11 +1353,8 @@ class _NLWriter_impl(object):
             if info[2]:
                 pass
             elif info[1] is None:
-                if info[0] is None:
-                    # Unused subexpression
-                    pass
-                else:
-                    n_subexpressions[3 if info[0] else 1] += 1
+                #assert info[0] is not None:
+                n_subexpressions[3 if info[0] else 1] += 1
             elif info[0] is None:
                 n_subexpressions[4 if info[1] else 2] += 1
             else:

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -43,6 +43,7 @@ class INFO(object):
             self.var_map,
             self.used_named_expressions,
             self.symbolic_solver_labels,
+            True,
         )
 
 class Test_AMPLRepnVisitor(unittest.TestCase):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
When testing the NLv2 writer on IDAES models, we came across a situation where model initialization would multiply a named subexpression by 0.  The compilation step would simplify this to 0 and not emit the named expression out to the NL file.  Unfortunately, the ASL will seg fault if you tell it to expect more named expressions than you actually provide.

This PR changes how we track named subexpressions to that simplifications like `0*expr` will be reflected correctly in the list of used named subexpressions.  This works by propagating the set of used named subexpressions up through the AMPLRepn object instead of calculating the set of used named expressions after the fact.  This ensures that simplifications like `0*expr*` are applied to both the compiled expression and the list of used named expressions.

These changes have a negligible impact on the NLv2 writer performance.

## Changes proposed in this PR:
- Track used named expressions through the AMPLRepn class
- Add a flag to the NLv2 writer to disable emitting named expressions as ASL defined variables.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
