### PR TITLE
Fix mindtpy gap check bug

### DIFF
--- a/pyomo/contrib/mindtpy/iterate.py
+++ b/pyomo/contrib/mindtpy/iterate.py
@@ -251,7 +251,7 @@ def algorithm_should_terminate(solve_data, config, check_cycling):
         config.logger.info(
             'MindtPy exiting on bound convergence. '
             'Absolute gap: {} <= absolute tolerance: {} \n'.format(
-                solve_data.rel_gap, config.absolute_bound_tolerance))
+                solve_data.abs_gap, config.absolute_bound_tolerance))
         solve_data.results.solver.termination_condition = tc.optimal
         return True
     # Check relative bound convergence
@@ -259,7 +259,7 @@ def algorithm_should_terminate(solve_data, config, check_cycling):
         if solve_data.rel_gap <= config.relative_bound_tolerance:
             config.logger.info(
                 'MindtPy exiting on bound convergence. '
-                'Relative gap : {} <= relative tolerance: {} \n'.format(solve_data.abs_gap, config.relative_bound_tolerance))
+                'Relative gap : {} <= relative tolerance: {} \n'.format(solve_data.rel_gap, config.relative_bound_tolerance))
             solve_data.results.solver.termination_condition = tc.optimal
             return True
 

--- a/pyomo/contrib/mindtpy/iterate.py
+++ b/pyomo/contrib/mindtpy/iterate.py
@@ -250,8 +250,8 @@ def algorithm_should_terminate(solve_data, config, check_cycling):
     if solve_data.abs_gap <= config.absolute_bound_tolerance:
         config.logger.info(
             'MindtPy exiting on bound convergence. '
-            '|Primal Bound: {} - Dual Bound: {}| <= (absolute tolerance {})  \n'.format(
-                solve_data.primal_bound, solve_data.dual_bound, config.absolute_bound_tolerance))
+            'Absolute gap: {} <= absolute tolerance: {} \n'.format(
+                solve_data.rel_gap, config.absolute_bound_tolerance))
         solve_data.results.solver.termination_condition = tc.optimal
         return True
     # Check relative bound convergence
@@ -259,7 +259,7 @@ def algorithm_should_terminate(solve_data, config, check_cycling):
         if solve_data.rel_gap <= config.relative_bound_tolerance:
             config.logger.info(
                 'MindtPy exiting on bound convergence. '
-                '|Primal Bound: {} - Dual Bound: {}| / (1e-10 + |Primal Bound|:{}) <= relative tolerance: {}'.format(solve_data.primal_bound, solve_data.dual_bound, abs(solve_data.primal_bound), config.relative_bound_tolerance))
+                'Relative gap : {} <= relative tolerance: {} \n'.format(solve_data.abs_gap, config.relative_bound_tolerance))
             solve_data.results.solver.termination_condition = tc.optimal
             return True
 

--- a/pyomo/contrib/mindtpy/tests/unit_test.py
+++ b/pyomo/contrib/mindtpy/tests/unit_test.py
@@ -23,7 +23,7 @@ from pyomo.contrib.mindtpy.nlp_solve import handle_subproblem_other_termination,
 from pyomo.core.base import TransformationFactory
 from pyomo.opt import TerminationCondition as tc
 from pyomo.contrib.gdpopt.util import time_code
-from pyomo.contrib.mindtpy.util import create_utility_block, process_objective, setup_results_object
+from pyomo.contrib.mindtpy.util import create_utility_block, process_objective, setup_results_object, update_gap
 from pyomo.contrib.mindtpy.initialization import MindtPy_initialize_main, init_rNLP
 from pyomo.contrib.mindtpy.feasibility_pump import generate_norm_constraint, handle_fp_main_tc
 from pyomo.core import Block, ConstraintList
@@ -314,6 +314,13 @@ class TestMindtPy(unittest.TestCase):
                 solve_data, config, check_cycling=False), True)
             self.assertIs(
                 solve_data.results.solver.termination_condition, tc.feasible)
