### PR TITLE
Apply `black` to `pyomo/common` directory `py` files

### DIFF
--- a/pyomo/common/__init__.py
+++ b/pyomo/common/__init__.py
@@ -17,9 +17,12 @@ from . import envvar
 from .factory import Factory
 
 from .fileutils import (
-    Executable, Library,
+    Executable,
+    Library,
     # The following will be deprecated soon
-    register_executable, registered_executable, unregister_executable
+    register_executable,
+    registered_executable,
+    unregister_executable,
 )
 from . import config, dependencies, shutdown, timing
 from .deprecation import deprecated

--- a/pyomo/common/_command.py
+++ b/pyomo/common/_command.py
@@ -28,19 +28,20 @@ registry = {}
 def pyomo_command(name=None, doc=None):
     #
     def wrap(fn):
-        if name is None:                                  #pragma:nocover
+        if name is None:  # pragma:nocover
             logger.error("Error applying decorator.  No command name!")
             return
-        if doc is None:                                  #pragma:nocover
+        if doc is None:  # pragma:nocover
             logger.error("Error applying decorator.  No command documentation!")
             return
         #
         global registry
         registry[name] = doc
         return fn
+
     #
     return wrap
 
 
-def get_pyomo_commands():   #pragma:nocover
+def get_pyomo_commands():  # pragma:nocover
     return registry

--- a/pyomo/common/_common.py
+++ b/pyomo/common/_common.py
@@ -25,7 +25,8 @@ try:
 except NameError:
     old_help = None
 
-def help(thing=None):                               #pragma:nocover
+
+def help(thing=None):  # pragma:nocover
     if not thing is None and hasattr(thing, '__help__'):
         print(thing.__help__)
     else:
@@ -33,8 +34,9 @@ def help(thing=None):                               #pragma:nocover
             raise NameError("Builtin 'help' is not available")
         old_help(thing)
 
+
 try:
     __builtins__['help'] = help
-except:                                             #pragma:nocover
+except:  # pragma:nocover
     # If this fails, then just die silently.
     pass

--- a/pyomo/common/autoslots.py
+++ b/pyomo/common/autoslots.py
@@ -15,9 +15,9 @@ from copy import deepcopy
 from weakref import ref as _weakref_ref
 
 _autoslot_info = namedtuple(
-    '_autoslot_info',
-    ['has_dict', 'slots', 'slot_mappers', 'field_mappers']
+    '_autoslot_info', ['has_dict', 'slots', 'slot_mappers', 'field_mappers']
 )
+
 
 def _deepcopy_tuple(obj, memo, _id):
     ans = []
@@ -42,11 +42,13 @@ def _deepcopy_tuple(obj, memo, _id):
     memo[_id] = ans = tuple(ans)
     return ans
 
+
 def _deepcopy_list(obj, memo, _id):
     # Two steps here because a list can include itself
     memo[_id] = ans = []
     ans.extend(fast_deepcopy(x, memo) for x in obj)
     return ans
+
 
 def _deepcopy_dict(obj, memo, _id):
     # Two steps here because a dict can include itself
@@ -55,17 +57,26 @@ def _deepcopy_dict(obj, memo, _id):
         ans[fast_deepcopy(key, memo)] = fast_deepcopy(val, memo)
     return ans
 
+
 def _deepcopier(obj, memo, _id):
     return deepcopy(obj, memo)
 
-_atomic_types = {int, float, bool, complex, bytes, str, type, range,
-                 type(None), types.BuiltinFunctionType, types.FunctionType}
 
-_deepcopy_mapper = {
-    tuple: _deepcopy_tuple,
-    list: _deepcopy_list,
-    dict: _deepcopy_dict,
+_atomic_types = {
+    int,
+    float,
+    bool,
+    complex,
+    bytes,
+    str,
+    type,
+    range,
+    type(None),
+    types.BuiltinFunctionType,
+    types.FunctionType,
 }
+
+_deepcopy_mapper = {tuple: _deepcopy_tuple, list: _deepcopy_list, dict: _deepcopy_dict}
 
 
 def fast_deepcopy(obj, memo):
@@ -141,6 +152,7 @@ class AutoSlots(type):
         decode that field value.
 
     """
+
     _ignore_slots = {'__weakref__', '__dict__'}
 
     def __init__(cls, name, bases, classdict):
@@ -172,8 +184,7 @@ class AutoSlots(type):
                 else:
                     dict_mappers[slot] = mapper
 
-        cls.__auto_slots__ = _autoslot_info(
-            has_dict, slots, slot_mappers, dict_mappers)
+        cls.__auto_slots__ = _autoslot_info(has_dict, slots, slot_mappers, dict_mappers)
 
     @staticmethod
     def weakref_mapper(encode, val):
@@ -231,6 +242,7 @@ class AutoSlots(type):
         `__setstate__`.
 
         """
+
         __slots__ = ()
 
         def __init_subclass__(cls, **kwds):
@@ -258,9 +270,9 @@ class AutoSlots(type):
             # Note: this implementation avoids deepcopying the temporary
             # 'state' list, significantly speeding things up.
             memo[id(self)] = ans = self.__class__.__new__(self.__class__)
-            ans.__setstate__([
-                fast_deepcopy(field, memo) for field in self.__getstate__()
-            ])
+            ans.__setstate__(
+                [fast_deepcopy(field, memo) for field in self.__getstate__()]
+            )
             return ans
 
         def __getstate__(self):
@@ -330,4 +342,3 @@ class AutoSlots(type):
                 # than to simplify assign to __dict__.
                 self.__dict__.clear()
                 self.__dict__.update(fields)
-    

--- a/pyomo/common/cmake_builder.py
+++ b/pyomo/common/cmake_builder.py
@@ -19,16 +19,19 @@ import tempfile
 import pyomo.common.envvar as envvar
 from pyomo.common.fileutils import this_file_dir, find_executable
 
+
 def handleReadonly(function, path, excinfo):
     excvalue = excinfo[1]
     if excvalue.errno == errno.EACCES:
-        os.chmod(path, stat.S_IRWXU| stat.S_IRWXG| stat.S_IRWXO) # 0777
+        os.chmod(path, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)  # 0777
         function(path)
     else:
         raise
 
-def build_cmake_project(targets, package_name=None, description=None,
-                        user_args=[], parallel=None):
+
+def build_cmake_project(
+    targets, package_name=None, description=None, user_args=[], parallel=None
+):
     import distutils.core
     from setuptools import Extension
     from distutils.command.build_ext import build_ext
@@ -57,8 +60,7 @@ def build_cmake_project(targets, package_name=None, description=None,
                     # --parallel was only added in cmake 3.12.  Use an
                     # environment variable so that we don't have to bump
                     # the minimum cmake version.
-                    os.environ['CMAKE_BUILD_PARALLEL_LEVEL'] = str(
-                        cmake_ext.parallel)
+                    os.environ['CMAKE_BUILD_PARALLEL_LEVEL'] = str(cmake_ext.parallel)
 
                 cmake = find_executable('cmake')
                 if cmake is None:
@@ -69,11 +71,19 @@ def build_cmake_project(targets, package_name=None, description=None,
                     # harness should take care of dependencies and this
                     # will prevent repeated builds in MSVS
                     #
-                    #self.spawn(['cmake', '--build', '.',
+                    # self.spawn(['cmake', '--build', '.',
                     #            '--config', cmake_config])
-                    self.spawn([cmake, '--build', '.',
-                                '--target', 'install',
-                                '--config', cmake_config])
+                    self.spawn(
+                        [
+                            cmake,
+                            '--build',
+                            '.',
+                            '--target',
+                            'install',
+                            '--config',
+                            cmake_config,
+                        ]
+                    )
             finally:
                 # Restore stderr
                 sys.stderr.flush()
@@ -85,7 +95,8 @@ def build_cmake_project(targets, package_name=None, description=None,
         def __init__(self, target_dir, user_args, parallel):
             # don't invoke the original build_ext for this special extension
             super(CMakeExtension, self).__init__(
-                self.__class__.__qualname__, sources=[])
+                self.__class__.__qualname__, sources=[]
+            )
             self.target_dir = target_dir
             self.user_args = user_args
             self.parallel = parallel

--- a/pyomo/common/collections/__init__.py
+++ b/pyomo/common/collections/__init__.py
@@ -10,9 +10,7 @@
 #  ___________________________________________________________________________
 
 
-from collections.abc import (
-    MutableMapping, MutableSet, Mapping, Set, Sequence
-)
+from collections.abc import MutableMapping, MutableSet, Mapping, Set, Sequence
 from collections import UserDict
 
 from .orderedset import OrderedDict, OrderedSet

--- a/pyomo/common/collections/bunch.py
+++ b/pyomo/common/collections/bunch.py
@@ -19,6 +19,7 @@
 import shlex
 from collections.abc import Mapping
 
+
 class Bunch(dict):
     """A class that can be used to store a bunch of data dynamically.
 
@@ -42,7 +43,8 @@ class Bunch(dict):
                 if len(item) != 2:
                     raise ValueError(
                         "Bunch() positional arguments must be space separated "
-                        f"strings of form 'key=value', got '{item[0]}'")
+                        f"strings of form 'key=value', got '{item[0]}'"
+                    )
 
                 # Historically, this used 'exec'.  That is unsafe in
                 # this context (because anyone can pass arguments to a
@@ -67,6 +69,7 @@ class Bunch(dict):
         The update is specialized for JSON-like data.  This
         recursively replaces dictionaries with Bunch objects.
         """
+
         def _replace_dict_in_list(lst):
             ans = []
             for v in lst:
@@ -97,22 +100,19 @@ class Bunch(dict):
 
     def __getitem__(self, name):
         if not isinstance(name, str):
-            raise ValueError(
-                f'Bunch keys must be str (got {type(name).__name__})')
+            raise ValueError(f'Bunch keys must be str (got {type(name).__name__})')
         # Map through Python's standard getattr functionality (which
         # will resolve known attributes without hitting __getattr__)
         return getattr(self, name)
 
     def __setitem__(self, name, val):
         if not isinstance(name, str):
-            raise ValueError(
-                f'Bunch keys must be str (got {type(name).__name__})')
+            raise ValueError(f'Bunch keys must be str (got {type(name).__name__})')
         setattr(self, name, val)
 
     def __delitem__(self, name):
         if not isinstance(name, str):
-            raise ValueError(
-                f'Bunch keys must be str (got {type(name).__name__})')
+            raise ValueError(f'Bunch keys must be str (got {type(name).__name__})')
         delattr(self, name)
 
     def __getattr__(self, name):
@@ -133,8 +133,9 @@ class Bunch(dict):
             super().__delitem__(name)
 
     def __repr__(self):
-        attrs = sorted("%s = %r" % (k, v) for k, v in self.items()
-                       if not k.startswith("_"))
+        attrs = sorted(
+            "%s = %r" % (k, v) for k, v in self.items() if not k.startswith("_")
+        )
         return "%s(%s)" % (self.__class__.__name__, ", ".join(attrs))
 
     def __str__(self, nesting=0, indent=''):

--- a/pyomo/common/collections/component_map.py
+++ b/pyomo/common/collections/component_map.py
@@ -13,13 +13,15 @@ from collections.abc import MutableMapping as collections_MutableMapping
 from collections.abc import Mapping as collections_Mapping
 from pyomo.common.autoslots import AutoSlots
 
+
 def _rebuild_ids(encode, val):
     if encode:
         return val
     else:
         # object id() may have changed after unpickling,
         # so we rebuild the dictionary keys
-        return {id(obj):(obj,v) for obj, v in val.values()}
+        return {id(obj): (obj, v) for obj, v in val.values()}
+
 
 class ComponentMap(AutoSlots.Mixin, collections_MutableMapping):
     """
@@ -45,6 +47,7 @@ class ComponentMap(AutoSlots.Mixin, collections_MutableMapping):
     components for which it contains map entries (e.g., as
     part of a block). ***
     """
+
     __slots__ = ("_dict",)
     __autoslot_mappers__ = {'_dict': _rebuild_ids}
 
@@ -56,8 +59,8 @@ class ComponentMap(AutoSlots.Mixin, collections_MutableMapping):
 
     def __str__(self):
         """String representation of the mapping."""
-        tmp = {str(c)+" (id="+str(id(c))+")":v for c,v in self.items()}
-        return "ComponentMap("+str(tmp)+")"
+        tmp = {str(c) + " (id=" + str(id(c)) + ")": v for c, v in self.items()}
+        return "ComponentMap(" + str(tmp) + ")"
 
     #
     # Implement MutableMapping abstract methods
@@ -67,23 +70,19 @@ class ComponentMap(AutoSlots.Mixin, collections_MutableMapping):
         try:
             return self._dict[id(obj)][1]
         except KeyError:
-            raise KeyError("Component with id '%s': %s"
-                           % (id(obj), str(obj)))
+            raise KeyError("Component with id '%s': %s" % (id(obj), str(obj)))
 
     def __setitem__(self, obj, val):
-        self._dict[id(obj)] = (obj,val)
+        self._dict[id(obj)] = (obj, val)
 
     def __delitem__(self, obj):
         try:
             del self._dict[id(obj)]
         except KeyError:
-            raise KeyError("Component with id '%s': %s"
-                           % (id(obj), str(obj)))
+            raise KeyError("Component with id '%s': %s" % (id(obj), str(obj)))
 
     def __iter__(self):
-        return (obj \
-                for obj, val in \
-                self._dict.values())
+        return (obj for obj, val in self._dict.values())
 
     def __len__(self):
         return self._dict.__len__()
@@ -99,10 +98,9 @@ class ComponentMap(AutoSlots.Mixin, collections_MutableMapping):
     def __eq__(self, other):
         if not isinstance(other, collections_Mapping):
             return False
-        return {(type(key), id(key)):val
-                    for key, val in self.items()} == \
-               {(type(key), id(key)):val
-                    for key, val in other.items()}
+        return {(type(key), id(key)): val for key, val in self.items()} == {
+            (type(key), id(key)): val for key, val in other.items()
+        }
 
     def __ne__(self, other):
         return not (self == other)
@@ -135,5 +133,3 @@ class ComponentMap(AutoSlots.Mixin, collections_MutableMapping):
         else:
             self[key] = default
         return default
-
-

--- a/pyomo/common/collections/component_set.py
+++ b/pyomo/common/collections/component_set.py
@@ -36,28 +36,29 @@ class ComponentSet(collections_MutableSet):
     deepcopied/pickled unless it is done so along with
     its component entries (e.g., as part of a block). ***
     """
+
     __slots__ = ("_data",)
+
     def __init__(self, *args):
         self._data = dict()
         if len(args) > 0:
             if len(args) > 1:
                 raise TypeError(
                     "%s expected at most 1 arguments, "
-                    "got %s" % (self.__class__.__name__,
-                                len(args)))
+                    "got %s" % (self.__class__.__name__, len(args))
+                )
             self.update(args[0])
 
     def __str__(self):
         """String representation of the mapping."""
         tmp = []
         for objid, obj in self._data.items():
-            tmp.append(str(obj)+" (id="+str(objid)+")")
-        return "ComponentSet("+str(tmp)+")"
+            tmp.append(str(obj) + " (id=" + str(objid) + ")")
+        return "ComponentSet(" + str(tmp) + ")"
 
     def update(self, args):
         """Update a set with the union of itself and others."""
-        self._data.update((id(obj), obj)
-                          for obj in args)
+        self._data.update((id(obj), obj) for obj in args)
 
     #
     # This method must be defined for deepcopy/pickling
@@ -67,7 +68,7 @@ class ComponentSet(collections_MutableSet):
         # object id() may have changed after unpickling,
         # so we rebuild the dictionary keys
         assert len(state) == 1
-        self._data = {id(obj):obj for obj in state['_data']}
+        self._data = {id(obj): obj for obj in state['_data']}
 
     def __getstate__(self):
         return {'_data': tuple(self._data.values())}
@@ -105,10 +106,9 @@ class ComponentSet(collections_MutableSet):
     def __eq__(self, other):
         if not isinstance(other, collections_Set):
             return False
-        return set((type(val), id(val))
-                   for val in self) == \
-               set((type(val), id(val))
-                   for val in other)
+        return set((type(val), id(val)) for val in self) == set(
+            (type(val), id(val)) for val in other
+        )
 
     def __ne__(self, other):
         return not (self == other)
@@ -127,5 +127,4 @@ class ComponentSet(collections_MutableSet):
         try:
             del self._data[id(val)]
         except KeyError:
-            raise KeyError("Component with id '%s': %s"
-                           % (id(val), str(val)))
+            raise KeyError("Component with id '%s': %s" % (id(val), str(val)))

--- a/pyomo/common/collections/orderedset.py
+++ b/pyomo/common/collections/orderedset.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 
 
 class OrderedSet(MutableSet):
-    __slots__ = '_dict'
+    __slots__ = ('_dict',)
 
     def __init__(self, iterable=None):
         # TODO: Starting in Python 3.7, dict is ordered (and is faster

--- a/pyomo/common/collections/orderedset.py
+++ b/pyomo/common/collections/orderedset.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 
 
 class OrderedSet(MutableSet):
-    __slots__ = ('_dict')
+    __slots__ = '_dict'
 
     def __init__(self, iterable=None):
         # TODO: Starting in Python 3.7, dict is ordered (and is faster
@@ -31,7 +31,6 @@ class OrderedSet(MutableSet):
     def __str__(self):
         """String representation of the mapping."""
         return "OrderedSet(%s)" % (', '.join(repr(x) for x in self))
-
 
     def update(self, iterable):
         for val in iterable:

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -45,12 +45,13 @@ from pyomo.common.modeling import NOTSET
 logger = logging.getLogger(__name__)
 
 relocated_module_attribute(
-    'PYOMO_CONFIG_DIR', 'pyomo.common.envvar.PYOMO_CONFIG_DIR',
-    version='6.1')
+    'PYOMO_CONFIG_DIR', 'pyomo.common.envvar.PYOMO_CONFIG_DIR', version='6.1'
+)
 
 USER_OPTION = 0
 ADVANCED_OPTION = 10
 DEVELOPER_OPTION = 20
+
 
 def Bool(val):
     """Domain validator for bool-like objects.
@@ -74,8 +75,8 @@ def Bool(val):
         v = int(val)
         if v in {0, 1}:
             return bool(v)
-    raise ValueError(
-        "Expected Boolean, but received %s" % (val,))
+    raise ValueError("Expected Boolean, but received %s" % (val,))
+
 
 def Integer(val):
     """Domain validation function admitting integers
@@ -89,9 +90,9 @@ def Integer(val):
     ans = int(val)
     # We want to give an error for floating point numbers...
     if ans != float(val):
-        raise ValueError(
-            "Expected integer, but received %s" % (val,))
+        raise ValueError("Expected integer, but received %s" % (val,))
     return ans
+
 
 def PositiveInt(val):
     """Domain validation function admitting strictly positive integers
@@ -103,9 +104,9 @@ def PositiveInt(val):
     ans = int(val)
     # We want to give an error for floating point numbers...
     if ans != float(val) or ans <= 0:
-        raise ValueError(
-            "Expected positive int, but received %s" % (val,))
+        raise ValueError("Expected positive int, but received %s" % (val,))
     return ans
+
 
 def NegativeInt(val):
     """Domain validation function admitting strictly negative integers
@@ -116,9 +117,9 @@ def NegativeInt(val):
     """
     ans = int(val)
     if ans != float(val) or ans >= 0:
-        raise ValueError(
-            "Expected negative int, but received %s" % (val,))
+        raise ValueError("Expected negative int, but received %s" % (val,))
     return ans
+
 
 def NonPositiveInt(val):
     """Domain validation function admitting integers <= 0
@@ -129,9 +130,9 @@ def NonPositiveInt(val):
     """
     ans = int(val)
     if ans != float(val) or ans > 0:
-        raise ValueError(
-            "Expected non-positive int, but received %s" % (val,))
+        raise ValueError("Expected non-positive int, but received %s" % (val,))
     return ans
+
 
 def NonNegativeInt(val):
     """Domain validation function admitting integers >= 0
@@ -142,9 +143,9 @@ def NonNegativeInt(val):
     """
     ans = int(val)
     if ans != float(val) or ans < 0:
-        raise ValueError(
-            "Expected non-negative int, but received %s" % (val,))
+        raise ValueError("Expected non-negative int, but received %s" % (val,))
     return ans
+
 
 def PositiveFloat(val):
     """Domain validation function admitting strictly positive numbers
@@ -156,9 +157,9 @@ def PositiveFloat(val):
     """
     ans = float(val)
     if ans <= 0:
-        raise ValueError(
-            "Expected positive float, but received %s" % (val,))
+        raise ValueError("Expected positive float, but received %s" % (val,))
     return ans
+
 
 def NegativeFloat(val):
     """Domain validation function admitting strictly negative numbers
@@ -170,9 +171,9 @@ def NegativeFloat(val):
     """
     ans = float(val)
     if ans >= 0:
-        raise ValueError(
-            "Expected negative float, but received %s" % (val,))
+        raise ValueError("Expected negative float, but received %s" % (val,))
     return ans
+
 
 def NonPositiveFloat(val):
     """Domain validation function admitting numbers less than or equal to 0
@@ -184,9 +185,9 @@ def NonPositiveFloat(val):
     """
     ans = float(val)
     if ans > 0:
-        raise ValueError(
-            "Expected non-positive float, but received %s" % (val,))
+        raise ValueError("Expected non-positive float, but received %s" % (val,))
     return ans
+
 
 def NonNegativeFloat(val):
     """Domain validation function admitting numbers greater than or equal to 0
@@ -198,8 +199,7 @@ def NonNegativeFloat(val):
     """
     ans = float(val)
     if ans < 0:
-        raise ValueError(
-            "Expected non-negative float, but received %s" % (val,))
+        raise ValueError("Expected non-negative float, but received %s" % (val,))
     return ans
 
 
@@ -237,8 +237,12 @@ class In(object):
         # Convenience: enum.Enum supported __contains__ through Python
         # 3.7.  If the domain is an Enum and cast is not specified,
         # automatically return an InEnum to handle casting and validation
-        if cls is In and cast is None and inspect.isclass(domain) \
-           and issubclass(domain, enum.Enum):
+        if (
+            cls is In
+            and cast is None
+            and inspect.isclass(domain)
+            and issubclass(domain, enum.Enum)
+        ):
             return InEnum(domain)
         return super(In, cls).__new__(cls)
 
@@ -276,6 +280,7 @@ class InEnum(object):
         The enum that incoming values should be mapped to
 
     """
+
     def __init__(self, domain):
         self._domain = domain
 
@@ -289,8 +294,7 @@ class InEnum(object):
                 return self._domain[value]
             except KeyError:
                 pass
-        raise ValueError("%r is not a valid %s" % (
-            value, self._domain.__name__))
+        raise ValueError("%r is not a valid %s" % (value, self._domain.__name__))
 
     def domain_name(self):
         return f'InEnum[{self._domain.__name__}]'
@@ -317,6 +321,7 @@ class ListOf(object):
         no tokenization is performed.
 
     """
+
     def __init__(self, itemtype, domain=None, string_lexer=NOTSET):
         self.itemtype = itemtype
         if domain is None:
@@ -327,8 +332,7 @@ class ListOf(object):
             self.string_lexer = _default_string_list_lexer
         else:
             self.string_lexer = string_lexer
-        self.__name__ = 'ListOf(%s)' % (
-            getattr(self.domain, '__name__', self.domain),)
+        self.__name__ = 'ListOf(%s)' % (getattr(self.domain, '__name__', self.domain),)
 
     def __call__(self, value):
         if isinstance(value, str) and self.string_lexer is not None:
@@ -392,6 +396,7 @@ class Module(object):
         >>> config.my_module = os.path
 
     """
+
     def __init__(self, basePath=None, expandPath=None):
         self.basePath = basePath
         self.expandPath = expandPath
@@ -438,6 +443,7 @@ class Path(object):
         value of :py:attr:`Path.SuppressPathExpansion`
 
     """
+
     BasePath = None
     SuppressPathExpansion = False
 
@@ -471,9 +477,14 @@ class Path(object):
         if path and path[:6].lower() == '${cwd}':
             path = os.getcwd() + path[6:]
 
-        ans = os.path.normpath(os.path.abspath(os.path.join(
-            os.path.expanduser(os.path.expandvars(base)),
-            os.path.expanduser(os.path.expandvars(path)))))
+        ans = os.path.normpath(
+            os.path.abspath(
+                os.path.join(
+                    os.path.expanduser(os.path.expandvars(base)),
+                    os.path.expanduser(os.path.expandvars(path)),
+                )
+            )
+        )
         return ans
 
 
@@ -501,9 +512,9 @@ class PathList(Path):
 
     def __call__(self, data):
         if hasattr(data, "__iter__") and not isinstance(data, str):
-            return [ super(PathList, self).__call__(i) for i in data ]
+            return [super(PathList, self).__call__(i) for i in data]
         else:
-            return [ super(PathList, self).__call__(data) ]
+            return [super(PathList, self).__call__(data)]
 
 
 class DynamicImplicitDomain(object):
@@ -555,6 +566,7 @@ class DynamicImplicitDomain(object):
         (ConfigValue, ConfigList, or ConfigDict)
 
     """
+
     def __init__(self, callback):
         self.callback = callback
 
@@ -572,12 +584,13 @@ class DynamicImplicitDomain(object):
 # the original __new__ to generate the class docstring.
 @deprecated()
 class ConfigEnum(enum.Enum):
-
-    @deprecated("The ConfigEnum base class is deprecated.  "
-                "Directly inherit from enum.Enum and then use "
-                "In() or InEnum() as the ConfigValue 'domain' for "
-                "validation and int/string type conversions.",
-                version='6.0')
+    @deprecated(
+        "The ConfigEnum base class is deprecated.  "
+        "Directly inherit from enum.Enum and then use "
+        "In() or InEnum() as the ConfigValue 'domain' for "
+        "validation and int/string type conversions.",
+        version='6.0',
+    )
     def __new__(cls, value, *args):
         member = object.__new__(cls)
         member._value_ = value
@@ -1011,16 +1024,18 @@ The defaults generate LaTeX documentation:
 
 """
 
+
 def _dump(*args, **kwds):
     try:
         from yaml import dump
     except ImportError:
-        #dump = lambda x,**y: str(x)
+        # dump = lambda x,**y: str(x)
         # YAML uses lowercase True/False
         def dump(x, **args):
             if type(x) is bool:
                 return str(x).lower()
             return str(x)
+
     assert '_dump' in globals()
     globals()['_dump'] = dump
     return dump(*args, **kwds)
@@ -1031,6 +1046,7 @@ def _munge_name(name, space_to_dash=True):
         name = re.sub(r'\s', '-', name)
     name = re.sub(r'_', '-', name)
     return re.sub(r'[^a-zA-Z0-9-_]', '_', name)
+
 
 def _domain_name(domain):
     if domain is None:
@@ -1044,7 +1060,9 @@ def _domain_name(domain):
     else:
         return None
 
+
 _leadingSpace = re.compile('^([ \t]*)')
+
 
 def _strip_indentation(doc):
     if not doc:
@@ -1069,8 +1087,7 @@ def _value2string(prefix, value, obj):
     if value is not None:
         try:
             _data = value._data if value is obj else value
-            if getattr(builtins, _data.__class__.__name__, None
-                   ) is not None:
+            if getattr(builtins, _data.__class__.__name__, None) is not None:
                 _str += _dump(_data, default_flow_style=True).rstrip()
                 if _str.endswith("..."):
                     _str = _str[:-3].rstrip()
@@ -1079,6 +1096,7 @@ def _value2string(prefix, value, obj):
         except:
             _str += str(type(_data))
     return _str.rstrip()
+
 
 def _value2yaml(prefix, value, obj):
     _str = prefix
@@ -1100,14 +1118,17 @@ class _UnpickleableDomain(object):
 
     def __call__(self, arg):
         logging.error(
-"""%s '%s' was pickled with an unpicklable domain.
+            """%s '%s' was pickled with an unpicklable domain.
     The domain was stripped and lost during the pickle process.  Setting
     new values on the restored object cannot be mapped into the correct
     domain.
-""" % ( self._type, self._name))
+"""
+            % (self._type, self._name)
+        )
         return arg
 
-def _picklable(field,obj):
+
+def _picklable(field, obj):
     ftype = type(field)
     # If the field is a type (class, etc), cache the 'known' status of
     # the actual field type and not the generic 'type' class
@@ -1140,33 +1161,33 @@ def _picklable(field,obj):
             _picklable.known[ftype] = False
         return _UnpickleableDomain(obj)
 
+
 _picklable.known = {}
 # The "picklability" of some types is not categorically "knowable"
 # (e.g., functions can be pickled, but only if they are declared at the
 # module scope)
-_picklable.unknowable_types = {type, types.FunctionType,}
+_picklable.unknowable_types = {type, types.FunctionType}
 
 _store_bool = {'store_true', 'store_false'}
+
 
 def _build_lexer(literals=''):
     # Ignore whitespace (space, tab, linefeed, and comma)
     t_ignore = " \t\r,"
 
-    tokens = [
-        "STRING", # quoted string
-        "WORD",   # unquoted string
-    ]
+    tokens = ["STRING", "WORD"]  # quoted string  # unquoted string
 
     # A "string" is a proper quoted string
     _quoted_str = r"'(?:[^'\\]|\\.)*'"
-    _general_str = "|".join([_quoted_str, _quoted_str.replace("'",'"')])
+    _general_str = "|".join([_quoted_str, _quoted_str.replace("'", '"')])
+
     @ply.lex.TOKEN(_general_str)
     def t_STRING(t):
         t.value = t.value[1:-1]
         return t
 
     # A "word" contains no whitesspace or commas
-    @ply.lex.TOKEN(r'[^' + repr(t_ignore+literals) + r']+')
+    @ply.lex.TOKEN(r'[^' + repr(t_ignore + literals) + r']+')
     def t_WORD(t):
         t.value = t.value
         return t
@@ -1175,10 +1196,12 @@ def _build_lexer(literals=''):
     def t_error(t):
         # Note this parser does not allow "\n", so lexpos is the
         # column number
-        raise IOError("ERROR: Token '%s' Line %s Column %s"
-          % (t.value, t.lineno, t.lexpos+1))
+        raise IOError(
+            "ERROR: Token '%s' Line %s Column %s" % (t.value, t.lineno, t.lexpos + 1)
+        )
 
     return ply.lex.lex()
+
 
 def _default_string_list_lexer(value):
     """Simple string tokenizer for lists of words.
@@ -1199,7 +1222,9 @@ def _default_string_list_lexer(value):
             break
         yield tok.value
 
+
 _default_string_list_lexer._lex = None
+
 
 def _default_string_dict_lexer(value):
     """Simple string tokenizer for dict data.
@@ -1221,18 +1246,20 @@ def _default_string_dict_lexer(value):
             break
         sep = _lex.token()
         if not sep:
-            raise ValueError(
-                "Expected ':' or '=' but encountered end of string")
+            raise ValueError("Expected ':' or '=' but encountered end of string")
         if sep.type not in ':=':
             raise ValueError(
                 f"Expected ':' or '=' but found '{sep.value}' at "
-                f"Line {sep.lineno} Column {sep.lexpos+1}")
+                f"Line {sep.lineno} Column {sep.lexpos+1}"
+            )
         val = _lex.token()
         if not val:
             raise ValueError(
                 f"Expected value following '{sep.type}' "
-                f"but encountered end of string")
+                f"but encountered end of string"
+            )
         yield key.value, val.value
+
 
 _default_string_dict_lexer._lex = None
 
@@ -1249,6 +1276,7 @@ def _formatter_str_to_callback(pattern, formatter):
     else:
         cb = lambda self, indent, obj: None
     return types.MethodType(cb, formatter)
+
 
 def _formatter_str_to_item_callback(pattern, formatter):
     "Wrapper function that converts item formatter strings to callback functions"
@@ -1271,10 +1299,7 @@ def _formatter_str_to_item_callback(pattern, formatter):
         _indent = indent + ' ' * self.indent_spacing
         if wraplines:
             doc_lines = textwrap.wrap(
-                _doc,
-                self.width,
-                initial_indent=_indent,
-                subsequent_indent=_indent,
+                _doc, self.width, initial_indent=_indent, subsequent_indent=_indent
             )
             self.out.write(('\n'.join(doc_lines)).rstrip() + '\n')
         else:
@@ -1364,13 +1389,17 @@ class numpydoc_ConfigFormatter(ConfigFormatter):
         self.wrapper = textwrap.TextWrapper(width=self.width)
 
     def _item_body(self, indent, obj):
-        typeinfo = ', '.join(filter(
-            None,
-            [
-                'dict' if isinstance(obj, ConfigDict) else obj.domain_name(),
-                'optional' if obj._default is None else f'default={repr(obj._default)}',
-            ]
-        ))
+        typeinfo = ', '.join(
+            filter(
+                None,
+                [
+                    'dict' if isinstance(obj, ConfigDict) else obj.domain_name(),
+                    'optional'
+                    if obj._default is None
+                    else f'default={repr(obj._default)}',
+                ],
+            )
+        )
         # Note that numpydoc / ReST specifies that the colon in
         # definition lists be surrounded by spaces (i.e., " : ").
         # However, as of numpydoc (1.1.0) / Sphinx (3.4.3) / napoleon
@@ -1391,9 +1420,11 @@ class numpydoc_ConfigFormatter(ConfigFormatter):
             if obj._visibility >= DEVELOPER_OPTION:
                 vis = "[DEVELOPER option]"
         itemdoc = wrap_reStructuredText(
-            '\n\n'.join(filter(
-                None, [vis, inspect.cleandoc(obj._doc or obj._description or "")]
-            )),
+            '\n\n'.join(
+                filter(
+                    None, [vis, inspect.cleandoc(obj._doc or obj._description or "")]
+                )
+            ),
             self.wrapper,
         )
         if itemdoc:
@@ -1401,6 +1432,7 @@ class numpydoc_ConfigFormatter(ConfigFormatter):
 
     def _finalize(self):
         return inspect.cleandoc(self.out.getvalue())
+
 
 ConfigFormatter.formats = {
     'latex': LaTeX_ConfigFormatter,
@@ -1418,9 +1450,14 @@ def add_docstring_list(docstring, configdict, indent_by=4):
     section = 'Keyword Arguments'
     return (
         inspect.cleandoc(docstring)
-        + '\n' + section + '\n' + '-'*len(section) + '\n'
+        + '\n'
+        + section
+        + '\n'
+        + '-' * len(section)
+        + '\n'
         + configdict.generate_documentation(
-            indent_spacing=indent_by, width=256, visibility=0, format='numpydoc')
+            indent_spacing=indent_by, width=256, visibility=0, format='numpydoc'
+        )
     )
 
 
@@ -1489,17 +1526,18 @@ class document_kwargs_from_configdict(object):
             If True, stream the solver output to the console
 
     """
+
     def __init__(
-            self,
-            config,
-            section='Keyword Arguments',
-            indent_spacing=4,
-            width=78,
-            visibility=None,
-            doc=None,
+        self,
+        config,
+        section='Keyword Arguments',
+        indent_spacing=4,
+        width=78,
+        visibility=None,
+        doc=None,
     ):
         if '\n' not in section:
-            section += '\n' + '-'*len(section) + '\n'
+            section += '\n' + '-' * len(section) + '\n'
         self.config = config
         self.section = section
         self.indent_spacing = indent_spacing
@@ -1535,22 +1573,30 @@ class document_kwargs_from_configdict(object):
 
 
 class ConfigBase(object):
-    __slots__ = ('_parent', '_name', '_userSet', '_userAccessed', '_data',
-                 '_default', '_domain', '_description', '_doc', '_visibility',
-                 '_argparse')
+    __slots__ = (
+        '_parent',
+        '_name',
+        '_userSet',
+        '_userAccessed',
+        '_data',
+        '_default',
+        '_domain',
+        '_description',
+        '_doc',
+        '_visibility',
+        '_argparse',
+    )
 
     # This just needs to be any singleton-like object; we use it so that
     # we can tell if an argument is provided (and we can't use None as
     # None is a valid user-specified argument).  Making it a class helps
     # when Config objects are pickled.
-    class NoArgument(object): pass
+    class NoArgument(object):
+        pass
 
-    def __init__(self,
-                 default=None,
-                 domain=None,
-                 description=None,
-                 doc=None,
-                 visibility=0):
+    def __init__(
+        self, default=None, domain=None, description=None, doc=None, visibility=0
+    ):
         self._parent = None
         self._name = None
         self._userSet = False
@@ -1592,11 +1638,18 @@ class ConfigBase(object):
             # of setting self.__dict__[key] = val.
             object.__setattr__(self, key, val)
 
-    def __call__(self, value=NOTSET, default=NOTSET,
-                 domain=NOTSET,  description=NOTSET,
-                 doc=NOTSET, visibility=NOTSET,
-                 implicit=NOTSET, implicit_domain=NOTSET,
-                 preserve_implicit=False):
+    def __call__(
+        self,
+        value=NOTSET,
+        default=NOTSET,
+        domain=NOTSET,
+        description=NOTSET,
+        doc=NOTSET,
+        visibility=NOTSET,
+        implicit=NOTSET,
+        implicit_domain=NOTSET,
+        preserve_implicit=False,
+    ):
         # We will pass through overriding arguments to the constructor.
         # This way if the constructor does special processing of any of
         # the arguments (like implicit_domain), we don't have to repeat
@@ -1611,16 +1664,14 @@ class ConfigBase(object):
             assert default is NOTSET
         else:
             fields += ('domain',)
-            kwds['default'] = (
-                self.value() if default is NOTSET else default
-            )
+            kwds['default'] = self.value() if default is NOTSET else default
             assert implicit is NOTSET
             assert implicit_domain is NOTSET
         for field in fields:
             if type(field) is tuple:
                 field, attr = field
             else:
-                attr = '_'+field
+                attr = '_' + field
             if locals()[field] is NOTSET:
                 kwds[field] = getattr(self, attr, NOTSET)
             else:
@@ -1690,9 +1741,11 @@ class ConfigBase(object):
                     _dom = self._domain.__name__
                 else:
                     _dom = type(self._domain)
-                raise ValueError("invalid value for configuration '%s':\n"
-                                 "\tFailed casting %s\n\tto %s\n\tError: %s" %
-                                 (self.name(True), value, _dom, err))
+                raise ValueError(
+                    "invalid value for configuration '%s':\n"
+                    "\tFailed casting %s\n\tto %s\n\tError: %s"
+                    % (self.name(True), value, _dom, err)
+                )
         else:
             return value
 
@@ -1726,7 +1779,8 @@ class ConfigBase(object):
             raise TypeError(
                 "You cannot specify an argparse default value with "
                 "ConfigBase.declare_as_argument().  The default value is "
-                "supplied automatically from the Config definition.")
+                "supplied automatically from the Config definition."
+            )
 
         if 'action' not in kwds and self._domain is bool:
             if not self._default:
@@ -1748,7 +1802,6 @@ class ConfigBase(object):
         return self
 
     def initialize_argparse(self, parser):
-
         def _get_subparser_or_group(_parser, name):
             # Note: strings also have a 'title()' method.  We are
             # looking for things that look like argparse
@@ -1756,15 +1809,16 @@ class ConfigBase(object):
             # is insufficient: it needs to be a string attribute as
             # well
             if isinstance(name, argparse._ActionsContainer):
-                #hasattr(_group, 'title') and \
+                # hasattr(_group, 'title') and \
                 #    isinstance(_group.title, str):
                 return 2, name
 
             if not isinstance(name, str):
                 raise RuntimeError(
                     'Unknown datatype (%s) for argparse group on '
-                    'configuration definition %s' %
-                    (type(name).__name__, obj.name(True)))
+                    'configuration definition %s'
+                    % (type(name).__name__, obj.name(True))
+                )
 
             try:
                 for _grp in _parser._subparsers._group_actions:
@@ -1791,14 +1845,17 @@ class ConfigBase(object):
                         if not _issub and _idx < len(_group) - 1:
                             raise RuntimeError(
                                 "Could not find argparse subparser '%s' for "
-                                "Config item %s" % (_grp, obj.name(True)))
+                                "Config item %s" % (_grp, obj.name(True))
+                            )
                 else:
                     _issub, _parser = _get_subparser_or_group(_parser, _group)
             if 'dest' not in _kwds:
                 _kwds['dest'] = 'CONFIGBLOCK.' + obj.name(True)
-                if ( 'metavar' not in _kwds
-                     and _kwds.get('action','') not in _store_bool
-                     and obj._domain is not None ):
+                if (
+                    'metavar' not in _kwds
+                    and _kwds.get('action', '') not in _store_bool
+                    and obj._domain is not None
+                ):
                     _kwds['metavar'] = obj.domain_name().upper()
             _parser.add_argument(*_args, default=argparse.SUPPRESS, **_kwds)
 
@@ -1824,18 +1881,21 @@ class ConfigBase(object):
                         del parsed_args.__dict__[_dest]
         return parsed_args
 
-    def display(self, content_filter=None, indent_spacing=2, ostream=None,
-                visibility=None):
+    def display(
+        self, content_filter=None, indent_spacing=2, ostream=None, visibility=None
+    ):
         if content_filter not in ConfigDict.content_filters:
-            raise ValueError("unknown content filter '%s'; valid values are %s"
-                             % (content_filter, ConfigDict.content_filters))
+            raise ValueError(
+                "unknown content filter '%s'; valid values are %s"
+                % (content_filter, ConfigDict.content_filters)
+            )
         _blocks = []
         if ostream is None:
-            ostream=sys.stdout
+            ostream = sys.stdout
 
         for lvl, prefix, value, obj in self._data_collector(0, "", visibility):
             _str = _value2string(prefix, value, obj)
-            _blocks[lvl:] = [' ' * indent_spacing * lvl + _str + "\n",]
+            _blocks[lvl:] = [' ' * indent_spacing * lvl + _str + "\n"]
             if content_filter == 'userdata' and not obj._userSet:
                 continue
             for i, v in enumerate(_blocks):
@@ -1853,20 +1913,24 @@ class ConfigBase(object):
             if lvl not in level_info:
                 level_info[lvl] = {'data': [], 'off': 0, 'line': 0, 'over': 0}
             level_info[lvl]['data'].append(
-                (_str.find(':') + 2, len(_str), len(obj._description or "")))
+                (_str.find(':') + 2, len(_str), len(obj._description or ""))
+            )
         for lvl in sorted(level_info):
             indent = lvl * indent_spacing
             _ok = width - indent - len(comment) - minDocWidth
-            offset = \
-                max( val if val < _ok else key
-                     for key,val,doc in level_info[lvl]['data'] )
+            offset = max(
+                val if val < _ok else key for key, val, doc in level_info[lvl]['data']
+            )
             offset += indent + len(comment)
-            over = sum(1 for key, val, doc in level_info[lvl]['data']
-                       if doc + offset > width)
+            over = sum(
+                1 for key, val, doc in level_info[lvl]['data'] if doc + offset > width
+            )
             if len(level_info[lvl]['data']) - over > 0:
-                line = max(offset + doc
-                           for key, val, doc in level_info[lvl]['data']
-                           if offset + doc <= width)
+                line = max(
+                    offset + doc
+                    for key, val, doc in level_info[lvl]['data']
+                    if offset + doc <= width
+                )
             else:
                 line = width
             level_info[lvl]['off'] = offset
@@ -1907,18 +1971,26 @@ class ConfigBase(object):
                 os.write(_str + '\n' + ' ' * field)
             os.write(comment)
             txtArea = max(width - field - len(comment), minDocWidth)
-            os.write(("\n" + ' ' * field + comment).join(
-                textwrap.wrap(
-                    obj._description, txtArea, subsequent_indent='  ')))
+            os.write(
+                ("\n" + ' ' * field + comment).join(
+                    textwrap.wrap(obj._description, txtArea, subsequent_indent='  ')
+                )
+            )
             os.write('\n')
         return os.getvalue()
 
-
     def generate_documentation(
-            self, block_start=None, block_end=None,
-            item_start=None, item_body=None, item_end=None,
-            indent_spacing=2, width=78, visibility=None,
-            format='latex'):
+        self,
+        block_start=None,
+        block_end=None,
+        item_start=None,
+        item_body=None,
+        item_end=None,
+        indent_spacing=2,
+        width=78,
+        visibility=None,
+        format='latex',
+    ):
 
         if isinstance(format, str):
             formatter = ConfigFormatter.formats.get(format, None)
@@ -1942,9 +2014,7 @@ class ConfigBase(object):
                     version='6.5.1.dev0',
                 )
                 setattr(
-                    formatter,
-                    "_" + name,
-                    _formatter_str_to_callback(arg, formatter)
+                    formatter, "_" + name, _formatter_str_to_callback(arg, formatter)
                 )
         if item_body is not None:
             deprecation_warning(
@@ -1956,7 +2026,7 @@ class ConfigBase(object):
             setattr(
                 formatter,
                 "_item_body",
-                _formatter_str_to_item_callback(item_body, formatter)
+                _formatter_str_to_item_callback(item_body, formatter),
             )
 
         return formatter.generate(self, indent_spacing, width, visibility)
@@ -2068,6 +2138,7 @@ class MarkImmutable(object):
 
     >>> locker.release_lock()
     """
+
     def __init__(self, *args):
         self._targets = args
         self._locked = []
@@ -2078,7 +2149,8 @@ class MarkImmutable(object):
             for cfg in self._targets:
                 if type(cfg) is not ConfigValue:
                     raise ValueError(
-                        'Only ConfigValue instances can be marked immutable.')
+                        'Only ConfigValue instances can be marked immutable.'
+                    )
                 cfg.__class__ = ImmutableConfigValue
                 self._locked.append(cfg)
         except:
@@ -2180,7 +2252,7 @@ class ConfigList(ConfigBase, Sequence):
         # As a result, *this* list doesn't change when someone tries to
         # change an element; instead, the *element* gets its _userSet
         # flag set.
-        #self._userSet = True
+        # self._userSet = True
         self._data[key].set_value(val)
 
     def __len__(self):
@@ -2204,8 +2276,7 @@ class ConfigList(ConfigBase, Sequence):
         try:
             if isinstance(value, str):
                 value = list(_default_string_list_lexer(value))
-            if (type(value) is list) or \
-               isinstance(value, ConfigList):
+            if (type(value) is list) or isinstance(value, ConfigList):
                 for val in value:
                     self.append(val)
             else:
@@ -2237,10 +2308,9 @@ class ConfigList(ConfigBase, Sequence):
         # Adding something to the container should not change the
         # userSet on the container (see Pyomo/pyomo#352; now
         # Pyomo/pysp#8 for justification)
-        #self._userSet = True
+        # self._userSet = True
 
-    @deprecated("ConfigList.add() has been deprecated.  Use append()",
-                version='5.7.2')
+    @deprecated("ConfigList.add() has been deprecated.  Use append()", version='5.7.2')
     def add(self, value=NOTSET):
         "Append the specified value to the list, casting as necessary."
         return self.append(value)
@@ -2256,8 +2326,9 @@ class ConfigList(ConfigBase, Sequence):
             # somewhat redundant, and worse, if the list is empty, then
             # no documentation is generated at all!)
             yield (level, prefix, None, self)
-            subDomain = self._domain._data_collector(level + 1, '- ',
-                                                     visibility, docMode)
+            subDomain = self._domain._data_collector(
+                level + 1, '- ', visibility, docMode
+            )
             # Pop off the (empty) block entry
             next(subDomain)
             for v in subDomain:
@@ -2309,22 +2380,30 @@ class ConfigDict(ConfigBase, Mapping):
 
     content_filters = {None, 'all', 'userdata'}
 
-    __slots__ = ('_decl_order', '_declared', '_implicit_declaration',
-                 '_implicit_domain')
+    __slots__ = (
+        '_decl_order',
+        '_declared',
+        '_implicit_declaration',
+        '_implicit_domain',
+    )
     _all_slots = set(__slots__ + ConfigBase.__slots__)
 
-    def __init__(self,
-                 description=None,
-                 doc=None,
-                 implicit=False,
-                 implicit_domain=None,
-                 visibility=0):
+    def __init__(
+        self,
+        description=None,
+        doc=None,
+        implicit=False,
+        implicit_domain=None,
+        visibility=0,
+    ):
         self._decl_order = []
         self._declared = set()
         self._implicit_declaration = implicit
-        if ( implicit_domain is None
-             or type(implicit_domain) is DynamicImplicitDomain
-             or isinstance(implicit_domain, ConfigBase) ):
+        if (
+            implicit_domain is None
+            or type(implicit_domain) is DynamicImplicitDomain
+            or isinstance(implicit_domain, ConfigBase)
+        ):
             self._implicit_domain = implicit_domain
         else:
             self._implicit_domain = ConfigValue(None, domain=implicit_domain)
@@ -2351,7 +2430,7 @@ class ConfigDict(ConfigBase, Mapping):
 
     def __getitem__(self, key):
         self._userAccessed = True
-        _key = str(key).replace(' ','_')
+        _key = str(key).replace(' ', '_')
         if isinstance(self._data[_key], ConfigValue):
             return self._data[_key].value()
         else:
@@ -2359,7 +2438,7 @@ class ConfigDict(ConfigBase, Mapping):
 
     def get(self, key, default=NOTSET):
         self._userAccessed = True
-        _key = str(key).replace(' ','_')
+        _key = str(key).replace(' ', '_')
         if _key in self._data:
             return self._data[_key]
         if default is NOTSET:
@@ -2374,7 +2453,7 @@ class ConfigDict(ConfigBase, Mapping):
 
     def setdefault(self, key, default=NOTSET):
         self._userAccessed = True
-        _key = str(key).replace(' ','_')
+        _key = str(key).replace(' ', '_')
         if _key in self._data:
             return self._data[_key]
         if default is NOTSET:
@@ -2383,24 +2462,24 @@ class ConfigDict(ConfigBase, Mapping):
             return self.add(key, default)
 
     def __setitem__(self, key, val):
-        _key = str(key).replace(' ','_')
+        _key = str(key).replace(' ', '_')
         if _key not in self._data:
             self.add(key, val)
         else:
             self._data[_key].set_value(val)
-        #self._userAccessed = True
+        # self._userAccessed = True
 
     def __delitem__(self, key):
         # Note that this will produce a KeyError if the key is not valid
         # for this ConfigDict.
-        _key = str(key).replace(' ','_')
+        _key = str(key).replace(' ', '_')
         del self._data[_key]
         # Clean up the other data structures
         self._decl_order.remove(_key)
         self._declared.discard(_key)
 
     def __contains__(self, key):
-        _key = str(key).replace(' ','_')
+        _key = str(key).replace(' ', '_')
         return _key in self._data
 
     def __len__(self):
@@ -2413,7 +2492,7 @@ class ConfigDict(ConfigBase, Mapping):
         # Note: __getattr__ is only called after all "usual" attribute
         # lookup methods have failed.  So, if we get here, we already
         # know that key is not a __slot__ or a method, etc...
-        #if name in ConfigDict._all_slots:
+        # if name in ConfigDict._all_slots:
         #    return super(ConfigDict,self).__getattribute__(name)
         _name = name.replace(' ', '_')
         if _name not in self._data:
@@ -2427,15 +2506,17 @@ class ConfigDict(ConfigBase, Mapping):
             ConfigDict.__setitem__(self, name, value)
 
     def __delattr__(self, name):
-        _key = str(name).replace(' ','_')
+        _key = str(name).replace(' ', '_')
         if _key in self._data:
             del self[_key]
         elif _key in dir(self):
-            raise AttributeError("'%s' object attribute '%s' is read-only" %
-                                 (type(self).__name__, name))
+            raise AttributeError(
+                "'%s' object attribute '%s' is read-only" % (type(self).__name__, name)
+            )
         else:
-            raise AttributeError("'%s' object has no attribute '%s'" %
-                                 (type(self).__name__, name))
+            raise AttributeError(
+                "'%s' object has no attribute '%s'" % (type(self).__name__, name)
+            )
 
     def keys(self):
         return iter(self)
@@ -2450,18 +2531,15 @@ class ConfigDict(ConfigBase, Mapping):
         for key in self._decl_order:
             yield (self._data[key]._name, self[key])
 
-    @deprecated('The iterkeys method is deprecated. Use dict.keys().',
-                version='6.0')
+    @deprecated('The iterkeys method is deprecated. Use dict.keys().', version='6.0')
     def iterkeys(self):
         return self.keys()
 
-    @deprecated('The itervalues method is deprecated. Use dict.keys().',
-                version='6.0')
+    @deprecated('The itervalues method is deprecated. Use dict.keys().', version='6.0')
     def itervalues(self):
         return self.values()
 
-    @deprecated('The iteritems method is deprecated. Use dict.keys().',
-                version='6.0')
+    @deprecated('The iteritems method is deprecated. Use dict.keys().', version='6.0')
     def iteritems(self):
         return self.items()
 
@@ -2471,12 +2549,14 @@ class ConfigDict(ConfigBase, Mapping):
         if config._parent is not None:
             raise ValueError(
                 "config '%s' is already assigned to ConfigDict '%s'; "
-                "cannot reassign to '%s'" %
-                (name, config._parent.name(True), self.name(True)))
+                "cannot reassign to '%s'"
+                % (name, config._parent.name(True), self.name(True))
+            )
         if _name in self._data:
             raise ValueError(
-                "duplicate config '%s' defined for ConfigDict '%s'" %
-                (name, self.name(True)))
+                "duplicate config '%s' defined for ConfigDict '%s'"
+                % (name, self.name(True))
+            )
         self._data[_name] = config
         self._decl_order.append(_name)
         config._parent = self
@@ -2491,23 +2571,25 @@ class ConfigDict(ConfigBase, Mapping):
 
     def declare_from(self, other, skip=None):
         if not isinstance(other, ConfigDict):
-            raise ValueError(
-                "ConfigDict.declare_from() only accepts other ConfigDicts")
+            raise ValueError("ConfigDict.declare_from() only accepts other ConfigDicts")
         # Note that we duplicate ["other()"] other so that this
         # ConfigDict's entries are independent of the other's
         for key in other.keys():
             if skip and key in skip:
                 continue
             if key in self:
-                raise ValueError("ConfigDict.declare_from passed a block "
-                                 "with a duplicate field, '%s'" % (key,))
+                raise ValueError(
+                    "ConfigDict.declare_from passed a block "
+                    "with a duplicate field, '%s'" % (key,)
+                )
             self.declare(key, other.get(key)())
 
     def add(self, name, config):
         if not self._implicit_declaration:
-            raise ValueError("Key '%s' not defined in ConfigDict '%s'"
-                             " and Dict disallows implicit entries" %
-                             (name, self.name(True)))
+            raise ValueError(
+                "Key '%s' not defined in ConfigDict '%s'"
+                " and Dict disallows implicit entries" % (name, self.name(True))
+            )
 
         if self._implicit_domain is None:
             if isinstance(config, ConfigBase):
@@ -2522,24 +2604,27 @@ class ConfigDict(ConfigBase, Mapping):
         # Adding something to the container should not change the
         # userSet on the container (see Pyomo/pyomo#352; now
         # Pyomo/pysp#8 for justification)
-        #self._userSet = True
+        # self._userSet = True
         return ans
 
     def value(self, accessValue=True):
         if accessValue:
             self._userAccessed = True
-        return { cfg._name: cfg.value(accessValue)
-                 for cfg in map(self._data.__getitem__, self._decl_order) }
+        return {
+            cfg._name: cfg.value(accessValue)
+            for cfg in map(self._data.__getitem__, self._decl_order)
+        }
 
     def set_value(self, value, skip_implicit=False):
         if value is None:
             return self
         if isinstance(value, str):
             value = dict(_default_string_dict_lexer(value))
-        if (type(value) is not dict) and \
-           (not isinstance(value, ConfigDict)):
-            raise ValueError("Expected dict value for %s.set_value, found %s" %
-                             (self.name(True), type(value).__name__))
+        if (type(value) is not dict) and (not isinstance(value, ConfigDict)):
+            raise ValueError(
+                "Expected dict value for %s.set_value, found %s"
+                % (self.name(True), type(value).__name__)
+            )
         if not value:
             return self
         _implicit = []
@@ -2559,8 +2644,9 @@ class ConfigDict(ConfigBase, Mapping):
                 else:
                     raise ValueError(
                         "key '%s' not defined for ConfigDict '%s' and "
-                        "implicit (undefined) keys are not allowed" %
-                        (key, self.name(True)))
+                        "implicit (undefined) keys are not allowed"
+                        % (key, self.name(True))
+                    )
 
         # If the set_value fails part-way through the new values, we
         # want to restore a deterministic state.  That is, either
@@ -2593,6 +2679,7 @@ class ConfigDict(ConfigBase, Mapping):
             else:
                 del self._data[key]
             return keep
+
         # this is an in-place slice of a list...
         self._decl_order[:] = [x for x in self._decl_order if _keep(self, x)]
         self._userAccessed = False
@@ -2607,9 +2694,8 @@ class ConfigDict(ConfigBase, Mapping):
                 level += 1
         for key in self._decl_order:
             cfg = self._data[key]
-            yield from cfg._data_collector(
-                level, cfg._name + ': ', visibility, docMode
-            )
+            yield from cfg._data_collector(level, cfg._name + ': ', visibility, docMode)
+
 
 # Backwards compatibility: ConfigDict was originally named ConfigBlock.
 ConfigBlock = ConfigDict

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -490,7 +490,7 @@ def attempt_import(
         )
         if catch_exceptions is not None:
             raise ValueError(
-                "Cannot specify both only_catch_importerror " "and catch_exceptions"
+                "Cannot specify both only_catch_importerror and catch_exceptions"
             )
         if only_catch_importerror:
             catch_exceptions = (ImportError,)

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -15,13 +15,13 @@ import importlib
 import logging
 import sys
 
-from .deprecation import (
-    deprecated, deprecation_warning, in_testing_environment,
-)
+from .deprecation import deprecated, deprecation_warning, in_testing_environment
 from . import numeric_types
+
 
 class DeferredImportError(ImportError):
     pass
+
 
 class ModuleUnavailable(object):
     """Mock object that raises a DeferredImportError upon attribute access
@@ -64,14 +64,13 @@ class ModuleUnavailable(object):
 
     def __init__(self, name, message, version_error, import_error, package):
         self.__name__ = name
-        self._moduleunavailable_info_ = (
-            message, version_error, import_error, package,
-        )
+        self._moduleunavailable_info_ = (message, version_error, import_error, package)
 
     def __getattr__(self, attr):
         if attr in ModuleUnavailable._getattr_raises_attributeerror:
-            raise AttributeError("'%s' object has no attribute '%s'"
-                                 % (type(self).__name__, attr))
+            raise AttributeError(
+                "'%s' object has no attribute '%s'" % (type(self).__name__, attr)
+            )
         raise DeferredImportError(self._moduleunavailable_message())
 
     def __getstate__(self):
@@ -99,12 +98,12 @@ class ModuleUnavailable(object):
                     "failed to import: %s" % (self.__name__, _pkg_str, _imp)
                 )
             else:
-                msg = "%s (import raised %s)" % (msg, _imp,)
+                msg = "%s (import raised %s)" % (msg, _imp)
         if _ver:
             if not msg or not str(msg):
                 msg = "The %s module %s" % (self.__name__, _ver)
             else:
-                msg = "%s (%s)" % (msg, _ver,)
+                msg = "%s (%s)" % (msg, _ver)
         return msg
 
     def log_import_warning(self, logger='pyomo', msg=None):
@@ -134,11 +133,12 @@ class DeferredImportModule(object):
     raise a DeferredImportError exception.
 
     """
+
     def __init__(self, indicator, deferred_submodules, submodule_name):
         self._indicator_flag = indicator
         self._submodule_name = submodule_name
-        self.__file__ = None # Disable coverage of this module
-        self.__spec__ = None # Indicate that this is not a "real" module
+        self.__file__ = None  # Disable coverage of this module
+        self.__spec__ = None  # Indicate that this is not a "real" module
 
         if not deferred_submodules:
             return
@@ -147,12 +147,16 @@ class DeferredImportModule(object):
         for name in deferred_submodules:
             if not name.startswith(submodule_name + '.'):
                 continue
-            _local_name = name[(1+len(submodule_name)):]
+            _local_name = name[(1 + len(submodule_name)) :]
             if '.' in _local_name:
                 continue
-            setattr(self, _local_name, DeferredImportModule(
-                indicator, deferred_submodules,
-                submodule_name + '.' + _local_name))
+            setattr(
+                self,
+                _local_name,
+                DeferredImportModule(
+                    indicator, deferred_submodules, submodule_name + '.' + _local_name
+                ),
+            )
 
     def __getattr__(self, attr):
         self._indicator_flag.resolve()
@@ -207,9 +211,17 @@ class DeferredImportIndicator(_DeferredImportIndicatorBase):
 
     """
 
-    def __init__(self, name, error_message, catch_exceptions,
-                 minimum_version, original_globals, callback, importer,
-                 deferred_submodules):
+    def __init__(
+        self,
+        name,
+        error_message,
+        catch_exceptions,
+        minimum_version,
+        original_globals,
+        callback,
+        importer,
+        deferred_submodules,
+    ):
         self._names = [name]
         for _n in tuple(self._names):
             if '.' in _n:
@@ -256,8 +268,7 @@ class DeferredImportIndicator(_DeferredImportIndicatorBase):
 
             # If this module was not found, then we need to check for
             # deferred submodules and resolve them as well
-            if self._deferred_submodules and \
-               type(self._module) is ModuleUnavailable:
+            if self._deferred_submodules and type(self._module) is ModuleUnavailable:
                 info = self._module._moduleunavailable_info_
                 for submod in self._deferred_submodules:
                     refmod = self._module
@@ -265,8 +276,11 @@ class DeferredImportIndicator(_DeferredImportIndicatorBase):
                         try:
                             refmod = getattr(refmod, name)
                         except DeferredImportError:
-                            setattr(refmod, name, ModuleUnavailable(
-                                refmod.__name__+submod, *info))
+                            setattr(
+                                refmod,
+                                name,
+                                ModuleUnavailable(refmod.__name__ + submod, *info),
+                            )
                             refmod = getattr(refmod, name)
 
             # Replace myself in the original globals() where I was
@@ -281,11 +295,10 @@ class DeferredImportIndicator(_DeferredImportIndicatorBase):
         self.replace_self_in_globals(_frame.f_globals)
 
     def replace_self_in_globals(self, _globals):
-        for k,v in _globals.items():
+        for k, v in _globals.items():
             if v is self:
                 _globals[k] = self._available
-            elif v.__class__ is DeferredImportModule and \
-                 v._indicator_flag is self:
+            elif v.__class__ is DeferredImportModule and v._indicator_flag is self:
                 if v._submodule_name is None:
                     _globals[k] = self._module
                 else:
@@ -325,6 +338,7 @@ def check_min_version(module, min_version):
     if check_min_version._parser is None:
         try:
             from packaging import version as _version
+
             _parser = _version.parse
         except ImportError:
             # pkg_resources is an order of magnitude slower to import than
@@ -338,13 +352,22 @@ def check_min_version(module, min_version):
     version = getattr(module, '__version__', '0.0.0')
     return _parser(min_version) <= _parser(version)
 
+
 check_min_version._parser = None
 
 
-def attempt_import(name, error_message=None, only_catch_importerror=None,
-                   minimum_version=None, alt_names=None, callback=None,
-                   importer=None, defer_check=True, deferred_submodules=None,
-                   catch_exceptions=None):
+def attempt_import(
+    name,
+    error_message=None,
+    only_catch_importerror=None,
+    minimum_version=None,
+    alt_names=None,
+    callback=None,
+    importer=None,
+    defer_check=True,
+    deferred_submodules=None,
+    catch_exceptions=None,
+):
     """Attempt to import the specified module.
 
     This will attempt to import the specified module, returning a
@@ -453,16 +476,22 @@ def attempt_import(name, error_message=None, only_catch_importerror=None,
 
     """
     if alt_names is not None:
-        deprecation_warning('alt_names=%s no longer needs to be specified '
-                            'and is ignored' % (alt_names,), version='6.0')
+        deprecation_warning(
+            'alt_names=%s no longer needs to be specified '
+            'and is ignored' % (alt_names,),
+            version='6.0',
+        )
 
     if only_catch_importerror is not None:
         deprecation_warning(
             "only_catch_importerror is deprecated.  Pass exceptions to "
-            "catch using the catch_exceptions argument", version='5.7.3')
+            "catch using the catch_exceptions argument",
+            version='5.7.3',
+        )
         if catch_exceptions is not None:
-            raise ValueError("Cannot specify both only_catch_importerror "
-                             "and catch_exceptions")
+            raise ValueError(
+                "Cannot specify both only_catch_importerror " "and catch_exceptions"
+            )
         if only_catch_importerror:
             catch_exceptions = (ImportError,)
         else:
@@ -478,7 +507,9 @@ def attempt_import(name, error_message=None, only_catch_importerror=None,
                 deprecation_warning(
                     'attempt_import(): deferred_submodules takes an iterable '
                     'and not a mapping (the alt_names supplied by the mapping '
-                    'are no longer needed and are ignored).', version='6.0')
+                    'are no longer needed and are ignored).',
+                    version='6.0',
+                )
                 deferred_submodules = list(deferred_submodules)
 
             # Ensures all names begin with '.'
@@ -508,12 +539,12 @@ def attempt_import(name, error_message=None, only_catch_importerror=None,
             original_globals=inspect.currentframe().f_back.f_globals,
             callback=callback,
             importer=importer,
-            deferred_submodules=deferred)
+            deferred_submodules=deferred,
+        )
         return DeferredImportModule(indicator, deferred, None), indicator
 
     if deferred_submodules:
-        raise ValueError(
-            "deferred_submodules is only valid if defer_check==True")
+        raise ValueError("deferred_submodules is only valid if defer_check==True")
 
     return _perform_import(
         name=name,
@@ -526,8 +557,9 @@ def attempt_import(name, error_message=None, only_catch_importerror=None,
     )
 
 
-def _perform_import(name, error_message, minimum_version, callback,
-                    importer, catch_exceptions, package):
+def _perform_import(
+    name, error_message, minimum_version, callback, importer, catch_exceptions, package
+):
     import_error = None
     version_error = None
     try:
@@ -535,21 +567,21 @@ def _perform_import(name, error_message, minimum_version, callback,
             module = importlib.import_module(name)
         else:
             module = importer()
-        if ( minimum_version is None
-             or check_min_version(module, minimum_version) ):
+        if minimum_version is None or check_min_version(module, minimum_version):
             if callback is not None:
                 callback(module, True)
             return module, True
         else:
             version = getattr(module, '__version__', 'UNKNOWN')
-            version_error = (
-                "version %s does not satisfy the minimum version %s"
-                % (version, minimum_version))
+            version_error = "version %s does not satisfy the minimum version %s" % (
+                version,
+                minimum_version,
+            )
     except catch_exceptions as e:
         import_error = "%s: %s" % (type(e).__name__, e)
 
     module = ModuleUnavailable(
-        name, error_message, version_error, import_error, package,
+        name, error_message, version_error, import_error, package
     )
     if callback is not None:
         callback(module, False)
@@ -597,15 +629,19 @@ def declare_deferred_modules_as_importable(globals_dict):
 
     """
     _global_name = globals_dict['__name__'] + '.'
-    deferred = list((k, v) for k, v in globals_dict.items()
-                    if type(v) is DeferredImportModule )
+    deferred = list(
+        (k, v) for k, v in globals_dict.items() if type(v) is DeferredImportModule
+    )
     while deferred:
         name, mod = deferred.pop(0)
         mod.__path__ = None
         mod.__spec__ = None
         sys.modules[_global_name + name] = mod
-        deferred.extend((name + '.' + k, v) for k, v in mod.__dict__.items()
-                        if type(v) is DeferredImportModule )
+        deferred.extend(
+            (name + '.' + k, v)
+            for k, v in mod.__dict__.items()
+            if type(v) is DeferredImportModule
+        )
 
 
 #
@@ -613,16 +649,20 @@ def declare_deferred_modules_as_importable(globals_dict):
 #
 
 yaml_load_args = {}
+
+
 def _finalize_yaml(module, available):
     # Recent versions of PyYAML issue warnings if the Loader argument is
     # not set
     if available and hasattr(module, 'SafeLoader'):
         yaml_load_args['Loader'] = module.SafeLoader
 
+
 def _finalize_scipy(module, available):
     if available:
         # Import key subpackages that we will want to assume are present
         import scipy.stats
+
         # As of scipy 1.6.0, importing scipy.stats causes the following
         # to be automatically imported.  However, we will still
         # explicitly import them here to guard against potential future
@@ -631,10 +671,12 @@ def _finalize_scipy(module, available):
         import scipy.sparse
         import scipy.spatial
 
+
 def _finalize_pympler(module, available):
     if available:
         # Import key subpackages that we will want to assume are present
         import pympler.muppy
+
 
 def _finalize_matplotlib(module, available):
     if not available:
@@ -647,13 +689,24 @@ def _finalize_matplotlib(module, available):
         module.use('Agg')
     import matplotlib.pyplot
 
+
 def _finalize_numpy(np, available):
     if not available:
         return
     numeric_types.RegisterBooleanType(np.bool_)
-    for t in (np.int_, np.intc, np.intp,
-              np.int8, np.int16, np.int32, np.int64,
-              np.uint8, np.uint16, np.uint32, np.uint64):
+    for t in (
+        np.int_,
+        np.intc,
+        np.intp,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+    ):
         numeric_types.RegisterIntegerType(t)
         numeric_types.RegisterBooleanType(t)
     for t in (np.float_, np.float16, np.float32, np.float64, np.ndarray):
@@ -671,7 +724,7 @@ pyutilib, pyutilib_available = attempt_import('pyutilib')
 scipy, scipy_available = attempt_import(
     'scipy',
     callback=_finalize_scipy,
-    deferred_submodules=['stats', 'sparse', 'spatial', 'integrate']
+    deferred_submodules=['stats', 'sparse', 'spatial', 'integrate'],
 )
 yaml, yaml_available = attempt_import('yaml', callback=_finalize_yaml)
 

--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -56,8 +56,10 @@ def default_deprecation_msg(obj, user_msg, version, remove_in):
         elif _qual and _obj:
             _obj += f' ({_qual})'
 
-        user_msg = 'This%s has been deprecated and may be removed in a ' \
-                   'future release.' % (_obj,)
+        user_msg = (
+            'This%s has been deprecated and may be removed in a '
+            'future release.' % (_obj,)
+        )
     comment = []
     if version:
         comment.append('deprecated in %s' % (version,))
@@ -111,16 +113,18 @@ def _wrap_class(cls, msg, logger, version, remove_in):
             for f in ('__new__', '__init__'):
                 if getattr(c, f, None) is not getattr(cls, f, None):
                     field = f
-        setattr(cls, field, _wrap_func(
-            getattr(cls, field), msg, logger, version, remove_in))
+        setattr(
+            cls, field, _wrap_func(getattr(cls, field), msg, logger, version, remove_in)
+        )
     return cls
 
 
 def _wrap_func(func, msg, logger, version, remove_in):
     message = default_deprecation_msg(func, msg, version, remove_in)
 
-    @functools.wraps(func, assigned=(
-        '__module__', '__name__', '__qualname__', '__annotations__'))
+    @functools.wraps(
+        func, assigned=('__module__', '__name__', '__qualname__', '__annotations__')
+    )
     def wrapper(*args, **kwargs):
         cf = _find_calling_frame(1)
         deprecation_warning(message, logger, version='', calling_frame=cf)
@@ -155,12 +159,12 @@ def in_testing_environment():
 
     """
 
-    return any(mod in sys.modules for mod in (
-        'nose', 'nose2', 'pytest', 'sphinx'))
+    return any(mod in sys.modules for mod in ('nose', 'nose2', 'pytest', 'sphinx'))
 
 
-def deprecation_warning(msg, logger=None, version=None,
-                        remove_in=None, calling_frame=None):
+def deprecation_warning(
+    msg, logger=None, version=None, remove_in=None, calling_frame=None
+):
     """Standardized formatter for deprecation warnings
 
     This is a standardized routine for formatting deprecation warnings
@@ -212,7 +216,8 @@ def deprecation_warning(msg, logger=None, version=None,
 
     msg = textwrap.fill(
         f'DEPRECATED: {default_deprecation_msg(None, msg, version, remove_in)}',
-        width=70)
+        width=70,
+    )
     if calling_frame is None:
         # The useful thing to let the user know is what called the
         # function that generated the deprecation warning.  The current
@@ -231,6 +236,7 @@ def deprecation_warning(msg, logger=None, version=None,
             deprecation_warning.emitted_warnings.add(msg)
 
     logger.warning(msg)
+
 
 if in_testing_environment():
     deprecation_warning.emitted_warnings = None
@@ -275,17 +281,20 @@ def deprecated(msg=None, logger=None, version=None, remove_in=None):
     10
 
     """
+
     def wrap(obj):
         if inspect.isclass(obj):
             return _wrap_class(obj, msg, logger, version, remove_in)
         else:
             return _wrap_func(obj, msg, logger, version, remove_in)
+
     return wrap
 
 
 def _import_object(name, target, version, remove_in, msg):
     from importlib import import_module
-    modname, targetname = target.rsplit('.',1)
+
+    modname, targetname = target.rsplit('.', 1)
     _object = getattr(import_module(modname), targetname)
     if msg is None:
         if inspect.isclass(_object):
@@ -294,14 +303,15 @@ def _import_object(name, target, version, remove_in, msg):
             _type = 'function'
         else:
             _type = 'attribute'
-        msg = (f"the '{name}' {_type} has been moved to '{target}'."
-               "  Please update your import.")
+        msg = (
+            f"the '{name}' {_type} has been moved to '{target}'."
+            "  Please update your import."
+        )
     deprecation_warning(msg, version=version, remove_in=remove_in)
     return _object
 
 
-def relocated_module(new_name, msg=None, logger=None,
-                     version=None, remove_in=None):
+def relocated_module(new_name, msg=None, logger=None, version=None, remove_in=None):
     """Provide a deprecation path for moved / renamed modules
 
     Upon import, the old module (that called `relocated_module()`) will
@@ -341,6 +351,7 @@ def relocated_module(new_name, msg=None, logger=None,
 
     """
     from importlib import import_module
+
     new_module = import_module(new_name)
 
     # The relevant module (the one being deprecated) is the one that
@@ -353,19 +364,23 @@ def relocated_module(new_name, msg=None, logger=None,
     cf = cf.f_back
     if cf is not None:
         importer = cf.f_back.f_globals['__name__'].split('.')[0]
-        while cf is not None and \
-              cf.f_globals['__name__'].split('.')[0] == importer:
+        while cf is not None and cf.f_globals['__name__'].split('.')[0] == importer:
             cf = cf.f_back
     if cf is None:
         cf = _find_calling_frame(1)
 
     sys.modules[old_name] = new_module
     if msg is None:
-        msg = f"The '{old_name}' module has been moved to '{new_name}'. " \
-              'Please update your import.'
+        msg = (
+            f"The '{old_name}' module has been moved to '{new_name}'. "
+            'Please update your import.'
+        )
     deprecation_warning(msg, logger, version, remove_in, cf)
 
-def relocated_module_attribute(local, target, version, remove_in=None, msg=None, f_globals=None):
+
+def relocated_module_attribute(
+    local, target, version, remove_in=None, msg=None, f_globals=None
+):
     """Provide a deprecation path for moved / renamed module attributes
 
     This function declares that a local module attribute has been moved
@@ -410,11 +425,13 @@ def relocated_module_attribute(local, target, version, remove_in=None, msg=None,
         if f_globals['__name__'].startswith('importlib.'):
             raise DeveloperError(
                 "relocated_module_attribute() called from a cythonized "
-                "module without passing f_globals")
+                "module without passing f_globals"
+            )
     _relocated = f_globals.get('__relocated_attrs__', None)
     if _relocated is None:
         f_globals['__relocated_attrs__'] = _relocated = {}
         _mod_getattr = f_globals.get('__getattr__', None)
+
         def __getattr__(name):
             info = _relocated.get(name, None)
             if info is not None:
@@ -423,8 +440,10 @@ def relocated_module_attribute(local, target, version, remove_in=None, msg=None,
                 return target_obj
             elif _mod_getattr is not None:
                 return _mod_getattr(name)
-            raise AttributeError("module '%s' has no attribute '%s'"
-                                 % (f_globals['__name__'], name))
+            raise AttributeError(
+                "module '%s' has no attribute '%s'" % (f_globals['__name__'], name)
+            )
+
         f_globals['__getattr__'] = __getattr__
     _relocated[local] = (target, version, remove_in, msg)
 
@@ -471,38 +490,44 @@ class RenamedClass(type):
     True
 
     """
+
     def __new__(cls, name, bases, classdict, *args, **kwargs):
         new_class = classdict.get('__renamed__new_class__', None)
         if new_class is not None:
+
             def __renamed__new__(cls, *args, **kwargs):
-                cls.__renamed__warning__(
-                    "Instantiating class '%s'." % (cls.__name__,))
+                cls.__renamed__warning__("Instantiating class '%s'." % (cls.__name__,))
                 return new_class(*args, **kwargs)
+
             classdict['__new__'] = __renamed__new__
 
             def __renamed__warning__(msg):
                 version = classdict.get('__renamed__version__')
                 remove_in = classdict.get('__renamed__remove_in__')
                 deprecation_warning(
-                    "%s  The class '%s' has been renamed to '%s'." % (
-                        msg, name, new_class.__name__),
-                    version=version, remove_in=remove_in,
-                    calling_frame=_find_calling_frame(1))
+                    "%s  The class '%s' has been renamed to '%s'."
+                    % (msg, name, new_class.__name__),
+                    version=version,
+                    remove_in=remove_in,
+                    calling_frame=_find_calling_frame(1),
+                )
+
             classdict['__renamed__warning__'] = __renamed__warning__
 
             if not classdict.get('__renamed__version__'):
                 raise DeveloperError(
                     "Declaring class '%s' using the RenamedClass metaclass, "
                     "but without specifying the __renamed__version__ class "
-                    "attribute" % (name,))
+                    "attribute" % (name,)
+                )
 
         renamed_bases = []
         for base in bases:
             new_class = getattr(base, '__renamed__new_class__', None)
             if new_class is not None:
                 base.__renamed__warning__(
-                    "Declaring class '%s' derived from '%s'." % (
-                        name, base.__name__,))
+                    "Declaring class '%s' derived from '%s'." % (name, base.__name__)
+                )
                 base = new_class
                 # Flag that this class is derived from a renamed class
                 classdict.setdefault('__renamed__new_class__', None)
@@ -520,26 +545,33 @@ class RenamedClass(type):
             renamed_bases.append(new_class)
 
         if new_class is None and '__renamed__new_class__' not in classdict:
-            if not any(hasattr(base, '__renamed__new_class__') for mro in
-                       itertools.chain.from_iterable(
-                           base.__mro__ for base in renamed_bases)):
+            if not any(
+                hasattr(base, '__renamed__new_class__')
+                for mro in itertools.chain.from_iterable(
+                    base.__mro__ for base in renamed_bases
+                )
+            ):
                 raise TypeError(
                     "Declaring class '%s' using the RenamedClass metaclass, "
                     "but without specifying the __renamed__new_class__ class "
-                    "attribute" % (name,))
+                    "attribute" % (name,)
+                )
 
         return super().__new__(
-            cls, name, tuple(renamed_bases), classdict, *args, **kwargs)
+            cls, name, tuple(renamed_bases), classdict, *args, **kwargs
+        )
 
     def __instancecheck__(cls, instance):
         # Note: the warning is issued by subclasscheck
-        return any(cls.__subclasscheck__(c)
-            for c in {type(instance), instance.__class__})
+        return any(
+            cls.__subclasscheck__(c) for c in {type(instance), instance.__class__}
+        )
 
     def __subclasscheck__(cls, subclass):
         if hasattr(cls, '__renamed__warning__'):
             cls.__renamed__warning__(
-                "Checking type relative to '%s'." % (cls.__name__,))
+                "Checking type relative to '%s'." % (cls.__name__,)
+            )
         if subclass is cls:
             return True
         elif getattr(cls, '__renamed__new_class__') is not None:

--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -386,7 +386,7 @@ class FileDownloader(object):
             if len(target) <= dirOffset:
                 if f[-1] != '/':
                     logger.warning(
-                        "Skipping file (%s) in zip archive due to " "dirOffset" % (f,)
+                        "Skipping file (%s) in zip archive due to dirOffset" % (f,)
                     )
                 continue
             info.filename = target[-1] + '/' if f[-1] == '/' else target[-1]

--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -35,6 +35,7 @@ logger = logging.getLogger('pyomo.common.download')
 
 DownloadFactory = pyomo.common.Factory('library downloaders')
 
+
 class FileDownloader(object):
     _os_version = None
 
@@ -46,9 +47,8 @@ class FileDownloader(object):
         if cacert is not None:
             if not self.cacert or not os.path.isfile(self.cacert):
                 raise RuntimeError(
-                    "cacert='%s' does not refer to a valid file."
-                    % (self.cacert,))
-
+                    "cacert='%s' does not refer to a valid file." % (self.cacert,)
+                )
 
     @classmethod
     def get_sysinfo(cls):
@@ -76,7 +76,7 @@ class FileDownloader(object):
                 line = line.strip()
                 if not line:
                     continue
-                key,val = line.lower().split('=')
+                key, val = line.lower().split('=')
                 if val[0] == val[-1] and val[0] in '"\'':
                     val = val[1:-1]
                 if key == 'id':
@@ -99,10 +99,18 @@ class FileDownloader(object):
 
     @classmethod
     def _get_distver_from_lsb_release(cls):
-        dist = subprocess.run(['lsb_release', '-si'], stdout=subprocess.PIPE,
-                              stderr=subprocess.STDOUT, universal_newlines=True)
-        ver = subprocess.run(['lsb_release', '-sr'], stdout=subprocess.PIPE,
-                             stderr=subprocess.STDOUT, universal_newlines=True)
+        dist = subprocess.run(
+            ['lsb_release', '-si'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+        ver = subprocess.run(
+            ['lsb_release', '-sr'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
         return cls._map_linux_dist(dist.stdout), ver.stdout.strip()
 
     @classmethod
@@ -117,7 +125,7 @@ class FileDownloader(object):
         _map = [
             ('redhat', 'rhel'),
             'fedora',
-            'ubuntu', # implicitly maps kubuntu / xubuntu
+            'ubuntu',  # implicitly maps kubuntu / xubuntu
             'debian',
             # Additional RHEL (Fedora) spins
             'centos',
@@ -144,15 +152,21 @@ class FileDownloader(object):
                 dist, ver = cls._get_distver_from_distro()
             elif os.path.exists('/etc/redhat-release'):
                 dist, ver = cls._get_distver_from_redhat_release()
-            elif subprocess.run(['lsb_release'], stdout=subprocess.DEVNULL,
-                              stderr=subprocess.DEVNULL).returncode == 0:
+            elif (
+                subprocess.run(
+                    ['lsb_release'],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                ).returncode
+                == 0
+            ):
                 dist, ver = cls._get_distver_from_lsb_release()
             elif os.path.exists('/etc/os-release'):
                 # Note that (at least on centos), os_release is an
                 # imprecise version string
                 dist, ver = cls._get_distver_from_os_release()
             else:
-                dist, ver = '',''
+                dist, ver = '', ''
             return dist, ver
         elif _os == 'darwin':
             return 'macos', platform.mac_ver()[0]
@@ -200,16 +214,14 @@ class FileDownloader(object):
         if _os in _map:
             _os = _map[_os]
 
-        if _os in {'ubuntu','macos','win'}:
+        if _os in {'ubuntu', 'macos', 'win'}:
             return _os + ''.join(_ver.split('.')[:2])
         else:
             return _os + _ver.split('.')[0]
 
-    @deprecated("get_url() is deprecated. Use get_platform_url()",
-                version='5.6.9')
+    @deprecated("get_url() is deprecated. Use get_platform_url()", version='5.6.9')
     def get_url(self, urlmap):
         return self.get_platform_url(urlmap)
-
 
     def get_platform_url(self, urlmap):
         """Select the url for this platform
@@ -229,10 +241,9 @@ class FileDownloader(object):
         url = urlmap.get(system, None)
         if url is None:
             raise RuntimeError(
-                "cannot infer the correct url for platform '%s'"
-                % (platform,))
+                "cannot infer the correct url for platform '%s'" % (platform,)
+            )
         return url
-
 
     def create_parser(self, parser=None):
         if parser is None:
@@ -253,7 +264,8 @@ class FileDownloader(object):
             "to verify peers.",
         )
         parser.add_argument(
-            '-v','--verbose',
+            '-v',
+            '--verbose',
             action='store_true',
             dest='verbose',
             default=False,
@@ -267,14 +279,14 @@ class FileDownloader(object):
             'target',
             nargs="?",
             default=None,
-            help="Target destination directory or filename"
+            help="Target destination directory or filename",
         )
         parser.parse_args(argv, self)
         if self.cacert is not None:
             if not self.cacert or not os.path.isfile(self.cacert):
                 raise RuntimeError(
-                    "--cacert='%s' does not refer to a valid file."
-                    % (self.cacert,))
+                    "--cacert='%s' does not refer to a valid file." % (self.cacert,)
+                )
 
     def set_destination_filename(self, default):
         if self.target is not None:
@@ -303,27 +315,25 @@ class FileDownloader(object):
         try:
             fetch = request.urlopen(url, context=ctx)
         except urllib_error.HTTPError as e:
-            if e.code != 403: # Forbidden
+            if e.code != 403:  # Forbidden
                 raise
             fetch = None
         if fetch is None:
             # This is a fix implemented if we get stuck behind server
             # security features (attempting to block "bot" agents).
             # We are setting a known user-agent to get around that.
-            req = request.Request(
-                url=url,
-                headers={'User-Agent': 'Mozilla/5.0'},
-            )
+            req = request.Request(url=url, headers={'User-Agent': 'Mozilla/5.0'})
             fetch = request.urlopen(req, context=ctx)
         ans = fetch.read()
         logger.info("  ...downloaded %s bytes" % (len(ans),))
         return ans
 
-
     def get_file(self, url, binary):
         if self._fname is None:
-            raise DeveloperError("target file name has not been initialized "
-                                 "with set_destination_filename")
+            raise DeveloperError(
+                "target file name has not been initialized "
+                "with set_destination_filename"
+            )
         with open(self._fname, 'wb' if binary else 'wt') as FILE:
             raw_file = self.retrieve_url(url)
             if binary:
@@ -332,64 +342,67 @@ class FileDownloader(object):
                 FILE.write(raw_file.decode())
             logger.info("  ...wrote %s bytes" % (len(raw_file),))
 
-
     def get_binary_file(self, url):
         """Retrieve the specified url and write as a binary file"""
         return self.get_file(url, binary=True)
-
 
     def get_text_file(self, url):
         """Retrieve the specified url and write as a text file"""
         return self.get_file(url, binary=False)
 
-
     def get_binary_file_from_zip_archive(self, url, srcname):
         if self._fname is None:
-            raise DeveloperError("target file name has not been initialized "
-                                 "with set_destination_filename")
+            raise DeveloperError(
+                "target file name has not been initialized "
+                "with set_destination_filename"
+            )
         with open(self._fname, 'wb') as FILE:
             zipped_file = io.BytesIO(self.retrieve_url(url))
             raw_file = zipfile.ZipFile(zipped_file).open(srcname).read()
             FILE.write(raw_file)
             logger.info("  ...wrote %s bytes" % (len(raw_file),))
 
-
     def get_zip_archive(self, url, dirOffset=0):
         if self._fname is None:
-            raise DeveloperError("target file name has not been initialized "
-                                 "with set_destination_filename")
+            raise DeveloperError(
+                "target file name has not been initialized "
+                "with set_destination_filename"
+            )
         if os.path.exists(self._fname) and not os.path.isdir(self._fname):
             raise RuntimeError(
-                "Target directory (%s) exists, but is not a directory"
-                % (self._fname,))
+                "Target directory (%s) exists, but is not a directory" % (self._fname,)
+            )
         zip_file = zipfile.ZipFile(io.BytesIO(self.retrieve_url(url)))
         # Simple sanity checks
         for info in zip_file.infolist():
             f = info.filename
             if f[0] in '\\/' or '..' in f:
-                logger.error("malformed (potentially insecure) filename (%s) "
-                             "found in zip archive.  Skipping file." % (f,))
+                logger.error(
+                    "malformed (potentially insecure) filename (%s) "
+                    "found in zip archive.  Skipping file." % (f,)
+                )
                 continue
             target = self._splitpath(f)
             if len(target) <= dirOffset:
                 if f[-1] != '/':
-                    logger.warning("Skipping file (%s) in zip archive due to "
-                                   "dirOffset" % (f,))
+                    logger.warning(
+                        "Skipping file (%s) in zip archive due to " "dirOffset" % (f,)
+                    )
                 continue
             info.filename = target[-1] + '/' if f[-1] == '/' else target[-1]
-            zip_file.extract(
-                f, os.path.join(self._fname, *tuple(target[dirOffset:-1])))
+            zip_file.extract(f, os.path.join(self._fname, *tuple(target[dirOffset:-1])))
 
     def get_gzipped_binary_file(self, url):
         if self._fname is None:
-            raise DeveloperError("target file name has not been initialized "
-                                 "with set_destination_filename")
+            raise DeveloperError(
+                "target file name has not been initialized "
+                "with set_destination_filename"
+            )
         with open(self._fname, 'wb') as FILE:
             gzipped_file = io.BytesIO(self.retrieve_url(url))
             raw_file = gzip.GzipFile(fileobj=gzipped_file).read()
             FILE.write(raw_file)
             logger.info("  ...wrote %s bytes" % (len(raw_file),))
-
 
     def _splitpath(self, path):
         components = []

--- a/pyomo/common/env.py
+++ b/pyomo/common/env.py
@@ -256,7 +256,7 @@ class _MsvcrtDLL(object):
             size += len(line)
             if len(line) == 0:
                 raise ValueError(
-                    "Error processing MSVCRT _environ: " "0-length string encountered"
+                    "Error processing MSVCRT _environ: 0-length string encountered"
                 )
             if size > 32767:
                 raise ValueError(

--- a/pyomo/common/envvar.py
+++ b/pyomo/common/envvar.py
@@ -14,12 +14,14 @@ import platform
 
 if 'PYOMO_CONFIG_DIR' in os.environ:
     PYOMO_CONFIG_DIR = os.path.abspath(os.environ['PYOMO_CONFIG_DIR'])
-elif platform.system().lower().startswith(('windows','cygwin')):
+elif platform.system().lower().startswith(('windows', 'cygwin')):
     PYOMO_CONFIG_DIR = os.path.abspath(
-        os.path.join(os.environ.get('LOCALAPPDATA', ''), 'Pyomo'))
+        os.path.join(os.environ.get('LOCALAPPDATA', ''), 'Pyomo')
+    )
 else:
     PYOMO_CONFIG_DIR = os.path.abspath(
-        os.path.join(os.environ.get('HOME', ''), '.pyomo'))
+        os.path.join(os.environ.get('HOME', ''), '.pyomo')
+    )
 
 # Note that alternative platform-independent implementation of the above
 # could be to use:

--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -16,7 +16,7 @@ class ApplicationError(Exception):
     """
 
     def __init__(self, *args, **kargs):
-        Exception.__init__(self, *args, **kargs)  #pragma:nocover
+        Exception.__init__(self, *args, **kargs)  # pragma:nocover
 
 
 class PyomoException(Exception):
@@ -25,6 +25,7 @@ class PyomoException(Exception):
     allowing pyomo exceptions to be caught in a general way
     (e.g., in other applications that use Pyomo).
     """
+
     pass
 
 
@@ -39,15 +40,17 @@ class DeveloperError(PyomoException, NotImplementedError):
         self.parameter = val
 
     def __str__(self):
-        return ( "Internal Pyomo implementation error:\n\t%s\n"
-                 "\tPlease report this to the Pyomo Developers."
-                 % ( repr(self.parameter), ) )
+        return (
+            "Internal Pyomo implementation error:\n\t%s\n"
+            "\tPlease report this to the Pyomo Developers." % (repr(self.parameter),)
+        )
 
 
 class IntervalException(PyomoException, ValueError):
     """
     Exception class used for errors in interval arithmetic.
     """
+
     pass
 
 
@@ -57,18 +60,22 @@ class InfeasibleConstraintException(PyomoException):
     that an infeasible constraint has been identified (e.g. in
     the course of range reduction).
     """
+
     pass
 
 
 class NondifferentiableError(PyomoException, ValueError):
     """A Pyomo-specific ValueError raised for non-differentiable expressions"""
+
     pass
+
 
 class TempfileContextError(PyomoException, IndexError):
     """A Pyomo-specific IndexError raised when attempting to use the
     TempfileManager when it does not have a currently active context.
 
     """
+
     pass
 
 
@@ -80,13 +87,15 @@ class MouseTrap(PyomoException, NotImplementedError):
     or solvable, or communicable to a solver, etc. (i.e., Really? Now you
     want a glass of milk too?)
     """
+
     def __init__(self, val):
         self.parameter = val
 
     def __str__(self):
-        return ("Sorry, mouse, no cookies here!\n\t%s\n"
-                "\tThis is functionality we think may be rational to "
-                "support, but is not yet implemented since it might go "
-                "beyond what can practically be solved. However, please "
-                "feed the mice: pull requests are always welcome!"
-                % (repr(self.parameter), ))
+        return (
+            "Sorry, mouse, no cookies here!\n\t%s\n"
+            "\tThis is functionality we think may be rational to "
+            "support, but is not yet implemented since it might go "
+            "beyond what can practically be solved. However, please "
+            "feed the mice: pull requests are always welcome!" % (repr(self.parameter),)
+        )

--- a/pyomo/common/factory.py
+++ b/pyomo/common/factory.py
@@ -58,10 +58,11 @@ class Factory(object):
         if name in self._cls:
             del self._cls[name]
             del self._doc[name]
-    
+
     def register(self, name, doc=None):
         def fn(cls):
             self._cls[name] = cls
             self._doc[name] = doc
             return cls
+
         return fn

--- a/pyomo/common/fileutils.py
+++ b/pyomo/common/fileutils.py
@@ -44,8 +44,8 @@ import sys
 from . import envvar
 from .deprecation import deprecated, relocated_module_attribute
 
-relocated_module_attribute(
-    'StreamIndenter', 'pyomo.common.formatting', version='6.2')
+relocated_module_attribute('StreamIndenter', 'pyomo.common.formatting', version='6.2')
+
 
 def this_file(stack_offset=1):
     """Returns the file name for the module that calls this function.
@@ -69,16 +69,22 @@ def this_file(stack_offset=1):
 
 
 def this_file_dir(stack_offset=1):
-    """Returns the directory containing the module that calls this function.
-    """
+    """Returns the directory containing the module that calls this function."""
     return os.path.dirname(this_file(stack_offset=1 + stack_offset))
 
 
 PYOMO_ROOT_DIR = os.path.dirname(os.path.dirname(this_file_dir()))
 
 
-def find_path(name, validate, cwd=True, mode=os.R_OK, ext=None,
-              pathlist=[], allow_pathlist_deep_references=True):
+def find_path(
+    name,
+    validate,
+    cwd=True,
+    mode=os.R_OK,
+    ext=None,
+    pathlist=[],
+    allow_pathlist_deep_references=True,
+):
     """Locate a path, given a set of search parameters
 
     Parameters
@@ -137,7 +143,7 @@ def find_path(name, validate, cwd=True, mode=os.R_OK, ext=None,
 
     if allow_pathlist_deep_references or os.path.basename(name) == name:
         if isinstance(pathlist, str):
-            locations.extend( pathlist.split(os.pathsep) )
+            locations.extend(pathlist.split(os.pathsep))
         else:
             locations.extend(pathlist)
 
@@ -152,7 +158,7 @@ def find_path(name, validate, cwd=True, mode=os.R_OK, ext=None,
         if not path:
             continue
         for _ext in extlist:
-            for test in glob.glob(os.path.join(path, name+_ext)):
+            for test in glob.glob(os.path.join(path, name + _ext)):
                 if not validate(test):
                     continue
                 if mode is not None and not os.access(test, mode):
@@ -161,14 +167,20 @@ def find_path(name, validate, cwd=True, mode=os.R_OK, ext=None,
     return None
 
 
-def find_file(filename, cwd=True, mode=os.R_OK, ext=None, pathlist=[],
-              allow_pathlist_deep_references=True):
+def find_file(
+    filename,
+    cwd=True,
+    mode=os.R_OK,
+    ext=None,
+    pathlist=[],
+    allow_pathlist_deep_references=True,
+):
     """Locate a file, given a set of search parameters
 
     Parameters
     ----------
     filename : str
-    
+
         The file name to locate.  The file name may contain references
         to a user's home directory (``~user``), environment variables
         (``${HOME}/bin``), and shell wildcards (``?`` and ``*``); all of
@@ -209,15 +221,19 @@ def find_file(filename, cwd=True, mode=os.R_OK, ext=None, pathlist=[],
 
     """
     return find_path(
-        filename, os.path.isfile, cwd=cwd, mode=mode, ext=ext,
+        filename,
+        os.path.isfile,
+        cwd=cwd,
+        mode=mode,
+        ext=ext,
         pathlist=pathlist,
-        allow_pathlist_deep_references=allow_pathlist_deep_references
+        allow_pathlist_deep_references=allow_pathlist_deep_references,
     )
 
 
-
-def find_dir(dirname, cwd=True, mode=os.R_OK, pathlist=[],
-             allow_pathlist_deep_references=True):
+def find_dir(
+    dirname, cwd=True, mode=os.R_OK, pathlist=[], allow_pathlist_deep_references=True
+):
     """Locate a directory, given a set of search parameters
 
     Parameters
@@ -260,24 +276,24 @@ def find_dir(dirname, cwd=True, mode=os.R_OK, pathlist=[],
 
     """
     return find_path(
-        dirname, os.path.isdir, cwd=cwd, mode=mode, pathlist=pathlist,
-        allow_pathlist_deep_references=allow_pathlist_deep_references
+        dirname,
+        os.path.isdir,
+        cwd=cwd,
+        mode=mode,
+        pathlist=pathlist,
+        allow_pathlist_deep_references=allow_pathlist_deep_references,
     )
 
 
-_exeExt = {
-    'linux':   None,
-    'windows': '.exe',
-    'cygwin':  '.exe',
-    'darwin':  None,
-}
+_exeExt = {'linux': None, 'windows': '.exe', 'cygwin': '.exe', 'darwin': None}
 
 _libExt = {
-    'linux':   ('.so', '.so.*'),
+    'linux': ('.so', '.so.*'),
     'windows': ('.dll', '.pyd'),
-    'cygwin':  ('.dll', '.so', '.so.*'),
-    'darwin':  ('.dylib', '.so', '.so.*'),
+    'cygwin': ('.dll', '.so', '.so.*'),
+    'darwin': ('.dylib', '.so', '.so.*'),
 }
+
 
 def _system():
     system = platform.system().lower()
@@ -287,7 +303,7 @@ def _system():
 
 
 def _path():
-    return (os.environ.get('PATH','') or os.defpath).split(os.pathsep)
+    return (os.environ.get('PATH', '') or os.defpath).split(os.pathsep)
 
 
 def find_library(libname, cwd=True, include_PATH=True, pathlist=None):
@@ -335,10 +351,10 @@ def find_library(libname, cwd=True, include_PATH=True, pathlist=None):
     if pathlist is None:
         # Note: PYOMO_CONFIG_DIR/lib comes before LD_LIBRARY_PATH, and
         # PYOMO_CONFIG_DIR/bin comes immediately before PATH
-        pathlist = [ os.path.join(envvar.PYOMO_CONFIG_DIR, 'lib') ]
-        pathlist.extend(os.environ.get('LD_LIBRARY_PATH','').split(os.pathsep))
+        pathlist = [os.path.join(envvar.PYOMO_CONFIG_DIR, 'lib')]
+        pathlist.extend(os.environ.get('LD_LIBRARY_PATH', '').split(os.pathsep))
         if include_PATH:
-            pathlist.append( os.path.join(envvar.PYOMO_CONFIG_DIR, 'bin') )
+            pathlist.append(os.path.join(envvar.PYOMO_CONFIG_DIR, 'bin'))
     elif isinstance(pathlist, str):
         pathlist = pathlist.split(os.pathsep)
     else:
@@ -350,7 +366,7 @@ def find_library(libname, cwd=True, include_PATH=True, pathlist=None):
     lib = find_file(libname, cwd=cwd, ext=ext, pathlist=pathlist)
     if lib is None and not libname.startswith('lib'):
         # Search 2: prepend 'lib' (with extensions) in our paths
-        lib = find_file('lib'+libname, cwd=cwd, ext=ext, pathlist=pathlist)
+        lib = find_file('lib' + libname, cwd=cwd, ext=ext, pathlist=pathlist)
     if lib is not None:
         return lib
     # Search 3: use ctypes.util.find_library (which expects 'lib' and
@@ -358,7 +374,7 @@ def find_library(libname, cwd=True, include_PATH=True, pathlist=None):
     libname_base, ext = os.path.splitext(os.path.basename(libname))
     if libname_base.startswith('lib') and _system() != 'windows':
         libname_base = libname_base[3:]
-    if ext.lower().startswith(('.so','.dll','.dylib')):
+    if ext.lower().startswith(('.so', '.dll', '.dylib')):
         return ctypes.util.find_library(libname_base)
     else:
         return ctypes.util.find_library(libname)
@@ -405,7 +421,7 @@ def find_executable(exename, cwd=True, include_PATH=True, pathlist=None):
 
     """
     if pathlist is None:
-        pathlist = [ os.path.join(envvar.PYOMO_CONFIG_DIR, 'bin') ]
+        pathlist = [os.path.join(envvar.PYOMO_CONFIG_DIR, 'bin')]
     elif isinstance(pathlist, str):
         pathlist = pathlist.split(os.pathsep)
     else:
@@ -413,15 +429,21 @@ def find_executable(exename, cwd=True, include_PATH=True, pathlist=None):
     if include_PATH:
         pathlist.extend(_path())
     ext = _exeExt.get(_system(), None)
-    return find_file(exename, cwd=cwd, ext=ext, mode=os.R_OK|os.X_OK,
-                     pathlist=pathlist, allow_pathlist_deep_references=False)
+    return find_file(
+        exename,
+        cwd=cwd,
+        ext=ext,
+        mode=os.R_OK | os.X_OK,
+        pathlist=pathlist,
+        allow_pathlist_deep_references=False,
+    )
 
 
 def import_file(path, clear_cache=False, infer_package=True, module_name=None):
     """
     Import a module given the full path/filename of the file.
     Replaces import_file from pyutilib (Pyomo 6.0.0).
-    
+
     This function returns the module object that is created.
 
     Parameters
@@ -431,16 +453,16 @@ def import_file(path, clear_cache=False, infer_package=True, module_name=None):
     clear_cache: bool
         Remove module if already loaded. The default is False.
     """
-    path = os.path.normpath(os.path.abspath(os.path.expanduser(
-        os.path.expandvars(path))))
+    path = os.path.normpath(
+        os.path.abspath(os.path.expanduser(os.path.expandvars(path)))
+    )
     if not os.path.exists(path):
         raise FileNotFoundError('File does not exist. Check path.')
     module_dir, module_file = os.path.split(path)
     if module_name is None:
         module_name, module_ext = os.path.splitext(module_file)
     if infer_package:
-        while module_dir and os.path.exists(
-                os.path.join(module_dir, '__init__.py')):
+        while module_dir and os.path.exists(os.path.join(module_dir, '__init__.py')):
             module_dir, mod = os.path.split(module_dir)
             module_name = mod + '.' + module_name
     if clear_cache and module_name in sys.modules:
@@ -455,9 +477,8 @@ def import_file(path, clear_cache=False, infer_package=True, module_name=None):
 
 
 class PathData(object):
-    """An object for storing and managing a :py:class:`PathManager` path
+    """An object for storing and managing a :py:class:`PathManager` path"""
 
-    """
     def __init__(self, manager, name):
         self._mngr = manager
         self._registered_name = name
@@ -489,11 +510,13 @@ class PathData(object):
             logging.getLogger('pyomo.common').warning(
                 "explicitly setting the path for '%s' to an "
                 "invalid object or nonexistent location ('%s')"
-                % (self._registered_name, value))
+                % (self._registered_name, value)
+            )
 
-    @deprecated("get_path() is deprecated; use "
-                "pyomo.common.Executable(name).path()",
-                version='5.6.2')
+    @deprecated(
+        "get_path() is deprecated; use " "pyomo.common.Executable(name).path()",
+        version='5.6.2',
+    )
     def get_path(self):
         return self.path()
 
@@ -546,9 +569,8 @@ class PathData(object):
 
 
 class ExecutableData(PathData):
-    """A :py:class:`PathData` class specifically for executables.
+    """A :py:class:`PathData` class specifically for executables."""
 
-    """
     @property
     def executable(self):
         """Get (or set) the path to the executable"""
@@ -681,6 +703,7 @@ class PathManager(object):
         ...     os.remove(_testfile)
 
     """
+
     def __init__(self, finder, dataClass):
         self._pathTo = {}
         self._find = finder
@@ -703,6 +726,7 @@ class PathManager(object):
         for _path in self._pathTo.values():
             _path.rehash()
 
+
 #
 # Define singleton objects for Pyomo / Users to interact with
 #
@@ -710,12 +734,15 @@ Executable = PathManager(find_executable, ExecutableData)
 Library = PathManager(find_library, PathData)
 
 
-@deprecated("pyomo.common.register_executable(name) has been deprecated; "
-            "explicit registration is no longer necessary",
-            version='5.6.2')
+@deprecated(
+    "pyomo.common.register_executable(name) has been deprecated; "
+    "explicit registration is no longer necessary",
+    version='5.6.2',
+)
 def register_executable(name, validate=None):
     # Setting to None will cause Executable to re-search the pathlist
     return Executable(name).rehash()
+
 
 @deprecated(
     """pyomo.common.registered_executable(name) has been deprecated; use
@@ -723,7 +750,8 @@ def register_executable(name, validate=None):
     pyomo.common.Executable(name).available() to get a bool indicating
     file availability.  Equivalent results can be obtained by casting
     Executable(name) to string or bool.""",
-    version='5.6.2')
+    version='5.6.2',
+)
 def registered_executable(name):
     ans = Executable(name)
     if ans.path() is None:
@@ -731,8 +759,11 @@ def registered_executable(name):
     else:
         return ans
 
-@deprecated("pyomo.common.unregister_executable(name) has been deprecated; "
-            "use Executable(name).disable()",
-            version='5.6.2')
+
+@deprecated(
+    "pyomo.common.unregister_executable(name) has been deprecated; "
+    "use Executable(name).disable()",
+    version='5.6.2',
+)
 def unregister_executable(name):
     Executable(name).disable()

--- a/pyomo/common/fileutils.py
+++ b/pyomo/common/fileutils.py
@@ -514,7 +514,7 @@ class PathData(object):
             )
 
     @deprecated(
-        "get_path() is deprecated; use " "pyomo.common.Executable(name).path()",
+        "get_path() is deprecated; use pyomo.common.Executable(name).path()",
         version='5.6.2',
     )
     def get_path(self):

--- a/pyomo/common/formatting.py
+++ b/pyomo/common/formatting.py
@@ -22,6 +22,7 @@ import re
 import types
 from pyomo.common.sorting import sorted_robust
 
+
 def tostr(value, quote_str=False):
     """Convert a value to a string
 
@@ -65,37 +66,38 @@ def tostr(value, quote_str=False):
         # in particular instances:
         tostr.handlers[_type] = tostr.handlers[None]
         if isinstance(value, list):
-            if ( _type.__str__ is list.__str__ and
-                 _type.__repr__ is list.__repr__ ):
+            if _type.__str__ is list.__str__ and _type.__repr__ is list.__repr__:
                 tostr.handlers[_type] = tostr.handlers[list]
         elif isinstance(value, tuple):
-            if ( _type.__str__ is tuple.__str__ and
-                 _type.__repr__ is tuple.__repr__ ):
+            if _type.__str__ is tuple.__str__ and _type.__repr__ is tuple.__repr__:
                 tostr.handlers[_type] = tostr.handlers[tuple]
         elif isinstance(value, dict):
-            if ( _type.__str__ is dict.__str__ and
-                 _type.__repr__ is dict.__repr__ ):
+            if _type.__str__ is dict.__str__ and _type.__repr__ is dict.__repr__:
                 tostr.handlers[_type] = tostr.handlers[dict]
         elif isinstance(value, str):
             tostr.handlers[_type] = tostr.handlers[str]
 
     return tostr.handlers[_type](value, quote_str)
 
+
 tostr.handlers = {
     list: lambda value, quote_str: (
         "[%s]" % (', '.join(tostr(v, True) for v in value))
     ),
     dict: lambda value, quote_str: (
-        "{%s}" % (', '.join('%s: %s' % (tostr(k, True), tostr(v, True))
-                            for k, v in value.items()))
+        "{%s}"
+        % (
+            ', '.join(
+                '%s: %s' % (tostr(k, True), tostr(v, True)) for k, v in value.items()
+            )
+        )
     ),
     tuple: lambda value, quote_str: (
-        "(%s,)" % (tostr(value[0], True),) if len(value) == 1
+        "(%s,)" % (tostr(value[0], True),)
+        if len(value) == 1
         else "(%s)" % (', '.join(tostr(v, True) for v in value))
     ),
-    str: lambda value, quote_str: (
-        repr(value) if quote_str else value
-    ),
+    str: lambda value, quote_str: (repr(value) if quote_str else value),
     None: lambda value, quote_str: str(value),
 }
 
@@ -144,19 +146,20 @@ def tabular_writer(ostream, prefix, data, header, row_generator):
             # A ValueError can be raised when row_generator is called
             # (if it is a function), or when it is exhausted generating
             # the list (if it is a generator)
-            _minWidth = 4 # Ensure columns are wide enough to output "None"
+            _minWidth = 4  # Ensure columns are wide enough to output "None"
             _rows[_key] = None
             continue
 
         _rows[_key] = [
             ((tostr("" if i else _key),) if header else ())
             + tuple(tostr(x) for x in _r)
-            for i, _r in enumerate(_rowSet) ]
+            for i, _r in enumerate(_rowSet)
+        ]
 
         if not _rows[_key]:
             _minWidth = 4
         elif not _width:
-            _width = [0]*len(_rows[_key][0])
+            _width = [0] * len(_rows[_key][0])
         for _row in _rows[_key]:
             for col, x in enumerate(_row):
                 _width[col] = max(_width[col], len(x), col and _minWidth)
@@ -166,10 +169,11 @@ def tabular_writer(ostream, prefix, data, header, row_generator):
         # Note: do not right-pad the last header with unnecessary spaces
         tmp = _width[-1]
         _width[-1] = 0
-        ostream.write(prefix
-                      + " : ".join( "%%-%ds" % _width[i] % x
-                                    for i,x in enumerate(header) )
-                      + "\n")
+        ostream.write(
+            prefix
+            + " : ".join("%%-%ds" % _width[i] % x for i, x in enumerate(header))
+            + "\n"
+        )
         _width[-1] = tmp
 
     # If there is no data, we are done...
@@ -178,21 +182,18 @@ def tabular_writer(ostream, prefix, data, header, row_generator):
 
     # right-justify data, except for the last column if there are spaces
     # in the data (probably an expression or vector)
-    _width = ["%"+str(i)+"s" for i in _width]
+    _width = ["%" + str(i) + "s" for i in _width]
 
-    if any( ' ' in r[-1]
-            for x in _rows.values() if x is not None
-            for r in x  ):
+    if any(' ' in r[-1] for x in _rows.values() if x is not None for r in x):
         _width[-1] = '%s'
     for _key in sorted_robust(_rows):
         _rowSet = _rows[_key]
         if not _rowSet:
-            _rowSet = [ [_key] + [None]*(len(_width)-1) ]
+            _rowSet = [[_key] + [None] * (len(_width) - 1)]
         for _data in _rowSet:
             ostream.write(
-                prefix
-                + " : ".join( _width[i] % x for i,x in enumerate(_data) )
-                + "\n")
+                prefix + " : ".join(_width[i] % x for i, x in enumerate(_data)) + "\n"
+            )
 
 
 class StreamIndenter(object):
@@ -203,7 +204,7 @@ class StreamIndenter(object):
     StreamIndenter objects may be arbitrarily nested.
     """
 
-    def __init__(self, ostream, indent=' '*4):
+    def __init__(self, ostream, indent=' ' * 4):
         self.os = ostream
         self.indent = indent
         self.stripped_indent = indent.rstrip()
@@ -218,7 +219,7 @@ class StreamIndenter(object):
         lines = data.split('\n')
         if self.newline:
             if lines[0]:
-                self.os.write(self.indent+lines[0])
+                self.os.write(self.indent + lines[0])
             else:
                 self.os.write(self.stripped_indent)
         else:
@@ -228,11 +229,11 @@ class StreamIndenter(object):
             return
         for line in lines[1:-1]:
             if line:
-                self.os.write("\n"+self.indent+line)
+                self.os.write("\n" + self.indent + line)
             else:
-                self.os.write("\n"+self.stripped_indent)
+                self.os.write("\n" + self.stripped_indent)
         if lines[-1]:
-            self.os.write("\n"+self.indent+lines[-1])
+            self.os.write("\n" + self.indent + lines[-1])
             self.newline = False
         else:
             self.os.write("\n")
@@ -245,19 +246,18 @@ class StreamIndenter(object):
 
 _indentation_re = re.compile(r'\s*')
 _bullet_re = re.compile(
-    r'([-+*] +)' # bulleted lists
-    r'|(\(?[0-9]+[\)\.] +)' # enumerated lists (arabic numerals)
-    r'|(\(?[ivxlcdm]+[\)\.] +)' # enumerated lists (roman numerals)
-    r'|(\(?[IVXLCDM]+[\)\.] +)' # enumerated lists (roman numerals)
-    r'|(\(?[a-zA-Z][\)\.] +)' # enumerated lists (letters)
-    r'|(\(?\#[\)\.] +)' # auto enumerated lists
-    r'|([a-zA-Z0-9_ ]+ +: +)' # definitions
-    r'|(:[a-zA-Z0-9_ ]+: +)' # field name
-    r'|(?:\[\s*[A-Za-z0-9\.]+\s*\] +)' # [PASS]|[FAIL]|[ OK ]
+    r'([-+*] +)'  # bulleted lists
+    r'|(\(?[0-9]+[\)\.] +)'  # enumerated lists (arabic numerals)
+    r'|(\(?[ivxlcdm]+[\)\.] +)'  # enumerated lists (roman numerals)
+    r'|(\(?[IVXLCDM]+[\)\.] +)'  # enumerated lists (roman numerals)
+    r'|(\(?[a-zA-Z][\)\.] +)'  # enumerated lists (letters)
+    r'|(\(?\#[\)\.] +)'  # auto enumerated lists
+    r'|([a-zA-Z0-9_ ]+ +: +)'  # definitions
+    r'|(:[a-zA-Z0-9_ ]+: +)'  # field name
+    r'|(?:\[\s*[A-Za-z0-9\.]+\s*\] +)'  # [PASS]|[FAIL]|[ OK ]
 )
 _verbatim_line_start = re.compile(
-    r'(\| )' # line blocks
-    r'|(\+((-{3,})|(={3,}))\+)' # grid table
+    r'(\| )' r'|(\+((-{3,})|(={3,}))\+)'  # line blocks  # grid table
 )
 _verbatim_line = re.compile(
     r'(={3,}[ =]+)'  # simple tables, ======== sections
@@ -311,8 +311,8 @@ def wrap_reStructuredText(docstr, wrapper):
                     paragraphs.append((None, None, line))
                     continue
                 elif (
-                        len(literal_block[1]) == len(leading)
-                        and content[0] in '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'
+                    len(literal_block[1]) == len(leading)
+                    and content[0] in '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'
                 ):
                     # quoted literal block
                     literal_block = 2, leading
@@ -347,11 +347,10 @@ def wrap_reStructuredText(docstr, wrapper):
             if matchBullet:
                 # Handle things that look like bullet lists specially
                 hang = matchBullet.group()
-                paragraphs.append(
-                    (leading, leading + ' '*len(hang), [content]))
+                paragraphs.append((leading, leading + ' ' * len(hang), [content]))
             elif paragraphs[-1][1] == leading:
                 # Continuing a text block
-                paragraphs[-1][2].append( content )
+                paragraphs[-1][2].append(content)
             else:
                 # Beginning a new text block
                 paragraphs.append((leading, leading, [content]))

--- a/pyomo/common/gc_manager.py
+++ b/pyomo/common/gc_manager.py
@@ -19,9 +19,11 @@
 import gc
 from pyomo.common.multithread import MultiThreadWrapper
 
+
 class __PauseGCCompanion(object):
     def __init__(self):
         self._stack_depth = 0
+
 
 PauseGCCompanion: __PauseGCCompanion = MultiThreadWrapper(__PauseGCCompanion)
 
@@ -40,6 +42,7 @@ PauseGCCompanion: __PauseGCCompanion = MultiThreadWrapper(__PauseGCCompanion)
 # if an outer function/method has its own instance of PauseGC.
 class PauseGC(object):
     __slots__ = ("reenable_gc", "stack_pointer")
+
     def __init__(self):
         self.stack_pointer = None
         self.reenable_gc = None
@@ -47,7 +50,8 @@ class PauseGC(object):
     def __enter__(self):
         if self.stack_pointer:
             raise RuntimeError(
-                "Entering PauseGC context manager that was already entered.")
+                "Entering PauseGC context manager that was already entered."
+            )
         PauseGCCompanion._stack_depth += 1
         self.stack_pointer = PauseGCCompanion._stack_depth
         self.reenable_gc = gc.isenabled()
@@ -67,7 +71,8 @@ class PauseGC(object):
                     "Exiting PauseGC context manager out of order: there "
                     "are other active PauseGC context managers that were "
                     "entered after this context manager and have not yet "
-                    "been exited.")
+                    "been exited."
+                )
             PauseGCCompanion._stack_depth -= 1
             self.stack_pointer = None
         if self.reenable_gc:

--- a/pyomo/common/getGSL.py
+++ b/pyomo/common/getGSL.py
@@ -9,6 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from pyomo.common.deprecation import (relocated_module)
+from pyomo.common.deprecation import relocated_module
 
 relocated_module('pyomo.common.gsl', version='6.5.0')

--- a/pyomo/common/gsl.py
+++ b/pyomo/common/gsl.py
@@ -16,14 +16,18 @@ from pyomo.common.deprecation import deprecated
 
 logger = logging.getLogger('pyomo.common')
 
+
 @deprecated(
-    "Use of get_gsl is deprecated and NO LONGER FUNCTIONS as of February 9, "
-    "2023. ",
-    version='6.5.0')
+    "Use of get_gsl is deprecated and NO LONGER FUNCTIONS as of February 9, " "2023. ",
+    version='6.5.0',
+)
 def get_gsl(downloader):
-    logger.info("As of February 9, 2023, AMPL GSL can no longer be downloaded\
+    logger.info(
+        "As of February 9, 2023, AMPL GSL can no longer be downloaded\
                 through download-extensions. Visit https://portal.ampl.com/\
-                to download the AMPL GSL binaries.")
+                to download the AMPL GSL binaries."
+    )
+
 
 def find_GSL():
     # FIXME: the GSL interface is currently broken in PyPy:

--- a/pyomo/common/gsl.py
+++ b/pyomo/common/gsl.py
@@ -18,7 +18,7 @@ logger = logging.getLogger('pyomo.common')
 
 
 @deprecated(
-    "Use of get_gsl is deprecated and NO LONGER FUNCTIONS as of February 9, " "2023. ",
+    "Use of get_gsl is deprecated and NO LONGER FUNCTIONS as of February 9, 2023. ",
     version='6.5.0',
 )
 def get_gsl(downloader):

--- a/pyomo/common/gsl.py
+++ b/pyomo/common/gsl.py
@@ -24,8 +24,8 @@ logger = logging.getLogger('pyomo.common')
 def get_gsl(downloader):
     logger.info(
         "As of February 9, 2023, AMPL GSL can no longer be downloaded\
-                through download-extensions. Visit https://portal.ampl.com/\
-                to download the AMPL GSL binaries."
+        through download-extensions. Visit https://portal.ampl.com/\
+        to download the AMPL GSL binaries."
     )
 
 

--- a/pyomo/common/log.py
+++ b/pyomo/common/log.py
@@ -34,21 +34,24 @@ _indentation_re = re.compile(r'\s*')
 
 _RTD_URL = "https://pyomo.readthedocs.io/en/%s/errors.html" % (
     'stable'
-    if (releaselevel == 'final'
-        or 'sphinx' in sys.modules
-        or 'Sphinx' in sys.modules)
-    else 'latest')
+    if (releaselevel == 'final' or 'sphinx' in sys.modules or 'Sphinx' in sys.modules)
+    else 'latest'
+)
+
 
 def RTD(_id):
     _id = str(_id).lower()
     assert _id[0] in 'wex'
     return f"{_RTD_URL}#{_id}"
 
+
 _DEBUG = logging.DEBUG
 _NOTSET = logging.NOTSET
 if not __debug__:
+
     def is_debug_set(logger):
         return False
+
 elif hasattr(getattr(logging.getLogger(), 'manager', None), 'disable'):
     # This works for CPython and PyPy, but relies on a manager attribute
     # to get the current value of the logging.disabled() flag
@@ -72,6 +75,7 @@ elif hasattr(getattr(logging.getLogger(), 'manager', None), 'disable'):
         _level = logger.getEffectiveLevel()
         # Filter out NOTSET and higher levels
         return _NOTSET < _level <= _DEBUG
+
 else:
     # This is inefficient (it indirectly checks effective level twice),
     # but is included for [as yet unknown] platforms that ONLY implement
@@ -80,6 +84,7 @@ else:
         if not logger.isEnabledFor(_DEBUG):
             return False
         return logger.getEffectiveLevel() > _NOTSET
+
 
 class WrappingFormatter(logging.Formatter):
     _flag = "<<!MSG!>>"
@@ -93,18 +98,18 @@ class WrappingFormatter(logging.Formatter):
             elif kwds['style'] == '$':
                 kwds['fmt'] = '$levelname: $message'
             else:
-                raise ValueError('unrecognized style flag "%s"'
-                                 % (kwds['style'],))
+                raise ValueError('unrecognized style flag "%s"' % (kwds['style'],))
         self._wrapper = textwrap.TextWrapper(width=kwds.pop('wrap', 78))
-        self._wrapper.subsequent_indent = kwds.pop('hang', ' '*4)
+        self._wrapper.subsequent_indent = kwds.pop('hang', ' ' * 4)
         if not self._wrapper.subsequent_indent:
             self._wrapper.subsequent_indent = ''
         self.basepath = kwds.pop('base', None)
         super(WrappingFormatter, self).__init__(**kwds)
 
     def format(self, record):
-        _orig = {k: getattr(record, k)
-                 for k in ('msg', 'args', 'pathname', 'levelname')}
+        _orig = {
+            k: getattr(record, k) for k in ('msg', 'args', 'pathname', 'levelname')
+        }
         _id = getattr(record, 'id', None)
         msg = record.getMessage()
         record.msg = self._flag
@@ -112,11 +117,11 @@ class WrappingFormatter(logging.Formatter):
         if _id:
             record.levelname += f" ({_id.upper()})"
         if self.basepath and record.pathname.startswith(self.basepath):
-            record.pathname = '[base]' + record.pathname[len(self.basepath):]
+            record.pathname = '[base]' + record.pathname[len(self.basepath) :]
         try:
             raw_msg = super(WrappingFormatter, self).format(record)
         finally:
-            for k,v in _orig.items():
+            for k, v in _orig.items():
                 setattr(record, k, v)
 
         # We want to normalize the incoming message *before* we start
@@ -171,13 +176,12 @@ class LegacyPyomoFormatter(logging.Formatter):
     templates will be used.
 
     """
+
     def __init__(self, **kwds):
         if 'fmt' in kwds:
-            raise ValueError(
-                "'fmt' is not a valid option for the LegacyFormatter")
+            raise ValueError("'fmt' is not a valid option for the LegacyFormatter")
         if 'style' in kwds:
-            raise ValueError(
-                "'style' is not a valid option for the LegacyFormatter")
+            raise ValueError("'style' is not a valid option for the LegacyFormatter")
 
         self.verbosity = kwds.pop('verbosity', lambda: True)
         self.standard_formatter = WrappingFormatter(**kwds)
@@ -185,7 +189,7 @@ class LegacyPyomoFormatter(logging.Formatter):
             fmt='%(levelname)s: "%(pathname)s", %(lineno)d, %(funcName)s\n'
             '    %(message)s',
             hang=False,
-            **kwds
+            **kwds,
         )
         super(LegacyPyomoFormatter, self).__init__()
 
@@ -223,29 +227,26 @@ class _GlobalLogFilter(object):
 pyomo_logger = logging.getLogger('pyomo')
 pyomo_handler = StdoutHandler()
 pyomo_formatter = LegacyPyomoFormatter(
-    base=PYOMO_ROOT_DIR,
-    verbosity=lambda: pyomo_logger.isEnabledFor(logging.DEBUG),
+    base=PYOMO_ROOT_DIR, verbosity=lambda: pyomo_logger.isEnabledFor(logging.DEBUG)
 )
 pyomo_handler.setFormatter(pyomo_formatter)
 pyomo_handler.addFilter(_GlobalLogFilter())
 pyomo_logger.addHandler(pyomo_handler)
 
 
-@deprecated('The pyomo.common.log.LogHandler class has been deprecated '
-            'in favor of standard Handlers from the Python logging module '
-            'combined with the pyomo.common.log.WrappingFormatter.',
-            version='5.7.3')
+@deprecated(
+    'The pyomo.common.log.LogHandler class has been deprecated '
+    'in favor of standard Handlers from the Python logging module '
+    'combined with the pyomo.common.log.WrappingFormatter.',
+    version='5.7.3',
+)
 class LogHandler(logging.StreamHandler):
-    def __init__(self, base='', stream=None,
-                 level=logging.NOTSET, verbosity=None):
+    def __init__(self, base='', stream=None, level=logging.NOTSET, verbosity=None):
         super(LogHandler, self).__init__(stream)
         self.setLevel(level),
         if verbosity is None:
             verbosity = lambda: True
-        self.setFormatter(LegacyPyomoFormatter(
-            base=base,
-            verbosity=verbosity,
-        ))
+        self.setFormatter(LegacyPyomoFormatter(base=base, verbosity=verbosity))
 
 
 class LoggingIntercept(object):
@@ -281,8 +282,7 @@ class LoggingIntercept(object):
 
     """
 
-    def __init__(self, output=None, module=None, level=logging.WARNING,
-                 formatter=None):
+    def __init__(self, output=None, module=None, level=logging.WARNING, formatter=None):
         self.handler = None
         self.output = output
         self.module = module
@@ -326,6 +326,7 @@ class LogStream(io.TextIOBase):
     This is useful for logging solver output (a LogStream
     instance can be handed to TeeStream from pyomo.common.tee).
     """
+
     def __init__(self, level, logger):
         self._level = level
         self._logger = logger

--- a/pyomo/common/modeling.py
+++ b/pyomo/common/modeling.py
@@ -13,7 +13,7 @@ from random import random
 import sys
 
 
-def randint(a,b):
+def randint(a, b):
     """Our implementation of random.randint.
 
     The Python random.randint is not consistent between python versions
@@ -21,20 +21,20 @@ def randint(a,b):
     can support deterministic testing (i.e., setting the random.seed and
     expecting the same sequence), we will implement a simple, but stable
     version of randint()."""
-    return int((b-a+1)*random())
+    return int((b - a + 1) * random())
 
 
 def unique_component_name(instance, name):
-    # test if this name already exists in model. If not, we're good. 
+    # test if this name already exists in model. If not, we're good.
     # Else, we add random numbers until it doesn't
     if instance.component(name) is None and not hasattr(instance, name):
         return name
-    name += '_%d' % (randint(0,9),)
+    name += '_%d' % (randint(0, 9),)
     while True:
         if instance.component(name) is None and not hasattr(instance, name):
             return name
         else:
-            name += str(randint(0,9))
+            name += str(randint(0, 9))
 
 
 class FlagType(type):
@@ -50,10 +50,14 @@ class FlagType(type):
     in functions so that the Sphinx-generated documentation is "cleaner"
 
     """
+
     if 'sphinx' in sys.modules or 'Sphinx' in sys.modules:
+
         def __repr__(cls):
             return cls.__qualname__
+
     else:
+
         def __repr__(cls):
             return cls.__module__ + "." + cls.__qualname__
 
@@ -71,7 +75,9 @@ class NOTSET(object, metaclass=FlagType):
       >>>         pass  # no argument was provided to `value`
 
     """
+
     pass
+
 
 # Backward compatibility with the previous name for this flag
 NoArgumentGiven = NOTSET

--- a/pyomo/common/multithread.py
+++ b/pyomo/common/multithread.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from threading import get_ident, main_thread
 
 
-class MultiThreadWrapper():
+class MultiThreadWrapper:
     """A python object proxy that wraps different instances for each thread.
 
     This is useful for handling thread-safe access to singleton objects without
@@ -20,27 +20,33 @@ class MultiThreadWrapper():
 
     def __getattr__(self, attr):
         return getattr(self._mtdict[get_ident()], attr)
-    
+
     def __setattr__(self, attr, value):
         setattr(self._mtdict[get_ident()], attr, value)
-    
+
     def __delattr__(self, attr):
         delattr(self._mtdict[get_ident()], attr)
-    
+
     def __enter__(self):
         return self._mtdict[get_ident()].__enter__()
-    
+
     def __exit__(self, exc_type, exc_value, traceback):
         return self._mtdict[get_ident()].__exit__(exc_type, exc_value, traceback)
-    
+
     def __dir__(self):
         return list(object.__dir__(self)) + list(self._mtdict[get_ident()].__dir__())
-    
+
     def __str__(self):
         return self._mtdict[get_ident()].__str__()
 
     def __new__(cls, wrapped):
-        return super().__new__(type('MultiThreadMeta' + wrapped.__name__, (cls,), {'__doc__': wrapped.__doc__}))
+        return super().__new__(
+            type(
+                'MultiThreadMeta' + wrapped.__name__,
+                (cls,),
+                {'__doc__': wrapped.__doc__},
+            )
+        )
 
 
 class MultiThreadWrapperWithMain(MultiThreadWrapper):
@@ -65,6 +71,6 @@ class MultiThreadWrapperWithMain(MultiThreadWrapper):
             raise ValueError('Setting `main_thread` attribute is not allowed')
         else:
             super().__setattr__(attr, value)
-    
+
     def __dir__(self):
         return super().__dir__() + ['main_thread']

--- a/pyomo/common/numeric_types.py
+++ b/pyomo/common/numeric_types.py
@@ -34,10 +34,10 @@ nonpyomo_leaf_types = set([])
 #: Python set used to identify numeric constants.  This set includes
 #: native Python types as well as numeric types from Python packages
 #: like numpy, which may be registered by users.
-native_numeric_types = set([ int, float, bool, complex ])
-native_integer_types = set([ int, bool ])
-native_boolean_types = set([ int, bool, str, bytes ])
-native_logical_types = {bool, }
+native_numeric_types = set([int, float, bool, complex])
+native_integer_types = set([int, bool])
+native_boolean_types = set([int, bool, str, bytes])
+native_logical_types = {bool}
 pyomo_constant_types = set()  # includes NumericConstant
 
 #: Python set used to identify numeric constants and related native
@@ -46,12 +46,13 @@ pyomo_constant_types = set()  # includes NumericConstant
 #: like numpy.
 #:
 #: :data:`native_types` = :data:`native_numeric_types <pyomo.core.expr.numvalue.native_numeric_types>` + { str }
-native_types = set([ bool, str, type(None), slice, bytes])
-native_types.update( native_numeric_types )
-native_types.update( native_integer_types )
-native_types.update( native_boolean_types )
+native_types = set([bool, str, type(None), slice, bytes])
+native_types.update(native_numeric_types)
+native_types.update(native_integer_types)
+native_types.update(native_boolean_types)
 
-nonpyomo_leaf_types.update( native_types )
+nonpyomo_leaf_types.update(native_types)
+
 
 def RegisterNumericType(new_type):
     """
@@ -63,6 +64,7 @@ def RegisterNumericType(new_type):
     native_numeric_types.add(new_type)
     native_types.add(new_type)
     nonpyomo_leaf_types.add(new_type)
+
 
 def RegisterIntegerType(new_type):
     """
@@ -76,6 +78,7 @@ def RegisterIntegerType(new_type):
     native_integer_types.add(new_type)
     native_types.add(new_type)
     nonpyomo_leaf_types.add(new_type)
+
 
 def RegisterBooleanType(new_type):
     """

--- a/pyomo/common/plugin.py
+++ b/pyomo/common/plugin.py
@@ -9,7 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from pyomo.common.deprecation import (relocated_module)
+from pyomo.common.deprecation import relocated_module
 
 relocated_module('pyomo.common.plugin_base', version='6.5.0')
-

--- a/pyomo/common/plugins.py
+++ b/pyomo/common/plugins.py
@@ -9,6 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+
 def load():
     pass
-

--- a/pyomo/common/pyomo_typing.py
+++ b/pyomo/common/pyomo_typing.py
@@ -13,8 +13,10 @@ import typing
 
 _overloads = {}
 
+
 def _get_fullqual_name(func: typing.Callable) -> str:
     return f"{func.__module__}.{func.__qualname__}"
+
 
 def overload(func: typing.Callable):
     """Wrap typing.overload that remembers the overloaded signatures
@@ -26,6 +28,7 @@ def overload(func: typing.Callable):
     """
     _overloads.setdefault(_get_fullqual_name(func), []).append(func)
     return typing.overload(func)
+
 
 def get_overloads_for(func: typing.Callable):
     return _overloads.get(_get_fullqual_name(func), [])

--- a/pyomo/common/shutdown.py
+++ b/pyomo/common/shutdown.py
@@ -1,5 +1,6 @@
 import atexit
 
+
 def python_is_shutting_down():
     """Returns `True` if the interpreter is in the process of shutting down.
 
@@ -10,7 +11,9 @@ def python_is_shutting_down():
     """
     return not python_is_shutting_down.isalive
 
+
 python_is_shutting_down.isalive = [True]
+
 
 @atexit.register
 def _flag_shutting_down():

--- a/pyomo/common/sorting.py
+++ b/pyomo/common/sorting.py
@@ -9,6 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+
 class _robust_sort_keyfcn(object):
     """Class for robustly generating sortable keys for arbitrary data.
 
@@ -23,6 +24,7 @@ class _robust_sort_keyfcn(object):
     user's original key function, if provided
 
     """
+
     _typemap = {
         int: (1, float.__name__),
         float: (1, float.__name__),
@@ -60,7 +62,7 @@ class _robust_sort_keyfcn(object):
             # it is, sort it as if it were a float.
             try:
                 # Extra check that the comparison returns a meaningful result
-                if bool(val < 1.) != bool(1. < val or 1. == val):
+                if bool(val < 1.0) != bool(1.0 < val or 1.0 == val):
                     _typename = float.__name__
             except:
                 pass

--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -25,10 +25,9 @@ import weakref
 from pyomo.common.deprecation import deprecated, deprecation_warning
 from pyomo.common.errors import TempfileContextError
 from pyomo.common.multithread import MultiThreadWrapperWithMain
+
 try:
-    from pyutilib.component.config.tempfiles import (
-        TempfileManager as pyutilib_mngr
-    )
+    from pyutilib.component.config.tempfiles import TempfileManager as pyutilib_mngr
 except ImportError:
     pyutilib_mngr = None
 
@@ -109,15 +108,19 @@ class TempfileManagerClass(object):
                 "Temporary files created through TempfileManager "
                 "contexts have not been deleted (observed during "
                 "TempfileManager instance shutdown).\n"
-                "Undeleted entries:\n\t"+ "\n\t".join(
+                "Undeleted entries:\n\t"
+                + "\n\t".join(
                     fname if isinstance(fname, str) else fname.decode()
                     for ctx in self._context_stack
-                    for fd, fname in ctx.tempfiles))
+                    for fd, fname in ctx.tempfiles
+                )
+            )
         if self._context_stack:
             logger.warning(
                 "TempfileManagerClass instance: un-popped tempfile "
                 "contexts still exist during TempfileManager instance "
-                "shutdown")
+                "shutdown"
+            )
         self.clear_tempfiles(remove)
         # Delete the stack so that subsequent operations generate an
         # exception
@@ -133,35 +136,37 @@ class TempfileManagerClass(object):
             raise TempfileContextError(
                 "TempfileManager has no currently active context.  "
                 "Create a context (with push() or __enter__()) before "
-                "attempting to create temporary objects.")
+                "attempting to create temporary objects."
+            )
         return self._context_stack[-1]
 
     def create_tempfile(self, suffix=None, prefix=None, text=False, dir=None):
         "Call :meth:`TempfileContext.create_tempfile` on the active context"
         return self.context().create_tempfile(
-            suffix=suffix, prefix=prefix, text=text, dir=dir)
+            suffix=suffix, prefix=prefix, text=text, dir=dir
+        )
 
     def create_tempdir(self, suffix=None, prefix=None, dir=None):
         "Call :meth:`TempfileContext.create_tempdir` on the active context"
-        return self.context().create_tempdir(
-            suffix=suffix, prefix=prefix, dir=dir)
+        return self.context().create_tempdir(suffix=suffix, prefix=prefix, dir=dir)
 
     def add_tempfile(self, filename, exists=True):
         "Call :meth:`TempfileContext.add_tempfile` on the active context"
-        return self.context().add_tempfile(
-            filename=filename, exists=exists)
+        return self.context().add_tempfile(filename=filename, exists=exists)
 
     def clear_tempfiles(self, remove=True):
         """Delete all temporary files and remove all contexts."""
         while self._context_stack:
             self.pop(remove)
 
-    @deprecated("The TempfileManager.sequential_files() method has been "
-                "removed.  All temporary files are created with guaranteed "
-                "unique names.  Users wishing sequentially numbered files "
-                "should create a temporary (empty) directory using mkdtemp "
-                "/ create_tempdir and place the sequential files within it.",
-                version='6.2')
+    @deprecated(
+        "The TempfileManager.sequential_files() method has been "
+        "removed.  All temporary files are created with guaranteed "
+        "unique names.  Users wishing sequentially numbered files "
+        "should create a temporary (empty) directory using mkdtemp "
+        "/ create_tempdir and place the sequential files within it.",
+        version='6.2',
+    )
     def sequential_files(self, ctr=0):
         pass
 
@@ -220,7 +225,8 @@ class TempfileManagerClass(object):
                 "the TempfileManager stack within a context manager "
                 "(i.e., `with TempfileManager:`) but was not popped "
                 "before the context manager exited.  Popping the "
-                "context to preserve the stack integrity.")
+                "context to preserve the stack integrity."
+            )
 
 
 class TempfileContext:
@@ -322,9 +328,7 @@ class TempfileContext:
         return dir
 
     def gettempdirb(self):
-        """Same as :meth:`gettempdir()`, but the return value is ``bytes``
-
-        """
+        """Same as :meth:`gettempdir()`, but the return value is ``bytes``"""
         dir = self._resolve_tempdir()
         if dir is None:
             return tempfile.gettempdirb()
@@ -341,9 +345,7 @@ class TempfileContext:
         return tempfile.gettempprefix()
 
     def gettempprefixb(self):
-        """Same as :meth:`gettempprefix()`, but the return value is ``bytes``
-
-        """
+        """Same as :meth:`gettempprefix()`, but the return value is ``bytes``"""
         return tempfile.gettempprefixb()
 
     def create_tempfile(self, suffix=None, prefix=None, text=False, dir=None):
@@ -360,8 +362,7 @@ class TempfileContext:
             The absolute path of the new file.
 
         """
-        fd, fname = self.mkstemp(suffix=suffix, prefix=prefix,
-                                 dir=dir, text=text)
+        fd, fname = self.mkstemp(suffix=suffix, prefix=prefix, dir=dir, text=text)
         os.close(fd)
         self.tempfiles[-1] = (None, fname)
         return fname
@@ -437,7 +438,9 @@ class TempfileContext:
                 "to specify the default location for Pyomo "
                 "temporary files has been deprecated.  "
                 "Please set TempfileManager.tempdir in "
-                "pyomo.common.tempfiles", version='5.7.2')
+                "pyomo.common.tempfiles",
+                version='5.7.2',
+            )
             return pyutilib_mngr.tempdir
         return None
 
@@ -462,13 +465,12 @@ class TempfileContext:
                         # Failure to delete a tempfile
                         # should NOT be fatal
                         logger = logging.getLogger(__name__)
-                        logger.warning("Unable to delete temporary "
-                                       "file %s" % (name,))
+                        logger.warning(
+                            "Unable to delete temporary " "file %s" % (name,)
+                        )
             return
         assert os.path.isdir(name)
-        shutil.rmtree(
-            name,
-            ignore_errors=not deletion_errors_are_fatal)
+        shutil.rmtree(name, ignore_errors=not deletion_errors_are_fatal)
 
 
 # The global Pyomo TempfileManager instance

--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -465,9 +465,7 @@ class TempfileContext:
                         # Failure to delete a tempfile
                         # should NOT be fatal
                         logger = logging.getLogger(__name__)
-                        logger.warning(
-                            "Unable to delete temporary " "file %s" % (name,)
-                        )
+                        logger.warning("Unable to delete temporary file %s" % (name,))
             return
         assert os.path.isdir(name)
         shutil.rmtree(name, ignore_errors=not deletion_errors_are_fatal)

--- a/pyomo/common/tests/config_plugin.py
+++ b/pyomo/common/tests/config_plugin.py
@@ -10,6 +10,7 @@
 #  ___________________________________________________________________________
 from pyomo.common.config import ConfigDict, ConfigValue
 
+
 def get_configuration(config):
     ans = ConfigDict()
     ans.declare('key1', ConfigValue(default=0, domain=int))

--- a/pyomo/common/tests/dep_mod.py
+++ b/pyomo/common/tests/dep_mod.py
@@ -15,7 +15,6 @@ __version__ = '1.5'
 
 numpy, numpy_available = attempt_import('numpy', defer_check=True)
 
-bogus_nonexisting_module, bogus_nonexisting_module_available \
-    = attempt_import('bogus_nonexisting_module',
-                     alt_names=['bogus_nem'],
-                     defer_check=True)
+bogus_nonexisting_module, bogus_nonexisting_module_available = attempt_import(
+    'bogus_nonexisting_module', alt_names=['bogus_nem'], defer_check=True
+)

--- a/pyomo/common/tests/deps.py
+++ b/pyomo/common/tests/deps.py
@@ -23,20 +23,20 @@ from pyomo.common.tests.dep_mod import (
     bogus_nonexisting_module_available as has_bogus_nem,
 )
 
-bogus, bogus_available \
-    = attempt_import('nonexisting.module.bogus', defer_check=True)
+bogus, bogus_available = attempt_import('nonexisting.module.bogus', defer_check=True)
 
 pkl_test, pkl_available = attempt_import(
-    'nonexisting.module.pickle_test',
-    deferred_submodules=['submod'], defer_check=True
+    'nonexisting.module.pickle_test', deferred_submodules=['submod'], defer_check=True
 )
 
 pyo, pyo_available = attempt_import(
-    'pyomo', alt_names=['pyo'],
-    deferred_submodules={'version': None,
-                         'common.tests.dep_mod': ['dm']})
+    'pyomo',
+    alt_names=['pyo'],
+    deferred_submodules={'version': None, 'common.tests.dep_mod': ['dm']},
+)
 
 dm = pyo.common.tests.dep_mod
+
 
 def test_access_bogus_hello():
     bogus_nem.hello

--- a/pyomo/common/tests/import_ex.py
+++ b/pyomo/common/tests/import_ex.py
@@ -1,4 +1,5 @@
 def a():
     pass
 
+
 b = 2

--- a/pyomo/common/tests/relo_mod_new.py
+++ b/pyomo/common/tests/relo_mod_new.py
@@ -11,4 +11,6 @@
 
 RELO_ATTR = 42
 
-class ReloClass(object): pass
+
+class ReloClass(object):
+    pass

--- a/pyomo/common/tests/relocated.py
+++ b/pyomo/common/tests/relocated.py
@@ -12,16 +12,16 @@
 
 from pyomo.common.deprecation import relocated_module_attribute
 
+
 class Bar(object):
     data = 42
+
 
 def __getattr__(name):
     if name.startswith('Foo'):
         return name[3:]
-    raise AttributeError(
-        "module '%s' has no attribute '%s'" % (__name__, name))
+    raise AttributeError("module '%s' has no attribute '%s'" % (__name__, name))
 
-relocated_module_attribute(
-    'Foo', 'pyomo.common.tests.test_deprecated.Bar', 'test')
-relocated_module_attribute(
-    'Foo_2', 'pyomo.common.tests.relocated.Bar', 'test')
+
+relocated_module_attribute('Foo', 'pyomo.common.tests.test_deprecated.Bar', 'test')
+relocated_module_attribute('Foo_2', 'pyomo.common.tests.relocated.Bar', 'test')

--- a/pyomo/common/tests/test_bunch.py
+++ b/pyomo/common/tests/test_bunch.py
@@ -20,6 +20,7 @@ import pickle
 import unittest
 from pyomo.common.collections import Bunch
 
+
 class Test(unittest.TestCase):
     def test_Bunch1(self):
         opt = Bunch('a=None c=d e="1 2 3" f=" 5 "', foo=1, bar='x')
@@ -34,20 +35,20 @@ class Test(unittest.TestCase):
         opt.xx = 1
         opt['yy'] = 2
         self.assertEqual(
-            set(opt.keys()),
-            set(['a', 'bar', 'c', 'f', 'foo', 'e', 'xx', 'yy'])
+            set(opt.keys()), set(['a', 'bar', 'c', 'f', 'foo', 'e', 'xx', 'yy'])
         )
         opt.x = Bunch(a=1, b=2)
         self.assertEqual(
-            set(opt.keys()),
-            set(['a', 'bar', 'c', 'f', 'foo', 'e', 'xx', 'yy', 'x'])
+            set(opt.keys()), set(['a', 'bar', 'c', 'f', 'foo', 'e', 'xx', 'yy', 'x'])
         )
         self.assertEqual(
             repr(opt),
             "Bunch(a = None, bar = 'x', c = 'd', e = '1 2 3', f = 5, "
-            "foo = 1, x = Bunch(a = 1, b = 2), xx = 1, yy = 2)")
+            "foo = 1, x = Bunch(a = 1, b = 2), xx = 1, yy = 2)",
+        )
         self.assertEqual(
-            str(opt), """a: None
+            str(opt),
+            """a: None
 bar: 'x'
 c: 'd'
 e: '1 2 3'
@@ -57,18 +58,20 @@ x:
     a: 1
     b: 2
 xx: 1
-yy: 2""")
+yy: 2""",
+        )
         opt._name_ = 'BUNCH'
         self.assertEqual(
-            set(opt.keys()),
-            set(['a', 'bar', 'c', 'f', 'foo', 'e', 'xx', 'yy', 'x'])
+            set(opt.keys()), set(['a', 'bar', 'c', 'f', 'foo', 'e', 'xx', 'yy', 'x'])
         )
         self.assertEqual(
             repr(opt),
             "Bunch(a = None, bar = 'x', c = 'd', e = '1 2 3', f = 5, "
-            "foo = 1, x = Bunch(a = 1, b = 2), xx = 1, yy = 2)")
+            "foo = 1, x = Bunch(a = 1, b = 2), xx = 1, yy = 2)",
+        )
         self.assertEqual(
-            str(opt), """a: None
+            str(opt),
+            """a: None
 bar: 'x'
 c: 'd'
 e: '1 2 3'
@@ -78,15 +81,19 @@ x:
     a: 1
     b: 2
 xx: 1
-yy: 2""")
+yy: 2""",
+        )
 
         with self.assertRaisesRegex(
-                TypeError, r"Bunch\(\) positional arguments must be strings"):
+            TypeError, r"Bunch\(\) positional arguments must be strings"
+        ):
             Bunch(5)
 
         with self.assertRaisesRegex(
-                ValueError, r"Bunch\(\) positional arguments must be space "
-                "separated strings of form 'key=value', got 'foo'"):
+            ValueError,
+            r"Bunch\(\) positional arguments must be space "
+            "separated strings of form 'key=value', got 'foo'",
+        ):
             Bunch('a=5 foo = 6')
 
     def test_pickle(self):
@@ -113,8 +120,7 @@ yy: 2""")
         del b._foo
         self.assertEqual(list(b.keys()), [])
         self.assertEqual(b.foo, None)
-        with self.assertRaisesRegex(
-                AttributeError, "Unknown attribute '_foo'"):
+        with self.assertRaisesRegex(AttributeError, "Unknown attribute '_foo'"):
             b._foo
 
     def test_item_methods(self):
@@ -135,28 +141,24 @@ yy: 2""")
         del b['_foo']
         self.assertEqual(list(b.keys()), [])
         self.assertEqual(b['foo'], None)
-        with self.assertRaisesRegex(
-                AttributeError, "Unknown attribute '_foo'"):
+        with self.assertRaisesRegex(AttributeError, "Unknown attribute '_foo'"):
             b['_foo']
 
-        with self.assertRaisesRegex(
-                ValueError, r"Bunch keys must be str \(got int\)"):
+        with self.assertRaisesRegex(ValueError, r"Bunch keys must be str \(got int\)"):
             b[5]
 
-        with self.assertRaisesRegex(
-                ValueError, r"Bunch keys must be str \(got int\)"):
+        with self.assertRaisesRegex(ValueError, r"Bunch keys must be str \(got int\)"):
             b[5] = 5
 
-        with self.assertRaisesRegex(
-                ValueError, r"Bunch keys must be str \(got int\)"):
+        with self.assertRaisesRegex(ValueError, r"Bunch keys must be str \(got int\)"):
             del b[5]
 
     def test_update(self):
         data = {
             'a': 1,
-            'b': [2, {'bb':3}, [4, {'bbb':5}]],
+            'b': [2, {'bb': 3}, [4, {'bbb': 5}]],
             'c': {'cc': 6, 'ccc': {'e': 7}},
-            'd': []
+            'd': [],
         }
 
         # Test passing a dict
@@ -167,7 +169,7 @@ yy: 2""")
             'Bunch(a = 1, '
             'b = [2, Bunch(bb = 3), [4, Bunch(bbb = 5)]], '
             'c = Bunch(cc = 6, ccc = Bunch(e = 7)), '
-            'd = [])'
+            'd = [])',
         )
 
         # Test passing a generator
@@ -178,7 +180,7 @@ yy: 2""")
             'Bunch(a = 1, '
             'b = [2, Bunch(bb = 3), [4, Bunch(bbb = 5)]], '
             'c = Bunch(cc = 6, ccc = Bunch(e = 7)), '
-            'd = [])'
+            'd = [])',
         )
 
         # Test passing a list
@@ -189,22 +191,22 @@ yy: 2""")
             'Bunch(a = 1, '
             'b = [2, Bunch(bb = 3), [4, Bunch(bbb = 5)]], '
             'c = Bunch(cc = 6, ccc = Bunch(e = 7)), '
-            'd = [])'
+            'd = [])',
         )
 
     def test_str(self):
         data = {
             'a': 1,
-            'b': [2, {'bb':3}, [4, {'bbb':5}]],
+            'b': [2, {'bb': 3}, [4, {'bbb': 5}]],
             'c': {'cc': 6, 'ccc': {'e': 7}},
-            'd': []
+            'd': [],
         }
 
         b = Bunch()
         b.update(data)
         self.assertEqual(
             str(b),
-'''
+            '''
 a: 1
 b:
 - 2
@@ -216,7 +218,7 @@ c:
     ccc:
         e: 7
 d: []
-'''.strip()
+'''.strip(),
         )
 
     def test_set_name(self):

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -38,19 +38,42 @@ from io import StringIO
 
 from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 
+
 def yaml_load(arg):
     return yaml.load(arg, **yaml_load_args)
 
+
 from pyomo.common.config import (
-    ConfigDict, ConfigValue,
-    ConfigList, MarkImmutable, ImmutableConfigValue,
-    Bool, Integer, PositiveInt, NegativeInt, NonPositiveInt, NonNegativeInt,
-    PositiveFloat, NegativeFloat, NonPositiveFloat, NonNegativeFloat,
-    In, ListOf, Module, Path, PathList, ConfigEnum, DynamicImplicitDomain,
-    ConfigFormatter, String_ConfigFormatter,
-    document_kwargs_from_configdict, add_docstring_list,
-    USER_OPTION, DEVELOPER_OPTION,
-    _UnpickleableDomain, _picklable,
+    ConfigDict,
+    ConfigValue,
+    ConfigList,
+    MarkImmutable,
+    ImmutableConfigValue,
+    Bool,
+    Integer,
+    PositiveInt,
+    NegativeInt,
+    NonPositiveInt,
+    NonNegativeInt,
+    PositiveFloat,
+    NegativeFloat,
+    NonPositiveFloat,
+    NonNegativeFloat,
+    In,
+    ListOf,
+    Module,
+    Path,
+    PathList,
+    ConfigEnum,
+    DynamicImplicitDomain,
+    ConfigFormatter,
+    String_ConfigFormatter,
+    document_kwargs_from_configdict,
+    add_docstring_list,
+    USER_OPTION,
+    DEVELOPER_OPTION,
+    _UnpickleableDomain,
+    _picklable,
 )
 from pyomo.common.log import LoggingIntercept
 
@@ -83,7 +106,7 @@ class TestConfigDomains(unittest.TestCase):
         self.assertEqual(c.a, False)
         c.a = '1'
         self.assertEqual(c.a, True)
-        c.a = 0.
+        c.a = 0.0
         self.assertEqual(c.a, False)
         c.a = True
         self.assertEqual(c.a, True)
@@ -97,7 +120,7 @@ class TestConfigDomains(unittest.TestCase):
         self.assertEqual(c.a, True)
         c.a = '0'
         self.assertEqual(c.a, False)
-        c.a = 1.
+        c.a = 1.0
         self.assertEqual(c.a, True)
 
         with self.assertRaises(ValueError):
@@ -114,7 +137,7 @@ class TestConfigDomains(unittest.TestCase):
         c = ConfigDict()
         c.declare('a', ConfigValue(5, Integer))
         self.assertEqual(c.a, 5)
-        c.a = 4.
+        c.a = 4.0
         self.assertEqual(c.a, 4)
         c.a = -6
         self.assertEqual(c.a, -6)
@@ -134,7 +157,7 @@ class TestConfigDomains(unittest.TestCase):
         c = ConfigDict()
         c.declare('a', ConfigValue(5, PositiveInt))
         self.assertEqual(c.a, 5)
-        c.a = 4.
+        c.a = 4.0
         self.assertEqual(c.a, 4)
         c.a = 6
         self.assertEqual(c.a, 6)
@@ -155,7 +178,7 @@ class TestConfigDomains(unittest.TestCase):
         c = ConfigDict()
         c.declare('a', ConfigValue(-5, NegativeInt))
         self.assertEqual(c.a, -5)
-        c.a = -4.
+        c.a = -4.0
         self.assertEqual(c.a, -4)
         c.a = -6
         self.assertEqual(c.a, -6)
@@ -176,7 +199,7 @@ class TestConfigDomains(unittest.TestCase):
         c = ConfigDict()
         c.declare('a', ConfigValue(-5, NonPositiveInt))
         self.assertEqual(c.a, -5)
-        c.a = -4.
+        c.a = -4.0
         self.assertEqual(c.a, -4)
         c.a = -6
         self.assertEqual(c.a, -6)
@@ -196,7 +219,7 @@ class TestConfigDomains(unittest.TestCase):
         c = ConfigDict()
         c.declare('a', ConfigValue(5, NonNegativeInt))
         self.assertEqual(c.a, 5)
-        c.a = 4.
+        c.a = 4.0
         self.assertEqual(c.a, 4)
         c.a = 6
         self.assertEqual(c.a, 6)
@@ -216,7 +239,7 @@ class TestConfigDomains(unittest.TestCase):
         c = ConfigDict()
         c.declare('a', ConfigValue(5, PositiveFloat))
         self.assertEqual(c.a, 5)
-        c.a = 4.
+        c.a = 4.0
         self.assertEqual(c.a, 4)
         c.a = 6
         self.assertEqual(c.a, 6)
@@ -236,7 +259,7 @@ class TestConfigDomains(unittest.TestCase):
         c = ConfigDict()
         c.declare('a', ConfigValue(-5, NegativeFloat))
         self.assertEqual(c.a, -5)
-        c.a = -4.
+        c.a = -4.0
         self.assertEqual(c.a, -4)
         c.a = -6
         self.assertEqual(c.a, -6)
@@ -256,7 +279,7 @@ class TestConfigDomains(unittest.TestCase):
         c = ConfigDict()
         c.declare('a', ConfigValue(-5, NonPositiveFloat))
         self.assertEqual(c.a, -5)
-        c.a = -4.
+        c.a = -4.0
         self.assertEqual(c.a, -4)
         c.a = -6
         self.assertEqual(c.a, -6)
@@ -275,7 +298,7 @@ class TestConfigDomains(unittest.TestCase):
         c = ConfigDict()
         c.declare('a', ConfigValue(5, NonNegativeFloat))
         self.assertEqual(c.a, 5)
-        c.a = 4.
+        c.a = 4.0
         self.assertEqual(c.a, 4)
         c.a = 6
         self.assertEqual(c.a, 6)
@@ -292,7 +315,7 @@ class TestConfigDomains(unittest.TestCase):
 
     def test_In(self):
         c = ConfigDict()
-        c.declare('a', ConfigValue(None, In([1,3,5])))
+        c.declare('a', ConfigValue(None, In([1, 3, 5])))
         self.assertEqual(c.get('a').domain_name(), 'In[1, 3, 5]')
         self.assertEqual(c.a, None)
         c.a = 3
@@ -307,7 +330,7 @@ class TestConfigDomains(unittest.TestCase):
             c.a = '1'
         self.assertEqual(c.a, 3)
 
-        c.declare('b', ConfigValue(None, In([1,3,5], int)))
+        c.declare('b', ConfigValue(None, In([1, 3, 5], int)))
         self.assertEqual(c.b, None)
         c.b = 3
         self.assertEqual(c.b, 3)
@@ -323,12 +346,14 @@ class TestConfigDomains(unittest.TestCase):
         class Container(object):
             def __init__(self, vals):
                 self._vals = vals
+
             def __str__(self):
                 return f'Container{self._vals}'
+
             def __contains__(self, val):
                 return val in self._vals
 
-        c.declare('c', ConfigValue(None, In(Container([1,3,5]))))
+        c.declare('c', ConfigValue(None, In(Container([1, 3, 5]))))
         self.assertEqual(c.get('c').domain_name(), 'In(Container[1, 3, 5])')
         self.assertEqual(c.c, None)
         c.c = 3
@@ -343,10 +368,7 @@ class TestConfigDomains(unittest.TestCase):
             ITEM_TWO = 'two'
 
         cfg = ConfigDict()
-        cfg.declare('enum', ConfigValue(
-            default=TestEnum.ITEM_TWO,
-            domain=In(TestEnum)
-        ))
+        cfg.declare('enum', ConfigValue(default=TestEnum.ITEM_TWO, domain=In(TestEnum)))
         self.assertEqual(cfg.get('enum').domain_name(), 'InEnum[TestEnum]')
         self.assertEqual(cfg.enum, TestEnum.ITEM_TWO)
         cfg.enum = 'ITEM_ONE'
@@ -360,14 +382,14 @@ class TestConfigDomains(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, '.*3 is not a valid'):
             cfg.enum = 3
         with self.assertRaisesRegex(ValueError, '.*invalid value'):
-            cfg.enum ='ITEM_THREE'
-
+            cfg.enum = 'ITEM_THREE'
 
     def test_Path(self):
         def norm(x):
             if cwd[1] == ':' and x[0] == '/':
                 x = cwd[:2] + x
-            return x.replace('/',os.path.sep)
+            return x.replace('/', os.path.sep)
+
         cwd = os.getcwd() + os.path.sep
         c = ConfigDict()
 
@@ -378,10 +400,10 @@ class TestConfigDomains(unittest.TestCase):
         self.assertEqual(c.a, norm('/a/b/c'))
         c.a = "a/b/c"
         self.assertTrue(os.path.sep in c.a)
-        self.assertEqual(c.a, norm(cwd+'a/b/c'))
+        self.assertEqual(c.a, norm(cwd + 'a/b/c'))
         c.a = "${CWD}/a/b/c"
         self.assertTrue(os.path.sep in c.a)
-        self.assertEqual(c.a, norm(cwd+'a/b/c'))
+        self.assertEqual(c.a, norm(cwd + 'a/b/c'))
         c.a = None
         self.assertIs(c.a, None)
 
@@ -392,10 +414,10 @@ class TestConfigDomains(unittest.TestCase):
         self.assertEqual(c.b, norm('/a/b/c'))
         c.b = "a/b/c"
         self.assertTrue(os.path.sep in c.b)
-        self.assertEqual(c.b, norm(cwd+'rel/path/a/b/c'))
+        self.assertEqual(c.b, norm(cwd + 'rel/path/a/b/c'))
         c.b = "${CWD}/a/b/c"
         self.assertTrue(os.path.sep in c.b)
-        self.assertEqual(c.b, norm(cwd+'a/b/c'))
+        self.assertEqual(c.b, norm(cwd + 'a/b/c'))
         c.b = None
         self.assertIs(c.b, None)
 
@@ -409,7 +431,7 @@ class TestConfigDomains(unittest.TestCase):
         self.assertEqual(c.c, norm('/my/dir/a/b/c'))
         c.c = "${CWD}/a/b/c"
         self.assertTrue(os.path.sep in c.c)
-        self.assertEqual(c.c, norm(cwd+'a/b/c'))
+        self.assertEqual(c.c, norm(cwd + 'a/b/c'))
         c.c = None
         self.assertIs(c.c, None)
 
@@ -421,10 +443,10 @@ class TestConfigDomains(unittest.TestCase):
         self.assertEqual(c.d, norm('/a/b/c'))
         c.d = "a/b/c"
         self.assertTrue(os.path.sep in c.d)
-        self.assertEqual(c.d, norm(cwd+'a/b/c'))
+        self.assertEqual(c.d, norm(cwd + 'a/b/c'))
         c.d = "${CWD}/a/b/c"
         self.assertTrue(os.path.sep in c.d)
-        self.assertEqual(c.d, norm(cwd+'a/b/c'))
+        self.assertEqual(c.d, norm(cwd + 'a/b/c'))
 
         c.d_base = '/my/dir'
         c.d = "/a/b/c"
@@ -435,7 +457,7 @@ class TestConfigDomains(unittest.TestCase):
         self.assertEqual(c.d, norm('/my/dir/a/b/c'))
         c.d = "${CWD}/a/b/c"
         self.assertTrue(os.path.sep in c.d)
-        self.assertEqual(c.d, norm(cwd+'a/b/c'))
+        self.assertEqual(c.d, norm(cwd + 'a/b/c'))
 
         c.d_base = 'rel/path'
         c.d = "/a/b/c"
@@ -443,10 +465,10 @@ class TestConfigDomains(unittest.TestCase):
         self.assertEqual(c.d, norm('/a/b/c'))
         c.d = "a/b/c"
         self.assertTrue(os.path.sep in c.d)
-        self.assertEqual(c.d, norm(cwd+'rel/path/a/b/c'))
+        self.assertEqual(c.d, norm(cwd + 'rel/path/a/b/c'))
         c.d = "${CWD}/a/b/c"
         self.assertTrue(os.path.sep in c.d)
-        self.assertEqual(c.d, norm(cwd+'a/b/c'))
+        self.assertEqual(c.d, norm(cwd + 'a/b/c'))
 
         try:
             Path.SuppressPathExpansion = True
@@ -469,7 +491,8 @@ class TestConfigDomains(unittest.TestCase):
         def norm(x):
             if cwd[1] == ':' and x[0] == '/':
                 x = cwd[:2] + x
-            return x.replace('/',os.path.sep)
+            return x.replace('/', os.path.sep)
+
         cwd = os.getcwd() + os.path.sep
         c = ConfigDict()
 
@@ -485,11 +508,11 @@ class TestConfigDomains(unittest.TestCase):
         c.a = ["a/b/c", "/a/b/c", "${CWD}/a/b/c"]
         self.assertEqual(len(c.a), 3)
         self.assertTrue(os.path.sep in c.a[0])
-        self.assertEqual(c.a[0], norm(cwd+'a/b/c'))
+        self.assertEqual(c.a[0], norm(cwd + 'a/b/c'))
         self.assertTrue(os.path.sep in c.a[1])
         self.assertEqual(c.a[1], norm('/a/b/c'))
         self.assertTrue(os.path.sep in c.a[2])
-        self.assertEqual(c.a[2], norm(cwd+'a/b/c'))
+        self.assertEqual(c.a[2], norm(cwd + 'a/b/c'))
 
         c.a = ()
         self.assertEqual(len(c.a), 0)
@@ -508,8 +531,10 @@ class TestConfigDomains(unittest.TestCase):
         c.a = '7,8'
         self.assertEqual(c.a, [7, 8])
 
-        ref=(r"(?m)Failed casting a\s+to ListOf\(int\)\s+"
-             r"Error: invalid literal for int\(\) with base 10: 'a'")
+        ref = (
+            r"(?m)Failed casting a\s+to ListOf\(int\)\s+"
+            r"Error: invalid literal for int\(\) with base 10: 'a'"
+        )
         with self.assertRaisesRegex(ValueError, ref):
             c.a = 'a'
 
@@ -525,8 +550,9 @@ class TestConfigDomains(unittest.TestCase):
         with self.assertRaises(ValueError):
             c.b = "'Hello, World"
 
-        c.declare('b1', ConfigValue(domain=ListOf(
-            str, string_lexer=None), default=None))
+        c.declare(
+            'b1', ConfigValue(domain=ListOf(str, string_lexer=None), default=None)
+        )
         self.assertEqual(c.get('b1').domain_name(), 'ListOf[str]')
         self.assertEqual(c.b1, None)
         c.b1 = "'Hello, World'"
@@ -544,8 +570,10 @@ class TestConfigDomains(unittest.TestCase):
         c.c = 6
         self.assertEqual(c.c, [6])
 
-        ref=(r"(?m)Failed casting %s\s+to ListOf\(PositiveInt\)\s+"
-             r"Error: Expected positive int, but received %s")
+        ref = (
+            r"(?m)Failed casting %s\s+to ListOf\(PositiveInt\)\s+"
+            r"Error: Expected positive int, but received %s"
+        )
         with self.assertRaisesRegex(ValueError, ref % (6.5, 6.5)):
             c.c = 6.5
         with self.assertRaisesRegex(ValueError, ref % (r"\[0\]", "0")):
@@ -562,10 +590,12 @@ class TestConfigDomains(unittest.TestCase):
         # Set using python module name to be imported
         c.a = 'os.path'
         import os.path
+
         self.assertIs(c.a, os.path)
 
         # Set to python module object
         import os
+
         c.a = os
         self.assertIs(c.a, os)
 
@@ -579,22 +609,20 @@ class TestConfigDomains(unittest.TestCase):
     def test_ConfigEnum(self):
         out = StringIO()
         with LoggingIntercept(out):
+
             class TestEnum(ConfigEnum):
                 ITEM_ONE = 1
                 ITEM_TWO = 2
+
         self.assertIn('The ConfigEnum base class is deprecated', out.getvalue())
-        self.assertEqual(TestEnum.from_enum_or_string(1),
-                TestEnum.ITEM_ONE)
-        self.assertEqual(TestEnum.from_enum_or_string(
-            TestEnum.ITEM_TWO), TestEnum.ITEM_TWO)
-        self.assertEqual(TestEnum.from_enum_or_string('ITEM_ONE'),
-                TestEnum.ITEM_ONE)
+        self.assertEqual(TestEnum.from_enum_or_string(1), TestEnum.ITEM_ONE)
+        self.assertEqual(
+            TestEnum.from_enum_or_string(TestEnum.ITEM_TWO), TestEnum.ITEM_TWO
+        )
+        self.assertEqual(TestEnum.from_enum_or_string('ITEM_ONE'), TestEnum.ITEM_ONE)
 
         cfg = ConfigDict()
-        cfg.declare('enum', ConfigValue(
-            default=2,
-            domain=TestEnum.from_enum_or_string
-        ))
+        cfg.declare('enum', ConfigValue(default=2, domain=TestEnum.from_enum_or_string))
         self.assertEqual(cfg.enum, TestEnum.ITEM_TWO)
         cfg.enum = 'ITEM_ONE'
         self.assertEqual(cfg.enum, TestEnum.ITEM_ONE)
@@ -605,7 +633,7 @@ class TestConfigDomains(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, '.*3 is not a valid'):
             cfg.enum = 3
         with self.assertRaisesRegex(ValueError, '.*invalid value'):
-            cfg.enum ='ITEM_THREE'
+            cfg.enum = 'ITEM_THREE'
 
     def test_DynamicImplicitDomain(self):
         def _rule(key, val):
@@ -619,11 +647,10 @@ class TestConfigDomains(unittest.TestCase):
             if 'l' in key:
                 raise ValueError('invalid key: %s' % key)
             return ans(val)
-        cfg = ConfigDict(
-            implicit=True, implicit_domain=DynamicImplicitDomain(_rule))
+
+        cfg = ConfigDict(implicit=True, implicit_domain=DynamicImplicitDomain(_rule))
         self.assertEqual(len(cfg), 0)
-        test = cfg({'hi': {'option_i': 10},
-                    'fast': {'option_f': 20}})
+        test = cfg({'hi': {'option_i': 10}, 'fast': {'option_f': 20}})
         self.assertEqual(len(test), 2)
         self.assertEqual(test.hi.value(), {'option_i': 10})
         self.assertEqual(test.fast.value(), {'option_f': 20, 'option_s': '3'})
@@ -639,9 +666,13 @@ class TestConfigDomains(unittest.TestCase):
         self.assertEqual(fit.value(), {'option_f': 2, 'option_i': 1})
 
         with self.assertRaisesRegex(ValueError, "invalid key: fail"):
-            test = cfg({'hi': {'option_i': 10},
-                        'fast': {'option_f': 20},
-                        'fail': {'option_f': 20}})
+            test = cfg(
+                {
+                    'hi': {'option_i': 10},
+                    'fast': {'option_f': 20},
+                    'fail': {'option_f': 20},
+                }
+            )
 
 
 class TestImmutableConfigValue(unittest.TestCase):
@@ -668,8 +699,8 @@ class TestImmutableConfigValue(unittest.TestCase):
         self.assertEqual(config.a, 4)
         self.assertEqual(config.b, 5)
         with self.assertRaisesRegex(
-                ValueError,
-                'Only ConfigValue instances can be marked immutable'):
+            ValueError, 'Only ConfigValue instances can be marked immutable'
+        ):
             locker = MarkImmutable(config.get('a'), config.b)
         self.assertEqual(type(config.get('a')), ConfigValue)
         config.a = 6
@@ -732,7 +763,6 @@ class TestImmutableConfigValue(unittest.TestCase):
 
 
 class TestConfig(unittest.TestCase):
-
     def setUp(self):
         # Save the original environment, then force a fixed column width
         # so tests do not fail on some platforms (notably, OSX)
@@ -740,100 +770,129 @@ class TestConfig(unittest.TestCase):
         os.environ["COLUMNS"] = "80"
 
         self.config = config = ConfigDict(
-            "Basic configuration for Flushing models", implicit=True)
+            "Basic configuration for Flushing models", implicit=True
+        )
         net = config.declare('network', ConfigDict())
-        net.declare('epanet file',
-                    ConfigValue('Net3.inp', str, 'EPANET network inp file',
-                                None)).declare_as_argument(dest='epanet')
+        net.declare(
+            'epanet file', ConfigValue('Net3.inp', str, 'EPANET network inp file', None)
+        ).declare_as_argument(dest='epanet')
 
         sc = config.declare(
             'scenario',
-            ConfigDict(
-                "Single scenario block", implicit=True, implicit_domain=str))
-        sc.declare('scenario file', ConfigValue(
-            'Net3.tsg', str,
-            'Scenario generation file, see the TEVASIM documentation',
-            """This is the (long) documentation for the 'scenario file'
+            ConfigDict("Single scenario block", implicit=True, implicit_domain=str),
+        )
+        sc.declare(
+            'scenario file',
+            ConfigValue(
+                'Net3.tsg',
+                str,
+                'Scenario generation file, see the TEVASIM documentation',
+                """This is the (long) documentation for the 'scenario file'
             parameter.  It contains multiple lines, and some internal
             formatting; like a bulleted list:
               - item 1
               - item 2
-            """)).declare_as_argument(group='Scenario definition')
-        sc.declare('merlion', ConfigValue(
-            default=False,
-            domain=bool,
-            description='Water quality model',
-            doc="""
+            """,
+            ),
+        ).declare_as_argument(group='Scenario definition')
+        sc.declare(
+            'merlion',
+            ConfigValue(
+                default=False,
+                domain=bool,
+                description='Water quality model',
+                doc="""
 
             This is the (long) documentation for the 'merlion'
             parameter.  It contains multiple lines, but no apparent internal
-            formatting; so the outputter should re-wrap everything."""
-        )).declare_as_argument(group='Scenario definition')
-        sc.declare('detection',
-                   ConfigValue(
-                       # Note use of lambda for an "integer list domain"
-                       [1, 2, 3],
-                       lambda x: list(int(i) for i in x),
-                       'Sensor placement list, epanetID',
-                       None))
+            formatting; so the outputter should re-wrap everything.""",
+            ),
+        ).declare_as_argument(group='Scenario definition')
+        sc.declare(
+            'detection',
+            ConfigValue(
+                # Note use of lambda for an "integer list domain"
+                [1, 2, 3],
+                lambda x: list(int(i) for i in x),
+                'Sensor placement list, epanetID',
+                None,
+            ),
+        )
 
-        config.declare('scenarios', ConfigList([], sc,
-                                               "List of scenario blocks", None))
+        config.declare('scenarios', ConfigList([], sc, "List of scenario blocks", None))
 
-        config.declare('nodes', ConfigList(
-            [], ConfigValue(0, int, 'Node ID', None), "List of node IDs", None))
+        config.declare(
+            'nodes',
+            ConfigList(
+                [], ConfigValue(0, int, 'Node ID', None), "List of node IDs", None
+            ),
+        )
 
         im = config.declare('impact', ConfigDict())
-        im.declare('metric', ConfigValue(
-            'MC', str, 'Population or network based impact metric', None))
+        im.declare(
+            'metric',
+            ConfigValue('MC', str, 'Population or network based impact metric', None),
+        )
 
         fl = config.declare('flushing', ConfigDict())
         n = fl.declare('flush nodes', ConfigDict())
-        n.declare('feasible nodes', ConfigValue(
-            'ALL', str, 'ALL, NZD, NONE, list or filename', None))
-        n.declare('infeasible nodes', ConfigValue(
-            'NONE', str, 'ALL, NZD, NONE, list or filename', None))
-        n.declare('max nodes',
-                  ConfigValue(2, int, 'Maximum number of nodes to flush', None))
-        n.declare('rate', ConfigValue(600, float, 'Flushing rate [gallons/min]',
-                                      None))
-        n.declare('response time', ConfigValue(
-            60, float, 'Time [min] between detection and flushing', None))
-        n.declare('duration', ConfigValue(600, float, 'Time [min] for flushing',
-                                          None))
+        n.declare(
+            'feasible nodes',
+            ConfigValue('ALL', str, 'ALL, NZD, NONE, list or filename', None),
+        )
+        n.declare(
+            'infeasible nodes',
+            ConfigValue('NONE', str, 'ALL, NZD, NONE, list or filename', None),
+        )
+        n.declare(
+            'max nodes', ConfigValue(2, int, 'Maximum number of nodes to flush', None)
+        )
+        n.declare('rate', ConfigValue(600, float, 'Flushing rate [gallons/min]', None))
+        n.declare(
+            'response time',
+            ConfigValue(60, float, 'Time [min] between detection and flushing', None),
+        )
+        n.declare('duration', ConfigValue(600, float, 'Time [min] for flushing', None))
 
         v = fl.declare('close valves', ConfigDict())
-        v.declare('feasible pipes', ConfigValue(
-            'ALL', str, 'ALL, DIAM min max [inch], NONE, list or filename',
-            None))
-        v.declare('infeasible pipes', ConfigValue(
-            'NONE', str, 'ALL, DIAM min max [inch], NONE, list or filename',
-            None))
-        v.declare('max pipes',
-                  ConfigValue(2, int, 'Maximum number of pipes to close', None))
-        v.declare('response time', ConfigValue(
-            60, float, 'Time [min] between detection and closing valves', None))
+        v.declare(
+            'feasible pipes',
+            ConfigValue(
+                'ALL', str, 'ALL, DIAM min max [inch], NONE, list or filename', None
+            ),
+        )
+        v.declare(
+            'infeasible pipes',
+            ConfigValue(
+                'NONE', str, 'ALL, DIAM min max [inch], NONE, list or filename', None
+            ),
+        )
+        v.declare(
+            'max pipes', ConfigValue(2, int, 'Maximum number of pipes to close', None)
+        )
+        v.declare(
+            'response time',
+            ConfigValue(
+                60, float, 'Time [min] between detection and closing valves', None
+            ),
+        )
 
         self._reference = {
-            'network': {
-                'epanet file': 'Net3.inp'
-            },
+            'network': {'epanet file': 'Net3.inp'},
             'scenario': {
                 'detection': [1, 2, 3],
                 'scenario file': 'Net3.tsg',
-                'merlion': False
+                'merlion': False,
             },
             'scenarios': [],
             'nodes': [],
-            'impact': {
-                'metric': 'MC'
-            },
+            'impact': {'metric': 'MC'},
             'flushing': {
                 'close valves': {
                     'infeasible pipes': 'NONE',
                     'max pipes': 2,
                     'feasible pipes': 'ALL',
-                    'response time': 60.0
+                    'response time': 60.0,
                 },
                 'flush nodes': {
                     'feasible nodes': 'ALL',
@@ -841,10 +900,11 @@ class TestConfig(unittest.TestCase):
                     'infeasible nodes': 'NONE',
                     'rate': 600.0,
                     'duration': 600.0,
-                    'response time': 60.0
+                    'response time': 60.0,
                 },
             },
         }
+
     def tearDown(self):
         # Restore the original environment
         os.environ = self.original_environ
@@ -921,8 +981,7 @@ flushing:
       response time: 60.0     # Time [min] between detection and closing
                               #   valves
 """
-        self._validateTemplate(self.config, reference_template,
-                               indent_spacing=3)
+        self._validateTemplate(self.config, reference_template, indent_spacing=3)
 
     def test_template_4space(self):
         reference_template = """# Basic configuration for Flushing models
@@ -954,8 +1013,7 @@ flushing:
         response time: 60.0     # Time [min] between detection and closing
                                 #   valves
 """
-        self._validateTemplate(self.config, reference_template,
-                               indent_spacing=4)
+        self._validateTemplate(self.config, reference_template, indent_spacing=4)
 
     def test_template_3space_narrow(self):
         reference_template = """# Basic configuration for Flushing models
@@ -988,8 +1046,9 @@ flushing:
       response time: 60.0     # Time [min] between detection and closing
                               #   valves
 """
-        self._validateTemplate(self.config, reference_template,
-                               indent_spacing=3, width=72)
+        self._validateTemplate(
+            self.config, reference_template, indent_spacing=3, width=72
+        )
 
     def test_display_default(self):
         reference = """network:
@@ -1068,41 +1127,52 @@ flushing:
         self.config['scenarios'].append()
         test = _display(self.config, 'userdata')
         sys.stdout.write(test)
-        self.assertEqual(test, """scenarios:
+        self.assertEqual(
+            test,
+            """scenarios:
   -
-""")
+""",
+        )
 
     def test_display_userdata_list_nonDefault(self):
         self.config['scenarios'].append()
         self.config['scenarios'].append({'merlion': True, 'detection': []})
         test = _display(self.config, 'userdata')
         sys.stdout.write(test)
-        self.assertEqual(test, """scenarios:
+        self.assertEqual(
+            test,
+            """scenarios:
   -
   -
     merlion: true
     detection: []
-""")
+""",
+        )
 
     def test_display_userdata_add_block(self):
         self.config.add("foo", ConfigValue(0, int, None, None))
         self.config.add("bar", ConfigDict())
         test = _display(self.config, 'userdata')
         sys.stdout.write(test)
-        self.assertEqual(test, """foo: 0
+        self.assertEqual(
+            test,
+            """foo: 0
 bar:
-""")
+""",
+        )
 
     def test_display_userdata_add_block_nonDefault(self):
         self.config.add("foo", ConfigValue(0, int, None, None))
-        self.config.add("bar", ConfigDict(implicit=True)) \
-                   .add("baz", ConfigDict())
+        self.config.add("bar", ConfigDict(implicit=True)).add("baz", ConfigDict())
         test = _display(self.config, 'userdata')
         sys.stdout.write(test)
-        self.assertEqual(test, """foo: 0
+        self.assertEqual(
+            test,
+            """foo: 0
 bar:
   baz:
-""")
+""",
+        )
 
     def test_display_userdata_declare_block(self):
         self.config.declare("foo", ConfigValue(0, int, None, None))
@@ -1113,8 +1183,7 @@ bar:
 
     def test_display_userdata_declare_block_nonDefault(self):
         self.config.declare("foo", ConfigValue(0, int, None, None))
-        self.config.declare("bar", ConfigDict(implicit=True)) \
-                   .add("baz", ConfigDict())
+        self.config.declare("bar", ConfigDict(implicit=True)).add("baz", ConfigDict())
         test = _display(self.config, 'userdata')
         sys.stdout.write(test)
         self.assertEqual(test, "bar:\n  baz:\n")
@@ -1141,10 +1210,13 @@ bar:
         self.config['scenarios'].append({'merlion': True, 'detection': []})
         test = '\n'.join(x.name(True) for x in self.config.unused_user_values())
         sys.stdout.write(test)
-        self.assertEqual(test, """scenarios[0]
+        self.assertEqual(
+            test,
+            """scenarios[0]
 scenarios[1]
 scenarios[1].merlion
-scenarios[1].detection""")
+scenarios[1].detection""",
+        )
 
     def test_unusedUserValues_list_nonDefault_listAccessed(self):
         self.config['scenarios'].append()
@@ -1153,10 +1225,13 @@ scenarios[1].detection""")
             pass
         test = '\n'.join(x.name(True) for x in self.config.unused_user_values())
         sys.stdout.write(test)
-        self.assertEqual(test, """scenarios[0]
+        self.assertEqual(
+            test,
+            """scenarios[0]
 scenarios[1]
 scenarios[1].merlion
-scenarios[1].detection""")
+scenarios[1].detection""",
+        )
 
     def test_unusedUserValues_list_nonDefault_itemAccessed(self):
         self.config['scenarios'].append()
@@ -1164,16 +1239,18 @@ scenarios[1].detection""")
         self.config['scenarios'][1]['merlion']
         test = '\n'.join(x.name(True) for x in self.config.unused_user_values())
         sys.stdout.write(test)
-        self.assertEqual(test, """scenarios[0]
-scenarios[1].detection""")
+        self.assertEqual(
+            test,
+            """scenarios[0]
+scenarios[1].detection""",
+        )
 
     def test_unusedUserValues_add_topBlock(self):
         self.config.add('foo', ConfigDict())
         test = '\n'.join(x.name(True) for x in self.config.unused_user_values())
         sys.stdout.write(test)
         self.assertEqual(test, "foo")
-        test = '\n'.join(x.name(True) for x in
-                         self.config.foo.unused_user_values())
+        test = '\n'.join(x.name(True) for x in self.config.foo.unused_user_values())
         sys.stdout.write(test)
         self.assertEqual(test, "foo")
 
@@ -1217,10 +1294,13 @@ scenarios[1].detection""")
         self.config['scenarios'].append({'merlion': True, 'detection': []})
         test = '\n'.join(x.name(True) for x in self.config.user_values())
         sys.stdout.write(test)
-        self.assertEqual(test, """scenarios[0]
+        self.assertEqual(
+            test,
+            """scenarios[0]
 scenarios[1]
 scenarios[1].merlion
-scenarios[1].detection""")
+scenarios[1].detection""",
+        )
 
     def test_UserValues_list_nonDefault_listAccessed(self):
         self.config['scenarios'].append()
@@ -1229,10 +1309,13 @@ scenarios[1].detection""")
             pass
         test = '\n'.join(x.name(True) for x in self.config.user_values())
         sys.stdout.write(test)
-        self.assertEqual(test, """scenarios[0]
+        self.assertEqual(
+            test,
+            """scenarios[0]
 scenarios[1]
 scenarios[1].merlion
-scenarios[1].detection""")
+scenarios[1].detection""",
+        )
 
     def test_UserValues_list_nonDefault_itemAccessed(self):
         self.config['scenarios'].append()
@@ -1240,10 +1323,13 @@ scenarios[1].detection""")
         self.config['scenarios'][1]['merlion']
         test = '\n'.join(x.name(True) for x in self.config.user_values())
         sys.stdout.write(test)
-        self.assertEqual(test, """scenarios[0]
+        self.assertEqual(
+            test,
+            """scenarios[0]
 scenarios[1]
 scenarios[1].merlion
-scenarios[1].detection""")
+scenarios[1].detection""",
+        )
 
     def test_UserValues_add_topBlock(self):
         self.config.add('foo', ConfigDict())
@@ -1303,12 +1389,11 @@ scenarios[1].detection""")
     def test_parseDisplay_userdata_list_nonDefault(self):
         self.config['scenarios'].append()
         self.config['scenarios'].append({'merlion': True, 'detection': []})
-        test = _display(self.config,'userdata')
+        test = _display(self.config, 'userdata')
         sys.stdout.write(test)
         self.assertEqual(
-            yaml_load(test), {'scenarios':
-                                  [None, {'merlion': True,
-                                          'detection': []}]})
+            yaml_load(test), {'scenarios': [None, {'merlion': True, 'detection': []}]}
+        )
 
     @unittest.skipIf(not yaml_available, "Test requires PyYAML")
     def test_parseDisplay_userdata_add_block(self):
@@ -1321,8 +1406,7 @@ scenarios[1].detection""")
     @unittest.skipIf(not yaml_available, "Test requires PyYAML")
     def test_parseDisplay_userdata_add_block_nonDefault(self):
         self.config.add("foo", ConfigValue(0, int, None, None))
-        self.config.add("bar", ConfigDict(implicit=True)) \
-                   .add("baz", ConfigDict())
+        self.config.add("bar", ConfigDict(implicit=True)).add("baz", ConfigDict())
         test = _display(self.config, 'userdata')
         sys.stdout.write(test)
         self.assertEqual(yaml_load(test), {'bar': {'baz': None}, foo: 0})
@@ -1338,8 +1422,7 @@ scenarios[1].detection""")
     @unittest.skipIf(not yaml_available, "Test requires PyYAML")
     def test_parseDisplay_userdata_add_block_nonDefault(self):
         self.config.declare("foo", ConfigValue(0, int, None, None))
-        self.config.declare("bar", ConfigDict(implicit=True)) \
-                   .add("baz", ConfigDict())
+        self.config.declare("bar", ConfigDict(implicit=True)).add("baz", ConfigDict())
         test = _display(self.config, 'userdata')
         sys.stdout.write(test)
         self.assertEqual(yaml_load(test), {'bar': {'baz': None}})
@@ -1368,25 +1451,27 @@ scenarios[1].detection""")
         val = self.config['scenarios'].value()
         self.assertIs(type(val), list)
         self.assertEqual(len(val), 1)
-        self.assertEqual(val, [{'detection': [1, 2, 3],
-                                'merlion': False,
-                                'scenario file': 'Net3.tsg'}])
+        self.assertEqual(
+            val,
+            [{'detection': [1, 2, 3], 'merlion': False, 'scenario file': 'Net3.tsg'}],
+        )
 
     def test_name(self):
         self.config['scenarios'].append()
         self.assertEqual(self.config.name(), "")
         self.assertEqual(self.config['scenarios'].name(), "scenarios")
         self.assertEqual(self.config['scenarios'][0].name(), "[0]")
-        self.assertEqual(self.config['scenarios'][0].get('merlion').name(),
-                         "merlion")
+        self.assertEqual(self.config['scenarios'][0].get('merlion').name(), "merlion")
 
     def test_name_fullyQualified(self):
         self.config['scenarios'].append()
         self.assertEqual(self.config.name(True), "")
         self.assertEqual(self.config['scenarios'].name(True), "scenarios")
         self.assertEqual(self.config['scenarios'][0].name(True), "scenarios[0]")
-        self.assertEqual(self.config['scenarios'][0].get('merlion').name(True),
-                         "scenarios[0].merlion")
+        self.assertEqual(
+            self.config['scenarios'][0].get('merlion').name(True),
+            "scenarios[0].merlion",
+        )
 
     def test_setValue_scalar(self):
         self.config['flushing']['flush nodes']['rate'] = 50
@@ -1395,8 +1480,7 @@ scenarios[1].detection""")
         self.assertEqual(val, 50.0)
 
     def test_setValue_scalar_badDomain(self):
-        with self.assertRaisesRegex(
-                ValueError, 'invalid value for configuration'):
+        with self.assertRaisesRegex(ValueError, 'invalid value for configuration'):
             self.config['flushing']['flush nodes']['rate'] = 'a'
         val = self.config['flushing']['flush nodes']['rate']
         self.assertIs(type(val), float)
@@ -1415,16 +1499,14 @@ scenarios[1].detection""")
         self.assertEqual(val, [6])
 
     def test_setValue_scalarList_badDomain(self):
-        with self.assertRaisesRegex(
-                ValueError, 'invalid value for configuration'):
+        with self.assertRaisesRegex(ValueError, 'invalid value for configuration'):
             self.config['scenario']['detection'] = 50
         val = self.config['scenario']['detection']
         self.assertIs(type(val), list)
         self.assertEqual(val, [1, 2, 3])
 
     def test_setValue_scalarList_badSubDomain(self):
-        with self.assertRaisesRegex(
-                ValueError, 'invalid value for configuration'):
+        with self.assertRaisesRegex(ValueError, 'invalid value for configuration'):
             self.config['scenario']['detection'] = [5.5, 'a']
         val = self.config['scenario']['detection']
         self.assertIs(type(val), list)
@@ -1443,8 +1525,7 @@ scenarios[1].detection""")
         self.assertEqual(val, [10])
 
     def test_setValue_list_badSubDomain(self):
-        with self.assertRaisesRegex(
-                ValueError, 'invalid value for configuration'):
+        with self.assertRaisesRegex(ValueError, 'invalid value for configuration'):
             self.config['nodes'] = [5, 'a']
         val = self.config['nodes'].value()
         self.assertIs(type(val), list)
@@ -1498,8 +1579,8 @@ scenarios[1].detection""")
     def test_setValue_block_noImplicit(self):
         _test = {'epanet file': 'no_file.inp', 'foo': 1}
         with self.assertRaisesRegex(
-                ValueError, "key 'foo' not defined for ConfigDict "
-                "'network' and implicit"):
+            ValueError, "key 'foo' not defined for ConfigDict " "'network' and implicit"
+        ):
             self.config['network'] = _test
         self.assertEqual(self._reference, self.config.value())
 
@@ -1529,14 +1610,13 @@ scenarios[1].detection""")
 
     def test_setValue_block_badDomain(self):
         _test = {'merlion': True, 'detection': ['a'], 'foo': 1, 'a': 1}
-        with self.assertRaisesRegex(
-                ValueError, 'invalid value for configuration'):
+        with self.assertRaisesRegex(ValueError, 'invalid value for configuration'):
             self.config['scenario'] = _test
         self.assertEqual(self._reference, self.config.value())
 
         with self.assertRaisesRegex(
-                ValueError, 'Expected dict value for scenario.set_value, '
-                'found list'):
+            ValueError, 'Expected dict value for scenario.set_value, found list'
+        ):
             self.config['scenario'] = []
         self.assertEqual(self._reference, self.config.value())
 
@@ -1548,12 +1628,10 @@ scenarios[1].detection""")
         c.reset()
         self.assertEqual(c.value(), 10)
 
-        with self.assertRaisesRegex(
-                TypeError, r"<lambda>\(\) .* argument"):
+        with self.assertRaisesRegex(TypeError, r"<lambda>\(\) .* argument"):
             c = ConfigValue(default=lambda x: 10 * x, domain=int)
 
-        with self.assertRaisesRegex(
-                ValueError, 'invalid value for configuration'):
+        with self.assertRaisesRegex(ValueError, 'invalid value for configuration'):
             c = ConfigValue('a', domain=int)
 
     def test_set_default(self):
@@ -1572,17 +1650,15 @@ scenarios[1].detection""")
         # a freshly-initialized object should not be accessed
         self.assertFalse(self.config._userAccessed)
         self.assertFalse(self.config._data['scenario']._userAccessed)
-        self.assertFalse(self.config._data['scenario']._data['detection']\
-                             ._userAccessed)
+        self.assertFalse(self.config._data['scenario']._data['detection']._userAccessed)
 
         # Getting a ConfigValue should not access it
         self.assertFalse(self.config['scenario'].get('detection')._userAccessed)
 
-        #... but should access the parent blocks traversed to get there
+        # ... but should access the parent blocks traversed to get there
         self.assertTrue(self.config._userAccessed)
         self.assertTrue(self.config._data['scenario']._userAccessed)
-        self.assertFalse(self.config._data['scenario']._data['detection']\
-                             ._userAccessed)
+        self.assertFalse(self.config._data['scenario']._data['detection']._userAccessed)
 
         # a freshly-initialized object should not be set
         self.assertFalse(self.config._userSet)
@@ -1633,17 +1709,16 @@ scenarios[1].detection""")
         self.assertEqual(sorted(config._declared), [])
 
         with self.assertRaisesRegex(
-                AttributeError,
-                "'ConfigDict' object attribute 'get' is read-only"):
+            AttributeError, "'ConfigDict' object attribute 'get' is read-only"
+        ):
             del config.get
         with self.assertRaisesRegex(
-                AttributeError,
-                "'ConfigDict' object has no attribute 'foo'"):
+            AttributeError, "'ConfigDict' object has no attribute 'foo'"
+        ):
             del config.foo
 
     def test_generate_custom_documentation(self):
-        reference = \
-"""startBlock{}
+        reference = """startBlock{}
   startItem{network}
   endItem{network}
   startBlock{network}
@@ -1749,51 +1824,52 @@ endBlock{}
 """
         with LoggingIntercept() as LOG:
             test = self.config.generate_documentation(
-                block_start= "startBlock{%s}\n",
-                block_end=   "endBlock{%s}\n",
-                item_start=  "startItem{%s}\n",
-                item_body=   "item{%s}\n",
-                item_end=    "endItem{%s}\n",
+                block_start="startBlock{%s}\n",
+                block_end="endBlock{%s}\n",
+                item_start="startItem{%s}\n",
+                item_body="item{%s}\n",
+                item_end="endItem{%s}\n",
             )
         LOG = LOG.getvalue().replace('\n', ' ')
         for name in ('block_start', 'block_end', 'item_start', 'item_end', 'item_body'):
             self.assertIn(
                 f"Overriding '{name}' by passing strings to "
                 "generate_documentation is deprecated.",
-                LOG
+                LOG,
             )
         self.maxDiff = None
-        #print(test)
-        self.assertEqual(test, reference)
-
-        with LoggingIntercept() as LOG:
-            test = self.config.generate_documentation(format=String_ConfigFormatter(
-                block_start= "startBlock{%s}\n",
-                block_end=   "endBlock{%s}\n",
-                item_start=  "startItem{%s}\n",
-                item_body=   "item{%s}\n",
-                item_end=    "endItem{%s}\n",
-            ))
-        self.assertEqual(LOG.getvalue(), "")
-        self.maxDiff = None
-        #print(test)
+        # print(test)
         self.assertEqual(test, reference)
 
         with LoggingIntercept() as LOG:
             test = self.config.generate_documentation(
-                block_start= "startBlock\n",
-                block_end=   "endBlock\n",
-                item_start=  "startItem\n",
-                item_body=   "item\n",
-                item_end=    "endItem\n",
+                format=String_ConfigFormatter(
+                    block_start="startBlock{%s}\n",
+                    block_end="endBlock{%s}\n",
+                    item_start="startItem{%s}\n",
+                    item_body="item{%s}\n",
+                    item_end="endItem{%s}\n",
+                )
+            )
+        self.assertEqual(LOG.getvalue(), "")
+        self.maxDiff = None
+        # print(test)
+        self.assertEqual(test, reference)
+
+        with LoggingIntercept() as LOG:
+            test = self.config.generate_documentation(
+                block_start="startBlock\n",
+                block_end="endBlock\n",
+                item_start="startItem\n",
+                item_body="item\n",
+                item_end="endItem\n",
             )
 
-        stripped_reference = re.sub(r'\{[^\}]*\}','',reference,flags=re.M)
-        #print(test)
+        stripped_reference = re.sub(r'\{[^\}]*\}', '', reference, flags=re.M)
+        # print(test)
         self.assertEqual(test, stripped_reference)
 
-        reference = \
-"""startBlock{}
+        reference = """startBlock{}
   startBlock{network}
   startBlock{scenario}
   startBlock{scenarios}
@@ -1814,39 +1890,45 @@ endBlock{}
             self.assertIn(
                 f"Overriding '{name}' by passing strings to "
                 "generate_documentation is deprecated.",
-                LOG
+                LOG,
             )
-        for name in ('item_end'):
+        for name in 'item_end':
             self.assertNotIn(
                 f"Overriding '{name}' by passing strings to "
                 "generate_documentation is deprecated.",
-                LOG
+                LOG,
             )
         self.maxDiff = None
-        #print(test)
+        # print(test)
         self.assertEqual(test, reference)
-
 
     def test_generate_latex_documentation(self):
         cfg = ConfigDict()
-        cfg.declare('int', ConfigValue(
-            domain=int, default=10,
-            doc="This is an integer parameter",
-        ))
-        cfg.declare('in', ConfigValue(
-            domain=In([1,3,5]), default=1,
-            description="This parameter must be in {1,3,5}",
-        ))
-        cfg.declare('lambda', ConfigValue(
-            domain=lambda x: int(x), default=1,
-            description="This is a float",
-            doc="This parameter is actually a float, but for testing "
-            "purposes we will use a lambda function for validation"
-        ))
-        cfg.declare('list', ConfigList(
-            domain=str,
-            description="A simple list of strings",
-        ))
+        cfg.declare(
+            'int',
+            ConfigValue(domain=int, default=10, doc="This is an integer parameter"),
+        )
+        cfg.declare(
+            'in',
+            ConfigValue(
+                domain=In([1, 3, 5]),
+                default=1,
+                description="This parameter must be in {1,3,5}",
+            ),
+        )
+        cfg.declare(
+            'lambda',
+            ConfigValue(
+                domain=lambda x: int(x),
+                default=1,
+                description="This is a float",
+                doc="This parameter is actually a float, but for testing "
+                "purposes we will use a lambda function for validation",
+            ),
+        )
+        cfg.declare(
+            'list', ConfigList(domain=str, description="A simple list of strings")
+        )
         self.assertEqual(
             cfg.generate_documentation(format='latex').strip(),
             """
@@ -1861,83 +1943,80 @@ endBlock{}
   \\item[{list}]\\hfill
     \\\\A simple list of strings
 \\end{description}
-            """.strip())
+            """.strip(),
+        )
 
     def test_empty_ConfigFormatter(self):
         cfg = ConfigDict()
         cfg.declare('field', ConfigValue())
         with self.assertRaisesRegex(
-                ValueError, "Unrecognized documentation formatter, 'unknown'"):
+            ValueError, "Unrecognized documentation formatter, 'unknown'"
+        ):
             cfg.generate_documentation(format="unknown")
 
-        self.assertEqual(
-            cfg.generate_documentation(format=ConfigFormatter()), ''
-        )
+        self.assertEqual(cfg.generate_documentation(format=ConfigFormatter()), '')
 
     def test_block_get(self):
         self.assertTrue('scenario' in self.config)
-        self.assertNotEqual(
-            self.config.get('scenario', 'bogus').value(), 'bogus')
+        self.assertNotEqual(self.config.get('scenario', 'bogus').value(), 'bogus')
         self.assertFalse('fubar' in self.config)
-        self.assertEqual(
-            self.config.get('fubar', 'bogus').value(), 'bogus')
+        self.assertEqual(self.config.get('fubar', 'bogus').value(), 'bogus')
 
         cfg = ConfigDict()
         cfg.declare('foo', ConfigValue(1, int))
-        self.assertEqual( cfg.get('foo', 5).value(), 1 )
-        self.assertEqual( len(cfg), 1 )
-        self.assertIs( cfg.get('bar'), None )
-        self.assertEqual( cfg.get('bar',None).value(), None )
-        self.assertEqual( len(cfg), 1 )
+        self.assertEqual(cfg.get('foo', 5).value(), 1)
+        self.assertEqual(len(cfg), 1)
+        self.assertIs(cfg.get('bar'), None)
+        self.assertEqual(cfg.get('bar', None).value(), None)
+        self.assertEqual(len(cfg), 1)
 
         cfg = ConfigDict(implicit=True)
         cfg.declare('foo', ConfigValue(1, int))
-        self.assertEqual( cfg.get('foo', 5).value(), 1 )
-        self.assertEqual( len(cfg), 1 )
-        self.assertEqual( cfg.get('bar', 5).value(), 5 )
-        self.assertEqual( len(cfg), 1 )
-        self.assertIs( cfg.get('baz'), None )
-        self.assertIs( cfg.get('baz', None).value(), None )
-        self.assertEqual( len(cfg), 1 )
+        self.assertEqual(cfg.get('foo', 5).value(), 1)
+        self.assertEqual(len(cfg), 1)
+        self.assertEqual(cfg.get('bar', 5).value(), 5)
+        self.assertEqual(len(cfg), 1)
+        self.assertIs(cfg.get('baz'), None)
+        self.assertIs(cfg.get('baz', None).value(), None)
+        self.assertEqual(len(cfg), 1)
 
-        cfg = ConfigDict( implicit=True,
-                           implicit_domain=ConfigList(domain=str) )
+        cfg = ConfigDict(implicit=True, implicit_domain=ConfigList(domain=str))
         cfg.declare('foo', ConfigValue(1, int))
-        self.assertEqual( cfg.get('foo', 5).value(), 1 )
-        self.assertEqual( len(cfg), 1 )
-        self.assertEqual( cfg.get('bar', [5]).value(), ['5'] )
-        self.assertEqual( len(cfg), 1 )
-        self.assertIs( cfg.get('baz'), None )
-        self.assertEqual( cfg.get('baz', None).value(), [] )
-        self.assertEqual( len(cfg), 1 )
+        self.assertEqual(cfg.get('foo', 5).value(), 1)
+        self.assertEqual(len(cfg), 1)
+        self.assertEqual(cfg.get('bar', [5]).value(), ['5'])
+        self.assertEqual(len(cfg), 1)
+        self.assertIs(cfg.get('baz'), None)
+        self.assertEqual(cfg.get('baz', None).value(), [])
+        self.assertEqual(len(cfg), 1)
 
     def test_setdefault(self):
         cfg = ConfigDict()
         cfg.declare('foo', ConfigValue(1, int))
-        self.assertEqual( cfg.setdefault('foo', 5).value(), 1 )
-        self.assertEqual( len(cfg), 1 )
-        self.assertRaisesRegex(ValueError, '.*disallows implicit entries',
-                                cfg.setdefault, 'bar', 0)
-        self.assertEqual( len(cfg), 1 )
+        self.assertEqual(cfg.setdefault('foo', 5).value(), 1)
+        self.assertEqual(len(cfg), 1)
+        self.assertRaisesRegex(
+            ValueError, '.*disallows implicit entries', cfg.setdefault, 'bar', 0
+        )
+        self.assertEqual(len(cfg), 1)
 
         cfg = ConfigDict(implicit=True)
         cfg.declare('foo', ConfigValue(1, int))
-        self.assertEqual( cfg.setdefault('foo', 5).value(), 1 )
-        self.assertEqual( len(cfg), 1 )
-        self.assertEqual( cfg.setdefault('bar', 5).value(), 5 )
-        self.assertEqual( len(cfg), 2 )
-        self.assertEqual( cfg.setdefault('baz').value(), None )
-        self.assertEqual( len(cfg), 3 )
+        self.assertEqual(cfg.setdefault('foo', 5).value(), 1)
+        self.assertEqual(len(cfg), 1)
+        self.assertEqual(cfg.setdefault('bar', 5).value(), 5)
+        self.assertEqual(len(cfg), 2)
+        self.assertEqual(cfg.setdefault('baz').value(), None)
+        self.assertEqual(len(cfg), 3)
 
-        cfg = ConfigDict( implicit=True,
-                           implicit_domain=ConfigList(domain=str) )
+        cfg = ConfigDict(implicit=True, implicit_domain=ConfigList(domain=str))
         cfg.declare('foo', ConfigValue(1, int))
-        self.assertEqual( cfg.setdefault('foo', 5).value(), 1 )
-        self.assertEqual( len(cfg), 1 )
-        self.assertEqual( cfg.setdefault('bar', [5]).value(), ['5'] )
-        self.assertEqual( len(cfg), 2 )
-        self.assertEqual( cfg.setdefault('baz').value(), [] )
-        self.assertEqual( len(cfg), 3 )
+        self.assertEqual(cfg.setdefault('foo', 5).value(), 1)
+        self.assertEqual(len(cfg), 1)
+        self.assertEqual(cfg.setdefault('bar', [5]).value(), ['5'])
+        self.assertEqual(len(cfg), 2)
+        self.assertEqual(cfg.setdefault('baz').value(), [])
+        self.assertEqual(len(cfg), 3)
 
     def test_block_keys(self):
         ref = ['scenario file', 'merlion', 'detection']
@@ -1987,8 +2066,11 @@ endBlock{}
         self.assertEqual(list(valueiter), ref)
 
     def test_block_items(self):
-        ref = [('scenario file', 'Net3.tsg'), ('merlion', False),
-               ('detection', [1, 2, 3])]
+        ref = [
+            ('scenario file', 'Net3.tsg'),
+            ('merlion', False),
+            ('detection', [1, 2, 3]),
+        ]
 
         # items iterator
         items = self.config['scenario'].items()
@@ -2008,7 +2090,7 @@ endBlock{}
         self.assertEqual(list(itemiter), ref)
 
     def test_value(self):
-        #print(self.config.value())
+        # print(self.config.value())
         self.assertEqual(self._reference, self.config.value())
 
     def test_list_manipulation(self):
@@ -2017,25 +2099,31 @@ endBlock{}
         os = StringIO()
         with LoggingIntercept(os):
             self.config['scenarios'].add()
-        self.assertIn("ConfigList.add() has been deprecated.  Use append()",
-                      os.getvalue())
+        self.assertIn(
+            "ConfigList.add() has been deprecated.  Use append()", os.getvalue()
+        )
         self.assertEqual(len(self.config['scenarios']), 2)
         self.config['scenarios'].append({'merlion': True, 'detection': []})
         self.assertEqual(len(self.config['scenarios']), 3)
         test = _display(self.config, 'userdata')
         sys.stdout.write(test)
-        self.assertEqual(test, """scenarios:
+        self.assertEqual(
+            test,
+            """scenarios:
   -
   -
   -
     merlion: true
     detection: []
-""")
+""",
+        )
         self.config['scenarios'][0] = {'merlion': True, 'detection': []}
         self.assertEqual(len(self.config['scenarios']), 3)
         test = _display(self.config, 'userdata')
         sys.stdout.write(test)
-        self.assertEqual(test, """scenarios:
+        self.assertEqual(
+            test,
+            """scenarios:
   -
     merlion: true
     detection: []
@@ -2043,10 +2131,13 @@ endBlock{}
   -
     merlion: true
     detection: []
-""")
+""",
+        )
         test = _display(self.config['scenarios'])
         sys.stdout.write(test)
-        self.assertEqual(test, """-
+        self.assertEqual(
+            test,
+            """-
   scenario file: Net3.tsg
   merlion: true
   detection: []
@@ -2058,7 +2149,8 @@ endBlock{}
   scenario file: Net3.tsg
   merlion: true
   detection: []
-""")
+""",
+        )
 
     def test_list_get(self):
         X = ConfigDict(implicit=True)
@@ -2066,12 +2158,11 @@ endBlock{}
         self.assertEqual(_display(X, 'userdata'), "")
         with self.assertRaisesRegex(IndexError, 'list index out of range'):
             self.assertIs(X.config.get(0), None)
-        self.assertIs(X.config.get(0,None).value(), None )
+        self.assertIs(X.config.get(0, None).value(), None)
         val = X.config.get(0, 1)
         self.assertIsInstance(val, ConfigValue)
         self.assertEqual(val.value(), 1)
-        self.assertRaisesRegex(
-            IndexError, '.*out of range', X.config.__getitem__, 0 )
+        self.assertRaisesRegex(IndexError, '.*out of range', X.config.__getitem__, 0)
         # get() shouldn't change the userdata flag...
         self.assertEqual(_display(X, 'userdata'), "")
 
@@ -2091,15 +2182,13 @@ endBlock{}
 
         with self.assertRaisesRegex(IndexError, 'list index out of range'):
             self.assertIs(X.config.get(1), None)
-        self.assertRaisesRegex(
-            IndexError, '.*out of range', X.config.__getitem__, 1)
+        self.assertRaisesRegex(IndexError, '.*out of range', X.config.__getitem__, 1)
 
         # this should ONLY change the userSet flag on the item (and not
         # the list)
         X.config.get(0).set_value(20)
         self.assertEqual(_display(X, 'userdata'), "config:\n  - 20\n")
-        self.assertEqual([_.name(True) for _ in X.user_values()],
-                         ["config[0]"])
+        self.assertEqual([_.name(True) for _ in X.user_values()], ["config[0]"])
 
         # this should ONLY change the userSet flag on the item (and not
         # the list)
@@ -2107,8 +2196,7 @@ endBlock{}
         X.declare('config', ConfigList([42], int))
         X.config[0] = 20
         self.assertEqual(_display(X, 'userdata'), "config:\n  - 20\n")
-        self.assertEqual([_.name(True) for _ in X.user_values()],
-                         ["config[0]"])
+        self.assertEqual([_.name(True) for _ in X.user_values()], ["config[0]"])
 
         # this should ONLY change the userSet flag on the item (and not
         # the list)
@@ -2116,8 +2204,7 @@ endBlock{}
         X.declare('config', ConfigList([42], int))
         X.config.append(20)
         self.assertEqual(_display(X, 'userdata'), "config:\n  - 20\n")
-        self.assertEqual([_.name(True) for _ in X.user_values()],
-                         ["config[1]"])
+        self.assertEqual([_.name(True) for _ in X.user_values()], ["config[1]"])
 
         # This should change both... because the [42] was "declared" as
         # the default for the List, it will *not* be a user-set value
@@ -2125,14 +2212,17 @@ endBlock{}
         X.add('config', ConfigList([42], int))
         X.config.append(20)
         self.assertEqual(_display(X, 'userdata'), "config:\n  - 20\n")
-        self.assertEqual([_.name(True) for _ in X.user_values()],
-                         ["config", "config[1]"])
+        self.assertEqual(
+            [_.name(True) for _ in X.user_values()], ["config", "config[1]"]
+        )
 
     def test_implicit_entries(self):
         config = ConfigDict()
         with self.assertRaisesRegex(
-                ValueError, "Key 'test' not defined in ConfigDict '' "
-                "and Dict disallows implicit entries"):
+            ValueError,
+            "Key 'test' not defined in ConfigDict '' "
+            "and Dict disallows implicit entries",
+        ):
             config['test'] = 5
 
         config = ConfigDict(implicit=True)
@@ -2140,8 +2230,7 @@ endBlock{}
         config.declare('formal', ConfigValue(42, int))
         config['implicit_2'] = 5
         self.assertEqual(3, len(config))
-        self.assertEqual(['implicit_1', 'formal', 'implicit_2'],
-                         list(config.keys()))
+        self.assertEqual(['implicit_1', 'formal', 'implicit_2'], list(config.keys()))
         config.reset()
         self.assertEqual(1, len(config))
         self.assertEqual(['formal'], list(config.keys()))
@@ -2151,19 +2240,22 @@ endBlock{}
         self.config.initialize_argparse(parser)
         help = parser.format_help()
         self.assertIn(
-"""  -h, --help            show this help message and exit
+            """  -h, --help            show this help message and exit
   --epanet-file EPANET  EPANET network inp file
 
 Scenario definition:
   --scenario-file STR   Scenario generation file, see the TEVASIM
                         documentation
   --merlion             Water quality model
-""", help)
+""",
+            help,
+        )
 
     def test_argparse_help_implicit_disable(self):
-        self.config['scenario'].declare('epanet', ConfigValue(
-            True, bool, 'Use EPANET as the Water quality model',
-            None)).declare_as_argument(group='Scenario definition')
+        self.config['scenario'].declare(
+            'epanet',
+            ConfigValue(True, bool, 'Use EPANET as the Water quality model', None),
+        ).declare_as_argument(group='Scenario definition')
         parser = argparse.ArgumentParser(prog='tester')
         self.config.initialize_argparse(parser)
         help = parser.format_help()
@@ -2178,7 +2270,9 @@ Scenario definition:
                         documentation
   --merlion             Water quality model
   --disable-epanet      [DON'T] Use EPANET as the Water quality model
-""", help)
+""",
+            help,
+        )
 
     def test_argparse_import(self):
         parser = argparse.ArgumentParser(prog='tester')
@@ -2196,8 +2290,9 @@ Scenario definition:
         self.assertEqual(1, len(vars(args)))
         leftovers = self.config.import_argparse(args)
         self.assertEqual(0, len(vars(args)))
-        self.assertEqual(['scenario.merlion'],
-                         [x.name(True) for x in self.config.user_values()])
+        self.assertEqual(
+            ['scenario.merlion'], [x.name(True) for x in self.config.user_values()]
+        )
 
         args = parser.parse_args(['--merlion', '--epanet-file', 'foo'])
         self.config.reset()
@@ -2206,8 +2301,10 @@ Scenario definition:
         self.assertEqual(2, len(vars(args)))
         leftovers = self.config.import_argparse(args)
         self.assertEqual(1, len(vars(args)))
-        self.assertEqual(['network.epanet file', 'scenario.merlion'],
-                         [x.name(True) for x in self.config.user_values()])
+        self.assertEqual(
+            ['network.epanet file', 'scenario.merlion'],
+            [x.name(True) for x in self.config.user_values()],
+        )
         self.assertTrue(self.config['scenario']['merlion'])
         self.assertEqual('foo', self.config['network']['epanet file'])
 
@@ -2216,15 +2313,18 @@ Scenario definition:
         subp = parser.add_subparsers(title="Subcommands").add_parser('flushing')
 
         # Declare an argument by passing in the name of the subparser
-        self.config['flushing']['flush nodes'].get(
-            'duration').declare_as_argument(group='flushing')
+        self.config['flushing']['flush nodes'].get('duration').declare_as_argument(
+            group='flushing'
+        )
         # Declare an argument by passing in the name of the subparser
         # and an implicit group
-        self.config['flushing']['flush nodes'].get('feasible nodes') \
-            .declare_as_argument( group=('flushing','Node information') )
+        self.config['flushing']['flush nodes'].get(
+            'feasible nodes'
+        ).declare_as_argument(group=('flushing', 'Node information'))
         # Declare an argument by passing in the subparser and a group name
-        self.config['flushing']['flush nodes'].get('infeasible nodes') \
-            .declare_as_argument( group=(subp,'Node information') )
+        self.config['flushing']['flush nodes'].get(
+            'infeasible nodes'
+        ).declare_as_argument(group=(subp, 'Node information'))
         self.config.initialize_argparse(parser)
 
         # Note that the output for argparse changes in diffeent versions
@@ -2243,7 +2343,9 @@ Scenario definition:
   --scenario-file STR   Scenario generation file, see the TEVASIM
                         documentation
   --merlion             Water quality model
-""", help)
+""",
+            help,
+        )
 
         help = subp.format_help()
         self.assertIn(
@@ -2255,7 +2357,9 @@ Node information:
   --feasible-nodes STR  ALL, NZD, NONE, list or filename
   --infeasible-nodes STR
                         ALL, NZD, NONE, list or filename
-""", help)
+""",
+            help,
+        )
 
     def test_argparse_lists(self):
         c = ConfigDict()
@@ -2266,14 +2370,11 @@ Node information:
         self.assertEqual(c.sub_dict.domain_name(), 'sub-dict')
         self.assertEqual(c.sub_dict.get('a').domain_name(), 'int')
         self.assertEqual(c.sub_dict.get('b').domain_name(), '')
-        c.declare(
-            'lst',
-            ConfigList(domain=int)).declare_as_argument(action='append')
-        c.declare(
-            'sub',
-            ConfigList(domain=c.sub_dict)).declare_as_argument(action='append')
-        c.declare('listof', ConfigValue(
-            domain=ListOf(int))).declare_as_argument()
+        c.declare('lst', ConfigList(domain=int)).declare_as_argument(action='append')
+        c.declare('sub', ConfigList(domain=c.sub_dict)).declare_as_argument(
+            action='append'
+        )
+        c.declare('listof', ConfigValue(domain=ListOf(int))).declare_as_argument()
 
         parser = argparse.ArgumentParser(prog='tester')
         c.initialize_argparse(parser)
@@ -2281,44 +2382,56 @@ Node information:
         # Note that the output for argparse changes in diffeent versions
         # (in particular, "options:" vs "optional arguments:").  We will
         # only test for a subset of the output that should stay consistent.
-        self.assertIn("""
+        self.assertIn(
+            """
   -h, --help            show this help message and exit
   --lst INT
   --sub SUB-DICT
-  --listof LISTOF[INT]""".strip(), parser.format_help())
+  --listof LISTOF[INT]""".strip(),
+            parser.format_help(),
+        )
 
-        args = parser.parse_args([
-            '--lst', '42', '--lst', '1',
-            '--sub', 'a=4', '--sub', 'b=12,a:0',
-            '--listof', '3,2 4'
-        ])
+        args = parser.parse_args(
+            [
+                '--lst',
+                '42',
+                '--lst',
+                '1',
+                '--sub',
+                'a=4',
+                '--sub',
+                'b=12,a:0',
+                '--listof',
+                '3,2 4',
+            ]
+        )
         leftovers = c.import_argparse(args)
         self.assertEqual(c.lst.value(), [42, 1])
-        self.assertEqual(c.sub.value(), [{'a':4, 'b':None}, {'a':0, 'b':'12'}])
+        self.assertEqual(c.sub.value(), [{'a': 4, 'b': None}, {'a': 0, 'b': '12'}])
         self.assertEqual(c.listof, [3, 2, 4])
 
         args = parser.parse_args(['--sub', 'b=12,a 0'])
         with self.assertRaisesRegex(
-                ValueError, r"(?s)invalid value for configuration 'sub':.*"
-                r"Expected ':' or '=' but found '0' at Line 1 Column 8"):
+            ValueError,
+            r"(?s)invalid value for configuration 'sub':.*"
+            r"Expected ':' or '=' but found '0' at Line 1 Column 8",
+        ):
             leftovers = c.import_argparse(args)
         args = parser.parse_args(['--sub', 'b='])
         with self.assertRaisesRegex(
-                ValueError, r"(?s)Expected value following '=' "
-                "but encountered end of string"):
+            ValueError,
+            r"(?s)Expected value following '=' " "but encountered end of string",
+        ):
             leftovers = c.import_argparse(args)
         args = parser.parse_args(['--sub', 'b'])
         with self.assertRaisesRegex(
-                ValueError, r"(?s)Expected ':' or '=' "
-                "but encountered end of string"):
+            ValueError, r"(?s)Expected ':' or '=' " "but encountered end of string"
+        ):
             leftovers = c.import_argparse(args)
-
 
     def test_getattr_setattr(self):
         config = ConfigDict()
-        foo = config.declare(
-            'foo', ConfigDict(
-                implicit=True, implicit_domain=int))
+        foo = config.declare('foo', ConfigDict(implicit=True, implicit_domain=int))
         foo.declare('explicit_bar', ConfigValue(0, int))
 
         self.assertEqual(1, len(foo))
@@ -2335,14 +2448,14 @@ Node information:
         self.assertEqual(20, foo.implicit_bar)
 
         with self.assertRaisesRegex(
-                ValueError, "Key 'baz' not defined in ConfigDict '' "
-                "and Dict disallows implicit entries"):
+            ValueError,
+            "Key 'baz' not defined in ConfigDict '' "
+            "and Dict disallows implicit entries",
+        ):
             config.baz = 10
 
-        with self.assertRaisesRegex(
-                AttributeError, "Unknown attribute 'baz'"):
+        with self.assertRaisesRegex(AttributeError, "Unknown attribute 'baz'"):
             a = config.baz
-
 
     def test_nonString_keys(self):
         config = ConfigDict(implicit=True)
@@ -2372,7 +2485,7 @@ Node information:
 
         self.assertEqual(_display(config), "5: 500\n1: 10\n")
 
-        config.set_value({5:5000})
+        config.set_value({5: 5000})
         self.assertIn(1, config)
         self.assertIn('1', config)
         self.assertEqual(config[1], 10)
@@ -2392,7 +2505,7 @@ Node information:
         config.declare('a_c', ConfigValue())
         config.declare('a d e', ConfigValue())
 
-        config.set_value({'a_b':10, 'a_c': 20, 'a_d_e': 30})
+        config.set_value({'a_b': 10, 'a_c': 20, 'a_d_e': 30})
         self.assertEqual(config.a_b, 10)
         self.assertEqual(config.a_c, 20)
         self.assertEqual(config.a_d_e, 30)
@@ -2437,10 +2550,9 @@ Node information:
         self.assertIn('g_h', config)
 
     def test_call_options(self):
-        config = ConfigDict(description="base description",
-                             doc="base doc",
-                             visibility=1,
-                             implicit=True)
+        config = ConfigDict(
+            description="base description", doc="base doc", visibility=1, implicit=True
+        )
         config.declare("a", ConfigValue(domain=int, doc="a doc", default=1))
         config.declare("b", config.get("a")(2))
         config.declare("c", config.get("a")(domain=float, doc="c doc"))
@@ -2478,9 +2590,7 @@ c: 1.0
         self.assertEqual(simple_copy._description, "base description")
         self.assertEqual(simple_copy._visibility, 1)
 
-        mod_copy = config(description="new description",
-                          doc="new doc",
-                          visibility=0)
+        mod_copy = config(description="new description", doc="new doc", visibility=0)
         reference_template = """# new description
 a: 1
 b: 2
@@ -2495,10 +2605,12 @@ c: 1.0
         def anon_domain(domain):
             def cast(x):
                 return domain(x)
+
             return cast
+
         cfg = ConfigDict()
         cfg.declare('int', ConfigValue(domain=int, default=10))
-        cfg.declare('in', ConfigValue(domain=In([1,3,5]), default=1))
+        cfg.declare('in', ConfigValue(domain=In([1, 3, 5]), default=1))
         cfg.declare('anon', ConfigValue(domain=anon_domain(int), default=1))
         cfg.declare('lambda', ConfigValue(domain=lambda x: int(x), default=1))
         cfg.declare('list', ConfigList(domain=str))
@@ -2506,27 +2618,23 @@ c: 1.0
         out = StringIO()
         with LoggingIntercept(out, module=None):
             cfg.set_value(
-                {'int': 100, 'in': 3, 'anon': 2.5, 'lambda': 1.5,
-                 'list': [2, 'a']}
+                {'int': 100, 'in': 3, 'anon': 2.5, 'lambda': 1.5, 'list': [2, 'a']}
             )
             self.assertEqual(
                 cfg.value(),
-                {'int': 100, 'in': 3, 'anon': 2, 'lambda': 1,
-                 'list': ['2', 'a']}
+                {'int': 100, 'in': 3, 'anon': 2, 'lambda': 1, 'list': ['2', 'a']},
             )
 
             cfg2 = pickle.loads(pickle.dumps(cfg))
             self.assertEqual(
                 cfg2.value(),
-                {'int': 100, 'in': 3, 'anon': 2, 'lambda': 1,
-                 'list': ['2', 'a']}
+                {'int': 100, 'in': 3, 'anon': 2, 'lambda': 1, 'list': ['2', 'a']},
             )
 
             cfg2.list.append(10)
             self.assertEqual(
                 cfg2.value(),
-                {'int': 100, 'in': 3, 'anon': 2, 'lambda': 1,
-                 'list': ['2', 'a', '10']}
+                {'int': 100, 'in': 3, 'anon': 2, 'lambda': 1, 'list': ['2', 'a', '10']},
             )
         # No warnings due to anything above.
         self.assertEqual(out.getvalue(), "")
@@ -2544,7 +2652,7 @@ c: 1.0
         if type(cfg2.get('anon')._domain) is _UnpickleableDomain:
             self.assertIn(
                 "ConfigValue 'anon' was pickled with an unpicklable domain",
-                out.getvalue()
+                out.getvalue(),
             )
             self.assertEqual(cfg2['anon'], 5.5)
         else:
@@ -2558,7 +2666,7 @@ c: 1.0
         if type(cfg2.get('lambda')._domain) is _UnpickleableDomain:
             self.assertIn(
                 "ConfigValue 'lambda' was pickled with an unpicklable domain",
-                out.getvalue()
+                out.getvalue(),
             )
             self.assertEqual(cfg2['lambda'], 6.5)
         else:
@@ -2568,8 +2676,10 @@ c: 1.0
 
     def test_unknowable_types(self):
         obj = ConfigValue()
+
         def local_fcn():
             pass
+
         try:
             pickle.dumps(local_fcn)
             local_picklable = True
@@ -2598,7 +2708,9 @@ c: 1.0
         def local_fcn():
             class LocalClass(object):
                 pass
+
             return LocalClass
+
         local_class = local_fcn()
 
         self.assertIsNone(_picklable.known.get(local_class, None))
@@ -2627,7 +2739,6 @@ c: 1.0
         # "known" dict
         self.assertNotIn(type, _picklable.known)
 
-
     def test_self_assignment(self):
         cfg = ConfigDict()
         self.assertNotIn('d', dir(cfg))
@@ -2638,21 +2749,20 @@ c: 1.0
         # test that dir is sorted
         self.assertEqual(dir(cfg), sorted(dir(cfg)))
         # check that inconsistent name is flagged
-        with self.assertRaisesRegex(
-                ValueError, "Key 'b' not defined in ConfigDict ''"):
+        with self.assertRaisesRegex(ValueError, "Key 'b' not defined in ConfigDict ''"):
             cfg.b = cfg.declare('bb', ConfigValue(2, int))
-
 
     def test_declaration_errors(self):
         cfg = ConfigDict()
         cfg.b = cfg.declare('b', ConfigValue(2, int))
         with self.assertRaisesRegex(
-                ValueError, "duplicate config 'b' defined for ConfigDict ''"):
+            ValueError, "duplicate config 'b' defined for ConfigDict ''"
+        ):
             cfg.b = cfg.declare('b', ConfigValue(2, int))
         with self.assertRaisesRegex(
-                ValueError, "config 'dd' is already assigned to ConfigDict ''"):
+            ValueError, "config 'dd' is already assigned to ConfigDict ''"
+        ):
             cfg.declare('dd', cfg.get('b'))
-
 
     def test_declare_from(self):
         cfg = ConfigDict()
@@ -2670,11 +2780,11 @@ c: 1.0
         self.assertNotIn('a', cfg2)
 
         with self.assertRaisesRegex(
-                ValueError, "passed a block with a duplicate field, 'b'"):
+            ValueError, "passed a block with a duplicate field, 'b'"
+        ):
             cfg2.declare_from(cfg)
 
-        with self.assertRaisesRegex(
-                ValueError, "only accepts other ConfigDicts"):
+        with self.assertRaisesRegex(ValueError, "only accepts other ConfigDicts"):
             cfg2.declare_from({})
 
     def test_docstring_decorator(self):
@@ -2683,22 +2793,28 @@ c: 1.0
         @document_kwargs_from_configdict('CONFIG')
         class ExampleClass(object):
             CONFIG = ConfigDict()
-            CONFIG.declare('option_1', ConfigValue(
-                default=5,
-                domain=int,
-                doc='The first configuration option',
-            ))
+            CONFIG.declare(
+                'option_1',
+                ConfigValue(
+                    default=5, domain=int, doc='The first configuration option'
+                ),
+            )
             SOLVER = CONFIG.declare('solver_options', ConfigDict())
-            SOLVER.declare('solver_option_1', ConfigValue(
-                default=1,
-                domain=float,
-                doc='The first solver configuration option',
-                visibility=DEVELOPER_OPTION,
-            ))
-            SOLVER.declare('solver_option_2', ConfigValue(
-                default=1,
-                domain=float,
-                doc="""The second solver configuration option
+            SOLVER.declare(
+                'solver_option_1',
+                ConfigValue(
+                    default=1,
+                    domain=float,
+                    doc='The first solver configuration option',
+                    visibility=DEVELOPER_OPTION,
+                ),
+            )
+            SOLVER.declare(
+                'solver_option_2',
+                ConfigValue(
+                    default=1,
+                    domain=float,
+                    doc="""The second solver configuration option
 
                 With a very long line containing
                 wrappable text in a long, silly paragraph
@@ -2706,16 +2822,20 @@ c: 1.0
                 #) but a bulleted list
                 #) with two bullets
                 """,
-            ))
-            CONFIG.declare('option_2', ConfigValue(
-                default=5,
-                domain=int,
-                doc="""The second solver configuration option
+                ),
+            )
+            CONFIG.declare(
+                'option_2',
+                ConfigValue(
+                    default=5,
+                    domain=int,
+                    doc="""The second solver configuration option
                 with a very long line containing
                 wrappable text in a long, silly paragraph
                 with little actual information.
                 """,
-            ))
+                ),
+            )
 
             @document_kwargs_from_configdict(CONFIG)
             def __init__(self):
@@ -2726,7 +2846,6 @@ c: 1.0
             )
             def fcn(self):
                 pass
-
 
         ref = """
 Keyword Arguments
@@ -2799,6 +2918,6 @@ option_2: int, default=5
             self.assertEqual(add_docstring_list("", ExampleClass.CONFIG), ref)
         self.assertIn('add_docstring_list is deprecated', LOG.getvalue())
 
+
 if __name__ == "__main__":
     unittest.main()
-

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -1579,7 +1579,7 @@ scenarios[1].detection""",
     def test_setValue_block_noImplicit(self):
         _test = {'epanet file': 'no_file.inp', 'foo': 1}
         with self.assertRaisesRegex(
-            ValueError, "key 'foo' not defined for ConfigDict " "'network' and implicit"
+            ValueError, "key 'foo' not defined for ConfigDict 'network' and implicit"
         ):
             self.config['network'] = _test
         self.assertEqual(self._reference, self.config.value())
@@ -2420,12 +2420,12 @@ Node information:
         args = parser.parse_args(['--sub', 'b='])
         with self.assertRaisesRegex(
             ValueError,
-            r"(?s)Expected value following '=' " "but encountered end of string",
+            r"(?s)Expected value following '=' but encountered end of string",
         ):
             leftovers = c.import_argparse(args)
         args = parser.parse_args(['--sub', 'b'])
         with self.assertRaisesRegex(
-            ValueError, r"(?s)Expected ':' or '=' " "but encountered end of string"
+            ValueError, r"(?s)Expected ':' or '=' but encountered end of string"
         ):
             leftovers = c.import_argparse(args)
 

--- a/pyomo/common/tests/test_dependencies.py
+++ b/pyomo/common/tests/test_dependencies.py
@@ -55,7 +55,7 @@ class TestDependencies(unittest.TestCase):
         # AttributeErrors and NOT DeferredImportError:
         with self.assertRaisesRegex(
             AttributeError,
-            "'ModuleUnavailable' object has no " "attribute '__sphinx_mock__'",
+            "'ModuleUnavailable' object has no attribute '__sphinx_mock__'",
         ):
             module_obj.__sphinx_mock__
 

--- a/pyomo/common/tests/test_dependencies.py
+++ b/pyomo/common/tests/test_dependencies.py
@@ -16,10 +16,16 @@ import pyomo.common.unittest as unittest
 
 from pyomo.common.log import LoggingIntercept
 from pyomo.common.dependencies import (
-    attempt_import, ModuleUnavailable, DeferredImportModule,
-    DeferredImportIndicator, DeferredImportError,
-    _DeferredAnd, _DeferredOr, check_min_version,
-    dill, dill_available
+    attempt_import,
+    ModuleUnavailable,
+    DeferredImportModule,
+    DeferredImportIndicator,
+    DeferredImportError,
+    _DeferredAnd,
+    _DeferredOr,
+    check_min_version,
+    dill,
+    dill_available,
 )
 
 import pyomo.common.tests.dep_mod as dep_mod
@@ -31,22 +37,26 @@ def _finalize_pyo(module, available):
     if available:
         import pyomo.core
 
+
 class TestDependencies(unittest.TestCase):
     def test_import_error(self):
         module_obj, module_available = attempt_import(
             '__there_is_no_module_named_this__',
             'Testing import of a non-existent module',
-            defer_check=False)
+            defer_check=False,
+        )
         self.assertFalse(module_available)
         with self.assertRaisesRegex(
-                DeferredImportError, 'Testing import of a non-existent module'):
+            DeferredImportError, 'Testing import of a non-existent module'
+        ):
             module_obj.try_to_call_a_method()
 
         # Note that some attribute will intentionally raise
         # AttributeErrors and NOT DeferredImportError:
         with self.assertRaisesRegex(
-                AttributeError, "'ModuleUnavailable' object has no "
-                "attribute '__sphinx_mock__'"):
+            AttributeError,
+            "'ModuleUnavailable' object has no " "attribute '__sphinx_mock__'",
+        ):
             module_obj.__sphinx_mock__
 
     @unittest.skipUnless(dill_available, "Test requires dill module")
@@ -60,7 +70,8 @@ class TestDependencies(unittest.TestCase):
         self.assertIsNot(deps.pkl_test, deps.new_pkl_test)
         self.assertIn('submod', deps.new_pkl_test.__dict__)
         with self.assertRaisesRegex(
-                DeferredImportError, 'nonexisting.module.pickle_test module'):
+            DeferredImportError, 'nonexisting.module.pickle_test module'
+        ):
             deps.new_pkl_test.try_to_call_a_method()
         # Pickle the ModuleUnavailable class
         self.assertIs(deps.new_pkl_test.__class__, ModuleUnavailable)
@@ -72,9 +83,11 @@ class TestDependencies(unittest.TestCase):
 
     def test_import_success(self):
         module_obj, module_available = attempt_import(
-            'ply', 'Testing import of ply', defer_check=False)
+            'ply', 'Testing import of ply', defer_check=False
+        )
         self.assertTrue(module_available)
         import ply
+
         self.assertTrue(module_obj is ply)
 
     def test_local_deferred_import(self):
@@ -86,16 +99,20 @@ class TestDependencies(unittest.TestCase):
         # Note: this also tests the implicit alt_names for dotted imports
         self.assertIs(type(deps.bogus), ModuleUnavailable)
         with self.assertRaisesRegex(
-                DeferredImportError, "The nonexisting.module.bogus module "
-                r"\(an optional Pyomo dependency\) failed to import"):
+            DeferredImportError,
+            "The nonexisting.module.bogus module "
+            r"\(an optional Pyomo dependency\) failed to import",
+        ):
             deps.bogus.hello
 
     def test_imported_deferred_import(self):
         self.assertIs(type(deps.has_bogus_nem), DeferredImportIndicator)
         self.assertIs(type(deps.bogus_nem), DeferredImportModule)
         with self.assertRaisesRegex(
-                DeferredImportError, "The bogus_nonexisting_module module "
-                r"\(an optional Pyomo dependency\) failed to import"):
+            DeferredImportError,
+            "The bogus_nonexisting_module module "
+            r"\(an optional Pyomo dependency\) failed to import",
+        ):
             deps.test_access_bogus_hello()
         self.assertIs(deps.has_bogus_nem, False)
         self.assertIs(type(deps.bogus_nem), ModuleUnavailable)
@@ -103,65 +120,63 @@ class TestDependencies(unittest.TestCase):
         self.assertIs(type(dep_mod.bogus_nonexisting_module), ModuleUnavailable)
 
     def test_min_version(self):
-        mod, avail = attempt_import('pyomo.common.tests.dep_mod',
-                                    minimum_version='1.0',
-                                    defer_check=False)
+        mod, avail = attempt_import(
+            'pyomo.common.tests.dep_mod', minimum_version='1.0', defer_check=False
+        )
         self.assertTrue(avail)
         self.assertTrue(inspect.ismodule(mod))
         self.assertTrue(check_min_version(mod, '1.0'))
         self.assertFalse(check_min_version(mod, '2.0'))
 
-        mod, avail = attempt_import('pyomo.common.tests.dep_mod',
-                                    minimum_version='2.0',
-                                    defer_check=False)
+        mod, avail = attempt_import(
+            'pyomo.common.tests.dep_mod', minimum_version='2.0', defer_check=False
+        )
         self.assertFalse(avail)
         self.assertIs(type(mod), ModuleUnavailable)
         with self.assertRaisesRegex(
-                DeferredImportError, "The pyomo.common.tests.dep_mod module "
-                "version 1.5 does not satisfy the minimum version 2.0"):
+            DeferredImportError,
+            "The pyomo.common.tests.dep_mod module "
+            "version 1.5 does not satisfy the minimum version 2.0",
+        ):
             mod.hello
 
-        mod, avail = attempt_import('pyomo.common.tests.dep_mod',
-                                    error_message="Failed import",
-                                    minimum_version='2.0',
-                                    defer_check=False)
+        mod, avail = attempt_import(
+            'pyomo.common.tests.dep_mod',
+            error_message="Failed import",
+            minimum_version='2.0',
+            defer_check=False,
+        )
         self.assertFalse(avail)
         self.assertIs(type(mod), ModuleUnavailable)
         with self.assertRaisesRegex(
-                DeferredImportError, "Failed import "
-                r"\(version 1.5 does not satisfy the minimum version 2.0\)"):
+            DeferredImportError,
+            "Failed import "
+            r"\(version 1.5 does not satisfy the minimum version 2.0\)",
+        ):
             mod.hello
 
         # Verify check_min_version works with deferred imports
 
-        mod, avail = attempt_import('pyomo.common.tests.dep_mod',
-                                    defer_check=True)
+        mod, avail = attempt_import('pyomo.common.tests.dep_mod', defer_check=True)
         self.assertTrue(check_min_version(mod, '1.0'))
 
-        mod, avail = attempt_import('pyomo.common.tests.dep_mod',
-                                    defer_check=True)
+        mod, avail = attempt_import('pyomo.common.tests.dep_mod', defer_check=True)
         self.assertFalse(check_min_version(mod, '2.0'))
 
         # Verify check_min_version works when called directly
 
-        mod, avail = attempt_import('pyomo.common.tests.dep_mod',
-                                    minimum_version='1.0')
+        mod, avail = attempt_import('pyomo.common.tests.dep_mod', minimum_version='1.0')
         self.assertTrue(check_min_version(mod, '1.0'))
 
-        mod, avail = attempt_import('pyomo.common.tests.bogus',
-                                    minimum_version='1.0')
+        mod, avail = attempt_import('pyomo.common.tests.bogus', minimum_version='1.0')
         self.assertFalse(check_min_version(mod, '1.0'))
 
-
-
     def test_and_or(self):
-        mod0, avail0 = attempt_import('ply',
-                                      defer_check=True)
-        mod1, avail1 = attempt_import('pyomo.common.tests.dep_mod',
-                                      defer_check=True)
-        mod2, avail2 = attempt_import('pyomo.common.tests.dep_mod',
-                                      minimum_version='2.0',
-                                      defer_check=True)
+        mod0, avail0 = attempt_import('ply', defer_check=True)
+        mod1, avail1 = attempt_import('pyomo.common.tests.dep_mod', defer_check=True)
+        mod2, avail2 = attempt_import(
+            'pyomo.common.tests.dep_mod', minimum_version='2.0', defer_check=True
+        )
 
         _and = avail0 & avail1
         self.assertIsInstance(_and, _DeferredAnd)
@@ -210,59 +225,70 @@ class TestDependencies(unittest.TestCase):
         self.assertIsInstance(_ror, _DeferredOr)
         self.assertTrue(_ror)
 
-
     def test_callbacks(self):
         ans = []
+
         def _record_avail(module, avail):
             ans.append(avail)
 
-        mod0, avail0 = attempt_import('ply',
-                                      defer_check=True,
-                                      callback=_record_avail)
-        mod1, avail1 = attempt_import('pyomo.common.tests.dep_mod',
-                                      minimum_version='2.0',
-                                      defer_check=True,
-                                      callback=_record_avail)
+        mod0, avail0 = attempt_import('ply', defer_check=True, callback=_record_avail)
+        mod1, avail1 = attempt_import(
+            'pyomo.common.tests.dep_mod',
+            minimum_version='2.0',
+            defer_check=True,
+            callback=_record_avail,
+        )
 
         self.assertEqual(ans, [])
         self.assertTrue(avail0)
         self.assertEqual(ans, [True])
         self.assertFalse(avail1)
-        self.assertEqual(ans, [True,False])
+        self.assertEqual(ans, [True, False])
 
     def test_import_exceptions(self):
-        mod, avail = attempt_import('pyomo.common.tests.dep_mod_except',
-                                    defer_check=True,
-                                    only_catch_importerror=True)
+        mod, avail = attempt_import(
+            'pyomo.common.tests.dep_mod_except',
+            defer_check=True,
+            only_catch_importerror=True,
+        )
         with self.assertRaisesRegex(ValueError, "cannot import module"):
             bool(avail)
         # second test will not re-trigger the exception
         self.assertFalse(avail)
 
-        mod, avail = attempt_import('pyomo.common.tests.dep_mod_except',
-                                    defer_check=True,
-                                    only_catch_importerror=False)
+        mod, avail = attempt_import(
+            'pyomo.common.tests.dep_mod_except',
+            defer_check=True,
+            only_catch_importerror=False,
+        )
         self.assertFalse(avail)
         self.assertFalse(avail)
 
-        mod, avail = attempt_import('pyomo.common.tests.dep_mod_except',
-                                    defer_check=True,
-                                    catch_exceptions=(ImportError, ValueError))
+        mod, avail = attempt_import(
+            'pyomo.common.tests.dep_mod_except',
+            defer_check=True,
+            catch_exceptions=(ImportError, ValueError),
+        )
         self.assertFalse(avail)
         self.assertFalse(avail)
 
         with self.assertRaisesRegex(
-                ValueError, 'Cannot specify both only_catch_importerror '
-                'and catch_exceptions'):
-            mod, avail = attempt_import('pyomo.common.tests.dep_mod_except',
-                                        defer_check=True,
-                                        only_catch_importerror=True,
-                                        catch_exceptions=(ImportError,))
+            ValueError,
+            'Cannot specify both only_catch_importerror and catch_exceptions',
+        ):
+            mod, avail = attempt_import(
+                'pyomo.common.tests.dep_mod_except',
+                defer_check=True,
+                only_catch_importerror=True,
+                catch_exceptions=(ImportError,),
+            )
 
     def test_generate_warning(self):
-        mod, avail = attempt_import('pyomo.common.tests.dep_mod_except',
-                                    defer_check=True,
-                                    only_catch_importerror=False)
+        mod, avail = attempt_import(
+            'pyomo.common.tests.dep_mod_except',
+            defer_check=True,
+            only_catch_importerror=False,
+        )
 
         # Test generate warning
         log = StringIO()
@@ -273,10 +299,11 @@ class TestDependencies(unittest.TestCase):
         self.assertIn(
             "The pyomo.common.tests.dep_mod_except module "
             "(an optional Pyomo dependency) failed to import",
-            log.getvalue())
+            log.getvalue(),
+        )
         self.assertIn(
-            "DEPRECATED: use :py:class:`log_import_warning()`",
-            dep.getvalue())
+            "DEPRECATED: use :py:class:`log_import_warning()`", dep.getvalue()
+        )
 
         log = StringIO()
         dep = StringIO()
@@ -286,15 +313,18 @@ class TestDependencies(unittest.TestCase):
         self.assertIn(
             "The pyomo.common.tests.dep_mod_except module "
             "(an optional Pyomo dependency) failed to import",
-            log.getvalue())
+            log.getvalue(),
+        )
         self.assertIn(
-            "DEPRECATED: use :py:class:`log_import_warning()`",
-            dep.getvalue())
+            "DEPRECATED: use :py:class:`log_import_warning()`", dep.getvalue()
+        )
 
     def test_log_warning(self):
-        mod, avail = attempt_import('pyomo.common.tests.dep_mod_except',
-                                    defer_check=True,
-                                    only_catch_importerror=False)
+        mod, avail = attempt_import(
+            'pyomo.common.tests.dep_mod_except',
+            defer_check=True,
+            only_catch_importerror=False,
+        )
         log = StringIO()
         dep = StringIO()
         with LoggingIntercept(dep, 'pyomo'):
@@ -303,7 +333,8 @@ class TestDependencies(unittest.TestCase):
         self.assertIn(
             "The pyomo.common.tests.dep_mod_except module "
             "(an optional Pyomo dependency) failed to import",
-            dep.getvalue())
+            dep.getvalue(),
+        )
         self.assertNotIn("DEPRECATED:", dep.getvalue())
         self.assertEqual("", log.getvalue())
 
@@ -315,7 +346,8 @@ class TestDependencies(unittest.TestCase):
         self.assertIn(
             "The pyomo.common.tests.dep_mod_except module "
             "(an optional Pyomo dependency) failed to import",
-            log.getvalue())
+            log.getvalue(),
+        )
         self.assertEqual("", dep.getvalue())
 
         log = StringIO()
@@ -323,20 +355,18 @@ class TestDependencies(unittest.TestCase):
             with LoggingIntercept(log, 'pyomo.core.base'):
                 mod.log_import_warning('pyomo.core.base', "Custom")
         self.assertIn(
-            "Custom (import raised ValueError: cannot import module)",
-            log.getvalue())
+            "Custom (import raised ValueError: cannot import module)", log.getvalue()
+        )
         self.assertEqual("", dep.getvalue())
 
     def test_importer(self):
         attempted_import = []
+
         def _importer():
             attempted_import.append(True)
-            return attempt_import('pyomo.common.tests.dep_mod',
-                                  defer_check=False)[0]
+            return attempt_import('pyomo.common.tests.dep_mod', defer_check=False)[0]
 
-        mod, avail = attempt_import('foo',
-                                    importer=_importer,
-                                    defer_check=True)
+        mod, avail = attempt_import('foo', importer=_importer, defer_check=True)
 
         self.assertEqual(attempted_import, [])
         self.assertIsInstance(mod, DeferredImportModule)
@@ -346,15 +376,15 @@ class TestDependencies(unittest.TestCase):
 
     def test_deferred_submodules(self):
         import pyomo
+
         pyo_ver = pyomo.version.version
 
         self.assertIsInstance(deps.pyo, DeferredImportModule)
         self.assertIsNone(deps.pyo._submodule_name)
-        self.assertEqual(deps.pyo_available._deferred_submodules,
-                         ['.version',
-                          '.common',
-                          '.common.tests',
-                          '.common.tests.dep_mod',])
+        self.assertEqual(
+            deps.pyo_available._deferred_submodules,
+            ['.version', '.common', '.common.tests', '.common.tests.dep_mod'],
+        )
         # This doesn't cause test_mod to be resolved
         version = deps.pyo.version
         self.assertIsInstance(deps.pyo, DeferredImportModule)
@@ -369,15 +399,19 @@ class TestDependencies(unittest.TestCase):
         self.assertTrue(inspect.ismodule(deps.dm))
 
         with self.assertRaisesRegex(
-                ValueError,
-                "deferred_submodules is only valid if defer_check==True"):
+            ValueError, "deferred_submodules is only valid if defer_check==True"
+        ):
             mod, mod_available = attempt_import(
-                'nonexisting.module', defer_check=False,
-                deferred_submodules={'submod': None})
+                'nonexisting.module',
+                defer_check=False,
+                deferred_submodules={'submod': None},
+            )
 
         mod, mod_available = attempt_import(
-            'nonexisting.module', defer_check=True,
-            deferred_submodules={'submod.subsubmod': None})
+            'nonexisting.module',
+            defer_check=True,
+            deferred_submodules={'submod.subsubmod': None},
+        )
         self.assertIs(type(mod), DeferredImportModule)
         self.assertFalse(mod_available)
         _mod = mod_available._module
@@ -386,6 +420,7 @@ class TestDependencies(unittest.TestCase):
         self.assertIs(type(_mod.submod), ModuleUnavailable)
         self.assertTrue(hasattr(_mod.submod, 'subsubmod'))
         self.assertIs(type(_mod.submod.subsubmod), ModuleUnavailable)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyomo/common/tests/test_deprecated.py
+++ b/pyomo/common/tests/test_deprecated.py
@@ -18,14 +18,18 @@ import pyomo.common.unittest as unittest
 
 from pyomo.common import DeveloperError
 from pyomo.common.deprecation import (
-    deprecated, deprecation_warning, relocated_module_attribute, RenamedClass,
-    _import_object
+    deprecated,
+    deprecation_warning,
+    relocated_module_attribute,
+    RenamedClass,
+    _import_object,
 )
 from pyomo.common.log import LoggingIntercept
 
 from io import StringIO
 
 import logging
+
 logger = logging.getLogger('local')
 
 
@@ -37,30 +41,35 @@ class TestDeprecated(unittest.TestCase):
         with LoggingIntercept(DEP_OUT, 'pyomo'):
             deprecation_warning(None, version='1.2', remove_in='3.4')
 
-        self.assertIn('DEPRECATED: This has been deprecated',
-                      DEP_OUT.getvalue())
-        self.assertIn('(deprecated in 1.2, will be removed in (or after) 3.4)',
-                      DEP_OUT.getvalue().replace('\n',' '))
+        self.assertIn('DEPRECATED: This has been deprecated', DEP_OUT.getvalue())
+        self.assertIn(
+            '(deprecated in 1.2, will be removed in (or after) 3.4)',
+            DEP_OUT.getvalue().replace('\n', ' '),
+        )
 
         DEP_OUT = StringIO()
         with LoggingIntercept(DEP_OUT, 'pyomo'):
             deprecation_warning("custom message here", version='1.2', remove_in='3.4')
 
-        self.assertIn('DEPRECATED: custom message here',
-                      DEP_OUT.getvalue())
-        self.assertIn('(deprecated in 1.2, will be removed in (or after) 3.4)',
-                      DEP_OUT.getvalue().replace('\n',' '))
-
+        self.assertIn('DEPRECATED: custom message here', DEP_OUT.getvalue())
+        self.assertIn(
+            '(deprecated in 1.2, will be removed in (or after) 3.4)',
+            DEP_OUT.getvalue().replace('\n', ' '),
+        )
 
     def test_no_version_exception(self):
         with self.assertRaisesRegex(
-                DeveloperError, "@deprecated\(\): missing 'version' argument"):
+            DeveloperError, "@deprecated\(\): missing 'version' argument"
+        ):
+
             @deprecated()
             def foo():
                 pass
 
         with self.assertRaisesRegex(
-                DeveloperError, "@deprecated\(\): missing 'version' argument"):
+            DeveloperError, "@deprecated\(\): missing 'version' argument"
+        ):
+
             @deprecated()
             class foo(object):
                 pass
@@ -72,12 +81,13 @@ class TestDeprecated(unittest.TestCase):
             @deprecated(version="1.2")
             def __init__(self):
                 pass
+
         self.assertIn('.. deprecated:: 1.2', foo.__doc__)
 
     def test_no_doc_string(self):
         # Note: No docstring, else nose replaces the function name with
         # the docstring in output.
-        #"""Test for deprecated function decorator."""
+        # """Test for deprecated function decorator."""
         @deprecated(version='test')
         def foo(bar='yeah'):
             logger.warning(bar)
@@ -85,7 +95,7 @@ class TestDeprecated(unittest.TestCase):
         self.assertRegex(
             foo.__doc__,
             r'^DEPRECATED.\n\n.. deprecated:: test\n'
-            r'   This function \(.*\.foo\) has been deprecated'
+            r'   This function \(.*\.foo\) has been deprecated',
         )
 
         # Test the default argument
@@ -118,7 +128,6 @@ class TestDeprecated(unittest.TestCase):
             DEP_OUT.getvalue().replace('\n', ' '),
             r'DEPRECATED: This function \(.*\.foo\) has been deprecated',
         )
-
 
     def test_with_doc_string(self):
         @deprecated(version='test')
@@ -134,7 +143,7 @@ class TestDeprecated(unittest.TestCase):
             foo.__doc__,
             r'I am a good person.\s+Because I document my public functions.\s+'
             r'.. deprecated:: test\n'
-            r'   This function \(.*\.foo\) has been deprecated'
+            r'   This function \(.*\.foo\) has been deprecated',
         )
 
         # Test the default argument
@@ -167,7 +176,6 @@ class TestDeprecated(unittest.TestCase):
             DEP_OUT.getvalue().replace('\n', ' '),
             r'DEPRECATED: This function \(.*\.foo\) has been deprecated',
         )
-
 
     def test_with_custom_message(self):
         @deprecated('This is a custom message, too.', version='test')
@@ -179,9 +187,7 @@ class TestDeprecated(unittest.TestCase):
             """
             logger.warning(bar)
 
-        self.assertIn(
-            '.. deprecated:: test\n   This is a custom message',
-            foo.__doc__)
+        self.assertIn('.. deprecated:: test\n   This is a custom message', foo.__doc__)
         self.assertIn('I am a good person.', foo.__doc__)
 
         # Test the default argument
@@ -194,8 +200,7 @@ class TestDeprecated(unittest.TestCase):
         self.assertIn('yeah', FCN_OUT.getvalue())
         self.assertNotIn('DEPRECATED', FCN_OUT.getvalue())
         # Test that the deprecation warning was logged
-        self.assertIn('DEPRECATED: This is a custom message',
-                      DEP_OUT.getvalue())
+        self.assertIn('DEPRECATED: This is a custom message', DEP_OUT.getvalue())
 
         # Test that the function argument gets passed in
         DEP_OUT = StringIO()
@@ -208,13 +213,10 @@ class TestDeprecated(unittest.TestCase):
         self.assertIn('custom', FCN_OUT.getvalue())
         self.assertNotIn('DEPRECATED', FCN_OUT.getvalue())
         # Test that the deprecation warning was logged
-        self.assertIn('DEPRECATED: This is a custom message',
-                      DEP_OUT.getvalue())
-
+        self.assertIn('DEPRECATED: This is a custom message', DEP_OUT.getvalue())
 
     def test_with_custom_logger(self):
-        @deprecated('This is a custom message', logger='local',
-                    version='test')
+        @deprecated('This is a custom message', logger='local', version='test')
         def foo(bar='yeah'):
             """Show that I am a good person.
 
@@ -223,9 +225,7 @@ class TestDeprecated(unittest.TestCase):
             """
             logger.warning(bar)
 
-        self.assertIn(
-            '.. deprecated:: test\n   This is a custom message',
-            foo.__doc__)
+        self.assertIn('.. deprecated:: test\n   This is a custom message', foo.__doc__)
         self.assertIn('I am a good person.', foo.__doc__)
 
         # Test the default argument
@@ -236,11 +236,9 @@ class TestDeprecated(unittest.TestCase):
                 foo()
         # Test that the function produces output
         self.assertIn('yeah', FCN_OUT.getvalue())
-        self.assertIn('DEPRECATED: This is a custom message',
-                      FCN_OUT.getvalue())
+        self.assertIn('DEPRECATED: This is a custom message', FCN_OUT.getvalue())
         # Test that the deprecation warning was logged
-        self.assertNotIn('DEPRECATED:',
-                      DEP_OUT.getvalue())
+        self.assertNotIn('DEPRECATED:', DEP_OUT.getvalue())
 
         # Test that the function argument gets passed in
         DEP_OUT = StringIO()
@@ -251,11 +249,9 @@ class TestDeprecated(unittest.TestCase):
         # Test that the function produces output
         self.assertNotIn('yeah', FCN_OUT.getvalue())
         self.assertIn('custom', FCN_OUT.getvalue())
-        self.assertIn('DEPRECATED: This is a custom message',
-                      FCN_OUT.getvalue())
+        self.assertIn('DEPRECATED: This is a custom message', FCN_OUT.getvalue())
         # Test that the deprecation warning was logged
         self.assertNotIn('DEPRECATED:', DEP_OUT.getvalue())
-
 
     def test_with_class(self):
         @deprecated(version='test')
@@ -266,8 +262,7 @@ class TestDeprecated(unittest.TestCase):
         self.assertIs(type(foo), type)
         self.assertRegex(
             foo.__doc__,
-            r'.. deprecated:: test\n'
-            r'   This class \(.*\.foo\) has been deprecated',
+            r'.. deprecated:: test\n' r'   This class \(.*\.foo\) has been deprecated',
         )
 
         # Test the default argument
@@ -286,11 +281,11 @@ class TestDeprecated(unittest.TestCase):
             r'\(deprecated in test\)',
         )
 
-
     def test_with_method(self):
         class foo(object):
             def __init__(self):
                 pass
+
             @deprecated(version='test')
             def bar(self):
                 logger.warning('yeah')
@@ -321,6 +316,7 @@ class TestDeprecated(unittest.TestCase):
         class foo(object):
             def __init__(self):
                 pass
+
             @deprecated(version='1.2', remove_in='3.4')
             def bar(self):
                 logger.warning('yeah')
@@ -329,7 +325,7 @@ class TestDeprecated(unittest.TestCase):
             foo.bar.__doc__,
             r'.. deprecated:: 1.2\n'
             r'   This function \(.*\.foo\.bar\) has been deprecated.*'
-            r'\(will be removed in \(or after\) 3.4\)'
+            r'\(will be removed in \(or after\) 3.4\)',
         )
 
         # Test the default argument
@@ -349,20 +345,21 @@ class TestDeprecated(unittest.TestCase):
         )
 
 
-
 class Bar(object):
     data = 21
 
-relocated_module_attribute(
-    'myFoo', 'pyomo.common.tests.relocated.Bar', 'test')
+
+relocated_module_attribute('myFoo', 'pyomo.common.tests.relocated.Bar', 'test')
+
 
 class TestRelocated(unittest.TestCase):
-
     def test_relocated_class(self):
         # Before we test multiple relocated objects, verify that it will
         # handle the import of a new module
-        warning = "DEPRECATED: the 'myFoo' class has been moved to " \
-                  "'pyomo.common.tests.relocated.Bar'"
+        warning = (
+            "DEPRECATED: the 'myFoo' class has been moved to "
+            "'pyomo.common.tests.relocated.Bar'"
+        )
         OUT = StringIO()
         with LoggingIntercept(OUT, 'pyomo'):
             from pyomo.common.tests.test_deprecated import myFoo
@@ -371,16 +368,17 @@ class TestRelocated(unittest.TestCase):
 
         from pyomo.common.tests import relocated
 
-        if sys.version_info < (3,5):
+        if sys.version_info < (3, 5):
             # Make sure that the module is only wrapped once
-            self.assertIs(type(relocated._wrapped_module),
-                          types.ModuleType)
+            self.assertIs(type(relocated._wrapped_module), types.ModuleType)
 
         self.assertNotIn('Foo', dir(relocated))
         self.assertNotIn('Foo_2', dir(relocated))
 
-        warning = "DEPRECATED: the 'Foo_2' class has been moved to " \
-                  "'pyomo.common.tests.relocated.Bar'"
+        warning = (
+            "DEPRECATED: the 'Foo_2' class has been moved to "
+            "'pyomo.common.tests.relocated.Bar'"
+        )
 
         OUT = StringIO()
         with LoggingIntercept(OUT, 'pyomo'):
@@ -392,12 +390,15 @@ class TestRelocated(unittest.TestCase):
         self.assertIn('Foo_2', dir(relocated))
         self.assertIs(relocated.Foo_2, relocated.Bar)
 
-        warning = "DEPRECATED: the 'Foo' class has been moved to " \
-                  "'pyomo.common.tests.test_deprecated.Bar'"
+        warning = (
+            "DEPRECATED: the 'Foo' class has been moved to "
+            "'pyomo.common.tests.test_deprecated.Bar'"
+        )
 
         OUT = StringIO()
         with LoggingIntercept(OUT, 'pyomo'):
             from pyomo.common.tests.relocated import Foo
+
             self.assertEqual(Foo.data, 21)
         self.assertIn(warning, OUT.getvalue().replace('\n', ' '))
 
@@ -408,47 +409,72 @@ class TestRelocated(unittest.TestCase):
         # Note that relocated defines a __getattr__, which changes how
         # attribute processing is handled in python 3.7+
         with self.assertRaisesRegex(
-                AttributeError,
-                "(?:module 'pyomo.common.tests.relocated')|"
-                "(?:'module' object) has no attribute 'Baz'"):
+            AttributeError,
+            "(?:module 'pyomo.common.tests.relocated')|"
+            "(?:'module' object) has no attribute 'Baz'",
+        ):
             relocated.Baz.data
         if sys.version_info[:2] >= (3, 7):
             self.assertEqual(relocated.Foo_3, '_3')
 
         with self.assertRaisesRegex(
-                AttributeError,
-                "(?:module 'pyomo.common.tests.test_deprecated')|"
-                "(?:'module' object) has no attribute 'Baz'"):
+            AttributeError,
+            "(?:module 'pyomo.common.tests.test_deprecated')|"
+            "(?:'module' object) has no attribute 'Baz'",
+        ):
             sys.modules[__name__].Baz.data
-
 
     def test_relocated_message(self):
         with LoggingIntercept() as LOG:
-            self.assertIs(_import_object(
-                'oldName', 'pyomo.common.tests.test_deprecated.logger',
-                'TBD', None, None), logger)
+            self.assertIs(
+                _import_object(
+                    'oldName',
+                    'pyomo.common.tests.test_deprecated.logger',
+                    'TBD',
+                    None,
+                    None,
+                ),
+                logger,
+            )
         self.assertRegex(
             LOG.getvalue().replace('\n', ' '),
             "DEPRECATED: the 'oldName' attribute has been moved to "
-            "'pyomo.common.tests.test_deprecated.logger'")
+            "'pyomo.common.tests.test_deprecated.logger'",
+        )
 
         with LoggingIntercept() as LOG:
-            self.assertIs(_import_object(
-                'oldName', 'pyomo.common.tests.test_deprecated._import_object',
-                'TBD', None, None), _import_object)
+            self.assertIs(
+                _import_object(
+                    'oldName',
+                    'pyomo.common.tests.test_deprecated._import_object',
+                    'TBD',
+                    None,
+                    None,
+                ),
+                _import_object,
+            )
         self.assertRegex(
             LOG.getvalue().replace('\n', ' '),
             "DEPRECATED: the 'oldName' function has been moved to "
-            "'pyomo.common.tests.test_deprecated._import_object'")
+            "'pyomo.common.tests.test_deprecated._import_object'",
+        )
 
         with LoggingIntercept() as LOG:
-            self.assertIs(_import_object(
-                'oldName', 'pyomo.common.tests.test_deprecated.TestRelocated',
-                'TBD', None, None), TestRelocated)
+            self.assertIs(
+                _import_object(
+                    'oldName',
+                    'pyomo.common.tests.test_deprecated.TestRelocated',
+                    'TBD',
+                    None,
+                    None,
+                ),
+                TestRelocated,
+            )
         self.assertRegex(
             LOG.getvalue().replace('\n', ' '),
             "DEPRECATED: the 'oldName' class has been moved to "
-            "'pyomo.common.tests.test_deprecated.TestRelocated'")
+            "'pyomo.common.tests.test_deprecated.TestRelocated'",
+        )
 
     def test_relocated_module(self):
         with LoggingIntercept() as LOG:
@@ -459,12 +485,14 @@ class TestRelocated(unittest.TestCase):
             r"DEPRECATED: The 'pyomo\.common\.tests\.relo_mod' module has "
             r"been moved to 'pyomo\.common\.tests\.relo_mod_new'. Please "
             r"update your import. \(deprecated in 1\.2\) \(called from "
-            r".*test_deprecated\.py")
+            r".*test_deprecated\.py",
+        )
         with LoggingIntercept() as LOG:
             # Second import: no warning
             import pyomo.common.tests.relo_mod as relo
         self.assertEqual(LOG.getvalue(), '')
         import pyomo.common.tests.relo_mod_new as relo_new
+
         self.assertIs(relo, relo_new)
         self.assertEqual(relo.RELO_ATTR, 42)
         self.assertIs(ReloClass, relo_new.ReloClass)
@@ -481,16 +509,20 @@ class TestRenamedClass(unittest.TestCase):
         # The deprecated class does not generate a warning
         out = StringIO()
         with LoggingIntercept(out):
+
             class DeprecatedClass(metaclass=RenamedClass):
                 __renamed__new_class__ = NewClass
                 __renamed__version__ = 'X.y'
+
         self.assertEqual(out.getvalue(), "")
 
         # Inheriting from the deprecated class generates the warning
         out = StringIO()
         with LoggingIntercept(out):
+
             class DeprecatedClassSubclass(DeprecatedClass):
                 attr = 'DeprecatedClassSubclass'
+
         self.assertRegex(
             out.getvalue().replace("\n", " ").strip(),
             r"^DEPRECATED: Declaring class 'DeprecatedClassSubclass' "
@@ -503,8 +535,10 @@ class TestRenamedClass(unittest.TestCase):
         # not generate a warning
         out = StringIO()
         with LoggingIntercept(out):
+
             class DeprecatedClassSubSubclass(DeprecatedClassSubclass):
                 attr = 'DeprecatedClassSubSubclass'
+
         self.assertEqual(out.getvalue(), "")
 
         #
@@ -545,8 +579,13 @@ class TestRenamedClass(unittest.TestCase):
             self.assertIsInstance(deprecatedsubsubclass, NewClass)
         self.assertEqual(out.getvalue(), "")
 
-        for obj in (newclass, newclasssubclass, deprecatedclass,
-                    deprecatedsubclass, deprecatedsubsubclass):
+        for obj in (
+            newclass,
+            newclasssubclass,
+            deprecatedclass,
+            deprecatedsubclass,
+            deprecatedsubsubclass,
+        ):
             out = StringIO()
             with LoggingIntercept(out):
                 self.assertIsInstance(obj, DeprecatedClass)
@@ -568,8 +607,13 @@ class TestRenamedClass(unittest.TestCase):
             self.assertTrue(issubclass(DeprecatedClassSubSubclass, NewClass))
         self.assertEqual(out.getvalue(), "")
 
-        for cls in (NewClass, NewClassSubclass, DeprecatedClass,
-                    DeprecatedClassSubclass, DeprecatedClassSubSubclass):
+        for cls in (
+            NewClass,
+            NewClassSubclass,
+            DeprecatedClass,
+            DeprecatedClassSubclass,
+            DeprecatedClassSubSubclass,
+        ):
             out = StringIO()
             with LoggingIntercept(out):
                 self.assertTrue(issubclass(cls, DeprecatedClass))
@@ -586,35 +630,38 @@ class TestRenamedClass(unittest.TestCase):
         self.assertEqual(newclass.attr, 'NewClass')
         self.assertEqual(newclasssubclass.attr, 'NewClass')
         self.assertEqual(deprecatedclass.attr, 'NewClass')
-        self.assertEqual(deprecatedsubclass.attr,
-                         'DeprecatedClassSubclass')
-        self.assertEqual(deprecatedsubsubclass.attr,
-                         'DeprecatedClassSubSubclass')
+        self.assertEqual(deprecatedsubclass.attr, 'DeprecatedClassSubclass')
+        self.assertEqual(deprecatedsubsubclass.attr, 'DeprecatedClassSubSubclass')
         self.assertEqual(NewClass.attr, 'NewClass')
         self.assertEqual(NewClassSubclass.attr, 'NewClass')
         self.assertEqual(DeprecatedClass.attr, 'NewClass')
-        self.assertEqual(DeprecatedClassSubclass.attr,
-                         'DeprecatedClassSubclass')
-        self.assertEqual(DeprecatedClassSubSubclass.attr,
-                         'DeprecatedClassSubSubclass')
+        self.assertEqual(DeprecatedClassSubclass.attr, 'DeprecatedClassSubclass')
+        self.assertEqual(DeprecatedClassSubSubclass.attr, 'DeprecatedClassSubSubclass')
 
     def test_renamed_errors(self):
         class NewClass(object):
             pass
 
         with self.assertRaisesRegex(
-                TypeError, "Declaring class 'DeprecatedClass' using the "
-                "RenamedClass metaclass, but without specifying the "
-                "__renamed__new_class__ class attribute"):
+            TypeError,
+            "Declaring class 'DeprecatedClass' using the "
+            "RenamedClass metaclass, but without specifying the "
+            "__renamed__new_class__ class attribute",
+        ):
+
             class DeprecatedClass(metaclass=RenamedClass):
                 __renamed_new_class__ = NewClass
 
         with self.assertRaisesRegex(
-                DeveloperError, "Declaring class 'DeprecatedClass' using the "
-                "RenamedClass metaclass, but without specifying the "
-                "__renamed__version__ class attribute"):
+            DeveloperError,
+            "Declaring class 'DeprecatedClass' using the "
+            "RenamedClass metaclass, but without specifying the "
+            "__renamed__version__ class attribute",
+        ):
+
             class DeprecatedClass(metaclass=RenamedClass):
                 __renamed__new_class__ = NewClass
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyomo/common/tests/test_download.py
+++ b/pyomo/common/tests/test_download.py
@@ -52,7 +52,7 @@ class Test_FileDownloader(unittest.TestCase):
 
         with self.assertRaisesRegex(
             RuntimeError,
-            "cacert='nonexistent_file_name' does not " "refer to a valid file.",
+            "cacert='nonexistent_file_name' does not refer to a valid file.",
         ):
             FileDownloader(True, 'nonexistent_file_name')
 
@@ -96,7 +96,7 @@ class Test_FileDownloader(unittest.TestCase):
         f = FileDownloader()
         with self.assertRaisesRegex(
             RuntimeError,
-            "--cacert='nonexistent_file_name' does " "not refer to a valid file",
+            "--cacert='nonexistent_file_name' does not refer to a valid file",
         ):
             f.parse_args(['--cacert', 'nonexistent_file_name'])
 

--- a/pyomo/common/tests/test_download.py
+++ b/pyomo/common/tests/test_download.py
@@ -24,6 +24,7 @@ from pyomo.common.fileutils import this_file
 from pyomo.common.download import FileDownloader, distro_available
 from pyomo.common.tee import capture_output
 
+
 class Test_FileDownloader(unittest.TestCase):
     def setUp(self):
         self.tmpdir = None
@@ -50,8 +51,9 @@ class Test_FileDownloader(unittest.TestCase):
         self.assertIsNone(f._fname)
 
         with self.assertRaisesRegex(
-                RuntimeError, "cacert='nonexistent_file_name' does not "
-                "refer to a valid file."):
+            RuntimeError,
+            "cacert='nonexistent_file_name' does not " "refer to a valid file.",
+        ):
             FileDownloader(True, 'nonexistent_file_name')
 
     def test_parse(self):
@@ -83,28 +85,26 @@ class Test_FileDownloader(unittest.TestCase):
         with capture_output() as io:
             with self.assertRaises(SystemExit):
                 f.parse_args(['--cacert'])
-        self.assertIn('argument --cacert: expected one argument',
-                          io.getvalue())
+        self.assertIn('argument --cacert: expected one argument', io.getvalue())
 
         f = FileDownloader()
         with capture_output() as io:
             with self.assertRaises(SystemExit):
                 f.parse_args(['--cacert', '--insecure'])
-        self.assertIn('argument --cacert: expected one argument',
-                          io.getvalue())
+        self.assertIn('argument --cacert: expected one argument', io.getvalue())
 
         f = FileDownloader()
         with self.assertRaisesRegex(
-                RuntimeError, "--cacert='nonexistent_file_name' does "
-                "not refer to a valid file"):
+            RuntimeError,
+            "--cacert='nonexistent_file_name' does " "not refer to a valid file",
+        ):
             f.parse_args(['--cacert', 'nonexistent_file_name'])
 
         f = FileDownloader()
         with capture_output() as io:
             with self.assertRaises(SystemExit):
                 f.parse_args(['--foo'])
-        self.assertIn('error: unrecognized arguments: --foo',
-                          io.getvalue())
+        self.assertIn('error: unrecognized arguments: --foo', io.getvalue())
 
     def test_set_destination_filename(self):
         self.tmpdir = os.path.abspath(tempfile.mkdtemp())
@@ -112,8 +112,7 @@ class Test_FileDownloader(unittest.TestCase):
         f = FileDownloader()
         self.assertIsNone(f._fname)
         f.set_destination_filename('foo')
-        self.assertEqual(f._fname,
-                         os.path.join(envvar.PYOMO_CONFIG_DIR, 'foo'))
+        self.assertEqual(f._fname, os.path.join(envvar.PYOMO_CONFIG_DIR, 'foo'))
         # By this point, the CONFIG_DIR is guaranteed to have been created
         self.assertTrue(os.path.isdir(envvar.PYOMO_CONFIG_DIR))
 
@@ -124,11 +123,11 @@ class Test_FileDownloader(unittest.TestCase):
         self.assertFalse(os.path.exists(target))
 
         f.target = self.tmpdir
-        f.set_destination_filename(os.path.join('foo','bar'))
+        f.set_destination_filename(os.path.join('foo', 'bar'))
         target = os.path.join(self.tmpdir, 'foo', 'bar')
         self.assertEqual(f._fname, target)
         self.assertFalse(os.path.exists(target))
-        target_dir = os.path.join(self.tmpdir, 'foo',)
+        target_dir = os.path.join(self.tmpdir, 'foo')
         self.assertTrue(os.path.isdir(target_dir))
 
     def test_get_sysinfo(self):
@@ -139,13 +138,13 @@ class Test_FileDownloader(unittest.TestCase):
         self.assertTrue(len(ans[0]) > 0)
         self.assertTrue(platform.system().lower().startswith(ans[0]))
         self.assertFalse(any(c in ans[0] for c in '.-_'))
-        self.assertIn(ans[1], (32,64))
+        self.assertIn(ans[1], (32, 64))
 
     def test_get_os_version(self):
         f = FileDownloader()
         _os, _ver = f.get_os_version(normalize=False)
         _norm = f.get_os_version(normalize=True)
-        #print(_os,_ver,_norm)
+        # print(_os,_ver,_norm)
         _sys = f.get_sysinfo()[0]
         if _sys == 'linux':
             dist, dist_ver = re.match('^([^0-9]+)(.*)', _norm).groups()
@@ -158,34 +157,40 @@ class Test_FileDownloader(unittest.TestCase):
 
             if distro_available:
                 d, v = f._get_distver_from_distro()
-                #print(d,v)
+                # print(d,v)
                 self.assertEqual(_os, d)
                 self.assertEqual(_ver, v)
-                self.assertTrue(v.replace('.','').startswith(dist_ver))
+                self.assertTrue(v.replace('.', '').startswith(dist_ver))
 
             if os.path.exists('/etc/redhat-release'):
                 d, v = f._get_distver_from_redhat_release()
-                #print(d,v)
+                # print(d,v)
                 self.assertEqual(_os, d)
                 self.assertEqual(_ver, v)
-                self.assertTrue(v.replace('.','').startswith(dist_ver))
+                self.assertTrue(v.replace('.', '').startswith(dist_ver))
 
-            if subprocess.run(['lsb_release'], stdout=subprocess.DEVNULL,
-                              stderr=subprocess.DEVNULL).returncode == 0:
+            if (
+                subprocess.run(
+                    ['lsb_release'],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                ).returncode
+                == 0
+            ):
                 d, v = f._get_distver_from_lsb_release()
-                #print(d,v)
+                # print(d,v)
                 self.assertEqual(_os, d)
                 self.assertEqual(_ver, v)
-                self.assertTrue(v.replace('.','').startswith(dist_ver))
+                self.assertTrue(v.replace('.', '').startswith(dist_ver))
 
             if os.path.exists('/etc/os-release'):
                 d, v = f._get_distver_from_os_release()
-                #print(d,v)
+                # print(d,v)
                 self.assertEqual(_os, d)
                 # Note that (at least on centos), os_release is an
                 # imprecise version string
                 self.assertTrue(_ver.startswith(v))
-                self.assertTrue(v.replace('.','').startswith(dist_ver))
+                self.assertTrue(v.replace('.', '').startswith(dist_ver))
 
         elif _sys == 'darwin':
             dist, dist_ver = re.match('^([^0-9]+)(.*)', _norm).groups()
@@ -193,47 +198,48 @@ class Test_FileDownloader(unittest.TestCase):
             self.assertEqual(dist, 'macos')
             self.assertNotIn('.', dist_ver)
             self.assertGreater(int(dist_ver), 0)
-            self.assertEqual(_norm, _os+''.join(_ver.split('.')[:2]))
+            self.assertEqual(_norm, _os + ''.join(_ver.split('.')[:2]))
         elif _sys == 'windows':
             self.assertEqual(_os, 'win')
-            self.assertEqual(_norm, _os+''.join(_ver.split('.')[:2]))
+            self.assertEqual(_norm, _os + ''.join(_ver.split('.')[:2]))
         else:
             self.assertEqual(ans, '')
 
         self.assertEqual((_os, _ver), FileDownloader._os_version)
         # Exercise the fetch from CACHE
         try:
-            FileDownloader._os_version, tmp \
-                = ("test", '2'), FileDownloader._os_version
-            self.assertEqual(f.get_os_version(False), ("test","2"))
+            FileDownloader._os_version, tmp = ("test", '2'), FileDownloader._os_version
+            self.assertEqual(f.get_os_version(False), ("test", "2"))
             self.assertEqual(f.get_os_version(), "test2")
         finally:
             FileDownloader._os_version = tmp
-
 
     def test_get_platform_url(self):
         f = FileDownloader()
         urlmap = {'bogus_sys': 'bogus'}
         with self.assertRaisesRegex(
-                RuntimeError, "cannot infer the correct url for platform '.*'"):
+            RuntimeError, "cannot infer the correct url for platform '.*'"
+        ):
             f.get_platform_url(urlmap)
 
         urlmap[f.get_sysinfo()[0]] = 'correct'
         self.assertEqual(f.get_platform_url(urlmap), 'correct')
 
-
     def test_get_files_requires_set_destination(self):
         f = FileDownloader()
         with self.assertRaisesRegex(
-                DeveloperError, 'target file name has not been initialized'):
+            DeveloperError, 'target file name has not been initialized'
+        ):
             f.get_binary_file('bogus')
 
         with self.assertRaisesRegex(
-                DeveloperError, 'target file name has not been initialized'):
+            DeveloperError, 'target file name has not been initialized'
+        ):
             f.get_binary_file_from_zip_archive('bogus', 'bogus')
 
         with self.assertRaisesRegex(
-                DeveloperError, 'target file name has not been initialized'):
+            DeveloperError, 'target file name has not been initialized'
+        ):
             f.get_gzipped_binary_file('bogus')
 
     def test_get_test_binary_file(self):

--- a/pyomo/common/tests/test_env.py
+++ b/pyomo/common/tests/test_env.py
@@ -14,8 +14,8 @@ import pyomo.common.unittest as unittest
 
 from pyomo.common.env import CtypesEnviron
 
+
 class TestCtypesEnviron(unittest.TestCase):
-    
     def test_temp_env_str(self):
         orig_env = CtypesEnviron()
         orig_env_has_1 = 'TEST_ENV_1' in orig_env
@@ -31,23 +31,17 @@ class TestCtypesEnviron(unittest.TestCase):
         for interface in orig_env.interfaces:
             self.assertIsNone(interface.dll.wgetenv(u'TEST_ENV_1'))
             self.assertIsNone(interface.dll.getenv(b'TEST_ENV_1'))
-            self.assertEqual(
-                interface.dll.wgetenv(u'TEST_ENV_2'), u"test value: 2")
-            self.assertEqual(
-                interface.dll.getenv(b'TEST_ENV_2'), b"test value: 2")
-            
+            self.assertEqual(interface.dll.wgetenv(u'TEST_ENV_2'), u"test value: 2")
+            self.assertEqual(interface.dll.getenv(b'TEST_ENV_2'), b"test value: 2")
+
         with CtypesEnviron(TEST_ENV_1="test value: 1") as env:
             self.assertEqual(os.environ['TEST_ENV_1'], "test value: 1")
             self.assertEqual(os.environ['TEST_ENV_2'], "test value: 2")
             for interface in env.interfaces:
-                self.assertEqual(
-                    interface.dll.wgetenv(u'TEST_ENV_1'), u"test value: 1")
-                self.assertEqual(
-                    interface.dll.getenv(b'TEST_ENV_1'), b"test value: 1")
-                self.assertEqual(
-                    interface.dll.wgetenv(u'TEST_ENV_2'), u"test value: 2")
-                self.assertEqual(
-                    interface.dll.getenv(b'TEST_ENV_2'), b"test value: 2")
+                self.assertEqual(interface.dll.wgetenv(u'TEST_ENV_1'), u"test value: 1")
+                self.assertEqual(interface.dll.getenv(b'TEST_ENV_1'), b"test value: 1")
+                self.assertEqual(interface.dll.wgetenv(u'TEST_ENV_2'), u"test value: 2")
+                self.assertEqual(interface.dll.getenv(b'TEST_ENV_2'), b"test value: 2")
 
             del env['TEST_ENV_2']
             self.assertIsNone(os.environ.get('TEST_ENV_2', None))
@@ -60,15 +54,12 @@ class TestCtypesEnviron(unittest.TestCase):
         for interface in orig_env.interfaces:
             self.assertIsNone(interface.dll.wgetenv(u'TEST_ENV_1'))
             self.assertIsNone(interface.dll.getenv(b'TEST_ENV_1'))
-            self.assertEqual(
-                interface.dll.wgetenv(u'TEST_ENV_2'), u"test value: 2")
-            self.assertEqual(
-                interface.dll.getenv(b'TEST_ENV_2'), b"test value: 2")
+            self.assertEqual(interface.dll.wgetenv(u'TEST_ENV_2'), u"test value: 2")
+            self.assertEqual(interface.dll.getenv(b'TEST_ENV_2'), b"test value: 2")
 
         orig_env.restore()
         self.assertEqual(orig_env_has_1, 'TEST_ENV_1' in os.environ)
         self.assertEqual(orig_env_has_2, 'TEST_ENV_2' in os.environ)
-
 
     def test_temp_env_unicode(self):
         orig_env = CtypesEnviron()
@@ -85,23 +76,17 @@ class TestCtypesEnviron(unittest.TestCase):
         for interface in orig_env.interfaces:
             self.assertIsNone(interface.dll.wgetenv(u'TEST_ENV_1'))
             self.assertIsNone(interface.dll.getenv(b'TEST_ENV_1'))
-            self.assertEqual(
-                interface.dll.wgetenv(u'TEST_ENV_2'), u"test value: 2")
-            self.assertEqual(
-                interface.dll.getenv(b'TEST_ENV_2'), b"test value: 2")
-            
+            self.assertEqual(interface.dll.wgetenv(u'TEST_ENV_2'), u"test value: 2")
+            self.assertEqual(interface.dll.getenv(b'TEST_ENV_2'), b"test value: 2")
+
         with CtypesEnviron(TEST_ENV_1=u"test value: 1") as env:
             self.assertEqual(os.environ[u'TEST_ENV_1'], u"test value: 1")
             self.assertEqual(os.environ[u'TEST_ENV_2'], u"test value: 2")
             for interface in env.interfaces:
-                self.assertEqual(
-                    interface.dll.wgetenv(u'TEST_ENV_1'), u"test value: 1")
-                self.assertEqual(
-                    interface.dll.getenv(b'TEST_ENV_1'), b"test value: 1")
-                self.assertEqual(
-                    interface.dll.wgetenv(u'TEST_ENV_2'), u"test value: 2")
-                self.assertEqual(
-                    interface.dll.getenv(b'TEST_ENV_2'), b"test value: 2")
+                self.assertEqual(interface.dll.wgetenv(u'TEST_ENV_1'), u"test value: 1")
+                self.assertEqual(interface.dll.getenv(b'TEST_ENV_1'), b"test value: 1")
+                self.assertEqual(interface.dll.wgetenv(u'TEST_ENV_2'), u"test value: 2")
+                self.assertEqual(interface.dll.getenv(b'TEST_ENV_2'), b"test value: 2")
 
             del env[u'TEST_ENV_2']
             self.assertIsNone(os.environ.get(u'TEST_ENV_2', None))
@@ -114,10 +99,8 @@ class TestCtypesEnviron(unittest.TestCase):
         for interface in orig_env.interfaces:
             self.assertIsNone(interface.dll.wgetenv(u'TEST_ENV_1'))
             self.assertIsNone(interface.dll.getenv(b'TEST_ENV_1'))
-            self.assertEqual(
-                interface.dll.wgetenv(u'TEST_ENV_2'), u"test value: 2")
-            self.assertEqual(
-                interface.dll.getenv(b'TEST_ENV_2'), b"test value: 2")
+            self.assertEqual(interface.dll.wgetenv(u'TEST_ENV_2'), u"test value: 2")
+            self.assertEqual(interface.dll.getenv(b'TEST_ENV_2'), b"test value: 2")
 
         orig_env.restore()
         self.assertEqual(orig_env_has_1, u'TEST_ENV_1' in os.environ)

--- a/pyomo/common/tests/test_formatting.py
+++ b/pyomo/common/tests/test_formatting.py
@@ -16,10 +16,23 @@ import pyomo.common.unittest as unittest
 
 from pyomo.common.formatting import tostr, tabular_writer, StreamIndenter
 
-class DerivedList(list): pass
-class DerivedTuple(tuple): pass
-class DerivedDict(dict): pass
-class DerivedStr(str): pass
+
+class DerivedList(list):
+    pass
+
+
+class DerivedTuple(tuple):
+    pass
+
+
+class DerivedDict(dict):
+    pass
+
+
+class DerivedStr(str):
+    pass
+
+
 NamedTuple = namedtuple('NamedTuple', ['x', 'y'])
 
 
@@ -37,7 +50,7 @@ class TestToStr(unittest.TestCase):
         self.assertIs(tostr.handlers[DerivedStr], tostr.handlers[str])
 
     def test_new_type_list(self):
-        self.assertEqual(tostr(DerivedList([1,2])), '[1, 2]')
+        self.assertEqual(tostr(DerivedList([1, 2])), '[1, 2]')
         self.assertIs(tostr.handlers[DerivedList], tostr.handlers[list])
 
     def test_new_type_dict(self):
@@ -45,7 +58,7 @@ class TestToStr(unittest.TestCase):
         self.assertIs(tostr.handlers[DerivedDict], tostr.handlers[dict])
 
     def test_new_type_tuple(self):
-        self.assertEqual(tostr(DerivedTuple([1,2])), '(1, 2)')
+        self.assertEqual(tostr(DerivedTuple([1, 2])), '(1, 2)')
         self.assertIs(tostr.handlers[DerivedTuple], tostr.handlers[tuple])
 
     def test_new_type_namedtuple(self):
@@ -100,9 +113,11 @@ Key : s : val
     def test_multiline_generator(self):
         os = StringIO()
         data = {'a': 0, 'b': 1, 'c': 3}
+
         def _data_gen(i, j):
             for n in range(j):
-                yield (n, chr(ord('a')+n)*j)
+                yield (n, chr(ord('a') + n) * j)
+
         tabular_writer(os, "", data.items(), ['i', 'j'], _data_gen)
         ref = u"""
 Key : i    : j
@@ -117,11 +132,13 @@ Key : i    : j
     def test_multiline_generator_exception(self):
         os = StringIO()
         data = {'a': 0, 'b': 1, 'c': 3}
+
         def _data_gen(i, j):
             if i == 'b':
                 raise ValueError("invalid")
             for n in range(j):
-                yield (n, chr(ord('a')+n)*j)
+                yield (n, chr(ord('a') + n) * j)
+
         tabular_writer(os, "", data.items(), ['i', 'j'], _data_gen)
         ref = u"""
 Key : i    : j
@@ -136,10 +153,12 @@ Key : i    : j
     def test_data_exception(self):
         os = StringIO()
         data = {'a': 0, 'b': 1, 'c': 3}
+
         def _data_gen(i, j):
             if i == 'b':
                 raise ValueError("invalid")
-            return (j, i*(j+1))
+            return (j, i * (j + 1))
+
         tabular_writer(os, "", data.items(), ['i', 'j'], _data_gen)
         ref = u"""
 Key : i    : j
@@ -152,14 +171,16 @@ Key : i    : j
     def test_multiline_alignment(self):
         os = StringIO()
         data = {'a': 1, 'b': 2, 'c': 3}
+
         def _data_gen(i, j):
             for n in range(j):
-                _str = chr(ord('a')+n)*(j+1)
+                _str = chr(ord('a') + n) * (j + 1)
                 if n % 2:
                     _str = list(_str)
                     _str[1] = ' '
                     _str = ''.join(_str)
                 yield (n, _str)
+
         tabular_writer(os, "", data.items(), ['i', 'j'], _data_gen)
         ref = u"""
 Key : i : j
@@ -178,8 +199,7 @@ class TestStreamIndenter(unittest.TestCase):
         OUT1 = StringIO()
         OUT2 = StreamIndenter(OUT1)
         OUT2.write('Hello?\nHello, world!')
-        self.assertEqual('    Hello?\n    Hello, world!',
-                         OUT2.getvalue())
+        self.assertEqual('    Hello?\n    Hello, world!', OUT2.getvalue())
 
     def test_prefix(self):
         prefix = 'foo:'
@@ -192,12 +212,10 @@ class TestStreamIndenter(unittest.TestCase):
         OUT1 = StringIO()
         OUT2 = StreamIndenter(OUT1)
         OUT2.write('Hello?\n\nText\n\nHello, world!')
-        self.assertEqual('    Hello?\n\n    Text\n\n    Hello, world!',
-                         OUT2.getvalue())
+        self.assertEqual('    Hello?\n\n    Text\n\n    Hello, world!', OUT2.getvalue())
 
     def test_writelines(self):
         OUT1 = StringIO()
         OUT2 = StreamIndenter(OUT1)
         OUT2.writelines(['Hello?\n', '\n', 'Text\n', '\n', 'Hello, world!'])
-        self.assertEqual('    Hello?\n\n    Text\n\n    Hello, world!',
-                         OUT2.getvalue())
+        self.assertEqual('    Hello?\n\n    Text\n\n    Hello, world!', OUT2.getvalue())

--- a/pyomo/common/tests/test_gc.py
+++ b/pyomo/common/tests/test_gc.py
@@ -52,7 +52,7 @@ class TestPauseGC(unittest.TestCase):
         with pgc:
             with self.assertRaisesRegex(
                 RuntimeError,
-                "Entering PauseGC context manager that " "was already entered",
+                "Entering PauseGC context manager that was already entered",
             ):
                 with pgc:
                     pass

--- a/pyomo/common/tests/test_gc.py
+++ b/pyomo/common/tests/test_gc.py
@@ -14,6 +14,7 @@ import gc
 
 import pyomo.common.unittest as unittest
 
+
 class TestPauseGC(unittest.TestCase):
     def test_gc_disable(self):
         self.assertTrue(gc.isenabled())
@@ -50,8 +51,9 @@ class TestPauseGC(unittest.TestCase):
 
         with pgc:
             with self.assertRaisesRegex(
-                    RuntimeError, "Entering PauseGC context manager that "
-                    "was already entered"):
+                RuntimeError,
+                "Entering PauseGC context manager that " "was already entered",
+            ):
                 with pgc:
                     pass
             self.assertFalse(gc.isenabled())
@@ -62,11 +64,12 @@ class TestPauseGC(unittest.TestCase):
             with PauseGC():
                 self.assertFalse(gc.isenabled())
                 with self.assertRaisesRegex(
-                        RuntimeError,
-                        "Exiting PauseGC context manager out of order: there "
-                        "are other active PauseGC context managers that were "
-                        "entered after this context manager and have not yet "
-                        "been exited."):
+                    RuntimeError,
+                    "Exiting PauseGC context manager out of order: there "
+                    "are other active PauseGC context managers that were "
+                    "entered after this context manager and have not yet "
+                    "been exited.",
+                ):
                     pgc.close()
             self.assertFalse(gc.isenabled())
         self.assertTrue(gc.isenabled())

--- a/pyomo/common/tests/test_log.py
+++ b/pyomo/common/tests/test_log.py
@@ -25,12 +25,17 @@ from io import StringIO
 import pyomo.common.unittest as unittest
 
 from pyomo.common.log import (
-    LoggingIntercept, WrappingFormatter, LegacyPyomoFormatter, LogHandler,
-    LogStream, pyomo_formatter
+    LoggingIntercept,
+    WrappingFormatter,
+    LegacyPyomoFormatter,
+    LogHandler,
+    LogStream,
+    pyomo_formatter,
 )
 
 logger = logging.getLogger('pyomo.common.log.testing')
 filename = getframeinfo(currentframe()).filename
+
 
 class TestLegacyLogHandler(unittest.TestCase):
     def setUp(self):
@@ -45,8 +50,8 @@ class TestLegacyLogHandler(unittest.TestCase):
         with LoggingIntercept(log):
             self.handler = LogHandler(
                 os.path.dirname(__file__),
-                stream = self.stream,
-                verbosity=lambda: logger.isEnabledFor(logging.DEBUG)
+                stream=self.stream,
+                verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
             )
         self.assertIn('LogHandler class has been deprecated', log.getvalue())
         logger.addHandler(self.handler)
@@ -61,26 +66,27 @@ class TestLegacyLogHandler(unittest.TestCase):
         logger.setLevel(logging.DEBUG)
         logger.warning("(warn)")
         lineno = getframeinfo(currentframe()).lineno - 1
-        ans += 'WARNING: "[base]%stest_log.py", %d, test_simple_log\n' \
-               '    (warn)\n' % (os.path.sep, lineno,)
+        ans += (
+            'WARNING: "[base]%stest_log.py", %d, test_simple_log\n'
+            '    (warn)\n' % (os.path.sep, lineno)
+        )
         self.assertEqual(self.stream.getvalue(), ans)
 
     def test_default_verbosity(self):
         # Testing positional base, configurable verbosity
         log = StringIO()
         with LoggingIntercept(log):
-            self.handler = LogHandler(
-                os.path.dirname(__file__),
-                stream = self.stream,
-            )
+            self.handler = LogHandler(os.path.dirname(__file__), stream=self.stream)
         self.assertIn('LogHandler class has been deprecated', log.getvalue())
         logger.addHandler(self.handler)
 
         logger.setLevel(logging.WARNING)
         logger.warning("(warn)")
         lineno = getframeinfo(currentframe()).lineno - 1
-        ans = 'WARNING: "[base]%stest_log.py", %d, test_default_verbosity\n' \
-               '    (warn)\n' % (os.path.sep, lineno,)
+        ans = (
+            'WARNING: "[base]%stest_log.py", %d, test_default_verbosity\n'
+            '    (warn)\n' % (os.path.sep, lineno)
+        )
         self.assertEqual(self.stream.getvalue(), ans)
 
 
@@ -114,6 +120,7 @@ class TestWrappingFormatter(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'unrecognized style flag "s"'):
             WrappingFormatter(style='s')
 
+
 class TestLegacyPyomoFormatter(unittest.TestCase):
     def setUp(self):
         self.stream = StringIO()
@@ -124,20 +131,20 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
         logger.removeHandler(self.handler)
 
     def test_unallowed_options(self):
-        with self.assertRaisesRegex(
-                ValueError, "'fmt' is not a valid option"):
+        with self.assertRaisesRegex(ValueError, "'fmt' is not a valid option"):
             LegacyPyomoFormatter(fmt='%(message)')
 
-        with self.assertRaisesRegex(
-                ValueError, "'style' is not a valid option"):
+        with self.assertRaisesRegex(ValueError, "'style' is not a valid option"):
             LegacyPyomoFormatter(style='%')
 
     def test_simple_log(self):
         # Testing positional base, configurable verbosity
-        self.handler.setFormatter(LegacyPyomoFormatter(
-            base=os.path.dirname(__file__),
-            verbosity=lambda: logger.isEnabledFor(logging.DEBUG)
-        ))
+        self.handler.setFormatter(
+            LegacyPyomoFormatter(
+                base=os.path.dirname(__file__),
+                verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
+            )
+        )
 
         logger.setLevel(logging.WARNING)
         logger.info("(info)")
@@ -149,22 +156,24 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
         logger.setLevel(logging.DEBUG)
         logger.warning("(warn)")
         lineno = getframeinfo(currentframe()).lineno - 1
-        ans += 'WARNING: "[base]%stest_log.py", %d, test_simple_log\n' \
-               '    (warn)\n' % (os.path.sep, lineno,)
+        ans += (
+            'WARNING: "[base]%stest_log.py", %d, test_simple_log\n'
+            '    (warn)\n' % (os.path.sep, lineno)
+        )
         self.assertEqual(self.stream.getvalue(), ans)
 
     def test_alternate_base(self):
-        self.handler.setFormatter(LegacyPyomoFormatter(
-            base = 'log_config',
-        ))
+        self.handler.setFormatter(LegacyPyomoFormatter(base='log_config'))
 
         logger.setLevel(logging.WARNING)
         logger.info("(info)")
         self.assertEqual(self.stream.getvalue(), "")
         logger.warning("(warn)")
         lineno = getframeinfo(currentframe()).lineno - 1
-        ans = 'WARNING: "%s", %d, test_alternate_base\n' \
-               '    (warn)\n' % (filename, lineno,)
+        ans = 'WARNING: "%s", %d, test_alternate_base\n    (warn)\n' % (
+            filename,
+            lineno,
+        )
         self.assertEqual(self.stream.getvalue(), ans)
 
     def test_no_base(self):
@@ -175,15 +184,16 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
         self.assertEqual(self.stream.getvalue(), "")
         logger.warning("(warn)")
         lineno = getframeinfo(currentframe()).lineno - 1
-        ans = 'WARNING: "%s", %d, test_no_base\n' \
-               '    (warn)\n' % (filename, lineno,)
+        ans = 'WARNING: "%s", %d, test_no_base\n    (warn)\n' % (filename, lineno)
         self.assertEqual(self.stream.getvalue(), ans)
 
     def test_no_message(self):
-        self.handler.setFormatter(LegacyPyomoFormatter(
-            base=os.path.dirname(__file__),
-            verbosity=lambda: logger.isEnabledFor(logging.DEBUG)
-        ))
+        self.handler.setFormatter(
+            LegacyPyomoFormatter(
+                base=os.path.dirname(__file__),
+                verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
+            )
+        )
 
         logger.setLevel(logging.WARNING)
         logger.info("")
@@ -196,15 +206,19 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
         logger.setLevel(logging.DEBUG)
         logger.warning("")
         lineno = getframeinfo(currentframe()).lineno - 1
-        ans += 'WARNING: "[base]%stest_log.py", %d, test_no_message\n\n' \
-               % (os.path.sep, lineno,)
+        ans += 'WARNING: "[base]%stest_log.py", %d, test_no_message\n\n' % (
+            os.path.sep,
+            lineno,
+        )
         self.assertEqual(self.stream.getvalue(), ans)
 
     def test_blank_lines(self):
-        self.handler.setFormatter(LegacyPyomoFormatter(
-            base=os.path.dirname(__file__),
-            verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
-        ))
+        self.handler.setFormatter(
+            LegacyPyomoFormatter(
+                base=os.path.dirname(__file__),
+                verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
+            )
+        )
 
         logger.setLevel(logging.WARNING)
         logger.warning("\n\nthis is a message.\n\n\n")
@@ -214,16 +228,20 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
         logger.setLevel(logging.DEBUG)
         logger.warning("\n\nthis is a message.\n\n\n")
         lineno = getframeinfo(currentframe()).lineno - 1
-        ans += 'WARNING: "[base]%stest_log.py", %d, test_blank_lines\n' \
-               "    this is a message.\n" % (os.path.sep, lineno)
+        ans += (
+            'WARNING: "[base]%stest_log.py", %d, test_blank_lines\n'
+            "    this is a message.\n" % (os.path.sep, lineno)
+        )
         self.assertEqual(self.stream.getvalue(), ans)
 
     def test_numbered_level(self):
-        testname ='test_numbered_level'
-        self.handler.setFormatter(LegacyPyomoFormatter(
-            base=os.path.dirname(__file__),
-            verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
-        ))
+        testname = 'test_numbered_level'
+        self.handler.setFormatter(
+            LegacyPyomoFormatter(
+                base=os.path.dirname(__file__),
+                verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
+            )
+        )
 
         logger.setLevel(logging.WARNING)
         logger.log(45, "(hi)")
@@ -237,96 +255,120 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
         logger.setLevel(logging.DEBUG)
         logger.log(45, "(hi)")
         lineno = getframeinfo(currentframe()).lineno - 1
-        ans += 'Level 45: "[base]%stest_log.py", %d, %s\n' \
-               '    (hi)\n' % (os.path.sep, lineno, testname)
+        ans += 'Level 45: "[base]%stest_log.py", %d, %s\n    (hi)\n' % (
+            os.path.sep,
+            lineno,
+            testname,
+        )
         self.assertEqual(self.stream.getvalue(), ans)
 
         logger.log(45, "")
         lineno = getframeinfo(currentframe()).lineno - 1
-        ans += 'Level 45: "[base]%stest_log.py", %d, %s\n\n' \
-               % (os.path.sep, lineno, testname)
+        ans += 'Level 45: "[base]%stest_log.py", %d, %s\n\n' % (
+            os.path.sep,
+            lineno,
+            testname,
+        )
         self.assertEqual(self.stream.getvalue(), ans)
 
     def test_long_messages(self):
-        self.handler.setFormatter(LegacyPyomoFormatter(
-            base=os.path.dirname(__file__),
-            verbosity=lambda: logger.isEnabledFor(logging.DEBUG)
-        ))
+        self.handler.setFormatter(
+            LegacyPyomoFormatter(
+                base=os.path.dirname(__file__),
+                verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
+            )
+        )
 
-        msg = ("This is a long message\n"
-               "\n"
-               "With some kind of internal formatting\n"
-               "    - including a bulleted list\n"
-               "    - list 2  ")
+        msg = (
+            "This is a long message\n"
+            "\n"
+            "With some kind of internal formatting\n"
+            "    - including a bulleted list\n"
+            "    - list 2  "
+        )
         logger.setLevel(logging.WARNING)
         logger.warning(msg)
-        ans = ( "WARNING: This is a long message\n"
-                "\n"
-                "    With some kind of internal formatting\n"
-                "        - including a bulleted list\n"
-                "        - list 2\n" )
+        ans = (
+            "WARNING: This is a long message\n"
+            "\n"
+            "    With some kind of internal formatting\n"
+            "        - including a bulleted list\n"
+            "        - list 2\n"
+        )
         self.assertEqual(self.stream.getvalue(), ans)
 
         logger.setLevel(logging.DEBUG)
         logger.info(msg)
         lineno = getframeinfo(currentframe()).lineno - 1
-        ans += ( 'INFO: "[base]%stest_log.py", %d, test_long_messages\n'
-                 "    This is a long message\n"
-                 "\n"
-                 "    With some kind of internal formatting\n"
-                 "        - including a bulleted list\n"
-                 "        - list 2\n" % (os.path.sep, lineno,))
+        ans += (
+            'INFO: "[base]%stest_log.py", %d, test_long_messages\n'
+            "    This is a long message\n"
+            "\n"
+            "    With some kind of internal formatting\n"
+            "        - including a bulleted list\n"
+            "        - list 2\n" % (os.path.sep, lineno)
+        )
         self.assertEqual(self.stream.getvalue(), ans)
 
         # test trailing newline
         msg += "\n"
         logger.setLevel(logging.WARNING)
         logger.warning(msg)
-        ans += ( "WARNING: This is a long message\n"
-                 "\n"
-                 "    With some kind of internal formatting\n"
-                 "        - including a bulleted list\n"
-                 "        - list 2\n" )
+        ans += (
+            "WARNING: This is a long message\n"
+            "\n"
+            "    With some kind of internal formatting\n"
+            "        - including a bulleted list\n"
+            "        - list 2\n"
+        )
         self.assertEqual(self.stream.getvalue(), ans)
 
         logger.setLevel(logging.DEBUG)
         logger.info(msg)
         lineno = getframeinfo(currentframe()).lineno - 1
-        ans += ( 'INFO: "[base]%stest_log.py", %d, test_long_messages\n'
-                 "    This is a long message\n"
-                 "\n"
-                 "    With some kind of internal formatting\n"
-                 "        - including a bulleted list\n"
-                 "        - list 2\n" % (os.path.sep, lineno,))
+        ans += (
+            'INFO: "[base]%stest_log.py", %d, test_long_messages\n'
+            "    This is a long message\n"
+            "\n"
+            "    With some kind of internal formatting\n"
+            "        - including a bulleted list\n"
+            "        - list 2\n" % (os.path.sep, lineno)
+        )
         self.assertEqual(self.stream.getvalue(), ans)
 
         # test initial and final blank lines
         msg = "\n" + msg + "\n\n"
         logger.setLevel(logging.WARNING)
         logger.warning(msg)
-        ans += ( "WARNING: This is a long message\n"
-                 "\n"
-                "    With some kind of internal formatting\n"
-                "        - including a bulleted list\n"
-                "        - list 2\n" )
+        ans += (
+            "WARNING: This is a long message\n"
+            "\n"
+            "    With some kind of internal formatting\n"
+            "        - including a bulleted list\n"
+            "        - list 2\n"
+        )
         self.assertEqual(self.stream.getvalue(), ans)
 
         logger.setLevel(logging.DEBUG)
         logger.info(msg)
         lineno = getframeinfo(currentframe()).lineno - 1
-        ans += ( 'INFO: "[base]%stest_log.py", %d, test_long_messages\n'
-                 "    This is a long message\n"
-                 "\n"
-                 "    With some kind of internal formatting\n"
-                 "        - including a bulleted list\n"
-                 "        - list 2\n" % (os.path.sep, lineno,))
+        ans += (
+            'INFO: "[base]%stest_log.py", %d, test_long_messages\n'
+            "    This is a long message\n"
+            "\n"
+            "    With some kind of internal formatting\n"
+            "        - including a bulleted list\n"
+            "        - list 2\n" % (os.path.sep, lineno)
+        )
         self.assertEqual(self.stream.getvalue(), ans)
 
     def test_verbatim(self):
-        self.handler.setFormatter(LegacyPyomoFormatter(
-            base=os.path.dirname(__file__),
-            verbosity=lambda: logger.isEnabledFor(logging.DEBUG)
-        ))
+        self.handler.setFormatter(
+            LegacyPyomoFormatter(
+                base=os.path.dirname(__file__),
+                verbosity=lambda: logger.isEnabledFor(logging.DEBUG),
+            )
+        )
 
         msg = (
             "This is a long message\n"
@@ -423,6 +465,7 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(self.stream.getvalue(), ans)
 
+
 class TestLogStream(unittest.TestCase):
     def test_log_stream(self):
         ls = LogStream(logging.INFO, logging.getLogger('pyomo'))
@@ -433,22 +476,18 @@ class TestLogStream(unittest.TestCase):
 
         with LI as OUT:
             ls.write("line 1\nline 2\n")
-            self.assertEqual(
-                OUT.getvalue(), "INFO: line 1\nINFO: line 2\n")
+            self.assertEqual(OUT.getvalue(), "INFO: line 1\nINFO: line 2\n")
 
         with LI as OUT:
             ls.write("line 1\nline 2")
-            self.assertEqual(
-                OUT.getvalue(), "INFO: line 1\n")
+            self.assertEqual(OUT.getvalue(), "INFO: line 1\n")
 
         with LI as OUT:
             ls.flush()
-            self.assertEqual(
-                OUT.getvalue(), "INFO: line 2\n")
+            self.assertEqual(OUT.getvalue(), "INFO: line 2\n")
             # Second flush should do nothing
             ls.flush()
-            self.assertEqual(
-                OUT.getvalue(), "INFO: line 2\n")
+            self.assertEqual(OUT.getvalue(), "INFO: line 2\n")
 
         with LI as OUT:
             with LogStream(logging.INFO, logging.getLogger('pyomo')) as ls:

--- a/pyomo/common/tests/test_modeling.py
+++ b/pyomo/common/tests/test_modeling.py
@@ -16,6 +16,7 @@ import pyomo.common.unittest as unittest
 from pyomo.environ import ConcreteModel, Var
 from pyomo.common.modeling import unique_component_name, NOTSET
 
+
 class TestModeling(unittest.TestCase):
     def test_unique_component_name(self):
         m = ConcreteModel()

--- a/pyomo/common/tests/test_multithread.py
+++ b/pyomo/common/tests/test_multithread.py
@@ -4,8 +4,10 @@ from pyomo.common.multithread import *
 from threading import Thread
 from pyomo.opt.base.solvers import check_available_solvers
 
-class Dummy():
+
+class Dummy:
     """asdfg"""
+
     def __init__(self):
         self.number = 1
         self.rnd = threading.get_ident()
@@ -15,7 +17,6 @@ class Dummy():
 
 
 class TestMultithreading(unittest.TestCase):
-
     def test_wrapper_docs(self):
         sut = MultiThreadWrapper(Dummy)
         self.assertEqual(sut.__class__.__doc__, Dummy.__doc__)
@@ -27,16 +28,20 @@ class TestMultithreading(unittest.TestCase):
     def test_independent_writes(self):
         sut = MultiThreadWrapper(Dummy)
         sut.number = 2
+
         def thread_func():
             self.assertEqual(sut.number, 1)
+
         t = Thread(target=thread_func)
         t.start()
         t.join()
 
     def test_independent_writes2(self):
         sut = MultiThreadWrapper(Dummy)
+
         def thread_func():
             sut.number = 2
+
         t = Thread(target=thread_func)
         t.start()
         t.join()
@@ -45,16 +50,20 @@ class TestMultithreading(unittest.TestCase):
     def test_independent_del(self):
         sut = MultiThreadWrapper(Dummy)
         del sut.number
+
         def thread_func():
             self.assertEqual(sut.number, 1)
+
         t = Thread(target=thread_func)
         t.start()
         t.join()
 
     def test_independent_del2(self):
         sut = MultiThreadWrapper(Dummy)
+
         def thread_func():
             del sut.number
+
         t = Thread(target=thread_func)
         t.start()
         t.join()
@@ -69,16 +78,20 @@ class TestMultithreading(unittest.TestCase):
         sut = MultiThreadWrapperWithMain(Dummy)
         self.assertIs(sut.main_thread.rnd, sut.rnd)
         sut.number = 5
+
         def thread_func():
             self.assertEqual(sut.number, 1)
             self.assertIsNot(sut.main_thread.rnd, sut.rnd)
             del sut.number
+
         t = Thread(target=thread_func)
         t.start()
         t.join()
         self.assertEqual(sut.number, 5)
-    
-    @unittest.skipIf(len(check_available_solvers('glpk')) < 1, "glpk solver not available")
+
+    @unittest.skipIf(
+        len(check_available_solvers('glpk')) < 1, "glpk solver not available"
+    )
     def test_solve(self):
         # Based on the minimal example in https://github.com/Pyomo/pyomo/issues/2475
         import pyomo.environ as pyo
@@ -94,7 +107,7 @@ class TestMultithreading(unittest.TestCase):
 
         def test(model):
             opt = SolverFactory('glpk')
-            opt.solve(model) 
+            opt.solve(model)
 
             # Iterate, adding a cut to exclude the previously found solution
             for _ in range(5):
@@ -103,8 +116,8 @@ class TestMultithreading(unittest.TestCase):
                     if pyo.value(model.x[j]) < 0.5:
                         expr += model.x[j]
                     else:
-                        expr += (1 - model.x[j])
-                model.cuts.add( expr >= 1 )
+                        expr += 1 - model.x[j]
+                model.cuts.add(expr >= 1)
                 results = opt.solve(model)
             return results, [v for v in model.x]
 
@@ -112,7 +125,9 @@ class TestMultithreading(unittest.TestCase):
         results = tp.map(test, [model.clone() for i in range(4)])
         tp.close()
         for result, _ in results:
-            self.assertEqual(result.solver.termination_condition, pyo.TerminationCondition.optimal)
+            self.assertEqual(
+                result.solver.termination_condition, pyo.TerminationCondition.optimal
+            )
         results = list(results)
         for _, values in results[1:]:
             self.assertEqual(values, results[0][1])

--- a/pyomo/common/tests/test_orderedset.py
+++ b/pyomo/common/tests/test_orderedset.py
@@ -14,6 +14,7 @@ import pyomo.common.unittest as unittest
 
 from pyomo.common.collections import OrderedSet
 
+
 class testOrderedSet(unittest.TestCase):
     def test_constructor(self):
         a = OrderedSet()
@@ -21,7 +22,7 @@ class testOrderedSet(unittest.TestCase):
         self.assertEqual(list(a), [])
         self.assertEqual(str(a), 'OrderedSet()')
 
-        ref = [1,9,'a',4,2,None]
+        ref = [1, 9, 'a', 4, 2, None]
         a = OrderedSet(ref)
         self.assertEqual(len(a), 6)
         self.assertEqual(list(a), ref)
@@ -41,29 +42,29 @@ class testOrderedSet(unittest.TestCase):
         self.assertIn(None, a)
 
         a.add(0)
-        self.assertEqual(list(a), [None,1,0])
+        self.assertEqual(list(a), [None, 1, 0])
 
         # Adding a member alrady in the set does not change the ordering
         a.add(1)
-        self.assertEqual(list(a), [None,1,0])
+        self.assertEqual(list(a), [None, 1, 0])
 
     def test_discard_remove_clear(self):
-        a = OrderedSet([1,3,2,4])
+        a = OrderedSet([1, 3, 2, 4])
         a.discard(3)
-        self.assertEqual(list(a), [1,2,4])
+        self.assertEqual(list(a), [1, 2, 4])
         a.discard(3)
-        self.assertEqual(list(a), [1,2,4])
+        self.assertEqual(list(a), [1, 2, 4])
 
         a.remove(2)
-        self.assertEqual(list(a), [1,4])
-        with self.assertRaisesRegex(KeyError,'2'):
+        self.assertEqual(list(a), [1, 4])
+        with self.assertRaisesRegex(KeyError, '2'):
             a.remove(2)
-        
+
         a.clear()
         self.assertEqual(list(a), [])
 
     def test_pickle(self):
-        ref = [1,9,'a',4,2,None]
+        ref = [1, 9, 'a', 4, 2, None]
         a = OrderedSet(ref)
         b = pickle.loads(pickle.dumps(a))
         self.assertEqual(a, b)
@@ -87,6 +88,6 @@ class testOrderedSet(unittest.TestCase):
         self.assertEqual(list(b), [3, 4, 'c', 'd'])
 
     def test_reversed(self):
-        a = OrderedSet([1,5,3])
+        a = OrderedSet([1, 5, 3])
         self.assertEqual(list(a), [1, 5, 3])
         self.assertEqual(list(reversed(a)), [3, 5, 1])

--- a/pyomo/common/tests/test_plugin.py
+++ b/pyomo/common/tests/test_plugin.py
@@ -15,13 +15,21 @@ import weakref
 from pyomo.common.unittest import TestCase
 from pyomo.common.log import LoggingIntercept
 from pyomo.common.plugin_base import (
-    Interface, Plugin, SingletonPlugin, ExtensionPoint, implements, alias,
-    PluginFactory, PluginError, PluginGlobals, DeprecatedInterface
+    Interface,
+    Plugin,
+    SingletonPlugin,
+    ExtensionPoint,
+    implements,
+    alias,
+    PluginFactory,
+    PluginError,
+    PluginGlobals,
+    DeprecatedInterface,
 )
+
 
 class TestPlugin(TestCase):
     def test_plugin_interface(self):
-
         class IFoo(Interface):
             pass
 
@@ -35,23 +43,17 @@ class TestPlugin(TestCase):
 
         a = myFoo()
         self.assertEqual(ep.extensions(), [])
-        self.assertEqual(IFoo._plugins, {
-            myFoo: {0: (weakref.ref(a), False)},
-        })
+        self.assertEqual(IFoo._plugins, {myFoo: {0: (weakref.ref(a), False)}})
         self.assertEqual(len(ep), 0)
 
         a.activate()
         self.assertEqual(ep.extensions(), [a])
-        self.assertEqual(IFoo._plugins, {
-            myFoo: {0: (weakref.ref(a), True)},
-        })
+        self.assertEqual(IFoo._plugins, {myFoo: {0: (weakref.ref(a), True)}})
         self.assertEqual(len(ep), 1)
 
         a.deactivate()
         self.assertEqual(ep.extensions(), [])
-        self.assertEqual(IFoo._plugins, {
-            myFoo: {0: (weakref.ref(a), False)},
-        })
+        self.assertEqual(IFoo._plugins, {myFoo: {0: (weakref.ref(a), False)}})
         self.assertEqual(len(ep), 0)
 
         # Free a and make sure the garbage collector collects it (so
@@ -66,7 +68,6 @@ class TestPlugin(TestCase):
         self.assertEqual(len(ep), 0)
 
     def test_singleton_plugin_interface(self):
-
         class IFoo(Interface):
             pass
 
@@ -75,56 +76,69 @@ class TestPlugin(TestCase):
 
         ep = ExtensionPoint(IFoo)
         self.assertEqual(ep.extensions(), [])
-        self.assertEqual(IFoo._plugins, {
-            mySingleton: {0: (weakref.ref(mySingleton.__singleton__), False)},
-        })
+        self.assertEqual(
+            IFoo._plugins,
+            {mySingleton: {0: (weakref.ref(mySingleton.__singleton__), False)}},
+        )
         self.assertIsNotNone(mySingleton.__singleton__)
 
         with self.assertRaisesRegex(
-                RuntimeError,
-                'Cannot create multiple singleton plugin instances'):
+            RuntimeError, 'Cannot create multiple singleton plugin instances'
+        ):
             mySingleton()
 
         class myDerivedSingleton(mySingleton):
             pass
+
         self.assertEqual(ep.extensions(), [])
-        self.assertEqual(IFoo._plugins, {
-            mySingleton: {0: (weakref.ref(mySingleton.__singleton__), False)},
-            myDerivedSingleton: {
-                1: (weakref.ref(myDerivedSingleton.__singleton__), False)},
-        })
+        self.assertEqual(
+            IFoo._plugins,
+            {
+                mySingleton: {0: (weakref.ref(mySingleton.__singleton__), False)},
+                myDerivedSingleton: {
+                    1: (weakref.ref(myDerivedSingleton.__singleton__), False)
+                },
+            },
+        )
         self.assertIsNotNone(myDerivedSingleton.__singleton__)
-        self.assertIsNot(mySingleton.__singleton__,
-                         myDerivedSingleton.__singleton__)
+        self.assertIsNot(mySingleton.__singleton__, myDerivedSingleton.__singleton__)
 
         class myDerivedNonSingleton(mySingleton):
             __singleton__ = False
 
         self.assertEqual(ep.extensions(), [])
-        self.assertEqual(IFoo._plugins, {
-            mySingleton: {0: (weakref.ref(mySingleton.__singleton__), False)},
-            myDerivedSingleton: {
-                1: (weakref.ref(myDerivedSingleton.__singleton__), False)},
-            myDerivedNonSingleton: {},
-        })
+        self.assertEqual(
+            IFoo._plugins,
+            {
+                mySingleton: {0: (weakref.ref(mySingleton.__singleton__), False)},
+                myDerivedSingleton: {
+                    1: (weakref.ref(myDerivedSingleton.__singleton__), False)
+                },
+                myDerivedNonSingleton: {},
+            },
+        )
         self.assertIsNone(myDerivedNonSingleton.__singleton__)
 
         class myServiceSingleton(mySingleton):
             implements(IFoo, service=True)
 
         self.assertEqual(ep.extensions(), [myServiceSingleton.__singleton__])
-        self.assertEqual(IFoo._plugins, {
-            mySingleton: {0: (weakref.ref(mySingleton.__singleton__), False)},
-            myDerivedSingleton: {
-                1: (weakref.ref(myDerivedSingleton.__singleton__), False)},
-            myDerivedNonSingleton: {},
-            myServiceSingleton: {
-                2: (weakref.ref(myServiceSingleton.__singleton__), True)},
-        })
+        self.assertEqual(
+            IFoo._plugins,
+            {
+                mySingleton: {0: (weakref.ref(mySingleton.__singleton__), False)},
+                myDerivedSingleton: {
+                    1: (weakref.ref(myDerivedSingleton.__singleton__), False)
+                },
+                myDerivedNonSingleton: {},
+                myServiceSingleton: {
+                    2: (weakref.ref(myServiceSingleton.__singleton__), True)
+                },
+            },
+        )
         self.assertIsNotNone(myServiceSingleton.__singleton__)
 
     def test_inherit_interface(self):
-
         class IFoo(Interface):
             def fcn(self):
                 return 'base'
@@ -160,7 +174,6 @@ class TestPlugin(TestCase):
         self.assertEqual(a.mock(), 'mock')
 
     def test_plugin_factory(self):
-
         class IFoo(Interface):
             pass
 
@@ -214,9 +227,10 @@ class TestPlugin(TestCase):
         self.assertTrue(a.enabled())
         self.assertTrue(b.enabled())
         with self.assertRaisesRegex(
-                PluginError,
-                r"The ExtensionPoint does not have a unique service!  "
-                r"2 services are defined for interface 'IFoo' \(key=None\)."):
+            PluginError,
+            r"The ExtensionPoint does not have a unique service!  "
+            r"2 services are defined for interface 'IFoo' \(key=None\).",
+        ):
             self.assertIsNone(ep.service())
 
         a.deactivate()
@@ -238,37 +252,51 @@ class TestPlugin(TestCase):
         out = StringIO()
         with LoggingIntercept(out):
             PluginGlobals.add_env(None)
-        self.assertIn("Pyomo only supports a single global environment",
-                      out.getvalue().replace('\n', ' '))
+        self.assertIn(
+            "Pyomo only supports a single global environment",
+            out.getvalue().replace('\n', ' '),
+        )
 
         out = StringIO()
         with LoggingIntercept(out):
             PluginGlobals.pop_env()
-        self.assertIn("Pyomo only supports a single global environment",
-                      out.getvalue().replace('\n', ' '))
+        self.assertIn(
+            "Pyomo only supports a single global environment",
+            out.getvalue().replace('\n', ' '),
+        )
 
         out = StringIO()
         with LoggingIntercept(out):
             PluginGlobals.clear()
-        self.assertIn("Pyomo only supports a single global environment",
-                      out.getvalue().replace('\n', ' '))
+        self.assertIn(
+            "Pyomo only supports a single global environment",
+            out.getvalue().replace('\n', ' '),
+        )
 
         class IFoo(Interface):
             pass
 
         out = StringIO()
         with LoggingIntercept(out):
+
             class myFoo(Plugin):
                 alias('myFoo', subclass=True)
-        self.assertIn("alias() function does not support the subclass",
-                      out.getvalue().replace('\n', ' '))
+
+        self.assertIn(
+            "alias() function does not support the subclass",
+            out.getvalue().replace('\n', ' '),
+        )
 
         out = StringIO()
         with LoggingIntercept(out):
+
             class myFoo(Plugin):
                 implements(IFoo, namespace='here')
-        self.assertIn("only supports a single global namespace.",
-                      out.getvalue().replace('\n', ' '))
+
+        self.assertIn(
+            "only supports a single global namespace.",
+            out.getvalue().replace('\n', ' '),
+        )
 
         class IGone(DeprecatedInterface):
             __deprecated_version__ = '1.2.3'
@@ -276,16 +304,20 @@ class TestPlugin(TestCase):
 
         out = StringIO()
         with LoggingIntercept(out):
+
             class myFoo(Plugin):
                 implements(IGone)
-        self.assertIn("The IGone interface has been deprecated",
-                      out.getvalue().replace('\n', ' '))
+
+        self.assertIn(
+            "The IGone interface has been deprecated", out.getvalue().replace('\n', ' ')
+        )
 
         out = StringIO()
         with LoggingIntercept(out):
             ExtensionPoint(IGone).extensions()
-        self.assertIn("The IGone interface has been deprecated",
-                      out.getvalue().replace('\n', ' '))
+        self.assertIn(
+            "The IGone interface has been deprecated", out.getvalue().replace('\n', ' ')
+        )
 
         class ICustomGone(DeprecatedInterface):
             __deprecated_message__ = 'This interface is gone!'
@@ -293,13 +325,13 @@ class TestPlugin(TestCase):
 
         out = StringIO()
         with LoggingIntercept(out):
+
             class myFoo(Plugin):
                 implements(ICustomGone)
-        self.assertIn("This interface is gone!",
-                      out.getvalue().replace('\n', ' '))
+
+        self.assertIn("This interface is gone!", out.getvalue().replace('\n', ' '))
 
         out = StringIO()
         with LoggingIntercept(out):
             ExtensionPoint(ICustomGone).extensions()
-        self.assertIn("This interface is gone!",
-                      out.getvalue().replace('\n', ' '))
+        self.assertIn("This interface is gone!", out.getvalue().replace('\n', ' '))

--- a/pyomo/common/tests/test_sorting.py
+++ b/pyomo/common/tests/test_sorting.py
@@ -24,28 +24,37 @@ from pyomo.common.sorting import sorted_robust, _robust_sort_keyfcn
 class LikeFloat(object):
     def __init__(self, n):
         self.n = n
+
     def __lt__(self, other):
         return self.n < other
+
     def __gt__(self, other):
         return self.n > other
+
 
 class Comparable(object):
     def __init__(self, n):
         self.n = str(n)
+
     def __lt__(self, other):
         return self.n < other
+
     def __gt__(self, other):
         return self.n > other
+
 
 class ToStr(object):
     def __init__(self, n):
         self.n = str(n)
+
     def __str__(self):
         return self.n
+
 
 class NoStr(object):
     def __init__(self, n):
         self.n = str(n)
+
     def __str__(self):
         raise ValueError('')
 
@@ -75,26 +84,20 @@ class TestSortedRobust(unittest.TestCase):
     def test_user_key(self):
         # ensure it doesn't throw an error
         # Test for issue https://github.com/Pyomo/pyomo/issues/2019
-        sorted_robust(
-            [
-                (("10_1", 2), None),
-                ((10, 2), None)
-            ],
-            key=lambda x: x[0]
-        )
+        sorted_robust([(("10_1", 2), None), ((10, 2), None)], key=lambda x: x[0])
 
     def test_unknown_types(self):
         orig = [
-            LikeFloat(4), # 0
-            Comparable('hello'), # 1
-            LikeFloat(1), # 2
-            2., # 3
-            Comparable('world'), # 4
-            ToStr(1), # 5
-            NoStr('bogus'), # 6
-            ToStr('a'), # 7
-            ToStr('A'), # 8
-            3, # 9
+            LikeFloat(4),  # 0
+            Comparable('hello'),  # 1
+            LikeFloat(1),  # 2
+            2.0,  # 3
+            Comparable('world'),  # 4
+            ToStr(1),  # 5
+            NoStr('bogus'),  # 6
+            ToStr('a'),  # 7
+            ToStr('A'),  # 8
+            3,  # 9
         ]
 
         ref = [orig[i] for i in (1, 4, 6, 5, 8, 7, 2, 3, 9, 0)]
@@ -102,15 +105,13 @@ class TestSortedRobust(unittest.TestCase):
         self.assertEqual(len(orig), len(ans))
         for _r, _a in zip(ref, ans):
             self.assertIs(_r, _a)
-        self.assertEqual(_robust_sort_keyfcn._typemap[LikeFloat],
-                         (1, float.__name__))
-        self.assertEqual(_robust_sort_keyfcn._typemap[Comparable],
-                         (1, Comparable.__name__))
-        self.assertEqual(_robust_sort_keyfcn._typemap[ToStr],
-                         (2, ToStr.__name__))
-        self.assertEqual(_robust_sort_keyfcn._typemap[NoStr],
-                         (3, NoStr.__name__))
+        self.assertEqual(_robust_sort_keyfcn._typemap[LikeFloat], (1, float.__name__))
+        self.assertEqual(
+            _robust_sort_keyfcn._typemap[Comparable], (1, Comparable.__name__)
+        )
+        self.assertEqual(_robust_sort_keyfcn._typemap[ToStr], (2, ToStr.__name__))
+        self.assertEqual(_robust_sort_keyfcn._typemap[NoStr], (3, NoStr.__name__))
+
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/pyomo/common/tests/test_tempfile.py
+++ b/pyomo/common/tests/test_tempfile.py
@@ -32,21 +32,21 @@ import pyomo.common.tempfiles as tempfiles
 
 from pyomo.common.log import LoggingIntercept
 from pyomo.common.tempfiles import (
-    TempfileManager, TempfileManagerClass, TempfileContextError,
+    TempfileManager,
+    TempfileManagerClass,
+    TempfileContextError,
 )
 
 try:
-    from pyutilib.component.config.tempfiles import (
-        TempfileManager as pyutilib_mngr
-    )
+    from pyutilib.component.config.tempfiles import TempfileManager as pyutilib_mngr
 except ImportError:
     pyutilib_mngr = None
 
 old_tempdir = TempfileManager.tempdir
 tempdir = None
 
-class Test_LegacyTestSuite(unittest.TestCase):
 
+class Test_LegacyTestSuite(unittest.TestCase):
     def setUp(self):
         global tempdir
         tempdir = tempfile.mkdtemp() + os.sep
@@ -58,7 +58,7 @@ class Test_LegacyTestSuite(unittest.TestCase):
         TempfileManager.pop()
         TempfileManager.tempdir = old_tempdir
         if os.path.exists(tempdir):
-           shutil.rmtree(tempdir)
+            shutil.rmtree(tempdir)
         tempdir = None
 
     def test_add1(self):
@@ -248,7 +248,6 @@ class Test_LegacyTestSuite(unittest.TestCase):
 
 
 class Test_TempfileManager(unittest.TestCase):
-
     def setUp(self):
         self.TM = TempfileManagerClass()
 
@@ -308,8 +307,9 @@ class Test_TempfileManager(unittest.TestCase):
         sub_fname = os.path.join(dname, "testfile")
         self.TM.add_tempfile(fname)
         with self.assertRaisesRegex(
-                IOError, "Temporary file does not exist: %s"
-                % sub_fname.replace('\\', '\\\\')):
+            IOError,
+            "Temporary file does not exist: %s" % sub_fname.replace('\\', '\\\\'),
+        ):
             self.TM.add_tempfile(sub_fname)
         self.TM.add_tempfile(sub_fname, exists=False)
         with open(sub_fname, "w") as FILE:
@@ -334,7 +334,8 @@ class Test_TempfileManager(unittest.TestCase):
             self.assertIsNone(self.TM.sequential_files())
         self.assertIn(
             "The TempfileManager.sequential_files() method has been removed",
-            LOG.getvalue().replace('\n',' '))
+            LOG.getvalue().replace('\n', ' '),
+        )
         self.assertIsNone(self.TM.unique_files())
 
     def test_gettempprefix(self):
@@ -414,7 +415,7 @@ class Test_TempfileManager(unittest.TestCase):
             LOG.getvalue().strip(),
             "TempfileManagerClass instance: un-popped tempfile "
             "contexts still exist during TempfileManager instance "
-            "shutdown"
+            "shutdown",
         )
 
         self.TM = TempfileManagerClass()
@@ -432,7 +433,7 @@ class Test_TempfileManager(unittest.TestCase):
             "Undeleted entries:\n\t%s\n"
             "TempfileManagerClass instance: un-popped tempfile "
             "contexts still exist during TempfileManager instance "
-            "shutdown" % fname
+            "shutdown" % fname,
         )
 
         # The TM is already shut down, so this should be a noop
@@ -459,7 +460,7 @@ class Test_TempfileManager(unittest.TestCase):
             "Undeleted entries:\n\t%s\n"
             "TempfileManagerClass instance: un-popped tempfile "
             "contexts still exist during TempfileManager instance "
-            "shutdown" % fname
+            "shutdown" % fname,
         )
 
     def test_tempfilemanager_as_context_manager(self):
@@ -481,7 +482,7 @@ class Test_TempfileManager(unittest.TestCase):
                 "the TempfileManager stack within a context manager "
                 "(i.e., `with TempfileManager:`) but was not popped "
                 "before the context manager exited.  Popping the "
-                "context to preserve the stack integrity."
+                "context to preserve the stack integrity.",
             )
 
     def test_tempfilecontext_as_context_manager(self):
@@ -493,8 +494,10 @@ class Test_TempfileManager(unittest.TestCase):
             self.assertFalse(os.path.exists(fname))
             self.assertEqual(LOG.getvalue(), "")
 
-    @unittest.skipIf(not sys.platform.lower().startswith('win'),
-                     "test only applies to Windows platforms")
+    @unittest.skipIf(
+        not sys.platform.lower().startswith('win'),
+        "test only applies to Windows platforms",
+    )
     def test_open_tempfile_windows(self):
         self.TM.push()
         fname = self.TM.create_tempfile()
@@ -503,7 +506,8 @@ class Test_TempfileManager(unittest.TestCase):
             _orig = tempfiles.deletion_errors_are_fatal
             tempfiles.deletion_errors_are_fatal = True
             with self.assertRaisesRegex(
-                    WindowsError, ".*process cannot access the file"):
+                WindowsError, ".*process cannot access the file"
+            ):
                 self.TM.pop()
         finally:
             tempfiles.deletion_errors_are_fatal = _orig
@@ -524,8 +528,7 @@ class Test_TempfileManager(unittest.TestCase):
             f.close()
             os.remove(fname)
 
-    @unittest.skipIf(pyutilib_mngr is None,
-                     "deprecation test requires pyutilib")
+    @unittest.skipIf(pyutilib_mngr is None, "deprecation test requires pyutilib")
     def test_deprecated_tempdir(self):
         self.TM.push()
         try:
@@ -539,25 +542,30 @@ class Test_TempfileManager(unittest.TestCase):
             self.assertIn(
                 "The use of the PyUtilib TempfileManager.tempdir "
                 "to specify the default location for Pyomo "
-                "temporary files", LOG.getvalue().replace("\n", " "))
+                "temporary files",
+                LOG.getvalue().replace("\n", " "),
+            )
 
             with LoggingIntercept() as LOG:
                 dname = self.TM.create_tempdir()
             self.assertIn(
                 "The use of the PyUtilib TempfileManager.tempdir "
                 "to specify the default location for Pyomo "
-                "temporary files", LOG.getvalue().replace("\n", " "))
+                "temporary files",
+                LOG.getvalue().replace("\n", " "),
+            )
         finally:
             self.TM.pop()
             pyutilib_mngr.tempdir = _orig
 
     def test_context(self):
         with self.assertRaisesRegex(
-                TempfileContextError,
-                "TempfileManager has no currently active context"):
+            TempfileContextError, "TempfileManager has no currently active context"
+        ):
             self.TM.context()
         ctx = self.TM.push()
         self.assertIs(ctx, self.TM.context())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -20,15 +20,20 @@ import time
 
 from pyomo.common.log import LoggingIntercept
 from pyomo.common.timing import (
-    ConstructionTimer, TransformationTimer, report_timing,
-    TicTocTimer, HierarchicalTimer,
+    ConstructionTimer,
+    TransformationTimer,
+    report_timing,
+    TicTocTimer,
+    HierarchicalTimer,
 )
 from pyomo.environ import ConcreteModel, RangeSet, Var, Any, TransformationFactory
 from pyomo.core.base.var import _VarData
 
+
 class _pseudo_component(Var):
     def getname(*args, **kwds):
         raise RuntimeError("fail")
+
 
 class TestTiming(unittest.TestCase):
     def setUp(self):
@@ -45,38 +50,34 @@ class TestTiming(unittest.TestCase):
         self.assertRegex(
             str(a),
             r"ConstructionTimer object for NoneType \(unknown\); "
-            r"[0-9\.]+ elapsed seconds")
+            r"[0-9\.]+ elapsed seconds",
+        )
         v = Var()
         v.construct()
         a = ConstructionTimer(_VarData(v))
         self.assertRegex(
             str(a),
             r"ConstructionTimer object for Var ScalarVar\[NOTSET\]; "
-            r"[0-9\.]+ elapsed seconds")
+            r"[0-9\.]+ elapsed seconds",
+        )
 
     def test_raw_transformation_timer(self):
         a = TransformationTimer(None)
         self.assertRegex(
             str(a),
-            r"TransformationTimer object for NoneType; "
-            r"[0-9\.]+ elapsed seconds")
+            r"TransformationTimer object for NoneType; " r"[0-9\.]+ elapsed seconds",
+        )
 
         v = _pseudo_component()
         a = ConstructionTimer(v)
-        self.assertIn(
-            "ConstructionTimer object for Var (unknown); ",
-            str(a))
+        self.assertIn("ConstructionTimer object for Var (unknown); ", str(a))
 
     def test_raw_transformation_timer(self):
         a = TransformationTimer(None, 'fwd')
-        self.assertIn(
-            "TransformationTimer object for NoneType (fwd); ",
-            str(a))
+        self.assertIn("TransformationTimer object for NoneType (fwd); ", str(a))
 
         a = TransformationTimer(None)
-        self.assertIn(
-            "TransformationTimer object for NoneType; ",
-            str(a))
+        self.assertIn("TransformationTimer object for NoneType; ", str(a))
 
     def test_report_timing(self):
         ref = r"""
@@ -134,7 +135,7 @@ class TestTiming(unittest.TestCase):
 
     def test_TicTocTimer_tictoc(self):
         SLEEP = 0.1
-        RES = 0.02 # resolution (seconds): 1/5 the sleep
+        RES = 0.02  # resolution (seconds): 1/5 the sleep
 
         # Note: pypy on GHA occasionally has timing
         # differences of >0.04s
@@ -158,8 +159,7 @@ class TestTiming(unittest.TestCase):
             start_time = time.perf_counter()
             timer.tic()
         self.assertRegex(
-            out.getvalue(),
-            r'\[    [.0-9]+\] Resetting the tic/toc delta timer'
+            out.getvalue(), r'\[    [.0-9]+\] Resetting the tic/toc delta timer'
         )
 
         time.sleep(SLEEP)
@@ -169,14 +169,14 @@ class TestTiming(unittest.TestCase):
             delta = timer.toc()
         self.assertAlmostEqual(ref - start_time, delta, delta=RES)
         self.assertRegex(
-            out.getvalue(),
-            r'\[\+   [.0-9]+\] .* in test_TicTocTimer_tictoc'
+            out.getvalue(), r'\[\+   [.0-9]+\] .* in test_TicTocTimer_tictoc'
         )
         with capture_output() as out:
             # entering / leaving the context manager can take non-trivial
             # time on some platforms (up to 0.03 on Windows / Python 3.10)
             self.assertAlmostEqual(
-                time.perf_counter() - ref, timer.toc(None), delta=RES)
+                time.perf_counter() - ref, timer.toc(None), delta=RES
+            )
         self.assertEqual(out.getvalue(), '')
 
         with capture_output() as out:
@@ -184,8 +184,7 @@ class TestTiming(unittest.TestCase):
             total = timer.toc(delta=False)
         self.assertAlmostEqual(ref - start_time, total, delta=RES)
         self.assertRegex(
-            out.getvalue(),
-            r'\[    [.0-9]+\] .* in test_TicTocTimer_tictoc'
+            out.getvalue(), r'\[    [.0-9]+\] .* in test_TicTocTimer_tictoc'
         )
 
         ref *= -1
@@ -196,8 +195,8 @@ class TestTiming(unittest.TestCase):
         cumul_stop1 = timer.toc(None)
         self.assertAlmostEqual(ref, cumul_stop1, delta=RES)
         with self.assertRaisesRegex(
-                RuntimeError,
-                'Stopping a TicTocTimer that was already stopped'):
+            RuntimeError, 'Stopping a TicTocTimer that was already stopped'
+        ):
             timer.stop()
         time.sleep(SLEEP)
         cumul_stop2 = timer.toc(None)
@@ -213,21 +212,19 @@ class TestTiming(unittest.TestCase):
             delta = timer.toc()
         self.assertAlmostEqual(ref, delta, delta=RES)
         self.assertRegex(
-            out.getvalue(),
-            r'\[    [.0-9]+\|   1\] .* in test_TicTocTimer_tictoc'
+            out.getvalue(), r'\[    [.0-9]+\|   1\] .* in test_TicTocTimer_tictoc'
         )
         with capture_output() as out:
             # Note that delta is ignored if the timer is a cumulative timer
             total = timer.toc(delta=False)
         self.assertAlmostEqual(delta, total, delta=RES)
         self.assertRegex(
-            out.getvalue(),
-            r'\[    [.0-9]+\|   1\] .* in test_TicTocTimer_tictoc'
+            out.getvalue(), r'\[    [.0-9]+\|   1\] .* in test_TicTocTimer_tictoc'
         )
 
     def test_TicTocTimer_context_manager(self):
         SLEEP = 0.1
-        RES = 0.05 # resolution (seconds): 1/2 the sleep
+        RES = 0.05  # resolution (seconds): 1/2 the sleep
 
         abs_time = time.perf_counter()
         with TicTocTimer() as timer:
@@ -238,7 +235,7 @@ class TestTiming(unittest.TestCase):
         with timer:
             time.sleep(SLEEP)
         abs_time = time.perf_counter() - abs_time
-        self.assertGreater(abs_time, SLEEP*3 - RES/10)
+        self.assertGreater(abs_time, SLEEP * 3 - RES / 10)
         self.assertAlmostEqual(timer.toc(None), abs_time - exclude, delta=RES)
 
     def test_TicTocTimer_logger(self):
@@ -278,7 +275,8 @@ class TestTiming(unittest.TestCase):
         self.assertRegex(
             LOG.getvalue().replace('\n', ' ').strip(),
             r"DEPRECATED: tic\(\): 'ostream' and 'logger' should be specified "
-            r"as keyword arguments( +\([^\)]+\)){2}")
+            r"as keyword arguments( +\([^\)]+\)){2}",
+        )
 
         with LoggingIntercept() as LOG, capture_output() as out:
             timer.toc("msg", True, None, None)
@@ -286,7 +284,8 @@ class TestTiming(unittest.TestCase):
         self.assertRegex(
             LOG.getvalue().replace('\n', ' ').strip(),
             r"DEPRECATED: toc\(\): 'delta', 'ostream', and 'logger' should be "
-            r"specified as keyword arguments( +\([^\)]+\)){2}")
+            r"specified as keyword arguments( +\([^\)]+\)){2}",
+        )
 
         timer = TicTocTimer()
         with LoggingIntercept() as LOG, capture_output() as out:
@@ -299,9 +298,8 @@ class TestTiming(unittest.TestCase):
         self.assertIn('msg True, None, None', out.getvalue())
         self.assertEqual(LOG.getvalue(), "")
 
-
     def test_HierarchicalTimer(self):
-        RES = 0.01 # resolution (seconds)
+        RES = 0.01  # resolution (seconds)
 
         timer = HierarchicalTimer()
         start_time = time.perf_counter()
@@ -319,8 +317,7 @@ class TestTiming(unittest.TestCase):
             timer.stop('a')
         end_time = time.perf_counter()
         timer.stop('all')
-        ref = \
-"""Identifier        ncalls   cumtime   percall      %
+        ref = """Identifier        ncalls   cumtime   percall      %
 ---------------------------------------------------
 all                    1     [0-9.]+ +[0-9.]+ +100.0
      ----------------------------------------------
@@ -339,32 +336,33 @@ all                    1     [0-9.]+ +[0-9.]+ +100.0
 
         self.assertEqual(1, timer.get_num_calls('all'))
         self.assertAlmostEqual(
-            end_time - start_time, timer.get_total_time('all'), delta=RES)
-        self.assertEqual(100., timer.get_relative_percent_time('all'))
-        self.assertTrue(100. > timer.get_relative_percent_time('all.a'))
-        self.assertTrue(50. < timer.get_relative_percent_time('all.a'))
+            end_time - start_time, timer.get_total_time('all'), delta=RES
+        )
+        self.assertEqual(100.0, timer.get_relative_percent_time('all'))
+        self.assertTrue(100.0 > timer.get_relative_percent_time('all.a'))
+        self.assertTrue(50.0 < timer.get_relative_percent_time('all.a'))
 
     def test_HierarchicalTimer_longNames(self):
-        RES = 0.01 # resolution (seconds)
+        RES = 0.01  # resolution (seconds)
 
         timer = HierarchicalTimer()
         start_time = time.perf_counter()
-        timer.start('all'*25)
+        timer.start('all' * 25)
         time.sleep(0.02)
         for i in range(10):
-            timer.start('a'*75)
+            timer.start('a' * 75)
             time.sleep(0.01)
             for j in range(5):
-                timer.start('aa'*20)
+                timer.start('aa' * 20)
                 time.sleep(0.001)
-                timer.stop('aa'*20)
-            timer.start('ab'*20)
-            timer.stop('ab'*20)
-            timer.stop('a'*75)
+                timer.stop('aa' * 20)
+            timer.start('ab' * 20)
+            timer.stop('ab' * 20)
+            timer.stop('a' * 75)
         end_time = time.perf_counter()
-        timer.stop('all'*25)
+        timer.stop('all' * 25)
         ref = (
-"""Identifier%s   ncalls   cumtime   percall      %%
+            """Identifier%s   ncalls   cumtime   percall      %%
 %s------------------------------------
 %s%s        1     [0-9.]+ +[0-9.]+ +100.0
     %s------------------------------------
@@ -377,20 +375,27 @@ all                    1     [0-9.]+ +[0-9.]+ +100.0
     other%s      n/a     [0-9.]+ +n/a +[0-9.]+
     %s====================================
 %s====================================
-""" % (
-    ' '*69,
-    '-'*79,
-    'all'*25, ' '*4,
-    '-'*75,
-    'a'*75, '',
-    '-'*71,
-    'aa'*20, ' '*31,
-    'ab'*20, ' '*31,
-    ' '*66,
-    '='*71,
-    ' '*70,
-    '='*75,
-    '='*79)).splitlines()
+"""
+            % (
+                ' ' * 69,
+                '-' * 79,
+                'all' * 25,
+                ' ' * 4,
+                '-' * 75,
+                'a' * 75,
+                '',
+                '-' * 71,
+                'aa' * 20,
+                ' ' * 31,
+                'ab' * 20,
+                ' ' * 31,
+                ' ' * 66,
+                '=' * 71,
+                ' ' * 70,
+                '=' * 75,
+                '=' * 79,
+            )
+        ).splitlines()
         for l, r in zip(str(timer).splitlines(), ref):
             self.assertRegex(l, r)
 
@@ -545,13 +550,15 @@ class TestFlattenHierarchicalTimer(unittest.TestCase):
         timer.timers["root"].timers["a"].timers["b"].total_time = 1.1
         timer.timers["root"].timers["a"].timers["c"].total_time = 2.2
         timer.timers["root"].timers["a"].timers["c"].timers["d"].total_time = 0.9
-        timer.timers["root"].timers["a"].timers["c"].timers["d"].timers["e"].total_time = 0.6
+        timer.timers["root"].timers["a"].timers["c"].timers["d"].timers[
+            "e"
+        ].total_time = 0.6
         timer.timers["root"].timers["b"].total_time = 0.88
         timer.timers["root"].timers["b"].timers["c"].total_time = 0.07
         timer.timers["root"].timers["b"].timers["c"].timers["e"].total_time = 0.04
         timer.timers["root"].timers["b"].timers["d"].total_time = 0.05
         return timer
-    
+
     def make_timer_depth_4_same_name(self):
         timer = HierarchicalTimer()
         timer.start("root")
@@ -568,7 +575,9 @@ class TestFlattenHierarchicalTimer(unittest.TestCase):
         timer.timers["root"].timers["a"].total_time = 1.0
         timer.timers["root"].timers["a"].timers["a"].total_time = 0.1
         timer.timers["root"].timers["a"].timers["a"].timers["a"].total_time = 0.01
-        timer.timers["root"].timers["a"].timers["a"].timers["a"].timers["a"].total_time = 0.001
+        timer.timers["root"].timers["a"].timers["a"].timers["a"].timers[
+            "a"
+        ].total_time = 0.001
         return timer
 
     def test_singleton(self):

--- a/pyomo/common/tests/test_typing.py
+++ b/pyomo/common/tests/test_typing.py
@@ -16,6 +16,7 @@ import inspect
 from pyomo.common.pyomo_typing import get_overloads_for
 from pyomo.environ import Block
 
+
 class TestTyping(unittest.TestCase):
     def test_get_overloads_for(self):
         func_list = get_overloads_for(Block.__init__)

--- a/pyomo/common/tests/test_unittest.py
+++ b/pyomo/common/tests/test_unittest.py
@@ -84,7 +84,7 @@ class TestPyomoUnittest(unittest.TestCase):
 
     def test_assertStructuredAlmostEqual_errorChecking(self):
         with self.assertRaisesRegex(
-            ValueError, "Cannot specify more than one of " "{places, delta, abstol}"
+            ValueError, "Cannot specify more than one of {places, delta, abstol}"
         ):
             self.assertStructuredAlmostEqual(1, 1, places=7, delta=1)
 

--- a/pyomo/common/tests/test_unittest.py
+++ b/pyomo/common/tests/test_unittest.py
@@ -18,18 +18,22 @@ import pyomo.common.unittest as unittest
 from pyomo.common.log import LoggingIntercept
 from pyomo.environ import ConcreteModel, Var, Param
 
+
 @unittest.timeout(10)
 def short_sleep():
     return 42
+
 
 @unittest.timeout(0.01)
 def long_sleep():
     time.sleep(1)
     return 42
 
+
 @unittest.timeout(10)
 def raise_exception():
     foo.bar
+
 
 @unittest.timeout(10)
 def fail():
@@ -80,38 +84,34 @@ class TestPyomoUnittest(unittest.TestCase):
 
     def test_assertStructuredAlmostEqual_errorChecking(self):
         with self.assertRaisesRegex(
-                ValueError, "Cannot specify more than one of "
-                "{places, delta, abstol}"):
+            ValueError, "Cannot specify more than one of " "{places, delta, abstol}"
+        ):
             self.assertStructuredAlmostEqual(1, 1, places=7, delta=1)
 
     def test_assertStructuredAlmostEqual_str(self):
         self.assertStructuredAlmostEqual("hi", "hi")
-        with self.assertRaisesRegex(
-                self.failureException, "'hi' !~= 'hello'"):
+        with self.assertRaisesRegex(self.failureException, "'hi' !~= 'hello'"):
             self.assertStructuredAlmostEqual("hi", "hello")
-        with self.assertRaisesRegex(
-                self.failureException, r"'hi' !~= \['h',"):
-            self.assertStructuredAlmostEqual("hi", ['h','i'])
+        with self.assertRaisesRegex(self.failureException, r"'hi' !~= \['h',"):
+            self.assertStructuredAlmostEqual("hi", ['h', 'i'])
 
     def test_assertStructuredAlmostEqual_othertype(self):
-        a = datetime.datetime(1,1,1)
-        b = datetime.datetime(1,1,1)
+        a = datetime.datetime(1, 1, 1)
+        b = datetime.datetime(1, 1, 1)
         self.assertStructuredAlmostEqual(a, b)
-        b = datetime.datetime(1,1,2)
-        with self.assertRaisesRegex(
-                self.failureException, "datetime.* !~= datetime"):
+        b = datetime.datetime(1, 1, 2)
+        with self.assertRaisesRegex(self.failureException, "datetime.* !~= datetime"):
             self.assertStructuredAlmostEqual(a, b)
 
     def test_assertStructuredAlmostEqual_list(self):
-        a = [1,2]
-        b = [1,2,3]
+        a = [1, 2]
+        b = [1, 2, 3]
         with self.assertRaisesRegex(
-                self.failureException,
-                r'sequences are different sizes \(2 != 3\)'):
+            self.failureException, r'sequences are different sizes \(2 != 3\)'
+        ):
             self.assertStructuredAlmostEqual(a, b)
         self.assertStructuredAlmostEqual(a, b, allow_second_superset=True)
         a.append(3)
-
 
         self.assertStructuredAlmostEqual(a, b)
         b[1] -= 1.999e-7
@@ -121,15 +121,14 @@ class TestPyomoUnittest(unittest.TestCase):
             self.assertStructuredAlmostEqual(a, b)
 
     def test_assertStructuredAlmostEqual_dict(self):
-        a = {1:2, 3:4}
-        b = {1:2, 3:4, 5:6}
+        a = {1: 2, 3: 4}
+        b = {1: 2, 3: 4, 5: 6}
         with self.assertRaisesRegex(
-                self.failureException,
-                r'mappings are different sizes \(2 != 3\)'):
+            self.failureException, r'mappings are different sizes \(2 != 3\)'
+        ):
             self.assertStructuredAlmostEqual(a, b)
         self.assertStructuredAlmostEqual(a, b, allow_second_superset=True)
         a[5] = 6
-
 
         self.assertStructuredAlmostEqual(a, b)
         b[1] -= 1.999e-7
@@ -141,44 +140,41 @@ class TestPyomoUnittest(unittest.TestCase):
         del b[1]
         b[6] = 6
         with self.assertRaisesRegex(
-                self.failureException,
-                r'key \(1\) from first not found in second'):
+            self.failureException, r'key \(1\) from first not found in second'
+        ):
             self.assertStructuredAlmostEqual(a, b)
 
     def test_assertStructuredAlmostEqual_nested(self):
-        a = {1.1: [1,2,3], 'a': 'hi', 3: {1:2, 3:4}}
-        b = {1.1: [1,2,3], 'a': 'hi', 3: {1:2, 3:4}}
+        a = {1.1: [1, 2, 3], 'a': 'hi', 3: {1: 2, 3: 4}}
+        b = {1.1: [1, 2, 3], 'a': 'hi', 3: {1: 2, 3: 4}}
         self.assertStructuredAlmostEqual(a, b)
         b[1.1][2] -= 1.999e-7
         b[3][1] -= 9.999e-8
         self.assertStructuredAlmostEqual(a, b)
         b[1.1][2] -= 1.999e-7
-        with self.assertRaisesRegex(self.failureException,
-                                    '3 !~= 2.999'):
+        with self.assertRaisesRegex(self.failureException, '3 !~= 2.999'):
             self.assertStructuredAlmostEqual(a, b)
 
     def test_assertStructuredAlmostEqual_numericvalue(self):
         m = ConcreteModel()
-        m.v = Var(initialize=2.)
-        m.p = Param(initialize=2.)
-        a = {1.1: [1,m.p,3], 'a': 'hi', 3: {1:2, 3:4}}
-        b = {1.1: [1,m.v,3], 'a': 'hi', 3: {1:2, 3:4}}
+        m.v = Var(initialize=2.0)
+        m.p = Param(initialize=2.0)
+        a = {1.1: [1, m.p, 3], 'a': 'hi', 3: {1: 2, 3: 4}}
+        b = {1.1: [1, m.v, 3], 'a': 'hi', 3: {1: 2, 3: 4}}
         self.assertStructuredAlmostEqual(a, b)
         m.v.set_value(m.v.value - 1.999e-7)
         self.assertStructuredAlmostEqual(a, b)
         m.v.set_value(m.v.value - 1.999e-7)
-        with self.assertRaisesRegex(self.failureException,
-                                    '2.0 !~= 1.999'):
+        with self.assertRaisesRegex(self.failureException, '2.0 !~= 1.999'):
             self.assertStructuredAlmostEqual(a, b)
 
     def test_timeout_fcn_call(self):
         self.assertEqual(short_sleep(), 42)
-        with self.assertRaisesRegex(
-                TimeoutError, 'test timed out after 0.01 seconds'):
+        with self.assertRaisesRegex(TimeoutError, 'test timed out after 0.01 seconds'):
             long_sleep()
         with self.assertRaisesRegex(
-                NameError,
-                r"name 'foo' is not defined\s+Original traceback:"):
+            NameError, r"name 'foo' is not defined\s+Original traceback:"
+        ):
             raise_exception()
         with self.assertRaisesRegex(AssertionError, r"^0 != 1$"):
             fail()
@@ -203,8 +199,7 @@ class TestPyomoUnittest(unittest.TestCase):
 
     def test_timeout_skip_fails(self):
         try:
-            with self.assertRaisesRegex(
-                    unittest.SkipTest, r"Skipping this test"):
+            with self.assertRaisesRegex(unittest.SkipTest, r"Skipping this test"):
                 self.test_timeout_skip()
             TestPyomoUnittest.test_timeout_skip.skip = False
             with self.assertRaisesRegex(AssertionError, r"0 != 1"):
@@ -225,8 +220,7 @@ class TestPyomoUnittest(unittest.TestCase):
             with self.assertRaises((TypeError, EOFError, AttributeError)):
                 self.bound_function()
         self.assertIn("platform that does not support 'fork'", LOG.getvalue())
-        self.assertIn(
-            "one of its arguments is not serializable", LOG.getvalue())
+        self.assertIn("one of its arguments is not serializable", LOG.getvalue())
 
     @unittest.timeout(10, require_fork=True)
     def bound_function_require_fork(self):
@@ -237,10 +231,9 @@ class TestPyomoUnittest(unittest.TestCase):
             self.bound_function_require_fork()
             return
         with self.assertRaisesRegex(
-                unittest.SkipTest,
-                "timeout requires unavailable fork interface"):
+            unittest.SkipTest, "timeout requires unavailable fork interface"
+        ):
             self.bound_function_require_fork()
-
 
 
 if __name__ == '__main__':

--- a/pyomo/common/timing.py
+++ b/pyomo/common/timing.py
@@ -43,6 +43,7 @@ _logger.setLevel(logging.WARNING)
 _construction_logger = logging.getLogger('pyomo.common.timing.construction')
 _transform_logger = logging.getLogger('pyomo.common.timing.transformation')
 
+
 def report_timing(stream=True, level=logging.INFO):
     """Set reporting of Pyomo timing information.
 
@@ -145,11 +146,13 @@ class ConstructionTimer(object):
         if total_time < 0:
             total_time += default_timer()
             return self.in_progress % (_type, self.name, total_time)
-        return self.msg % ( 2 if total_time >= 0.005 else 0,
-                            total_time,
-                            _type,
-                            self.name,
-                            idx_label )
+        return self.msg % (
+            2 if total_time >= 0.005 else 0,
+            total_time,
+            _type,
+            self.name,
+            idx_label,
+        )
 
 
 class TransformationTimer(object):
@@ -180,16 +183,19 @@ class TransformationTimer(object):
         if total_time < 0:
             total_time += default_timer()
             return self.in_progress % (self.name, self.mode, total_time)
-        return self.msg % ( 2 if total_time>=0.005 else 0,
-                            total_time,
-                            self.name,
-                            self.mode )
+        return self.msg % (
+            2 if total_time >= 0.005 else 0,
+            total_time,
+            self.name,
+            self.mode,
+        )
+
 
 #
 # Setup the timer
 #
 # TODO: Remove this bit for Pyomo 6.0 - we won't care about older versions
-if sys.version_info >= (3,3):
+if sys.version_info >= (3, 3):
     # perf_counter is guaranteed to be monotonic and the most accurate timer
     default_timer = time.perf_counter
 elif sys.platform.startswith('win'):
@@ -225,6 +231,7 @@ class TicTocTimer(object):
         logger (Logger): an optional output stream using the python
            logging package. Note: the timing logged using ``logger.info()``
     """
+
     def __init__(self, ostream=_NotSpecified, logger=None):
         if ostream is _NotSpecified and logger is not None:
             ostream = None
@@ -235,8 +242,14 @@ class TicTocTimer(object):
         self._start_count = 0
         self._cumul = 0
 
-    def tic(self, msg=_NotSpecified, *args,
-            ostream=_NotSpecified, logger=_NotSpecified, level=_NotSpecified):
+    def tic(
+        self,
+        msg=_NotSpecified,
+        *args,
+        ostream=_NotSpecified,
+        logger=_NotSpecified,
+        level=_NotSpecified,
+    ):
         """Reset the tic/toc delta timer.
 
         This resets the reference time from which the next delta time is
@@ -266,17 +279,26 @@ class TicTocTimer(object):
                 # pyomo.common.timing logger.
                 deprecation_warning(
                     "tic(): 'ostream' and 'logger' should be "
-                    "specified as keyword arguments", version='6.4.2',
-                    logger=__package__)
+                    "specified as keyword arguments",
+                    version='6.4.2',
+                    logger=__package__,
+                )
                 ostream, *args = args
                 if args:
                     logger, *args = args
-            self.toc(msg, *args, delta=False,
-                     ostream=ostream, logger=logger, level=level)
+            self.toc(
+                msg, *args, delta=False, ostream=ostream, logger=logger, level=level
+            )
 
-
-    def toc(self, msg=_NotSpecified, *args, delta=True,
-            ostream=_NotSpecified, logger=_NotSpecified, level=_NotSpecified):
+    def toc(
+        self,
+        msg=_NotSpecified,
+        *args,
+        delta=True,
+        ostream=_NotSpecified,
+        logger=_NotSpecified,
+        level=_NotSpecified,
+    ):
         """Print out the elapsed time.
 
         This resets the reference time from which the next delta time is
@@ -302,16 +324,17 @@ class TicTocTimer(object):
         """
 
         if msg is _NotSpecified:
-            msg = 'File "%s", line %s in %s' % \
-                  traceback.extract_stack(limit=2)[0][:3]
+            msg = 'File "%s", line %s in %s' % traceback.extract_stack(limit=2)[0][:3]
         if args and msg is not None and '%' not in msg:
             # Note: specify the parent module scope for the logger
             # so this does not hit (and get handled by) the local
             # pyomo.common.timing logger.
             deprecation_warning(
                 "toc(): 'delta', 'ostream', and 'logger' should be "
-                "specified as keyword arguments", version='6.4.2',
-                logger=__package__)
+                "specified as keyword arguments",
+                version='6.4.2',
+                logger=__package__,
+            )
             delta, *args = args
             if args:
                 ostream, *args = args
@@ -367,8 +390,7 @@ class TicTocTimer(object):
     def stop(self):
         delta, self._lastTime = self._lastTime, None
         if delta is None:
-            raise RuntimeError(
-                "Stopping a TicTocTimer that was already stopped")
+            raise RuntimeError("Stopping a TicTocTimer that was already stopped")
         delta = default_timer() - delta
         self._cumul += delta
         return delta
@@ -428,11 +450,11 @@ def _move_grandchildren_to_root(root, child):
             root.timers[gchild_key].n_calls += gchild_n_calls
         else:
             root.timers[gchild_key] = gchild_timer
-    
+
         # Subtract the grandchild's total time from the child (which
         # will no longer be a parent of the grandchild)
         child.total_time -= gchild_timer.total_time
-    
+
     # Clear the child timer's dict to make it a leaf node
     child.timers.clear()
 
@@ -484,16 +506,20 @@ class _HierarchicalHelper(object):
                 else:
                     _percent = float('nan')
                 s += indent
-                s += ( name_formatter + '{ncalls:>9d} {cumtime:>9.3f} '
-                       '{percall:>9.3f} {percent:>6.1f}\n' ).format(
-                           name=name,
-                           ncalls=timer.n_calls,
-                           cumtime=timer.total_time,
-                           percall=timer.total_time/timer.n_calls,
-                           percent=_percent )
+                s += (
+                    name_formatter + '{ncalls:>9d} {cumtime:>9.3f} '
+                    '{percall:>9.3f} {percent:>6.1f}\n'
+                ).format(
+                    name=name,
+                    ncalls=timer.n_calls,
+                    cumtime=timer.total_time,
+                    percall=timer.total_time / timer.n_calls,
+                    percent=_percent,
+                )
                 s += timer.to_str(
-                    indent=indent + ' '*stage_identifier_lengths[0],
-                    stage_identifier_lengths=sub_stage_identifier_lengths)
+                    indent=indent + ' ' * stage_identifier_lengths[0],
+                    stage_identifier_lengths=sub_stage_identifier_lengths,
+                )
                 other_time -= timer.total_time
 
             if self.total_time > 0:
@@ -501,13 +527,16 @@ class _HierarchicalHelper(object):
             else:
                 _percent = float('nan')
             s += indent
-            s += ( name_formatter + '{ncalls:>9} {cumtime:>9.3f} '
-                   '{percall:>9} {percent:>6.1f}\n' ).format(
-                       name='other',
-                       ncalls='n/a',
-                       cumtime=other_time,
-                       percall='n/a',
-                       percent=_percent )
+            s += (
+                name_formatter + '{ncalls:>9} {cumtime:>9.3f} '
+                '{percall:>9} {percent:>6.1f}\n'
+            ).format(
+                name='other',
+                ncalls='n/a',
+                cumtime=other_time,
+                percall='n/a',
+                percent=_percent,
+            )
             s += underline.replace('-', '=')
         return s
 
@@ -732,6 +761,7 @@ class HierarchicalTimer(object):
     code is not).
 
     """
+
     def __init__(self):
         self.stack = list()
         self.timers = dict()
@@ -762,7 +792,9 @@ class HierarchicalTimer(object):
             if should_exist:
                 raise RuntimeError(
                     'Could not find timer {0}'.format(
-                        '.'.join(self.stack + [identifier])))
+                        '.'.join(self.stack + [identifier])
+                    )
+                )
             parent.timers[identifier] = _HierarchicalHelper()
             return parent.timers[identifier]
 
@@ -790,7 +822,8 @@ class HierarchicalTimer(object):
             raise ValueError(
                 str(identifier) + ' is not the currently active timer.  '
                 'The only timer that can currently be stopped is '
-                + '.'.join(self.stack))
+                + '.'.join(self.stack)
+            )
         self.stack.pop()
         timer = self._get_timer(identifier, should_exist=True)
         timer.stop()
@@ -820,36 +853,41 @@ class HierarchicalTimer(object):
             # switch to a constant indentation of const_indent spaces
             # (to hopefully shorten the line lengths
             name_field_width = max(
-                const_indent*i + l
-                for i, l in enumerate(stage_identifier_lengths)
+                const_indent * i + l for i, l in enumerate(stage_identifier_lengths)
             )
             for i in range(len(stage_identifier_lengths) - 1):
                 stage_identifier_lengths[i] = const_indent
-            stage_identifier_lengths[-1] = (
-                name_field_width -
-                const_indent*(len(stage_identifier_lengths) - 1) )
+            stage_identifier_lengths[-1] = name_field_width - const_indent * (
+                len(stage_identifier_lengths) - 1
+            )
         name_formatter = '{name:<' + str(name_field_width) + '}'
-        s = ( name_formatter + '{ncalls:>9} {cumtime:>9} '
-              '{percall:>9} {percent:>6}\n').format(
-                  name='Identifier',
-                  ncalls='ncalls',
-                  cumtime='cumtime',
-                  percall='percall',
-                  percent='%')
+        s = (
+            name_formatter + '{ncalls:>9} {cumtime:>9} {percall:>9} {percent:>6}\n'
+        ).format(
+            name='Identifier',
+            ncalls='ncalls',
+            cumtime='cumtime',
+            percall='percall',
+            percent='%',
+        )
         underline = '-' * (name_field_width + 36) + '\n'
         s += underline
         sub_stage_identifier_lengths = stage_identifier_lengths[1:]
         for name, timer in sorted(self.timers.items()):
-            s += ( name_formatter + '{ncalls:>9d} {cumtime:>9.3f} '
-                   '{percall:>9.3f} {percent:>6.1f}\n').format(
-                       name=name,
-                       ncalls=timer.n_calls,
-                       cumtime=timer.total_time,
-                       percall=timer.total_time/timer.n_calls,
-                       percent=self.get_total_percent_time(name))
+            s += (
+                name_formatter + '{ncalls:>9d} {cumtime:>9.3f} '
+                '{percall:>9.3f} {percent:>6.1f}\n'
+            ).format(
+                name=name,
+                ncalls=timer.n_calls,
+                cumtime=timer.total_time,
+                percall=timer.total_time / timer.n_calls,
+                percent=self.get_total_percent_time(name),
+            )
             s += timer.to_str(
-                indent=' '*stage_identifier_lengths[0],
-                stage_identifier_lengths=sub_stage_identifier_lengths)
+                indent=' ' * stage_identifier_lengths[0],
+                stage_identifier_lengths=sub_stage_identifier_lengths,
+            )
         s += underline.replace('-', '=')
         return s
 
@@ -1009,8 +1047,7 @@ class HierarchicalTimer(object):
             raise RuntimeError(
                 "Cannot clear a HierarchicalTimer while any timers are"
                 " active. Current active timer is %s. clear_except should"
-                " only be called as a post-processing step."
-                % self.stack[-1]
+                " only be called as a post-processing step." % self.stack[-1]
             )
         to_retain = set(args)
         _clear_timers_except(self, to_retain)

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -141,7 +141,7 @@ def assertStructuredAlmostEqual(
 
     """
     if sum(1 for _ in (places, delta, abstol) if _ is not None) > 1:
-        raise ValueError("Cannot specify more than one of " "{places, delta, abstol}")
+        raise ValueError("Cannot specify more than one of {places, delta, abstol}")
 
     if places is not None:
         abstol = 10 ** (-places)

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -34,8 +34,10 @@ from pyomo.common.tee import capture_output
 
 from unittest import mock
 
+
 def _defaultFormatter(msg, default):
     return msg or default
+
 
 def _floatOrCall(val):
     """Cast the value to float, if that fails call it and then cast.
@@ -52,13 +54,20 @@ def _floatOrCall(val):
     except TypeError:
         return float(val())
 
-def assertStructuredAlmostEqual(first, second,
-                                places=None, msg=None, delta=None,
-                                reltol=None, abstol=None,
-                                allow_second_superset=False,
-                                item_callback=_floatOrCall,
-                                exception=ValueError,
-                                formatter=_defaultFormatter):
+
+def assertStructuredAlmostEqual(
+    first,
+    second,
+    places=None,
+    msg=None,
+    delta=None,
+    reltol=None,
+    abstol=None,
+    allow_second_superset=False,
+    item_callback=_floatOrCall,
+    exception=ValueError,
+    formatter=_defaultFormatter,
+):
     """Test that first and second are equal up to a tolerance
 
     This compares first and second using both an absolute (`abstol`) and
@@ -132,11 +141,10 @@ def assertStructuredAlmostEqual(first, second,
 
     """
     if sum(1 for _ in (places, delta, abstol) if _ is not None) > 1:
-        raise ValueError("Cannot specify more than one of "
-                         "{places, delta, abstol}")
+        raise ValueError("Cannot specify more than one of " "{places, delta, abstol}")
 
     if places is not None:
-        abstol = 10**(-places)
+        abstol = 10 ** (-places)
     if delta is not None:
         abstol = delta
     if abstol is None and reltol is None:
@@ -145,28 +153,36 @@ def assertStructuredAlmostEqual(first, second,
     fail = None
     try:
         _assertStructuredAlmostEqual(
-            first, second, abstol, reltol, not allow_second_superset,
-            item_callback, exception)
+            first,
+            second,
+            abstol,
+            reltol,
+            not allow_second_superset,
+            item_callback,
+            exception,
+        )
     except exception as e:
         fail = formatter(
             msg,
             "%s\n    Found when comparing with tolerance "
             "(abs=%s, rel=%s):\n"
-            "        first=%s\n        second=%s" % (
+            "        first=%s\n        second=%s"
+            % (
                 str(e),
                 abstol,
                 reltol,
                 _unittest.case.safe_repr(first),
                 _unittest.case.safe_repr(second),
-            ))
+            ),
+        )
 
     if fail:
         raise exception(fail)
 
 
-def _assertStructuredAlmostEqual(first, second,
-                                 abstol, reltol, exact,
-                                 item_callback, exception):
+def _assertStructuredAlmostEqual(
+    first, second, abstol, reltol, exact, item_callback, exception
+):
     """Recursive implementation of assertStructuredAlmostEqual"""
 
     args = (first, second)
@@ -174,46 +190,49 @@ def _assertStructuredAlmostEqual(first, second,
     if all(isinstance(_, Mapping) for _ in args):
         if exact and len(first) != len(second):
             raise exception(
-                "mappings are different sizes (%s != %s)" % (
-                    len(first),
-                    len(second),
-                ))
+                "mappings are different sizes (%s != %s)" % (len(first), len(second))
+            )
         for key in first:
             if key not in second:
                 raise exception(
-                    "key (%s) from first not found in second" % (
-                        _unittest.case.safe_repr(key),
-                    ))
+                    "key (%s) from first not found in second"
+                    % (_unittest.case.safe_repr(key),)
+                )
             try:
                 _assertStructuredAlmostEqual(
-                    first[key], second[key], abstol, reltol, exact,
-                    item_callback, exception)
+                    first[key],
+                    second[key],
+                    abstol,
+                    reltol,
+                    exact,
+                    item_callback,
+                    exception,
+                )
             except exception as e:
                 raise exception(
-                    "%s\n    Found when comparing key %s" % (
-                        str(e), _unittest.case.safe_repr(key)))
-        return # PASS!
+                    "%s\n    Found when comparing key %s"
+                    % (str(e), _unittest.case.safe_repr(key))
+                )
+        return  # PASS!
 
     elif any(isinstance(_, str) for _ in args):
         if first == second:
-            return # PASS!
+            return  # PASS!
 
     elif all(isinstance(_, Sequence) for _ in args):
         # Note that Sequence includes strings
         if exact and len(first) != len(second):
             raise exception(
-                "sequences are different sizes (%s != %s)" % (
-                    len(first),
-                    len(second),
-                ))
+                "sequences are different sizes (%s != %s)" % (len(first), len(second))
+            )
         for i, (f, s) in enumerate(zip(first, second)):
             try:
                 _assertStructuredAlmostEqual(
-                    f, s, abstol, reltol, exact, item_callback, exception)
+                    f, s, abstol, reltol, exact, item_callback, exception
+                )
             except exception as e:
-                raise exception(
-                    "%s\n    Found at position %s" % (str(e), i))
-        return # PASS!
+                raise exception("%s\n    Found at position %s" % (str(e), i))
+        return  # PASS!
 
     else:
         # Catch things like None, which may cause problems for the
@@ -224,7 +243,7 @@ def _assertStructuredAlmostEqual(first, second,
         # the values to be comparable.
         try:
             if first is second or first == second:
-                return # PASS!
+                return  # PASS!
         except:
             pass
         try:
@@ -234,11 +253,11 @@ def _assertStructuredAlmostEqual(first, second,
                 return
             diff = abs(f - s)
             if abstol is not None and diff <= abstol:
-                return # PASS!
+                return  # PASS!
             if reltol is not None and diff / max(abs(f), abs(s)) <= reltol:
-                return # PASS!
+                return  # PASS!
             if math.isnan(f) and math.isnan(s):
-                return # PASS! (we will treat NaN as equal)
+                return  # PASS! (we will treat NaN as equal)
         except:
             pass
 
@@ -254,6 +273,7 @@ def _assertStructuredAlmostEqual(first, second,
         )
     raise exception(msg)
 
+
 def _runner(q, qualname):
     "Utility wrapper for running functions, used by timeout()"
     resultType = _RunnerResult.call
@@ -262,11 +282,13 @@ def _runner(q, qualname):
     elif isinstance(qualname, str):
         # Use unittest to instantiate the TestCase and run it
         resultType = _RunnerResult.unittest
+
         def fcn():
             s = _unittest.TestLoader().loadTestsFromName(qualname)
             r = _unittest.TestResult()
             s.run(r)
             return r.errors + r.failures, r.skipped
+
         args = ()
         kwargs = {}
     else:
@@ -279,17 +301,21 @@ def _runner(q, qualname):
         q.put((resultType, result, OUT.getvalue()))
     except:
         import traceback
+
         etype, e, tb = sys.exc_info()
         if not isinstance(e, AssertionError):
-            e = etype("%s\nOriginal traceback:\n%s" % (
-                e, ''.join(traceback.format_tb(tb))))
+            e = etype(
+                "%s\nOriginal traceback:\n%s" % (e, ''.join(traceback.format_tb(tb)))
+            )
         q.put((_RunnerResult.exception, e, OUT.getvalue()))
     finally:
         _runner.data.pop(qualname)
 
+
 # Data structure for passing functions/arguments to the _runner
 # without forcing them to be pickled / unpickled
 _runner.data = {}
+
 
 class _RunnerResult(enum.Enum):
     exception = 0
@@ -347,6 +373,7 @@ def timeout(seconds, require_fork=False, timeout_raises=TimeoutError):
     import functools
     import multiprocessing
     import queue
+
     def timeout_decorator(fcn):
         @functools.wraps(fcn)
         def test_timer(*args, **kwargs):
@@ -354,8 +381,7 @@ def timeout(seconds, require_fork=False, timeout_raises=TimeoutError):
             if qualname in _runner.data:
                 return fcn(*args, **kwargs)
             if require_fork and multiprocessing.get_start_method() != 'fork':
-                raise _unittest.SkipTest(
-                    "timeout requires unavailable fork interface")
+                raise _unittest.SkipTest("timeout requires unavailable fork interface")
 
             q = multiprocessing.Queue()
             if multiprocessing.get_start_method() == 'fork':
@@ -364,8 +390,11 @@ def timeout(seconds, require_fork=False, timeout_raises=TimeoutError):
                 # wrapped function operates in the same environment.
                 _runner.data[q] = (fcn, args, kwargs)
                 runner_args = (q, qualname)
-            elif (args and fcn.__name__.startswith('test')
-                  and _unittest.case.TestCase in args[0].__class__.__mro__):
+            elif (
+                args
+                and fcn.__name__.startswith('test')
+                and _unittest.case.TestCase in args[0].__class__.__mro__
+            ):
                 # Option 2: this is wrapping a unittest.  Re-run
                 # unittest in the child process with this function as
                 # the sole target.  This ensures that things like setUp
@@ -378,8 +407,7 @@ def timeout(seconds, require_fork=False, timeout_raises=TimeoutError):
                 # environment configuration that it does not set up
                 # itself.
                 runner_args = (q, (qualname, test_timer, args, kwargs))
-            test_proc = multiprocessing.Process(
-                target=_runner, args=runner_args)
+            test_proc = multiprocessing.Process(target=_runner, args=runner_args)
             test_proc.daemon = True
             try:
                 test_proc.start()
@@ -389,14 +417,16 @@ def timeout(seconds, require_fork=False, timeout_raises=TimeoutError):
                         "Exception raised spawning timeout subprocess "
                         "on a platform that does not support 'fork'.  "
                         "It is likely that either the wrapped function or "
-                        "one of its arguments is not serializable")
+                        "one of its arguments is not serializable"
+                    )
                 raise
             try:
                 resultType, result, stdout = q.get(True, seconds)
             except queue.Empty:
                 test_proc.terminate()
                 raise timeout_raises(
-                    "test timed out after %s seconds" % (seconds,)) from None
+                    "test timed out after %s seconds" % (seconds,)
+                ) from None
             finally:
                 _runner.data.pop(q, None)
             sys.stdout.write(stdout)
@@ -412,7 +442,9 @@ def timeout(seconds, require_fork=False, timeout_raises=TimeoutError):
                         args[0].skipTest(msg)
             else:
                 raise result
+
         return test_timer
+
     return timeout_decorator
 
 
@@ -427,13 +459,21 @@ class TestCase(_unittest.TestCase):
     unittest.TestCase documentation
     -------------------------------
     """
+
     __doc__ += _unittest.TestCase.__doc__
 
-    def assertStructuredAlmostEqual(self, first, second,
-                                    places=None, msg=None, delta=None,
-                                    reltol=None, abstol=None,
-                                    allow_second_superset=False,
-                                    item_callback=_floatOrCall):
+    def assertStructuredAlmostEqual(
+        self,
+        first,
+        second,
+        places=None,
+        msg=None,
+        delta=None,
+        reltol=None,
+        abstol=None,
+        allow_second_superset=False,
+        item_callback=_floatOrCall,
+    ):
         assertStructuredAlmostEqual(
             first=first,
             second=second,

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -383,7 +383,7 @@ class PseudoMap(AutoSlots.Mixin):
             msg += self._active and "active " or "inactive "
         if self._ctypes is not Any:
             if len(self._ctypes) == 1:
-                msg += next(iter(self._ctypes)).__name__ + 
+                msg += next(iter(self._ctypes)).__name__ + ' '
             else:
                 types = sorted(x.__name__ for x in self._ctypes)
                 msg += '%s or %s ' % (', '.join(types[:-1]), types[-1])

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -383,7 +383,7 @@ class PseudoMap(AutoSlots.Mixin):
             msg += self._active and "active " or "inactive "
         if self._ctypes is not Any:
             if len(self._ctypes) == 1:
-                msg += next(iter(self._ctypes)).__name__ + " "
+                msg += next(iter(self._ctypes)).__name__ + 
             else:
                 types = sorted(x.__name__ for x in self._ctypes)
                 msg += '%s or %s ' % (', '.join(types[:-1]), types[-1])

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -383,7 +383,7 @@ class PseudoMap(AutoSlots.Mixin):
             msg += self._active and "active " or "inactive "
         if self._ctypes is not Any:
             if len(self._ctypes) == 1:
-                msg += next(iter(self._ctypes)).__name__ + ' '
+                msg += next(iter(self._ctypes)).__name__ + " "
             else:
                 types = sorted(x.__name__ for x in self._ctypes)
                 msg += '%s or %s ' % (', '.join(types[:-1]), types[-1])

--- a/pyomo/core/plugins/transform/model.py
+++ b/pyomo/core/plugins/transform/model.py
@@ -304,7 +304,7 @@ def to_standard_form(self):
     # Generate the variable names
     varNames = [None]*len(colID)
     for name in colID:
-        tmp_name = " " + name
+        tmp_name =  + name
         if len(tmp_name) > maxColWidth:
             maxColWidth = len(tmp_name)
         varNames[colID[name]] = tmp_name
@@ -320,22 +320,22 @@ def to_standard_form(self):
         varNames.append(tmp_name)
 
     # Variable names
-    line = " "*maxConNameLen + (" "*constraintPadding) + " "
+    line = *maxConNameLen + (*constraintPadding) + 
     for col in range(0, nVariables):
         # Format entry
         token = varNames[col]
 
         # Pad with trailing whitespace
-        token += " "*(maxColWidth - len(token))
+        token += *(maxColWidth - len(token))
 
         # Add to line
-        line += " " + token + " "
+        line +=  + token + 
     print(line+'\n')
 
     # Cost vector
-    print(" "*maxConNameLen + (" "*constraintPadding) + "+--" + \
-          " "*((maxColWidth+2)*nVariables - 4) + "--+" + '\n')
-    line = " "*maxConNameLen + (" "*constraintPadding) + "|"
+    print(*maxConNameLen + (*constraintPadding) + "+--" + \
+          *((maxColWidth+2)*nVariables - 4) + "--+" + '\n')
+    line = *maxConNameLen + (*constraintPadding) + "|"
     for col in range(0, nVariables):
         # Format entry
         token = numFmt % costs[col]
@@ -343,23 +343,23 @@ def to_standard_form(self):
             token = altFmt % costs[col]
 
         # Pad with trailing whitespace
-        token += " "*(maxColWidth - len(token))
+        token += *(maxColWidth - len(token))
 
         # Add to line
-        line += " " + token + " "
+        line +=  + token + 
     line += "|"
     print(line+'\n')
-    print(" "*maxConNameLen + (" "*constraintPadding) + "+--" + \
-          " "*((maxColWidth+2)*nVariables - 4) + "--+"+'\n')
+    print(*maxConNameLen + (*constraintPadding) + "+--" + \
+          *((maxColWidth+2)*nVariables - 4) + "--+"+'\n')
 
     # Constraints
-    print(" "*maxConNameLen + (" "*constraintPadding) + "+--" + \
-          " "*((maxColWidth+2)*nVariables - 4) + "--+" + \
-          (" "*constraintPadding) + "+--" + \
-          (" "*(maxConstraintColWidth-1)) + "--+"+'\n')
+    print(*maxConNameLen + (*constraintPadding) + "+--" + \
+          *((maxColWidth+2)*nVariables - 4) + "--+" + \
+          (*constraintPadding) + "+--" + \
+          (*(maxConstraintColWidth-1)) + "--+"+'\n')
     for row in range(0, nConstraints):
         # Print constraint name
-        line = conNames[row] + (" "*constraintPadding) + (" "*(maxConNameLen - len(conNames[row]))) + "|"
+        line = conNames[row] + (*constraintPadding) + (*(maxConNameLen - len(conNames[row]))) + "|"
 
         # Print each coefficient
         for col in range(0, nVariables):
@@ -369,12 +369,12 @@ def to_standard_form(self):
                 token = altFmt % coefficients[nVariables*row + col]
 
             # Pad with trailing whitespace
-            token += " "*(maxColWidth - len(token))
+            token += *(maxColWidth - len(token))
 
             # Add to line
-            line += " " + token + " "
+            line +=  + token + 
 
-        line += "|" + (" "*constraintPadding) + "|"
+        line += "|" + (*constraintPadding) + "|"
 
         # Add constraint vector
         token = numFmt % constraints[row]
@@ -382,13 +382,13 @@ def to_standard_form(self):
             token = altFmt % constraints[row]
 
         # Pad with trailing whitespace
-        token += " "*(maxConstraintColWidth - len(token))
+        token += *(maxConstraintColWidth - len(token))
 
-        line += " " + token + "  |"
+        line +=  + token + "  |"
         print(line+'\n')
-    print(" "*maxConNameLen + (" "*constraintPadding) + "+--" + \
-          " "*((maxColWidth+2)*nVariables - 4) + "--+" + \
-          (" "*constraintPadding) + "+--" + (" "*(maxConstraintColWidth-1))\
+    print(*maxConNameLen + (*constraintPadding) + "+--" + \
+          *((maxColWidth+2)*nVariables - 4) + "--+" + \
+          (*constraintPadding) + "+--" + (*(maxConstraintColWidth-1))\
           + "--+"+'\n')
 
     return (coefficients, costs, constraints)

--- a/pyomo/core/plugins/transform/model.py
+++ b/pyomo/core/plugins/transform/model.py
@@ -304,7 +304,7 @@ def to_standard_form(self):
     # Generate the variable names
     varNames = [None]*len(colID)
     for name in colID:
-        tmp_name =  + name
+        tmp_name = " " + name
         if len(tmp_name) > maxColWidth:
             maxColWidth = len(tmp_name)
         varNames[colID[name]] = tmp_name
@@ -320,22 +320,22 @@ def to_standard_form(self):
         varNames.append(tmp_name)
 
     # Variable names
-    line = *maxConNameLen + (*constraintPadding) + 
+    line = " "*maxConNameLen + (" "*constraintPadding) + " "
     for col in range(0, nVariables):
         # Format entry
         token = varNames[col]
 
         # Pad with trailing whitespace
-        token += *(maxColWidth - len(token))
+        token += " "*(maxColWidth - len(token))
 
         # Add to line
-        line +=  + token + 
+        line += " " + token + " "
     print(line+'\n')
 
     # Cost vector
-    print(*maxConNameLen + (*constraintPadding) + "+--" + \
-          *((maxColWidth+2)*nVariables - 4) + "--+" + '\n')
-    line = *maxConNameLen + (*constraintPadding) + "|"
+    print(" "*maxConNameLen + (" "*constraintPadding) + "+--" + \
+          " "*((maxColWidth+2)*nVariables - 4) + "--+" + '\n')
+    line = " "*maxConNameLen + (" "*constraintPadding) + "|"
     for col in range(0, nVariables):
         # Format entry
         token = numFmt % costs[col]
@@ -343,23 +343,23 @@ def to_standard_form(self):
             token = altFmt % costs[col]
 
         # Pad with trailing whitespace
-        token += *(maxColWidth - len(token))
+        token += " "*(maxColWidth - len(token))
 
         # Add to line
-        line +=  + token + 
+        line += " " + token + " "
     line += "|"
     print(line+'\n')
-    print(*maxConNameLen + (*constraintPadding) + "+--" + \
-          *((maxColWidth+2)*nVariables - 4) + "--+"+'\n')
+    print(" "*maxConNameLen + (" "*constraintPadding) + "+--" + \
+          " "*((maxColWidth+2)*nVariables - 4) + "--+"+'\n')
 
     # Constraints
-    print(*maxConNameLen + (*constraintPadding) + "+--" + \
-          *((maxColWidth+2)*nVariables - 4) + "--+" + \
-          (*constraintPadding) + "+--" + \
-          (*(maxConstraintColWidth-1)) + "--+"+'\n')
+    print(" "*maxConNameLen + (" "*constraintPadding) + "+--" + \
+          " "*((maxColWidth+2)*nVariables - 4) + "--+" + \
+          (" "*constraintPadding) + "+--" + \
+          (" "*(maxConstraintColWidth-1)) + "--+"+'\n')
     for row in range(0, nConstraints):
         # Print constraint name
-        line = conNames[row] + (*constraintPadding) + (*(maxConNameLen - len(conNames[row]))) + "|"
+        line = conNames[row] + (" "*constraintPadding) + (" "*(maxConNameLen - len(conNames[row]))) + "|"
 
         # Print each coefficient
         for col in range(0, nVariables):
@@ -369,12 +369,12 @@ def to_standard_form(self):
                 token = altFmt % coefficients[nVariables*row + col]
 
             # Pad with trailing whitespace
-            token += *(maxColWidth - len(token))
+            token += " "*(maxColWidth - len(token))
 
             # Add to line
-            line +=  + token + 
+            line += " " + token + " "
 
-        line += "|" + (*constraintPadding) + "|"
+        line += "|" + (" "*constraintPadding) + "|"
 
         # Add constraint vector
         token = numFmt % constraints[row]
@@ -382,13 +382,13 @@ def to_standard_form(self):
             token = altFmt % constraints[row]
 
         # Pad with trailing whitespace
-        token += *(maxConstraintColWidth - len(token))
+        token += " "*(maxConstraintColWidth - len(token))
 
-        line +=  + token + "  |"
+        line += " " + token + "  |"
         print(line+'\n')
-    print(*maxConNameLen + (*constraintPadding) + "+--" + \
-          *((maxColWidth+2)*nVariables - 4) + "--+" + \
-          (*constraintPadding) + "+--" + (*(maxConstraintColWidth-1))\
+    print(" "*maxConNameLen + (" "*constraintPadding) + "+--" + \
+          " "*((maxColWidth+2)*nVariables - 4) + "--+" + \
+          (" "*constraintPadding) + "+--" + (" "*(maxConstraintColWidth-1))\
           + "--+"+'\n')
 
     return (coefficients, costs, constraints)

--- a/pyomo/core/tests/examples/test_amplbook2.py
+++ b/pyomo/core/tests/examples/test_amplbook2.py
@@ -33,7 +33,7 @@ class TestAmplbook2(unittest.TestCase): pass
 #for file in files:
 #    bname=os.path.basename(file)
 #    name=bname.split('.')[0]
-#    TestAmplbook2.add_commandline_test(cmd="cd "+data_dir+"; "+topdir+os.sep+"scripts/pyomo "+bname+" "+name+".dat", baseline=data_dir+name+".log", name=name)
+#    TestAmplbook2.add_commandline_test(cmd="cd "+data_dir+"; "+topdir+os.sep+"scripts/pyomo "+bname++name+".dat", baseline=data_dir+name+".log", name=name)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/core/tests/examples/test_amplbook2.py
+++ b/pyomo/core/tests/examples/test_amplbook2.py
@@ -33,7 +33,7 @@ class TestAmplbook2(unittest.TestCase): pass
 #for file in files:
 #    bname=os.path.basename(file)
 #    name=bname.split('.')[0]
-#    TestAmplbook2.add_commandline_test(cmd="cd "+data_dir+"; "+topdir+os.sep+"scripts/pyomo "+bname++name+".dat", baseline=data_dir+name+".log", name=name)
+#    TestAmplbook2.add_commandline_test(cmd="cd "+data_dir+"; "+topdir+os.sep+"scripts/pyomo "+bname+" "+name+".dat", baseline=data_dir+name+".log", name=name)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/core/tests/unit/test_numeric_expr.py
+++ b/pyomo/core/tests/unit/test_numeric_expr.py
@@ -4639,7 +4639,7 @@ class TestLinearExpression(unittest.TestCase):
             e = LinearExpression([20, 6, 7, m.x, m.y])
         self.assertIn("LinearExpression has been updated to expect args= "
                       "to be a constant followed by MonomialTermExpressions",
-                      OUT.getvalue().replace("\n", ))
+                      OUT.getvalue().replace("\n", " "))
         self.assertIsNotNone(e._args_cache_)
         self.assertEqual(len(e._args_cache_), 3)
         self.assertEqual(e._args_cache_[0], 20)
@@ -4654,7 +4654,7 @@ class TestLinearExpression(unittest.TestCase):
             e = LinearExpression([20, 6, 7, 8, m.x, m.y, m.x])
         self.assertIn("LinearExpression has been updated to expect args= "
                       "to be a constant followed by MonomialTermExpressions",
-                      OUT.getvalue().replace("\n", ))
+                      OUT.getvalue().replace("\n", " "))
         self.assertIsNotNone(e._args_cache_)
         self.assertEqual(len(e._args_cache_), 4)
         self.assertEqual(e._args_cache_[0], 20)

--- a/pyomo/core/tests/unit/test_numeric_expr.py
+++ b/pyomo/core/tests/unit/test_numeric_expr.py
@@ -4639,7 +4639,7 @@ class TestLinearExpression(unittest.TestCase):
             e = LinearExpression([20, 6, 7, m.x, m.y])
         self.assertIn("LinearExpression has been updated to expect args= "
                       "to be a constant followed by MonomialTermExpressions",
-                      OUT.getvalue().replace("\n", " "))
+                      OUT.getvalue().replace("\n", ))
         self.assertIsNotNone(e._args_cache_)
         self.assertEqual(len(e._args_cache_), 3)
         self.assertEqual(e._args_cache_[0], 20)
@@ -4654,7 +4654,7 @@ class TestLinearExpression(unittest.TestCase):
             e = LinearExpression([20, 6, 7, 8, m.x, m.y, m.x])
         self.assertIn("LinearExpression has been updated to expect args= "
                       "to be a constant followed by MonomialTermExpressions",
-                      OUT.getvalue().replace("\n", " "))
+                      OUT.getvalue().replace("\n", ))
         self.assertIsNotNone(e._args_cache_)
         self.assertEqual(len(e._args_cache_), 4)
         self.assertEqual(e._args_cache_[0], 20)


### PR DESCRIPTION
## Fixes (Partly) #329 

## Summary/Motivation:
This is the first in a relatively long string of PRs to apply PEP8 standards via `black` to Pyomo. We are following the standard used by IDAES _except_ that we are adding the `-S` option: `Don't normalize string quotes or prefixes` and the `-C` option: `Don't use trailing commas as a reason to split lines.`

**NOTE**: All changes are NFC.

Full command used: `cd pyomo/common && black -S -C .`

:warning: Please squash this at merge. :warning:

## Changes proposed in this PR:
- Apply `black` to the `pyomo/common` directory `py` files
- Manually fix instances where two lines were merged and left `" "` or `' '`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
