### PR TITLE
Pickle transformed GDP models

### DIFF
--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -318,7 +318,8 @@ class _DisjunctData(_BlockData):
 
     @property
     def transformation_block(self):
-        return self._transformation_block
+        return None if self._transformation_block is None else \
+            self._transformation_block()
 
     def __init__(self, component):
         _BlockData.__init__(self, component)

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -312,6 +312,7 @@ class _Initializer(object):
 
 
 class _DisjunctData(_BlockData):
+    __autoslot_mappers__ = {'_transformation_block': AutoSlots.weakref_mapper}
 
     _Block_reserved_words = set()
 
@@ -427,6 +428,7 @@ _DisjunctData._Block_reserved_words = set(dir(Disjunct()))
 
 class _DisjunctionData(ActiveComponentData):
     __slots__ = ('disjuncts', 'xor', '_algebraic_constraint')
+    __autoslot_mappers__ = {'_algebraic_constraint': AutoSlots.weakref_mapper}
     _NoArgument = (0,)
 
     @property
@@ -514,6 +516,7 @@ class _DisjunctionData(ActiveComponentData):
 @ModelComponentFactory.register("Disjunction expressions.")
 class Disjunction(ActiveIndexedComponent):
     _ComponentDataClass = _DisjunctionData
+    __autoslot_mappers__ = {'_algebraic_constraint': AutoSlots.weakref_mapper}
 
     def __new__(cls, *args, **kwds):
         if cls != Disjunction:

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -29,6 +29,7 @@ from pyomo.core.base.external import ExternalFunction
 from pyomo.core.base import Transformation, TransformationFactory, Reference
 import pyomo.core.expr.current as EXPR
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
+from pyomo.gdp.transformed_disjunct import _TransformedDisjunct
 from pyomo.gdp.util import (
     is_child_of, get_src_disjunction, get_src_constraint, get_gdp_tree,
     get_transformed_constraints, _get_constraint_transBlock, get_src_disjunct,
@@ -304,7 +305,7 @@ class BigM_Transformation(Transformation):
             '_pyomo_gdp_bigm_reformulation')
         self._transformation_blocks[to_block] = transBlock = Block()
         to_block.add_component(transBlockName, transBlock)
-        transBlock.relaxedDisjuncts = Block(NonNegativeIntegers)
+        transBlock.relaxedDisjuncts = _TransformedDisjunct(NonNegativeIntegers)
         transBlock.lbub = Set(initialize=['lb', 'ub'])
 
         return transBlock
@@ -394,7 +395,7 @@ class BigM_Transformation(Transformation):
         relaxationBlock.bigm_src = {}
         relaxationBlock.localVarReferences = Block()
         obj._transformation_block = weakref_ref(relaxationBlock)
-        relaxationBlock._srcDisjunct = weakref_ref(obj)
+        relaxationBlock._src_disjunct = weakref_ref(obj)
 
         # This is crazy, but if the disjunction has been previously
         # relaxed, the disjunct *could* be deactivated.  This is a big

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -878,9 +878,9 @@ class BigM_Transformation(Transformation):
                 Disjunct,
                 active=None,
                 descend_into=(Block, Disjunct)):
+            transBlock = disj.transformation_block
             # First check if it was transformed at all.
-            if disj.transformation_block is not None:
-                transBlock = disj.transformation_block()
+            if transBlock is not None:
                 # If it was transformed with BigM, we get the M values.
                 if hasattr(transBlock, 'bigm_src'):
                     for cons in transBlock.bigm_src:

--- a/pyomo/gdp/plugins/cuttingplane.py
+++ b/pyomo/gdp/plugins/cuttingplane.py
@@ -820,8 +820,8 @@ class CuttingPlane_Transformation(Transformation):
                                                         descend_into=(Disjunct,
                                                                       Block)):
             for disjunct in disjunction.disjuncts:
