### PR TITLE
Allow `nan` to compare equal in `assertStructuredAlmostEqual()`

### DIFF
--- a/pyomo/common/tests/test_unittest.py
+++ b/pyomo/common/tests/test_unittest.py
@@ -73,6 +73,11 @@ class TestPyomoUnittest(unittest.TestCase):
         with self.assertRaisesRegex(self.failureException, '10 !~= 10.01'):
             self.assertStructuredAlmostEqual(10, 10.01, delta=1e-3)
 
+    def test_assertStructuredAlmostEqual_nan(self):
+        a = float('nan')
+        b = float('nan')
+        self.assertStructuredAlmostEqual(a, b)
+
     def test_assertStructuredAlmostEqual_errorChecking(self):
         with self.assertRaisesRegex(
                 ValueError, "Cannot specify more than one of "

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -18,6 +18,7 @@
 
 import enum
 import logging
+import math
 import sys
 from io import StringIO
 
@@ -236,6 +237,8 @@ def _assertStructuredAlmostEqual(first, second,
                 return # PASS!
             if reltol is not None and diff / max(abs(f), abs(s)) <= reltol:
                 return # PASS!
+            if math.isnan(f) and math.isnan(s):
+                return # PASS! (we will treat NaN as equal)
         except:
             pass
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
When developing other tests (that ended up not being committed), we ran across an issue where `float('nan') ==float('nan')` is False (per IEEE-754).  This was breaking structured comparisons.  Given the use cases for `assertStructuredAlmostEqual()`, it seems more logical to violate IEEE-754 and allow `float('nan')` to compare equal.

This PR makes that change

(re-opening #2579 without spurious commits)

## Changes proposed in this PR:
- allow `float('nan') ==float('nan')`  to be True in `assertStructuredAlmostEqual()`
- add test for this behavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
