### PR TITLE
Add docstring formatting requirements

### DIFF
--- a/doc/OnlineDocs/contribution_guide.rst
+++ b/doc/OnlineDocs/contribution_guide.rst
@@ -28,11 +28,14 @@ Coding Standards
       maintainer (such as a Github ID) should be included in the Sphinx
       documentation
 
-Sphinx-compliant documentation is required for:
+Pyomo documentation is generated using `Sphinx <https://www.sphinx-doc.org/en/master/>`_
+with the ``napoleon`` extension enabled.
+See `supported styles <https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html>`_.
+We recommend use of one of the listed styles on documentation for:
     
     * Modules
     * Public and Private Classes
-    * Public and Private Functions 
+    * Public and Private Functions
 
 We also encourage you to include examples, especially for new features
 and contributions to ``pyomo.contrib``.

--- a/doc/OnlineDocs/contribution_guide.rst
+++ b/doc/OnlineDocs/contribution_guide.rst
@@ -31,7 +31,8 @@ Coding Standards
 Pyomo documentation is generated using `Sphinx <https://www.sphinx-doc.org/en/master/>`_
 with the ``napoleon`` extension enabled.
 See `supported styles <https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html>`_.
-We recommend use of one of the listed styles on documentation for:
+We recommend use of one of the supported styles, but we prefer the
+NumPy standard. Whichever you choose, we require compliant documentation for:
     
     * Modules
     * Public and Private Classes

--- a/doc/OnlineDocs/contribution_guide.rst
+++ b/doc/OnlineDocs/contribution_guide.rst
@@ -28,11 +28,10 @@ Coding Standards
       maintainer (such as a Github ID) should be included in the Sphinx
       documentation
 
-Pyomo documentation is generated using `Sphinx <https://www.sphinx-doc.org/en/master/>`_
-with the ``napoleon`` extension enabled.
-See `supported styles <https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html>`_.
-We recommend use of one of the supported styles, but we prefer the
-NumPy standard. Whichever you choose, we require compliant documentation for:
+Online Pyomo documentation is generated using `Sphinx <https://www.sphinx-doc.org/en/master/>`_
+with the ``napoleon`` extension enabled. For API documentation we use of one of these 
+`supported styles for docstrings <https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html>`_, 
+but we prefer the NumPy standard. Whichever you choose, we require compliant docstrings for:
     
     * Modules
     * Public and Private Classes


### PR DESCRIPTION
## Fixes #828 

## Summary/Motivation:
This adds clarification and links to the preferred docstring format.

## Changes proposed in this PR:
- Links to Sphinx
- Clarification on preferred standard

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
