### PR TITLE
Fix `pyomo --version` version string

### DIFF
--- a/pyomo/version/info.py
+++ b/pyomo/version/info.py
@@ -54,6 +54,7 @@ elif releaselevel == 'invalid':
         # sys.argv[0] also fails because it doesn't always contains the path
         from inspect import getfile as _getfile, currentframe as _frame
         from os.path import abspath as _abspath, dirname as _dirname
+
         _rootdir = _join(_dirname(_abspath(_getfile(_frame()))), '..', '..')
 
     if _exists(_join(_rootdir, '.git')):

--- a/pyomo/version/info.py
+++ b/pyomo/version/info.py
@@ -36,12 +36,12 @@ if releaselevel == 'final':
 elif '/tags/' in _init_url:  # pragma:nocover
     releaselevel = 'final'
 elif releaselevel == 'invalid':
-    from os.path import exists as _exists, join as _join
+    from os.path import exists as _exists, join as _join, dirname as _dirname
 
     if __file__.endswith('setup.py'):
         # This file is being sourced (exec'ed) from setup.py.
         # dirname(__file__) setup.py's scope is the root source directory
-        _rootdir = dirname(__file__)
+        _rootdir = _dirname(__file__)
     else:
         # Ideally, this should import PYOMO_ROOT_DIR from pyomo.common
         # instead of reimplementing that logic here.  Unfortunately,
@@ -53,7 +53,7 @@ elif releaselevel == 'invalid':
         # __file__ fails if someone does os.chdir() before
         # sys.argv[0] also fails because it doesn't always contains the path
         from inspect import getfile as _getfile, currentframe as _frame
-        from os.path import abspath as _abspath, dirname as _dirname
+        from os.path import abspath as _abspath
 
         _rootdir = _join(_dirname(_abspath(_getfile(_frame()))), '..', '..')
 

--- a/pyomo/version/info.py
+++ b/pyomo/version/info.py
@@ -36,36 +36,35 @@ if releaselevel == 'final':
 elif '/tags/' in _init_url:  # pragma:nocover
     releaselevel = 'final'
 elif releaselevel == 'invalid':
-    from os.path import abspath, dirname, exists, join
+    from os.path import exists as _exists, join as _join
 
     if __file__.endswith('setup.py'):
-        # This file is being sources (exec'ed) from setup.py.
-        # dirname(__file__) setup.py's scope is the root sourec directory
+        # This file is being sourced (exec'ed) from setup.py.
+        # dirname(__file__) setup.py's scope is the root source directory
         _rootdir = dirname(__file__)
     else:
-        # Eventually this should import PYOMO_ROOT_DIR from
-        # pyomo.common instead of reimplementing that logic here.
+        # Ideally, this should import PYOMO_ROOT_DIR from pyomo.common
+        # instead of reimplementing that logic here.  Unfortunately,
+        # there is a circular reference (pyomo.common.log imports
+        # releaselevel).  We will leave this module completely
+        # independent of the rest of Pyomo.
         #
         # __file__ fails if script is called in different ways on Windows
         # __file__ fails if someone does os.chdir() before
-        # sys.argv[0] also fails because it doesn't not always contains the path
-        from inspect import getfile, currentframe
+        # sys.argv[0] also fails because it doesn't always contains the path
+        from inspect import getfile as _getfile, currentframe as _frame
+        from os.path import abspath as _abspath, dirname as _dirname
+        _rootdir = _join(_dirname(_abspath(_getfile(_frame()))), '..', '..')
 
-        _rootdir = join(dirname(abspath(getfile(currentframe()))), '..', '..')
-
-    if exists(join(_rootdir, '.git')):
+    if _exists(_join(_rootdir, '.git')):
         try:
-            with open(join(_rootdir, '.git', 'HEAD')) as _FILE:
-                _ref = _FILE.readline().strip()  # pragma:nocover
-            releaselevel = 'devel {%s}' % (
-                _ref.split('/')[-1].split('\\')[-1],
-            )  # pragma:nocover
+            with open(_join(_rootdir, '.git', 'HEAD')) as _FILE:
+                _ref = _FILE.readline().strip()
+            releaselevel = 'devel {%s}' % (_ref.split('/')[-1].split('\\')[-1],)
         except:
-            releaselevel = 'devel'  # pragma:nocover
-    elif exists(join(_rootdir, '.svn')):
-        releaselevel = 'devel {svn}'  # pragma:nocover
+            releaselevel = 'devel'
     else:
-        releaselevel = 'VOTD'  # pragma:nocover
+        releaselevel = 'VOTD'
 
 
 version_info = (major, minor, micro, releaselevel, serial)

--- a/pyomo/version/info.py
+++ b/pyomo/version/info.py
@@ -69,11 +69,12 @@ elif releaselevel == 'invalid':
 
 version_info = (major, minor, micro, releaselevel, serial)
 
-version = '.'.join(str(x) for x in version_info[:3])
-__version__ = version
-if releaselevel != 'final':
-    version += ' (' + releaselevel + ')'
+__version__ = '.'.join(str(x) for x in version_info[:3])
 if releaselevel.startswith('devel'):
     __version__ += ".dev%d" % (serial,)
 elif releaselevel.startswith('VOTD'):
     __version__ += "a%d" % (serial,)
+
+version = __version__
+if releaselevel != 'final':
+    version += ' (' + releaselevel + ')'


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
#2741 requests that developers set the `version=` parameter to the development version returned by `pyomo --version`.  This PR fixes `pyomo --version` so that the full `__version__` is printed out (including the `.dev0`).

This also cleans up some of the logic around the version system, adding a little documentation, and removing support for development in Subversion (which we haven't supported in more than 4 years).

## Changes proposed in this PR:
- include the development serial number in `pyomo --version`
- clean up logic in `pyomo/version/info.py`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
