### PR TITLE
Deprecate `add_docstring_list`

### DIFF
--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -1420,7 +1420,7 @@ def add_docstring_list(docstring, configdict, indent_by=4):
         inspect.cleandoc(docstring)
         + '\n' + section + '\n' + '-'*len(section) + '\n'
         + configdict.generate_documentation(
-            indent_spacing=indent_by, width=256, format='numpydoc')
+            indent_spacing=indent_by, width=256, visibility=0, format='numpydoc')
     )
 
 

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -1401,6 +1401,11 @@ ConfigFormatter.formats = {
 }
 
 
+@deprecated(
+    "add_docstring_list is deprecated.  Please use the "
+    "@document_kwargs_from_configdict() decorator.",
+    version='6.5.1.dev0',
+)
 def add_docstring_list(docstring, configdict, indent_by=4):
     """Returns the docstring with a formatted configuration arguments listing."""
     section = 'Keyword Arguments'

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -2678,6 +2678,8 @@ c: 1.0
             cfg2.declare_from({})
 
     def test_docstring_decorator(self):
+        self.maxDiff = None
+
         @document_kwargs_from_configdict('CONFIG')
         class ExampleClass(object):
             CONFIG = ConfigDict()
@@ -2783,9 +2785,6 @@ option_1: int, default=5
     The first configuration option
 
 solver_options: dict, optional
-
-    solver_option_1: float, default=1
-        The first solver configuration option
 
     solver_option_2: float, default=1
         The second solver configuration option

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -48,7 +48,7 @@ from pyomo.common.config import (
     PositiveFloat, NegativeFloat, NonPositiveFloat, NonNegativeFloat,
     In, ListOf, Module, Path, PathList, ConfigEnum, DynamicImplicitDomain,
     ConfigFormatter, String_ConfigFormatter,
-    document_kwargs_from_configdict,
+    document_kwargs_from_configdict, add_docstring_list,
     _UnpickleableDomain, _picklable,
 )
 from pyomo.common.log import LoggingIntercept
@@ -2749,6 +2749,29 @@ option_2: int, default=5
         self.assertEqual(ExampleClass.__init__.__doc__, "A simple docstring\n" + ref)
         self.assertEqual(ExampleClass.fcn.__doc__, "A simple docstring\n" + ref)
 
+        ref = """
+Keyword Arguments
+-----------------
+option_1: int, default=5
+    The first configuration option
+
+solver_options: dict, optional
+
+    solver_option_1: float, default=1
+        The first solver configuration option
+
+    solver_option_2: float, default=1
+        The second solver configuration option
+
+        With a very long line containing wrappable text in a long, silly paragraph with little actual information.
+        #) but a bulleted list
+        #) with two bullets
+
+option_2: int, default=5
+    The second solver configuration option with a very long line containing wrappable text in a long, silly paragraph with little actual information."""
+        with LoggingIntercept() as LOG:
+            self.assertEqual(add_docstring_list("", ExampleClass.CONFIG), ref)
+        self.assertIn('add_docstring_list is deprecated', LOG.getvalue())
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/contrib/gdpopt/GDPopt.py
+++ b/pyomo/contrib/gdpopt/GDPopt.py
@@ -44,8 +44,7 @@
 - start keeping basic changelog
 
 """
-from pyomo.common.config import (
-    add_docstring_list, ConfigDict)
+from pyomo.common.config import document_kwargs_from_configdict, ConfigDict
 from pyomo.contrib.gdpopt import __version__
 from pyomo.contrib.gdpopt.config_options import (
     _add_common_configs, _supported_algorithms, _get_algorithm_config)
@@ -97,6 +96,7 @@ class GDPoptSolver(object):
     CONFIG = ConfigDict("GDPopt")
     _add_common_configs(CONFIG)
 
+    @document_kwargs_from_configdict(CONFIG)
     def solve(self, model, **kwds):
         """Solve the model.
 
@@ -154,6 +154,3 @@ class GDPoptSolver(object):
         return __version__
 
     _metasolver = False
-
-GDPoptSolver.solve.__doc__ = add_docstring_list(
-    GDPoptSolver.solve.__doc__, GDPoptSolver.CONFIG, indent_by=8)

