### PR TITLE
Deepcopy improvements

### DIFF
--- a/pyomo/common/autoslots.py
+++ b/pyomo/common/autoslots.py
@@ -33,7 +33,7 @@ def _deepcopy_tuple(obj, memo, _id):
         # preserve that behavior here.
         #
         # It also appears to be faster *not* to cache the fact that this
-        # particular tuple was unchanged by the deepcopy (Note the the
+        # particular tuple was unchanged by the deepcopy (Note: the
         # standard library also does not cache the unchanged tuples in
         # the memo)
         #

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -261,7 +261,7 @@ class _ComponentBase(PyomoObject):
     def _deepcopy_field(self, memo, slot_name, value):
         saved_memo = len(memo)
         try:
-            return deepcopy(value, memo)
+            return fast_deepcopy(value, memo)
         except CloneError:
             raise
         except:

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -27,6 +27,7 @@ from pyomo.core.base.component import Component, ActiveComponent
 from pyomo.core.base.config import PyomoOptions
 from pyomo.core.base.global_set import UnindexedComponent_set
 from pyomo.common import DeveloperError
+from pyomo.common.autoslots import fast_deepcopy
 from pyomo.common.dependencies import numpy as np, numpy_available
 from pyomo.common.deprecation import deprecated
 from pyomo.common.modeling import NOTSET
@@ -330,19 +331,12 @@ class IndexedComponent(Component):
                 # Because we are already checking / updating the memo
                 # for the _data dict, we can effectively "deepcopy" it
                 # right now (almost for free!)
-                memo[id(self._data)] = _new._data = _data = {}
-                for idx, obj in self._data.items():
-                    # We need to deepcopy the index, but deepcopying
-                    # tuples in Python is SLOW.  We will only deepcopy
-                    # if necessary.
-                    if idx.__class__ is tuple:
-                        if any(x.__class__ not in native_types for x in idx):
-                            idx = deepcopy(idx, memo)
-                    elif idx.__class__ not in native_types:
-                        idx = deepcopy(idx, memo)
+                _src = self._data
+                memo[id(_src)] = _new._data = _data = _src.__class__()
+                for idx, obj in _src.items():
+                    _data[fast_deepcopy(idx, memo)] \
+                        = obj._create_objects_for_deepcopy(memo, component_list)
 
-                    _data[idx] = obj._create_objects_for_deepcopy(
-                        memo, component_list)
         return _ans
 
     def to_dense_data(self):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This is a series of minor performance improvements to the Component deepcopy logic in an ongoing attempt to track down intermittent incomplete deepcopies (encountered in a GDP BasicSteps test).

This PR standardizes deepcopy operations to leverage the `fast_deepcopy()` function and makes improvements in block scope detection and the routine for cloning tuples.  The net effect is about a ~7% reductin in the time to clone pmedian8.

## Changes proposed in this PR:
- improve efficiency of the tuple deepcopier (and remove reliance on global state)
- improve the block scope detection logic
- use `fast_deepcopy` in more places

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
