### PR TITLE
Apply `black` to `pyomo/scripting` directory `py` files

### DIFF
--- a/pyomo/scripting/commands.py
+++ b/pyomo/scripting/commands.py
@@ -28,10 +28,11 @@ def pyomo_python(args=None):
         args = sys.argv[1:]
     if args is None or len(args) == 0:
         console = code.InteractiveConsole()
-        console.interact('Pyomo Python Console\n'+sys.version)
+        console.interact('Pyomo Python Console\n' + sys.version)
     else:
-        cmd = sys.executable+' '+ ' '.join(args)
+        cmd = sys.executable + ' ' + ' '.join(args)
         subprocess.run(cmd)
+
 
 @pyomo_command('pyomo', "The main command interface for Pyomo")
 def pyomo(args=None):

--- a/pyomo/scripting/convert.py
+++ b/pyomo/scripting/convert.py
@@ -16,11 +16,7 @@ import sys
 
 from pyomo.common.collections import Bunch
 from pyomo.opt import ProblemFormat
-from pyomo.core.base import (Objective,
-                             Var,
-                             Constraint,
-                             value,
-                             ConcreteModel)
+from pyomo.core.base import Objective, Var, Constraint, value, ConcreteModel
 
 _format = None
 
@@ -38,7 +34,7 @@ def convert(options=Bunch(), parser=None, model_format=None):
         if _format == ProblemFormat.cpxlp:
             options.model.save_file = 'unknown.lp'
         else:
-            options.model.save_file = 'unknown.'+str(_format)
+            options.model.save_file = 'unknown.' + str(_format)
     options.model.save_format = _format
 
     data = Bunch(options=options)
@@ -62,10 +58,9 @@ def convert(options=Bunch(), parser=None, model_format=None):
         #      calling finalize with its default keyword value for
         #      model(=None) results in an a different error related to
         #      task port values.  Not sure how to interpret that.
-        pyomo.scripting.util.finalize(data,
-                                      model=ConcreteModel(),
-                                      instance=None,
-                                      results=None)
+        pyomo.scripting.util.finalize(
+            data, model=ConcreteModel(), instance=None, results=None
+        )
         raise
 
     else:
@@ -73,6 +68,7 @@ def convert(options=Bunch(), parser=None, model_format=None):
         pyomo.scripting.util.finalize(data, model=model_data.model)
 
     return model_data
+
 
 def convert_dakota(options=Bunch(), parser=None):
     #
@@ -89,7 +85,7 @@ def convert_dakota(options=Bunch(), parser=None):
 
     # By default replace .py with .nl
     if options.model.save_file is None:
-       options.model.save_file = model_file_no_ext + '.nl'
+        options.model.save_file = model_file_no_ext + '.nl'
     options.model.save_format = ProblemFormat.nl
     # Dakota requires .row/.col files
     options.model.symbolic_solver_labels = True
@@ -109,9 +105,9 @@ def convert_dakota(options=Bunch(), parser=None):
     model = model_data.instance
 
     # Easy way
-    #print "VARIABLE:"
-    #lines = open(options.save_model.replace('.nl','.col'),'r').readlines()
-    #for varName in lines:
+    # print "VARIABLE:"
+    # lines = open(options.save_model.replace('.nl','.col'),'r').readlines()
+    # for varName in lines:
     #    varName = varName.strip()
     #    var = model_data.symbol_map.getObject(varName)
     #    print "'%s': %s" % (varName, var)
@@ -185,13 +181,13 @@ def convert_dakota(options=Bunch(), parser=None):
 
     dakfrag.write("#--- Dakota interface block ---#\n")
     dakfrag.write("interface\n")
-    dakfrag.write("  algebraic_mappings = '" + options.model.save_file  + "'\n")
+    dakfrag.write("  algebraic_mappings = '" + options.model.save_file + "'\n")
 
     dakfrag.write("#--- Dakota responses block ---#\n")
     dakfrag.write("responses\n")
     dakfrag.write("  objective_functions " + str(objectives) + '\n')
 
-    if (constraints > 0):
+    if constraints > 0:
         dakfrag.write("  nonlinear_inequality_constraints " + str(constraints) + '\n')
         dakfrag.write("    lower_bounds " + " ".join(cons_lb) + '\n')
         dakfrag.write("    upper_bounds " + " ".join(cons_ub) + '\n')
@@ -199,7 +195,7 @@ def convert_dakota(options=Bunch(), parser=None):
     dakfrag.write("    descriptors\n")
     for od in obj_descriptors:
         dakfrag.write("      '%s'\n" % od)
-    if (constraints > 0):
+    if constraints > 0:
         for cd in cons_descriptors:
             dakfrag.write("      '%s'\n" % cd)
 
@@ -209,35 +205,43 @@ def convert_dakota(options=Bunch(), parser=None):
 
     dakfrag.close()
 
-    sys.stdout.write( "Dakota input fragment written to file '%s'\n" 
-                      % (model_file_no_ext + ".dak",) )
+    sys.stdout.write(
+        "Dakota input fragment written to file '%s'\n" % (model_file_no_ext + ".dak",)
+    )
     return model_data
 
 
 def pyomo2lp(args=None):
     from pyomo.scripting.pyomo_main import main
+
     if args is None:
         return main()
     else:
-        return main(['convert', '--format=lp']+args)
+        return main(['convert', '--format=lp'] + args)
+
 
 def pyomo2nl(args=None):
     from pyomo.scripting.pyomo_main import main
+
     if args is None:
         return main()
     else:
-        return main(['convert', '--format=nl']+args)
+        return main(['convert', '--format=nl'] + args)
+
 
 def pyomo2bar(args=None):
     from pyomo.scripting.pyomo_main import main
+
     if args is None:
         return main()
     else:
-        return main(['convert', '--format=bar']+args)
+        return main(['convert', '--format=bar'] + args)
+
 
 def pyomo2dakota(args=None):
     from pyomo.scripting.pyomo_main import main
+
     if args is None:
         return main()
     else:
-        return main(['convert','--format=dakota']+args)
+        return main(['convert', '--format=dakota'] + args)

--- a/pyomo/scripting/driver_help.py
+++ b/pyomo/scripting/driver_help.py
@@ -25,24 +25,33 @@ import pyomo.scripting.pyomo_parser
 
 logger = logging.getLogger('pyomo.solvers')
 
-#--------------------------------------------------
+# --------------------------------------------------
 # run
 #   --list
-#--------------------------------------------------
+# --------------------------------------------------
+
 
 def setup_command_parser(parser):
-    parser.add_argument("--list", dest="summary", action='store_true', default=False,
-                        help="List the commands that are installed with Pyomo")
-    parser.add_argument("command", nargs='*', help="The command and command-line options")
+    parser.add_argument(
+        "--list",
+        dest="summary",
+        action='store_true',
+        default=False,
+        help="List the commands that are installed with Pyomo",
+    )
+    parser.add_argument(
+        "command", nargs='*', help="The command and command-line options"
+    )
+
 
 def command_exec(options):
-    cmddir = os.path.dirname(os.path.abspath(sys.executable))+os.sep
+    cmddir = os.path.dirname(os.path.abspath(sys.executable)) + os.sep
     if options.summary:
         print("")
         print("The following commands are installed in the Pyomo bin directory:")
         print("----------------------------------------------------------------")
-        for file in sorted(glob.glob(cmddir+'*')):
-            print(" "+os.path.basename(file))
+        for file in sorted(glob.glob(cmddir + '*')):
+            print(" " + os.path.basename(file))
         print("")
         if len(options.command) > 0:
             print("WARNING: ignoring command specification")
@@ -50,18 +59,22 @@ def command_exec(options):
     if len(options.command) == 0:
         print("  ERROR: no command specified")
         return 1
-    if not os.path.exists(cmddir+options.command[0]):
-        print("  ERROR: the command '%s' does not exist" % (cmddir+options.command[0]))
+    if not os.path.exists(cmddir + options.command[0]):
+        print(
+            "  ERROR: the command '%s' does not exist" % (cmddir + options.command[0])
+        )
         return 1
-    return subprocess.run([cmddir] + options.command,
-                          stdout=subprocess.DEVNULL,
-                          stderr=subprocess.DEVNULL).returncode
+    return subprocess.run(
+        [cmddir] + options.command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    ).returncode
+
 
 #
 # Add a subparser for the pyomo command
 #
 setup_command_parser(
-    pyomo.scripting.pyomo_parser.add_subparser('run',
+    pyomo.scripting.pyomo_parser.add_subparser(
+        'run',
         func=command_exec,
         help='Execute a command from the Pyomo bin (or Scripts) directory.',
         description='This pyomo subcommand is used to execute commands installed with Pyomo.',
@@ -72,21 +85,23 @@ includes any commands that are installed by other Python packages
 that are installed with Pyomo.  Thus, if Pyomo is installed in the
 Python system directories, then this command executes any command
 included with Python.
-"""
-        ))
+""",
+    )
+)
 
-#--------------------------------------------------
+# --------------------------------------------------
 # help
 #   --components
 #   --command
 #   --transformations
 #   --solvers
-#--------------------------------------------------
+# --------------------------------------------------
+
 
 def help_commands():
     print("")
     print("The following commands are installed with Pyomo:")
-    print("-"*75)
+    print("-" * 75)
     registry = pyomo.common.get_pyomo_commands()
     d = max(len(key) for key in registry)
     fmt = "%%-%ds  %%s" % d
@@ -94,9 +109,11 @@ def help_commands():
         print(fmt % (key, registry[key]))
     print("")
 
+
 def help_writers():
     import pyomo.environ
     from pyomo.opt.base import WriterFactory
+
     wrapper = textwrap.TextWrapper()
     wrapper.initial_indent = '      '
     wrapper.subsequent_indent = '      '
@@ -104,13 +121,15 @@ def help_writers():
     print("Pyomo Problem Writers")
     print("---------------------")
     for writer in sorted(WriterFactory):
-        print("  "+writer)
+        print("  " + writer)
         print(wrapper.fill(WriterFactory.doc(writer)))
+
 
 def help_checkers():
     import pyomo.environ
     import pyomo.common.plugin_base
     from pyomo.checker import IModelChecker
+
     wrapper = textwrap.TextWrapper()
     wrapper.initial_indent = '      '
     wrapper.subsequent_indent = '      '
@@ -123,12 +142,14 @@ def help_checkers():
         for alias in getattr(checker, '_factory_aliases', set()):
             tmp[alias[0]] = alias[1]
     for key in sorted(tmp.keys()):
-        print("  "+key)
+        print("  " + key)
         print(wrapper.fill(tmp[key]))
+
 
 def help_datamanagers(options):
     import pyomo.environ
     from pyomo.dataportal import DataManagerFactory
+
     wrapper = textwrap.TextWrapper()
     wrapper.initial_indent = '      '
     wrapper.subsequent_indent = '      '
@@ -136,8 +157,9 @@ def help_datamanagers(options):
     print("Pyomo Data Managers")
     print("-------------------")
     for xform in sorted(DataManagerFactory):
-        print("  "+xform)
+        print("  " + xform)
         print(wrapper.fill(DataManagerFactory.doc(xform)))
+
 
 def help_environment():
     info = Bunch()
@@ -149,9 +171,9 @@ def help_environment():
     try:
         packages = []
         import pip
+
         for package in pip.get_installed_distributions():
-            packages.append(Bunch(name=package.project_name,
-                                    version=package.version))
+            packages.append(Bunch(name=package.project_name, version=package.version))
         info.python.packages = packages
     except:
         pass
@@ -167,9 +189,11 @@ def help_environment():
     print('#')
     print(str(info))
 
+
 def help_transformations():
     import pyomo.environ
     from pyomo.core import TransformationFactory
+
     wrapper = textwrap.TextWrapper()
     wrapper.initial_indent = '      '
     wrapper.subsequent_indent = '      '
@@ -177,7 +201,7 @@ def help_transformations():
     print("Pyomo Model Transformations")
     print("---------------------------")
     for xform in sorted(TransformationFactory):
-        print("  "+xform)
+        print("  " + xform)
         _doc = TransformationFactory.doc(xform) or ""
         # Ideally, the Factory would ensure that the doc string
         # indicated deprecation, but as @deprecated() is Pyomo
@@ -185,32 +209,41 @@ def help_transformations():
         # PyUtilib probably shouldn't contain Pyomo-specific processing.
         # The next best thing is to ensure that the deprecation status
         # is indicated here.
-        _init_doc = TransformationFactory.get_class(xform).__init__.__doc__ \
-                    or ""
+        _init_doc = TransformationFactory.get_class(xform).__init__.__doc__ or ""
         if _init_doc.strip().startswith('DEPRECATED') and 'DEPRECAT' not in _doc:
             _doc = ' '.join(('[DEPRECATED]', _doc))
         if _doc:
             print(wrapper.fill(_doc))
 
+
 def help_solvers():
     import pyomo.environ
+
     wrapper = textwrap.TextWrapper(replace_whitespace=False)
     print("")
     print("Pyomo Solvers and Solver Managers")
     print("---------------------------------")
 
-    print(wrapper.fill("Pyomo uses 'solver managers' to execute 'solvers' that perform optimization and other forms of model analysis.  A solver directly executes an optimizer, typically using an executable found on the user's PATH environment.  Solver managers support a flexible mechanism for asyncronously executing solvers either locally or remotely.  The following solver managers are available in Pyomo:"))
+    print(
+        wrapper.fill(
+            "Pyomo uses 'solver managers' to execute 'solvers' that perform optimization and other forms of model analysis.  A solver directly executes an optimizer, typically using an executable found on the user's PATH environment.  Solver managers support a flexible mechanism for asyncronously executing solvers either locally or remotely.  The following solver managers are available in Pyomo:"
+        )
+    )
     print("")
     solvermgr_list = list(pyomo.opt.SolverManagerFactory)
-    solvermgr_list = sorted( filter(lambda x: '_' != x[0], solvermgr_list) )
+    solvermgr_list = sorted(filter(lambda x: '_' != x[0], solvermgr_list))
     n = max(map(len, solvermgr_list))
-    wrapper = textwrap.TextWrapper(subsequent_indent=' '*(n+9))
+    wrapper = textwrap.TextWrapper(subsequent_indent=' ' * (n + 9))
     for s in solvermgr_list:
-        format = '    %-'+str(n)+'s     %s'
-        print(wrapper.fill(format % (s , pyomo.opt.SolverManagerFactory.doc(s))))
+        format = '    %-' + str(n) + 's     %s'
+        print(wrapper.fill(format % (s, pyomo.opt.SolverManagerFactory.doc(s))))
     print("")
     wrapper = textwrap.TextWrapper(subsequent_indent='')
-    print(wrapper.fill("If no solver manager is specified, Pyomo uses the serial solver manager to execute solvers locally.  The neos solver manager is used to execute solvers on the NEOS optimization server."))
+    print(
+        wrapper.fill(
+            "If no solver manager is specified, Pyomo uses the serial solver manager to execute solvers locally.  The neos solver manager is used to execute solvers on the NEOS optimization server."
+        )
+    )
     print("")
 
     print("")
@@ -219,7 +252,7 @@ def help_solvers():
     print(wrapper.fill("The serial manager supports the following solver interfaces:"))
     print("")
     solver_list = list(pyomo.opt.SolverFactory)
-    solver_list = sorted( filter(lambda x: '_' != x[0], solver_list) )
+    solver_list = sorted(filter(lambda x: '_' != x[0], solver_list))
     _data = []
     try:
         # Disable warnings
@@ -258,21 +291,38 @@ def help_solvers():
     verFieldLen = max(len(line[2]) for line in _data)
     fmt = '   %%1s%%-%ds %%-%ds %%s' % (nameFieldLen, verFieldLen)
     wrapper = textwrap.TextWrapper(
-        subsequent_indent=' '*(nameFieldLen + verFieldLen + 6))
+        subsequent_indent=' ' * (nameFieldLen + verFieldLen + 6)
+    )
     for _line in _data:
         print(wrapper.fill(fmt % _line))
 
     print("")
     wrapper = textwrap.TextWrapper(subsequent_indent='')
