### PR TITLE
Resolve consistency issues in the Bunch class

### DIFF
--- a/pyomo/common/collections/bunch.py
+++ b/pyomo/common/collections/bunch.py
@@ -27,7 +27,7 @@ class Bunch(dict):
     ActiveState Code Container (recipe 496697).
 
     For historical reasons, attributes / keys are stored in the
-    unterlying dict unless they begin with an underscore, in which case
+    underlying dict unless they begin with an underscore, in which case
     they are stored as object attributes.
 
     """

--- a/pyomo/common/collections/bunch.py
+++ b/pyomo/common/collections/bunch.py
@@ -4,7 +4,7 @@
 #  Copyright (c) 2008-2022
 #  National Technology and Engineering Solutions of Sandia, LLC
 #  Under the terms of Contract DE-NA0003525 with National Technology and
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
@@ -42,7 +42,7 @@ class Bunch(dict):
                 if len(item) != 2:
                     raise ValueError(
                         "Bunch() positional arguments must be space separated "
-                        f"strings of form 'key=value', got {item[0]}")
+                        f"strings of form 'key=value', got '{item[0]}'")
 
                 # Historically, this used 'exec'.  That is unsafe in
                 # this context (because anyone can pass arguments to a

--- a/pyomo/common/collections/bunch.py
+++ b/pyomo/common/collections/bunch.py
@@ -17,106 +17,139 @@
 #  ___________________________________________________________________________
 
 import shlex
-
+from collections.abc import Mapping
 
 class Bunch(dict):
-    """
-    A class that can be used to store a bunch of data dynamically.
-    This class allows all other attributes to have a default value of None. 
-    This borrows the output formatting ideas from the
+    """A class that can be used to store a bunch of data dynamically.
+
+    This class allows for unspecified attributes to have a default value
+    of None.  This borrows the output formatting ideas from the
     ActiveState Code Container (recipe 496697).
+
+    For historical reasons, attributes / keys are stored in the
+    unterlying dict unless they begin with an underscore, in which case
+    they are stored as object attributes.
+
     """
 
     def __init__(self, *args, **kw):
+        self._name_ = self.__class__.__name__
         for arg in args:
+            if not isinstance(arg, str):
+                raise TypeError("Bunch() positional arguments must be strings")
             for item in shlex.split(arg):
-                r = item.find('=')
-                if r != -1:
-                    try:
-                        val = eval(item[r + 1:])
-                    except:
-                        val = item[r + 1:]
-                    kw[item[:r]] = val
-        dict.__init__(self, kw)
-        self.__dict__.update(kw)
-        if not '_name_' in kw:
-            self._name_ = self.__class__.__name__
+                item = item.split('=', 1)
+                if len(item) != 2:
+                    raise ValueError(
+                        "Bunch() positional arguments must be space separated "
+                        f"strings of form 'key=value', got {item[0]}")
+
+                # Historically, this used 'exec'.  That is unsafe in
+                # this context (because anyone can pass arguments to a
+                # Bunch).  While not strictly backwards compatible,
+                # Pyomo was not using this for anything past parsing
+                # None/float/int values.  We will explicitly parse those
+                # values
+                try:
+                    val = float(item[1])
+                    if int(val) == val:
+                        val = int(val)
+                    item[1] = val
+                except:
+                    if item[1].strip() == 'None':
+                        item[1] = None
+                self[item[0]] = item[1]
+        for k, v in kw.items():
+            self[k] = v
 
     def update(self, d):
         """
         The update is specialized for JSON-like data.  This
-        recursively replaces dictionaries with Container objects.
+        recursively replaces dictionaries with Bunch objects.
         """
-        for k in d:
-            if type(d[k]) is dict:
-                tmp = Bunch()
-                tmp.update(d[k])
-                self.__setattr__(k, tmp)
-            elif type(d[k]) is list:
+        if isinstance(d, Mapping):
+            item_iter = d.items()
+        else:
+            item_iter = d
+        for k, v in item_iter:
+            if type(v) is dict:
+                self[k] = Bunch(**v)
+            elif type(v) is list:
                 val = []
-                for i in d[k]:
+                for i in v:
                     if type(i) is dict:
