### PR TITLE
perf: don't parse quadratic terms when solver doesn't support them

### DIFF
--- a/pyomo/repn/plugins/cpxlp.py
+++ b/pyomo/repn/plugins/cpxlp.py
@@ -552,7 +552,10 @@ class ProblemWriter_cpxlp(AbstractProblemWriter):
                 if gen_obj_repn == False:
                     repn = block_repn[objective_data]
                 else:
-                    repn = generate_standard_repn(objective_data.expr)
+                    repn = generate_standard_repn(
+                        objective_data.expr,
+                        quadratic=supports_quadratic_objective,
+                    )
                     if gen_obj_repn:
                         block_repn[objective_data] = repn
 
@@ -637,7 +640,10 @@ class ProblemWriter_cpxlp(AbstractProblemWriter):
                         if constraint_data._linear_canonical_form:
                             repn = constraint_data.canonical_form()
                         else:
-                            repn = generate_standard_repn(constraint_data.body)
+                            repn = generate_standard_repn(
+                                constraint_data.body,
+                                quadratic=supports_quadratic_constraint,
+                            )
                         if gen_con_repn:
                             block_repn[constraint_data] = repn
 


### PR DESCRIPTION


## Fixes #2584  .

## Summary/Motivation:

See issue #2584

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
