### PR TITLE
Apply `black` to `pyomo/pysp` directory `py` file

### DIFF
--- a/pyomo/pysp/__init__.py
+++ b/pyomo/pysp/__init__.py
@@ -11,21 +11,21 @@
 
 import logging
 import sys
-from pyomo.common.deprecation import (
-    deprecation_warning, in_testing_environment,
-)
+from pyomo.common.deprecation import deprecation_warning, in_testing_environment
 
 try:
     # Warn the user
     deprecation_warning(
         "PySP has been removed from the pyomo.pysp namespace.  "
         "Please import PySP directly from the pysp namespace.",
-        version='6.0')
+        version='6.0',
+    )
     from pysp import *
+
     # Redirect all (imported) pysp modules into the pyomo.pysp namespace
     for mod in list(sys.modules):
         if mod.startswith('pysp.'):
-            sys.modules['pyomo.'+mod] = sys.modules[mod]
+            sys.modules['pyomo.' + mod] = sys.modules[mod]
 except ImportError:
     # Only raise the exception if nose/pytest/sphinx are NOT running
     # (otherwise test discovery can result in exceptions)
@@ -34,5 +34,5 @@ except ImportError:
             "No module named 'pyomo.pysp'.  "
             "Beginning in Pyomo 6.0, PySP is distributed as a separate "
             "package.  Please see https://github.com/Pyomo/pysp for "
-            "information on downloading and installing PySP")
-
+            "information on downloading and installing PySP"
+        )


### PR DESCRIPTION
## Fixes (Partly) #329 

## Summary/Motivation:
This is the first in a relatively long string of PRs to apply PEP8 standards via `black` to Pyomo. We are following the standard used by IDAES _except_ that we are adding the `-S` option: `Don't normalize string quotes or prefixes` and the `-C` option: `Don't use trailing commas as a reason to split lines.`

**NOTE**: All changes are NFC.

Full command used: `cd pyomo/pysp && black -S -C .`

## Changes proposed in this PR:
- Apply `black` to the `pyomo/pysp` directory `py` file

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
