### PR TITLE
Add utility methods to HierarchicalTimer

### DIFF
--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -394,6 +394,40 @@ all                    1     [0-9.]+ +[0-9.]+ +100.0
         for l, r in zip(str(timer).splitlines(), ref):
             self.assertRegex(l, r)
 
+    def test_clear_except_base_timer(self):
+        timer = HierarchicalTimer()
+        timer.start("a")
+        timer.start("b")
+        timer.stop("b")
+        timer.stop("a")
+        timer.start("c")
+        timer.stop("c")
+        timer.start("d")
+        timer.stop("d")
+        timer.clear_except("b", "c")
+        key_set = set(timer.timers.keys())
+        self.assertEqual(key_set, {"c"})
+
+    def test_clear_except_subtimer(self):
+        # Testing this method on "sub-timers" exercises different code
+        # as while the base timer is a HierarchicalTimer, the sub-timers
+        # are _HierarchicalHelpers
+        timer = HierarchicalTimer()
+        timer.start("root")
+        timer.start("a")
+        timer.start("b")
+        timer.stop("b")
+        timer.stop("a")
+        timer.start("c")
+        timer.stop("c")
+        timer.start("d")
+        timer.stop("d")
+        timer.stop("root")
+        root = timer.timers["root"]
+        root.clear_except("b", "c")
+        key_set = set(root.timers.keys())
+        self.assertEqual(key_set, {"c"})
+
 
 class TestFlattenHierarchicalTimer(unittest.TestCase):
 

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -393,3 +393,227 @@ all                    1     [0-9.]+ +[0-9.]+ +100.0
     '='*79)).splitlines()
         for l, r in zip(str(timer).splitlines(), ref):
             self.assertRegex(l, r)
