### PR TITLE
Apply `black` to `doc` directory `py` files

### DIFF
--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -30,9 +30,11 @@ sys.path.insert(0, os.path.abspath('tests'))
 try:
     print("Regenerating SPY files...")
     from strip_examples import generate_spy_files
+
     generate_spy_files(os.path.abspath('tests'))
-    generate_spy_files(os.path.abspath(os.path.join(
-        'library_reference','kernel','examples')))
+    generate_spy_files(
+        os.path.abspath(os.path.join('library_reference', 'kernel', 'examples'))
+    )
 finally:
     sys.path.pop(0)
 
@@ -74,7 +76,7 @@ extensions = [
 ]
 
 viewcode_follow_imported_members = True
-#napoleon_include_private_with_doc = True
+# napoleon_include_private_with_doc = True
 
 copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
 copybutton_prompt_is_regexp = True
@@ -102,6 +104,7 @@ author = u'Pyomo Developers'
 #
 # The short X.Y version.
 import pyomo.version
+
 version = pyomo.version.__version__
 # The full version, including alpha/beta/rc tags.
 release = pyomo.version.__version__
@@ -138,7 +141,7 @@ numfig = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-#html_theme = 'alabaster'
+# html_theme = 'alabaster'
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 html_theme = 'sphinx_rtd_theme'
@@ -148,10 +151,11 @@ html_theme = 'sphinx_rtd_theme'
 # method prototype (tested 15 April 21 with Sphinx=3.5.4 and
 # sphinx-rtd-theme=0.5.2).
 html4_writer = True
-#html5_writer = True
+# html5_writer = True
 
 if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme
+
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
@@ -164,9 +168,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
-html_css_files = [
-    'theme_overrides.css',
-]
+html_css_files = ['theme_overrides.css']
 
 html_favicon = "../logos/pyomo/favicon.ico"
 
@@ -183,15 +185,12 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
@@ -200,20 +199,14 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-    (master_doc, 'pyomo.tex', 'Pyomo Documentation',
-     'Pyomo', 'manual'),
-]
+latex_documents = [(master_doc, 'pyomo.tex', 'Pyomo Documentation', 'Pyomo', 'manual')]
 
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'pyomo', 'Pyomo Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, 'pyomo', 'Pyomo Documentation', [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -222,27 +215,41 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'pyomo', 'Pyomo Documentation',
-     author, 'Pyomo', 'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        'pyomo',
+        'Pyomo Documentation',
+        author,
+        'Pyomo',
+        'One line description of project.',
+        'Miscellaneous',
+    )
 ]
 
-#autodoc_member_order = 'bysource'
-#autodoc_member_order = 'groupwise'
+# autodoc_member_order = 'bysource'
+# autodoc_member_order = 'groupwise'
 
 # -- Check which conditional dependencies are available ------------------
 # Used for skipping certain doctests
 from sphinx.ext.doctest import doctest
+
 doctest_default_flags = (
-    doctest.ELLIPSIS + doctest.NORMALIZE_WHITESPACE +
-    doctest.IGNORE_EXCEPTION_DETAIL + doctest.DONT_ACCEPT_TRUE_FOR_1
+    doctest.ELLIPSIS
+    + doctest.NORMALIZE_WHITESPACE
+    + doctest.IGNORE_EXCEPTION_DETAIL
+    + doctest.DONT_ACCEPT_TRUE_FOR_1
 )
+
+
 class IgnoreResultOutputChecker(doctest.OutputChecker):
     IGNORE_RESULT = doctest.register_optionflag('IGNORE_RESULT')
+
     def check_output(self, want, got, optionflags):
         if optionflags & self.IGNORE_RESULT:
             return True
         return super().check_output(want, got, optionflags)