--- a/pyomo/contrib/gdpopt/algorithm_base_class.py
+++ b/pyomo/contrib/gdpopt/algorithm_base_class.py
@@ -86,8 +86,10 @@ class _GDPoptAlgorithm():
     def solve(self, model, **kwds):
         """Solve the model.
 
-        Args:
-            model (Block): a Pyomo model or block to be solved
+        Parameters
+        ----------
+        model : Block
+            the Pyomo model or block to be solved
 
         """
         # I'm going to be nice for now and intercept with a more informative

--- a/pyomo/contrib/gdpopt/branch_and_bound.py
+++ b/pyomo/contrib/gdpopt/branch_and_bound.py
@@ -14,7 +14,7 @@ from heapq import heappush, heappop
 import traceback
 
 from pyomo.common.collections import ComponentMap
-from pyomo.common.config import add_docstring_list
+from pyomo.common.config import document_kwargs_from_configdict
 from pyomo.common.errors import InfeasibleConstraintException
 from pyomo.contrib.fbbt.fbbt import fbbt
 from pyomo.contrib.gdpopt.algorithm_base_class import _GDPoptAlgorithm
@@ -68,6 +68,11 @@ class GDP_LBB_Solver(_GDPoptAlgorithm):
     _add_BB_configs(CONFIG)
 
     algorithm = 'LBB'