+
+
+class TestFlattenHierarchicalTimer(unittest.TestCase):
+
+    #
+    # The following methods create some hierarchical timers, then
+    # hand-code the total time of each timer in the data structure.
+    # This is so we can assert that total_time fields of flattened
+    # timers are computed correctly without relying on the actual
+    # time spent.
+    #
+    def make_singleton_timer(self):
+        timer = HierarchicalTimer()
+        timer.start("root")
+        timer.stop("root")
+        timer.timers["root"].total_time = 5.0
+        return timer
+
+    def make_flat_timer(self):
+        timer = HierarchicalTimer()
+        timer.start("root")
+        timer.start("a")
+        timer.stop("a")
+        timer.start("b")
+        timer.stop("b")
+        timer.stop("root")
+        timer.timers["root"].total_time = 5.0
+        timer.timers["root"].timers["a"].total_time = 1.0
+        timer.timers["root"].timers["b"].total_time = 2.5
+        return timer
+
+    def make_timer_depth_2_one_child(self):
+        timer = HierarchicalTimer()
+        timer.start("root")
+        timer.start("a")
+        timer.start("b")
+        timer.stop("b")
+        timer.start("c")
+        timer.stop("c")
+        timer.stop("a")
+        timer.stop("root")
+        timer.timers["root"].total_time = 5.0
+        timer.timers["root"].timers["a"].total_time = 4.0
+        timer.timers["root"].timers["a"].timers["b"].total_time = 1.1
+        timer.timers["root"].timers["a"].timers["c"].total_time = 2.2
+        return timer
+
+    def make_timer_depth_2_with_name_collision(self):
+        timer = HierarchicalTimer()
+        timer.start("root")
+        timer.start("a")
+        timer.start("b")
+        timer.stop("b")
+        timer.start("c")
+        timer.stop("c")
+        timer.stop("a")
+        timer.start("b")
+        timer.stop("b")
+        timer.stop("root")
+        timer.timers["root"].total_time = 5.0
+        timer.timers["root"].timers["a"].total_time = 4.0
+        timer.timers["root"].timers["a"].timers["b"].total_time = 1.1
+        timer.timers["root"].timers["a"].timers["c"].total_time = 2.2
+        timer.timers["root"].timers["b"].total_time = 0.11
+        return timer
+
+    def make_timer_depth_2_two_children(self):
+        timer = HierarchicalTimer()
+        timer.start("root")
+        timer.start("a")
+        timer.start("b")
+        timer.stop("b")
+        timer.start("c")
+        timer.stop("c")
+        timer.stop("a")
+        timer.start("b")
+        timer.start("c")
+        timer.stop("c")
+        timer.start("d")
+        timer.stop("d")
+        timer.stop("b")
+        timer.stop("root")
+        timer.timers["root"].total_time = 5.0
+        timer.timers["root"].timers["a"].total_time = 4.0
+        timer.timers["root"].timers["a"].timers["b"].total_time = 1.1
+        timer.timers["root"].timers["a"].timers["c"].total_time = 2.2
+        timer.timers["root"].timers["b"].total_time = 0.88
+        timer.timers["root"].timers["b"].timers["c"].total_time = 0.07
+        timer.timers["root"].timers["b"].timers["d"].total_time = 0.05
+        return timer
+
+    def make_timer_depth_4(self):
+        timer = HierarchicalTimer()
+        timer.start("root")
+        timer.start("a")
+        timer.start("b")
+        timer.stop("b")
+        timer.start("c")
+        timer.start("d")
+        timer.start("e")
+        timer.stop("e")
+        timer.stop("d")
+        timer.stop("c")
+        timer.stop("a")
+        timer.start("b")
+        timer.start("c")
+        timer.start("e")
+        timer.stop("e")
+        timer.stop("c")
+        timer.start("d")
+        timer.stop("d")
+        timer.stop("b")
+        timer.stop("root")
+        timer.timers["root"].total_time = 5.0
+        timer.timers["root"].timers["a"].total_time = 4.0
+        timer.timers["root"].timers["a"].timers["b"].total_time = 1.1
+        timer.timers["root"].timers["a"].timers["c"].total_time = 2.2
+        timer.timers["root"].timers["a"].timers["c"].timers["d"].total_time = 0.9
+        timer.timers["root"].timers["a"].timers["c"].timers["d"].timers["e"].total_time = 0.6
+        timer.timers["root"].timers["b"].total_time = 0.88
+        timer.timers["root"].timers["b"].timers["c"].total_time = 0.07
+        timer.timers["root"].timers["b"].timers["c"].timers["e"].total_time = 0.04
+        timer.timers["root"].timers["b"].timers["d"].total_time = 0.05
+        return timer
+    
+    def make_timer_depth_4_same_name(self):
+        timer = HierarchicalTimer()
+        timer.start("root")
+        timer.start("a")
+        timer.start("a")
+        timer.start("a")
+        timer.start("a")
+        timer.stop("a")
+        timer.stop("a")
+        timer.stop("a")
+        timer.stop("a")
+        timer.stop("root")
+        timer.timers["root"].total_time = 5.0
+        timer.timers["root"].timers["a"].total_time = 1.0
+        timer.timers["root"].timers["a"].timers["a"].total_time = 0.1
+        timer.timers["root"].timers["a"].timers["a"].timers["a"].total_time = 0.01
+        timer.timers["root"].timers["a"].timers["a"].timers["a"].timers["a"].total_time = 0.001
+        return timer
+
+    def test_singleton(self):
+        timer = self.make_singleton_timer()
+        root = timer.timers["root"]
+        root.flatten()
+        self.assertAlmostEqual(root.total_time, 5.0)
+
+    def test_already_flat(self):
+        timer = self.make_flat_timer()
+        root = timer.timers["root"]
+        root.flatten()
+        self.assertAlmostEqual(root.total_time, 5.0)
+        self.assertAlmostEqual(root.timers["a"].total_time, 1.0)
+        self.assertAlmostEqual(root.timers["b"].total_time, 2.5)
+
+    def test_depth_2_one_child(self):
+        timer = self.make_timer_depth_2_one_child()
+        root = timer.timers["root"]
+        root.flatten()
+        self.assertAlmostEqual(root.total_time, 5.0)
+        self.assertAlmostEqual(root.timers["a"].total_time, 0.7)
+        self.assertAlmostEqual(root.timers["b"].total_time, 1.1)
+        self.assertAlmostEqual(root.timers["c"].total_time, 2.2)
+
+    def test_timer_depth_2_with_name_collision(self):
+        timer = self.make_timer_depth_2_with_name_collision()
+        root = timer.timers["root"]
+        root.flatten()
+        self.assertAlmostEqual(root.total_time, 5.0)
+        self.assertAlmostEqual(root.timers["a"].total_time, 0.700)
+        self.assertAlmostEqual(root.timers["b"].total_time, 1.210)
+        self.assertAlmostEqual(root.timers["c"].total_time, 2.200)
+
+    def test_timer_depth_2_two_children(self):
+        timer = self.make_timer_depth_2_two_children()
+        root = timer.timers["root"]
+        root.flatten()
+        self.assertAlmostEqual(root.total_time, 5.0)
+        self.assertAlmostEqual(root.timers["a"].total_time, 0.700)
+        self.assertAlmostEqual(root.timers["b"].total_time, 1.860)
+        self.assertAlmostEqual(root.timers["c"].total_time, 2.270)
+        self.assertAlmostEqual(root.timers["d"].total_time, 0.050)
+
+    def test_timer_depth_4(self):
+        timer = self.make_timer_depth_4()
+        root = timer.timers["root"]
+        root.flatten()
+        self.assertAlmostEqual(root.total_time, 5.0)
+        self.assertAlmostEqual(root.timers["a"].total_time, 0.700)
+        self.assertAlmostEqual(root.timers["b"].total_time, 1.860)
+        self.assertAlmostEqual(root.timers["c"].total_time, 1.330)
+        self.assertAlmostEqual(root.timers["d"].total_time, 0.350)
+        self.assertAlmostEqual(root.timers["e"].total_time, 0.640)
+
+    def test_timer_depth_4_same_name(self):
+        timer = self.make_timer_depth_4_same_name()
+        root = timer.timers["root"]
+        root.flatten()
+        self.assertAlmostEqual(root.total_time, 5.0)
+        self.assertAlmostEqual(root.timers["a"].total_time, 1.0)
+
+    def test_base_timer_depth_3(self):
+        # This is depth 2 wrt the root, depth 3 wrt the
+        # "base timer"
+        timer = self.make_timer_depth_2_two_children()
+        timer.flatten()
+        self.assertAlmostEqual(timer.timers["root"].total_time, 0.120)
+        self.assertAlmostEqual(timer.timers["a"].total_time, 0.700)
+        self.assertAlmostEqual(timer.timers["b"].total_time, 1.860)
+        self.assertAlmostEqual(timer.timers["c"].total_time, 2.270)
+        self.assertAlmostEqual(timer.timers["d"].total_time, 0.050)
+
+    def test_timer_still_active(self):
+        timer = HierarchicalTimer()
+        timer.start("a")
+        timer.stop("a")
+        timer.start("b")
+        msg = "Cannot flatten.*while any timers are active"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            timer.flatten()
+        timer.stop("b")

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -616,8 +616,10 @@ class HierarchicalTimer(object):
     profile, it is often best to retain only the most relevant information
     in a flattened data structure. In the following example, suppose a
     theoretical analysis tells us that either subroutine ``"c"`` or ``"f"``
