### PR TITLE
contrib.piecewise: Adding transformation to "reduced" inner representation GDP

### DIFF
--- a/pyomo/contrib/piecewise/__init__.py
+++ b/pyomo/contrib/piecewise/__init__.py
@@ -11,4 +11,7 @@ from pyomo.contrib.piecewise.transform.outer_representation_gdp import (
     OuterRepresentationGDPTransformation)
 from pyomo.contrib.piecewise.transform.multiple_choice import (
     MultipleChoiceTransformation)
-                                                               
+from pyomo.contrib.piecewise.transform.reduced_inner_representation_gdp import (
+    ReducedInnerRepresentationGDPTransformation)
+from pyomo.contrib.piecewise.transform.convex_combination import (
+    ConvexCombinationTransformation)

--- a/pyomo/contrib/piecewise/tests/test_reduced_inner_repn.py
+++ b/pyomo/contrib/piecewise/tests/test_reduced_inner_repn.py
@@ -1,0 +1,184 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import pyomo.common.unittest as unittest
+from pyomo.contrib.piecewise.tests import models
+import pyomo.contrib.piecewise.tests.common_tests as ct
+from pyomo.core.base import TransformationFactory
+from pyomo.core.expr.compare import (
+    assertExpressionsEqual, assertExpressionsStructurallyEqual)
+from pyomo.gdp import Disjunct, Disjunction
+from pyomo.environ import Constraint, SolverFactory, Var
+
+class TestTransformPiecewiseModelToReducedInnerRepnGDP(unittest.TestCase):
+    def check_log_disjunct(self, d, not_pts, f, substitute_var, x):
+        self.assertEqual(len(d.component_map(Constraint)), 1)
+        # just the indicator_var
+        self.assertEqual(len(d.component_map(Var)), 1)
+        self.assertIsInstance(d.lambdas_zero_for_other_simplices, Constraint)
+        self.assertEqual(len(d.lambdas_zero_for_other_simplices), 2)
+        transBlock = d.parent_block()
+        for i, cons in zip(not_pts,
+                            d.lambdas_zero_for_other_simplices.values()):
+            assertExpressionsEqual(self, cons.expr, transBlock.lambdas[i] <= 0)
+
+    def check_paraboloid_disjunct(self, d, pts, f, substitute_var, x1, x2):
+        self.assertEqual(len(d.component_map(Constraint)), 3)
+        # lambdas and indicator_var
+        self.assertEqual(len(d.component_map(Var)), 2)
+        self.assertIsInstance(d.lambdas, Var)
+        self.assertEqual(len(d.lambdas), 3)
+        for lamb in d.lambdas.values():
+            self.assertEqual(lamb.lb, 0)
+            self.assertEqual(lamb.ub, 1)
+        self.assertIsInstance(d.convex_combo, Constraint)
+        assertExpressionsEqual(self, d.convex_combo.expr,
+                               d.lambdas[0] + d.lambdas[1] + d.lambdas[2] == 1)
+        self.assertIsInstance(d.set_substitute, Constraint)
+        assertExpressionsEqual(self, d.set_substitute.expr,
+                               substitute_var == f(x1, x2), places=7)
+        self.assertIsInstance(d.linear_combo, Constraint)
+        self.assertEqual(len(d.linear_combo), 2)
+        assertExpressionsEqual(
+            self, d.linear_combo[0].expr,
+            x1 == pts[0][0]*d.lambdas[0] + pts[1][0]*d.lambdas[1] +
+            pts[2][0]*d.lambdas[2])
+        assertExpressionsEqual(
+            self, d.linear_combo[1].expr,
+            x2 == pts[0][1]*d.lambdas[0] + pts[1][1]*d.lambdas[1] +
+            pts[2][1]*d.lambdas[2])
+
+    def check_log_trans_block_structure(self, transBlock, x, pts):
+        # One (indexed) disjunct
+        self.assertEqual(len(transBlock.component_map(Disjunct)), 1)
+        # One disjunction
+        self.assertEqual(len(transBlock.component_map(Disjunction)), 1)
+        # substitute Var and lambdas:
+        self.assertEqual(len(transBlock.component_map(Var)), 2)
+        # The 'z' var (that we will substitute in for the function being
+        # approximated) is here:
+        self.assertIsInstance(transBlock.substitute_var, Var)
+
+        self.assertIsInstance(transBlock.lambdas, Var)
+        self.assertEqual(len(transBlock.lambdas), 4)
+        for lamb in transBlock.lambdas.values():
+            self.assertEqual(lamb.lb, 0)
+            self.assertEqual(lamb.ub, 1)
+        self.assertIsInstance(transBlock.convex_combo, Constraint)
+        assertExpressionsEqual(self, transBlock.convex_combo.expr,
+                               transBlock.lambdas[0] + transBlock.lambdas[1] +
+                               transBlock.lambdas[2] + transBlock.lambdas[3] ==
+                               1)
+        self.assertIsInstance(transBlock.linear_combo, Constraint)
+        self.assertEqual(len(transBlock.linear_combo), 1)
+        assertExpressionsEqual(self, transBlock.linear_combo[0].expr, x ==
+                               pts[0][0]*transBlock.lambdas[0] +
+                               pts[1][0]*transBlock.lambdas[1] +
+                               pts[2][0]*transBlock.lambdas[2] +
+                               pts[3][0]*transBlock.lambdas[3])
+
+    def check_pw_log(self, m):
+        ##
+        # Check the transformation of the approximation of log(x)
+        ##
+        z = m.pw_log.get_transformation_var(m.log_expr)
+        self.assertIsInstance(z, Var)
+        # Now we can use those Vars to check on what the transformation created
+        log_block = z.parent_block()
+        self.check_log_trans_block_structure(log_block, m.x, m.pw_log._points)
+
+        # Check that all of the Disjuncts have what they should
+        self.assertEqual(len(log_block.disjuncts), 3)
+        disjuncts_dict = {
+            log_block.disjuncts[0]: ((2, 3), m.f1),
+            log_block.disjuncts[1]: ((0, 3), m.f2),
+            log_block.disjuncts[2]: ((0, 1), m.f3),
+        }
+        for d, (pts, f) in disjuncts_dict.items():
+            self.check_log_disjunct(d, pts, f, log_block.substitute_var, m.x)
+
+        # Check the Disjunction
+        self.assertIsInstance(log_block.pick_a_piece, Disjunction)
+        self.assertEqual(len(log_block.pick_a_piece.disjuncts), 3)
+        for i in range(2):
+            self.assertIs(log_block.pick_a_piece.disjuncts[i],
+                          log_block.disjuncts[i])
+
+        # And check the substitute Var is in the objective now.
+        self.assertIs(m.obj.expr.expr, log_block.substitute_var)
+
+    def check_pw_paraboloid(self, m):
+        # TODO: you are here!
+        ##
+        # Check the approximation of the transformation of the paraboloid
+        ##
+        z = m.pw_paraboloid.get_transformation_var(m.paraboloid_expr)
+        self.assertIsInstance(z, Var)
+        paraboloid_block = z.parent_block()
+        ct.check_trans_block_structure(self, paraboloid_block)
+
+        self.assertEqual(len(paraboloid_block.disjuncts), 4)
+        disjuncts_dict = {
+            paraboloid_block.disjuncts[0]: ([(0, 1), (0, 4), (3, 4)], m.g1),
+            paraboloid_block.disjuncts[1]: ([(0, 1), (3, 4), (3, 1)], m.g1),
+            paraboloid_block.disjuncts[2]: ([(3, 4), (3, 7), (0, 7)], m.g2),
+            paraboloid_block.disjuncts[3]: ([(0, 7), (0, 4), (3, 4)], m.g2),
+        }
+        for d, (pts, f) in disjuncts_dict.items():
+            self.check_paraboloid_disjunct(d, pts, f,
+                                           paraboloid_block.substitute_var,
+                                           m.x1, m.x2)
+
+        # Check the Disjunction
+        self.assertIsInstance(paraboloid_block.pick_a_piece, Disjunction)
+        self.assertEqual(len(paraboloid_block.pick_a_piece.disjuncts), 4)
+        for i in range(3):
+            self.assertIs(paraboloid_block.pick_a_piece.disjuncts[i],
+                          paraboloid_block.disjuncts[i])
+
+        # And check the substitute Var is in the objective now.
+        self.assertIs(m.indexed_c[0].body.args[0].expr,
+                      paraboloid_block.substitute_var)
+
+    def test_transformation_do_not_descend(self):
+       ct.check_transformation_do_not_descend(
+           self,
+           'contrib.piecewise.reduced_inner_repn_gdp')
+
+    def test_transformation_PiecewiseLinearFunction_targets(self):
+        ct.check_transformation_PiecewiseLinearFunction_targets(
+            self,
+            'contrib.piecewise.reduced_inner_repn_gdp')
+
+    def test_descend_into_expressions(self):
+        ct.check_descend_into_expressions(
+            self,
+            'contrib.piecewise.reduced_inner_repn_gdp')
+
+    def test_descend_into_expressions_constraint_target(self):
+        ct.check_descend_into_expressions_constraint_target(
+            self,
+            'contrib.piecewise.reduced_inner_repn_gdp')
+
+    def test_descend_into_expressions_objective_target(self):
+        ct.check_descend_into_expressions_objective_target(
+            self,
+            'contrib.piecewise.reduced_inner_repn_gdp')
+
+    @unittest.skipUnless(SolverFactory('gurobi').available(),
+                         'Gurobi is not available')
+    def test_solve_convex_combo_model(self):
+        m = models.make_log_x_model()
+        TransformationFactory(
+            'contrib.piecewise.convex_combination').apply_to(m)
+        SolverFactory('gurobi').solve(m)
+
+        ct.check_log_x_model_soln(self, m)

