### PR TITLE
Adjust Routine for Loading DR Polishing Model Solutions to Master Model

### DIFF
--- a/pyomo/contrib/pyros/master_problem_methods.py
+++ b/pyomo/contrib/pyros/master_problem_methods.py
@@ -70,20 +70,10 @@ def get_state_vars(model, iterations):
     """
     iter_state_var_map = dict()
     for itn in iterations:
-        fsv_set = ComponentSet(
-                model.scenarios[itn, 0].util.first_stage_variables)
-        state_vars = list()
-        for blk in model.scenarios[itn, :]:
-            ssv_set = ComponentSet(blk.util.second_stage_variables)
-            state_vars.extend(
-                    v for v in blk.component_data_objects(
-                        Var,
-                        active=True,
-                        descend_into=True,
-                        sort=SortComponents.deterministic,  # guarantee order
-                    )
-                    if v not in fsv_set and v not in ssv_set
-            )
+        state_vars = [
+            var for blk in model.scenarios[itn, :]
+            for var in blk.util.state_vars
+        ]
         iter_state_var_map[itn] = state_vars
 
     return iter_state_var_map
@@ -466,13 +456,14 @@ def minimize_dr_vars(model_data, config):
             polishing_model.scenarios[idx].util.second_stage_variables,
         )
         sv_zip = zip(
-            get_state_vars(model_data.master_model, [idx[0]])[idx[0]],
-            get_state_vars(polishing_model, [idx[0]])[idx[0]],
+            blk.util.state_vars,
+            polishing_model.scenarios[idx].util.state_vars,
         )
-
         for master_ssv, polish_ssv in ssv_zip:
             master_ssv.set_value(value(polish_ssv))
         for master_sv, polish_sv in sv_zip:
+            print("master", master_sv.name, master_sv.value)
+            print("polish", polish_sv.name, polish_sv.value)
             master_sv.set_value(value(polish_sv))
 
         # update master problem decision rule variables

--- a/pyomo/contrib/pyros/master_problem_methods.py
+++ b/pyomo/contrib/pyros/master_problem_methods.py
@@ -462,8 +462,6 @@ def minimize_dr_vars(model_data, config):
         for master_ssv, polish_ssv in ssv_zip:
             master_ssv.set_value(value(polish_ssv))
         for master_sv, polish_sv in sv_zip:
-            print("master", master_sv.name, master_sv.value)
-            print("polish", polish_sv.name, polish_sv.value)
             master_sv.set_value(value(polish_sv))
 
         # update master problem decision rule variables

--- a/pyomo/contrib/pyros/tests/test_grcs.py
+++ b/pyomo/contrib/pyros/tests/test_grcs.py
@@ -3406,6 +3406,7 @@ class RegressionTest(unittest.TestCase):
         m.working_model.util.second_stage_variables = [m.z1, m.z2]
         m.working_model.util.uncertain_params = [m.p1, m.p2]
         m.working_model.util.first_stage_variables = []
+        m.working_model.util.state_vars = []
 
         m.working_model.util.first_stage_variables = []
         config = Block()


### PR DESCRIPTION
## Summary/Motivation:

For a PyROS decision rule polishing problem, the routine `pyros.master_problem_methods.get_state_vars` inadvertently (and undesirably) includes auxiliary variables added to the master problem as state variables. As a result, a master problem state variable value may be set to that of one of the auxiliary polishing model variables after the polishing model has been solved (through `pyros.master_problem_methods.minimize_dr_vars`). This may adversely affect the initialization of the state variables for subsequent separation and master models, and is not in agreement with the intentions of #2515.

## Changes proposed in this PR:
- Adjust routine for loading DR polishing model state variable values
- Simplify retrieval of state variables from master-type model scenario blocks

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
