### PR TITLE
Allow more characters in CPLEX Filenames

### DIFF
--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -69,7 +69,7 @@ def _validate_file_name(cplex, filename, description):
 # The full list of allowed characters, per IBM, is:
     # (a-z, A-Z, 0-9) or ! " # $ % & ( ) / , . ; ? @ _ ` ' { } | ~
 _validate_file_name.allowed_characters = \
-    r"a-zA-Z0-9 ~:;,!'`|\(\)\{\}\?\#\&\.\-_\@\%s" % (os.path.sep,)
+    r"a-zA-Z0-9 ~:;,!'`|\$\(\)\{\}\?\#\&\.\-_\@\%s" % (os.path.sep,)
 _validate_file_name.illegal_characters = re.compile(
     '[^%s]' % (_validate_file_name.allowed_characters,))
 

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -66,7 +66,7 @@ def _validate_file_name(cplex, filename, description):
                 "CPLEX or remove the space from the %s path."
                 % (description, filename, description))
     return filename
-_validate_file_name.allowed_characters = r"a-zA-Z0-9 ~:\.\-_\%s" % (
+_validate_file_name.allowed_characters = r"a-zA-Z0-9 ~:\.\-_\@\%s" % (
     os.path.sep,)
 _validate_file_name.illegal_characters = re.compile(
     '[^%s]' % (_validate_file_name.allowed_characters,))

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -66,8 +66,10 @@ def _validate_file_name(cplex, filename, description):
                 "CPLEX or remove the space from the %s path."
                 % (description, filename, description))
     return filename
-_validate_file_name.allowed_characters = r"a-zA-Z0-9 ~:\.\-_\@\%s" % (
-    os.path.sep,)
+# The full list of allowed characters, per IBM, is:
+    # (a-z, A-Z, 0-9) or ! " # $ % & ( ) / , . ; ? @ _ ` ' { } | ~
+_validate_file_name.allowed_characters = \
+    r"a-zA-Z0-9 ~:;,!'`|\(\)\{\}\?\#\&\.\-_\@\%s" % (os.path.sep,)
 _validate_file_name.illegal_characters = re.compile(
     '[^%s]' % (_validate_file_name.allowed_characters,))
 

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -61,6 +61,33 @@ class CPLEX_utils(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             _validate_file_name(_128, fname, 'xxx')
 
+        # check allowable characters
+        fname = 'foo$$bar.lp'
+        self.assertEqual(fname, _validate_file_name(_126, fname, 'xxx'))
+        self.assertEqual(fname, _validate_file_name(_128, fname, 'xxx'))
+        fname = 'foo_bar.lp'
+        self.assertEqual(fname, _validate_file_name(_126, fname, 'xxx'))
+        self.assertEqual(fname, _validate_file_name(_128, fname, 'xxx'))
+        fname = 'foo&bar.lp'
+        self.assertEqual(fname, _validate_file_name(_126, fname, 'xxx'))
+        self.assertEqual(fname, _validate_file_name(_128, fname, 'xxx'))
+        fname = 'foo~bar.lp'
+        self.assertEqual(fname, _validate_file_name(_126, fname, 'xxx'))
+        self.assertEqual(fname, _validate_file_name(_128, fname, 'xxx'))
+        fname = 'foo-bar.lp'
+        self.assertEqual(fname, _validate_file_name(_126, fname, 'xxx'))
+        self.assertEqual(fname, _validate_file_name(_128, fname, 'xxx'))
+
+        # Check unallowable character
+        bad_char = '^'
+        fname = 'foo%sbar.lp' % (bad_char,)
+        msg = r"Unallowed character \(\^\) found in CPLEX xxx file"
+        with self.assertRaisesRegex(ValueError, msg):
+            _validate_file_name(_126, fname, 'xxx')
+        with self.assertRaisesRegex(ValueError, msg):
+            _validate_file_name(_128, fname, 'xxx')
+
+
 
 class CPLEXShellWritePrioritiesFile(unittest.TestCase):
     """ Unit test on writing of priorities via `CPLEXSHELL._write_priorities_file()` """


### PR DESCRIPTION
## Fixes #2548 

## Summary/Motivation:
The list of allowable characters has changed. This PR updates the list and adds extra tests for it.

## Changes proposed in this PR:
- Add full list of allowable characters (see [IBM's docs](https://www.ibm.com/docs/en/icos/12.10.0?topic=representation-variable-names-in-lp-file-format))

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