-    print(wrapper.fill("""The leading symbol (one of *, -, +) indicates the current solver availability.  A plus (+) indicates the solver is currently available to be run from Pyomo with the serial solver manager, and (if applicable) has a valid license.  A minus (-) indicates the solver executables are available but do not report having a valid license.  The solver may still be usable in an unlicensed or "demo" mode for limited problem sizes. An asterisk (*) indicates meta-solvers or generic interfaces, which are always available."""))
+    print(
+        wrapper.fill(
+            """The leading symbol (one of *, -, +) indicates the current solver availability.  A plus (+) indicates the solver is currently available to be run from Pyomo with the serial solver manager, and (if applicable) has a valid license.  A minus (-) indicates the solver executables are available but do not report having a valid license.  The solver may still be usable in an unlicensed or "demo" mode for limited problem sizes. An asterisk (*) indicates meta-solvers or generic interfaces, which are always available."""
+        )
+    )
     print('')
-    print(wrapper.fill('Pyomo also supports solver interfaces that are wrappers around third-party solver interfaces. These interfaces require a subsolver specification that indicates the solver being executed.  For example, the following indicates that the ipopt solver will be used:'))
+    print(
+        wrapper.fill(
+            'Pyomo also supports solver interfaces that are wrappers around third-party solver interfaces. These interfaces require a subsolver specification that indicates the solver being executed.  For example, the following indicates that the ipopt solver will be used:'
+        )
+    )
     print('')
     print('   asl:ipopt')
     print('')
-    print(wrapper.fill('The asl interface provides a generic wrapper for all solvers that use the AMPL Solver Library.'))
+    print(
+        wrapper.fill(
+            'The asl interface provides a generic wrapper for all solvers that use the AMPL Solver Library.'
+        )
+    )
     print('')
-    print(wrapper.fill('Note that subsolvers can not be enumerated automatically for these interfaces.  However, if a solver is specified that is not found, Pyomo assumes that the asl solver interface is being used.  Thus the following solver name will launch ipopt if the \'ipopt\' executable is on the user\'s path:'))
+    print(
+        wrapper.fill(
+            'Note that subsolvers can not be enumerated automatically for these interfaces.  However, if a solver is specified that is not found, Pyomo assumes that the asl solver interface is being used.  Thus the following solver name will launch ipopt if the \'ipopt\' executable is on the user\'s path:'
+        )
+    )
     print('')
     print('   ipopt')
     print('')
@@ -280,33 +330,56 @@ def help_solvers():
         logging.disable(logging.WARNING)
         socket.setdefaulttimeout(10)
         import pyomo.neos.kestrel
+
         kestrel = pyomo.neos.kestrel.kestrelAMPL()
-        #print "HERE", solver_list
-        solver_list = list(set([name[:-5].lower() for name in kestrel.solvers() if name.endswith('AMPL')]))
-        #print "HERE", solver_list
+        # print "HERE", solver_list
+        solver_list = list(
+            set(
+                [
+                    name[:-5].lower()
+                    for name in kestrel.solvers()
+                    if name.endswith('AMPL')
+                ]
+            )
+        )
+        # print "HERE", solver_list
         if len(solver_list) > 0:
             print("")
             print("NEOS Solver Interfaces")
             print("----------------------")
-            print(wrapper.fill("The neos solver manager supports solver interfaces that can be executed remotely on the NEOS optimization server.  The following solver interfaces are available with your current system configuration:"))
+            print(
+                wrapper.fill(
+                    "The neos solver manager supports solver interfaces that can be executed remotely on the NEOS optimization server.  The following solver interfaces are available with your current system configuration:"
+                )
+            )
             print("")
             solver_list = sorted(solver_list)
             n = max(map(len, solver_list))
-            format = '    %-'+str(n)+'s     %s'
+            format = '    %-' + str(n) + 's     %s'
             for name in solver_list:
-                print(wrapper.fill(format % (name , pyomo.neos.doc.get(name,'Unexpected NEOS solver'))))
+                print(
+                    wrapper.fill(
+                        format
+                        % (name, pyomo.neos.doc.get(name, 'Unexpected NEOS solver'))
+                    )
+                )
             print("")
         else:
             print("")
             print("NEOS Solver Interfaces")
             print("----------------------")
-            print(wrapper.fill("The neos solver manager supports solver interfaces that can be executed remotely on the NEOS optimization server.  This server is not available with your current system configuration."))
+            print(
+                wrapper.fill(
+                    "The neos solver manager supports solver interfaces that can be executed remotely on the NEOS optimization server.  This server is not available with your current system configuration."
+                )
+            )
             print("")
     except ImportError:
         pass
     finally:
         logging.disable(logging.NOTSET)
         socket.setdefaulttimeout(None)
+
 
 def print_components(data):
     """
@@ -318,86 +391,154 @@ def print_components(data):
     print("----------------------------------------------------------------")
     for name in sorted(ModelComponentFactory):
         print("")
-        print(" "+name)
+        print(" " + name)
         for line in textwrap.wrap(ModelComponentFactory.doc(name), 59):
-            print("    "+line)
+            print("    " + line)
     print("")
     print("----------------------------------------------------------------")
     print("Pyomo Virtual Sets:")
     print("----------------------------------------------------------------")
     for name, obj in sorted(GlobalSets.items()):
         print("")
-        print(" "+name)
-        print("    "+obj.doc)
+        print(" " + name)
+        print("    " + obj.doc)
+
 
 def help_exec(options):
-    flag=False
+    flag = False
     if options.commands:
         if options.asciidoc:
-            print("The '--commands' help information is not printed in an asciidoc format.")
-        flag=True
+            print(
+                "The '--commands' help information is not printed in an asciidoc format."
+            )
+        flag = True
         help_commands()
     if options.components:
         if options.asciidoc:
-            print("The '--components' help information is not printed in an asciidoc format.")
-        flag=True
+            print(
+                "The '--components' help information is not printed in an asciidoc format."
+            )
+        flag = True
         print_components(None)
     if options.datamanager:
-        flag=True
+        flag = True
         help_datamanagers(options)
     if options.environment:
-        flag=True
+        flag = True
         help_environment()
     if options.transformations:
         if options.asciidoc:
-            print("The '--transformations' help information is not printed in an asciidoc format.")
-        flag=True
+            print(
+                "The '--transformations' help information is not printed in an asciidoc format."
+            )
+        flag = True
         help_transformations()
     if options.solvers:
         if options.asciidoc:
-            print("The '--solvers' help information is not printed in an asciidoc format.")
-        flag=True
+            print(
+                "The '--solvers' help information is not printed in an asciidoc format."
+            )
+        flag = True
         help_solvers()
     if options.writers:
-        flag=True
+        flag = True
         if options.asciidoc:
-            print("The '--writers' help information is not printed in an asciidoc format.")
+            print(
+                "The '--writers' help information is not printed in an asciidoc format."
+            )
         help_writers()
     if options.checkers:
-        flag=True
+        flag = True
         if options.asciidoc:
-            print("The '--checkers' help information is not printed in an asciidoc format.")
+            print(
+                "The '--checkers' help information is not printed in an asciidoc format."
+            )
         help_checkers()
     if not flag:
         help_parser.print_help()
+
 
 #
 # Add a subparser for the pyomo command
 #
 def setup_help_parser(parser):
-    parser.add_argument("--asciidoc", dest="asciidoc", action='store_true', default=False,
-                        help="Generate output that is compatible with asciidoc's markup language")
-    parser.add_argument("--checkers", dest="checkers", action='store_true', default=False,
-                        help="List the available model checkers")
-    parser.add_argument("-c", "--commands", dest="commands", action='store_true', default=False,
-                        help="List the commands that are installed with Pyomo")
-    parser.add_argument("--components", dest="components", action='store_true', default=False,
-                        help="List the components that are available in Pyomo's modeling environment")
-    parser.add_argument("-d", "--data-managers", dest="datamanager", action='store_true', default=False,
-                        help="Print a summary of the data managers in Pyomo")
-    parser.add_argument("-i", "--info", dest="environment", action='store_true', default=False,
-                        help="Summarize the environment and Python installation")
-    parser.add_argument("-s", "--solvers", dest="solvers", action='store_true', default=False,
-                        help="Summarize the available solvers and solver interfaces")
-    parser.add_argument("-t", "--transformations", dest="transformations", action='store_true', default=False,
-                        help="List the available model transformations")
-    parser.add_argument("-w", "--writers", dest="writers", action='store_true', default=False,
-                        help="List the available problem writers")
+    parser.add_argument(
+        "--asciidoc",
+        dest="asciidoc",
+        action='store_true',
+        default=False,
+        help="Generate output that is compatible with asciidoc's markup language",
+    )
+    parser.add_argument(
+        "--checkers",
+        dest="checkers",
+        action='store_true',
+        default=False,
+        help="List the available model checkers",
+    )
+    parser.add_argument(
+        "-c",
+        "--commands",
+        dest="commands",
+        action='store_true',
+        default=False,
+        help="List the commands that are installed with Pyomo",
+    )
+    parser.add_argument(
+        "--components",
+        dest="components",
+        action='store_true',
+        default=False,
+        help="List the components that are available in Pyomo's modeling environment",
+    )
+    parser.add_argument(
+        "-d",
+        "--data-managers",
+        dest="datamanager",
+        action='store_true',
+        default=False,
+        help="Print a summary of the data managers in Pyomo",
+    )
+    parser.add_argument(
+        "-i",
+        "--info",
+        dest="environment",
+        action='store_true',
+        default=False,
+        help="Summarize the environment and Python installation",
+    )
+    parser.add_argument(
+        "-s",
+        "--solvers",
+        dest="solvers",
+        action='store_true',
+        default=False,
+        help="Summarize the available solvers and solver interfaces",
+    )
+    parser.add_argument(
+        "-t",
+        "--transformations",
+        dest="transformations",
+        action='store_true',
+        default=False,
+        help="List the available model transformations",
+    )
+    parser.add_argument(
+        "-w",
+        "--writers",
+        dest="writers",
+        action='store_true',
+        default=False,
+        help="List the available problem writers",
+    )
     return parser
 
+
 help_parser = setup_help_parser(
-  pyomo.scripting.pyomo_parser.add_subparser('help',
+    pyomo.scripting.pyomo_parser.add_subparser(
+        'help',
         func=help_exec,
         help='Print help information.',
-        description="This pyomo subcommand is used to print information about Pyomo's subcommands and installed Pyomo services."
-        ))
+        description="This pyomo subcommand is used to print information about Pyomo's subcommands and installed Pyomo services.",
+    )
+)

--- a/pyomo/scripting/interface.py
+++ b/pyomo/scripting/interface.py
@@ -10,13 +10,19 @@
 #  ___________________________________________________________________________
 
 from pyomo.common.plugin_base import (
-    Interface, DeprecatedInterface, Plugin, SingletonPlugin,
-    ExtensionPoint, implements, alias
+    Interface,
+    DeprecatedInterface,
+    Plugin,
+    SingletonPlugin,
+    ExtensionPoint,
+    implements,
+    alias,
 )
 
 registered_callback = {}
 
-def pyomo_callback( name ):
+
+def pyomo_callback(name):
     """This is a decorator that declares a function to be
     a callback function.  The callback functions are
     added to the solver when run from the pyomo script.
@@ -27,64 +33,65 @@ def pyomo_callback( name ):
     def my_cut_generator(solver, model):
         ...
     """
+
     def fn(f):
         registered_callback[name] = f
         return f
+
     return fn
 
 
 class IPyomoScriptPreprocess(Interface):
-
     def apply(self, **kwds):
         """Apply preprocessing step in the Pyomo script"""
 
-class IPyomoScriptCreateModel(Interface):
 
+class IPyomoScriptCreateModel(Interface):
     def apply(self, **kwds):
         """Apply model creation step in the Pyomo script"""
 
-class IPyomoScriptModifyInstance(Interface):
 
+class IPyomoScriptModifyInstance(Interface):
     def apply(self, **kwds):
         """Modify and return the model instance"""
 
-class IPyomoScriptCreateDataPortal(Interface):
 
+class IPyomoScriptCreateDataPortal(Interface):
     def apply(self, **kwds):
         """Apply model data creation step in the Pyomo script"""
 
-class IPyomoScriptPrintModel(Interface):
 
+class IPyomoScriptPrintModel(Interface):
     def apply(self, **kwds):
         """Apply model printing step in the Pyomo script"""
 
-class IPyomoScriptPrintInstance(Interface):
 
+class IPyomoScriptPrintInstance(Interface):
     def apply(self, **kwds):
         """Apply instance printing step in the Pyomo script"""
 
-class IPyomoScriptSaveInstance(Interface):
 
+class IPyomoScriptSaveInstance(Interface):
     def apply(self, **kwds):
         """Apply instance saving step in the Pyomo script"""
 
-class IPyomoScriptPrintResults(Interface):
 
+class IPyomoScriptPrintResults(Interface):
     def apply(self, **kwds):
         """Apply results printing step in the Pyomo script"""
 
-class IPyomoScriptSaveResults(Interface):
 
+class IPyomoScriptSaveResults(Interface):
     def apply(self, **kwds):
         """Apply results saving step in the Pyomo script"""
 
-class IPyomoScriptPostprocess(Interface):
 
+class IPyomoScriptPostprocess(Interface):
     def apply(self, **kwds):
         """Apply postprocessing step in the Pyomo script"""
 
-class IPyomoPresolver(Interface):
 
+class IPyomoPresolver(Interface):
     def get_actions(self):
         """Return a list of presolve actions, in the order in which
         they will be applied."""
@@ -104,7 +111,6 @@ class IPyomoPresolver(Interface):
 
 
 class IPyomoPresolveAction(Interface):
-
     def presolve(self, instance):
         """Apply the presolve action to this instance, and return the
         revised instance"""

--- a/pyomo/scripting/plugins/__init__.py
+++ b/pyomo/scripting/plugins/__init__.py
@@ -9,6 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+
 def load():
     import pyomo.scripting.plugins.check
     import pyomo.scripting.plugins.convert

--- a/pyomo/scripting/plugins/build_ext.py
+++ b/pyomo/scripting/plugins/build_ext.py
@@ -15,6 +15,7 @@ import sys
 from pyomo.common.extensions import ExtensionBuilderFactory
 from pyomo.scripting.pyomo_parser import add_subparser
 
+
 class ExtensionBuilder(object):
     def create_parser(self, parser):
         return parser
@@ -45,24 +46,29 @@ class ExtensionBuilder(object):
                     result = ' OK '
             except SystemExit:
                 _info = sys.exc_info()
-                _cls = str(_info[0].__name__ if _info[0] is not None
-                           else "NoneType") + ": "
+                _cls = (
+                    str(_info[0].__name__ if _info[0] is not None else "NoneType")
+                    + ": "
+                )
                 logger.error(_cls + str(_info[1]))
                 result = 'FAIL'
                 returncode |= 2
             except:
                 _info = sys.exc_info()
-                _cls = str(_info[0].__name__ if _info[0] is not None
-                           else "NoneType") + ": "
+                _cls = (
+                    str(_info[0].__name__ if _info[0] is not None else "NoneType")
+                    + ": "
+                )
                 logger.error(_cls + str(_info[1]))
                 result = 'FAIL'
                 returncode |= 1
             results.append(result_fmt % (result, target))
         logger.info("Finished building Pyomo extensions.")
         logger.info(
-            "The following extensions were built:\n    " +
-            "\n    ".join(results))
+            "The following extensions were built:\n    " + "\n    ".join(results)
+        )
         return returncode
+
 
 #
 # Add a subparser for the download-extensions command
@@ -74,14 +80,16 @@ _parser = _extension_builder.create_parser(
         func=_extension_builder.call,
         help='Build compiled extension modules',
         add_help=False,
-        description='This builds all registered (compileable) extension modules'
-    ))
+        description='This builds all registered (compileable) extension modules',
+    )
+)
 
 _parser.add_argument(
-    '-j', '--parallel',
+    '-j',
+    '--parallel',
     action='store',
     type=int,
     dest='parallel',
     default=None,
     help="Build with this many processes/cores",
-    )
+)

--- a/pyomo/scripting/plugins/check.py
+++ b/pyomo/scripting/plugins/check.py
@@ -13,8 +13,8 @@ import argparse
 import pyomo.scripting.pyomo_parser
 import os.path
 
-class EnableDisableAction(argparse.Action):
 
+class EnableDisableAction(argparse.Action):
     def add_package(self, namespace, package):
         if namespace.checkers.get(package, None) is None:
             namespace.checkers[package] = []
@@ -38,7 +38,9 @@ class EnableDisableAction(argparse.Action):
         for c in pyomo.core.check.ModelCheckRunner._checkers(all=True):
             if c._checkerName() == checker:
                 if namespace.checkers.get(c._checkerPackage(), None) is not None:
-                    for i in range(namespace.checkers[c._checkerPackage()].count(c._checkerName())):
+                    for i in range(
+                        namespace.checkers[c._checkerPackage()].count(c._checkerName())
+                    ):
                         namespace.checkers[c._checkerPackage()].remove(c._checkerName())
 
     def add_default_checkers(self, namespace):
@@ -49,7 +51,7 @@ class EnableDisableAction(argparse.Action):
         if 'checkers' not in dir(namespace):
             setattr(namespace, 'checkers', {})
             self.add_default_checkers(namespace)
-        
+
         if option_string == '-c':
             self.add_checker(namespace, values)
         elif option_string == '-C':
@@ -59,19 +61,47 @@ class EnableDisableAction(argparse.Action):
         elif option_string == '-X':
             self.remove_package(namespace, values)
 
+
 def setup_parser(parser):
-    parser.add_argument("script", metavar="SCRIPT", default=None,
-                        help="A Pyomo script that is checked")
-    parser.add_argument("-v", "--verbose", action="store_true", dest="verbose",
-                        default=False, help="Enable additional output messages")
-    parser.add_argument("-c", "--enable-checker", metavar="CHECKER", action=EnableDisableAction, 
-                        help="Activate a specific checker")
-    parser.add_argument("-C", "--enable-package", metavar="PACKAGE", action=EnableDisableAction,
-                        help="Activate an entire checker package")
-    parser.add_argument("-x", "--disable-checker", metavar="CHECKER", action=EnableDisableAction,
-                        help="Disable a specific checker")
-    parser.add_argument("-X", "--disable-package", metavar="PACKAGE", action=EnableDisableAction,
-                        help="Disable an entire checker package")
+    parser.add_argument(
+        "script", metavar="SCRIPT", default=None, help="A Pyomo script that is checked"
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        dest="verbose",
+        default=False,
+        help="Enable additional output messages",
+    )
+    parser.add_argument(
+        "-c",
+        "--enable-checker",
+        metavar="CHECKER",
+        action=EnableDisableAction,
+        help="Activate a specific checker",
+    )
+    parser.add_argument(
+        "-C",
+        "--enable-package",
+        metavar="PACKAGE",
+        action=EnableDisableAction,
+        help="Activate an entire checker package",
+    )
+    parser.add_argument(
+        "-x",
+        "--disable-checker",
+        metavar="CHECKER",
+        action=EnableDisableAction,
+        help="Disable a specific checker",
+    )
+    parser.add_argument(
+        "-X",
+        "--disable-package",
+        metavar="PACKAGE",
+        action=EnableDisableAction,
+        help="Disable an entire checker package",
+    )
 
 
 def main_exec(options):
@@ -89,17 +119,20 @@ def main_exec(options):
     runner = check.ModelCheckRunner()
     runner.run(**vars(options))
 
+
 #
 # Add a subparser for the check command
 #
 setup_parser(
-    pyomo.scripting.pyomo_parser.add_subparser('check',
-        func=main_exec, 
+    pyomo.scripting.pyomo_parser.add_subparser(
+        'check',
+        func=main_exec,
         help='Check a model for errors.',
         description='This pyomo subcommand is used to check a model script for errors.',
         epilog="""
 The default behavior of this command is to assume that the model
 script is a simple Pyomo model.  Eventually, this script will support
 options that allow other Pyomo models to be checked.
