### PR TITLE
[WIP] Adding JPOF Contrib Package (deprecated)

### DIFF
--- a/pyomo/contrib/jpof/__init__.py
+++ b/pyomo/contrib/jpof/__init__.py
@@ -1,0 +1,13 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+from pyomo.contrib.jpof.jpof_writer import JPOFWriter
+

--- a/pyomo/contrib/jpof/example/dsrosen.py
+++ b/pyomo/contrib/jpof/example/dsrosen.py
@@ -1,0 +1,29 @@
+import pyomo.environ as pe
+import json_writer
+
+def create(N):
+    M = pe.ConcreteModel()
+
+    def x_init(model, i):
+        if i % 2 == 1:
+            return -1.2 
+        else:
+            return 1.2
+
+    M.x = pe.Var(pe.RangeSet(1,N), initialize=x_init)
+    M.p = pe.Param(initialize=0, mutable=True)
+    M.I = pe.RangeSet(1,N-1)
+
+    M.f = pe.Objective(expr=sum( 100*(M.x[i+1]-M.x[i]**2+M.p)**2 + (1-M.x[i])**2 for i in M.I))
+
+    return M
+
+writer = json_writer.JPOFWriter()
+
+M = create(3)
+writer(M, filename="dsrosen3.jpof", io_options={'file_determinism':3, 'symbolic_solver_labels':True})
+M = create(6)
+writer(M, filename="dsrosen6.jpof", io_options={'file_determinism':3, 'symbolic_solver_labels':True})
+M = create(10)
+writer(M, filename="dsrosen10.jpof", io_options={'file_determinism':3, 'symbolic_solver_labels':True})
+

--- a/pyomo/contrib/jpof/example/dsrosen.py
+++ b/pyomo/contrib/jpof/example/dsrosen.py
@@ -1,5 +1,5 @@
 import pyomo.environ as pe
-import json_writer
+import pyomo.contrib.jpof
 
 def create(N):
     M = pe.ConcreteModel()
@@ -18,7 +18,7 @@ def create(N):
 
     return M
 
-writer = json_writer.JPOFWriter()
+writer = pyomo.contrib.jpof.JPOFWriter()
 
 M = create(3)
 writer(M, filename="dsrosen3.jpof", io_options={'file_determinism':3, 'symbolic_solver_labels':True})

