### PR TITLE
Reapply `black` to previously completed directories

### DIFF
--- a/examples/pyomobook/scripts-ch/value_expression.py
+++ b/examples/pyomobook/scripts-ch/value_expression.py
@@ -5,13 +5,10 @@ model.u = pyo.Var(initialize=2.0)
 
 # unexpected expression instead of value
 a = model.u - 1
-print(a)       # "u - 1"
-print(type(a)) # <class 'pyomo.core.expr.numeric_expr.SumExpression'>
+print(a)  # "u - 1"
+print(type(a))  # <class 'pyomo.core.expr.numeric_expr.SumExpression'>
 
 # correct way to access the value
 b = pyo.value(model.u) - 1
-print(b) # 1.0 
-print(type(b)) # <class 'float'>
-
-
-
+print(b)  # 1.0
+print(type(b))  # <class 'float'>

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -807,9 +807,7 @@ class ProblemWriter_gams(AbstractProblemWriter):
         output_file.write("MODELSTAT = %s.modelstat;\n" % model_name)
         output_file.write("SOLVESTAT = %s.solvestat;\n\n" % model_name)
 
-        output_file.write(
-            "Scalar OBJEST 'best objective', OBJVAL 'objective value';\n"
-        )
+        output_file.write("Scalar OBJEST 'best objective', OBJVAL 'objective value';\n")
         output_file.write("OBJEST = %s.objest;\n" % model_name)
         output_file.write("OBJVAL = %s.objval;\n\n" % model_name)
 

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -1746,9 +1746,9 @@ class AMPLRepn(object):
             # by side-effect, which prevents iterating over the linear
             # terms twice.
             nl_sum = ''.join(
-                args.append(v) or (
-                    _v_template if c == 1 else _m_template % c
-                ) for v, c in self.linear.items() if c
+                args.append(v) or (_v_template if c == 1 else _m_template % c)
+                for v, c in self.linear.items()
+                if c
             )
             nterms += len(args)
         else:
@@ -2233,7 +2233,8 @@ def handle_named_expression_node(visitor, node, arg1):
     else:
         repn.nonlinear = None
         if repn.linear:
-            if (not repn.const
+            if (
+                not repn.const
                 and len(repn.linear) == 1
                 and next(iter(repn.linear.values())) == 1
             ):

--- a/pyomo/scripting/driver_help.py
+++ b/pyomo/scripting/driver_help.py
@@ -364,6 +364,7 @@ def print_components(data):
     Print information about modeling components supported by Pyomo.
     """
     from pyomo.core.base.component import ModelComponentFactory, GlobalSets
+
     print("")
     print("----------------------------------------------------------------")
     print("Pyomo Model Components:")

--- a/pyomo/scripting/pyomo_main.py
+++ b/pyomo/scripting/pyomo_main.py
@@ -62,14 +62,18 @@ def main(args=None):
         args.append('-h')
     if args[0][0] == '-':
         if args[0] not in ['-h', '--help', '--version']:
-            deprecation_warning("Running the 'pyomo' script with no subcommand is deprecated. "
-                                "Defaulting to 'pyomo solve'",
-                                version='6.5.0')
+            deprecation_warning(
+                "Running the 'pyomo' script with no subcommand is deprecated. "
+                "Defaulting to 'pyomo solve'",
+                version='6.5.0',
+            )
             args = ['solve'] + args[0:]
     elif args[0] not in pyomo_parser.subparsers:
-        deprecation_warning("Running the 'pyomo' script with no subcommand is deprecated. "
-                            "Defaulting to 'pyomo solve'",
-                            version='6.5.0')
+        deprecation_warning(
+            "Running the 'pyomo' script with no subcommand is deprecated. "
+            "Defaulting to 'pyomo solve'",
+            version='6.5.0',
+        )
         args = ['solve'] + args[0:]
     #
     # Process arguments

--- a/pyomo/scripting/tests/test_cmds.py
+++ b/pyomo/scripting/tests/test_cmds.py
@@ -20,7 +20,6 @@ from pyomo.scripting.pyomo_main import main
 
 
 class Test(unittest.TestCase):
-
     def test_pyomo_main_deprecation(self):
         with LoggingIntercept() as LOG:
             with unittest.pytest.raises(SystemExit) as e:


### PR DESCRIPTION
## Fixes (Partly) #329 

## Summary/Motivation:
This is the first in a relatively long string of PRs to apply PEP8 standards via `black` to Pyomo. We are following the standard used by IDAES _except_ that we are adding the `-S` option: `Don't normalize string quotes or prefixes` and the `-C` option: `Don't use trailing commas as a reason to split lines.`

**NOTE**: All changes are NFC.

## Changes proposed in this PR:
- Reapply `black` to all previously modified directories

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