+
+            solve_data.primal_bound = 0.5
+            solve_data.dual_bound = 1
+            update_gap(solve_data)
+            self.assertEqual(solve_data.abs_gap, -0.5)
+            self.assertIs(algorithm_should_terminate(
+                solve_data, config, check_cycling=False), True)
 
             solve_data.primal_bound_progress = [float('inf'), 5, 4, 3, 2, 1]
             solve_data.primal_bound_progress_time = [1, 2, 3, 4, 5, 6]

--- a/pyomo/contrib/mindtpy/tests/unit_test.py
+++ b/pyomo/contrib/mindtpy/tests/unit_test.py
@@ -70,7 +70,7 @@ class TestMindtPy(unittest.TestCase):
             setup_results_object(solve_data, config)
             process_objective(solve_data, config,
                               move_objective=(config.init_strategy == 'FP'
-                                                     or config.add_regularization is not None),
+                                              or config.add_regularization is not None),
                               use_mcpp=config.use_mcpp,
                               update_var_con_list=config.add_regularization is None
                               )
@@ -163,21 +163,21 @@ class TestMindtPy(unittest.TestCase):
                 tc.optimal, MindtPy, solve_data, config)
             handle_feasibility_subproblem_tc(
                 tc.infeasible, MindtPy, solve_data, config)
-            self.assertIs(solve_data.should_terminate, True)
+            self.assertTrue(solve_data.should_terminate)
             self.assertIs(solve_data.results.solver.status, SolverStatus.error)
 
             solve_data.should_terminate = False
             solve_data.results.solver.status = None
             handle_feasibility_subproblem_tc(
                 tc.maxIterations, MindtPy, solve_data, config)
-            self.assertIs(solve_data.should_terminate, True)
+            self.assertTrue(solve_data.should_terminate)
             self.assertIs(solve_data.results.solver.status, SolverStatus.error)
 
             solve_data.should_terminate = False
             solve_data.results.solver.status = None
             handle_feasibility_subproblem_tc(
                 tc.solverFailure, MindtPy, solve_data, config)
-            self.assertIs(solve_data.should_terminate, True)
+            self.assertTrue(solve_data.should_terminate)
             self.assertIs(solve_data.results.solver.status, SolverStatus.error)
 
             # test NLP subproblem infeasible
@@ -193,21 +193,21 @@ class TestMindtPy(unittest.TestCase):
             fixed_nlp_results.solver.termination_condition = tc.maxTimeLimit
             handle_nlp_subproblem_tc(
                 fixed_nlp, fixed_nlp_results, solve_data, config)
-            self.assertIs(solve_data.should_terminate, True)
+            self.assertTrue(solve_data.should_terminate)
             self.assertIs(
                 solve_data.results.solver.termination_condition, tc.maxTimeLimit)
 
             fixed_nlp_results.solver.termination_condition = tc.maxEvaluations
             handle_nlp_subproblem_tc(
                 fixed_nlp, fixed_nlp_results, solve_data, config)
-            self.assertIs(solve_data.should_terminate, True)
+            self.assertTrue(solve_data.should_terminate)
             self.assertIs(
                 solve_data.results.solver.termination_condition, tc.maxEvaluations)
 
             fixed_nlp_results.solver.termination_condition = tc.maxIterations
             handle_nlp_subproblem_tc(
                 fixed_nlp, fixed_nlp_results, solve_data, config)
-            self.assertIs(solve_data.should_terminate, True)
+            self.assertTrue(solve_data.should_terminate)
             self.assertIs(
                 solve_data.results.solver.termination_condition, tc.maxEvaluations)
 
@@ -220,35 +220,35 @@ class TestMindtPy(unittest.TestCase):
             feas_main_results.solver.termination_condition = tc.optimal
             fp_should_terminate = handle_fp_main_tc(
                 feas_main_results, solve_data, config)
-            self.assertIs(fp_should_terminate, False)
+            self.assertFalse(fp_should_terminate)
 
             feas_main_results.solver.termination_condition = tc.maxTimeLimit
             fp_should_terminate = handle_fp_main_tc(
                 feas_main_results, solve_data, config)
-            self.assertIs(fp_should_terminate, True)
+            self.assertTrue(fp_should_terminate)
             self.assertIs(
                 solve_data.results.solver.termination_condition, tc.maxTimeLimit)
 
             feas_main_results.solver.termination_condition = tc.infeasible
             fp_should_terminate = handle_fp_main_tc(
                 feas_main_results, solve_data, config)
