### PR TITLE
Apply `black` to `pyomo/version` directory `py` files

### DIFF
--- a/pyomo/version/info.py
+++ b/pyomo/version/info.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-_init_url="$URL$"
+_init_url = "$URL$"
 
 # NOTE: releaselevel should be left at 'invalid' for trunk development
 #     and set to 'final' for releases.  During development, the
@@ -24,19 +24,20 @@ _init_url="$URL$"
 # {hash}" and set the serial number to YYMMDDhhmm.  The serial number
 # should generally be left at 0, unless a downstream package is tracking
 # main and needs a hard reference to "suitably new" development.
-major=6
-minor=4
-micro=5
-releaselevel='invalid'
-#releaselevel='final'
-serial=0
+major = 6
+minor = 4
+micro = 5
+releaselevel = 'invalid'
+# releaselevel='final'
+serial = 0
 
 if releaselevel == 'final':
     pass
-elif '/tags/' in _init_url:                #pragma:nocover
+elif '/tags/' in _init_url:  # pragma:nocover
     releaselevel = 'final'
 elif releaselevel == 'invalid':
     from os.path import abspath, dirname, exists, join
+
     if __file__.endswith('setup.py'):
         # This file is being sources (exec'ed) from setup.py.
         # dirname(__file__) setup.py's scope is the root sourec directory
@@ -49,20 +50,22 @@ elif releaselevel == 'invalid':
         # __file__ fails if someone does os.chdir() before
         # sys.argv[0] also fails because it doesn't not always contains the path
         from inspect import getfile, currentframe
+
         _rootdir = join(dirname(abspath(getfile(currentframe()))), '..', '..')
 
     if exists(join(_rootdir, '.git')):
         try:
             with open(join(_rootdir, '.git', 'HEAD')) as _FILE:
-                _ref = _FILE.readline().strip()           #pragma:nocover
+                _ref = _FILE.readline().strip()  # pragma:nocover
             releaselevel = 'devel {%s}' % (
-                _ref.split('/')[-1].split('\\')[-1], )    #pragma:nocover
+                _ref.split('/')[-1].split('\\')[-1],
+            )  # pragma:nocover
         except:
-            releaselevel = 'devel'         #pragma:nocover
+            releaselevel = 'devel'  # pragma:nocover
     elif exists(join(_rootdir, '.svn')):
-        releaselevel = 'devel {svn}'       #pragma:nocover
+        releaselevel = 'devel {svn}'  # pragma:nocover
     else:
-        releaselevel = 'VOTD'              #pragma:nocover
+        releaselevel = 'VOTD'  # pragma:nocover
 
 
 version_info = (major, minor, micro, releaselevel, serial)
@@ -70,7 +73,7 @@ version_info = (major, minor, micro, releaselevel, serial)
 version = '.'.join(str(x) for x in version_info[:3])
 __version__ = version
 if releaselevel != 'final':
-    version += ' ('+releaselevel+')'
+    version += ' (' + releaselevel + ')'
 if releaselevel.startswith('devel'):
     __version__ += ".dev%d" % (serial,)
 elif releaselevel.startswith('VOTD'):

--- a/pyomo/version/tests/check.py
+++ b/pyomo/version/tests/check.py
@@ -15,7 +15,8 @@ try:
     import pyomo
     import pyomo.environ
     import pyomo.core
+
     print("OK")
 except Exception:
     e = sys.exc_info()[1]
-    print("Pyomo package error: "+str(e))
+    print("Pyomo package error: " + str(e))

--- a/pyomo/version/tests/test_version.py
+++ b/pyomo/version/tests/test_version.py
@@ -14,14 +14,14 @@ import pyomo.version as pyomo_ver
 
 
 class Tests(unittest.TestCase):
-
     def test_releaselevel(self):
         _relLevel = pyomo_ver.version_info[3].split('{')[0].strip()
-        self.assertIn( _relLevel,('devel','VOTD','final') )
+        self.assertIn(_relLevel, ('devel', 'VOTD', 'final'))
 
     def test_version(self):
         try:
             import pkg_resources
+
             version = pkg_resources.get_distribution('pyomo').version
         except:
             self.skipTest('pkg_resources is not available')
@@ -35,6 +35,7 @@ class Tests(unittest.TestCase):
             self.assertEqual(str(tmp_[1]), str(pyomo_ver.version_info[1]))
             if tmp_[-1].startswith('dev'):
                 import pyomo.version.info as info
+
                 self.assertEqual(int(tmp_[-1][3:]), info.serial)
                 tmp_.pop()
             if len(tmp_) > 2:


### PR DESCRIPTION
## Fixes (Partly) #329 

## Summary/Motivation:
This is the first in a relatively long string of PRs to apply PEP8 standards via `black` to Pyomo. We are following the standard used by IDAES _except_ that we are adding the `-S` option: `Don't normalize string quotes or prefixes` and the `-C` option: `Don't use trailing commas as a reason to split lines.`

**NOTE**: All changes are NFC.

Full command used: `cd pyomo/version && black -S -C .`

## Changes proposed in this PR:
- Apply `black` to the `pyomo/version` directory `py` files

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