--- a/pyomo/contrib/piecewise/transform/convex_combination.py
+++ b/pyomo/contrib/piecewise/transform/convex_combination.py
@@ -1,0 +1,37 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+from pyomo.core.base import Transformation, TransformationFactory
+import pyomo.gdp.plugins.multiple_bigm
+
+@TransformationFactory.register('contrib.piecewise.convex_combination',
+                                doc="Convert piecewise-linear model to a GDP "
+                                "to 'Convex Combination' MIP formulation.")
+class ConvexCombinationTransformation(Transformation):
+    """
+    Converts a model containing PiecewiseLinearFunctions to a an equivalent
+    MIP via the Convex Combination method from [1]. Note that,
+    while this model probably resolves to the model described in [1] after
+    presolve, the Pyomo version is not as simplified.
+
+    References
+    ----------
+    [1] J.P. Vielma, S. Ahmed, and G. Nemhauser, "Mixed-integer models
+        for nonseparable piecewise-linear optimization: unifying framework
+        and extensions," Operations Research, vol. 58, no. 2, pp. 305-315,
+        2010.
+    """
+    def _apply_to(self, instance, **kwds):
+        TransformationFactory(
+            'contrib.piecewise.reduced_inner_repn_gdp').apply_to(instance)
+        TransformationFactory('gdp.mbigm').apply_to(
+            instance,
+            reduce_bound_constraints=True)

