### PR TITLE
Adding Developers' call information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Pyomo development moved to this repository in June, 2016 from
 Sandia National Laboratories. Developer discussions are hosted by
 [Google Groups](https://groups.google.com/forum/#!forum/pyomo-developers).
 
+The Pyomo Development team holds weekly coordination meetings on
+Tuesdays 12:30 - 14:00 (MT).  Please contact wg-pyomo@sandia.gov to
+request call-in information.
+
 By contributing to this software project, you are agreeing to the
 following terms and conditions for your contributions:
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
As discussed in the 13 Dec 22 Developers' Call, this adds information on the time and how to get call-in information to the main README.md

## Changes proposed in this PR:
- Add Developers' call information to the README

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