-                        tmp = Bunch()
-                        tmp.update(i)
-                        val.append(tmp)
+                        val.append(Bunch(**i))
                     else:
                         val.append(i)
-                self.__setattr__(k, val)
+                self[k] = val
             else:
-                self.__setattr__(k, d[k])
+                self[k] = v
 
     def set_name(self, name):
         self._name_ = name
 
-    def __setitem__(self, name, val):
-        self.__setattr__(name, val)
-
     def __getitem__(self, name):
-        return self.__getattr__(name)
+        # Map through Python's standard getattr functionality (which
+        # will resolve known attributes without hitting __getattr__)
+        return getattr(self, name)
 
-    def __setattr__(self, name, val):
-        if name[0] != '_':
-            dict.__setitem__(self, name, val)
-        self.__dict__[name] = val
+    def __setitem__(self, name, val):
+        if name[0] == '_':
+            super().__setattr__(name, val)
+        else:
+            super().__setitem__(name, val)
+
+    def __delitem__(self, name):
+        if name[0] == '_':
+            super().__delattr__(name)
+        else:
+            super().__delitem__(name)
 
     def __getattr__(self, name):
-        try:
-            return dict.__getitem__(self, name)
-        except:
-            if name[0] == '_':
-                raise AttributeError("Unknown attribute %s" % name)
-        return None
+        if name[0] == '_':
+            raise AttributeError(f"Unknown attribute '{name}'")
+        return self.get(name, None)
+
+    def __setattr__(self, name, val):
+        if name[0] == '_':
+            super().__setattr__(name, val)
+        else:
+            super().__setitem__(name, val)
+
+    def __delattr__(self, name):
+        if name[0] == '_':
+            super().__delattr__(name)
+        else:
+            super().__delitem__(name)
 
     def __repr__(self):
