### PR TITLE
Bugfix: component indexes specified as lists

### DIFF
--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -802,6 +802,7 @@ You can silence this warning by one of three ways:
         # Iterate through the index and look for slices and constant
         # components
         #
+        orig_idx = idx
         fixed = {}
         sliced = {}
         ellipsis = None
@@ -942,7 +943,7 @@ value() function.""" % ( self.name, i ))
         else:
             raise DeveloperError(
                 "Unknown problem encountered when trying to retrieve "
-                "index for component %s" % (self.name,) )
+                f"index '{orig_idx}' for component '{self.name}'")
 
     def _getitem_when_not_present(self, index):
         """Returns/initializes a value when the index is not in the _data dict.

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -805,7 +805,6 @@ You can silence this warning by one of three ways:
         fixed = {}
         sliced = {}
         ellipsis = None
-        _found_numeric = False
         #
         # Setup the slice template (in fixed)
         #
@@ -844,8 +843,6 @@ You can silence this warning by one of three ways:
                 # should raise a TemplateExpressionError
                 try:
                     val = EXPR.evaluate_expression(val, constant=True)
-                    _found_numeric = True
-
                 except TemplateExpressionError:
                     #
                     # The index is a template expression, so return the
@@ -937,7 +934,7 @@ value() function.""" % ( self.name, i ))
                     IndexedComponent_slice._getitem_args_to_str(list(idx)),
                     self.name, set_dim, slice_dim))
             return IndexedComponent_slice(self, fixed, sliced, ellipsis)
-        elif _found_numeric:
+        elif len(idx) == len(fixed):
             if len(idx) == 1:
                 return fixed[0]
             else:

--- a/pyomo/core/tests/unit/test_indexed.py
+++ b/pyomo/core/tests/unit/test_indexed.py
@@ -223,9 +223,26 @@ class TestIndexedComponent(unittest.TestCase):
     def test_index_by_unhashable_type(self):
         m = ConcreteModel()
         m.x = Var([1,2,3], initialize=lambda m,x: 2*x)
+        # Indexing by a dict raises an error
         self.assertRaisesRegex(
             TypeError, '.*',
             m.x.__getitem__, {})
+        # Indexing by lists works...
+        # ... scalar
+        self.assertIs(m.x[[1]], m.x[1])
+        # ... "tuple"
+        m.y = Var([(1, 1), (1, 2)])
+        self.assertIs(m.y[[1, 1]], m.y[1, 1])
+        m.y[[1, 2]] = 5
+        y12 = m.y[[1, 2]]
+        self.assertEqual(y12.value, 5)
+        m.y[[1, 2]] = 15
+        self.assertIs(y12, m.y[[1, 2]])
+        self.assertEqual(y12.value, 15)
+        with self.assertRaisesRegex(
+                KeyError, r"Index '\(2, 2\)' is not valid for indexed component 'y'"):
+            m.y[[2, 2]] = 5
+
 
     def test_ordered_keys(self):
         m = ConcreteModel()


### PR DESCRIPTION
## Fixes #2764

## Summary/Motivation:
There was an error resolving unhashable indexes that were convertible to tuples (e.g. passing the index as a `list`).  This PR resolves that bug.

## Changes proposed in this PR:
- correct processing of unhashable indexes that are easily convertable to tuples
- add a test for indexing components with lists

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
