### PR TITLE
Explicitly release MOSEK licenses when `optimize()` raises a `mosek.Error`

### DIFF
--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -172,6 +172,11 @@ class MOSEKDirect(DirectSolver):
             self._termcode = self._solver_model.optimize()
             self._solver_model.solutionsummary(mosek.streamtype.msg)
         except mosek.Error as e:
+            # MOSEK is not good about releasing licenses when an
+            # exception is raised during optimize().  We will explicitly
+            # release all licenses to prevent (among other things) a
+            # "license leak" during testing with expected failures.
+            self._mosek_env.checkinall()
             logger.error(e)
             raise
         return Bunch(rc=None, log=None)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
MOSEK is not good about releasing licenses if t raises an exception (`mosek.Error`) from within `optimize()`.  This PR works around that by explicitly releasing all licenses in the event that `optimize()` raises an exception.

This was discovered through the `test_writers.py` QCP and MIQCP tests (which test a series of expected failures for MOSEK in rapid succession, resulting in as many as 9 licenses being consumed).

## Changes proposed in this PR:
- explicitly release MOSEK licenses when MOSEK raises an exception

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
