### PR TITLE
Adding Python 3.11 to wheel creation

### DIFF
--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -36,7 +36,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install twine wheel setuptools pybind11
     - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.5.0-manylinux2010_x86_64
+      uses: RalfG/python-wheels-manylinux-build@a1e012c58ed3960f81b7ed2759a037fb0ad28e2d
       with:
         python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
         build-requirements: 'cython pybind11'

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -35,6 +35,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install twine wheel setuptools pybind11
+    # TODO: Update the manylinux builder to next tagged release
     - name: Build manylinux Python wheels
       uses: RalfG/python-wheels-manylinux-build@a1e012c58ed3960f81b7ed2759a037fb0ad28e2d
       with:

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Build manylinux Python wheels
       uses: RalfG/python-wheels-manylinux-build@v0.4.0-manylinux2010_x86_64
       with:
-        python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
+        python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
         build-requirements: 'cython pybind11'
         package-path: ''
         pip-wheel-args: ''
@@ -141,7 +141,7 @@ jobs:
         include:
         - os: macos-latest
           TARGET: osx
-        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
+        python-version: [ 3.7, 3.8, 3.9, '3.10', '3.11' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -172,7 +172,7 @@ jobs:
         include:
         - os: windows-latest
           TARGET: win
-        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
+        python-version: [ 3.7, 3.8, 3.9, '3.10', '3.11' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -36,7 +36,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install twine wheel setuptools pybind11
     - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.4.0-manylinux2010_x86_64
+      uses: RalfG/python-wheels-manylinux-build@v0.5.0-manylinux2010_x86_64
       with:
         python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
         build-requirements: 'cython pybind11'


### PR DESCRIPTION
## Fixes #2595 

## Summary/Motivation:
In order to fully support Python 3.11, need to add it to the automatic wheel creation workflow.

## Changes proposed in this PR:
- Add 3.11 support to release workflow

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
