### PR TITLE
GDP: Avoid two mapped autoslots with the same name

### DIFF
--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -518,7 +518,8 @@ class _DisjunctionData(ActiveComponentData):
 @ModelComponentFactory.register("Disjunction expressions.")
 class Disjunction(ActiveIndexedComponent):
     _ComponentDataClass = _DisjunctionData
-    __autoslot_mappers__ = {'_algebraic_constraint': AutoSlots.weakref_mapper}
+    __autoslot_mappers__ = {
+        '_indexed_algebraic_constraint': AutoSlots.weakref_mapper}
 
     def __new__(cls, *args, **kwds):
         if cls != Disjunction:
@@ -533,7 +534,7 @@ class Disjunction(ActiveIndexedComponent):
         self._init_expr = kwargs.pop('expr', None)
         self._init_xor = _Initializer.process(kwargs.pop('xor', True))
         self._autodisjuncts = None
-        self._algebraic_constraint = None
+        self._indexed_algebraic_constraint = None
         kwargs.setdefault('ctype', Disjunction)
         super(Disjunction, self).__init__(*args, **kwargs)
 
@@ -541,6 +542,17 @@ class Disjunction(ActiveIndexedComponent):
             raise ValueError(
                 "Cannot specify both rule= and expr= for Disjunction %s"
                 % ( self.name, ))
+
+    # FIXME: This is a workaround for double-declating the
+    # _algebraic_constraint autoslot for ScalarDisjunctions,
+    # necessitated by test failures encountered during release.
+    @property
+    def _algebraic_constraint(self):
+        return self._indexed_algebraic_constraint
+
+    @_algebraic_constraint.setter
+    def _algebraic_constraint(self, val):
+        self._indexed_algebraic_constraint = val
 
     #
     # TODO: Ideally we would not override these methods and instead add

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -437,6 +437,13 @@ class _DisjunctionData(ActiveComponentData):
         return None if self._algebraic_constraint is None else \
             self._algebraic_constraint()
 
+    @algebraic_constraint.setter
+    def algebraic_constraint(self, val):
+        if val is None:
+            self._algebraic_constraint = val
+        else:
+            self._algebraic_constraint = weakref_ref(val)
+
     def __init__(self, component=None):
         #
         # These lines represent in-lining of the
@@ -543,16 +550,21 @@ class Disjunction(ActiveIndexedComponent):
                 "Cannot specify both rule= and expr= for Disjunction %s"
                 % ( self.name, ))
 
-    # FIXME: This is a workaround for double-declating the
+    # FIXME: This is a workaround for double-declaring the
     # _algebraic_constraint autoslot for ScalarDisjunctions,
     # necessitated by test failures encountered during release.
+    # [JDS; 21 Nov 2022]
     @property
-    def _algebraic_constraint(self):
-        return self._indexed_algebraic_constraint
+    def algebraic_constraint(self):
+        return None if self._indexed_algebraic_constraint is None else \
+            self._indexed_algebraic_constraint()
 
-    @_algebraic_constraint.setter
-    def _algebraic_constraint(self, val):
-        self._indexed_algebraic_constraint = val
+    @algebraic_constraint.setter
+    def algebraic_constraint(self, val):
+        if val is None:
+            self._indexed_algebraic_constraint = val
+        else:
+            self._indexed_algebraic_constraint = weakref_ref(val)
 
     #
     # TODO: Ideally we would not override these methods and instead add

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -289,8 +289,8 @@ class BigM_Transformation(Transformation):
         # DisjunctionData, we did something wrong.
 
         # first check if the constraint already exists
-        if disjunction._algebraic_constraint is not None:
-            return disjunction._algebraic_constraint()
+        if disjunction.algebraic_constraint is not None:
+            return disjunction.algebraic_constraint
 
         # add the XOR (or OR) constraints to parent block (with unique name)
         # It's indexed if this is an IndexedDisjunction, not otherwise
@@ -301,7 +301,7 @@ class BigM_Transformation(Transformation):
         orCname = unique_component_name(
             transBlock,disjunction.getname(fully_qualified=False) + '_xor')
         transBlock.add_component(orCname, orC)
-        disjunction._algebraic_constraint = weakref_ref(orC)
+        disjunction.algebraic_constraint = orC
 
         return orC
 
