### PR TITLE
Apply `black` to `pyomo/checker` directory `py` files

### DIFF
--- a/pyomo/checker/checker.py
+++ b/pyomo/checker/checker.py
@@ -13,14 +13,13 @@ from pyomo.common.plugin_base import Interface
 
 
 class IModelChecker(Interface):
-
     def check(self, runner, script, info):
         """
         Check a particular piece of Python information for errors.
 
         Provides the primary interface for checking some code for problems,
-        according to the particular subclass's definition. 
-        
+        according to the particular subclass's definition.
+
         @param runner the ModelCheckRunner instance that has dispatched
                       this call to check().
         @param script the ModelScript instance being checked.
@@ -39,7 +38,7 @@ class IModelChecker(Interface):
         Finish checking the given script from the given runner.
         """
 
-    def problem(self, script = None, message = "Error", lineno = None):
+    def problem(self, script=None, message="Error", lineno=None):
         """
         Write a problem to the console. The format varies and can be
         changed in subclasses; by default, this method prints the following:
@@ -51,4 +50,3 @@ class IModelChecker(Interface):
         @param message the error to display.
         @param lineno the line number on which the error occurred.
         """
-

--- a/pyomo/checker/hooks.py
+++ b/pyomo/checker/hooks.py
@@ -13,13 +13,12 @@ __all__ = ['IPreCheckHook', 'IPostCheckHook']
 
 from pyomo.common.plugin_base import Interface
 
-class IPreCheckHook(Interface):
 
+class IPreCheckHook(Interface):
     def precheck(self, runner, script, info):
         pass
 
 
 class IPostCheckHook(Interface):
-
     def postcheck(self, runner, script, info):
         pass

--- a/pyomo/checker/plugins/__init__.py
+++ b/pyomo/checker/plugins/__init__.py
@@ -9,6 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+
 def load():
     import pyomo.checker.plugins.checker
     import pyomo.checker.plugins.function

--- a/pyomo/checker/plugins/checker.py
+++ b/pyomo/checker/plugins/checker.py
@@ -31,7 +31,7 @@ class PyomoModelChecker(SingletonPlugin):
     def _check(self, runner, script, info):
         self._runner = runner
         self._script = script
-        
+
         for prehook in self._prehooks:
             prehook.precheck(runner, script, info)
 
@@ -84,14 +84,14 @@ class PyomoModelChecker(SingletonPlugin):
     def _checkerPackage(self):
         match = re.search(r"<class '([a-zA-Z0-9_\.]+)'>", str(self.__class__))
         return match.group(1).split(".")[-3]
-        
+
     def checkerLabel(self):
         return "[" + self._checkerPackage() + "::" + self._checkerName() + "] "
 
     def checkerDoc(self):
         return ""
 
-    def problem(self, message = "Error", runner = None, script = None, lineno = None):
+    def problem(self, message="Error", runner=None, script=None, lineno=None):
         if script is None:
             script = self._currentScript
         if runner is None:
@@ -114,7 +114,7 @@ class PyomoModelChecker(SingletonPlugin):
             if runner.verbose:
                 if len(self.checkerDoc()) > 0:
                     lines = textwrap.dedent(self.checkerDoc()).split("\n")
-                    lines = filter((lambda x : len(x) > 0), lines)
+                    lines = filter((lambda x: len(x) > 0), lines)
                     for line in lines:
                         print(self.checkerLabel() + line)
                 print

--- a/pyomo/checker/plugins/checkers/model/_rulebase.py
+++ b/pyomo/checker/plugins/checkers/model/_rulebase.py
@@ -16,10 +16,15 @@ from pyomo.checker.plugins.function import FunctionTrackerHook
 
 
 class _ModelRuleChecker(IterativeTreeChecker, FunctionTrackerHook):
-
     def check(self, runner, script, info):
         if isinstance(info, ast.Call):
-            if hasattr(info.func,'id') and info.func.id in ['Objective', 'Constraint', 'Var', 'Param', 'Set']:
+            if hasattr(info.func, 'id') and info.func.id in [
+                'Objective',
+                'Constraint',
+                'Var',
+                'Param',
+                'Set',
+            ]:
                 for keyword in info.keywords:
                     if keyword.arg == 'rule':
                         if isinstance(keyword.value, ast.Name):

