### PR TITLE
Remove residual `nose` references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ doc/OnlineDocs/**/*.spy
 pyomo/dataportal/parse_table_datacmds.py
 gurobi.log
 
-# Results from nosetests --with-coverage
+# Results from pytest --with-coverage
 .coverage
 *.cover
 

--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -11,7 +11,7 @@
 #
 # CATEGORY: the category to pass to pytest
 #
-# TEST_SUITES: Paths (module or directory) to be passed to nosetests to
+# TEST_SUITES: Paths (module or directory) to be passed to pytest to
 #     run. (defaults to "pyomo '$WORKSPACE/pyomo-model-libraries'")
 #
 # SLIM: If nonempty, then the virtualenv will only have pip, setuptools,

--- a/doc/OnlineDocs/contribution_guide.rst
+++ b/doc/OnlineDocs/contribution_guide.rst
@@ -41,7 +41,7 @@ Testing
 +++++++
 
 Pyomo uses `unittest <https://docs.python.org/3/library/unittest.html>`_,
-`nose <https://nose.readthedocs.io/>`_,
+`pytest <https://docs.pytest.org/>`_,
 `GitHub Actions <https://docs.github.com/en/free-pro-team@latest/actions>`_,
 and Jenkins
 for testing and continuous integration. Submitted code should include 

--- a/examples/doc/samples/__init__.py
+++ b/examples/doc/samples/__init__.py
@@ -1,1 +1,1 @@
-# Dummy file for nose tests
+# Dummy file for pytest

--- a/examples/doc/samples/scripts/__init__.py
+++ b/examples/doc/samples/scripts/__init__.py
@@ -1,1 +1,1 @@
-# Dummy file for nose tests
+# Dummy file for pytest

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -137,7 +137,7 @@ class DeferredImportModule(object):
     def __init__(self, indicator, deferred_submodules, submodule_name):
         self._indicator_flag = indicator
         self._submodule_name = submodule_name
-        self.__file__ = None # Disable nose's coverage of this module
+        self.__file__ = None # Disable coverage of this module
         self.__spec__ = None # Indicate that this is not a "real" module
 
         if not deferred_submodules:

--- a/pyomo/core/tests/examples/test_kernel_examples.py
+++ b/pyomo/core/tests/examples/test_kernel_examples.py
@@ -51,7 +51,7 @@ def setUpModule():
 
 def create_method(example):
     # It is important that this inner function has a name that
-    # starts with 'test' in order for nose to discover it
+    # starts with 'test' in order for pytest to discover it
     # after we assign it to the class. I have _no_ idea why
     # this is the case since we are returing the function object
     # and placing it on the class with a different name.


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
In the process of working on a different PR, I found several references to `nosetests` still floating around. This removes them.

## Changes proposed in this PR:
- Remove residual references to `nose`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
