### PR TITLE
Separate identification from logging for `pyomo.util.infeasible.log_*`

### DIFF
--- a/pyomo/util/infeasible.py
+++ b/pyomo/util/infeasible.py
@@ -261,7 +261,7 @@ def find_close_to_bounds(m, tol=1E-6):
     """Find variables and constraints whose values are close to their bounds.
 
     Uses the current model state. Variables with no values and
-    Constraints with evaluation errors are returned as if they were
+    constraints with evaluation errors are returned as if they were
     close to their bounds.
 
     Note
@@ -270,9 +270,9 @@ def find_close_to_bounds(m, tol=1E-6):
       - Equality constraints are omitted (as they should always
         be close to their bounds!).
       - Range constraints where both the upper and lower bounds are
-        close are omitted (these are basically equality constriants).
+        close are omitted (these are basically equality constraints).
       - Fixed variables are omitted (this is analogous to an equality
-        constriant).
+        constraint).
       - Variables where both the upper and lower bounds are close are
         omitted (these are basically fixed variables).
 
@@ -288,7 +288,7 @@ def find_close_to_bounds(m, tol=1E-6):
     Yields
     ------
     var: ComponentData
-        The variable or Constraint that is close to its bounds
+        The variable or constraint that is close to its bounds
 
     val: float
         The value of the variable or constraint body

--- a/pyomo/util/tests/test_infeasible.py
+++ b/pyomo/util/tests/test_infeasible.py
@@ -68,8 +68,8 @@ class TestInfeasible(unittest.TestCase):
             "CONSTR c1: 2.0 </= 1",
             "CONSTR c2: 1 =/= 4.0",
             "CONSTR c3: 1 </= 0.0",
-            "CONSTR c5: 5.0 <?= missing variable value <?= 10.0",
-            "CONSTR c7: missing variable value =?= 6.0",
+            "CONSTR c5: 5.0 <?= evaluation error <?= 10.0",
+            "CONSTR c7: evaluation error =?= 6.0",
             "CONSTR c8: 3.0 </= 1 <= 6.0",
             "CONSTR c9: 0.0 <= 1 </= 0.5",
         ]
@@ -133,9 +133,11 @@ class TestInfeasible(unittest.TestCase):
         with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
             log_close_to_bounds(m)
         expected_output = [
-            "y near UB of 2", "yy near LB of 0", "c4 near LB",
-            "Skipping CONSTR c5: missing variable value.",
-            "c11 near UB",
+            "y near UB of 2",
+            "yy near LB of 0",
+            "c4 near LB of 1.9999999",
+            "Skipping CONSTR c5: evaluation error.",
+            "c11 near UB of 1.9999999",
         ]
         self.assertEqual(expected_output, output.getvalue().splitlines())
 
@@ -149,8 +151,8 @@ class TestInfeasible(unittest.TestCase):
             "CONSTR c1: 2.0 </= 1", "  - EXPR: 2.0 </= x",
             "CONSTR c2: 1 =/= 4.0", "  - EXPR: x =/= 4.0",
             "CONSTR c3: 1 </= 0.0", "  - EXPR: x </= 0.0",
-            "CONSTR c5: 5.0 <?= missing variable value <?= 10.0", "  - EXPR: 5.0 <?= z <?= 10.0",
-            "CONSTR c7: missing variable value =?= 6.0", "  - EXPR: z =?= 6.0",
+            "CONSTR c5: 5.0 <?= evaluation error <?= 10.0", "  - EXPR: 5.0 <?= z <?= 10.0",
+            "CONSTR c7: evaluation error =?= 6.0", "  - EXPR: z =?= 6.0",
             "CONSTR c8: 3.0 </= 1 <= 6.0", "  - EXPR: 3.0 </= x <= 6.0",
             "CONSTR c9: 0.0 <= 1 </= 0.5", "  - EXPR: 0.0 <= x </= 0.5",
         ]
@@ -166,8 +168,8 @@ class TestInfeasible(unittest.TestCase):
             "CONSTR c1: 2.0 </= 1", "  - VAR x: 1",
             "CONSTR c2: 1 =/= 4.0", "  - VAR x: 1",
             "CONSTR c3: 1 </= 0.0", "  - VAR x: 1",
-            "CONSTR c5: 5.0 <?= missing variable value <?= 10.0", "  - VAR z: None",
-            "CONSTR c7: missing variable value =?= 6.0", "  - VAR z: None",
+            "CONSTR c5: 5.0 <?= evaluation error <?= 10.0", "  - VAR z: None",
+            "CONSTR c7: evaluation error =?= 6.0", "  - VAR z: None",
             "CONSTR c8: 3.0 </= 1 <= 6.0", "  - VAR x: 1",
             "CONSTR c9: 0.0 <= 1 </= 0.5", "  - VAR x: 1",
         ]

--- a/pyomo/util/tests/test_infeasible.py
+++ b/pyomo/util/tests/test_infeasible.py
@@ -94,7 +94,10 @@ class TestInfeasible(unittest.TestCase):
         with LoggingIntercept(output, 'pyomo.util', logging.INFO):
             log_infeasible_bounds(m)
         expected_output = [
-            "VAR x: 1 >/= LB 2", "VAR x: 1 </= UB 0", "VAR y4: 2 </= UB 1",
+            "VAR x: LB 2 </= 1",
+            "VAR x: 1 </= UB 0",
+            "VAR z: no assigned value.",
+            "VAR y4: 2 </= UB 1",
         ]
         self.assertEqual(expected_output, output.getvalue().splitlines())
 
@@ -136,7 +139,6 @@ class TestInfeasible(unittest.TestCase):
             "y near UB of 2",
             "yy near LB of 0",
             "c4 near LB of 1.9999999",
-            "Skipping CONSTR c5: evaluation error.",
             "c11 near UB of 1.9999999",
         ]
         self.assertEqual(expected_output, output.getvalue().splitlines())


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
The utility methods in `pyomo.util.infeasible` (`log_infeasible_constraints()`, `log_infeasible_bounds`, `log_close_to_bounds`) both identify the relevant components *and* generate the output to the logger.  This assumes that these utilities will only be used by a user with access to the console.  This PR splits the logic into a "finder" that generates the relevant component data objects and a "logger" that wraps the generator to produce the logged output.

There also was inconsistency in the definition of "feasibility within tolerance" (`val <= UB + tol`, or `val < UB + tol`).  This standardizes on the former.  In addition, the previous implementation logged evaluation errors (and missing variable values) in `close_to_bounds` instead of including them in the infeasible lists.

This PR builds on (and includes) #2666.

## Changes proposed in this PR:
- Split `log_infeasible_constraints()`, `log_infeasible_bounds`, `log_close_to_bounds` into separate `find_*` and `log_*` functions
- Standardize the definition of "tolerance": `val == bound + tolerance` is considered to be "within tolerance" and therefore "feasible".
- Correct the message for constraint bodies that fail to evaluate (it can be due to uninitialized variables or math errors)
- Log evaluation errors as infeasible vars / constraints (and not in close_to_bounds)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
