### PR TITLE
Skip test in MOSEK 10 (warmstart failure)

### DIFF
--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -847,7 +847,8 @@ class MOSEKDirect(DirectSolver):
         return DirectOrPersistentSolver._postsolve(self)
 
     def warm_start_capable(self):
-        return True
+        # See #2613: enabling warmstart on MOSEK 10 breaks an MIQP test.
+        return self.version() < (10, 0)
 
     def _warm_start(self):
         for pyomo_var, mosek_var in self._pyomo_var_to_solver_var_map.items():

--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -848,7 +848,8 @@ class MOSEKDirect(DirectSolver):
 
     def warm_start_capable(self):
         # See #2613: enabling warmstart on MOSEK 10 breaks an MIQP test.
-        return self.version() < (10, 0)
+        # return self.version() < (10, 0)
+        return True
 
     def _warm_start(self):
         for pyomo_var, mosek_var in self._pyomo_var_to_solver_var_map.items():

--- a/pyomo/solvers/tests/testcases.py
+++ b/pyomo/solvers/tests/testcases.py
@@ -55,6 +55,11 @@ for _io in ('python', 'persistent'):
             lambda v: True,
             "Mosek does not handle nonconvex quadratic constraints")
 
+    for _test in ('MIQP_simple', ):
+        SkipTests['mosek', _io, _test] = (
+            lambda v: v[0] == 10,
+            "Mosek 10 fails on assertion warmstarting MIQP models; see #2613")
+
 #
 # CPLEX
 #


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
As outlined in #2613, warmstarting MIQPs in MOSEK 10 triggers an assertion error in the C side of the MOSEK solver.  This assertion kills the entire Python interpreted (and is not trappable).  As a result, this PR will skip the offending test in MOSEK 10 until the issue is fixed in MOSEK.

## Changes proposed in this PR:
- skip MIQP test for MOSEK 10

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