--- a/pyomo/checker/plugins/checkers/model/assignment.py
+++ b/pyomo/checker/plugins/checkers/model/assignment.py
@@ -18,7 +18,9 @@ from pyomo.checker.plugins.model import ModelTrackerHook
 
 class ArrayValue(IterativeTreeChecker, ModelTrackerHook):
 
-    pyomo.common.plugin_base.alias('model.array_value', 'Check if assigning a value to an array of variables')
+    pyomo.common.plugin_base.alias(
+        'model.array_value', 'Check if assigning a value to an array of variables'
+    )
 
     varArrays = {}
 
@@ -40,7 +42,9 @@ class ArrayValue(IterativeTreeChecker, ModelTrackerHook):
                                     if target.value.id in script.modelVars:
                                         if target.value.id not in self.varArrays:
                                             self.varArrays[target.value.id] = []
-                                        self.varArrays[target.value.id].append(target.attr)
+                                        self.varArrays[target.value.id].append(
+                                            target.attr
+                                        )
 
     def checkArrayValue(self, script, node):
         for target in node.targets:
@@ -49,9 +53,17 @@ class ArrayValue(IterativeTreeChecker, ModelTrackerHook):
                     if isinstance(target.value.value, ast.Name):
                         if target.value.value.id in script.modelVars:
                             if target.value.value.id in self.varArrays:
-                                if target.value.attr in self.varArrays[target.value.value.id]:
+                                if (
+                                    target.value.attr
+                                    in self.varArrays[target.value.value.id]
+                                ):
                                     if target.attr == 'value':
-                                        self.problem("Assigning value to variable array {0}.{1}".format(target.value.value.id, target.value.attr), lineno = node.lineno)
+                                        self.problem(
+                                            "Assigning value to variable array {0}.{1}".format(
+                                                target.value.value.id, target.value.attr
+                                            ),
+                                            lineno=node.lineno,
+                                        )
 
     def check(self, runner, script, info):
         if isinstance(info, ast.Assign):

--- a/pyomo/checker/plugins/checkers/model/conditional.py
+++ b/pyomo/checker/plugins/checkers/model/conditional.py
@@ -18,7 +18,9 @@ from pyomo.checker.plugins.checkers.model._rulebase import _ModelRuleChecker
 
 class ModelValue(_ModelRuleChecker, ModelTrackerHook):
 
-    pyomo.common.plugin_base.alias('model.value', 'Check if comparisons are done using the "value()" function.')
+    pyomo.common.plugin_base.alias(
+        'model.value', 'Check if comparisons are done using the "value()" function.'
+    )
 
     def checkerDoc(self):
         return """\
@@ -33,11 +35,11 @@ class ModelValue(_ModelRuleChecker, ModelTrackerHook):
 
         # also check global If statements
         if isinstance(info, ast.If):
-            self.checkCompare(info.test, script = script)
+            self.checkCompare(info.test, script=script)
 
     def checkBody(self, funcdef):
         """Check the body of a function definition for model comparisons local
-           to its scope (i.e. using its model argument)."""
+        to its scope (i.e. using its model argument)."""
 
         if not isinstance(funcdef.args.args[0], ast.Name):
             return
@@ -46,15 +48,15 @@ class ModelValue(_ModelRuleChecker, ModelTrackerHook):
         for bodyNode in funcdef.body:
             for node in ast.walk(bodyNode):
                 if isinstance(node, ast.If):
-                    self.checkCompare(node.test, modelName = modelArg)
+                    self.checkCompare(node.test, modelName=modelArg)
 
-    def checkCompare(self, compare, modelName = None, script = None):
+    def checkCompare(self, compare, modelName=None, script=None):
         """Check an AST Compare node - iterate for Attribute nodes and match
-           against modelName argument. Recurse for script's model defs."""
+        against modelName argument. Recurse for script's model defs."""
 
         if modelName is None and script is None:
             return
-        
+
         if modelName is not None:
             valueCallArgs = []
             generatorExps = []
@@ -62,9 +64,16 @@ class ModelValue(_ModelRuleChecker, ModelTrackerHook):
                 if isinstance(node, ast.Attribute):
                     if isinstance(node.value, ast.Name):
                         if node.value.id == modelName:
-                            wrapped = self.checkWrapped(node, valueCallArgs, generatorExps)
+                            wrapped = self.checkWrapped(
+                                node, valueCallArgs, generatorExps
+                            )
                             if not wrapped:
-                                self.problem("Comparison on attribute {0}.{1} not wrapped in value()".format(modelName, node.attr), lineno=compare.lineno)
+                                self.problem(
+                                    "Comparison on attribute {0}.{1} not wrapped in value()".format(
+                                        modelName, node.attr
+                                    ),
+                                    lineno=compare.lineno,
+                                )
                 elif isinstance(node, ast.Call):
                     if isinstance(node.func, ast.Name):
                         if node.func.id == 'value':
@@ -74,12 +83,12 @@ class ModelValue(_ModelRuleChecker, ModelTrackerHook):
 
         if script is not None:
             for name in script.modelVars:
-                self.checkCompare(compare, modelName = name)
+                self.checkCompare(compare, modelName=name)
 
     def checkWrapped(self, attrNode, valueCallArgs, generatorExps):
         """check if the given attribute node has been 'wrapped', either
-           in a value() call or as part of the iterator in a generator
-           expression"""
+        in a value() call or as part of the iterator in a generator
+        expression"""
         for i in range(len(valueCallArgs)):
             for j in range(len(valueCallArgs[i])):
                 # i = call idx (to return), j = arg idx

--- a/pyomo/checker/plugins/checkers/model/imports.py
+++ b/pyomo/checker/plugins/checkers/model/imports.py
@@ -17,11 +17,13 @@ from pyomo.checker.plugins.checker import IterativeTreeChecker
 
 class Imports(IterativeTreeChecker):
     """
-    Check that an import for the pyomo.core or pyomo.environ packages 
+    Check that an import for the pyomo.core or pyomo.environ packages
     exists somewhere within the initial imports block
     """
 
-    pyomo.common.plugin_base.alias('model.imports', 'Check if pyomo.core or pyomo.environ has been imported.')
+    pyomo.common.plugin_base.alias(
+        'model.imports', 'Check if pyomo.core or pyomo.environ has been imported.'
+    )
 
     def beginChecking(self, runner, script):
         self.pyomoImported = False

--- a/pyomo/checker/plugins/checkers/model/model.py
+++ b/pyomo/checker/plugins/checkers/model/model.py
@@ -17,7 +17,10 @@ from pyomo.checker.plugins.checker import IterativeTreeChecker
 
 class ModelName(IterativeTreeChecker):
 
-    pyomo.common.plugin_base.alias('model.model_name', 'Check that the "model" variable is assigned with a Pyomo model.')
+    pyomo.common.plugin_base.alias(
+        'model.model_name',
+        'Check that the "model" variable is assigned with a Pyomo model.',
+    )
 
     def beginChecking(self, runner, script):
         self.modelAssigned = False
@@ -50,7 +53,9 @@ class ModelName(IterativeTreeChecker):
 
 class ModelCreate(IterativeTreeChecker):
 
-    pyomo.common.plugin_base.alias('model.create', 'Check if a Pyomo model class is being assigned to a variable.')
+    pyomo.common.plugin_base.alias(
+        'model.create', 'Check if a Pyomo model class is being assigned to a variable.'
+    )
 
     def getTargetStrings(self, assign):
         ls = []
@@ -58,7 +63,9 @@ class ModelCreate(IterativeTreeChecker):
             if isinstance(target, ast.Name):
                 ls.append(target.id)
             elif isinstance(target, ast.Tuple):
-                ls.extend(list(map((lambda x: x.id), target.elts))) # TODO probably not resilient
+                ls.extend(
+                    list(map((lambda x: x.id), target.elts))
+                )  # TODO probably not resilient
         return ls
 
     def checkerDoc(self):
@@ -74,12 +81,19 @@ class ModelCreate(IterativeTreeChecker):
             if 'model' in self.getTargetStrings(info):
                 if isinstance(info.value, ast.Name):
                     if info.value.id in ['Model', 'AbstractModel', 'ConcreteModel']:
-                        self.problem("Possible incorrect assignment of " + info.value.id + " class instead of instance", lineno = info.lineno)
+                        self.problem(
+                            "Possible incorrect assignment of "
+                            + info.value.id
+                            + " class instead of instance",
+                            lineno=info.lineno,
+                        )
 
 
 class DeprecatedModel(IterativeTreeChecker):
 
-    pyomo.common.plugin_base.alias('model.Model_class', 'Check if the deprecated Model class is being used.')
+    pyomo.common.plugin_base.alias(
+        'model.Model_class', 'Check if the deprecated Model class is being used.'
+    )
 
     def checkerDoc(self):
         return """\