-"""
-        ))
+""",
+    )
+)

--- a/pyomo/scripting/plugins/convert.py
+++ b/pyomo/scripting/plugins/convert.py
@@ -18,33 +18,34 @@ from pyomo.opt import guess_format
 from pyomo.scripting.pyomo_parser import add_subparser, CustomHelpFormatter
 from pyomo.scripting.solve_config import Default_Config
 
+
 def create_parser(parser=None):
     #
     # Setup command-line options.
     #
     if parser is None:
         parser = argparse.ArgumentParser(
-                usage = '%(prog)s [options] <model_or_config_file> [<data_files>]'
-                )
-    parser.add_argument('--output',
+            usage='%(prog)s [options] <model_or_config_file> [<data_files>]'
+        )
+    parser.add_argument(
+        '--output',
         action='store',
         dest='filename',
         help="Output file name. This option is required unless the file name is specified in a       configuration file.",
-        default=None)
-    parser.add_argument('--format',
-        action='store',
-        dest='format',
-        help="Output format",
-        default=None)
-    parser.add_argument('--generate-config-template',
-        action='store',
-        dest='template',
-        default=None)
+        default=None,
+    )
+    parser.add_argument(
+        '--format', action='store', dest='format', help="Output format", default=None
+    )
+    parser.add_argument(
+        '--generate-config-template', action='store', dest='template', default=None
+    )
     return parser
 
 
 def run_convert(options=Bunch(), parser=None):
     from pyomo.scripting.convert import convert, convert_dakota
+
     if options.model.save_format is None and options.model.save_file:
         options.model.save_format = options.model.save_file.split('.')[-1]
     #
@@ -56,8 +57,10 @@ def run_convert(options=Bunch(), parser=None):
         if options.model.save_format is None:
             raise RuntimeError("Unspecified target conversion format!")
         else:
-            raise RuntimeError("Unrecognized target conversion format (%s)!"
-                               % (options.model.save_format,) )
+            raise RuntimeError(
+                "Unrecognized target conversion format (%s)!"
+                % (options.model.save_format,)
+            )
     else:
         return convert(options, parser, _format)
 
@@ -65,6 +68,7 @@ def run_convert(options=Bunch(), parser=None):
 def convert_exec(args, unparsed):
     #
     import pyomo.scripting.util
+
     #
     # Generate a template file
     #
@@ -79,11 +83,11 @@ def convert_exec(args, unparsed):
         print("  Created template file '%s'" % args.template)
         sys.exit(0)
     #
-    save_filename = getattr(args,'filename',None)
+    save_filename = getattr(args, 'filename', None)
     if save_filename is None:
-        save_format = getattr(args,'format',None)
+        save_format = getattr(args, 'format', None)
         if not save_format is None:
-            save_filename = 'unknown.'+save_format
+            save_filename = 'unknown.' + save_format
     if save_filename is None:
         #
         # Get configuration values if no model file has been specified
@@ -104,7 +108,7 @@ def convert_exec(args, unparsed):
                 pass
             if save_filename is None:
                 try:
-                    save_filename = 'unknown.'+str(val['model']['save format'])
+                    save_filename = 'unknown.' + str(val['model']['save format'])
                 except:
                     pass
     #
@@ -117,7 +121,7 @@ def convert_exec(args, unparsed):
         config, blocks = Default_Config().config_block()
         parser = create_temporary_parser(output=True, generate=True)
         config.initialize_argparse(parser)
-        parser.parse_args(args=unparsed+['-h'])
+        parser.parse_args(args=unparsed + ['-h'])
         sys.exit(1)
     #
     # Parse previously unparsed options
@@ -138,24 +142,29 @@ def convert_exec(args, unparsed):
         config.data.files = _options.data_files
     else:
         val = pyomo.scripting.util.get_config_values(_options.model_or_config_file)
-        config.set_value( val )
+        config.set_value(val)
     #
     # Note that we pass-in pre-parsed options.  The run_command()
     # function knows to not perform a parse, but instead to simply
     # used these parsed values.
     #
-    return pyomo.scripting.util.run_command(command=run_convert, parser=convert_parser, options=config, name='convert')
+    return pyomo.scripting.util.run_command(
+        command=run_convert, parser=convert_parser, options=config, name='convert'
+    )
+
 
 #
 # Add a subparser for the pyomo command
 #
-convert_parser = create_parser(add_subparser('convert',
+convert_parser = create_parser(
+    add_subparser(
+        'convert',
         func=convert_exec,
         help='Convert a Pyomo model to another format',
         add_help=False,
-        description='This pyomo subcommand is used to create a new model file in a specified format from a Pyomo model.'
-        ))
-
+        description='This pyomo subcommand is used to create a new model file in a specified format from a Pyomo model.',
+    )
+)
 
 
 def create_temporary_parser(output=False, generate=False):
@@ -166,28 +175,34 @@ def create_temporary_parser(output=False, generate=False):
     parser = argparse.ArgumentParser(formatter_class=CustomHelpFormatter)
     _subparsers = parser.add_subparsers()
     _parser = _subparsers.add_parser('convert')
-    _parser.formatter_class=CustomHelpFormatter
+    _parser.formatter_class = CustomHelpFormatter
     if generate:
         #
-        # Adding documentation about the two options that are 
+        # Adding documentation about the two options that are
         # defined in the initial parser.
         #
-        _parser.add_argument('--generate-config-template',
+        _parser.add_argument(
+            '--generate-config-template',
             action='store',
             dest='template',
             default=None,
-            help='Create a configuration template file in YAML or JSON and exit.')
+            help='Create a configuration template file in YAML or JSON and exit.',
+        )
     if output:
-        parser.add_argument('--output',
+        parser.add_argument(
+            '--output',
             action='store',
             dest='filename',
             help="Output file name. This option is required unless the file name is specified in a       configuration file.",
-            default=None)
-        parser.add_argument('--format',
+            default=None,
+        )
+        parser.add_argument(
+            '--format',
             action='store',
             dest='format',
             help="Output format",
-            default=None)
+            default=None,
+        )
         _parser.usage = '%(prog)s [options] <model_or_config_file> [<data_files>]'
         _parser.epilog = """
 Description:
@@ -229,25 +244,29 @@ more configuration options than are available with command-line options.
 
 """
     #
-    _parser.add_argument('--output',
+    _parser.add_argument(
+        '--output',
         action='store',
         dest='filename',
         help="Output file name. This option is required unless the file name is specified in a       configuration file.",
-        default=None)
-    _parser.add_argument('--format',
+        default=None,
+    )
+    _parser.add_argument(
+        '--format', action='store', dest='format', help="Output format", default=None
+    )
+    _parser.add_argument(
+        'model_or_config_file',
         action='store',
-        dest='format',
-        help="Output format",
-        default=None)
-    _parser.add_argument('model_or_config_file', 
-        action='store', 
-        nargs='?', 
+        nargs='?',
         default='',
-        help="A Python module that defines a Pyomo model, or a configuration file that defines options for 'pyomo convert' (in either YAML or JSON format)")
-    _parser.add_argument('data_files', 
-        action='store', 
-        nargs='*', 
+        help="A Python module that defines a Pyomo model, or a configuration file that defines options for 'pyomo convert' (in either YAML or JSON format)",
+    )
+    _parser.add_argument(
+        'data_files',
+        action='store',
+        nargs='*',
         default=[],
-        help='Pyomo data files that defined data used to initialize the model (specified in the first argument)')
+        help='Pyomo data files that defined data used to initialize the model (specified in the first argument)',
+    )
     #
     return _parser

--- a/pyomo/scripting/plugins/download.py
+++ b/pyomo/scripting/plugins/download.py
@@ -14,6 +14,7 @@ import sys
 from pyomo.common.download import FileDownloader, DownloadFactory
 from pyomo.scripting.pyomo_parser import add_subparser
 
+
 class GroupDownloader(object):
     def __init__(self):
         self.downloader = FileDownloader()
@@ -36,9 +37,11 @@ class GroupDownloader(object):
         returncode = 0
         self.downloader.cacert = args.cacert
         self.downloader.insecure = args.insecure
-        logger.info("As of February 9, 2023, AMPL GSL can no longer be downloaded\
+        logger.info(
+            "As of February 9, 2023, AMPL GSL can no longer be downloaded\
                     through download-extensions. Visit https://portal.ampl.com/\
-                    to download the AMPL GSL binaries.")
+                    to download the AMPL GSL binaries."
+        )
         for target in DownloadFactory:
             try:
                 ext = DownloadFactory(target, downloader=self.downloader)
@@ -52,23 +55,27 @@ class GroupDownloader(object):
                     result = ' OK '
             except SystemExit:
                 _info = sys.exc_info()
-                _cls = str(_info[0].__name__ if _info[0] is not None
-                           else "NoneType") + ": "
+                _cls = (
+                    str(_info[0].__name__ if _info[0] is not None else "NoneType")
+                    + ": "
+                )
                 logger.error(_cls + str(_info[1]))
                 result = 'FAIL'
                 returncode |= 2
             except:
                 _info = sys.exc_info()
-                _cls = str(_info[0].__name__ if _info[0] is not None
-                           else "NoneType") + ": "
+                _cls = (
+                    str(_info[0].__name__ if _info[0] is not None else "NoneType")
+                    + ": "
+                )
                 logger.error(_cls + str(_info[1]))
                 result = 'FAIL'
                 returncode |= 1
             results.append(result_fmt % (result, target))
         logger.info("Finished downloading Pyomo extensions.")
         logger.info(
-            "The following extensions were downloaded:\n    " +
-            "\n    ".join(results))
+            "The following extensions were downloaded:\n    " + "\n    ".join(results)
+        )
         return returncode
 
 
@@ -82,6 +89,6 @@ _parser = _group_downloader.create_parser(
         func=_group_downloader.call,
         help='Download compiled extension modules',
         add_help=False,
-        description='This downloads all registered (compiled) extension modules'
-    ))
-
+        description='This downloads all registered (compiled) extension modules',
+    )
+)

--- a/pyomo/scripting/plugins/extras.py
+++ b/pyomo/scripting/plugins/extras.py
@@ -139,5 +139,5 @@ _parser.add_argument(
     "--pip-args",
     dest="args",
     action="append",
-    help=("Arguments that are passed to the 'pip' command when " "installing packages"),
+    help=("Arguments that are passed to the 'pip' command when installing packages"),
 )

--- a/pyomo/scripting/plugins/extras.py
+++ b/pyomo/scripting/plugins/extras.py
@@ -13,35 +13,39 @@ from pyomo.scripting.pyomo_parser import add_subparser, CustomHelpFormatter
 
 from pyomo.common.deprecation import deprecated
 
+
 def get_packages():
     packages = [
-        'sympy', 
-        'xlrd', 
-        'openpyxl', 
-        #('suds-jurko', 'suds'),
+        'sympy',
+        'xlrd',
+        'openpyxl',
+        # ('suds-jurko', 'suds'),
         ('PyYAML', 'yaml'),
-        'pypyodbc', 
-        'pymysql', 
-        #'openopt', 
-        #'FuncDesigner', 
-        #'DerApproximator', 
+        'pypyodbc',
+        'pymysql',
+        #'openopt',
+        #'FuncDesigner',
+        #'DerApproximator',
         ('ipython[notebook]', 'IPython'),
     ]
     return packages
 
+
 @deprecated(
-        "Use of the pyomo install-extras is deprecated."
-        "The current recommended course of action is to manually install "
-        "optional dependencies as needed.",
-        version='5.7.1')
+    "Use of the pyomo install-extras is deprecated."
+    "The current recommended course of action is to manually install "
+    "optional dependencies as needed.",
+    version='5.7.1',
+)
 def install_extras(args=[], quiet=False):
     #
     # Verify that pip is installed
     #
     try:
         import pip
+
         pip_version = pip.__version__.split('.')
-        for i,s in enumerate(pip_version):
+        for i, s in enumerate(pip_version):
             try:
                 pip_version[i] = int(s)
             except:
@@ -51,7 +55,7 @@ def install_extras(args=[], quiet=False):
         print("You must have 'pip' installed to run this script.")
         raise SystemExit
 
-    cmd = ['--disable-pip-version-check', 'install','--upgrade']
+    cmd = ['--disable-pip-version-check', 'install', '--upgrade']
     # Disable the PIP download cache
     if pip_version[0] >= 6:
         cmd.append('--no-cache-dir')
