### PR TITLE
Allow `nan` to compare equal in `assertStructuredAlmostEqual()`

### DIFF
--- a/pyomo/common/tests/test_unittest.py
+++ b/pyomo/common/tests/test_unittest.py
@@ -73,6 +73,11 @@ class TestPyomoUnittest(unittest.TestCase):
         with self.assertRaisesRegex(self.failureException, '10 !~= 10.01'):
             self.assertStructuredAlmostEqual(10, 10.01, delta=1e-3)
 
+    def test_assertStructuredAlmostEqual_nan(self):
+        a = float('nan')
+        b = float('nan')
+        self.assertStructuredAlmostEqual(a, b)
+
     def test_assertStructuredAlmostEqual_errorChecking(self):
         with self.assertRaisesRegex(
                 ValueError, "Cannot specify more than one of "

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -18,6 +18,7 @@
 
 import enum
 import logging
+import math
 import sys
 from io import StringIO
 
@@ -236,6 +237,8 @@ def _assertStructuredAlmostEqual(first, second,
                 return # PASS!
             if reltol is not None and diff / max(abs(f), abs(s)) <= reltol:
                 return # PASS!
+            if math.isnan(f) and math.isnan(s):
+                return # PASS! (we will treat NaN as equal)
         except:
             pass
 

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -798,11 +798,13 @@ class ProblemWriter_gams(AbstractProblemWriter):
                 output_file.write("\nput results;")
                 output_file.write("\nput 'SYMBOL  :  LEVEL  :  MARGINAL' /;")
                 for var in var_list:
-                    output_file.write("\nput %s ' ' %s.l ' ' %s.m /;" % (var, var, var))
+                    output_file.write("\nput %s ' ' %s.l ' ' %s.m /;"
+                                      % (var, var, var))
                 for con in constraint_names:
-                    output_file.write("\nput %s ' ' %s.l ' ' %s.m /;" % (con, con, con))
-                output_file.write("\nput GAMS_OBJECTIVE GAMS_OBJECTIVE.l "
-                                  "GAMS_OBJECTIVE.m;\n")
+                    output_file.write("\nput %s ' ' %s.l ' ' %s.m /;"
+                                      % (con, con, con))
+                output_file.write("\nput GAMS_OBJECTIVE ' ' GAMS_OBJECTIVE.l "
+                                  "' ' GAMS_OBJECTIVE.m;\n")
 
                 statresults = put_results + 'stat.dat'
                 output_file.write("\nfile statresults /'%s'/;" % statresults)

--- a/pyomo/solvers/tests/test_gams.py
+++ b/pyomo/solvers/tests/test_gams.py
@@ -1,0 +1,38 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import pyomo.common.unittest as unittest
+
+import pyomo.environ as pyo
+import pyomo.solvers.plugins.solvers.GAMS as GAMS
+from pyomo.common.tempfiles import TempfileManager
+
+gams_avail = pyo.SolverFactory('gams').available()
+
+@unittest.skipUnless(gams_avail, "Tests require GAMS")
+class TestGAMS(unittest.TestCase):
+    def test_dat_parser(self):
+        # This tests issue 2571
+        m = pyo.ConcreteModel()
+        m.S = pyo.Set(initialize=list(range(5)))
+        m.a_long_var_name = pyo.Var(m.S, bounds=(0, 1), initialize=1)
+        m.obj = pyo.Objective(
+            expr=2000 * pyo.summation(m.a_long_var_name), sense=pyo.maximize)
+        solver = pyo.SolverFactory("gams:conopt")
+        res = solver.solve(
+            m, symbolic_solver_labels=True, load_solutions=False,
+            io_options={'put_results_format': 'dat'})
+        self.assertEqual(res.solution[0].Objective['obj']['Value'], 10000)
+        for i in range(5):
+            self.assertEqual(
+                res.solution[0].Variable[f'a_long_var_name_{i}_']['Value'],
+                1
+            )


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
When developing other tests (that ended up not being committed), we ran across an issue where `float('nan') ==float('nan')` is False (per IEEE-754).  This was breaking structured comparisons.  Given the use cases for `assertStructuredAlmostEqual()`, it seems more logical to violate IEEE-754 and allow `float('nan')` to compare equal.

This PR makes that change

## Changes proposed in this PR:
- allow `float('nan') ==float('nan')`  to be True in `assertStructuredAlmostEqual()`
- add test for this behavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