-                if disjunct.transformation_block is not None:
-                    transBlock = disjunct.transformation_block()
+                transBlock = disjunct.transformation_block
+                if transBlock is not None:
                     for v in transBlock.disaggregatedVars.\
                         component_data_objects(Var):
                         disaggregatedVars.add(v)

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -26,6 +26,7 @@ from pyomo.core import (
 from pyomo.core.base.boolean_var import (
     _DeprecatedImplicitAssociatedBinaryVariable)
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
+from pyomo.gdp.transformed_disjunct import _TransformedDisjunct
 from pyomo.gdp.util import (
     clone_without_expression_components, is_child_of, get_src_disjunction,
     get_src_constraint, get_transformed_constraints,
@@ -309,7 +310,7 @@ class Hull_Reformulation(Transformation):
         transBlock = Block()
         instance.add_component(transBlockName, transBlock)
         self._transformation_blocks[instance] = transBlock
-        transBlock.relaxedDisjuncts = Block(NonNegativeIntegers)
+        transBlock.relaxedDisjuncts = _TransformedDisjunct(NonNegativeIntegers)
         transBlock.lbub = Set(initialize = ['lb','ub','eq'])
         # Map between disaggregated variables and their
         # originals
@@ -599,7 +600,7 @@ class Hull_Reformulation(Transformation):
 
         # add mappings to source disjunct (so we'll know we've relaxed)
         obj._transformation_block = weakref_ref(relaxationBlock)
-        relaxationBlock._srcDisjunct = weakref_ref(obj)
+        relaxationBlock._src_disjunct = weakref_ref(obj)
 
         # add the disaggregated variables and their bigm constraints
         # to the relaxationBlock

--- a/pyomo/gdp/tests/common_tests.py
+++ b/pyomo/gdp/tests/common_tests.py
@@ -111,7 +111,7 @@ def checkb0TargetsTransformed(self, m, transformation):
             (1,1),
     ]
     for i, j in pairs:
-        self.assertIs(m.b[0].disjunct[i].transformation_block(),
+        self.assertIs(m.b[0].disjunct[i].transformation_block,
                       disjBlock[j])
         self.assertIs(trans.get_src_disjunct(disjBlock[j]),
                       m.b[0].disjunct[i])
@@ -133,7 +133,7 @@ def check_user_deactivated_disjuncts(self, transformation,
         rBlock = m.component("_pyomo_gdp_%s_reformulation" % transformation)
         disjBlock = rBlock.relaxedDisjuncts
         self.assertEqual(len(disjBlock), 1)
-        self.assertIs(disjBlock[0], m.d[1].transformation_block())
+        self.assertIs(disjBlock[0], m.d[1].transformation_block)
         self.assertIs(transform.get_src_disjunct(disjBlock[0]), m.d[1])
 
 def check_improperly_deactivated_disjuncts(self, transformation, **kwargs):
@@ -537,7 +537,7 @@ def check_only_targets_get_transformed(self, transformation):
         (1, 1)
     ]
     for i, j in pairs:
-        self.assertIs(disjBlock[i], m.disjunct1[j].transformation_block())
+        self.assertIs(disjBlock[i], m.disjunct1[j].transformation_block)
         self.assertIs(trans.get_src_disjunct(disjBlock[i]), m.disjunct1[j])
 
     self.assertIsNone(m.disjunct2[0].transformation_block)
@@ -604,16 +604,16 @@ def check_indexedDisj_only_targets_transformed(self, transformation):
                 relaxedDisjuncts
     self.assertEqual(len(disjBlock), 4)
     self.assertIsInstance(
-        m.disjunct1[1,0].transformation_block().component("disjunct1[1,0].c"),
+        m.disjunct1[1,0].transformation_block.component("disjunct1[1,0].c"),
         Constraint)
     self.assertIsInstance(
-        m.disjunct1[1,1].transformation_block().component("disjunct1[1,1].c"),
+        m.disjunct1[1,1].transformation_block.component("disjunct1[1,1].c"),
         Constraint)
     self.assertIsInstance(
-        m.disjunct1[2,0].transformation_block().component("disjunct1[2,0].c"),
+        m.disjunct1[2,0].transformation_block.component("disjunct1[2,0].c"),
         Constraint)
     self.assertIsInstance(
-        m.disjunct1[2,1].transformation_block().component("disjunct1[2,1].c"),
+        m.disjunct1[2,1].transformation_block.component("disjunct1[2,1].c"),
         Constraint)
 
     # This relies on the disjunctions being transformed in the same order
@@ -637,7 +637,7 @@ def check_indexedDisj_only_targets_transformed(self, transformation):
 
     for i, j in pairs:
         self.assertIs(trans.get_src_disjunct(disjBlock[j]), m.disjunct1[i])
-        self.assertIs(disjBlock[j], m.disjunct1[i].transformation_block())
+        self.assertIs(disjBlock[j], m.disjunct1[i].transformation_block)
 
 def check_warn_for_untransformed(self, transformation, **kwargs):
     # Check that we complain if we find an untransformed Disjunct inside of
@@ -725,7 +725,7 @@ def check_disjData_only_targets_transformed(self, transformation):
         ((2,1), 1),
     ]
     for i, j in pairs:
-        self.assertIs(m.disjunct1[i].transformation_block(), disjBlock[j])
+        self.assertIs(m.disjunct1[i].transformation_block, disjBlock[j])
         self.assertIs(trans.get_src_disjunct(disjBlock[j]), m.disjunct1[i])
 
 def check_indexedBlock_targets_inactive(self, transformation, **kwargs):
@@ -798,7 +798,7 @@ def check_indexedBlock_only_targets_transformed(self, transformation):
                 disjBlock = disjBlock1
             if blocknum == 1:
                 disjBlock = disjBlock2
-            self.assertIs(original[i].transformation_block(), disjBlock[j])
+            self.assertIs(original[i].transformation_block, disjBlock[j])
             self.assertIs(trans.get_src_disjunct(disjBlock[j]), original[i])
 
 def check_blockData_targets_inactive(self, transformation, **kwargs):
@@ -1156,7 +1156,7 @@ def check_block_only_targets_transformed(self, transformation):
         (1,1),
     ]
     for i, j in pairs:
-        self.assertIs(m.b.disjunct[i].transformation_block(), disjBlock[j])
+        self.assertIs(m.b.disjunct[i].transformation_block, disjBlock[j])
         self.assertIs(trans.get_src_disjunct(disjBlock[j]), m.b.disjunct[i])
 
 # common error messages
@@ -1483,7 +1483,7 @@ def check_disjunct_only_targets_transformed(self, transformation):
                       transform.get_src_disjunct(disjBlock[j]))
         self.assertIs(disjBlock[j],
                       m.simpledisjunct.component(
-                          'innerdisjunct%d'%i).transformation_block())
+                          'innerdisjunct%d'%i).transformation_block)
 
 def check_disjunctData_targets_inactive(self, transformation, **kwargs):
     m = models.makeNestedDisjunctions()
