### PR TITLE
NLv2: fix warning for skipped suffix values

### DIFF
--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -382,14 +382,14 @@ class _SuffixData(object):
                     missing_other += missing
         if missing_component:
             logger.warning(
-                f"model contained export suffix {suffix.name} that "
-                f"contained {missing_component} component keys that are "
+                f"model contains export suffix '{suffix.name}' that "
+                f"contains {missing_component} component keys that are "
                 "not exported as part of the NL file.  "
                 "Skipping.")
         if missing_other:
             logger.warning(
-                f"model contained export suffix {suffix.name} that "
-                f"contained {missing_other} keys that are not "
+                f"model contains export suffix '{suffix.name}' that "
+                f"contains {missing_other} keys that are not "
                 "Var, Constraint, Objective, or the model.  Skipping.")
 
     def store(self, obj, val):
@@ -398,20 +398,20 @@ class _SuffixData(object):
             return
         if missing == 1:
             logger.warning(
-                f"model contained export suffix {self._name} with "
+                f"model contains export suffix '{self._name}' with "
                 f"{obj.ctype.__name__} key '{obj.name}', but that "
                 "object is not exported as part of the NL file.  "
                 "Skipping.")
         elif missing > 1:
             logger.warning(
-                f"model contained export suffix {self._name} with "
+                f"model contains export suffix '{self._name}' with "
                 f"{obj.ctype.__name__} key '{obj.name}', but that "
                 "object contained {missing} data objects that are "
                 "not exported as part of the NL file.  "
                 "Skipping.")
         else:
             logger.warning(
-                f"model contained export suffix {self._name} with "
+                f"model contains export suffix '{self._name}' with "
                 f"{obj.__class__.__name__} key '{obj}' that is not "
                 "a Var, Constraint, Objective, or the model.  Skipping.")
 

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -416,6 +416,7 @@ class _SuffixData(object):
                 "a Var, Constraint, Objective, or the model.  Skipping.")
 
     def _store(self, obj, val):
+        missing_ct = 0
         _id = id(obj)
         if _id in self._column_order:
             self.var[self._column_order[_id]] = val
@@ -427,14 +428,13 @@ class _SuffixData(object):
             self.prob[0] = val
         elif isinstance(obj, PyomoObject):
             if obj.is_indexed():
-                missing_ct = 0
                 for o in obj.values():
                     missing_ct += self._store(o, val)
-                return missing_ct
             else:
-                return 1
+                missing_ct = 1
         else:
-            return -1
+            missing_ct = -1
+        return missing_ct
 
 
 class _NLWriter_impl(object):

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -379,7 +379,7 @@ class _SuffixData(object):
                 if missing > 0:
                     missing_component += missing
                 else:
-                    missing_other += missing
+                    missing_other -= missing
         if missing_component:
             logger.warning(
                 f"model contains export suffix '{suffix.name}' that "


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
@andrewlee94 pointed out a bug in generating the warning message for Suffix values that are being skipped by the NLv2 writer.

## Changes proposed in this PR:
- Correctly tabulate the number of skipped Suffix values for the case where only some of an indexed suffix is skipped
- Improve warning message grammar/formatting
- Add tests covering these warnings

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
