### PR TITLE
Add missing version argument to relocated_module warning in incidence_analysis

### DIFF
--- a/pyomo/contrib/incidence_analysis/util.py
+++ b/pyomo/contrib/incidence_analysis/util.py
@@ -16,4 +16,4 @@ msg = (
     " importing this functionality (e.g. solve_strongly_connected_components)"
     " directly from 'pyomo.contrib.incidence_analysis'."
 )
-relocated_module("pyomo.contrib.incidence_analysis.scc_solver", msg=msg)
+relocated_module("pyomo.contrib.incidence_analysis.scc_solver", version='TBD', msg=msg)


### PR DESCRIPTION
## Summary/Motivation:
#2727 and #2744 were merged without syncing the main branch in between which caused tests to start failing. This adds the missing version argument in incidence_analysis. The version number will be updated as part of the release process.

## Changes proposed in this PR:
- Add missing version argument in `incidence_analysis.util`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