-            self.assertIs(fp_should_terminate, True)
+            self.assertTrue(fp_should_terminate)
 
             feas_main_results.solver.termination_condition = tc.unbounded
             fp_should_terminate = handle_fp_main_tc(
                 feas_main_results, solve_data, config)
-            self.assertIs(fp_should_terminate, True)
+            self.assertTrue(fp_should_terminate)
 
             feas_main_results.solver.termination_condition = tc.other
             feas_main_results.solution.status = SolutionStatus.feasible
             fp_should_terminate = handle_fp_main_tc(
                 feas_main_results, solve_data, config)
-            self.assertIs(fp_should_terminate, False)
+            self.assertFalse(fp_should_terminate)
 
             feas_main_results.solver.termination_condition = tc.solverFailure
             fp_should_terminate = handle_fp_main_tc(
                 feas_main_results, solve_data, config)
-            self.assertIs(fp_should_terminate, True)
+            self.assertTrue(fp_should_terminate)
 
             # test generate_norm_constraint
             fp_nlp = solve_data.working_model.clone()
@@ -304,14 +304,14 @@ class TestMindtPy(unittest.TestCase):
             # test algorithm_should_terminate
             solve_data.should_terminate = True
             solve_data.primal_bound = float('inf')
-            self.assertIs(algorithm_should_terminate(
-                solve_data, config, check_cycling=False), True)
+            self.assertTrue(algorithm_should_terminate(
+                solve_data, config, check_cycling=False))
             self.assertIs(
                 solve_data.results.solver.termination_condition, tc.noSolution)
 
             solve_data.primal_bound = 100
-            self.assertIs(algorithm_should_terminate(
-                solve_data, config, check_cycling=False), True)
+            self.assertTrue(algorithm_should_terminate(
+                solve_data, config, check_cycling=False))
             self.assertIs(
                 solve_data.results.solver.termination_condition, tc.feasible)
 
@@ -319,8 +319,8 @@ class TestMindtPy(unittest.TestCase):
             solve_data.dual_bound = 1
             update_gap(solve_data)
             self.assertEqual(solve_data.abs_gap, -0.5)
-            self.assertIs(algorithm_should_terminate(
-                solve_data, config, check_cycling=False), True)
+            self.assertTrue(algorithm_should_terminate(
+                solve_data, config, check_cycling=False))
 
             solve_data.primal_bound_progress = [float('inf'), 5, 4, 3, 2, 1]
             solve_data.primal_bound_progress_time = [1, 2, 3, 4, 5, 6]
@@ -353,7 +353,7 @@ class TestMindtPy(unittest.TestCase):
             self.assertFalse(config.equality_relaxation)
             self.assertTrue(config.add_no_good_cuts)
             self.assertFalse(config.use_tabu_list)
-            
+
             config.single_tree = False
             config.strategy = 'FP'
             config.init_strategy = 'rNLP'
@@ -365,6 +365,7 @@ class TestMindtPy(unittest.TestCase):
             self.assertEqual(config.iteration_limit, 0)
             self.assertEqual(config.add_no_good_cuts, True)
             self.assertEqual(config.use_tabu_list, False)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyomo/contrib/mindtpy/util.py
