### PR TITLE
Warn when infeasibility tools will not log output

### DIFF
--- a/pyomo/util/infeasible.py
+++ b/pyomo/util/infeasible.py
@@ -41,7 +41,7 @@ def log_infeasible_constraints(
         logger.warning(
             'log_infeasible_constraints() called with a logger whose '
             'effective level is higher than logging.INFO: no output '
-            'will be logged reguardless of constraint feasibility'
+            'will be logged regardless of constraint feasibility'
         )
 
     # Iterate through all active constraints on the model
@@ -137,7 +137,7 @@ def log_infeasible_bounds(m, tol=1E-6, logger=logger):
         logger.warning(
             'log_infeasible_bounds() called with a logger whose '
             'effective level is higher than logging.INFO: no output '
-            'will be logged reguardless of bound feasibility'
+            'will be logged regardless of bound feasibility'
         )
 
     for var in m.component_data_objects(
@@ -167,7 +167,7 @@ def log_close_to_bounds(m, tol=1E-6, logger=logger):
         logger.warning(
             'log_close_to_bounds() called with a logger whose '
             'effective level is higher than logging.INFO: no output '
-            'will be logged reguardless of bound status'
+            'will be logged regardless of bound status'
         )
 
     for var in m.component_data_objects(

--- a/pyomo/util/infeasible.py
+++ b/pyomo/util/infeasible.py
@@ -37,6 +37,13 @@ def log_infeasible_constraints(
         log_variables (bool): If true, prints the constraint variable names and values
 
     """
+    if logger.getEffectiveLevel() > logging.INFO:
+        logger.warning(
+            'log_infeasible_constraints() called with a logger whose '
+            'effective level is higher than logging.INFO: no output '
+            'will be logged reguardless of constraint feasibility'
+        )
+
     # Iterate through all active constraints on the model
     for constr in m.component_data_objects(
             ctype=Constraint, active=True, descend_into=True):
@@ -126,6 +133,13 @@ def log_infeasible_bounds(m, tol=1E-6, logger=logger):
         tol (float): feasibility tolerance
 
     """
+    if logger.getEffectiveLevel() > logging.INFO:
+        logger.warning(
+            'log_infeasible_bounds() called with a logger whose '
+            'effective level is higher than logging.INFO: no output '
+            'will be logged reguardless of bound feasibility'
+        )
+
     for var in m.component_data_objects(
             ctype=Var, descend_into=True):
         var_value = var.value
@@ -149,6 +163,13 @@ def log_close_to_bounds(m, tol=1E-6, logger=logger):
         m (Block): Pyomo block or model to check
         tol (float): bound tolerance
     """
+    if logger.getEffectiveLevel() > logging.INFO:
+        logger.warning(
+            'log_close_to_bounds() called with a logger whose '
+            'effective level is higher than logging.INFO: no output '
+            'will be logged reguardless of bound status'
+        )
+
     for var in m.component_data_objects(
             ctype=Var, descend_into=True):
         if var.fixed:

--- a/pyomo/util/tests/test_infeasible.py
+++ b/pyomo/util/tests/test_infeasible.py
@@ -57,7 +57,7 @@ class TestInfeasible(unittest.TestCase):
         self.assertEqual(
             'log_infeasible_constraints() called with a logger whose '
             'effective level is higher than logging.INFO: no output '
-            'will be logged reguardless of constraint feasibility',
+            'will be logged regardless of constraint feasibility',
             LOG.getvalue().strip(),
         )
 
@@ -86,7 +86,7 @@ class TestInfeasible(unittest.TestCase):
         self.assertEqual(
             'log_infeasible_bounds() called with a logger whose '
             'effective level is higher than logging.INFO: no output '
-            'will be logged reguardless of bound feasibility',
+            'will be logged regardless of bound feasibility',
             LOG.getvalue().strip(),
         )
 
@@ -125,7 +125,7 @@ class TestInfeasible(unittest.TestCase):
         self.assertEqual(
             'log_close_to_bounds() called with a logger whose '
             'effective level is higher than logging.INFO: no output '
-            'will be logged reguardless of bound status',
+            'will be logged regardless of bound status',
             LOG.getvalue().strip(),
         )
 

--- a/pyomo/util/tests/test_infeasible.py
+++ b/pyomo/util/tests/test_infeasible.py
@@ -51,6 +51,16 @@ class TestInfeasible(unittest.TestCase):
     def test_log_infeasible_constraints(self):
         """Test for logging of infeasible constraints."""
         m = self.build_model()
+
+        with LoggingIntercept(None, 'pyomo.util.infeasible') as LOG:
+            log_infeasible_constraints(m)
+        self.assertEqual(
+            'log_infeasible_constraints() called with a logger whose '
+            'effective level is higher than logging.INFO: no output '
+            'will be logged reguardless of constraint feasibility',
+            LOG.getvalue().strip(),
+        )
+
         output = StringIO()
         with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
             log_infeasible_constraints(m)
@@ -70,6 +80,16 @@ class TestInfeasible(unittest.TestCase):
         m = self.build_model()
         m.x.setlb(2)
         m.x.setub(0)
+
+        with LoggingIntercept(None, 'pyomo.util.infeasible') as LOG:
+            log_infeasible_bounds(m)
+        self.assertEqual(
+            'log_infeasible_bounds() called with a logger whose '
+            'effective level is higher than logging.INFO: no output '
+            'will be logged reguardless of bound feasibility',
+            LOG.getvalue().strip(),
+        )
+
         output = StringIO()
         with LoggingIntercept(output, 'pyomo.util', logging.INFO):
             log_infeasible_bounds(m)
@@ -99,6 +119,16 @@ class TestInfeasible(unittest.TestCase):
     def test_log_close_to_bounds(self):
         """Test logging of variables and constraints near bounds."""
         m = self.build_model()
+
+        with LoggingIntercept(None, 'pyomo.util.infeasible') as LOG:
+            log_close_to_bounds(m)
+        self.assertEqual(
+            'log_close_to_bounds() called with a logger whose '
+            'effective level is higher than logging.INFO: no output '
+            'will be logged reguardless of bound status',
+            LOG.getvalue().strip(),
+        )
+
         output = StringIO()
         with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
             log_close_to_bounds(m)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
One of our developers was recently burned by using `log_infeasible_constraints()` and assuming that because they didn't see any output that the model was feasible.  In fact the model was infeasible; but, because the default Pyomo logging level is WARNING, the log messages were suppressed.

This PR is a quick fix to emit a warning when the infeasibility tools are called with a logger that will not output INFO level messages.

## Changes proposed in this PR:
- Log a warning when the logger passed to `pyomo.util.infeasible.log_*()` will not emit INFO level messages

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
