### PR TITLE
Dont try to use PyomoNLP in incidence analysis unless necessary

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -661,19 +661,19 @@ def _finalize_numpy(np, available):
         numeric_types.RegisterBooleanType(t)
 
 
-yaml, yaml_available = attempt_import(
-    'yaml', callback=_finalize_yaml)
-pympler, pympler_available = attempt_import(
-    'pympler', callback=_finalize_pympler)
-numpy, numpy_available = attempt_import(
-    'numpy', callback=_finalize_numpy)
-scipy, scipy_available = attempt_import(
-    'scipy', callback=_finalize_scipy,
-    deferred_submodules=['stats', 'sparse', 'spatial', 'integrate'])
-networkx, networkx_available = attempt_import('networkx')
-pandas, pandas_available = attempt_import('pandas')
 dill, dill_available = attempt_import('dill')
+networkx, networkx_available = attempt_import('networkx')
+numpy, numpy_available = attempt_import('numpy', callback=_finalize_numpy)
+pandas, pandas_available = attempt_import('pandas')
+plotly, plotly_available = attempt_import('plotly')
+pympler, pympler_available = attempt_import('pympler', callback=_finalize_pympler)
 pyutilib, pyutilib_available = attempt_import('pyutilib')
+scipy, scipy_available = attempt_import(
+    'scipy',
+    callback=_finalize_scipy,
+    deferred_submodules=['stats', 'sparse', 'spatial', 'integrate']
+)
+yaml, yaml_available = attempt_import('yaml', callback=_finalize_yaml)
 
 # Note that matplotlib.pyplot can generate a runtime error on OSX when
 # not installed as a Framework (as is the case in the CI systems)

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -15,7 +15,7 @@ useful graph algorithms.
 
 import enum
 import textwrap
-from pyomo.core.base.block import Block
+from pyomo.core.base.block import _BlockData
 from pyomo.core.base.var import Var
 from pyomo.core.base.constraint import Constraint
 from pyomo.core.base.objective import Objective
@@ -288,7 +288,7 @@ class IncidenceGraphInterface(object):
             self._incidence_graph = None
             self._variables = None
             self._constraints = None
