### PR TITLE
Add default `_cuid` flag to `Solution`

### DIFF
--- a/pyomo/opt/results/solution.py
+++ b/pyomo/opt/results/solution.py
@@ -64,6 +64,7 @@ class Solution(MapContainer):
         self.declare('constraint', value={})
 
         self._option = default_print_options
+        self._cuid = False
 
     def load(self, repn):
         # delete key from dictionary, call base class load, handle variable loading.


### PR DESCRIPTION
## Fixes https://github.com/Pyomo/pyomo/issues/2771

## Summary/Motivation:
`ModelSolutions.add_solution` appeared to be relying on `Solution` objects having a `_cuid` attribute, which they only have if they were created via `ModelSolutions.store_to`. Adding a default `_cuid` flag to `Solution` seems to fix the immediate problem, although it still does not add a public API to specify whether a `Solution`'s keys are CUIDs (I think that's what this flag is specifying...)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
