### PR TITLE
Adding Python 3.11 to GHA

### DIFF
--- a/.coin-or/projDesc.xml
+++ b/.coin-or/projDesc.xml
@@ -287,7 +287,7 @@ Carl D. Laird, Chair, Pyomo Management Committee, claird at andrew dot cmu dot e
 
 			<platform>
 				<operatingSystem>Any</operatingSystem>
-				<compiler>Python 3.7, 3.8, 3.9, 3.10</compiler>
+				<compiler>Python 3.7, 3.8, 3.9, 3.10, 3.11</compiler>
 			</platform>
 
 		</testedPlatforms>

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -31,23 +31,23 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ['3.10']
+        python: ['3.11']
         other: [""]
         category: [""]
 
         include:
         - os: ubuntu-latest
-          python: '3.10'
+          python: '3.11'
           TARGET: linux
           PYENV: pip
 
         - os: macos-latest
-          python: 3.8
+          python: '3.10'
           TARGET: osx
           PYENV: pip
 
         - os: windows-latest
-          python: 3.7
+          python: 3.9
           TARGET: win
           PYENV: conda
           PACKAGES: glpk
@@ -78,7 +78,7 @@ jobs:
           PYENV: pip
 
         - os: ubuntu-latest
-          python: 3.8
+          python: '3.10'
           other: /cython
           setup_options: --with-cython
           skip_doctest: 1

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -114,6 +114,11 @@ jobs:
           TARGET: win
           PYENV: pip
 
+        exclude:
+        # Exclude 3.11 on conda until matplotlib!=3.6.1 is released on
+        # conda-forge for python 3.11
+        - {os: windows-latest, python: 3.11}
+
     steps:
     - name: Checkout Pyomo source
       uses: actions/checkout@v3

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.7, 3.8, 3.9, '3.10']
+        python: [3.7, 3.8, 3.9, '3.10', '3.11']
         other: [""]
         category: [""]
 
@@ -78,7 +78,7 @@ jobs:
           PYENV: pip
 
         - os: ubuntu-latest
-          python: 3.8
+          python: '3.10'
           other: /cython
           setup_options: --with-cython
           skip_doctest: 1

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Pyomo is available under the BSD License, see the LICENSE.txt file.
 
 Pyomo is currently tested with the following Python implementations:
 
-* CPython: 3.7, 3.8, 3.9, 3.10
+* CPython: 3.7, 3.8, 3.9, 3.10, 3.11
 * PyPy: 3.7, 3.8, 3.9
 
 ### Installation

--- a/doc/OnlineDocs/installation.rst
+++ b/doc/OnlineDocs/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 Pyomo currently supports the following versions of Python:
 
-* CPython: 3.7, 3.8, 3.9, 3.10
+* CPython: 3.7, 3.8, 3.9, 3.10, 3.11
 * PyPy: 3
 
 

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -1285,12 +1285,7 @@ class ConfigBase(object):
         # can allocate the state dictionary.  If it is not, then we call
         # the super-class's __getstate__ (since that class is NOT
         # 'object').
-        _base = super()
-        if hasattr(_base, '__getstate__'):
-            state = _base.__getstate__()
-        else:
-            state = {}
-        state.update((key, getattr(self, key)) for key in ConfigBase.__slots__)
+        state = {key: getattr(self, key) for key in ConfigBase.__slots__}
         state['_domain'] = _picklable(state['_domain'], self)
         state['_parent'] = None
         return state

--- a/pyomo/core/tests/unit/test_disable_methods.py
+++ b/pyomo/core/tests/unit/test_disable_methods.py
@@ -150,7 +150,8 @@ class TestDisableMethods(unittest.TestCase):
                 RuntimeError, "Cannot access property 'g' on _abstract_simple "
                 "'foo' before it has been constructed"):
             x.g
-        with self.assertRaisesRegex(AttributeError, "can't set attribute"):
+        with self.assertRaisesRegex(
+                AttributeError, "(can't set attribute)|(object has no setter)"):
             x.g = 1
         with self.assertRaisesRegex(
                 RuntimeError, "Cannot custom_pmsg _abstract_simple "

--- a/pyomo/core/tests/unit/test_disable_methods.py
+++ b/pyomo/core/tests/unit/test_disable_methods.py
@@ -157,7 +157,8 @@ class TestDisableMethods(unittest.TestCase):
                 RuntimeError, "Cannot custom_pmsg _abstract_simple "
                 "'foo' before it has been constructed"):
             x.h
-        with self.assertRaisesRegex(AttributeError, "can't set attribute"):
+        with self.assertRaisesRegex(
+                AttributeError, "(can't set attribute)|(object has no setter)"):
             x.h = 1
 
         self.assertEqual(x.construct(), 'construct')

--- a/setup.py
+++ b/setup.py
@@ -250,7 +250,10 @@ setup_kwargs = dict(
             # The following optional dependencies are difficult to
             # install on PyPy (binary wheels are not available), so we
             # will only "require" them on other (CPython) platforms:
-            'casadi; implementation_name!="pypy"',  # dae
+            #
+            # DAE can use casadi; as of 1 Nov 22, casadi has not been
+            # released for Python 3.11
+            'casadi; implementation_name!="pypy" and python_version<"3.11"',
             'numdifftools; implementation_name!="pypy"', # pynumero
             'pandas; implementation_name!="pypy"',
             'seaborn; implementation_name!="pypy"',   # parmest.graphics

--- a/setup.py
+++ b/setup.py
@@ -199,6 +199,7 @@ setup_kwargs = dict(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Scientific/Engineering :: Mathematics',


### PR DESCRIPTION
## Fixes #2595 

## Summary/Motivation:
This adds Python 3.11 builds to the GHA workflows.

## Changes proposed in this PR:
- Add python 3.11
- update some other builds to more recent Python versions

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