@@ -92,4 +106,7 @@ class DeprecatedModel(IterativeTreeChecker):
             if isinstance(info.value, ast.Call):
                 if isinstance(info.value.func, ast.Name):
                     if info.value.func.id == 'Model':
-                        self.problem("Deprecated use of Model class", lineno = info.value.func.lineno)
+                        self.problem(
+                            "Deprecated use of Model class",
+                            lineno=info.value.func.lineno,
+                        )

--- a/pyomo/checker/plugins/checkers/py3k/printing.py
+++ b/pyomo/checker/plugins/checkers/py3k/printing.py
@@ -16,7 +16,9 @@ from pyomo.checker.plugins.checker import IterativeDataChecker
 
 class PrintParens(IterativeDataChecker):
 
-    pyomo.common.plugin_base.alias('py3k.print_parens', 'Check if print statements have parentheses.')
+    pyomo.common.plugin_base.alias(
+        'py3k.print_parens', 'Check if print statements have parentheses.'
+    )
 
     def __init__(self):
         self.current_lineno = 0
@@ -25,7 +27,9 @@ class PrintParens(IterativeDataChecker):
         self.current_lineno = info[0]
         line = info[1]
         if re.search(r"print[^\(]", line) is not None:
-            self.problem("Print statements in Python 3.x require parentheses", lineno = info[0])
+            self.problem(
+                "Print statements in Python 3.x require parentheses", lineno=info[0]
+            )
 
     def checkerDoc(self):
         return """\

--- a/pyomo/checker/plugins/checkers/py3k/range.py
+++ b/pyomo/checker/plugins/checkers/py3k/range.py
@@ -16,7 +16,9 @@ from pyomo.checker.plugins.checker import IterativeTreeChecker
 
 class XRange(IterativeTreeChecker):
 
-    pyomo.common.plugin_base.alias('py3k.xrange', 'Check if the xrange() function is used.')
+    pyomo.common.plugin_base.alias(
+        'py3k.xrange', 'Check if the xrange() function is used.'
+    )
 
     def check(self, runner, script, info):
         if isinstance(info, ast.Name):

--- a/pyomo/checker/plugins/checkers/sample/printing.py
+++ b/pyomo/checker/plugins/checkers/sample/printing.py
@@ -11,13 +11,13 @@
 
 from pyomo.checker.plugins.checker import IterativeTreeChecker
 
-class PrintASTNodes(IterativeTreeChecker):
 
+class PrintASTNodes(IterativeTreeChecker):
     def __init__(self):
         self.disable()
 
     def check(self, runner, script, info):
         if 'lineno' in dir(info):
-            self.problem(str(info), lineno = info.lineno)
+            self.problem(str(info), lineno=info.lineno)
         else:
             self.problem(str(info))

--- a/pyomo/checker/plugins/function.py
+++ b/pyomo/checker/plugins/function.py
@@ -39,7 +39,9 @@ class FunctionTrackerHook(SingletonPlugin):
                 if info.value.id in script.functionDefs:
                     for target in info.targets:
                         if isinstance(target, ast.Name):
-                            script.functionDefs[target.id] = script.functionDefs[info.value.id]
+                            script.functionDefs[target.id] = script.functionDefs[
+                                info.value.id
+                            ]
             else:
                 for target in info.targets:
                     if isinstance(target, ast.Name):
@@ -50,4 +52,3 @@ class FunctionTrackerHook(SingletonPlugin):
         """Remove function args from the stack"""
         if isinstance(info, ast.FunctionDef):
             script.functionArgs.pop()
-

--- a/pyomo/checker/runner.py
+++ b/pyomo/checker/runner.py
@@ -17,8 +17,7 @@ from pyomo.checker.script import ModelScript
 
 
 class CheckingNodeVisitor(ast.NodeVisitor):
-    
-    def __init__(self, runner, script, tc = [], dc = [], pt = ""):
+    def __init__(self, runner, script, tc=[], dc=[], pt=""):
         """
         @param tc iterative tree checkers
         @param dc iterative data checkers
@@ -48,7 +47,11 @@ class CheckingNodeVisitor(ast.NodeVisitor):
             if current_lineno > self.running_lineno:
                 self.running_lineno = current_lineno
                 for checker in self.dataCheckers:
-                    checker._check(self.runner, self.script, (current_lineno, self.programLines[current_lineno - 1]))
+                    checker._check(
+                        self.runner,
+                        self.script,
+                        (current_lineno, self.programLines[current_lineno - 1]),
+                    )
 
         for checker in self.treeCheckers:
             checker._check(self.runner, self.script, node)
@@ -64,7 +67,12 @@ class ModelCheckRunner(object):
         self.scripts = []
 
     def run(self, *args, **kwargs):
-        from pyomo.checker.plugins.checker import ImmediateDataChecker, IterativeDataChecker, ImmediateTreeChecker, IterativeTreeChecker
+        from pyomo.checker.plugins.checker import (
+            ImmediateDataChecker,
+            IterativeDataChecker,
+            ImmediateTreeChecker,
+            IterativeTreeChecker,
+        )
 
         # Get args
         script = kwargs.pop("script", None)
@@ -98,16 +106,24 @@ class ModelCheckRunner(object):
                     printable[c._checkerPackage()] = [c._checkerName()]
                 else:
                     printable[c._checkerPackage()].append(c._checkerName())
-            
+
             for package in printable:
                 print("{0}: {1}".format(package, " ".join(printable[package])))
             print("")
 
         # Pre-partition checkers
-        immDataCheckers = [c for c in self._checkers if isinstance(c, ImmediateDataChecker)]
-        iterDataCheckers = [c for c in self._checkers if isinstance(c, IterativeDataChecker)]
-        immTreeCheckers = [c for c in self._checkers if isinstance(c, ImmediateTreeChecker)]
-        iterTreeCheckers = [c for c in self._checkers if isinstance(c, IterativeTreeChecker)]
+        immDataCheckers = [
+            c for c in self._checkers if isinstance(c, ImmediateDataChecker)
+        ]
+        iterDataCheckers = [
+            c for c in self._checkers if isinstance(c, IterativeDataChecker)
+        ]
+        immTreeCheckers = [
+            c for c in self._checkers if isinstance(c, ImmediateTreeChecker)
+        ]
+        iterTreeCheckers = [
+            c for c in self._checkers if isinstance(c, IterativeTreeChecker)
+        ]
 
         for script in self.scripts:
             # Read in the script and call data checkers
@@ -125,7 +141,9 @@ class ModelCheckRunner(object):
                 checker._endChecking(self, script)
 
             # Start walking the tree, calling checkers along the way
-            visitor = CheckingNodeVisitor(self, script, tc=iterTreeCheckers, dc=iterDataCheckers, pt = data)
+            visitor = CheckingNodeVisitor(
+                self, script, tc=iterTreeCheckers, dc=iterDataCheckers, pt=data
+            )
             visitor.sendBegin()
             visitor.visit(tree)
             visitor.sendEnd()

--- a/pyomo/checker/script.py
+++ b/pyomo/checker/script.py
@@ -9,8 +9,8 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-class ModelScript(object):
 
+class ModelScript(object):
     def __init__(self, filename=None, text=None):
         if filename is not None:
             self._filename = filename

--- a/pyomo/checker/tests/examples/model/ArrayValue_nomodel.py
+++ b/pyomo/checker/tests/examples/model/ArrayValue_nomodel.py
@@ -11,8 +11,11 @@
 
 from pyomo.environ import Var
 
+
 class Foo:
     pass
+
+
 anotherObject = Foo()
 anotherObject.x = Var([10])
 anotherObject.x.value = 42

--- a/pyomo/checker/tests/examples/model/Imports_wrong.py
+++ b/pyomo/checker/tests/examples/model/Imports_wrong.py
@@ -8,4 +8,3 @@
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
-

--- a/pyomo/checker/tests/examples/model/ModelAccess_global.py
+++ b/pyomo/checker/tests/examples/model/ModelAccess_global.py
@@ -14,6 +14,9 @@ from pyomo.environ import ConcreteModel, Var, Constraint
 model = ConcreteModel()
 model.X = Var()
 
+
 def c_rule(m):
-    return model.X >= 10.0 # wrongly access global 'model'
+    return model.X >= 10.0  # wrongly access global 'model'
+
+
 model.C = Constraint(rule=c_rule)

--- a/pyomo/checker/tests/examples/model/ModelAccess_global2.py
+++ b/pyomo/checker/tests/examples/model/ModelAccess_global2.py
@@ -14,9 +14,12 @@ from pyomo.environ import ConcreteModel, Var, Constraint
 model = ConcreteModel()
 model.X = Var()
 
