### PR TITLE
Update GAMS license check to avoid exception when not available

### DIFF
--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -632,13 +632,16 @@ class GAMSShell(_GAMSSolver):
         return self._run_simple_model(5001)
 
     def _run_simple_model(self, n):
+        solver_exec = self.executable()
+        if solver_exec is None:
+            return False
         tmpdir = mkdtemp()
         try:
             test = os.path.join(tmpdir, 'test.gms')
             with open(test, 'w') as FILE:
                 FILE.write(self._simple_model(n))
             result = subprocess.run(
-                [self.executable(), test, "curdir=" + tmpdir, 'lo=0'],
+                [solver_exec, test, "curdir=" + tmpdir, 'lo=0'],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL)
             return not result.returncode


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This resolves an exception raised when checking the GAMS subprocess-based solver interface license availability when the GAMS executable is not present in the search path.

## Changes proposed in this PR:
- Check to make sure the GAMS solver executable exists before trying to run it

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
