### PR TITLE
NEOS: fix typo in `kestrelAMPL.kill()` argument

### DIFF
--- a/pyomo/neos/kestrel.py
+++ b/pyomo/neos/kestrel.py
@@ -131,7 +131,7 @@ class kestrelAMPL(object):
     def tempfile(self):
         return os.path.join(tempfile.gettempdir(), 'at%s.jobs' % os.getenv('ampl_id'))
 
-    def kill(self, jobnumber, password):
+    def kill(self, jobNumber, password):
         response = self.neos.killJob(jobNumber, password)
         logger.info(response)
 

--- a/pyomo/util/check_units.py
+++ b/pyomo/util/check_units.py
@@ -57,7 +57,7 @@ def check_units_equivalent(*args):
 
     Returns
     -------
-    bool : True if all the expressions passed as argments have the same units
+    bool : True if all the expressions passed as arguments have the same units
     """
     try:
         assert_units_equivalent(*args)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This fixes a typo in the argument to `kill()` that led to an unexpected testing failure (https://github.com/Pyomo/pyomo/actions/runs/4289618992/jobs/7483643619).

## Changes proposed in this PR:
- Correct argument name in `kestrelAMPL.kill()`
- NFC: fix unrelated doc spelling error (identified by @eslickj)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