@@ -61,10 +65,10 @@ def install_extras(args=[], quiet=False):
 
     if not quiet:
         print(' ')
-        print('-'*60)
+        print('-' * 60)
         print("Installation Output Logs")
         print("  (A summary will be printed below)")
-        print('-'*60)
+        print('-' * 60)
         print(' ')
 
     results = {}
@@ -89,9 +93,9 @@ def install_extras(args=[], quiet=False):
     if not quiet:
         print(' ')
         print(' ')
-    print('-'*60)
+    print('-' * 60)
     print("Installation Summary")
-    print('-'*60)
+    print('-' * 60)
     print(' ')
     for package, result in sorted(results.items()):
         if result:
@@ -124,7 +128,8 @@ the command line.  For example:\n\n
 )
 
 _parser.add_argument(
-    '-q', '--quiet',
+    '-q',
+    '--quiet',
     action='store_true',
     dest='quiet',
     default=False,
@@ -134,7 +139,5 @@ _parser.add_argument(
     "--pip-args",
     dest="args",
     action="append",
-    help=("Arguments that are passed to the 'pip' command when "
-          "installing packages"),
+    help=("Arguments that are passed to the 'pip' command when " "installing packages"),
 )
-

--- a/pyomo/scripting/plugins/solve.py
+++ b/pyomo/scripting/plugins/solve.py
@@ -63,7 +63,8 @@ def create_temporary_parser(solver=False, generate=False):
             action='store',
             dest='solver',
             default=None,
-            help='Solver name.  This option is required unless the solver name is specified in a configuration file.',
+            help='Solver name. This option is required unless the solver name is'
+            'specified in a configuration file.',
         )
         _parser.usage = '%(prog)s [options] <model_or_config_file> [<data_files>]'
         _parser.epilog = """
@@ -120,14 +121,16 @@ more configuration options than are available with command-line options.
         action='store',
         nargs='?',
         default='',
-        help="A Python module that defines a Pyomo model, or a configuration file that defines options for 'pyomo solve' (in either YAML or JSON format)",
+        help="A Python module that defines a Pyomo model, or a configuration file "
+        "that defines options for 'pyomo solve' (in either YAML or JSON format)",
     )
     _parser.add_argument(
         'data_files',
         action='store',
         nargs='*',
         default=[],
-        help='Pyomo data files that defined data used to initialize the model (specified in the first argument)',
+        help='Pyomo data files that defined data used to initialize the model '
+        '(specified in the first argument)',
     )
     #
     return _parser

--- a/pyomo/scripting/plugins/solve.py
+++ b/pyomo/scripting/plugins/solve.py
@@ -24,20 +24,15 @@ def create_parser(parser=None):
     #
     if parser is None:
         parser = argparse.ArgumentParser(
-                usage = '%(prog)s [options] <model_or_config_file> [<data_files>]'
-                )
-    parser.add_argument('--solver',
-        action='store',
-        dest='solver',
-        default=None)
-    parser.add_argument('--solver-manager',
-        action='store',
-        dest='solver_manager',
-        default='serial')
-    parser.add_argument('--generate-config-template',
-        action='store',
-        dest='template',
-        default=None)
+            usage='%(prog)s [options] <model_or_config_file> [<data_files>]'
+        )
+    parser.add_argument('--solver', action='store', dest='solver', default=None)
+    parser.add_argument(
+        '--solver-manager', action='store', dest='solver_manager', default='serial'
+    )
+    parser.add_argument(
+        '--generate-config-template', action='store', dest='template', default=None
+    )
     return parser
 
 
@@ -49,23 +44,27 @@ def create_temporary_parser(solver=False, generate=False):
     parser = argparse.ArgumentParser(formatter_class=CustomHelpFormatter)
     _subparsers = parser.add_subparsers()
     _parser = _subparsers.add_parser('solve')
-    _parser.formatter_class=CustomHelpFormatter
+    _parser.formatter_class = CustomHelpFormatter
     if generate:
         #
         # Adding documentation about the two options that are
         # defined in the initial parser.
         #
-        _parser.add_argument('--generate-config-template',
+        _parser.add_argument(
+            '--generate-config-template',
             action='store',
             dest='template',
             default=None,
-            help='Create a configuration template file in YAML or JSON and exit.')
+            help='Create a configuration template file in YAML or JSON and exit.',
+        )
     if solver:
-        _parser.add_argument('--solver',
+        _parser.add_argument(
+            '--solver',
             action='store',
             dest='solver',
             default=None,
-            help='Solver name.  This option is required unless the solver name is specified in a configuration file.')
+            help='Solver name.  This option is required unless the solver name is specified in a configuration file.',
+        )
         _parser.usage = '%(prog)s [options] <model_or_config_file> [<data_files>]'
         _parser.epilog = """
 Description:
@@ -116,16 +115,20 @@ more configuration options than are available with command-line options.
 
 """
     #
-    _parser.add_argument('model_or_config_file',
+    _parser.add_argument(
+        'model_or_config_file',
         action='store',
         nargs='?',
         default='',
-        help="A Python module that defines a Pyomo model, or a configuration file that defines options for 'pyomo solve' (in either YAML or JSON format)")
-    _parser.add_argument('data_files',
+        help="A Python module that defines a Pyomo model, or a configuration file that defines options for 'pyomo solve' (in either YAML or JSON format)",
+    )
+    _parser.add_argument(
+        'data_files',
         action='store',
         nargs='*',
         default=[],
-        help='Pyomo data files that defined data used to initialize the model (specified in the first argument)')
+        help='Pyomo data files that defined data used to initialize the model (specified in the first argument)',
+    )
     #
     return _parser
 
@@ -133,9 +136,10 @@ more configuration options than are available with command-line options.
 def solve_exec(args, unparsed):
 
     import pyomo.scripting.util
+
     #
-    solver_manager = getattr(args,'solver_manager',None)
-    solver = getattr(args,'solver',None)
+    solver_manager = getattr(args, 'solver_manager', None)
+    solver = getattr(args, 'solver', None)
     #
     if solver is None:
         #
@@ -163,7 +167,7 @@ def solve_exec(args, unparsed):
                 print("ERROR: No solver specified!")
                 print("")
             parser = create_temporary_parser(solver=True, generate=True)
-            parser.parse_args(args=unparsed+['-h'])
+            parser.parse_args(args=unparsed + ['-h'])
             sys.exit(1)
 
     config = None
@@ -215,23 +219,26 @@ def solve_exec(args, unparsed):
     config.solvers[0].manager = solver_manager
 
     from pyomo.scripting.pyomo_command import run_pyomo
+
     #
     # Note that we pass-in pre-parsed options.  The run_command()
     # function knows to not perform a parse, but instead to simply
     # used these parsed values.
     #
-    return pyomo.scripting.util.run_command(command=run_pyomo,
-                                            parser=_parser,
-                                            options=config,
-                                            name='pyomo solve')
+    return pyomo.scripting.util.run_command(
+        command=run_pyomo, parser=_parser, options=config, name='pyomo solve'
+    )
+
 
 #
 # Add a subparser for the solve command
 #
-solve_parser = create_parser(add_subparser('solve',
-    func=solve_exec,
-    help='Optimize a model',
-    add_help=False,
-    description='This pyomo subcommand is used to analyze optimization models.'
-    ))
-
+solve_parser = create_parser(
+    add_subparser(
+        'solve',
+        func=solve_exec,
+        help='Optimize a model',
+        add_help=False,
+        description='This pyomo subcommand is used to analyze optimization models.',
+    )
+)

--- a/pyomo/scripting/pyomo_command.py
+++ b/pyomo/scripting/pyomo_command.py
@@ -25,18 +25,16 @@ def run_pyomo(options=Bunch(), parser=None):
     try:
         pyomo.scripting.util.setup_environment(data)
 
-        pyomo.scripting.util.apply_preprocessing(data,
-                                                 parser=parser)
+        pyomo.scripting.util.apply_preprocessing(data, parser=parser)
     except:
         # TBD: I should be able to call this function in the case of
         #      an exception to perform cleanup. However, as it stands
         #      calling finalize with its default keyword value for
         #      model(=None) results in an a different error related to
         #      task port values.  Not sure how to interpret that.
-        pyomo.scripting.util.finalize(data,
-                                      model=ConcreteModel(),
-                                      instance=None,
-                                      results=None)
+        pyomo.scripting.util.finalize(
+            data, model=ConcreteModel(), instance=None, results=None
+        )
         raise
     else:
         if data.error:
@@ -45,11 +43,10 @@ def run_pyomo(options=Bunch(), parser=None):
             #      calling finalize with its default keyword value for
             #      model(=None) results in an a different error related to
             #      task port values.  Not sure how to interpret that.
-            pyomo.scripting.util.finalize(data,
-                                          model=ConcreteModel(),
-                                          instance=None,
-                                          results=None)
-            return Bunch()                                   #pragma:nocover
+            pyomo.scripting.util.finalize(
+                data, model=ConcreteModel(), instance=None, results=None
+            )
+            return Bunch()  # pragma:nocover
 
     try:
         model_data = pyomo.scripting.util.create_model(data)
@@ -59,53 +56,55 @@ def run_pyomo(options=Bunch(), parser=None):
         #      calling finalize with its default keyword value for
         #      model(=None) results in an a different error related to
         #      task port values.  Not sure how to interpret that.
-        pyomo.scripting.util.finalize(data,
-                                      model=ConcreteModel(),
-                                      instance=None,
-                                      results=None)
+        pyomo.scripting.util.finalize(
+            data, model=ConcreteModel(), instance=None, results=None
+        )
         raise
     else:
-        if (((not options.runtime.logging == 'debug') and \
-             options.model.save_file) or \
-            options.runtime.only_instance):
-            pyomo.scripting.util.finalize(data,
-                                          model=model_data.model,
-                                          instance=model_data.instance,
-                                          results=None)
+        if (
+            (not options.runtime.logging == 'debug') and options.model.save_file
+        ) or options.runtime.only_instance:
+            pyomo.scripting.util.finalize(
+                data, model=model_data.model, instance=model_data.instance, results=None
+            )
             return Bunch(instance=model_data.instance)
 
     try:
-        opt_data = pyomo.scripting.util.apply_optimizer(data,
-                                                        instance=model_data.instance)
+        opt_data = pyomo.scripting.util.apply_optimizer(
+            data, instance=model_data.instance
+        )
 
-        pyomo.scripting.util.process_results(data,
-                                             instance=model_data.instance,
-                                             results=opt_data.results,
-                                             opt=opt_data.opt)
+        pyomo.scripting.util.process_results(
+            data,
+            instance=model_data.instance,
+            results=opt_data.results,
+            opt=opt_data.opt,
+        )
 
-        pyomo.scripting.util.apply_postprocessing(data,
-                                                  instance=model_data.instance,
-                                                  results=opt_data.results)
+        pyomo.scripting.util.apply_postprocessing(
+            data, instance=model_data.instance, results=opt_data.results
+        )
     except:
         # TBD: I should be able to call this function in the case of
         #      an exception to perform cleanup. However, as it stands
         #      calling finalize with its default keyword value for
         #      model(=None) results in an a different error related to
         #      task port values.  Not sure how to interpret that.
-        pyomo.scripting.util.finalize(data,
-                                      model=ConcreteModel(),
-                                      instance=None,
-                                      results=None)
+        pyomo.scripting.util.finalize(
+            data, model=ConcreteModel(), instance=None, results=None
+        )
         raise
     else:
-        pyomo.scripting.util.finalize(data,
-                                      model=model_data.model,
-                                      instance=model_data.instance,
-                                      results=opt_data.results)
+        pyomo.scripting.util.finalize(
+            data,
+            model=model_data.model,
+            instance=model_data.instance,
+            results=opt_data.results,
+        )
 
-        return Bunch(options=options,
-                         instance=model_data.instance,
-                         results=opt_data.results,
-                         local=opt_data.local)
-
-
+        return Bunch(
+            options=options,
+            instance=model_data.instance,
+            results=opt_data.results,
+            local=opt_data.local,
+        )

--- a/pyomo/scripting/pyomo_main.py
+++ b/pyomo/scripting/pyomo_main.py
@@ -14,6 +14,7 @@ import copy
 
 try:
     import pkg_resources
+
     pyomo_commands = pkg_resources.iter_entry_points('pyomo.command')
 except:
     pyomo_commands = []
@@ -27,10 +28,12 @@ for entrypoint in pyomo_commands:
     except Exception:
         exctype, err, tb = sys.exc_info()  # BUG?
         import traceback
-        msg = "Error loading pyomo.command entry point %s:\nOriginal %s: %s\n"\
-              "Traceback:\n%s" \
-              % (entrypoint, exctype.__name__, err,
-                 ''.join(traceback.format_tb(tb)),)
+
+        msg = (
+            "Error loading pyomo.command entry point %s:\nOriginal %s: %s\n"
+            "Traceback:\n%s"
+            % (entrypoint, exctype.__name__, err, ''.join(traceback.format_tb(tb)))
+        )
         # clear local variables to remove circular references
         exctype = err = tb = None
         # TODO: Should this just log an error and re-raise the original
@@ -44,6 +47,7 @@ def main(args=None):
     #
     from pyomo.scripting import pyomo_parser
     import pyomo.environ
+
     #
     # Parse the arguments
     #
@@ -95,6 +99,7 @@ def main_console_script():
         return ans.errorcode
     except AttributeError:
         return ans
+
 
 if __name__ == '__main__':
     sys.exit(main_console_script())

--- a/pyomo/scripting/pyomo_parser.py
+++ b/pyomo/scripting/pyomo_parser.py
@@ -21,7 +21,6 @@ import sys
 # mucking with a non-public API here ...
 #
 class CustomHelpFormatter(argparse.RawDescriptionHelpFormatter):
-
     def _metavar_formatter(self, action, default_metavar):
         if action.metavar is not None:
             result = action.metavar
@@ -35,7 +34,8 @@ class CustomHelpFormatter(argparse.RawDescriptionHelpFormatter):
             if isinstance(result, tuple):
                 return result
             else:
-                return (result, ) * tuple_size
+                return (result,) * tuple_size
+
         return format
 
     def _iter_indented_subactions(self, action):
@@ -57,18 +57,21 @@ class CustomHelpFormatter(argparse.RawDescriptionHelpFormatter):
 def get_version():
     from pyomo.version import version
     import platform
+
     return "Pyomo %s (%s %s on %s %s)" % (
-            version,
-            platform.python_implementation(),
-            '.'.join( str(x) for x in sys.version_info[:3] ),
-            platform.system(),
-            platform.release() )
+        version,
+        platform.python_implementation(),
+        '.'.join(str(x) for x in sys.version_info[:3]),
+        platform.system(),
+        platform.release(),
+    )
+
 
 #
 # Create the argparse parser for Pyomo
 #
-doc="This is the main driver for the Pyomo optimization software."
-epilog="""
+doc = "This is the main driver for the Pyomo optimization software."
+epilog = """
 -------------------------------------------------------------------------
 Pyomo supports a variety of modeling and optimization capabilities,
 which are executed either as subcommands of 'pyomo' or as separate
@@ -86,6 +89,7 @@ _pyomo_subparsers = None
 
 subparsers = []
 
+
 def add_subparser(name, **args):
     """
     Add a subparser to the 'pyomo' command.
@@ -100,6 +104,7 @@ def add_subparser(name, **args):
         parser.set_defaults(func=func)
     return parser
 