+
 def c_rule(m):
     try:
         return model.X >= 10.0
     except Exception:
         return model.X >= 20.0
+
+
 model.C = Constraint(rule=c_rule)

--- a/pyomo/checker/tests/examples/model/ModelArgument_firstarg.py
+++ b/pyomo/checker/tests/examples/model/ModelArgument_firstarg.py
@@ -15,6 +15,9 @@ model = ConcreteModel()
 model.S = RangeSet(10)
 model.X = Var(model.S)
 
+
 def C_rule(m, i):
     return m.X[i] >= 10.0
+
+
 model.C = Constraint(rule=C_rule)

--- a/pyomo/checker/tests/examples/model/ModelArgument_lastarg.py
+++ b/pyomo/checker/tests/examples/model/ModelArgument_lastarg.py
@@ -15,6 +15,9 @@ model = ConcreteModel()
 model.S = RangeSet(10)
 model.X = Var(model.S)
 
+
 def C_rule(i, m):
     return m.X[i] >= 10.0
+
+
 model.C = Constraint(rule=C_rule)

--- a/pyomo/checker/tests/examples/model/ModelValue_multiif.py
+++ b/pyomo/checker/tests/examples/model/ModelValue_multiif.py
@@ -19,11 +19,13 @@ if model.X >= 10.0:
 if value(model.X) >= 10.0:
     pass
 
+
 def c_rule(m):
     if m.X >= 10.0:
         pass
     if value(m.X) >= 10.0:
         pass
     return m.X >= 10.0
+
 
 model.C = Constraint(rule=c_rule)

--- a/pyomo/checker/tests/examples/model/ModelValue_ruleif.py
+++ b/pyomo/checker/tests/examples/model/ModelValue_ruleif.py
@@ -14,11 +14,13 @@ from pyomo.environ import AbstractModel, Var, Constraint, value
 model = AbstractModel()
 model.X = Var()
 
+
 def c_rule(m):
     if m.X >= 10.0:
         pass
     if value(m.X) >= 10.0:
         pass
     return m.X >= 10.0
+
 
 model.C = Constraint(rule=c_rule)

--- a/pyomo/checker/tests/examples/model/ModelValue_rulelistcomp.py
+++ b/pyomo/checker/tests/examples/model/ModelValue_rulelistcomp.py
@@ -15,10 +15,13 @@ model = AbstractModel()
 model.S = RangeSet(10)
 model.X = Var(model.S)
 
+
 def c_rule(m, i):
     if sum(m.X[i] for i in m.S) <= 10.0:
         pass
     if sum(value(m.X[i]) for i in m.S) <= 10.0:
         pass
     return sum(m.X[i] for i in m.S) <= 10.0
+
+
 model.C = Constraint(rule=c_rule)

--- a/pyomo/checker/tests/examples/model/NoneReturn_wrong.py
+++ b/pyomo/checker/tests/examples/model/NoneReturn_wrong.py
@@ -14,6 +14,9 @@ from pyomo.environ import AbstractModel, Var, Constraint
 model = AbstractModel()
 model.X = Var()
 
+
 def c_rule(m):
     return None
+
+
 model.C = Constraint(rule=c_rule)

--- a/pyomo/checker/tests/test_examples.py
+++ b/pyomo/checker/tests/test_examples.py
@@ -22,33 +22,39 @@ from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 currdir = os.path.dirname(os.path.abspath(__file__))
 exdir = os.path.join(currdir, "examples")
 
+
 def createTestMethod(defs, package, checkerName, key):
     def testMethod(obj, name):
         import pyomo.environ
+
         runner = ModelCheckRunner()
         path = os.path.join(exdir, package, "{0}_{1}.py".format(checkerName, key))
-        runner.run(script = path, checkers = {package:[checkerName]})
-        
+        runner.run(script=path, checkers={package: [checkerName]})
+
         checker = runner._checkers()[0]
         pc = checker.problemCount
         lns = checker.linenos
         checker.resetProblemCount()
         obj.assertEqual(defs[package][checkerName][key]['problems'], pc)
         if 'lines' in defs[package][checkerName][key]:
-            obj.assertEqual(sorted(lns), sorted(defs[package][checkerName][key]['lines']))
+            obj.assertEqual(
+                sorted(lns), sorted(defs[package][checkerName][key]['lines'])
+            )
+
     return testMethod
 
 
 def assignTests(cls):
