### PR TITLE
Suppress mpi-sppy output in import

### DIFF
--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -12,12 +12,20 @@
 #### Adding option for "local" EF starting Sept 2020
 #### Wrapping mpi-sppy functionality and local option Jan 2021, Feb 2021
 
+# TODO: move use_mpisppy to a Pyomo configuration option
+#
 # False implies always use the EF that is local to parmest
 use_mpisppy = True  # Use it if we can but use local if not.
 if use_mpisppy:
     try:
-        import mpisppy.utils.sputils as sputils
-    except:
+        # MPI-SPPY has an unfortunate side effect of outputting
+        # "[ 0.00] Initializing mpi-sppy" when it is imported.  This can
+        # cause things like doctests to fail.  We will suppress that
+        # information here.
+        from pyomo.common.tee import capture_output
+        with capture_output():
+            import mpisppy.utils.sputils as sputils
+    except ImportError:
         use_mpisppy = False  # we can't use it
 if use_mpisppy:
     # These things should be outside the try block.


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
`mpi-sppy` outputs an initialization message to the console the first time it is imported.  This is causing some doctests to fail when mpisppy is installed on the system.  This PR updates parmest to suppress the output to stdout when importing mpisppy

## Changes proposed in this PR:
- suppress output to stdout when importing mpisppy through parmest.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