-        elif isinstance(model, Block):
+        elif isinstance(model, _BlockData):
             self._constraints = [
                 con for con in model.component_data_objects(
                     Constraint, active=active

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -26,10 +26,10 @@ from pyomo.util.subsystems import create_subsystem_block
 from pyomo.common.collections import ComponentSet, ComponentMap
 from pyomo.common.dependencies import (
     attempt_import,
-    scipy_available,
+    networkx as nx,
     scipy as sp,
+    plotly,
 )
-from pyomo.common.dependencies import networkx as nx
 from pyomo.common.deprecation import deprecated
 from pyomo.contrib.incidence_analysis.matching import maximum_matching
 from pyomo.contrib.incidence_analysis.connected import (
@@ -46,17 +46,12 @@ from pyomo.contrib.incidence_analysis.dulmage_mendelsohn import (
     RowPartition,
     ColPartition,
 )
-
 from pyomo.contrib.pynumero.asl import AmplInterface
-asl_available = AmplInterface.available()
-if asl_available and scipy_available:
-    # Need this check due to unguarded scipy import in pyomo_nlp.py
-    # Not sure if asl_available is necessary for this import...
-    from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP
 
-plotly, plotly_available = attempt_import("plotly")
-if plotly_available:
-    go = plotly.graph_objects
+pyomo_nlp, pyomo_nlp_available = attempt_import(
+    'pyomo.contrib.pynumero.interfaces.pyomo_nlp'
+)
+asl_available = pyomo_nlp_available & AmplInterface.available()
 
 
 def _check_unindexed(complist):
@@ -245,7 +240,7 @@ def get_numeric_incidence_matrix(variables, constraints):
     _check_unindexed(comps)
     block = create_subsystem_block(constraints, variables)
     block._obj = Objective(expr=0)
-    nlp = PyomoNLP(block)
+    nlp = pyomo_nlp.PyomoNLP(block)
     return nlp.extract_submatrix_jacobian(variables, constraints)
 
 
@@ -315,7 +310,7 @@ class IncidenceGraphInterface(object):
                 # Note that include_fixed is not necessary here. We have
                 # already checked this condition above.
             )
-        elif isinstance(model, PyomoNLP):
+        elif isinstance(model, pyomo_nlp.PyomoNLP):
             if not active:
                 raise ValueError(
                     "Cannot get the Jacobian of inactive constraints from the "
@@ -349,7 +344,7 @@ class IncidenceGraphInterface(object):
         else:
             raise TypeError(
                 "Unsupported type for incidence matrix. Expected "
-                "%s or %s but got %s." % (PyomoNLP, Block, type(model))
+                "%s or %s but got %s." % (pyomo_nlp.PyomoNLP, Block, type(model))
             )
 
     @property
@@ -881,7 +876,7 @@ class IncidenceGraphInterface(object):
             edge_y.append(y0)
             edge_y.append(y1)
             edge_y.append(None)
-        edge_trace = go.Scatter(
+        edge_trace = plotly.graph_objects.Scatter(
             x=edge_x,
             y=edge_y,
             line=dict(width=0.5, color='#888'),
@@ -919,7 +914,7 @@ class IncidenceGraphInterface(object):
                     f'value: {str(v.value)}<br>domain: {str(v.domain)}<br>'
                     f'fixed: {str(v.is_fixed())}'
                 )
-        node_trace = go.Scatter(
+        node_trace = plotly.graph_objects.Scatter(
             x=node_x,
             y=node_y,
             mode='markers',
@@ -927,7 +922,7 @@ class IncidenceGraphInterface(object):
             text=node_text,
             marker=dict(color=node_color, size=10),
         )
-        fig = go.Figure(data=[edge_trace, node_trace])
+        fig = plotly.graph_objects.Figure(data=[edge_trace, node_trace])
         if title is not None:
             fig.update_layout(title=dict(text=title))
         if show:

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -24,7 +24,11 @@ from pyomo.core.expr.visitor import identify_variables
 from pyomo.core.expr.current import EqualityExpression
 from pyomo.util.subsystems import create_subsystem_block
 from pyomo.common.collections import ComponentSet, ComponentMap
-from pyomo.common.dependencies import scipy_available, attempt_import
+from pyomo.common.dependencies import (
+    attempt_import,
+    scipy_available,
+    scipy as sp,
+)
 from pyomo.common.dependencies import networkx as nx
 from pyomo.common.deprecation import deprecated
 from pyomo.contrib.incidence_analysis.matching import maximum_matching
@@ -43,13 +47,12 @@ from pyomo.contrib.incidence_analysis.dulmage_mendelsohn import (
     ColPartition,
 )
 
-asl_available = False
-if scipy_available:
-    import scipy as sp
-    from pyomo.contrib.pynumero.asl import AmplInterface
-    if AmplInterface.available():
-        asl_available = True
-        from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP
+from pyomo.contrib.pynumero.asl import AmplInterface
+asl_available = AmplInterface.available()
+if asl_available and scipy_available:
+    # Need this check due to unguarded scipy import in pyomo_nlp.py
+    # Not sure if asl_available is necessary for this import...
+    from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP
 
 plotly, plotly_available = attempt_import("plotly")
 if plotly_available:

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -12,12 +12,12 @@
 import pyomo.environ as pyo
 from pyomo.common.dependencies import (
     networkx_available,
+    plotly_available,
     scipy_available,
-    attempt_import,
 )
-plotly, plotly_available = attempt_import("plotly")
 from pyomo.common.collections import ComponentSet, ComponentMap
 from pyomo.contrib.incidence_analysis.interface import (
+    asl_available,
     IncidenceGraphInterface,
     get_structural_incidence_matrix,
     get_numeric_incidence_matrix,
@@ -42,14 +42,13 @@ if scipy_available:
 if networkx_available:
     import networkx as nx
     from networkx.algorithms.bipartite.matrix import from_biadjacency_matrix
-from pyomo.contrib.pynumero.asl import AmplInterface
 
 import pyomo.common.unittest as unittest
 
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
 @unittest.skipUnless(scipy_available, "scipy is not available.")
-@unittest.skipUnless(AmplInterface.available(), "pynumero_ASL is not available")
+@unittest.skipUnless(asl_available, "pynumero PyomoNLP is not available")
 class TestGasExpansionNumericIncidenceMatrix(unittest.TestCase):
     """
     This class tests the get_numeric_incidence_matrix function on
@@ -434,7 +433,7 @@ class TestGasExpansionStructuralIncidenceMatrix(unittest.TestCase):
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
 @unittest.skipUnless(scipy_available, "scipy is not available.")
-@unittest.skipUnless(AmplInterface.available(), "pynumero_ASL is not available")
+@unittest.skipUnless(asl_available, "pynumero PyomoNLP is not available")
 class TestGasExpansionModelInterfaceClassNumeric(unittest.TestCase):
     # In these tests, we pass the interface a PyomoNLP and cache
     # its Jacobian.

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -1345,7 +1345,7 @@ class TestExtraVars(unittest.TestCase):
 class TestExceptions(unittest.TestCase):
 
     @unittest.skipUnless(scipy_available, "scipy is not available.")
-    @unittest.skipUnless(AmplInterface.available(), "pynumero_ASL is not available")
+    @unittest.skipUnless(asl_available, "pynumero_ASL is not available")
     def test_nlp_fixed_error(self):
         m = pyo.ConcreteModel()
         m.v1 = pyo.Var()
@@ -1358,7 +1358,7 @@ class TestExceptions(unittest.TestCase):
             igraph = IncidenceGraphInterface(nlp, include_fixed=True)
 
     @unittest.skipUnless(scipy_available, "scipy is not available.")
-    @unittest.skipUnless(AmplInterface.available(), "pynumero_ASL is not available")
+    @unittest.skipUnless(asl_available, "pynumero_ASL is not available")
     def test_nlp_active_error(self):
         m = pyo.ConcreteModel()
         m.v1 = pyo.Var()
@@ -1403,7 +1403,7 @@ class TestIncludeInequality(unittest.TestCase):
         igraph = IncidenceGraphInterface(m, include_inequality=True)
         self.assertEqual(igraph.incidence_matrix.shape, (12, 8))
 
-    @unittest.skipUnless(AmplInterface.available(), "pynumero_ASL is not available")
+    @unittest.skipUnless(asl_available, "pynumero_ASL is not available")
     def test_dont_include_inequality_nlp(self):
         m = self.make_model_with_inequalities()
         m._obj = pyo.Objective(expr=0)
@@ -1411,7 +1411,7 @@ class TestIncludeInequality(unittest.TestCase):
         igraph = IncidenceGraphInterface(nlp, include_inequality=False)
         self.assertEqual(igraph.incidence_matrix.shape, (8, 8))
 
-    @unittest.skipUnless(AmplInterface.available(), "pynumero_ASL is not available")
+    @unittest.skipUnless(asl_available, "pynumero_ASL is not available")
     def test_include_inequality_nlp(self):
         m = self.make_model_with_inequalities()
         m._obj = pyo.Objective(expr=0)

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -589,7 +589,6 @@ class TestGasExpansionModelInterfaceClassNumeric(unittest.TestCase):
 
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
-@unittest.skipUnless(scipy_available, "scipy is not available.")
 class TestGasExpansionModelInterfaceClassStructural(unittest.TestCase):
     # In these tests we pass a model to the interface and are caching a
     # structural incidence matrix.
@@ -840,6 +839,7 @@ class TestGasExpansionModelInterfaceClassStructural(unittest.TestCase):
             igraph.block_triangularize(variables, constraints)
         self.assertIn('must be unindexed', str(exc.exception))
 
+    @unittest.skipUnless(scipy_available, "scipy is not available.")
     def test_remove(self):
         model = make_gas_expansion_model()
         igraph = IncidenceGraphInterface(model)
@@ -883,7 +883,6 @@ class TestGasExpansionModelInterfaceClassStructural(unittest.TestCase):
 
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
-@unittest.skipUnless(scipy_available, "scipy is not available.")
 class TestGasExpansionModelInterfaceClassNoCache(unittest.TestCase):
     # In these tests we do not cache anything and use the interface
     # simply as a convenient wrapper around the analysis functions,
@@ -1092,7 +1091,6 @@ class TestGasExpansionModelInterfaceClassNoCache(unittest.TestCase):
 
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
-@unittest.skipUnless(scipy_available, "scipy is not available.")
 class TestDulmageMendelsohnInterface(unittest.TestCase):
 
     def test_degenerate_solid_phase_model(self):
@@ -1168,6 +1166,7 @@ class TestDulmageMendelsohnInterface(unittest.TestCase):
         for con in dmp_cons_over:
             self.assertIn(con, overconstrained_cons)
 
+    @unittest.skipUnless(scipy_available, "scipy is not available.")
     def test_incidence_graph(self):
         m = make_degenerate_solid_phase_model()
         variables = list(m.component_data_objects(pyo.Var))
@@ -1218,6 +1217,7 @@ class TestDulmageMendelsohnInterface(unittest.TestCase):
         for con in con_dmp[0]+con_dmp[1]:
             self.assertIn(con, overconstrained_cons)
 
+    @unittest.skipUnless(scipy_available, "scipy is not available.")
     def test_remove(self):
         m = make_degenerate_solid_phase_model()
         variables = list(m.component_data_objects(pyo.Var))
@@ -1256,7 +1256,6 @@ class TestDulmageMendelsohnInterface(unittest.TestCase):
 
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
-@unittest.skipUnless(scipy_available, "scipy is not available.")
 class TestConnectedComponents(unittest.TestCase):
 
     def test_dynamic_model_backward(self):
@@ -1344,10 +1343,10 @@ class TestExtraVars(unittest.TestCase):
 
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
-@unittest.skipUnless(scipy_available, "scipy is not available.")
-@unittest.skipUnless(AmplInterface.available(), "pynumero_ASL is not available")
 class TestExceptions(unittest.TestCase):
 
+    @unittest.skipUnless(scipy_available, "scipy is not available.")
+    @unittest.skipUnless(AmplInterface.available(), "pynumero_ASL is not available")
     def test_nlp_fixed_error(self):
         m = pyo.ConcreteModel()
         m.v1 = pyo.Var()
@@ -1359,6 +1358,8 @@ class TestExceptions(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "fixed variables"):
             igraph = IncidenceGraphInterface(nlp, include_fixed=True)
 
+    @unittest.skipUnless(scipy_available, "scipy is not available.")
+    @unittest.skipUnless(AmplInterface.available(), "pynumero_ASL is not available")
     def test_nlp_active_error(self):
         m = pyo.ConcreteModel()
         m.v1 = pyo.Var()
@@ -1379,7 +1380,6 @@ class TestExceptions(unittest.TestCase):
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
 @unittest.skipUnless(scipy_available, "scipy is not available.")
-@unittest.skipUnless(AmplInterface.available(), "pynumero_ASL is not available")
 class TestIncludeInequality(unittest.TestCase):
     def make_model_with_inequalities(self):
         m = make_degenerate_solid_phase_model()
@@ -1404,6 +1404,7 @@ class TestIncludeInequality(unittest.TestCase):
         igraph = IncidenceGraphInterface(m, include_inequality=True)
         self.assertEqual(igraph.incidence_matrix.shape, (12, 8))
 
+    @unittest.skipUnless(AmplInterface.available(), "pynumero_ASL is not available")
     def test_dont_include_inequality_nlp(self):
         m = self.make_model_with_inequalities()
         m._obj = pyo.Objective(expr=0)
@@ -1411,6 +1412,7 @@ class TestIncludeInequality(unittest.TestCase):
         igraph = IncidenceGraphInterface(nlp, include_inequality=False)
         self.assertEqual(igraph.incidence_matrix.shape, (8, 8))
 
+    @unittest.skipUnless(AmplInterface.available(), "pynumero_ASL is not available")
     def test_include_inequality_nlp(self):
         m = self.make_model_with_inequalities()
         m._obj = pyo.Objective(expr=0)
@@ -1420,7 +1422,6 @@ class TestIncludeInequality(unittest.TestCase):
 
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
-@unittest.skipUnless(scipy_available, "scipy is not available.")
 class TestGetIncidenceGraph(unittest.TestCase):
 
     def make_test_model(self):
@@ -1582,7 +1583,6 @@ class TestGetIncidenceGraph(unittest.TestCase):
 
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
-@unittest.skipUnless(scipy_available, "scipy is not available.")
 class TestGetAdjacent(unittest.TestCase):
 
     def test_get_adjacent_to_var(self):
@@ -1628,7 +1628,6 @@ class TestGetAdjacent(unittest.TestCase):
 
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
-@unittest.skipUnless(scipy_available, "scipy is not available.")
 class TestInterface(unittest.TestCase):
 
     def test_subgraph_with_fewer_var_or_con(self):


### PR DESCRIPTION
## Fixes
Test failures when PyNumero Ampl interface not available

## Summary/Motivation:
A lot of the Incidence Analysis functionality doesn't require the ASL interface, but I was referencing `PyomoNLP` in a code path that was hit in some of these situations. This switches the order of checks in an "if" statement so that we don't try to use the ASL interface (PyomoNLP) if it's not necessary.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
