### PR TITLE
Be more targeted when retrying failed downloads

### DIFF
--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -25,6 +25,7 @@ import pyomo.common
 from pyomo.common.dependencies import attempt_import
 
 request = attempt_import('urllib.request')[0]
+urllib_error = attempt_import('urllib.error')[0]
 ssl = attempt_import('ssl')[0]
 zipfile = attempt_import('zipfile')[0]
 gzip = attempt_import('gzip')[0]
@@ -293,22 +294,27 @@ class FileDownloader(object):
 
     def retrieve_url(self, url):
         """Return the contents of a URL as an io.BytesIO object"""
+        ctx = ssl.create_default_context()
+        if self.cacert:
+            ctx.load_verify_locations(cafile=self.cacert)
+        if self.insecure:
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
         try:
-            ctx = ssl.create_default_context()
-            if self.cacert:
-                ctx.load_verify_locations(cafile=self.cacert)
-            if self.insecure:
-                ctx.check_hostname = False
-                ctx.verify_mode = ssl.CERT_NONE
             fetch = request.urlopen(url, context=ctx)
-        except:
+        except urllib_error.HTTPError as e:
+            if e.code != 403: # Forbidden
+                raise
+            fetch = None
+        if fetch is None:
             # This is a fix implemented if we get stuck behind server
-            # security features (blocks "bot" agents).
+            # security features (attempting to block "bot" agents).
             # We are setting a known user-agent to get around that.
             req = request.Request(
                 url=url,
-                headers={'User-Agent': 'Mozilla/5.0'})
-            fetch = request.urlopen(req)
+                headers={'User-Agent': 'Mozilla/5.0'},
+            )
+            fetch = request.urlopen(req, context=ctx)
         ans = fetch.read()
         logger.info("  ...downloaded %s bytes" % (len(ans),))
         return ans


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This provides a more target implementation for retrying downloads that fail with a '403: Forbidden' error.  It also corrects a bug in the previous implementation that did not pass the SSL context when retrying the download.

## Changes proposed in this PR:
- Only retry the download when a HTTP:403 error is encountered
- Use the SSL context when retrying the download

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