--- a/pyomo/contrib/piecewise/transform/reduced_inner_representation_gdp.py
+++ b/pyomo/contrib/piecewise/transform/reduced_inner_representation_gdp.py
@@ -16,9 +16,6 @@ from pyomo.core import Constraint, NonNegativeIntegers, Var
 from pyomo.core.base import TransformationFactory
 from pyomo.gdp import Disjunct, Disjunction
 
-##DEBUG
-from pytest import set_trace
-
 @TransformationFactory.register('contrib.piecewise.reduced_inner_repn_gdp',
                                 doc="Convert piecewise-linear model to a GDP "
                                 "using an inner representation of the "

--- a/pyomo/contrib/piecewise/transform/reduced_inner_representation_gdp.py
+++ b/pyomo/contrib/piecewise/transform/reduced_inner_representation_gdp.py
@@ -1,0 +1,122 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
+from pyomo.contrib.piecewise.transform.piecewise_to_gdp_transformation import (
+    PiecewiseLinearToGDP)
+from pyomo.core import Constraint, NonNegativeIntegers, Var
+from pyomo.core.base import TransformationFactory
+from pyomo.gdp import Disjunct, Disjunction
+
+@TransformationFactory.register('contrib.piecewise.reduced_inner_repn_gdp',
+                                doc="Convert piecewise-linear model to a GDP "
+                                "using an inner representation of the "
+                                "simplices that are the domains of the linear "
+                                "functions.")
+class ReducedInnerRepresentationGDPTransformation(PiecewiseLinearToGDP):
+    """
+    Convert a model involving piecewise linear expressions into a GDP by
+    representing the piecewise linear functions as Disjunctions where the
+    simplices over which the linear functions are defined are represented
+    in a reduced "inner" representation--as convex combinations of their extreme
+    points. We refer to this as 'reduced' since we create only one multiplier
+    for each extreme point in the union of the extreme points over all the 
+    simplices. Within the Disjuncts, we then enforce that all of the multipliers
+    for extreme points not in the simplex are 0.
+
+    This transformation can be called in one of two ways:
+        1) The default, where 'descend_into_expressions' is False. This is
+           more computationally efficient, but relies on the
+           PiecewiseLinearFunctions being declared on the same Block in which
+           they are used in Expressions (if you are hoping to maintain the
+           original hierarchical structure of the model). In this mode,
+           targets must be Blocks and/or PiecewiseLinearFunctions.
+        2) With 'descend_into_expressions' True. This is less computationally
+           efficient, but will respect hierarchical structure by finding
+           uses of PiecewiseLinearFunctions in Constraint and Obective
+           expressions and putting their transformed counterparts on the same
+           parent Block as the component owning their parent expression. In
+           this mode, targets must be Blocks, Constraints, and/or Objectives.
+    """
+    CONFIG = PiecewiseLinearToGDP.CONFIG()
+    _transformation_name = 'pw_linear_reduced_inner_repn'
+
+    def _transform_pw_linear_expr(self, pw_expr, pw_linear_func,
+                                  transformation_block):
+        transBlock = transformation_block.transformed_functions[
+            len(transformation_block.transformed_functions)]
+        transBlock.lambdas = Var(NonNegativeIntegers, dense=False, bounds=(0,1))
+        multipliers_by_pt = transBlock.multipliers_by_pt = {}
+
+        # get the PiecewiseLinearFunctionExpression
+        dimension = pw_expr.nargs()
+        transBlock.disjuncts = Disjunct(NonNegativeIntegers)
+        substitute_var = transBlock.substitute_var = Var()
+        pw_linear_func.map_transformation_var(pw_expr,
+                                              substitute_var)
+        substitute_var_lb = float('inf')
+        substitute_var_ub = -float('inf')
+        extreme_pts_by_simplex = {}
+        all_extreme_pts = []
+        # Collect all of the extreme pts, and map each one to *one* lambda
+        # multiplier
+        for simplex, linear_func in zip(pw_linear_func._simplices,
+                                        pw_linear_func._linear_functions):
+            extreme_pts = extreme_pts_by_sinples[simplex] = set()
+            for idx in simplex:
+                pt = pw_linear_func._points[idx]
+                extreme_pts.add(idx)
+                if idx not in multipliers_by_pt:
+                    all_extreme_pts.append((idx, pt))
+                    multipliers_by_pt[idx] = transBlock.lambdas[
+                        len(transBlock.lambdas)]
+
+            # We're going to want bounds on the substitute var, so we use
+            # interval arithmeltic to figure those out as we go.
+            (lb, ub) = compute_bounds_on_expr(linear_func(*pw_expr.args))
+            if lb is not None and lb < substitute_var_lb:
+                substitute_var_lb = lb
+            if ub is not None and ub > substitute_var_ub:
+                substitute_var_ub = ub
+
+        # set the bounds on the substitute var
+        if substitute_var_lb < float('inf'):
+            transBlock.substitute_var.setlb(substitute_var_lb)
+        if substitute_var_ub > -float('inf'):
+            transBlock.substitute_var.setub(substitute_var_ub)
+
+        # Now that we have all of the extreme points, we can make the
+        # disjunctive constraints
+        for simplex in pw_linear_func._simplices:
+            disj = transBlock.disjuncts[len(transBlock.disjuncts)]
+            cons = disj.lambdas_zero_for_other_simplices = Constraint(
+                NonNegaativeIntegers)
+            extreme_pts = extreme_pts_by_simplex[simplex]
+            for i, pt in all_extreme_pts:
+                if i not in extreme_pts:
+                    cons[len(cons)] = multipliers_by_pt[i] <= 0
+        # Make the disjunction
+        transBlock.pick_a_piece = Disjunction(
+            expr=[d for d in transBlock.disjuncts.values()])
+        
+        # Now we make the global constraints
+        num_extreme_pts = len(disj.lambdas)
+        transBlock.convex_combo = Constraint(
+            expr=sum(disj.lambdas[i] for i in range(len(num_extreme_pts))) == 1)
+        transBlock.linear_func = Constraint(
+            expr=sum(linear_func(*pt)*multipliers_by_pt[j] for (j, pt) in
+                     all_extreme_pts) == substitute_var)
+        @transBlock.Constraint(range(dimension))
+        def linear_combo(b, i):
+            return pw_expr.args[i] == sum(pt[i]*multipliers_by_pt[j] for (j, pt)
+                                          in all_extreme_pts)
+
+        return transBlock.substitute_var

--- a/pyomo/contrib/piecewise/transform/reduced_inner_representation_gdp.py
+++ b/pyomo/contrib/piecewise/transform/reduced_inner_representation_gdp.py
@@ -70,7 +70,7 @@ class ReducedInnerRepresentationGDPTransformation(PiecewiseLinearToGDP):
         # multiplier
         for simplex, linear_func in zip(pw_linear_func._simplices,
                                         pw_linear_func._linear_functions):
-            extreme_pts = extreme_pts_by_sinples[simplex] = set()
+            extreme_pts = extreme_pts_by_simplex[simplex] = set()
             for idx in simplex:
                 pt = pw_linear_func._points[idx]
                 extreme_pts.add(idx)
@@ -98,7 +98,7 @@ class ReducedInnerRepresentationGDPTransformation(PiecewiseLinearToGDP):
         for simplex in pw_linear_func._simplices:
             disj = transBlock.disjuncts[len(transBlock.disjuncts)]
             cons = disj.lambdas_zero_for_other_simplices = Constraint(
-                NonNegaativeIntegers)
+                NonNegativeIntegers)
             extreme_pts = extreme_pts_by_simplex[simplex]
             for i, pt in all_extreme_pts:
                 if i not in extreme_pts:
