### PR TITLE
Check that AmplInterface is available in SciPy solver tests

### DIFF
--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_scipy_solvers.py
@@ -17,11 +17,6 @@ if not scipy_available:
     raise unittest.SkipTest("SciPy is needed to test the SciPy solvers")
 
 from pyomo.contrib.pynumero.asl import AmplInterface
-if not AmplInterface.available():
-    raise unittest.SkipTest(
-        "Pynumero needs the ASL extension to run SciPy solver tests"
-    )
-
 from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP
 from pyomo.contrib.pynumero.algorithms.solvers.square_solver_base import (
     SquareNlpSolverBase,
@@ -45,7 +40,6 @@ def make_simple_model():
     return m, nlp
 
 
-@unittest.skipUnless(scipy_available, "SciPy is not available")
 @unittest.skipUnless(AmplInterface.available(), "AmplInterface is not available")
 class TestSquareSolverBase(unittest.TestCase):
 
@@ -74,7 +68,6 @@ class TestSquareSolverBase(unittest.TestCase):
         solver = SquareNlpSolverBase(nlp)
 
 
-@unittest.skipUnless(scipy_available, "SciPy is not available")
 @unittest.skipUnless(AmplInterface.available(), "AmplInterface is not available")
 class TestFsolveNLP(unittest.TestCase):
 
@@ -122,7 +115,6 @@ class TestFsolveNLP(unittest.TestCase):
             x, info, ier, msg = solver.solve()
 
 
-@unittest.skipUnless(scipy_available, "SciPy is not available")
 @unittest.skipUnless(AmplInterface.available(), "AmplInterface is not available")
 class TestPyomoScipySolver(unittest.TestCase):
 
@@ -137,7 +129,6 @@ class TestPyomoScipySolver(unittest.TestCase):
         self.assertEqual(sp_version, solver.version())
 
 
-@unittest.skipUnless(scipy_available, "SciPy is not available")
 @unittest.skipUnless(AmplInterface.available(), "AmplInterface is not available")
 class TestFsolvePyomo(unittest.TestCase):
 
@@ -207,7 +198,6 @@ class TestFsolvePyomo(unittest.TestCase):
             res = solver.solve(m)
 
 
-@unittest.skipUnless(scipy_available, "SciPy is not available")
 @unittest.skipUnless(AmplInterface.available(), "AmplInterface is not available")
 class TestRootNLP(unittest.TestCase):
 
@@ -230,7 +220,6 @@ class TestRootNLP(unittest.TestCase):
         )
 
 
-@unittest.skipUnless(scipy_available, "SciPy is not available")
 @unittest.skipUnless(AmplInterface.available(), "AmplInterface is not available")
 class TestRootPyomo(unittest.TestCase):
 

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_scipy_solvers.py
@@ -16,6 +16,12 @@ import pyomo.environ as pyo
 if not scipy_available:
     raise unittest.SkipTest("SciPy is needed to test the SciPy solvers")
 
+from pyomo.contrib.pynumero.asl import AmplInterface
+if not AmplInterface.available():
+    raise unittest.SkipTest(
+        "Pynumero needs the ASL extension to run SciPy solver tests"
+    )
+
 from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP
 from pyomo.contrib.pynumero.algorithms.solvers.square_solver_base import (
     SquareNlpSolverBase,
@@ -40,6 +46,7 @@ def make_simple_model():
 
 
 @unittest.skipUnless(scipy_available, "SciPy is not available")
+@unittest.skipUnless(AmplInterface.available(), "AmplInterface is not available")
 class TestSquareSolverBase(unittest.TestCase):
 
     def test_not_implemented_solve(self):
@@ -68,6 +75,7 @@ class TestSquareSolverBase(unittest.TestCase):
 
 
 @unittest.skipUnless(scipy_available, "SciPy is not available")
+@unittest.skipUnless(AmplInterface.available(), "AmplInterface is not available")
 class TestFsolveNLP(unittest.TestCase):
 
     def test_solve_simple_nlp(self):
@@ -115,6 +123,7 @@ class TestFsolveNLP(unittest.TestCase):
 
 
 @unittest.skipUnless(scipy_available, "SciPy is not available")
+@unittest.skipUnless(AmplInterface.available(), "AmplInterface is not available")
 class TestPyomoScipySolver(unittest.TestCase):
 
     def test_available_and_version(self):
@@ -129,6 +138,7 @@ class TestPyomoScipySolver(unittest.TestCase):
 
 
 @unittest.skipUnless(scipy_available, "SciPy is not available")
+@unittest.skipUnless(AmplInterface.available(), "AmplInterface is not available")
 class TestFsolvePyomo(unittest.TestCase):
 
     def test_available_and_version(self):
@@ -198,6 +208,7 @@ class TestFsolvePyomo(unittest.TestCase):
 
 
 @unittest.skipUnless(scipy_available, "SciPy is not available")
+@unittest.skipUnless(AmplInterface.available(), "AmplInterface is not available")
 class TestRootNLP(unittest.TestCase):
 
     def test_solve_simple_nlp(self):
@@ -220,6 +231,7 @@ class TestRootNLP(unittest.TestCase):
 
 
 @unittest.skipUnless(scipy_available, "SciPy is not available")
+@unittest.skipUnless(AmplInterface.available(), "AmplInterface is not available")
 class TestRootPyomo(unittest.TestCase):
 
     def test_available_and_version(self):


### PR DESCRIPTION
## Fixes Jenkins failure

## Summary/Motivation:
SciPy solver tests rely on pynumeroASL as well as SciPy, but are only guarded with `skipUnless(scipy_available)`

## Changes proposed in this PR:
- Add `skipUnless(AmplInterface.available())` to tests in test_scipy_solvers.py

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