-    defs = yaml.load(open(os.path.join(currdir, 'examples.yml'), 'r'),
-                     **yaml_load_args)
-    
+    defs = yaml.load(open(os.path.join(currdir, 'examples.yml'), 'r'), **yaml_load_args)
+
     for package in defs:
         for checkerName in defs[package]:
             for key in defs[package][checkerName]:
                 attrName = "{0}_{1}_{2}".format(package, checkerName, key)
-                cls.add_fn_test(name=attrName, fn=createTestMethod(defs, package, checkerName, key))
-                #setattr(cls, attrName, createTestMethod(defs, package, checkerName, key))
+                cls.add_fn_test(
+                    name=attrName, fn=createTestMethod(defs, package, checkerName, key)
+                )
+                # setattr(cls, attrName, createTestMethod(defs, package, checkerName, key))
 
 
 class ExampleTest(unittest.TestCase):
@@ -57,13 +63,15 @@ class ExampleTest(unittest.TestCase):
     """
 
     def setUp(self):
-        def mockProblem(self, message = "Error", runner = None, script = None, lineno = None):
+        def mockProblem(self, message="Error", runner=None, script=None, lineno=None):
             self.problemCount += 1
             if lineno is not None:
                 self.linenos.append(lineno)
+
         def resetProblemCount(self):
             self.problemCount = 0
             self.linenos = []
+
         PyomoModelChecker.problem_ = PyomoModelChecker.problem
         PyomoModelChecker.problem = mockProblem
         PyomoModelChecker.problemCount = 0
@@ -75,12 +83,12 @@ class ExampleTest(unittest.TestCase):
         del PyomoModelChecker.problemCount
         del PyomoModelChecker.resetProblemCount
 
+
 if yaml_available:
     # Disable test for py3k.  For some reason, this messes up nose
-    if not (sys.version_info[0:2] >= (3,0)):
+    if not (sys.version_info[0:2] >= (3, 0)):
         assignTests(ExampleTest)
 
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/pyomo/checker/tests/test_runner.py
+++ b/pyomo/checker/tests/test_runner.py
@@ -13,29 +13,52 @@ import os
 
 import pyomo.common.unittest as unittest
 
-from pyomo.checker import  ModelCheckRunner, ModelScript
-from pyomo.checker.plugins.checker import IModelChecker, ImmediateDataChecker, ImmediateTreeChecker, IterativeDataChecker, IterativeTreeChecker
+from pyomo.checker import ModelCheckRunner, ModelScript
+from pyomo.checker.plugins.checker import (
+    IModelChecker,
+    ImmediateDataChecker,
+    ImmediateTreeChecker,
+    IterativeDataChecker,
+    IterativeTreeChecker,
+)
 
 
 currdir = os.path.dirname(os.path.abspath(__file__))
 
+
 class MockChecker(object):
     checkCount = 0
+
     def check(self, runner, script, info):
         self.checkCount += 1
+
     def _checkerPackage(self):
         return 'mock'
+
     def resetCount(self):
         self.checkCount = 0
+
 
 # Multiple inheritance, because otherwise something weird happens with the plugin system
 # MockChecker MUST BE specified first so that its overridden methods take precedence
 # See http://www.python.org/download/releases/2.3/mro/
 
-class MockImmediateDataChecker(MockChecker, ImmediateDataChecker): pass
-class MockImmediateTreeChecker(MockChecker, ImmediateTreeChecker): pass
-class MockIterativeDataChecker(MockChecker, IterativeDataChecker): pass
-class MockIterativeTreeChecker(MockChecker, IterativeTreeChecker): pass
+
+class MockImmediateDataChecker(MockChecker, ImmediateDataChecker):
+    pass
+
+
+class MockImmediateTreeChecker(MockChecker, ImmediateTreeChecker):
+    pass
+
+
+class MockIterativeDataChecker(MockChecker, IterativeDataChecker):
+    pass
+
+
+class MockIterativeTreeChecker(MockChecker, IterativeTreeChecker):
+    pass
+
 
 class RunnerTest(unittest.TestCase):
     """
@@ -45,7 +68,7 @@ class RunnerTest(unittest.TestCase):
     testScripts = [
         "print('Hello, world!')\n",
         "import sys\nsys.stdout.write('Hello, world!\\n')\n"
-        "for i in range(10):\n\tprint(i)\n"
+        "for i in range(10):\n\tprint(i)\n",
     ]
 
     def test_init(self):