@@ -108,9 +108,10 @@ class ReducedInnerRepresentationGDPTransformation(PiecewiseLinearToGDP):
             expr=[d for d in transBlock.disjuncts.values()])
         
         # Now we make the global constraints
-        num_extreme_pts = len(disj.lambdas)
+        num_extreme_pts = len(transBlock.lambdas)
         transBlock.convex_combo = Constraint(
-            expr=sum(disj.lambdas[i] for i in range(len(num_extreme_pts))) == 1)
+            expr=sum(transBlock.lambdas[i] for i in
+                     range(num_extreme_pts)) == 1)
         transBlock.linear_func = Constraint(
             expr=sum(linear_func(*pt)*multipliers_by_pt[j] for (j, pt) in
                      all_extreme_pts) == substitute_var)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

This adds a transformation to a GDP where the simplices underlying the piecewise linear functions are represented via an inner representation (convex combination of extreme points), but there is exactly one multiplier per extreme point in the *union* of the extreme points of all the simplices. This means that the multipliers are in the global scope, not local to a Disjunct (as in the inner representation GDP), and the disjunctive constraints for a given simplex are used to fix multipliers corresponding to extreme points not in the simplex to 0. (Note that this transformation assumes that the piecewise-linear function is continuous, so the constraint setting the value of the piecewise linear function can be in the global scope and calculate the value as a convex combination of the function values at the extreme points.)

NOTE: This includes the changes in #2766, so will be easier to review after that is merged.

## Changes proposed in this PR:
- Adds 'contrib.piecewise.reduced_inner_repn_gdp' transformation and tests for the transformation
- Adds 'contrib.piecewise.convex_combination` transformation that does multiple bigm on the reduced inner representation GDP to get the formulation from Vielma et al. 2010

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