-    should be the bottleneck, depending on problem data. To clearly
-    communicate this, we
+    should be the bottleneck, depending on problem data. We would like to
+    generate a timing profile that displays only the time spent in these
+    two subroutines in a flattened structure so that they are easy to
+    compare. To do this, we
 
     #. Ignore subroutines of ``"c"`` and ``"f"`` that are unnecessary for\
     this comparison

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -437,9 +437,6 @@ def _move_grandchildren_to_root(root, child):
     child.timers.clear()
 
 
-iterable_scalars = (str, bytes)
-
-
 def _clear_timers_except(timer, to_retain):
     """A helper function for removing keys, except for those specified,
     from the dictionary of timers

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -408,13 +408,13 @@ def _move_grandchildren_to_root(root, child):
 
     Parameters
     ----------
-        root: HierarchicalTimer or _HierarchicalHelper
-            The root node. Children of `child` will become children of
-            this node
+    root: HierarchicalTimer or _HierarchicalHelper
+        The root node. Children of `child` will become children of
+        this node
 
-        child: _HierarchicalHelper
-            The child node that will be turned into a leaf by moving
-            its children to the root
+    child: _HierarchicalHelper
+        The child node that will be turned into a leaf by moving
+        its children to the root
 
     """
     for gchild_key, gchild_timer in child.timers.items():
