### PR TITLE
Fix preservation of stale flags through clone/pickle

### DIFF
--- a/pyomo/core/staleflag.py
+++ b/pyomo/core/staleflag.py
@@ -21,7 +21,7 @@ class _StaleFlagManager(object):
             if value:
                 return 0
             else:
-                self.get_flag(0)
+                return self.get_flag(0)
 
     def _get_flag(self, current_flag):
         """Return the current global stale flag value"""

--- a/pyomo/core/tests/unit/test_var.py
+++ b/pyomo/core/tests/unit/test_var.py
@@ -1598,5 +1598,27 @@ class MiscVarTests(unittest.TestCase):
         self.assertFalse(m.x.stale)
         self.assertFalse(m.y.stale)
 
+    def test_stale_clone(self):
+        m = ConcreteModel()
+        m.x = Var(initialize=0)
+        self.assertFalse(m.x.stale)
+        m.y = Var()
+        self.assertTrue(m.y.stale)
+        m.z = Var(initialize=0)
+        self.assertFalse(m.z.stale)
+
+        i = m.clone()
+        self.assertFalse(i.x.stale)
+        self.assertTrue(i.y.stale)
+        self.assertFalse(i.z.stale)
+
+        StaleFlagManager.mark_all_as_stale(delayed=True)
+        m.z = 5
+        i = m.clone()
+        self.assertTrue(i.x.stale)
+        self.assertTrue(i.y.stale)
+        self.assertFalse(i.z.stale)
+        
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Fixes #2626

## Summary/Motivation:
This resolves a bug in the `stale_mapper` that caused non-stale variables to become stale when pickled or cloned.

## Changes proposed in this PR:
- Fix a bug in the `stale_mapper` where the result was not being returned
- Ass a test to exercise (and verify) the expected behavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
