### PR TITLE
Fix Sphinx warnings

### DIFF
--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -68,6 +68,7 @@ extensions = [
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
+    'sphinx.ext.todo',
     'sphinx_copybutton',
     #'sphinx.ext.githubpages',
 ]
@@ -121,7 +122,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = False
+todo_include_todos = True
 
 # If true, doctest flags (comments looking like # doctest: FLAG, ...) at
 # the ends of lines and <BLANKLINE> markers are removed for all code

--- a/pyomo/contrib/appsi/solvers/highs.py
+++ b/pyomo/contrib/appsi/solvers/highs.py
@@ -165,11 +165,13 @@ class Highs(PersistentBase, PersistentSolver):
     @property
     def highs_options(self):
         """
+        A dictionary mapping solver options to values for those options. These
+        are solver specific.
+
         Returns
         -------
-        highs_options: dict
-            A dictionary mapping solver options to values for those options. These
-            are solver specific.
+        dict
+           A dictionary mapping solver options to values for those options
         """
         return self._solver_options
 

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1679,10 +1679,11 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
 
         This is roughly equivalent to
 
+        .. code-block:: python
+
             iter(block for block in itertools.chain(
-                [self], self.component_data_objects(descend_into, ...))
-                if block.active == active
-            )
+                 [self], self.component_data_objects(descend_into, ...))
+                 if block.active == active)
 
         Notes
         -----

--- a/pyomo/core/plugins/transform/scaling.py
+++ b/pyomo/core/plugins/transform/scaling.py
@@ -68,9 +68,7 @@ class ScaleModel(Transformation):
         >>> print(value(scaled_model.scaled_obj))
         101.0
 
-    ToDo
-    ====
-    - implement an option to change the variables names or not
+    .. todo:: Implement an option to change the variables names or not
 
     """
 


### PR DESCRIPTION
## Summary/Motivation:
Fixing sphinx warnings that have been accumulating from docstring formatting issues. I also made a slight change to the docs configuration to display `todo` blocks in docstrings. Remaining warnings will be fixed in #2711 

## Changes proposed in this PR:
- Fix sphinx formatting issues in several docstrings
- Display todo blocks that appear in docstrings

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
