### PR TITLE
Unit test for QCQO

### DIFF
--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -291,15 +291,13 @@ class MOSEKDirect(DirectSolver):
         else:
             q_vars = itertools.chain.from_iterable(repn.quadratic_vars)
             referenced_vars.update(q_vars)
-            qsubi = tuple(
-                self._pyomo_var_to_solver_var_map[i] for i,
-                j in repn.quadratic_vars)
-            qsubj = tuple(
-                self._pyomo_var_to_solver_var_map[j] for i,
-                j in repn.quadratic_vars)
+            qsubi, qsubj = zip(*[(i, j) if self._pyomo_var_to_solver_var_map[i] >=
+                               self._pyomo_var_to_solver_var_map[j] else (j, i) for i, j in repn.quadratic_vars])
+            qsubi = tuple(self._pyomo_var_to_solver_var_map[i] for i in qsubi)
+            qsubj = tuple(self._pyomo_var_to_solver_var_map[j] for j in qsubj)
             qvals = tuple(v * 2 if qsubi[i] is qsubj[i] else v
                           for i, v in enumerate(repn.quadratic_coefs))
-            mosek_qexp = (qsubj, qsubi, qvals)
+            mosek_qexp = (qsubi, qsubj, qvals)
         return mosek_arow, mosek_qexp, referenced_vars
 
     def _get_expr_from_pyomo_expr(self, expr, max_degree=2):

--- a/pyomo/solvers/tests/checks/test_MOSEKDirect.py
+++ b/pyomo/solvers/tests/checks/test_MOSEKDirect.py
@@ -145,6 +145,26 @@ class MOSEKDirectTests(unittest.TestCase):
         self.assertEqual(results.solution.status,
                          SolutionStatus.optimal)
 
+    def test_qcqo(self):
+        model = pmo.block()
+        model.x = pmo.variable_list()
+        for i in range(3):
+            model.x.append(pmo.variable(lb=0.0))
+
+        model.cons = pmo.constraint(expr=model.x[0] + model.x[1] + model.x[2] - model.x[0]
+                                    ** 2 - model.x[1]**2 - 0.1*model.x[2]**2 + 0.2*model.x[0]*model.x[2] >= 1.0)
+
+        model.o = pmo.objective(expr=model.x[0]**2 + 0.1*model.x[1]**2 +
+                                model.x[2]**2 - model.x[0]*model.x[2] - model.x[1], sense=pmo.minimize)
+
+        opt = pmo.SolverFactory("mosek_direct")
+        results = opt.solve(model)
+
+        self.assertAlmostEqual(results.problem.upper_bound, -4.9176e-01, 4)
+        self.assertAlmostEqual(results.problem.lower_bound, -4.9180e-01, 4)
+
+        del model
+
     def test_conic(self):
 
         model = pmo.block()


### PR DESCRIPTION
## Change  # 
- Added a small unit test for QCQO problems for Pyomo-MOSEK.

( I did not want to obfuscate the purpose of #2647, so I made this a separate PR)

## Summary/Motivation:
A while ago there was a bug due to mosek_direct passing upper-triangular elements when setting Q matrix elements. This was fixed, but no unit test was added for this. That has been changed.

## Changes proposed in this PR:
- Unit test (small qcqo problem).

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