+
 def get_parser():
     """
     Return the parser used by the 'pyomo' commmand.
@@ -107,13 +112,11 @@ def get_parser():
     global _pyomo_parser
     if _pyomo_parser is None:
         _pyomo_parser = argparse.ArgumentParser(
-            description=doc,
-            epilog=epilog,
-            formatter_class=CustomHelpFormatter
+            description=doc, epilog=epilog, formatter_class=CustomHelpFormatter
         )
-        _pyomo_parser.add_argument(
-            "--version", action="version", version=get_version())
+        _pyomo_parser.add_argument("--version", action="version", version=get_version())
         global _pyomo_subparsers
         _pyomo_subparsers = _pyomo_parser.add_subparsers(
-            dest='subparser_name', title='subcommands' )
+            dest='subparser_name', title='subcommands'
+        )
     return _pyomo_parser

--- a/pyomo/scripting/solve_config.py
+++ b/pyomo/scripting/solve_config.py
@@ -20,7 +20,7 @@ class Default_Config(object):
 
 def minlp_config_block(init=False):
     config = ConfigBlock(
-        "Configuration for a canonical model " "construction and optimization sequence"
+        "Configuration for a canonical model construction and optimization sequence"
     )
     blocks = {}
 

--- a/pyomo/scripting/solve_config.py
+++ b/pyomo/scripting/solve_config.py
@@ -13,35 +13,38 @@ from pyomo.common.config import ConfigBlock, ConfigList, ConfigValue
 
 
 class Default_Config(object):
-
     def config_block(self, init=False):
         config, blocks = minlp_config_block(init=init)
         return config, blocks
 
 
 def minlp_config_block(init=False):
-    config = ConfigBlock("Configuration for a canonical model "
-                         "construction and optimization sequence")
-    blocks={}
-       
+    config = ConfigBlock(
+        "Configuration for a canonical model " "construction and optimization sequence"
+    )
+    blocks = {}
+
     #
     # Data
     #
     data = config.declare('data', ConfigBlock())
     blocks['data'] = data
 
-    data.declare('files', ConfigList(
-        [],
-        ConfigValue(None, str, 'Filename', None),
-        'Model data files',
-        None,
-    ))
-    data.declare('namespaces', ConfigList(
-        [],
-        ConfigValue(None, str, 'Namespace', None),
-        'A namespace that is used to select data in Pyomo data files.',
-        None,
-    )).declare_as_argument('--namespace', dest='namespaces', action='append')
+    data.declare(
+        'files',
+        ConfigList(
+            [], ConfigValue(None, str, 'Filename', None), 'Model data files', None
+        ),
+    )
+    data.declare(
+        'namespaces',
+        ConfigList(
+            [],
+            ConfigValue(None, str, 'Namespace', None),
+            'A namespace that is used to select data in Pyomo data files.',
+            None,
+        ),
+    ).declare_as_argument('--namespace', dest='namespaces', action='append')
 
     #
     # Model
@@ -49,72 +52,83 @@ def minlp_config_block(init=False):
     model = config.declare('model', ConfigBlock())
     blocks['model'] = model
 
-    model.declare('filename', ConfigValue(
-        None,
-        str,
-        'The Python module that specifies the model',
-        None,
-    ))
-    model.declare('object name', ConfigValue(
-        None, 
-        str,
-        'The name of the model object that is created in the '
-        'specified Pyomo module',
-        None,
-    )).declare_as_argument('--model-name', dest='model_name') 
-    model.declare('type', ConfigValue(
-        None,
-        str,
-        'The problem type',
-        None,
-    ))
-    model.declare('options', ConfigBlock(
-        implicit=True,
-        description='Options used to construct the model',
-    ))
-    model.declare('linearize expressions', ConfigValue(
-        False,
-        bool,
-        'An option intended for use on linear or mixed-integer models '
-        'in which expression trees in a model (constraints or objectives) '
-        'are compacted into a more memory-efficient and concise form.',
-        None,
-    ))
-    model.declare('save file', ConfigValue(
-        None,
-        str,
-        'The filename to which the model is saved. The suffix of this '
-        'filename specifies the file format.',
-        None,
-    ))
-    model.declare('save format', ConfigValue(
-        None,
-        str,
-        "The format that the model is saved. When specified, this "
-        "overrides the format implied by the 'save file' option.",
-        None,
-    ))
-    model.declare('symbolic solver labels', ConfigValue(
-        False,
-        bool,
-        'When interfacing with the solver, use symbol names derived '
-        'from the model. For example, "my_special_variable[1_2_3]" '
-        'instead of "v1". Useful for debugging. When using the ASL '
-        'interface (--solver-io=nl), generates corresponding .row '
-        '(constraints) and .col (variables) files. The ordering in '
-        'these files provides a mapping from ASL index to symbolic '
-        'model names.',
-        None,
-    )).declare_as_argument(dest='symbolic_solver_labels')
-    model.declare('file determinism', ConfigValue(
-        None,
-        int,
-        'When interfacing with a solver using file based I/O, set '
-        'the effort level for ensuring the file creation process is '
-        'determistic. See the individual solver interfaces for '
-        'valid values and default level of file determinism.',
-        None,
-    )).declare_as_argument(dest='file_determinism')
+    model.declare(
+        'filename',
+        ConfigValue(None, str, 'The Python module that specifies the model', None),
+    )
+    model.declare(
+        'object name',
+        ConfigValue(
+            None,
+            str,
+            'The name of the model object that is created in the '
+            'specified Pyomo module',
+            None,
+        ),
+    ).declare_as_argument('--model-name', dest='model_name')
+    model.declare('type', ConfigValue(None, str, 'The problem type', None))
+    model.declare(
+        'options',
+        ConfigBlock(implicit=True, description='Options used to construct the model'),
+    )
+    model.declare(
+        'linearize expressions',
+        ConfigValue(
+            False,
+            bool,
+            'An option intended for use on linear or mixed-integer models '
+            'in which expression trees in a model (constraints or objectives) '
+            'are compacted into a more memory-efficient and concise form.',
+            None,
+        ),
+    )
+    model.declare(
+        'save file',
+        ConfigValue(
+            None,
+            str,
+            'The filename to which the model is saved. The suffix of this '
+            'filename specifies the file format.',
+            None,
+        ),
+    )
+    model.declare(
+        'save format',
+        ConfigValue(
+            None,
+            str,
+            "The format that the model is saved. When specified, this "
+            "overrides the format implied by the 'save file' option.",
+            None,
+        ),
+    )
+    model.declare(
+        'symbolic solver labels',
+        ConfigValue(
+            False,
+            bool,
+            'When interfacing with the solver, use symbol names derived '
+            'from the model. For example, "my_special_variable[1_2_3]" '
+            'instead of "v1". Useful for debugging. When using the ASL '
+            'interface (--solver-io=nl), generates corresponding .row '
+            '(constraints) and .col (variables) files. The ordering in '
+            'these files provides a mapping from ASL index to symbolic '
+            'model names.',
+            None,
+        ),
+    ).declare_as_argument(dest='symbolic_solver_labels')
+    model.declare(
+        'file determinism',
+        ConfigValue(
+            None,
+            int,
+            'When interfacing with a solver using file based I/O, set '
+            'the effort level for ensuring the file creation process is '
+            'determistic. See the individual solver interfaces for '
+            'valid values and default level of file determinism.',
+            None,
+        ),
+    ).declare_as_argument(dest='file_determinism')
 
     #
     # Transform
@@ -122,36 +136,38 @@ def minlp_config_block(init=False):
     transform = ConfigBlock()
     blocks['transform'] = transform
 
-    transform.declare('name', ConfigValue(
-        None, 
-        str,
-        'Name of the model transformation',
-        None,
-    ))
-    transform.declare('options', ConfigBlock(
-        implicit=True,
-        description='Transformation options',
-    ))
+    transform.declare(
+        'name', ConfigValue(None, str, 'Name of the model transformation', None)
+    )
+    transform.declare(
+        'options', ConfigBlock(implicit=True, description='Transformation options')
+    )
     #
-    transform_list = config.declare('transform', ConfigList(
-        [],
-        ConfigValue(None, str, 'Transformation', None),
-        'List of model transformations',
-        None,
-    )).declare_as_argument(dest='transformations', action='append')
+    transform_list = config.declare(
+        'transform',
+        ConfigList(
+            [],
+            ConfigValue(None, str, 'Transformation', None),
+            'List of model transformations',
+            None,
+        ),
+    ).declare_as_argument(dest='transformations', action='append')
     if init:
         transform_list.append()
 
     #
     # Preprocess
     #
-    config.declare('preprocess', ConfigList(
-        [],
-        ConfigValue(None, str, 'Module', None),
-        'Specify a Python module that gets immediately executed '
-        '(before the optimization model is setup).',
-        None,
-    )).declare_as_argument(dest='preprocess')
+    config.declare(
+        'preprocess',
+        ConfigList(
+            [],
+            ConfigValue(None, str, 'Module', None),
+            'Specify a Python module that gets immediately executed '
+            '(before the optimization model is setup).',
+            None,
+        ),
+    ).declare_as_argument(dest='preprocess')
 
     #
     # Runtime
@@ -159,87 +175,99 @@ def minlp_config_block(init=False):
     runtime = config.declare('runtime', ConfigBlock())
     blocks['runtime'] = runtime
 
-    runtime.declare('logging', ConfigValue(
-        None, 
-        str,
-        'Logging level:  quiet, warning, info, verbose, debug',
-        None,
-    )).declare_as_argument(dest="logging", metavar="LEVEL")
-    runtime.declare('logfile', ConfigValue(
-        None, 
-        str,
-        'Redirect output to the specified file.',
-        None,
-    )).declare_as_argument(dest="output", metavar="FILE")
-    runtime.declare('catch errors', ConfigValue(
-        False, 
-        bool,
-        'Trigger failures for exceptions to print the program stack.',
-        None,
-    )).declare_as_argument('-c', '--catch-errors', dest="catch")
-    runtime.declare('disable gc', ConfigValue(
-        False, 
-        bool,
-        'Disable the garbage collecter.',
-        None,
-    )).declare_as_argument('--disable-gc', dest='disable_gc')
-    runtime.declare('interactive', ConfigValue(
-        False, 
-        bool,
-        'After executing Pyomo, launch an interactive Python shell. '
-        'If IPython is installed, this shell is an IPython shell.',
-        None,
-    ))
-    runtime.declare('keep files', ConfigValue(
-        False, 
-        bool,
-        'Keep temporary files',
-        None,
-    )).declare_as_argument('-k', '--keepfiles', dest='keepfiles')
-    runtime.declare('paths', ConfigList(
-        [], 
-        ConfigValue(None, str, 'Path', None),
-        'Give a path that is used to find the Pyomo python files.',
-        None,
-    )).declare_as_argument('--path', dest='path')
-    runtime.declare('profile count', ConfigValue(
-        0, 
-        int,
-        'Enable profiling of Python code. The value of this option '
-        'is the number of functions that are summarized.',
-        None,
-    )).declare_as_argument(dest='profile_count', metavar='COUNT')
-    runtime.declare('profile memory', ConfigValue(
-        0, 
-        int,
-        "Report memory usage statistics for the generated instance "
-        "and any associated processing steps. A value of 0 indicates "
-        "disabled. A value of 1 forces the print of the total memory "
-        "after major stages of the pyomo script. A value of 2 forces "
-        "summary memory statistics after major stages of the pyomo "
-        "script. A value of 3 forces detailed memory statistics "
-        "during instance creation and various steps of preprocessing. "
-        "Values equal to 4 and higher currently provide no additional "
-        "information. Higher values automatically enable all "
-        "functionality associated with lower values, e.g., 3 turns "
-        "on detailed and summary statistics.",
-        None,
-    ))
-    runtime.declare('report timing', ConfigValue(
-        False, 
-        bool,
-        'Report various timing statistics during model construction.',
-        None,
-    )).declare_as_argument(dest='report_timing')
-    runtime.declare('tempdir', ConfigValue(
-        None, 
-        str,
-        'Specify the directory where temporary files are generated.',
-        None,
-    )).declare_as_argument(dest='tempdir')
+    runtime.declare(
+        'logging',
+        ConfigValue(
+            None, str, 'Logging level:  quiet, warning, info, verbose, debug', None
+        ),
+    ).declare_as_argument(dest="logging", metavar="LEVEL")
+    runtime.declare(
+        'logfile',
+        ConfigValue(None, str, 'Redirect output to the specified file.', None),
+    ).declare_as_argument(dest="output", metavar="FILE")
+    runtime.declare(
+        'catch errors',
+        ConfigValue(
+            False,
+            bool,
+            'Trigger failures for exceptions to print the program stack.',
+            None,
+        ),
+    ).declare_as_argument('-c', '--catch-errors', dest="catch")
+    runtime.declare(
+        'disable gc', ConfigValue(False, bool, 'Disable the garbage collecter.', None)
+    ).declare_as_argument('--disable-gc', dest='disable_gc')
+    runtime.declare(
+        'interactive',
+        ConfigValue(
+            False,
+            bool,
+            'After executing Pyomo, launch an interactive Python shell. '
+            'If IPython is installed, this shell is an IPython shell.',
+            None,
+        ),
+    )
+    runtime.declare(
+        'keep files', ConfigValue(False, bool, 'Keep temporary files', None)
+    ).declare_as_argument('-k', '--keepfiles', dest='keepfiles')
+    runtime.declare(
+        'paths',
+        ConfigList(
+            [],
+            ConfigValue(None, str, 'Path', None),
+            'Give a path that is used to find the Pyomo python files.',
+            None,
+        ),
+    ).declare_as_argument('--path', dest='path')
+    runtime.declare(
+        'profile count',
+        ConfigValue(
+            0,
+            int,
+            'Enable profiling of Python code. The value of this option '
+            'is the number of functions that are summarized.',
+            None,
+        ),
+    ).declare_as_argument(dest='profile_count', metavar='COUNT')
+    runtime.declare(
+        'profile memory',
+        ConfigValue(
+            0,
+            int,
+            "Report memory usage statistics for the generated instance "
+            "and any associated processing steps. A value of 0 indicates "
+            "disabled. A value of 1 forces the print of the total memory "
+            "after major stages of the pyomo script. A value of 2 forces "
+            "summary memory statistics after major stages of the pyomo "
+            "script. A value of 3 forces detailed memory statistics "
+            "during instance creation and various steps of preprocessing. "
+            "Values equal to 4 and higher currently provide no additional "
+            "information. Higher values automatically enable all "
+            "functionality associated with lower values, e.g., 3 turns "
+            "on detailed and summary statistics.",
+            None,
+        ),
+    )
+    runtime.declare(
+        'report timing',
+        ConfigValue(
+            False,
+            bool,
+            'Report various timing statistics during model construction.',
+            None,
+        ),
+    ).declare_as_argument(dest='report_timing')
+    runtime.declare(
+        'tempdir',
+        ConfigValue(
+            None,
+            str,
+            'Specify the directory where temporary files are generated.',
+            None,
+        ),
+    ).declare_as_argument(dest='tempdir')
 
     return config, blocks
-
 
 
 def default_config_block(solver, init=False):
@@ -249,71 +277,79 @@ def default_config_block(solver, init=False):
     # Solver
     #
     solver = ConfigBlock()
-    solver.declare('solver name', ConfigValue(
-        'glpk',
-        str,
-        'Solver name',
-        None,
-    ))
-    solver.declare('solver executable', ConfigValue(
-        default=None,
-        domain=str,
-        description="The solver executable used by the solver interface.",
-        doc=("The solver executable used by the solver interface. "
-             "This option is only valid for those solver interfaces that "
-             "interact with a local executable through the shell. If unset, "
-             "the solver interface will attempt to find an executable within "
-             "the search path of the shell's environment that matches a name "
-             "commonly associated with the solver interface."),
-    ))
-    solver.declare('io format', ConfigValue(
-        None,
-        str,
-        'The type of IO used to execute the solver. Different solvers '
-        'support different types of IO, but the following are common '
-        'options: lp - generate LP files, nl - generate NL files, '
-        'python - direct Python interface, os - generate OSiL XML files.',
-        None,
-    ))
-    solver.declare('manager', ConfigValue(
-        'serial',
-        str,
-        'The technique that is used to manage solver executions.',
-        None,
-    ))
-    solver.declare('options', ConfigBlock(
-        implicit=True,
-        implicit_domain=ConfigValue(
+    solver.declare('solver name', ConfigValue('glpk', str, 'Solver name', None))
+    solver.declare(
+        'solver executable',
+        ConfigValue(
+            default=None,
+            domain=str,
+            description="The solver executable used by the solver interface.",
+            doc=(
+                "The solver executable used by the solver interface. "
+                "This option is only valid for those solver interfaces that "
+                "interact with a local executable through the shell. If unset, "
+                "the solver interface will attempt to find an executable within "
+                "the search path of the shell's environment that matches a name "
+                "commonly associated with the solver interface."
+            ),
+        ),
+    )
+    solver.declare(
+        'io format',
+        ConfigValue(
             None,
             str,
-            'Solver option',
-            None),
-        description="Options passed into the solver",
-    ))
-    solver.declare('options string', ConfigValue(
-        None,
-        str,
-        'String describing solver options',
-        None,
-    ))
-    solver.declare('suffixes', ConfigList(
-        [],
-        ConfigValue(None, str, 'Suffix', None),
-        'Solution suffixes that will be extracted by the solver '
-        '(e.g., rc, dual, or slack). The use of this option is not '
-        'required when a suffix has been declared on the model '
-        'using Pyomo\'s Suffix component.',
-        None,
-    ))
+            'The type of IO used to execute the solver. Different solvers '
+            'support different types of IO, but the following are common '
+            'options: lp - generate LP files, nl - generate NL files, '
+            'python - direct Python interface, os - generate OSiL XML files.',
+            None,
+        ),
+    )
+    solver.declare(
+        'manager',
+        ConfigValue(
+            'serial',
+            str,
+            'The technique that is used to manage solver executions.',
+            None,
+        ),
+    )
+    solver.declare(
+        'options',
+        ConfigBlock(
+            implicit=True,
+            implicit_domain=ConfigValue(None, str, 'Solver option', None),
+            description="Options passed into the solver",
+        ),
+    )
+    solver.declare(
+        'options string',
+        ConfigValue(None, str, 'String describing solver options', None),
+    )
+    solver.declare(
+        'suffixes',
+        ConfigList(
+            [],
+            ConfigValue(None, str, 'Suffix', None),
+            'Solution suffixes that will be extracted by the solver '
+            '(e.g., rc, dual, or slack). The use of this option is not '
+            'required when a suffix has been declared on the model '
+            'using Pyomo\'s Suffix component.',
+            None,
+        ),
+    )
     blocks['solver'] = solver
     #
-    solver_list = config.declare('solvers', ConfigList(
-        [],
-        solver, #ConfigValue(None, str, 'Solver', None),
-        'List of solvers.  The first solver in this list is the '
-        'master solver.',
-        None,
-    ))
+    solver_list = config.declare(
+        'solvers',
+        ConfigList(
+            [],
+            solver,  # ConfigValue(None, str, 'Solver', None),
+            'List of solvers.  The first solver in this list is the ' 'master solver.',
+            None,
+        ),
+    )
     #
     # Make sure that there is one solver in the list.
     #
@@ -326,31 +362,36 @@ def default_config_block(solver, init=False):
     # than one solver defined, we wouldn't want command line options
     # going to both.
     solver_list.append()
-    #solver_list[0].get('solver name').\
+    # solver_list[0].get('solver name').\
     #    declare_as_argument('--solver', dest='solver')
-    solver_list[0].get('solver executable').\
-        declare_as_argument('--solver-executable',
-                            dest="solver_executable", metavar="FILE")
-    solver_list[0].get('io format').\
-        declare_as_argument('--solver-io', dest='io_format', metavar="FORMAT")
-    solver_list[0].get('manager').\
-        declare_as_argument('--solver-manager', dest="smanager_type",
-                            metavar="TYPE")
-    solver_list[0].get('options string').\
-        declare_as_argument('--solver-options', dest='options_string',
-                            metavar="STRING")
-    solver_list[0].get('suffixes').\
-        declare_as_argument('--solver-suffix', dest="solver_suffixes")
+    solver_list[0].get('solver executable').declare_as_argument(
+        '--solver-executable', dest="solver_executable", metavar="FILE"
+    )
+    solver_list[0].get('io format').declare_as_argument(
+        '--solver-io', dest='io_format', metavar="FORMAT"
+    )
+    solver_list[0].get('manager').declare_as_argument(
+        '--solver-manager', dest="smanager_type", metavar="TYPE"
+    )
+    solver_list[0].get('options string').declare_as_argument(
+        '--solver-options', dest='options_string', metavar="STRING"
+    )
+    solver_list[0].get('suffixes').declare_as_argument(
+        '--solver-suffix', dest="solver_suffixes"
+    )
 
     #
     # Postprocess
     #
-    config.declare('postprocess', ConfigList(
-        [],
-        ConfigValue(None, str, 'Module', None),
-        'Specify a Python module that gets executed after optimization.',
-        None,
-    )).declare_as_argument(dest='postprocess')
+    config.declare(
+        'postprocess',
+        ConfigList(
+            [],
+            ConfigValue(None, str, 'Module', None),
+            'Specify a Python module that gets executed after optimization.',
+            None,
+        ),
+    ).declare_as_argument(dest='postprocess')
 
     #
     # Postsolve
@@ -358,60 +399,61 @@ def default_config_block(solver, init=False):
     postsolve = config.declare('postsolve', ConfigBlock())
     blocks['postsolve'] = postsolve
 
-    postsolve.declare('print logfile', ConfigValue(
-        False,
-        bool,
-        'Print the solver logfile after performing optimization.',
-        None,
-    )).declare_as_argument('-l', '--log', dest="log")
-    postsolve.declare('save results', ConfigValue(
-        None,
-        str,
-        'Specify the filename to which the results are saved.',
-        None,
-    )).declare_as_argument('--save-results', dest="save_results",
-                           metavar="FILE")
-    postsolve.declare('show results', ConfigValue(
-        False,
-        bool,
-        'Print the results object after optimization.',
-        None,
-    )).declare_as_argument(dest="show_results")
-    postsolve.declare('results format', ConfigValue(
-        None,
-        str,
-        'Specify the results format:  json or yaml.',
-        None)
+    postsolve.declare(
+        'print logfile',
+        ConfigValue(
+            False, bool, 'Print the solver logfile after performing optimization.', None
+        ),
+    ).declare_as_argument('-l', '--log', dest="log")
+    postsolve.declare(
+        'save results',
+        ConfigValue(
+            None, str, 'Specify the filename to which the results are saved.', None
+        ),
+    ).declare_as_argument('--save-results', dest="save_results", metavar="FILE")
+    postsolve.declare(
+        'show results',
+        ConfigValue(False, bool, 'Print the results object after optimization.', None),
+    ).declare_as_argument(dest="show_results")
+    postsolve.declare(
+        'results format',
+        ConfigValue(None, str, 'Specify the results format:  json or yaml.', None),
     ).declare_as_argument(
         '--results-format', dest="results_format", metavar="FORMAT"
     ).declare_as_argument(
-        '--json', dest="results_format", action="store_const",
-        const="json", help="Store results in JSON format",
+        '--json',
+        dest="results_format",
+        action="store_const",
+        const="json",
+        help="Store results in JSON format",
     )
-    postsolve.declare('summary', ConfigValue(
-        False,
-        bool,
-        'Summarize the final solution after performing optimization.',
-        None,
-    )).declare_as_argument(dest="summary")
+    postsolve.declare(
+        'summary',
+        ConfigValue(
+            False,
+            bool,
+            'Summarize the final solution after performing optimization.',
+            None,
+        ),
+    ).declare_as_argument(dest="summary")
 
     #
     # Runtime
     #
     runtime = blocks['runtime']
-    runtime.declare('only instance', ConfigValue(
-        False,
-        bool,
-        "Generate a model instance, and then exit",
-        None,
-    )).declare_as_argument('--instance-only', dest='only_instance')
-    runtime.declare('stream output', ConfigValue(
-        False,
-        bool,
-        "Stream the solver output to provide information about the "
-        "solver's progress.",
-        None,
-    )).declare_as_argument('--stream-output', '--stream-solver', dest="tee")
+    runtime.declare(
+        'only instance',
+        ConfigValue(False, bool, "Generate a model instance, and then exit", None),
+    ).declare_as_argument('--instance-only', dest='only_instance')
+    runtime.declare(
+        'stream output',
+        ConfigValue(
+            False,
+            bool,
+            "Stream the solver output to provide information about the "
+            "solver's progress.",
+            None,
+        ),
+    ).declare_as_argument('--stream-output', '--stream-solver', dest="tee")
     #
     return config, blocks
-

--- a/pyomo/scripting/tests/test_cmds.py
+++ b/pyomo/scripting/tests/test_cmds.py
@@ -18,7 +18,6 @@ from pyomo.scripting.driver_help import help_solvers, help_transformations
 
 
 class Test(unittest.TestCase):
-
     def test_help_solvers(self):
         with capture_output() as OUT:
             help_solvers()
@@ -30,30 +29,35 @@ class Test(unittest.TestCase):
         self.assertTrue(re.search(r'\n   \*asl ', OUT))
         # MindtPY is bundled with Pyomo so should always be available
         self.assertTrue(re.search(r'\n   \+mindtpy ', OUT))
-        for solver in ('ipopt','cbc','glpk'):
+        for solver in ('ipopt', 'cbc', 'glpk'):
             s = SolverFactory(solver)
             if s.available():
                 self.assertTrue(
                     re.search(r"\n   \+%s " % solver, OUT),
-                    "'   +%s' not found in help --solvers" % solver)
+                    "'   +%s' not found in help --solvers" % solver,
+                )
             else:
                 self.assertTrue(
                     re.search(r"\n    %s " % solver, OUT),
-                    "'    %s' not found in help --solvers" % solver)
+                    "'    %s' not found in help --solvers" % solver,
+                )
         for solver in ('baron',):
             s = SolverFactory(solver)
             if s.license_is_valid():
                 self.assertTrue(
                     re.search(r"\n   \+%s " % solver, OUT),
-                    "'   +%s' not found in help --solvers" % solver)
+                    "'   +%s' not found in help --solvers" % solver,
+                )
             elif s.available():
                 self.assertTrue(
                     re.search(r"\n   \-%s " % solver, OUT),
-                    "'   -%s' not found in help --solvers" % solver)
+                    "'   -%s' not found in help --solvers" % solver,
+                )
             else:
                 self.assertTrue(
                     re.search(r"\n    %s " % solver, OUT),
-                    "'    %s' not found in help --solvers" % solver)
+                    "'    %s' not found in help --solvers" % solver,
+                )
 
     def test_help_transformations(self):
         with capture_output() as OUT:
@@ -62,8 +66,7 @@ class Test(unittest.TestCase):
         self.assertTrue(re.search('Pyomo Model Transformations', OUT))
         self.assertTrue(re.search('core.relax_integer_vars', OUT))
         # test a transformation that we know is deprecated
-        self.assertTrue(
-            re.search(r'duality.linear_dual\s+\[DEPRECATED\]', OUT))
+        self.assertTrue(re.search(r'duality.linear_dual\s+\[DEPRECATED\]', OUT))
 
 
 if __name__ == "__main__":

--- a/pyomo/scripting/util.py
+++ b/pyomo/scripting/util.py
@@ -25,8 +25,11 @@ from pyomo.common.fileutils import import_file
 from pyomo.common.tee import capture_output
 
 from pyomo.common.dependencies import (
-    yaml, yaml_available, yaml_load_args,
-    pympler, pympler_available,
+    yaml,
+    yaml_available,
+    yaml_load_args,
+    pympler,
+    pympler_available,
 )
 from pyomo.common.collections import Bunch
 from pyomo.opt import ProblemFormat
@@ -34,13 +37,20 @@ from pyomo.opt.base import SolverFactory
 from pyomo.opt.parallel import SolverManagerFactory
 from pyomo.dataportal import DataPortal
 from pyomo.scripting.interface import (
-    ExtensionPoint, Plugin, implements,
+    ExtensionPoint,
+    Plugin,
+    implements,
     registered_callback,
-    IPyomoScriptCreateModel, IPyomoScriptCreateDataPortal,
-    IPyomoScriptPrintModel, IPyomoScriptModifyInstance,
-    IPyomoScriptPrintInstance, IPyomoScriptSaveInstance,
-    IPyomoScriptPrintResults, IPyomoScriptSaveResults,
-    IPyomoScriptPostprocess, IPyomoScriptPreprocess,
+    IPyomoScriptCreateModel,
+    IPyomoScriptCreateDataPortal,
+    IPyomoScriptPrintModel,
+    IPyomoScriptModifyInstance,
+    IPyomoScriptPrintInstance,
+    IPyomoScriptSaveInstance,
+    IPyomoScriptPrintResults,
+    IPyomoScriptSaveResults,
+    IPyomoScriptPostprocess,
+    IPyomoScriptPreprocess,
 )
 from pyomo.core import Model, TransformationFactory, Suffix, display
 
@@ -49,16 +59,18 @@ memory_data = Bunch()
 # actually needed.
 IPython_available = None
 
-filter_excepthook=False
-modelapi = {    'pyomo_create_model':IPyomoScriptCreateModel,
-                'pyomo_create_dataportal':IPyomoScriptCreateDataPortal,
-                'pyomo_print_model':IPyomoScriptPrintModel,
-                'pyomo_modify_instance':IPyomoScriptModifyInstance,
-                'pyomo_print_instance':IPyomoScriptPrintInstance,
-                'pyomo_save_instance':IPyomoScriptSaveInstance,
-                'pyomo_print_results':IPyomoScriptPrintResults,
-                'pyomo_save_results':IPyomoScriptSaveResults,
-                'pyomo_postprocess':IPyomoScriptPostprocess}
+filter_excepthook = False
+modelapi = {
+    'pyomo_create_model': IPyomoScriptCreateModel,
+    'pyomo_create_dataportal': IPyomoScriptCreateDataPortal,
+    'pyomo_print_model': IPyomoScriptPrintModel,
+    'pyomo_modify_instance': IPyomoScriptModifyInstance,
+    'pyomo_print_instance': IPyomoScriptPrintInstance,
+    'pyomo_save_instance': IPyomoScriptSaveInstance,
+    'pyomo_print_results': IPyomoScriptPrintResults,
+    'pyomo_save_results': IPyomoScriptSaveResults,
+    'pyomo_postprocess': IPyomoScriptPostprocess,
+}
 
 
 logger = logging.getLogger('pyomo.scripting')
@@ -73,7 +85,9 @@ def setup_environment(data):
     postsolve = getattr(data.options, 'postsolve', None)
     if postsolve:
         if data.options.postsolve.results_format == 'yaml' and not yaml_available:
-            raise ValueError("Configuration specifies a yaml file, but pyyaml is not installed!")
+            raise ValueError(
+                "Configuration specifies a yaml file, but pyyaml is not installed!"
+            )
     #
     global start_time
     start_time = time.time()
@@ -91,14 +105,14 @@ def setup_environment(data):
     #
     if not data.options.runtime.tempdir is None:
         if not os.path.exists(data.options.runtime.tempdir):
-            msg =  'Directory for temporary files does not exist: %s'
+            msg = 'Directory for temporary files does not exist: %s'
             raise ValueError(msg % data.options.runtime.tempdir)
         TempfileManager.tempdir = data.options.runtime.tempdir
 
     #
     # Configure exception management
     #
-    def pyomo_excepthook(etype,value,tb):
+    def pyomo_excepthook(etype, value, tb):
         """
         This exception hook gets called when debugging is on. Otherwise,
         run_command in this module is called.