+
+    # Override solve() to customize the docstring for this solver
+    @document_kwargs_from_configdict(CONFIG, doc=_GDPoptAlgorithm.solve.__doc__)
+    def solve(self, model, **kwds):
+        return super().solve(model, **kwds)
 
     def _log_citation(self, config):
         config.logger.info("\n" + """- LBB algorithm:
@@ -523,6 +528,3 @@ class GDP_LBB_Solver(_GDPoptAlgorithm):
                 config=config, ignore_integrality=True
             )
             return float('-inf'), float('inf')
-
-GDP_LBB_Solver.solve.__doc__ = add_docstring_list(
-    GDP_LBB_Solver.solve.__doc__, GDP_LBB_Solver.CONFIG, indent_by=8)

--- a/pyomo/contrib/gdpopt/enumerate.py
+++ b/pyomo/contrib/gdpopt/enumerate.py
@@ -12,7 +12,7 @@
 from itertools import product
 
 from pyomo.common.collections import ComponentSet
-from pyomo.common.config import add_docstring_list
+from pyomo.common.config import document_kwargs_from_configdict
 
 from pyomo.contrib.gdpopt.algorithm_base_class import _GDPoptAlgorithm
 from pyomo.contrib.gdpopt.config_options import (
@@ -56,6 +56,11 @@ class GDP_Enumeration_Solver(_GDPoptAlgorithm):
     _add_mip_solver_configs(CONFIG)
 
     algorithm = 'enumerate'
+
+    # Override solve() to customize the docstring for this solver
+    @document_kwargs_from_configdict(CONFIG, doc=_GDPoptAlgorithm.solve.__doc__)
+    def solve(self, model, **kwds):
+        return super().solve(model, **kwds)
 
     def _discrete_solution_iterator(self, disjunctions,
                                     non_indicator_boolean_vars,
@@ -157,8 +162,3 @@ class GDP_Enumeration_Solver(_GDPoptAlgorithm):
                         'enumerated.')
                     self.pyomo_results.solver.termination_condition = tc.optimal
                     break
-
-
-GDP_Enumeration_Solver.solve.__doc__ = add_docstring_list(
-    GDP_Enumeration_Solver.solve.__doc__, GDP_Enumeration_Solver.CONFIG,
-    indent_by=8)

--- a/pyomo/contrib/gdpopt/gloa.py
+++ b/pyomo/contrib/gdpopt/gloa.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from pyomo.common.config import add_docstring_list
+from pyomo.common.config import document_kwargs_from_configdict
 from pyomo.common.errors import DeveloperError
 from pyomo.common.modeling import unique_component_name
 from pyomo.contrib.gdp_bounds.info import disjunctive_bounds
@@ -52,6 +52,11 @@ class GDP_GLOA_Solver(_GDPoptAlgorithm, _OAAlgorithmMixIn):
     _add_tolerance_configs(CONFIG)
 
     algorithm = 'GLOA'
+
+    # Override solve() to customize the docstring for this solver
+    @document_kwargs_from_configdict(CONFIG, doc=_GDPoptAlgorithm.solve.__doc__)
+    def solve(self, model, **kwds):
+        return super().solve(model, **kwds)
 
     def _log_citation(self, config):
         config.logger.info("\n" + """- GLOA algorithm:
@@ -191,6 +196,3 @@ class GDP_GLOA_Solver(_GDPoptAlgorithm, _OAAlgorithmMixIn):
                 counter += 2
 
                 config.logger.debug("Added %s affine cuts" % counter)
-
-GDP_GLOA_Solver.solve.__doc__ = add_docstring_list(
-    GDP_GLOA_Solver.solve.__doc__, GDP_GLOA_Solver.CONFIG, indent_by=8)

--- a/pyomo/contrib/gdpopt/loa.py
+++ b/pyomo/contrib/gdpopt/loa.py
@@ -13,7 +13,7 @@ from collections import namedtuple
 from math import copysign
 
 from pyomo.common.collections import ComponentMap
-from pyomo.common.config import add_docstring_list
+from pyomo.common.config import document_kwargs_from_configdict
 from pyomo.common.modeling import unique_component_name
 from pyomo.contrib.gdpopt.algorithm_base_class import _GDPoptAlgorithm
 from pyomo.contrib.gdpopt.config_options import (
@@ -59,6 +59,11 @@ class GDP_LOA_Solver(_GDPoptAlgorithm, _OAAlgorithmMixIn):
     _add_tolerance_configs(CONFIG)
 
     algorithm = 'LOA'
+
+    # Override solve() to customize the docstring for this solver
+    @document_kwargs_from_configdict(CONFIG, doc=_GDPoptAlgorithm.solve.__doc__)
+    def solve(self, model, **kwds):
+        return super().solve(model, **kwds)
 
     def _log_citation(self, config):
         config.logger.info("\n" + """- LOA algorithm:
@@ -275,6 +280,3 @@ class GDP_LOA_Solver(_GDPoptAlgorithm, _OAAlgorithmMixIn):
                 jacobian.jac.clear()
 
         config.logger.debug('Added %s OA cuts' % counter)
-
-GDP_LOA_Solver.solve.__doc__ = add_docstring_list(
-    GDP_LOA_Solver.solve.__doc__, GDP_LOA_Solver.CONFIG, indent_by=8)

--- a/pyomo/contrib/gdpopt/ric.py
+++ b/pyomo/contrib/gdpopt/ric.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from pyomo.common.config import add_docstring_list
+from pyomo.common.config import document_kwargs_from_configdict
 from pyomo.contrib.gdpopt.algorithm_base_class import _GDPoptAlgorithm
 from pyomo.contrib.gdpopt.config_options import (
     _add_mip_solver_configs, _add_nlp_solver_configs, _add_tolerance_configs,
@@ -47,6 +47,11 @@ class GDP_RIC_Solver(_GDPoptAlgorithm, _OAAlgorithmMixIn):
     _add_oa_configs(CONFIG)
 
     algorithm = 'RIC'
+
+    # Override solve() to customize the docstring for this solver
+    @document_kwargs_from_configdict(CONFIG, doc=_GDPoptAlgorithm.solve.__doc__)
+    def solve(self, model, **kwds):
+        return super().solve(model, **kwds)
 
     def _solve_gdp(self, original_model, config):
         logger = config.logger
@@ -93,6 +98,3 @@ class GDP_RIC_Solver(_GDPoptAlgorithm, _OAAlgorithmMixIn):
                                       objective_sense, config, timing):
         # Nothing to do here
         pass
-
-GDP_RIC_Solver.solve.__doc__ = add_docstring_list(
-    GDP_RIC_Solver.solve.__doc__, GDP_RIC_Solver.CONFIG, indent_by=8)

--- a/pyomo/contrib/mindtpy/MindtPy.py
+++ b/pyomo/contrib/mindtpy/MindtPy.py
@@ -55,7 +55,7 @@
 from pyomo.contrib.mindtpy import __version__
 from pyomo.opt import SolverFactory
 from pyomo.contrib.mindtpy.config_options import _get_MindtPy_config
-from pyomo.common.config import add_docstring_list
+from pyomo.common.config import document_kwargs_from_configdict
 from pyomo.contrib.mindtpy.config_options import _supported_algorithms
 
 
@@ -99,7 +99,7 @@ class MindtPySolver(object):
         return __version__
 
 
-
+    @document_kwargs_from_configdict(CONFIG)
     def solve(self, model, **kwds):
         """Solve the model.
 
@@ -127,8 +127,3 @@ class MindtPySolver(object):
 
     def __exit__(self, t, v, traceback):
         pass
-
-
-# Add the CONFIG arguments to the solve method docstring
-MindtPySolver.solve.__doc__ = add_docstring_list(
-    MindtPySolver.solve.__doc__, MindtPySolver.CONFIG, indent_by=8)

--- a/pyomo/contrib/multistart/multi.py
+++ b/pyomo/contrib/multistart/multi.py
@@ -15,7 +15,7 @@ from __future__ import division
 import logging
 
 from pyomo.common.config import (
-    ConfigBlock, ConfigValue, In, add_docstring_list
+    ConfigBlock, ConfigValue, In, document_kwargs_from_configdict
 )
 from pyomo.common.modeling import unique_component_name
 from pyomo.contrib.multistart.high_conf_stop import should_stop
@@ -29,6 +29,7 @@ logger = logging.getLogger('pyomo.contrib.multistart')
 
 @SolverFactory.register('multistart',
                         doc='MultiStart solver for NLPs')
+@document_kwargs_from_configdict('CONFIG')
 class MultiStart(object):
     """Solver wrapper that initializes at multiple starting points.
 
@@ -95,8 +96,6 @@ class MultiStart(object):
         default=0,
         description="Tolerance on HCS objective value equality. Defaults to Python float equality precision."
     ))
-
-    __doc__ = add_docstring_list(__doc__, CONFIG)
 
     def available(self, exception_flag=True):
         """Check if solver is available.

--- a/pyomo/contrib/preprocessing/plugins/bounds_to_vars.py
+++ b/pyomo/contrib/preprocessing/plugins/bounds_to_vars.py
@@ -17,8 +17,12 @@ from math import fabs
 import math
 
 from pyomo.core.base.transformation import TransformationFactory
-from pyomo.common.config import (ConfigBlock, ConfigValue, NonNegativeFloat,
-                                 add_docstring_list)
+from pyomo.common.config import (
+    ConfigBlock,
+    ConfigValue,
+    NonNegativeFloat,
+    document_kwargs_from_configdict,
+)
 from pyomo.core.base.constraint import Constraint
 from pyomo.core.expr.numvalue import value
 from pyomo.core.plugins.transform.hierarchy import IsomorphicTransformation
@@ -27,6 +31,7 @@ from pyomo.repn import generate_standard_repn
 
 @TransformationFactory.register('contrib.constraints_to_var_bounds',
           doc="Change constraints to be a bound on the variable.")
+@document_kwargs_from_configdict('CONFIG')
 class ConstraintToVarBoundTransform(IsomorphicTransformation):
     """Change constraints to be a bound on the variable.
 
@@ -49,8 +54,6 @@ class ConstraintToVarBoundTransform(IsomorphicTransformation):
         description="If True, fix variable when "
         ":math:`| LB - UB | \\leq tolerance`."
     ))
-
-    __doc__ = add_docstring_list(__doc__, CONFIG)
 
     def _apply_to(self, model, **kwds):
         config = self.CONFIG(kwds)

--- a/pyomo/contrib/preprocessing/plugins/deactivate_trivial_constraints.py
+++ b/pyomo/contrib/preprocessing/plugins/deactivate_trivial_constraints.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 #  ___________________________________________________________________________
 #
 #  Pyomo: Python Optimization Modeling Objects
@@ -15,8 +14,12 @@
 import logging
 
 from pyomo.common.collections import ComponentSet
-from pyomo.common.config import (ConfigBlock, ConfigValue, NonNegativeFloat,
-                                 add_docstring_list)
+from pyomo.common.config import (
+    ConfigBlock,
+    ConfigValue,
+    NonNegativeFloat,
+    document_kwargs_from_configdict,
+)
 from pyomo.common.errors import InfeasibleConstraintException
 from pyomo.core.base.constraint import Constraint
 from pyomo.core.base.transformation import TransformationFactory
@@ -29,6 +32,7 @@ logger = logging.getLogger('pyomo.contrib.preprocessing')
 @TransformationFactory.register(
         'contrib.deactivate_trivial_constraints',
         doc="Deactivate trivial constraints.")
+@document_kwargs_from_configdict('CONFIG')
 class TrivialConstraintDeactivator(IsomorphicTransformation):
     """Deactivates trivial constraints.
 
@@ -61,8 +65,6 @@ class TrivialConstraintDeactivator(IsomorphicTransformation):
         default=1E-13, domain=NonNegativeFloat,
         description="tolerance on constraint violations"
     ))
-
-    __doc__ = add_docstring_list(__doc__, CONFIG)
 
 
     def _apply_to(self, instance, **kwargs):

--- a/pyomo/contrib/preprocessing/plugins/detect_fixed_vars.py
+++ b/pyomo/contrib/preprocessing/plugins/detect_fixed_vars.py
@@ -14,8 +14,12 @@ from math import fabs
 
 from pyomo.core.base.transformation import TransformationFactory
 from pyomo.common.collections import ComponentMap
-from pyomo.common.config import (ConfigBlock, ConfigValue, NonNegativeFloat,
-                                 add_docstring_list)
+from pyomo.common.config import (
+    ConfigBlock,
+    ConfigValue,
+    NonNegativeFloat,
+    document_kwargs_from_configdict,
+)
 from pyomo.core.base.var import Var
 from pyomo.core.expr.numvalue import value
 from pyomo.core.plugins.transform.hierarchy import IsomorphicTransformation
@@ -24,6 +28,7 @@ from pyomo.core.plugins.transform.hierarchy import IsomorphicTransformation
 @TransformationFactory.register(
         'contrib.detect_fixed_vars',
         doc="Detect variables that are de-facto fixed but not considered fixed.")
+@document_kwargs_from_configdict('CONFIG')
 class FixedVarDetector(IsomorphicTransformation):
     """Detects variables that are de-facto fixed but not considered fixed.
 
@@ -46,8 +51,6 @@ class FixedVarDetector(IsomorphicTransformation):
         default=1E-13, domain=NonNegativeFloat,
         description="tolerance on bound equality (LB == UB)"
     ))
-
-    __doc__ = add_docstring_list(__doc__, CONFIG)
 
     def _apply_to(self, instance, **kwargs):
         config = self.CONFIG(kwargs)

--- a/pyomo/contrib/preprocessing/plugins/equality_propagate.py
+++ b/pyomo/contrib/preprocessing/plugins/equality_propagate.py
@@ -18,7 +18,11 @@ from pyomo.core.base.suffix import Suffix
 from pyomo.core.expr.numvalue import value
 from pyomo.core.plugins.transform.hierarchy import IsomorphicTransformation
 from pyomo.repn.standard_repn import generate_standard_repn
-from pyomo.common.config import ConfigBlock, ConfigValue, add_docstring_list
+from pyomo.common.config import (
+    ConfigBlock,
+    ConfigValue,
+    document_kwargs_from_configdict,
+)
 from pyomo.common.errors import InfeasibleConstraintException
 
 
@@ -80,6 +84,7 @@ def _detect_fixed_variables(m):
 
 @TransformationFactory.register('contrib.propagate_fixed_vars',
           doc="Propagate variable fixing for equalities of type x = y.")
+@document_kwargs_from_configdict('CONFIG')
 class FixedVarPropagator(IsomorphicTransformation):
     """Propagate variable fixing for equalities of type :math:`x = y`.
 
@@ -100,8 +105,6 @@ class FixedVarPropagator(IsomorphicTransformation):
         description="True to store the set of transformed variables and "
         "their old states so that they can be later restored."
     ))
