### PR TITLE
Update handling of mosek `Env` and python module

### DIFF
--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -125,13 +125,12 @@ class MOSEKDirect(DirectSolver):
         Runs a check for a valid MOSEK license. Returns False if MOSEK fails
         to run on a trivial test case.
         """
-        try:
-            import mosek
-        except ImportError:
+        if not mosek_available:
             return False
         try:
-            mosek.Env().checkoutlicense(mosek.feature.pton)
-            mosek.Env().checkinlicense(mosek.feature.pton)
+            with mosek.Env() as env:
+                env.checkoutlicense(mosek.feature.pton)
+                env.checkinlicense(mosek.feature.pton)
         except mosek.Error:
             return False
         return True

--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -185,7 +185,7 @@ class MOSEKDirect(DirectSolver):
         self._whichsol = getattr(mosek.soltype, kwds.pop(
             'soltype', 'bas'))
         try:
-            self._solver_model = self._mosek.Env().Task()
+            self._solver_model = self._mosek_env.Task()
         except:
             err_msg = sys.exc_info()[1]
             logger.error("MOSEK task creation failed. "


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
We are seeing cases where the test infrastructure is regularly running out of Mosek licenses during tests.  This PR attempts to be more careful with checking out and reusing Mosek `Env` instances.  It also updates the Mosek solver interface to leverage `attempt_import` for deferred imports of the `mosek` module

## Changes proposed in this PR:
- Explicitly delete `Env` when checking for license availability
- Reuse the `Env` assigned to the solver instance when solving a model
- Switch to using `attempt_import` for importing the `mosek` module

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
