### PR TITLE
Improve GHA conda setup performance

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -211,8 +211,9 @@ jobs:
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python }}
+        mamba-version: "*"
         channels: conda-forge,gurobi,ibmdecisionoptimization,fico-xpress
-        #channel-priority: strict
+        channel-priority: strict
 
     # GitHub actions is very fragile when it comes to setting up various
     # Python interpreters, expecially the setup-miniconda interface.
@@ -269,15 +270,11 @@ jobs:
     - name: Install Python packages (conda)
       if: matrix.PYENV == 'conda'
       run: |
-        # Switch to a faster environment solver
-        conda install -q -y conda-libmamba-solver
-        conda config --set solver libmamba
         # Set up environment
         mkdir -p $GITHUB_WORKSPACE/cache/conda
         conda config --set always_yes yes
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
-        conda config --set channel_priority strict
         # Print environment info
         echo "*** CONDA environment: ***"
         conda info
@@ -311,20 +308,20 @@ jobs:
             fi
         done
         echo "*** Install Pyomo dependencies ***""
-        conda install -q -y $CONDA_DEPENDENCIES
+        mamba install -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
             echo "*** Install CPLEX ***""
-            conda install -q -y 'cplex>=12.10' docplex \
+            mamba install -q -y 'cplex>=12.10' docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
             echo "*** Install Gurobi ***""
-            conda install -q -y gurobi \
+            mamba install -q -y gurobi \
                 || echo "WARNING: Gurobi is not available"
             echo "*** Install Xpress ***""
-            conda install -q -y xpress \
+            mamba install -q -y xpress \
                 || echo "WARNING: Xpress Community Edition is not available"
             for PKG in cyipopt pymumps scip; do
                 echo "*** Install $PKG ***""
-                conda install -q -y $PKG \
+                mamba install -q -y $PKG \
                     || echo "WARNING: $PKG is not available"
             done
             # TODO: This is a hack to stop test_qt.py from running until we

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -274,7 +274,7 @@ jobs:
         conda config --set always_yes yes
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
-        # Try and install mamba
+        # Try to install mamba
         conda install -q -y -n base conda-libmamba-solver || MAMBA_FAILED=1
         if test -z "$MAMBA_FAILED"; then
             echo "*** Activating the mamba environment solver ***"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -211,9 +211,8 @@ jobs:
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python }}
-        mamba-version: "*"
-        channels: conda,conda-forge,gurobi,ibmdecisionoptimization,fico-xpress
-        #channel-priority: strict
+        channels: conda-forge,gurobi,ibmdecisionoptimization,fico-xpress
+        channel-priority: strict
 
     # GitHub actions is very fragile when it comes to setting up various
     # Python interpreters, expecially the setup-miniconda interface.
@@ -275,6 +274,11 @@ jobs:
         conda config --set always_yes yes
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
+        # Try and install mamba
+        conda install -q -y conda-libmamba-solver
+        if test "$?" == 0; then
+            conda config --set solver libmamba
+        fi
         # Print environment info
         echo "*** CONDA environment: ***"
         conda info
@@ -308,20 +312,20 @@ jobs:
             fi
         done
         echo "*** Install Pyomo dependencies ***"
-        mamba install -q -y $CONDA_DEPENDENCIES
+        conda install -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
             echo "*** Install CPLEX ***"
-            mamba install -q -y 'cplex>=12.10' docplex \
+            conda install -q -y 'cplex>=12.10' docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
             echo "*** Install Gurobi ***"
-            mamba install -q -y gurobi \
+            conda install -q -y gurobi \
                 || echo "WARNING: Gurobi is not available"
             echo "*** Install Xpress ***"
-            mamba install -q -y xpress \
+            conda install -q -y xpress \
                 || echo "WARNING: Xpress Community Edition is not available"
             for PKG in cyipopt pymumps scip; do
                 echo "*** Install $PKG ***"
-                mamba install -q -y $PKG \
+                conda install -q -y $PKG \
                     || echo "WARNING: $PKG is not available"
             done
             # TODO: This is a hack to stop test_qt.py from running until we

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -211,8 +211,8 @@ jobs:
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python }}
-        channels: conda-forge
-        channel-priority: strict
+        channels: conda-forge,gurobi,ibmdecisionoptimization,fico-xpress
+        #channel-priority: strict
 
     # GitHub actions is very fragile when it comes to setting up various
     # Python interpreters, expecially the setup-miniconda interface.
@@ -270,14 +270,15 @@ jobs:
       if: matrix.PYENV == 'conda'
       run: |
         # Switch to a faster environment solver