@@ -109,14 +123,16 @@ def setup_environment(data):
         else:
             name = "model"
 
-
         if filter_excepthook:
             action = "loading"
         else:
             action = "running"
 
-        msg = "Unexpected exception (%s) while %s %s:\n    " \
-              % (etype.__name__, action, name)
+        msg = "Unexpected exception (%s) while %s %s:\n    " % (
+            etype.__name__,
+            action,
+            name,
+        )
 
         #
         # This handles the case where the error is propagated by a KeyError.
@@ -126,13 +142,13 @@ def setup_environment(data):
         #
         valueStr = str(value)
         if etype == KeyError:
-            valueStr = valueStr.replace(r"\n","\n")
+            valueStr = valueStr.replace(r"\n", "\n")
             if valueStr[0] == valueStr[-1] and valueStr[0] in "\"'":
                 valueStr = valueStr[1:-1]
 
-        logger.error(msg+valueStr)
+        logger.error(msg + valueStr)
 
-        tb_list = traceback.extract_tb(tb,None)
+        tb_list = traceback.extract_tb(tb, None)
         i = 0
         if not is_debug_set(logger) and filter_excepthook:
             while i < len(tb_list):
@@ -143,10 +159,13 @@ def setup_environment(data):
                 i = 0
         print("\nTraceback (most recent call last):")
         for item in tb_list[i:]:
-            print("  File \""+item[0]+"\", line "+str(item[1])+", in "+item[2])
+            print(
+                "  File \"" + item[0] + "\", line " + str(item[1]) + ", in " + item[2]
+            )
             if item[3] is not None:
-                print("    "+item[3])
+                print("    " + item[3])
         sys.exit(1)
+
     sys.excepthook = pyomo_excepthook
 
 
@@ -163,7 +182,10 @@ def apply_preprocessing(data, parser=None):
     data.local = Bunch()
     #
     if not data.options.runtime.logging == 'quiet':
-        sys.stdout.write('[%8.2f] Applying Pyomo preprocessing actions\n' % (time.time()-start_time))
+        sys.stdout.write(
+            '[%8.2f] Applying Pyomo preprocessing actions\n'
+            % (time.time() - start_time)
+        )
         sys.stdout.flush()
     #
     global filter_excepthook
@@ -182,42 +204,48 @@ def apply_preprocessing(data, parser=None):
             preprocess = import_file(config_value, clear_cache=True)
     #
     for ep in ExtensionPoint(IPyomoScriptPreprocess):
-        ep.apply( options=data.options )
+        ep.apply(options=data.options)
     #
     # Verify that files exist
     #
-    for file in [data.options.model.filename]+data.options.data.files.value():
+    for file in [data.options.model.filename] + data.options.data.files.value():
         if not os.path.exists(file):
-            raise IOError("File "+file+" does not exist!")
+            raise IOError("File " + file + " does not exist!")
     #
-    filter_excepthook=True
+    filter_excepthook = True
     tick = time.time()
-    data.local.usermodel = import_file(data.options.model.filename,
-                                       clear_cache=True)
-    data.local.time_initial_import = time.time()-tick
-    filter_excepthook=False
+    data.local.usermodel = import_file(data.options.model.filename, clear_cache=True)
+    data.local.time_initial_import = time.time() - tick
+    filter_excepthook = False
 
     usermodel_dir = dir(data.local.usermodel)
     data.local._usermodel_plugins = []
     for key in modelapi:
         if key in usermodel_dir:
+
             class TMP(Plugin):
                 implements(modelapi[key], service=True)
+
                 def __init__(self):
                     self.fn = getattr(data.local.usermodel, key)
-                def apply(self,**kwds):
+
+                def apply(self, **kwds):
                     return self.fn(**kwds)
+
             tmp = TMP()
-            data.local._usermodel_plugins.append( tmp )
+            data.local._usermodel_plugins.append(tmp)
 
     if 'pyomo_preprocess' in usermodel_dir:
         if data.options.model.object_name in usermodel_dir:
-            msg = "Preprocessing function 'pyomo_preprocess' defined in file" \
-                  " '%s', but model is already constructed!"
+            msg = (
+                "Preprocessing function 'pyomo_preprocess' defined in file"
+                " '%s', but model is already constructed!"
+            )
             raise SystemExit(msg % data.options.model.filename)
-        getattr(data.local.usermodel, 'pyomo_preprocess')( options=data.options )
+        getattr(data.local.usermodel, 'pyomo_preprocess')(options=data.options)
     #
     return data
+
 
 def create_model(data):
     """
@@ -231,7 +259,7 @@ def create_model(data):
     """
     #
     if not data.options.runtime.logging == 'quiet':
-        sys.stdout.write('[%8.2f] Creating model\n' % (time.time()-start_time))
+        sys.stdout.write('[%8.2f] Creating model\n' % (time.time() - start_time))
         sys.stdout.flush()
     #
     if data.options.runtime.profile_memory >= 1 and pympler_available:
@@ -250,9 +278,9 @@ def create_model(data):
             _model_IDS.add(id(_obj))
     model_name = data.options.model.object_name
     if len(_models) == 1:
-        _name  = list(_models.keys())[0]
+        _name = list(_models.keys())[0]
         if model_name is None:
-            model_name  = _name
+            model_name = _name
         elif model_name != _name:
             msg = "Model '%s' is not defined in file '%s'!"
             raise SystemExit(msg % (model_name, data.options.model.filename))
@@ -268,19 +296,27 @@ def create_model(data):
 
     if model_name is None:
         if len(ep) == 0:
-            msg = "A model is not defined and the 'pyomo_create_model' is not "\
-                  "provided in module %s"
+            msg = (
+                "A model is not defined and the 'pyomo_create_model' is not "
+                "provided in module %s"
+            )
             raise SystemExit(msg % data.options.model.filename)
         elif len(ep) > 1:
-            msg = 'Multiple model construction plugins have been registered in module %s!'
+            msg = (
+                'Multiple model construction plugins have been registered in module %s!'
+            )
             raise SystemExit(msg % data.options.model.filename)
         else:
             model_options = data.options.model.options.value()
             tick = time.time()
-            model = ep.service().apply( options = Bunch(**data.options),
-                                       model_options=Bunch(**model_options) )
+            model = ep.service().apply(
+                options=Bunch(**data.options), model_options=Bunch(**model_options)
+            )
             if data.options.runtime.report_timing is True:
-                print("      %6.2f seconds required to construct instance" % (time.time() - tick))
+                print(
+                    "      %6.2f seconds required to construct instance"
+                    % (time.time() - tick)
+                )
                 data.local.time_initial_import = None
                 tick = time.time()
     else:
@@ -292,15 +328,17 @@ def create_model(data):
             msg = "'%s' object is 'None' in module %s"
             raise SystemExit(msg % (model_name, data.options.model.filename))
         elif len(ep) > 0:
-            msg = "Model construction function 'create_model' defined in "    \
-                  "file '%s', but model is already constructed!"
+            msg = (
+                "Model construction function 'create_model' defined in "
+                "file '%s', but model is already constructed!"
+            )
             raise SystemExit(msg % data.options.model.filename)
 
     #
     # Print model
     #
     for ep in ExtensionPoint(IPyomoScriptPrintModel):
-        ep.apply( options=data.options, model=model )
+        ep.apply(options=data.options, model=model)
 
     #
     # Create Problem Instance
@@ -311,18 +349,23 @@ def create_model(data):
         raise SystemExit(msg)
 
     if len(ep) == 1:
-        modeldata = ep.service().apply( options=data.options, model=model )
+        modeldata = ep.service().apply(options=data.options, model=model)
     else:
         modeldata = DataPortal()
-
 
     if model._constructed:
         #
         # TODO: use a better test for ConcreteModel
         #
         instance = model
-        if data.options.runtime.report_timing is True and not data.local.time_initial_import is None:
-            print("      %6.2f seconds required to construct instance" % (data.local.time_initial_import))
+        if (
+            data.options.runtime.report_timing is True
+            and not data.local.time_initial_import is None
+        ):
+            print(
+                "      %6.2f seconds required to construct instance"
+                % (data.local.time_initial_import)
+            )
     else:
         tick = time.time()
         if len(data.options.data.files) > 1:
@@ -332,16 +375,20 @@ def create_model(data):
             for file in data.options.data.files:
                 suffix = (file).split(".")[-1]
                 if suffix != "dat":
-                    msg = 'When specifiying multiple data files, they must all '  \
-                          'be *.dat files.  File specified: %s'
-                    raise SystemExit(msg % str( file ))
+                    msg = (
+                        'When specifiying multiple data files, they must all '
+                        'be *.dat files.  File specified: %s'
+                    )
+                    raise SystemExit(msg % str(file))
 
                 modeldata.load(filename=file, model=model)
 
-            instance = model.create_instance(modeldata,
-                                             namespaces=data.options.data.namespaces,
-                                             profile_memory=data.options.runtime.profile_memory,
-                                             report_timing=data.options.runtime.report_timing)
+            instance = model.create_instance(
+                modeldata,
+                namespaces=data.options.data.namespaces,
+                profile_memory=data.options.runtime.profile_memory,
+                report_timing=data.options.runtime.report_timing,
+            )
 
         elif len(data.options.data.files) == 1:
             #
@@ -349,58 +396,76 @@ def create_model(data):
             #
             suffix = (data.options.data.files[0]).split(".")[-1].lower()
             if suffix == "dat":
-                instance = model.create_instance(data.options.data.files[0],
-                                                 namespaces=data.options.data.namespaces,
-                                                 profile_memory=data.options.runtime.profile_memory,
-                                                 report_timing=data.options.runtime.report_timing)
+                instance = model.create_instance(
+                    data.options.data.files[0],
+                    namespaces=data.options.data.namespaces,
+                    profile_memory=data.options.runtime.profile_memory,
+                    report_timing=data.options.runtime.report_timing,
+                )
             elif suffix == "py":
-                userdata = import_file(data.options.data.files[0],
-                                       clear_cache=True)
+                userdata = import_file(data.options.data.files[0], clear_cache=True)
                 if "modeldata" in dir(userdata):
                     if len(ep) == 1:
-                        msg = "Cannot apply 'pyomo_create_modeldata' and use the" \
-                              " 'modeldata' object that is provided in the model"
+                        msg = (
+                            "Cannot apply 'pyomo_create_modeldata' and use the"
+                            " 'modeldata' object that is provided in the model"
+                        )
                         raise SystemExit(msg)
 
                     if userdata.modeldata is None:
                         msg = "'modeldata' object is 'None' in module %s"
-                        raise SystemExit(msg % str( data.options.data.files[0] ))
+                        raise SystemExit(msg % str(data.options.data.files[0]))
 
-                    modeldata=userdata.modeldata
+                    modeldata = userdata.modeldata
 
                 else:
                     if len(ep) == 0:
-                        msg = "Neither 'modeldata' nor 'pyomo_create_dataportal' "  \
-                              'is defined in module %s'
-                        raise SystemExit(msg % str( data.options.data.files[0] ))
+                        msg = (
+                            "Neither 'modeldata' nor 'pyomo_create_dataportal' "
+                            'is defined in module %s'
+                        )
+                        raise SystemExit(msg % str(data.options.data.files[0]))
 
                 modeldata.read(model)
-                instance = model.create_instance(modeldata,
-                                                 namespaces=data.options.data.namespaces,
-                                                 profile_memory=data.options.runtime.profile_memory,
-                                                 report_timing=data.options.runtime.report_timing)
+                instance = model.create_instance(
+                    modeldata,
+                    namespaces=data.options.data.namespaces,
+                    profile_memory=data.options.runtime.profile_memory,
+                    report_timing=data.options.runtime.report_timing,
+                )
             elif suffix == "yml" or suffix == 'yaml':
-                modeldata = yaml.load(open(data.options.data.files[0]), **yaml_load_args)
-                instance = model.create_instance(modeldata,
-                                                 namespaces=data.options.data.namespaces,
-                                                 profile_memory=data.options.runtime.profile_memory,
-                                                 report_timing=data.options.runtime.report_timing)
+                modeldata = yaml.load(
+                    open(data.options.data.files[0]), **yaml_load_args
+                )
+                instance = model.create_instance(
+                    modeldata,
+                    namespaces=data.options.data.namespaces,
+                    profile_memory=data.options.runtime.profile_memory,
+                    report_timing=data.options.runtime.report_timing,
+                )
             else:
-                raise ValueError("Unknown data file type: "+data.options.data.files[0])
+                raise ValueError(
+                    "Unknown data file type: " + data.options.data.files[0]
+                )
         else:
-            instance = model.create_instance(modeldata,
-                                             namespaces=data.options.data.namespaces,
-                                             profile_memory=data.options.runtime.profile_memory,
-                                             report_timing=data.options.runtime.report_timing)
+            instance = model.create_instance(
+                modeldata,
+                namespaces=data.options.data.namespaces,
+                profile_memory=data.options.runtime.profile_memory,
+                report_timing=data.options.runtime.report_timing,
+            )
         if data.options.runtime.report_timing is True:
-            print("      %6.2f seconds required to construct instance" % (time.time() - tick))
+            print(
+                "      %6.2f seconds required to construct instance"
+                % (time.time() - tick)
+            )
 
     #
     modify_start_time = time.time()
     for ep in ExtensionPoint(IPyomoScriptModifyInstance):
         if data.options.runtime.report_timing is True:
             tick = time.time()
-        ep.apply( options=data.options, model=model, instance=instance )
+        ep.apply(options=data.options, model=model, instance=instance)
         if data.options.runtime.report_timing is True:
             print("      %6.2f seconds to apply %s" % (time.time() - tick, type(ep)))
             tick = time.time()
@@ -409,8 +474,10 @@ def create_model(data):
         with TransformationFactory(transformation) as xfrm:
             instance = xfrm.create_using(instance)
             if instance is None:
-                raise SystemExit("Unexpected error while applying "
-                                 "transformation '%s'" % transformation)
+                raise SystemExit(
+                    "Unexpected error while applying "
+                    "transformation '%s'" % transformation
+                )
     #
     if data.options.runtime.report_timing is True:
         total_time = time.time() - modify_start_time
@@ -422,10 +489,10 @@ def create_model(data):
         print("")
 
     for ep in ExtensionPoint(IPyomoScriptPrintInstance):
-        ep.apply( options=data.options, instance=instance )
+        ep.apply(options=data.options, instance=instance)
 
-    fname=None
-    smap_id=None
+    fname = None
+    smap_id = None
     if not data.options.model.save_file is None:
 
         if data.options.runtime.report_timing is True:
@@ -433,28 +500,28 @@ def create_model(data):
 
         if data.options.model.save_file == True:
             if data.local.model_format in (ProblemFormat.cpxlp, ProblemFormat.lpxlp):
-                fname = (data.options.data.files[0])[:-3]+'lp'
+                fname = (data.options.data.files[0])[:-3] + 'lp'
             else:
-                fname = (data.options.data.files[0])[:-3]+str(data.local.model_format)
-            format=data.local.model_format
+                fname = (data.options.data.files[0])[:-3] + str(data.local.model_format)
+            format = data.local.model_format
         else:
             fname = data.options.model.save_file
-            format= data.options.model.save_format
+            format = data.options.model.save_format
 
         io_options = {}
         if data.options.model.symbolic_solver_labels:
             io_options['symbolic_solver_labels'] = True
         if data.options.model.file_determinism is not None:
             io_options['file_determinism'] = data.options.model.file_determinism
-        (fname, smap_id) = instance.write(filename=fname,
-                                          format=format,
-                                          io_options=io_options)
+        (fname, smap_id) = instance.write(
+            filename=fname, format=format, io_options=io_options
+        )
 
         if not data.options.runtime.logging == 'quiet':
             if not os.path.exists(fname):
-                print("ERROR: file "+fname+" has not been created!")
+                print("ERROR: file " + fname + " has not been created!")
             else:
-                print("Model written to file '"+str(fname)+"'")
+                print("Model written to file '" + str(fname) + "'")
 
         if data.options.runtime.report_timing is True:
             total_time = time.time() - write_start_time
@@ -463,13 +530,15 @@ def create_model(data):
         if data.options.runtime.profile_memory >= 2 and pympler_available:
             print("")
             print("      Summary of objects following file output")
-            post_file_output_summary = pympler.summary.summarize(pympler.muppy.get_objects())
+            post_file_output_summary = pympler.summary.summarize(
+                pympler.muppy.get_objects()
+            )
             pympler.summary.print_(post_file_output_summary, limit=100)
 
             print("")
 
     for ep in ExtensionPoint(IPyomoScriptSaveInstance):
-        ep.apply( options=data.options, instance=instance )
+        ep.apply(options=data.options, instance=instance)
 
     if data.options.runtime.profile_memory >= 1 and pympler_available:
         mem_used = pympler.muppy.get_size(pympler.muppy.get_objects())
@@ -477,8 +546,14 @@ def create_model(data):
             data.local.max_memory = mem_used
         print("   Total memory = %d bytes following Pyomo instance creation" % mem_used)
 
