### PR TITLE
Add test utilities for comparing expressions

### DIFF
--- a/pyomo/core/expr/compare.py
+++ b/pyomo/core/expr/compare.py
@@ -161,9 +161,7 @@ def convert_expression_to_prefix_notation(expr, include_named_exprs=True):
 
 
 def compare_expressions(expr1, expr2, include_named_exprs=True):
-    """
-    Returns True if 2 expression trees are identical. Returns False
-    otherwise.
+    """Returns True if 2 expression trees are identical, False otherwise.
 
     Parameters
     ----------
@@ -172,9 +170,10 @@ def compare_expressions(expr1, expr2, include_named_exprs=True):
     expr2: NumericValue
         A Pyomo Var, Param, or expression
     include_named_exprs: bool
-        If False, then named expressions will be ignored. In other words, this function
-        will return True if one expression has a named expression and the other does not
-        as long as the rest of the expression trees are identical.
+        If False, then named expressions will be ignored. In other
+        words, this function will return True if one expression has a
+        named expression and the other does not as long as the rest of
+        the expression trees are identical.
 
     Returns
     -------
@@ -182,8 +181,10 @@ def compare_expressions(expr1, expr2, include_named_exprs=True):
         A bool indicating whether or not the expressions are identical.
 
     """
-    pn1 = convert_expression_to_prefix_notation(expr1, include_named_exprs=include_named_exprs)
-    pn2 = convert_expression_to_prefix_notation(expr2, include_named_exprs=include_named_exprs)
+    pn1 = convert_expression_to_prefix_notation(
+        expr1, include_named_exprs=include_named_exprs)
+    pn2 = convert_expression_to_prefix_notation(
+        expr2, include_named_exprs=include_named_exprs)
     try:
         res = pn1 == pn2
     except PyomoException:
@@ -227,7 +228,7 @@ def assertExpressionsStructurallyEqual(test, a, b, include_named_exprs=True):
 
     This converts the expressions `a` and `b` into prefix notation and
     then compares the resulting lists.  Operators and (non-native type)
-    leaf nodes in the prefix epresentation are converted to strings
+    leaf nodes in the prefix representation are converted to strings
     before comparing (so that things like variables can be compared
     across clones or pickles)
 
@@ -253,9 +254,18 @@ def assertExpressionsStructurallyEqual(test, a, b, include_named_exprs=True):
             if type(v) in native_types:
                 continue
             if type(v) is tuple:
+                # This is an expression node.  Most expression nodes are
+                # 2-tuples (node type, nargs), but some are 3-tuples
+                # with supplemental data.  The biggest problem is
+                # external functions, where the third element is the
+                # external function.  We need to convert that to a
+                # string to support "structural" comparisons.
                 if len(v) == 3:
                     prefix[i] = v[:2] + (str(v[2]),)
                 continue
+            # This should be a leaf node (Var, mutable Param, etc.).
+            # Convert to string to support "structural" comparison
+            # (e.g., across clones)
             prefix[i] = str(v)
     try:
         test.assertEqual(len(prefix_a), len(prefix_b))

--- a/pyomo/core/expr/compare.py
+++ b/pyomo/core/expr/compare.py
@@ -20,8 +20,11 @@ from .current import (
     NPV_AbsExpression, NumericValue,
     RangedExpression, InequalityExpression, EqualityExpression,
 )
+from .template_expr import GetItemExpression
 from typing import List
 from pyomo.common.errors import PyomoException
+from pyomo.common.formatting import tostr
+from pyomo.common.numeric_types import native_types
 
 
 def handle_linear_expression(node: LinearExpression, pn: List):
@@ -76,6 +79,7 @@ handler[NPV_AbsExpression] = handle_unary_expression
 handler[RangedExpression] = handle_expression
 handler[InequalityExpression] = handle_expression
 handler[EqualityExpression] = handle_expression
+handler[GetItemExpression] = handle_expression
 
 
 class PrefixVisitor(StreamBasedExpressionVisitor):
@@ -185,3 +189,79 @@ def compare_expressions(expr1, expr2, include_named_exprs=True):
     except PyomoException:
         res = False
     return res
+
+
+def assertExpressionsEqual(test, a, b, include_named_exprs=True):
+    """unittest-based assertion for comparing expressions
+
+    This converts the expressions `a` and `b` into prefix notation and
+    then compares the resulting lists.
+
+    Parameters
+    ----------
+    test: unittest.TestCase
+        The unittest `TestCase` class that is performing the test.
+
+    a: ExpressionBase or native type
+
+    b: ExpressionBase or native type
+
+    include_named_exprs: bool
+       If True (the default), the comparison expands all named
+       expressions when generating the prefix notation
+    """
+    prefix_a = convert_expression_to_prefix_notation(a, include_named_exprs)
+    prefix_b = convert_expression_to_prefix_notation(b, include_named_exprs)
+    try:
+        test.assertEqual(len(prefix_a), len(prefix_b))
+        for _a, _b in zip(prefix_a, prefix_b):
+            test.assertIs(_a.__class__, _b.__class__)
+            test.assertEqual(_a, _b)
+    except (PyomoException, AssertionError):
+        test.fail(f"Expressions not equal:\n\t"
+                  f"{tostr(prefix_a)}\n\t!=\n\t{tostr(prefix_b)}")
+
+
+def assertExpressionsStructurallyEqual(test, a, b, include_named_exprs=True):
+    """unittest-based assertion for comparing expressions
+
+    This converts the expressions `a` and `b` into prefix notation and
+    then compares the resulting lists.  Operators and (non-native type)
+    leaf nodes in the prefix epresentation are converted to strings
+    before comparing (so that things like variables can be compared
+    across clones or pickles)
+
+    Parameters
+    ----------
+    test: unittest.TestCase
+        The unittest `TestCase` class that is performing the test.
+
+    a: ExpressionBase or native type
+
+    b: ExpressionBase or native type
+
+    include_named_exprs: bool
+       If True (the default), the comparison expands all named
+       expressions when generating the prefix notation
+
+    """
+    prefix_a = convert_expression_to_prefix_notation(a, include_named_exprs)
+    prefix_b = convert_expression_to_prefix_notation(b, include_named_exprs)
+    # Convert leaf nodes and operators to their string equivalents
+    for prefix in (prefix_a, prefix_b):
+        for i, v in enumerate(prefix):
+            if type(v) in native_types:
+                continue
+            if type(v) is tuple:
+                if len(v) == 3:
+                    prefix[i] = v[:2] + (str(v[2]),)
+                continue
+            prefix[i] = str(v)
+    try:
+        test.assertEqual(len(prefix_a), len(prefix_b))
+        for _a, _b in zip(prefix_a, prefix_b):
+            test.assertIs(_a.__class__, _b.__class__)
+            test.assertEqual(_a, _b)
+    except (PyomoException, AssertionError):
+        test.fail(f"Expressions not structurally equal:\n\t"
+                  f"{tostr(prefix_a)}\n\t!=\n\t{tostr(prefix_b)}")

--- a/pyomo/core/tests/unit/test_compare.py
+++ b/pyomo/core/tests/unit/test_compare.py
@@ -20,7 +20,8 @@ from pyomo.core.expr.relational_expr import (
     InequalityExpression, EqualityExpression, RangedExpression
 )
 from pyomo.core.expr.compare import (
-    convert_expression_to_prefix_notation, compare_expressions
+    convert_expression_to_prefix_notation, compare_expressions,
+    assertExpressionsEqual, assertExpressionsStructurallyEqual,
 )
 from pyomo.common.getGSL import find_GSL
 
@@ -159,3 +160,28 @@ class TestConvertToPrefixNotation(unittest.TestCase):
                     m.x,
                     1]
         self.assertEqual(pn, expected)
+
+    def test_assertExpressionsEqual(self):
+        m = pe.ConcreteModel()
+        m.x = pe.Var()
+        m.e1 = pe.Expression(expr=m.x**2 + m.x - 1)
+        m.e2 = pe.Expression(expr=m.x**2 + m.x - 1)
+        m.f = pe.Expression(expr=m.x**2 + 2*m.x - 1)
+        m.g = pe.Expression(expr=m.x**2 + m.x - 2)
+
+        assertExpressionsEqual(self, m.e1.expr, m.e2.expr)
+        assertExpressionsStructurallyEqual(self, m.e1.expr, m.e2.expr)
+        with self.assertRaisesRegex(
+                AssertionError, 'Expressions not equal:'):
+            assertExpressionsEqual(self, m.e1.expr, m.f.expr)
+        with self.assertRaisesRegex(
+                AssertionError, 'Expressions not structurally equal:'):
+            assertExpressionsStructurallyEqual(self, m.e1.expr, m.f.expr)
+
+        # Structurally equal will compare across clones, whereas strict
+        # equality will not
+        i = m.clone()
+        with self.assertRaisesRegex(
+                AssertionError, 'Expressions not equal:'):
+            assertExpressionsEqual(self, m.e1.expr, i.e1.expr)
+        assertExpressionsStructurallyEqual(self, m.e1.expr, i.e1.expr)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This PR defines two new functions for comparing expression trees in unittest test suites: `assertExpressionsEqual()` and `assertExpressionsStructurallyEqual()`  These functions support more robust comparison of Expression trees using a convenient syntax like:
```python
    def test_simpleSum_API(self):
        m = ConcreteModel()
        m.a = Var()
        m.b = Var()
        e = m.a + m.b
        e += (2*m.a)
        assertExpressionsEqual(
            self,
            e,
            LinearExpression([
                MonomialTermExpression((1, m.a)),
                MonomialTermExpression((1, m.b)),
                MonomialTermExpression((2, m.a)),
            ])
        )
```

## Changes proposed in this PR:
- add  `assertExpressionsEqual()` and `assertExpressionsStructurallyEqual()`
- add tests exercising the test functions

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