@@ -1530,7 +1530,7 @@ def check_disjunctData_only_targets_transformed(self, transformation):
     for i, j in pairs:
         self.assertIs(transform.get_src_disjunct(disjBlock[j]),
                       m.disjunct[1].innerdisjunct[i])
-        self.assertIs(m.disjunct[1].innerdisjunct[i].transformation_block(),
+        self.assertIs(m.disjunct[1].innerdisjunct[i].transformation_block,
                       disjBlock[j])
 
 def check_all_components_transformed(self, m):
@@ -1538,25 +1538,25 @@ def check_all_components_transformed(self, m):
     # makeNestedDisjunctions_NestedDisjuncts model.
     self.assertIsInstance(m.disj.algebraic_constraint(), Constraint)
     self.assertIsInstance(m.d1.disj2.algebraic_constraint(), Constraint)
-    self.assertIsInstance(m.d1.transformation_block(), _BlockData)
-    self.assertIsInstance(m.d2.transformation_block(), _BlockData)
-    self.assertIsInstance(m.d1.d3.transformation_block(), _BlockData)
-    self.assertIsInstance(m.d1.d4.transformation_block(), _BlockData)
+    self.assertIsInstance(m.d1.transformation_block, _BlockData)
+    self.assertIsInstance(m.d2.transformation_block, _BlockData)
+    self.assertIsInstance(m.d1.d3.transformation_block, _BlockData)
+    self.assertIsInstance(m.d1.d4.transformation_block, _BlockData)
 
 def check_transformation_blocks_nestedDisjunctions(self, m, transformation):
     disjunctionTransBlock = m.disj.algebraic_constraint().parent_block()
     transBlocks = disjunctionTransBlock.relaxedDisjuncts
     self.assertEqual(len(transBlocks), 4)
     if transformation == 'bigm':
-        self.assertIs(transBlocks[0], m.d1.d3.transformation_block())
-        self.assertIs(transBlocks[1], m.d1.d4.transformation_block())
-        self.assertIs(transBlocks[2], m.d1.transformation_block())
-        self.assertIs(transBlocks[3], m.d2.transformation_block())
+        self.assertIs(transBlocks[0], m.d1.d3.transformation_block)
+        self.assertIs(transBlocks[1], m.d1.d4.transformation_block)
+        self.assertIs(transBlocks[2], m.d1.transformation_block)
+        self.assertIs(transBlocks[3], m.d2.transformation_block)
     if transformation == 'hull':
-        self.assertIs(transBlocks[2], m.d1.d3.transformation_block())
-        self.assertIs(transBlocks[3], m.d1.d4.transformation_block())
-        self.assertIs(transBlocks[0], m.d1.transformation_block())
-        self.assertIs(transBlocks[1], m.d2.transformation_block())
+        self.assertIs(transBlocks[2], m.d1.d3.transformation_block)
+        self.assertIs(transBlocks[3], m.d1.d4.transformation_block)
+        self.assertIs(transBlocks[0], m.d1.transformation_block)
+        self.assertIs(transBlocks[1], m.d2.transformation_block)
 
 def check_nested_disjunction_target(self, transformation):
     m = models.makeNestedDisjunctions_NestedDisjuncts()

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -9,6 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+from pyomo.common.dependencies import dill_available
 import pyomo.common.unittest as unittest
 from pyomo.common.deprecation import RenamedClass
 
@@ -1801,22 +1802,22 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         # transformation blocks on the inner Disjuncts.
         self.assertIs(m.disjunct[1].innerdisjunct[0].transformation_block(),
                       disjunctBlocks[4])
-        self.assertIs(disjunctBlocks[4]._srcDisjunct(),
+        self.assertIs(disjunctBlocks[4]._src_disjunct(),
                       m.disjunct[1].innerdisjunct[0])
 
         self.assertIs(m.disjunct[1].innerdisjunct[1].transformation_block(),
                       disjunctBlocks[5])
-        self.assertIs(disjunctBlocks[5]._srcDisjunct(),
+        self.assertIs(disjunctBlocks[5]._src_disjunct(),
                       m.disjunct[1].innerdisjunct[1])
 
         self.assertIs(m.simpledisjunct.innerdisjunct0.transformation_block(),
                       disjunctBlocks[0])
-        self.assertIs(disjunctBlocks[0]._srcDisjunct(),
+        self.assertIs(disjunctBlocks[0]._src_disjunct(),
                       m.simpledisjunct.innerdisjunct0)
 
         self.assertIs(m.simpledisjunct.innerdisjunct1.transformation_block(),
                       disjunctBlocks[1])
-        self.assertIs(disjunctBlocks[1]._srcDisjunct(),
+        self.assertIs(disjunctBlocks[1]._src_disjunct(),
                       m.simpledisjunct.innerdisjunct1)
 
     def test_m_value_mappings(self):
@@ -2650,6 +2651,13 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         # of the Disjuncts
         m = models.makeBooleanVarsOnDisjuncts()
         ct.check_solution_obeys_logical_constraints(self, 'bigm', m)
+
+    def test_pickle(self):
+        ct.check_transformed_model_pickles(self, 'bigm')
+
+    @unittest.skipIf(not dill_available, "Dill is not available")
+    def test_dill_pickle(self):
+        ct.check_transformed_model_pickles_with_dill(self, 'bigm')
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -95,7 +95,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         # we are counting on the fact that the disjuncts get relaxed in the
         # same order every time.
         for i in [0,1]:
-            self.assertIs(oldblock[i].transformation_block(), disjBlock[i])
+            self.assertIs(oldblock[i].transformation_block, disjBlock[i])
             self.assertIs(bigm.get_src_disjunct(disjBlock[i]), oldblock[i])
 
         # check the constraint mappings
@@ -662,7 +662,7 @@ class TwoTermIndexedDisj(unittest.TestCase, CommonTests):
             self.assertIs(bigm.get_src_disjunct(transformedDisjunct),
                           srcDisjunct)
             self.assertIs(transformedDisjunct,
-                          srcDisjunct.transformation_block())
+                          srcDisjunct.transformation_block)
 
             transformed = bigm.get_transformed_constraints(srcDisjunct.c)
             if src[0]:
@@ -1800,22 +1800,22 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
 
         # I want to check that I correctly updated the pointers to the
         # transformation blocks on the inner Disjuncts.
-        self.assertIs(m.disjunct[1].innerdisjunct[0].transformation_block(),
+        self.assertIs(m.disjunct[1].innerdisjunct[0].transformation_block,
                       disjunctBlocks[4])
         self.assertIs(disjunctBlocks[4]._src_disjunct(),
                       m.disjunct[1].innerdisjunct[0])
 
-        self.assertIs(m.disjunct[1].innerdisjunct[1].transformation_block(),
+        self.assertIs(m.disjunct[1].innerdisjunct[1].transformation_block,
                       disjunctBlocks[5])
         self.assertIs(disjunctBlocks[5]._src_disjunct(),
                       m.disjunct[1].innerdisjunct[1])
 
-        self.assertIs(m.simpledisjunct.innerdisjunct0.transformation_block(),
+        self.assertIs(m.simpledisjunct.innerdisjunct0.transformation_block,
                       disjunctBlocks[0])
         self.assertIs(disjunctBlocks[0]._src_disjunct(),
                       m.simpledisjunct.innerdisjunct0)
 
-        self.assertIs(m.simpledisjunct.innerdisjunct1.transformation_block(),
+        self.assertIs(m.simpledisjunct.innerdisjunct1.transformation_block,
                       disjunctBlocks[1])
         self.assertIs(disjunctBlocks[1]._src_disjunct(),
                       m.simpledisjunct.innerdisjunct1)
@@ -1918,7 +1918,7 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         # transformed by the outer ones.
         m = models.makeNestedDisjunctions()
         TransformationFactory('gdp.bigm').apply_to(m)
-        cons1 = m.disjunct[1].innerdisjunct[0].transformation_block().component(
+        cons1 = m.disjunct[1].innerdisjunct[0].transformation_block.component(
             m.disjunct[1].innerdisjunct[0].c.name)
         cons1lb = cons1['lb']
         self.assertEqual(cons1lb.lower, 0)
@@ -1930,14 +1930,14 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         self.check_bigM_constraint(cons1ub, m.z, 10,
                                  m.disjunct[1].innerdisjunct[0].indicator_var)
 
-        cons2 = m.disjunct[1].innerdisjunct[1].transformation_block().component(
+        cons2 = m.disjunct[1].innerdisjunct[1].transformation_block.component(
             m.disjunct[1].innerdisjunct[1].c.name)['lb']
         self.assertEqual(cons2.lower, 5)
         self.assertIsNone(cons2.upper)
         self.check_bigM_constraint(cons2, m.z, -5,
                                    m.disjunct[1].innerdisjunct[1].indicator_var)
 
-        cons3 = m.simpledisjunct.innerdisjunct0.transformation_block().\
+        cons3 = m.simpledisjunct.innerdisjunct0.transformation_block.\
                 component(
             m.simpledisjunct.innerdisjunct0.c.name)['ub']
         self.assertEqual(cons3.upper, 2)
@@ -1946,7 +1946,7 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
             cons3, m.x, 7,
             m.simpledisjunct.innerdisjunct0.indicator_var)
 
-        cons4 = m.simpledisjunct.innerdisjunct1.transformation_block().\
+        cons4 = m.simpledisjunct.innerdisjunct1.transformation_block.\
                 component(
             m.simpledisjunct.innerdisjunct1.c.name)['lb']
         self.assertEqual(cons4.lower, 4)
@@ -1977,7 +1977,7 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         ct.check_linear_coef(self, repn, m.simpledisjunct.binary_indicator_var,
                              -1)
 
-        cons6 = m.disjunct[0].transformation_block().component("disjunct[0].c")
+        cons6 = m.disjunct[0].transformation_block.component("disjunct[0].c")
         cons6lb = cons6['lb']
         self.assertIsNone(cons6lb.upper)
         self.assertEqual(cons6lb.lower, 2)
@@ -1995,7 +1995,7 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
                                         [m.disjunct[1].innerdisjunct[0],
                                          m.disjunct[1].innerdisjunct[1]])
 
-        cons8 = m.disjunct[1].transformation_block().component(
+        cons8 = m.disjunct[1].transformation_block.component(
             "disjunct[1].c")['ub']
         self.assertIsNone(cons8.lower)
         self.assertEqual(cons8.upper, 2)
@@ -2056,7 +2056,7 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
                      m.d1.indexedDisjunct1[1], m.d1.indexedDisjunct2[0],
                      m.d1.indexedDisjunct2[1]]
         for disjunct in disjuncts:
-            self.assertIs(disjunct.transformation_block().parent_component(),
+            self.assertIs(disjunct.transformation_block.parent_component(),
                           m._pyomo_gdp_bigm_reformulation.relaxedDisjuncts)
 
     def check_first_disjunct_constraint(self, disj1c, x, ind_var):

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -442,7 +442,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
         # check that we used the bounds on the local variable as if they are
         # global. Which means checking the bounds constraints...
-        y_disagg = m.disj2.transformation_block().disaggregatedVars.component(
+        y_disagg = m.disj2.transformation_block.disaggregatedVars.component(
             "disj2.y")
         cons = hull.get_var_bounds_constraint(y_disagg)
         lb = cons['lb']
@@ -471,10 +471,10 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         disj1y = hull.get_disaggregated_var(m.disj2.y, m.disj1)
         disj2y = hull.get_disaggregated_var(m.disj2.y, m.disj2)
         self.assertIs(disj1y,
-                      m.disj1._transformation_block().parent_block().\
+                      m.disj1.transformation_block.parent_block().\
                       _disaggregatedVars[0])
         self.assertIs(disj2y,
-                      m.disj2._transformation_block().disaggregatedVars.\
+                      m.disj2.transformation_block.disaggregatedVars.\
                       component("disj2.y"))
         self.assertIs(hull.get_src_var(disj1y), m.disj2.y)
         self.assertIs(hull.get_src_var(disj2y), m.disj2.y)
@@ -513,7 +513,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         # check that all the variables are disaggregated
         # disj1 has both x and y
         disj = m.disj1
-        transBlock = disj.transformation_block()
+        transBlock = disj.transformation_block
         varBlock = transBlock.disaggregatedVars
         self.assertEqual(len([v for v in
                               varBlock.component_data_objects(Var)]), 2)
@@ -527,7 +527,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         self.assertIs(hull.get_src_var(y), m.disj1.y)
         # disj2 and disj4 have just y
         for disj in [m.disj2, m.disj4]:
-            transBlock = disj.transformation_block()
+            transBlock = disj.transformation_block
             varBlock = transBlock.disaggregatedVars
             self.assertEqual(len([v for v in
                                   varBlock.component_data_objects(Var)]), 1)
@@ -537,7 +537,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
             self.assertIs(hull.get_src_var(y), m.disj1.y)
         # disj3 has just x
         disj = m.disj3
-        transBlock = disj.transformation_block()
+        transBlock = disj.transformation_block
         varBlock = transBlock.disaggregatedVars
         self.assertEqual(len([v for v in
                               varBlock.component_data_objects(Var)]), 1)
@@ -564,7 +564,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
     def check_name_collision_disaggregated_vars(self, m, disj):
         hull = TransformationFactory('gdp.hull')
-        transBlock = disj.transformation_block()
+        transBlock = disj.transformation_block
         varBlock = transBlock.disaggregatedVars
         self.assertEqual(len([v for v in
                               varBlock.component_data_objects(Var)]), 2)
@@ -763,14 +763,14 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         # simpledisj2.c[1] is a <= constraint
         self.assertEqual(len(transformed), 1)
         self.assertIs(transformed[0],
-                      m.b.simpledisj2.transformation_block().\
+                      m.b.simpledisj2.transformation_block.\
                       component("b.simpledisj2.c")[(1,'ub')])
 
         transformed = hull.get_transformed_constraints(m.b.simpledisj2.c[2])
         # simpledisj2.c[2] is a <= constraint
         self.assertEqual(len(transformed), 1)
         self.assertIs(transformed[0],
-                      m.b.simpledisj2.transformation_block().\
+                      m.b.simpledisj2.transformation_block.\
                       component("b.simpledisj2.c")[(2,'ub')])
 
 
@@ -952,7 +952,7 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertEqual(len(transBlock1.relaxedDisjuncts), 4)
 
         firstTerm2 = transBlock1.relaxedDisjuncts[0]
-        self.assertIs(firstTerm2, m.firstTerm[2].transformation_block())
+        self.assertIs(firstTerm2, m.firstTerm[2].transformation_block)
         self.assertIsInstance(firstTerm2.disaggregatedVars.component("x"), Var)
         self.assertIsInstance(firstTerm2.component("firstTerm[2].cons"),
                               Constraint)
@@ -962,7 +962,7 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertEqual(len(firstTerm2.component("x_bounds")), 2)
 
         secondTerm2 = transBlock1.relaxedDisjuncts[1]
-        self.assertIs(secondTerm2, m.secondTerm[2].transformation_block())
+        self.assertIs(secondTerm2, m.secondTerm[2].transformation_block)
         self.assertIsInstance(secondTerm2.disaggregatedVars.component("x"), Var)
         self.assertIsInstance(secondTerm2.component("secondTerm[2].cons"),
                               Constraint)
@@ -971,7 +971,7 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertEqual(len(secondTerm2.component("x_bounds")), 2)
 
         firstTerm1 = transBlock1.relaxedDisjuncts[2]
-        self.assertIs(firstTerm1, m.firstTerm[1].transformation_block())
+        self.assertIs(firstTerm1, m.firstTerm[1].transformation_block)
         self.assertIsInstance(firstTerm1.disaggregatedVars.component("x"), Var)
         self.assertTrue(firstTerm1.disaggregatedVars.x.is_fixed())
         self.assertEqual(value(firstTerm1.disaggregatedVars.x), 0)
@@ -983,7 +983,7 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertEqual(len(firstTerm1.component("x_bounds")), 2)
 
         secondTerm1 = transBlock1.relaxedDisjuncts[3]
-        self.assertIs(secondTerm1, m.secondTerm[1].transformation_block())
+        self.assertIs(secondTerm1, m.secondTerm[1].transformation_block)
         self.assertIsInstance(secondTerm1.disaggregatedVars.component("x"), Var)
         self.assertIsInstance(secondTerm1.component("secondTerm[1].cons"),
                               Constraint)
@@ -1409,7 +1409,7 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
 
         disj1 = disjBlocks[0]
         self.assertTrue(disj1.active)
-        self.assertIs(disj1, m.d1.transformation_block())
+        self.assertIs(disj1, m.d1.transformation_block)
         self.assertIs(m.d1, hull.get_src_disjunct(disj1))
         # check the disaggregated x is here
         self.assertIsInstance(disj1.disaggregatedVars.x, Var)
@@ -1431,7 +1431,7 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
 
         disj2 = disjBlocks[1]
         self.assertTrue(disj2.active)
-        self.assertIs(disj2, m.d2.transformation_block())
+        self.assertIs(disj2, m.d2.transformation_block)
         self.assertIs(m.d2, hull.get_src_disjunct(disj2))
         # disaggregated var
         x2 = disj2.disaggregatedVars.x
@@ -1453,7 +1453,7 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
 
         disj3 = disjBlocks[2]
         self.assertTrue(disj3.active)
-        self.assertIs(disj3, m.d1.d3.transformation_block())
+        self.assertIs(disj3, m.d1.d3.transformation_block)
         self.assertIs(m.d1.d3, hull.get_src_disjunct(disj3))
         # disaggregated var
         x3 = disj3.disaggregatedVars.x
@@ -1474,7 +1474,7 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
 
         disj4 = disjBlocks[3]
         self.assertTrue(disj4.active)
-        self.assertIs(disj4, m.d1.d4.transformation_block())
+        self.assertIs(disj4, m.d1.d4.transformation_block)
         self.assertIs(m.d1.d4, hull.get_src_disjunct(disj4))
         # disaggregated var
         x4 = disj4.disaggregatedVars.x
@@ -1651,7 +1651,7 @@ class TestSpecialCases(unittest.TestCase):
         m = hull.create_using(model)
         self.assertEqual(m.d2.z.lb, -9)
         self.assertEqual(m.d2.z.ub, -7)
-        z_disaggregated = m.d2.transformation_block().disaggregatedVars.\
+        z_disaggregated = m.d2.transformation_block.disaggregatedVars.\
                           component("d2.z")
         self.assertIsInstance(z_disaggregated, Var)
         self.assertIs(z_disaggregated,
@@ -1669,7 +1669,7 @@ class TestSpecialCases(unittest.TestCase):
         # it is its own disaggregated variable
         self.assertIs(hull.get_disaggregated_var(m.d2.z, m.d2), m.d2.z)
         # it does not exist on the transformation block
-        self.assertIsNone(m.d2.transformation_block().disaggregatedVars.\
+        self.assertIsNone(m.d2.transformation_block.disaggregatedVars.\
                           component("z"))
 
 class UntransformableObjectsOnDisjunct(unittest.TestCase):
@@ -1838,7 +1838,7 @@ class TestErrors(unittest.TestCase):
                 r".*_pyomo_gdp_hull_reformulation.relaxedDisjuncts\[1\]."
                 r"disaggregatedVars.w",
                 hull.get_disaggregation_constraint,
-                m.d[1].transformation_block().disaggregatedVars.w,
+                m.d[1].transformation_block.disaggregatedVars.w,
                 m.disjunction)
         self.assertRegex(log.getvalue(), ".*It doesn't appear that "
                          r"'_pyomo_gdp_hull_reformulation."
@@ -1864,7 +1864,7 @@ class TestErrors(unittest.TestCase):
                 r".*_pyomo_gdp_hull_reformulation.relaxedDisjuncts\[1\]."
                 r"disaggregatedVars.w",
                 hull.get_disaggregated_var,
-                m.d[1].transformation_block().disaggregatedVars.w,
+                m.d[1].transformation_block.disaggregatedVars.w,
                 m.d[1])
         self.assertRegex(log.getvalue(),
                          r".*It does not appear "
@@ -1923,7 +1923,7 @@ class BlocksOnDisjuncts(unittest.TestCase):
         hull = TransformationFactory('gdp.hull')
         hull.apply_to(m)
 
-        transBlock = m.disj1.transformation_block()
+        transBlock = m.disj1.transformation_block
         self.assertIsInstance(transBlock.component("disj1.b.any_index"),
                               Constraint)
         self.assertIsInstance(transBlock.component("disj1.'b.any_index'"),
@@ -1956,9 +1956,9 @@ class BlocksOnDisjuncts(unittest.TestCase):
         self.assertIs(hull.get_disaggregated_var(m.x, m.disj1), m.x)
         self.assertEqual(m.x.lb, 0)
         self.assertEqual(m.x.ub, 5)
-        self.assertIsNone(m.disj1.transformation_block().disaggregatedVars.\
+        self.assertIsNone(m.disj1.transformation_block.disaggregatedVars.\
                           component("x"))
-        self.assertIsInstance(m.disj1.transformation_block().disaggregatedVars.\
+        self.assertIsInstance(m.disj1.transformation_block.disaggregatedVars.\
                               component("y"), Var)
 
     # this doesn't require the block, I'm just coopting this test to make sure
@@ -2023,7 +2023,7 @@ class DisaggregatingFixedVars(unittest.TestCase):
         hull = TransformationFactory('gdp.hull')
         hull.apply_to(m)
         # check that we did indeed disaggregate x
-        transBlock = m.d[1]._transformation_block()
+        transBlock = m.d[1].transformation_block
         self.assertIsInstance(transBlock.disaggregatedVars.component("x"), Var)
         self.assertIs(hull.get_disaggregated_var(m.x, m.d[1]),
                       transBlock.disaggregatedVars.x)
@@ -2035,7 +2035,7 @@ class DisaggregatingFixedVars(unittest.TestCase):
         hull = TransformationFactory('gdp.hull')
         hull.apply_to(m, assume_fixed_vars_permanent=True)
         # check that we didn't disaggregate x
-        transBlock = m.d[1]._transformation_block()
+        transBlock = m.d[1].transformation_block
         self.assertIsNone(transBlock.disaggregatedVars.component("x"))
 
 class NameDeprecationTest(unittest.TestCase):

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -9,6 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+from pyomo.common.dependencies import dill_available
 import pyomo.common.unittest as unittest
 from pyomo.common.log import LoggingIntercept
 import logging
@@ -2212,3 +2213,10 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         # of the Disjuncts
         m = models.makeBooleanVarsOnDisjuncts()
         ct.check_solution_obeys_logical_constraints(self, 'hull', m)
+
+    def test_pickle(self):
+        ct.check_transformed_model_pickles(self, 'hull')
+
+    @unittest.skipIf(not dill_available, "Dill is not available")
+    def test_dill_pickle(self):
+        ct.check_transformed_model_pickles_with_dill(self, 'hull')

--- a/pyomo/gdp/tests/test_partition_disjuncts.py
+++ b/pyomo/gdp/tests/test_partition_disjuncts.py
@@ -838,9 +838,9 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
             compute_bounds_method=compute_fbbt_bounds)
 
         b = m.component("_pyomo_gdp_partition_disjuncts_reformulation")
-        self.assertIs(m.disjunction.disjuncts[0].transformation_block(),
+        self.assertIs(m.disjunction.disjuncts[0].transformation_block,
                       b.disjunction.disjuncts[0])
-        self.assertIs(m.disjunction.disjuncts[1].transformation_block(),
+        self.assertIs(m.disjunction.disjuncts[1].transformation_block,
                       b.disjunction.disjuncts[1])
 
     def test_transformed_disjunctions_mapped_correctly(self):
@@ -1886,7 +1886,7 @@ class LogicalExpressions(unittest.TestCase, CommonTests):
             m,
             variable_partitions=[[m.x], [m.y]],
             compute_bounds_method=compute_fbbt_bounds)
-        d1 = m.d[1].transformation_block()
+        d1 = m.d[1].transformation_block
         self.assertEqual(len(d1.component_map(LogicalConstraint)), 1)
         c = d1.component("logical_constraints")
         self.assertIsInstance(c, LogicalConstraint)
@@ -1894,7 +1894,7 @@ class LogicalExpressions(unittest.TestCase, CommonTests):
         self.assertIsInstance(c[1].expr, NotExpression)
         self.assertIs(c[1].expr.args[0], m.Y[1])
 
-        d2 = m.d[2].transformation_block()
+        d2 = m.d[2].transformation_block
         self.assertEqual(len(d2.component_map(LogicalConstraint)), 1)
         c = d2.component("logical_constraints")
         self.assertIsInstance(c, LogicalConstraint)
@@ -1904,12 +1904,12 @@ class LogicalExpressions(unittest.TestCase, CommonTests):
         self.assertIs(c[1].expr.args[0], m.Y[1])
         self.assertIs(c[1].expr.args[1], m.Y[2])
 
-        d3 = m.d[3].transformation_block()
+        d3 = m.d[3].transformation_block
         self.assertEqual(len(d3.component_map(LogicalConstraint)), 1)
         c = d3.component("logical_constraints")
         self.assertEqual(len(c), 0)
 
-        d4 = m.d[4].transformation_block()
+        d4 = m.d[4].transformation_block
         self.assertEqual(len(d4.component_map(LogicalConstraint)), 1)
         c = d4.component("logical_constraints")
         self.assertIsInstance(c, LogicalConstraint)

--- a/pyomo/gdp/transformed_disjunct.py
+++ b/pyomo/gdp/transformed_disjunct.py
@@ -11,7 +11,9 @@
 
 from pyomo.common.autoslots import AutoSlots
 from pyomo.core.base.block import _BlockData, Block
-from pyomo.core.base.global_set import UnindexedComponent_index
+from pyomo.core.base.global_set import (
+    UnindexedComponent_index, UnindexedComponent_set
+)
 
 class _TransformedDisjunctData(_BlockData):
     __slots__ = ('_src_disjunct',)
@@ -32,7 +34,7 @@ class _TransformedDisjunct(Block):
     def __new__(cls, *args, **kwds):
         if cls != _TransformedDisjunct:
             return super(_TransformedDisjunct, cls).__new__(cls)
-        if args == ():
+        if not args or (args[0] is UnindexedComponent_set and len(args) == 1):
             return _ScalarTransformedDisjunct.__new__(
                 _ScalarTransformedDisjunct)
         else:

--- a/pyomo/gdp/transformed_disjunct.py
+++ b/pyomo/gdp/transformed_disjunct.py
@@ -31,27 +31,6 @@ class _TransformedDisjunctData(_BlockData):
 class _TransformedDisjunct(Block):
     _ComponentDataClass = _TransformedDisjunctData
 
-    def __new__(cls, *args, **kwds):
-        if cls != _TransformedDisjunct:
-            return super(_TransformedDisjunct, cls).__new__(cls)
-        if not args or (args[0] is UnindexedComponent_set and len(args) == 1):
-            return _ScalarTransformedDisjunct.__new__(
-                _ScalarTransformedDisjunct)
-        else:
-            return _IndexedTransformedDisjunct.__new__(
-                _IndexedTransformedDisjunct)
-
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ctype', Block)
         Block.__init__(self, *args, **kwargs)
-
-class _ScalarTransformedDisjunct(_TransformedDisjunctData,
-                                 _TransformedDisjunct):
-    def __init__(self, *args, **kwds):
-        _TransformedDisjunctData.__init__(self, self)
-        _TransformedDisjunct.__init__(self, *args, **kwds)
-        self._data[None] = self
-        self._index = UnindexedComponent_index
-
-class _IndexedTransformedDisjunct(_TransformedDisjunct):
-    pass

--- a/pyomo/gdp/transformed_disjunct.py
+++ b/pyomo/gdp/transformed_disjunct.py
@@ -10,7 +10,7 @@
 #  ___________________________________________________________________________
 
 from pyomo.common.autoslots import AutoSlots
-from pyomo.core.base.block import _BlockData, Block
+from pyomo.core.base.block import _BlockData, IndexedBlock
 from pyomo.core.base.global_set import (
     UnindexedComponent_index, UnindexedComponent_set
 )
@@ -28,9 +28,5 @@ class _TransformedDisjunctData(_BlockData):
         # pointer to the Disjunct whose transformation block this is.
         self._src_disjunct = None
 
-class _TransformedDisjunct(Block):
+class _TransformedDisjunct(IndexedBlock):
     _ComponentDataClass = _TransformedDisjunctData
-
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault('ctype', Block)
-        Block.__init__(self, *args, **kwargs)

--- a/pyomo/gdp/transformed_disjunct.py
+++ b/pyomo/gdp/transformed_disjunct.py
@@ -1,0 +1,55 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+from pyomo.common.autoslots import AutoSlots
+from pyomo.core.base.block import _BlockData, Block
+from pyomo.core.base.global_set import UnindexedComponent_index
+
+class _TransformedDisjunctData(_BlockData):
+    __slots__ = ('_src_disjunct',)
+    __autoslot_mappers__ = {'_src_disjunct': AutoSlots.weakref_mapper}
+
+    @property
+    def src_disjunct(self):
+        return self._src_disjunct
+
+    def __init__(self, component):
+        _BlockData.__init__(self, component)
+        # pointer to the Disjunct whose transformation block this is.
+        self._src_disjunct = None
+
+class _TransformedDisjunct(Block):
+    _ComponentDataClass = _TransformedDisjunctData
+
+    def __new__(cls, *args, **kwds):
+        if cls != _TransformedDisjunct:
+            return super(_TransformedDisjunct, cls).__new__(cls)
+        if args == ():
+            return _ScalarTransformedDisjunct.__new__(
+                _ScalarTransformedDisjunct)
+        else:
+            return _IndexedTransformedDisjunct.__new__(
+                _IndexedTransformedDisjunct)
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('ctype', Block)
+        Block.__init__(self, *args, **kwargs)
+
+class _ScalarTransformedDisjunct(_TransformedDisjunctData,
+                                 _TransformedDisjunct):
+    def __init__(self, *args, **kwds):
+        _TransformedDisjunctData.__init__(self, self)
+        _TransformedDisjunct.__init__(self, *args, **kwds)
+        self._data[None] = self
+        self._index = UnindexedComponent_index
+
+class _IndexedTransformedDisjunct(_TransformedDisjunct):
+    pass

--- a/pyomo/gdp/transformed_disjunct.py
+++ b/pyomo/gdp/transformed_disjunct.py
@@ -21,7 +21,7 @@ class _TransformedDisjunctData(_BlockData):
 
     @property
     def src_disjunct(self):
-        return self._src_disjunct
+        return None if self._src_disjunct is None else self._src_disjunct()
 
     def __init__(self, component):
         _BlockData.__init__(self, component)

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -371,12 +371,12 @@ def get_src_disjunct(transBlock):
     transBlock: _BlockData which is in the relaxedDisjuncts IndexedBlock
                 on a transformation block.
     """
-    if not hasattr(transBlock, "_srcDisjunct") or \
-       type(transBlock._srcDisjunct) is not weakref_ref:
+    if not hasattr(transBlock, "_src_disjunct") or \
+       type(transBlock._src_disjunct) is not weakref_ref:
         raise GDP_Error("Block '%s' doesn't appear to be a transformation "
                         "block for a disjunct. No source disjunct found."
                         % transBlock.name)
-    return transBlock._srcDisjunct()
+    return transBlock._src_disjunct()
 
 def get_src_constraint(transformedConstraint):
     """Return the original Constraint whose transformed counterpart is


### PR DESCRIPTION
## Fixes #2417 

## Summary/Motivation:

The `bigm` and `hull` transformations create Blocks for each `Disjunct` they transform, each with a weakref back to the original component. This PR makes those Blocks into a new component that defines an `__autoslot_mappers__` dict so that the transformed model can be pickled.

## Changes proposed in this PR:
- Defines `_TransformedDisjunct` class, which is just a Block with a weakref on it
- Adds `__autoslot_mappers__` dicts to Disjuncts and Disjunctions
- Tests pickling GDP models transformed with bigm and hull

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
