### PR TITLE
Apply `black` to `pyomo/util` directory `py` files

### DIFF
--- a/pyomo/util/blockutil.py
+++ b/pyomo/util/blockutil.py
@@ -31,9 +31,11 @@ def has_discrete_variables(block):
 def log_model_constraints(m, logger=logger, active=True):
     """Prints the model constraints in the model."""
     for constr in m.component_data_objects(
-            ctype=Constraint, active=active, descend_into=True,
-            descent_order=TraversalStrategy.PrefixDepthFirstSearch):
-        logger.info("%s %s" % (
-            constr.name,
-            ("active" if constr.active else "deactivated")
-        ))
+        ctype=Constraint,
+        active=active,
+        descend_into=True,
+        descent_order=TraversalStrategy.PrefixDepthFirstSearch,
+    ):
+        logger.info(
+            "%s %s" % (constr.name, ("active" if constr.active else "deactivated"))
+        )

--- a/pyomo/util/calc_var_value.py
+++ b/pyomo/util/calc_var_value.py
@@ -14,12 +14,19 @@ from pyomo.core.expr.calculus.derivatives import differentiate
 from pyomo.core.base.constraint import Constraint, _ConstraintData
 
 import logging
+
 logger = logging.getLogger(__name__)
 
-def calculate_variable_from_constraint(variable, constraint,
-                                       eps=1e-8, iterlim=1000,
-                                       linesearch=True, alpha_min=1e-8,
-                                       diff_mode=differentiate.Modes.sympy):
+
+def calculate_variable_from_constraint(
+    variable,
+    constraint,
+    eps=1e-8,
+    iterlim=1000,
+    linesearch=True,
+    alpha_min=1e-8,
+    diff_mode=differentiate.Modes.sympy,
+):
     """Calculate the variable value given a specified equality constraint
 
     This function calculates the value of the specified variable
@@ -101,7 +108,8 @@ def calculate_variable_from_constraint(variable, constraint,
             else:
                 # set the initial value to the midpoint of the bounds
                 variable.set_value(
-                    (variable.lb+variable.ub)/2.0, skip_validation=True)
+                    (variable.lb + variable.ub) / 2.0, skip_validation=True
+                )
 
     # store the initial value to use later if necessary
     orig_initial_value = variable.value
@@ -118,7 +126,8 @@ def calculate_variable_from_constraint(variable, constraint,
     except:
         logger.error(
             "Encountered an error evaluating the expression at the "
-            "initial guess.\n\tPlease provide a different initial guess.")
+            "initial guess.\n\tPlease provide a different initial guess."
+        )
         raise
 
     try:
@@ -145,12 +154,15 @@ def calculate_variable_from_constraint(variable, constraint,
         # Assume the variable appears linearly and calculate the coefficient
         x2 = value(variable)
         slope = float(residual_1 - residual_2) / (x1 - x2)
-        intercept = (residual_1 - upper) - slope*x1
+        intercept = (residual_1 - upper) - slope * x1
         if slope:
-            variable.set_value(-intercept/slope, skip_validation=True)
+            variable.set_value(-intercept / slope, skip_validation=True)
             body_val = value(body, exception=False)
-            if (body_val is not None and body_val.__class__ is not complex
-                and abs(body_val - upper) < eps):
+            if (
+                body_val is not None
+                and body_val.__class__ is not complex
+                and abs(body_val - upper) < eps
+            ):
                 # Re-set the variable value to trigger any warnings WRT
                 # the final variable state
                 variable.set_value(variable.value)
@@ -164,8 +176,7 @@ def calculate_variable_from_constraint(variable, constraint,
 
     expr_deriv = None
     if diff_mode in {differentiate.Modes.sympy, differentiate.Modes.reverse_symbolic}:
-        expr_deriv = differentiate(expr, wrt=variable,
-                                   mode=diff_mode)
+        expr_deriv = differentiate(expr, wrt=variable, mode=diff_mode)
 
         if type(expr_deriv) in native_numeric_types and expr_deriv == 0:
             raise ValueError("Variable derivative == 0, cannot solve for variable")
@@ -178,7 +189,8 @@ def calculate_variable_from_constraint(variable, constraint,
     if abs(value(fp0)) < 1e-12:
         raise RuntimeError(
             'Initial value for variable results in a derivative value that is '
-            'very close to zero.\n\tPlease provide a different initial guess.')
+            'very close to zero.\n\tPlease provide a different initial guess.'
+        )
 
     iter_left = iterlim
     fk = residual_1 - upper
@@ -187,22 +199,23 @@ def calculate_variable_from_constraint(variable, constraint,
         if not iter_left:
             raise RuntimeError(
                 "Iteration limit (%s) reached; remaining residual = %s"
-                % (iterlim, value(expr)) )
+                % (iterlim, value(expr))
+            )
 
         # compute step
         xk = value(variable)
         try:
             fk = value(expr)
             if type(fk) is complex:
-                raise ValueError(
-                    "Complex numbers are not allowed in Newton's method.")
+                raise ValueError("Complex numbers are not allowed in Newton's method.")
         except:
             # We hit numerical problems with the last step (possible if
             # the line search is turned off)
             logger.error(
                 "Newton's method encountered an error evaluating the "
                 "expression.\n\tPlease provide a different initial guess "
-                "or enable the linesearch if you have not.")
+                "or enable the linesearch if you have not."
+            )
             raise
 
         if expr_deriv is None:
@@ -214,15 +227,16 @@ def calculate_variable_from_constraint(variable, constraint,
             raise RuntimeError(
                 "Newton's method encountered a derivative that was too "
                 "close to zero.\n\tPlease provide a different initial guess "
-                "or enable the linesearch if you have not.")
-        pk = -fk/fpk
+                "or enable the linesearch if you have not."
+            )
+        pk = -fk / fpk
         alpha = 1.0
         xkp1 = xk + alpha * pk
         variable.set_value(xkp1, skip_validation=True)
 
         # perform line search
         if linesearch:
-            c1 = 0.999 # ensure sufficient progress
+            c1 = 0.999  # ensure sufficient progress
             while alpha > alpha_min:
                 # check if the value at xkp1 has sufficient reduction in
                 # the residual
@@ -233,7 +247,7 @@ def calculate_variable_from_constraint(variable, constraint,
                 if type(fkp1) is complex:
                     # We cannot perform computations on complex numbers
                     fkp1 = None
-                if fkp1 is not None and fkp1**2 < c1*fk**2:
+                if fkp1 is not None and fkp1**2 < c1 * fk**2:
                     # found an alpha value with sufficient reduction
                     # continue to the next step
                     fk = fkp1
@@ -248,7 +262,8 @@ def calculate_variable_from_constraint(variable, constraint,
                     residual = "{function evaluation error}"
                 raise RuntimeError(
                     "Linesearch iteration limit reached; remaining "
-                    "residual = %s." % (residual,))
+                    "residual = %s." % (residual,)
+                )
     #
     # Re-set the variable value to trigger any warnings WRT the final
     # variable state

--- a/pyomo/util/check_units.py
+++ b/pyomo/util/check_units.py
@@ -15,10 +15,23 @@ This module has some helpful methods to support checking units on Pyomo
 module objects.
 """
 from pyomo.core.base.units_container import units, UnitsError
-from pyomo.core.base import (Objective, Constraint, Var, Param,
-                             Suffix, Set, SetOf, RangeSet, Block,
-                             ExternalFunction, Expression,
-                             value, BooleanVar, BuildAction, BuildCheck)
+from pyomo.core.base import (
+    Objective,
+    Constraint,
+    Var,
+    Param,
+    Suffix,
+    Set,
+    SetOf,
+    RangeSet,
+    Block,
+    ExternalFunction,
+    Expression,
+    value,
+    BooleanVar,
+    BuildAction,
+    BuildCheck,
+)
 from pyomo.dae import ContinuousSet, DerivativeVar
 from pyomo.network import Port, Arc
 from pyomo.mpec import Complementarity
@@ -26,6 +39,7 @@ from pyomo.gdp import Disjunct, Disjunction
 from pyomo.core.expr.template_expr import IndexTemplate
 from pyomo.core.expr.numvalue import native_types
 from pyomo.util.components import iter_component
+
 
 def check_units_equivalent(*args):
     """
@@ -51,6 +65,7 @@ def check_units_equivalent(*args):
     except UnitsError:
         return False
 
+
 def assert_units_equivalent(*args):
     """
     Raise an exception if the units are inconsistent within an
@@ -73,7 +88,10 @@ def assert_units_equivalent(*args):
         if not units._equivalent_pint_units(pint_unit_compare, pint_unit):
             raise UnitsError(
                 "Units between {} and {} are not consistent.".format(
-                    str(pint_unit_compare), str(pint_unit)))
+                    str(pint_unit_compare), str(pint_unit)
+                )
+            )
+
 
 def _assert_units_consistent_constraint_data(condata):
     """
@@ -99,6 +117,7 @@ def _assert_units_consistent_constraint_data(condata):
     else:
         assert_units_equivalent(*args)
 
+
 def _assert_units_consistent_arc_data(arcdata):
     """
     Raise an exception if the any units do not match for the connected ports
@@ -123,12 +142,14 @@ def _assert_units_consistent_arc_data(arcdata):
         else:
             assert_units_equivalent(svar, dvar)
 
+
 def _assert_units_consistent_property_expr(obj):
     """
     Check the .expr property of the object and raise
     an exception if the units are not consistent
     """
     _assert_units_consistent_expression(obj.expr)
+
 
 def _assert_units_consistent_expression(expr):
     """
@@ -139,11 +160,12 @@ def _assert_units_consistent_expression(expr):
     pint_unit = units._get_pint_units(expr)
     # pyomo_unit = units.get_units(expr)
 
+
 # Complementarities that are not in standard form do not
 # current work with the checking code. The Units container
 # should be modified to allow sum and relationals with zero
 # terms (e.g., unitless). Then this code can be enabled.
-#def _assert_units_complementarity(cdata):
+# def _assert_units_complementarity(cdata):
 #    """
 #    Raise an exception if any units in either of the complementarity
 #    expressions are inconsistent, and also check the standard block
@@ -155,6 +177,7 @@ def _assert_units_consistent_expression(expr):
 #        pyomo_unit, pint_unit = units._get_units_tuple(cdata._args[1])
 #    _assert_units_consistent_block(cdata)
 
+
 def _assert_units_consistent_block(obj):
     """
     This method gets all the components from the block
@@ -164,9 +187,10 @@ def _assert_units_consistent_block(obj):
     for component in obj.component_objects(descend_into=False, active=True):
         assert_units_consistent(component)
 
+
 _component_data_handlers = {
     Objective: _assert_units_consistent_property_expr,
-    Constraint:  _assert_units_consistent_constraint_data,
+    Constraint: _assert_units_consistent_constraint_data,
     Var: _assert_units_consistent_expression,
     DerivativeVar: _assert_units_consistent_expression,
     Port: None,
@@ -192,7 +216,8 @@ _component_data_handlers = {
     # complementarities that are not in normal form are not working yet
     # see comment in test_check_units
     # TODO: Complementarity: _assert_units_complementarity
-    }
+}
+
 
 def assert_units_consistent(obj):
     """
@@ -224,7 +249,9 @@ def assert_units_consistent(obj):
 
     # if object is not in our component handler, raise an exception
     if obj.ctype not in _component_data_handlers:
-        raise TypeError("Units checking not supported for object of type {}.".format(obj.ctype))
+        raise TypeError(
+            "Units checking not supported for object of type {}.".format(obj.ctype)
+        )
 
     # get the function form the list of handlers
     handler = _component_data_handlers[obj.ctype]
@@ -243,6 +270,5 @@ def assert_units_consistent(obj):
         try:
             handler(obj)
         except UnitsError:
-                print('Error in units when checking {}'.format(obj))
-                raise
-            
+            print('Error in units when checking {}'.format(obj))
+            raise

--- a/pyomo/util/diagnostics.py
+++ b/pyomo/util/diagnostics.py
@@ -12,8 +12,16 @@ logger.setLevel(logging.INFO)
 def log_disjunct_values(m):
     """Prints the values of the disjunct indicator variables."""
     for disj in m.component_data_objects(
-        ctype=Disjunct, active=True, descend_into=(Block, Disjunct),
-        descent_order=TraversalStrategy.PrefixDepthFirstSearch
+        ctype=Disjunct,
+        active=True,
+        descend_into=(Block, Disjunct),
+        descent_order=TraversalStrategy.PrefixDepthFirstSearch,
     ):
-        logger.info("%s %s%s" % (disj.name, disj.indicator_var.value,
-                                 " fixed" if disj.indicator_var.fixed else ""))
+        logger.info(
+            "%s %s%s"
+            % (
+                disj.name,
+                disj.indicator_var.value,
+                " fixed" if disj.indicator_var.fixed else "",
+            )
+        )

--- a/pyomo/util/infeasible.py
+++ b/pyomo/util/infeasible.py
@@ -21,6 +21,7 @@ from pyomo.util.blockutil import log_model_constraints
 
 logger = logging.getLogger(__name__)
 
+
 def _check_infeasible(obj, val, tol):
     if val is None:
         # Undefined value due to missing variable value or evaluation error
@@ -42,7 +43,7 @@ def _check_infeasible(obj, val, tol):
     return infeasible
 
 
-def find_infeasible_constraints(m, tol=1E-6):
+def find_infeasible_constraints(m, tol=1e-6):
     """Find the infeasible constraints in the model.
 
     Uses the current model state.
@@ -72,7 +73,8 @@ def find_infeasible_constraints(m, tol=1E-6):
     """
     # Iterate through all active constraints on the model
     for constr in m.component_data_objects(
-            ctype=Constraint, active=True, descend_into=True):
+        ctype=Constraint, active=True, descend_into=True
+    ):
         body_value = value(constr.body, exception=False)
         infeasible = _check_infeasible(constr, body_value, tol)
         if infeasible:
@@ -80,8 +82,7 @@ def find_infeasible_constraints(m, tol=1E-6):
 
 
 def log_infeasible_constraints(
-        m, tol=1E-6, logger=logger,
-        log_expression=False, log_variables=False
+    m, tol=1e-6, logger=logger, log_expression=False, log_variables=False
 ):
     """Logs the infeasible constraints in the model.
 
@@ -154,9 +155,7 @@ def log_infeasible_constraints(
 
         line = f"CONSTR {constr.name}: {lb}{lb_op}{body}{ub_op}{ub}"
         if log_expression:
-            line += (
-                f"\n  - EXPR: {lb_expr}{lb_op}{constr.body}{ub_op}{ub_expr}"
-            )
+            line += f"\n  - EXPR: {lb_expr}{lb_op}{constr.body}{ub_op}{ub_expr}"
         if log_variables:
             line += ''.join(
                 f"\n  - VAR {v.name}: {v.value}"
@@ -166,7 +165,7 @@ def log_infeasible_constraints(
         logger.info(line)
 
 
-def find_infeasible_bounds(m, tol=1E-6):
+def find_infeasible_bounds(m, tol=1e-6):
     """Find variables whose values are outside their bounds
 
     Uses the current model state. Variables with no values are returned
@@ -191,8 +190,7 @@ def find_infeasible_bounds(m, tol=1E-6):
         value or a bound was undefined)
 
     """
-    for var in m.component_data_objects(
-            ctype=Var, descend_into=True):
+    for var in m.component_data_objects(ctype=Var, descend_into=True):
         val = var.value
         infeasible = _check_infeasible(var, val, tol)
         if infeasible:
@@ -206,7 +204,8 @@ _evaluation_errors = {
     7: 'error evaluating lower or upper bounds',
 }
 
-def log_infeasible_bounds(m, tol=1E-6, logger=logger):
+
+def log_infeasible_bounds(m, tol=1e-6, logger=logger):
     """Logs the infeasible variable bounds in the model.
 
     Parameters
@@ -257,7 +256,7 @@ def _check_close(obj, val, tol):
     return close
 
 
-def find_close_to_bounds(m, tol=1E-6):
+def find_close_to_bounds(m, tol=1e-6):
     """Find variables and constraints whose values are close to their bounds.
 
     Uses the current model state. Variables with no values and
@@ -315,7 +314,8 @@ def find_close_to_bounds(m, tol=1E-6):
         yield var, val, close
 
     for con in m.component_data_objects(
-            ctype=Constraint, active=True, descend_into=True):
+        ctype=Constraint, active=True, descend_into=True
+    ):
         if con.equality:
             continue
         val = value(con.body, exception=False)
@@ -330,7 +330,7 @@ def find_close_to_bounds(m, tol=1E-6):
         yield con, val, close
 
 
-def log_close_to_bounds(m, tol=1E-6, logger=logger):
+def log_close_to_bounds(m, tol=1e-6, logger=logger):
     """Print the variables and constraints that are near their bounds.
 
     See :py:func:`find_close_to_bounds()` for a description of the
@@ -362,8 +362,7 @@ def log_close_to_bounds(m, tol=1E-6, logger=logger):
             elif obj.ctype is Constraint:
                 logger.info(f"Skipping CONSTR {obj.name}: evaluation error.")
             else:
-                logger.error(
-                    f"Object {obj.name} was neither a Var nor Constraint")
+                logger.error(f"Object {obj.name} was neither a Var nor Constraint")
             continue
         if close & 1:
             logger.info(f'{obj.name} near LB of {obj.lb}')
@@ -372,8 +371,10 @@ def log_close_to_bounds(m, tol=1E-6, logger=logger):
     return
 
 
