### PR TITLE
Sunset mosek warmstart test skip

### DIFF
--- a/pyomo/solvers/tests/testcases.py
+++ b/pyomo/solvers/tests/testcases.py
@@ -57,7 +57,7 @@ for _io in ('python', 'persistent'):
 
     for _test in ('MIQP_simple', ):
         SkipTests['mosek', _io, _test] = (
-            lambda v: v[0] == 10,
+            lambda v: v[0] == 10 and v < (10, 0, 30),
             "Mosek 10 fails on assertion warmstarting MIQP models; see #2613")
 
 #


### PR DESCRIPTION
## Fixes #2613

## Summary/Motivation:
MOSEK 10.0.30 resolved the warmstart test assertion error.

## Changes proposed in this PR:
- Add version upper bound on MOSEK warmstart test skip

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