-
-    __doc__ = add_docstring_list(__doc__, CONFIG)
 
     def _apply_to(self, instance, **kwds):
         config = self.CONFIG(kwds)
@@ -150,6 +153,7 @@ class FixedVarPropagator(IsomorphicTransformation):
 
 @TransformationFactory.register('contrib.propagate_eq_var_bounds',
           doc="Propagate variable bounds for equalities of type x = y.")
+@document_kwargs_from_configdict('CONFIG')
 class VarBoundPropagator(IsomorphicTransformation):
     """Propagate variable bounds for equalities of type :math:`x = y`.
 
@@ -167,8 +171,6 @@ class VarBoundPropagator(IsomorphicTransformation):
         description="True to store the set of transformed variables and "
         "their old states so that they can be later restored."
     ))
-
-    __doc__ = add_docstring_list(__doc__, CONFIG)
 
     def _apply_to(self, instance, **kwds):
         config = self.CONFIG(kwds)

--- a/pyomo/contrib/preprocessing/plugins/induced_linearity.py
+++ b/pyomo/contrib/preprocessing/plugins/induced_linearity.py
@@ -24,8 +24,12 @@ import textwrap
 from math import fabs
 
 from pyomo.common.collections import ComponentMap, ComponentSet
-from pyomo.common.config import (ConfigBlock, ConfigValue, NonNegativeFloat,
-                                 add_docstring_list)
+from pyomo.common.config import (
+    ConfigBlock,
+    ConfigValue,
+    NonNegativeFloat,
+    document_kwargs_from_configdict,
+)
 from pyomo.common.modeling import unique_component_name
 from pyomo.contrib.preprocessing.util import SuppressConstantObjectiveWarning
 from pyomo.core import (Binary, Block, Constraint, Objective, Set,
@@ -41,6 +45,7 @@ logger = logging.getLogger('pyomo.contrib.preprocessing')
 
 @TransformationFactory.register('contrib.induced_linearity',
           doc="Reformulate nonlinear constraints with induced linearity.")
+@document_kwargs_from_configdict('CONFIG')
 class InducedLinearity(IsomorphicTransformation):
     """Reformulate nonlinear constraints with induced linearity.
 
