### PR TITLE
Fix incorrect documentation for sending options to solvers

### DIFF
--- a/doc/OnlineDocs/tests/scripting/spy4scripts.py
+++ b/doc/OnlineDocs/tests/scripting/spy4scripts.py
@@ -171,7 +171,7 @@ optimizer.options["threads"] = 4
 # @Add_option_to_solver
 
 # @Add_multiple_options_to_solver
-results = optimizer.solve(instance, options="threads=4", tee=True)
+results = optimizer.solve(instance, options={'threads' : 4}, tee=True)
 # @Add_multiple_options_to_solver
 
 # @Set_path_to_solver_executable

--- a/doc/OnlineDocs/working_abstractmodels/pyomo_command.rst
+++ b/doc/OnlineDocs/working_abstractmodels/pyomo_command.rst
@@ -25,7 +25,7 @@ gap can be set using
 
 ::
 
-   --solver-options= "mipgap=0.01 "
+   --solver-options="mipgap=0.01"
 
 Multiple options are separated by a space.  Options that do not take an
 argument should be specified with the equals sign followed by either a
@@ -36,7 +36,7 @@ mipgap of two percent and the GLPK cuts option, use
 
 ::
 
-   solver=glpk --solver-options="mipgap=0.02 cuts="
+   --solver=glpk --solver-options="mipgap=0.02 cuts="
 
 If there are multiple "levels" to the keyword, as is the case for some
 Gurobi and CPLEX options, the tokens are separated by underscore.  For


### PR DESCRIPTION
## Fixes #2684 

## Summary/Motivation:
There was some either out of date or incorrect documentation pointed out by @ZedongPeng in the referenced issue. This fixes that issue.

## Changes proposed in this PR:
- Correct documentation for passing options to solvers

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