-        conda update -n base conda
-        conda install -q -y -n base conda-libmamba-solver
+        conda update conda
+        conda install -q -y conda-libmamba-solver
         conda config --set solver libmamba
         # Set up environment
         mkdir -p $GITHUB_WORKSPACE/cache/conda
         conda config --set always_yes yes
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
+        conda config --set channel_priority strict
         # Print environment info
         echo "*** CONDA environment: ***"
         conda info
@@ -311,21 +312,20 @@ jobs:
             fi
         done
         echo "*** Install Pyomo dependencies ***""
-        conda install -q -y -c conda-forge $CONDA_DEPENDENCIES
+        conda install -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
             echo "*** Install CPLEX ***""
-            conda install -q -y -c ibmdecisionoptimization \
-                'cplex>=12.10' docplex \
+            conda install -q -y 'cplex>=12.10' docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
             echo "*** Install Gurobi ***""
-            conda install -q -y -c gurobi gurobi \
+            conda install -q -y gurobi \
                 || echo "WARNING: Gurobi is not available"
             echo "*** Install Xpress ***""
-            conda install -q -y -c fico-xpress xpress \
+            conda install -q -y xpress \
                 || echo "WARNING: Xpress Community Edition is not available"
             for PKG in cyipopt pymumps scip; do
                 echo "*** Install $PKG ***""
-                conda install -q -y -c conda-forge $PKG \
+                conda install -q -y $PKG \
                     || echo "WARNING: $PKG is not available"
             done
             # TODO: This is a hack to stop test_qt.py from running until we

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -275,7 +275,7 @@ jobs:
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
         # Try and install mamba
-        conda install -q -y -n base conda-libmamba-solver || MAMBA_FAILEd=1
+        conda install -q -y -n base conda-libmamba-solver || MAMBA_FAILED=1
         if test -z "$MAMBA_FAILED"; then
             conda config --set solver libmamba
         fi

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -275,7 +275,7 @@ jobs:
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
         # Try and install mamba
-        conda install -q -y conda-libmamba-solver
+        conda install -q -y -n base conda-libmamba-solver
         if test "$?" == 0; then
             conda config --set solver libmamba
         fi

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -213,7 +213,7 @@ jobs:
         python-version: ${{ matrix.python }}
         mamba-version: "*"
         channels: conda,conda-forge,gurobi,ibmdecisionoptimization,fico-xpress
-        channel-priority: strict
+        #channel-priority: strict
 
     # GitHub actions is very fragile when it comes to setting up various
     # Python interpreters, expecially the setup-miniconda interface.

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -273,6 +273,11 @@ jobs:
         conda config --set always_yes yes
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
+        # Switch to a faster environment solver
+        conda install -q -y -n base conda-libmamba-solver
+        conda config --set solver libmamba
+        # Print environment info
+        echo "*** CONDA environment: ***"
         conda info
         conda config --show-sources
         conda config --show channels
@@ -303,16 +308,21 @@ jobs:
                 CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $PKG"
             fi
         done
+        echo "*** Install Pyomo dependencies ***""
         conda install -q -y -c conda-forge $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
+            echo "*** Install CPLEX ***""
             conda install -q -y -c ibmdecisionoptimization \
                 'cplex>=12.10' docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
+            echo "*** Install Gurobi ***""
             conda install -q -y -c gurobi gurobi \
                 || echo "WARNING: Gurobi is not available"
+            echo "*** Install Xpress ***""
             conda install -q -y -c fico-xpress xpress \
                 || echo "WARNING: Xpress Community Edition is not available"
             for PKG in cyipopt pymumps scip; do
+                echo "*** Install $PKG ***""
                 conda install -q -y -c conda-forge $PKG \
                     || echo "WARNING: $PKG is not available"
             done

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -275,8 +275,8 @@ jobs:
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
         # Try and install mamba
-        conda install -q -y -n base conda-libmamba-solver
-        if test "$?" == 0; then
+        conda install -q -y -n base conda-libmamba-solver || MAMBA_FAILEd=1
+        if test -z "$MAMBA_FAILED"; then
             conda config --set solver libmamba
         fi
         # Print environment info

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -269,13 +269,14 @@ jobs:
     - name: Install Python packages (conda)
       if: matrix.PYENV == 'conda'
       run: |
+        # Switch to a faster environment solver
+        conda install -q -y -n base -c conda-forge conda-libmamba-solver
+        conda config --set solver libmamba
+        # Set up environment
         mkdir -p $GITHUB_WORKSPACE/cache/conda
         conda config --set always_yes yes
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
-        # Switch to a faster environment solver
-        conda install -q -y -n base -c conda-forge conda-libmamba-solver
-        conda config --set solver libmamba
         # Print environment info
         echo "*** CONDA environment: ***"
         conda info

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -209,6 +209,8 @@ jobs:
       if: matrix.PYENV == 'conda'
       uses: conda-incubator/setup-miniconda@v2
       with:
+        auto-activate-base: true
+        activate-environment: ""
         auto-update-conda: true
         python-version: ${{ matrix.python }}
         channels: conda-forge
@@ -270,7 +272,8 @@ jobs:
       if: matrix.PYENV == 'conda'
       run: |
         # Switch to a faster environment solver
-        conda install -q -y -n base -c conda-forge conda-libmamba-solver
+        conda update -n base conda
+        conda install -q -y -n base conda-libmamba-solver
         conda config --set solver libmamba
         # Set up environment
         mkdir -p $GITHUB_WORKSPACE/cache/conda

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -277,6 +277,7 @@ jobs:
         # Try and install mamba
         conda install -q -y -n base conda-libmamba-solver || MAMBA_FAILED=1
         if test -z "$MAMBA_FAILED"; then
+            echo "*** Activating the mamba environment solver ***"
             conda config --set solver libmamba
         fi
         # Print environment info

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -270,7 +270,6 @@ jobs:
       if: matrix.PYENV == 'conda'
       run: |
         # Switch to a faster environment solver
-        conda update conda
         conda install -q -y conda-libmamba-solver
         conda config --set solver libmamba
         # Set up environment

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -209,8 +209,6 @@ jobs:
       if: matrix.PYENV == 'conda'
       uses: conda-incubator/setup-miniconda@v2
       with:
-        auto-activate-base: true
-        activate-environment: ""
         auto-update-conda: true
         python-version: ${{ matrix.python }}
         channels: conda-forge

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -212,7 +212,7 @@ jobs:
         auto-update-conda: true
         python-version: ${{ matrix.python }}
         mamba-version: "*"
-        channels: conda-forge,gurobi,ibmdecisionoptimization,fico-xpress
+        channels: conda,conda-forge,gurobi,ibmdecisionoptimization,fico-xpress
         channel-priority: strict
 
     # GitHub actions is very fragile when it comes to setting up various

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -320,7 +320,7 @@ jobs:
             mamba install -q -y xpress \
                 || echo "WARNING: Xpress Community Edition is not available"
             for PKG in cyipopt pymumps scip; do
-                echo "*** Install $PKG ***""
+                echo "*** Install $PKG ***"
                 mamba install -q -y $PKG \
                     || echo "WARNING: $PKG is not available"
             done

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -274,7 +274,7 @@ jobs:
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
         # Switch to a faster environment solver
-        conda install -q -y -n base conda-libmamba-solver
+        conda install -q -y -n base -c conda-forge conda-libmamba-solver
         conda config --set solver libmamba
         # Print environment info
         echo "*** CONDA environment: ***"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -307,16 +307,16 @@ jobs:
                 CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $PKG"
             fi
         done
-        echo "*** Install Pyomo dependencies ***""
+        echo "*** Install Pyomo dependencies ***"
         mamba install -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
-            echo "*** Install CPLEX ***""
+            echo "*** Install CPLEX ***"
             mamba install -q -y 'cplex>=12.10' docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
-            echo "*** Install Gurobi ***""
+            echo "*** Install Gurobi ***"
             mamba install -q -y gurobi \
                 || echo "WARNING: Gurobi is not available"
-            echo "*** Install Xpress ***""
+            echo "*** Install Xpress ***"
             mamba install -q -y xpress \
                 || echo "WARNING: Xpress Community Edition is not available"
             for PKG in cyipopt pymumps scip; do

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -295,7 +295,7 @@ jobs:
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
         # Switch to a faster environment solver
-        conda install -q -y -n base conda-libmamba-solver
+        conda install -q -y -n base -c conda-forge conda-libmamba-solver
         conda config --set solver libmamba
         # Print environment info
         echo "*** CONDA environment: ***"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -290,13 +290,14 @@ jobs:
     - name: Install Python packages (conda)
       if: matrix.PYENV == 'conda'
       run: |
+        # Switch to a faster environment solver
+        conda install -q -y -n base -c conda-forge conda-libmamba-solver
+        conda config --set solver libmamba
+        # Set up environment
         mkdir -p $GITHUB_WORKSPACE/cache/conda
         conda config --set always_yes yes
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
-        # Switch to a faster environment solver
-        conda install -q -y -n base -c conda-forge conda-libmamba-solver
-        conda config --set solver libmamba
         # Print environment info
         echo "*** CONDA environment: ***"
         conda info

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -294,6 +294,11 @@ jobs:
         conda config --set always_yes yes
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
+        # Switch to a faster environment solver
+        conda install -q -y -n base conda-libmamba-solver
+        conda config --set solver libmamba
+        # Print environment info
+        echo "*** CONDA environment: ***"
         conda info
         conda config --show-sources
         conda config --show channels