-    return Bunch(model=model, instance=instance,
-                 smap_id=smap_id, filename=fname, local=data.local )
+    return Bunch(
+        model=model,
+        instance=instance,
+        smap_id=smap_id,
+        filename=fname,
+        local=data.local,
+    )
+
 
 def apply_optimizer(data, instance=None):
     """
@@ -493,7 +568,7 @@ def apply_optimizer(data, instance=None):
     """
     #
     if not data.options.runtime.logging == 'quiet':
-        sys.stdout.write('[%8.2f] Applying solver\n' % (time.time()-start_time))
+        sys.stdout.write('[%8.2f] Applying solver\n' % (time.time() - start_time))
         sys.stdout.flush()
     #
     #
@@ -505,16 +580,18 @@ def apply_optimizer(data, instance=None):
 
     if len(data.options.solvers[0].suffixes) > 0:
         for suffix_name in data.options.solvers[0].suffixes:
-            if suffix_name[0] in ['"',"'"]:
+            if suffix_name[0] in ['"', "'"]:
                 suffix_name = suffix_name[1:-1]
             # Don't redeclare the suffix if it already exists
             suffix = getattr(instance, suffix_name, None)
             if suffix is None:
                 setattr(instance, suffix_name, Suffix(direction=Suffix.IMPORT))
             else:
-                raise ValueError("Problem declaring solver suffix %s. A component "\
-                                  "with that name already exists on model %s."
-                                 % (suffix_name, instance.name))
+                raise ValueError(
+                    "Problem declaring solver suffix %s. A component "
+                    "with that name already exists on model %s."
+                    % (suffix_name, instance.name)
+                )
 
     if getattr(data.options.solvers[0].options, 'timelimit', 0) == 0:
         data.options.solvers[0].options.timelimit = None
@@ -529,8 +606,7 @@ def apply_optimizer(data, instance=None):
     if data.options.solvers[0].manager is None:
         solver_mngr_name = 'serial'
     elif not data.options.solvers[0].manager in SolverManagerFactory:
-        raise ValueError("Unknown solver manager %s"
-                         % data.options.solvers[0].manager)
+        raise ValueError("Unknown solver manager %s" % data.options.solvers[0].manager)
     else:
         solver_mngr_name = data.options.solvers[0].manager
     #
@@ -545,8 +621,7 @@ def apply_optimizer(data, instance=None):
         # Setup keywords for the solve
         #
         keywords = {}
-        if (data.options.runtime.keep_files or \
-            data.options.postsolve.print_logfile):
+        if data.options.runtime.keep_files or data.options.postsolve.print_logfile:
             keywords['keepfiles'] = True
         if data.options.model.symbolic_solver_labels:
             keywords['symbolic_solver_labels'] = True
@@ -580,7 +655,7 @@ def apply_optimizer(data, instance=None):
 
                 if len(data.options.solvers[0].options) > 0:
                     opt.set_options(data.options.solvers[0].options)
-                    #opt.set_options(" ".join("%s=%s" % (key, value)
+                    # opt.set_options(" ".join("%s=%s" % (key, value)
                     #                         for key, value in data.options.solvers[0].options.iteritems()
                     #                         if not key == 'timelimit'))
                 if not data.options.solvers[0].options_string is None:
@@ -593,13 +668,20 @@ def apply_optimizer(data, instance=None):
             #
             # Get the solver option arguments
             #
-            if len(data.options.solvers[0].options) > 0 and not data.options.solvers[0].options_string is None:
+            if (
+                len(data.options.solvers[0].options) > 0
+                and not data.options.solvers[0].options_string is None
+            ):
                 # If both 'options' and 'options_string' were specified, then create a
                 # single options string that is passed to the solver.
-                ostring = " ".join("%s=%s" % (key, value)
-                                             for key, value in data.options.solvers[0].options.iteritems()
-                                             if not value is None)
-                keywords['options'] = ostring + ' ' + data.options.solvers[0].options_string
+                ostring = " ".join(
+                    "%s=%s" % (key, value)
+                    for key, value in data.options.solvers[0].options.iteritems()
+                    if not value is None
+                )
+                keywords['options'] = (
+                    ostring + ' ' + data.options.solvers[0].options_string
+                )
             elif len(data.options.solvers[0].options) > 0:
                 keywords['options'] = data.options.solvers[0].options
             else:
@@ -631,13 +713,13 @@ def process_results(data, instance=None, results=None, opt=None):
     """
     #
     if not data.options.runtime.logging == 'quiet':
-        sys.stdout.write('[%8.2f] Processing results\n' % (time.time()-start_time))
+        sys.stdout.write('[%8.2f] Processing results\n' % (time.time() - start_time))
         sys.stdout.flush()
     #
     if data.options.postsolve.print_logfile:
         print("")
         print("==========================================================")
-        print("Solver Logfile: "+str(opt._log_file))
+        print("Solver Logfile: " + str(opt._log_file))
         print("==========================================================")
         print("")
         with open(opt._log_file, "r") as INPUT:
@@ -663,20 +745,24 @@ def process_results(data, instance=None, results=None, opt=None):
             # The ordering of the elif and else conditions is important here
             # to ensure that the default file format is yaml
             results_file = 'results.yml'
-        results.write(filename=results_file,
-                      format=data.options.postsolve.results_format)
+        results.write(
+            filename=results_file, format=data.options.postsolve.results_format
+        )
         if not data.options.runtime.logging == 'quiet':
-            print("    Number of solutions: "+str(len(results.solution)))
+            print("    Number of solutions: " + str(len(results.solution)))
             if len(results.solution) > 0:
                 print("    Solution Information")
-                print("      Gap: "+str(results.solution[0].gap))
-                print("      Status: "+str(results.solution[0].status))
+                print("      Gap: " + str(results.solution[0].gap))
+                print("      Status: " + str(results.solution[0].status))
                 if len(results.solution[0].objective) == 1:
                     key = list(results.solution[0].objective.keys())[0]
-                    print("      Function Value: "+str(results.solution[0].objective[key]['Value']))
-            print("    Solver results file: "+results_file)
+                    print(
+                        "      Function Value: "
+                        + str(results.solution[0].objective[key]['Value'])
+                    )
+            print("    Solver results file: " + results_file)
     #
-    #ep = ExtensionPoint(IPyomoScriptPrintResults)
+    # ep = ExtensionPoint(IPyomoScriptPrintResults)
     if data.options.postsolve.show_results:
         print("")
         results.write(num=1, format=data.options.postsolve.results_format)
@@ -695,10 +781,10 @@ def process_results(data, instance=None, results=None, opt=None):
             print("No solutions reported by solver.")
     #
     for ep in ExtensionPoint(IPyomoScriptPrintResults):
-        ep.apply( options=data.options, instance=instance, results=results )
+        ep.apply(options=data.options, instance=instance, results=results)
     #
     for ep in ExtensionPoint(IPyomoScriptSaveResults):
-        ep.apply( options=data.options, instance=instance, results=results )
+        ep.apply(options=data.options, instance=instance, results=results)
     #
     if data.options.runtime.profile_memory >= 1 and pympler_available:
         global memory_data
@@ -706,6 +792,7 @@ def process_results(data, instance=None, results=None, opt=None):
         if mem_used > data.local.max_memory:
             data.local.max_memory = mem_used
         print("   Total memory = %d bytes following results processing" % mem_used)
+
 
 def apply_postprocessing(data, instance=None, results=None):
     """
@@ -717,23 +804,27 @@ def apply_postprocessing(data, instance=None, results=None):
     """
     #
     if not data.options.runtime.logging == 'quiet':
-        sys.stdout.write('[%8.2f] Applying Pyomo postprocessing actions\n' % (time.time()-start_time))
+        sys.stdout.write(
+            '[%8.2f] Applying Pyomo postprocessing actions\n'
+            % (time.time() - start_time)
+        )
         sys.stdout.flush()
 
     # options are of type ConfigValue, not raw strings / atomics.
     for config_value in data.options.postprocess:
         postprocess = import_file(config_value, clear_cache=True)
         if "pyomo_postprocess" in dir(postprocess):
-            postprocess.pyomo_postprocess(data.options, instance,results)
+            postprocess.pyomo_postprocess(data.options, instance, results)
 
     for ep in ExtensionPoint(IPyomoScriptPostprocess):
-        ep.apply( options=data.options, instance=instance, results=results )
+        ep.apply(options=data.options, instance=instance, results=results)
 
     if data.options.runtime.profile_memory >= 1 and pympler_available:
         mem_used = pympler.muppy.get_size(pympler.muppy.get_objects())
         if mem_used > data.local.max_memory:
             data.local.max_memory = mem_used
         print("   Total memory = %d bytes upon termination" % mem_used)
+
 
 def finalize(data, model=None, instance=None, results=None):
     """
@@ -760,7 +851,7 @@ def finalize(data, model=None, instance=None, results=None):
     # NOTE: This function gets called for cleanup during exceptions
     #       to prevent memory leaks. Don't reconfigure the loggers
     #       here or we will lose the exception information.
-    #configure_loggers(reset=True)
+    # configure_loggers(reset=True)
     data.local._usermodel_plugins = []
     ##gc.collect()
     ##print gc.get_referrers(_tmp)
@@ -768,50 +859,56 @@ def finalize(data, model=None, instance=None, results=None):
     ##print "HERE - usermodel_plugins"
     ##
     if not data.options.runtime.logging == 'quiet':
-        sys.stdout.write('[%8.2f] Pyomo Finished\n' % (time.time()-start_time))
+        sys.stdout.write('[%8.2f] Pyomo Finished\n' % (time.time() - start_time))
         if (pympler_available is True) and (data.options.runtime.profile_memory >= 1):
             sys.stdout.write('Maximum memory used = %d bytes\n' % data.local.max_memory)
         sys.stdout.flush()
     #
-    model=model
-    instance=instance
-    results=results
+    model = model
+    instance = instance
+    results = results
     #
     if data.options.runtime.interactive:
         global IPython_available
         if IPython_available is None:
             try:
                 import IPython
-                IPython_available=True
+
+                IPython_available = True
             except:
-                IPython_available=False
+                IPython_available = False
 
         if IPython_available:
             IPython.Shell.IPShellEmbed(
-                    [''],
-                    banner = '\n# Dropping into Python interpreter',
-                    exit_msg = '\n# Leaving Interpreter, back to Pyomo\n')()
+                [''],
+                banner='\n# Dropping into Python interpreter',
+                exit_msg='\n# Leaving Interpreter, back to Pyomo\n',
+            )()
         else:
             import code
+
             shell = code.InteractiveConsole(locals())
             print('\n# Dropping into Python interpreter')
             shell.interact()
             print('\n# Leaving Interpreter, back to Pyomo\n')
 
 
-@deprecated("configure_loggers is deprecated. The Pyomo command uses the "
-            "PyomoCommandLogContext to update the logger configuration",
-            version='5.7.3')
+@deprecated(
+    "configure_loggers is deprecated. The Pyomo command uses the "
+    "PyomoCommandLogContext to update the logger configuration",
+    version='5.7.3',
+)
 def configure_loggers(options=None, shutdown=False):
     context = PyomoCommandLogContext(options)
     if shutdown:
         # historically, configure_loggers(shutdown=True) forced 'quiet'
         context.options.runtime.logging = 'quiet'
         context.fileLogger = configure_loggers.fileLogger
-        context.__exit__(None,None,None)
+        context.__exit__(None, None, None)
     else:
         context.__enter__()
         configure_loggers.fileLogger = context.fileLogger
+
 
 configure_loggers.fileLogger = None
 
@@ -830,7 +927,7 @@ class PyomoCommandLogContext(object):
 
     def __enter__(self):
         _pyomo = logging.getLogger('pyomo')
-        self.original = ( _pyomo.level, _pyomo.handlers)
+        self.original = (_pyomo.level, _pyomo.handlers)
 
         #
         # Configure the logger
@@ -872,7 +969,9 @@ class PyomoCommandLogContext(object):
             self.capture.reset()
 
 
-def run_command(command=None, parser=None, args=None, name='unknown', data=None, options=None):
+def run_command(
+    command=None, parser=None, args=None, name='unknown', data=None, options=None
+):
     """
     Execute a function that processes command-line arguments and
     then calls a command-line driver.
@@ -928,7 +1027,8 @@ def run_command(command=None, parser=None, args=None, name='unknown', data=None,
     try:
         with PyomoCommandLogContext(options):
             retval, errorcode = _run_command_impl(
-                command, parser, args, name, data, options)
+                command, parser, args, name, data, options
+            )
     finally:
         if options.runtime.disable_gc:
             gc.enable()
@@ -956,18 +1056,21 @@ def _run_command_impl(command, parser, args, name, data, options):
         except ImportError:
             raise ValueError(
                 "Cannot use the 'profile' option: the Python "
-                "'profile' or 'pstats' package cannot be imported!")
+                "'profile' or 'pstats' package cannot be imported!"
+            )
         tfile = TempfileManager.create_tempfile(suffix=".profile")
         tmp = profile.runctx(
             command.__name__ + '(options=options,parser=parser)',
-            command.__globals__, locals(), tfile
+            command.__globals__,
+            locals(),
+            tfile,
         )
         p = pstats.Stats(tfile).strip_dirs()
         p.sort_stats('time', 'cumulative')
         p = p.print_stats(pcount)
         p.print_callers(pcount)
         p.print_callees(pcount)
-        p = p.sort_stats('cumulative','calls')
+        p = p.sort_stats('cumulative', 'calls')
         p.print_stats(pcount)
         p.print_callers(pcount)
         p.print_callees(pcount)
@@ -988,7 +1091,9 @@ def _run_command_impl(command, parser, args, name, data, options):
             # If debugging is enabled or the 'catch' option is specified, then
             # exit.  Otherwise, print an "Exiting..." message.
             #
-            if __debug__ and (options.runtime.logging == 'debug' or options.runtime.catch_errors):
+            if __debug__ and (
+                options.runtime.logging == 'debug' or options.runtime.catch_errors
+            ):
                 sys.exit(0)
             print('Exiting %s: %s' % (name, str(err)))
             errorcode = err.code
@@ -998,7 +1103,9 @@ def _run_command_impl(command, parser, args, name, data, options):
             # If debugging is enabled or the 'catch' option is specified, then
             # pass the exception up the chain (to pyomo_excepthook)
             #
-            if __debug__ and (options.runtime.logging == 'debug' or options.runtime.catch_errors):
+            if __debug__ and (
+                options.runtime.logging == 'debug' or options.runtime.catch_errors
+            ):
                 raise
 
             if not options.model is None and not options.model.save_file is None:
@@ -1021,9 +1128,9 @@ def _run_command_impl(command, parser, args, name, data, options):
             #
             errStr = str(err)
             if type(err) == KeyError and errStr != "None":
-                errStr = str(err).replace(r"\n","\n")[1:-1]
+                errStr = str(err).replace(r"\n", "\n")[1:-1]
 
-            logger.error(msg+errStr)
+            logger.error(msg + errStr)
             errorcode = 1
 
     return retval, errorcode
@@ -1034,10 +1141,13 @@ def cleanup():
         for ep in ExtensionPoint(modelapi[key]):
             ep.deactivate()
 
+
 def get_config_values(filename):
     if filename.endswith('.yml') or filename.endswith('.yaml'):
         if not yaml_available:
-            raise ValueError("ERROR: yaml configuration file specified, but pyyaml is not installed!")
+            raise ValueError(
+                "ERROR: yaml configuration file specified, but pyyaml is not installed!"
+            )
         INPUT = open(filename, 'r')
         val = yaml.load(INPUT, **yaml_load_args)
         INPUT.close()


### PR DESCRIPTION
## Fixes (Partly) #329 

## Summary/Motivation:
This is the first in a relatively long string of PRs to apply PEP8 standards via `black` to Pyomo. We are following the standard used by IDAES _except_ that we are adding the `-S` option: `Don't normalize string quotes or prefixes` and the `-C` option: `Don't use trailing commas as a reason to split lines.`

**NOTE**: All changes are NFC.

Full command used: `cd pyomo/scripting && black -S -C .`

## Changes proposed in this PR:
- Apply `black` to the `pyomo/scripting` directory `py` files

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