+
+
 doctest.OutputChecker = IgnoreResultOutputChecker
 
 doctest_global_setup = '''

--- a/doc/OnlineDocs/library_reference/kernel/examples/aml_example.py
+++ b/doc/OnlineDocs/library_reference/kernel/examples/aml_example.py
@@ -1,5 +1,6 @@
 # @Import_Syntax
 import pyomo.environ as aml
+
 # @Import_Syntax
 
 datafile = None
@@ -7,8 +8,7 @@ datafile = None
 # @AbstractModels
 m = aml.AbstractModel()
 # ... define model ...
-instance = \
-    m.create_instance(datafile)
+instance = m.create_instance(datafile)
 
 # @AbstractModels
 del datafile
@@ -19,29 +19,25 @@ m.b = aml.Block()
 # @ConcreteModels
 
 
-
 # @Sets_1
-m.s = aml.Set(initialize=[1,2],
-              ordered=True)
+m.s = aml.Set(initialize=[1, 2], ordered=True)
 # @Sets_1
 # @Sets_2
 # [1,2,3]
-m.q = aml.RangeSet(1,3)
+m.q = aml.RangeSet(1, 3)
 # @Sets_2
 
 
-
 # @Parameters_single
-m.p = aml.Param(mutable=True,
-                initialize=0)
+m.p = aml.Param(mutable=True, initialize=0)
 # @Parameters_single
 # @Parameters_dict
 # pd[1] = 0, pd[2] = 1
 def pd_(m, i):
     return m.s.ord(i) - 1
-m.pd = aml.Param(m.s,
-                 mutable=True,
-                 rule=pd_)
+
+
+m.pd = aml.Param(m.s, mutable=True, rule=pd_)
 # @Parameters_dict
 # @Parameters_list
 
@@ -53,36 +49,34 @@ m.pd = aml.Param(m.s,
 # @Parameters_list
 
 
-
 # @Variables_single
-m.v = aml.Var(initialize=1.0,
-              bounds=(1,4))
+m.v = aml.Var(initialize=1.0, bounds=(1, 4))
 
 # @Variables_single
 # @Variables_dict
-m.vd = aml.Var(m.s,
-               bounds=(None,9))
+m.vd = aml.Var(m.s, bounds=(None, 9))
 
 # @Variables_dict
 # @Variables_list
 # used 1-based indexing
 def vl_(m, i):
     return (i, None)
+
+
 m.vl = aml.VarList(bounds=vl_)
 for j in m.q:
     m.vl.add()
 # @Variables_list
 
 # @Constraints_single
-m.c = aml.Constraint(expr=\
-    sum(m.vd.values()) <= 9)
+m.c = aml.Constraint(expr=sum(m.vd.values()) <= 9)
 # @Constraints_single
 # @Constraints_dict
-def cd_(m,i,j):
+def cd_(m, i, j):
     return m.vd[i] == j
-m.cd = aml.Constraint(m.s,
-                      m.q,
-                      rule=cd_)
+
+
+m.cd = aml.Constraint(m.s, m.q, rule=cd_)
 
 
 # @Constraints_dict
@@ -90,13 +84,8 @@ m.cd = aml.Constraint(m.s,
 # uses 1-based indexing
 m.cl = aml.ConstraintList()
 for j in m.q:
-    m.cl.add(
-        aml.inequality(
-            -5,
-            m.vl[j]-m.v,
-            5))
+    m.cl.add(aml.inequality(-5, m.vl[j] - m.v, 5))
 # @Constraints_list
-
 
 
 # @Expressions_single
@@ -105,8 +94,9 @@ m.e = aml.Expression(expr=-m.v)
 # @Expressions_dict
 def ed_(m, i):
     return -m.vd[i]
-m.ed = aml.Expression(m.s,
-                      rule=ed_)
+
+
+m.ed = aml.Expression(m.s, rule=ed_)
 # @Expressions_dict
 # @Expressions_list
 
@@ -117,15 +107,15 @@ m.ed = aml.Expression(m.s,
 # @Expressions_list
 
 
-
 # @Objectives_single
 m.o = aml.Objective(expr=-m.v)
 # @Objectives_single
 # @Objectives_dict
 def od_(m, i):
     return -m.vd[i]
-m.od = aml.Objective(m.s,
-                     rule=od_)
+
+
+m.od = aml.Objective(m.s, rule=od_)
 # @Objectives_dict
 # @Objectives_list
 # uses 1-based indexing
@@ -136,14 +126,9 @@ for j in m.q:
 # @Objectives_list
 
 
-
 # @SOS_single
-m.sos1 = aml.SOSConstraint(
-    var=m.vl,
-    level=1)
-m.sos2 = aml.SOSConstraint(
-    var=m.vd,
-    level=2)
+m.sos1 = aml.SOSConstraint(var=m.vl, level=1)
+m.sos2 = aml.SOSConstraint(var=m.vd, level=2)
 # @SOS_single
 # @SOS_dict
 def sd_(m, i):
@@ -152,10 +137,9 @@ def sd_(m, i):
     elif i == 2:
         t = list(m.vl.values())
     return t
-m.sd = aml.SOSConstraint(
-    [1,2],
-    rule=sd_,
-    level=1)
+
+
+m.sd = aml.SOSConstraint([1, 2], rule=sd_, level=1)
 # @SOS_dict
 # @SOS_list
 
@@ -166,10 +150,8 @@ m.sd = aml.SOSConstraint(
 # @SOS_list
 
 
-
 # @Suffix_single
-m.dual = aml.Suffix(
-    direction=aml.Suffix.IMPORT)
+m.dual = aml.Suffix(direction=aml.Suffix.IMPORT)
 # @Suffix_single
 # @Suffix_dict
 #
@@ -178,20 +160,12 @@ m.dual = aml.Suffix(
 # @Suffix_dict
 
 
-
 # @Piecewise_1d
-breakpoints = [1,2,3,4]
-values = [1,2,1,2]
+breakpoints = [1, 2, 3, 4]
+values = [1, 2, 1, 2]
 m.f = aml.Var()
-m.pw = aml.Piecewise(
-    m.f,
-    m.v,
-    pw_pts=breakpoints,
-    f_rule=values,
-    pw_constr_type='EQ')
+m.pw = aml.Piecewise(m.f, m.v, pw_pts=breakpoints, f_rule=values, pw_constr_type='EQ')
 # @Piecewise_1d
-
 
 
 m.pprint()
-

--- a/doc/OnlineDocs/library_reference/kernel/examples/conic.py
+++ b/doc/OnlineDocs/library_reference/kernel/examples/conic.py
@@ -1,24 +1,22 @@
 # @Class
 import pyomo.kernel as pmo
+
 m = pmo.block()
 m.x1 = pmo.variable(lb=0)
 m.x2 = pmo.variable()
 m.r = pmo.variable(lb=0)
-m.q = pmo.conic.primal_exponential(
-    x1=m.x1,
-    x2=m.x2,
-    r=m.r)
+m.q = pmo.conic.primal_exponential(x1=m.x1, x2=m.x2, r=m.r)
 # @Class
 del m
 
 # @Domain
 import pyomo.kernel as pmo
 import math
+
 m = pmo.block()
 m.x = pmo.variable(lb=0)
 m.y = pmo.variable(lb=0)
 m.b = pmo.conic.primal_exponential.as_domain(
-    x1=math.sqrt(2)*m.x,
-    x2=2.0,
-    r=2*(m.x + m.y))
+    x1=math.sqrt(2) * m.x, x2=2.0, r=2 * (m.x + m.y)
+)
 # @Domain

--- a/doc/OnlineDocs/library_reference/kernel/examples/kernel_example.py
+++ b/doc/OnlineDocs/library_reference/kernel/examples/kernel_example.py
@@ -1,5 +1,6 @@
 # @Import_Syntax
 import pyomo.kernel as pmo
+
 # @Import_Syntax
 
 data = None
@@ -9,6 +10,8 @@ def create(data):
     instance = pmo.block()
     # ... define instance ...
     return instance
+
+
 instance = create(data)
 # @AbstractModels
 del data
@@ -19,16 +22,14 @@ m.b = pmo.block()
 # @ConcreteModels
 
 
-
 # @Sets_1
-m.s = [1,2]
+m.s = [1, 2]
 
 # @Sets_1
 # @Sets_2
 # [0,1,2]
 m.q = range(3)
 # @Sets_2
-
 
 
 # @Parameters_single
@@ -38,7 +39,7 @@ m.p = pmo.parameter(0)
 # @Parameters_dict
 # pd[1] = 0, pd[2] = 1
 m.pd = pmo.parameter_dict()
-for k,i in enumerate(m.s):
+for k, i in enumerate(m.s):
     m.pd[i] = pmo.parameter(k)
 
 
@@ -48,16 +49,12 @@ for k,i in enumerate(m.s):
 # pl[0] = 0, pl[0] = 1, ...
 m.pl = pmo.parameter_list()
 for j in m.q:
-    m.pl.append(
-        pmo.parameter(j))
+    m.pl.append(pmo.parameter(j))
 # @Parameters_list
 
 
-
 # @Variables_single
-m.v = pmo.variable(value=1,
-                   lb=1,
-                   ub=4)
+m.v = pmo.variable(value=1, lb=1, ub=4)
 # @Variables_single
 # @Variables_dict
 m.vd = pmo.variable_dict()
@@ -68,37 +65,26 @@ for i in m.s:
 # used 0-based indexing
 m.vl = pmo.variable_list()
 for j in m.q:
-    m.vl.append(
-        pmo.variable(lb=i))
+    m.vl.append(pmo.variable(lb=i))
 
 # @Variables_list
 
 
-
 # @Constraints_single
-m.c = pmo.constraint(
-    sum(m.vd.values()) <= 9)
+m.c = pmo.constraint(sum(m.vd.values()) <= 9)
 # @Constraints_single
 # @Constraints_dict
 m.cd = pmo.constraint_dict()
 for i in m.s:
     for j in m.q:
-        m.cd[i,j] = \
-            pmo.constraint(
-                body=m.vd[i],
-                rhs=j)
+        m.cd[i, j] = pmo.constraint(body=m.vd[i], rhs=j)
 # @Constraints_dict
 # @Constraints_list
 # uses 0-based indexing
 m.cl = pmo.constraint_list()
 for j in m.q:
-    m.cl.append(
-        pmo.constraint(
-            lb=-5,
-            body=m.vl[j]-m.v,
-            ub=5))
+    m.cl.append(pmo.constraint(lb=-5, body=m.vl[j] - m.v, ub=5))
 # @Constraints_list
-
 
 
 # @Expressions_single
@@ -107,17 +93,14 @@ m.e = pmo.expression(-m.v)
 # @Expressions_dict
 m.ed = pmo.expression_dict()
 for i in m.s:
-    m.ed[i] = \
-        pmo.expression(-m.vd[i])
+    m.ed[i] = pmo.expression(-m.vd[i])
 # @Expressions_dict
 # @Expressions_list
 # uses 0-based indexed
 m.el = pmo.expression_list()
 for j in m.q:
-    m.el.append(
-        pmo.expression(-m.vl[j]))
+    m.el.append(pmo.expression(-m.vl[j]))
 # @Expressions_list
-
 
 
 # @Objectives_single
@@ -126,17 +109,14 @@ m.o = pmo.objective(-m.v)
 # @Objectives_dict
 m.od = pmo.objective_dict()
 for i in m.s:
-    m.od[i] = \
-        pmo.objective(-m.vd[i])
+    m.od[i] = pmo.objective(-m.vd[i])
 # @Objectives_dict
 # @Objectives_list
 # uses 0-based indexing
 m.ol = pmo.objective_list()
 for j in m.q:
-    m.ol.append(
-        pmo.objective(-m.vl[j]))
+    m.ol.append(pmo.objective(-m.vl[j]))
 # @Objectives_list
-
 
 
 # @SOS_single
@@ -153,46 +133,30 @@ m.sd[1] = pmo.sos1(m.vd.values())
 m.sd[2] = pmo.sos1(m.vl)
 
 
-
-
-
-
-
 # @SOS_dict
 # @SOS_list
 # uses 0-based indexing
 m.sl = pmo.sos_list()
 for i in m.s:
-    m.sl.append(pmo.sos1(
-        [m.vl[i], m.vd[i]]))
+    m.sl.append(pmo.sos1([m.vl[i], m.vd[i]]))
 # @SOS_list
 
 
-
 # @Suffix_single
-m.dual = pmo.suffix(
-    direction=pmo.suffix.IMPORT)
+m.dual = pmo.suffix(direction=pmo.suffix.IMPORT)
 # @Suffix_single
 # @Suffix_dict
 m.suffixes = pmo.suffix_dict()
-m.suffixes['dual'] = pmo.suffix(
-    direction=pmo.suffix.IMPORT)
+m.suffixes['dual'] = pmo.suffix(direction=pmo.suffix.IMPORT)
 # @Suffix_dict
 
 
-
 # @Piecewise_1d
-breakpoints = [1,2,3,4]
-values = [1,2,1,2]
+breakpoints = [1, 2, 3, 4]
+values = [1, 2, 1, 2]
 m.f = pmo.variable()
-m.pw = pmo.piecewise(
-    breakpoints,
-    values,
-    input=m.v,
-    output=m.f,
-    bound='eq')
+m.pw = pmo.piecewise(breakpoints, values, input=m.v, output=m.f, bound='eq')
 # @Piecewise_1d
-
 
 
 pmo.pprint(m)

--- a/doc/OnlineDocs/library_reference/kernel/examples/kernel_subclassing.py
+++ b/doc/OnlineDocs/library_reference/kernel/examples/kernel_subclassing.py
@@ -3,6 +3,7 @@ import pyomo.kernel
 # @Nonnegative
 class NonNegativeVariable(pyomo.kernel.variable):
     """A non-negative variable."""
+
     __slots__ = ()
 
     def __init__(self, **kwds):
@@ -19,45 +20,55 @@ class NonNegativeVariable(pyomo.kernel.variable):
     def lb(self):
         # calls the base class property getter
         return pyomo.kernel.variable.lb.fget(self)
+
     @lb.setter
     def lb(self, lb):
         if lb < 0:
             raise ValueError("lower bound must be non-negative")
         # calls the base class property setter
         pyomo.kernel.variable.lb.fset(self, lb)
+
+
 # @Nonnegative
 
 # @Point
 class Point(pyomo.kernel.variable_tuple):
     """A 3-dimensional point in Cartesian space with the
     z coordinate restricted to non-negative values."""
+
     __slots__ = ()
 
     def __init__(self):
         super(Point, self).__init__(
-            (pyomo.kernel.variable(),
-             pyomo.kernel.variable(),
-             NonNegativeVariable()))
+            (pyomo.kernel.variable(), pyomo.kernel.variable(), NonNegativeVariable())
+        )
+
     @property
     def x(self):
         return self[0]
+
     @property
     def y(self):
         return self[1]
+
     @property
     def z(self):
         return self[2]
+
+
 # @Point
 
 # @SOC
 class SOC(pyomo.kernel.constraint):
     """A convex second-order cone constraint"""
+
     __slots__ = ()
 
     def __init__(self, point):
         assert isinstance(point.z, NonNegativeVariable)
-        super(SOC, self).__init__(
-            point.x**2 + point.y**2 <= point.z**2)
+        super(SOC, self).__init__(point.x**2 + point.y**2 <= point.z**2)
+
+
 # @SOC
 
 # @Usage

--- a/doc/OnlineDocs/library_reference/kernel/examples/transformer.py
+++ b/doc/OnlineDocs/library_reference/kernel/examples/transformer.py
@@ -3,32 +3,38 @@ import pyomo.kernel
 
 import pympler.asizeof
 
+
 def _fmt(num, suffix='B'):
     """format memory output"""
     if num is None:
         return "<unknown>"
-    for unit in ['','K','M','G','T','P','E','Z']:
+    for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
         if abs(num) < 1000.0:
             return "%3.1f %s%s" % (num, unit, suffix)
         num /= 1000.0
     return "%.1f %s%s" % (num, 'Yi', suffix)
 
+
 # @kernel
 class Transformer(pyomo.kernel.block):
     def __init__(self):
-        super(Transformer,self).__init__()
+        super(Transformer, self).__init__()
         self._a = pyomo.kernel.parameter()
         self._v_in = pyomo.kernel.expression()
         self._v_out = pyomo.kernel.expression()
-        self._c = pyomo.kernel.constraint(
-            self._a * self._v_out == self._v_in)
+        self._c = pyomo.kernel.constraint(self._a * self._v_out == self._v_in)
+
     def set_ratio(self, a):
         assert a > 0
         self._a.value = a
+
     def connect_v_in(self, v_in):
         self._v_in.expr = v_in
+
     def connect_v_out(self, v_out):
         self._v_out.expr = v_out
+
+
 # @kernel
 
 print(_fmt(pympler.asizeof.asizeof(Transformer())))
@@ -39,9 +45,10 @@ def Transformer():
     b._a = pyomo.environ.Param(mutable=True)
     b._v_in = pyomo.environ.Expression()
     b._v_out = pyomo.environ.Expression()
-    b._c = pyomo.environ.Constraint(expr=\
-        b._a * b._v_out == b._v_in)
+    b._c = pyomo.environ.Constraint(expr=b._a * b._v_out == b._v_in)
     return b
+
+
 # @aml
 
 print(_fmt(pympler.asizeof.asizeof(Transformer())))

--- a/doc/OnlineDocs/tests/data/ABCD2.py
+++ b/doc/OnlineDocs/tests/data/ABCD2.py
@@ -2,13 +2,13 @@ from pyomo.environ import *
 
 model = AbstractModel()
 
-model.Z = Set(initialize=[('A1','B1',1), ('A2','B2',2), ('A3','B3',3)])
-#model.Z = Set(dimen=3)
+model.Z = Set(initialize=[('A1', 'B1', 1), ('A2', 'B2', 2), ('A3', 'B3', 3)])
+# model.Z = Set(dimen=3)
 model.D = Param(model.Z)
 
 instance = model.create_instance('ABCD2.dat')
 
-print('Z '+str(sorted(list(instance.Z.data()))))
+print('Z ' + str(sorted(list(instance.Z.data()))))
 print('D')
 for key in sorted(instance.D.keys()):
-    print(name(instance.D,key)+" "+str(value(instance.D[key])))
+    print(name(instance.D, key) + " " + str(value(instance.D[key])))

--- a/doc/OnlineDocs/tests/data/ABCD3.py
+++ b/doc/OnlineDocs/tests/data/ABCD3.py
@@ -7,7 +7,7 @@ model.D = Param(model.Z)
 
 instance = model.create_instance('ABCD3.dat')
 
-print('Z '+str(sorted(list(instance.Z.data()))))
+print('Z ' + str(sorted(list(instance.Z.data()))))
 print('D')
 for key in sorted(instance.D.keys()):
-    print(name(instance.D,key)+" "+str(value(instance.D[key])))
+    print(name(instance.D, key) + " " + str(value(instance.D[key])))

--- a/doc/OnlineDocs/tests/data/ABCD4.py
+++ b/doc/OnlineDocs/tests/data/ABCD4.py
@@ -7,7 +7,7 @@ model.Y = Param(model.Z)
 
 instance = model.create_instance('ABCD4.dat')
 
-print('Z '+str(sorted(list(instance.Z.data()))))
+print('Z ' + str(sorted(list(instance.Z.data()))))
 print('Y')
 for key in sorted(instance.Y.keys()):
-    print(name(instance.Y,key)+" "+str(value(instance.Y[key])))
+    print(name(instance.Y, key) + " " + str(value(instance.Y[key])))

--- a/doc/OnlineDocs/tests/data/ABCD5.py
+++ b/doc/OnlineDocs/tests/data/ABCD5.py
@@ -10,10 +10,10 @@ model.W = Param(model.Z)
 
 instance = model.create_instance('ABCD5.dat')
 
-print('Z '+str(sorted(list(instance.Z.data()))))
+print('Z ' + str(sorted(list(instance.Z.data()))))
 print('Y')
 for key in sorted(instance.Y.keys()):
-    print(name(instance.Y,key)+" "+str(value(instance.Y[key])))
+    print(name(instance.Y, key) + " " + str(value(instance.Y[key])))
 print('W')
 for key in sorted(instance.W.keys()):
-    print(name(instance.W,key)+" "+str(value(instance.W[key])))
+    print(name(instance.W, key) + " " + str(value(instance.W[key])))

--- a/doc/OnlineDocs/tests/data/ABCD6.py
+++ b/doc/OnlineDocs/tests/data/ABCD6.py
@@ -7,7 +7,7 @@ model.D = Param(model.Z)
 
 instance = model.create_instance('ABCD6.dat')
 
-print('Z '+str(sorted(list(instance.Z.data()))))
+print('Z ' + str(sorted(list(instance.Z.data()))))
 print('D')
 for key in sorted(instance.D.keys()):
-    print(name(instance.D,key)+" "+str(value(instance.D[key])))
+    print(name(instance.D, key) + " " + str(value(instance.D[key])))

--- a/doc/OnlineDocs/tests/data/ABCD7.py
+++ b/doc/OnlineDocs/tests/data/ABCD7.py
@@ -10,10 +10,10 @@ model.Y = Param(model.Z)
 try:
     instance = model.create_instance('ABCD7.dat')
 except pyomo.common.errors.ApplicationError as e:
-    print("ERROR "+str(e))
+    print("ERROR " + str(e))
     sys.exit(1)
 
-print('Z '+str(sorted(list(instance.Z.data()))))
+print('Z ' + str(sorted(list(instance.Z.data()))))
 print('Y')
 for key in sorted(instance.Y.keys()):
-    print(name(instance.Y,key)+" "+str(value(instance.Y[key])))
+    print(name(instance.Y, key) + " " + str(value(instance.Y[key])))

--- a/doc/OnlineDocs/tests/data/ABCD8.py
+++ b/doc/OnlineDocs/tests/data/ABCD8.py
@@ -10,10 +10,10 @@ model.Y = Param(model.Z)
 try:
     instance = model.create_instance('ABCD8.dat')
 except pyomo.common.errors.ApplicationError as e:
-    print("ERROR "+str(e))
+    print("ERROR " + str(e))
     sys.exit(1)
 
-print('Z '+str(sorted(list(instance.Z.data()))))
+print('Z ' + str(sorted(list(instance.Z.data()))))
 print('Y')
 for key in sorted(instance.Y.keys()):
-    print(name(instance.Y,key)+" "+str(value(instance.Y[key])))
+    print(name(instance.Y, key) + " " + str(value(instance.Y[key])))

--- a/doc/OnlineDocs/tests/data/ABCD9.py
+++ b/doc/OnlineDocs/tests/data/ABCD9.py
@@ -10,10 +10,10 @@ model.Y = Param(model.Z)
 try:
     instance = model.create_instance('ABCD9.dat')
 except pyomo.common.errors.ApplicationError as e:
-    print("ERROR "+str(e))
+    print("ERROR " + str(e))
     sys.exit(1)
 
-print('Z '+str(sorted(list(instance.Z.data()))))
+print('Z ' + str(sorted(list(instance.Z.data()))))
 print('Y')
 for key in sorted(instance.Y.keys()):
-    print(instance.Y[key]+" "+str(value(instance.Y[key])))
+    print(instance.Y[key] + " " + str(value(instance.Y[key])))

--- a/doc/OnlineDocs/tests/data/diet1.py
+++ b/doc/OnlineDocs/tests/data/diet1.py
@@ -2,7 +2,7 @@
 from pyomo.environ import *
 
 infinity = float('inf')
-MAX_FOOD_SUPPLY = 20.0 # There is a finite food supply
+MAX_FOOD_SUPPLY = 20.0  # There is a finite food supply
 
 model = AbstractModel()
 
@@ -11,8 +11,12 @@ model = AbstractModel()
 model.FOOD = Set()
 model.cost = Param(model.FOOD, within=PositiveReals)
 model.f_min = Param(model.FOOD, within=NonNegativeReals, default=0.0)
-def f_max_validate (model, value, j):
+
+
+def f_max_validate(model, value, j):
     return model.f_max[j] > model.f_min[j]
+
+
 model.f_max = Param(model.FOOD, validate=f_max_validate, default=MAX_FOOD_SUPPLY)
 
 model.NUTR = Set()
@@ -22,29 +26,50 @@ model.amt = Param(model.NUTR, model.FOOD, within=NonNegativeReals)
 
 # --------------------------------------------------------
 
+
 def Buy_bounds(model, i):
     return (model.f_min[i], model.f_max[i])
+
+
 model.Buy = Var(model.FOOD, bounds=Buy_bounds, within=NonNegativeIntegers)
 
 # --------------------------------------------------------
 
+
 def Total_Cost_rule(model):
     return sum(model.cost[j] * model.Buy[j] for j in model.FOOD)
+
+
 model.Total_Cost = Objective(rule=Total_Cost_rule, sense=minimize)
 
 # --------------------------------------------------------
 
+
 def Entree_rule(model):
-    entrees = ['Cheeseburger', 'Ham Sandwich', 'Hamburger', 'Fish Sandwich', 'Chicken Sandwich']
+    entrees = [
+        'Cheeseburger',
+        'Ham Sandwich',
+        'Hamburger',
+        'Fish Sandwich',
+        'Chicken Sandwich',
+    ]
     return sum(model.Buy[e] for e in entrees) >= 1
+
+
 model.Entree = Constraint(rule=Entree_rule)
+
 
 def Side_rule(model):
     sides = ['Fries', 'Sausage Biscuit']
     return sum(model.Buy[s] for s in sides) >= 1
+
+
 model.Side = Constraint(rule=Side_rule)
+
 
 def Drink_rule(model):
     drinks = ['Lowfat Milk', 'Orange Juice']
     return sum(model.Buy[d] for d in drinks) >= 1
+
+
 model.Drink = Constraint(rule=Drink_rule)

--- a/doc/OnlineDocs/tests/data/import1.tab.py
+++ b/doc/OnlineDocs/tests/data/import1.tab.py
@@ -10,4 +10,4 @@ instance = model.create_instance('import1.tab.dat')
 print('Y')
 keys = instance.Y.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.Y[key])))
+    print(str(key) + " " + str(value(instance.Y[key])))

--- a/doc/OnlineDocs/tests/data/import2.tab.py
+++ b/doc/OnlineDocs/tests/data/import2.tab.py
@@ -7,8 +7,8 @@ model.Y = Param(model.A)
 
 instance = model.create_instance('import2.tab.dat')
 
-print('A '+str(sorted(list(instance.A.data()))))
+print('A ' + str(sorted(list(instance.A.data()))))
 print('Y')
 keys = instance.Y.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.Y[key])))
+    print(str(key) + " " + str(value(instance.Y[key])))

--- a/doc/OnlineDocs/tests/data/import3.tab.py
+++ b/doc/OnlineDocs/tests/data/import3.tab.py
@@ -6,4 +6,4 @@ model.A = Set()
 
 instance = model.create_instance('import3.tab.dat')
 
-print('A '+str(sorted(list(instance.A.data()))))
+print('A ' + str(sorted(list(instance.A.data()))))

--- a/doc/OnlineDocs/tests/data/import4.tab.py
+++ b/doc/OnlineDocs/tests/data/import4.tab.py
@@ -6,4 +6,4 @@ model.C = Set(dimen=2)
 
 instance = model.create_instance('import4.tab.dat')
 
-print('C '+str(sorted(list(instance.C.data()))))
+print('C ' + str(sorted(list(instance.C.data()))))

--- a/doc/OnlineDocs/tests/data/import5.tab.py
+++ b/doc/OnlineDocs/tests/data/import5.tab.py
@@ -6,4 +6,4 @@ model.B = Set(dimen=2)
 
 instance = model.create_instance('import5.tab.dat')
 
-print('B '+str(list(sorted(instance.B.data()))))
+print('B ' + str(list(sorted(instance.B.data()))))

--- a/doc/OnlineDocs/tests/data/import6.tab.py
+++ b/doc/OnlineDocs/tests/data/import6.tab.py
@@ -6,4 +6,4 @@ model.p = Param()
 
 instance = model.create_instance('import6.tab.dat')
 
-print('p '+str(value(instance.p)))
+print('p ' + str(value(instance.p)))

--- a/doc/OnlineDocs/tests/data/import7.tab.py
+++ b/doc/OnlineDocs/tests/data/import7.tab.py
@@ -4,14 +4,14 @@ model = AbstractModel()
 
 model.I = Set(initialize=['I1', 'I2', 'I3', 'I4'])
 model.A = Set(initialize=['A1', 'A2', 'A3'])
-model.U = Param(model.I,model.A)
+model.U = Param(model.I, model.A)
 # BUG:  This should cause an error
-#model.U = Param(model.A,model.I)
+# model.U = Param(model.A,model.I)
 
 instance = model.create_instance('import7.tab.dat')
 
-print('I '+str(sorted(list(instance.I.data()))))
-print('A '+str(sorted(list(instance.A.data()))))
+print('I ' + str(sorted(list(instance.I.data()))))
+print('A ' + str(sorted(list(instance.A.data()))))
 print('U')
 for key in sorted(instance.U.keys()):
-    print(name(instance.U,key)+" "+str(value(instance.U[key])))
+    print(name(instance.U, key) + " " + str(value(instance.U[key])))

--- a/doc/OnlineDocs/tests/data/import8.tab.py
+++ b/doc/OnlineDocs/tests/data/import8.tab.py
@@ -4,12 +4,12 @@ model = AbstractModel()
 
 model.I = Set(initialize=['I1', 'I2', 'I3', 'I4'])
 model.A = Set(initialize=['A1', 'A2', 'A3'])
-model.U = Param(model.A,model.I)
+model.U = Param(model.A, model.I)
 
 instance = model.create_instance('import8.tab.dat')
 
-print('A '+str(sorted(list(instance.A.data()))))
-print('I '+str(sorted(list(instance.I.data()))))
+print('A ' + str(sorted(list(instance.A.data()))))
+print('I ' + str(sorted(list(instance.I.data()))))
 print('U')
 for key in sorted(instance.U.keys()):
-    print(name(instance.U,key)+" "+str(value(instance.U[key])))
+    print(name(instance.U, key) + " " + str(value(instance.U[key])))

--- a/doc/OnlineDocs/tests/data/param2.py
+++ b/doc/OnlineDocs/tests/data/param2.py
@@ -11,4 +11,4 @@ instance = model.create_instance('param2.dat')
 
 keys = instance.B.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.B[key])))
+    print(str(key) + " " + str(value(instance.B[key])))

--- a/doc/OnlineDocs/tests/data/param2a.py
+++ b/doc/OnlineDocs/tests/data/param2a.py
@@ -11,4 +11,4 @@ instance = model.create_instance('param2a.dat')
 
 keys = instance.B.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.B[key])))
+    print(str(key) + " " + str(value(instance.B[key])))

--- a/doc/OnlineDocs/tests/data/param3.py
+++ b/doc/OnlineDocs/tests/data/param3.py
@@ -14,12 +14,12 @@ instance = model.create_instance('param3.dat')
 print('B')
 keys = instance.B.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.B[key])))
+    print(str(key) + " " + str(value(instance.B[key])))
 print('C')
 keys = instance.C.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.C[key])))
+    print(str(key) + " " + str(value(instance.C[key])))
 print('D')
 keys = instance.D.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.D[key])))
+    print(str(key) + " " + str(value(instance.D[key])))

--- a/doc/OnlineDocs/tests/data/param3a.py
+++ b/doc/OnlineDocs/tests/data/param3a.py
@@ -14,12 +14,12 @@ instance = model.create_instance('param3a.dat')
 print('B')
 keys = instance.B.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.B[key])))
+    print(str(key) + " " + str(value(instance.B[key])))
 print('C')
 keys = instance.C.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.C[key])))
+    print(str(key) + " " + str(value(instance.C[key])))
 print('D')
 keys = instance.D.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.D[key])))
+    print(str(key) + " " + str(value(instance.D[key])))

--- a/doc/OnlineDocs/tests/data/param3b.py
+++ b/doc/OnlineDocs/tests/data/param3b.py
@@ -14,12 +14,12 @@ instance = model.create_instance('param3b.dat')
 print('B')
 keys = instance.B.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.B[key])))
+    print(str(key) + " " + str(value(instance.B[key])))
 print('C')
 keys = instance.C.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.C[key])))
+    print(str(key) + " " + str(value(instance.C[key])))
 print('D')
 keys = instance.D.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.D[key])))
+    print(str(key) + " " + str(value(instance.D[key])))

--- a/doc/OnlineDocs/tests/data/param3c.py
+++ b/doc/OnlineDocs/tests/data/param3c.py
@@ -14,12 +14,12 @@ instance = model.create_instance('param3c.dat')
 print('B')
 keys = instance.B.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.B[key])))
+    print(str(key) + " " + str(value(instance.B[key])))
 print('C')
 keys = instance.C.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.C[key])))
+    print(str(key) + " " + str(value(instance.C[key])))
 print('D')
 keys = instance.D.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.D[key])))
+    print(str(key) + " " + str(value(instance.D[key])))

--- a/doc/OnlineDocs/tests/data/param4.py
+++ b/doc/OnlineDocs/tests/data/param4.py
@@ -12,4 +12,4 @@ instance = model.create_instance('param4.dat')
 print('B')
 keys = instance.B.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.B[key])))
+    print(str(key) + " " + str(value(instance.B[key])))

--- a/doc/OnlineDocs/tests/data/param5.py
+++ b/doc/OnlineDocs/tests/data/param5.py
@@ -11,4 +11,4 @@ instance = model.create_instance('param5.dat')
 
 keys = instance.B.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.B[key])))
+    print(str(key) + " " + str(value(instance.B[key])))

--- a/doc/OnlineDocs/tests/data/param5a.py
+++ b/doc/OnlineDocs/tests/data/param5a.py
@@ -11,4 +11,4 @@ instance = model.create_instance('param5a.dat')
 
 keys = instance.B.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.B[key])))
+    print(str(key) + " " + str(value(instance.B[key])))

--- a/doc/OnlineDocs/tests/data/param6.py
+++ b/doc/OnlineDocs/tests/data/param6.py
@@ -14,12 +14,12 @@ instance = model.create_instance('param6.dat')
 keys = instance.B.keys()
 print('B')
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.B[key])))
+    print(str(key) + " " + str(value(instance.B[key])))
 print('C')
 keys = instance.C.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.C[key])))
+    print(str(key) + " " + str(value(instance.C[key])))
 print('D')
 keys = instance.D.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.D[key])))
+    print(str(key) + " " + str(value(instance.D[key])))

--- a/doc/OnlineDocs/tests/data/param6a.py
+++ b/doc/OnlineDocs/tests/data/param6a.py
@@ -14,12 +14,12 @@ instance = model.create_instance('param6a.dat')
 keys = instance.B.keys()
 print('B')
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.B[key])))
+    print(str(key) + " " + str(value(instance.B[key])))
 print('C')
 keys = instance.C.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.C[key])))
+    print(str(key) + " " + str(value(instance.C[key])))
 print('D')
 keys = instance.D.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.D[key])))
+    print(str(key) + " " + str(value(instance.D[key])))

--- a/doc/OnlineDocs/tests/data/param7a.py
+++ b/doc/OnlineDocs/tests/data/param7a.py
@@ -11,4 +11,4 @@ instance = model.create_instance('param7a.dat')
 
 keys = instance.B.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.B[key])))
+    print(str(key) + " " + str(value(instance.B[key])))

--- a/doc/OnlineDocs/tests/data/param7b.py
+++ b/doc/OnlineDocs/tests/data/param7b.py
@@ -11,4 +11,4 @@ instance = model.create_instance('param7b.dat')
 
 keys = instance.B.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.B[key])))
+    print(str(key) + " " + str(value(instance.B[key])))

--- a/doc/OnlineDocs/tests/data/param8a.py
+++ b/doc/OnlineDocs/tests/data/param8a.py
@@ -11,4 +11,4 @@ instance = model.create_instance('param8a.dat')
 
 keys = instance.B.keys()
 for key in sorted(keys):
-    print(str(key)+" "+str(value(instance.B[key])))
+    print(str(key) + " " + str(value(instance.B[key])))

--- a/doc/OnlineDocs/tests/data/set1.py
+++ b/doc/OnlineDocs/tests/data/set1.py
@@ -10,4 +10,4 @@ instance = model.create_instance('set1.dat')
 
 print(sorted(list(instance.A.data())))
 print(sorted((instance.B.data())))
-print(sorted(list((instance.C.data())), key=lambda x:x if type(x) is str else str(x)))
+print(sorted(list((instance.C.data())), key=lambda x: x if type(x) is str else str(x)))

--- a/doc/OnlineDocs/tests/data/set3.py
+++ b/doc/OnlineDocs/tests/data/set3.py
@@ -6,10 +6,14 @@ model = AbstractModel()
 model.A = Set()
 model.B = Set(model.A)
 # @decl
-#model.C = Set(model.A,model.A)
+# model.C = Set(model.A,model.A)
 
 instance = model.create_instance('set3.dat')
 
-print(sorted(list(instance.A.data()), key=lambda x:x if type(x) is str else str(x)))
-print(sorted(list(instance.B[1].data()), key=lambda x:x if type(x) is str else str(x)))
-print(sorted(list(instance.B['aaa'].data()), key=lambda x:x if type(x) is str else str(x)))
+print(sorted(list(instance.A.data()), key=lambda x: x if type(x) is str else str(x)))
+print(sorted(list(instance.B[1].data()), key=lambda x: x if type(x) is str else str(x)))
+print(
+    sorted(
+        list(instance.B['aaa'].data()), key=lambda x: x if type(x) is str else str(x)
+    )
+)

--- a/doc/OnlineDocs/tests/data/set5.py
+++ b/doc/OnlineDocs/tests/data/set5.py
@@ -9,5 +9,5 @@ model.A = Set(dimen=4)
 instance = model.create_instance('set5.dat')
 
 
-for tpl in sorted(list(instance.A.data()), key=lambda x:tuple(map(str,x))):
+for tpl in sorted(list(instance.A.data()), key=lambda x: tuple(map(str, x))):
     print(tpl)

--- a/doc/OnlineDocs/tests/data/table0.py
+++ b/doc/OnlineDocs/tests/data/table0.py
@@ -2,7 +2,7 @@ from pyomo.environ import *
 
 model = AbstractModel()
 
-model.A = Set(initialize=['A1','A2','A3'])
+model.A = Set(initialize=['A1', 'A2', 'A3'])
 model.M = Param(model.A)
 
 instance = model.create_instance('table0.dat')

--- a/doc/OnlineDocs/tests/data/table0.ul.py
+++ b/doc/OnlineDocs/tests/data/table0.ul.py
@@ -2,7 +2,7 @@ from pyomo.environ import *
 
 model = AbstractModel()
 
-model.A = Set(initialize=['A1','A2','A3'])
+model.A = Set(initialize=['A1', 'A2', 'A3'])
 model.M = Param(model.A)
 
 instance = model.create_instance('table0.ul.dat')

--- a/doc/OnlineDocs/tests/data/table1.py
+++ b/doc/OnlineDocs/tests/data/table1.py
@@ -2,7 +2,7 @@ from pyomo.environ import *
 
 model = AbstractModel()
 
-model.A = Set(initialize=['A1','A2','A3'])
+model.A = Set(initialize=['A1', 'A2', 'A3'])
 model.M = Param(model.A)
 
 instance = model.create_instance('table1.dat')

--- a/doc/OnlineDocs/tests/data/table2.py
+++ b/doc/OnlineDocs/tests/data/table2.py
@@ -2,8 +2,8 @@ from pyomo.environ import *
 
 model = AbstractModel()
 
-model.A = Set(initialize=['A1','A2','A3'])
-model.B = Set(initialize=['B1','B2','B3'])
+model.A = Set(initialize=['A1', 'A2', 'A3'])
+model.B = Set(initialize=['B1', 'B2', 'B3'])
 
 model.M = Param(model.A)
 model.N = Param(model.A, model.B)

--- a/doc/OnlineDocs/tests/data/table3.py
+++ b/doc/OnlineDocs/tests/data/table3.py
@@ -3,7 +3,7 @@ from pyomo.environ import *
 model = AbstractModel()
 
 model.A = Set()
-model.B = Set(initialize=['B1','B2','B3'])
+model.B = Set(initialize=['B1', 'B2', 'B3'])
 model.Z = Set(dimen=2)
 
 model.M = Param(model.A)

--- a/doc/OnlineDocs/tests/data/table3.ul.py
+++ b/doc/OnlineDocs/tests/data/table3.ul.py
@@ -3,7 +3,7 @@ from pyomo.environ import *
 model = AbstractModel()
 
 model.A = Set()
-model.B = Set(initialize=['B1','B2','B3'])
+model.B = Set(initialize=['B1', 'B2', 'B3'])
 model.Z = Set(dimen=2)
 
 model.M = Param(model.A)

--- a/doc/OnlineDocs/tests/data/table7.py
+++ b/doc/OnlineDocs/tests/data/table7.py
@@ -2,7 +2,7 @@ from pyomo.environ import *
 
 model = AbstractModel()
 
-model.A = Set(initialize=['A1','A2','A3'])
+model.A = Set(initialize=['A1', 'A2', 'A3'])
 model.M = Param(model.A)
 model.Z = Set(dimen=2)
 

--- a/doc/OnlineDocs/tests/dataportal/PP_sqlite.py
+++ b/doc/OnlineDocs/tests/dataportal/PP_sqlite.py
@@ -23,20 +23,18 @@ for table in ['PPtable']:
     c.execute('DROP TABLE IF EXISTS ' + table)
 conn.commit()
 
-c.execute('''
+c.execute(
+    '''
 CREATE TABLE PPtable (
     A text not null,
     B text not null,
     PP float not null
 )
-''')
+'''
+)
 conn.commit()
 
-data = [
-    ("A1", "B1", 4.3),
-    ("A2", "B2", 4.4),
-    ("A3", "B3", 4.5)
-]
+data = [("A1", "B1", 4.3), ("A2", "B2", 4.4), ("A3", "B3", 4.5)]
 for row in data:
     c.execute('''INSERT INTO PPtable VALUES (?,?,?)''', row)
 conn.commit()

--- a/doc/OnlineDocs/tests/dataportal/dataportal_tab.py
+++ b/doc/OnlineDocs/tests/dataportal/dataportal_tab.py
@@ -50,7 +50,7 @@ instance.pprint()
 # @param2
 model = AbstractModel()
 data = DataPortal()
-model.A = Set(initialize=['A1','A2','A3'])
+model.A = Set(initialize=['A1', 'A2', 'A3'])
 model.y = Param(model.A)
 data.load(filename='Y.tab', param=model.y)
 instance = model.create_instance(data)
@@ -60,10 +60,10 @@ instance.pprint()
 # @param4
 model = AbstractModel()
 data = DataPortal()
-model.A = Set(initialize=['A1','A2','A3'])
+model.A = Set(initialize=['A1', 'A2', 'A3'])
 model.x = Param(model.A)
 model.w = Param(model.A)
-data.load(filename='XW.tab', param=(model.x,model.w))
+data.load(filename='XW.tab', param=(model.x, model.w))
 instance = model.create_instance(data)
 # @param4
 instance.pprint()
@@ -83,8 +83,7 @@ model = AbstractModel()
 data = DataPortal()
 model.A = Set()
 model.w = Param(model.A)
-data.load(filename='XW.tab', select=('A','W'), 
-                param=model.w, index=model.A)
+data.load(filename='XW.tab', select=('A', 'W'), param=model.w, index=model.A)
 instance = model.create_instance(data)
 # @param5
 instance.pprint()
@@ -92,11 +91,10 @@ instance.pprint()
 # @param6
 model = AbstractModel()
 data = DataPortal()
-model.A = Set(initialize=['A1','A2','A3'])
-model.I = Set(initialize=['I1','I2','I3','I4'])
+model.A = Set(initialize=['A1', 'A2', 'A3'])
+model.I = Set(initialize=['I1', 'I2', 'I3', 'I4'])
 model.u = Param(model.I, model.A)
-data.load(filename='U.tab', param=model.u, 
-                                    format='array')
+data.load(filename='U.tab', param=model.u, format='array')
 instance = model.create_instance(data)
 # @param6
 instance.pprint()
@@ -104,11 +102,10 @@ instance.pprint()
 # @param7
 model = AbstractModel()
 data = DataPortal()
-model.A = Set(initialize=['A1','A2','A3'])
-model.I = Set(initialize=['I1','I2','I3','I4'])
+model.A = Set(initialize=['A1', 'A2', 'A3'])
+model.I = Set(initialize=['I1', 'I2', 'I3', 'I4'])
 model.t = Param(model.A, model.I)
-data.load(filename='U.tab', param=model.t, 
-                                    format='transposed_array')
+data.load(filename='U.tab', param=model.t, format='transposed_array')
 instance = model.create_instance(data)
 # @param7
 instance.pprint()
@@ -126,7 +123,7 @@ instance.pprint()
 # @param9
 model = AbstractModel()
 data = DataPortal()
-model.A = Set(initialize=['A1','A2','A3','A4'])
+model.A = Set(initialize=['A1', 'A2', 'A3', 'A4'])
 model.y = Param(model.A)
 data.load(filename='Y.tab', param=model.y)
 instance = model.create_instance(data)
@@ -149,8 +146,8 @@ data = DataPortal()
 model.A = Set()
 model.B = Set()
 model.q = Param(model.A, model.B)
-data.load(filename='PP.tab', param=model.q, index=(model.A,model.B))
-#instance = model.create_instance(data)
+data.load(filename='PP.tab', param=model.q, index=(model.A, model.B))
+# instance = model.create_instance(data)
 # @param11
 # --------------------------------------------------
 # @concrete1
@@ -169,17 +166,17 @@ data.load(filename='Y.tab', param="y", format="table")
 
 model = ConcreteModel()
 model.z = Param(initialize=data['z'])
-model.y = Param(['A1','A2','A3'], initialize=data['y'])
+model.y = Param(['A1', 'A2', 'A3'], initialize=data['y'])
 # @concrete2
 model.pprint()
 # --------------------------------------------------
 # @getitem
 data = DataPortal()
 data.load(filename='A.tab', set="A", format="set")
-print(data['A'])    #['A1', 'A2', 'A3']
+print(data['A'])  # ['A1', 'A2', 'A3']
 
 data.load(filename='Z.tab', param="z", format="param")
-print(data['z'])    #1.1
+print(data['z'])  # 1.1
 
 data.load(filename='Y.tab', param="y", format="table")
 for key in sorted(data['y']):
@@ -191,8 +188,7 @@ model = AbstractModel()
 data = DataPortal()
 model.A = Set(dimen=2)
 model.p = Param(model.A)
-data.load(filename='excel.xls', range='PPtable', 
-                    param=model.p, index=model.A)
+data.load(filename='excel.xls', range='PPtable', param=model.p, index=model.A)
 instance = model.create_instance(data)
 # @excel1
 instance.pprint()
@@ -202,7 +198,7 @@ model = AbstractModel()
 data = DataPortal()
 model.A = Set(dimen=2)
 model.p = Param(model.A)
-#data.load(filename='excel.xls', range='AX2:AZ5', 
+# data.load(filename='excel.xls', range='AX2:AZ5',
 #                    param=model.p, index=model.A)
 instance = model.create_instance(data)
 # @excel2
@@ -213,15 +209,20 @@ model = AbstractModel()
 data = DataPortal()
 model.A = Set(dimen=2)
 model.p = Param(model.A)
-data.load(filename='PP.sqlite', using='sqlite3',
-                   table='PPtable',
-                   param=model.p, index=model.A)
+data.load(
+    filename='PP.sqlite', using='sqlite3', table='PPtable', param=model.p, index=model.A
+)
 instance = model.create_instance(data)
 # @db1
 data = DataPortal()
-data.load(filename='PP.sqlite', using='sqlite3',
-                   table='PPtable',
-                   param=model.p, index=model.A, text_factory=str)
+data.load(
+    filename='PP.sqlite',
+    using='sqlite3',
+    table='PPtable',
+    param=model.p,
+    index=model.A,
+    text_factory=str,
+)
 instance = model.create_instance(data)
 instance.pprint()
 # --------------------------------------------------
@@ -230,15 +231,24 @@ model = AbstractModel()
 data = DataPortal()
 model.A = Set()
 model.p = Param(model.A)
-data.load(filename='PP.sqlite', using='sqlite3',
-                   query="SELECT A,PP FROM PPtable",
-                   param=model.p, index=model.A)
+data.load(
+    filename='PP.sqlite',
+    using='sqlite3',
+    query="SELECT A,PP FROM PPtable",
+    param=model.p,
+    index=model.A,
+)
 instance = model.create_instance(data)
 # @db2
 data = DataPortal()
-data.load(filename='PP.sqlite', using='sqlite3',
-                   query="SELECT A,PP FROM PPtable",
-                   param=model.p, index=model.A, text_factory=str)
+data.load(
+    filename='PP.sqlite',
+    using='sqlite3',
+    query="SELECT A,PP FROM PPtable",
+    param=model.p,
+    index=model.A,
+    text_factory=str,
+)
 instance = model.create_instance(data)
 instance.pprint()
 # --------------------------------------------------
@@ -248,17 +258,24 @@ if False:
     data = DataPortal()
     model.A = Set()
     model.p = Param(model.A)
-    data.load(filename="Driver={MySQL ODBC 5.2 UNICODE Driver}; Database=Pyomo; Server=localhost; User=pyomo;",
-            using='pypyodbc',
-            query="SELECT A,PP FROM PPtable",
-            param=model.p, index=model.A)
+    data.load(
+        filename="Driver={MySQL ODBC 5.2 UNICODE Driver}; Database=Pyomo; Server=localhost; User=pyomo;",
+        using='pypyodbc',
+        query="SELECT A,PP FROM PPtable",
+        param=model.p,
+        index=model.A,
+    )
     instance = model.create_instance(data)
     # @db3
     data = DataPortal()
-    data.load(filename="Driver={MySQL ODBC 5.2 UNICODE Driver}; Database=Pyomo; Server=localhost; User=pyomo;",
-            using='pypyodbc',
-            query="SELECT A,PP FROM PPtable",
-            param=model.p, index=model.A, text_factory=str)
+    data.load(
+        filename="Driver={MySQL ODBC 5.2 UNICODE Driver}; Database=Pyomo; Server=localhost; User=pyomo;",
+        using='pypyodbc',
+        query="SELECT A,PP FROM PPtable",
+        param=model.p,
+        index=model.A,
+        text_factory=str,
+    )
     instance = model.create_instance(data)
     instance.pprint()
 # --------------------------------------------------
@@ -298,11 +315,9 @@ model = AbstractModel()
 model.C = Set(dimen=2)
 data = DataPortal()
 data.load(filename='C.tab', set=model.C, namespace='ns1')
-data.load(filename='D.tab', set=model.C, namespace='ns2', 
-                            format='set_array')
+data.load(filename='D.tab', set=model.C, namespace='ns2', format='set_array')
 instance1 = model.create_instance(data, namespaces=['ns1'])
 instance2 = model.create_instance(data, namespaces=['ns2'])
 # @namespaces1
 instance1.pprint()
 instance2.pprint()
-

--- a/doc/OnlineDocs/tests/dataportal/param_initialization.py
+++ b/doc/OnlineDocs/tests/dataportal/param_initialization.py
@@ -9,14 +9,16 @@ model.a = Param(initialize=1.1)
 
 # Initialize with a dictionary
 # @decl2
-model.b = Param([1,2,3], initialize={1:1, 2:2, 3:3})
+model.b = Param([1, 2, 3], initialize={1: 1, 2: 2, 3: 3})
 # @decl2
 
 # Initialize with a function that returns native Python data
 # @decl3
 def c(model):
-    return {1:1, 2:2, 3:3}
-model.c = Param([1,2,3], initialize=c)
+    return {1: 1, 2: 2, 3: 3}
+
+
+model.c = Param([1, 2, 3], initialize=c)
 # @decl3
 
 model.pprint(verbose=True)

--- a/doc/OnlineDocs/tests/dataportal/set_initialization.py
+++ b/doc/OnlineDocs/tests/dataportal/set_initialization.py
@@ -5,15 +5,15 @@ model = ConcreteModel()
 
 # Initialize with a list, tuple or set
 # @decl2
-model.A = Set(initialize=[2,3,5])
-model.B = Set(initialize=set([2,3,5]))
-model.C = Set(initialize=(2,3,5))
+model.A = Set(initialize=[2, 3, 5])
+model.B = Set(initialize=set([2, 3, 5]))
+model.C = Set(initialize=(2, 3, 5))
 # @decl2
 
 # Initialize with a generator
 # @decl3
 model.D = Set(initialize=range(9))
-model.E = Set(initialize=(i for i in model.B if i%2 == 0))
+model.E = Set(initialize=(i for i in model.B if i % 2 == 0))
 # @decl3
 
 # Initialize with a numpy
@@ -25,17 +25,19 @@ model.F = Set(initialize=f)
 # Initialize with a function that returns native Python data
 # @decl5
 def g(model):
-    return [2,3,5]
+    return [2, 3, 5]
+
+
 model.G = Set(initialize=g)
 # @decl5
 
 # Initialize an indexed set with a dictionary
 # @decl6
 H_init = {}
-H_init[2] = [1,3,5]
-H_init[3] = [2,4,6]
-H_init[4] = [3,5,7]
-model.H = Set([2,3,4],initialize=H_init)
+H_init[2] = [1, 3, 5]
+H_init[3] = [2, 4, 6]
+H_init[4] = [3, 5, 7]
+model.H = Set([2, 3, 4], initialize=H_init)
 # @decl6
 
 model.pprint(verbose=True)

--- a/doc/OnlineDocs/tests/expr/design.py
+++ b/doc/OnlineDocs/tests/expr/design.py
@@ -1,6 +1,6 @@
 from pyomo.environ import *
 
-#---------------------------------------------
+# ---------------------------------------------
 # @categories
 m = ConcreteModel()
 m.p = Param(default=10, mutable=False)
@@ -11,18 +11,18 @@ m.y.fixed = True
 # @categories
 m.pprint()
 
-#---------------------------------------------
+# ---------------------------------------------
 # @named_expression
 M = ConcreteModel()
 M.v = Var()
 M.w = Var()
 
-M.e = Expression(expr=2*M.v)
-f = M.e + 3                     # f == 2*v + 3
-M.e += M.w                      # f == 2*v + 3 + w
+M.e = Expression(expr=2 * M.v)
+f = M.e + 3  # f == 2*v + 3
+M.e += M.w  # f == 2*v + 3 + w
 # @named_expression
 
-#---------------------------------------------
+# ---------------------------------------------
 # @cm1
 M = ConcreteModel()
 M.x = Var(range(5))
@@ -39,7 +39,7 @@ print(s)
 print(e)
 
 
-#---------------------------------------------
+# ---------------------------------------------
 # @cm2
 M = ConcreteModel()
 M.x = Var(range(5))
@@ -51,4 +51,3 @@ with linear_expression() as e:
 # @cm2
 print("cm2")
 print(e)
-

--- a/doc/OnlineDocs/tests/expr/index.py
+++ b/doc/OnlineDocs/tests/expr/index.py
@@ -1,11 +1,10 @@
 from pyomo.environ import *
 
-#---------------------------------------------
+# ---------------------------------------------
 # @simple
 M = ConcreteModel()
 M.v = Var()
 
-e = M.v*2
+e = M.v * 2
 # @simple
 print(e)
-

--- a/doc/OnlineDocs/tests/expr/managing.py
+++ b/doc/OnlineDocs/tests/expr/managing.py
@@ -3,14 +3,14 @@ from math import isclose
 import math
 import copy
 
-#---------------------------------------------
+# ---------------------------------------------
 # @ex1
 from pyomo.core.expr import current as EXPR
 
 M = ConcreteModel()
 M.x = Var()
 
-e = sin(M.x) + 2*M.x
+e = sin(M.x) + 2 * M.x
 
 # sin(x) + 2*x
 print(EXPR.expression_to_string(e))
@@ -19,7 +19,7 @@ print(EXPR.expression_to_string(e))
 print(EXPR.expression_to_string(e, verbose=True))
 # @ex1
 
-#---------------------------------------------
+# ---------------------------------------------
 # @ex2
 from pyomo.core.expr import current as EXPR
 
@@ -27,13 +27,13 @@ M = ConcreteModel()
 M.x = Var()
 M.y = Var()
 
-e = sin(M.x) + 2*M.y
+e = sin(M.x) + 2 * M.y
 
 # sin(x1) + 2*x2
 print(EXPR.expression_to_string(e, labeler=NumericLabeler('x')))
 # @ex2
 
-#---------------------------------------------
+# ---------------------------------------------
 # @ex3
 from pyomo.core.expr import current as EXPR
 
@@ -41,13 +41,13 @@ M = ConcreteModel()
 M.x = Var()
 M.y = Var()
 
-e = sin(M.x) + 2*M.y + M.x*M.y - 3
+e = sin(M.x) + 2 * M.y + M.x * M.y - 3
 
 # -3 + 2*y + sin(x) + x*y
 print(EXPR.expression_to_string(e, standardize=True))
 # @ex3
 
-#---------------------------------------------
+# ---------------------------------------------
 # @ex4
 from pyomo.core.expr import current as EXPR
 
@@ -59,31 +59,31 @@ with EXPR.clone_counter() as counter:
     e1 = sin(M.x)
     e2 = e1.clone()
     total = counter.count - start
-    assert(total == 1)
+    assert total == 1
 # @ex4
 
-#---------------------------------------------
+# ---------------------------------------------
 # @ex5
 M = ConcreteModel()
 M.x = Var()
-M.x.value = math.pi/2.0
+M.x.value = math.pi / 2.0
 val = value(M.x)
-assert(isclose(val, math.pi/2.0))
+assert isclose(val, math.pi / 2.0)
 # @ex5
 # @ex6
 val = M.x()
-assert(isclose(val, math.pi/2.0))
+assert isclose(val, math.pi / 2.0)
 # @ex6
 
-#---------------------------------------------
+# ---------------------------------------------
 # @ex7
 M = ConcreteModel()
 M.x = Var()
 val = value(M.x, exception=False)
-assert(val is None)
+assert val is None
 # @ex7
 
-#---------------------------------------------
+# ---------------------------------------------
 # @ex8
 from pyomo.core.expr import current as EXPR
 
@@ -91,12 +91,12 @@ M = ConcreteModel()
 M.x = Var()
 M.p = Param(mutable=True)
 
-e = M.p+M.x
+e = M.p + M.x
 s = set([type(M.p)])
-assert(list(EXPR.identify_components(e, s)) == [M.p])
+assert list(EXPR.identify_components(e, s)) == [M.p]
 # @ex8
 
-#---------------------------------------------
+# ---------------------------------------------
 # @ex9
 from pyomo.core.expr import current as EXPR
 
@@ -104,20 +104,22 @@ M = ConcreteModel()
 M.x = Var()
 M.y = Var()
 
-e = M.x+M.y
+e = M.x + M.y
 M.y.value = 1
 M.y.fixed = True
 
-assert(set(id(v) for v in EXPR.identify_variables(e)) == set([id(M.x), id(M.y)]))
-assert(set(id(v) for v in EXPR.identify_variables(e, include_fixed=False)) == set([id(M.x)]))
+assert set(id(v) for v in EXPR.identify_variables(e)) == set([id(M.x), id(M.y)])
+assert set(id(v) for v in EXPR.identify_variables(e, include_fixed=False)) == set(
+    [id(M.x)]
+)
 # @ex9
 
-#---------------------------------------------
+# ---------------------------------------------
 # @visitor1
 from pyomo.core.expr import current as EXPR
 
-class SizeofVisitor(EXPR.SimpleExpressionVisitor):
 
+class SizeofVisitor(EXPR.SimpleExpressionVisitor):
     def __init__(self):
         self.counter = 0
 
@@ -126,9 +128,11 @@ class SizeofVisitor(EXPR.SimpleExpressionVisitor):
 
     def finalize(self):
         return self.counter
+
+
 # @visitor1
 
-#---------------------------------------------
+# ---------------------------------------------
 # @visitor2
 def sizeof_expression(expr):
     #
@@ -139,16 +143,18 @@ def sizeof_expression(expr):
     # Compute the value using the :func:`xbfs` search method.
     #
     return visitor.xbfs(expr)
+
+
 # @visitor2
 
-#---------------------------------------------
+# ---------------------------------------------
 # @visitor3
 from pyomo.core.expr import current as EXPR
 
-class CloneVisitor(EXPR.ExpressionValueVisitor):
 
+class CloneVisitor(EXPR.ExpressionValueVisitor):
     def __init__(self):
-        self.memo = {'__block_scope__': { id(None): False }}
+        self.memo = {'__block_scope__': {id(None): False}}
 
     def visit(self, node, values):
         #
@@ -160,14 +166,18 @@ class CloneVisitor(EXPR.ExpressionValueVisitor):
         #
         # Clone leaf nodes in the expression tree
         #
-        if node.__class__ in native_numeric_types or\
-           node.__class__ not in pyomo5_expression_types:\
+        if (
+            node.__class__ in native_numeric_types
+            or node.__class__ not in pyomo5_expression_types
+        ):
             return True, copy.deepcopy(node, self.memo)
 
         return False, None
+
+
 # @visitor3
 
-#---------------------------------------------
+# ---------------------------------------------
 # @visitor4
 def clone_expression(expr):
     #
@@ -175,18 +185,20 @@ def clone_expression(expr):
     #
     visitor = CloneVisitor()
     #
-    # Clone the expression using the :func:`dfs_postorder_stack` 
+    # Clone the expression using the :func:`dfs_postorder_stack`
     # search method.
     #
     return visitor.dfs_postorder_stack(expr)
+
+
 # @visitor4
 
-#---------------------------------------------
+# ---------------------------------------------
 # @visitor5
 from pyomo.core.expr import current as EXPR
 
-class ScalingVisitor(EXPR.ExpressionReplacementVisitor):
 
+class ScalingVisitor(EXPR.ExpressionReplacementVisitor):
     def __init__(self, scale):
         super(ScalingVisitor, self).__init__()
         self.scale = scale
@@ -199,21 +211,23 @@ class ScalingVisitor(EXPR.ExpressionReplacementVisitor):
             return True, node
 
         if node.is_variable_type():
-            return True, self.scale[id(node)]*node
+            return True, self.scale[id(node)] * node
 
         if isinstance(node, EXPR.LinearExpression):
             node_ = copy.deepcopy(node)
             node_.constant = node.constant
             node_.linear_vars = copy.copy(node.linear_vars)
             node_.linear_coefs = []
-            for i,v in enumerate(node.linear_vars):
-                node_.linear_coefs.append( node.linear_coefs[i]*self.scale[id(v)] )
+            for i, v in enumerate(node.linear_vars):
+                node_.linear_coefs.append(node.linear_coefs[i] * self.scale[id(v)])
             return True, node_
 
         return False, None
+
+
 # @visitor5
 
-#---------------------------------------------
+# ---------------------------------------------
 # @visitor6
 def scale_expression(expr, scale):
     #
@@ -221,26 +235,27 @@ def scale_expression(expr, scale):
     #
     visitor = ScalingVisitor(scale)
     #
-    # Scale the expression using the :func:`dfs_postorder_stack` 
+    # Scale the expression using the :func:`dfs_postorder_stack`
     # search method.
     #
     return visitor.dfs_postorder_stack(expr)
+
+
 # @visitor6
 
-#---------------------------------------------
+# ---------------------------------------------
 # @visitor7
 M = ConcreteModel()
 M.x = Var(range(5))
 M.p = Param(range(5), mutable=True)
 
-scale={}
+scale = {}
 for i in M.x:
-  scale[id(M.x[i])] = M.p[i]
+    scale[id(M.x[i])] = M.p[i]
 
 e = quicksum(M.x[i] for i in M.x)
-f = scale_expression(e,scale)
+f = scale_expression(e, scale)
 
 # p[0]*x[0] + p[1]*x[1] + p[2]*x[2] + p[3]*x[3] + p[4]*x[4]
 print(f)
 # @visitor7
-

--- a/doc/OnlineDocs/tests/expr/overview.py
+++ b/doc/OnlineDocs/tests/expr/overview.py
@@ -1,6 +1,6 @@
 from pyomo.environ import *
 
-#---------------------------------------------
+# ---------------------------------------------
 # @example1
 M = ConcreteModel()
 M.x = Var(range(100))
@@ -17,46 +17,46 @@ for i in range(100):
 # @example1
 print(e)
 
-#---------------------------------------------
+# ---------------------------------------------
 # @example2
 M = ConcreteModel()
 M.p = Param(initialize=3)
-M.q = 1/M.p
+M.q = 1 / M.p
 M.x = Var(range(100))
 
 # The value M.q is cloned every time it is used.
 e = 0
 for i in range(100):
-    e = e + M.x[i]*M.q
+    e = e + M.x[i] * M.q
 # @example2
 print(e)
 
-#---------------------------------------------
+# ---------------------------------------------
 # @tree1
 M = ConcreteModel()
 M.v = Var()
 
-e = f = 2*M.v
+e = f = 2 * M.v
 # @tree1
 print(e)
 
-#---------------------------------------------
+# ---------------------------------------------
 # @tree2
 M = ConcreteModel()
 M.v = Var()
 
-e = 2*M.v
+e = 2 * M.v
 f = e + 3
 # @tree2
 print(e)
 print(f)
 
-#---------------------------------------------
+# ---------------------------------------------
 # @tree3
 M = ConcreteModel()
 M.v = Var()
 
-e = 2*M.v
+e = 2 * M.v
 f = e + 3
 g = e + 4
 # @tree3
@@ -64,13 +64,13 @@ print(e)
 print(f)
 print(g)
 
-#---------------------------------------------
+# ---------------------------------------------
 # @tree4
 M = ConcreteModel()
 M.v = Var()
 M.w = Var()
 
-e = 2*M.v
+e = 2 * M.v
 f = e + 3
 
 e += M.w
@@ -78,16 +78,15 @@ e += M.w
 print(e)
 print(f)
 
-#---------------------------------------------
+# ---------------------------------------------
 # @tree5
 M = ConcreteModel()
 M.v = Var()
 M.w = Var()
 
-M.e = Expression(expr=2*M.v)
+M.e = Expression(expr=2 * M.v)
 f = M.e + 3
 
 M.e += M.w
 # @tree5
 print(M.e)
-

--- a/doc/OnlineDocs/tests/expr/performance.py
+++ b/doc/OnlineDocs/tests/expr/performance.py
@@ -1,6 +1,6 @@
 from pyomo.environ import *
 
-#---------------------------------------------
+# ---------------------------------------------
 # @loop1
 M = ConcreteModel()
 M.x = Var(range(5))
@@ -11,19 +11,19 @@ for i in range(5):
 # @loop1
 print(s)
 
-#---------------------------------------------
+# ---------------------------------------------
 # @loop2
 s = sum(M.x[i] for i in range(5))
 # @loop2
 print(s)
 
-#---------------------------------------------
+# ---------------------------------------------
 # @loop3
-s = sum(M.x[i] for i in range(5))**2
+s = sum(M.x[i] for i in range(5)) ** 2
 # @loop3
 print(s)
 
-#---------------------------------------------
+# ---------------------------------------------
 # @prod
 M = ConcreteModel()
 M.x = Var(range(5))
@@ -42,30 +42,30 @@ print(e1)
 print(e2)
 print(e3)
 
-#---------------------------------------------
+# ---------------------------------------------
 # @quicksum
 M = ConcreteModel()
 M.x = Var(range(5))
 
 # Summation using the Python sum() function
-e1 = sum(M.x[i]**2 for i in M.x)
+e1 = sum(M.x[i] ** 2 for i in M.x)
 
 # Summation using the Pyomo quicksum function
-e2 = quicksum(M.x[i]**2 for i in M.x)
+e2 = quicksum(M.x[i] ** 2 for i in M.x)
 # @quicksum
 print(e1)
 print(e2)
 
-#---------------------------------------------
+# ---------------------------------------------
 # @warning
 M = ConcreteModel()
 M.x = Var(range(5))
 
-e = quicksum(M.x[i]**2 if i > 0 else M.x[i] for i in range(5))
+e = quicksum(M.x[i] ** 2 if i > 0 else M.x[i] for i in range(5))
 # @warning
 print(e)
 
-#---------------------------------------------
+# ---------------------------------------------
 # @sum_product1
 M = ConcreteModel()
 M.z = RangeSet(5)
@@ -85,7 +85,7 @@ print(e1)
 print(e2)
 print(e3)
 
-#---------------------------------------------
+# ---------------------------------------------
 # @sum_product2
 # Sum the product of x_i/y_i
 e1 = sum_product(M.x, denom=M.y)
@@ -95,4 +95,3 @@ e2 = sum_product(denom=(M.x, M.y))
 # @sum_product2
 print(e1)
 print(e2)
-

--- a/doc/OnlineDocs/tests/expr/quicksum.py
+++ b/doc/OnlineDocs/tests/expr/quicksum.py
@@ -9,7 +9,7 @@ M.p = Param(M.A, mutable=True, initialize=1)
 M.x = Var(M.A)
 
 start = time.time()
-e = sum( (M.x[i] - 1)**M.p[i] for i in M.A)
+e = sum((M.x[i] - 1) ** M.p[i] for i in M.A)
 print("sum:      %f" % (time.time() - start))
 
 start = time.time()
@@ -17,7 +17,7 @@ generate_standard_repn(e)
 print("repn:     %f" % (time.time() - start))
 
 start = time.time()
-e = quicksum( (M.x[i] - 1)**M.p[i] for i in M.A)
+e = quicksum((M.x[i] - 1) ** M.p[i] for i in M.A)
 print("quicksum: %f" % (time.time() - start))
 
 start = time.time()

--- a/doc/OnlineDocs/tests/scripting/AbstractSuffixes.py
+++ b/doc/OnlineDocs/tests/scripting/AbstractSuffixes.py
@@ -1,17 +1,24 @@
 from pyomo.environ import *
 
 model = AbstractModel()
-model.I = RangeSet(1,4)
+model.I = RangeSet(1, 4)
 model.x = Var(model.I)
+
+
 def c_rule(m, i):
     return m.x[i] >= i
+
+
 model.c = Constraint(model.I, rule=c_rule)
 
+
 def foo_rule(m):
-    return ((m.x[i], 3.0*i) for i in m.I)
+    return ((m.x[i], 3.0 * i) for i in m.I)
+
+
 model.foo = Suffix(rule=foo_rule)
 
 # instantiate the model
 inst = model.create_instance()
 for i in inst.I:
-    print (i, inst.foo[inst.x[i]])
+    print(i, inst.foo[inst.x[i]])

--- a/doc/OnlineDocs/tests/scripting/Isinglebuild.py
+++ b/doc/OnlineDocs/tests/scripting/Isinglebuild.py
@@ -10,13 +10,15 @@ model.Arcs = Set(dimen=2)
 model.NodesOut = Set(model.Nodes, within=model.Nodes, initialize=[])
 model.NodesIn = Set(model.Nodes, within=model.Nodes, initialize=[])
 
+
 def Populate_In_and_Out(model):
     # loop over the arcs and put the end points in the appropriate places
-    for (i,j) in model.Arcs:
+    for (i, j) in model.Arcs:
         model.NodesIn[j].add(i)
         model.NodesOut[i].add(j)
 
-model.In_n_Out = BuildAction(rule = Populate_In_and_Out)
+
+model.In_n_Out = BuildAction(rule=Populate_In_and_Out)
 
 model.Flow = Var(model.Arcs, domain=NonNegativeReals)
 model.FlowCost = Param(model.Arcs)
@@ -24,14 +26,22 @@ model.FlowCost = Param(model.Arcs)
 model.Demand = Param(model.Nodes)
 model.Supply = Param(model.Nodes)
 
+
 def Obj_rule(model):
     return summation(model.FlowCost, model.Flow)
+
+
 model.Obj = Objective(rule=Obj_rule, sense=minimize)
 
+
 def FlowBalance_rule(model, node):
-    return model.Supply[node] \
-     + sum(model.Flow[i, node] for i in model.NodesIn[node]) \
-     - model.Demand[node] \
-     - sum(model.Flow[node, j] for j in model.NodesOut[node]) \
-     == 0
+    return (
+        model.Supply[node]
+        + sum(model.Flow[i, node] for i in model.NodesIn[node])
+        - model.Demand[node]
+        - sum(model.Flow[node, j] for j in model.NodesOut[node])
+        == 0
+    )
+
+
 model.FlowBalance = Constraint(model.Nodes, rule=FlowBalance_rule)

--- a/doc/OnlineDocs/tests/scripting/NodesIn_init.py
+++ b/doc/OnlineDocs/tests/scripting/NodesIn_init.py
@@ -1,7 +1,9 @@
 def NodesIn_init(model, node):
     retval = []
-    for (i,j) in model.Arcs:
+    for (i, j) in model.Arcs:
         if j == node:
             retval.append(i)
     return retval
+
+
 model.NodesIn = Set(model.Nodes, initialize=NodesIn_init)

--- a/doc/OnlineDocs/tests/scripting/Z_init.py
+++ b/doc/OnlineDocs/tests/scripting/Z_init.py
@@ -1,5 +1,7 @@
 def Z_init(model, i):
     if i > 10:
         return Set.End
-    return 2*i+1
+    return 2 * i + 1
+
+
 model.Z = Set(initialize=Z_init)

--- a/doc/OnlineDocs/tests/scripting/abstract2.py
+++ b/doc/OnlineDocs/tests/scripting/abstract2.py
@@ -15,14 +15,18 @@ model.c = Param(model.J)
 # the next line declares a variable indexed by the set J
 model.x = Var(model.J, domain=NonNegativeReals)
 
+
 def obj_expression(model):
     return summation(model.c, model.x)
 
+
 model.OBJ = Objective(rule=obj_expression)
+
 
 def ax_constraint_rule(model, i):
     # return the expression for the constraint for i
-    return sum(model.a[i,j] * model.x[j] for j in model.J) >= model.b[i]
+    return sum(model.a[i, j] * model.x[j] for j in model.J) >= model.b[i]
+
 
 # the next line creates one constraint for each member of the set model.I
 model.AxbConstraint = Constraint(model.I, rule=ax_constraint_rule)

--- a/doc/OnlineDocs/tests/scripting/abstract2piece.py
+++ b/doc/OnlineDocs/tests/scripting/abstract2piece.py
@@ -8,7 +8,7 @@ model = AbstractModel()
 model.I = Set()
 model.J = Set()
 
-Topx = 6.1 # range of x variables
+Topx = 6.1  # range of x variables
 
 model.a = Param(model.I, model.J)
 model.b = Param(model.I)
@@ -21,23 +21,31 @@ model.y = Var(model.J, domain=NonNegativeReals)
 # to avoid warnings, we set breakpoints at or beyond the bounds
 PieceCnt = 100
 bpts = []
-for i in range(PieceCnt+2):
-    bpts.append(float((i*Topx)/PieceCnt))
+for i in range(PieceCnt + 2):
+    bpts.append(float((i * Topx) / PieceCnt))
+
 
 def f4(model, j, xp):
     # we not need j, but it is passed as the index for the constraint
     return xp**4
 
-model.ComputeObj = Piecewise(model.J, model.y, model.x, pw_pts=bpts, pw_constr_type='EQ', f_rule=f4)
+
+model.ComputeObj = Piecewise(
+    model.J, model.y, model.x, pw_pts=bpts, pw_constr_type='EQ', f_rule=f4
+)
+
 
 def obj_expression(model):
     return summation(model.c, model.y)
 
+
 model.OBJ = Objective(rule=obj_expression)
+
 
 def ax_constraint_rule(model, i):
     # return the expression for the constraint for i
-    return sum(model.a[i,j] * model.x[j] for j in model.J) >= model.b[i]
+    return sum(model.a[i, j] * model.x[j] for j in model.J) >= model.b[i]
+
 
 # the next line creates one constraint for each member of the set model.I
 model.AxbConstraint = Constraint(model.I, rule=ax_constraint_rule)

--- a/doc/OnlineDocs/tests/scripting/abstract2piecebuild.py
+++ b/doc/OnlineDocs/tests/scripting/abstract2piecebuild.py
@@ -12,11 +12,11 @@ model.a = Param(model.I, model.J)
 model.b = Param(model.I)
 model.c = Param(model.J)
 
-model.Topx = Param(default=6.1) # range of x variables
+model.Topx = Param(default=6.1)  # range of x variables
 model.PieceCnt = Param(default=100)
 
 # the next line declares a variable indexed by the set J
-model.x = Var(model.J, domain=NonNegativeReals, bounds=(0,model.Topx))
+model.x = Var(model.J, domain=NonNegativeReals, bounds=(0, model.Topx))
 model.y = Var(model.J, domain=NonNegativeReals)
 
 # to avoid warnings, we set breakpoints beyond the bounds
@@ -25,30 +25,40 @@ model.y = Var(model.J, domain=NonNegativeReals)
 model.bpts = {}
 # @Function_valid_declaration
 def bpts_build(model, j):
-# @Function_valid_declaration
+    # @Function_valid_declaration
     model.bpts[j] = []
-    for i in range(model.PieceCnt+2):
-        model.bpts[j].append(float((i*model.Topx)/model.PieceCnt))
+    for i in range(model.PieceCnt + 2):
+        model.bpts[j].append(float((i * model.Topx) / model.PieceCnt))
+
+
 # The object model.BuildBpts is not refered to again;
 # the only goal is to trigger the action at build time
 # @BuildAction_example
 model.BuildBpts = BuildAction(model.J, rule=bpts_build)
 # @BuildAction_example
 
+
 def f4(model, j, xp):
     # we not need j in this example, but it is passed as the index for the constraint
     return xp**4
 
-model.ComputePieces = Piecewise(model.J, model.y, model.x, pw_pts=model.bpts, pw_constr_type='EQ', f_rule=f4)
+
+model.ComputePieces = Piecewise(
+    model.J, model.y, model.x, pw_pts=model.bpts, pw_constr_type='EQ', f_rule=f4
+)
+
 
 def obj_expression(model):
     return summation(model.c, model.y)
 
+
 model.OBJ = Objective(rule=obj_expression)
+
 
 def ax_constraint_rule(model, i):
     # return the expression for the constraint for i
-    return sum(model.a[i,j] * model.x[j] for j in model.J) >= model.b[i]
+    return sum(model.a[i, j] * model.x[j] for j in model.J) >= model.b[i]
+
 
 # the next line creates one constraint for each member of the set model.I
 model.AxbConstraint = Constraint(model.I, rule=ax_constraint_rule)

--- a/doc/OnlineDocs/tests/scripting/block_iter_example.py
+++ b/doc/OnlineDocs/tests/scripting/block_iter_example.py
@@ -1,12 +1,15 @@
 # written by jds, adapted for doc by dlw
 from pyomo.environ import *
 
-# simple way to get arbitrary, unique values for each thing 
+# simple way to get arbitrary, unique values for each thing
 val_iter = 0
+
+
 def get_val(*args, **kwds):
     global val_iter
     val_iter += 1
     return val_iter
+
 
 model = ConcreteModel()
 model.I = RangeSet(3)
@@ -17,10 +20,13 @@ model.b = Block()
 model.b.a = Var(initialize=get_val)
 model.b.b = Var(model.I, initialize=get_val)
 
-def c_rule(b,i):
+
+def c_rule(b, i):
     b.c = Var(initialize=get_val)
     b.d = Var(b.model().I, initialize=get_val)
-model.c = Block([1,2], rule=c_rule)
+
+
+model.c = Block([1, 2], rule=c_rule)
 
 model.pprint()
 
@@ -30,5 +36,5 @@ for v in model.component_objects(Var, descend_into=True):
     v.pprint()
 
 for v_data in model.component_data_objects(Var, descend_into=True):
-    print("Found: "+v_data.name+", value = "+str(value(v_data)))
+    print("Found: " + v_data.name + ", value = " + str(value(v_data)))
 # @compprintloop

--- a/doc/OnlineDocs/tests/scripting/concrete1.py
+++ b/doc/OnlineDocs/tests/scripting/concrete1.py
@@ -3,8 +3,8 @@ from pyomo.environ import *
 
 model = ConcreteModel()
 
-model.x = Var([1,2], domain=NonNegativeReals)
+model.x = Var([1, 2], domain=NonNegativeReals)
 
-model.OBJ = Objective(expr = 2*model.x[1] + 3*model.x[2])
+model.OBJ = Objective(expr=2 * model.x[1] + 3 * model.x[2])
 
-model.Constraint1 = Constraint(expr = 3*model.x[1] + 4*model.x[2] >= 1)
+model.Constraint1 = Constraint(expr=3 * model.x[1] + 4 * model.x[2] >= 1)

--- a/doc/OnlineDocs/tests/scripting/doubleA.py
+++ b/doc/OnlineDocs/tests/scripting/doubleA.py
@@ -1,3 +1,5 @@
 def doubleA_init(model):
-    return (i*2 for i in model.A)
+    return (i * 2 for i in model.A)
+
+
 model.C = Set(initialize=DoubleA_init)

--- a/doc/OnlineDocs/tests/scripting/driveabs2.py
+++ b/doc/OnlineDocs/tests/scripting/driveabs2.py
@@ -23,14 +23,14 @@ results = opt.solve(instance)
 
 # @Access_all_dual
 # display all duals
-print ("Duals")
+print("Duals")
 for c in instance.component_objects(pyo.Constraint, active=True):
-    print ("   Constraint",c)
+    print("   Constraint", c)
     for index in c:
-        print ("      ", index, instance.dual[c[index]])
+        print("      ", index, instance.dual[c[index]])
 # @Access_all_dual
 
 # @Access_one_dual
 # access one dual
-print ("Dual for Film=", instance.dual[instance.AxbConstraint['Film']])
+print("Dual for Film=", instance.dual[instance.AxbConstraint['Film']])
 # @Access_one_dual

--- a/doc/OnlineDocs/tests/scripting/driveconc1.py
+++ b/doc/OnlineDocs/tests/scripting/driveconc1.py
@@ -13,14 +13,11 @@ from concrete1 import model
 # so the solver plugin will know which suffixes to collect
 model.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT)
 
-results = opt.solve(model) # also load results to model
+results = opt.solve(model)  # also load results to model
 
 # display all duals
-print ("Duals")
+print("Duals")
 for c in model.component_objects(pyo.Constraint, active=True):
-    print ("   Constraint",c)
+    print("   Constraint", c)
     for index in c:
-        print ("      ", index, model.dual[c[index]])
-
-
-
+        print("      ", index, model.dual[c[index]])

--- a/doc/OnlineDocs/tests/scripting/iterative1.py
+++ b/doc/OnlineDocs/tests/scripting/iterative1.py
@@ -2,6 +2,7 @@
 # iterative1.py
 import pyomo.environ as pyo
 from pyomo.opt import SolverFactory
+
 # @Import_symbols_for_pyomo
 
 # @Call_SolverFactory_with_argument
@@ -17,8 +18,12 @@ opt = pyo.SolverFactory('glpk')
 model = pyo.AbstractModel()
 model.n = pyo.Param(default=4)
 model.x = pyo.Var(pyo.RangeSet(model.n), within=pyo.Binary)
+
+
 def o_rule(model):
     return pyo.summation(model.x)
+
+
 model.o = pyo.Objective(rule=o_rule)
 # @Create_base_model
 # @Create_empty_constraint_list
@@ -39,20 +44,20 @@ instance.display()
 # Iterate to eliminate the previously found solution
 # @Assign_integers
 for i in range(5):
-# @Assign_integers
-# @Iteratively_assign_and_test
+    # @Assign_integers
+    # @Iteratively_assign_and_test
     expr = 0
     for j in instance.x:
         if pyo.value(instance.x[j]) == 0:
             expr += instance.x[j]
         else:
-            expr += (1-instance.x[j])
-# @Iteratively_assign_and_test
-# @Add_expression_constraint
-    instance.c.add( expr >= 1 )
-# @Add_expression_constraint
-# @Find_and_display_solution
+            expr += 1 - instance.x[j]
+    # @Iteratively_assign_and_test
+    # @Add_expression_constraint
+    instance.c.add(expr >= 1)
+    # @Add_expression_constraint
+    # @Find_and_display_solution
     results = opt.solve(instance)
-    print ("\n===== iteration",i)
+    print("\n===== iteration", i)
     instance.display()
 # @Find_and_display_solution

--- a/doc/OnlineDocs/tests/scripting/iterative2.py
+++ b/doc/OnlineDocs/tests/scripting/iterative2.py
@@ -13,8 +13,12 @@ opt = pyo.SolverFactory('cplex')
 model = pyo.AbstractModel()
 model.n = pyo.Param(default=4)
 model.x = pyo.Var(pyo.RangeSet(model.n), within=pyo.Binary)
+
+
 def o_rule(model):
     return pyo.summation(model.x)
+
+
 model.o = pyo.Objective(rule=o_rule)
 model.c = pyo.ConstraintList()
 

--- a/doc/OnlineDocs/tests/scripting/noiteration1.py
+++ b/doc/OnlineDocs/tests/scripting/noiteration1.py
@@ -13,8 +13,12 @@ opt = SolverFactory('glpk')
 model = pyo.ConcreteModel()
 model.n = pyo.Param(default=4)
 model.x = pyo.Var(pyo.RangeSet(model.n), within=pyo.Binary)
+
+
 def o_rule(model):
     return pyo.summation(model.x)
+
+
 model.o = pyo.Objective(rule=o_rule)
 model.c = pyo.ConstraintList()
 
@@ -23,5 +27,4 @@ results = opt.solve(model)
 if pyo.value(model.x[2]) == 0:
     print("The second index has a zero")
 else:
-    print("x[2]=",pyo.value(model.x[2]))
-
+    print("x[2]=", pyo.value(model.x[2]))

--- a/doc/OnlineDocs/tests/scripting/parallel.py
+++ b/doc/OnlineDocs/tests/scripting/parallel.py
@@ -5,7 +5,9 @@ from mpi4py import MPI
 
 rank = MPI.COMM_WORLD.Get_rank()
 size = MPI.COMM_WORLD.Get_size()
-assert size == 2, 'This example only works with 2 processes; please us mpirun -np 2 python -m mpi4py parallel.py'
+assert (
+    size == 2
+), 'This example only works with 2 processes; please us mpirun -np 2 python -m mpi4py parallel.py'
 
 # Create a solver
 opt = pyo.SolverFactory('cplex_direct')

--- a/doc/OnlineDocs/tests/scripting/spy4Constraints.py
+++ b/doc/OnlineDocs/tests/scripting/spy4Constraints.py
@@ -3,33 +3,46 @@ David L. Woodruff and Mingye Yang, Spring 2018
 Code snippets for Constraints.rst in testable form
 """
 from pyomo.environ import *
+
 model = ConcreteModel()
 # @Inequality_constraints_2expressions
 model.x = Var()
 
+
 def aRule(model):
-   return model.x >= 2
+    return model.x >= 2
+
+
 model.Boundx = Constraint(rule=aRule)
 
+
 def bRule(model):
-   return (2, model.x, None)
+    return (2, model.x, None)
+
+
 model.boundx = Constraint(rule=bRule)
 # @Inequality_constraints_2expressions
 
 model = ConcreteModel()
-model.J = Set(initialize=['butter','scones'])
+model.J = Set(initialize=['butter', 'scones'])
 model.x = Var(model.J)
 # @Constraint_example
 def teaOKrule(model):
-    return(model.x['butter'] + model.x['scones'] == 3)
+    return model.x['butter'] + model.x['scones'] == 3
+
+
 model.TeaConst = Constraint(rule=teaOKrule)
 # @Constraint_example
 
 # @Passing_elements_crossproduct
-model.A = RangeSet(1,10)
+model.A = RangeSet(1, 10)
 model.a = Param(model.A, within=PositiveReals)
 model.ToBuy = Var(model.A)
+
+
 def bud_rule(model, i):
-    return model.a[i]*model.ToBuy[i] <= i
+    return model.a[i] * model.ToBuy[i] <= i
+
+
 aBudget = Constraint(model.A, rule=bud_rule)
 # @Passing_elements_crossproduct

--- a/doc/OnlineDocs/tests/scripting/spy4Expressions.py
+++ b/doc/OnlineDocs/tests/scripting/spy4Expressions.py
@@ -3,6 +3,7 @@ David L. Woodruff and Mingye Yang, Spring 2018
 Code snippets for Expressions.rst in testable form
 """
 from pyomo.environ import *
+
 model = ConcreteModel()
 
 # @Buildup_expression_switch
@@ -13,11 +14,14 @@ model.c = Param(model.A)
 model.d = Param()
 model.x = Var(model.A, domain=Boolean)
 
+
 def pi_rule(model):
     accexpr = summation(model.c, model.x)
     if switch >= 2:
         accexpr = accexpr - model.d
     return accexpr >= 0.5
+
+
 PieSlice = Constraint(rule=pi_rule)
 # @Buildup_expression_switch
 
@@ -27,64 +31,74 @@ model.c = Param(model.A)
 model.d = Param()
 model.x = Var(model.A, domain=Boolean)
 
+
 def pi_rule(model):
     accexpr = summation(model.c, model.x)
     if model.d >= 2:  # NOT in an abstract model!!
         accexpr = accexpr - model.d
     return accexpr >= 0.5
+
+
 PieSlice = Constraint(rule=pi_rule)
 # @Abstract_wrong_usage
 
 # @Declare_piecewise_constraints
-#model.pwconst = Piecewise(indexes, yvar, xvar, **Keywords)
-#model.pwconst = Piecewise(yvar,xvar,**Keywords)
+# model.pwconst = Piecewise(indexes, yvar, xvar, **Keywords)
+# model.pwconst = Piecewise(yvar,xvar,**Keywords)
 # @Declare_piecewise_constraints
 
 # @f_rule_Function_examples
 # A function that changes with index
-def f(model,j,x):
-   if (j == 2):
-      return x**2 + 1.0
-   else:
-      return x**2 + 5.0
+def f(model, j, x):
+    if j == 2:
+        return x**2 + 1.0
+    else:
+        return x**2 + 5.0
+
 
 # A nonlinear function
-f = lambda model,x : exp(x) + value(model.p)
+f = lambda model, x: exp(x) + value(model.p)
 
 # A step function
-f = [0,0,1,1,2,2]
+f = [0, 0, 1, 1, 2, 2]
 # @f_rule_Function_examples
 
 # @Keyword_assignment_example
-kwds = {'pw_constr_type':'EQ','pw_repn':'SOS2','sense':maximize,'force_pw':True}
+kwds = {'pw_constr_type': 'EQ', 'pw_repn': 'SOS2', 'sense': maximize, 'force_pw': True}
 # @Keyword_assignment_example
 
 # @Expression_objects_illustration
 model = ConcreteModel()
 model.x = Var(initialize=1.0)
-def _e(m,i):
-    return m.x*i
-model.e = Expression([1,2,3], rule=_e)
+
+
+def _e(m, i):
+    return m.x * i
+
+
+model.e = Expression([1, 2, 3], rule=_e)
 
 instance = model.create_instance()
 
-print (value(instance.e[1])) # -> 1.0
-print (instance.e[1]())           # -> 1.0
-print (instance.e[1].value)  # -> a pyomo expression object
+print(value(instance.e[1]))  # -> 1.0
+print(instance.e[1]())  # -> 1.0
+print(instance.e[1].value)  # -> a pyomo expression object
 
 # Change the underlying expression
 instance.e[1].value = instance.x**2
 
-#... solve
-#... load results
+# ... solve
+# ... load results
 
 # print the value of the expression given the loaded optimal solution
-print (value(instance.e[1]))
+print(value(instance.e[1]))
 # @Expression_objects_illustration
 
 # @Define_python_function
 def f(x, p):
     return x + p
+
+
 # @Define_python_function
 
 # @Generate_new_expression

--- a/doc/OnlineDocs/tests/scripting/spy4PyomoCommand.py
+++ b/doc/OnlineDocs/tests/scripting/spy4PyomoCommand.py
@@ -3,6 +3,7 @@ David L. Woodruff and Mingye Yang, Spring 2018
 Code snippets for PyomoCommand.rst in testable form
 """
 from pyomo.environ import *
+
 model = ConcreteModel()
 model.I = RangeSet(3)
 model.J = RangeSet(3)
@@ -12,9 +13,10 @@ model.b = Param(model.I, default=1.0)
 
 # @Troubleshooting_printed_command
 def ax_constraint_rule(model, i):
-     # return the expression for the constraint for i
-     print ("ax_constraint_rule was called for i=",str(i))
-     return sum(model.a[i,j] * model.x[j] for j in model.J) >= model.b[i]
+    # return the expression for the constraint for i
+    print("ax_constraint_rule was called for i=", str(i))
+    return sum(model.a[i, j] * model.x[j] for j in model.J) >= model.b[i]
+
 
 # the next line creates one constraint for each member of the set model.I
 model.AxbConstraint = Constraint(model.I, rule=ax_constraint_rule)

--- a/doc/OnlineDocs/tests/scripting/spy4Variables.py
+++ b/doc/OnlineDocs/tests/scripting/spy4Variables.py
@@ -3,9 +3,10 @@ David L. Woodruff and Mingye Yang, Spring 2018
 Code snippets for Variables.rst in testable form
 """
 from pyomo.environ import *
+
 model = ConcreteModel()
 # @Declare_singleton_variable
-model.LumberJack = Var(within=NonNegativeReals, bounds=(0,6), initialize=1.5)
+model.LumberJack = Var(within=NonNegativeReals, bounds=(0, 6), initialize=1.5)
 # @Declare_singleton_variable
 
 # @Assign_value
@@ -14,9 +15,13 @@ model.LumberJack = 1.5
 
 # @Declare_bounds
 model.A = Set(initialize=['Scones', 'Tea'])
-lb = {'Scones':2, 'Tea':4}
-ub = {'Scones':5, 'Tea':7}
+lb = {'Scones': 2, 'Tea': 4}
+ub = {'Scones': 5, 'Tea': 7}
+
+
 def fb(model, i):
-   return (lb[i], ub[i])
+    return (lb[i], ub[i])
+
+
 model.PriceToCharge = Var(model.A, domain=PositiveIntegers, bounds=fb)
 # @Declare_bounds

--- a/doc/OnlineDocs/tests/scripting/spy4scripts.py
+++ b/doc/OnlineDocs/tests/scripting/spy4scripts.py
@@ -9,7 +9,7 @@ Code snippets for scripts.rst in testable form
 import pyomo.environ as pyo
 
 instance = pyo.ConcreteModel()
-instance.I = pyo.Set(initialize=[1,2,3])
+instance.I = pyo.Set(initialize=[1, 2, 3])
 instance.sigma = pyo.Param(mutable=True, initialize=2.3)
 instance.Theta = pyo.Param(instance.I, mutable=True)
 for i in instance.I:
@@ -28,7 +28,7 @@ ParamName = "sigma"
 instance.ParamName.value = NewVal
 # @Assign_value_to_unindexed_parametername_2
 
-instance.x = pyo.Var([1,2,3], initialize=0)
+instance.x = pyo.Var([1, 2, 3], initialize=0)
 instance.y = pyo.Var()
 # @Set_upper&lower_bound
 
@@ -45,9 +45,9 @@ instance.y.value = 2
 instance.y.fixed = True
 # @Equivalent_form_of_instance.x.fix(2)
 
-model=ConcreteModel()
-model.obj1 = pyo.Objective(expr = 0)
-model.obj2 = pyo.Objective(expr = 0)
+model = ConcreteModel()
+model.obj1 = pyo.Objective(expr=0)
+model.obj2 = pyo.Objective(expr=0)
 
 # @Pass_multiple_objectives_to_solver
 model.obj1.deactivate()
@@ -56,32 +56,38 @@ model.obj2.activate()
 
 # @Listing_arguments
 def pyomo_preprocess(options=None):
-   if options == None:
-      print ("No command line options were given.")
-   else:
-      print ("Command line arguments were: %s" % options)
+    if options == None:
+        print("No command line options were given.")
+    else:
+        print("Command line arguments were: %s" % options)
+
+
 # @Listing_arguments
 
 
 # @Provide_dictionary_for_arbitrary_keywords
 def pyomo_preprocess(**kwds):
-   options = kwds.get('options',None)
-   if options == None:
-      print ("No command line options were given.")
-   else:
-      print ("Command line arguments were: %s" % options)
+    options = kwds.get('options', None)
+    if options == None:
+        print("No command line options were given.")
+    else:
+        print("Command line arguments were: %s" % options)
+
+
 # @Provide_dictionary_for_arbitrary_keywords
 
 # @Pyomo_preprocess_argument
 def pyomo_preprocess(options=None):
     pass
+
+
 # @Pyomo_preprocess_argument
 
 # @Display_all_variables&values
 for v in instance.component_objects(pyo.Var, active=True):
-    print("Variable",v)
+    print("Variable", v)
     for index in v:
-        print ("   ",index, pyo.value(v[index]))
+        print("   ", index, pyo.value(v[index]))
 # @Display_all_variables&values
 
 # @Display_all_variables&values_data
@@ -90,41 +96,45 @@ for v in instance.component_data_objects(pyo.Var, active=True):
 # @Display_all_variables&values_data
 
 
-instance.iVar = pyo.Var([1,2,3], initialize=1, domain=pyo.Boolean)
+instance.iVar = pyo.Var([1, 2, 3], initialize=1, domain=pyo.Boolean)
 instance.sVar = pyo.Var(initialize=1, domain=pyo.Boolean)
 # dlw may 2018: the next snippet does not trigger any fixing ("active?")
 # @Fix_all_integers&values
 for var in instance.component_data_objects(pyo.Var, active=True):
     if var.domain is pyo.IntegerSet or var.domain is pyo.BooleanSet:
-        print ("fixing "+str(v))
-        var.fixed = True # fix the current value
+        print("fixing " + str(v))
+        var.fixed = True  # fix the current value
 # @Fix_all_integers&values
 
 # @Include_definition_in_modelfile
 def pyomo_print_results(options, instance, results):
     for v in instance.component_objects(pyo.Var, active=True):
-        print ("Variable "+str(v))
+        print("Variable " + str(v))
         varobject = getattr(instance, v)
         for index in varobject:
-            print ("   ",index, varobject[index].value)
+            print("   ", index, varobject[index].value)
+
+
 # @Include_definition_in_modelfile
 
 # @Print_parameter_name&value
 for parmobject in instance.component_objects(pyo.Param, active=True):
-    print ("Parameter "+str(parmobject.name))
+    print("Parameter " + str(parmobject.name))
     for index in parmobject:
-        print ("   ",index, parmobject[index].value)
+        print("   ", index, parmobject[index].value)
 # @Print_parameter_name&value
 
 # @Include_definition_output_constraints&duals
 def pyomo_print_results(options, instance, results):
     # display all duals
-    print ("Duals")
+    print("Duals")
     for c in instance.component_objects(pyo.Constraint, active=True):
-        print ("   Constraint",c)
+        print("   Constraint", c)
         cobject = getattr(instance, c)
         for index in cobject:
-            print ("      ", index, instance.dual[cobject[index]])
+            print("      ", index, instance.dual[cobject[index]])
+
+
 # @Include_definition_output_constraints&duals
 
 """

--- a/doc/OnlineDocs/tests/strip_examples.py
+++ b/doc/OnlineDocs/tests/strip_examples.py
@@ -10,7 +10,7 @@
 #    # @block
 #    print("END HERE")
 #
-# If this file was foo.py, then a file foo_block.spy is created, which 
+# If this file was foo.py, then a file foo_block.spy is created, which
 # contains the lines between the lines starting with "# @".
 #
 # Additionally, the file foo.spy is created, which strips all lines
@@ -24,13 +24,14 @@ import sys
 import os
 import os.path
 
+
 def f(root, file):
     if not file.endswith('.py'):
         return
     prefix = os.path.splitext(file)[0]
-    #print([root, file, prefix])
-    OUTPUT = open(root+'/'+prefix+'.spy','w')
-    INPUT = open(root+'/'+file,'r')
+    # print([root, file, prefix])
+    OUTPUT = open(root + '/' + prefix + '.spy', 'w')
+    INPUT = open(root + '/' + file, 'r')
     flag = False
     block_name = None
     for line in INPUT:
@@ -39,10 +40,13 @@ def f(root, file):
             if flag is False:
                 block_name = tmp[3:]
                 flag = True
-                OUTPUT_ = open(root+'/'+prefix+'_%s.spy' % block_name,'w')
+                OUTPUT_ = open(root + '/' + prefix + '_%s.spy' % block_name, 'w')
             else:
                 if block_name != tmp[3:]:
-                    print("ERROR parsing file '%s': Started block '%s' but ended with '%s'" % (root+'/'+file, block_name, tmp[3:]))
+                    print(
+                        "ERROR parsing file '%s': Started block '%s' but ended with '%s'"
+                        % (root + '/' + file, block_name, tmp[3:])
+                    )
                     sys.exit(1)
                 flag = False
                 block_name is None

--- a/doc/OnlineDocs/tests/test_examples.py
+++ b/doc/OnlineDocs/tests/test_examples.py
@@ -8,16 +8,17 @@ import pyomo.environ
 
 try:
     import yaml
-    yaml_available=True
+
+    yaml_available = True
 except:
-    yaml_available=False
+    yaml_available = False
 
 # Find all *.txt files, and use them to define baseline tests
 currdir = os.path.dirname(os.path.abspath(__file__))
 datadir = currdir
-testdirs = [currdir, ]
+testdirs = [currdir]
 
-solver_dependencies =   {
+solver_dependencies = {
     'Test_nonlinear_ch': {
         'test_rosen_pyomo_rosen': 'ipopt',
         'test_react_design_run_pyomo_reactor_table': 'ipopt',
@@ -28,18 +29,14 @@ solver_dependencies =   {
         'test_disease_est_run_disease_callback': 'ipopt',
         'test_deer_run_deer': 'ipopt',
     },
-    'Test_mpec_ch': {
-        'test_mpec_ch_path1': 'path',
-    },
-    'Test_dae_ch': {
-        'test_run_path_constraint_tester': 'ipopt',
-    },
+    'Test_mpec_ch': {'test_mpec_ch_path1': 'path'},
+    'Test_dae_ch': {'test_run_path_constraint_tester': 'ipopt'},
 }
-package_dependencies =  {
+package_dependencies = {
     'Test_data': {
-        'test_data_ABCD9': ['pyodbc',],
-        'test_data_ABCD8': ['pyodbc',],
-        'test_data_ABCD7': ['win32com',],
+        'test_data_ABCD9': ['pyodbc'],
+        'test_data_ABCD8': ['pyodbc'],
+        'test_data_ABCD7': ['win32com'],
     },
     'Test_dataportal': {
         'test_dataportal_dataportal_tab': ['xlrd'],
@@ -52,9 +49,12 @@ package_available = {}
 
 only_book_tests = set(['Test_nonlinear_ch', 'Test_scripts_ch'])
 
+
 def _check_available(name):
     from pyomo.opt.base.solvers import check_available_solvers
+
     return bool(check_available_solvers(name))
+
 
 def check_skip(tfname_, name):
     #
@@ -85,12 +85,15 @@ def check_skip(tfname_, name):
     # Return a boolean if the test should be skipped
     #
     if tfname_ in solver_dependencies:
-        if name in solver_dependencies[tfname_] and \
-           not solver_available[solver_dependencies[tfname_][name]]:
+        if (
+            name in solver_dependencies[tfname_]
+            and not solver_available[solver_dependencies[tfname_][name]]
+        ):
             # Skip the test because a solver is not available
-            # print('Skipping %s because of missing solver' %(name)) 
+            # print('Skipping %s because of missing solver' %(name))
             return 'Solver "%s" is not available' % (
-                solver_dependencies[tfname_][name], )
+                solver_dependencies[tfname_][name],
+            )
     if tfname_ in package_dependencies:
         if name in package_dependencies[tfname_]:
             packages_ = package_dependencies[tfname_][name]
@@ -104,7 +107,8 @@ def check_skip(tfname_, name):
                 return "Package%s %s %s not available" % (
                     's' if len(_missing) > 1 else '',
                     ", ".join(_missing),
-                    'are' if len(_missing) > 1 else 'is',)
+                    'are' if len(_missing) > 1 else 'is',
+                )
     return False
 
 
@@ -112,135 +116,156 @@ def filter(line):
     # Ignore certain text when comparing output with baseline
 
     # Ipopt 3.12.4 puts BACKSPACE (chr(8) / ^H) into the output.
-    line = line.strip(" \n\t"+chr(8))
+    line = line.strip(" \n\t" + chr(8))
 
     if not line:
         return True
-    for field in ( '[',
-                   'password:',
-                   'http:',
-                   'Job ',
-                   'Importing module',
-                   'Function',
-                   'File',):
+    for field in (
+        '[',
+        'password:',
+        'http:',
+        'Job ',
+        'Importing module',
+        'Function',
+        'File',
+    ):
         if line.startswith(field):
             return True
-    for field in ( 'Total CPU',
-                   'Ipopt',
-                   'Status: optimal',
-                   'Status: feasible',
-                   'time:',
-                   'Time:',
-                   'with format cpxlp',
-                   'usermodel = <module',
-                   'execution time=',
-                   'Solver results file:' ):
+    for field in (
+        'Total CPU',
+        'Ipopt',
+        'Status: optimal',
+        'Status: feasible',
+        'time:',
+        'Time:',
+        'with format cpxlp',
+        'usermodel = <module',
+        'execution time=',
+        'Solver results file:',
+    ):
         if field in line:
             return True
     return False
 
+
 for tdir in testdirs:
 
-  for testdir in glob.glob(os.path.join(tdir,'*')):
-    if not os.path.isdir(testdir):
-        continue
+    for testdir in glob.glob(os.path.join(tdir, '*')):
+        if not os.path.isdir(testdir):
+            continue
 
-    # print("Testing ",testdir)
+        # print("Testing ",testdir)
 
-    #
-    # JDS: This is crazy fragile.  If testdirs is ever anything BUT
-    # "pyomobook" you will be creating invalid class names
-    #
-    #testdir_ = testdir.replace('-','_')
-    #testClassName = 'Test_'+testdir_.split("pyomobook"+os.sep)[1]
-    testClassName = 'Test_'+os.path.basename(testdir).replace('-', '_')
-    assert '.' not in testClassName
-    Test = globals()[testClassName] = type(
-        testClassName, (unittest.TestCase,), {})
-    # Adding the marker to the class instance
-    if testClassName in only_book_tests:
-        Test = unittest.pytest.mark.book(Test)
-    else:
-        Test = unittest.pytest.mark.book(Test)
-        Test = unittest.pytest.mark.default(Test)
-    
-    # Find all .py files in the test directory
-    for file in list(glob.glob(os.path.join(testdir,'*.py'))) \
-        + list(glob.glob(os.path.join(testdir,'*','*.py'))):
-    
-        test_file = os.path.abspath(file)
-        bname = os.path.basename(test_file)
-        dir_ = os.path.dirname(test_file)
-        name=os.path.splitext(bname)[0]
-        tname = os.path.basename(dir_)+'_'+name
-    
-        suffix = None
-        # Look for txt and yml file names matching py file names. Add
-        # a test for any found
-        for suffix_ in ['.txt', '.yml']:
-            if os.path.exists(os.path.join(dir_,name+suffix_)):
-                suffix = suffix_
-                break
-            elif os.path.exists(os.path.join(dir_,name+'.py2'+suffix_)) \
-                 and sys.version_info[0] == 2:
-                suffix = '.py2'+suffix_
-                break
-            elif os.path.exists(os.path.join(dir_, name+'.py3'+suffix_)) \
-                 and sys.version_info[0] == 3:
-                suffix = '.py3'+suffix_
-                break
-        if not suffix is None:
-            cwd = os.getcwd()
-            tname = tname.replace('-','_')
-            tname = tname.replace('.','_')
-            # print(tname)
-            forceskip = check_skip(testClassName, 'test_'+tname)
-            Test.add_baseline_test(
-                cmd=(sys.executable, test_file),
-                cwd = dir_,
-                baseline=os.path.join(dir_,name+suffix),
-                name=tname,
-                filter=filter,
-                tolerance=1e-3,
-                forceskip=forceskip)
-            os.chdir(cwd)
+        #
+        # JDS: This is crazy fragile.  If testdirs is ever anything BUT
+        # "pyomobook" you will be creating invalid class names
+        #
+        # testdir_ = testdir.replace('-','_')
+        # testClassName = 'Test_'+testdir_.split("pyomobook"+os.sep)[1]
+        testClassName = 'Test_' + os.path.basename(testdir).replace('-', '_')
+        assert '.' not in testClassName
+        Test = globals()[testClassName] = type(testClassName, (unittest.TestCase,), {})
+        # Adding the marker to the class instance
+        if testClassName in only_book_tests:
+            Test = unittest.pytest.mark.book(Test)
+        else:
+            Test = unittest.pytest.mark.book(Test)
+            Test = unittest.pytest.mark.default(Test)
 
-    # Find all .sh files in the test directory
-    for file in list(glob.glob(os.path.join(testdir,'*.sh'))) \
-            + list(glob.glob(os.path.join(testdir,'*','*.sh'))):
-        bname = os.path.basename(file)
-        dir_ = os.path.dirname(os.path.abspath(file))+os.sep
-        name='.'.join(bname.split('.')[:-1])
-        tname = os.path.basename(os.path.dirname(dir_))+'_'+name
-        suffix = None
-        # Look for txt and yml file names matching sh file names. Add
-        # a test for any found
-        for suffix_ in ['.txt', '.yml']:
-            if os.path.exists(dir_+name+suffix_):
-                suffix = suffix_
-                break
-            elif os.path.exists(dir_+name+'.py2'+suffix_) and sys.version_info[0] == 2:
-                suffix = '.py2'+suffix_
-                break
-            elif os.path.exists(dir_+name+'.py3'+suffix_) and sys.version_info[0] == 3:
-                suffix = '.py3'+suffix_
-                break
-        if not suffix is None:
-            cwd = os.getcwd()
-            os.chdir(dir_)
-            tname = tname.replace('-','_')
-            tname = tname.replace('.','_')
-            # For now, skip all shell tests on Windows.
-            if os.name == 'nt':
-                forceskip = "Shell tests are not runnable on Windows"
-            else:
-                forceskip = check_skip(testClassName, 'test_'+tname)
-            Test.add_baseline_test(cmd='cd %s; %s' % (dir_,
-                                                      os.path.abspath(bname)), baseline=dir_+name+suffix,
-                                   name=tname, filter=filter, tolerance=1e-3,
-                                   forceskip=forceskip)
-            os.chdir(cwd)
-    Test = None
+        # Find all .py files in the test directory
+        for file in list(glob.glob(os.path.join(testdir, '*.py'))) + list(
+            glob.glob(os.path.join(testdir, '*', '*.py'))
+        ):
+
+            test_file = os.path.abspath(file)
+            bname = os.path.basename(test_file)
+            dir_ = os.path.dirname(test_file)
+            name = os.path.splitext(bname)[0]
+            tname = os.path.basename(dir_) + '_' + name
+
+            suffix = None
+            # Look for txt and yml file names matching py file names. Add
+            # a test for any found
+            for suffix_ in ['.txt', '.yml']:
+                if os.path.exists(os.path.join(dir_, name + suffix_)):
+                    suffix = suffix_
+                    break
+                elif (
+                    os.path.exists(os.path.join(dir_, name + '.py2' + suffix_))
+                    and sys.version_info[0] == 2
+                ):
+                    suffix = '.py2' + suffix_
+                    break
+                elif (
+                    os.path.exists(os.path.join(dir_, name + '.py3' + suffix_))
+                    and sys.version_info[0] == 3
+                ):
+                    suffix = '.py3' + suffix_
+                    break
+            if not suffix is None:
+                cwd = os.getcwd()
+                tname = tname.replace('-', '_')
+                tname = tname.replace('.', '_')
+                # print(tname)
+                forceskip = check_skip(testClassName, 'test_' + tname)
+                Test.add_baseline_test(
+                    cmd=(sys.executable, test_file),
+                    cwd=dir_,
+                    baseline=os.path.join(dir_, name + suffix),
+                    name=tname,
+                    filter=filter,
+                    tolerance=1e-3,
+                    forceskip=forceskip,
+                )
+                os.chdir(cwd)
+
+        # Find all .sh files in the test directory
+        for file in list(glob.glob(os.path.join(testdir, '*.sh'))) + list(
+            glob.glob(os.path.join(testdir, '*', '*.sh'))
+        ):
+            bname = os.path.basename(file)
+            dir_ = os.path.dirname(os.path.abspath(file)) + os.sep
+            name = '.'.join(bname.split('.')[:-1])
+            tname = os.path.basename(os.path.dirname(dir_)) + '_' + name
+            suffix = None
+            # Look for txt and yml file names matching sh file names. Add
+            # a test for any found
+            for suffix_ in ['.txt', '.yml']:
+                if os.path.exists(dir_ + name + suffix_):
+                    suffix = suffix_
+                    break
+                elif (
+                    os.path.exists(dir_ + name + '.py2' + suffix_)
+                    and sys.version_info[0] == 2
+                ):
+                    suffix = '.py2' + suffix_
+                    break
+                elif (
+                    os.path.exists(dir_ + name + '.py3' + suffix_)
+                    and sys.version_info[0] == 3
+                ):
+                    suffix = '.py3' + suffix_
+                    break
+            if not suffix is None:
+                cwd = os.getcwd()
+                os.chdir(dir_)
+                tname = tname.replace('-', '_')
+                tname = tname.replace('.', '_')
+                # For now, skip all shell tests on Windows.
+                if os.name == 'nt':
+                    forceskip = "Shell tests are not runnable on Windows"
+                else:
+                    forceskip = check_skip(testClassName, 'test_' + tname)
+                Test.add_baseline_test(
+                    cmd='cd %s; %s' % (dir_, os.path.abspath(bname)),
+                    baseline=dir_ + name + suffix,
+                    name=tname,
+                    filter=filter,
+                    tolerance=1e-3,
+                    forceskip=forceskip,
+                )
+                os.chdir(cwd)
+        Test = None
 
 # Execute the tests
 if __name__ == '__main__':


### PR DESCRIPTION
## Fixes (Partly) #329 

## Summary/Motivation:
This is the first in a relatively long string of PRs to apply PEP8 standards via `black` to Pyomo. We are following the standard used by IDAES _except_ that we are adding the `-S` option: `Don't normalize string quotes or prefixes` and the `-C` option: `Don't use trailing commas as a reason to split lines.`

**NOTE**: All changes are NFC.

Full command used: `cd doc && black -S -C .`

## Changes proposed in this PR:
- Apply `black` to the `doc` directory `py` files

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