@@ -446,16 +446,13 @@ def _clear_timers_except(timer, to_retain):
 
     Parameters
     ----------
-        timer: HierarchicalTimer or _HierarchichalHelper
-            The timer whose dict of "sub-timers" will be pruned
+    timer: HierarchicalTimer or _HierarchichalHelper
+        The timer whose dict of "sub-timers" will be pruned
 
-        to_retain: str or list
-            Key, or list of keys, of the "sub-timers" to retain
+    to_retain: set
+        Set of keys of the "sub-timers" to retain
 
     """
-    if isinstance(to_retain, iterable_scalars):
-        to_retain = (to_retain,)
-    to_retain = set(to_retain)
     keys = list(timer.timers.keys())
     for key in keys:
         if key not in to_retain:
@@ -533,7 +530,8 @@ class _HierarchicalHelper(object):
             # of the root.
             _move_grandchildren_to_root(self, child_timer)
 
-    def clear_except(self, to_retain):
+    def clear_except(self, *args):
+        to_retain = set(args)
         _clear_timers_except(self, to_retain)
 
 
@@ -904,8 +902,13 @@ class HierarchicalTimer(object):
             timer.flatten()
             _move_grandchildren_to_root(self, timer)
 
-    def clear_except(self, to_retain):
+    def clear_except(self, *args):
         """Prune all "sub-timers" except those specified
+
+        Parameters
+        ----------
+        args: str
+            Keys that will be retained
 
         """
         if self.stack:
@@ -915,4 +918,5 @@ class HierarchicalTimer(object):
                 " only be called as a post-processing step."
                 % self.stack[-1]
             )
+        to_retain = set(args)
         _clear_timers_except(self, to_retain)

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -978,6 +978,12 @@ class HierarchicalTimer(object):
         """Flatten the HierarchicalTimer in-place, moving all the timing
         categories into a single level
 
+        If any timers moved into the same level have the same identifier,
+        the ``total_time`` and ``n_calls`` fields are added together.
+        The ``total_time`` of a "child timer" that is "moved upwards" is
+        subtracted from the ``total_time`` of that timer's original
+        parent.
+
         """
         if self.stack:
             raise RuntimeError(

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -858,7 +858,7 @@ class HierarchicalTimer(object):
 
     def flatten(self):
         """Flatten the HierarchicalTimer in-place, moving all the timing