@@ -75,8 +80,6 @@ class InducedLinearity(IsomorphicTransformation):
         default='glpk',
         description="Solver to use when pruning possible values."
     ))
-
-    __doc__ = add_docstring_list(__doc__, CONFIG)
 
     def _apply_to(self, model, **kwds):
         """Apply the transformation to the given model."""

--- a/pyomo/contrib/preprocessing/plugins/strip_bounds.py
+++ b/pyomo/contrib/preprocessing/plugins/strip_bounds.py
@@ -12,7 +12,11 @@
 """Transformation to strip variable bounds from a model."""
 
 from pyomo.common.collections import ComponentMap
-from pyomo.common.config import ConfigBlock, ConfigValue, add_docstring_list
+from pyomo.common.config import (
+    ConfigBlock,
+    ConfigValue,
+    document_kwargs_from_configdict,
+)
 from pyomo.core.base.transformation import TransformationFactory
 from pyomo.core.base.var import Var
 from pyomo.core.base.set_types import Reals
@@ -21,6 +25,7 @@ from pyomo.core.plugins.transform.hierarchy import NonIsomorphicTransformation
 
 @TransformationFactory.register('contrib.strip_var_bounds',
           doc="Strip bounds from varaibles.")
+@document_kwargs_from_configdict('CONFIG')
 class VariableBoundStripper(NonIsomorphicTransformation):
     """Strip bounds from variables.
 
@@ -39,8 +44,6 @@ class VariableBoundStripper(NonIsomorphicTransformation):
         description="Whether the bound stripping will be temporary. "
         "If so, store information for reversion."
     ))
-
-    __doc__ = add_docstring_list(__doc__, CONFIG)
 
     def _apply_to(self, instance, **kwds):
         config = self.CONFIG(kwds)

--- a/pyomo/contrib/trustregion/TRF.py
+++ b/pyomo/contrib/trustregion/TRF.py
@@ -22,7 +22,7 @@ from pyomo.core.base.range import NumericRange
 from pyomo.common.config import (ConfigDict, ConfigValue,
                                  Bool, PositiveInt,
                                  PositiveFloat, In,
-                                 add_docstring_list)
+                                 document_kwargs_from_configdict)
 from pyomo.contrib.trustregion.filter import Filter, FilterElement
 from pyomo.contrib.trustregion.interface import TRFInterface
 from pyomo.contrib.trustregion.util import IterationLogger
@@ -390,6 +390,7 @@ class TrustRegionSolver(object):
     def __exit__(self, et, ev, tb):
         pass
 
+    @document_kwargs_from_configdict(CONFIG)
     def solve(self, model, degrees_of_freedom_variables,
               ext_fcn_surrogate_map_rule=None, **kwds):
         """
