### PR TITLE
Fixing bug in gdpopt.enumerate when appsi is not installed

### DIFF
--- a/pyomo/contrib/gdpopt/config_options.py
+++ b/pyomo/contrib/gdpopt/config_options.py
@@ -191,6 +191,13 @@ def _add_nlp_solve_configs(CONFIG, default_nlp_init_method):
         description="""Flag to round subproblem discrete variable values to the
         nearest integer. Rounding is done before fixing disjuncts."""
     ))
+    CONFIG.declare("max_fbbt_iterations", ConfigValue(
+        default=3,
+        description="""
+        Maximum number of feasibility-based bounds tightening
+        iterations to do during NLP subproblem preprocessing.""",
+        domain=PositiveInt
+    ))
 
 def _add_oa_configs(CONFIG):
     _add_nlp_solve_configs(
@@ -275,13 +282,6 @@ def _add_oa_configs(CONFIG):
         Flag to enable or disable GDPopt MIP presolve.
         Default=True.""",
         domain=bool
-    ))
-    CONFIG.declare("max_fbbt_iterations", ConfigValue(
-        default=3,
-        description="""
-        Maximum number of feasibility-based bounds tightening
-        iterations to do during NLP subproblem preprocessing.""",
-        domain=PositiveInt
     ))
     CONFIG.declare("calc_disjunctive_bounds", ConfigValue(
         default=False,

--- a/pyomo/contrib/gdpopt/solve_subproblem.py
+++ b/pyomo/contrib/gdpopt/solve_subproblem.py
@@ -230,20 +230,18 @@ class preprocess_subproblem(object):
 
         try:
             # First do FBBT
-            if cmodel_available:
-                # [ESJ 8/16/22] We can do this when #2491 is resolved. For now,
-                # we'll just use contrib.fbbt.
-                pass
-                # # use the appsi fbbt implementation since we can
-                # it = appsi.fbbt.IntervalTightener()
-                # it.config.integer_tol = self.config.integer_tolerance
-                # it.config.feasibility_tol = self.config.constraint_tolerance
-                # it.config.max_iter = self.config.max_fbbt_iterations
-                # it.perform_fbbt(m)
-            else:
-                fbbt(m, integer_tol=self.config.integer_tolerance,
-                     feasibility_tol=self.config.constraint_tolerance,
-                     max_iter=self.config.max_fbbt_iterations)
+            # When #2574 is resolved, we can do the below. For now
+            # we'll use contrib.fbbt
+            # if cmodel_available:
+            #     # use the appsi fbbt implementation since we can
+            #     it = appsi.fbbt.IntervalTightener()
+            #     it.config.integer_tol = self.config.integer_tolerance
+            #     it.config.feasibility_tol = self.config.constraint_tolerance
+            #     it.config.max_iter = self.config.max_fbbt_iterations
+            #     it.perform_fbbt(m)
+            fbbt(m, integer_tol=self.config.integer_tolerance,
+                 feasibility_tol=self.config.constraint_tolerance,
+                 max_iter=self.config.max_fbbt_iterations)
             xfrm = TransformationFactory
             # Now that we've tightened bounds, see if any variables are fixed
             # because their lb is equal to the ub (within tolerance)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

This fixes two problems: The most obvious is that, in #2559, I reorganized the config options and `max_fbbt_iterations` was not defined for `gdpopt.enumerate`. The second is that, since #2406, I accidentally disabled fbbt altogether when appsi is installed (but I wasn't using appsi fbbt yet). This PR uses `contrib.fbbt` always in the subproblem preprocessing, but leaves a note to switch to appsi later.

## Changes proposed in this PR:
- Add `max_fbbt_iterations` config option to `gdpopt.enumerate`. (Actually for any algorithm that solves NLP subproblems)
- Restore use of fbbt in subproblem preprocessing.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
