### PR TITLE
NFC: Fixing typo

### DIFF
--- a/pyomo/dae/__init__.py
+++ b/pyomo/dae/__init__.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-# Import the key modeling componente here...
+# Import the key modeling components here...
 
 from pyomo.dae.contset import ContinuousSet
 from pyomo.dae.diffvar import DAE_Error, DerivativeVar


### PR DESCRIPTION
## Summary/Motivation:
Fixing a typo in the `__init__.py` file in pyomo.dae

## Changes proposed in this PR:
- Fix typo in pyomo.dae

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
