### PR TITLE
Add wrappers for SciPy scalar Newton solver

### DIFF
--- a/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
@@ -107,11 +107,14 @@ class RootNlpSolver(DenseSquareNlpSolver):
     ))
     OPTIONS.declare("method", ConfigValue(
         default="hybr",
-        # NOTE: Only supporting Powell hybrid method and Levenberg-Marquardt
-        # methods (both from MINPACK) for now.
         domain=In({"hybr", "lm"}),
-        #domain=str,
         description="Method used to solve for the function root",
+        doc=(
+            """The 'method' argument in the scipy.optimize.root function.
+            For now only 'hybr' (Powell hybrid method from MINPACK) and
+            'lm' (Legenberg-Marquardt from MINPACK) are supported.
+            """
+        ),
     ))
 
     def solve(self, x0=None):

--- a/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
@@ -34,7 +34,7 @@ pyomo_nlp, _ = attempt_import("pyomo.contrib.pynumero.interfaces.pyomo_nlp")
 
 class FsolveNlpSolver(DenseSquareNlpSolver):
 
-    OPTIONS = ConfigBlock(
+    OPTIONS = DenseSquareNlpSolver.OPTIONS(
         description="Options for SciPy fsolve wrapper",
     )
     OPTIONS.declare("xtol", ConfigValue(
@@ -98,7 +98,7 @@ class FsolveNlpSolver(DenseSquareNlpSolver):
 
 class RootNlpSolver(DenseSquareNlpSolver):
 
-    OPTIONS = ConfigBlock(
+    OPTIONS = DenseSquareNlpSolver.OPTIONS(
         description="Options for SciPy fsolve wrapper",
     )
     OPTIONS.declare("tol", ConfigValue(
@@ -137,7 +137,7 @@ class NewtonNlpSolver(ScalarDenseSquareNlpSolver):
 
     """
 
-    OPTIONS = ConfigBlock(
+    OPTIONS = ScalarDenseSquareNlpSolver.OPTIONS(
         description="Options for SciPy newton wrapper",
     )
     OPTIONS.declare("tol", ConfigValue(

--- a/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
@@ -113,7 +113,7 @@ class RootNlpSolver(DenseSquareNlpSolver):
         doc=(
             """The 'method' argument in the scipy.optimize.root function.
             For now only 'hybr' (Powell hybrid method from MINPACK) and
-            'lm' (Legenberg-Marquardt from MINPACK) are supported.
+            'lm' (Levenberg-Marquardt from MINPACK) are supported.
             """
         ),
     ))

--- a/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
@@ -360,7 +360,7 @@ class PyomoFsolveSolver(PyomoScipySolver):
         results.problem.number_of_continuous_variables = nlp.n_primals()
 
         # Record solver data
-        results.solver.name = "fsolve"
+        results.solver.name = "scipy.fsolve"
         results.solver.return_code = ier
         results.solver.message = msg
         results.solver.wallclock_time = self._timer.timers["solve"].total_time
@@ -396,7 +396,7 @@ class PyomoRootSolver(PyomoScipySolver):
         results.problem.number_of_continuous_variables = nlp.n_primals()
 
         # Record solver data
-        results.solver.name = "root"
+        results.solver.name = "scipy.root"
         results.solver.return_code = scipy_results.status
         results.solver.message = scipy_results.message
         results.solver.wallclock_time = self._timer.timers["solve"].total_time
@@ -423,6 +423,8 @@ class PyomoRootSolver(PyomoScipySolver):
 
 class PyomoNewtonSolver(PyomoScipySolver):
 
+    _solver_name = "scipy.newton"
+
     def create_nlp_solver(self, **kwds):
         nlp = self.get_nlp()
         solver = NewtonNlpSolver(nlp, **kwds)
@@ -446,7 +448,7 @@ class PyomoNewtonSolver(PyomoScipySolver):
         results.problem.number_of_continuous_variables = nlp.n_primals()
 
         # Record solver data
-        results.solver.name = "scipy.newton"
+        results.solver.name = self._solver_name
 
         results.solver.wallclock_time = self._timer.timers["solve"].total_time
 
@@ -472,6 +474,8 @@ class PyomoNewtonSolver(PyomoScipySolver):
 
 
 class PyomoSecantNewtonSolver(PyomoNewtonSolver):
+
+    _solver_name = "scipy.secant-newton"
 
     def converged_with_secant(self):
         return self._nlp_solver.converged_with_secant

--- a/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
@@ -383,10 +383,6 @@ class PyomoFsolveSolver(PyomoScipySolver):
 
 class PyomoRootSolver(PyomoScipySolver):
 
-    _term_cond = {
-        1: TerminationCondition.feasible,
-    }
-
     def create_nlp_solver(self, **kwds):
         nlp = self.get_nlp()
         solver = RootNlpSolver(nlp, **kwds)

--- a/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
@@ -18,10 +18,8 @@ from pyomo.contrib.pynumero.algorithms.solvers.square_solver_base import (
     DenseSquareNlpSolver,
 )
 from pyomo.opt import (
-    SolverStatus,
     SolverResults,
     TerminationCondition,
-    ProblemSense,
 )
 from pyomo.common.dependencies import (
     attempt_import,

--- a/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
@@ -16,6 +16,7 @@ from pyomo.common.modeling import unique_component_name
 from pyomo.common.config import ConfigBlock, ConfigValue, In
 from pyomo.contrib.pynumero.algorithms.solvers.square_solver_base import (
     DenseSquareNlpSolver,
+    ScalarDenseSquareNlpSolver,
 )
 from pyomo.opt import (
     SolverResults,
@@ -131,22 +132,7 @@ class RootNlpSolver(DenseSquareNlpSolver):
         return results
 
 
-class _ScalarDenseSquareNlpSolver(DenseSquareNlpSolver):
-    # A base class for solvers for scalar equations.
-    # Not intended to be instantiated directly. Instead,
-    # NewtonNlpSolver or SecantNewtonNlpSolver should be used.
-
-    def __init__(self, nlp, timer=None, options=None):
-        super().__init__(nlp, timer=timer, options=options)
-        if nlp.n_primals() != 1:
-            raise RuntimeError(
-                "Cannot use the scipy.optimize.newton solver on an NLP with"
-                " more than one variable and equality constraint. Got %s"
-                " primals. Please use RootNlpSolver or FsolveNlpSolver instead."
-            )
-
-
-class NewtonNlpSolver(_ScalarDenseSquareNlpSolver):
+class NewtonNlpSolver(ScalarDenseSquareNlpSolver):
     """A wrapper around the SciPy scalar Newton solver for NLP objects
 
     """

--- a/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
@@ -128,7 +128,25 @@ class RootNlpSolver(DenseSquareNlpSolver):
         return results
 
 
-class NewtonNlpSolver(DenseSquareNlpSolver):
+class _ScalarDenseSquareNlpSolver(DenseSquareNlpSolver):
+    # A base class for solvers for scalar equations.
+    # Not intended to be instantiated directly. Instead,
+    # NewtonNlpSolver or SecantNewtonNlpSolver should be used.
+
+    def __init__(self, nlp, timer=None, options=None):
+        super().__init__(nlp, timer=timer, options=options)
+        if nlp.n_primals() != 1:
+            raise RuntimeError(
+                "Cannot use the scipy.optimize.newton solver on an NLP with"
+                " more than one variable and equality constraint. Got %s"
+                " primals. Please use RootNlpSolver or FsolveNlpSolver instead."
+            )
+
+
+class NewtonNlpSolver(_ScalarDenseSquareNlpSolver):
+    """A wrapper around the SciPy scalar Newton solver for NLP objects
+
+    """
 
     OPTIONS = ConfigBlock(
         description="Options for SciPy newton wrapper",
@@ -154,15 +172,6 @@ class NewtonNlpSolver(DenseSquareNlpSolver):
         description="Maximum number of function evaluations per solve",
     ))
 
-    def __init__(self, nlp, timer=None, options=None):
-        super().__init__(nlp, timer=timer, options=options)
-        if nlp.n_primals() != 1:
-            raise RuntimeError(
-                "Cannot use the scipy.optimize.newton solver on an NLP with"
-                " more than one variable and equality constraint. Got %s"
-                " primals. Please use RootNlpSolver or FsolveNlpSolver instead."
-            )
-
     def solve(self, x0=None):
         self._timer.start("solve")
         if x0 is None:
@@ -184,10 +193,17 @@ class NewtonNlpSolver(DenseSquareNlpSolver):
         return results
 
 
-class SecantNewtonNlpSolver(NewtonNlpSolver):
+class SecantNewtonNlpSolver(_ScalarDenseSquareNlpSolver):
+    """A wrapper around the SciPy scalar Newton solver for NLP objects
+    that takes a specified number of secant iterations (default is 2) to
+    try to converge a linear equation quickly then switches to Newton's
+    method if this is not successful. This strategy is inspired by
+    calculate_variable_from_constraint in pyomo.util.calc_var_value.
+
+    """
 
     OPTIONS = ConfigBlock(
-        description="Options for SciPy newton wrapper",
+        description="Options for the SciPy Newton-secant hybrid",
     )
     OPTIONS.declare("tol", ConfigValue(
         default=1e-8,
@@ -202,8 +218,21 @@ class SecantNewtonNlpSolver(NewtonNlpSolver):
             " to Newton's method."
         ),
     ))
+    OPTIONS.declare("full_output", ConfigValue(
+        default=True,
+        domain=bool,
+        description="Whether underlying solver should return its full output",
+    ))
+    OPTIONS.declare("newton_iter", ConfigValue(
+        default=50,
+        domain=int,
+        description="Maximum iterations for the Newton solve",
+    ))
 
-    # TODO: Check that NLP is one-dimensional
+    def __init__(self, nlp, timer=None, options=None):
+        super().__init__(nlp, timer=timer, options=options)
+        self.converged_with_secant = None
+
     def solve(self, x0=None):
         self._timer.start("solve")
         if x0 is None:
@@ -216,14 +245,19 @@ class SecantNewtonNlpSolver(NewtonNlpSolver):
                 fprime=None,
                 tol=self.options.tol,
                 maxiter=self.options.secant_iter,
+                full_output=self.options.full_output,
             )
+            self.converged_with_secant = True
         except RuntimeError:
+            self.converged_with_secant = False
             x0 = self._nlp.get_primals()
             results = sp.optimize.newton(
                 lambda x: self.evaluate_function(np.array([x]))[0],
                 x0[0],
                 fprime=lambda x: self.evaluate_jacobian(np.array([x]))[0, 0],
                 tol=self.options.tol,
+                maxiter=self.options.newton_iter,
+                full_output=self.options.full_output,
             )
         self._timer.stop("solve")
         return results
@@ -422,6 +456,59 @@ class PyomoNewtonSolver(PyomoScipySolver):
 
         # Record solver data
         results.solver.name = "scipy.newton"
+
+        results.solver.wallclock_time = self._timer.timers["solve"].total_time
+
+        if self._nlp_solver.options.full_output:
+            # We only have access to any of this information if the solver was
+            # requested to return its full output.
+
+            # For this solver, res.flag is a string.
+            # If successful, it is 'converged'
+            results.solver.message = res.flag
+
+            if res.converged:
+                term_cond = TerminationCondition.feasible
+            else:
+                term_cond = TerminationCondition.Error
+            results.solver.termination_condition = term_cond
+            results.solver.status = TerminationCondition.to_solver_status(
+                results.solver.termination_condition
+            )
+
+            results.solver.number_of_function_evaluations = res.function_calls
+        return results
+
+
+class PyomoSecantNewtonSolver(PyomoScipySolver):
+
+    def converged_with_secant(self):
+        return self._nlp_solver.converged_with_secant
+
+    def create_nlp_solver(self, **kwds):
+        nlp = self.get_nlp()
+        solver = SecantNewtonNlpSolver(nlp, **kwds)
+        return solver
+
+    def get_pyomo_results(self, model, scipy_results):
+        nlp = self.get_nlp()
+        results = SolverResults()
+
+        if self._nlp_solver.options.full_output:
+            root, res = scipy_results
+        else:
+            root = scipy_results
+
+        # Record problem data
+        results.problem.name = model.name
+        results.problem.number_of_constraints = nlp.n_eq_constraints()
+        results.problem.number_of_variables = nlp.n_primals()
+        results.problem.number_of_binary_variables = 0
+        results.problem.number_of_integer_variables = 0
+        results.problem.number_of_continuous_variables = nlp.n_primals()
+
+        # Record solver data
+        results.solver.name = "scipy.secant-newton"
 
         results.solver.wallclock_time = self._timer.timers["solve"].total_time
 

--- a/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
@@ -191,7 +191,7 @@ class NewtonNlpSolver(_ScalarDenseSquareNlpSolver):
         return results
 
 
-class SecantNewtonNlpSolver(_ScalarDenseSquareNlpSolver):
+class SecantNewtonNlpSolver(NewtonNlpSolver):
     """A wrapper around the SciPy scalar Newton solver for NLP objects
     that takes a specified number of secant iterations (default is 2) to
     try to converge a linear equation quickly then switches to Newton's
@@ -203,11 +203,10 @@ class SecantNewtonNlpSolver(_ScalarDenseSquareNlpSolver):
     OPTIONS = ConfigBlock(
         description="Options for the SciPy Newton-secant hybrid",
     )
-    OPTIONS.declare("tol", ConfigValue(
-        default=1e-8,
-        domain=float,
-        description="Convergence tolerance",
-    ))
+    OPTIONS.declare_from(
+        NewtonNlpSolver.OPTIONS,
+        skip={"maxiter", "secant"},
+    )
     OPTIONS.declare("secant_iter", ConfigValue(
         default=2,
         domain=int,
@@ -215,11 +214,6 @@ class SecantNewtonNlpSolver(_ScalarDenseSquareNlpSolver):
             "Number of secant iterations to perform before switching"
             " to Newton's method."
         ),
-    ))
-    OPTIONS.declare("full_output", ConfigValue(
-        default=True,
-        domain=bool,
-        description="Whether underlying solver should return its full output",
     ))
     OPTIONS.declare("newton_iter", ConfigValue(
         default=50,

--- a/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
@@ -148,6 +148,11 @@ class NewtonNlpSolver(DenseSquareNlpSolver):
         domain=bool,
         description="Whether underlying solver should return its full output",
     ))
+    OPTIONS.declare("maxiter", ConfigValue(
+        default=50,
+        domain=int,
+        description="Maximum number of function evaluations per solve",
+    ))
 
     def __init__(self, nlp, timer=None, options=None):
         super().__init__(nlp, timer=timer, options=options)
@@ -173,6 +178,7 @@ class NewtonNlpSolver(DenseSquareNlpSolver):
             fprime=fprime,
             tol=self.options.tol,
             full_output=self.options.full_output,
+            maxiter=self.options.maxiter,
         )
         self._timer.stop("solve")
         return results

--- a/pyomo/contrib/pynumero/algorithms/solvers/square_solver_base.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/square_solver_base.py
@@ -102,5 +102,3 @@ class ScalarDenseSquareNlpSolver(DenseSquareNlpSolver):
                 " more than one variable and equality constraint. Got %s"
                 " primals. Please use RootNlpSolver or FsolveNlpSolver instead."
             )
-
-

--- a/pyomo/contrib/pynumero/algorithms/solvers/square_solver_base.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/square_solver_base.py
@@ -88,3 +88,19 @@ class DenseSquareNlpSolver(SquareNlpSolverBase):
         sparse_jac = super().evaluate_jacobian(x0)
         dense_jac = sparse_jac.toarray()
         return dense_jac
+
+class ScalarDenseSquareNlpSolver(DenseSquareNlpSolver):
+    # A base class for solvers for scalar equations.
+    # Not intended to be instantiated directly. Instead,
+    # NewtonNlpSolver or SecantNewtonNlpSolver should be used.
+
+    def __init__(self, nlp, timer=None, options=None):
+        super().__init__(nlp, timer=timer, options=options)
+        if nlp.n_primals() != 1:
+            raise RuntimeError(
+                "Cannot use the scipy.optimize.newton solver on an NLP with"
+                " more than one variable and equality constraint. Got %s"
+                " primals. Please use RootNlpSolver or FsolveNlpSolver instead."
+            )
+
+

--- a/pyomo/contrib/pynumero/algorithms/solvers/square_solver_base.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/square_solver_base.py
@@ -18,6 +18,14 @@ class SquareNlpSolverBase(object):
     of equality constraints.
 
     """
+    # Ideally, this ConfigBlock would contain options that are valid for any
+    # square NLP solver. However, no such options seem to exist while
+    # preserving the names of the SciPy function arguments. E.g., tolerance
+    # is "tol" in some solvers and "xtol" in others, and some solvers
+    # support "maxiter" while others support "maxfev". It may be useful to
+    # attempt some standardization by, e.g., mapping tol->xtol, then
+    # specifying "universal" options here, but this can happen at a later
+    # date as these solvers see more use.
     OPTIONS = ConfigBlock()
 
     def __init__(self, nlp, timer=None, options=None):

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_scipy_solvers.py
@@ -341,6 +341,7 @@ class TestRootPyomo(unittest.TestCase):
         self.assertEqual(results.solver.message, "The solution converged.")
 
 
+@unittest.skipUnless(AmplInterface.available(), "AmplInterface is not available")
 class TestNewtonPyomo(unittest.TestCase):
 
     def test_available(self):
@@ -443,6 +444,7 @@ class TestNewtonPyomo(unittest.TestCase):
             n_eval = results.solver.number_of_function_evaluations
 
 
+@unittest.skipUnless(AmplInterface.available(), "AmplInterface is not available")
 class TestSecantNewtonPyomo(unittest.TestCase):
 
     def test_available(self):

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_scipy_solvers.py
@@ -25,6 +25,7 @@ from pyomo.contrib.pynumero.algorithms.solvers.scipy_solvers import (
     FsolveNlpSolver,
     RootNlpSolver,
     PyomoScipySolver,
+    SecantNewtonNlpSolver,
 )
 
 
@@ -442,6 +443,24 @@ class TestNewtonPyomo(unittest.TestCase):
             # This attribute has no default, I guess.
             # Assert that it hasn't been set.
             n_eval = results.solver.number_of_function_evaluations
+
+
+@unittest.skipUnless(AmplInterface.available(), "AmplInterface is not available")
+class TestSecantNewton(unittest.TestCase):
+
+    def test_inherited_options_skipped(self):
+        m, nlp = make_scalar_model()
+        options = SecantNewtonNlpSolver.OPTIONS
+        self.assertNotIn("maxiter", options)
+        self.assertNotIn("secant", options)
+        self.assertIn("secant_iter", options)
+        self.assertIn("newton_iter", options)
+
+        with self.assertRaisesRegex(
+                ValueError,
+                "implicit.*keys are not allowed",
+            ):
+            solver = SecantNewtonNlpSolver(nlp, options={"maxiter": 10})
 
 
 @unittest.skipUnless(AmplInterface.available(), "AmplInterface is not available")

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_scipy_solvers.py
@@ -152,7 +152,7 @@ class TestPyomoScipySolver(unittest.TestCase):
 class TestFsolvePyomo(unittest.TestCase):
 
     def test_available_and_version(self):
-        solver = pyo.SolverFactory("fsolve")
+        solver = pyo.SolverFactory("scipy.fsolve")
         self.assertTrue(solver.available())
         self.assertTrue(solver.license_is_valid())
 
@@ -163,7 +163,7 @@ class TestFsolvePyomo(unittest.TestCase):
 
     def test_solve_simple_nlp(self):
         m, _ = make_simple_model()
-        solver = pyo.SolverFactory("fsolve")
+        solver = pyo.SolverFactory("scipy.fsolve")
 
         # Just want to make sure this option works
         solver.set_options(dict(full_output=False))
@@ -175,7 +175,7 @@ class TestFsolvePyomo(unittest.TestCase):
 
     def test_solve_results_obj(self):
         m, _ = make_simple_model()
-        solver = pyo.SolverFactory("fsolve")
+        solver = pyo.SolverFactory("scipy.fsolve")
         results = solver.solve(m)
         solution = [m.x[1].value, m.x[2].value, m.x[3].value]
         predicted = [0.92846891, -0.22610731, 0.29465397]
@@ -199,7 +199,7 @@ class TestFsolvePyomo(unittest.TestCase):
 
     def test_solve_max_iter(self):
         m, _ = make_simple_model()
-        solver = pyo.SolverFactory("fsolve")
+        solver = pyo.SolverFactory("scipy.fsolve")
         solver.set_options(dict(xtol=1e-9, maxfev=10))
         res = solver.solve(m)
         self.assertNotEqual(res.solver.return_code, 1)
@@ -207,7 +207,7 @@ class TestFsolvePyomo(unittest.TestCase):
 
     def test_solve_too_tight_tol(self):
         m, _ = make_simple_model()
-        solver = pyo.SolverFactory("fsolve", options=dict(
+        solver = pyo.SolverFactory("scipy.fsolve", options=dict(
             xtol=1e-3,
             maxfev=20,
             tol=1e-8,
@@ -221,7 +221,7 @@ class TestFsolvePyomo(unittest.TestCase):
         # equation with a default starting point (x=1). This may be
         # worth looking into.
         m, _ = make_scalar_model()
-        solver = pyo.SolverFactory("fsolve")
+        solver = pyo.SolverFactory("scipy.fsolve")
         res = solver.solve(m)
         predicted_x = 4.90547401
         self.assertNotEqual(predicted_x, m.x.value)
@@ -230,7 +230,7 @@ class TestFsolvePyomo(unittest.TestCase):
         # NOTE: fsolve can solve this equation with a good starting point.
         m, _ = make_scalar_model()
         m.x.set_value(4.0)
-        solver = pyo.SolverFactory("fsolve")
+        solver = pyo.SolverFactory("scipy.fsolve")
         res = solver.solve(m)
         predicted_x = 4.90547401
         self.assertAlmostEqual(predicted_x, m.x.value)
@@ -280,7 +280,7 @@ class TestRootNLP(unittest.TestCase):
 class TestRootPyomo(unittest.TestCase):
 
     def test_available_and_version(self):
-        solver = pyo.SolverFactory("root")
+        solver = pyo.SolverFactory("scipy.root")
         self.assertTrue(solver.available())
         self.assertTrue(solver.license_is_valid())
 
@@ -291,7 +291,7 @@ class TestRootPyomo(unittest.TestCase):
 
     def test_solve_simple_nlp(self):
         m, _ = make_simple_model()
-        solver = pyo.SolverFactory("root")
+        solver = pyo.SolverFactory("scipy.root")
 
         solver.set_options(dict(tol=1e-7))
 
@@ -302,7 +302,7 @@ class TestRootPyomo(unittest.TestCase):
 
     def test_solve_simple_nlp_levenberg_marquardt(self):
         m, _ = make_simple_model()
-        solver = pyo.SolverFactory("root")
+        solver = pyo.SolverFactory("scipy.root")
 
         solver.set_options(dict(tol=1e-7, method="lm"))
 
@@ -313,7 +313,7 @@ class TestRootPyomo(unittest.TestCase):
 
     def test_bad_method(self):
         m, _ = make_simple_model()
-        solver = pyo.SolverFactory("root")
+        solver = pyo.SolverFactory("scipy.root")
 
         solver.set_options(dict(tol=1e-7, method="some-solver"))
         with self.assertRaisesRegex(ValueError, "not in domain"):
@@ -321,7 +321,7 @@ class TestRootPyomo(unittest.TestCase):
 
     def test_solver_results_obj(self):
         m, _ = make_simple_model()
-        solver = pyo.SolverFactory("root")
+        solver = pyo.SolverFactory("scipy.root")
 
         solver.set_options(dict(tol=1e-7))
 
@@ -341,7 +341,7 @@ class TestRootPyomo(unittest.TestCase):
 
     def test_solver_results_obj_levenberg_marquardt(self):
         m, _ = make_simple_model()
-        solver = pyo.SolverFactory("root")
+        solver = pyo.SolverFactory("scipy.root")
 
         solver.set_options(dict(tol=1e-7, method="lm"))
 

--- a/pyomo/contrib/pynumero/plugins.py
+++ b/pyomo/contrib/pynumero/plugins.py
@@ -16,6 +16,7 @@ from .algorithms.solvers.cyipopt_solver import PyomoCyIpoptSolver
 from .algorithms.solvers.scipy_solvers import (
     PyomoFsolveSolver,
     PyomoRootSolver,
+    PyomoNewtonSolver,
 )
 
 def load():
@@ -37,3 +38,7 @@ def load():
             "root: Find the root of a vector function"
         ),
     )(PyomoRootSolver)
+    SolverFactory.register(
+        "scipy.newton",
+        doc="newton: Find a zero of a scalar-valued function",
+    )(PyomoNewtonSolver)

--- a/pyomo/contrib/pynumero/plugins.py
+++ b/pyomo/contrib/pynumero/plugins.py
@@ -17,6 +17,7 @@ from .algorithms.solvers.scipy_solvers import (
     PyomoFsolveSolver,
     PyomoRootSolver,
     PyomoNewtonSolver,
+    PyomoSecantNewtonSolver,
 )
 
 def load():
@@ -42,3 +43,11 @@ def load():
         "scipy.newton",
         doc="newton: Find a zero of a scalar-valued function",
     )(PyomoNewtonSolver)
+    SolverFactory.register(
+        "scipy.secant-newton",
+        doc=(
+            "secant-newton: Take a few secant iterations to try to converge"
+            " a potentially linear equation quickly, then switch to Newton's"
+            " method"
+        ),
+    )(PyomoSecantNewtonSolver)

--- a/pyomo/contrib/pynumero/plugins.py
+++ b/pyomo/contrib/pynumero/plugins.py
@@ -27,14 +27,14 @@ def load():
         doc='Cyipopt: direct python bindings to the Ipopt NLP solver'
     )(PyomoCyIpoptSolver)
     SolverFactory.register(
-        "fsolve",
+        "scipy.fsolve",
         doc=(
             "fsolve: A SciPy wrapper around MINPACK's hybrd and"
             " hybrj algorithms"
         ),
     )(PyomoFsolveSolver)
     SolverFactory.register(
-        "root",
+        "scipy.root",
         doc=(
             "root: Find the root of a vector function"
         ),


### PR DESCRIPTION
## Summary/Motivation:
I've noticed some performance benefits to using SciPy's scalar Newton solver instead of something like `fsolve` or `root` when we know that we only have to solve a scalar equation. This PR adds two wrappers for the `scipy.optimize.newton` solver for NLPs with a single variable and equality constraint. One wrapper just calls the solver directly. The other first runs the solver in "secant mode" for (a default of) two iterations, then switches to "Newton mode" (actually using the derivative). This is intended to solve linear equations quickly while not sacrificing much performance for nonlinear equations, and is inspired by `calculate_variable_from_constraint`

## Changes proposed in this PR:
- Adds `NewtonNlpSolver` and `SecantNewtonNlpSolver`, which are light wrappers around SciPy's `newton` solver for NLP objects
- Adds `PyomoNewtonSolver` and `PyomoSecantNewtonSolver`, which are wrappers around the NLP solvers that accept Pyomo models in the `solve` method
- Adds these Pyomo solvers to the SolverFactory with names `"scipy.newton"` and `"scipy.secant-newton"`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
