### PR TITLE
Generalize and Fix Uncertain Parameter Bounds Evaluation for PyROS `FactorModelSet`

### DIFF
--- a/pyomo/contrib/pyros/CHANGELOG.txt
+++ b/pyomo/contrib/pyros/CHANGELOG.txt
@@ -3,6 +3,14 @@ PyROS CHANGELOG
 ===============
 
 -------------------------------------------------------------------------------
+PyROS 1.2.3    22 Nov 2022
+-------------------------------------------------------------------------------
+- Generalize FactorModelSet.
+- Resolve issues with FactorModelSet parameter bounds.
+- Modularize construction of uncertainty set bounding problems.
+
+
+-------------------------------------------------------------------------------
 PyROS 1.2.2    09 Nov 2022
 -------------------------------------------------------------------------------
 - Rewrite PyROS `UncertaintySet` module, class, and attribute docstrings

--- a/pyomo/contrib/pyros/pyros.py
+++ b/pyomo/contrib/pyros/pyros.py
@@ -46,7 +46,7 @@ from pyomo.contrib.pyros.uncertainty_sets import uncertainty_sets
 from pyomo.core.base import Constraint
 
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 
 
 def NonNegIntOrMinusOne(obj):

--- a/pyomo/contrib/pyros/tests/test_grcs.py
+++ b/pyomo/contrib/pyros/tests/test_grcs.py
@@ -2460,6 +2460,93 @@ class testFactorModelUncertaintySetClass(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, big_exc_str):
             fset.beta = big_beta
 
+    @unittest.skipUnless(
+        SolverFactory("cbc").available(exception_flag=False),
+        "LP solvers CPLEX, GUROBI, and CBC not available",
+    )
+    def test_factor_model_parameter_bounds_correct(self):
+        """
+        If LP solver is available, test parameter bounds method
+        for factor model set is correct (check against
+        results from an LP solver).
+        """
+        def eval_parameter_bounds(uncertainty_set, solver):
+            """
+            Evaluate parameter bounds of uncertainty set by solving
+            bounding problems (as opposed to via the `parameter_bounds`
+            method).
+            """
+            bounding_mdl = uncertainty_set.bounding_model()
+
+            param_bounds = []
+            for idx, obj in bounding_mdl.param_var_objectives.items():
+                # activate objective for corresponding dimension
+                obj.activate()
+                bounds = []
+
+                # solve for lower bound, then upper bound
+                # solve should be successful
+                for sense in (minimize, maximize):
+                    obj.sense = sense
+                    solver.solve(bounding_mdl)
+                    bounds.append(value(obj))
+
+                # add parameter bounds for current dimension
+                param_bounds.append(tuple(bounds))
+
+                # ensure sense is minimize when done, deactivate
+                obj.sense = minimize
+                obj.deactivate()
+
+            return param_bounds
+
+        solver = SolverFactory("cbc")
+
+        # four cases where prior parameter bounds
+        # approximations were probably too tight
+        fset1 = FactorModelSet(
+            origin=[0, 0],
+            number_of_factors=3,
+            psi_mat=[[1, -1, 1], [1, 0.1, 1]],
+            beta=1/6,
+        )
+        fset2 = FactorModelSet(
+            origin=[0],
+            number_of_factors=3,
+            psi_mat=[[1, 6, 8]],
+            beta=1/2,
+        )
+        fset3 = FactorModelSet(
+            origin=[1],
+            number_of_factors=2,
+            psi_mat=[[1, 2]],
+            beta=1/4,
+        )
+        fset4 = FactorModelSet(
+            origin=[1],
+            number_of_factors=3,
+            psi_mat=[[-1, -6, -8]],
+            beta=1/2,
+        )
+
+        # check parameter bounds matches LP results
+        # exactly for each case
+        for fset in [fset1, fset2, fset3, fset4]:
+            param_bounds = fset.parameter_bounds
+            lp_param_bounds = eval_parameter_bounds(fset, solver)
+
+            self.assertTrue(
+                np.allclose(param_bounds, lp_param_bounds),
+                msg=(
+                    "Parameter bounds not consistent with LP values for "
+                    "FactorModelSet with parameterization:\n"
+                    f"F={fset.number_of_factors},\n"
+                    f"beta={fset.beta},\n"
+                    f"psi_mat={fset.psi_mat},\n"
+                    f"origin={fset.origin}."
+                ),
+            )
+
     @unittest.skipIf(not numpy_available, 'Numpy is not available.')
     def test_uncertainty_set_with_correct_params(self):
         '''

--- a/pyomo/contrib/pyros/tests/test_grcs.py
+++ b/pyomo/contrib/pyros/tests/test_grcs.py
@@ -2462,7 +2462,7 @@ class testFactorModelUncertaintySetClass(unittest.TestCase):
 
     @unittest.skipUnless(
         SolverFactory("cbc").available(exception_flag=False),
-        "LP solvers CPLEX, GUROBI, and CBC not available",
+        "LP solver CBC not available",
     )
     def test_factor_model_parameter_bounds_correct(self):
         """

--- a/pyomo/contrib/pyros/uncertainty_sets.py
+++ b/pyomo/contrib/pyros/uncertainty_sets.py
@@ -1804,26 +1804,22 @@ class FactorModelSet(UncertaintySet):
 
             # now evaluate max deviation from origin
             # (depends on number nonneg entries and critical point type)
-            if M >= crit_pt_type + 1 and crit_pt_type < F:
+            if M > crit_pt_type:
                 max_deviation = (
                     sorted_psi_row[:crit_pt_type].sum()
                     + beta_F_fill_in * sorted_psi_row[crit_pt_type]
                     - sorted_psi_row[crit_pt_type + 1:].sum()
                 )
-            elif M <= F - crit_pt_type - 1 and crit_pt_type < F:
+            elif M < F - crit_pt_type:
                 max_deviation = (
                     sorted_psi_row[:F - crit_pt_type - 1].sum()
                     - beta_F_fill_in * sorted_psi_row[F - crit_pt_type - 1]
                     - sorted_psi_row[F - crit_pt_type:].sum()
                 )
             else:
-                hypercub_vertex_type = max(
-                    int(np.ceil((F - int(beta_F)) / 2)),
-                    min(M, int((F + int(beta_F)) / 2)),
-                )
                 max_deviation = (
-                    sorted_psi_row[:hypercub_vertex_type].sum()
-                    - sorted_psi_row[hypercub_vertex_type:].sum()
+                    sorted_psi_row[:M].sum()
+                    - sorted_psi_row[M:].sum()
                 )
 
             # finally, evaluate the bounds for this dimension


### PR DESCRIPTION
## Summary/Motivation:

Generalize the PyROS `FactorModelSet` to allow for cases in which the `psi_mat` attribute
contains nonnegative entries.

Additionally, we target the following issues  with the PyROS `FactorModelSet.parameter_bounds` method:
1. Current implementation is inconsistent with what was originally intended.
2. The current implementation and originally intended formulas may give bounds which are too tight. This is problematic as (a) the bounds are explicitly enforced on the uncertain parameter variables in PyROS separation problems; (b) as a consequence, portions of the uncertainty set may be excluded from separation problems, thereby invalidating any certificate of robustness.

## Changes proposed in this PR:
- Generalize `FactorModelSet` to allow cases in which `psi_mat` contains negative entries (and update the documentation accordingly)
- Resolve issues with `FactorModelSet.parameter_bounds`
- Modularize setup of bounding problems for `UncertaintySet` instances
- Add unit tests to verify that `parameter_bounds` gives results which are consistent with bounding LP solutions.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
5. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
