### PR TITLE
Link documentation in incidence analysis readme

### DIFF
--- a/pyomo/contrib/incidence_analysis/README.md
+++ b/pyomo/contrib/incidence_analysis/README.md
@@ -6,7 +6,9 @@ constraints.
 These tools can be used to detect whether and (approximately) why the Jacobian
 of equality constraints is structurally or numerically singular, which
 commonly happens as the result of a modeling error.
-See the documentation (TODO: link) for more information and examples.
+See the
+[documentation](https://pyomo.readthedocs.io/en/stable/contributed_packages/incidence/index.html)
+for more information and examples.
 
 ## Dependencies
 
@@ -65,7 +67,7 @@ for con in oc_con:
 print()
 
 print("Underconstrained subsystem")
-print("-------------------------")
+print("--------------------------")
 print("Variables")
 for var in uc_var:
     print(f"  {var.name}")
@@ -90,7 +92,7 @@ Constraints
   density_eqn
 
 Underconstrained subsystem
--------------------------
+--------------------------
 Variables
   flow_comp[1]
   flow

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_implicit_functions.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_implicit_functions.py
@@ -17,6 +17,7 @@ from pyomo.common.dependencies import (
     scipy_available,
     numpy as np,
     numpy_available,
+    networkx_available,
 )
 from pyomo.contrib.pynumero.asl import AmplInterface
 from pyomo.contrib.pynumero.algorithms.solvers.implicit_functions import (
@@ -301,6 +302,7 @@ class TestImplicitFunctionSolver(_TestSolver):
         self._test_implicit_function_with_extra_variables()
 
 
+@unittest.skipUnless(networkx_available, "NetworkX is not available")
 class TestSccImplicitFunctionSolver(_TestSolver):
 
     def get_solver_class(self):


### PR DESCRIPTION
Adds link to documentation in Incidence Analysis readme. Previously this was left as a TODO. 

Also adds a skipUnless mark to some tests in PyNumero so they don't fail on environments where SciPy and ASL are available but NetworkX isn't.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
