### PR TITLE
NFC: Update enhancement template to link to wiki

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,6 +4,9 @@ about: Suggest adding an enhancement of a current feature or a new feature in Py
 labels: enhancement
 
 ---
+
+<!-- BEFORE SUBMITTING AN ENHANCEMENT REQUEST - please browse the open issues and the [Archived Design Discussions wiki page](https://github.com/Pyomo/pyomo/wiki/Archived-Design-Discussions).-->
+
 ## Summary
 
 <!-- Please add a concise summary of your suggestion here. -->


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
To enable us to keep track of good ideas without cluttering our Issue backlog, we have an [Archived Design Discussions wiki](https://github.com/Pyomo/pyomo/wiki/Archived-Design-Discussions). This PR adds language about its existence and requirement to browse it to the Issue enhancement template.

## Changes proposed in this PR:
- Prompt users to browse the existing issues and wiki page

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
