### PR TITLE
GDPOpt: Switching a LBB test to use Gurobi as MINLP solver

### DIFF
--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -1578,10 +1578,13 @@ class TestConfigOptions(unittest.TestCase):
         self.assertAlmostEqual(value(m.obj), -0.25)
         self.assertEqual(opt.config.mip_solver, 'gurobi')
 
+    @unittest.skipUnless(SolverFactory('gurobi').available(),
+                         'Gurobi not available')
     def test_no_default_algorithm(self):
         m = self.make_model()
 
         opt = SolverFactory('gdpopt')
+
         buf = StringIO()
         with redirect_stdout(buf):
             opt.solve(m, algorithm='RIC', tee=True, mip_solver=mip_solver,
@@ -1592,7 +1595,7 @@ class TestConfigOptions(unittest.TestCase):
         buf = StringIO()
         with redirect_stdout(buf):
             opt.solve(m, algorithm='LBB', tee=True, mip_solver=mip_solver,
-                      nlp_solver=nlp_solver)
+                      nlp_solver=nlp_solver, minlp_solver='gurobi')
         self.assertIn('using LBB algorithm', buf.getvalue())
         self.assertAlmostEqual(value(m.obj), -0.25)
 


### PR DESCRIPTION
## Fixes current GDPopt test failure after BARON released 23.1.5

## Summary/Motivation:

BARON 23.1.5 is returning a wrong answer during `gdpopt.lbb`, causing it to converge to the wrong solution. This switches the test to use Gurobi for now because it's quadratic anyway...

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
