### PR TITLE
Change GAMS solver type for time limit adjustment

### DIFF
--- a/pyomo/contrib/pyros/util.py
+++ b/pyomo/contrib/pyros/util.py
@@ -117,7 +117,7 @@ def adjust_solver_time_settings(timing_data_obj, solver, config):
         time_remaining = (
             config.time_limit - get_main_elapsed_time(timing_data_obj)
         )
-        if isinstance(solver, type(SolverFactory("gams"))):
+        if isinstance(solver, type(SolverFactory("gams", solver_io="shell"))):
             original_max_time_setting = solver.options["add_options"]
             custom_setting_present = "add_options" in solver.options
 
@@ -185,7 +185,7 @@ def revert_solver_max_time_adjustment(
         assert isinstance(custom_setting_present, bool)
 
         # determine name of option to adjust
-        if isinstance(solver, type(SolverFactory("gams"))):
+        if isinstance(solver, type(SolverFactory("gams", solver_io="shell"))):
             options_key = "add_options"
         elif isinstance(solver, SolverFactory.get_class("baron")):
             options_key = "MaxTime"
@@ -202,7 +202,7 @@ def revert_solver_max_time_adjustment(
                 # if GAMS solver used, need to remove the last entry
                 # of 'add_options', which contains the max time setting
                 # added by PyROS
-                if isinstance(solver, type(SolverFactory("gams"))):
+                if isinstance(solver, type(SolverFactory("gams", solver_io="shell"))):
                     solver.options[options_key].pop()
             else:
                 # remove the max time specification introduced.

--- a/pyomo/contrib/pyros/util.py
+++ b/pyomo/contrib/pyros/util.py
@@ -117,7 +117,7 @@ def adjust_solver_time_settings(timing_data_obj, solver, config):
         time_remaining = (
             config.time_limit - get_main_elapsed_time(timing_data_obj)
         )
-        if isinstance(solver, SolverFactory.get_class("gams")):
+        if isinstance(solver, type(SolverFactory("gams"))):
             original_max_time_setting = solver.options["add_options"]
             custom_setting_present = "add_options" in solver.options
 
@@ -185,7 +185,7 @@ def revert_solver_max_time_adjustment(
         assert isinstance(custom_setting_present, bool)
 
         # determine name of option to adjust
-        if isinstance(solver, SolverFactory.get_class("gams")):
+        if isinstance(solver, type(SolverFactory("gams"))):
             options_key = "add_options"
         elif isinstance(solver, SolverFactory.get_class("baron")):
             options_key = "MaxTime"
@@ -202,7 +202,7 @@ def revert_solver_max_time_adjustment(
                 # if GAMS solver used, need to remove the last entry
                 # of 'add_options', which contains the max time setting
                 # added by PyROS
-                if isinstance(solver, SolverFactory.get_class("gams")):
+                if isinstance(solver, type(SolverFactory("gams"))):
                     solver.options[options_key].pop()
             else:
                 # remove the max time specification introduced.


### PR DESCRIPTION
## Summary/Motivation:

The PyROS subsolver time limit adjustment routine introduced in #2660 does not properly detect the GAMS shell solver type (`solvers.plugins.solvers.GAMS.GAMSShell` or `type(SolverFactory("gams", solver_io="shell"))`,  for which the routine was originally written. This detection issue occurs as the GAMS shell solver type does not inherit from the generic GAMS solver interface type `solvers.plugins.solvers.GAMS.GAMSSolver` (accessed via `SolverFactory.get_class("gams")`).

In this PR, we ensure that the GAMS shell type, rather than the more generic interface, is detected
and acted upon in the subsolver time limit adjustment routine of #2660.

## Changes proposed in this PR:
See summary.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