-        categories present into a single level
+        categories into a single level
 
         """
         if self.stack:

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -614,12 +614,11 @@ class HierarchicalTimer(object):
     When implementing an algorithm, it is often useful to collect detailed
     hierarchical timing information. However, when communicating a timing
     profile, it is often best to retain only the most relevant information
-    in a flattened data structure. In the following example, suppose a
-    theoretical analysis tells us that either subroutine ``"c"`` or ``"f"``
-    should be the bottleneck, depending on problem data. We would like to
-    generate a timing profile that displays only the time spent in these
-    two subroutines in a flattened structure so that they are easy to
-    compare. To do this, we
+    in a flattened data structure. In the following example, suppose we
+    want to compare the time spent in the ``"c"`` and ``"f"`` subroutines.
+    We would like to generate a timing profile that displays only the time
+    spent in these two subroutines, in a flattened structure so that they
+    are easy to compare. To do this, we
 
     #. Ignore subroutines of ``"c"`` and ``"f"`` that are unnecessary for\
     this comparison

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -465,7 +465,16 @@ class _HierarchicalHelper(object):
 
 
 class HierarchicalTimer(object):
-    """A class for hierarchical timing.
+    """A class for collecting and displaying hierarchical timing
+    information
+
+    When implementing an iterative algorithm with nested subroutines
+    (e.g. an optimization solver), we often want to know the cumulative
+    time spent in each subroutine as well as this time as a proportion
+    of time spent in the calling routine. This class collects timing
+    information, for user-specified keys, that accumulates over the life
+    of the timer object and preserves the hierarchical (nested) structure
+    of timing categories.
 
     Examples
     --------

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -15,6 +15,19 @@
 #  Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 #  the U.S. Government retains certain rights in this software.
 #  ___________________________________________________________________________
+
+"""A module of utilities for collecting timing information
+
+.. autosummary::
+
+    report_timing
+    TicTocTimer
+    tic
+    toc
+    HierarchicalTimer
+
+"""
+
 import functools
 import logging
 import sys


### PR DESCRIPTION
## Fixes most of #2503

## Summary/Motivation:
I am using `HierarchicalTimer` to collect fairly detailed timing information in `ExternalPyomoModel`, and when comparing different configurations, I sometimes want to highlight different timing categories. I want to do this by (a) removing redundant information from the timer and (b) flattening the timer so that categories I care about are easy to compare.

For example, I would like to convert the first timer shown into the second timer shown for the purpose of comparing the amount of time spent in NLP Newton solvers.
```console
Identifier                                        ncalls   cumtime   percall      %
-----------------------------------------------------------------------------------
root                                                   1     8.908     8.908  100.0
     ------------------------------------------------------------------------------
     __init__                                         10     1.930     0.193   21.7
               --------------------------------------------------------------------
               PyomoNLP                               10     0.277     0.028   14.4
               __init__                               10     1.467     0.147   76.0
                             ------------------------------------------------------
                             NlpSolver                10     0.027     0.003    1.9
                             PyomoNLP                 10     0.181     0.018   12.3
                             partition                10     0.415     0.042   28.3
                             other                   n/a     0.843       n/a   57.5
                             ======================================================
               other                                 n/a     0.187       n/a    9.7
               ====================================================================
     hessian                                          90     1.303     0.014   14.6
     jacobian                                        100     0.568     0.006    6.4
     set_inputs                                      120     4.549     0.038   51.1
               --------------------------------------------------------------------
               set_parameters                        120     4.522     0.038   99.4
                             ------------------------------------------------------
                             solve                 44520     4.256     0.000   94.1
                                      ---------------------------------------------
                                      calc_var     42120     2.293     0.000   53.9
                                      solve_nlp     2400     1.886     0.001   44.3
                                      other          n/a     0.077       n/a    1.8
                                      =============================================
                             other                   n/a     0.267       n/a    5.9
                             ======================================================
               other                                 n/a     0.027       n/a    0.6
               ====================================================================
     other                                           n/a     0.557       n/a    6.3
     ==============================================================================
===================================================================================

Identifier                 ncalls   cumtime   percall      %
------------------------------------------------------------
root                            1     8.908     8.908  100.0
     -------------------------------------------------------
     __init__                  10     1.930     0.193   21.7
     hessian                   90     1.303     0.014   14.6
     jacobian                 100     0.568     0.006    6.4
     set_inputs               120     4.549     0.038   51.1
               ---------------------------------------------
               solve_nlp     2400     1.886     0.001   41.5
               other          n/a     2.663       n/a   58.5
               =============================================
     other                    n/a     0.557       n/a    6.3
     =======================================================
============================================================
```
With the changes proposed in this PR, I can do this with the following few lines:
```python
root = timer.timers["root"]
# Clear __init__ to get rid of some visual cruft
root.timers["__init__"].timers.clear()
# Clear solve_nlp to make it a leaf node so that it will retain all of its
# total_time when we flatten
set_params = root.timers["set_inputs"].timers["set_parameters"]
set_params.timers["solve"].timers["solve_nlp"].timers.clear()
# Flatten
root.timers["set_inputs"].flatten()
# Clear everything under set_inputs except solve_nlp, which we want to compare
root.timers["set_inputs"].clear_except("solve_nlp")
```

## Changes proposed in this PR:
- Add the `flatten` method to `HierarchicalTimer`. This recursively flattens the "child timers" into a single layer. If any timers in this layer have the same identifier, their `total_time` and `n_calls` fields are combined.
- Add the `clear_except` method to `HierarchicalTimer`. This pops timers from the dict of "child timers" except those whose identifier match one of the identifiers provided as arguments
- Add an example of this to the `HierarchicalTimer` documentation

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
