### PR TITLE
PyNumero: Add `tee` argument to Pyomo-SciPy square solvers

### DIFF
--- a/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/scipy_solvers.py
@@ -268,7 +268,26 @@ class PyomoScipySolver(object):
     def set_options(self, options):
         self.options = options
 
-    def solve(self, model, timer=None):
+    def solve(self, model, timer=None, tee=False):
+        """
+        Parameters
+        ----------
+        model: BlockData
+            The model that will be solved
+        timer: HierarchicalTimer
+            A HierarchicalTimer that "sub-timers" created by this object
+            will be attached to. If not provided, a new timer is created.
+        tee: Bool
+            A dummy flag indicating whether solver output should be displayed.
+            The current SciPy solvers supported have no output, so setting this
+            flag does not do anything.
+
+        Returns
+        -------
+        SolverResults
+            Contains the results of the solve
+
+        """
         if timer is None:
             timer = HierarchicalTimer()
         self._timer = timer

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_scipy_solvers.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_scipy_solvers.py
@@ -383,7 +383,7 @@ class TestNewtonPyomo(unittest.TestCase):
     def test_solve(self):
         m, _ = make_scalar_model()
         solver = pyo.SolverFactory("scipy.newton")
-        results = solver.solve(m)
+        results = solver.solve(m, tee=True)
         predicted_x = 4.90547401
         self.assertAlmostEqual(predicted_x, m.x.value)
 


### PR DESCRIPTION
## Fixes error when sending `tee` argument to SciPy solver

## Summary/Motivation:
This argument is supported for most (all?) other Pyomo solvers. Even though it doesn't do anything for the current scipy solvers, which display no output, it should probably be supported here for consistency.

## Changes proposed in this PR:
- Add `tee=False` argument to `PyomoScipySolver` class

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