@@ -324,16 +329,21 @@ jobs:
                 CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $PKG"
             fi
         done
+        echo "*** Install Pyomo dependencies ***""
         conda install -q -y -c conda-forge $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
+            echo "*** Install CPLEX ***""
             conda install -q -y -c ibmdecisionoptimization \
                 'cplex>=12.10' docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
+            echo "*** Install Gurobi ***""
             conda install -q -y -c gurobi gurobi \
                 || echo "WARNING: Gurobi is not available"
+            echo "*** Install Xpress ***""
             conda install -q -y -c fico-xpress xpress \
                 || echo "WARNING: Xpress Community Edition is not available"
             for PKG in cyipopt pymumps scip; do
+                echo "*** Install $PKG ***""
                 conda install -q -y -c conda-forge $PKG \
                     || echo "WARNING: $PKG is not available"
             done

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -295,7 +295,7 @@ jobs:
         conda config --set always_yes yes
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
-        # Try and install mamba
+        # Try to install mamba
         conda install -q -y -n base conda-libmamba-solver || MAMBA_FAILED=1
         if test -z "$MAMBA_FAILED"; then
             echo "*** Activating the mamba environment solver ***"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -232,7 +232,7 @@ jobs:
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python }}
-        channels: conda-forge
+        channels: conda-forge,gurobi,ibmdecisionoptimization,fico-xpress
         channel-priority: strict
 
     # GitHub actions is very fragile when it comes to setting up various
@@ -290,14 +290,17 @@ jobs:
     - name: Install Python packages (conda)
       if: matrix.PYENV == 'conda'
       run: |
-        # Switch to a faster environment solver
-        conda install -q -y -n base -c conda-forge conda-libmamba-solver
-        conda config --set solver libmamba
         # Set up environment
         mkdir -p $GITHUB_WORKSPACE/cache/conda
         conda config --set always_yes yes
         conda config --set auto_update_conda false
         conda config --prepend pkgs_dirs $GITHUB_WORKSPACE/cache/conda
+        # Try and install mamba
+        conda install -q -y -n base conda-libmamba-solver || MAMBA_FAILED=1
+        if test -z "$MAMBA_FAILED"; then
+            echo "*** Activating the mamba environment solver ***"
+            conda config --set solver libmamba
+        fi
         # Print environment info
         echo "*** CONDA environment: ***"
         conda info
@@ -330,22 +333,21 @@ jobs:
                 CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $PKG"
             fi
         done
-        echo "*** Install Pyomo dependencies ***""
-        conda install -q -y -c conda-forge $CONDA_DEPENDENCIES
+        echo "*** Install Pyomo dependencies ***"
+        conda install -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
-            echo "*** Install CPLEX ***""
-            conda install -q -y -c ibmdecisionoptimization \
-                'cplex>=12.10' docplex \
+            echo "*** Install CPLEX ***"
+            conda install -q -y 'cplex>=12.10' docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
-            echo "*** Install Gurobi ***""
-            conda install -q -y -c gurobi gurobi \
+            echo "*** Install Gurobi ***"
+            conda install -q -y gurobi \
                 || echo "WARNING: Gurobi is not available"
-            echo "*** Install Xpress ***""
-            conda install -q -y -c fico-xpress xpress \
+            echo "*** Install Xpress ***"
+            conda install -q -y xpress \
                 || echo "WARNING: Xpress Community Edition is not available"
             for PKG in cyipopt pymumps scip; do
-                echo "*** Install $PKG ***""
-                conda install -q -y -c conda-forge $PKG \
+                echo "*** Install $PKG ***"
+                conda install -q -y $PKG \
                     || echo "WARNING: $PKG is not available"
             done
             # TODO: This is a hack to stop test_qt.py from running until we


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This PR reworks how the GHA jobs configure conda environments, with an eye to reducing the  overall GHA test time.  This makes two significant changes:
- use a consistent set of conda channels instead of specifying a single channel for each `conda install` command.  This prevents unnecessary rework (e.g., installing a package and then later upgrading it from a different channel)
- use `mamba` to solve the environment, if possible.  This improved solver can be significantly more efficient than the default conda solver.

Preliminary testing shaves ~20 minutes off the `win/3.9` job and more than an hour off the problematic win/3.11 job.

## Changes proposed in this PR:
- use `mamba` to solve the environment, if possible
- set a global list of channels (with consistent priority)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
