### PR TITLE
Convert subprocess timeout adjustment parameters to module attributes

### DIFF
--- a/pyomo/opt/solver/shellcmd.py
+++ b/pyomo/opt/solver/shellcmd.py
@@ -32,6 +32,16 @@ from pyomo.opt.results import SolverStatus, SolverResults
 
 logger = logging.getLogger('pyomo.opt')
 
+# The minimum absolute time (in seconds) to add to the solver timeout
+# when setting the timeout for the solver subprocess.  This provides
+# time for a solver that timed out to clean up / report a solution
+# before we forcibly kill the subprocess.
+SUBPROCESS_TIMEOUT_ABS_ADJUST = 1
+# The additional time (relative to the user-specified timeout) to add to
+# the solver timeout when setting the timeout for the solver subprocess.
+# This provides time for a solver that timed out to clean up / report a
+# solution before we forcibly kill the subprocess.
+SUBPROCESS_TIMEOUT_REL_ADJUST = 0.01
 
 class SystemCallSolver(OptSolver):
     """ A generic command line solver """
@@ -312,7 +322,8 @@ class SystemCallSolver(OptSolver):
 
         timeout = self._timelimit
         if timeout is not None:
-            timeout += max(120, 0.01*self._timelimit)
+            timeout += max(SUBPROCESS_TIMEOUT_ABS_ADJUST,
+                           SUBPROCESS_TIMEOUT_REL_ADJUST*self._timelimit)
 
         ostreams = [StringIO()]
         if self._tee:

--- a/pyomo/opt/solver/shellcmd.py
+++ b/pyomo/opt/solver/shellcmd.py
@@ -312,7 +312,7 @@ class SystemCallSolver(OptSolver):
 
         timeout = self._timelimit
         if timeout is not None:
-            timeout += max(1, 0.01*self._timelimit)
+            timeout += max(120, 0.01*self._timelimit)
 
         ostreams = [StringIO()]
         if self._tee:


### PR DESCRIPTION
## Fixes #2671.

## Summary/Motivation:
The parameters that control how the subprocess adjusts the timeout to allow for subprocess termination are currently embedded constants that do not allow users to adjust them for their specific environment.  This PR converts them to module attributes that can be changed from user code before invoking the solver.

## Changes proposed in this PR:
- convert timeout-related embedded constants to module attributes 

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
