### PR TITLE
Patch `IntEnum` to preserve pre-3.11 formatting behaviour

### DIFF
--- a/pyomo/contrib/appsi/base.py
+++ b/pyomo/contrib/appsi/base.py
@@ -494,7 +494,14 @@ class Solver(abc.ABC):
             # We want general formatting of this Enum to return the
             # formatted string value and not the int (which is the
             # default implementation from IntEnum)
-            return format(str(self).split('.')[-1], format_spec)
+            return format(self.name, format_spec)
+
+        def __str__(self):
+            # Note: Python 3.11 changed the core enums so that the
+            # "mixin" type for standard enums overrides the behavior
+            # specified in __format__.  We will override str() here to
+            # preserve the previous behavior
+            return self.name
 
     @abc.abstractmethod
     def solve(self, model: _BlockData, timer: HierarchicalTimer = None) -> Results:


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This resolves test failures in Python 3.11 due to a change in how CPython handles formatting for IntEnum objects.  See the cpython bug report [here](https://github.com/python/cpython/issues/93363).

## Changes proposed in this PR:
- Explicitly override `__str__` in `Solver.Availability` to restore behavior from previous Python versions

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