-        attrs = sorted("%s = %r" % (k, v) for k, v in self.__dict__.items()
+        attrs = sorted("%s = %r" % (k, v) for k, v in self.items()
                        if not k.startswith("_"))
         return "%s(%s)" % (self.__class__.__name__, ", ".join(attrs))
-
-    def __str__(self):
-        return self.as_string()
 
     def __str__(self, nesting=0, indent=''):
         attrs = []
         indentation = indent + "    " * nesting
-        for k, v in self.__dict__.items():
-            if not k.startswith("_"):
-                text = [indentation, k, ":"]
-                if isinstance(v, Bunch):
-                    if len(v) > 0:
-                        text.append('\n')
-                    text.append(v.__str__(nesting + 1))
-                elif isinstance(v, list):
-                    if len(v) == 0:
-                        text.append(' []')
-                    else:
-                        for v_ in v:
-                            text.append('\n' + indentation + "-")
-                            if isinstance(v_, Bunch):
-                                text.append('\n' + v_.__str__(nesting + 1))
-                            else:
-                                text.append(" " + repr(v_))
+        for k, v in self.items():
+            if k.startswith("_"):
+                continue
+            text = [indentation, k, ":"]
+            if isinstance(v, Bunch):
+                if len(v) > 0:
+                    text.append('\n')
+                text.append(v.__str__(nesting + 1))
+            elif isinstance(v, list):
+                if len(v) == 0:
+                    text.append(' []')
                 else:
-                    text.append(' ' + repr(v))
-                attrs.append("".join(text))
+                    for v_ in v:
+                        text.append('\n' + indentation + "-")
+                        if isinstance(v_, Bunch):
+                            text.append('\n' + v_.__str__(nesting + 1))
+                        else:
+                            text.append(" " + repr(v_))
+            else:
+                text.append(' ' + repr(v))
+            attrs.append("".join(text))
         attrs.sort()
         return "\n".join(attrs)

--- a/pyomo/common/collections/bunch.py
+++ b/pyomo/common/collections/bunch.py
@@ -141,8 +141,6 @@ class Bunch(dict):
         attrs = []
         indentation = indent + "    " * nesting
         for k, v in self.items():
-            if k.startswith("_"):
-                continue
             text = [indentation, k, ":"]
             if isinstance(v, Bunch):
                 if len(v) > 0:

--- a/pyomo/common/collections/bunch.py
+++ b/pyomo/common/collections/bunch.py
@@ -96,21 +96,24 @@ class Bunch(dict):
         self._name_ = name
 
     def __getitem__(self, name):
+        if not isinstance(name, str):
+            raise ValueError(
+                f'Bunch keys must be str (got {type(name).__name__})')
         # Map through Python's standard getattr functionality (which
         # will resolve known attributes without hitting __getattr__)
         return getattr(self, name)
 
     def __setitem__(self, name, val):
-        if name[0] == '_':
-            super().__setattr__(name, val)
-        else:
-            super().__setitem__(name, val)
+        if not isinstance(name, str):
+            raise ValueError(
+                f'Bunch keys must be str (got {type(name).__name__})')
+        setattr(self, name, val)
 
     def __delitem__(self, name):
-        if name[0] == '_':
-            super().__delattr__(name)
-        else:
-            super().__delitem__(name)
+        if not isinstance(name, str):
+            raise ValueError(
+                f'Bunch keys must be str (got {type(name).__name__})')
+        delattr(self, name)
 
     def __getattr__(self, name):
         if name[0] == '_':

--- a/pyomo/common/collections/bunch.py
+++ b/pyomo/common/collections/bunch.py
@@ -67,21 +67,28 @@ class Bunch(dict):
         The update is specialized for JSON-like data.  This
         recursively replaces dictionaries with Bunch objects.
         """
+        def _replace_dict_in_list(lst):
+            ans = []
+            for v in lst:
+                if type(v) is dict:
+                    ans.append(Bunch())
+                    ans[-1].update(v)
+                elif type(v) is list:
+                    ans.append(_replace_dict_in_list(v))
+                else:
+                    ans.append(v)
+            return ans
+
         if isinstance(d, Mapping):
             item_iter = d.items()
         else:
             item_iter = d
         for k, v in item_iter:
             if type(v) is dict:
-                self[k] = Bunch(**v)
+                self[k] = Bunch()
+                self[k].update(v)
             elif type(v) is list:
-                val = []
-                for i in v:
-                    if type(i) is dict:
-                        val.append(Bunch(**i))
-                    else:
-                        val.append(i)
-                self[k] = val
+                self[k] = _replace_dict_in_list(v)
             else:
                 self[k] = v
 

--- a/pyomo/common/tests/test_bunch.py
+++ b/pyomo/common/tests/test_bunch.py
@@ -4,7 +4,7 @@
 #  Copyright (c) 2008-2022
 #  National Technology and Engineering Solutions of Sandia, LLC
 #  Under the terms of Contract DE-NA0003525 with National Technology and
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
@@ -22,30 +22,36 @@ from pyomo.common.collections import Bunch
 
 class Test(unittest.TestCase):
     def test_Bunch1(self):
-        opt = Bunch('a=None c=d e="1 2 3"', foo=1, bar='x')
+        opt = Bunch('a=None c=d e="1 2 3" f=" 5 "', foo=1, bar='x')
         self.assertEqual(opt.ll, None)
         self.assertEqual(opt.a, None)
         self.assertEqual(opt.c, 'd')
         self.assertEqual(opt.e, '1 2 3')
+        self.assertEqual(opt.f, 5)
         self.assertEqual(opt.foo, 1)
         self.assertEqual(opt.bar, 'x')
         self.assertEqual(opt['bar'], 'x')
         opt.xx = 1
         opt['yy'] = 2
         self.assertEqual(
-            set(opt.keys()), set(['a', 'bar', 'c', 'foo', 'e', 'xx', 'yy']))
+            set(opt.keys()),
+            set(['a', 'bar', 'c', 'f', 'foo', 'e', 'xx', 'yy'])
+        )
         opt.x = Bunch(a=1, b=2)
         self.assertEqual(
-            set(opt.keys()), set(
-                ['a', 'bar', 'c', 'foo', 'e', 'xx', 'yy', 'x']))
+            set(opt.keys()),
+            set(['a', 'bar', 'c', 'f', 'foo', 'e', 'xx', 'yy', 'x'])
+        )
         self.assertEqual(
             repr(opt),
-            "Bunch(a = None, bar = 'x', c = 'd', e = '1 2 3', foo = 1, x = Bunch(a = 1, b = 2), xx = 1, yy = 2)")
+            "Bunch(a = None, bar = 'x', c = 'd', e = '1 2 3', f = 5, "
+            "foo = 1, x = Bunch(a = 1, b = 2), xx = 1, yy = 2)")
         self.assertEqual(
             str(opt), """a: None
 bar: 'x'
 c: 'd'
 e: '1 2 3'
+f: 5
 foo: 1
 x:
     a: 1
@@ -54,16 +60,19 @@ xx: 1
 yy: 2""")
         opt._name_ = 'BUNCH'
         self.assertEqual(
-            set(opt.keys()), set(
-                ['a', 'bar', 'c', 'foo', 'e', 'xx', 'yy', 'x']))
+            set(opt.keys()),
+            set(['a', 'bar', 'c', 'f', 'foo', 'e', 'xx', 'yy', 'x'])
+        )
         self.assertEqual(
             repr(opt),
-            "Bunch(a = None, bar = 'x', c = 'd', e = '1 2 3', foo = 1, x = Bunch(a = 1, b = 2), xx = 1, yy = 2)")
+            "Bunch(a = None, bar = 'x', c = 'd', e = '1 2 3', f = 5, "
+            "foo = 1, x = Bunch(a = 1, b = 2), xx = 1, yy = 2)")
         self.assertEqual(
             str(opt), """a: None
 bar: 'x'
 c: 'd'
 e: '1 2 3'
+f: 5
 foo: 1
 x:
     a: 1
@@ -71,8 +80,147 @@ x:
 xx: 1
 yy: 2""")
 
-    def test_Container2(self):
+        with self.assertRaisesRegex(
+                TypeError, r"Bunch\(\) positional arguments must be strings"):
+            Bunch(5)
+
+        with self.assertRaisesRegex(
+                ValueError, r"Bunch\(\) positional arguments must be space "
+                "separated strings of form 'key=value', got 'foo'"):
+            Bunch('a=5 foo = 6')
+
+    def test_pickle(self):
         o1 = Bunch('a=None c=d e="1 2 3"', foo=1, bar='x')
         s = pickle.dumps(o1)
         o2 = pickle.loads(s)
         self.assertEqual(o1, o2)
+
+    def test_attr_methods(self):
+        b = Bunch()
+        b.foo = 5
+        self.assertEqual(list(b.keys()), ['foo'])
+        self.assertEqual(b.foo, 5)
+        b._foo = 50
+        self.assertEqual(list(b.keys()), ['foo'])
+        self.assertEqual(b.foo, 5)
+        self.assertEqual(b._foo, 50)
+
+        del b.foo
+        self.assertEqual(list(b.keys()), [])
+        self.assertEqual(b.foo, None)
+        self.assertEqual(b._foo, 50)
+
+        del b._foo
+        self.assertEqual(list(b.keys()), [])
+        self.assertEqual(b.foo, None)
+        with self.assertRaisesRegex(
+                AttributeError, "Unknown attribute '_foo'"):
+            b._foo
+
+    def test_item_methods(self):
+        b = Bunch()
+        b['foo'] = 5
+        self.assertEqual(list(b.keys()), ['foo'])
+        self.assertEqual(b['foo'], 5)
+        b['_foo'] = 50
+        self.assertEqual(list(b.keys()), ['foo'])
+        self.assertEqual(b['foo'], 5)
+        self.assertEqual(b['_foo'], 50)
+
+        del b['foo']
+        self.assertEqual(list(b.keys()), [])
+        self.assertEqual(b['foo'], None)
+        self.assertEqual(b['_foo'], 50)
+
+        del b['_foo']
+        self.assertEqual(list(b.keys()), [])
+        self.assertEqual(b['foo'], None)
+        with self.assertRaisesRegex(
+                AttributeError, "Unknown attribute '_foo'"):
+            b['_foo']
+
+        with self.assertRaisesRegex(
+                ValueError, r"Bunch keys must be str \(got int\)"):
+            b[5]
+
+        with self.assertRaisesRegex(
+                ValueError, r"Bunch keys must be str \(got int\)"):
+            b[5] = 5
+
+        with self.assertRaisesRegex(
+                ValueError, r"Bunch keys must be str \(got int\)"):
+            del b[5]
+
+    def test_update(self):
+        data = {
+            'a': 1,
+            'b': [2, {'bb':3}, [4, {'bbb':5}]],
+            'c': {'cc': 6, 'ccc': {'e': 7}},
+            'd': []
+        }
+
+        # Test passing a dict
+        b = Bunch()
+        b.update(data)
+        self.assertEqual(
+            repr(b),
+            'Bunch(a = 1, '
+            'b = [2, Bunch(bb = 3), [4, Bunch(bbb = 5)]], '
+            'c = Bunch(cc = 6, ccc = Bunch(e = 7)), '
+            'd = [])'
+        )
+
+        # Test passing a generator
+        b = Bunch()
+        b.update(data.items())
+        self.assertEqual(
+            repr(b),
+            'Bunch(a = 1, '
+            'b = [2, Bunch(bb = 3), [4, Bunch(bbb = 5)]], '
+            'c = Bunch(cc = 6, ccc = Bunch(e = 7)), '
+            'd = [])'
+        )
+
+        # Test passing a list
+        b = Bunch()
+        b.update(list(data.items()))
+        self.assertEqual(
+            repr(b),
+            'Bunch(a = 1, '
+            'b = [2, Bunch(bb = 3), [4, Bunch(bbb = 5)]], '
+            'c = Bunch(cc = 6, ccc = Bunch(e = 7)), '
+            'd = [])'
+        )
+
+    def test_str(self):
+        data = {
+            'a': 1,
+            'b': [2, {'bb':3}, [4, {'bbb':5}]],
+            'c': {'cc': 6, 'ccc': {'e': 7}},
+            'd': []
+        }
+
+        b = Bunch()
+        b.update(data)
+        self.assertEqual(
+            str(b),
+'''
+a: 1
+b:
+- 2
+-
+    bb: 3
+- [4, Bunch(bbb = 5)]
+c:
+    cc: 6
+    ccc:
+        e: 7
+d: []
+'''.strip()
+        )
+
+    def test_set_name(self):
+        b = Bunch()
+        self.assertEqual(b._name_, 'Bunch')
+        b.set_name('TEST')
+        self.assertEqual(b._name_, 'TEST')

--- a/pyomo/core/tests/examples/test_pyomo.py
+++ b/pyomo/core/tests/examples/test_pyomo.py
@@ -127,10 +127,15 @@ class TestJson(BaseTester):
                 f1_filtered = []
                 f2_filtered = []
                 for item1, item2 in zip_longest(f1_contents, f2_contents):
-                    if not item1.startswith('['):
+                    if not item1:
+                        f1_filtered.append(item1)
+                    elif not item1.startswith('['):
                         items1 = item1.strip().split()
-                        items2 = item2.strip().split()
                         f1_filtered.append(self.filter_items(items1))
+                    if not item2:
+                        f2_filtered.append(item2)
+                    elif not item2.startswith('['):
+                        items2 = item2.strip().split()
                         f2_filtered.append(self.filter_items(items2))
                 self.assertStructuredAlmostEqual(f2_filtered, f1_filtered,
                                                  abstol=1e-6,

--- a/pyomo/scripting/util.py
+++ b/pyomo/scripting/util.py
@@ -277,8 +277,8 @@ def create_model(data):
         else:
             model_options = data.options.model.options.value()
             tick = time.time()
-            model = ep.service().apply( options = Bunch(*data.options),
-                                       model_options=Bunch(*model_options) )
+            model = ep.service().apply( options = Bunch(**data.options),
+                                       model_options=Bunch(**model_options) )
             if data.options.runtime.report_timing is True:
                 print("      %6.2f seconds required to construct instance" % (time.time() - tick))
                 data.local.time_initial_import = None


### PR DESCRIPTION
## Fixes #2677 .

## Summary/Motivation:
This resolves issues where Bunch behaved differently when accessing data through the `*item` and `*attr` interfaces.  In particular, `delattr` now works as expected, and there is improved error checking in the constructor

## Changes proposed in this PR:
- implement `__delattr__`
- standardize mapping of kets to either the dict or attributes
- remove (unsafe) use of `eval` when parsing arguments
- improve error checking in init
- resolve bugs identified by improved error cehcking

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