@@ -397,9 +398,9 @@ class TrustRegionSolver(object):
 
         Parameters
         ----------
-        model: ``ConcreteModel``
+        model : ConcreteModel
             The model to be solved using the Trust Region Framework.
-        degrees_of_freedom_variables : List of Vars
+        degrees_of_freedom_variables : List[Var]
             User-supplied input. The user must provide a list of vars which
             are the degrees of freedom or decision variables within
             the model.
@@ -423,10 +424,3 @@ class TrustRegionSolver(object):
                             ext_fcn_surrogate_map_rule,
                             config)
         return result
-
-
-def _generate_filtered_docstring():
-    cfg = _trf_config()
-    return add_docstring_list(TrustRegionSolver.solve.__doc__, cfg, indent_by=8)
-
-TrustRegionSolver.solve.__doc__ = _generate_filtered_docstring()

--- a/pyomo/gdp/plugins/partition_disjuncts.py
+++ b/pyomo/gdp/plugins/partition_disjuncts.py
@@ -17,7 +17,11 @@ Relaxations between big-M and Convex Hull Reformulations," 2021.
 """
 from __future__ import division
 
-from pyomo.common.config import (ConfigBlock, ConfigValue, add_docstring_list)
+from pyomo.common.config import (
+    ConfigBlock,
+    ConfigValue,
+    document_kwargs_from_configdict,
+)
 from pyomo.common.modeling import unique_component_name
 from pyomo.core import ( Block, Constraint, Var, SortComponents, Transformation,
                          TransformationFactory, TraversalStrategy,
@@ -153,6 +157,7 @@ def compute_fbbt_bounds(expr, global_constraints, opt):
                                 doc="Reformulates a convex disjunctive model "
                                 "into a new GDP by splitting additively "
                                 "separable constraints on P sets of variables")
+@document_kwargs_from_configdict('CONFIG')
 class PartitionDisjuncts_Transformation(Transformation):
     """
     Transform disjunctive model to equivalent disjunctive model (with
@@ -789,8 +794,3 @@ class PartitionDisjuncts_Transformation(Transformation):
                                   transformed_parent_disjunct, transBlock,
                                   partition):
         _warn_for_active_disjunct(disjunct, parent_disjunct)
