### PR TITLE
FBBT: Add tolerances to tests

### DIFF
--- a/pyomo/contrib/fbbt/tests/test_fbbt.py
+++ b/pyomo/contrib/fbbt/tests/test_fbbt.py
@@ -669,8 +669,8 @@ class FbbtTestBase(object):
             x = 10**z
             print(xl, xu, cl, cu)
             print(x)
-            self.assertTrue(np.all(xl <= x))
-            self.assertTrue(np.all(xu >= x))
+            self.assertTrue(np.all(xl - 1e-14 <= x))
+            self.assertTrue(np.all(xu + 1e-14 >= x))
 
     def test_sin(self):
         m = pyo.Block(concrete=True)

--- a/pyomo/contrib/fbbt/tests/test_interval.py
+++ b/pyomo/contrib/fbbt/tests/test_interval.py
@@ -165,7 +165,7 @@ class IntervalTestBase(object):
                 for _x in x:
                     _z = _x ** y
                     self.assertTrue(np.all(zl - 1e-14 <= _z))
-                    self.assertTrue(np.all(zu + 1e-14>= _z))
+                    self.assertTrue(np.all(zu + 1e-14 >= _z))
 
         x_bounds = [(np.random.uniform(-5, -2), np.random.uniform(2, 5)),
                     (np.random.uniform(-5, -2), np.random.uniform(-2, 0)),

--- a/pyomo/contrib/fbbt/tests/test_interval.py
+++ b/pyomo/contrib/fbbt/tests/test_interval.py
@@ -164,8 +164,8 @@ class IntervalTestBase(object):
                 y = np.linspace(yl, yu, 100)
                 for _x in x:
                     _z = _x ** y
-                    self.assertTrue(np.all(zl <= _z))
-                    self.assertTrue(np.all(zu >= _z))
+                    self.assertTrue(np.all(zl - 1e-14 <= _z))
+                    self.assertTrue(np.all(zu + 1e-14>= _z))
 
         x_bounds = [(np.random.uniform(-5, -2), np.random.uniform(2, 5)),
                     (np.random.uniform(-5, -2), np.random.uniform(-2, 0)),


### PR DESCRIPTION
## Summary/Motivation:
Following the latest NumPy release a couple FBBT tests started failing. I added a machine precision tolerance to the failing tests following #2445 as an example.

## Changes proposed in this PR:
- Add machine precision tolerance to a couple fbbt tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
