### PR TITLE
Jenkins: remove requirement for a 'pyutilib' directory

### DIFF
--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -86,9 +86,13 @@ if test -z "$MODE" -o "$MODE" == setup; then
     echo "#"
     echo "# Installing pyomo modules"
     echo "#"
-    pushd "$WORKSPACE/pyutilib" || echo "PyUtilib not found"
-    python setup.py develop || echo "PyUtilib failed - skipping."
-    popd
+    if test -d "$WORKSPACE/pyutilib"; then
+        pushd "$WORKSPACE/pyutilib"
+        python setup.py develop || echo "PyUtilib failed - skipping."
+        popd
+    else
+        echo "PyUtilib not found; skipping"
+    fi
     pushd "$WORKSPACE/pyomo" || exit 1
     python setup.py develop $PYOMO_SETUP_ARGS || exit 1
     popd


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
The Jenkins driver implicitly assumes the existence of a "`$WORKSPACE/pyutilib`" directory (even though it was designed to proceed without one).  This PR resolves that issue so that the build script will continue even if the directory is missing.

## Changes proposed in this PR:
- Remove strict requirement for a "`$WORKSPACE/pyutilib`" directory

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