-@deprecated("log_active_constraints is deprecated.  "
-            "Please use pyomo.util.blockutil.log_model_constraints()",
-            version="5.7.3")
+@deprecated(
+    "log_active_constraints is deprecated.  "
+    "Please use pyomo.util.blockutil.log_model_constraints()",
+    version="5.7.3",
+)
 def log_active_constraints(m, logger=logger):
     log_model_constraints(m, logger)

--- a/pyomo/util/model_size.py
+++ b/pyomo/util/model_size.py
@@ -42,6 +42,7 @@ class ModelSizeReport(Bunch):
     Activated disjunctions follow the same rules as activated constraints.
 
     """
+
     pass
 
 
@@ -62,18 +63,20 @@ def build_model_size_report(model):
         new_activated_constraints = ComponentSet()
 
         for container in new_containers:
-            (next_activated_disjunctions,
-             next_fixed_true_disjuncts,
-             next_activated_disjuncts,
-             next_activated_constraints
-             ) = _process_activated_container(container)
+            (
+                next_activated_disjunctions,
+                next_fixed_true_disjuncts,
+                next_activated_disjuncts,
+                next_activated_constraints,
+            ) = _process_activated_container(container)
             new_activated_disjunctions.update(next_activated_disjunctions)
             new_activated_disjuncts.update(next_activated_disjuncts)
             new_fixed_true_disjuncts.update(next_fixed_true_disjuncts)
             new_activated_constraints.update(next_activated_constraints)
 
-        new_containers = ((new_activated_disjuncts - activated_disjuncts) |
-                          (new_fixed_true_disjuncts - fixed_true_disjuncts))
+        new_containers = (new_activated_disjuncts - activated_disjuncts) | (
+            new_fixed_true_disjuncts - fixed_true_disjuncts
+        )
 
         activated_disjunctions.update(new_activated_disjunctions)
         activated_disjuncts.update(new_activated_disjuncts)
@@ -81,57 +84,60 @@ def build_model_size_report(model):
         activated_constraints.update(new_activated_constraints)
 
     activated_vars.update(
-        var for constr in activated_constraints
-        for var in EXPR.identify_variables(
-            constr.body, include_fixed=False))
+        var
+        for constr in activated_constraints
+        for var in EXPR.identify_variables(constr.body, include_fixed=False)
+    )
     activated_vars.update(
-        disj.indicator_var.get_associated_binary()
-        for disj in activated_disjuncts)
+        disj.indicator_var.get_associated_binary() for disj in activated_disjuncts
+    )
 
     report.activated = Bunch()
     report.activated.variables = len(activated_vars)
-    report.activated.binary_variables = sum(
-        1 for v in activated_vars if v.is_binary())
+    report.activated.binary_variables = sum(1 for v in activated_vars if v.is_binary())
     report.activated.integer_variables = sum(
-        1 for v in activated_vars if v.is_integer() and not v.is_binary())
+        1 for v in activated_vars if v.is_integer() and not v.is_binary()
+    )
     report.activated.continuous_variables = sum(
-        1 for v in activated_vars if v.is_continuous())
+        1 for v in activated_vars if v.is_continuous()
+    )
     report.activated.disjunctions = len(activated_disjunctions)
     report.activated.disjuncts = len(activated_disjuncts)
     report.activated.constraints = len(activated_constraints)
     report.activated.nonlinear_constraints = sum(
-        1 for c in activated_constraints
-        if c.body.polynomial_degree() not in (1, 0))
+        1 for c in activated_constraints if c.body.polynomial_degree() not in (1, 0)
+    )
 
     report.overall = Bunch()
     block_like = (Block, Disjunct)
-    all_vars = ComponentSet(
-        model.component_data_objects(Var, descend_into=block_like))
+    all_vars = ComponentSet(model.component_data_objects(Var, descend_into=block_like))
     report.overall.variables = len(all_vars)
     report.overall.binary_variables = sum(1 for v in all_vars if v.is_binary())
     report.overall.integer_variables = sum(
-        1 for v in all_vars if v.is_integer() and not v.is_binary())
-    report.overall.continuous_variables = sum(
-        1 for v in all_vars if v.is_continuous())
+        1 for v in all_vars if v.is_integer() and not v.is_binary()
+    )
+    report.overall.continuous_variables = sum(1 for v in all_vars if v.is_continuous())
     report.overall.disjunctions = sum(
-        1 for d in model.component_data_objects(
-            Disjunction, descend_into=block_like))
+        1 for d in model.component_data_objects(Disjunction, descend_into=block_like)
+    )
     report.overall.disjuncts = sum(
-        1 for d in model.component_data_objects(
-            Disjunct, descend_into=block_like))
+        1 for d in model.component_data_objects(Disjunct, descend_into=block_like)
+    )
     report.overall.constraints = sum(
-        1 for c in model.component_data_objects(
-            Constraint, descend_into=block_like))
+        1 for c in model.component_data_objects(Constraint, descend_into=block_like)
+    )
     report.overall.nonlinear_constraints = sum(
-        1 for c in model.component_data_objects(
-            Constraint, descend_into=block_like)
-        if c.body.polynomial_degree() not in (1, 0))
+        1
+        for c in model.component_data_objects(Constraint, descend_into=block_like)
+        if c.body.polynomial_degree() not in (1, 0)
+    )
 
     report.warning = Bunch()
     report.warning.unassociated_disjuncts = sum(
-        1 for d in model.component_data_objects(
-            Disjunct, descend_into=block_like)
-        if not d.indicator_var.fixed and d not in activated_disjuncts)
+        1
+        for d in model.component_data_objects(Disjunct, descend_into=block_like)
+        if not d.indicator_var.fixed and d not in activated_disjuncts
+    )
 
     return report
 
@@ -144,24 +150,33 @@ def log_model_size_report(model, logger=default_logger):
 def _process_activated_container(blk):
     """Process a container object, returning the new components found."""
     new_fixed_true_disjuncts = ComponentSet(
-        disj for disj in blk.component_data_objects(Disjunct, active=True)
-        if disj.indicator_var.value and disj.indicator_var.fixed)
+        disj
+        for disj in blk.component_data_objects(Disjunct, active=True)
+        if disj.indicator_var.value and disj.indicator_var.fixed
+    )
     new_activated_disjunctions = ComponentSet(
-        blk.component_data_objects(Disjunction, active=True))
+        blk.component_data_objects(Disjunction, active=True)
+    )
     new_activated_disjuncts = ComponentSet(
-        disj for disjtn in new_activated_disjunctions
-        for disj in _activated_disjuncts_in_disjunction(disjtn))
+        disj
+        for disjtn in new_activated_disjunctions
+        for disj in _activated_disjuncts_in_disjunction(disjtn)
+    )
     new_activated_constraints = ComponentSet(
-        blk.component_data_objects(Constraint, active=True))
+        blk.component_data_objects(Constraint, active=True)
+    )
     return (
         new_activated_disjunctions,
         new_fixed_true_disjuncts,
         new_activated_disjuncts,
-        new_activated_constraints
+        new_activated_constraints,
     )
 
 
 def _activated_disjuncts_in_disjunction(disjtn):
     """Retrieve generator of activated disjuncts on disjunction."""
-    return (disj for disj in disjtn.disjuncts
-            if disj.active and not disj.indicator_var.fixed)
+    return (
+        disj
+        for disj in disjtn.disjuncts
+        if disj.active and not disj.indicator_var.fixed
+    )

--- a/pyomo/util/report_scaling.py
+++ b/pyomo/util/report_scaling.py
@@ -68,7 +68,9 @@ def _print_coefficients(comp_map):
     return s
 
 
-def _check_coefficents(comp, expr, too_large, too_small, largs_coef_map, small_coef_map):
+def _check_coefficents(
+    comp, expr, too_large, too_small, largs_coef_map, small_coef_map
+):
     ders = reverse_sd(expr)
     for _v, _der in ders.items():
         if isinstance(_v, _GeneralVarData):
@@ -87,7 +89,9 @@ def _check_coefficents(comp, expr, too_large, too_small, largs_coef_map, small_c
                     small_coef_map[comp].append((_v, der_lb, der_ub))
 
 
-def report_scaling(m: _BlockData, too_large: float = 5e4, too_small: float = 1e-6) -> bool:
+def report_scaling(
+    m: _BlockData, too_large: float = 5e4, too_small: float = 1e-6
+) -> bool:
     """
     This function logs potentially poorly scaled parts of the model.
     It requires that all variables be bounded.