--- a/pyomo/contrib/jpof/example/dsrosen10.jpof
+++ b/pyomo/contrib/jpof/example/dsrosen10.jpof
@@ -1,0 +1,106 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "sum,18,*,N,100,pow,sum,3,V,1,neg,pow,V,0,N,2,P,0,N,2,pow,+,*,N,-1,V,0,N,1,N,2,*,N,100,pow,sum,3,V,2,neg,pow,V,1,N,2,P,0,N,2,pow,+,*,N,-1,V,1,N,1,N,2,*,N,100,pow,sum,3,V,3,neg,pow,V,2,N,2,P,0,N,2,pow,+,*,N,-1,V,2,N,1,N,2,*,N,100,pow,sum,3,V,4,neg,pow,V,3,N,2,P,0,N,2,pow,+,*,N,-1,V,3,N,1,N,2,*,N,100,pow,sum,3,V,5,neg,pow,V,4,N,2,P,0,N,2,pow,+,*,N,-1,V,4,N,1,N,2,*,N,100,pow,sum,3,V,6,neg,pow,V,5,N,2,P,0,N,2,pow,+,*,N,-1,V,5,N,1,N,2,*,N,100,pow,sum,3,V,7,neg,pow,V,6,N,2,P,0,N,2,pow,+,*,N,-1,V,6,N,1,N,2,*,N,100,pow,sum,3,V,8,neg,pow,V,7,N,2,P,0,N,2,pow,+,*,N,-1,V,7,N,1,N,2,*,N,100,pow,sum,3,V,9,neg,pow,V,8,N,2,P,0,N,2,pow,+,*,N,-1,V,8,N,1,N,2",
+        "sense": "min",
+        "label": "f"
+      }
+    ],
+    "con": [],
+    "var": [
+      {
+        "label": "x[1]",
+        "id": 0,
+        "value": -1.2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[2]",
+        "id": 1,
+        "value": 1.2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[3]",
+        "id": 2,
+        "value": -1.2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[4]",
+        "id": 3,
+        "value": 1.2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[5]",
+        "id": 4,
+        "value": -1.2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[6]",
+        "id": 5,
+        "value": 1.2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[7]",
+        "id": 6,
+        "value": -1.2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[8]",
+        "id": 7,
+        "value": 1.2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[9]",
+        "id": 8,
+        "value": -1.2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[10]",
+        "id": 9,
+        "value": 1.2,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [
+      {
+        "label": "p",
+        "id": 0,
+        "value": 0
+      }
+    ],
+    "set": {},
+    "indexed_vars": [
+      "x"
+    ],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/example/dsrosen3.jpof
+++ b/pyomo/contrib/jpof/example/dsrosen3.jpof
@@ -1,0 +1,57 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "sum,4,*,N,100,pow,sum,3,V,1,neg,pow,V,0,N,2,P,0,N,2,pow,+,*,N,-1,V,0,N,1,N,2,*,N,100,pow,sum,3,V,2,neg,pow,V,1,N,2,P,0,N,2,pow,+,*,N,-1,V,1,N,1,N,2",
+        "sense": "min",
+        "label": "f"
+      }
+    ],
+    "con": [],
+    "var": [
+      {
+        "label": "x[1]",
+        "id": 0,
+        "value": -1.2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[2]",
+        "id": 1,
+        "value": 1.2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[3]",
+        "id": 2,
+        "value": -1.2,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [
+      {
+        "label": "p",
+        "id": 0,
+        "value": 0
+      }
+    ],
+    "set": {},
+    "indexed_vars": [
+      "x"
+    ],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/example/dsrosen6.jpof
+++ b/pyomo/contrib/jpof/example/dsrosen6.jpof
@@ -1,0 +1,78 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "sum,10,*,N,100,pow,sum,3,V,1,neg,pow,V,0,N,2,P,0,N,2,pow,+,*,N,-1,V,0,N,1,N,2,*,N,100,pow,sum,3,V,2,neg,pow,V,1,N,2,P,0,N,2,pow,+,*,N,-1,V,1,N,1,N,2,*,N,100,pow,sum,3,V,3,neg,pow,V,2,N,2,P,0,N,2,pow,+,*,N,-1,V,2,N,1,N,2,*,N,100,pow,sum,3,V,4,neg,pow,V,3,N,2,P,0,N,2,pow,+,*,N,-1,V,3,N,1,N,2,*,N,100,pow,sum,3,V,5,neg,pow,V,4,N,2,P,0,N,2,pow,+,*,N,-1,V,4,N,1,N,2",
+        "sense": "min",
+        "label": "f"
+      }
+    ],
+    "con": [],
+    "var": [
+      {
+        "label": "x[1]",
+        "id": 0,
+        "value": -1.2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[2]",
+        "id": 1,
+        "value": 1.2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[3]",
+        "id": 2,
+        "value": -1.2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[4]",
+        "id": 3,
+        "value": 1.2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[5]",
+        "id": 4,
+        "value": -1.2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[6]",
+        "id": 5,
+        "value": 1.2,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [
+      {
+        "label": "p",
+        "id": 0,
+        "value": 0
+      }
+    ],
+    "set": {},
+    "indexed_vars": [
+      "x"
+    ],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/jpof_writer.py
+++ b/pyomo/contrib/jpof/jpof_writer.py
@@ -1,0 +1,520 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+__all__ = ['ProblemWriter_json']
+
+#
+# JSON Problem Writer Plugin
+#
+"""
+The goal of this format is to enable rapid serialization of Pyomo models
+capturing information about the mutable parameters and fixed variables
+in the model.  Additionally, this format uses JSON to enable robust
+parsing with standard techniques.
+
+Note that this format does not do some of the reformulation that is
+done with serialization formats like LP or NL, where linear or quadratic 
+structure is identified.  Instead, the assumption is that the solver
+interface would analyze the model expressions in a manner that is best
+suited for their analysis.
+
+This formulation expresses objective and constraint expressions in a
+compact expression tree.  However, this uses a comma-separated format
+that is relatively easy to read.
+"""
+
+try:
+    basestring
+except:
+    basestring = str
+
+import itertools
+import logging
+import operator
+import os
+import time
+try:
+    import ujson as json
+except:
+    import json
+
+from math import isclose
+
+from pyomo.common.gc_manager import PauseGC
+from pyomo.opt import ProblemFormat, AbstractProblemWriter, WriterFactory
+from pyomo.core.expr import current as EXPR
+from pyomo.core.expr.numvalue import (NumericConstant,
+                                      native_numeric_types,
+                                      value,
+                                      is_constant,
+                                      is_fixed)
+from pyomo.core.base import SymbolMap, NameLabeler, _ExpressionData, SortComponents, var, param, Var, ExternalFunction, ComponentMap, Objective, Constraint, SOSConstraint, Suffix, Param
+import pyomo.core.base.suffix
+from pyomo.repn.standard_repn import generate_standard_repn
+
+import pyomo.core.kernel.suffix
+from pyomo.core.kernel.block import IBlock
+from pyomo.core.kernel.expression import IIdentityExpression
+from pyomo.core.kernel.variable import IVariable
+
+from six import iteritems
+from six.moves import xrange
+
+logger = logging.getLogger('pyomo.core')
+
+
+
+class JPOFWriter(AbstractProblemWriter):
+
+    def __init__(self):
+        pass
+
+    def __call__(self,
+                 model,
+                 filename=None,
+                 solver_capability=None,
+                 io_options={},
+                 sets=[]):
+
+        # Make sure not to modify the user's dictionary, they may be
+        # reusing it outside of this call
+        io_options = dict(io_options)
+
+        # Skip writing constraints whose body section is fixed (i.e., no variables)
+        skip_trivial_constraints = io_options.pop("skip_trivial_constraints", False)
+
+        # How much effort do we want to put into ensuring the
+        # file is written deterministically for a Pyomo model:
+        #    0 : None
+        #    1 : sort keys of indexed components (default)
+        #    2 : sort keys AND sort names (over declaration order)
+        file_determinism = io_options.pop("file_determinism", 1)
+
+        # Add row/col data that labels variable and constraint indices in the NLP
+        # matrix.
+        self._symbolic_solver_labels = io_options.pop("symbolic_solver_labels", False)
+
+        # If False, we raise an error if fixed variables are
+        # encountered in the list of active variables (i.e., an
+        # expression containing some fixed variable was not
+        # preprocessed after the variable was fixed). If True, we
+        # allow this case and modify the variable bounds section to
+        # fix the variable.
+        self._output_fixed_variable_bounds = io_options.pop("output_fixed_variable_bounds", False)
+
+        # If False, unused variables will not be included in
+        # the JSON file. Otherwise, include all variables in
+        # the bounds sections.
+        include_all_variable_bounds = io_options.pop("include_all_variable_bounds", False)
+
+        if len(io_options):
+            raise ValueError(
+                "ProblemWriter_json passed unrecognized io_options:\n\t" +
+                "\n\t".join("%s = %s" % (k,v) for k,v in iteritems(io_options)))
+
+        if filename is None:
+            filename = model.name + ".json"
+
+
+        # Setup labeler
+        self._name_labeler = NameLabeler()
+
+        # Pause the GC for the duration of this method
+        with PauseGC() as pgc:
+            symbol_map, model_dict = self._collect_model(
+                model,
+                solver_capability,
+                skip_trivial_constraints=skip_trivial_constraints,
+                file_determinism=file_determinism,
+                include_all_variable_bounds=include_all_variable_bounds,
+                sets=sets)
+        with open(filename,"w") as f:
+            json.dump(model_dict, f, indent=2)
+
+        # Cleanup memory
+        self._symbolic_solver_labels = False
+        self._output_fixed_variable_bounds = False
+        self._name_labeler = None
+
+        return filename, symbol_map
+
+    def _nonlinear_expr_to_string(self, exp, used_vars, used_params):
+        slist = []
+        self._nonlinear_expr_to_list(exp, slist, used_vars, used_params)
+        return ",".join(slist)
+
+    def _nonlinear_expr_to_list(self, exp, slist, used_vars, used_params):
+        exp_type = type(exp)
+
+        if exp_type is list:
+            raise RuntimeError("LIST EXPRESSION???")
+            # this is an implied summation of expressions (we did not
+            # create a new sum expression for efficiency) this should
+            # be a list of tuples where [0] is the coeff and [1] is
+            # the expr to write
+            nary_sum_str, binary_sum_str, coef_term_str = \
+                self._op_string[EXPR.SumExpressionBase]
+            n = len(exp)
+            if n > 2:
+                OUTPUT.write(nary_sum_str % (n))
+                for i in xrange(0,n):
+                    assert(exp[i].__class__ is tuple)
+                    coef = exp[i][0]
+                    child_exp = exp[i][1]
+                    if coef != 1:
+                        OUTPUT.write(coef_term_str % (coef))
+                    self._print_nonlinear_terms_NL(child_exp)
+            else: # n == 1 or 2
+                for i in xrange(0,n):
+                    assert(exp[i].__class__ is tuple)
+                    coef = exp[i][0]
+                    child_exp = exp[i][1]
+                    if i != n-1:
+                        # need the + op if it is not the last entry in the list
+                        OUTPUT.write(binary_sum_str)
+                    if coef != 1:
+                        OUTPUT.write(coef_term_str % (coef))
+                    self._print_nonlinear_terms_NL(child_exp)
+
+        elif exp_type in native_numeric_types:
+            slist.extend(("N", str(exp)))
+
+        elif exp.is_expression_type():
+            #
+            # Identify NPV expressions
+            #
+            if exp.is_constant():
+                slist.extend(("N", str(value(exp))))
+            #
+            # We are assuming that _Constant_* expression objects
+            # have been preprocessed to form constant values.
+            #
+            elif exp.__class__ in [EXPR.SumExpression,EXPR.NPV_SumExpression]:
+                n = exp.nargs()
+                const = 0
+                vargs = []
+                for v in exp.args:
+                    if v.__class__ in native_numeric_types:
+                        const += v
+                    else:
+                        vargs.append(v)
+                if not isclose(const, 0.0):
+                    vargs.append(const)
+                n = len(vargs)
+                if n == 2:
+                    slist.append("+")
+                    self._nonlinear_expr_to_list(vargs[0], slist, used_vars, used_params)
+                    self._nonlinear_expr_to_list(vargs[1], slist, used_vars, used_params)
+                elif n == 1:
+                    self._nonlinear_expr_to_list(vargs[0], slist, used_vars, used_params)
+                else:
+                    slist.extend(("sum",str(n)))
+                    for child_exp in vargs:
+                        self._nonlinear_expr_to_list(child_exp, slist, used_vars, used_params)
+
+            elif exp_type is EXPR.SumExpressionBase:
+                slist.append("+")
+                self._nonlinear_expr_to_list(exp.arg(0), slist, used_vars, used_params)
+                self._nonlinear_expr_to_list(exp.arg(1), slist, used_vars, used_params)
+
+            elif exp_type is EXPR.MonomialTermExpression:
+                slist.append("*")
+                if not exp.is_potentially_variable():
+                    self._nonlinear_expr_to_list(value(exp.arg(0)), slist, used_vars, used_params)
+                else:
+                    self._nonlinear_expr_to_list(exp.arg(0), slist, used_vars, used_params)
+                self._nonlinear_expr_to_list(exp.arg(1), slist, used_vars, used_params)
+
+            elif exp_type in [EXPR.ProductExpression, EXPR.NPV_ProductExpression]:
+                slist.append("*")
+                self._nonlinear_expr_to_list(exp.arg(0), slist, used_vars, used_params)
+                self._nonlinear_expr_to_list(exp.arg(1), slist, used_vars, used_params)
+
+            elif exp_type in [EXPR.DivisionExpression, EXPR.NPV_DivisionExpression]:
+                assert exp.nargs() == 2
+                slist.append("/")
+                self._nonlinear_expr_to_list(exp.arg(0), slist, used_vars, used_params)
+                self._nonlinear_expr_to_list(exp.arg(1), slist, used_vars, used_params)
+
+            # elif exp_type in [EXPR.ReciprocalExpression, EXPR.NPV_ReciprocalExpression]:
+            #     assert exp.nargs() == 1
+            #     slist.append("/")
+            #     self._nonlinear_expr_to_list(1.0, slist, used_vars, used_params)
+            #     self._nonlinear_expr_to_list(exp.arg(0), slist, used_vars, used_params)
+
+            elif exp_type in [EXPR.NegationExpression, EXPR.NPV_NegationExpression]:
+                assert exp.nargs() == 1
+                slist.append("neg")
+                self._nonlinear_expr_to_list(exp.arg(0), slist, used_vars, used_params)
+
+            elif exp_type in [EXPR.PowExpression, EXPR.NPV_PowExpression]:
+                assert exp.nargs() == 2
+                slist.append("pow")
+                self._nonlinear_expr_to_list(exp.arg(0), slist, used_vars, used_params)
+                self._nonlinear_expr_to_list(exp.arg(1), slist, used_vars, used_params)
+
+            elif isinstance(exp, EXPR.UnaryFunctionExpression) or isinstance(exp, EXPR.NPV_UnaryFunctionExpression):
+                assert exp.nargs() == 1
+                slist.append(exp.name)
+                self._nonlinear_expr_to_list(exp.arg(0), slist, used_vars, used_params)
+
+            elif exp_type is EXPR.Expr_ifExpression:
+                pass
+                #slist.append("if")
+                #self._nonlinear_expr_to_list(exp._if, slist)
+                #self._nonlinear_expr_to_list(exp._then, slist)
+                #self._nonlinear_expr_to_list(exp._else, slist)
+
+            elif exp_type is EXPR.InequalityExpression:
+                pass
+                #if exp._strict:
+                #    slist.append("<")
+                #else:
+                #    slist.append("<=")
+                #self._nonlinear_expr_to_list(exp.arg(0), slist)
+                #self._nonlinear_expr_to_list(exp.arg(1), slist)
+
+            elif exp_type is EXPR.RangedExpression:
+                pass
+                #left = exp.arg(0)
+                #middle = exp.arg(1)
+                #right = exp.arg(2)
+                #OUTPUT.write(and_str)
+                #if exp._strict[0]:
+                #    OUTPUT.write(lt_str)
+                #else:
+                #    OUTPUT.write(le_str)
+                #self._print_nonlinear_terms_NL(left)
+                #self._print_nonlinear_terms_NL(middle)
+                #if exp._strict[1]:
+                #    OUTPUT.write(lt_str)
+                #else:
+                #    OUTPUT.write(le_str)
+                #self._print_nonlinear_terms_NL(middle)
+                #self._print_nonlinear_terms_NL(right)
+
+            elif exp_type is EXPR.EqualityExpression:
+                pass
+                #OUTPUT.write(self._op_string[EXPR.EqualityExpression])
+                #self._print_nonlinear_terms_NL(exp.arg(0))
+                #self._print_nonlinear_terms_NL(exp.arg(1))
+
+            elif isinstance(exp, (_ExpressionData, IIdentityExpression)) \
+                 or isinstance(exp, (_ExpressionData, NPV_IIdentityExpression)):
+                self._nonlinear_expr_to_list(exp.arg(0), slist, used_vars, used_params)
+
+            else:
+                raise ValueError(
+                    "Unsupported expression type (%s) in _nonlinear_expr_to_list"
+                    % (exp_type))
+
+        elif isinstance(exp, (var._VarData, IVariable)):
+            slist.extend(("V", str(self._varID[id(exp)])))
+            used_vars.add(id(exp))
+
+        elif isinstance(exp,param._ParamData):
+            slist.extend(("P", str(self._paramID[id(exp)])))
+            used_params.add(id(exp))
+
+        elif isinstance(exp,NumericConstant):
+            slist.extend(("N", str(value(exp))))
+
+        else:
+            raise ValueError(
+                "Unsupported expression type (%s) in _nonlinear_expr_to_list"
+                % (exp_type))
+
+    def _collect_model(self, model,
+                        solver_capability,
+                        skip_trivial_constraints=False,
+                        file_determinism=1,
+                        include_all_variable_bounds=False,
+                        sets=[]):
+
+        sorter = SortComponents.unsorted
+        if file_determinism >= 1:
+            sorter = sorter | SortComponents.indices
+            if file_determinism >= 2:
+                sorter = sorter | SortComponents.alphabetical
+
+        # Cache the list of model blocks so we don't have to call
+        # model.block_data_objects() many many times
+        all_blocks_list = list(model.block_data_objects(active=True, sort=sorter))
+
+        # create a deterministic var labeling
+        Vars_dict = dict( enumerate( model.component_data_objects(Var, sort=sorter) ) )
+        self._varID = dict((id(val),key) for key,val in iteritems(Vars_dict))
+        Params_dict = dict( enumerate( model.component_data_objects(Param, sort=sorter) ) )
+        self._paramID = dict((id(val),key) for key,val in iteritems(Params_dict))
+        used_vars = set()
+        used_params = set()
+
+        output_fixed_variable_bounds = self._output_fixed_variable_bounds
+        symbolic_solver_labels = self._symbolic_solver_labels
+
+        # create the symbol_map
+        symbol_map = SymbolMap()
+        name_labeler = self._name_labeler
+
+        indexed_vars = set()
+        indexed_params = set()
+
+        data = {}
+        data['__metadata__'] = {'version':20210301, 'format':'JSON Parameterized Optimization Format (JPOF)'}
+
+        Model = {}
+        data['model'] = Model
+        Model['config'] = {}
+        Model['config']['symbolic_solver_labels'] = int(symbolic_solver_labels)
+        Model['config']['skip_trivial_constraints'] = int(skip_trivial_constraints)
+        Model['config']['file_determinism'] = file_determinism
+        Model['config']['include_all_variable_bounds'] = int(include_all_variable_bounds)
+        Model['obj'] = []
+        Model['con'] = []
+
+        #
+        # Count number of objectives and build the repns
+        #
+        n_obj = 0
+        n_con = 0
+        for block in all_blocks_list:
+
+            for active_objective in block.component_data_objects(Objective,
+                                                                 active=True,
+                                                                 sort=sorter,
+                                                                 descend_into=False):
+                objdata = {}
+                objdata['expr'] = self._nonlinear_expr_to_string(active_objective, used_vars, used_params)
+                if active_objective.is_minimizing():
+                    objdata['sense'] = 'min'
+                else:
+                    objdata['sense'] = 'max'
+                if symbolic_solver_labels:
+                    objdata['label'] = name_labeler(active_objective)
+
+                symbol_map.addSymbols([(active_objective, "o%d"%n_obj)])
+                symbol_map.alias(symbol_map.bySymbol["o0"](),"__default_objective__")
+                n_obj += 1
+                Model['obj'].append(objdata)
+
+            for constraint_data in block.component_data_objects(Constraint,
+                                                                active=True,
+                                                                sort=sorter,
+                                                                descend_into=False):
+                if (not constraint_data.has_lb()) and \
+                   (not constraint_data.has_ub()):
+                    assert not constraint_data.equality
+                    continue  # non-binding, so skip
+
+                _type = getattr(constraint_data, '_complementarity', None)
+                if not _type is None:
+                    # Skip complementarity conditions for now
+                    continue
+
+                condata = {}
+                condata['expr'] = self._nonlinear_expr_to_string(constraint_data.body, used_vars, used_params)
+                if symbolic_solver_labels:
+                    condata['label'] = name_labeler(constraint_data)
+
+                L = None
+                U = None
+                if constraint_data.has_lb():
+                    L = self._get_bound(constraint_data.lower, used_vars, used_params)
+                else:
+                    assert constraint_data.has_ub()
+                if constraint_data.has_ub():
+                    U = self._get_bound(constraint_data.upper, used_vars, used_params)
+                else:
+                    assert constraint_data.has_lb()
+                if constraint_data.equality:
+                    assert L == U
+                    if L is not None:
+                        condata['eq'] = L
+                else:
+                    if L is not None:
+                        condata['geq'] = L
+                    if U is not None:
+                        condata['leq'] = U
+
+                n_con += 1
+                Model['con'].append(condata)
+
+        Model['var'] = []
+        v = Model['var']
+        if file_determinism >= 1:
+            varids = sorted(self._varID[i] for i in used_vars)
+        else:
+            varids = set(self._varID[i] for i in used_vars)
+        for i in varids:
+            tmp = {}
+            v_ = Vars_dict[i]
+            if symbolic_solver_labels:
+                tmp['label'] = str(v_)
+                if v_.parent_component().is_indexed():
+                    indexed_vars.add(v_.parent_component().name)
+            tmp['id'] = i
+            if v_.value is not None:
+                tmp['value'] = v_.value
+            lb = self._get_bound(v_.lb)
+            if lb is not None:
+                tmp['lb'] = lb
+            ub = self._get_bound(v_.ub)
+            if ub is not None:
+                tmp['ub'] = ub
+            if v_.is_binary():
+                tmp['type'] = 'B'
+            elif v_.is_integer():
+                tmp['type'] = 'Z'
+            else:
+                tmp['type'] = 'R'
+            tmp['fixed'] = int(v_.fixed)
+            v.append(tmp)
+
+        Model['param'] = []
+        p = Model['param']
+        if file_determinism >= 1:
+            paramids = sorted(self._paramID[i] for i in used_params)
+        else:
+            paramids = set(self._paramID[i] for i in used_params)
+        for i in paramids:
+            tmp = {}
+            p_ = Params_dict[i]
+            if symbolic_solver_labels:
+                tmp['label'] = str(p_)
+                if p_.parent_component().is_indexed():
+                    indexed_params.add(p_.parent_component().name)
+            tmp['id'] = i
+            if p_.value is not None:
+                tmp['value'] = p_.value
+            p.append(tmp)
+
+        Model['set'] = {}
+        s = Model['set']
+        for setname in sets:
+            modelset = getattr(model,setname)
+            values = [str(value) for value in modelset]
+            s[setname] = values
+
+        Model['indexed_vars'] = list(sorted(indexed_vars))
+        Model['indexed_params'] = list(sorted(indexed_params))
+
+        return symbol_map, data
+
+    def _get_bound(self, exp, used_vars=None, used_params=None):
+        if exp is None:
+            return None
+        if is_constant(exp):
+            return value(exp)
+        if not is_fixed(exp):
+            raise ValueError("non-fixed bound or weight: " + str(exp))
+        if used_vars is None or used_params is None:
+            return self._nonlinear_expr_to_string(exp, set(), set())
+        return self._nonlinear_expr_to_string(exp, used_vars, used_params)
+

--- a/pyomo/contrib/jpof/testCase/small10_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small10_testCase.py
@@ -1,0 +1,78 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Author:  Gabe Hackebeil
+# Purpose: For regression testing to ensure that the Pyomo
+#          NL writer properly reclassifies nonlinear expressions
+#          as linear or trivial when fixing variables or params
+#          cause such a situation.
+#
+#          This test model relies on the gjh_asl_json executable. It
+#          will not solve if sent to a real optimizer.
+#
+
+from pyomo.environ import ConcreteModel, Var, Param, Objective, Constraint, simple_constraint_rule
+
+model = ConcreteModel()
+
+model.x = Var()
+model.y = Var()
+model.z = Var()
+model.q = Param(initialize=0.0)
+model.p = Param(initialize=0.0,mutable=True)
+
+model.obj = Objective( expr=model.x*model.y +\
+                            model.z*model.y +\
+                            model.q*model.y +\
+                            model.y*model.y*model.q +\
+                            model.p*model.y +\
+                            model.y*model.y*model.p +\
+                            model.y*model.y*model.z +\
+                            model.z*(model.y**2))
+
+model.con1 = Constraint(expr=model.x*model.y == 0)
+model.con2 = Constraint(expr=model.z*model.y + model.y == 0)
+model.con3 = Constraint(expr=model.q*(model.y**2) + model.y == 0)
+model.con4 = Constraint(expr=model.q*model.y*model.x + model.y == 0)
+model.con5 = Constraint(expr=model.p*(model.y**2) + model.y == 0)
+model.con6 = Constraint(expr=model.p*model.y*model.x + model.y == 0)
+model.con7 = Constraint(expr=model.z*(model.y**2) + model.y == 0)
+model.con8 = Constraint(expr=model.z*model.y*model.x + model.y == 0)
+# Pyomo differs from AMPL in these cases that involve immutable params (q).
+# These never actually become constraints in Pyomo, and for good reason.
+model.con9 = Constraint(expr=model.z*model.y == 0)
+model.con10 = Constraint(
+    rule= simple_constraint_rule(model.q*(model.y**2) == 0) )
+model.con11 = Constraint(
+    rule= simple_constraint_rule(model.q*model.y*model.x == 0) )
+model.con12 = Constraint(expr=model.p*(model.y**2) == 0)
+model.con13 = Constraint(expr=model.p*model.y*model.x == 0)
+model.con14 = Constraint(expr=model.z*(model.y**2) == 0)
+model.con15 = Constraint(expr=model.z*model.y*model.x == 0)
+model.con16 = Constraint(
+    rule= simple_constraint_rule(model.q*model.y == 0) )
+model.con17 = Constraint(expr=model.p*model.y == 0)
+
+###### Add some constraint which we deactivate just
+###### to make sure this is working properly
+model.con1D = Constraint(expr=model.x*model.y == 0)
+model.con1D_indexeda = Constraint([1,2],rule=lambda model,i: model.x*model.y == 0)
+model.con1D_indexedb = Constraint([1,2],rule=lambda model,i: model.x*model.y == 0)
+model.con1D.deactivate()
+model.con1D_indexeda.deactivate()
+model.con1D_indexedb[1].deactivate()
+model.con1D_indexedb[2].deactivate()
+#####
+
+
+model.x = 1.0
+model.x.fixed = True
+model.z = 0.0
+model.z.fixed = True

--- a/pyomo/contrib/jpof/testCase/small11_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small11_testCase.py
@@ -1,0 +1,39 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Author:  Gabe Hackebeil
+# Purpose: For regression testing to ensure that the Pyomo
+#          NL writer properly labels constraint ids in the "J"
+#          section of the NL file when trivial constraints exist.
+#          At the creation of this test, trivial constraints
+#          (constraints with no variables) are being written to
+#          the nl file as a feasibility check for the user.
+#
+#          This test model relies on the gjh_asl_json executable. It
+#          will not solve if sent to a real optimizer.
+#
+
+from pyomo.environ import ConcreteModel, Var, Objective, Constraint, RangeSet
+model = ConcreteModel()
+
+n=3
+
+model.x = Var([(k,i) for k in range(1,n+1) for i in range(k,n+1)])
+
+def obj_rule(model):
+	return model.x[n,n]
+model.obj = Objective(rule=obj_rule)
+
+def var_bnd_rule(model,i):
+	return (-1.0, model.x[1,i], 1.0)
+model.var_bnd = Constraint(RangeSet(1,n),rule=var_bnd_rule)
+
+model.x[1,1] = 1.0
+model.x[1,1].fixed = True

--- a/pyomo/contrib/jpof/testCase/small12_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small12_testCase.py
@@ -1,0 +1,77 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Author:  Gabe Hackebeil
+# Purpose: For testing to ensure that the Pyomo NL writer properly
+#          handles the Expr_if component.
+#
+#          This test model relies on the gjh_asl_json executable. It
+#          will not solve if sent to a real optimizer.
+#
+
+from pyomo.environ import ConcreteModel, Var, Param, Objective, Constraint, inequality
+from pyomo.core.expr.current import Expr_if
+
+
+model = ConcreteModel()
+
+model.vTrue  = Var(initialize=1)
+model.vFalse = Var(initialize=-1)
+
+model.pTrue  = Param(initialize=1)
+model.pFalse = Param(initialize=-1)
+
+model.vN1 = Var(initialize=-1)
+model.vP1 = Var(initialize=1)
+model.v0  = Var(initialize=0)
+model.vN2 = Var(initialize=-2)
+model.vP2 = Var(initialize=2)
+
+model.obj = Objective(expr=10.0*Expr_if(IF=model.v0,
+                                            THEN=model.vTrue,
+                                            ELSE=model.vFalse))
+
+# True/False
+model.c1 = Constraint(expr= Expr_if(IF=(0), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pFalse)
+model.c2 = Constraint(expr= Expr_if(IF=(1), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pTrue)
+
+# x <= 0
+model.c3 = Constraint(expr= Expr_if(IF=(model.vN1 <= 0), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pTrue)
+model.c4 = Constraint(expr= Expr_if(IF=(model.v0  <= 0), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pTrue)
+model.c5 = Constraint(expr= Expr_if(IF=(model.vP1 <= 0), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pFalse)
+
+# x < 0
+model.c6 = Constraint(expr= Expr_if(IF=(model.vN1 < 0), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pTrue)
+model.c7 = Constraint(expr= Expr_if(IF=(model.v0  < 0), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pFalse)
+model.c8 = Constraint(expr= Expr_if(IF=(model.vP1 < 0), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pFalse)
+
+# x >= 0
+model.c9 = Constraint(expr= Expr_if(IF=(model.vN1*10.0 >= 0), THEN=(model.vTrue), ELSE=(model.vFalse))  == model.pFalse)
+model.c10 = Constraint(expr= Expr_if(IF=(model.v0*10.0  >= 0), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pTrue)
+model.c11 = Constraint(expr= Expr_if(IF=(model.vP1*10.0 >= 0), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pTrue)
+
+# x > 0
+model.c12 = Constraint(expr= Expr_if(IF=(model.vN1*10.0 > 0), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pFalse)
+model.c13 = Constraint(expr= Expr_if(IF=(model.v0*10.0  > 0), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pFalse)
+model.c14 = Constraint(expr= Expr_if(IF=(model.vP1*10.0 > 0), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pTrue)
+
+# -1 <= x <= 1
+model.c15 = Constraint(expr= Expr_if(IF=inequality(-1,              model.vN2, 1), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pFalse)
+model.c16 = Constraint(expr= Expr_if(IF=inequality(-1*model.vP1,    model.vN1, 1), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pTrue)
+model.c17 = Constraint(expr= Expr_if(IF=inequality(-1*model.vP1**2, model.v0,  1), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pTrue)
+model.c18 = Constraint(expr= Expr_if(IF=inequality(model.vN1,       model.vP1, 1), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pTrue)
+model.c19 = Constraint(expr= Expr_if(IF=inequality(-1,              model.vP2, 1), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pFalse)
+
+# -1 < x < 1
+model.c20 = Constraint(expr= Expr_if(IF=inequality(-1, model.vN2, 1, strict=True), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pFalse)
+model.c21 = Constraint(expr= Expr_if(IF=inequality(-1, model.vN1, 1*model.vP1, strict=True), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pFalse)
+model.c22 = Constraint(expr= Expr_if(IF=inequality(-1, model.v0,  1*model.vP1**2, strict=True), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pTrue)
+model.c23 = Constraint(expr= Expr_if(IF=inequality(-1, model.vP1, model.vP1, strict=True), THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pFalse)
+model.c24 = Constraint(expr= Expr_if(IF=inequality(-1, model.vP2, 1, strict=True) , THEN=(model.vTrue), ELSE=(model.vFalse)) == model.pFalse)

--- a/pyomo/contrib/jpof/testCase/small13_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small13_testCase.py
@@ -1,0 +1,29 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Author:  Gabe Hackebeil
+# Purpose: For testing to ensure that the Pyomo NL writer properly
+#          converts the nonlinear expression to the NL file format.
+#
+#          This test model relies on the gjh_asl_json executable. It
+#          will not solve if sent to a real optimizer.
+#
+
+from pyomo.environ import ConcreteModel, Var, Objective, Constraint, maximize
+
+model = ConcreteModel()
+
+model.x = Var(initialize=0.5)
+
+model.obj = Objective(expr=model.x, sense=maximize)
+
+model.c1 = Constraint(expr= (model.x**3 - model.x) == 0)
+model.c2 = Constraint(expr= 10*(model.x**3 - model.x) == 0)
+model.c3 = Constraint(expr= (model.x**3 - model.x)/10.0 == 0)

--- a/pyomo/contrib/jpof/testCase/small14_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small14_testCase.py
@@ -1,0 +1,46 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+from pyomo.environ import ConcreteModel, Var, Objective, Constraint, log, log10, sin, cos, tan, sinh, cosh, tanh, asin, acos, atan, asinh, acosh, atanh, exp, sqrt, ceil, floor
+from math import e, pi
+
+model = ConcreteModel()
+
+# pick a value in the domain of all of these functions
+model.ONE = Var(initialize=1)
+model.ZERO = Var(initialize=0)
+
+
+model.obj = Objective(expr=model.ONE+model.ZERO)
+
+model.c_log     = Constraint(expr=log(model.ONE) == 0)
+model.c_log10   = Constraint(expr=log10(model.ONE) == 0)
+
+model.c_sin     = Constraint(expr=sin(model.ZERO) == 0)
+model.c_cos     = Constraint(expr=cos(model.ZERO) == 1)
+model.c_tan     = Constraint(expr=tan(model.ZERO) == 0)
+
+model.c_sinh    = Constraint(expr=sinh(model.ZERO) == 0)
+model.c_cosh    = Constraint(expr=cosh(model.ZERO) == 1)
+model.c_tanh    = Constraint(expr=tanh(model.ZERO) == 0)
+
+model.c_asin    = Constraint(expr=asin(model.ZERO) == 0)
+model.c_acos    = Constraint(expr=acos(model.ZERO) == pi/2)
+model.c_atan    = Constraint(expr=atan(model.ZERO) == 0)
+
+model.c_asinh   = Constraint(expr=asinh(model.ZERO) == 0)
+model.c_acosh   = Constraint(expr=acosh((e**2 + model.ONE)/(2*e)) == 0)
+model.c_atanh   = Constraint(expr=atanh(model.ZERO) == 0)
+
+model.c_exp     = Constraint(expr=exp(model.ZERO) == 1)
+model.c_sqrt    = Constraint(expr=sqrt(model.ONE) == 1)
+model.c_ceil    = Constraint(expr=ceil(model.ONE) == 1)
+model.c_floor   = Constraint(expr=floor(model.ONE) == 1)
+model.c_abs     = Constraint(expr=abs(model.ONE) == 1)

--- a/pyomo/contrib/jpof/testCase/small15_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small15_testCase.py
@@ -1,0 +1,33 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Author:  Gabe Hackebeil
+# Purpose: For regression testing to ensure that the Pyomo
+#          NL writer properly reports the values corresponding
+#          to the nl file header line with the label
+#          '# nonlinear vars in constraints, objectives, both'
+#
+# Test if variables in deactivated blocks are found
+#
+
+from pyomo.environ import ConcreteModel, Var, Block, Objective, Constraint
+
+model = ConcreteModel()
+
+model.x = Var(initialize=1.0)
+model.b = Block()
+model.b.y = Var(initialize=1.0)
+
+model.OBJ = Objective(expr=model.x**2)
+
+model.CON1 = Constraint(expr=model.b.y**2 == 4)
+
+model.b.deactivate()
+

--- a/pyomo/contrib/jpof/testCase/small1_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small1_testCase.py
@@ -1,0 +1,28 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Author:  Gabe Hackebeil
+# Purpose: For regression testing to ensure that the Pyomo
+#          NL writer properly reports the values corresponding
+#          to the nl file header line with the label
+#          '# nonlinear vars in constraints, objectives, both'
+#
+
+from pyomo.environ import ConcreteModel, Var, Objective, Constraint
+
+model = ConcreteModel()
+
+model.x = Var(initialize=1.0)
+model.y = Var(initialize=1.0)
+
+model.OBJ = Objective(expr=model.x**2)
+
+model.CON1 = Constraint(expr=model.y**2 == 4)
+

--- a/pyomo/contrib/jpof/testCase/small2_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small2_testCase.py
@@ -1,0 +1,27 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Author:  Gabe Hackebeil
+# Purpose: For regression testing to ensure that the Pyomo
+#          NL writer properly reports the values corresponding
+#          to the nl file header line with the label
+#          '# nonlinear vars in constraints, objectives, both'
+#
+
+from pyomo.environ import ConcreteModel, Var, Objective, Constraint
+
+model = ConcreteModel()
+
+model.x = Var(initialize=1.0)
+model.y = Var(initialize=1.0)
+
+model.OBJ = Objective(expr=model.x)
+
+model.CON1 = Constraint(expr=model.y**2 == 4)

--- a/pyomo/contrib/jpof/testCase/small3_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small3_testCase.py
@@ -1,0 +1,28 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Author:  Gabe Hackebeil
+# Purpose: For regression testing to ensure that the Pyomo
+#          NL writer properly reports the values corresponding
+#          to the nl file header line with the label
+#          '# nonlinear vars in constraints, objectives, both'
+#
+
+from pyomo.environ import ConcreteModel, Var, Objective, Constraint
+
+model = ConcreteModel()
+
+model.x = Var(initialize=1.0)
+model.y = Var(initialize=1.0)
+
+model.OBJ = Objective(expr=model.x*model.y)
+
+model.CON1 = Constraint(expr=model.y**2 == 4)
+

--- a/pyomo/contrib/jpof/testCase/small3a_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small3a_testCase.py
@@ -1,0 +1,30 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Author:  Gabe Hackebeil
+# Purpose: For regression testing to ensure that the Pyomo
+#          NL writer properly reports the values corresponding
+#          to the nl file header line with the label
+#          '# nonlinear vars in constraints, objectives, both'
+#
+
+from pyomo.environ import ConcreteModel, Var, Objective, Constraint, Expression
+
+model = ConcreteModel()
+
+model.x = Var(initialize=1.0)
+model.y = Var(initialize=1.0)
+
+model.e = Expression(expr=model.x*model.y)
+model.OBJ = Objective(expr=model.e+4)
+
+model.E = Expression(expr=model.y**2)
+model.CON1 = Constraint(expr=model.E * model.x == 4)
+

--- a/pyomo/contrib/jpof/testCase/small4_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small4_testCase.py
@@ -1,0 +1,29 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Author:  Gabe Hackebeil
+# Purpose: For regression testing to ensure that the Pyomo
+#          NL writer properly reports the values corresponding
+#          to the nl file header line with the label
+#          '# nonlinear vars in constraints, objectives, both'
+#
+
+
+from pyomo.environ import ConcreteModel, Var, Objective, Constraint
+
+model = ConcreteModel()
+
+model.x = Var(initialize=1.0)
+model.y = Var(initialize=1.0)
+
+model.OBJ = Objective(expr=model.y**2)
+
+model.CON1 = Constraint(expr=model.y*model.x == 4)
+

--- a/pyomo/contrib/jpof/testCase/small5_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small5_testCase.py
@@ -1,0 +1,47 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Author:  Gabe Hackebeil
+# Purpose: For regression testing to ensure that the Pyomo
+#          NL writer properly modifies product expressions
+#          with only constant terms in the denominator (that
+#          are involved in nonlinear expressions).
+#          The ASL differentiation routines seem to have a
+#          bug that causes the lagrangian hessian to become
+#          dense unless this constant term in moved to the
+#          numerator.
+#
+#          This test model relies on the gjh_asl_json executable. It
+#          will not solve if sent to a real optimizer.
+#
+
+from pyomo.environ import ConcreteModel, Var, Param, Objective, Constraint
+
+model = ConcreteModel()
+model.x = Var(bounds=(-1.0,1.0),initialize=1.0)
+model.y = Var(bounds=(-1.0,1.0),initialize=2.0)
+model.v = Var(bounds=(-1.0,1.0),initialize=3.0)
+model.p = Param(initialize=2.0)
+model.q = Param(initialize=2.0,mutable=True)
+
+model.OBJ = Objective(expr=model.x**2/model.p + model.x**2/model.q)
+model.CON1 = Constraint(expr=1.0/model.p*model.v*(model.x-model.y) == 2.0)
+model.CON2 = Constraint(expr=model.v*1.0/model.p*(model.x-model.y) == 2.0)
+model.CON3 = Constraint(expr=model.v*(model.x-model.y)/model.p == 2.0)
+model.CON4 = Constraint(expr=model.v*(model.x/model.p-model.y/model.p) == 2.0)
+model.CON5 = Constraint(expr=model.v*(model.x-model.y)*(1.0/model.p) == 2.0)
+model.CON6 = Constraint(expr=model.v*(model.x-model.y) == 2.0*model.p)
+
+model.CON7 = Constraint(expr=1.0/model.q*model.v*(model.x-model.y) == 2.0)
+model.CON8 = Constraint(expr=model.v*1.0/model.q*(model.x-model.y) == 2.0)
+model.CON9 = Constraint(expr=model.v*(model.x-model.y)/model.q == 2.0)
+model.CON10 = Constraint(expr=model.v*(model.x/model.q-model.y/model.q) == 2.0)
+model.CON11 = Constraint(expr=model.v*(model.x-model.y)*(1.0/model.q) == 2.0)
+model.CON12 = Constraint(expr=model.v*(model.x-model.y) == 2.0*model.q)

--- a/pyomo/contrib/jpof/testCase/small5a_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small5a_testCase.py
@@ -1,0 +1,36 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Author:  Gabe Hackebeil
+# Purpose: For regression testing to ensure that the Pyomo
+#          NL writer properly modifies product expressions
+#          with only constant terms in the denominator (that
+#          are involved in nonlinear expressions).
+#          The ASL differentiation routines seem to have a
+#          bug that causes the lagrangian hessian to become
+#          dense unless this constant term in moved to the
+#          numerator.
+#
+#          This test model relies on the gjh_asl_json executable. It
+#          will not solve if sent to a real optimizer.
+#
+
+from pyomo.environ import ConcreteModel, Var, Param, Objective, Constraint, Binary, Integers, inequality
+
+model = ConcreteModel()
+model.x = Var(within=Binary)
+model.y = Var(within=Integers)
+model.q = Param(initialize=2.0,mutable=True)
+
+model.OBJ = Objective(expr=model.x*model.y)
+
+model.CON1 = Constraint(expr=model.x+model.y <= 2.0*model.q)
+model.CON2 = Constraint(expr=model.x+model.y >= model.q)
+model.CON3 = Constraint(expr=inequality( model.q, model.x+model.y, 2.0*model.q ))

--- a/pyomo/contrib/jpof/testCase/small6_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small6_testCase.py
@@ -1,0 +1,40 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Author:  Gabe Hackebeil
+# Purpose: For regression testing to ensure that the Pyomo
+#          NL writer properly modifies product expressions
+#          with only constant terms in the denominator (that
+#          are involved in nonlinear expressions).
+#          The ASL differentiation routines seem to have a
+#          bug that causes the lagrangian hessian to become
+#          dense unless this constant term in moved to the
+#          numerator.
+#
+#          This test model relies on the gjh_asl_json executable. It
+#          will not solve if sent to a real optimizer.
+#
+
+from pyomo.environ import ConcreteModel, Var, Objective, Constraint
+
+model = ConcreteModel()
+model.x = Var(bounds=(-1.0,1.0),initialize=1.0)
+model.y = Var(bounds=(-1.0,1.0),initialize=2.0)
+model.v = Var(bounds=(-1.0,1.0),initialize=3.0)
+model.p = Var(initialize=2.0)
+model.p.fixed = True
+
+model.OBJ = Objective(expr=model.x)
+model.CON1 = Constraint(rule=lambda model: (2.0,1.0/model.p*model.v*(model.x-model.y)))
+model.CON2 = Constraint(expr=model.v*1.0/model.p*(model.x-model.y) == 2.0)
+model.CON3 = Constraint(expr=model.v*(model.x-model.y)/model.p == 2.0)
+model.CON4 = Constraint(expr=model.v*(model.x/model.p-model.y/model.p) == 2.0)
+model.CON5 = Constraint(expr=model.v*(model.x-model.y)*(1.0/model.p) == 2.0)
+model.CON6 = Constraint(expr=model.v*(model.x-model.y) - 2.0*model.p == 0)

--- a/pyomo/contrib/jpof/testCase/small7_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small7_testCase.py
@@ -1,0 +1,62 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Author:  Gabe Hackebeil
+# Purpose: For regression testing to ensure that the Pyomo
+#          NL writer properly modifies product expressions
+#          with only constant terms in the denominator (that
+#          are involved in nonlinear expressions).
+#          The ASL differentiation routines seem to have a
+#          bug that causes the lagrangian hessian to become
+#          dense unless this constant term in moved to the
+#          numerator.
+#
+#          This test model relies on the gjh_asl_json executable. It
+#          will not solve if sent to a real optimizer.
+#
+
+from pyomo.environ import ConcreteModel, Var, Param, Objective, Constraint
+
+model = ConcreteModel()
+model.x = Var(bounds=(-1.0,1.0),initialize=1.0)
+model.y = Var(bounds=(-1.0,1.0),initialize=2.0)
+model.v = Var(bounds=(-1.0,1.0),initialize=3.0)
+model.p = Var(initialize=2.0)
+model.p.fixed = True
+model.q = Param(initialize=2.0)
+
+model.OBJ = Objective(expr=model.x)
+model.CON1a = Constraint(expr=1.0/model.p/model.q*model.v*(model.x-model.y) == 2.0)
+model.CON2a = Constraint(expr=model.v*1.0/model.p/model.p*(model.x-model.y) == 2.0)
+model.CON3a = Constraint(expr=model.v*(model.x-model.y)/model.p/model.q == 2.0)
+model.CON4a = Constraint(expr=model.v*(model.x/model.p/model.q-model.y/model.p/model.q) == 2.0)
+model.CON5a = Constraint(expr=model.v*(model.x-model.y)*(1.0/model.p/model.q) == 2.0)
+model.CON6a = Constraint(expr=model.v*(model.x-model.y) - 2.0*model.p*model.q == 0)
+
+model.CON1b = Constraint(expr=1.0/(model.p*model.q)*model.v*(model.x-model.y) == 2.0)
+model.CON2b = Constraint(expr=model.v*1.0/(model.p*model.p)*(model.x-model.y) == 2.0)
+model.CON3b = Constraint(expr=model.v*(model.x-model.y)/(model.p*model.q) == 2.0)
+model.CON4b = Constraint(expr=model.v*(model.x/(model.p*model.q)-model.y/(model.p*model.q)) == 2.0)
+model.CON5b = Constraint(expr=model.v*(model.x-model.y)*(1.0/(model.p*model.q)) == 2.0)
+model.CON6b = Constraint(expr=model.v*(model.x-model.y) - 2.0*(model.p*model.q) == 0)
+
+model.CON1c = Constraint(expr=1.0/(model.p+model.q)*model.v*(model.x-model.y) == 2.0)
+model.CON2c = Constraint(expr=model.v*1.0/(model.p+model.p)*(model.x-model.y) == 2.0)
+model.CON3c = Constraint(expr=model.v*(model.x-model.y)/(model.p+model.q) == 2.0)
+model.CON4c = Constraint(expr=model.v*(model.x/(model.p+model.q)-model.y/(model.p+model.q)) == 2.0)
+model.CON5c = Constraint(expr=model.v*(model.x-model.y)*(1.0/(model.p+model.q)) == 2.0)
+model.CON6c = Constraint(expr=model.v*(model.x-model.y) == 2.0*(model.p+model.q))
+
+model.CON1d = Constraint(expr=1.0/((model.p+model.q)**2)*model.v*(model.x-model.y) == 2.0)
+model.CON2d = Constraint(expr=model.v*1.0/((model.p+model.p)**2)*(model.x-model.y) == 2.0)
+model.CON3d = Constraint(expr=model.v*(model.x-model.y)/((model.p+model.q)**2) == 2.0)
+model.CON4d = Constraint(expr=model.v*(model.x/((model.p+model.q)**2)-model.y/((model.p+model.q)**2)) == 2.0)
+model.CON5d = Constraint(expr=model.v*(model.x-model.y)*(1.0/((model.p+model.q)**2)) == 2.0)
+model.CON6d = Constraint(expr=model.v*(model.x-model.y) - 2.0*((model.p+model.q)**2) == 0)

--- a/pyomo/contrib/jpof/testCase/small8_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small8_testCase.py
@@ -1,0 +1,46 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Author:  Gabe Hackebeil
+# Purpose: For regression testing to ensure that the Pyomo
+#          NL writer properly modifies product expressions
+#          with only constant terms in the denominator (that
+#          are involved in linear expressions).
+#
+#          This test model relies on the gjh_asl_json executable. It
+#          will not solve if sent to a real optimizer.
+#
+
+from pyomo.environ import AbstractModel, Param, Var, NonNegativeReals, Objective, Constraint, minimize
+
+model = AbstractModel()
+
+model.a = Param(initialize=2.0)
+
+model.x = Var(within=NonNegativeReals)
+model.y = Var(within=NonNegativeReals)
+model.z = Var(within=NonNegativeReals,bounds=(7,None))
+
+def obj_rule(model):
+    return model.z + model.x*model.x + model.y
+model.obj = Objective(rule=obj_rule,sense=minimize)
+
+def constr_rule(model):
+    return (model.a,model.y*model.y,None)
+model.constr = Constraint(rule=constr_rule)
+
+def constr2_rule(model):
+    return model.x/model.a >= model.y
+model.constr2 = Constraint(rule=constr2_rule)
+
+def constr3_rule(model):
+    return model.z <= model.y + model.a
+model.constr3 = Constraint(rule=constr3_rule)
+

--- a/pyomo/contrib/jpof/testCase/small9_testCase.py
+++ b/pyomo/contrib/jpof/testCase/small9_testCase.py
@@ -1,0 +1,42 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Author:  Gabe Hackebeil
+# Purpose: For regression testing to ensure that the Pyomo
+#          NL writer properly reclassifies nonlinear expressions
+#          as linear or trivial when fixing variables or params
+#          cause such a situation.
+#
+#          This test model relies on the gjh_asl_json executable. It
+#          will not solve if sent to a real optimizer.
+#
+
+from pyomo.environ import ConcreteModel, Var, Param, Objective, Constraint, simple_constraint_rule
+
+model = ConcreteModel()
+
+model.x = Var()
+model.y = Var(initialize=0.0)
+model.z = Var()
+model.p = Param(initialize=0.0,mutable=True)
+model.q = Param(initialize=0.0,mutable=False)
+
+model.y.fixed = True
+
+model.obj = Objective( expr=model.x )
+
+model.con1 = Constraint(expr= model.x*model.y*model.z + model.x == 1.0)
+model.con2 = Constraint(expr= model.x*model.p*model.z + model.x == 1.0)
+model.con3 = Constraint(expr= model.x*model.q*model.z + model.x == 1.0)
+# Pyomo differs from AMPL in these cases that involve immutable params (q).
+# These never actually become constants in Pyomo, and for good reason.
+model.con4 = Constraint(expr= model.x*model.y*model.z == 1.0)
+model.con5 = Constraint(expr= model.x*model.p*model.z == 1.0)
+model.con6 = Constraint(rule= simple_constraint_rule(model.x*model.q*model.z == 0.0) )

--- a/pyomo/contrib/jpof/tests/__init__.py
+++ b/pyomo/contrib/jpof/tests/__init__.py
@@ -1,0 +1,3 @@
+#
+# Pyomo JSON writer tests
+#

--- a/pyomo/contrib/jpof/tests/small1.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small1.pyomo.json
@@ -1,0 +1,48 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "pow,V,0,N,2",
+        "sense": "min",
+        "label": "OBJ"
+      }
+    ],
+    "con": [
+      {
+        "expr": "pow,V,1,N,2",
+        "label": "CON1",
+        "eq": 4.0
+      }
+    ],
+    "var": [
+      {
+        "label": "x",
+        "id": 0,
+        "value": 1.0,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "y",
+        "id": 1,
+        "value": 1.0,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [],
+    "set": {},
+    "indexed_vars": [],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/small10.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small10.pyomo.json
@@ -1,0 +1,125 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "sum,6,*,V,0,V,1,*,V,2,V,1,*,P,0,V,1,*,*,V,1,V,1,P,0,*,*,V,1,V,1,V,2,*,V,2,pow,V,1,N,2",
+        "sense": "min",
+        "label": "obj"
+      }
+    ],
+    "con": [
+      {
+        "expr": "*,V,0,V,1",
+        "label": "con1",
+        "eq": 0.0
+      },
+      {
+        "expr": "*,P,0,pow,V,1,N,2",
+        "label": "con12",
+        "eq": 0.0
+      },
+      {
+        "expr": "*,*,P,0,V,1,V,0",
+        "label": "con13",
+        "eq": 0.0
+      },
+      {
+        "expr": "*,V,2,pow,V,1,N,2",
+        "label": "con14",
+        "eq": 0.0
+      },
+      {
+        "expr": "*,*,V,2,V,1,V,0",
+        "label": "con15",
+        "eq": 0.0
+      },
+      {
+        "expr": "*,P,0,V,1",
+        "label": "con17",
+        "eq": 0.0
+      },
+      {
+        "expr": "+,*,V,2,V,1,V,1",
+        "label": "con2",
+        "eq": 0.0
+      },
+      {
+        "expr": "V,1",
+        "label": "con3",
+        "eq": 0.0
+      },
+      {
+        "expr": "V,1",
+        "label": "con4",
+        "eq": 0.0
+      },
+      {
+        "expr": "+,*,P,0,pow,V,1,N,2,V,1",
+        "label": "con5",
+        "eq": 0.0
+      },
+      {
+        "expr": "+,*,*,P,0,V,1,V,0,V,1",
+        "label": "con6",
+        "eq": 0.0
+      },
+      {
+        "expr": "+,*,V,2,pow,V,1,N,2,V,1",
+        "label": "con7",
+        "eq": 0.0
+      },
+      {
+        "expr": "+,*,*,V,2,V,1,V,0,V,1",
+        "label": "con8",
+        "eq": 0.0
+      },
+      {
+        "expr": "*,V,2,V,1",
+        "label": "con9",
+        "eq": 0.0
+      }
+    ],
+    "var": [
+      {
+        "label": "x",
+        "id": 0,
+        "value": 1.0,
+        "type": "R",
+        "fixed": 1
+      },
+      {
+        "label": "y",
+        "id": 1,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "z",
+        "id": 2,
+        "value": 0.0,
+        "type": "R",
+        "fixed": 1
+      }
+    ],
+    "param": [
+      {
+        "label": "p",
+        "id": 0,
+        "value": 0.0
+      }
+    ],
+    "set": {},
+    "indexed_vars": [],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/small11.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small11.pyomo.json
@@ -1,0 +1,74 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "V,5",
+        "sense": "min",
+        "label": "obj"
+      }
+    ],
+    "con": [
+      {
+        "expr": "V,0",
+        "label": "var_bnd[1]",
+        "geq": -1.0,
+        "leq": 1.0
+      },
+      {
+        "expr": "V,1",
+        "label": "var_bnd[2]",
+        "geq": -1.0,
+        "leq": 1.0
+      },
+      {
+        "expr": "V,2",
+        "label": "var_bnd[3]",
+        "geq": -1.0,
+        "leq": 1.0
+      }
+    ],
+    "var": [
+      {
+        "label": "x[1,1]",
+        "id": 0,
+        "value": 1.0,
+        "type": "R",
+        "fixed": 1
+      },
+      {
+        "label": "x[1,2]",
+        "id": 1,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[1,3]",
+        "id": 2,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x[3,3]",
+        "id": 5,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [],
+    "set": {},
+    "indexed_vars": [
+      "x"
+    ],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/small12.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small12.pyomo.json
@@ -1,0 +1,163 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "*,N,10.0",
+        "sense": "min",
+        "label": "obj"
+      }
+    ],
+    "con": [
+      {
+        "expr": "V,1",
+        "label": "c1",
+        "eq": -1.0
+      },
+      {
+        "expr": "",
+        "label": "c10",
+        "eq": 1.0
+      },
+      {
+        "expr": "",
+        "label": "c11",
+        "eq": 1.0
+      },
+      {
+        "expr": "",
+        "label": "c12",
+        "eq": -1.0
+      },
+      {
+        "expr": "",
+        "label": "c13",
+        "eq": -1.0
+      },
+      {
+        "expr": "",
+        "label": "c14",
+        "eq": 1.0
+      },
+      {
+        "expr": "",
+        "label": "c15",
+        "eq": -1.0
+      },
+      {
+        "expr": "",
+        "label": "c16",
+        "eq": 1.0
+      },
+      {
+        "expr": "",
+        "label": "c17",
+        "eq": 1.0
+      },
+      {
+        "expr": "",
+        "label": "c18",
+        "eq": 1.0
+      },
+      {
+        "expr": "",
+        "label": "c19",
+        "eq": -1.0
+      },
+      {
+        "expr": "V,6",
+        "label": "c2",
+        "eq": 1.0
+      },
+      {
+        "expr": "",
+        "label": "c20",
+        "eq": -1.0
+      },
+      {
+        "expr": "",
+        "label": "c21",
+        "eq": -1.0
+      },
+      {
+        "expr": "",
+        "label": "c22",
+        "eq": 1.0
+      },
+      {
+        "expr": "",
+        "label": "c23",
+        "eq": -1.0
+      },
+      {
+        "expr": "",
+        "label": "c24",
+        "eq": -1.0
+      },
+      {
+        "expr": "",
+        "label": "c3",
+        "eq": 1.0
+      },
+      {
+        "expr": "",
+        "label": "c4",
+        "eq": 1.0
+      },
+      {
+        "expr": "",
+        "label": "c5",
+        "eq": -1.0
+      },
+      {
+        "expr": "",
+        "label": "c6",
+        "eq": 1.0
+      },
+      {
+        "expr": "",
+        "label": "c7",
+        "eq": -1.0
+      },
+      {
+        "expr": "",
+        "label": "c8",
+        "eq": -1.0
+      },
+      {
+        "expr": "",
+        "label": "c9",
+        "eq": -1.0
+      }
+    ],
+    "var": [
+      {
+        "label": "vFalse",
+        "id": 1,
+        "value": -1,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "vTrue",
+        "id": 6,
+        "value": 1,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [],
+    "set": {},
+    "indexed_vars": [],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/small13.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small13.pyomo.json
@@ -1,0 +1,51 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "V,0",
+        "sense": "max",
+        "label": "obj"
+      }
+    ],
+    "con": [
+      {
+        "expr": "+,pow,V,0,N,3,*,N,-1,V,0",
+        "label": "c1",
+        "eq": 0.0
+      },
+      {
+        "expr": "*,N,10,+,pow,V,0,N,3,*,N,-1,V,0",
+        "label": "c2",
+        "eq": 0.0
+      },
+      {
+        "expr": "/,+,pow,V,0,N,3,*,N,-1,V,0,N,10.0",
+        "label": "c3",
+        "eq": 0.0
+      }
+    ],
+    "var": [
+      {
+        "label": "x",
+        "id": 0,
+        "value": 0.5,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [],
+    "set": {},
+    "indexed_vars": [],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/small14.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small14.pyomo.json
@@ -1,0 +1,138 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "+,V,0,V,1",
+        "sense": "min",
+        "label": "obj"
+      }
+    ],
+    "con": [
+      {
+        "expr": "abs,V,0",
+        "label": "c_abs",
+        "eq": 1.0
+      },
+      {
+        "expr": "acos,V,1",
+        "label": "c_acos",
+        "eq": 1.5707963267948966
+      },
+      {
+        "expr": "acosh,/,+,V,0,N,7.3890560989306495,N,5.43656365691809",
+        "label": "c_acosh",
+        "eq": 0.0
+      },
+      {
+        "expr": "asin,V,1",
+        "label": "c_asin",
+        "eq": 0.0
+      },
+      {
+        "expr": "asinh,V,1",
+        "label": "c_asinh",
+        "eq": 0.0
+      },
+      {
+        "expr": "atan,V,1",
+        "label": "c_atan",
+        "eq": 0.0
+      },
+      {
+        "expr": "atanh,V,1",
+        "label": "c_atanh",
+        "eq": 0.0
+      },
+      {
+        "expr": "ceil,V,0",
+        "label": "c_ceil",
+        "eq": 1.0
+      },
+      {
+        "expr": "cos,V,1",
+        "label": "c_cos",
+        "eq": 1.0
+      },
+      {
+        "expr": "cosh,V,1",
+        "label": "c_cosh",
+        "eq": 1.0
+      },
+      {
+        "expr": "exp,V,1",
+        "label": "c_exp",
+        "eq": 1.0
+      },
+      {
+        "expr": "floor,V,0",
+        "label": "c_floor",
+        "eq": 1.0
+      },
+      {
+        "expr": "log,V,0",
+        "label": "c_log",
+        "eq": 0.0
+      },
+      {
+        "expr": "log10,V,0",
+        "label": "c_log10",
+        "eq": 0.0
+      },
+      {
+        "expr": "sin,V,1",
+        "label": "c_sin",
+        "eq": 0.0
+      },
+      {
+        "expr": "sinh,V,1",
+        "label": "c_sinh",
+        "eq": 0.0
+      },
+      {
+        "expr": "sqrt,V,0",
+        "label": "c_sqrt",
+        "eq": 1.0
+      },
+      {
+        "expr": "tan,V,1",
+        "label": "c_tan",
+        "eq": 0.0
+      },
+      {
+        "expr": "tanh,V,1",
+        "label": "c_tanh",
+        "eq": 0.0
+      }
+    ],
+    "var": [
+      {
+        "label": "ONE",
+        "id": 0,
+        "value": 1,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "ZERO",
+        "id": 1,
+        "value": 0,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [],
+    "set": {},
+    "indexed_vars": [],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/small15.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small15.pyomo.json
@@ -1,0 +1,48 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "pow,V,0,N,2",
+        "sense": "min",
+        "label": "OBJ"
+      }
+    ],
+    "con": [
+      {
+        "expr": "pow,V,1,N,2",
+        "label": "CON1",
+        "eq": 4.0
+      }
+    ],
+    "var": [
+      {
+        "label": "x",
+        "id": 0,
+        "value": 1.0,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "b.y",
+        "id": 1,
+        "value": 1.0,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [],
+    "set": {},
+    "indexed_vars": [],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/small2.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small2.pyomo.json
@@ -1,0 +1,48 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "V,0",
+        "sense": "min",
+        "label": "OBJ"
+      }
+    ],
+    "con": [
+      {
+        "expr": "pow,V,1,N,2",
+        "label": "CON1",
+        "eq": 4.0
+      }
+    ],
+    "var": [
+      {
+        "label": "x",
+        "id": 0,
+        "value": 1.0,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "y",
+        "id": 1,
+        "value": 1.0,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [],
+    "set": {},
+    "indexed_vars": [],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/small3.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small3.pyomo.json
@@ -1,0 +1,48 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "*,V,0,V,1",
+        "sense": "min",
+        "label": "OBJ"
+      }
+    ],
+    "con": [
+      {
+        "expr": "pow,V,1,N,2",
+        "label": "CON1",
+        "eq": 4.0
+      }
+    ],
+    "var": [
+      {
+        "label": "x",
+        "id": 0,
+        "value": 1.0,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "y",
+        "id": 1,
+        "value": 1.0,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [],
+    "set": {},
+    "indexed_vars": [],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/small3a.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small3a.pyomo.json
@@ -1,0 +1,48 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "+,*,V,0,V,1,N,4",
+        "sense": "min",
+        "label": "OBJ"
+      }
+    ],
+    "con": [
+      {
+        "expr": "*,pow,V,1,N,2,V,0",
+        "label": "CON1",
+        "eq": 4.0
+      }
+    ],
+    "var": [
+      {
+        "label": "x",
+        "id": 0,
+        "value": 1.0,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "y",
+        "id": 1,
+        "value": 1.0,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [],
+    "set": {},
+    "indexed_vars": [],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/small4.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small4.pyomo.json
@@ -1,0 +1,48 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "pow,V,1,N,2",
+        "sense": "min",
+        "label": "OBJ"
+      }
+    ],
+    "con": [
+      {
+        "expr": "*,V,1,V,0",
+        "label": "CON1",
+        "eq": 4.0
+      }
+    ],
+    "var": [
+      {
+        "label": "x",
+        "id": 0,
+        "value": 1.0,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "y",
+        "id": 1,
+        "value": 1.0,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [],
+    "set": {},
+    "indexed_vars": [],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/small5.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small5.pyomo.json
@@ -1,0 +1,122 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "+,/,pow,V,1,N,2,N,2.0,/,pow,V,1,N,2,P,1",
+        "sense": "min",
+        "label": "OBJ"
+      }
+    ],
+    "con": [
+      {
+        "expr": "*,*,N,0.5,V,0,+,V,1,*,N,-1,V,2",
+        "label": "CON1",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,V,0,+,*,/,N,1,P,1,V,1,*,neg,/,N,1,P,1,V,2",
+        "label": "CON10",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,*,V,0,+,V,1,*,N,-1,V,2,/,N,1.0,P,1",
+        "label": "CON11",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,V,0,+,V,1,*,N,-1,V,2",
+        "label": "CON12",
+        "eq": "*,N,2.0,P,1"
+      },
+      {
+        "expr": "*,*,N,0.5,V,0,+,V,1,*,N,-1,V,2",
+        "label": "CON2",
+        "eq": 2.0
+      },
+      {
+        "expr": "/,*,V,0,+,V,1,*,N,-1,V,2,N,2.0",
+        "label": "CON3",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,V,0,+,*,N,0.5,V,1,*,N,-0.5,V,2",
+        "label": "CON4",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,*,V,0,+,V,1,*,N,-1,V,2,N,0.5",
+        "label": "CON5",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,V,0,+,V,1,*,N,-1,V,2",
+        "label": "CON6",
+        "eq": 4.0
+      },
+      {
+        "expr": "*,*,/,N,1.0,P,1,V,0,+,V,1,*,N,-1,V,2",
+        "label": "CON7",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,*,/,N,1,P,1,V,0,+,V,1,*,N,-1,V,2",
+        "label": "CON8",
+        "eq": 2.0
+      },
+      {
+        "expr": "/,*,V,0,+,V,1,*,N,-1,V,2,P,1",
+        "label": "CON9",
+        "eq": 2.0
+      }
+    ],
+    "var": [
+      {
+        "label": "v",
+        "id": 0,
+        "value": 3.0,
+        "lb": -1.0,
+        "ub": 1.0,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x",
+        "id": 1,
+        "value": 1.0,
+        "lb": -1.0,
+        "ub": 1.0,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "y",
+        "id": 2,
+        "value": 2.0,
+        "lb": -1.0,
+        "ub": 1.0,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [
+      {
+        "label": "q",
+        "id": 1,
+        "value": 2.0
+      }
+    ],
+    "set": {},
+    "indexed_vars": [],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/small5a.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small5a.pyomo.json
@@ -1,0 +1,65 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "*,V,0,V,1",
+        "sense": "min",
+        "label": "OBJ"
+      }
+    ],
+    "con": [
+      {
+        "expr": "+,V,0,V,1",
+        "label": "CON1",
+        "leq": "*,N,2.0,P,0"
+      },
+      {
+        "expr": "+,V,0,V,1",
+        "label": "CON2",
+        "geq": "P,0"
+      },
+      {
+        "expr": "+,V,0,V,1",
+        "label": "CON3",
+        "geq": "P,0",
+        "leq": "*,N,2.0,P,0"
+      }
+    ],
+    "var": [
+      {
+        "label": "x",
+        "id": 0,
+        "lb": 0,
+        "ub": 1,
+        "type": "B",
+        "fixed": 0
+      },
+      {
+        "label": "y",
+        "id": 1,
+        "type": "Z",
+        "fixed": 0
+      }
+    ],
+    "param": [
+      {
+        "label": "q",
+        "id": 0,
+        "value": 2.0
+      }
+    ],
+    "set": {},
+    "indexed_vars": [],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/small6.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small6.pyomo.json
@@ -1,0 +1,93 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "V,2",
+        "sense": "min",
+        "label": "OBJ"
+      }
+    ],
+    "con": [
+      {
+        "expr": "*,*,/,N,1.0,V,0,V,1,+,V,2,*,N,-1,V,3",
+        "label": "CON1",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,/,V,1,V,0,+,V,2,*,N,-1,V,3",
+        "label": "CON2",
+        "eq": 2.0
+      },
+      {
+        "expr": "/,*,V,1,+,V,2,*,N,-1,V,3,V,0",
+        "label": "CON3",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,V,1,+,/,V,2,V,0,neg,/,V,3,V,0",
+        "label": "CON4",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,*,V,1,+,V,2,*,N,-1,V,3,/,N,1.0,V,0",
+        "label": "CON5",
+        "eq": 2.0
+      },
+      {
+        "expr": "+,*,V,1,+,V,2,*,N,-1,V,3,*,N,-2.0,V,0",
+        "label": "CON6",
+        "eq": 0.0
+      }
+    ],
+    "var": [
+      {
+        "label": "p",
+        "id": 0,
+        "value": 2.0,
+        "type": "R",
+        "fixed": 1
+      },
+      {
+        "label": "v",
+        "id": 1,
+        "value": 3.0,
+        "lb": -1.0,
+        "ub": 1.0,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x",
+        "id": 2,
+        "value": 1.0,
+        "lb": -1.0,
+        "ub": 1.0,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "y",
+        "id": 3,
+        "value": 2.0,
+        "lb": -1.0,
+        "ub": 1.0,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [],
+    "set": {},
+    "indexed_vars": [],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/small7.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small7.pyomo.json
@@ -1,0 +1,183 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "V,2",
+        "sense": "min",
+        "label": "OBJ"
+      }
+    ],
+    "con": [
+      {
+        "expr": "*,*,/,/,N,1.0,V,0,N,2.0,V,1,+,V,2,*,N,-1,V,3",
+        "label": "CON1a",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,*,/,N,1.0,*,N,2.0,V,0,V,1,+,V,2,*,N,-1,V,3",
+        "label": "CON1b",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,*,/,N,1.0,+,V,0,N,2.0,V,1,+,V,2,*,N,-1,V,3",
+        "label": "CON1c",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,*,/,N,1.0,pow,+,V,0,N,2.0,N,2,V,1,+,V,2,*,N,-1,V,3",
+        "label": "CON1d",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,/,/,V,1,V,0,V,0,+,V,2,*,N,-1,V,3",
+        "label": "CON2a",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,/,V,1,*,V,0,V,0,+,V,2,*,N,-1,V,3",
+        "label": "CON2b",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,/,V,1,+,V,0,V,0,+,V,2,*,N,-1,V,3",
+        "label": "CON2c",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,/,V,1,pow,+,V,0,V,0,N,2,+,V,2,*,N,-1,V,3",
+        "label": "CON2d",
+        "eq": 2.0
+      },
+      {
+        "expr": "/,/,*,V,1,+,V,2,*,N,-1,V,3,V,0,N,2.0",
+        "label": "CON3a",
+        "eq": 2.0
+      },
+      {
+        "expr": "/,*,V,1,+,V,2,*,N,-1,V,3,*,N,2.0,V,0",
+        "label": "CON3b",
+        "eq": 2.0
+      },
+      {
+        "expr": "/,*,V,1,+,V,2,*,N,-1,V,3,+,V,0,N,2.0",
+        "label": "CON3c",
+        "eq": 2.0
+      },
+      {
+        "expr": "/,*,V,1,+,V,2,*,N,-1,V,3,pow,+,V,0,N,2.0,N,2",
+        "label": "CON3d",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,V,1,+,/,/,V,2,V,0,N,2.0,neg,/,/,V,3,V,0,N,2.0",
+        "label": "CON4a",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,V,1,+,/,V,2,*,N,2.0,V,0,neg,/,V,3,*,N,2.0,V,0",
+        "label": "CON4b",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,V,1,+,/,V,2,+,V,0,N,2.0,neg,/,V,3,+,V,0,N,2.0",
+        "label": "CON4c",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,V,1,+,/,V,2,pow,+,V,0,N,2.0,N,2,neg,/,V,3,pow,+,V,0,N,2.0,N,2",
+        "label": "CON4d",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,*,V,1,+,V,2,*,N,-1,V,3,/,/,N,1.0,V,0,N,2.0",
+        "label": "CON5a",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,*,V,1,+,V,2,*,N,-1,V,3,/,N,1.0,*,N,2.0,V,0",
+        "label": "CON5b",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,*,V,1,+,V,2,*,N,-1,V,3,/,N,1.0,+,V,0,N,2.0",
+        "label": "CON5c",
+        "eq": 2.0
+      },
+      {
+        "expr": "*,*,V,1,+,V,2,*,N,-1,V,3,/,N,1.0,pow,+,V,0,N,2.0,N,2",
+        "label": "CON5d",
+        "eq": 2.0
+      },
+      {
+        "expr": "+,*,V,1,+,V,2,*,N,-1,V,3,*,N,-4.0,V,0",
+        "label": "CON6a",
+        "eq": 0.0
+      },
+      {
+        "expr": "+,*,V,1,+,V,2,*,N,-1,V,3,*,N,-4.0,V,0",
+        "label": "CON6b",
+        "eq": 0.0
+      },
+      {
+        "expr": "+,*,V,1,+,V,2,*,N,-1,V,3,neg,*,N,2.0,+,V,0,N,2.0",
+        "label": "CON6c",
+        "eq": 0.0
+      },
+      {
+        "expr": "+,*,V,1,+,V,2,*,N,-1,V,3,neg,*,N,2.0,pow,+,V,0,N,2.0,N,2",
+        "label": "CON6d",
+        "eq": 0.0
+      }
+    ],
+    "var": [
+      {
+        "label": "p",
+        "id": 0,
+        "value": 2.0,
+        "type": "R",
+        "fixed": 1
+      },
+      {
+        "label": "v",
+        "id": 1,
+        "value": 3.0,
+        "lb": -1.0,
+        "ub": 1.0,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "x",
+        "id": 2,
+        "value": 1.0,
+        "lb": -1.0,
+        "ub": 1.0,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "y",
+        "id": 3,
+        "value": 2.0,
+        "lb": -1.0,
+        "ub": 1.0,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [],
+    "set": {},
+    "indexed_vars": [],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/small8.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small8.pyomo.json
@@ -1,0 +1,21 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [],
+    "con": [],
+    "var": [],
+    "param": [],
+    "set": {},
+    "indexed_vars": [],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/small9.pyomo.json
+++ b/pyomo/contrib/jpof/tests/small9.pyomo.json
@@ -1,0 +1,79 @@
+{
+  "__metadata__": {
+    "version": 20210301,
+    "format": "JSON Parameterized Optimization Format (JPOF)"
+  },
+  "model": {
+    "config": {
+      "symbolic_solver_labels": 1,
+      "skip_trivial_constraints": 0,
+      "file_determinism": 3,
+      "include_all_variable_bounds": 0
+    },
+    "obj": [
+      {
+        "expr": "V,0",
+        "sense": "min",
+        "label": "obj"
+      }
+    ],
+    "con": [
+      {
+        "expr": "+,*,*,V,0,V,1,V,2,V,0",
+        "label": "con1",
+        "eq": 1.0
+      },
+      {
+        "expr": "+,*,*,P,0,V,0,V,2,V,0",
+        "label": "con2",
+        "eq": 1.0
+      },
+      {
+        "expr": "V,0",
+        "label": "con3",
+        "eq": 1.0
+      },
+      {
+        "expr": "*,*,V,0,V,1,V,2",
+        "label": "con4",
+        "eq": 1.0
+      },
+      {
+        "expr": "*,*,P,0,V,0,V,2",
+        "label": "con5",
+        "eq": 1.0
+      }
+    ],
+    "var": [
+      {
+        "label": "x",
+        "id": 0,
+        "type": "R",
+        "fixed": 0
+      },
+      {
+        "label": "y",
+        "id": 1,
+        "value": 0.0,
+        "type": "R",
+        "fixed": 1
+      },
+      {
+        "label": "z",
+        "id": 2,
+        "type": "R",
+        "fixed": 0
+      }
+    ],
+    "param": [
+      {
+        "label": "p",
+        "id": 0,
+        "value": 0.0
+      }
+    ],
+    "set": {},
+    "indexed_vars": [],
+    "indexed_params": []
+  }
+}

--- a/pyomo/contrib/jpof/tests/test_json_comparison.py
+++ b/pyomo/contrib/jpof/tests/test_json_comparison.py
@@ -1,0 +1,68 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+#
+# Test the Pyomo writer for the JSON Parameterized Optimization Format (JPOF)
+#
+
+import itertools
+import sys
+import re
+import glob
+import os
+from os.path import abspath, dirname, join
+import json
+import pytest
+
+from pyomo.common.fileutils import import_file
+from pyomo.common.unittest import assertStructuredAlmostEqual
+from pyomo.contrib.jpof import JPOFWriter
+
+currdir = dirname(abspath(__file__))+os.sep
+datadir = abspath(join(dirname(dirname(currdir)), 'testCase'))+os.sep
+
+
+testnames = []
+for f in itertools.chain(glob.glob(datadir+'*_testCase.py'),
+                         glob.glob(currdir+'*_testCase.py')):
+    testnames.append( re.split('[._]',os.path.basename(f))[0] )
+
+
+@pytest.mark.default
+@pytest.mark.parametrize("name", testnames)
+def test_jpof_writer(name):
+    baseline = currdir+name+'.pyomo.json'
+    output = currdir+name+'.test.json'
+    if not os.path.exists(baseline):
+        pytest.skip("baseline file (%s) not found" % (baseline,))
+
+    if os.path.exists(datadir+name+'_testCase.py'):
+        testDir = datadir
+    else:
+        testDir = currdir
+    testCase = import_file(testDir+name+'_testCase.py')
+    
+
+    writer = JPOFWriter()
+    writer(testCase.model, filename=output, io_options={'file_determinism':3, 'symbolic_solver_labels':True})
+
+    # Check that the pyomo JSON file matches its own baseline
+    try:
+        with open(baseline, 'r') as f1, open(output, 'r') as f2:
+            baseline_contents = json.load(f1)
+            output_contents = json.load(f2)
+        assertStructuredAlmostEqual(output_contents, baseline_contents,
+                                         allow_second_superset=True)
+        os.remove(output)
+    except Exception:
+        err = sys.exc_info()[1]
+        pytest.fail("JSON testfile does not match the baseline:\n   testfile="
+                  + output + "\n   baseline=" + baseline + "\n" + str(
+                      err))
+


### PR DESCRIPTION
## Fixes NONE

## Summary/Motivation:

Adds a contrib package, jpof, that contains a new Pyomo writer.  This write generates a JSON formatted file that describes the problem representation in the Pyomo model.  This file format is like LP and NL files, which represent the Pyomo optimization model in a concise format.  The JPOF format has several features:

* It is in a standard format that is easily parsed.
* It captures Pyomo expressions with fixed variables and parameterized constant values.  These values are explicit, which allows for downstream tools to modify these values as intended by the user.

The Coek software includes a JPOF reader.

## Changes proposed in this PR:
- Initial commit of JPOF writer logic, with tests and examples.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
