### PR TITLE
Require `version=` for all deprecation utilities

### DIFF
--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -93,8 +93,8 @@ def _wrap_class(cls, msg, logger, version, remove_in):
         if _flagIdx >= 0:
             _doc = _funcDoc[_flagIdx:]
             break
-    # Note: test msg is not None to revert back to the user-supplied
-    # message.  Checking the fields is still useful as it lets us know
+    # Note: test 'msg is not None' to revert back to the user-supplied
+    # message.  Checking the fields above is still useful as it lets us know
     # if there is already a deprecation message on either new or init.
     if msg is not None or _doc is None:
         _doc = _deprecation_docstring(cls, msg, version, remove_in)
@@ -174,8 +174,9 @@ def deprecation_warning(msg, logger=None, version=None,
 
         version (str): [required] the version in which the decorated
             object was deprecated.  General practice is to set version
-            to '' or 'TBD' during development and update it to the
-            actual release as part of the release process.
+            to the current development version (from `pyomo --version`)
+            during development and update it to the actual release as
+            part of the release process.
 
         remove_in (str): the version in which the decorated object will be
             removed from the code.
@@ -249,8 +250,9 @@ def deprecated(msg=None, logger=None, version=None, remove_in=None):
 
         version (str): [required] the version in which the decorated
             object was deprecated.  General practice is to set version
-            to '' or 'TBD' during development and update it to the
-            actual release as part of the release process.
+            to the current development version (from `pyomo --version`)
+            during development and update it to the actual release as
+            part of the release process.
 
         remove_in (str): the version in which the decorated object will be
             removed from the code.
@@ -304,10 +306,10 @@ def relocated_module(new_name, msg=None, logger=None,
         pyomo package, or "pyomo")
 
     version: str [required]
-        The version in which the module was renamed or moved.
-        General practice is to set version to '' or 'TBD' during
-        development and update it to the actual release as part of the
-        release process.
+        The version in which the module was renamed or moved.  General
+        practice is to set version to the current development version
+        (from `pyomo --version`) during development and update it to the
+        actual release as part of the release process.
 
     remove_in: str
         The version in which the module will be removed from the code.

--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -33,7 +33,7 @@ from pyomo.common.errors import DeveloperError
 _doc_flag = '.. deprecated::'
 
 
-def _default_msg(obj, user_msg, version, remove_in):
+def default_deprecation_msg(obj, user_msg, version, remove_in):
     """Generate the default deprecation message.
 
     See deprecated() function for argument details.
@@ -73,8 +73,8 @@ def _deprecation_docstring(obj, msg, version, remove_in):
     if version is None: # or version in ('','tbd','TBD'):
         raise DeveloperError("@deprecated missing initial version")
     return (
-        '%s %s\n   %s\n'
-        % (_doc_flag, version, _default_msg(obj, msg, None, remove_in))
+        f'{_doc_flag} {version}\n'
+        f'   {default_deprecation_msg(obj, msg, None, remove_in)}\n'
     )
 
 
@@ -112,7 +112,7 @@ def _wrap_class(cls, msg, logger, version, remove_in):
 
 
 def _wrap_func(func, msg, logger, version, remove_in):
-    message = _default_msg(func, msg, version, remove_in)
+    message = default_deprecation_msg(func, msg, version, remove_in)
 
     @functools.wraps(func, assigned=(
         '__module__', '__name__', '__qualname__', '__annotations__'))
@@ -196,7 +196,7 @@ def deprecation_warning(msg, logger=None, version=None,
         logger = logging.getLogger(logger)
 
     msg = textwrap.fill(
-        'DEPRECATED: %s' % (_default_msg(None, msg, version, remove_in),),
+        f'DEPRECATED: {default_deprecation_msg(None, msg, version, remove_in)}',
         width=70)
     if calling_frame is None:
         # The useful thing to let the user know is what called the

--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -107,8 +107,8 @@ def _wrap_class(cls, msg, logger, version, remove_in):
         # find the "most derived" implementation of either __new__ or
         # __init__ and wrap that (breaking ties in favor of __init__)
         field = '__init__'
-        for c in cls.__mro__:
-            for f in ('__init__', '__new__'):
+        for c in reversed(cls.__mro__):
+            for f in ('__new__', '__init__'):
                 if getattr(c, f, None) is not getattr(cls, f, None):
                     field = f
         setattr(cls, field, _wrap_func(

--- a/pyomo/common/tests/test_deprecated.py
+++ b/pyomo/common/tests/test_deprecated.py
@@ -54,13 +54,13 @@ class TestDeprecated(unittest.TestCase):
 
     def test_no_version_exception(self):
         with self.assertRaisesRegex(
-                DeveloperError, "@deprecated missing initial version"):
+                DeveloperError, "@deprecated\(\): missing 'version' argument"):
             @deprecated()
             def foo():
                 pass
 
         with self.assertRaisesRegex(
-                DeveloperError, "@deprecated missing initial version"):
+                DeveloperError, "@deprecated\(\): missing 'version' argument"):
             @deprecated()
             class foo(object):
                 pass
@@ -610,7 +610,7 @@ class TestRenamedClass(unittest.TestCase):
                 __renamed_new_class__ = NewClass
 
         with self.assertRaisesRegex(
-                TypeError, "Declaring class 'DeprecatedClass' using the "
+                DeveloperError, "Declaring class 'DeprecatedClass' using the "
                 "RenamedClass metaclass, but without specifying the "
                 "__renamed__version__ class attribute"):
             class DeprecatedClass(metaclass=RenamedClass):

--- a/pyomo/common/tests/test_plugin.py
+++ b/pyomo/common/tests/test_plugin.py
@@ -271,6 +271,7 @@ class TestPlugin(TestCase):
                       out.getvalue().replace('\n', ' '))
 
         class IGone(DeprecatedInterface):
+            __deprecated_version__ = '1.2.3'
             pass
 
         out = StringIO()
@@ -288,6 +289,7 @@ class TestPlugin(TestCase):
 
         class ICustomGone(DeprecatedInterface):
             __deprecated_message__ = 'This interface is gone!'
+            __deprecated_version__ = '1.2.3'
 
         out = StringIO()
         with LoggingIntercept(out):

--- a/pyomo/scripting/plugins/check.py
+++ b/pyomo/scripting/plugins/check.py
@@ -12,9 +12,8 @@
 import argparse
 import pyomo.scripting.pyomo_parser
 import os.path
-from pyomo.common.deprecation import (
-    default_deprecation_msg as _default_deprecation_msg,
-)
+from pyomo.common.deprecation import default_deprecation_msg as _default_deprecation_msg
+
 
 class EnableDisableAction(argparse.Action):
     def add_package(self, namespace, package):
@@ -125,16 +124,20 @@ def main_exec(options):
 #
 # Add a subparser for the check command
 #
-_description="""
-WARNING: DEPRECATED: """ + _default_deprecation_msg(
-    None,
-    'The pyomo.checker module has been deprecated',
-    version='TBD',
-    remove_in='6.6',
-) + """.
+_description = (
+    """
+WARNING: DEPRECATED: """
+    + _default_deprecation_msg(
+        None,
+        'The pyomo.checker module has been deprecated',
+        version='TBD',
+        remove_in='6.6',
+    )
+    + """.
 
 This check subcommand is used to check a model script for errors.
 """
+)
 
 setup_parser(
     pyomo.scripting.pyomo_parser.add_subparser(

--- a/pyomo/scripting/plugins/check.py
+++ b/pyomo/scripting/plugins/check.py
@@ -12,7 +12,9 @@
 import argparse
 import pyomo.scripting.pyomo_parser
 import os.path
-
+from pyomo.common.deprecation import (
+    default_deprecation_msg as _default_deprecation_msg,
+)
 
 class EnableDisableAction(argparse.Action):
     def add_package(self, namespace, package):
@@ -123,17 +125,23 @@ def main_exec(options):
 #
 # Add a subparser for the check command
 #
+_description="""
+WARNING: DEPRECATED: """ + _default_deprecation_msg(
+    None,
+    'The pyomo.checker module has been deprecated',
+    version='TBD',
+    remove_in='6.6',
+) + """.
+
+This check subcommand is used to check a model script for errors.
+"""
+
 setup_parser(
     pyomo.scripting.pyomo_parser.add_subparser(
         'check',
         func=main_exec,
         help='Check a model for errors.',
-        description="""
-        WARNING: DEPRECATED: The pyomo.checker module has been deprecated as of version TBD.
-        It will be removed in version 6.6.
-        
-        This pyomo subcommand is used to check a model script for errors.
-        """,
+        description=_description,
         epilog="""
 The default behavior of this command is to assume that the model
 script is a simple Pyomo model.  Eventually, this script will support


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This overhauls the logic in the deprecation utilities to require the specification of the `version=` argument.  It also makes a useful utility public so that we don't have to hard-code a deprecation string in `pyomo/scripting/plugins/check.py`

## Changes proposed in this PR:
- rename `_default_msg` to `default_deprecation_msg`
- Require `version=` in all deprecation methods
- Correct logic when inferring the method to wrap when deprecating classes
- remove hard-coded deprecation string from `pyomo/scripting/plugins/check.py`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