@@ -125,7 +129,14 @@ def report_scaling(m: _BlockData, too_large: float = 5e4, too_small: float = 1e-
     objs_with_small_coefficients = pyo.ComponentMap()
 
     for c in m.component_data_objects(pyo.Constraint, active=True, descend_into=True):
-        _check_coefficents(c, c.body, too_large, too_small, cons_with_large_coefficients, cons_with_small_coefficients)
+        _check_coefficents(
+            c,
+            c.body,
+            too_large,
+            too_small,
+            cons_with_large_coefficients,
+            cons_with_small_coefficients,
+        )
 
     for c in m.component_data_objects(pyo.Constraint, active=True, descend_into=True):
         c_lb, c_ub = compute_bounds_on_expr(c.body)
@@ -134,7 +145,14 @@ def report_scaling(m: _BlockData, too_large: float = 5e4, too_small: float = 1e-
             cons_with_large_bounds[c] = (c_lb, c_ub)
 
     for c in m.component_data_objects(pyo.Objective, active=True, descend_into=True):
-        _check_coefficents(c, c.expr, too_large, too_small, objs_with_large_coefficients, objs_with_small_coefficients)
+        _check_coefficents(
+            c,
+            c.expr,
+            too_large,
+            too_small,
+            objs_with_large_coefficients,
+            objs_with_small_coefficients,
+        )
 
     s = '\n\n'
 
@@ -168,13 +186,15 @@ def report_scaling(m: _BlockData, too_large: float = 5e4, too_small: float = 1e-
         for c, (c_lb, c_ub) in cons_with_large_bounds.items():
             s += f'{c_lb:>12.2e}{c_ub:>12.2e}    {str(c)}\n'
 
-    if (len(vars_without_bounds) > 0
-            or len(vars_with_large_bounds) > 0
-            or len(cons_with_large_coefficients) > 0
-            or len(cons_with_small_coefficients) > 0
-            or len(objs_with_small_coefficients) > 0
-            or len(objs_with_large_coefficients) > 0
-            or len(cons_with_large_bounds) > 0):
+    if (
+        len(vars_without_bounds) > 0
+        or len(vars_with_large_bounds) > 0
+        or len(cons_with_large_coefficients) > 0
+        or len(cons_with_small_coefficients) > 0
+        or len(objs_with_small_coefficients) > 0
+        or len(objs_with_large_coefficients) > 0
+        or len(cons_with_large_bounds) > 0
+    ):
         logger.info(s)
         return False
     return True

--- a/pyomo/util/slices.py
+++ b/pyomo/util/slices.py
@@ -14,6 +14,7 @@ from pyomo.core.base.indexed_component import normalize_index
 from pyomo.core.base.indexed_component_slice import IndexedComponent_slice
 from pyomo.core.base.global_set import UnindexedComponent_set
 
+
 def _to_iterable(source):
     iterable_scalars = (str, bytes)
     if hasattr(source, '__iter__'):
@@ -25,10 +26,11 @@ def _to_iterable(source):
     else:
         yield source
 
+
 def get_component_call_stack(comp, context=None):
     """Get the call stack necessary to locate a `Component`
 
-    The call stack is a `list` of `tuple`s where the first entry is a 
+    The call stack is a `list` of `tuple`s where the first entry is a
     code for `__getattr__` or  `__getitem__`, using the same convention
     as `IndexedComponent_slice`. The second entry is the argument of
     the corresponding function. Following this sequence of calls from
@@ -54,7 +56,7 @@ def get_component_call_stack(comp, context=None):
     # A component is not said to exist in "the context of" itself.
     call_stack = []
     while comp.parent_block() is not None:
-        # If parent_block is None, comp is the root 
+        # If parent_block is None, comp is the root
         # of the model, so we don't add anything else
         # to the call stack.
         if comp is context:
@@ -72,12 +74,12 @@ def get_component_call_stack(comp, context=None):
             break
 
         # Add (get_attribute, name) to the call stack
-        call_stack.append((
-            IndexedComponent_slice.get_attribute,
-            parent_component.local_name
-            ))
+        call_stack.append(
+            (IndexedComponent_slice.get_attribute, parent_component.local_name)
+        )
         comp = comp.parent_block()
     return call_stack
+
 
 def slice_component_along_sets(comp, sets, context=None):
     """Slice a component along the indices corresponding to some sets,
@@ -85,12 +87,12 @@ def slice_component_along_sets(comp, sets, context=None):
 
     Given a component or component data object, for all parent components
     and parent blocks between the object and the `context` block, replace
-    any index corresponding to a set in `sets` with slices or an 
+    any index corresponding to a set in `sets` with slices or an
     ellipsis.
 
     Parameters:
     -----------
-    comp: `pyomo.core.base.component.Component` or 
+    comp: `pyomo.core.base.component.Component` or
     `pyomo.core.base.component.ComponentData`
         Component whose parent structure to search and replace
     sets: `pyomo.common.collections.ComponentSet`
@@ -102,7 +104,7 @@ def slice_component_along_sets(comp, sets, context=None):
     Returns:
     --------
     `pyomo.core.base.indexed_component_slice.IndexedComponent_slice`:
-        Slice of `comp` with wildcards replacing the indices of `sets`    
+        Slice of `comp` with wildcards replacing the indices of `sets`
 
     """
     # Cast to ComponentSet so a tuple or list of sets is an appropriate
@@ -135,6 +137,7 @@ def slice_component_along_sets(comp, sets, context=None):
             sliced_comp = sliced_comp[arg]
 
     return sliced_comp
+
 
 def replace_indices(index, location_set_map, sets):
     """Use `location_set_map` to replace values in `index` with slices
@@ -183,6 +186,7 @@ def replace_indices(index, location_set_map, sets):
         loc += 1
     return tuple(new_index)
 
+
 def get_location_set_map(index, index_set):
     """Map each value in an index to the set from which it originates
 
@@ -226,7 +230,7 @@ def get_location_set_map(index, index_set):
             # Although in this case, the location of an index should
             # just be its position in the subsets list, so maybe
             # the info we need is actually more simple to obtain.
-            )
+        )
 
     subsets = list(index_set.subsets())
 
@@ -244,8 +248,8 @@ def get_location_set_map(index, index_set):
             dimen_none_set_coord = sub_coord
             break
         for i in range(dimen):
-            location_set_map[location+i] = sub
-            locations_left.remove(location+i)
+            location_set_map[location + i] = sub
+            locations_left.remove(location + i)
         location += dimen
 
     # We are either done or have encountered a set of dimen None
@@ -263,20 +267,20 @@ def get_location_set_map(index, index_set):
                 # Make sure this set is the same one we encountered
                 # earlier. It is sufficient to check the coordinate.
                 raise RuntimeError(
-                'Cannot get locations when multiple sets of dimen==None '
-                'are present.'
-                '\nFound %s at position %s and %s at position %s.'
-                '\nLocation is ambiguous in this case.'
-                % (dimen_none_set, dimen_none_set_coord, sub, sub_coord)
+                    'Cannot get locations when multiple sets of dimen==None '
+                    'are present.'
+                    '\nFound %s at position %s and %s at position %s.'
+                    '\nLocation is ambiguous in this case.'
+                    % (dimen_none_set, dimen_none_set_coord, sub, sub_coord)
                 )
             break
         for i in range(dimen):
-            location_set_map[location-i] = sub
-            locations_left.remove(location-i)
+            location_set_map[location - i] = sub
+            locations_left.remove(location - i)
         location -= sub.dimen
 
     for loc in locations_left:
-        # All remaining locations, that cannot be accessed from some 
+        # All remaining locations, that cannot be accessed from some
         # constant offset from the beginning or end of the tuple,
         # must belong to the dimen-None set.
         location_set_map[loc] = dimen_none_set

--- a/pyomo/util/subsystems.py
+++ b/pyomo/util/subsystems.py
@@ -24,7 +24,6 @@ from pyomo.core.expr.numvalue import native_types
 
 
 class _ExternalFunctionVisitor(StreamBasedExpressionVisitor):
-
     def initializeWalker(self, expr):
         self._functions = []
         self._seen = set()
@@ -57,9 +56,7 @@ def identify_external_functions(expr):
 
 def add_local_external_functions(block):
     ef_exprs = []
-    for comp in block.component_data_objects(
-            (Constraint, Expression), active=True
-            ):
+    for comp in block.component_data_objects((Constraint, Expression), active=True):
         ef_exprs.extend(identify_external_functions(comp.expr))
     unique_functions = []
     fcn_set = set()
@@ -79,7 +76,7 @@ def add_local_external_functions(block):
 
 
 def create_subsystem_block(constraints, variables=None, include_fixed=False):
-    """ This function creates a block to serve as a subsystem with the
+    """This function creates a block to serve as a subsystem with the
     specified variables and constraints. To satisfy certain writers, other
     variables that appear in the constraints must be added to the block as
     well. We call these the "input vars." They may be thought of as
@@ -120,7 +117,7 @@ def create_subsystem_block(constraints, variables=None, include_fixed=False):
 
 
 def generate_subsystem_blocks(subsystems, include_fixed=False):
-    """ Generates blocks that contain subsystems of variables and constraints.
+    """Generates blocks that contain subsystems of variables and constraints.
 
     Arguments
     ---------
@@ -144,7 +141,7 @@ def generate_subsystem_blocks(subsystems, include_fixed=False):
 
 
 class TemporarySubsystemManager(object):
-    """ This class is a context manager for cases when we want to
+    """This class is a context manager for cases when we want to
     temporarily fix or deactivate certain variables or constraints
     in order to perform some solve or calculation with the resulting
     subsystem.
@@ -210,7 +207,7 @@ class TemporarySubsystemManager(object):
 
 
 class ParamSweeper(TemporarySubsystemManager):
-    """ This class enables setting values of variables/parameters
+    """This class enables setting values of variables/parameters
     according to a provided sequence. Iterating over this object
     sets values to the next in the sequence, at which point a
     calculation may be performed and output values compared.
@@ -243,14 +240,15 @@ class ParamSweeper(TemporarySubsystemManager):
 
     """
 
-    def __init__(self,
-            n_scenario,
-            input_values,
-            output_values=None,
-            to_fix=None,
-            to_deactivate=None,
-            to_reset=None,
-            ):
+    def __init__(
+        self,
+        n_scenario,
+        input_values,
+        output_values=None,
+        to_fix=None,
+        to_deactivate=None,
+        to_reset=None,
+    ):
         """
         Parameters
         ----------
@@ -276,7 +274,7 @@ class ParamSweeper(TemporarySubsystemManager):
         self.output_values = output
         self.n_scenario = n_scenario
         self.initial_state_values = None
-        self._ip = -1 # Index pointer for iteration
+        self._ip = -1  # Index pointer for iteration
 
         if to_reset is None:
             # Input values will be set repeatedly by iterating over this
@@ -290,10 +288,8 @@ class ParamSweeper(TemporarySubsystemManager):
             to_reset.extend(var for var in output)
 
         super(ParamSweeper, self).__init__(
-                to_fix=to_fix,
-                to_deactivate=to_deactivate,
-                to_reset=to_reset,
-                )
+            to_fix=to_fix, to_deactivate=to_deactivate, to_reset=to_reset
+        )
 
     def __iter__(self):
         return self
@@ -317,8 +313,8 @@ class ParamSweeper(TemporarySubsystemManager):
                 var.set_value(val)
                 inputs[var] = val
 
-            outputs = ComponentMap([
-                (var, values[i]) for var, values in output_values.items()
-                ])
+            outputs = ComponentMap(
+                [(var, values[i]) for var, values in output_values.items()]
+            )
 
             return inputs, outputs

--- a/pyomo/util/tests/test_blockutil.py
+++ b/pyomo/util/tests/test_blockutil.py
@@ -18,9 +18,8 @@ import pyomo.common.unittest as unittest
 
 from pyomo.common.log import LoggingIntercept
 from pyomo.environ import ConcreteModel, Constraint, Var, inequality
-from pyomo.util.blockutil import (
-    log_model_constraints,
-)
+from pyomo.util.blockutil import log_model_constraints
+
 
 class TestBlockutil(unittest.TestCase):
     """Tests block utilities."""
@@ -42,8 +41,8 @@ class TestBlockutil(unittest.TestCase):
         m.c10 = Constraint(expr=m.y >= 3, doc="Inactive")
         m.c10.deactivate()
         m.c11 = Constraint(expr=m.y <= m.y.value)
-        m.yy = Var(bounds=(0, 1), initialize=1E-7, doc="Close to lower bound")
-        m.y3 = Var(bounds=(0, 1E-7), initialize=0, doc="Bounds too close")
+        m.yy = Var(bounds=(0, 1), initialize=1e-7, doc="Close to lower bound")
+        m.y3 = Var(bounds=(0, 1e-7), initialize=0, doc="Bounds too close")
         m.y4 = Var(bounds=(0, 1), initialize=2, doc="Fixed out of bounds.")
         m.y4.fix()
 
@@ -51,8 +50,15 @@ class TestBlockutil(unittest.TestCase):
         with LoggingIntercept(output, 'pyomo.util', logging.INFO):
             log_model_constraints(m)
         expected_output = [
-            "c1 active", "c2 active", "c3 active", "c4 active",
-            "c5 active", "c6 active", "c7 active", "c8 active",
-            "c9 active", "c11 active"
+            "c1 active",
+            "c2 active",
+            "c3 active",
+            "c4 active",
+            "c5 active",
+            "c6 active",
+            "c7 active",
+            "c8 active",
+            "c9 active",
+            "c11 active",
         ]
         self.assertEqual(expected_output, output.getvalue().splitlines())

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -16,7 +16,13 @@ import pyomo.common.unittest as unittest
 
 from pyomo.common.log import LoggingIntercept
 from pyomo.environ import (
-    ConcreteModel, Var, Constraint, Param, value, exp, NonNegativeReals,
+    ConcreteModel,
+    Var,
+    Constraint,
+    Param,
+    value,
+    exp,
+    NonNegativeReals,
     Binary,
 )
 from pyomo.util.calc_var_value import calculate_variable_from_constraint
@@ -24,9 +30,11 @@ from pyomo.core.expr.calculus.diff_with_sympy import differentiate_available
 from pyomo.core.expr.calculus.derivatives import differentiate
 
 
-all_diff_modes = [differentiate.Modes.sympy,
-                  differentiate.Modes.reverse_symbolic,
-                  differentiate.Modes.reverse_numeric]
+all_diff_modes = [
+    differentiate.Modes.sympy,
+    differentiate.Modes.reverse_symbolic,
+    differentiate.Modes.reverse_numeric,
+]
 
 
 class Test_calc_var(unittest.TestCase):
@@ -79,13 +87,14 @@ class Test_calc_var(unittest.TestCase):
 
         m.lt = Constraint(expr=m.x <= m.y)
         with self.assertRaisesRegex(
-                ValueError, "Constraint must be an equality constraint"):
+            ValueError, "Constraint must be an equality constraint"
+        ):
             calculate_variable_from_constraint(m.x, m.lt)
 
     def test_linear(self):
         m = ConcreteModel()
         m.x = Var()
-        m.c = Constraint(expr=5*m.x == 10)
+        m.c = Constraint(expr=5 * m.x == 10)
 
         for mode in all_diff_modes:
             m.x.set_value(None)
@@ -99,20 +108,21 @@ class Test_calc_var(unittest.TestCase):
 
         for mode in all_diff_modes:
             m.x.set_value(None)
-            calculate_variable_from_constraint(m.x, 5*m.x == 5, diff_mode=mode)
+            calculate_variable_from_constraint(m.x, 5 * m.x == 5, diff_mode=mode)
             self.assertEqual(value(m.x), 1)
         for mode in all_diff_modes:
             m.x.set_value(None)
-            calculate_variable_from_constraint(m.x, (5*m.x, 10), diff_mode=mode)
+            calculate_variable_from_constraint(m.x, (5 * m.x, 10), diff_mode=mode)
             self.assertEqual(value(m.x), 2)
         for mode in all_diff_modes:
             m.x.set_value(None)
-            calculate_variable_from_constraint(m.x, (15, 5*m.x, m.p), diff_mode=mode)
+            calculate_variable_from_constraint(m.x, (15, 5 * m.x, m.p), diff_mode=mode)
             self.assertEqual(value(m.x), 3)
         with self.assertRaisesRegex(
-                ValueError, "Constraint 'tuple' is a Ranged Inequality "
-                "with a variable upper bound."):
-            calculate_variable_from_constraint(m.x, (15, 5*m.x, m.x))
+            ValueError,
+            "Constraint 'tuple' is a Ranged Inequality " "with a variable upper bound.",
+        ):
+            calculate_variable_from_constraint(m.x, (15, 5 * m.x, m.x))
 
     @unittest.skipIf(not differentiate_available, "this test requires sympy")
     def test_nonlinear(self):
@@ -122,7 +132,7 @@ class Test_calc_var(unittest.TestCase):
 
         m.c = Constraint(expr=m.x**2 == 16)
         for mode in all_diff_modes:
-            m.x.set_value(1.0) # set an initial value
+            m.x.set_value(1.0)  # set an initial value
             calculate_variable_from_constraint(
                 m.x, m.c, linesearch=False, diff_mode=mode
             )
@@ -131,28 +141,32 @@ class Test_calc_var(unittest.TestCase):
         # test that infeasible constraint throws error
         m.d = Constraint(expr=m.x**2 == -1)
         for mode in all_diff_modes:
-            m.x.set_value(1.25) # set the initial value
+            m.x.set_value(1.25)  # set the initial value
             with self.assertRaisesRegex(
-                   RuntimeError, r'Iteration limit \(10\) reached'):
-               calculate_variable_from_constraint(
-                   m.x, m.d, iterlim=10, linesearch=False, diff_mode=mode
-               )
+                RuntimeError, r'Iteration limit \(10\) reached'
+            ):
+                calculate_variable_from_constraint(
+                    m.x, m.d, iterlim=10, linesearch=False, diff_mode=mode
+                )
 
         # same problem should throw a linesearch error if linesearch is on
         for mode in all_diff_modes:
-            m.x.set_value(1.25) # set the initial value
+            m.x.set_value(1.25)  # set the initial value
             with self.assertRaisesRegex(
-                    RuntimeError, "Linesearch iteration limit reached"):
-               calculate_variable_from_constraint(
-                   m.x, m.d, iterlim=10, linesearch=True, diff_mode=mode
-               )
+                RuntimeError, "Linesearch iteration limit reached"
+            ):
+                calculate_variable_from_constraint(
+                    m.x, m.d, iterlim=10, linesearch=True, diff_mode=mode
+                )
 
         # same problem should raise an error if initialized at 0
         for mode in all_diff_modes:
             m.x = 0
             with self.assertRaisesRegex(
-                    RuntimeError, "Initial value for variable results in a "
-                                  "derivative value that is very close to zero."):
+                RuntimeError,
+                "Initial value for variable results in a "
+                "derivative value that is very close to zero.",
+            ):
                 calculate_variable_from_constraint(m.x, m.c, diff_mode=mode)
 
         # same problem should raise a value error if we are asked to
@@ -162,16 +176,17 @@ class Test_calc_var(unittest.TestCase):
                 # numeric differentiation should not be used to check if a
                 # derivative is always zero
                 with self.assertRaisesRegex(
-                        RuntimeError, "Initial value for variable results in a "
-                                      "derivative value that is very close to zero."):
+                    RuntimeError,
+                    "Initial value for variable results in a "
+                    "derivative value that is very close to zero.",
+                ):
                     calculate_variable_from_constraint(m.y, m.c, diff_mode=mode)
             else:
-                with self.assertRaisesRegex(
-                        ValueError, "Variable derivative == 0"):
+                with self.assertRaisesRegex(ValueError, "Variable derivative == 0"):
                     calculate_variable_from_constraint(m.y, m.c, diff_mode=mode)
 
         # should succeed with or without a linesearch
-        m.e = Constraint(expr=(m.x - 2.0)**2 - 1 == 0)
+        m.e = Constraint(expr=(m.x - 2.0) ** 2 - 1 == 0)
         for mode in all_diff_modes:
             m.x.set_value(3.1)
             calculate_variable_from_constraint(
@@ -186,9 +201,8 @@ class Test_calc_var(unittest.TestCase):
             )
             self.assertAlmostEqual(value(m.x), 3)
 
-
         # we expect this to succeed with the linesearch
-        m.f = Constraint(expr=1.0/(1.0+exp(-m.x))-0.5 == 0)
+        m.f = Constraint(expr=1.0 / (1.0 + exp(-m.x)) - 0.5 == 0)
         for mode in all_diff_modes:
             m.x.set_value(3.0)
             calculate_variable_from_constraint(
@@ -200,8 +214,10 @@ class Test_calc_var(unittest.TestCase):
         for mode in all_diff_modes:
             m.x.set_value(3.0)
             with self.assertRaisesRegex(
-                    RuntimeError, "Newton's method encountered a derivative "
-                    "that was too close to zero"):
+                RuntimeError,
+                "Newton's method encountered a derivative "
+                "that was too close to zero",
+            ):
                 calculate_variable_from_constraint(
                     m.x, m.f, linesearch=False, diff_mode=mode
                 )
@@ -214,20 +230,26 @@ class Test_calc_var(unittest.TestCase):
         m.x = Var()
         m.pc = 48.9e5
         m.tc = 562.2
-        m.psc = {'A': -6.98273,
-                 'B': 1.33213,
-                 'C': -2.62863,
-                 'D': -3.33399,
-        }
+        m.psc = {'A': -6.98273, 'B': 1.33213, 'C': -2.62863, 'D': -3.33399}
         m.p = 101325
+
         @m.Constraint()
         def f(m):
-            return m.pc * \
-                exp((m.psc['A'] * (1 - m.x / m.tc) +
-                     m.psc['B'] * (1 - m.x / m.tc)**1.5 +
-                     m.psc['C'] * (1 - m.x / m.tc)**3 +
-                     m.psc['D'] * (1 - m.x / m.tc)**6
-                 ) / (1 - (1 - m.x / m.tc))) - m.p == 0
+            return (
+                m.pc
+                * exp(
+                    (
+                        m.psc['A'] * (1 - m.x / m.tc)
+                        + m.psc['B'] * (1 - m.x / m.tc) ** 1.5
+                        + m.psc['C'] * (1 - m.x / m.tc) ** 3
+                        + m.psc['D'] * (1 - m.x / m.tc) ** 6
+                    )
+                    / (1 - (1 - m.x / m.tc))
+                )
+                - m.p
+                == 0
+            )
+
         m.x.set_value(298.15)
         calculate_variable_from_constraint(m.x, m.f, linesearch=False)
         self.assertAlmostEqual(value(m.x), 353.31855602)
@@ -242,19 +264,21 @@ class Test_calc_var(unittest.TestCase):
         with LoggingIntercept(output, 'pyomo', logging.WARNING):
             with self.assertRaises(TypeError):
                 calculate_variable_from_constraint(m.x, m.f, linesearch=False)
-        self.assertIn('Encountered an error evaluating the expression '
-                      'at the initial guess', output.getvalue())
+        self.assertIn(
+            'Encountered an error evaluating the expression ' 'at the initial guess',
+            output.getvalue(),
+        )
 
         # This example triggers an expression evaluation error if the
         # linesearch is turned off because the first step in Newton's
         # method will cause the LHS to become complex
         m = ConcreteModel()
         m.x = Var()
-        m.c = Constraint(expr=(1/m.x**3)**0.5 == 100)
-        m.x = .1
+        m.c = Constraint(expr=(1 / m.x**3) ** 0.5 == 100)
+        m.x = 0.1
         calculate_variable_from_constraint(m.x, m.c, linesearch=True)
         self.assertAlmostEqual(value(m.x), 0.046415888)
-        m.x = .1
+        m.x = 0.1
         output = StringIO()
         with LoggingIntercept(output, 'pyomo', logging.WARNING):
             with self.assertRaises(ValueError):
@@ -265,8 +289,10 @@ class Test_calc_var(unittest.TestCase):
                 # raising a generic ValueError in
                 # calculate_variable_from_constraint
                 calculate_variable_from_constraint(m.x, m.c, linesearch=False)
-        self.assertIn("Newton's method encountered an error evaluating "
-                      "the expression.", output.getvalue())
+        self.assertIn(
+            "Newton's method encountered an error evaluating " "the expression.",
+            output.getvalue(),
+        )
 
         # This is a completely contrived example where the linesearch
         # hits the iteration limit before Newton's method ever finds a
@@ -274,12 +300,13 @@ class Test_calc_var(unittest.TestCase):
         m = ConcreteModel()
         m.x = Var()
         m.c = Constraint(expr=m.x**0.5 == -1e-8)
-        m.x = 1e-8#197.932807183
+        m.x = 1e-8  # 197.932807183
         with self.assertRaisesRegex(
-                RuntimeError, "Linesearch iteration limit reached; "
-                "remaining residual = {function evaluation error}"):
-            calculate_variable_from_constraint(m.x, m.c, linesearch=True,
-                                               alpha_min=.5)
+            RuntimeError,
+            "Linesearch iteration limit reached; "
+            "remaining residual = {function evaluation error}",
+        ):
+            calculate_variable_from_constraint(m.x, m.c, linesearch=True, alpha_min=0.5)
 
     def test_bound_violation(self):
         # Test Issue #2176: solving a constraint where the intermediate
@@ -295,14 +322,14 @@ class Test_calc_var(unittest.TestCase):
             self.assertEqual(value(m.v1), 0)
 
         # Calculate value of v1 using a scaled constraint c2
-        m.c2 = Constraint(expr=m.v1*10 == 0)
+        m.c2 = Constraint(expr=m.v1 * 10 == 0)
         for mode in all_diff_modes:
             m.v1.set_value(1)
             calculate_variable_from_constraint(m.v1, m.c2, diff_mode=mode)
             self.assertEqual(value(m.v1), 0)
 
         # Test linear solution falling outside bounds
-        m.c3 = Constraint(expr=m.v1*10 == -1)
+        m.c3 = Constraint(expr=m.v1 * 10 == -1)
         for mode in all_diff_modes:
             m.v1.set_value(1)
             calculate_variable_from_constraint(m.v1, m.c3, diff_mode=mode)
@@ -323,38 +350,39 @@ class Test_calc_var(unittest.TestCase):
 
     def test_warn_final_value_linear(self):
         m = ConcreteModel()
-        m.x = Var(bounds=(0,1))
+        m.x = Var(bounds=(0, 1))
         m.c1 = Constraint(expr=m.x == 10)
-        m.c2 = Constraint(expr=5*m.x == 10)
+        m.c2 = Constraint(expr=5 * m.x == 10)
 
         with LoggingIntercept() as LOG:
             calculate_variable_from_constraint(m.x, m.c1)
         self.assertEqual(
             LOG.getvalue().strip(),
-            "Setting Var 'x' to a numeric value `10` outside the "
-            "bounds (0, 1).")
+            "Setting Var 'x' to a numeric value `10` outside the " "bounds (0, 1).",
+        )
         self.assertEqual(value(m.x), 10)
 
         with LoggingIntercept() as LOG:
             calculate_variable_from_constraint(m.x, m.c2)
         self.assertEqual(
             LOG.getvalue().strip(),
-            "Setting Var 'x' to a numeric value `2.0` outside the "
-            "bounds (0, 1).")
+            "Setting Var 'x' to a numeric value `2.0` outside the " "bounds (0, 1).",
+        )
         self.assertEqual(value(m.x), 2)
 
     @unittest.skipUnless(differentiate_available, "this test requires sympy")
     def test_warn_final_value_nonlinear(self):
         m = ConcreteModel()
-        m.x = Var(bounds=(0,1))
-        m.c3 = Constraint(expr=(m.x - 3.5)**2 == 0)
+        m.x = Var(bounds=(0, 1))
+        m.c3 = Constraint(expr=(m.x - 3.5) ** 2 == 0)
 
         with LoggingIntercept() as LOG:
             calculate_variable_from_constraint(m.x, m.c3)
         self.assertRegex(
             LOG.getvalue().strip(),
             r"Setting Var 'x' to a numeric value `[0-9\.]+` outside the "
-            r"bounds \(0, 1\).")
+            r"bounds \(0, 1\).",
+        )
         self.assertAlmostEqual(value(m.x), 3.5, 3)
 
         m.x.domain = Binary
@@ -362,8 +390,8 @@ class Test_calc_var(unittest.TestCase):
             calculate_variable_from_constraint(m.x, m.c3)
         self.assertRegex(
             LOG.getvalue().strip(),
-            r"Setting Var 'x' to a value `[0-9\.]+` \(float\) not in "
-            "domain Binary.")
+            r"Setting Var 'x' to a value `[0-9\.]+` \(float\) not in " "domain Binary.",
+        )
         self.assertAlmostEqual(value(m.x), 3.5, 3)
 
     @unittest.skipUnless(differentiate_available, "this test requires sympy")
@@ -373,7 +401,7 @@ class Test_calc_var(unittest.TestCase):
         # results in OverflowErrors
         m = ConcreteModel()
         m.x = Var(initialize=1)
-        m.c = Constraint(expr=exp(1e2*m.x**2) == 100)
+        m.c = Constraint(expr=exp(1e2 * m.x**2) == 100)
 
         calculate_variable_from_constraint(m.x, m.c)
 

--- a/pyomo/util/tests/test_check_units.py
+++ b/pyomo/util/tests/test_check_units.py
@@ -14,19 +14,36 @@
 
 import pyomo.common.unittest as unittest
 from pyomo.environ import (
-    ConcreteModel, Var, Param, Set, Constraint, Objective, Expression,
-    Suffix, RangeSet, ExternalFunction, units, maximize, sin, cos, sqrt,
+    ConcreteModel,
+    Var,
+    Param,
+    Set,
+    Constraint,
+    Objective,
+    Expression,
+    Suffix,
+    RangeSet,
+    ExternalFunction,
+    units,
+    maximize,
+    sin,
+    cos,
+    sqrt,
 )
 from pyomo.network import Port, Arc
 from pyomo.dae import ContinuousSet, DerivativeVar
 from pyomo.gdp import Disjunct, Disjunction
-from pyomo.core.base.units_container import (
-    pint_available, UnitsError,
+from pyomo.core.base.units_container import pint_available, UnitsError
+from pyomo.util.check_units import (
+    assert_units_consistent,
+    assert_units_equivalent,
+    check_units_equivalent,
 )
-from pyomo.util.check_units import assert_units_consistent, assert_units_equivalent, check_units_equivalent
+
 
 def python_callback_function(arg1, arg2):
     return 42.0
+
 
 @unittest.skipIf(not pint_available, 'Testing units requires pint')
 class TestUnitsChecking(unittest.TestCase):
@@ -35,52 +52,65 @@ class TestUnitsChecking(unittest.TestCase):
         m = ConcreteModel()
         m.dx = Var(units=u.m, initialize=0.10188943773836046)
         m.dy = Var(units=u.m, initialize=0.0)
-        m.vx = Var(units=u.m/u.s, initialize=0.7071067769802851)
-        m.vy = Var(units=u.m/u.s, initialize=0.7071067769802851)
-        m.t = Var(units=u.s, bounds=(1e-5,10.0), initialize=0.0024015570927624456)
-        m.theta = Var(bounds=(0, 0.49*3.14), initialize=0.7853981693583533, units=u.radians)
-        m.a = Param(initialize=-32.2, units=u.ft/u.s**2)
+        m.vx = Var(units=u.m / u.s, initialize=0.7071067769802851)
+        m.vy = Var(units=u.m / u.s, initialize=0.7071067769802851)
+        m.t = Var(units=u.s, bounds=(1e-5, 10.0), initialize=0.0024015570927624456)
+        m.theta = Var(
+            bounds=(0, 0.49 * 3.14), initialize=0.7853981693583533, units=u.radians
+        )
+        m.a = Param(initialize=-32.2, units=u.ft / u.s**2)
         m.x_unitless = Var()
         return m
-    
+
     def test_assert_units_consistent_equivalent(self):
         u = units
         m = ConcreteModel()
         m.dx = Var(units=u.m, initialize=0.10188943773836046)
         m.dy = Var(units=u.m, initialize=0.0)
-        m.vx = Var(units=u.m/u.s, initialize=0.7071067769802851)
-        m.vy = Var(units=u.m/u.s, initialize=0.7071067769802851)
-        m.t = Var(units=u.min, bounds=(1e-5,10.0), initialize=0.0024015570927624456)
-        m.theta = Var(bounds=(0, 0.49*3.14), initialize=0.7853981693583533, units=u.radians)
-        m.a = Param(initialize=-32.2, units=u.ft/u.s**2)
+        m.vx = Var(units=u.m / u.s, initialize=0.7071067769802851)
+        m.vy = Var(units=u.m / u.s, initialize=0.7071067769802851)
+        m.t = Var(units=u.min, bounds=(1e-5, 10.0), initialize=0.0024015570927624456)
+        m.theta = Var(
+            bounds=(0, 0.49 * 3.14), initialize=0.7853981693583533, units=u.radians
+        )
+        m.a = Param(initialize=-32.2, units=u.ft / u.s**2)
         m.x_unitless = Var()
 
-        m.obj = Objective(expr = m.dx, sense=maximize)
-        m.vx_con = Constraint(expr = m.vx == 1.0*u.m/u.s*cos(m.theta))
-        m.vy_con = Constraint(expr = m.vy == 1.0*u.m/u.s*sin(m.theta))
-        m.dx_con = Constraint(expr = m.dx == m.vx*u.convert(m.t, to_units=u.s))
-        m.dy_con = Constraint(expr = m.dy == m.vy*u.convert(m.t, to_units=u.s)
-                              + 0.5*(u.convert(m.a, to_units=u.m/u.s**2))*(u.convert(m.t, to_units=u.s))**2)
-        m.ground = Constraint(expr = m.dy == 0)
-        m.unitless_con = Constraint(expr = m.x_unitless == 5.0)
+        m.obj = Objective(expr=m.dx, sense=maximize)
+        m.vx_con = Constraint(expr=m.vx == 1.0 * u.m / u.s * cos(m.theta))
+        m.vy_con = Constraint(expr=m.vy == 1.0 * u.m / u.s * sin(m.theta))
+        m.dx_con = Constraint(expr=m.dx == m.vx * u.convert(m.t, to_units=u.s))
+        m.dy_con = Constraint(
+            expr=m.dy
+            == m.vy * u.convert(m.t, to_units=u.s)
+            + 0.5
+            * (u.convert(m.a, to_units=u.m / u.s**2))
+            * (u.convert(m.t, to_units=u.s)) ** 2
+        )
+        m.ground = Constraint(expr=m.dy == 0)
+        m.unitless_con = Constraint(expr=m.x_unitless == 5.0)
 
-        assert_units_consistent(m) # check model
-        assert_units_consistent(m.dx) # check var - this should never fail
-        assert_units_consistent(m.x_unitless) # check unitless var - this should never fail
-        assert_units_consistent(m.vx_con) # check constraint
-        assert_units_consistent(m.unitless_con) # check unitless constraint
+        assert_units_consistent(m)  # check model
+        assert_units_consistent(m.dx)  # check var - this should never fail
+        assert_units_consistent(
+            m.x_unitless
+        )  # check unitless var - this should never fail
+        assert_units_consistent(m.vx_con)  # check constraint
+        assert_units_consistent(m.unitless_con)  # check unitless constraint
 
-        assert_units_equivalent(m.dx, m.dy) # check var
-        assert_units_equivalent(m.x_unitless, u.dimensionless) # check unitless var
-        assert_units_equivalent(m.x_unitless, None) # check unitless var
-        assert_units_equivalent(m.vx_con.body, u.m/u.s) # check constraint
-        assert_units_equivalent(m.unitless_con.body, u.dimensionless) # check unitless constraint
-        assert_units_equivalent(m.dx, m.dy) # check var
-        assert_units_equivalent(m.x_unitless, u.dimensionless) # check unitless var
-        assert_units_equivalent(m.x_unitless, None) # check unitless var
-        assert_units_equivalent(m.vx_con.body, u.m/u.s) # check constraint
+        assert_units_equivalent(m.dx, m.dy)  # check var
+        assert_units_equivalent(m.x_unitless, u.dimensionless)  # check unitless var
+        assert_units_equivalent(m.x_unitless, None)  # check unitless var
+        assert_units_equivalent(m.vx_con.body, u.m / u.s)  # check constraint
+        assert_units_equivalent(
+            m.unitless_con.body, u.dimensionless
+        )  # check unitless constraint
+        assert_units_equivalent(m.dx, m.dy)  # check var
+        assert_units_equivalent(m.x_unitless, u.dimensionless)  # check unitless var
+        assert_units_equivalent(m.x_unitless, None)  # check unitless var
+        assert_units_equivalent(m.vx_con.body, u.m / u.s)  # check constraint
 
-        m.broken = Constraint(expr = m.dy == 42.0*u.kg)
+        m.broken = Constraint(expr=m.dy == 42.0 * u.kg)
         with self.assertRaises(UnitsError):
             assert_units_consistent(m)
         assert_units_consistent(m.dx)
@@ -94,48 +124,55 @@ class TestUnitsChecking(unittest.TestCase):
     def test_assert_units_consistent_on_datas(self):
         u = units
         m = ConcreteModel()
-        m.S = Set(initialize=[1,2,3])
+        m.S = Set(initialize=[1, 2, 3])
         m.x = Var(m.S, units=u.m)
         m.t = Var(m.S, units=u.s)
-        m.v = Var(m.S, units=u.m/u.s)
+        m.v = Var(m.S, units=u.m / u.s)
         m.unitless = Var(m.S)
 
         @m.Constraint(m.S)
-        def vel_con(m,i):
-            return m.v[i] == m.x[i]/m.t[i]
+        def vel_con(m, i):
+            return m.v[i] == m.x[i] / m.t[i]
+
         @m.Constraint(m.S)
-        def unitless_con(m,i):
+        def unitless_con(m, i):
             return m.unitless[i] == 42.0
+
         @m.Constraint(m.S)
-        def sqrt_con(m,i):
-            return sqrt(m.v[i]) == sqrt(m.x[i]/m.t[i])
+        def sqrt_con(m, i):
+            return sqrt(m.v[i]) == sqrt(m.x[i] / m.t[i])
 
         assert_units_consistent(m)  # check model
         assert_units_consistent(m.x)  # check var
         assert_units_consistent(m.t)  # check var
         assert_units_consistent(m.v)  # check var
         assert_units_consistent(m.unitless)  # check var
-        assert_units_consistent(m.vel_con) # check constraint
-        assert_units_consistent(m.unitless_con) # check unitless constraint
+        assert_units_consistent(m.vel_con)  # check constraint
+        assert_units_consistent(m.unitless_con)  # check unitless constraint
 
         assert_units_consistent(m.x[2])  # check var data
         assert_units_consistent(m.t[2])  # check var data
         assert_units_consistent(m.v[2])  # check var data
         assert_units_consistent(m.unitless[2])  # check var
-        assert_units_consistent(m.vel_con[2]) # check constraint data
-        assert_units_consistent(m.unitless_con[2]) # check unitless constraint data
+        assert_units_consistent(m.vel_con[2])  # check constraint data
+        assert_units_consistent(m.unitless_con[2])  # check unitless constraint data
 
         assert_units_equivalent(m.x[2], m.x[1])  # check var data
         assert_units_equivalent(m.t[2], u.s)  # check var data
-        assert_units_equivalent(m.v[2], u.m/u.s)  # check var data
-        assert_units_equivalent(m.unitless[2], u.dimensionless)  # check var data unitless
+        assert_units_equivalent(m.v[2], u.m / u.s)  # check var data
+        assert_units_equivalent(
+            m.unitless[2], u.dimensionless
+        )  # check var data unitless
         assert_units_equivalent(m.unitless[2], None)  # check var
-        assert_units_equivalent(m.vel_con[2].body, u.m/u.s) # check constraint data
-        assert_units_equivalent(m.unitless_con[2].body, u.dimensionless) # check unitless constraint data
+        assert_units_equivalent(m.vel_con[2].body, u.m / u.s)  # check constraint data
+        assert_units_equivalent(
+            m.unitless_con[2].body, u.dimensionless
+        )  # check unitless constraint data
 
         @m.Constraint(m.S)
-        def broken(m,i):
-            return m.x[i] == 42.0*m.v[i]
+        def broken(m, i):
+            return m.x[i] == 42.0 * m.v[i]
+
         with self.assertRaises(UnitsError):
             assert_units_consistent(m)
         with self.assertRaises(UnitsError):
@@ -148,52 +185,59 @@ class TestUnitsChecking(unittest.TestCase):
         assert_units_consistent(m.t)  # check var
         assert_units_consistent(m.v)  # check var
         assert_units_consistent(m.unitless)  # check var
-        assert_units_consistent(m.vel_con) # check constraint
-        assert_units_consistent(m.unitless_con) # check unitless constraint
+        assert_units_consistent(m.vel_con)  # check constraint
+        assert_units_consistent(m.unitless_con)  # check unitless constraint
 
         assert_units_consistent(m.x[2])  # check var data
         assert_units_consistent(m.t[2])  # check var data
         assert_units_consistent(m.v[2])  # check var data
         assert_units_consistent(m.unitless[2])  # check var
-        assert_units_consistent(m.vel_con[2]) # check constraint data
-        assert_units_consistent(m.unitless_con[2]) # check unitless constraint data
+        assert_units_consistent(m.vel_con[2])  # check constraint data
+        assert_units_consistent(m.unitless_con[2])  # check unitless constraint data
 
     def test_assert_units_consistent_all_components(self):
         # test all scalar components consistent
         u = units
         m = self._create_model_and_vars()
-        m.obj = Objective(expr=m.dx/m.t - m.vx)
-        m.con = Constraint(expr=m.dx/m.t == m.vx)
+        m.obj = Objective(expr=m.dx / m.t - m.vx)
+        m.con = Constraint(expr=m.dx / m.t == m.vx)
         # vars already added
-        m.exp = Expression(expr=m.dx/m.t - m.vx)
+        m.exp = Expression(expr=m.dx / m.t - m.vx)
         m.suff = Suffix(direction=Suffix.LOCAL)
         # params already added
         # sets already added
         m.rs = RangeSet(5)
         m.disj1 = Disjunct()
-        m.disj1.constraint = Constraint(expr=m.dx/m.t <= m.vx)
+        m.disj1.constraint = Constraint(expr=m.dx / m.t <= m.vx)
         m.disj2 = Disjunct()
-        m.disj2.constraint = Constraint(expr=m.dx/m.t <= m.vx)
+        m.disj2.constraint = Constraint(expr=m.dx / m.t <= m.vx)
         m.disjn = Disjunction(expr=[m.disj1, m.disj2])
         # block tested as part of model
-        m.extfn = ExternalFunction(python_callback_function, units=u.m/u.s, arg_units=[u.m, u.s])
-        m.conext = Constraint(expr=m.extfn(m.dx, m.t) - m.vx==0)
-        m.cset = ContinuousSet(bounds=(0,1))
+        m.extfn = ExternalFunction(
+            python_callback_function, units=u.m / u.s, arg_units=[u.m, u.s]
+        )
+        m.conext = Constraint(expr=m.extfn(m.dx, m.t) - m.vx == 0)
+        m.cset = ContinuousSet(bounds=(0, 1))
         m.svar = Var(m.cset, units=u.m)
-        m.dvar = DerivativeVar(sVar=m.svar, units=u.m/u.s)
+        m.dvar = DerivativeVar(sVar=m.svar, units=u.m / u.s)
+
         def prt1_rule(m):
             return {'avar': m.dx}
+
         def prt2_rule(m):
             return {'avar': m.dy}
+
         m.prt1 = Port(rule=prt1_rule)
         m.prt2 = Port(rule=prt2_rule)
+
         def arcrule(m):
             return dict(source=m.prt1, destination=m.prt2)
+
         m.arc = Arc(rule=arcrule)
 
         # complementarities do not work yet
         # The expression system removes the u.m since it is multiplied by zero.
-        # We need to change the units_container to allow 0 when comparing units 
+        # We need to change the units_container to allow 0 when comparing units
         # m.compl = Complementarity(expr=complements(m.dx/m.t >= m.vx, m.dx == 0*u.m))
 
         assert_units_consistent(m)
@@ -201,27 +245,25 @@ class TestUnitsChecking(unittest.TestCase):
     def test_units_roundoff_error(self):
         # Issue 2393: this example resulted in roundoff error where the
         # computed units for var_1 were
-        #(0.9999999999999986,
+        # (0.9999999999999986,
         # <Unit('kilogram ** 1 / kelvin / meter ** 1.66533e-16 / second ** 3')>
-        #)
+        # )
         m = ConcreteModel()
         m.var_1 = Var(
             initialize=400,
-            units=((units.J**0.4) *
-                   (units.kg**0.2) *
-                   (units.W**0.6) /
-                   units.K /
-                   (units.m**2.2) /
-                   (units.Pa**0.2) /
-                   (units.s**0.8))
+            units=(
+                (units.J**0.4)
+                * (units.kg**0.2)
+                * (units.W**0.6)
+                / units.K
+                / (units.m**2.2)
+                / (units.Pa**0.2)
+                / (units.s**0.8)
+            ),
         )
         m.var_1.fix()
-        m.var_2 = Var(
-            initialize=400,
-            units=units.kg/units.s**3/units.K
-        )
+        m.var_2 = Var(initialize=400, units=units.kg / units.s**3 / units.K)
         assert_units_equivalent(m.var_1, m.var_2)
-
 
 
 if __name__ == "__main__":

--- a/pyomo/util/tests/test_components.py
+++ b/pyomo/util/tests/test_components.py
@@ -17,8 +17,8 @@ import pyomo.environ as pyo
 import pyomo.kernel as pmo
 from pyomo.util.components import iter_component, rename_components
 
-class TestUtilComponents(unittest.TestCase):
 
+class TestUtilComponents(unittest.TestCase):
     def test_rename_components(self):
         model = pyo.ConcreteModel()
         model.x = pyo.Var([1, 2, 3], bounds=(-10, 10), initialize=5.0)
@@ -27,20 +27,23 @@ class TestUtilComponents(unittest.TestCase):
 
         def con_rule(m, i):
             return m.x[i] + m.z == i
+
         model.con = pyo.Constraint([1, 2, 3], rule=con_rule)
         model.zcon = pyo.Constraint(expr=model.z >= model.x[2])
         model.b = pyo.Block()
-        model.b.bx = pyo.Var([1,2,3], initialize=42)
+        model.b.bx = pyo.Var([1, 2, 3], initialize=42)
         model.b.bz = pyo.Var(initialize=42)
 
         model.x_ref = pyo.Reference(model.x)
         model.zcon_ref = pyo.Reference(model.zcon)
         model.b.bx_ref = pyo.Reference(model.b.bx[2])
 
-        c_list = list(model.component_objects(ctype=[pyo.Var,pyo.Constraint,pyo.Objective]))
-        name_map = rename_components(model=model,
-                                     component_list=c_list,
-                                     prefix='scaled_')
+        c_list = list(
+            model.component_objects(ctype=[pyo.Var, pyo.Constraint, pyo.Objective])
+        )
+        name_map = rename_components(
+            model=model, component_list=c_list, prefix='scaled_'
+        )
 
         self.assertEqual(name_map[model.scaled_obj], 'obj')
         self.assertEqual(name_map[model.scaled_x], 'x')

--- a/pyomo/util/tests/test_infeasible.py
+++ b/pyomo/util/tests/test_infeasible.py
@@ -17,9 +17,12 @@ from io import StringIO
 import pyomo.common.unittest as unittest
 from pyomo.common.log import LoggingIntercept
 from pyomo.environ import ConcreteModel, Constraint, Var, inequality
-from pyomo.util.infeasible import (log_active_constraints, log_close_to_bounds,
-                                   log_infeasible_bounds,
-                                   log_infeasible_constraints)
+from pyomo.util.infeasible import (
+    log_active_constraints,
+    log_close_to_bounds,
+    log_infeasible_bounds,
+    log_infeasible_constraints,
+)
 
 
 class TestInfeasible(unittest.TestCase):
@@ -42,8 +45,8 @@ class TestInfeasible(unittest.TestCase):
         m.c10 = Constraint(expr=m.y >= 3, doc="Inactive")
         m.c10.deactivate()
         m.c11 = Constraint(expr=m.y <= m.y.value)
-        m.yy = Var(bounds=(0, 1), initialize=1E-7, doc="Close to lower bound")
-        m.y3 = Var(bounds=(0, 1E-7), initialize=0, doc="Bounds too close")
+        m.yy = Var(bounds=(0, 1), initialize=1e-7, doc="Close to lower bound")
+        m.y3 = Var(bounds=(0, 1e-7), initialize=0, doc="Bounds too close")
         m.y4 = Var(bounds=(0, 1), initialize=2, doc="Fixed out of bounds.")
         m.y4.fix()
         return m
@@ -112,12 +115,20 @@ class TestInfeasible(unittest.TestCase):
         with LoggingIntercept(output, 'pyomo.util', logging.INFO):
             log_active_constraints(m)
         expected_output = [
-            "c1 active", "c2 active", "c3 active", "c4 active",
-            "c5 active", "c6 active", "c7 active", "c8 active",
-            "c9 active", "c11 active"
+            "c1 active",
+            "c2 active",
+            "c3 active",
+            "c4 active",
+            "c5 active",
+            "c6 active",
+            "c7 active",
+            "c8 active",
+            "c9 active",
+            "c11 active",
         ]
-        self.assertEqual(expected_output,
-                         output.getvalue()[len(depr.getvalue()):].splitlines())
+        self.assertEqual(
+            expected_output, output.getvalue()[len(depr.getvalue()) :].splitlines()
+        )
 
     def test_log_close_to_bounds(self):
         """Test logging of variables and constraints near bounds."""
@@ -150,13 +161,20 @@ class TestInfeasible(unittest.TestCase):
         with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
             log_infeasible_constraints(m, log_expression=True)
         expected_output = [
-            "CONSTR c1: 2.0 </= 1", "  - EXPR: 2.0 </= x",
-            "CONSTR c2: 1 =/= 4.0", "  - EXPR: x =/= 4.0",
-            "CONSTR c3: 1 </= 0.0", "  - EXPR: x </= 0.0",
-            "CONSTR c5: 5.0 <?= evaluation error <?= 10.0", "  - EXPR: 5.0 <?= z <?= 10.0",
-            "CONSTR c7: evaluation error =?= 6.0", "  - EXPR: z =?= 6.0",
-            "CONSTR c8: 3.0 </= 1 <= 6.0", "  - EXPR: 3.0 </= x <= 6.0",
-            "CONSTR c9: 0.0 <= 1 </= 0.5", "  - EXPR: 0.0 <= x </= 0.5",
+            "CONSTR c1: 2.0 </= 1",
+            "  - EXPR: 2.0 </= x",
+            "CONSTR c2: 1 =/= 4.0",
+            "  - EXPR: x =/= 4.0",
+            "CONSTR c3: 1 </= 0.0",
+            "  - EXPR: x </= 0.0",
+            "CONSTR c5: 5.0 <?= evaluation error <?= 10.0",
+            "  - EXPR: 5.0 <?= z <?= 10.0",
+            "CONSTR c7: evaluation error =?= 6.0",
+            "  - EXPR: z =?= 6.0",
+            "CONSTR c8: 3.0 </= 1 <= 6.0",
+            "  - EXPR: 3.0 </= x <= 6.0",
+            "CONSTR c9: 0.0 <= 1 </= 0.5",
+            "  - EXPR: 0.0 <= x </= 0.5",
         ]
         self.assertEqual(expected_output, output.getvalue().splitlines())
 
@@ -167,13 +185,20 @@ class TestInfeasible(unittest.TestCase):
         with LoggingIntercept(output, 'pyomo.util.infeasible', logging.INFO):
             log_infeasible_constraints(m, log_variables=True)
         expected_output = [
-            "CONSTR c1: 2.0 </= 1", "  - VAR x: 1",
-            "CONSTR c2: 1 =/= 4.0", "  - VAR x: 1",
-            "CONSTR c3: 1 </= 0.0", "  - VAR x: 1",
-            "CONSTR c5: 5.0 <?= evaluation error <?= 10.0", "  - VAR z: None",
-            "CONSTR c7: evaluation error =?= 6.0", "  - VAR z: None",
-            "CONSTR c8: 3.0 </= 1 <= 6.0", "  - VAR x: 1",
-            "CONSTR c9: 0.0 <= 1 </= 0.5", "  - VAR x: 1",
+            "CONSTR c1: 2.0 </= 1",
+            "  - VAR x: 1",
+            "CONSTR c2: 1 =/= 4.0",
+            "  - VAR x: 1",
+            "CONSTR c3: 1 </= 0.0",
+            "  - VAR x: 1",
+            "CONSTR c5: 5.0 <?= evaluation error <?= 10.0",
+            "  - VAR z: None",
+            "CONSTR c7: evaluation error =?= 6.0",
+            "  - VAR z: None",
+            "CONSTR c8: 3.0 </= 1 <= 6.0",
+            "  - VAR x: 1",
+            "CONSTR c9: 0.0 <= 1 </= 0.5",
+            "  - VAR x: 1",
         ]
         self.assertEqual(expected_output, output.getvalue().splitlines())
 

--- a/pyomo/util/tests/test_model_size.py
+++ b/pyomo/util/tests/test_model_size.py
@@ -19,8 +19,7 @@ import pyomo.common.unittest as unittest
 from pyomo.common.log import LoggingIntercept
 from pyomo.core import Binary, Block, ConcreteModel, Constraint, Integers, Var
 from pyomo.gdp import Disjunct, Disjunction
-from pyomo.util.model_size import (build_model_size_report,
-                                   log_model_size_report)
+from pyomo.util.model_size import build_model_size_report, log_model_size_report
 from pyomo.common.fileutils import import_file
 
 currdir = dirname(abspath(__file__))
@@ -39,8 +38,7 @@ class TestModelSizeReport(unittest.TestCase):
 
     def test_eight_process(self):
         """Test with the eight process problem model."""
-        exfile = import_file(
-            join(exdir, 'eight_process', 'eight_proc_model.py'))
+        exfile = import_file(join(exdir, 'eight_process', 'eight_proc_model.py'))
         eight_process = exfile.build_eight_process_flowsheet()
         model_size = build_model_size_report(eight_process)
         self.assertEqual(model_size.activated.variables, 44)
@@ -66,8 +64,7 @@ class TestModelSizeReport(unittest.TestCase):
 
     def test_constrained_layout(self):
         """Test with the constrained layout GDP model."""
-        exfile = import_file(join(
-            exdir, 'constrained_layout', 'cons_layout_model.py'))
+        exfile = import_file(join(exdir, 'constrained_layout', 'cons_layout_model.py'))
         model = exfile.build_constrained_layout_model()
         model_size = build_model_size_report(model)
         self.assertEqual(model_size.activated.variables, 30)
@@ -123,6 +120,7 @@ class TestModelSizeReport(unittest.TestCase):
 
     def test_disjunctive_model(self):
         from pyomo.gdp.tests.models import makeNestedDisjunctions
+
         m = makeNestedDisjunctions()
         model_size = build_model_size_report(m)
         self.assertEqual(model_size.activated.variables, 10)
@@ -145,7 +143,7 @@ class TestModelSizeReport(unittest.TestCase):
         m.y = Var()
         m.z = Var()
         m.z.fix(3)
-        m.c = Constraint(expr=m.x ** 2 == 4)
+        m.c = Constraint(expr=m.x**2 == 4)
         m.c2 = Constraint(expr=m.x / m.y == 3)
         m.c3 = Constraint(expr=m.x * m.z == 5)
         m.c4 = Constraint(expr=m.x * m.y == 5)

--- a/pyomo/util/tests/test_report_scaling.py
+++ b/pyomo/util/tests/test_report_scaling.py
@@ -40,7 +40,7 @@ class TestReportScaling(unittest.TestCase):
         m.c[0] = m.x[0] + m.x[3] == 0
         m.c[1] = 1 / m.x[1] == 1
         m.c[2] = m.x[1] * m.x[3] == 1
-        m.c[3] = m.x[3] + m.p*m.x[0] == 1
+        m.c[3] = m.x[3] + m.p * m.x[0] == 1
 
         out = StringIO()
         with LoggingIntercept(out, 'pyomo.util.report_scaling', level=logging.INFO):

--- a/pyomo/util/tests/test_slices.py
+++ b/pyomo/util/tests/test_slices.py
@@ -17,11 +17,11 @@ import pyomo.environ as pyo
 import pyomo.dae as dae
 from pyomo.common.collections import ComponentSet, ComponentMap
 from pyomo.util.slices import (
-        get_component_call_stack,
-        slice_component_along_sets,
-        replace_indices,
-        get_location_set_map,
-        )
+    get_component_call_stack,
+    slice_component_along_sets,
+    replace_indices,
+    get_location_set_map,
+)
 
 
 class TestGetComponentCallStack(unittest.TestCase):
@@ -41,8 +41,8 @@ class TestGetComponentCallStack(unittest.TestCase):
     def model(self):
 
         m = pyo.ConcreteModel()
-        m.s1 = pyo.Set(initialize=[1,2,3])
-        m.s2 = pyo.Set(initialize=[('a',1),('b',2)])
+        m.s1 = pyo.Set(initialize=[1, 2, 3])
+        m.s2 = pyo.Set(initialize=[('a', 1), ('b', 2)])
 
         m.v0 = pyo.Var()
         m.v1 = pyo.Var(m.s1)
@@ -50,7 +50,6 @@ class TestGetComponentCallStack(unittest.TestCase):
 
         @m.Block()
         def b(b):
-
             @b.Block(m.s1)
             def b1(b):
                 b.v0 = pyo.Var()
@@ -62,7 +61,7 @@ class TestGetComponentCallStack(unittest.TestCase):
                     b.v2 = pyo.Var(m.s2)
 
                     @b.Block(m.s1, m.s2)
-                    def b2(b,i1,i2,i3=None):
+                    def b2(b, i1, i2, i3=None):
                         # Optional i3 is to allow for the case
                         # when normalize_index.flatten is False
                         b.v0 = pyo.Var()
@@ -72,60 +71,56 @@ class TestGetComponentCallStack(unittest.TestCase):
                         def b(b):
                             b.v0 = pyo.Var()
                             b.v2 = pyo.Var(m.s2)
+
         return m
 
     def test_no_context(self):
         m = self.model()
-        
+
         comp = m.v1[1]
-        pred_stack = [
-                (self.get_item, 1),
-                (self.get_attribute, 'v1'), 
-                ]
+        pred_stack = [(self.get_item, 1), (self.get_attribute, 'v1')]
         self.assertCorrectStack(comp, pred_stack)
 
         comp = m.v1
-        pred_stack = [
-                (self.get_attribute, 'v1'),
-                ]
+        pred_stack = [(self.get_attribute, 'v1')]
         self.assertCorrectStack(comp, pred_stack)
 
         comp = m.b.b1[1].b.b2
         pred_stack = [
-                (self.get_attribute, 'b2'),
-                (self.get_attribute, 'b'),
-                (self.get_item, 1),
-                (self.get_attribute, 'b1'),
-                (self.get_attribute, 'b'),
-                ]
+            (self.get_attribute, 'b2'),
+            (self.get_attribute, 'b'),
+            (self.get_item, 1),
+            (self.get_attribute, 'b1'),
+            (self.get_attribute, 'b'),
+        ]
         self.assertCorrectStack(comp, pred_stack)
 
-        comp = m.b.b1[1].b.b2[1,'a',1]
+        comp = m.b.b1[1].b.b2[1, 'a', 1]
         pred_stack = [
-                (self.get_item, (1,'a',1)),
-                (self.get_attribute, 'b2'),
-                (self.get_attribute, 'b'),
-                (self.get_item, 1),
-                (self.get_attribute, 'b1'),
-                (self.get_attribute, 'b'),
-                ]
+            (self.get_item, (1, 'a', 1)),
+            (self.get_attribute, 'b2'),
+            (self.get_attribute, 'b'),
+            (self.get_item, 1),
+            (self.get_attribute, 'b1'),
+            (self.get_attribute, 'b'),
+        ]
         self.assertCorrectStack(comp, pred_stack)
 
         normalize_index.flatten = False
-        comp = m.b.b1[1].b.b2[1,('a',1)]
+        comp = m.b.b1[1].b.b2[1, ('a', 1)]
         # NOTE: This fails without the parenthesis around ('a',1)
         # as comp.index() is None. The actual stack just starts one
         # layer higher...
         # It is confusing that comp can even be generated in this case;
         # shouldn't (1,'a',1) be an invalid index?
         pred_stack = [
-                (self.get_item, (1,('a',1))),
-                (self.get_attribute, 'b2'),
-                (self.get_attribute, 'b'),
-                (self.get_item, 1),
-                (self.get_attribute, 'b1'),
-                (self.get_attribute, 'b'),
-                ]
+            (self.get_item, (1, ('a', 1))),
+            (self.get_attribute, 'b2'),
+            (self.get_attribute, 'b'),
+            (self.get_item, 1),
+            (self.get_attribute, 'b1'),
+            (self.get_attribute, 'b'),
+        ]
         self.assertCorrectStack(comp, pred_stack)
         normalize_index.flatten = True
 
@@ -133,46 +128,42 @@ class TestGetComponentCallStack(unittest.TestCase):
         m = self.model()
 
         comp = m.v0
-        pred_stack = [
-                (self.get_attribute, 'v0'),
-                ]
+        pred_stack = [(self.get_attribute, 'v0')]
         self.assertCorrectStack(comp, pred_stack, context=m)
 
-        comp = m.b.b1[2].b.b2[1,'a',1]
+        comp = m.b.b1[2].b.b2[1, 'a', 1]
         pred_stack = [
-                (self.get_item, (1,'a',1)),
-                (self.get_attribute, 'b2'),
-                (self.get_attribute, 'b'),
-                (self.get_item, 2),
-                (self.get_attribute, 'b1'),
-                (self.get_attribute, 'b'),
-                ]
+            (self.get_item, (1, 'a', 1)),
+            (self.get_attribute, 'b2'),
+            (self.get_attribute, 'b'),
+            (self.get_item, 2),
+            (self.get_attribute, 'b1'),
+            (self.get_attribute, 'b'),
+        ]
         self.assertCorrectStack(comp, pred_stack, context=m)
 
-        comp = m.b.b1[2].b.b2[1,'a',1].b.v2['b',2]
+        comp = m.b.b1[2].b.b2[1, 'a', 1].b.v2['b', 2]
         pred_stack = [
-                (self.get_item, ('b',2)),
-                (self.get_attribute, 'v2'),
-                (self.get_attribute, 'b'),
-                (self.get_item, (1,'a',1)),
-                (self.get_attribute, 'b2'),
-                (self.get_attribute, 'b'),
-                (self.get_item, 2),
-                ]
+            (self.get_item, ('b', 2)),
+            (self.get_attribute, 'v2'),
+            (self.get_attribute, 'b'),
+            (self.get_item, (1, 'a', 1)),
+            (self.get_attribute, 'b2'),
+            (self.get_attribute, 'b'),
+            (self.get_item, 2),
+        ]
         self.assertCorrectStack(comp, pred_stack, context=m.b.b1)
 
         comp = m.b.b1[2].b.b2
         pred_stack = [
-                (self.get_attribute, 'b2'),
-                (self.get_attribute, 'b'),
-                (self.get_item, 2),
-                ]
+            (self.get_attribute, 'b2'),
+            (self.get_attribute, 'b'),
+            (self.get_item, 2),
+        ]
         self.assertCorrectStack(comp, pred_stack, context=m.b.b1)
 
         comp = m.b.b1[2]
-        pred_stack = [
-                (self.get_item, 2),
-                ]
+        pred_stack = [(self.get_item, 2)]
         self.assertCorrectStack(comp, pred_stack, context=m.b.b1)
 
         comp = m.b.b1
@@ -183,19 +174,17 @@ class TestGetComponentCallStack(unittest.TestCase):
 
         m = self.model()
 
-        context = m.b.b1[3].b.b2[2,'b',2]
-        comp = m.b.b1[3].b.b2[2,'b',2].b
-        pred_stack = [
-                (self.get_attribute, 'b'),
-                ]
+        context = m.b.b1[3].b.b2[2, 'b', 2]
+        comp = m.b.b1[3].b.b2[2, 'b', 2].b
+        pred_stack = [(self.get_attribute, 'b')]
         self.assertCorrectStack(comp, pred_stack, context=context)
 
-        comp = m.b.b1[3].b.b2[2,'b',2].b.v2['a',1]
+        comp = m.b.b1[3].b.b2[2, 'b', 2].b.v2['a', 1]
         pred_stack = [
-                (self.get_item, ('a',1)),
-                (self.get_attribute, 'v2'),
-                (self.get_attribute, 'b'),
-                ]
+            (self.get_item, ('a', 1)),
+            (self.get_attribute, 'v2'),
+            (self.get_attribute, 'b'),
+        ]
         self.assertCorrectStack(comp, pred_stack, context=context)
 
         context = m.b.b1[3]
@@ -203,17 +192,17 @@ class TestGetComponentCallStack(unittest.TestCase):
         act_stack = get_component_call_stack(comp, context=context)
         self.assertEqual(len(act_stack), 0)
 
-class TestGetLocationAndReplacement(unittest.TestCase):
 
+class TestGetLocationAndReplacement(unittest.TestCase):
     def model(self):
 
         m = pyo.ConcreteModel()
 
-        m.time = pyo.Set(initialize=[1,2,3])
-        m.space = dae.ContinuousSet(initialize=[0,2])
-        m.comp = pyo.Set(initialize=['a','b'])
-        m.d_2 = pyo.Set(initialize=[('a',1),('b',2)])
-        m.d_none = pyo.Set(initialize=[('c',1,10), ('d',3)], dimen=None)
+        m.time = pyo.Set(initialize=[1, 2, 3])
+        m.space = dae.ContinuousSet(initialize=[0, 2])
+        m.comp = pyo.Set(initialize=['a', 'b'])
+        m.d_2 = pyo.Set(initialize=[('a', 1), ('b', 2)])
+        m.d_none = pyo.Set(initialize=[('c', 1, 10), ('d', 3)], dimen=None)
 
         m.b0 = pyo.Block()
         m.b1 = pyo.Block(m.time)
@@ -240,7 +229,7 @@ class TestGetLocationAndReplacement(unittest.TestCase):
         for k, v in pred.items():
             self.assertIn(k, act)
             self.assertIs(pred[k], act[k])
-        
+
     def test_one_to_one(self):
         m = self.model()
 
@@ -252,18 +241,13 @@ class TestGetLocationAndReplacement(unittest.TestCase):
 
         index_set = m.b1.index_set()
         index = 1
-        pred_map = {
-                0: m.time,
-                }
+        pred_map = {0: m.time}
         location_set_map = get_location_set_map(index, index_set)
         self.assertSameMap(pred_map, location_set_map)
 
         index_set = m.b2.index_set()
-        index = (1,2)
-        pred_map = {
-                0: m.time,
-                1: m.space,
-                }
+        index = (1, 2)
+        pred_map = {0: m.time, 1: m.space}
         location_set_map = get_location_set_map(index, index_set)
         self.assertSameMap(pred_map, location_set_map)
 
@@ -295,10 +279,10 @@ class TestGetLocationAndReplacement(unittest.TestCase):
 
         # Two one-d sets
         index_set = m.b2.index_set()
-        index = (1,2)
+        index = (1, 2)
         location_set_map = get_location_set_map(index, index_set)
         sets = ComponentSet()
-        pred_index = (1,2)
+        pred_index = (1, 2)
         new_index = replace_indices(index, location_set_map, sets)
         self.assertEqual(pred_index, new_index)
 
@@ -315,11 +299,8 @@ class TestGetLocationAndReplacement(unittest.TestCase):
     def test_multi_dim(self):
         m = self.model()
         index_set = m.b0d2.index_set()
-        index = ('a',1)
-        pred_map = {
-                0: m.d_2,
-                1: m.d_2,
-                }
+        index = ('a', 1)
+        pred_map = {0: m.d_2, 1: m.d_2}
         location_set_map = get_location_set_map(index, index_set)
         self.assertSameMap(pred_map, location_set_map)
 
@@ -329,11 +310,8 @@ class TestGetLocationAndReplacement(unittest.TestCase):
         # Should we just fail in this case?
         # Note that the index (('a',1),) will not work.
         index_set = m.b0d2.index_set()
-        index = ('a',1)
-        pred_map = {
-                0: m.d_2,
-                1: m.d_2,
-                }
+        index = ('a', 1)
+        pred_map = {0: m.d_2, 1: m.d_2}
         with self.assertRaises(ValueError) as cm:
             location_set_map = get_location_set_map(index, index_set)
         self.assertIn('normalize_index.flatten', str(cm.exception))
@@ -341,34 +319,19 @@ class TestGetLocationAndReplacement(unittest.TestCase):
 
         index_set = m.b1d2.index_set()
         index = (1, 'a', 1)
-        pred_map = {
-                0: m.time,
-                1: m.d_2,
-                2: m.d_2,
-                }
+        pred_map = {0: m.time, 1: m.d_2, 2: m.d_2}
         location_set_map = get_location_set_map(index, index_set)
         self.assertSameMap(pred_map, location_set_map)
 
         index_set = m.b2d2.index_set()
         index = (1, 'a', 1, 2)
-        pred_map = {
-                0: m.time,
-                1: m.d_2,
-                2: m.d_2,
-                3: m.space,
-                }
+        pred_map = {0: m.time, 1: m.d_2, 2: m.d_2, 3: m.space}
         location_set_map = get_location_set_map(index, index_set)
         self.assertSameMap(pred_map, location_set_map)
 
         index_set = m.b3d2.index_set()
         index = (1, 'a', 1, 2, 1)
-        pred_map = {
-                0: m.time,
-                1: m.d_2,
-                2: m.d_2,
-                3: m.space,
-                4: m.time,
-                }
+        pred_map = {0: m.time, 1: m.d_2, 2: m.d_2, 3: m.space, 4: m.time}
         location_set_map = get_location_set_map(index, index_set)
         self.assertSameMap(pred_map, location_set_map)
 
@@ -377,7 +340,7 @@ class TestGetLocationAndReplacement(unittest.TestCase):
 
         # One two-dimen set
         index_set = m.b0d2.index_set()
-        index = ('a',1)
+        index = ('a', 1)
         location_set_map = get_location_set_map(index, index_set)
         sets = ComponentSet()
         pred_index = ('a', 1)
@@ -430,88 +393,68 @@ class TestGetLocationAndReplacement(unittest.TestCase):
         m = self.model()
 
         index_set = m.b0dn.index_set()
-        index = ('c',1,10)
-        pred_map = {
-                0: m.d_none,
-                1: m.d_none,
-                2: m.d_none,
-                }
+        index = ('c', 1, 10)
+        pred_map = {0: m.d_none, 1: m.d_none, 2: m.d_none}
         location_set_map = get_location_set_map(index, index_set)
         self.assertSameMap(pred_map, location_set_map)
 
         index_set = m.b1dn.index_set()
         index = (1, 'c', 1, 10)
-        pred_map = {
-                0: m.time,
-                1: m.d_none,
-                2: m.d_none,
-                3: m.d_none,
-                }
+        pred_map = {0: m.time, 1: m.d_none, 2: m.d_none, 3: m.d_none}
         location_set_map = get_location_set_map(index, index_set)
         self.assertSameMap(pred_map, location_set_map)
 
         index_set = m.b1dnd2.index_set()
         index = (1, 'c', 1, 10, 'a', 1)
         pred_map = {
-                0: m.time,
-                1: m.d_none,
-                2: m.d_none,
-                3: m.d_none,
-                4: m.d_2,
-                5: m.d_2,
-                }
+            0: m.time,
+            1: m.d_none,
+            2: m.d_none,
+            3: m.d_none,
+            4: m.d_2,
+            5: m.d_2,
+        }
         location_set_map = get_location_set_map(index, index_set)
         self.assertSameMap(pred_map, location_set_map)
 
         index_set = m.b2dn.index_set()
         index = (1, 0, 'd', 3)
-        pred_map = {
-                0: m.time,
-                1: m.space,
-                2: m.d_none,
-                3: m.d_none,
-                }
+        pred_map = {0: m.time, 1: m.space, 2: m.d_none, 3: m.d_none}
         location_set_map = get_location_set_map(index, index_set)
         self.assertSameMap(pred_map, location_set_map)
 
         index_set = m.b2dnd2.index_set()
         index = (1, 'c', 1, 10, 'b', 2, 0)
         pred_map = {
-                0: m.time,
-                1: m.d_none,
-                2: m.d_none,
-                3: m.d_none,
-                4: m.d_2,
-                5: m.d_2,
-                6: m.space,
-                }
+            0: m.time,
+            1: m.d_none,
+            2: m.d_none,
+            3: m.d_none,
+            4: m.d_2,
+            5: m.d_2,
+            6: m.space,
+        }
         location_set_map = get_location_set_map(index, index_set)
         self.assertSameMap(pred_map, location_set_map)
 
         index_set = m.dnd2b1.index_set()
         index = ('d', 3, 'b', 2, 1)
-        pred_map = {
-                0: m.d_none,
-                1: m.d_none,
-                2: m.d_2,
-                3: m.d_2,
-                4: m.time,
-                }
+        pred_map = {0: m.d_none, 1: m.d_none, 2: m.d_2, 3: m.d_2, 4: m.time}
         location_set_map = get_location_set_map(index, index_set)
         self.assertSameMap(pred_map, location_set_map)
 
         index_set = m.b3dn.index_set()
         index = (1, 'a', 1, 'd', 3, 0, 'b', 2)
         pred_map = {
-                0: m.time,
-                1: m.d_2,
-                2: m.d_2,
-                3: m.d_none,
-                4: m.d_none,
-                5: m.space,
-                6: m.d_2,
-                7: m.d_2,
-                }
+            0: m.time,
+            1: m.d_2,
+            2: m.d_2,
+            3: m.d_none,
+            4: m.d_none,
+            5: m.space,
+            6: m.d_2,
+            7: m.d_2,
+        }
         location_set_map = get_location_set_map(index, index_set)
         self.assertSameMap(pred_map, location_set_map)
 
@@ -526,7 +469,7 @@ class TestGetLocationAndReplacement(unittest.TestCase):
 
         # Single set of dimen None
         index_set = m.b0dn.index_set()
-        index = ('c',1,10)
+        index = ('c', 1, 10)
         location_set_map = get_location_set_map(index, index_set)
         sets = ComponentSet((m.d_none,))
         pred_index = (Ellipsis,)
@@ -609,14 +552,14 @@ class TestGetLocationAndReplacement(unittest.TestCase):
         location_set_map = get_location_set_map(index, index_set)
         sets = ComponentSet((m.d_none, m.d_2))
         pred_index = (
-                1,
-                slice(None),
-                slice(None),
-                Ellipsis,
-                0,
-                slice(None),
-                slice(None),
-                )
+            1,
+            slice(None),
+            slice(None),
+            Ellipsis,
+            0,
+            slice(None),
+            slice(None),
+        )
         new_index = replace_indices(index, location_set_map, sets)
         self.assertEqual(new_index, pred_index)
 
@@ -625,14 +568,10 @@ class TestGetLocationAndReplacement(unittest.TestCase):
 
         # index of m.b2d2
         index = (1, 0, ('a', 1))
-        location_set_map = {
-                0: m.time,
-                1: m.space,
-                2: m.d_2,
-                }
+        location_set_map = {0: m.time, 1: m.space, 2: m.d_2}
         sets = ComponentSet((m.d_2,))
         pred_index = (1, 0, slice(None))
-        # If you can assemble the proper location_set_map 
+        # If you can assemble the proper location_set_map
         # (get_location_set_map will not work), this function
         # should work when normalize_index.flatten is False.
         normalize_index.flatten = False
@@ -645,11 +584,11 @@ class SliceComponentDataAlongSets(unittest.TestCase):
     def model(self):
         m = pyo.ConcreteModel()
 
-        m.time = pyo.Set(initialize=[1,2,3])
-        m.space = dae.ContinuousSet(initialize=[0,2])
-        m.comp = pyo.Set(initialize=['a','b'])
-        m.d_2 = pyo.Set(initialize=[('a',1),('b',2)])
-        m.d_none = pyo.Set(initialize=[('c',1,10), ('d',3)], dimen=None)
+        m.time = pyo.Set(initialize=[1, 2, 3])
+        m.space = dae.ContinuousSet(initialize=[0, 2])
+        m.comp = pyo.Set(initialize=['a', 'b'])
+        m.d_2 = pyo.Set(initialize=[('a', 1), ('b', 2)])
+        m.d_none = pyo.Set(initialize=[('c', 1, 10), ('d', 3)], dimen=None)
 
         @m.Block()
         def b(b):
@@ -663,14 +602,14 @@ class SliceComponentDataAlongSets(unittest.TestCase):
                 b2.v1 = pyo.Var(m.comp)
                 b2.v2 = pyo.Var(m.time, m.comp)
                 b2.vn = pyo.Var(m.time, m.d_none, m.d_2)
-    
+
             @b.Block(m.d_none, m.d_2)
             def bn(bn):
                 bn.v0 = pyo.Var()
                 bn.v2 = pyo.Var(m.time, m.space)
                 bn.v3 = pyo.Var(m.time, m.space, m.time)
                 bn.vn = pyo.Var(m.time, m.d_none, m.d_2)
-        
+
         return m
 
     def test_with_tuple_of_sets(self):
@@ -688,7 +627,7 @@ class SliceComponentDataAlongSets(unittest.TestCase):
 
     def test_no_context(self):
         m = self.model()
-        
+
         comp = m.b.v0
         sets = ComponentSet((m.time, m.space))
         _slice = slice_component_along_sets(comp, sets)
@@ -700,112 +639,111 @@ class SliceComponentDataAlongSets(unittest.TestCase):
         _slice = slice_component_along_sets(comp, sets)
         self.assertEqual(_slice, m.b.v1[:])
 
-        comp = m.b.v2[1,0]
+        comp = m.b.v2[1, 0]
         sets = ComponentSet((m.time, m.space))
         _slice = slice_component_along_sets(comp, sets)
-        self.assertEqual(_slice, m.b.v2[:,:])
+        self.assertEqual(_slice, m.b.v2[:, :])
 
-        comp = m.b.b2[1,0].v1['a']
+        comp = m.b.b2[1, 0].v1['a']
         sets = ComponentSet((m.time, m.space))
         _slice = slice_component_along_sets(comp, sets)
-        self.assertEqual(_slice, m.b.b2[:,:].v1['a'])
+        self.assertEqual(_slice, m.b.b2[:, :].v1['a'])
 
-        comp = m.b.b2[1,0].v1
+        comp = m.b.b2[1, 0].v1
         sets = ComponentSet((m.time, m.space))
         _slice = slice_component_along_sets(comp, sets)
-        self.assertEqual(_slice, m.b.b2[:,:].v1)
+        self.assertEqual(_slice, m.b.b2[:, :].v1)
 
-        comp = m.b.b2[1,0].v2[1,'a']
+        comp = m.b.b2[1, 0].v2[1, 'a']
         sets = ComponentSet((m.time,))
         _slice = slice_component_along_sets(comp, sets)
-        self.assertEqual(_slice, m.b.b2[:,0].v2[:,'a'])
+        self.assertEqual(_slice, m.b.b2[:, 0].v2[:, 'a'])
 
-        comp = m.b.bn['c',1,10,'a',1].v3[1,0,1]
+        comp = m.b.bn['c', 1, 10, 'a', 1].v3[1, 0, 1]
         sets = ComponentSet((m.time,))
         _slice = slice_component_along_sets(comp, sets)
-        self.assertEqual(_slice, m.b.bn['c',1,10,'a',1].v3[:,0,:])
+        self.assertEqual(_slice, m.b.bn['c', 1, 10, 'a', 1].v3[:, 0, :])
 
     def test_context(self):
         m = self.model()
 
-        comp = m.b.v2[1,0]
+        comp = m.b.v2[1, 0]
         context = m.b
         sets = ComponentSet((m.time,))
         _slice = slice_component_along_sets(comp, sets)
         # Context makes no difference in resulting slice here.
-        self.assertEqual(_slice, m.b.v2[:,0])
+        self.assertEqual(_slice, m.b.v2[:, 0])
 
-        comp = m.b.b2[1,0].v2[1,'a']
-        context = m.b.b2[1,0]
+        comp = m.b.b2[1, 0].v2[1, 'a']
+        context = m.b.b2[1, 0]
         sets = ComponentSet((m.time,))
         _slice = slice_component_along_sets(comp, sets, context=context)
         # Here, context does make a difference
-        self.assertEqual(_slice, m.b.b2[1,0].v2[:,'a'])
+        self.assertEqual(_slice, m.b.b2[1, 0].v2[:, 'a'])
 
-        comp = m.b.b2[1,0].v1['a']
-        context = m.b.b2[1,0]
+        comp = m.b.b2[1, 0].v1['a']
+        context = m.b.b2[1, 0]
         sets = ComponentSet((m.time,))
         _slice = slice_component_along_sets(comp, sets, context=context)
-        self.assertIs(_slice, m.b.b2[1,0].v1['a'])
+        self.assertIs(_slice, m.b.b2[1, 0].v1['a'])
 
         sets = ComponentSet((m.comp,))
         _slice = slice_component_along_sets(comp, sets, context=context)
-        self.assertEqual(_slice, m.b.b2[1,0].v1[:])
+        self.assertEqual(_slice, m.b.b2[1, 0].v1[:])
 
         context = m.b.b2
         sets = ComponentSet((m.time, m.comp))
         _slice = slice_component_along_sets(comp, sets, context=context)
-        self.assertEqual(_slice, m.b.b2[:,0].v1[:])
+        self.assertEqual(_slice, m.b.b2[:, 0].v1[:])
 
     def test_none_dimen(self):
         m = self.model()
 
-        comp = m.b.b2[1,0].vn
+        comp = m.b.b2[1, 0].vn
         sets = ComponentSet((m.d_none,))
         _slice = slice_component_along_sets(comp, sets)
-        self.assertIs(_slice, m.b.b2[1,0].vn)
+        self.assertIs(_slice, m.b.b2[1, 0].vn)
 
-        comp = m.b.b2[1,0].vn[1,'d',3,'a',1]
+        comp = m.b.b2[1, 0].vn[1, 'd', 3, 'a', 1]
         sets = ComponentSet((m.d_2, m.time))
         _slice = slice_component_along_sets(comp, sets)
-        self.assertEqual(_slice, m.b.b2[:,0].vn[:,'d',3,:,:])
+        self.assertEqual(_slice, m.b.b2[:, 0].vn[:, 'd', 3, :, :])
 
         sets = ComponentSet((m.d_none, m.d_2))
         _slice = slice_component_along_sets(comp, sets)
-        self.assertEqual(_slice, m.b.b2[1,0].vn[1,...,:,:])
+        self.assertEqual(_slice, m.b.b2[1, 0].vn[1, ..., :, :])
 
-        comp = m.b.bn['c',1,10,'a',1].v3[1,0,1]
+        comp = m.b.bn['c', 1, 10, 'a', 1].v3[1, 0, 1]
         sets = ComponentSet((m.d_none, m.time))
         _slice = slice_component_along_sets(comp, sets)
-        self.assertEqual(_slice, m.b.bn[...,'a',1].v3[:,0,:])
+        self.assertEqual(_slice, m.b.bn[..., 'a', 1].v3[:, 0, :])
 
-        comp = m.b.bn['c',1,10,'a',1].vn[1,'d',3,'b',2]
+        comp = m.b.bn['c', 1, 10, 'a', 1].vn[1, 'd', 3, 'b', 2]
         sets = ComponentSet((m.d_none,))
         _slice = slice_component_along_sets(comp, sets)
-        self.assertEqual(_slice, m.b.bn[...,'a',1].vn[1,...,'b',2])
+        self.assertEqual(_slice, m.b.bn[..., 'a', 1].vn[1, ..., 'b', 2])
 
         sets = ComponentSet((m.d_none, m.d_2))
         _slice = slice_component_along_sets(comp, sets)
-        self.assertEqual(_slice, m.b.bn[...,:,:].vn[1,...,:,:])
-        
-        comp = m.b.bn['c',1,10,'a',1].vn[1,'d',3,'b',2]
-        context = m.b.bn['c',1,10,'a',1]
+        self.assertEqual(_slice, m.b.bn[..., :, :].vn[1, ..., :, :])
+
+        comp = m.b.bn['c', 1, 10, 'a', 1].vn[1, 'd', 3, 'b', 2]
+        context = m.b.bn['c', 1, 10, 'a', 1]
         sets = ComponentSet((m.d_none,))
         _slice = slice_component_along_sets(comp, sets, context=context)
-        self.assertEqual(_slice, m.b.bn['c',1,10,'a',1].vn[1,...,'b',2])
+        self.assertEqual(_slice, m.b.bn['c', 1, 10, 'a', 1].vn[1, ..., 'b', 2])
 
         sets = ComponentSet((m.d_none, m.d_2))
         _slice = slice_component_along_sets(comp, sets, context=context)
-        self.assertEqual(_slice, m.b.bn['c',1,10,'a',1].vn[1,...,:,:])
+        self.assertEqual(_slice, m.b.bn['c', 1, 10, 'a', 1].vn[1, ..., :, :])
 
         context = m.b.bn
         sets = ComponentSet((m.d_none,))
         _slice = slice_component_along_sets(comp, sets, context=context)
-        self.assertEqual(_slice, m.b.bn[...,'a',1].vn[1,...,'b',2])
+        self.assertEqual(_slice, m.b.bn[..., 'a', 1].vn[1, ..., 'b', 2])
 
 
 class TestCUID(unittest.TestCase):
-
     def test_cuid_of_slice(self):
         m = pyo.ConcreteModel()
         m.s1 = pyo.Set(initialize=["a", "b"])
@@ -817,9 +755,7 @@ class TestCUID(unittest.TestCase):
         cuid = pyo.ComponentUID(slice_)
         self.assertEqual(str(cuid), "b[*].v[c]")
 
-        slice_ = slice_component_along_sets(
-            m.b["a"].v[("c",)], ComponentSet((m.s1,))
-        )
+        slice_ = slice_component_along_sets(m.b["a"].v[("c",)], ComponentSet((m.s1,)))
         cuid = pyo.ComponentUID(slice_)
         self.assertEqual(str(cuid), "b[*].v[c]")
 

--- a/pyomo/util/tests/test_subsystems.py
+++ b/pyomo/util/tests/test_subsystems.py
@@ -13,13 +13,13 @@ import pyomo.environ as pyo
 import pyomo.common.unittest as unittest
 from pyomo.common.collections import ComponentSet, ComponentMap
 from pyomo.util.subsystems import (
-        create_subsystem_block,
-        generate_subsystem_blocks,
-        TemporarySubsystemManager,
-        ParamSweeper,
-        identify_external_functions,
-        add_local_external_functions,
-        )
+    create_subsystem_block,
+    generate_subsystem_blocks,
+    TemporarySubsystemManager,
+    ParamSweeper,
+    identify_external_functions,
+    add_local_external_functions,
+)
 from pyomo.common.gsl import find_GSL
 
 
@@ -31,15 +31,14 @@ def _make_simple_model():
     m.v3 = pyo.Var()
     m.v4 = pyo.Var()
 
-    m.con1 = pyo.Constraint(expr=m.v1*m.v2*m.v3 == m.v4)
-    m.con2 = pyo.Constraint(expr=m.v1 + m.v2**2 == 2*m.v4)
-    m.con3 = pyo.Constraint(expr=m.v1**2 - m.v3 == 3*m.v4)
+    m.con1 = pyo.Constraint(expr=m.v1 * m.v2 * m.v3 == m.v4)
+    m.con2 = pyo.Constraint(expr=m.v1 + m.v2**2 == 2 * m.v4)
+    m.con3 = pyo.Constraint(expr=m.v1**2 - m.v3 == 3 * m.v4)
 
     return m
 
 
 class TestSubsystemBlock(unittest.TestCase):
-
     def test_square_subsystem(self):
         m = _make_simple_model()
 
@@ -51,12 +50,14 @@ class TestSubsystemBlock(unittest.TestCase):
         self.assertEqual(len(block.vars), 2)
         self.assertEqual(len(block.cons), 2)
         self.assertEqual(len(block.input_vars), 2)
-        self.assertEqual(len([v for v in block.component_data_objects(pyo.Var)
-            if not v.fixed]), 4)
+        self.assertEqual(
+            len([v for v in block.component_data_objects(pyo.Var) if not v.fixed]), 4
+        )
 
         block.input_vars.fix()
-        self.assertEqual(len([v for v in block.component_data_objects(pyo.Var)
-            if not v.fixed]), 2)
+        self.assertEqual(
+            len([v for v in block.component_data_objects(pyo.Var) if not v.fixed]), 2
+        )
 
         self.assertIs(block.cons[0], m.con2)
         self.assertIs(block.cons[1], m.con3)
@@ -86,12 +87,14 @@ class TestSubsystemBlock(unittest.TestCase):
         self.assertEqual(len(block.input_vars), 4)
         self.assertEqual(len(block.cons), 2)
 
-        self.assertEqual(len([v for v in block.component_data_objects(pyo.Var)
-            if not v.fixed]), 4)
+        self.assertEqual(
+            len([v for v in block.component_data_objects(pyo.Var) if not v.fixed]), 4
+        )
 
         block.input_vars.fix()
-        self.assertEqual(len([v for v in block.component_data_objects(pyo.Var)
-            if not v.fixed]), 0)
+        self.assertEqual(
+            len([v for v in block.component_data_objects(pyo.Var) if not v.fixed]), 0
+        )
 
         var_set = ComponentSet([m.v1, m.v2, m.v3, m.v4])
         self.assertIs(block.cons[0], m.con2)
@@ -112,8 +115,9 @@ class TestSubsystemBlock(unittest.TestCase):
             for data in comp.values():
                 self.assertIs(data.model(), m)
 
-    @unittest.skipUnless(pyo.SolverFactory("ipopt").available(),
-            "Ipopt is not available")
+    @unittest.skipUnless(
+        pyo.SolverFactory("ipopt").available(), "Ipopt is not available"
+    )
     def test_solve_subsystem(self):
         # This is a test of this function's intended use. We extract a
         # subsystem then solve it without altering the rest of the model.
@@ -137,29 +141,22 @@ class TestSubsystemBlock(unittest.TestCase):
 
         # Have solved model to expected values
         self.assertAlmostEqual(m.v1.value, pyo.sqrt(7.0), delta=1e-8)
-        self.assertAlmostEqual(m.v2.value, pyo.sqrt(4.0-pyo.sqrt(7.0)),
-                delta=1e-8)
+        self.assertAlmostEqual(m.v2.value, pyo.sqrt(4.0 - pyo.sqrt(7.0)), delta=1e-8)
 
         # Rest of model has not changed
         self.assertEqual(m.v5.value, 1.0)
 
     def test_generate_subsystems_without_fixed_var(self):
         m = _make_simple_model()
-        subs = [
-                ([m.con1], [m.v1, m.v4]),
-                ([m.con2, m.con3], [m.v2, m.v3]),
-                ]
-        other_vars = [
-                [m.v2, m.v3],
-                [m.v1, m.v4],
-                ]
+        subs = [([m.con1], [m.v1, m.v4]), ([m.con2, m.con3], [m.v2, m.v3])]
+        other_vars = [[m.v2, m.v3], [m.v1, m.v4]]
         for i, (block, inputs) in enumerate(generate_subsystem_blocks(subs)):
             with TemporarySubsystemManager(to_fix=inputs):
                 self.assertIs(block.model(), block)
                 var_set = ComponentSet(subs[i][1])
                 con_set = ComponentSet(subs[i][0])
                 input_set = ComponentSet(other_vars[i])
-                
+
                 self.assertEqual(len(var_set), len(block.vars))
                 self.assertEqual(len(con_set), len(block.cons))
                 self.assertEqual(len(input_set), len(block.input_vars))
@@ -170,19 +167,12 @@ class TestSubsystemBlock(unittest.TestCase):
                 self.assertFalse(any(var.fixed for var in block.vars[:]))
 
         # Test that we have properly unfixed variables
-        self.assertFalse(any(var.fixed for var in
-            m.component_data_objects(pyo.Var)))
+        self.assertFalse(any(var.fixed for var in m.component_data_objects(pyo.Var)))
 
     def test_generate_subsystems_with_exception(self):
         m = _make_simple_model()
-        subs = [
-                ([m.con1], [m.v1, m.v4]),
-                ([m.con2, m.con3], [m.v2, m.v3]),
-                ]
-        other_vars = [
-                [m.v2, m.v3],
-                [m.v1, m.v4],
-                ]
+        subs = [([m.con1], [m.v1, m.v4]), ([m.con2, m.con3], [m.v2, m.v3])]
+        other_vars = [[m.v2, m.v3], [m.v1, m.v4]]
         with self.assertRaises(RuntimeError):
             for i, (block, inputs) in enumerate(generate_subsystem_blocks(subs)):
                 with TemporarySubsystemManager(to_fix=inputs):
@@ -192,20 +182,13 @@ class TestSubsystemBlock(unittest.TestCase):
                         raise RuntimeError()
 
         # Test that we have properly unfixed variables
-        self.assertFalse(any(var.fixed for var in
-            m.component_data_objects(pyo.Var)))
+        self.assertFalse(any(var.fixed for var in m.component_data_objects(pyo.Var)))
 
     def test_generate_subsystems_with_fixed_var(self):
         m = _make_simple_model()
         m.v4.fix()
-        subs = [
-                ([m.con1], [m.v1]),
-                ([m.con2, m.con3], [m.v2, m.v3]),
-                ]
-        other_vars = [
-                [m.v2, m.v3],
-                [m.v1],
-                ]
+        subs = [([m.con1], [m.v1]), ([m.con2, m.con3], [m.v2, m.v3])]
+        other_vars = [[m.v2, m.v3], [m.v1]]
         for i, (block, inputs) in enumerate(generate_subsystem_blocks(subs)):
             inputs = list(block.input_vars.values())
             with TemporarySubsystemManager(to_fix=inputs):
@@ -233,24 +216,17 @@ class TestSubsystemBlock(unittest.TestCase):
     def test_generate_subsystems_include_fixed_var(self):
         m = _make_simple_model()
         m.v4.fix()
-        subsystems = [
-                ([m.con1], [m.v1]),
-                ([m.con2, m.con3], [m.v2, m.v3]),
-                ]
-        other_vars = [
-                [m.v2, m.v3, m.v4],
-                [m.v1, m.v4],
-                ]
-        for i, (block, inputs) in enumerate(generate_subsystem_blocks(
-            subsystems,
-            include_fixed=True,
-            )):
+        subsystems = [([m.con1], [m.v1]), ([m.con2, m.con3], [m.v2, m.v3])]
+        other_vars = [[m.v2, m.v3, m.v4], [m.v1, m.v4]]
+        for i, (block, inputs) in enumerate(
+            generate_subsystem_blocks(subsystems, include_fixed=True)
+        ):
             with TemporarySubsystemManager(to_fix=inputs):
                 self.assertIs(block.model(), block)
                 var_set = ComponentSet(subsystems[i][1])
                 con_set = ComponentSet(subsystems[i][0])
                 input_set = ComponentSet(other_vars[i])
-                
+
                 self.assertEqual(len(var_set), len(block.vars))
                 self.assertEqual(len(con_set), len(block.cons))
                 self.assertEqual(len(input_set), len(block.input_vars))
@@ -267,20 +243,14 @@ class TestSubsystemBlock(unittest.TestCase):
 
     def test_generate_subsystems_dont_fix_inputs(self):
         m = _make_simple_model()
-        subs = [
-                ([m.con1], [m.v1]),
-                ([m.con2, m.con3], [m.v2, m.v3]),
-                ]
-        other_vars = [
-                [m.v2, m.v3, m.v4],
-                [m.v1, m.v4],
-                ]
+        subs = [([m.con1], [m.v1]), ([m.con2, m.con3], [m.v2, m.v3])]
+        other_vars = [[m.v2, m.v3, m.v4], [m.v1, m.v4]]
         for i, (block, inputs) in enumerate(generate_subsystem_blocks(subs)):
             self.assertIs(block.model(), block)
             var_set = ComponentSet(subs[i][1])
             con_set = ComponentSet(subs[i][0])
             input_set = ComponentSet(other_vars[i])
-            
+
             self.assertEqual(len(var_set), len(block.vars))
             self.assertEqual(len(con_set), len(block.cons))
             self.assertEqual(len(input_set), len(inputs))
@@ -298,20 +268,14 @@ class TestSubsystemBlock(unittest.TestCase):
     def test_generate_dont_fix_inputs_with_fixed_var(self):
         m = _make_simple_model()
         m.v4.fix()
-        subs = [
-                ([m.con1], [m.v1]),
-                ([m.con2, m.con3], [m.v2, m.v3]),
-                ]
-        other_vars = [
-                [m.v2, m.v3],
-                [m.v1],
-                ]
+        subs = [([m.con1], [m.v1]), ([m.con2, m.con3], [m.v2, m.v3])]
+        other_vars = [[m.v2, m.v3], [m.v1]]
         for i, (block, inputs) in enumerate(generate_subsystem_blocks(subs)):
             self.assertIs(block.model(), block)
             var_set = ComponentSet(subs[i][1])
             con_set = ComponentSet(subs[i][0])
             input_set = ComponentSet(other_vars[i])
-            
+
             self.assertEqual(len(var_set), len(block.vars))
             self.assertEqual(len(con_set), len(block.cons))
             self.assertEqual(len(input_set), len(inputs))
@@ -331,26 +295,20 @@ class TestSubsystemBlock(unittest.TestCase):
     def _make_model_with_external_functions(self):
         m = pyo.ConcreteModel()
         gsl = find_GSL()
-        m.bessel = pyo.ExternalFunction(
-            library=gsl, function="gsl_sf_bessel_J0"
-        )
-        m.fermi = pyo.ExternalFunction(
-            library=gsl, function="gsl_sf_fermi_dirac_m1"
-        )
+        m.bessel = pyo.ExternalFunction(library=gsl, function="gsl_sf_bessel_J0")
+        m.fermi = pyo.ExternalFunction(library=gsl, function="gsl_sf_fermi_dirac_m1")
         m.v1 = pyo.Var(initialize=1.0)
         m.v2 = pyo.Var(initialize=2.0)
         m.v3 = pyo.Var(initialize=3.0)
         m.con1 = pyo.Constraint(expr=m.v1 == 0.5)
-        m.con2 = pyo.Constraint(expr=2*m.fermi(m.v1) + m.v2**2 - m.v3 == 1.0)
-        m.con3 = pyo.Constraint(
-            expr=m.bessel(m.v1) - m.bessel(m.v2) + m.v3**2 == 2.0
-        )
+        m.con2 = pyo.Constraint(expr=2 * m.fermi(m.v1) + m.v2**2 - m.v3 == 1.0)
+        m.con3 = pyo.Constraint(expr=m.bessel(m.v1) - m.bessel(m.v2) + m.v3**2 == 2.0)
         return m
 
     @unittest.skipUnless(find_GSL(), "Could not find the AMPL GSL library")
     def test_identify_external_functions(self):
         m = self._make_model_with_external_functions()
-        m._con = pyo.Constraint(expr=2*m.fermi(m.bessel(m.v1**2) + 0.1) == 1.0)
+        m._con = pyo.Constraint(expr=2 * m.fermi(m.bessel(m.v1**2) + 0.1) == 1.0)
 
         gsl = find_GSL()
 
@@ -368,10 +326,7 @@ class TestSubsystemBlock(unittest.TestCase):
         fcns = list(identify_external_functions(m._con.expr))
         fcn_data = set((fcn._fcn._library, fcn._fcn._function) for fcn in fcns)
         self.assertEqual(len(fcns), 2)
-        pred_fcn_data = {
-            (gsl, "gsl_sf_bessel_J0"),
-            (gsl, "gsl_sf_fermi_dirac_m1"),
-        }
+        pred_fcn_data = {(gsl, "gsl_sf_bessel_J0"), (gsl, "gsl_sf_fermi_dirac_m1")}
         self.assertEqual(fcn_data, pred_fcn_data)
 
     def _solve_ef_model_with_ipopt(self):
@@ -382,8 +337,7 @@ class TestSubsystemBlock(unittest.TestCase):
 
     @unittest.skipUnless(find_GSL(), "Could not find the AMPL GSL library")
     @unittest.skipUnless(
-        pyo.SolverFactory("ipopt").available(),
-        "ipopt is not available"
+        pyo.SolverFactory("ipopt").available(), "ipopt is not available"
     )
     def test_with_external_function(self):
         m = self._make_model_with_external_functions()
@@ -413,9 +367,7 @@ class TestSubsystemBlock(unittest.TestCase):
         m = self._make_model_with_external_functions()
         m.b = pyo.Block()
         m.b._gsl_sf_bessel_J0 = pyo.Var()
-        m.b.con = pyo.Constraint(
-            expr=m.b._gsl_sf_bessel_J0 == m.bessel(m.v1)
-        )
+        m.b.con = pyo.Constraint(expr=m.b._gsl_sf_bessel_J0 == m.bessel(m.v1))
         add_local_external_functions(m.b)
         self.assertTrue(isinstance(m.b._gsl_sf_bessel_J0, pyo.Var))
         ex_fcns = list(m.b.component_objects(pyo.ExternalFunction))
@@ -425,7 +377,6 @@ class TestSubsystemBlock(unittest.TestCase):
 
 
 class TestTemporarySubsystemManager(unittest.TestCase):
-
     def test_context(self):
         m = _make_simple_model()
 
@@ -476,8 +427,9 @@ class TestTemporarySubsystemManager(unittest.TestCase):
         self.assertTrue(m.con2.active)
         self.assertFalse(m.con1.active)
 
-    @unittest.skipUnless(pyo.SolverFactory("ipopt").available(),
-            "Ipopt is not available")
+    @unittest.skipUnless(
+        pyo.SolverFactory("ipopt").available(), "Ipopt is not available"
+    )
     def test_fix_then_solve(self):
         # This is a test of the expected use case. We have a (square)
         # subsystem that we can solve easily after fixing and deactivating
@@ -492,27 +444,19 @@ class TestTemporarySubsystemManager(unittest.TestCase):
         m.v3.set_value(1.0)
         m.v4.set_value(2.0)
 
-        with TemporarySubsystemManager(to_fix=[m.v3, m.v4],
-                to_deactivate=[m.con1]):
+        with TemporarySubsystemManager(to_fix=[m.v3, m.v4], to_deactivate=[m.con1]):
             # Solve the subsystem with m.v1, m.v2 unfixed and
             # m.con2, m.con3 inactive.
             ipopt.solve(m)
 
         # Have solved model to expected values
         self.assertAlmostEqual(m.v1.value, pyo.sqrt(7.0), delta=1e-8)
-        self.assertAlmostEqual(m.v2.value, pyo.sqrt(4.0-pyo.sqrt(7.0)),
-                delta=1e-8)
+        self.assertAlmostEqual(m.v2.value, pyo.sqrt(4.0 - pyo.sqrt(7.0)), delta=1e-8)
 
     def test_generate_subsystems_with_exception(self):
         m = _make_simple_model()
-        subsystems = [ 
-                ([m.con1], [m.v1, m.v4]),
-                ([m.con2, m.con3], [m.v2, m.v3]),
-                ]
-        other_vars = [ 
-                [m.v2, m.v3],
-                [m.v1, m.v4],
-                ]
+        subsystems = [([m.con1], [m.v1, m.v4]), ([m.con2, m.con3], [m.v2, m.v3])]
+        other_vars = [[m.v2, m.v3], [m.v1, m.v4]]
         block = create_subsystem_block(*subsystems[0])
         with self.assertRaises(RuntimeError):
             inputs = list(block.input_vars[:])
@@ -522,26 +466,22 @@ class TestTemporarySubsystemManager(unittest.TestCase):
                 raise RuntimeError()
 
         # Test that we have properly unfixed variables
-        self.assertFalse(any(var.fixed for var in
-            m.component_data_objects(pyo.Var)))
+        self.assertFalse(any(var.fixed for var in m.component_data_objects(pyo.Var)))
 
 
 class TestParamSweeper(unittest.TestCase):
-
     def test_set_values(self):
         m = _make_simple_model()
 
         n_scenario = 2
-        input_values = ComponentMap([
-            (m.v3, [1.3, 2.3]),
-            (m.v4, [1.4, 2.4]),
-            ])
+        input_values = ComponentMap([(m.v3, [1.3, 2.3]), (m.v4, [1.4, 2.4])])
 
         to_fix = [m.v3, m.v4]
         to_deactivate = [m.con1]
 
-        with ParamSweeper(2, input_values, to_fix=to_fix,
-                to_deactivate=to_deactivate) as sweeper:
+        with ParamSweeper(
+            2, input_values, to_fix=to_fix, to_deactivate=to_deactivate
+        ) as sweeper:
             self.assertFalse(m.v1.fixed)
             self.assertFalse(m.v2.fixed)
             self.assertTrue(m.v3.fixed)
@@ -567,17 +507,16 @@ class TestParamSweeper(unittest.TestCase):
         m.p1 = pyo.Param(mutable=True, initialize=7.0)
 
         n_scenario = 2
-        input_values = ComponentMap([
-            (m.v3, [1.3, 2.3]),
-            (m.v4, [1.4, 2.4]),
-            (m.p1, [1.5, 2.5]),
-            ])
+        input_values = ComponentMap(
+            [(m.v3, [1.3, 2.3]), (m.v4, [1.4, 2.4]), (m.p1, [1.5, 2.5])]
+        )
 
         to_fix = [m.v3, m.v4]
         to_deactivate = [m.con1]
 
-        with ParamSweeper(2, input_values, to_fix=to_fix,
-                to_deactivate=to_deactivate) as sweeper:
+        with ParamSweeper(
+            2, input_values, to_fix=to_fix, to_deactivate=to_deactivate
+        ) as sweeper:
             self.assertFalse(m.v1.fixed)
             self.assertFalse(m.v2.fixed)
             self.assertTrue(m.v3.fixed)
@@ -603,21 +542,16 @@ class TestParamSweeper(unittest.TestCase):
         m = _make_simple_model()
 
         n_scenario = 2
-        input_values = ComponentMap([
-            (m.v3, [1.3, 2.3]),
-            (m.v4, [1.4, 2.4]),
-            ])
+        input_values = ComponentMap([(m.v3, [1.3, 2.3]), (m.v4, [1.4, 2.4])])
 
-        output_values = ComponentMap([
-            (m.v1, [1.1, 2.1]),
-            (m.v2, [1.2, 2.2]),
-            ])
+        output_values = ComponentMap([(m.v1, [1.1, 2.1]), (m.v2, [1.2, 2.2])])
 
         to_fix = [m.v3, m.v4]
         to_deactivate = [m.con1]
 
-        with ParamSweeper(2, input_values, output_values,
-                to_fix=to_fix, to_deactivate=to_deactivate) as sweeper:
+        with ParamSweeper(
+            2, input_values, output_values, to_fix=to_fix, to_deactivate=to_deactivate
+        ) as sweeper:
             self.assertFalse(m.v1.fixed)
             self.assertFalse(m.v2.fixed)
             self.assertTrue(m.v3.fixed)
@@ -645,27 +579,23 @@ class TestParamSweeper(unittest.TestCase):
         self.assertIs(m.v3.value, None)
         self.assertIs(m.v4.value, None)
 
-
-    @unittest.skipUnless(pyo.SolverFactory("ipopt").available(),
-            "Ipopt is not available")
+    @unittest.skipUnless(
+        pyo.SolverFactory("ipopt").available(), "Ipopt is not available"
+    )
     def test_with_solve(self):
         m = _make_simple_model()
         ipopt = pyo.SolverFactory("ipopt")
 
         n_scenario = 2
-        input_values = ComponentMap([
-            (m.v3, [1.3, 2.3]),
-            (m.v4, [1.4, 2.4]),
-            ])
+        input_values = ComponentMap([(m.v3, [1.3, 2.3]), (m.v4, [1.4, 2.4])])
 
-        _v1_val_1 = pyo.sqrt(3*1.4+1.3)
-        _v1_val_2 = pyo.sqrt(3*2.4+2.3)
-        _v2_val_1 = pyo.sqrt(2*1.4 - _v1_val_1)
-        _v2_val_2 = pyo.sqrt(2*2.4 - _v1_val_2)
-        output_values = ComponentMap([
-            (m.v1, [_v1_val_1, _v1_val_2]),
-            (m.v2, [_v2_val_1, _v2_val_2]),
-            ])
+        _v1_val_1 = pyo.sqrt(3 * 1.4 + 1.3)
+        _v1_val_2 = pyo.sqrt(3 * 2.4 + 2.3)
+        _v2_val_1 = pyo.sqrt(2 * 1.4 - _v1_val_1)
+        _v2_val_2 = pyo.sqrt(2 * 2.4 - _v1_val_2)
+        output_values = ComponentMap(
+            [(m.v1, [_v1_val_1, _v1_val_2]), (m.v2, [_v2_val_1, _v2_val_2])]
+        )
 
         to_fix = [m.v3, m.v4]
         to_deactivate = [m.con1]
@@ -675,11 +605,14 @@ class TestParamSweeper(unittest.TestCase):
         m.v1.set_value(1.0)
         m.v2.set_value(1.0)
 
-        with ParamSweeper(n_scenario, input_values, output_values,
-                to_fix=to_fix,
-                to_deactivate=to_deactivate,
-                to_reset=to_reset,
-                ) as sweeper:
+        with ParamSweeper(
+            n_scenario,
+            input_values,
+            output_values,
+            to_fix=to_fix,
+            to_deactivate=to_deactivate,
+            to_reset=to_reset,
+        ) as sweeper:
             self.assertFalse(m.v1.fixed)
             self.assertFalse(m.v2.fixed)
             self.assertTrue(m.v3.fixed)
@@ -698,8 +631,7 @@ class TestParamSweeper(unittest.TestCase):
 
                 for var, val in outputs.items():
                     self.assertAlmostEqual(var.value, val, delta=1e-8)
-                    self.assertAlmostEqual(var.value, output_values[var][i],
-                            delta=1e-8)
+                    self.assertAlmostEqual(var.value, output_values[var][i], delta=1e-8)
 
         # Values have been reset after exit.
         self.assertIs(m.v1.value, 1.0)
@@ -711,22 +643,21 @@ class TestParamSweeper(unittest.TestCase):
         m = _make_simple_model()
 
         n_scenario = 2
-        input_values = ComponentMap([
-            (m.v3, [1.3, 2.3]),
-            (m.v4, [1.4, 2.4]),
-            ])
+        input_values = ComponentMap([(m.v3, [1.3, 2.3]), (m.v4, [1.4, 2.4])])
 
-        output_values = ComponentMap([
-            (m.v1, [1.1, 2.1]),
-            (m.v2, [1.2, 2.2]),
-            ])
+        output_values = ComponentMap([(m.v1, [1.1, 2.1]), (m.v2, [1.2, 2.2])])
 
         to_fix = [m.v3, m.v4]
         to_deactivate = [m.con1]
 
         with self.assertRaises(RuntimeError):
-            with ParamSweeper(2, input_values, output_values,
-                    to_fix=to_fix, to_deactivate=to_deactivate) as sweeper:
+            with ParamSweeper(
+                2,
+                input_values,
+                output_values,
+                to_fix=to_fix,
+                to_deactivate=to_deactivate,
+            ) as sweeper:
                 self.assertFalse(m.v1.fixed)
                 self.assertFalse(m.v2.fixed)
                 self.assertTrue(m.v3.fixed)

--- a/pyomo/util/vars_from_expressions.py
+++ b/pyomo/util/vars_from_expressions.py
@@ -19,9 +19,16 @@ actually in the subtree or not.
 from pyomo.core import Block
 from pyomo.core.expr import current as EXPR
 
-def get_vars_from_components(block, ctype, include_fixed=True, active=None,
-                             sort=False, descend_into=Block,
-                             descent_order=None):
+
+def get_vars_from_components(
+    block,
+    ctype,
+    include_fixed=True,
+    active=None,
+    sort=False,
+    descend_into=Block,
+    descent_order=None,
+):
     """Returns a generator of all the Var objects which are used in Constraint
     expressions on the block. By default, this recurses into sub-blocks.
 
@@ -29,20 +36,23 @@ def get_vars_from_components(block, ctype, include_fixed=True, active=None,
         ctype: The type of component from which to get Vars, assumed to have
                an expr attribute.
         include_fixed: Whether or not to include fixed variables
-        active: Whether to find Vars that appear in Constraints accessible 
+        active: Whether to find Vars that appear in Constraints accessible
                 via the active tree
         sort: sort method for iterating through Constraint objects
         descend_into: Ctypes to descend into when finding Constraints
         descent_order: Traversal strategy for finding the objects of type ctype
     """
     seen = set()
-    for constraint in block.component_data_objects(ctype,
-                                                   active=active,
-                                                   sort=sort,
-                                                   descend_into=descend_into,
-                                                   descent_order=descent_order):
-        for var in EXPR.identify_variables(constraint.expr,
-                                           include_fixed=include_fixed):
+    for constraint in block.component_data_objects(
+        ctype,
+        active=active,
+        sort=sort,
+        descend_into=descend_into,
+        descent_order=descent_order,
+    ):
+        for var in EXPR.identify_variables(
+            constraint.expr, include_fixed=include_fixed
+        ):
             if id(var) not in seen:
                 seen.add(id(var))
                 yield var


### PR DESCRIPTION
## Fixes (Partly) #329 

## Summary/Motivation:
This is the first in a relatively long string of PRs to apply PEP8 standards via `black` to Pyomo. We are following the standard used by IDAES _except_ that we are adding the `-S` option: `Don't normalize string quotes or prefixes` and the `-C` option: `Don't use trailing commas as a reason to split lines.`

**NOTE**: All changes are NFC.

Full command used: `cd pyomo/util && black -S -C .`

## Changes proposed in this PR:
- Apply `black` to the `pyomo/util` directory `py` files

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