@@ -67,7 +90,7 @@ class RunnerTest(unittest.TestCase):
         for text in self.testScripts:
             self.assertEqual(expectedScriptCount, len(runner.scripts))
 
-            script = ModelScript(text = text)
+            script = ModelScript(text=text)
             runner.addScript(script)
             expectedScriptCount += 1
 
@@ -78,15 +101,21 @@ class RunnerTest(unittest.TestCase):
         "Check that a runner calls check() on an immediate checker"
 
         for text in self.testScripts:
-            
+
             runner = ModelCheckRunner()
-            script = ModelScript(text = text)
+            script = ModelScript(text=text)
             runner.addScript(script)
 
-            runner.run(checkers = {'mock':['MockImmediateDataChecker', 'MockImmediateTreeChecker']})
+            runner.run(
+                checkers={
+                    'mock': ['MockImmediateDataChecker', 'MockImmediateTreeChecker']
+                }
+            )
 
             for klass in [MockImmediateDataChecker, MockImmediateTreeChecker]:
-                mockChecker = list(filter((lambda c : c.__class__ == klass), runner._checkers()))[0]
+                mockChecker = list(
+                    filter((lambda c: c.__class__ == klass), runner._checkers())
+                )[0]
                 self.assertEqual(1, mockChecker.checkCount)
                 mockChecker.resetCount()
 
@@ -94,19 +123,24 @@ class RunnerTest(unittest.TestCase):
         "Check that a runner calls check() on an iterative checker"
 
         for text in self.testScripts:
-            
+
             runner = ModelCheckRunner()
-            script = ModelScript(text = text)
+            script = ModelScript(text=text)
             runner.addScript(script)
 
-            runner.run(checkers = {'mock':['MockIterativeDataChecker', 'MockIterativeTreeChecker']})
+            runner.run(
+                checkers={
+                    'mock': ['MockIterativeDataChecker', 'MockIterativeTreeChecker']
+                }
+            )
 
             for klass in [MockIterativeDataChecker, MockIterativeTreeChecker]:
-                mockChecker = list(filter((lambda c : c.__class__ == klass), runner._checkers()))[0]
+                mockChecker = list(
+                    filter((lambda c: c.__class__ == klass), runner._checkers())
+                )[0]
                 self.assertTrue(mockChecker.checkCount >= 1)
                 mockChecker.resetCount()
 
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/pyomo/checker/tests/test_script.py
+++ b/pyomo/checker/tests/test_script.py
@@ -18,6 +18,7 @@ from pyomo.checker import ModelScript
 
 currdir = os.path.dirname(os.path.abspath(__file__))
 
+
 class ScriptTest(unittest.TestCase):
     """
     Test the ModelScript class. Checks both raw text and file-based
@@ -27,14 +28,14 @@ class ScriptTest(unittest.TestCase):
     testScripts = [
         "print('Hello, world!')\n",
         "import sys\nsys.stdout.write('Hello, world!\\n')\n"
-        "for i in range(10):\n\tprint(i)\n"
+        "for i in range(10):\n\tprint(i)\n",
     ]
 
     def testScriptText(self):
         "Check ModelScript handling of raw text scripts"
 
         for text in self.testScripts:
-            script = ModelScript(text = text)
+            script = ModelScript(text=text)
             self.assertEqual(text, script.read())
             self.assertEqual("<unknown>", script.filename())
 
@@ -47,7 +48,7 @@ class ScriptTest(unittest.TestCase):
             with os.fdopen(file, 'w') as f:
                 f.write(text)
 
-            script = ModelScript(filename = filename)
+            script = ModelScript(filename=filename)
 
             self.assertEqual(text, script.read())
             self.assertEqual(filename, script.filename())
@@ -57,4 +58,3 @@ class ScriptTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Fixes (Partly) #329 

## Summary/Motivation:
This is the first in a relatively long string of PRs to apply PEP8 standards via `black` to Pyomo. We are following the standard used by IDAES _except_ that we are adding the `-S` option: `Don't normalize string quotes or prefixes` and the `-C` option: `Don't use trailing commas as a reason to split lines.`

**NOTE**: All changes are NFC.

Full command used: `cd pyomo/checker && black -S -C .`

## Changes proposed in this PR:
- Apply `black` to the `pyomo/checker` directory `py` files

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