-
-# Add the CONFIG arguments to the transformation's docstring
-PartitionDisjuncts_Transformation.__doc__ = add_docstring_list(
-    PartitionDisjuncts_Transformation.__doc__,
-    PartitionDisjuncts_Transformation.CONFIG, indent_by=8)

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -17,7 +17,12 @@ from collections import deque
 from operator import itemgetter, attrgetter, setitem
 
 from pyomo.common.backports import nullcontext
-from pyomo.common.config import ConfigBlock, ConfigValue, InEnum, add_docstring_list
+from pyomo.common.config import (
+    ConfigBlock,
+    ConfigValue,
+    InEnum,
+    document_kwargs_from_configdict,
+)
 from pyomo.common.deprecation import deprecation_warning
 from pyomo.common.errors import DeveloperError
 from pyomo.common.gc_manager import PauseGC
@@ -347,6 +352,7 @@ class NLWriter(object):
         # was generated and the symbol_map
         return filename, symbol_map
 
+    @document_kwargs_from_configdict(CONFIG)
     def write(self, model, ostream, rowstream=None, colstream=None, **options):
         """Write a model in NL format.
 
@@ -380,8 +386,6 @@ class NLWriter(object):
         # small objects.
         with _NLWriter_impl(ostream, rowstream, colstream, config) as impl:
             return impl.write(model)
-
-    write.__doc__ = add_docstring_list(write.__doc__, CONFIG)
 
     def _generate_symbol_map(self, info):
         # Now that the row/column ordering is resolved, create the labels


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This PR is a follow-on to #2754 (and includes it). This 
- removes use of `add_docstring_list`, replacing it with `@document_kwargs_from_configdict`
- deprecates `add_docstring_list`
- tests the deprecation warning

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
