### PR TITLE
Fix GAMS logfile storage location

### DIFF
--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -261,6 +261,12 @@ class GAMSDirect(_GAMSSolver):
 
         initial_time = time.time()
 
+        # Because GAMS changes the CWD when running the solver, we need
+        # to convert user-provided file names to absolute paths
+        # (relative to the current directory)
+        if logfile is not None:
+            logfile = os.path.abspath(logfile)
+
         ####################################################################
         # Presolve
         ####################################################################
@@ -734,6 +740,12 @@ class GAMSShell(_GAMSSolver):
         # Pass remaining keywords to writer, which will handle
         # any unrecognized arguments
         initial_time = time.time()
+
+        # Because GAMS changes the CWD when running the solver, we need
+        # to convert user-provided file names to absolute paths
+        # (relative to the current directory)
+        if logfile is not None:
+            logfile = os.path.abspath(logfile)
 
         ####################################################################
         # Presolve

--- a/pyomo/solvers/tests/checks/test_GAMS.py
+++ b/pyomo/solvers/tests/checks/test_GAMS.py
@@ -17,6 +17,7 @@ from pyomo.solvers.plugins.solvers.GAMS import (
     GAMSShell, GAMSDirect, gdxcc_available
 )
 import pyomo.common.unittest as unittest
+from pyomo.common.tempfiles import TempfileManager
 from pyomo.common.tee import capture_output
 import os, shutil
 from tempfile import mkdtemp
@@ -395,6 +396,23 @@ class GAMSLogfileGmsTests(GAMSLogfileTestBase):
         self._check_stdout(output.getvalue(), exists=False)
         self._check_logfile(exists=True)
 
+    def test_logfile_relative(self):
+        cwd = os.getcwd()
+        with TempfileManager:
+            tmpdir = TempfileManager.create_tempdir()
+            os.chdir(tmpdir)
+            try:
+                self.logfile = 'test-gams.log'
+                with SolverFactory("gams", solver_io="gms") as opt:
+                    with capture_output() as output:
+                        opt.solve(self.m, logfile=self.logfile)
+                self._check_stdout(output.getvalue(), exists=False)
+                self._check_logfile(exists=True)
+                self.assertTrue(
+                    os.path.exists(os.path.join(tmpdir, self.logfile)))
+            finally:
+                os.chdir(cwd)
+
     def test_tee_and_logfile(self):
         with SolverFactory("gams", solver_io="gms") as opt:
             with capture_output() as output:
@@ -433,6 +451,22 @@ class GAMSLogfilePyTests(GAMSLogfileTestBase):
         self._check_stdout(output.getvalue(), exists=False)
         self._check_logfile(exists=True)
 
+    def test_logfile_relative(self):
+        cwd = os.getcwd()
+        with TempfileManager:
+            tmpdir = TempfileManager.create_tempdir()
+            os.chdir(tmpdir)
+            try:
+                self.logfile = 'test-gams.log'
+                with SolverFactory("gams", solver_io="python") as opt:
+                    with capture_output() as output:
+                        opt.solve(self.m, logfile=self.logfile)
+                self._check_stdout(output.getvalue(), exists=False)
+                self._check_logfile(exists=True)
+                self.assertTrue(
+                    os.path.exists(os.path.join(tmpdir, self.logfile)))
+            finally:
+                os.chdir(cwd)
     def test_tee_and_logfile(self):
         with SolverFactory("gams", solver_io="python") as opt:
             with capture_output() as output:


### PR DESCRIPTION
## Fixes #2572.

## Summary/Motivation:
When users provide non-absolute paths to the `logfile` GAMS currently writes the logfile relative to the GAMS temporary directory.  This is different from user expectations and the practice of other solvers.  This PR corrects the GAMS interface so that logfiles specified as relative paths are stored relative to the CWD.

## Changes proposed in this PR:
- Update the GAMS solver interface `logfile=` option to treat relative paths as relative to the CWD when the solver interface was invoked
- Add a test exercising this behavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
