### PR TITLE
NL writer: improve linear datastructure

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -25,7 +25,7 @@ env:
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
-  BASE_REF: ${{ github.base_ref }}
+  SRC_REF: ${{ github.head_ref }}
 
 jobs:
   build:
@@ -531,7 +531,7 @@ jobs:
         echo ""
         echo "Clone Pyomo-model-libraries..."
         URL=https://github.com/Pyomo/pyomo-model-libraries.git
-        git clone -b ${BASE_REF##*/} $URL || git clone -b main $URL
+        git clone -b ${SRC_REF##*/} $URL || git clone -b main $URL
         echo ""
         echo "Install Pyomo..."
         echo ""

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -25,7 +25,7 @@ env:
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
-  SRC_REF: ${{ github.head_ref }}
+  SRC_REF: ${{ github.head_ref || github.ref }}
 
 jobs:
   build:

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -531,6 +531,9 @@ jobs:
         echo "Clone Pyomo-model-libraries..."
         git clone -b main https://github.com/Pyomo/pyomo-model-libraries.git
         echo ""
+        echo "Attempt to check out an alternative branch (${GITHUB_REF##*/})"
+        git checkout ${GITHUB_REF##*/} || echo "Branch not found"
+        echo ""
         echo "Install Pyomo..."
         echo ""
         $PYTHON_EXE setup.py develop ${{matrix.setup_options}}

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -529,12 +529,8 @@ jobs:
       run: |
         echo ""
         echo "Clone Pyomo-model-libraries..."
-        git clone -b main https://github.com/Pyomo/pyomo-model-libraries.git
-        echo ""
-        echo "Attempt to check out an alternative branch (${GITHUB_REF##*/})"
-        pushd pyomo-model-libraries
-        git checkout ${GITHUB_REF##*/} || echo "Branch not found"
-        popd
+        URL=https://github.com/Pyomo/pyomo-model-libraries.git
+        git clone -b ${GITHUB_REF##*/} $URL || git clone -b main $URL
         echo ""
         echo "Install Pyomo..."
         echo ""

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -25,6 +25,7 @@ env:
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
+  BASE_REF: ${{ github.base_ref }}
 
 jobs:
   build:
@@ -530,7 +531,7 @@ jobs:
         echo ""
         echo "Clone Pyomo-model-libraries..."
         URL=https://github.com/Pyomo/pyomo-model-libraries.git
-        git clone -b ${GITHUB_REF##*/} $URL || git clone -b main $URL
+        git clone -b ${BASE_REF##*/} $URL || git clone -b main $URL
         echo ""
         echo "Install Pyomo..."
         echo ""

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -532,7 +532,9 @@ jobs:
         git clone -b main https://github.com/Pyomo/pyomo-model-libraries.git
         echo ""
         echo "Attempt to check out an alternative branch (${GITHUB_REF##*/})"
+        pushd pyomo-model-libraries
         git checkout ${GITHUB_REF##*/} || echo "Branch not found"
+        popd
         echo ""
         echo "Install Pyomo..."
         echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -552,6 +552,9 @@ jobs:
         echo "Clone Pyomo-model-libraries..."
         git clone -b main https://github.com/Pyomo/pyomo-model-libraries.git
         echo ""
+        echo "Attempt to check out an alternative branch (${GITHUB_REF##*/})"
+        git checkout ${GITHUB_REF##*/} || echo "Branch not found"
+        echo ""
         echo "Install Pyomo..."
         echo ""
         $PYTHON_EXE setup.py develop ${{matrix.setup_options}}

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -28,7 +28,7 @@ env:
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
-  SRC_REF: ${{ github.head_ref }}
+  SRC_REF: ${{ github.head_ref || github.ref }}
 
 jobs:
   build:

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -553,7 +553,9 @@ jobs:
         git clone -b main https://github.com/Pyomo/pyomo-model-libraries.git
         echo ""
         echo "Attempt to check out an alternative branch (${GITHUB_REF##*/})"
+        pushd pyomo-model-libraries
         git checkout ${GITHUB_REF##*/} || echo "Branch not found"
+        popd
         echo ""
         echo "Install Pyomo..."
         echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -28,7 +28,7 @@ env:
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
-  BASE_REF: ${{ github.base_ref }}
+  SRC_REF: ${{ github.head_ref }}
 
 jobs:
   build:
@@ -552,7 +552,7 @@ jobs:
         echo ""
         echo "Clone Pyomo-model-libraries..."
         URL=https://github.com/Pyomo/pyomo-model-libraries.git
-        git clone -b ${BASE_REF##*/} $URL || git clone -b main $URL
+        git clone -b ${SRC_REF##*/} $URL || git clone -b main $URL
         echo ""
         echo "Install Pyomo..."
         echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -550,12 +550,8 @@ jobs:
       run: |
         echo ""
         echo "Clone Pyomo-model-libraries..."
-        git clone -b main https://github.com/Pyomo/pyomo-model-libraries.git
-        echo ""
-        echo "Attempt to check out an alternative branch (${GITHUB_REF##*/})"
-        pushd pyomo-model-libraries
-        git checkout ${GITHUB_REF##*/} || echo "Branch not found"
-        popd
+        URL=https://github.com/Pyomo/pyomo-model-libraries.git
+        git clone -b ${GITHUB_REF##*/} $URL || git clone -b main $URL
         echo ""
         echo "Install Pyomo..."
         echo ""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -28,6 +28,7 @@ env:
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
+  BASE_REF: ${{ github.base_ref }}
 
 jobs:
   build:
@@ -551,7 +552,7 @@ jobs:
         echo ""
         echo "Clone Pyomo-model-libraries..."
         URL=https://github.com/Pyomo/pyomo-model-libraries.git
-        git clone -b ${GITHUB_REF##*/} $URL || git clone -b main $URL
+        git clone -b ${BASE_REF##*/} $URL || git clone -b main $URL
         echo ""
         echo "Install Pyomo..."
         echo ""

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -1515,14 +1515,6 @@ class _NLWriter_impl(object):
             #
             # Process the linear portion of this component
             if expr_info.linear:
-                if expr_info.linear.__class__ is list:
-                    linear = {}
-                    for v, c in expr_info.linear:
-                        if v in linear:
-                            linear[v] += c
-                        else:
-                            linear[v] = c
-                    expr_info.linear = linear
                 linear_vars = set(expr_info.linear)
                 all_linear_vars.update(linear_vars)
             # else:
@@ -1738,14 +1730,20 @@ class AMPLRepn(object):
         if args is None:
             args = []
         if self.linear:
-            nterms = len(self.linear)
+            nterms = -len(args)
             _v_template = template.var
             _m_template = template.monomial
+            # Because we are compiling this expression (into a NL
+            # expression), we will go ahead and filter the 0*x terms
+            # from the expression.  Note that the args are accumulated
+            # by side-effect, which prevents iterating over the linear
+            # terms twice.
             nl_sum = ''.join(
-                _v_template if c == 1 else _m_template % c
-                for c in map(itemgetter(1), self.linear)
+                args.append(v) or (
+                    _v_template if c == 1 else _m_template % c
+                ) for v, c in self.linear.items() if c
             )
-            args.extend(map(itemgetter(0), self.linear))
+            nterms += len(args)
         else:
             nterms = 0
             nl_sum = ''
@@ -1804,9 +1802,13 @@ class AMPLRepn(object):
         # assert self.mult == 1
         _type = other[0]
         if _type is _MONOMIAL:
-            self.linear.append(other[1:])
+            _, v, c = other
+            if v in self.linear:
+                self.linear[v] += c
+            else:
+                self.linear[v] = c
         elif _type is _GENERAL:
-            other = other[1]
+            _, other = other
             if other.nl is not None and other.nl[1]:
                 if other.linear:
                     # This is a named expression with both a linear and
@@ -1836,7 +1838,12 @@ class AMPLRepn(object):
                 mult = other.mult
                 self.const += mult * other.const
                 if other.linear:
-                    self.linear.extend((v, c * mult) for v, c in other.linear)
+                    linear = self.linear
+                    for v, c in other.linear.items():
+                        if v in linear:
+                            linear[v] += c * mult
+                        else:
+                            linear[v] = c * mult
                 if other.nonlinear:
                     if other.nonlinear.__class__ is list:
                         other.compile_nonlinear_fragment(self.ActiveVisitor)
@@ -1850,7 +1857,12 @@ class AMPLRepn(object):
             else:
                 self.const += other.const
                 if other.linear:
-                    self.linear.extend(other.linear)
+                    linear = self.linear
+                    for v, c in other.linear.items():
+                        if v in linear:
+                            linear[v] += c
+                        else:
+                            linear[v] = c
                 if other.nonlinear:
                     if other.nonlinear.__class__ is list:
                         self.nonlinear.extend(other.nonlinear)
@@ -1938,8 +1950,9 @@ def node_result_to_amplrepn(data):
     if data[0] is _GENERAL:
         return data[1]
     elif data[0] is _MONOMIAL:
-        if data[2]:
-            return AMPLRepn(0, [data[1:]], None)
+        _, v, c = data
+        if c:
+            return AMPLRepn(0, {v: c}, None)
         else:
             return AMPLRepn(0, None, None)
     elif data[0] is _CONSTANT:
@@ -2213,7 +2226,10 @@ def handle_named_expression_node(visitor, node, arg1):
     else:
         repn.nonlinear = None
         if repn.linear:
-            if not repn.const and len(repn.linear) == 1 and repn.linear[0][1] == 1:
+            if (not repn.const
+                and len(repn.linear) == 1
+                and next(repn.linear.values()) == 1
+            ):
                 # This Expression holds only a variable (multiplied by
                 # 1).  Do not emit this as a named variable and instead
                 # just inject the variable where this expression is
@@ -2230,7 +2246,9 @@ def handle_named_expression_node(visitor, node, arg1):
     if mult != 1:
         repn.const *= mult
         if repn.linear:
-            repn.linear = [(v, c * mult) for v, c in repn.linear]
+            _lin = repn.linear
+            for v in repn.linear:
+                _lin[v] *= mult
         if repn.nonlinear:
             if mult == -1:
                 prefix = visitor.template.negation
@@ -2240,7 +2258,7 @@ def handle_named_expression_node(visitor, node, arg1):
 
     if expression_source[2]:
         if repn.linear:
-            return (_MONOMIAL, repn.linear[0][0], 1)
+            return (_MONOMIAL, next(repn.linear.keys()), 1)
         else:
             return (_CONSTANT, repn.const)
 
@@ -2420,7 +2438,7 @@ def _before_linear(visitor, child):
     # the original expression tree.
     var_map = visitor.var_map
     const = child.constant
-    linear = []
+    linear = {}
     for v, c in zip(child.linear_vars, child.linear_coefs):
         if c.__class__ not in native_types:
             c = c()
@@ -2432,7 +2450,10 @@ def _before_linear(visitor, child):
             _id = id(v)
             if _id not in var_map:
                 var_map[_id] = v
-            linear.append((_id, c))
+            if _id in linear:
+                linear[_id] += c
+            else:
+                linear[_id] = c
     return False, (_GENERAL, AMPLRepn(const, linear, None))
 
 
@@ -2442,7 +2463,7 @@ def _before_named_expression(visitor, child):
         obj, repn, info = visitor.subexpression_cache[_id]
         if info[2]:
             if repn.linear:
-                return False, (_MONOMIAL, repn.linear[0][0], 1)
+                return False, (_MONOMIAL, next(repn.linear.keys()), 1)
             else:
                 return False, (_CONSTANT, repn.const)
         return False, (_GENERAL, repn.duplicate())
@@ -2525,7 +2546,7 @@ class AMPLRepnVisitor(StreamBasedExpressionVisitor):
         # SumExpression are potentially large nary operators.  Directly
         # populate the result
         if node.__class__ is SumExpression:
-            data = AMPLRepn(0, [], None)
+            data = AMPLRepn(0, {}, None)
             data.nonlinear = []
             return node.args, data
         else:
@@ -2583,29 +2604,21 @@ class AMPLRepnVisitor(StreamBasedExpressionVisitor):
         if ans.nonlinear.__class__ is list:
             ans.compile_nonlinear_fragment(self)
 
-        linear = {}
+        if not ans.linear:
+            ans.linear = {}
+        linear = ans.linear
         if ans.mult != 1:
             mult, ans.mult = ans.mult, 1
             ans.const *= mult
-            if ans.linear:
-                for v, c in ans.linear:
-                    if v in linear:
-                        linear[v] += mult * c
-                    else:
-                        linear[v] = mult * c
+            if linear:
+                for k in linear:
+                    linear[k] *= mult
             if ans.nonlinear:
                 if mult == -1:
                     prefix = self.template.negation
                 else:
                     prefix = self.template.multiplier % mult
                 ans.nonlinear = prefix + ans.nonlinear[0], ans.nonlinear[1]
-        elif ans.linear:
-            for v, c in ans.linear:
-                if v in linear:
-                    linear[v] += c
-                else:
-                    linear[v] = c
-        ans.linear = linear
         #
         self.active_expression_source = None
         return ans

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -1271,15 +1271,22 @@ class _NLWriter_impl(object):
         single_use_subexpressions = {}
         self.next_V_line_id = n_vars
         for _id in self.subexpression_order:
-            cache_info = self.subexpression_cache[_id][2]
-            if cache_info[2]:
+            _con_id, _obj_id, _sub = self.subexpression_cache[_id][2]
+            if _sub:
                 # substitute expression directly into expression trees
                 # and do NOT emit the V line
                 continue
-            elif 0 in cache_info[:2] or None not in cache_info[:2]:
+            target_expr = 0
+            if _obj_id is None:
+                target_expr = _con_id
+            elif _con_id is None:
+                target_expr = _obj_id
+            if target_expr == 0:
+                # Note: checking target_expr == 0 is equivalent to
+                # testing "(_con_id is not None and _obj_id is not None)
+                # or _con_id == 0 or _obj_id == 0"
                 self._write_v_line(_id, 0)
             else:
-                target_expr = tuple(filter(None, cache_info))[0]
                 if target_expr not in single_use_subexpressions:
                     single_use_subexpressions[target_expr] = []
                 single_use_subexpressions[target_expr].append(_id)

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -2235,7 +2235,7 @@ def handle_named_expression_node(visitor, node, arg1):
         if repn.linear:
             if (not repn.const
                 and len(repn.linear) == 1
-                and next(repn.linear.values()) == 1
+                and next(iter(repn.linear.values()))) == 1
             ):
                 # This Expression holds only a variable (multiplied by
                 # 1).  Do not emit this as a named variable and instead
@@ -2265,7 +2265,7 @@ def handle_named_expression_node(visitor, node, arg1):
 
     if expression_source[2]:
         if repn.linear:
-            return (_MONOMIAL, next(repn.linear.keys()), 1)
+            return (_MONOMIAL, next(iter(repn.linear)), 1)
         else:
             return (_CONSTANT, repn.const)
 
@@ -2470,7 +2470,7 @@ def _before_named_expression(visitor, child):
         obj, repn, info = visitor.subexpression_cache[_id]
         if info[2]:
             if repn.linear:
-                return False, (_MONOMIAL, next(repn.linear.keys()), 1)
+                return False, (_MONOMIAL, next(iter(repn.linear)), 1)
             else:
                 return False, (_CONSTANT, repn.const)
         return False, (_GENERAL, repn.duplicate())

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -2235,7 +2235,7 @@ def handle_named_expression_node(visitor, node, arg1):
         if repn.linear:
             if (not repn.const
                 and len(repn.linear) == 1
-                and next(iter(repn.linear.values()))) == 1
+                and next(iter(repn.linear.values())) == 1
             ):
                 # This Expression holds only a variable (multiplied by
                 # 1).  Do not emit this as a named variable and instead

--- a/pyomo/repn/tests/ampl/nl_diff.py
+++ b/pyomo/repn/tests/ampl/nl_diff.py
@@ -142,11 +142,11 @@ def load_nl_baseline(baseline, testfile, version='nl'):
         baseline = _tmp
     with open(baseline, 'r') as FILE:
         base = FILE.read()
-    return base, test
+    return base, test, baseline, testfile
 
 
 def load_and_compare_nl_baseline(baseline, testfile, version='nl'):
-    return nl_diff(*load_nl_baseline(baseline, testfile, version), baseline, testfile)
+    return nl_diff(*load_nl_baseline(baseline, testfile, version))
 
 
 if __name__ == '__main__':

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -708,7 +708,7 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
         self.assertEqual(repn.nl, ('v%s\n', (id(m.e),)))
         self.assertEqual(repn.mult, 1)
         self.assertEqual(repn.const, 3)
-        self.assertEqual(repn.linear, [(id(m.x), 1)])
+        self.assertEqual(repn.linear, {id(m.x): 1})
         self.assertEqual(repn.nonlinear, None)
         self.assertEqual(info, [None, None, False])
 

--- a/pyomo/solvers/tests/mip/test_scip_log_data.py
+++ b/pyomo/solvers/tests/mip/test_scip_log_data.py
@@ -144,7 +144,7 @@ def problem_milp_feasible():
 
     # a knapsack-type problem
 
-    number_binary_variables = 40  # may need to be tweaked depending on specs
+    number_binary_variables = 20  # may need to be tweaked depending on specs
 
     model.Y = pyo.RangeSet(number_binary_variables)
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Pyomo/pyomo-model-libraries#20 must be merged in conjunction with this PR.

This makes a slight performance improvement to the data structures used in the NL_v2 writer.  Linear components are now directly stored in a dict, facilitating faster combination of linear terms and more aggressive simplification of linear systems.  In particular, expressions like "`x - x`" will be correctly simplified to `0`.

This also includes some updates that offer slightly faster execution.

This has the net effect of improving the NLv2 performance tests by ~2%:
![image](https://user-images.githubusercontent.com/356359/225968973-0f530e21-496d-4f58-b0ce-ff38409d20d9.png)

## Changes proposed in this PR:
- Switch AMPLRepn.linear from list to dict
- More aggressive simplification of linear expression components
- update GHA driver to support testing against alternative pyomo-model-libraries branches
- make a SCIP test slightly smaller to avoid timeouts on recent SCIP versions

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
