### PR TITLE
Enable GHA builds on Windows/Python3.11

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -114,11 +114,6 @@ jobs:
           TARGET: win
           PYENV: pip
 
-        exclude:
-        # Exclude 3.11 on conda until matplotlib!=3.6.1 is released on
-        # conda-forge for python 3.11
-        - {os: windows-latest, python: 3.11}
-
     steps:
     - name: Checkout Pyomo source
       uses: actions/checkout@v3


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Python 3.11 builds were disabled on Windows until Matplotlib released a 3.11 build other than version 3.6.1.  That has happened, so we can now enable Python 3.11 builds on Windows.

## Changes proposed in this PR:
- Enable the Windows / conda / Python 3.11 build

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
