### PR TITLE
Update skipped CBC tests

### DIFF
--- a/pyomo/solvers/tests/testcases.py
+++ b/pyomo/solvers/tests/testcases.py
@@ -120,7 +120,7 @@ ExpectedFailures['cbc', 'nl', 'MILP_unbounded'] = \
      "(in 2.10.x).")
 
 ExpectedFailures['cbc', 'nl', 'LP_unbounded'] = \
-    (lambda v: v[:2] == (2, 10),
+    (lambda v: v > (2, 10) and v < (2, 10, 6),
      "Cbc fails (invalid free()) for unbounded LP models through "
      "the NL interface in 2.10.x versions "
      "(reported upstream as coin-or/Cbc#389)")

--- a/pyomo/solvers/tests/testcases.py
+++ b/pyomo/solvers/tests/testcases.py
@@ -119,10 +119,13 @@ ExpectedFailures['cbc', 'nl', 'MILP_unbounded'] = \
      "the NL interface (through 2.9.x), and fails with invalid free() "
      "(in 2.10.x).")
 
+# The following is due to a bug introduced into Clp as part of CBC 2.10
+# and was resolved by Clp commit 130dd199 (13 Feb 2021), and included
+# in the CBC 2.10.6 release
 ExpectedFailures['cbc', 'nl', 'LP_unbounded'] = \
     (lambda v: v > (2, 10) and v < (2, 10, 6),
      "Cbc fails (invalid free()) for unbounded LP models through "
-     "the NL interface in 2.10.x versions "
+     "the NL interface in 2.10.x versions through 2.10.5 "
      "(reported upstream as coin-or/Cbc#389)")
 
 ExpectedFailures['cbc', 'nl', 'SOS1_simple'] = \


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
CBC resolved the unbounded bug in 2.10.6.  This PR sunsets that skipped test.

## Changes proposed in this PR:
- Only skip the unbounded LP test for CBC 2.10 - 2.10.5

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