+++ b/pyomo/contrib/mindtpy/util.py
@@ -785,7 +785,10 @@ def update_gap(solve_data):
     solve_data : MindtPySolveData
         Data container that holds solve-instance data.
     """
-    solve_data.abs_gap = abs(solve_data.primal_bound - solve_data.dual_bound)
+    if solve_data.objective_sense == minimize:
+        solve_data.abs_gap = solve_data.primal_bound - solve_data.dual_bound
+    else:
+        solve_data.abs_gap = solve_data.dual_bound - solve_data.primal_bound
     solve_data.rel_gap = solve_data.abs_gap / (abs(solve_data.primal_bound) + 1E-10)
 
 


### PR DESCRIPTION
## Summary/Motivation:

In MindtPy, the absolute and relative gap calculation is as follows.
```
solve_data.abs_gap = abs(solve_data.primal_bound - solve_data.dual_bound)
solve_data.rel_gap = solve_data.abs_gap / (abs(solve_data.primal_bound) + 1E-10)
```
Calculating the absolute gap using the `abs()` function might not be appropriate. In the following example(objective sense = maximize), the primal bound is greater than the dual bound in the first iteration. MindtPy should terminate here. However, since `abs()` function is used, `rel_gap` equals `3.27%` instead of `-3.27%`.
Therefore, we should check the objective sense and calculate the absolute and relative gap without `abs()`.
```
---------------------------------------------------------------------------------------------
              Mixed-Integer Nonlinear Decomposition Toolbox in Pyomo (MindtPy)               
---------------------------------------------------------------------------------------------
For more information, please visit https://pyomo.readthedocs.io/en/stable/contributed_packages/mindtpy.html
Original model has 480 constraints (0 nonlinear) and 0 disjunctions, with 144 variables, of which 96 are binary, 0 are integer, and 48 are continuous.
Objective is nonlinear. Moving it to constraint set.
rNLP is the initial strategy being used.

 ===============================================================================================
 Iteration | Subproblem Type | Objective Value | Primal Bound |   Dual Bound |   Gap   | Time(s)

         -       Relaxed NLP           0.27937           -inf        0.27937      nan%      2.51
         1              MILP         0.0416634           -inf      0.0416634      nan%      3.40
*        1         Fixed NLP         0.0430716      0.0430716      0.0416634     3.27%      5.38
         2              MILP         0.0168333      0.0430716      0.0168333    60.92%      6.00
         2         Fixed NLP        -0.0458686      0.0430716      0.0168333    60.92%      6.84
         3              MILP         0.0148974      0.0430716      0.0148974    65.41%      7.70
         3         Fixed NLP        -0.0221965      0.0430716      0.0148974    65.41%      9.44
         4              MILP         0.0140234      0.0430716      0.0140234    67.44%     10.33
         4         Fixed NLP        -0.0230704      0.0430716      0.0140234    67.44%     11.20
         5              MILP         0.0139126      0.0430716      0.0139126    67.70%     11.81
         5         Fixed NLP        -0.0231813      0.0430716      0.0139126    67.70%     12.63
         6              MILP         0.0138067      0.0430716      0.0138067    67.94%     13.18
         6         Fixed NLP        -0.0232871      0.0430716      0.0138067    67.94%     14.51
         7              MILP         0.0136959      0.0430716      0.0136959    68.20%     15.23
         7         Fixed NLP         -0.023398      0.0430716      0.0136959    68.20%     16.04
         8              MILP         0.0133259      0.0430716      0.0133259    69.06%     16.88
         8         Fixed NLP        -0.0470632      0.0430716      0.0133259    69.06%     17.76
         9              MILP         0.0129318      0.0430716      0.0129318    69.98%     18.37
         9         Fixed NLP        -0.0111678      0.0430716      0.0129318    69.98%     19.76
        10              MILP          0.012822      0.0430716       0.012822    70.23%     20.37
        10         Fixed NLP        -0.0242719      0.0430716       0.012822    70.23%     21.25
        11              MILP           0.01282      0.0430716        0.01282    70.24%     21.89
        11         Fixed NLP        -0.0113398      0.0430716        0.01282    70.24%     23.25
        12              MILP         0.0127211      0.0430716      0.0127211    70.47%     23.85
        12         Fixed NLP        -0.0243728      0.0430716      0.0127211    70.47%     24.65
        13              MILP         0.0126337      0.0430716      0.0126337    70.67%     25.28
        13         Fixed NLP        -0.0244602      0.0430716      0.0126337    70.67%     26.23
        14              MILP         0.0125044      0.0430716      0.0125044    70.97%     26.83
        14         Fixed NLP        -0.0245895      0.0430716      0.0125044    70.97%     28.18
        15              MILP          0.012417      0.0430716       0.012417    71.17%     29.03
        15         Fixed NLP        -0.0246769      0.0430716       0.012417    71.17%     29.99
Algorithm is not making enough progress. Exiting iteration loop.
Final bound values: Primal Bound: 0.043071553722709155  Dual Bound: 0.012417005261587122
 ===============================================================================================
 Primal integral          :    0.0000 
 Dual integral            :    0.7267 
 Primal-dual gap integral :    0.7267 
```


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