@@ -339,7 +339,7 @@ class BigM_Transformation(Transformation):
             xorConstraint[index] = or_expr >= rhs
         # Mark the DisjunctionData as transformed by mapping it to its XOR
         # constraint.
-        obj._algebraic_constraint = weakref_ref(xorConstraint[index])
+        obj.algebraic_constraint = xorConstraint[index]
 
         # and deactivate for the writers
         obj.deactivate()

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -341,8 +341,8 @@ class Hull_Reformulation(Transformation):
         # Put XOR constraint on the transformation block
 
         # check if the constraint already exists
-        if disjunction._algebraic_constraint is not None:
-            return disjunction._algebraic_constraint()
+        if disjunction.algebraic_constraint is not None:
+            return disjunction.algebraic_constraint
 
         # add the XOR constraints to parent block (with unique name) It's
         # indexed if this is an IndexedDisjunction, not otherwise
@@ -351,7 +351,7 @@ class Hull_Reformulation(Transformation):
             unique_component_name(transBlock,
                                   disjunction.getname(
                                       fully_qualified=True) + '_xor'), orC)
-        disjunction._algebraic_constraint = weakref_ref(orC)
+        disjunction.algebraic_constraint = orC
 
         return orC
 
@@ -488,7 +488,7 @@ class Hull_Reformulation(Transformation):
         orConstraint.add(index, (or_expr, rhs))
         # map the DisjunctionData to its XOR constraint to mark it as
         # transformed
-        obj._algebraic_constraint = weakref_ref(orConstraint[index])
+        obj.algebraic_constraint = orConstraint[index]
 
         # add the reaggregation constraints
         for i, var in enumerate(varsToDisaggregate):

--- a/pyomo/gdp/plugins/multiple_bigm.py
+++ b/pyomo/gdp/plugins/multiple_bigm.py
@@ -288,7 +288,7 @@ class MultipleBigMTransformation(Transformation):
         algebraic_constraint.add(index, (or_expr, rhs))
         # map the DisjunctionData to its XOR constraint to mark it as
         # transformed
-        obj._algebraic_constraint = weakref_ref(algebraic_constraint[index])
+        obj.algebraic_constraint = algebraic_constraint[index]
 
         obj.deactivate()
 
@@ -573,7 +573,7 @@ class MultipleBigMTransformation(Transformation):
             unique_component_name(transBlock,
                                   disjunction.getname(
                                       fully_qualified=False) + '_xor'), orC)
-        disjunction._algebraic_constraint = weakref_ref(orC)
+        disjunction.algebraic_constraint = orC
 
         return orC
 

--- a/pyomo/gdp/plugins/partition_disjuncts.py
+++ b/pyomo/gdp/plugins/partition_disjuncts.py
@@ -526,7 +526,7 @@ class PartitionDisjuncts_Transformation(Transformation):
             unique_component_name(transBlock,
                                   obj.getname(fully_qualified=True)),
             transformed_disjunction)
-        obj._algebraic_constraint = weakref_ref(transformed_disjunction)
+        obj.algebraic_constraint = transformed_disjunction
 
         obj.deactivate()
 

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -355,8 +355,8 @@ def get_src_disjunction(xor_constraint):
     m = xor_constraint.model()
     for disjunction in m.component_data_objects(Disjunction,
                                                 descend_into=(Block, Disjunct)):
-        if disjunction._algebraic_constraint:
-            if disjunction._algebraic_constraint() is xor_constraint:
+        if disjunction.algebraic_constraint is not None:
+            if disjunction.algebraic_constraint is xor_constraint:
                 return disjunction
     raise GDP_Error("It appears that '%s' is not an XOR or OR constraint "
                     "resulting from transforming a Disjunction."


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
We are observing intermittent errors related to deepcopying GDP models (leading to partially-constructed ScalarConstraint objects).  I believe that it is because the ScalarDisjunction ends up with two different autoslots declared with the same name (`_algebraic_constraint`).  This PR is a workaround to rename one of the attributes and hopefully resolve the intermittent test failures.

## Changes proposed in this PR:
- rename the `_algebraic_constraint` autoslot on `Disjunction` to `_indexed_algebraic_constraint`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
