### PR TITLE
NLv2: determinism, iteration updates

### DIFF
--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -389,7 +389,7 @@ class _SuffixData(object):
             logger.warning(
                 f"model contained export suffix {suffix.name} that "
                 f"contained {missing_other} keys that are not "
-                "Var, Constrtaint, Objective, or the model.  Skipping.")
+                "Var, Constraint, Objective, or the model.  Skipping.")
 
     def store(self, obj, val):
         missing = self._store(obj, val)
@@ -412,7 +412,7 @@ class _SuffixData(object):
             logger.warning(
                 f"model contained export suffix {self._name} with "
                 f"{obj.__class__.__name__} key '{obj}' that is not "
-                "a Var, Constrtaint, Objective, or the model.  Skipping.")
+                "a Var, Constraint, Objective, or the model.  Skipping.")
 
     def _store(self, obj, val):
         _id = id(obj)

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -124,9 +124,11 @@ class NLWriterInfo(object):
 
 class FileDeterminism(enum.IntEnum):
     NONE = 0
-    ORDERED = 1
-    SORT_INDICES = 2
-    SORT_SYMBOLS = 3
+    DEPRECATED_KEYS = 1
+    DEPRECATED_KEYS_AND_NAMES = 2
+    ORDERED = 10
+    SORT_INDICES = 20
+    SORT_SYMBOLS = 30
 
 
 def _activate_nl_writer_version(n):
@@ -210,9 +212,9 @@ class NLWriter(object):
         How much effort do we want to put into ensuring the
         NL file is written deterministically for a Pyomo model:
             NONE (0) : None
-            ORDERED (1): rely on underlying component ordering (default)
-            SORT_INDICES (2) : sort keys of indexed components
-            SORT_SYMBOLS (3) : sort keys AND sort names (over declaration order)
+            ORDERED (10): rely on underlying component ordering (default)
+            SORT_INDICES (20) : sort keys of indexed components
+            SORT_SYMBOLS (30) : sort keys AND sort names (not declaration order)
         """
     ))
     CONFIG.declare('symbolic_solver_labels', ConfigValue(
@@ -428,6 +430,16 @@ class _NLWriter_impl(object):
         )
         self.next_V_line_id = 0
         self.pause_gc = None
+
+        if config.file_determinism in (
+                FileDeterminism.DEPRECATED_KEYS,
+                FileDeterminism.DEPRECATED_KEYS_AND_NAMES):
+            old = config.file_determinism
+            config.file_determinism = 10*(old + 1)
+            new = config.file_determinism
+            deprecation_warning(
+                f'{str(old)} ({int(old)}) is deprecated.  '
+                f'Please use {str(new)} ({int(new)})', version='TBD')
 
     def __enter__(self):
         assert AMPLRepn.ActiveVisitor is None


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This contains several minor updates to the NLv2 writer:
- Update the definition of the `file_determinism` enum so that it is backwards compatible with the `file_determinism` flag in the NLv1 writer.
- Update component iteration so that duplicate Objectives / Constraints are not emitted
- Reduce the number of warnings emitted for unused Suffix values

This has minimal impact on performance:

![image](https://user-images.githubusercontent.com/356359/203461997-9dd31ab0-61ff-4fc7-b2be-dea3f1354108.png)

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
