### PR TITLE
fix MindtPy user_time and wallclock_time bug

### DIFF
--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -274,22 +274,22 @@ class MindtPySolver(object):
                 solve_data.results.problem.lower_bound = solve_data.primal_bound
                 solve_data.results.problem.upper_bound = solve_data.dual_bound
 
-            solve_data.results.solver.timing = solve_data.timing
-            solve_data.results.solver.user_time = solve_data.timing.total
-            solve_data.results.solver.wallclock_time = solve_data.timing.total
-            solve_data.results.solver.iterations = solve_data.mip_iter
-            solve_data.results.solver.num_infeasible_nlp_subproblem = solve_data.nlp_infeasible_counter
-            solve_data.results.solver.best_solution_found_time = solve_data.best_solution_found_time
-            solve_data.results.solver.primal_integral = get_primal_integral(solve_data, config)
-            solve_data.results.solver.dual_integral = get_dual_integral(solve_data, config)
-            solve_data.results.solver.primal_dual_gap_integral = solve_data.results.solver.primal_integral + \
-                solve_data.results.solver.dual_integral
-            config.logger.info(' {:<25}:   {:>7.4f} '.format(
-                'Primal-dual gap integral', solve_data.results.solver.primal_dual_gap_integral))
+        solve_data.results.solver.timing = solve_data.timing
+        solve_data.results.solver.user_time = solve_data.timing.total
+        solve_data.results.solver.wallclock_time = solve_data.timing.total
+        solve_data.results.solver.iterations = solve_data.mip_iter
+        solve_data.results.solver.num_infeasible_nlp_subproblem = solve_data.nlp_infeasible_counter
+        solve_data.results.solver.best_solution_found_time = solve_data.best_solution_found_time
+        solve_data.results.solver.primal_integral = get_primal_integral(solve_data, config)
+        solve_data.results.solver.dual_integral = get_dual_integral(solve_data, config)
+        solve_data.results.solver.primal_dual_gap_integral = solve_data.results.solver.primal_integral + \
+            solve_data.results.solver.dual_integral
+        config.logger.info(' {:<25}:   {:>7.4f} '.format(
+            'Primal-dual gap integral', solve_data.results.solver.primal_dual_gap_integral))
 
-            if config.single_tree:
-                solve_data.results.solver.num_nodes = solve_data.nlp_iter - \
-                    (1 if config.init_strategy == 'rNLP' else 0)
+        if config.single_tree:
+            solve_data.results.solver.num_nodes = solve_data.nlp_iter - \
+                (1 if config.init_strategy == 'rNLP' else 0)
 
         return solve_data.results
 

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -274,18 +274,19 @@ class MindtPySolver(object):
                 solve_data.results.problem.lower_bound = solve_data.primal_bound
                 solve_data.results.problem.upper_bound = solve_data.dual_bound
 
+            solve_data.results.solver.primal_integral = get_primal_integral(solve_data, config)
+            solve_data.results.solver.dual_integral = get_dual_integral(solve_data, config)
+            solve_data.results.solver.primal_dual_gap_integral = solve_data.results.solver.primal_integral + \
+                solve_data.results.solver.dual_integral
+            config.logger.info(' {:<25}:   {:>7.4f} '.format(
+                'Primal-dual gap integral', solve_data.results.solver.primal_dual_gap_integral))
+
         solve_data.results.solver.timing = solve_data.timing
         solve_data.results.solver.user_time = solve_data.timing.total
         solve_data.results.solver.wallclock_time = solve_data.timing.total
         solve_data.results.solver.iterations = solve_data.mip_iter
         solve_data.results.solver.num_infeasible_nlp_subproblem = solve_data.nlp_infeasible_counter
         solve_data.results.solver.best_solution_found_time = solve_data.best_solution_found_time
-        solve_data.results.solver.primal_integral = get_primal_integral(solve_data, config)
-        solve_data.results.solver.dual_integral = get_dual_integral(solve_data, config)
-        solve_data.results.solver.primal_dual_gap_integral = solve_data.results.solver.primal_integral + \
-            solve_data.results.solver.dual_integral
-        config.logger.info(' {:<25}:   {:>7.4f} '.format(
-            'Primal-dual gap integral', solve_data.results.solver.primal_dual_gap_integral))
 
         if config.single_tree:
             solve_data.results.solver.num_nodes = solve_data.nlp_iter - \

--- a/pyomo/contrib/mindtpy/util.py
+++ b/pyomo/contrib/mindtpy/util.py
@@ -1080,7 +1080,6 @@ def setup_results_object(solve_data, config):
     res.solver.termination_condition = None
     res.solver.message = None
     res.solver.user_time = None
-    res.solver.system_time = None
     res.solver.wallclock_time = None
     res.solver.termination_message = None
 


### PR DESCRIPTION
## Summary/Motivation:

This PR fixes the `User time` and `Wallclock time` bug in the result of MindtPy. 
Currently, the result of MindtPy looks like the following.
```
Problem: 
- Name: unknown
  Lower bound: 2.935165399586513
  Upper bound: 2.924999999633073
  Number of objectives: 1
  Number of constraints: 7
  Number of variables: 8
  Number of binary variables: 4
  Number of integer variables: 0
  Number of continuous variables: 4
  Number of nonzeros: None
  Sense: minimize
  Number of disjunctions: 0
Solver: 
- Name: MindtPyOA
  Status: ok
  Message: None
  User time: None
  System time: None
  Wallclock time: None
  Termination condition: feasible
  Termination message: None
```
where `User time` and `Wallclock time` are both `None.`

https://github.com/Pyomo/pyomo/blob/31192366f1009ca2cdfe14b4ec60386ad422675d/pyomo/contrib/mindtpy/MindtPy.py#L278-L279
This is because that `timing.total` is not available within `with time_code(solve_data.timing, 'total', is_main_timer=True)`. Therefore, we need to move the code outside the `with time_code(solve_data.timing, 'total', is_main_timer=True)` statement.

Moreover, we also remove `system_time` since it is not assigned.


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
