### PR TITLE
Parallel build of manylinux wheels

### DIFF
--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -15,16 +15,17 @@ env:
 
 jobs:
   manylinux:
-    name: ${{ matrix.TARGET }}/wheel_creation
+    name: ${{ matrix.TARGET }}/${{ matrix.wheel-version }}_wheel_creation
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        wheel-version: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311']
         os: [ubuntu-latest]
         include:
         - os: ubuntu-latest
           TARGET: manylinux
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -39,7 +40,7 @@ jobs:
     - name: Build manylinux Python wheels
       uses: RalfG/python-wheels-manylinux-build@a1e012c58ed3960f81b7ed2759a037fb0ad28e2d
       with:
-        python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
+        python-versions: ${{ matrix.wheel-version }}
         build-requirements: 'cython pybind11'
         package-path: ''
         pip-wheel-args: ''

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -58,51 +58,6 @@ jobs:
         name: manylinux-wheels
         path: dist
 
-  manylinuxaarch64:
-    name: ${{ matrix.TARGET }}/${{ matrix.wheel-version }}_wheel_creation
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        wheel-version: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311']
-        os: [ubuntu-latest]
-        include:
-        - os: ubuntu-latest
-          TARGET: manylinuxaarch64
-        python-version: [3.8]
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - uses: docker/setup-qemu-action@v1
-      name: Set up QEMU
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install twine wheel setuptools pybind11
-    - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.4.0-manylinux2014_aarch64
-      with:
-        python-versions: ${{ matrix.wheel-version }}
-        build-requirements: 'cython pybind11'
-        package-path: ''
-        pip-wheel-args: ''
-        # When locally testing, --no-deps flag is necessary (PyUtilib dependency will trigger an error otherwise)
-    - name: Consolidate wheels
-      run: |
-        sudo test -d dist || mkdir -v dist
-        sudo find . -name \*.whl | grep -v /dist/ | xargs -n1 -i mv -v "{}" dist/
-    - name: Delete linux wheels
-      run: |
-        sudo rm -rfv dist/*-linux_aarch64.whl
-    - name: Upload artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: manylinux-aarch64-wheels
-        path: dist
-
   generictarball:
     name: ${{ matrix.TARGET }}
     runs-on: ${{ matrix.os }}
@@ -113,7 +68,7 @@ jobs:
         include:
         - os: ubuntu-latest
           TARGET: generic_tarball
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-      wheel-version: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311']
+        wheel-version: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311']
         os: [ubuntu-latest]
         include:
         - os: ubuntu-latest

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -59,17 +59,17 @@ jobs:
         path: dist
 
   manylinuxaarch64:
-    if: ${{ false }}
-    name: ${{ matrix.TARGET }}/wheel_creation
+    name: ${{ matrix.TARGET }}/${{ matrix.wheel-version }}_wheel_creation
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+      wheel-version: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311']
         os: [ubuntu-latest]
         include:
         - os: ubuntu-latest
           TARGET: manylinuxaarch64
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -85,8 +85,8 @@ jobs:
     - name: Build manylinux Python wheels
       uses: RalfG/python-wheels-manylinux-build@v0.4.0-manylinux2014_aarch64
       with:
-        python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39'
-        build-requirements: 'cython'
+        python-versions: ${{ matrix.wheel-version }}
+        build-requirements: 'cython pybind11'
         package-path: ''
         pip-wheel-args: ''
         # When locally testing, --no-deps flag is necessary (PyUtilib dependency will trigger an error otherwise)


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:

The manylinux wheel build is the bottleneck in the release process; this breaks the serial run into individual jobs.

## Changes proposed in this PR:
- Remove `aarch64` because it just takes too long

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
