### PR TITLE
Apply `black` to `pyomo/dataportal` directory `py` files

### DIFF
--- a/pyomo/dataportal/DataPortal.py
+++ b/pyomo/dataportal/DataPortal.py
@@ -39,7 +39,7 @@ class DataPortal(object):
             Default is :const:`None`.
         filename (str): A file from which data is loaded.  Default
             is :const:`None`.
-        data_dict (dict): A dictionary used to initialize the data 
+        data_dict (dict): A dictionary used to initialize the data
             in this object.  Default is :const:`None`.
     """
 
@@ -48,16 +48,18 @@ class DataPortal(object):
         Constructor
         """
         if len(args) > 0:
-            raise RuntimeError("Unexpected constructor argument for a DataPortal object")
+            raise RuntimeError(
+                "Unexpected constructor argument for a DataPortal object"
+            )
 
         # Initialize this object with no data manager
         self._data_manager = None
 
         # Map initialization data as follows: _data[namespace][symbol] -> data
-        self._data={}
+        self._data = {}
 
         # This is the data that is imported from various sources
-        self._default={}
+        self._default = {}
 
         # Get the model for which this data is associated.
         self._model = kwds.pop('model', None)
@@ -82,9 +84,9 @@ class DataPortal(object):
         This data manager is used to process future data imports and exports.
 
         Args:
-            filename (str): A filename that specifies the data source.  
+            filename (str): A filename that specifies the data source.
                 Default is :const:`None`.
-            server (str): The name of the remote server that hosts the data.  
+            server (str): The name of the remote server that hosts the data.
                 Default is :const:`None`.
             using (str): The name of the resource used to load the data.
                 Default is :const:`None`.
@@ -93,11 +95,11 @@ class DataPortal(object):
         """
         if not self._data_manager is None:
             self._data_manager.close()
-        data = kwds.get('using',None)
+        data = kwds.get('using', None)
         if data is None:
-            data = kwds.get('filename',None)
+            data = kwds.get('filename', None)
         if data is None:
-            data = kwds.get('server',None)
+            data = kwds.get('server', None)
         if '.' in data:
             tmp = data.split(".")[-1]
         else:
@@ -126,25 +128,25 @@ class DataPortal(object):
 
         Other keyword arguments are passed to the :func:`connect()` method.
         """
-        if is_debug_set(logger):        #pragma:nocover
+        if is_debug_set(logger):  # pragma:nocover
             logger.debug("Loading data...")
         #
         # Process arguments
         #
         _model = kwds.pop('model', None)
         if not _model is None:
-            self._model=_model
+            self._model = _model
         #
-        # If _disconnect is True, then disconnect the data 
+        # If _disconnect is True, then disconnect the data
         # manager after we load data
         #
-        _disconnect=False
+        _disconnect = False
         if self._data_manager is None:
             #
             # Start a new connection
             #
             self.connect(**kwds)
-            _disconnect=True
+            _disconnect = True
         elif len(kwds) > 0:
             #
             # We are continuing to store using an existing connection.
@@ -160,7 +162,7 @@ class DataPortal(object):
         #
         # Read from data manager into self._data and self._default
         #
-        if is_debug_set(logger):        #pragma:nocover
+        if is_debug_set(logger):  # pragma:nocover
             logger.debug("Processing data ...")
         self._data_manager.read()
         status = self._data_manager.process(self._model, self._data, self._default)
@@ -170,7 +172,7 @@ class DataPortal(object):
         #
         if _disconnect:
             self.disconnect()
-        if is_debug_set(logger):        #pragma:nocover
+        if is_debug_set(logger):  # pragma:nocover
             logger.debug("Done.")
 
     def store(self, **kwds):
@@ -183,22 +185,22 @@ class DataPortal(object):
 
         Other keyword arguments are passed to the :func:`connect()` method.
         """
-        if is_debug_set(logger):        #pragma:nocover
+        if is_debug_set(logger):  # pragma:nocover
             logger.debug("Storing data...")
         #
         # Process arguments
         #
         _model = kwds.pop('model', None)
         if not _model is None:
-            self._model=_model
+            self._model = _model
         #
-	    # If _disconnect is True, then disconnect the data manager
-	    # after we load data
+        # If _disconnect is True, then disconnect the data manager
+        # after we load data
         #
-        _disconnect=False
+        _disconnect = False
         if self._data_manager is None:
             self.connect(**kwds)
-            _disconnect=True
+            _disconnect = True
         elif len(kwds) > 0:
             #
             # Q: Should we reinitialize?  The semantic difference between
@@ -219,12 +221,12 @@ class DataPortal(object):
         #
         if _disconnect:
             self.disconnect()
-        if is_debug_set(logger):        #pragma:nocover
+        if is_debug_set(logger):  # pragma:nocover
             logger.debug("Done.")
 
     def data(self, name=None, namespace=None):
         """
-	    Return the data associated with a symbol and namespace
+            Return the data associated with a symbol and namespace
 
         Args:
             name (str): The name of the symbol that is returned.
@@ -235,11 +237,11 @@ class DataPortal(object):
 
         Returns:
             If ``name`` is :const:`None`, then the dictionary for
-            the namespace is returned.  Otherwise, the data 
+            the namespace is returned.  Otherwise, the data
             associated with ``name`` in given namespace is returned.
-            The return value is a constant if :const:`None` if 
+            The return value is a constant if :const:`None` if
             there is a single value in the symbol dictionary, and otherwise
-            the symbol dictionary is returned.            
+            the symbol dictionary is returned.
         """
         if not namespace in self._data:
             raise IOError("Unknown namespace '%s'" % str(namespace))
@@ -253,7 +255,7 @@ class DataPortal(object):
 
     def __getitem__(self, *args):
         """
-        Return the specified data value.  
+        Return the specified data value.
 
         If a single argument is given, then this is the symbol name::
 
@@ -276,15 +278,17 @@ class DataPortal(object):
             symbol in the given namespace is returned.
         """
         if type(args[0]) is tuple or type(args[0]) is list:
-            assert(len(args) == 1)
+            assert len(args) == 1
             args = args[0]
         if len(args) > 2:
-            raise IOError("Must specify data name:  DataPortal[name] or Data[namespace, name]")
+            raise IOError(
+                "Must specify data name:  DataPortal[name] or Data[namespace, name]"
+            )
         elif len(args) == 2:
             namespace = args[0]
             name = args[1]
         else:
-            namespace=None
+            namespace = None
             name = args[0]
 
         ans = self._data[namespace][name]
@@ -366,27 +370,31 @@ class DataPortal(object):
         """
         options = self._data_manager.options
         #
-        if options.data is None and (not options.set is None or not options.param is None or not options.index is None):
+        if options.data is None and (
+            not options.set is None
+            or not options.param is None
+            or not options.index is None
+        ):
             #
             # Set options.data to a list of elements of the options.set,
             # options.param and options.index values.
             #
             options.data = []
             if not options.set is None:
-                assert(type(options.set) not in (list, tuple))
+                assert type(options.set) not in (list, tuple)
                 options.data.append(options.set)
                 #
                 # The set option should not be a list or tuple.
                 #
-                #if type(options.set) in (list,tuple):
+                # if type(options.set) in (list,tuple):
                 #    for item in options.set:
                 #        options.data.append(item)
-                #else:
+                # else:
                 #    options.data.append(options.set)
             if not options.index is None:
                 options.data.append(options.index)
             if not options.param is None:
-                if type(options.param) in (list,tuple):
+                if type(options.param) in (list, tuple):
                     for item in options.param:
                         options.data.append(item)
                 else:
@@ -418,7 +426,7 @@ class DataPortal(object):
             #
             try:
                 self._model = options.data.model()
-                options.data = [ self._data_manager.options.data.local_name ]
+                options.data = [self._data_manager.options.data.local_name]
             except:
                 pass
 
@@ -434,4 +442,3 @@ class DataPortal(object):
                 self._data[name] = c.data()
             except:
                 self._data[name] = c.extract_values()
-

--- a/pyomo/dataportal/TableData.py
+++ b/pyomo/dataportal/TableData.py
@@ -25,8 +25,8 @@ class TableData(object):
         """
         Constructor
         """
-        self._info=None
-        self._data=None
+        self._info = None
+        self._data = None
         self.options = Bunch()
         self.options.ncolumns = 1
 
@@ -54,25 +54,25 @@ class TableData(object):
         """
         self.options.update(kwds)
 
-    def open(self):                        #pragma:nocover
+    def open(self):  # pragma:nocover
         """
         Open the data manager.
         """
         pass
 
-    def read(self):                         #pragma:nocover
+    def read(self):  # pragma:nocover
         """
         Read data from the data manager.
         """
         return False
 
-    def write(self, data):                  #pragma:nocover
+    def write(self, data):  # pragma:nocover
         """
         Write data to the data manager.
         """
         return False
 
-    def close(self):                        #pragma:nocover
+    def close(self):  # pragma:nocover
         """
         Close the data manager.
         """
@@ -88,15 +88,16 @@ class TableData(object):
         if not self.options.namespace in data:
             data[self.options.namespace] = {}
         return _process_data(
-          self._info,
-          model,
-          data[self.options.namespace],
-          default,
-          self.filename,
-          index=self.options.index,
-          set=self.options.set,
-          param=self.options.param,
-          ncolumns = self.options.ncolumns)
+            self._info,
+            model,
+            data[self.options.namespace],
+            default,
+            self.filename,
+            index=self.options.index,
+            set=self.options.set,
+            param=self.options.param,
+            ncolumns=self.options.ncolumns,
+        )
 
     def clear(self):
         """
@@ -117,7 +118,10 @@ class TableData(object):
                 try:
                     header_index.append(headers.index(str(i)))
                 except:
-                    print("Model declaration '%s' not found in returned query columns" %str(i))
+                    print(
+                        "Model declaration '%s' not found in returned query columns"
+                        % str(i)
+                    )
                     raise
         self.options.ncolumns = len(headers)
 
@@ -167,7 +171,7 @@ class TableData(object):
                 msg = "Cannot specify index for data with the 'set' format: %s"
                 raise IOError(msg % str(self.options.index))
 
-            self._info = ["set",self.options.set,":="]
+            self._info = ["set", self.options.set, ":="]
             for row in rows:
                 if self.options.ncolumns > 1:
                     self._info.append(tuple(row))
@@ -176,25 +180,24 @@ class TableData(object):
 
         elif self.options.format == 'set_array':
             if not self.options.index is None:
-                msg = "Cannot specify index for data with the 'set_array' "   \
-                      'format: %s'
+                msg = "Cannot specify index for data with the 'set_array' " 'format: %s'
                 raise IOError(msg % str(self.options.index))
 
-            self._info = ["set",self.options.set, ":"]
+            self._info = ["set", self.options.set, ":"]
             self._info.extend(headers[1:])
             self._info.append(":=")
             for row in rows:
                 self._info.extend(row)
 
         elif self.options.format == 'transposed_array':
-            self._info = ["param",self.options.param[0],"(tr)",":"]
+            self._info = ["param", self.options.param[0], "(tr)", ":"]
             self._info.extend(headers[1:])
             self._info.append(":=")
             for row in rows:
                 self._info.extend(row)
 
         elif self.options.format == 'array':
-            self._info = ["param",self.options.param[0],":"]
+            self._info = ["param", self.options.param[0], ":"]
             self._info.extend(headers[1:])
             self._info.append(":=")
             for row in rows:
@@ -202,9 +205,9 @@ class TableData(object):
 
         elif self.options.format == 'table':
             if self.options.index is not None:
-                self._info = ["param",":",self.options.index,":"]
+                self._info = ["param", ":", self.options.index, ":"]
             else:
-                self._info = ["param",":"]
+                self._info = ["param", ":"]
             for param in self.options.param:
                 self._info.append(param)
             self._info.append(":=")
@@ -227,7 +230,7 @@ class TableData(object):
             if self.options.columns is None:
                 cols = []
                 for i in range(self.options.set.dimen):
-                    cols.append(self.options.set.local_name+str(i))
+                    cols.append(self.options.set.local_name + str(i))
                 tmp.append(cols)
             # Get rows
             if self.options.sort is not None:
@@ -243,7 +246,7 @@ class TableData(object):
                     else:
                         tmp.append([data])
         elif self.options.param is not None:
-            if type(self.options.param) in (list,tuple):
+            if type(self.options.param) in (list, tuple):
                 _param = self.options.param
             else:
                 _param = [self.options.param]
@@ -251,7 +254,7 @@ class TableData(object):
             for index in _param[0]:
                 if index is None:
                     row = []
-                elif type(index) in (list,tuple):
+                elif type(index) in (list, tuple):
                     row = list(index)
                 else:
                     row = [index]
@@ -261,9 +264,9 @@ class TableData(object):
             # Create column names
             if self.options.columns is None:
                 cols = []
-                for i in range(len(tmp[0])-len(_param)):
-                    cols.append('I'+str(i))
+                for i in range(len(tmp[0]) - len(_param)):
+                    cols.append('I' + str(i))
                 for param in _param:
                     cols.append(param)
-                tmp.insert(0,cols)
+                tmp.insert(0, cols)
         return tmp

--- a/pyomo/dataportal/factory.py
+++ b/pyomo/dataportal/factory.py
@@ -9,10 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = [
-        'DataManagerFactory',
-        'UnknownDataManager'
-        ]
+__all__ = ['DataManagerFactory', 'UnknownDataManager']
 
 import logging
 from pyomo.common import Factory
@@ -22,7 +19,6 @@ logger = logging.getLogger('pyomo.core')
 
 
 class UnknownDataManager(object):
-
     def __init__(self, *args, **kwds):
         #
         # The 'type' is the class type of the solver instance
@@ -41,14 +37,17 @@ class DataManagerFactoryClass(Factory):
     def __call__(self, _name=None, args=[], **kwds):
         if _name is None:
             return self
-        _name=str(_name)
+        _name = str(_name)
         if _name in self._cls:
             dm = self._cls[_name](**kwds)
             if not dm.available():
-                raise PluginError("Cannot process data in %s files.  The following python packages need to be installed: %s" % (_name, dm.requirements()))
+                raise PluginError(
+                    "Cannot process data in %s files.  The following python packages need to be installed: %s"
+                    % (_name, dm.requirements())
+                )
         else:
             dm = UnknownDataManager(type=_name)
         return dm
 
-DataManagerFactory = DataManagerFactoryClass('data file')
 
+DataManagerFactory = DataManagerFactoryClass('data file')

--- a/pyomo/dataportal/plugins/__init__.py
+++ b/pyomo/dataportal/plugins/__init__.py
@@ -11,6 +11,7 @@
 
 from pyomo.common.dependencies import pyutilib, pyutilib_available
 
+
 def load():
     import pyomo.dataportal.plugins.csv_table
     import pyomo.dataportal.plugins.datacommands
@@ -18,6 +19,6 @@ def load():
     import pyomo.dataportal.plugins.json_dict
     import pyomo.dataportal.plugins.text
     import pyomo.dataportal.plugins.xml_table
+
     if pyutilib_available:
         import pyomo.dataportal.plugins.sheet
-

--- a/pyomo/dataportal/plugins/csv_table.py
+++ b/pyomo/dataportal/plugins/csv_table.py
@@ -18,12 +18,11 @@ from pyomo.dataportal.factory import DataManagerFactory
 
 @DataManagerFactory.register("csv", "CSV file interface")
 class CSVTable(TableData):
-
     def __init__(self):
         TableData.__init__(self)
 
     def open(self):
-        if self.filename is None:                       #pragma:nocover
+        if self.filename is None:  # pragma:nocover
             raise IOError("No filename specified")
 
     def close(self):
@@ -31,10 +30,11 @@ class CSVTable(TableData):
 
     def read(self):
         from pyomo.core.base.param import Param
-        if not os.path.exists(self.filename):           #pragma:nocover
+
+        if not os.path.exists(self.filename):  # pragma:nocover
             raise IOError("Cannot find file '%s'" % self.filename)
         self.FILE = open(self.filename, 'r')
-        tmp=[]
+        tmp = []
         for tokens in csv.reader(self.FILE):
             if tokens != ['']:
                 tmp.append(tokens)
@@ -50,11 +50,19 @@ class CSVTable(TableData):
                 if isinstance(p, Param):
                     self.options.model = p.model()
                     p = p.local_name
-                self._info = ["param",p,":=",tmp[0][0]]
+                self._info = ["param", p, ":=", tmp[0][0]]
             elif len(self.options.symbol_map) == 1:
-                self._info = ["param",self.options.symbol_map[self.options.symbol_map.keys()[0]],":=",tmp[0][0]]
+                self._info = [
+                    "param",
+                    self.options.symbol_map[self.options.symbol_map.keys()[0]],
+                    ":=",
+                    tmp[0][0],
+                ]
             else:
-                raise IOError("Data looks like a parameter, but multiple parameter names have been specified: %s" % str(self.options.symbol_map))
+                raise IOError(
+                    "Data looks like a parameter, but multiple parameter names have been specified: %s"
+                    % str(self.options.symbol_map)
+                )
         else:
             self._set_data(tmp[0], tmp[1:])
 
@@ -66,4 +74,3 @@ class CSVTable(TableData):
         writer = csv.writer(self.FILE)
         writer.writerows(table)
         self.FILE.close()
-

--- a/pyomo/dataportal/plugins/datacommands.py
+++ b/pyomo/dataportal/plugins/datacommands.py
@@ -18,7 +18,6 @@ from pyomo.dataportal.process_data import _process_include
 
 @DataManagerFactory.register("dat", "Pyomo data command file interface")
 class PyomoDataCommands(object):
-
     def __init__(self):
         self._info = []
         self.options = Bunch()
@@ -34,9 +33,9 @@ class PyomoDataCommands(object):
         self.options.update(kwds)
 
     def open(self):
-        if self.filename is None:               #pragma:nocover
+        if self.filename is None:  # pragma:nocover
             raise IOError("No filename specified")
-        if not os.path.exists(self.filename):   #pragma:nocover
+        if not os.path.exists(self.filename):  # pragma:nocover
             raise IOError("Cannot find file '%s'" % self.filename)
 
     def close(self):
@@ -49,7 +48,7 @@ class PyomoDataCommands(object):
         """
         pass
 
-    def write(self, data):                      #pragma:nocover
+    def write(self, data):  # pragma:nocover
         """
         This function does nothing, because we cannot write to a *.dat file.
         """

--- a/pyomo/dataportal/plugins/db_table.py
+++ b/pyomo/dataportal/plugins/db_table.py
@@ -31,8 +31,8 @@ pymysql, pymysql_available = attempt_import('pymysql')
 # password=
 # table=
 
-class db_Table(TableData):
 
+class db_Table(TableData):
     def __init__(self):
         TableData.__init__(self)
         self.using = None
@@ -79,6 +79,7 @@ class db_Table(TableData):
             tmp = [tmp]
         except sqlite3.OperationalError:
             import logging
+
             logging.getLogger('pyomo.core').error(
                 """Fatal error reading from an external ODBC data source.
 
@@ -94,13 +95,15 @@ for the query:
 It is possible that you have an error in your external data file,
 the ODBC connector for this data source is not correctly installed,
 or that there is a bug in the ODBC connector.
-""" % (self.filename, self.options.query) )
+"""
+                % (self.filename, self.options.query)
+            )
             raise
         for row in rows:
-            #print("DATA %s" % str(list(row))) # XXX
-            ttmp=[]
+            # print("DATA %s" % str(list(row))) # XXX
+            ttmp = []
             for data in list(row):
-                if isinstance(data,Decimal):
+                if isinstance(data, Decimal):
                     ttmp.append(float(data))
                 elif data is None:
                     ttmp.append('.')
@@ -112,7 +115,7 @@ or that there is a bug in the ODBC connector.
                 else:
                     ttmp.append(data)
             tmp.append(ttmp)
-        #print('FINAL %s' % str(tmp)) # XXX
+        # print('FINAL %s' % str(tmp)) # XXX
         #
         # Process data from the table
         #
@@ -120,15 +123,23 @@ or that there is a bug in the ODBC connector.
             if not self.options.param is None:
                 self._info = ["param", self.options.param.local_name, ":=", tmp]
             elif len(self.options.symbol_map) == 1:
-                self._info = ["param", self.options.symbol_map[self.options.symbol_map.keys()[0]], ":=", tmp]
+                self._info = [
+                    "param",
+                    self.options.symbol_map[self.options.symbol_map.keys()[0]],
+                    ":=",
+                    tmp,
+                ]
             else:
-                raise IOError("Data looks like a scalar parameter, but multiple parameter names have been specified: %s" % str(self.options.symbol_map))
+                raise IOError(
+                    "Data looks like a scalar parameter, but multiple parameter names have been specified: %s"
+                    % str(self.options.symbol_map)
+                )
         elif len(tmp) == 0:
             raise IOError("Empty range '%s'" % self.options.range)
         else:
-            #print("_info %s" % str(self._info))
-            #print("SETTING DATA %s %s" % (str(tmp[0]), str(tmp[1:]))) # XXX
-            #print("OPTIONS %s" % str(self.options))
+            # print("_info %s" % str(self._info))
+            # print("SETTING DATA %s %s" % (str(tmp[0]), str(tmp[1:]))) # XXX
+            # print("OPTIONS %s" % str(self.options))
             self._set_data(tmp[0], tmp[1:])
 
     def close(self):
@@ -149,6 +160,7 @@ or that there is a bug in the ODBC connector.
         except ImportError:
             return None
 
+
 #
 # NOTE: The pyodbc interface currently doesn't work.  Notably, nothing
 # sets the "table" or "query" options, which causes db_table.read() to
@@ -156,16 +168,20 @@ or that there is a bug in the ODBC connector.
 # in sheet.py
 #
 
+
 @DataManagerFactory.register('pyodbc', "%s database interface" % 'pyodbc')
 class pyodbc_db_Table(db_Table):
 
     _drivers = {
         'mdb': ["Microsoft Access Driver (*.mdb)"],
-        'xls': ["Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)","Microsoft Excel Driver (*.xls)"],
+        'xls': [
+            "Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)",
+            "Microsoft Excel Driver (*.xls)",
+        ],
         'xlsx': ["Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)"],
         'xlsm': ["Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)"],
         'xlsb': ["Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)"],
-        'mysql': ["MySQL"]
+        'mysql': ["MySQL"],
     }
     _drivers['access'] = _drivers['mdb']
     _drivers['excel'] = _drivers['xls']
@@ -190,7 +206,13 @@ class pyodbc_db_Table(db_Table):
         else:
             ctype = ''
         extras = {}
-        if ctype in ['xls', 'xlsx', 'xlsm', 'xlsb', 'excel'] or '.xls' in connection or '.xlsx' in connection or '.xlsm' in connection or '.xlsb' in connection:
+        if (
+            ctype in ['xls', 'xlsx', 'xlsm', 'xlsb', 'excel']
+            or '.xls' in connection
+            or '.xlsx' in connection
+            or '.xlsm' in connection
+            or '.xlsb' in connection
+        ):
             extras['autocommit'] = True
 
         connection = self.create_connection_string(ctype, connection, options)
@@ -220,7 +242,9 @@ class pyodbc_db_Table(db_Table):
                         config = ODBCConfig()
 
                     dsninfo = self.create_dsn_dict(connection, config)
-                    dsnid = re.sub('[^A-Za-z0-9]', '', dsninfo['Database']) # Strip filenames of funny characters
+                    dsnid = re.sub(
+                        '[^A-Za-z0-9]', '', dsninfo['Database']
+                    )  # Strip filenames of funny characters
                     dsn = 'PYOMO{0}'.format(dsnid)
 
                     config.add_source(dsn, dsninfo['Driver'])
@@ -235,12 +259,14 @@ class pyodbc_db_Table(db_Table):
                     connstr = []
                     for k, v in dsninfo.items():
                         if ' ' in v and (v[0] != "{" or v[-1] != "}"):
-                            connstr.append("%s={%s}" % (k.upper(),v))
+                            connstr.append("%s={%s}" % (k.upper(), v))
                         else:
-                            connstr.append("%s=%s" % (k.upper(),v))
+                            connstr.append("%s=%s" % (k.upper(), v))
                     connstr = ";".join(connstr)
 
-                conn = db_Table.connect(self, connstr, options, extras) # Will raise its own exception on failure
+                conn = db_Table.connect(
+                    self, connstr, options, extras
+                )  # Will raise its own exception on failure
 
             # Propagate the exception
             else:
@@ -255,7 +281,7 @@ class pyodbc_db_Table(db_Table):
         argdict = {}
         for part in parts:
             if len(part) > 0 and '=' in part:
-                key, val = part.split('=',1)
+                key, val = part.split('=', 1)
                 argdict[key.lower().strip()] = val.strip()
 
         if 'driver' in argdict:
@@ -266,8 +292,13 @@ class pyodbc_db_Table(db_Table):
                 return existing_config.source_specs[argdict['dsn']]
             else:
                 import logging
+
                 logger = logging.getLogger("pyomo.core")
-                logger.warning("DSN with name {0} not found. Attempting to continue with options...".format(argdict['dsn']))
+                logger.warning(
+                    "DSN with name {0} not found. Attempting to continue with options...".format(
+                        argdict['dsn']
+                    )
+                )
 
         if 'dbq' in argdict:
             # Using a file for db access.
@@ -297,7 +328,11 @@ class pyodbc_db_Table(db_Table):
                 result['Password'] = argdict.get('password', '')
                 result['Description'] = argdict.get('description', '')
             else:
-                raise Exception("Unknown driver type '{0}' for database connection".format(result['Driver']))
+                raise Exception(
+                    "Unknown driver type '{0}' for database connection".format(
+                        result['Driver']
+                    )
+                )
 
         return result
 
@@ -315,7 +350,7 @@ class pyodbc_db_Table(db_Table):
         # a match in the pyodbc.drivvers() list.  If a match is found,
         # return it.  Otherwise (arbitrarily) return the first one.  If
         # the ctype is not known, return None.
-        drivers = self._drivers.get(ctype,[])
+        drivers = self._drivers.get(ctype, [])
         for driver in drivers:
             if driver in pyodbc.drivers():
                 return driver
@@ -328,11 +363,12 @@ class pyodbc_db_Table(db_Table):
 class ODBCError(Exception):
     def __init__(self, value):
         self.parameter = value
+
     def __repr__(self):
         return repr(self.parameter)
 
 
-class ODBCConfig():
+class ODBCConfig:
     """
     Encapsulates an ODBC configuration file, usually odbc.ini or
     .odbc.ini, as specified by IBM. ODBC config data can be loaded
@@ -391,11 +427,17 @@ class ODBCConfig():
         self.source_specs.update(sections)
 
     def __str__(self):
-        return "<ODBC config: {0} sources, {1} source specs>".format(len(self.sources), len(self.source_specs))
+        return "<ODBC config: {0} sources, {1} source specs>".format(
+            len(self.sources), len(self.source_specs)
+        )
 
     def __eq__(self, other):
         if isinstance(other, ODBCConfig):
-            return self.sources == other.sources and self.source_specs == other.source_specs and self.odbc_info == other.odbc_info
+            return (
+                self.sources == other.sources
+                and self.source_specs == other.source_specs
+                and self.odbc_info == other.odbc_info
+            )
         return False
 
     def odbc_repr(self):
@@ -468,9 +510,13 @@ class ODBCConfig():
         """
 
         if name is None or spec is None or len(name) == 0:
-            raise ODBCError("A source spec must specify both a name and a spec dictionary")
+            raise ODBCError(
+                "A source spec must specify both a name and a spec dictionary"
+            )
         if name not in self.sources:
-            raise ODBCError("A source spec must have a corresponding source; call .add_source() first")
+            raise ODBCError(
+                "A source spec must have a corresponding source; call .add_source() first"
+            )
 
         self.source_specs[name] = dict(spec)
 
@@ -522,7 +568,9 @@ class ODBCConfig():
                 pass
             elif len(line) < 2:
                 # Not enough room for even 'k='; can't contain info
-                raise ODBCError("Malformed line in ODBC config (no meaningful data): " + line)
+                raise ODBCError(
+                    "Malformed line in ODBC config (no meaningful data): " + line
+                )
             elif line[0] == '[' and line[-1] == ']':
                 # Starts a new section; '=' has no special meaning here
                 sections[sectionKey] = sectionContents
@@ -531,11 +579,15 @@ class ODBCConfig():
             else:
                 # Not whitespace or section header; must be key=value. No duplicate '=' permitted.
                 if '=' not in line:
-                    raise ODBCError("Malformed line in ODBC config (no key-value mapping): " + line)
+                    raise ODBCError(
+                        "Malformed line in ODBC config (no key-value mapping): " + line
+                    )
 
-                key, value = line.split("=",1)
+                key, value = line.split("=", 1)
                 if '=' in value:
-                    raise ODBCError("Malformed line in ODBC config (too many '='): " + line)
+                    raise ODBCError(
+                        "Malformed line in ODBC config (too many '='): " + line
+                    )
 
                 sectionContents[key.strip()] = value.strip()
         sections[sectionKey] = sectionContents
@@ -548,7 +600,6 @@ class ODBCConfig():
 
 @DataManagerFactory.register('pypyodbc', "%s database interface" % 'pypyodbc')
 class pypyodbc_db_Table(pyodbc_db_Table):
-
     def __init__(self):
         pyodbc_db_Table.__init__(self)
         self.using = 'pypyodbc'
@@ -560,14 +611,13 @@ class pypyodbc_db_Table(pyodbc_db_Table):
         return 'pypyodbc'
 
     def connect(self, connection, options):
-        assert(options['using'] == 'pypyodbc')
+        assert options['using'] == 'pypyodbc'
 
         return pyodbc_db_Table.connect(self, connection, options)
 
 
 @DataManagerFactory.register('sqlite3', "sqlite3 database interface")
 class sqlite3_db_Table(db_Table):
-
     def __init__(self):
         db_Table.__init__(self)
         self.using = 'sqlite3'
@@ -579,7 +629,7 @@ class sqlite3_db_Table(db_Table):
         return 'sqlite3'
 
     def connect(self, connection, options):
-        assert(options['using'] == 'sqlite3')
+        assert options['using'] == 'sqlite3'
 
         filename = connection
         if not os.path.exists(filename):
@@ -593,7 +643,6 @@ class sqlite3_db_Table(db_Table):
 
 @DataManagerFactory.register('pymysql', "pymysql database interface")
 class pymysql_db_Table(db_Table):
-
     def __init__(self):
         db_Table.__init__(self)
         self.using = 'pymysql'

--- a/pyomo/dataportal/plugins/json_dict.py
+++ b/pyomo/dataportal/plugins/json_dict.py
@@ -18,11 +18,11 @@ from pyomo.dataportal.factory import DataManagerFactory
 
 
 def detuplize(d, sort=False):
-    #print("detuplize %s" % str(d))
-    if type(d) in (list,tuple,set):
+    # print("detuplize %s" % str(d))
+    if type(d) in (list, tuple, set):
         ans = []
         for item in d:
-            if type(item) in (list,tuple,set):
+            if type(item) in (list, tuple, set):
                 ans.append(list(item))
             else:
                 ans.append(item)
@@ -36,17 +36,18 @@ def detuplize(d, sort=False):
         # De-tuplize keys via list of key/value pairs
         #
         ans = []
-        for k,v in d.items():
+        for k, v in d.items():
             if type(k) is tuple:
-                ans.append( {'index':list(k), 'value':v} )
+                ans.append({'index': list(k), 'value': v})
             else:
-                ans.append( {'index':k, 'value':v} )
+                ans.append({'index': k, 'value': v})
         if sort:
-            return sorted(ans, key=lambda x:x['value'])
+            return sorted(ans, key=lambda x: x['value'])
         return ans
 
+
 def tuplize(d):
-    #print("tuplize %s" % str(d))
+    # print("tuplize %s" % str(d))
     if type(d) is list and len(d) > 0 and not type(d[0]) is dict:
         ans = []
         for val in d:
@@ -85,12 +86,11 @@ def tuplize(d):
     elif type(d) is dict:
         return d
     else:
-        return {None:d}
+        return {None: d}
 
 
 @DataManagerFactory.register("json", "JSON file interface")
 class JSONDictionary(object):
-
     def __init__(self):
         self._info = {}
         self.options = Bunch()
@@ -125,7 +125,7 @@ class JSONDictionary(object):
         if jdata is None or len(jdata) == 0:
             raise IOError("Empty JSON data file")
         self._info = {}
-        for k,v in jdata.items():
+        for k, v in jdata.items():
             self._info[k] = tuplize(v)
 
     def write(self, data):
@@ -135,7 +135,7 @@ class JSONDictionary(object):
         with open(self.filename, 'w') as OUTPUT:
             jdata = {}
             if self.options.data is None:
-                for k,v in data.items():
+                for k, v in data.items():
                     jdata[k] = detuplize(v)
             elif type(self.options.data) in (list, tuple):
                 for k in self.options.data:
@@ -163,7 +163,10 @@ class JSONDictionary(object):
                 key = self.options.data
                 self._set_data(data, self.options.namespace, key, self._info[key])
         except KeyError:
-            raise IOError("Data value for '%s' is not available in JSON file '%s'" % (key, self.filename))
+            raise IOError(
+                "Data value for '%s' is not available in JSON file '%s'"
+                % (key, self.filename)
+            )
 
     def _set_data(self, data, namespace, name, value):
         if type(value) is dict:
@@ -175,10 +178,8 @@ class JSONDictionary(object):
         self._info = {}
 
 
-
 @DataManagerFactory.register("yaml", "YAML file interface")
 class YamlDictionary(object):
-
     def __init__(self):
         self._info = {}
         self.options = Bunch()
@@ -216,7 +217,7 @@ class YamlDictionary(object):
         if jdata is None:
             raise IOError("Empty YAML file")
         self._info = {}
-        for k,v in jdata.items():
+        for k, v in jdata.items():
             self._info[k] = tuplize(v)
 
     def write(self, data):
@@ -226,7 +227,7 @@ class YamlDictionary(object):
         with open(self.filename, 'w') as OUTPUT:
             jdata = {}
             if self.options.data is None:
-                for k,v in data.items():
+                for k, v in data.items():
                     jdata[k] = detuplize(v)
             elif type(self.options.data) in (list, tuple):
                 for k in self.options.data:
@@ -254,7 +255,10 @@ class YamlDictionary(object):
                 key = self.options.data
                 self._set_data(data, self.options.namespace, key, self._info[key])
         except KeyError:
-            raise IOError("Data value for '%s' is not available in YAML file '%s'" % (key, self.filename))
+            raise IOError(
+                "Data value for '%s' is not available in YAML file '%s'"
+                % (key, self.filename)
+            )
 
     def _set_data(self, data, namespace, name, value):
         if type(value) is dict:
@@ -264,5 +268,3 @@ class YamlDictionary(object):
 
     def clear(self):
         self._info = {}
-
-

--- a/pyomo/dataportal/plugins/sheet.py
+++ b/pyomo/dataportal/plugins/sheet.py
@@ -12,22 +12,24 @@
 import os.path
 
 from pyomo.dataportal import TableData
+
 # from pyomo.dataportal.plugins.db_table import (
 #     pyodbc_available, pyodbc_db_Table, pypyodbc_available, pypyodbc_db_Table
 # )
 from pyomo.dataportal.factory import DataManagerFactory
 from pyomo.common.errors import ApplicationError
 from pyomo.common.dependencies import pyutilib, pyutilib_available
+
 if pyutilib_available:
     from pyutilib.excel.spreadsheet import ExcelSpreadsheet, Interfaces
 else:
-    raise(RuntimeError('PyUtilib is required to use pyomo.dataportal.plugins.sheet.'))
+    raise (RuntimeError('PyUtilib is required to use pyomo.dataportal.plugins.sheet.'))
+
 
 def _attempt_open_excel():
     if _attempt_open_excel.result is None:
-        from pyutilib.excel.spreadsheet_win32com import (
-            ExcelSpreadsheet_win32com
-        )
+        from pyutilib.excel.spreadsheet_win32com import ExcelSpreadsheet_win32com
+
         try:
             tmp = ExcelSpreadsheet_win32com()
             tmp._excel_dispatch()
@@ -37,14 +39,14 @@ def _attempt_open_excel():
             _attempt_open_excel.result = False
     return _attempt_open_excel.result
 
+
 _attempt_open_excel.result = None
 
 
 class SheetTable(TableData):
-
     def __init__(self, ctype=None):
         TableData.__init__(self)
-        self.ctype=ctype
+        self.ctype = ctype
 
     def open(self):
         if self.filename is None:
@@ -66,15 +68,23 @@ class SheetTable(TableData):
         tmp = self.sheet.get_range(self.options.range, raw=True)
         if type(tmp) is float or type(tmp) is int:
             if not self.options.param is None:
-                self._info = ["param"] + list(self.options.param) + [":=",tmp]
+                self._info = ["param"] + list(self.options.param) + [":=", tmp]
             elif len(self.options.symbol_map) == 1:
-                self._info = ["param",self.options.symbol_map[self.options.symbol_map.keys()[0]],":=",tmp]
+                self._info = [
+                    "param",
+                    self.options.symbol_map[self.options.symbol_map.keys()[0]],
+                    ":=",
+                    tmp,
+                ]
             else:
-                raise IOError("Data looks like a parameter, but multiple parameter names have been specified: %s" % str(self.options.symbol_map))
+                raise IOError(
+                    "Data looks like a parameter, but multiple parameter names have been specified: %s"
+                    % str(self.options.symbol_map)
+                )
         elif len(tmp) == 0:
             raise IOError("Empty range '%s'" % self.options.range)
         else:
-            if type(tmp[1]) in (list,tuple):
+            if type(tmp[1]) in (list, tuple):
                 tmp_ = tmp[1:]
             else:
                 tmp_ = [[x] for x in tmp[1:]]
@@ -85,24 +95,23 @@ class SheetTable(TableData):
             del self.sheet
 
 
-
-
 @DataManagerFactory.register("xls", "Excel XLS file interface")
 class SheetTable_xls(SheetTable):
-
     def __init__(self):
         if Interfaces()['win32com'].available and _attempt_open_excel():
             SheetTable.__init__(self, ctype='win32com')
         elif Interfaces()['xlrd'].available:
             SheetTable.__init__(self, ctype='xlrd')
         else:
-            raise RuntimeError("No excel interface is available; install %s"
-                               % self.requirements())
+            raise RuntimeError(
+                "No excel interface is available; install %s" % self.requirements()
+            )
 
     def available(self):
         _inter = Interfaces()
-        return (_inter['win32com'].available and _attempt_open_excel()) \
-            or _inter['xlrd'].available
+        return (_inter['win32com'].available and _attempt_open_excel()) or _inter[
+            'xlrd'
+        ].available
 
     def requirements(self):
         return "win32com or xlrd"
@@ -127,23 +136,25 @@ class SheetTable_xls(SheetTable):
 
 @DataManagerFactory.register("xlsx", "Excel XLSX file interface")
 class SheetTable_xlsx(SheetTable):
-
     def __init__(self):
         if Interfaces()['win32com'].available and _attempt_open_excel():
             SheetTable.__init__(self, ctype='win32com')
         elif Interfaces()['openpyxl'].available:
             SheetTable.__init__(self, ctype='openpyxl')
         else:
-            raise RuntimeError("No excel interface is available; install %s"
-                               % self.requirements())
+            raise RuntimeError(
+                "No excel interface is available; install %s" % self.requirements()
+            )
 
     def available(self):
         _inter = Interfaces()
-        return (_inter['win32com'].available and _attempt_open_excel()) \
-            or _inter['openpyxl'].available
+        return (_inter['win32com'].available and _attempt_open_excel()) or _inter[
+            'openpyxl'
+        ].available
 
     def requirements(self):
         return "win32com or openpyxl"
+
 
 #
 # This class is OK, but the pyodbc interface doesn't work right now.
@@ -185,23 +196,25 @@ class SheetTable_xlsx(SheetTable):
 
 @DataManagerFactory.register("xlsm", "Excel XLSM file interface")
 class SheetTable_xlsm(SheetTable):
-
     def __init__(self):
         if Interfaces()['win32com'].available and _attempt_open_excel():
             SheetTable.__init__(self, ctype='win32com')
         elif Interfaces()['openpyxl'].available:
             SheetTable.__init__(self, ctype='openpyxl')
         else:
-            raise RuntimeError("No excel interface is available; install %s"
-                               % self.requirements())
+            raise RuntimeError(
+                "No excel interface is available; install %s" % self.requirements()
+            )
 
     def available(self):
         _inter = Interfaces()
-        return (_inter['win32com'].available and _attempt_open_excel()) \
-            or _inter['openpyxl'].available
+        return (_inter['win32com'].available and _attempt_open_excel()) or _inter[
+            'openpyxl'
+        ].available
 
     def requirements(self):
         return "win32com or openpyxl"
+
 
 # @DataManagerFactory.register("xlsm", "Excel XLSM file interface")
 # class SheetTable_xlsm(pyodbc_db_base):
@@ -218,4 +231,3 @@ class SheetTable_xlsm(SheetTable):
 #         if not os.path.exists(self.filename):
 #             raise IOError("Cannot find file '%s'" % self.filename)
 #         return pyodbc_db_base.open(self)
-

--- a/pyomo/dataportal/plugins/text.py
+++ b/pyomo/dataportal/plugins/text.py
@@ -19,7 +19,6 @@ from pyomo.dataportal import TableData
 
 @DataManagerFactory.register("tab", "TAB file interface")
 class TextTable(TableData):
-
     def __init__(self):
         TableData.__init__(self)
         self.FILE = None
@@ -39,10 +38,10 @@ class TextTable(TableData):
             raise IOError("Cannot find file '%s'" % self.filename)
         self.FILE = open(self.filename, 'r')
         try:
-            tmp=[]
+            tmp = []
             for line in self.FILE:
-                line=line.strip()
-                tokens = re.split("[\t ]+",line)
+                line = line.strip()
+                tokens = re.split("[\t ]+", line)
                 if tokens != ['']:
                     tmp.append(tokens)
             if len(tmp) == 0:
@@ -56,11 +55,19 @@ class TextTable(TableData):
                     if isinstance(p, Param):
                         self.options.model = p.model()
                         p = p.local_name
-                    self._info = ["param",p,":=",tmp[0][0]]
+                    self._info = ["param", p, ":=", tmp[0][0]]
                 elif len(self.options.symbol_map) == 1:
-                    self._info = ["param",self.options.symbol_map[self.options.symbol_map.keys()[0]],":=",tmp[0][0]]
+                    self._info = [
+                        "param",
+                        self.options.symbol_map[self.options.symbol_map.keys()[0]],
+                        ":=",
+                        tmp[0][0],
+                    ]
                 else:
-                    raise IOError("Data looks like a parameter, but multiple parameter names have been specified: %s" % str(self.options.symbol_map))
+                    raise IOError(
+                        "Data looks like a parameter, but multiple parameter names have been specified: %s"
+                        % str(self.options.symbol_map)
+                    )
             else:
                 self._set_data(tmp[0], tmp[1:])
         except Exception:
@@ -78,7 +85,6 @@ class TextTable(TableData):
         self.FILE = open(self.filename, 'w')
         table = self._get_table()
         for line in table:
-            self.FILE.write(' '.join(map(str, line))+'\n')
+            self.FILE.write(' '.join(map(str, line)) + '\n')
         self.FILE.close()
         self.FILE = None
-

--- a/pyomo/dataportal/plugins/xml_table.py
+++ b/pyomo/dataportal/plugins/xml_table.py
@@ -14,9 +14,11 @@ from pyomo.common.dependencies import attempt_import
 from pyomo.dataportal.factory import DataManagerFactory
 from pyomo.dataportal import TableData
 
+
 def _xml_importer():
     try:
         from lxml import etree
+
         return etree
     except ImportError:
         pass
@@ -24,19 +26,22 @@ def _xml_importer():
     try:
         # Python 2.5+
         import xml.etree.cElementTree as etree
+
         return etree
     except ImportError:
         pass
 
     # Python 2.5+
     import xml.etree.ElementTree as etree
+
     return etree
+
 
 ET, ET_available = attempt_import('ET', importer=_xml_importer)
 
+
 @DataManagerFactory.register("xml", "XML file interface")
 class XMLTable(TableData):
-
     def __init__(self):
         TableData.__init__(self)
 
@@ -60,7 +65,7 @@ class XMLTable(TableData):
             parents = [parent for parent in tree.findall(self.options.query)]
         else:
             parents = [parent for parent in tree.getroot()]
-        tmp=[]
+        tmp = []
         labels = []
         for parent in parents:
             if len(tmp) == 0:
@@ -73,7 +78,7 @@ class XMLTable(TableData):
                     row[child.tag] = child.get('value')
                 else:
                     row[child.tag] = child.text
-            tmp.append( [row.get(label,'.') for label in labels] )
+            tmp.append([row.get(label, '.') for label in labels])
         #
         if len(tmp) == 0:
             raise IOError("Empty *.xml file")
@@ -86,11 +91,19 @@ class XMLTable(TableData):
                 if isinstance(p, Param):
                     self.options.model = p._model()
                     p = p.local_name
-                self._info = ["param",p,":=",tmp[0][0]]
+                self._info = ["param", p, ":=", tmp[0][0]]
             elif len(self.options.symbol_map) == 1:
-                self._info = ["param",self.options.symbol_map[self.options.symbol_map.keys()[0]],":=",tmp[0][0]]
+                self._info = [
+                    "param",
+                    self.options.symbol_map[self.options.symbol_map.keys()[0]],
+                    ":=",
+                    tmp[0][0],
+                ]
             else:
-                raise IOError("Data looks like a parameter, but multiple parameter names have been specified: %s" % str(self.options.symbol_map))
+                raise IOError(
+                    "Data looks like a parameter, but multiple parameter names have been specified: %s"
+                    % str(self.options.symbol_map)
+                )
         else:
             self._set_data(tmp[0], tmp[1:])
 
@@ -110,4 +123,3 @@ class XMLTable(TableData):
         #
         tree = ET.ElementTree(root)
         tree.write(self.filename)
-

--- a/pyomo/dataportal/process_data.py
+++ b/pyomo/dataportal/process_data.py
@@ -18,9 +18,7 @@ from pyomo.common.log import is_debug_set
 from pyomo.common.collections import Bunch, OrderedDict
 from pyomo.common.errors import ApplicationError
 
-from pyomo.dataportal.parse_datacmds import (
-    parse_data_commands, _re_number
-)
+from pyomo.dataportal.parse_datacmds import parse_data_commands, _re_number
 from pyomo.dataportal.factory import DataManagerFactory, UnknownDataManager
 from pyomo.core.base.set import UnknownSetDimen
 from pyomo.core.base.util import flatten_tuple
@@ -32,10 +30,11 @@ logger = logging.getLogger('pyomo.core')
 global Lineno
 global Filename
 
-_num_pattern = re.compile("^("+_re_number+")$")
-_str_false_values = {'False','false','FALSE'}
-_str_bool_values = {'True','true','TRUE'}
+_num_pattern = re.compile("^(" + _re_number + ")$")
+_str_false_values = {'False', 'false', 'FALSE'}
+_str_bool_values = {'True', 'true', 'TRUE'}
 _str_bool_values.update(_str_false_values)
+
 
 def _guess_set_dimen(index):
     d = 0
@@ -58,8 +57,9 @@ def _guess_set_dimen(index):
             d += sub_d
     return d
 
+
 def _process_token(token):
-    #print("TOKEN:", token, type(token))
+    # print("TOKEN:", token, type(token))
     if type(token) is tuple:
         return tuple(_process_token(i) for i in token)
     elif type(token) in numlist:
@@ -74,7 +74,7 @@ def _process_token(token):
         token = token[1:-1]
         for item in token.split(","):
             if item[0] in '"\'' and item[0] == item[-1]:
-                vals.append( item[1:-1] )
+                vals.append(item[1:-1])
             elif _num_pattern.match(item):
                 _num = float(item)
                 if '.' in item:
@@ -83,7 +83,7 @@ def _process_token(token):
                     _int = int(_num)
                     vals.append(_int if _int == _num else _num)
             else:
-                vals.append( item )
+                vals.append(item)
         return tuple(vals)
     elif _num_pattern.match(token):
         _num = float(token)
@@ -103,16 +103,18 @@ def _preprocess_data(cmd):
     """
     generate_debug_messages = is_debug_set(logger)
     if generate_debug_messages:
-        logger.debug("_preprocess_data(start) %s",cmd)
+        logger.debug("_preprocess_data(start) %s", cmd)
     state = 0
-    newcmd=[]
+    newcmd = []
     tpl = []
     for token in cmd:
         if state == 0:
             if type(token) in numlist:
                 newcmd.append(token)
             elif token == ',':
-                raise ValueError("Unexpected comma outside of (), {} or [] declarations")
+                raise ValueError(
+                    "Unexpected comma outside of (), {} or [] declarations"
+                )
             elif token == '(':
                 state = 1
             elif token == ')':
@@ -137,7 +139,7 @@ def _preprocess_data(cmd):
             elif token == '(':
                 raise ValueError("Two '('s follow each other in the data")
             elif token == ')':
-                newcmd.append( tuple(tpl) )
+                newcmd.append(tuple(tpl))
                 tpl = []
                 state = 0
             else:
@@ -152,7 +154,9 @@ def _preprocess_data(cmd):
             elif token == '{':
                 raise ValueError("Two '{'s follow each other in the data")
             elif token == '}':
-                newcmd.append( tpl )    # Keep this as a list, so we can distinguish it while parsing tables
+                newcmd.append(
+                    tpl
+                )  # Keep this as a list, so we can distinguish it while parsing tables
                 tpl = []
                 state = 0
             else:
@@ -167,7 +171,7 @@ def _preprocess_data(cmd):
             elif token == '[':
                 raise ValueError("Two '['s follow each other in the data")
             elif token == ']':
-                newcmd.append( tuple(tpl) )
+                newcmd.append(tuple(tpl))
                 tpl = []
                 state = 0
             else:
@@ -188,10 +192,10 @@ def _process_set(cmd, _model, _data):
     """
     Called by _process_data() to process a set declaration.
     """
-    #print("SET %s" % cmd)
+    # print("SET %s" % cmd)
     generate_debug_messages = is_debug_set(logger)
     if generate_debug_messages:
-        logger.debug("DEBUG: _process_set(start) %s",cmd)
+        logger.debug("DEBUG: _process_set(start) %s", cmd)
     #
     # Process a set
     #
@@ -199,13 +203,15 @@ def _process_set(cmd, _model, _data):
         #
         # An indexed set
         #
-        ndx=cmd[2]
+        ndx = cmd[2]
         if len(ndx) == 0:
             # At this point, if the index is an empty tuple, then there is an
             # issue with the specification of this indexed set.
-            raise ValueError("Illegal indexed set specification encountered: "+str(cmd[1]))
+            raise ValueError(
+                "Illegal indexed set specification encountered: " + str(cmd[1])
+            )
         elif len(ndx) == 1:
-            ndx=ndx[0]
+            ndx = ndx[0]
         if cmd[1] not in _data:
             _data[cmd[1]] = {}
         _data[cmd[1]][ndx] = _process_set_data(cmd[4:], cmd[1], _model)
@@ -216,18 +222,18 @@ def _process_set(cmd, _model, _data):
         #
         _data[cmd[1]] = {}
         _data[cmd[1]][None] = []
-        i=3
+        i = 3
         while cmd[i] != ":=":
             i += 1
         ndx1 = cmd[3:i]
         i += 1
-        while i<len(cmd):
-            ndx=cmd[i]
-            for j in range(0,len(ndx1)):
-                if cmd[i+j+1] == "+":
-                    #print("DATA %s %s" % (ndx1[j], cmd[i]))
+        while i < len(cmd):
+            ndx = cmd[i]
+            for j in range(0, len(ndx1)):
+                if cmd[i + j + 1] == "+":
+                    # print("DATA %s %s" % (ndx1[j], cmd[i]))
                     _data[cmd[1]][None].append((ndx1[j], cmd[i]))
-            i += len(ndx1)+1
+            i += len(ndx1) + 1
     else:
         #
         # Processing a general set
@@ -242,15 +248,15 @@ def _process_set_data(cmd, sname, _model):
     """
     generate_debug_messages = is_debug_set(logger)
     if generate_debug_messages:
-        logger.debug("DEBUG: _process_set_data(start) %s",cmd)
+        logger.debug("DEBUG: _process_set_data(start) %s", cmd)
     if len(cmd) == 0:
         return []
-    ans=[]
-    i=0
-    template=None
-    ndx=[]
+    ans = []
+    i = 0
+    template = None
+    ndx = []
     template = []
-    while i<len(cmd):
+    while i < len(cmd):
         if type(cmd[i]) is not tuple:
             if len(ndx) == 0:
                 ans.append(cmd[i])
@@ -260,10 +266,12 @@ def _process_set_data(cmd, sname, _model):
                 # contains the indices of the values that need
                 # to be filled-in
                 #
-                tmpval=template
+                tmpval = template
                 for kk in range(len(ndx)):
                     if i == len(cmd):
-                        raise IOError("Expected another set value to flush out a tuple pattern!")
+                        raise IOError(
+                            "Expected another set value to flush out a tuple pattern!"
+                        )
                     tmpval[ndx[kk]] = cmd[i]
                     i += 1
                 ans.append(tuple(tmpval))
@@ -271,14 +279,14 @@ def _process_set_data(cmd, sname, _model):
         elif "*" not in cmd[i]:
             ans.append(cmd[i])
         else:
-            template=list(cmd[i])
-            ndx=[]
+            template = list(cmd[i])
+            ndx = []
             for kk in range(len(template)):
                 if template[kk] == '*':
                     ndx.append(kk)
         i += 1
     if generate_debug_messages:
-        logger.debug("DEBUG: _process_set_data(end) %s",ans)
+        logger.debug("DEBUG: _process_set_data(end) %s", ans)
     return ans
 
 
@@ -286,10 +294,10 @@ def _process_param(cmd, _model, _data, _default, index=None, param=None, ncolumn
     """
     Called by _process_data to process data for a Parameter declaration
     """
-    #print('PARAM %s index=%s ncolumns=%s' %(cmd, index, ncolumns))
+    # print('PARAM %s index=%s ncolumns=%s' %(cmd, index, ncolumns))
     generate_debug_messages = is_debug_set(logger)
     if generate_debug_messages:
-        logger.debug("DEBUG: _process_param(start) %s",cmd)
+        logger.debug("DEBUG: _process_param(start) %s", cmd)
     #
     # Process parameters
     #
@@ -299,7 +307,7 @@ def _process_param(cmd, _model, _data, _default, index=None, param=None, ncolumn
     if cmd[0] == ":":
         singledef = False
         cmd = cmd[1:]
-    #print "SINGLEDEF", singledef
+    # print "SINGLEDEF", singledef
     if singledef:
         pname = cmd[0]
         cmd = cmd[1:]
@@ -318,16 +326,16 @@ def _process_param(cmd, _model, _data, _default, index=None, param=None, ncolumn
             else:
                 cmd[0] = ":"
         if cmd[0] != ":":
-            #print "HERE YYY", pname, transpose, _model, ncolumns
+            # print "HERE YYY", pname, transpose, _model, ncolumns
             if generate_debug_messages:
-                logger.debug("DEBUG: _process_param (singledef without :...:=) %s",cmd)
+                logger.debug("DEBUG: _process_param (singledef without :...:=) %s", cmd)
             cmd = _apply_templates(cmd)
-            #print 'cmd',cmd
+            # print 'cmd',cmd
             if not transpose:
                 if pname not in _data:
                     _data[pname] = {}
                 if not ncolumns is None:
-                    finaldata = _process_data_list(pname, ncolumns-1, cmd)
+                    finaldata = _process_data_list(pname, ncolumns - 1, cmd)
                 elif not _model is None:
                     _param = getattr(_model, pname)
                     _dim = _param.dim()
@@ -337,73 +345,91 @@ def _process_param(cmd, _model, _data, _default, index=None, param=None, ncolumn
                 else:
                     finaldata = _process_data_list(pname, 1, cmd)
                 for key in finaldata:
-                    _data[pname][key]=finaldata[key]
+                    _data[pname][key] = finaldata[key]
             else:
                 tmp = ["param", pname, ":="]
-                i=1
+                i = 1
                 while i < len(cmd):
                     i0 = i
                     while cmd[i] != ":=":
-                        i=i+1
+                        i = i + 1
                     ncol = i - i0 + 1
                     lcmd = i
                     while lcmd < len(cmd) and cmd[lcmd] != ":":
                         lcmd += 1
                     j0 = i0 - 1
-                    for j in range(1,ncol):
+                    for j in range(1, ncol):
                         ii = 1 + i
                         kk = ii + j
                         while kk < lcmd:
                             if cmd[kk] != ".":
-                            #if 1>0:
-                                tmp.append(copy.copy(cmd[j+j0]))
+                                # if 1>0:
+                                tmp.append(copy.copy(cmd[j + j0]))
                                 tmp.append(copy.copy(cmd[ii]))
                                 tmp.append(copy.copy(cmd[kk]))
                             ii = ii + ncol
                             kk = kk + ncol
                     i = lcmd + 1
-                _process_param(tmp, _model, _data, _default, index=index, param=param, ncolumns=ncolumns)
+                _process_param(
+                    tmp,
+                    _model,
+                    _data,
+                    _default,
+                    index=index,
+                    param=param,
+                    ncolumns=ncolumns,
+                )
         else:
             tmp = ["param", pname, ":="]
             if param is None:
-                param = [ pname ]
-            i=1
+                param = [pname]
+            i = 1
             if generate_debug_messages:
-                logger.debug("DEBUG: _process_param (singledef with :...:=) %s",cmd)
+                logger.debug("DEBUG: _process_param (singledef with :...:=) %s", cmd)
             while i < len(cmd):
                 i0 = i
-                while i<len(cmd) and cmd[i] != ":=":
-                    i=i+1
-                if i==len(cmd):
-                    raise ValueError("ERROR: Trouble on line "+str(Lineno)+" of file "+Filename)
+                while i < len(cmd) and cmd[i] != ":=":
+                    i = i + 1
+                if i == len(cmd):
+                    raise ValueError(
+                        "ERROR: Trouble on line " + str(Lineno) + " of file " + Filename
+                    )
                 ncol = i - i0 + 1
                 lcmd = i
                 while lcmd < len(cmd) and cmd[lcmd] != ":":
                     lcmd += 1
                 j0 = i0 - 1
-                for j in range(1,ncol):
+                for j in range(1, ncol):
                     ii = 1 + i
                     kk = ii + j
                     while kk < lcmd:
                         if cmd[kk] != ".":
                             if transpose:
-                                tmp.append(copy.copy(cmd[j+j0]))
+                                tmp.append(copy.copy(cmd[j + j0]))
                                 tmp.append(copy.copy(cmd[ii]))
                             else:
                                 tmp.append(copy.copy(cmd[ii]))
-                                tmp.append(copy.copy(cmd[j+j0]))
+                                tmp.append(copy.copy(cmd[j + j0]))
                             tmp.append(copy.copy(cmd[kk]))
                         ii = ii + ncol
                         kk = kk + ncol
                 i = lcmd + 1
-                _process_param(tmp, _model, _data, _default, index=index, param=param[0], ncolumns=3)
+                _process_param(
+                    tmp,
+                    _model,
+                    _data,
+                    _default,
+                    index=index,
+                    param=param[0],
+                    ncolumns=3,
+                )
 
     else:
         if generate_debug_messages:
-            logger.debug("DEBUG: _process_param (cmd[0]=='param:') %s",cmd)
-        i=0
-        nsets=0
-        while i<len(cmd):
+            logger.debug("DEBUG: _process_param (cmd[0]=='param:') %s", cmd)
+        i = 0
+        nsets = 0
+        while i < len(cmd):
             if cmd[i] == ':=':
                 i = -1
                 break
@@ -411,52 +437,54 @@ def _process_param(cmd, _model, _data, _default, index=None, param=None, ncolumn
                 nsets = i
                 break
             i += 1
-        nparams=0
-        _i = i+1
-        while i<len(cmd):
+        nparams = 0
+        _i = i + 1
+        while i < len(cmd):
             if cmd[i] == ':=':
-                nparams = i-_i
+                nparams = i - _i
                 break
             i += 1
-        if i==len(cmd):
-            raise ValueError("Trouble on data file line "+str(Lineno)+" of file "+Filename)
+        if i == len(cmd):
+            raise ValueError(
+                "Trouble on data file line " + str(Lineno) + " of file " + Filename
+            )
         if generate_debug_messages:
-            logger.debug("NSets %d",nsets)
+            logger.debug("NSets %d", nsets)
         Lcmd = len(cmd)
-        j=0
+        j = 0
         d = 1
-        #print "HERE", nsets, nparams
+        # print "HERE", nsets, nparams
         #
         # Process sets first
         #
-        while j<nsets:
+        while j < nsets:
             # NOTE: I'm pretty sure that nsets is always equal to 1
             sname = cmd[j]
             if not ncolumns is None:
-                d = ncolumns-nparams
+                d = ncolumns - nparams
             elif _model is None:
                 d = 1
             else:
                 index = getattr(_model, sname)
                 d = _guess_set_dimen(index)
-            #print "SET",sname,d,_model#,getattr(_model,sname).dimen, type(index)
-            #d = getattr(_model,sname).dimen
-            np = i-1
+            # print "SET",sname,d,_model#,getattr(_model,sname).dimen, type(index)
+            # d = getattr(_model,sname).dimen
+            np = i - 1
             if generate_debug_messages:
-                logger.debug("I %d, J %d, SName %s, d %d",i,j,sname,d)
+                logger.debug("I %d, J %d, SName %s, d %d", i, j, sname, d)
             dnp = d + np - 1
-            #k0 = i + d - 2
+            # k0 = i + d - 2
             ii = i + j + 1
-            tmp = [ "set", cmd[j], ":=" ]
+            tmp = ["set", cmd[j], ":="]
             while ii < Lcmd:
                 if d > 1:
                     _tmp = []
-                    for dd in range(0,d):
-                        _tmp.append(copy.copy(cmd[ii+dd]))
+                    for dd in range(0, d):
+                        _tmp.append(copy.copy(cmd[ii + dd]))
                     tmp.append(tuple(_tmp))
                 else:
-                    for dd in range(0,d):
-                        tmp.append(copy.copy(cmd[ii+dd]))
+                    for dd in range(0, d):
+                        tmp.append(copy.copy(cmd[ii + dd]))
                 ii += dnp
             _process_set(tmp, _model, _data)
             j += 1
@@ -465,21 +493,21 @@ def _process_param(cmd, _model, _data, _default, index=None, param=None, ncolumn
         #
         # Process parameters second
         #
-        #print "HERE", cmd
-        #print "HERE", param
-        #print "JI",j,i # XXX
+        # print "HERE", cmd
+        # print "HERE", param
+        # print "JI",j,i # XXX
         jstart = j
         if param is None:
             param = []
             _j = j
             while _j < i:
-                param.append( cmd[_j] )
+                param.append(cmd[_j])
                 _j += 1
         while j < i:
-            #print "HERE", i, j, jstart, cmd[j]
-            pname = param[j-jstart]
+            # print "HERE", i, j, jstart, cmd[j]
+            pname = param[j - jstart]
             if generate_debug_messages:
-                logger.debug("I %d, J %d, Pname %s",i,j,pname)
+                logger.debug("I %d, J %d, Pname %s", i, j, pname)
             if not ncolumns is None:
                 d = ncolumns - nparams
             elif _model is None:
@@ -490,35 +518,43 @@ def _process_param(cmd, _model, _data, _default, index=None, param=None, ncolumn
                 if d is UnknownSetDimen:
                     d = _guess_set_dimen(_param.index_set())
             if nsets > 0:
-                np = i-1
-                dnp = d+np-1
+                np = i - 1
+                dnp = d + np - 1
                 ii = i + 1
-                kk = i + d + j-1
+                kk = i + d + j - 1
             else:
                 np = i
                 dnp = d + np
                 ii = i + 1
                 kk = np + 1 + d + nsets + j
-            #print cmd[ii], d, np, dnp, ii, kk
-            tmp = [ "param", pname, ":=" ]
+            # print cmd[ii], d, np, dnp, ii, kk
+            tmp = ["param", pname, ":="]
             if generate_debug_messages:
                 logger.debug('dnp %d\nnp %d', dnp, np)
             while kk < Lcmd:
                 if generate_debug_messages:
-                    logger.debug("kk %d, ii %d",kk,ii)
+                    logger.debug("kk %d, ii %d", kk, ii)
                 iid = ii + d
                 while ii < iid:
                     tmp.append(copy.copy(cmd[ii]))
                     ii += 1
-                ii += dnp-d
+                ii += dnp - d
                 tmp.append(copy.copy(cmd[kk]))
                 kk += dnp
-            #print "TMP", tmp, ncolumns-nparams+1
+            # print "TMP", tmp, ncolumns-nparams+1
             if not ncolumns is None:
-                nc = ncolumns-nparams+1
+                nc = ncolumns - nparams + 1
             else:
                 nc = None
-            _process_param(tmp, _model, _data, _default, index=index, param=param[j-jstart], ncolumns=nc)
+            _process_param(
+                tmp,
+                _model,
+                _data,
+                _default,
+                index=index,
+                param=param[j - jstart],
+                ncolumns=nc,
+            )
             j += 1
 
 
@@ -528,12 +564,12 @@ def _apply_templates(cmd):
     ans = []
     i = 0
     while i < len(cmd):
-    #print i, len(cmd), cmd[i], ilist, template, ans
+        # print i, len(cmd), cmd[i], ilist, template, ans
         if type(cmd[i]) is tuple and '*' in cmd[i]:
             j = i
-            tmp=list(cmd[j])
+            tmp = list(cmd[j])
             nindex = len(tmp)
-            template=tmp
+            template = tmp
             ilist = set()
             for kk in range(nindex):
                 if tmp[kk] == '*':
@@ -558,13 +594,15 @@ def _process_data_list(param_name, dim, cmd):
  """
     generate_debug_messages = is_debug_set(logger)
     if generate_debug_messages:
-        logger.debug("process_data_list %d %s",dim,cmd)
+        logger.debug("process_data_list %d %s", dim, cmd)
 
-    if len(cmd) % (dim+1) != 0:
-        msg = "Parameter '%s' defined with '%d' dimensions, " \
-              "but data has '%d' values: %s."
+    if len(cmd) % (dim + 1) != 0:
+        msg = (
+            "Parameter '%s' defined with '%d' dimensions, "
+            "but data has '%d' values: %s."
+        )
         msg = msg % (param_name, dim, len(cmd), cmd)
-        if len(cmd) % (dim+1) == dim:
+        if len(cmd) % (dim + 1) == dim:
             msg += " Are you missing a value for a %d-dimensional index?" % dim
         elif len(cmd) % dim == 0:
             msg += " Are you missing the values for %d-dimensional indices?" % dim
@@ -572,19 +610,19 @@ def _process_data_list(param_name, dim, cmd):
             msg += " Data declaration must be given in multiples of %d." % (dim + 1)
         raise ValueError(msg)
 
-    ans={}
+    ans = {}
     if dim == 0:
-        ans[None]=cmd[0]
+        ans[None] = cmd[0]
         return ans
-    i=0
+    i = 0
     while i < len(cmd):
         if dim > 1:
-            ndx = tuple(cmd[i:i+dim])
+            ndx = tuple(cmd[i : i + dim])
         else:
             ndx = cmd[i]
-        if cmd[i+dim] != ".":
-            ans[ndx] = cmd[i+dim]
-        i += dim+1
+        if cmd[i + dim] != ".":
+            ans[ndx] = cmd[i + dim]
+        i += dim + 1
     return ans
 
 
@@ -624,14 +662,16 @@ def _process_include(cmd, _model, _data, _default, options=None):
                         if key is None:
                             _data[scenario].update(_tmpdata[key])
                         else:
-                            raise IOError("Cannot define a scenario within another scenario")
+                            raise IOError(
+                                "Cannot define a scenario within another scenario"
+                            )
             else:
                 _process_data(cmd, _model, _data[scenario], _default, Filename, Lineno)
     return True
 
 
 def _process_table(cmd, _model, _data, _default, options=None):
-    #print("TABLE %s" % cmd)
+    # print("TABLE %s" % cmd)
     #
     _options = {}
     _set = OrderedDict()
@@ -644,7 +684,7 @@ def _process_table(cmd, _model, _data, _default, options=None):
     i = 0
     while i < _cmd_len:
         try:
-            #print("CMD i=%s cmd=%s" % (i, _cmd[i:]))
+            # print("CMD i=%s cmd=%s" % (i, _cmd[i:]))
             #
             # This should not be error prone, so we treat errors
             # with a general exception
@@ -663,49 +703,50 @@ def _process_table(cmd, _model, _data, _default, options=None):
             # Processing options
             #
             name = _cmd[i]
-            if i+1 == _cmd_len:
+            if i + 1 == _cmd_len:
                 _param[name] = []
                 _labels = ['Z']
                 i += 1
                 continue
-            if _cmd[i+1] == '=':
-                if type(_cmd[i+2]) is list:
-                    _set[name] = _cmd[i+2]
+            if _cmd[i + 1] == '=':
+                if type(_cmd[i + 2]) is list:
+                    _set[name] = _cmd[i + 2]
                 else:
-                    _options[name] = _cmd[i+2]
+                    _options[name] = _cmd[i + 2]
                 i += 3
                 continue
             # This should be a parameter declaration
-            if not type(_cmd[i+1]) is tuple:
+            if not type(_cmd[i + 1]) is tuple:
                 raise IOError
-            if i+2 < _cmd_len and _cmd[i+2] == '=':
-                _param[name] = (_cmd[i+1], _cmd[i+3][0])
+            if i + 2 < _cmd_len and _cmd[i + 2] == '=':
+                _param[name] = (_cmd[i + 1], _cmd[i + 3][0])
                 i += 4
             else:
-                _param[name] = _cmd[i+1]
+                _param[name] = _cmd[i + 1]
                 i += 2
         except:
             raise IOError("Error parsing table options: %s" % name)
 
-
-    #print("_options %s" % _options)
-    #print("_set %s" % _set)
-    #print("_param %s" % _param)
-    #print("_labels %s" % _labels)
-#
+    # print("_options %s" % _options)
+    # print("_set %s" % _set)
+    # print("_param %s" % _param)
+    # print("_labels %s" % _labels)
+    #
     options = Bunch(**_options)
     for key in options:
         if not key in ['columns']:
             raise ValueError("Unknown table option '%s'" % key)
     #
-    ncolumns=options.columns
+    ncolumns = options.columns
     if ncolumns is None:
         ncolumns = len(_labels)
         if ncolumns == 0:
             if not (len(_set) == 1 and len(_set[_set.keys()[0]]) == 0):
-                raise IOError("Must specify either the 'columns' option or column headers")
+                raise IOError(
+                    "Must specify either the 'columns' option or column headers"
+                )
             else:
-                ncolumns=1
+                ncolumns = 1
     else:
         ncolumns = int(ncolumns)
     #
@@ -715,7 +756,7 @@ def _process_table(cmd, _model, _data, _default, options=None):
     cmap = {}
     if len(_labels) == 0:
         for i in range(ncolumns):
-            cmap[i+1] = i
+            cmap[i + 1] = i
         for label in _param:
             ndx = cmap[_param[label][1]]
             if ndx < 0 or ndx >= ncolumns:
@@ -727,17 +768,19 @@ def _process_table(cmd, _model, _data, _default, options=None):
         for label in _labels:
             cmap[label] = i
             i += 1
-    #print("CMAP %s" % cmap)
+    # print("CMAP %s" % cmap)
     #
-    #print("_param %s" % _param)
-    #print("_set %s" % _set)
+    # print("_param %s" % _param)
+    # print("_set %s" % _set)
     for sname in _set:
         # Creating set sname
         cols = _set[sname]
         tmp = []
         for col in cols:
             if not col in cmap:
-                raise IOError("Unexpected table column '%s' for index set '%s'" % (col, sname))
+                raise IOError(
+                    "Unexpected table column '%s' for index set '%s'" % (col, sname)
+                )
             tmp.append(cmap[col])
         if not sname in cmap:
             cmap[sname] = tmp
@@ -747,20 +790,20 @@ def _process_table(cmd, _model, _data, _default, options=None):
         i = 0
         while i < Ldata:
             row = []
-            #print("COLS %s  NCOLS %d" % (cols, ncolumns))
+            # print("COLS %s  NCOLS %d" % (cols, ncolumns))
             for col in cols:
-                #print("Y %s %s" % (i, col))
-                row.append( data[i+col] )
+                # print("Y %s %s" % (i, col))
+                row.append(data[i + col])
             if len(row) > 1:
-                    _cmd.append( tuple(row) )
+                _cmd.append(tuple(row))
             else:
-                    _cmd.append( row[0] )
+                _cmd.append(row[0])
             i += ncolumns
-        #print("_data %s" % _data)
+        # print("_data %s" % _data)
         _process_set(_cmd, _model, _data)
     #
-    #print("CMAP %s" % cmap)
-    _i=0
+    # print("CMAP %s" % cmap)
+    _i = 0
     if ncolumns == 0:
         raise IOError
     for vname in _param:
@@ -769,55 +812,57 @@ def _process_table(cmd, _model, _data, _default, options=None):
         cols = _param[vname]
         tmp = []
         for col in cols:
-            #print("COL %s" % col)
+            # print("COL %s" % col)
             if not col in cmap:
-                raise IOError("Unexpected table column '%s' for table value '%s'" % (col, vname))
+                raise IOError(
+                    "Unexpected table column '%s' for table value '%s'" % (col, vname)
+                )
             tmp.append(cmap[col])
-        #print("X %s %s" % (len(cols), tmp))
+        # print("X %s %s" % (len(cols), tmp))
         cols = list(flatten_tuple(tmp))
-        #print("X %s" % len(cols))
-        #print("VNAME %s %s" % (vname, cmap[vname]))
+        # print("X %s" % len(cols))
+        # print("VNAME %s %s" % (vname, cmap[vname]))
         if vname in cmap:
             cols.append(cmap[vname])
         else:
-            cols.append( ncolumns-1 - (len(_param)-_i) )
-        #print("X %s" % len(cols))
+            cols.append(ncolumns - 1 - (len(_param) - _i))
+        # print("X %s" % len(cols))
         #
         _cmd = ['param', vname, ':=']
         i = 0
         while i < Ldata:
-            #print("HERE %s %s %s" % (i, cols, ncolumns))
+            # print("HERE %s %s %s" % (i, cols, ncolumns))
             for col in cols:
-                _cmd.append( data[i+col] )
+                _cmd.append(data[i + col])
             i += ncolumns
-        #print("HERE %s" % _cmd)
-        #print("_data %s" % _data)
+        # print("HERE %s" % _cmd)
+        # print("_data %s" % _data)
         _process_param(_cmd, _model, _data, None, ncolumns=len(cols))
 
 
 def _process_load(cmd, _model, _data, _default, options=None):
-    #print("LOAD %s" % cmd)
+    # print("LOAD %s" % cmd)
     from pyomo.core import Set
 
     _cmd_len = len(cmd)
     _options = {}
     _options['filename'] = cmd[1]
-    i=2
+    i = 2
     while cmd[i] != ':':
-        _options[cmd[i]] = cmd[i+2]
+        _options[cmd[i]] = cmd[i + 2]
         i += 3
     i += 1
     _Index = (None, [])
     if type(cmd[i]) is tuple:
         _Index = (None, cmd[i])
         i += 1
-    elif i+1 < _cmd_len and cmd[i+1] == '=':
-        _Index = (cmd[i], cmd[i+2])
+    elif i + 1 < _cmd_len and cmd[i + 1] == '=':
+        _Index = (cmd[i], cmd[i + 2])
         i += 3
     _smap = OrderedDict()
-    while i<_cmd_len:
-        if i+2 < _cmd_len and cmd[i+1] == '=':
-            _smap[cmd[i+2]] = cmd[i]
+    while i < _cmd_len:
+        if i + 2 < _cmd_len and cmd[i + 1] == '=':
+            _smap[cmd[i + 2]] = cmd[i]
             i += 3
         else:
             _smap[cmd[i]] = cmd[i]
@@ -828,7 +873,18 @@ def _process_load(cmd, _model, _data, _default, options=None):
 
     options = Bunch(**_options)
     for key in options:
-        if not key in ['range','filename','format','using','driver','query','table','user','password','database']:
+        if not key in [
+            'range',
+            'filename',
+            'format',
+            'using',
+            'driver',
+            'query',
+            'table',
+            'user',
+            'password',
+            'database',
+        ]:
             raise ValueError("Unknown load option '%s'" % key)
 
     global Filename
@@ -842,29 +898,31 @@ def _process_load(cmd, _model, _data, _default, options=None):
     if options.using is None:
         tmp = options.filename.split(".")[-1]
         data = DataManagerFactory(tmp)
-        if (data is None) or \
-           isinstance(data, UnknownDataManager):
+        if (data is None) or isinstance(data, UnknownDataManager):
             raise ApplicationError("Data manager '%s' is not available." % tmp)
     else:
         try:
             data = DataManagerFactory(options.using)
         except:
             data = None
-        if (data is None) or \
-           isinstance(data, UnknownDataManager):
-            raise ApplicationError("Data manager '%s' is not available." % options.using)
-    set_name=None
+        if (data is None) or isinstance(data, UnknownDataManager):
+            raise ApplicationError(
+                "Data manager '%s' is not available." % options.using
+            )
+    set_name = None
     #
     # Create symbol map
     #
     symb_map = _smap
     if len(symb_map) == 0:
-        raise IOError("Must specify at least one set or parameter name that will be loaded")
+        raise IOError(
+            "Must specify at least one set or parameter name that will be loaded"
+        )
     #
     # Process index data
     #
-    _index=None
-    index_name=_Index[0]
+    _index = None
+    index_name = _Index[0]
     _select = None
     #
     # Set the 'set name' based on the format
@@ -872,16 +930,26 @@ def _process_load(cmd, _model, _data, _default, options=None):
     _set = None
     if options.format == 'set' or options.format == 'set_array':
         if len(_smap) != 1:
-            raise IOError("A single set name must be specified when using format '%s'" % options.format)
-        set_name=list(_smap.keys())[0]
+            raise IOError(
+                "A single set name must be specified when using format '%s'"
+                % options.format
+            )
+        set_name = list(_smap.keys())[0]
         _set = set_name
     #
     # Set the 'param name' based on the format
     #
     _param = None
-    if options.format == 'transposed_array' or options.format == 'array' or options.format == 'param':
+    if (
+        options.format == 'transposed_array'
+        or options.format == 'array'
+        or options.format == 'param'
+    ):
         if len(_smap) != 1:
-            raise IOError("A single parameter name must be specified when using format '%s'" % options.format)
+            raise IOError(
+                "A single parameter name must be specified when using format '%s'"
+                % options.format
+            )
     if options.format in ('transposed_array', 'array', 'param', None):
         if _Index[0] is None:
             _index = None
@@ -890,21 +958,43 @@ def _process_load(cmd, _model, _data, _default, options=None):
         _param = []
         _select = list(_Index[1])
         for key in _smap:
-            _param.append( _smap[key] )
-            _select.append( key )
+            _param.append(_smap[key])
+            _select.append(key)
     if options.format in ('transposed_array', 'array'):
         _select = None
 
-    #print "YYY", _param, options
-    if not _param is None and len(_param) == 1 and not _model is None and isinstance(getattr(_model, _param[0]), Set):
+    # print "YYY", _param, options
+    if (
+        not _param is None
+        and len(_param) == 1
+        and not _model is None
+        and isinstance(getattr(_model, _param[0]), Set)
+    ):
         _select = None
         _set = _param[0]
         _param = None
         _index = None
 
-    #print "SELECT", _param, _select
+    # print "SELECT", _param, _select
     #
-    data.initialize(model=options.model, filename=options.filename, index=_index, index_name=index_name, param_name=symb_map, set=_set, param=_param, format=options.format, range=options.range, query=options.query, using=options.using, table=options.table, select=_select,user=options.user,password=options.password,database=options.database)
+    data.initialize(
+        model=options.model,
+        filename=options.filename,
+        index=_index,
+        index_name=index_name,
+        param_name=symb_map,
+        set=_set,
+        param=_param,
+        format=options.format,
+        range=options.range,
+        query=options.query,
+        using=options.using,
+        table=options.table,
+        select=_select,
+        user=options.user,
+        password=options.password,
+        database=options.database,
+    )
     #
     data.open()
     try:
@@ -916,20 +1006,31 @@ def _process_load(cmd, _model, _data, _default, options=None):
     data.process(_model, _data, _default)
 
 
-def _process_data(cmd, _model, _data, _default, Filename_, Lineno_=0, index=None, set=None, param=None, ncolumns=None):
+def _process_data(
+    cmd,
+    _model,
+    _data,
+    _default,
+    Filename_,
+    Lineno_=0,
+    index=None,
+    set=None,
+    param=None,
+    ncolumns=None,
+):
     """
     Called by import_file() to (1) preprocess data and (2) call
     subroutines to process different types of data
     """
-    #print("CMD %s" %cmd)
+    # print("CMD %s" %cmd)
     global Lineno
     global Filename
-    Lineno=Lineno_
-    Filename=Filename_
+    Lineno = Lineno_
+    Filename = Filename_
     generate_debug_messages = is_debug_set(logger)
     if generate_debug_messages:
-        logger.debug("DEBUG: _process_data (start) %s",cmd)
-    if len(cmd) == 0:                       #pragma:nocover
+        logger.debug("DEBUG: _process_data (start) %s", cmd)
+    if len(cmd) == 0:  # pragma:nocover
         raise ValueError("ERROR: Empty list passed to Model::_process_data")
 
     if cmd[0] == "data":
@@ -944,7 +1045,9 @@ def _process_data(cmd, _model, _data, _default, Filename_, Lineno_=0, index=None
 
     elif cmd[0].startswith('param'):
         cmd = _preprocess_data(cmd)
-        _process_param(cmd, _model, _data, _default, index=index, param=param, ncolumns=ncolumns)
+        _process_param(
+            cmd, _model, _data, _default, index=index, param=param, ncolumns=ncolumns
+        )
 
     elif cmd[0] == 'include':
         cmd = _preprocess_data(cmd)
@@ -959,6 +1062,6 @@ def _process_data(cmd, _model, _data, _default, Filename_, Lineno_=0, index=None
         _process_table(cmd, _model, _data, _default)
 
     else:
-        raise IOError("ERROR: Unknown data command: "+" ".join(cmd))
+        raise IOError("ERROR: Unknown data command: " + " ".join(cmd))
 
     return True

--- a/pyomo/dataportal/tests/test_dat_parser.py
+++ b/pyomo/dataportal/tests/test_dat_parser.py
@@ -17,6 +17,7 @@ import pyomo.common.unittest as unittest
 
 import pyomo.dataportal.parse_datacmds as parser
 
+
 class TestDatParser(unittest.TestCase):
     def test_update_parsetable(self):
         parser.parse_data_commands('')

--- a/pyomo/dataportal/tests/test_dataportal.py
+++ b/pyomo/dataportal/tests/test_dataportal.py
@@ -16,18 +16,52 @@ from itertools import zip_longest
 import json
 import os
 from os.path import abspath, dirname, join
-pyomo_dir=dirname(dirname(abspath(__file__)))+os.sep+".."
+
+pyomo_dir = dirname(dirname(abspath(__file__))) + os.sep + ".."
 
 import pyomo.common.unittest as unittest
 
 from pyomo.common.errors import ApplicationError
 from pyomo.common.tee import capture_output
 from pyomo.dataportal.factory import DataManagerFactory
-from pyomo.environ import AbstractModel, ConcreteModel, Set, DataPortal, Param, Boolean, Any, value
+from pyomo.environ import (
+    AbstractModel,
+    ConcreteModel,
+    Set,
+    DataPortal,
+    Param,
+    Boolean,
+    Any,
+    value,
+)
 
-currdir=dirname(abspath(__file__))+os.sep
-example_dir=pyomo_dir+os.sep+".."+os.sep+"examples"+os.sep+"pyomo"+os.sep+"tutorials"+os.sep+"tab"+os.sep
-tutorial_dir=pyomo_dir+os.sep+".."+os.sep+"examples"+os.sep+"pyomo"+os.sep+"tutorials"+os.sep
+currdir = dirname(abspath(__file__)) + os.sep
+example_dir = (
+    pyomo_dir
+    + os.sep
+    + ".."
+    + os.sep
+    + "examples"
+    + os.sep
+    + "pyomo"
+    + os.sep
+    + "tutorials"
+    + os.sep
+    + "tab"
+    + os.sep
+)
+tutorial_dir = (
+    pyomo_dir
+    + os.sep
+    + ".."
+    + os.sep
+    + "examples"
+    + os.sep
+    + "pyomo"
+    + os.sep
+    + "tutorials"
+    + os.sep
+)
 
 try:
     xls_interface = DataManagerFactory('xls').available()
@@ -52,90 +86,284 @@ except:
     yaml_interface = False
 
 
-
 @unittest.skipIf(not xls_interface, "No XLS interface available")
 class PyomoTableData(unittest.TestCase):
-
     def setUp(self):
         pass
 
-    def construct(self,filename):
+    def construct(self, filename):
         pass
 
     def test_read_set(self):
         td = DataManagerFactory('xls')
-        td.initialize(filename=currdir+"Book1.xls", range="TheRange", format='set', set="X")
+        td.initialize(
+            filename=currdir + "Book1.xls", range="TheRange", format='set', set="X"
+        )
         try:
             td.open()
             td.read()
             td.close()
-            self.assertEqual( td._info, ['set', 'X', ':=', ('A1', 2.0, 3.0, 4.0), ('A5', 6.0, 7.0, 8.0), ('A9', 10.0, 11.0, 12.0), ('A13', 14.0, 15.0, 16.0)])
+            self.assertEqual(
+                td._info,
+                [
+                    'set',
+                    'X',
+                    ':=',
+                    ('A1', 2.0, 3.0, 4.0),
+                    ('A5', 6.0, 7.0, 8.0),
+                    ('A9', 10.0, 11.0, 12.0),
+                    ('A13', 14.0, 15.0, 16.0),
+                ],
+            )
         except ApplicationError:
             pass
 
     def test_read_param1(self):
         td = DataManagerFactory('xls')
-        td.initialize(filename=currdir+"Book1.xls", range="TheRange", param=['bb','cc','dd'])
+        td.initialize(
+            filename=currdir + "Book1.xls", range="TheRange", param=['bb', 'cc', 'dd']
+        )
         try:
             td.open()
             td.read()
             td.close()
-            self.assertEqual( td._info, ['param', ':', 'bb', 'cc', 'dd', ':=', 'A1', 2.0, 3.0, 4.0, 'A5', 6.0, 7.0, 8.0, 'A9', 10.0, 11.0, 12.0, 'A13', 14.0, 15.0, 16.0])
+            self.assertEqual(
+                td._info,
+                [
+                    'param',
+                    ':',
+                    'bb',
+                    'cc',
+                    'dd',
+                    ':=',
+                    'A1',
+                    2.0,
+                    3.0,
+                    4.0,
+                    'A5',
+                    6.0,
+                    7.0,
+                    8.0,
+                    'A9',
+                    10.0,
+                    11.0,
+                    12.0,
+                    'A13',
+                    14.0,
+                    15.0,
+                    16.0,
+                ],
+            )
         except ApplicationError:
             pass
 
     def test_read_param2(self):
         td = DataManagerFactory('xls')
-        td.initialize(filename=currdir+"Book1.xls",range="TheRange", index="X", param=['bb','cc','dd'])
+        td.initialize(
+            filename=currdir + "Book1.xls",
+            range="TheRange",
+            index="X",
+            param=['bb', 'cc', 'dd'],
+        )
         try:
             td.open()
             td.read()
             td.close()
-            self.assertEqual( td._info, ['param', ':', 'X', ':', 'bb', 'cc', 'dd', ':=', 'A1', 2.0, 3.0, 4.0, 'A5', 6.0, 7.0, 8.0, 'A9', 10.0, 11.0, 12.0, 'A13', 14.0, 15.0, 16.0])
+            self.assertEqual(
+                td._info,
+                [
+                    'param',
+                    ':',
+                    'X',
+                    ':',
+                    'bb',
+                    'cc',
+                    'dd',
+                    ':=',
+                    'A1',
+                    2.0,
+                    3.0,
+                    4.0,
+                    'A5',
+                    6.0,
+                    7.0,
+                    8.0,
+                    'A9',
+                    10.0,
+                    11.0,
+                    12.0,
+                    'A13',
+                    14.0,
+                    15.0,
+                    16.0,
+                ],
+            )
         except ApplicationError:
             pass
 
     def test_read_param3(self):
         td = DataManagerFactory('xls')
-        td.initialize(filename=currdir+"Book1.xls",range="TheRange", index="X", param=["a"])
+        td.initialize(
+            filename=currdir + "Book1.xls", range="TheRange", index="X", param=["a"]
+        )
         try:
             td.open()
             td.read()
             td.close()
-            self.assertEqual( td._info, ['param', ':', 'X', ':', 'a', ':=', 'A1', 2.0, 3.0, 4.0, 'A5', 6.0, 7.0, 8.0, 'A9', 10.0, 11.0, 12.0, 'A13', 14.0, 15.0, 16.0])
+            self.assertEqual(
+                td._info,
+                [
+                    'param',
+                    ':',
+                    'X',
+                    ':',
+                    'a',
+                    ':=',
+                    'A1',
+                    2.0,
+                    3.0,
+                    4.0,
+                    'A5',
+                    6.0,
+                    7.0,
+                    8.0,
+                    'A9',
+                    10.0,
+                    11.0,
+                    12.0,
+                    'A13',
+                    14.0,
+                    15.0,
+                    16.0,
+                ],
+            )
         except ApplicationError:
             pass
 
     def test_read_param4(self):
         td = DataManagerFactory('xls')
-        td.initialize(filename=currdir+"Book1.xls", range="TheRange", index="X", param=['a','b'],)
+        td.initialize(
+            filename=currdir + "Book1.xls",
+            range="TheRange",
+            index="X",
+            param=['a', 'b'],
+        )
         try:
             td.open()
             td.read()
             td.close()
-            self.assertEqual( td._info, ['param', ':', 'X', ':', 'a', 'b', ':=', 'A1', 2.0, 3.0, 4.0, 'A5', 6.0, 7.0, 8.0, 'A9', 10.0, 11.0, 12.0, 'A13', 14.0, 15.0, 16.0])
+            self.assertEqual(
+                td._info,
+                [
+                    'param',
+                    ':',
+                    'X',
+                    ':',
+                    'a',
+                    'b',
+                    ':=',
+                    'A1',
+                    2.0,
+                    3.0,
+                    4.0,
+                    'A5',
+                    6.0,
+                    7.0,
+                    8.0,
+                    'A9',
+                    10.0,
+                    11.0,
+                    12.0,
+                    'A13',
+                    14.0,
+                    15.0,
+                    16.0,
+                ],
+            )
         except ApplicationError:
             pass
 
     def test_read_array1(self):
         td = DataManagerFactory('xls')
-        td.initialize(filename=currdir+"Book1.xls",range="TheRange", param="X", format="array")
+        td.initialize(
+            filename=currdir + "Book1.xls", range="TheRange", param="X", format="array"
+        )
         try:
             td.open()
             td.read()
             td.close()
-            self.assertEqual( td._info, ['param', 'X', ':', 'bb', 'cc', 'dd', ':=', 'A1', 2.0, 3.0, 4.0, 'A5', 6.0, 7.0, 8.0, 'A9', 10.0, 11.0, 12.0, 'A13', 14.0, 15.0, 16.0])
+            self.assertEqual(
+                td._info,
+                [
+                    'param',
+                    'X',
+                    ':',
+                    'bb',
+                    'cc',
+                    'dd',
+                    ':=',
+                    'A1',
+                    2.0,
+                    3.0,
+                    4.0,
+                    'A5',
+                    6.0,
+                    7.0,
+                    8.0,
+                    'A9',
+                    10.0,
+                    11.0,
+                    12.0,
+                    'A13',
+                    14.0,
+                    15.0,
+                    16.0,
+                ],
+            )
         except ApplicationError:
             pass
 
     def test_read_array2(self):
         td = DataManagerFactory('xls')
-        td.initialize(filename=currdir+"Book1.xls",range="TheRange",param="X",format="transposed_array")
+        td.initialize(
+            filename=currdir + "Book1.xls",
+            range="TheRange",
+            param="X",
+            format="transposed_array",
+        )
         try:
             td.open()
             td.read()
             td.close()
-            self.assertEqual( td._info, ['param', 'X', '(tr)',':', 'bb', 'cc', 'dd', ':=', 'A1', 2.0, 3.0, 4.0, 'A5', 6.0, 7.0, 8.0, 'A9', 10.0, 11.0, 12.0, 'A13', 14.0, 15.0, 16.0])
+            self.assertEqual(
+                td._info,
+                [
+                    'param',
+                    'X',
+                    '(tr)',
+                    ':',
+                    'bb',
+                    'cc',
+                    'dd',
+                    ':=',
+                    'A1',
+                    2.0,
+                    3.0,
+                    4.0,
+                    'A5',
+                    6.0,
+                    7.0,
+                    8.0,
+                    'A9',
+                    10.0,
+                    11.0,
+                    12.0,
+                    'A13',
+                    14.0,
+                    15.0,
+                    16.0,
+                ],
+            )
         except ApplicationError:
             pass
 
@@ -153,13 +381,13 @@ class PyomoTableData(unittest.TestCase):
         try:
             td.open()
             self.fail("Expected IOError because no file specified")
-        except (IOError,AttributeError):
+        except (IOError, AttributeError):
             pass
 
     def test_error3(self):
         td = DataManagerFactory('txt')
         try:
-            td.initialize(filename=currdir+"display.txt")
+            td.initialize(filename=currdir + "display.txt")
             td.open()
             self.fail("Expected IOError because of bad file type")
         except (IOError, AttributeError):
@@ -168,7 +396,7 @@ class PyomoTableData(unittest.TestCase):
     def test_error4(self):
         td = DataManagerFactory('txt')
         try:
-            td.initialize(filename=currdir+"dummy")
+            td.initialize(filename=currdir + "dummy")
             td.open()
             self.fail("Expected IOError because of bad file type")
         except (IOError, AttributeError):
@@ -176,7 +404,7 @@ class PyomoTableData(unittest.TestCase):
 
     def test_error5(self):
         td = DataManagerFactory('tab')
-        td.initialize(filename=example_dir+"D.tab", param="D", format="foo")
+        td.initialize(filename=example_dir + "D.tab", param="D", format="foo")
         td.open()
         try:
             td.read()
@@ -186,33 +414,32 @@ class PyomoTableData(unittest.TestCase):
 
 
 class PyomoDataPortal(unittest.TestCase):
-
     def test_tableA1_1(self):
         # Importing a single column of data
-        model=AbstractModel()
+        model = AbstractModel()
         model.A = Set()
-        data = DataPortal(filename=os.path.abspath(example_dir+'A.tab'), set=model.A)
+        data = DataPortal(filename=os.path.abspath(example_dir + 'A.tab'), set=model.A)
         self.assertEqual(set(data['A']), set(['A1', 'A2', 'A3']))
         instance = model.create_instance(data)
         self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3']))
 
     def test_tableA1_2(self):
         # Importing a single column of data
-        model=AbstractModel()
+        model = AbstractModel()
         model.A = Set()
         data = DataPortal()
-        data.load(filename=os.path.abspath(example_dir+'A.tab'), set=model.A)
+        data.load(filename=os.path.abspath(example_dir + 'A.tab'), set=model.A)
         instance = model.create_instance(data)
         self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3']))
 
     def test_tableA1_3(self):
         # Importing a single column of data
-        model=AbstractModel()
+        model = AbstractModel()
         model.A = Set()
         data = DataPortal()
-        data.connect(filename=os.path.abspath(example_dir+'B.tab'))
+        data.connect(filename=os.path.abspath(example_dir + 'B.tab'))
         # The first connection will be closed here
-        data.connect(filename=os.path.abspath(example_dir+'A.tab'))
+        data.connect(filename=os.path.abspath(example_dir + 'A.tab'))
         data.load(set=model.A)
         data.disconnect()
         instance = model.create_instance(data)
@@ -220,150 +447,159 @@ class PyomoDataPortal(unittest.TestCase):
 
     def test_md1(self):
         md = DataPortal()
-        md.connect(filename=example_dir+"A.tab")
+        md.connect(filename=example_dir + "A.tab")
         try:
             md.load()
             self.fail("Must specify a model")
         except ValueError:
             pass
-        model=AbstractModel()
+        model = AbstractModel()
         try:
             md.load(model=model)
             self.fail("Expected ValueError")
         except ValueError:
             pass
-        model.A=Set()
+        model.A = Set()
 
     def test_md2(self):
         md = DataPortal()
-        model=AbstractModel()
-        model.A=Set()
-        md.load(model=model, filename=currdir+"data1.dat")
-        self.assertEqual(set(md['A']), set([1,2,3]))
+        model = AbstractModel()
+        model.A = Set()
+        md.load(model=model, filename=currdir + "data1.dat")
+        self.assertEqual(set(md['A']), set([1, 2, 3]))
 
     def test_md3(self):
         md = DataPortal()
-        model=AbstractModel()
-        model.A=Set()
+        model = AbstractModel()
+        model.A = Set()
         try:
-            md.load(model=model, filename=currdir+"data2.dat")
+            md.load(model=model, filename=currdir + "data2.dat")
             self.fail("Expected error because of extraneous text")
         except IOError:
             pass
 
     def test_md4(self):
         md = DataPortal()
-        model=AbstractModel()
-        model.A=Set()
-        model.B=Set()
-        model.C=Set()
-        md.load(model=model, filename=currdir+"data3.dat")
+        model = AbstractModel()
+        model.A = Set()
+        model.B = Set()
+        model.C = Set()
+        md.load(model=model, filename=currdir + "data3.dat")
         self.assertEqual(set(md['A']), set([]))
-        self.assertEqual(set(md['B']), set([(1,2)]))
-        self.assertEqual(set(md['C']), set([('a','b','c')]))
+        self.assertEqual(set(md['B']), set([(1, 2)]))
+        self.assertEqual(set(md['C']), set([('a', 'b', 'c')]))
 
     def test_md5(self):
         md = DataPortal()
-        model=AbstractModel()
-        model.A=Set()
+        model = AbstractModel()
+        model.A = Set()
         try:
-            md.load(model=model, filename=currdir+"data4.dat")
-        except (ValueError,IOError):
+            md.load(model=model, filename=currdir + "data4.dat")
+        except (ValueError, IOError):
             pass
 
     def test_md6(self):
         md = DataPortal()
-        model=AbstractModel()
-        model.A=Set()
+        model = AbstractModel()
+        model.A = Set()
         try:
-            md.load(model=model, filename=currdir+"data5.dat")
+            md.load(model=model, filename=currdir + "data5.dat")
         except ValueError:
             pass
 
     def test_md7(self):
         md = DataPortal()
-        model=AbstractModel()
+        model = AbstractModel()
         try:
-            md.load(model=model, filename=currdir+"data1.tab")
+            md.load(model=model, filename=currdir + "data1.tab")
             self.fail("Expected IOError")
         except IOError:
             pass
 
     def test_md8(self):
         md = DataPortal()
-        model=AbstractModel()
-        model.A=Set()
+        model = AbstractModel()
+        model.A = Set()
         try:
-            md.load(model=model, filename=currdir+"data6.dat")
+            md.load(model=model, filename=currdir + "data6.dat")
             self.fail("Expected IOError")
         except IOError:
             pass
 
     def test_md9(self):
         md = DataPortal()
-        model=AbstractModel()
-        model.A=Set()
-        model.B=Param(model.A)
-        md.load(model=model, filename=currdir+"data7.dat")
-        self.assertEqual(set(md['A']), set(['a','b','c']))
-        self.assertEqual(md['B'], {'a':1.0, 'c':3.0})
+        model = AbstractModel()
+        model.A = Set()
+        model.B = Param(model.A)
+        md.load(model=model, filename=currdir + "data7.dat")
+        self.assertEqual(set(md['A']), set(['a', 'b', 'c']))
+        self.assertEqual(md['B'], {'a': 1.0, 'c': 3.0})
 
     def test_md10(self):
         md = DataPortal()
-        model=AbstractModel()
-        model.A=Param(within=Boolean)
-        model.B=Param(within=Boolean)
-        model.Z=Set()
-        model.Y=Set(model.Z)
-        md.load(model=model, filename=currdir+"data8.dat")
+        model = AbstractModel()
+        model.A = Param(within=Boolean)
+        model.B = Param(within=Boolean)
+        model.Z = Set()
+        model.Y = Set(model.Z)
+        md.load(model=model, filename=currdir + "data8.dat")
         self.assertEqual(md['A'], False)
         self.assertEqual(md['B'], True)
-        self.assertEqual(md['Z'], ['foo[*]', 'bar[ * ]', 'bar[1,*,a,*]', 'foo-bar', 'hello-goodbye'])
-        self.assertEqual(md['Y']['foo-bar'], ['foo[*]', 'bar[ * ]', 'bar[1,*,a,*]', 'foo-bar', 'hello-goodbye'])
+        self.assertEqual(
+            md['Z'], ['foo[*]', 'bar[ * ]', 'bar[1,*,a,*]', 'foo-bar', 'hello-goodbye']
+        )
+        self.assertEqual(
+            md['Y']['foo-bar'],
+            ['foo[*]', 'bar[ * ]', 'bar[1,*,a,*]', 'foo-bar', 'hello-goodbye'],
+        )
         instance = model.create_instance(md)
 
     def test_md11(self):
         cwd = os.getcwd()
         os.chdir(currdir)
         md = DataPortal()
-        model=AbstractModel()
-        model.A=Set()
-        model.B=Set()
-        model.C=Set()
-        model.D=Set()
-        md.load(model=model, filename=currdir+"data11.dat")
+        model = AbstractModel()
+        model.A = Set()
+        model.B = Set()
+        model.C = Set()
+        model.D = Set()
+        md.load(model=model, filename=currdir + "data11.dat")
         self.assertEqual(set(md['A']), set([]))
-        self.assertEqual(set(md['B']), set([(1,2)]))
-        self.assertEqual(set(md['C']), set([('a','b','c')]))
-        self.assertEqual(set(md['D']), set([1,3,5]))
+        self.assertEqual(set(md['B']), set([(1, 2)]))
+        self.assertEqual(set(md['C']), set([('a', 'b', 'c')]))
+        self.assertEqual(set(md['D']), set([1, 3, 5]))
         os.chdir(cwd)
 
     def test_md11a(self):
         cwd = os.getcwd()
         os.chdir(currdir)
-        model=AbstractModel()
-        model.a=Param()
-        model.b=Param()
-        model.c=Param()
-        model.d=Param()
+        model = AbstractModel()
+        model.a = Param()
+        model.b = Param()
+        model.c = Param()
+        model.d = Param()
         # Test 1
-        instance = model.create_instance(currdir+'data14.dat', namespaces=['ns1','ns2'])
-        self.assertEqual( value(instance.a), 1)
-        self.assertEqual( value(instance.b), 2)
-        self.assertEqual( value(instance.c), 2)
-        self.assertEqual( value(instance.d), 2)
+        instance = model.create_instance(
+            currdir + 'data14.dat', namespaces=['ns1', 'ns2']
+        )
+        self.assertEqual(value(instance.a), 1)
+        self.assertEqual(value(instance.b), 2)
+        self.assertEqual(value(instance.c), 2)
+        self.assertEqual(value(instance.d), 2)
         # Test 2
-        instance = model.create_instance(currdir+'data14.dat', namespaces=['ns1','ns3','nsX'])
-        self.assertEqual( value(instance.a), 1)
-        self.assertEqual( value(instance.b), 100)
-        self.assertEqual( value(instance.c), 3)
-        self.assertEqual( value(instance.d), 100)
+        instance = model.create_instance(
+            currdir + 'data14.dat', namespaces=['ns1', 'ns3', 'nsX']
+        )
+        self.assertEqual(value(instance.a), 1)
+        self.assertEqual(value(instance.b), 100)
+        self.assertEqual(value(instance.c), 3)
+        self.assertEqual(value(instance.d), 100)
         # Test None
-        instance = model.create_instance(currdir+'data14.dat')
-        self.assertEqual( value(instance.a), -1)
-        self.assertEqual( value(instance.b), -2)
-        self.assertEqual( value(instance.c), -3)
-        self.assertEqual( value(instance.d), -4)
+        instance = model.create_instance(currdir + 'data14.dat')
+        self.assertEqual(value(instance.a), -1)
+        self.assertEqual(value(instance.b), -2)
+        self.assertEqual(value(instance.c), -3)
+        self.assertEqual(value(instance.d), -4)
         #
         os.chdir(cwd)
 
@@ -372,12 +608,12 @@ class PyomoDataPortal(unittest.TestCase):
         model.A = Set()
         md = DataPortal()
         try:
-            md.load(filename=example_dir+'A.tab', format='bad', set=model.A)
+            md.load(filename=example_dir + 'A.tab', format='bad', set=model.A)
             self.fail("Bad format error")
         except ValueError:
             pass
         try:
-            md.load(filename=example_dir+'A.tab')
+            md.load(filename=example_dir + 'A.tab')
             self.fail("Bad format error")
         except ValueError:
             pass
@@ -385,12 +621,12 @@ class PyomoDataPortal(unittest.TestCase):
     @unittest.expectedFailure
     def test_md13(self):
         md = DataPortal()
-        model=AbstractModel()
-        model.p=Param()
-        instance = model.create_instance(currdir+"data15.dat")
-        md.load(model=model, filename=currdir+"data15.dat")
+        model = AbstractModel()
+        model.p = Param()
+        instance = model.create_instance(currdir + "data15.dat")
+        md.load(model=model, filename=currdir + "data15.dat")
         try:
-            md.load(model=model, filename=currdir+"data15.dat")
+            md.load(model=model, filename=currdir + "data15.dat")
             self.fail("Expected IOError")
         except IOError:
             pass
@@ -406,7 +642,7 @@ class PyomoDataPortal(unittest.TestCase):
             self.fail("Expected ValueError")
         except ValueError:
             pass
-        
+
     def test_md15(self):
         md = DataPortal()
         try:
@@ -428,7 +664,7 @@ class PyomoDataPortal(unittest.TestCase):
     def test_md17(self):
         md = DataPortal()
         try:
-            md[1,2,3,4]
+            md[1, 2, 3, 4]
             self.fail("Expected IOError")
         except IOError:
             pass
@@ -437,32 +673,32 @@ class PyomoDataPortal(unittest.TestCase):
         model = AbstractModel()
         model.I = Set()
         model.p = Param(model.I, domain=Any)
-        i = model.create_instance(currdir+"data_types.dat")
+        i = model.create_instance(currdir + "data_types.dat")
         ref = {
-            50:  (int, 2),
+            50: (int, 2),
             55: (int, -2),
-            51:  (int, 200),
+            51: (int, 200),
             52: (int, -200),
             53: (float, 0.02),
             54: (float, -0.02),
-            10: (float, 1.),
-            11: (float, -1.),
-            12: (float, .1),
-            13: (float, -.1),
+            10: (float, 1.0),
+            11: (float, -1.0),
+            12: (float, 0.1),
+            13: (float, -0.1),
             14: (float, 1.1),
             15: (float, -1.1),
-            20: (float, 200.),
-            21: (float, -200.),
-            22: (float, .02),
-            23: (float, -.02),
-            30: (float, 210.),
-            31: (float, -210.),
-            32: (float, .021),
-            33: (float, -.021),
-            40: (float, 10.),
-            41: (float, -10.),
-            42: (float, .001),
-            43: (float, -.001),
+            20: (float, 200.0),
+            21: (float, -200.0),
+            22: (float, 0.02),
+            23: (float, -0.02),
+            30: (float, 210.0),
+            31: (float, -210.0),
+            32: (float, 0.021),
+            33: (float, -0.021),
+            40: (float, 10.0),
+            41: (float, -10.0),
+            42: (float, 0.001),
+            43: (float, -0.001),
             1000: (str, "a_string"),
             1001: (str, "a_string"),
             1002: (str, 'a_string'),
@@ -472,44 +708,91 @@ class PyomoDataPortal(unittest.TestCase):
             1006: (str, '123'),
         }
         for k, v in i.p.items():
-            #print(k,v, type(v))
+            # print(k,v, type(v))
             if k in ref:
-                err="index %s: (%s, %s) does not match ref %s" % (
-                    k, type(v), v, ref[k],)
+                err = "index %s: (%s, %s) does not match ref %s" % (
+                    k,
+                    type(v),
+                    v,
+                    ref[k],
+                )
                 self.assertIs(type(v), ref[k][0], err)
                 self.assertEqual(v, ref[k][1], err)
             else:
                 n = k // 10
-                err="index %s: (%s, %s) does not match ref %s" % (
-                    k, type(v), v, ref[n],)
+                err = "index %s: (%s, %s) does not match ref %s" % (
+                    k,
+                    type(v),
+                    v,
+                    ref[n],
+                )
                 self.assertIs(type(v), ref[n][0], err)
                 self.assertEqual(v, ref[n][1], err)
 
     def test_data_namespace(self):
-        model=AbstractModel()
-        model.a=Param()
-        model.b=Param()
-        model.c=Param()
-        model.d=Param()
-        model.A=Set()
-        model.e=Param(model.A)
+        model = AbstractModel()
+        model.a = Param()
+        model.b = Param()
+        model.c = Param()
+        model.d = Param()
+        model.A = Set()
+        model.e = Param(model.A)
         md = DataPortal()
-        md.load(model=model, filename=currdir+"data16.dat")
+        md.load(model=model, filename=currdir + "data16.dat")
         # data()
-        self.assertEqual(md.data(namespace='ns1'), {'a': {None: 1}, 'A': {None:[7,9,11]}, 'e': {9:90, 7:70, 11:110}})
+        self.assertEqual(
+            md.data(namespace='ns1'),
+            {'a': {None: 1}, 'A': {None: [7, 9, 11]}, 'e': {9: 90, 7: 70, 11: 110}},
+        )
         # __getitem__
         self.assertEqual(md['ns1', 'a'], 1)
         # namespaces()
-        self.assertEqual(sorted(md.namespaces(), key=lambda x: 'None' if x is None else x), [None, 'ns1', 'ns2', 'ns3', 'nsX'])
+        self.assertEqual(
+            sorted(md.namespaces(), key=lambda x: 'None' if x is None else x),
+            [None, 'ns1', 'ns2', 'ns3', 'nsX'],
+        )
         # keys()
-        self.assertEqual(sorted(md.keys()), ['A', 'a','b','c','d','e'])
+        self.assertEqual(sorted(md.keys()), ['A', 'a', 'b', 'c', 'd', 'e'])
         self.assertEqual(sorted(md.keys('ns1')), ['A', 'a', 'e'])
         # values()
-        self.assertEqual(sorted(md.values(),      key=lambda x: tuple(sorted(x)+[0]) if type(x) is list else tuple(sorted(x.values())) if not type(x) is int else (x, )), [-4, -3, -2, -1, [1,3,5], {1:10, 3:30, 5:50}])
-        self.assertEqual(sorted(md.values('ns1'), key=lambda x: tuple(sorted(x)+[0]) if type(x) is list else tuple(sorted(x.values())) if not type(x) is int else (x, )), [1, [7,9,11], {7:70, 9:90, 11:110}])
+        self.assertEqual(
+            sorted(
+                md.values(),
+                key=lambda x: tuple(sorted(x) + [0])
+                if type(x) is list
+                else tuple(sorted(x.values()))
+                if not type(x) is int
+                else (x,),
+            ),
+            [-4, -3, -2, -1, [1, 3, 5], {1: 10, 3: 30, 5: 50}],
+        )
+        self.assertEqual(
+            sorted(
+                md.values('ns1'),
+                key=lambda x: tuple(sorted(x) + [0])
+                if type(x) is list
+                else tuple(sorted(x.values()))
+                if not type(x) is int
+                else (x,),
+            ),
+            [1, [7, 9, 11], {7: 70, 9: 90, 11: 110}],
+        )
         # items()
-        self.assertEqual(sorted(md.items()), [('A', [1,3,5]), ('a',-1), ('b',-2), ('c',-3), ('d',-4), ('e', {1:10, 3:30, 5:50})])
-        self.assertEqual(sorted(md.items('ns1')), [('A', [7,9,11]), ('a',1), ('e',{7:70, 9:90, 11:110})])
+        self.assertEqual(
+            sorted(md.items()),
+            [
+                ('A', [1, 3, 5]),
+                ('a', -1),
+                ('b', -2),
+                ('c', -3),
+                ('d', -4),
+                ('e', {1: 10, 3: 30, 5: 50}),
+            ],
+        )
+        self.assertEqual(
+            sorted(md.items('ns1')),
+            [('A', [7, 9, 11]), ('a', 1), ('e', {7: 70, 9: 90, 11: 110})],
+        )
 
 
 class TestOnlyTextPortal(unittest.TestCase):
@@ -522,17 +805,27 @@ class TestOnlyTextPortal(unittest.TestCase):
             self.skipTest('Skipping test %s' % name)
 
     def create_options(self, name):
-        return {'filename':os.path.abspath(tutorial_dir+os.sep+'tab'+os.sep+name+self.suffix)}
+        return {
+            'filename': os.path.abspath(
+                tutorial_dir + os.sep + 'tab' + os.sep + name + self.suffix
+            )
+        }
 
     def create_write_options(self, name):
-        return {'filename':os.path.abspath(currdir+os.sep+name+self.suffix), 'sort':True}
+        return {
+            'filename': os.path.abspath(currdir + os.sep + name + self.suffix),
+            'sort': True,
+        }
 
     def test_empty(self):
         # Importing an empty file
         self.check_skiplist('empty')
         dp = DataPortal()
         try:
-            dp.load(set='A', filename=os.path.abspath(currdir+os.sep+'empty'+self.suffix))
+            dp.load(
+                set='A',
+                filename=os.path.abspath(currdir + os.sep + 'empty' + self.suffix),
+            )
             self.fail("Expected IOError")
         except IOError:
             pass
@@ -557,14 +850,29 @@ class TestOnlyTextPortal(unittest.TestCase):
         self.check_skiplist('tableC')
         dp = DataPortal()
         dp.load(set='C', **self.create_options('C'))
-        self.assertEqual(set(dp.data('C')), set([('A1',1), ('A1',2), ('A1',3), ('A2',1), ('A2',2), ('A2',3), ('A3',1), ('A3',2), ('A3',3)]))
+        self.assertEqual(
+            set(dp.data('C')),
+            set(
+                [
+                    ('A1', 1),
+                    ('A1', 2),
+                    ('A1', 3),
+                    ('A2', 1),
+                    ('A2', 2),
+                    ('A2', 3),
+                    ('A3', 1),
+                    ('A3', 2),
+                    ('A3', 3),
+                ]
+            ),
+        )
 
     def test_tableD(self):
         # Importing a 2D array of data as a set.
         self.check_skiplist('tableD')
         dp = DataPortal()
         dp.load(set='D', format='set_array', **self.create_options('D'))
-        self.assertEqual(set(dp.data('D')), set([('A1',1), ('A2',2), ('A3',3)]))
+        self.assertEqual(set(dp.data('D')), set([('A1', 1), ('A2', 2), ('A3', 3)]))
 
     def test_tableZ(self):
         # Importing a single parameter
@@ -578,7 +886,7 @@ class TestOnlyTextPortal(unittest.TestCase):
         self.check_skiplist('tableY')
         dp = DataPortal()
         dp.load(param='Y', **self.create_options('Y'))
-        self.assertEqual(dp.data('Y'), {'A1':3.3,'A2':3.4,'A3':3.5})
+        self.assertEqual(dp.data('Y'), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
 
     def test_tableXW_1(self):
         # Importing a table, but only reporting the values for the non-index
@@ -587,40 +895,77 @@ class TestOnlyTextPortal(unittest.TestCase):
         self.check_skiplist('tableXW_1')
         dp = DataPortal()
         dp.load(param=('X', 'W'), **self.create_options('XW'))
-        self.assertEqual(dp.data('X'), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(dp.data('W'), {'A1':4.3,'A2':4.4,'A3':4.5})
+        self.assertEqual(dp.data('X'), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(dp.data('W'), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
 
     def test_tableXW_3(self):
         # Like test_tableXW_1, except that set A is defined in the load statment.
         self.check_skiplist('tableXW_3')
         dp = DataPortal()
         dp.load(index='A', param=('X', 'W'), **self.create_options('XW'))
-        self.assertEqual(set(dp.data('A')), set(['A1','A2','A3']))
-        self.assertEqual(dp.data('X'), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(dp.data('W'), {'A1':4.3,'A2':4.4,'A3':4.5})
+        self.assertEqual(set(dp.data('A')), set(['A1', 'A2', 'A3']))
+        self.assertEqual(dp.data('X'), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(dp.data('W'), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
 
     def test_tableXW_4(self):
         # Like test_tableXW_1, except that set A is defined in the load statment and all values are mapped.
         self.check_skiplist('tableXW_4')
         dp = DataPortal()
-        dp.load(select=('A', 'W', 'X'), index='B', param=('R', 'S'), **self.create_options('XW'))
-        self.assertEqual(set(dp.data('B')), set(['A1','A2','A3']))
-        self.assertEqual(dp.data('S'), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(dp.data('R'), {'A1':4.3,'A2':4.4,'A3':4.5})
+        dp.load(
+            select=('A', 'W', 'X'),
+            index='B',
+            param=('R', 'S'),
+            **self.create_options('XW')
+        )
+        self.assertEqual(set(dp.data('B')), set(['A1', 'A2', 'A3']))
+        self.assertEqual(dp.data('S'), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(dp.data('R'), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
 
     def test_tableT(self):
         # Importing a 2D array of parameters that are transposed.
         self.check_skiplist('tableT')
         dp = DataPortal()
         dp.load(format='transposed_array', param='T', **self.create_options('T'))
-        self.assertEqual(dp.data('T'), {('A2', 'I1'): 2.3, ('A1', 'I2'): 1.4, ('A1', 'I3'): 1.5, ('A1', 'I4'): 1.6, ('A1', 'I1'): 1.3, ('A3', 'I4'): 3.6, ('A2', 'I4'): 2.6, ('A3', 'I1'): 3.3, ('A2', 'I3'): 2.5, ('A3', 'I2'): 3.4, ('A2', 'I2'): 2.4, ('A3', 'I3'): 3.5})
+        self.assertEqual(
+            dp.data('T'),
+            {
+                ('A2', 'I1'): 2.3,
+                ('A1', 'I2'): 1.4,
+                ('A1', 'I3'): 1.5,
+                ('A1', 'I4'): 1.6,
+                ('A1', 'I1'): 1.3,
+                ('A3', 'I4'): 3.6,
+                ('A2', 'I4'): 2.6,
+                ('A3', 'I1'): 3.3,
+                ('A2', 'I3'): 2.5,
+                ('A3', 'I2'): 3.4,
+                ('A2', 'I2'): 2.4,
+                ('A3', 'I3'): 3.5,
+            },
+        )
 
     def test_tableU(self):
         # Importing a 2D array of parameters.
         self.check_skiplist('tableU')
         dp = DataPortal()
         dp.load(format='array', param='U', **self.create_options('U'))
-        self.assertEqual(dp.data('U'), {('I2', 'A1'): 1.4, ('I3', 'A1'): 1.5, ('I3', 'A2'): 2.5, ('I4', 'A1'): 1.6, ('I3', 'A3'): 3.5, ('I1', 'A2'): 2.3, ('I4', 'A3'): 3.6, ('I1', 'A3'): 3.3, ('I4', 'A2'): 2.6, ('I2', 'A3'): 3.4, ('I1', 'A1'): 1.3, ('I2', 'A2'): 2.4})
+        self.assertEqual(
+            dp.data('U'),
+            {
+                ('I2', 'A1'): 1.4,
+                ('I3', 'A1'): 1.5,
+                ('I3', 'A2'): 2.5,
+                ('I4', 'A1'): 1.6,
+                ('I3', 'A3'): 3.5,
+                ('I1', 'A2'): 2.3,
+                ('I4', 'A3'): 3.6,
+                ('I1', 'A3'): 3.3,
+                ('I4', 'A2'): 2.6,
+                ('I2', 'A3'): 3.4,
+                ('I1', 'A1'): 1.3,
+                ('I2', 'A2'): 2.4,
+            },
+        )
 
     def test_tableS(self):
         # Importing a table, but only reporting the values for the non-index
@@ -629,24 +974,32 @@ class TestOnlyTextPortal(unittest.TestCase):
         self.check_skiplist('tableS')
         dp = DataPortal()
         dp.load(param='S', **self.create_options('S'))
-        self.assertEqual(dp.data('S'), {'A1':3.3,'A3':3.5})
+        self.assertEqual(dp.data('S'), {'A1': 3.3, 'A3': 3.5})
 
     def test_tablePO(self):
         # Importing a table that has multiple indexing columns
         self.check_skiplist('tablePO')
         dp = DataPortal()
         dp.load(index='J', param=('P', 'O'), **self.create_options('PO'))
-        self.assertEqual(set(dp.data('J')), set([('A3', 'B3'), ('A1', 'B1'), ('A2', 'B2')]) )
-        self.assertEqual(dp.data('P'), {('A3', 'B3'): 4.5, ('A1', 'B1'): 4.3, ('A2', 'B2'): 4.4} )
-        self.assertEqual(dp.data('O'), {('A3', 'B3'): 5.5, ('A1', 'B1'): 5.3, ('A2', 'B2'): 5.4})
+        self.assertEqual(
+            set(dp.data('J')), set([('A3', 'B3'), ('A1', 'B1'), ('A2', 'B2')])
+        )
+        self.assertEqual(
+            dp.data('P'), {('A3', 'B3'): 4.5, ('A1', 'B1'): 4.3, ('A2', 'B2'): 4.4}
+        )
+        self.assertEqual(
+            dp.data('O'), {('A3', 'B3'): 5.5, ('A1', 'B1'): 5.3, ('A2', 'B2'): 5.4}
+        )
 
     def test_tablePP(self):
         # Importing a table that has a 2-d indexing
         self.check_skiplist('tablePP')
         dp = DataPortal()
         dp.load(param='PP', **self.create_options('PP'))
-        #self.assertEqual(set(dp.data('J')), set([('A3', 'B3'), ('A1', 'B1'), ('A2', 'B2')]) )
-        self.assertEqual(dp.data('PP'), {('A3', 'B3'): 4.5, ('A1', 'B1'): 4.3, ('A2', 'B2'): 4.4} )
+        # self.assertEqual(set(dp.data('J')), set([('A3', 'B3'), ('A1', 'B1'), ('A2', 'B2')]) )
+        self.assertEqual(
+            dp.data('PP'), {('A3', 'B3'): 4.5, ('A1', 'B1'): 4.3, ('A2', 'B2'): 4.4}
+        )
 
 
 class TestOnlyCsvPortal(TestOnlyTextPortal):
@@ -654,7 +1007,11 @@ class TestOnlyCsvPortal(TestOnlyTextPortal):
     suffix = '.csv'
 
     def create_options(self, name):
-        return {'filename':os.path.abspath(tutorial_dir+os.sep+'csv'+os.sep+name+self.suffix)}
+        return {
+            'filename': os.path.abspath(
+                tutorial_dir + os.sep + 'csv' + os.sep + name + self.suffix
+            )
+        }
 
 
 class TestOnlyXmlPortal(TestOnlyTextPortal):
@@ -663,7 +1020,11 @@ class TestOnlyXmlPortal(TestOnlyTextPortal):
     skiplist = ['tableD', 'tableT', 'tableU']
 
     def create_options(self, name):
-        return {'filename':os.path.abspath(tutorial_dir+os.sep+'xml'+os.sep+name+self.suffix)}
+        return {
+            'filename': os.path.abspath(
+                tutorial_dir + os.sep + 'xml' + os.sep + name + self.suffix
+            )
+        }
 
 
 class TestOnlyJsonPortal(TestOnlyTextPortal):
@@ -672,35 +1033,44 @@ class TestOnlyJsonPortal(TestOnlyTextPortal):
     skiplist = ['tableD', 'tableT', 'tableU', 'tableXW_4']
 
     def create_options(self, name):
-        return {'filename':os.path.abspath(tutorial_dir+os.sep+'json'+os.sep+name+self.suffix)}
+        return {
+            'filename': os.path.abspath(
+                tutorial_dir + os.sep + 'json' + os.sep + name + self.suffix
+            )
+        }
 
     def compare_data(self, name, file_suffix):
         if file_suffix == '.json':
-            with open(join(currdir, name+file_suffix), 'r') as out, \
-                open(join(currdir, name+'.baseline'+file_suffix), 'r') as txt:
-                self.assertStructuredAlmostEqual(json.load(txt), json.load(out),
-                                                 allow_second_superset=True,
-                                                 abstol=0)
+            with open(join(currdir, name + file_suffix), 'r') as out, open(
+                join(currdir, name + '.baseline' + file_suffix), 'r'
+            ) as txt:
+                self.assertStructuredAlmostEqual(
+                    json.load(txt), json.load(out), allow_second_superset=True, abstol=0
+                )
         elif file_suffix == '.yaml':
-            with open(join(currdir, name+file_suffix), 'r') as out, \
-                open(join(currdir, name+'.baseline'+file_suffix), 'r') as txt:
-                self.assertStructuredAlmostEqual(yaml.full_load(txt),
-                                                 yaml.full_load(out),
-                                                 allow_second_superset=True,
-                                                 abstol=0)
+            with open(join(currdir, name + file_suffix), 'r') as out, open(
+                join(currdir, name + '.baseline' + file_suffix), 'r'
+            ) as txt:
+                self.assertStructuredAlmostEqual(
+                    yaml.full_load(txt),
+                    yaml.full_load(out),
+                    allow_second_superset=True,
+                    abstol=0,
+                )
         else:
-            with open(join(currdir, name+file_suffix), 'r') as f1, \
-                open(join(currdir, name+'.baseline'+file_suffix), 'r') as f2:
-                    f1_contents = list(filter(None, f1.read().split()))
-                    f2_contents = list(filter(None, f2.read().split()))
-                    for item1, item2 in zip_longest(f1_contents, f2_contents):
-                        self.assertEqual(item1, item2)
-        os.remove(currdir+name+file_suffix)
+            with open(join(currdir, name + file_suffix), 'r') as f1, open(
+                join(currdir, name + '.baseline' + file_suffix), 'r'
+            ) as f2:
+                f1_contents = list(filter(None, f1.read().split()))
+                f2_contents = list(filter(None, f2.read().split()))
+                for item1, item2 in zip_longest(f1_contents, f2_contents):
+                    self.assertEqual(item1, item2)
+        os.remove(currdir + name + file_suffix)
 
     def test_store_set1(self):
         # Write 1-D set
         model = ConcreteModel()
-        model.A = Set(initialize=[1,3,5])
+        model.A = Set(initialize=[1, 3, 5])
         data = DataPortal()
         data.store(data=model.A, **self.create_write_options('set1'))
         self.compare_data('set1', self.suffix)
@@ -708,7 +1078,7 @@ class TestOnlyJsonPortal(TestOnlyTextPortal):
     def test_store_set1a(self):
         # Write 1-D set
         model = ConcreteModel()
-        model.A = Set(initialize=[1,3,5])
+        model.A = Set(initialize=[1, 3, 5])
         data = DataPortal()
         data.store(data="A", model=model, **self.create_write_options('set1'))
         self.compare_data('set1', self.suffix)
@@ -716,7 +1086,7 @@ class TestOnlyJsonPortal(TestOnlyTextPortal):
     def test_store_set2(self):
         # Write 2-D set
         model = ConcreteModel()
-        model.A = Set(initialize=[(1,2),(3,4),(5,6)], dimen=2)
+        model.A = Set(initialize=[(1, 2), (3, 4), (5, 6)], dimen=2)
         data = DataPortal()
         data.store(data=model.A, **self.create_write_options('set2'))
         self.compare_data('set2', self.suffix)
@@ -732,8 +1102,8 @@ class TestOnlyJsonPortal(TestOnlyTextPortal):
     def test_store_param2(self):
         # Write 1-D param
         model = ConcreteModel()
-        model.A = Set(initialize=[1,2,3])
-        model.p = Param(model.A, initialize={1:10, 2:20, 3:30})
+        model.A = Set(initialize=[1, 2, 3])
+        model.p = Param(model.A, initialize={1: 10, 2: 20, 3: 30})
         data = DataPortal()
         data.store(data=model.p, **self.create_write_options('param2'))
         self.compare_data('param2', self.suffix)
@@ -741,21 +1111,25 @@ class TestOnlyJsonPortal(TestOnlyTextPortal):
     def test_store_param3(self):
         # Write 2-D params
         model = ConcreteModel()
-        model.A = Set(initialize=[(1,2),(2,3),(3,4)], dimen=2)
-        model.p = Param(model.A, initialize={(1,2):10, (2,3):20, (3,4):30})
-        model.q = Param(model.A, initialize={(1,2):11, (2,3):21, (3,4):31})
+        model.A = Set(initialize=[(1, 2), (2, 3), (3, 4)], dimen=2)
+        model.p = Param(model.A, initialize={(1, 2): 10, (2, 3): 20, (3, 4): 30})
+        model.q = Param(model.A, initialize={(1, 2): 11, (2, 3): 21, (3, 4): 31})
         data = DataPortal()
-        data.store(data=(model.p,model.q), **self.create_write_options('param3'))
+        data.store(data=(model.p, model.q), **self.create_write_options('param3'))
         self.compare_data('param3', self.suffix)
 
     def test_store_param4(self):
         # Write 2-D params
         model = ConcreteModel()
-        model.A = Set(initialize=[(1,2),(2,3),(3,4)], dimen=2)
-        model.p = Param(model.A, initialize={(1,2):10, (2,3):20, (3,4):30})
-        model.q = Param(model.A, initialize={(1,2):11, (2,3):21, (3,4):31})
+        model.A = Set(initialize=[(1, 2), (2, 3), (3, 4)], dimen=2)
+        model.p = Param(model.A, initialize={(1, 2): 10, (2, 3): 20, (3, 4): 30})
+        model.q = Param(model.A, initialize={(1, 2): 11, (2, 3): 21, (3, 4): 31})
         data = DataPortal()
-        data.store(data=(model.p,model.q), columns=('a','b','c','d'), **self.create_write_options('param4'))
+        data.store(
+            data=(model.p, model.q),
+            columns=('a', 'b', 'c', 'd'),
+            **self.create_write_options('param4')
+        )
         self.compare_data('param4', self.suffix)
 
 
@@ -765,7 +1139,11 @@ class TestOnlyYamlPortal(TestOnlyJsonPortal):
     suffix = '.yaml'
 
     def create_options(self, name):
-        return {'filename':os.path.abspath(tutorial_dir+os.sep+'yaml'+os.sep+name+self.suffix)}
+        return {
+            'filename': os.path.abspath(
+                tutorial_dir + os.sep + 'yaml' + os.sep + name + self.suffix
+            )
+        }
 
 
 class TestTextPortal(unittest.TestCase):
@@ -778,44 +1156,59 @@ class TestTextPortal(unittest.TestCase):
             self.skipTest('Skipping test %s' % name)
 
     def create_options(self, name):
-        return {'filename':os.path.abspath(tutorial_dir+os.sep+'tab'+os.sep+name+self.suffix)}
+        return {
+            'filename': os.path.abspath(
+                tutorial_dir + os.sep + 'tab' + os.sep + name + self.suffix
+            )
+        }
 
     def create_write_options(self, name):
-        return {'filename':os.path.abspath(currdir+os.sep+name+self.suffix), 'sort':True}
+        return {
+            'filename': os.path.abspath(currdir + os.sep + name + self.suffix),
+            'sort': True,
+        }
 
     def compare_data(self, name, file_suffix):
         if file_suffix == '.json':
-            with open(join(currdir, name+file_suffix), 'r') as out, \
-                open(join(currdir, name+'.baseline'+file_suffix), 'r') as txt:
-                self.assertStructuredAlmostEqual(json.load(txt), json.load(out),
-                                                 allow_second_superset=True,
-                                                 abstol=0)
+            with open(join(currdir, name + file_suffix), 'r') as out, open(
+                join(currdir, name + '.baseline' + file_suffix), 'r'
+            ) as txt:
+                self.assertStructuredAlmostEqual(
+                    json.load(txt), json.load(out), allow_second_superset=True, abstol=0
+                )
         elif file_suffix == '.yaml':
-            with open(join(currdir, name+file_suffix), 'r') as out, \
-                open(join(currdir, name+'.baseline'+file_suffix), 'r') as txt:
-                self.assertStructuredAlmostEqual(yaml.full_load(txt),
-                                                 yaml.full_load(out),
-                                                 allow_second_superset=True,
-                                                 abstol=0)
+            with open(join(currdir, name + file_suffix), 'r') as out, open(
+                join(currdir, name + '.baseline' + file_suffix), 'r'
+            ) as txt:
+                self.assertStructuredAlmostEqual(
+                    yaml.full_load(txt),
+                    yaml.full_load(out),
+                    allow_second_superset=True,
+                    abstol=0,
+                )
         else:
             try:
-                with open(join(currdir, name+file_suffix), 'r') as f1, \
-                open(join(currdir, name+'.baseline'+file_suffix), 'r') as f2:
+                with open(join(currdir, name + file_suffix), 'r') as f1, open(
+                    join(currdir, name + '.baseline' + file_suffix), 'r'
+                ) as f2:
                     f1_contents = list(filter(None, f1.read().split()))
                     f2_contents = list(filter(None, f2.read().split()))
                     for item1, item2 in zip_longest(f1_contents, f2_contents):
                         self.assertEqual(item1, item2)
             except:
-                with open(join(currdir, name+file_suffix), 'r') as out, \
-                    open(join(currdir, name+'.baseline'+file_suffix), 'r') as txt:
-                    self.assertEqual(out.read().strip().replace(' ',''),
-                                     txt.read().strip().replace(' ',''))
-        os.remove(currdir+name+file_suffix)
+                with open(join(currdir, name + file_suffix), 'r') as out, open(
+                    join(currdir, name + '.baseline' + file_suffix), 'r'
+                ) as txt:
+                    self.assertEqual(
+                        out.read().strip().replace(' ', ''),
+                        txt.read().strip().replace(' ', ''),
+                    )
+        os.remove(currdir + name + file_suffix)
 
     def test_tableA(self):
         # Importing an unordered set of arbitrary data
         self.check_skiplist('tableA')
-        model=AbstractModel()
+        model = AbstractModel()
         model.A = Set()
         data = DataPortal()
         data.load(set=model.A, **self.create_options('A'))
@@ -825,7 +1218,7 @@ class TestTextPortal(unittest.TestCase):
     def test_tableB(self):
         # Importing an unordered set of numeric data
         self.check_skiplist('tableB')
-        model=AbstractModel()
+        model = AbstractModel()
         model.B = Set()
         data = DataPortal()
         data.load(set=model.B, **self.create_options('B'))
@@ -834,29 +1227,44 @@ class TestTextPortal(unittest.TestCase):
 
     def test_tableC(self):
         # Importing a multi-column table, where all columns are
-        #treated as values for a set with tuple values.
+        # treated as values for a set with tuple values.
         self.check_skiplist('tableC')
-        model=AbstractModel()
+        model = AbstractModel()
         model.C = Set(dimen=2)
         data = DataPortal()
         data.load(set=model.C, **self.create_options('C'))
         instance = model.create_instance(data)
-        self.assertEqual(set(instance.C.data()), set([('A1',1), ('A1',2), ('A1',3), ('A2',1), ('A2',2), ('A2',3), ('A3',1), ('A3',2), ('A3',3)]))
+        self.assertEqual(
+            set(instance.C.data()),
+            set(
+                [
+                    ('A1', 1),
+                    ('A1', 2),
+                    ('A1', 3),
+                    ('A2', 1),
+                    ('A2', 2),
+                    ('A2', 3),
+                    ('A3', 1),
+                    ('A3', 2),
+                    ('A3', 3),
+                ]
+            ),
+        )
 
     def test_tableD(self):
         # Importing a 2D array of data as a set.
         self.check_skiplist('tableD')
-        model=AbstractModel()
+        model = AbstractModel()
         model.C = Set(dimen=2)
         data = DataPortal()
         data.load(set=model.C, format='set_array', **self.create_options('D'))
         instance = model.create_instance(data)
-        self.assertEqual(set(instance.C.data()), set([('A1',1), ('A2',2), ('A3',3)]))
+        self.assertEqual(set(instance.C.data()), set([('A1', 1), ('A2', 2), ('A3', 3)]))
 
     def test_tableZ(self):
         # Importing a single parameter
         self.check_skiplist('tableZ')
-        model=AbstractModel()
+        model = AbstractModel()
         model.Z = Param(default=99.0)
         data = DataPortal()
         data.load(param=model.Z, **self.create_options('Z'))
@@ -866,130 +1274,175 @@ class TestTextPortal(unittest.TestCase):
     def test_tableY(self):
         # Same as tableXW.
         self.check_skiplist('tableY')
-        model=AbstractModel()
-        model.A = Set(initialize=['A1','A2','A3','A4'])
+        model = AbstractModel()
+        model.A = Set(initialize=['A1', 'A2', 'A3', 'A4'])
         model.Y = Param(model.A)
         data = DataPortal()
         data.load(param=model.Y, **self.create_options('Y'))
         instance = model.create_instance(data)
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3','A4']))
-        self.assertEqual(instance.Y.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3', 'A4']))
+        self.assertEqual(instance.Y.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
 
     def test_tableXW_1(self):
         # Importing a table, but only reporting the values for the non-index
-        #parameter columns.  The first column is assumed to represent an
-        #index column.
+        # parameter columns.  The first column is assumed to represent an
+        # index column.
         self.check_skiplist('tableXW_1')
-        model=AbstractModel()
-        model.A = Set(initialize=['A1','A2','A3','A4'])
+        model = AbstractModel()
+        model.A = Set(initialize=['A1', 'A2', 'A3', 'A4'])
         model.X = Param(model.A)
         model.W = Param(model.A)
         data = DataPortal()
         data.load(param=(model.X, model.W), **self.create_options('XW'))
         instance = model.create_instance(data)
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3','A4']))
-        self.assertEqual(instance.X.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(instance.W.extract_values(), {'A1':4.3,'A2':4.4,'A3':4.5})
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3', 'A4']))
+        self.assertEqual(instance.X.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(instance.W.extract_values(), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
 
     def test_tableXW_2(self):
         # Like test_tableXW_1, except that set A is not defined.
         self.check_skiplist('tableXW_2')
-        model=AbstractModel()
-        model.A = Set(initialize=['A1','A2','A3'])
+        model = AbstractModel()
+        model.A = Set(initialize=['A1', 'A2', 'A3'])
         model.X = Param(model.A)
         model.W = Param(model.A)
         data = DataPortal()
         data.load(param=(model.X, model.W), **self.create_options('XW'))
         instance = model.create_instance(data)
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3']))
-        self.assertEqual(instance.X.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(instance.W.extract_values(), {'A1':4.3,'A2':4.4,'A3':4.5})
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3']))
+        self.assertEqual(instance.X.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(instance.W.extract_values(), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
 
     def test_tableXW_3(self):
         # Like test_tableXW_1, except that set A is defined in the load statment.
         self.check_skiplist('tableXW_3')
-        model=AbstractModel()
+        model = AbstractModel()
         model.A = Set()
         model.X = Param(model.A)
         model.W = Param(model.A)
         data = DataPortal()
         data.load(index=model.A, param=(model.X, model.W), **self.create_options('XW'))
         instance = model.create_instance(data)
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3']))
-        self.assertEqual(instance.X.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(instance.W.extract_values(), {'A1':4.3,'A2':4.4,'A3':4.5})
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3']))
+        self.assertEqual(instance.X.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(instance.W.extract_values(), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
 
     def test_tableXW_4(self):
         # Like test_tableXW_1, except that set A is defined in the load statment and all values are mapped.
         self.check_skiplist('tableXW_4')
-        model=AbstractModel()
+        model = AbstractModel()
         model.B = Set()
         model.R = Param(model.B)
         model.S = Param(model.B)
         data = DataPortal()
-        data.load(select=('A', 'W', 'X'), index=model.B, param=(model.R, model.S), **self.create_options('XW'))
+        data.load(
+            select=('A', 'W', 'X'),
+            index=model.B,
+            param=(model.R, model.S),
+            **self.create_options('XW')
+        )
         instance = model.create_instance(data)
-        self.assertEqual(set(instance.B.data()), set(['A1','A2','A3']))
-        self.assertEqual(instance.S.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(instance.R.extract_values(), {'A1':4.3,'A2':4.4,'A3':4.5})
+        self.assertEqual(set(instance.B.data()), set(['A1', 'A2', 'A3']))
+        self.assertEqual(instance.S.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(instance.R.extract_values(), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
 
     def test_tableT(self):
         # Importing a 2D array of parameters that are transposed.
         self.check_skiplist('tableT')
-        model=AbstractModel()
-        model.B = Set(initialize=['I1','I2','I3','I4'])
-        model.A = Set(initialize=['A1','A2','A3'])
+        model = AbstractModel()
+        model.B = Set(initialize=['I1', 'I2', 'I3', 'I4'])
+        model.A = Set(initialize=['A1', 'A2', 'A3'])
         model.T = Param(model.A, model.B)
         data = DataPortal()
         data.load(format='transposed_array', param=model.T, **self.create_options('T'))
         instance = model.create_instance(data)
-        self.assertEqual(instance.T.extract_values(), {('A2', 'I1'): 2.3, ('A1', 'I2'): 1.4, ('A1', 'I3'): 1.5, ('A1', 'I4'): 1.6, ('A1', 'I1'): 1.3, ('A3', 'I4'): 3.6, ('A2', 'I4'): 2.6, ('A3', 'I1'): 3.3, ('A2', 'I3'): 2.5, ('A3', 'I2'): 3.4, ('A2', 'I2'): 2.4, ('A3', 'I3'): 3.5})
+        self.assertEqual(
+            instance.T.extract_values(),
+            {
+                ('A2', 'I1'): 2.3,
+                ('A1', 'I2'): 1.4,
+                ('A1', 'I3'): 1.5,
+                ('A1', 'I4'): 1.6,
+                ('A1', 'I1'): 1.3,
+                ('A3', 'I4'): 3.6,
+                ('A2', 'I4'): 2.6,
+                ('A3', 'I1'): 3.3,
+                ('A2', 'I3'): 2.5,
+                ('A3', 'I2'): 3.4,
+                ('A2', 'I2'): 2.4,
+                ('A3', 'I3'): 3.5,
+            },
+        )
 
     def test_tableU(self):
         # Importing a 2D array of parameters.
         self.check_skiplist('tableU')
-        model=AbstractModel()
-        model.A = Set(initialize=['I1','I2','I3','I4'])
-        model.B = Set(initialize=['A1','A2','A3'])
+        model = AbstractModel()
+        model.A = Set(initialize=['I1', 'I2', 'I3', 'I4'])
+        model.B = Set(initialize=['A1', 'A2', 'A3'])
         model.U = Param(model.A, model.B)
         data = DataPortal()
         data.load(format='array', param=model.U, **self.create_options('U'))
         instance = model.create_instance(data)
-        self.assertEqual(instance.U.extract_values(), {('I2', 'A1'): 1.4, ('I3', 'A1'): 1.5, ('I3', 'A2'): 2.5, ('I4', 'A1'): 1.6, ('I3', 'A3'): 3.5, ('I1', 'A2'): 2.3, ('I4', 'A3'): 3.6, ('I1', 'A3'): 3.3, ('I4', 'A2'): 2.6, ('I2', 'A3'): 3.4, ('I1', 'A1'): 1.3, ('I2', 'A2'): 2.4})
+        self.assertEqual(
+            instance.U.extract_values(),
+            {
+                ('I2', 'A1'): 1.4,
+                ('I3', 'A1'): 1.5,
+                ('I3', 'A2'): 2.5,
+                ('I4', 'A1'): 1.6,
+                ('I3', 'A3'): 3.5,
+                ('I1', 'A2'): 2.3,
+                ('I4', 'A3'): 3.6,
+                ('I1', 'A3'): 3.3,
+                ('I4', 'A2'): 2.6,
+                ('I2', 'A3'): 3.4,
+                ('I1', 'A1'): 1.3,
+                ('I2', 'A2'): 2.4,
+            },
+        )
 
     def test_tableS(self):
         # Importing a table, but only reporting the values for the non-index
-        #parameter columns.  The first column is assumed to represent an
-        #index column.  A missing value is represented in the column data.
+        # parameter columns.  The first column is assumed to represent an
+        # index column.  A missing value is represented in the column data.
         self.check_skiplist('tableS')
-        model=AbstractModel()
-        model.A = Set(initialize=['A1','A2','A3','A4'])
+        model = AbstractModel()
+        model.A = Set(initialize=['A1', 'A2', 'A3', 'A4'])
         model.S = Param(model.A)
         data = DataPortal()
         data.load(param=model.S, **self.create_options('S'))
         instance = model.create_instance(data)
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3','A4']))
-        self.assertEqual(instance.S.extract_values(), {'A1':3.3,'A3':3.5})
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3', 'A4']))
+        self.assertEqual(instance.S.extract_values(), {'A1': 3.3, 'A3': 3.5})
 
     def test_tablePO(self):
         # Importing a table that has multiple indexing columns
         self.check_skiplist('tablePO')
-        model=AbstractModel()
+        model = AbstractModel()
         model.J = Set(dimen=2)
         model.P = Param(model.J)
         model.O = Param(model.J)
         data = DataPortal()
         data.load(index=model.J, param=(model.P, model.O), **self.create_options('PO'))
         instance = model.create_instance(data)
-        self.assertEqual(set(instance.J.data()), set([('A3', 'B3'), ('A1', 'B1'), ('A2', 'B2')]) )
-        self.assertEqual(instance.P.extract_values(), {('A3', 'B3'): 4.5, ('A1', 'B1'): 4.3, ('A2', 'B2'): 4.4} )
-        self.assertEqual(instance.O.extract_values(), {('A3', 'B3'): 5.5, ('A1', 'B1'): 5.3, ('A2', 'B2'): 5.4})
+        self.assertEqual(
+            set(instance.J.data()), set([('A3', 'B3'), ('A1', 'B1'), ('A2', 'B2')])
+        )
+        self.assertEqual(
+            instance.P.extract_values(),
+            {('A3', 'B3'): 4.5, ('A1', 'B1'): 4.3, ('A2', 'B2'): 4.4},
+        )
+        self.assertEqual(
+            instance.O.extract_values(),
+            {('A3', 'B3'): 5.5, ('A1', 'B1'): 5.3, ('A2', 'B2'): 5.4},
+        )
 
     def test_store_set1(self):
         # Write 1-D set
         self.check_skiplist('store_set1')
         model = ConcreteModel()
-        model.A = Set(initialize=[1,3,5])
+        model.A = Set(initialize=[1, 3, 5])
         data = DataPortal()
         data.store(set=model.A, **self.create_write_options('set1'))
         self.compare_data('set1', self.suffix)
@@ -998,7 +1451,7 @@ class TestTextPortal(unittest.TestCase):
         # Write 2-D set
         self.check_skiplist('store_set2')
         model = ConcreteModel()
-        model.A = Set(initialize=[(1,2),(3,4),(5,6)], dimen=2)
+        model.A = Set(initialize=[(1, 2), (3, 4), (5, 6)], dimen=2)
         data = DataPortal()
         data.store(set=model.A, **self.create_write_options('set2'))
         self.compare_data('set2', self.suffix)
@@ -1016,8 +1469,8 @@ class TestTextPortal(unittest.TestCase):
         # Write 1-D param
         self.check_skiplist('store_param2')
         model = ConcreteModel()
-        model.A = Set(initialize=[1,2,3])
-        model.p = Param(model.A, initialize={1:10, 2:20, 3:30})
+        model.A = Set(initialize=[1, 2, 3])
+        model.p = Param(model.A, initialize={1: 10, 2: 20, 3: 30})
         data = DataPortal()
         data.store(param=model.p, **self.create_write_options('param2'))
         self.compare_data('param2', self.suffix)
@@ -1026,22 +1479,22 @@ class TestTextPortal(unittest.TestCase):
         # Write 2-D params
         self.check_skiplist('store_param3')
         model = ConcreteModel()
-        model.A = Set(initialize=[(1,2),(2,3),(3,4)], dimen=2)
-        model.p = Param(model.A, initialize={(1,2):10, (2,3):20, (3,4):30})
-        model.q = Param(model.A, initialize={(1,2):11, (2,3):21, (3,4):31})
+        model.A = Set(initialize=[(1, 2), (2, 3), (3, 4)], dimen=2)
+        model.p = Param(model.A, initialize={(1, 2): 10, (2, 3): 20, (3, 4): 30})
+        model.q = Param(model.A, initialize={(1, 2): 11, (2, 3): 21, (3, 4): 31})
         data = DataPortal()
-        data.store(param=(model.p,model.q), **self.create_write_options('param3'))
+        data.store(param=(model.p, model.q), **self.create_write_options('param3'))
         self.compare_data('param3', self.suffix)
 
     def test_store_param4(self):
         # Write 2-D params
         self.check_skiplist('store_param4')
         model = ConcreteModel()
-        model.A = Set(initialize=[(1,2),(2,3),(3,4)], dimen=2)
-        model.p = Param(model.A, initialize={(1,2):10, (2,3):20, (3,4):30})
-        model.q = Param(model.A, initialize={(1,2):11, (2,3):21, (3,4):31})
+        model.A = Set(initialize=[(1, 2), (2, 3), (3, 4)], dimen=2)
+        model.p = Param(model.A, initialize={(1, 2): 10, (2, 3): 20, (3, 4): 30})
+        model.q = Param(model.A, initialize={(1, 2): 11, (2, 3): 21, (3, 4): 31})
         data = DataPortal()
-        data.store(param=(model.p,model.q), **self.create_write_options('param4'))
+        data.store(param=(model.p, model.q), **self.create_write_options('param4'))
         self.compare_data('param4', self.suffix)
 
 
@@ -1050,7 +1503,11 @@ class TestCsvPortal(TestTextPortal):
     suffix = '.csv'
 
     def create_options(self, name):
-        return {'filename':os.path.abspath(tutorial_dir+os.sep+'csv'+os.sep+name+self.suffix)}
+        return {
+            'filename': os.path.abspath(
+                tutorial_dir + os.sep + 'csv' + os.sep + name + self.suffix
+            )
+        }
 
 
 class TestXmlPortal(TestTextPortal):
@@ -1059,7 +1516,11 @@ class TestXmlPortal(TestTextPortal):
     skiplist = ['tableD', 'tableT', 'tableU']
 
     def create_options(self, name):
-        return {'filename':os.path.abspath(tutorial_dir+os.sep+'xml'+os.sep+name+self.suffix)}
+        return {
+            'filename': os.path.abspath(
+                tutorial_dir + os.sep + 'xml' + os.sep + name + self.suffix
+            )
+        }
 
 
 class TestJsonPortal(TestTextPortal):
@@ -1068,7 +1529,11 @@ class TestJsonPortal(TestTextPortal):
     skiplist = ['tableD', 'tableT', 'tableU', 'tableXW_4']
 
     def create_options(self, name):
-        return {'filename':os.path.abspath(tutorial_dir+os.sep+'json'+os.sep+name+self.suffix)}
+        return {
+            'filename': os.path.abspath(
+                tutorial_dir + os.sep + 'json' + os.sep + name + self.suffix
+            )
+        }
 
 
 @unittest.skipIf(not yaml_interface, "YAML interface not available")
@@ -1078,7 +1543,11 @@ class TestYamlPortal(TestTextPortal):
     skiplist = ['tableD', 'tableT', 'tableU', 'tableXW_4']
 
     def create_options(self, name):
-        return {'filename':os.path.abspath(tutorial_dir+os.sep+'yaml'+os.sep+name+self.suffix)}
+        return {
+            'filename': os.path.abspath(
+                tutorial_dir + os.sep + 'yaml' + os.sep + name + self.suffix
+            )
+        }
 
 
 class LoadTests(object):
@@ -1102,220 +1571,277 @@ class LoadTests(object):
             self.skipTest('Skipping test %s' % name)
 
     def filename(self, tname):
-        return os.path.abspath(tutorial_dir+os.sep+self.suffix+os.sep+tname+'.'+self.suffix)
+        return os.path.abspath(
+            tutorial_dir + os.sep + self.suffix + os.sep + tname + '.' + self.suffix
+        )
 
     def test_tableA1(self):
         # Importing a single column of data
         self.check_skiplist('tableA1')
-        with capture_output(currdir+'loadA1.dat'):
-            print("load "+self.filename('A')+" format=set : A;")
-        model=AbstractModel()
+        with capture_output(currdir + 'loadA1.dat'):
+            print("load " + self.filename('A') + " format=set : A;")
+        model = AbstractModel()
         model.A = Set()
-        instance = model.create_instance(currdir+'loadA1.dat')
+        instance = model.create_instance(currdir + 'loadA1.dat')
         self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3']))
-        os.remove(currdir+'loadA1.dat')
+        os.remove(currdir + 'loadA1.dat')
 
     def test_tableA2(self):
         # Importing a single column of data
         self.check_skiplist('tableA2')
-        with capture_output(currdir+'loadA2.dat'):
-            print("load "+self.filename('A')+" ;")
-        model=AbstractModel()
+        with capture_output(currdir + 'loadA2.dat'):
+            print("load " + self.filename('A') + " ;")
+        model = AbstractModel()
         model.A = Set()
         try:
-            instance = model.create_instance(currdir+'loadA2.dat')
+            instance = model.create_instance(currdir + 'loadA2.dat')
             self.fail("Should fail because no set name is specified")
         except IOError:
             pass
         except IndexError:
             pass
-        os.remove(currdir+'loadA2.dat')
+        os.remove(currdir + 'loadA2.dat')
 
     def test_tableA3(self):
         # Importing a single column of data
         self.check_skiplist('tableA3')
-        with capture_output(currdir+'loadA3.dat'):
-            print("load "+self.filename('A')+" format=set : A ;")
-        model=AbstractModel()
+        with capture_output(currdir + 'loadA3.dat'):
+            print("load " + self.filename('A') + " format=set : A ;")
+        model = AbstractModel()
         model.A = Set()
-        instance = model.create_instance(currdir+'loadA3.dat')
+        instance = model.create_instance(currdir + 'loadA3.dat')
         self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3']))
-        os.remove(currdir+'loadA3.dat')
+        os.remove(currdir + 'loadA3.dat')
 
     def test_tableB1(self):
         # Same as test_tableA
         self.check_skiplist('tableB1')
-        with capture_output(currdir+'loadB.dat'):
-            print("load "+self.filename('B')+" format=set : B;")
-        model=AbstractModel()
+        with capture_output(currdir + 'loadB.dat'):
+            print("load " + self.filename('B') + " format=set : B;")
+        model = AbstractModel()
         model.B = Set()
-        instance = model.create_instance(currdir+'loadB.dat')
+        instance = model.create_instance(currdir + 'loadB.dat')
         self.assertEqual(set(instance.B.data()), set([1, 2, 3]))
-        os.remove(currdir+'loadB.dat')
+        os.remove(currdir + 'loadB.dat')
 
     def test_tableC(self):
         # Importing a multi-column table, where all columns are
         # treated as values for a set with tuple values.
         self.check_skiplist('tableC')
-        with capture_output(currdir+'loadC.dat'):
-            print("load "+self.filename('C')+" format=set : C ;")
-        model=AbstractModel()
+        with capture_output(currdir + 'loadC.dat'):
+            print("load " + self.filename('C') + " format=set : C ;")
+        model = AbstractModel()
         model.C = Set(dimen=2)
-        instance = model.create_instance(currdir+'loadC.dat')
-        self.assertEqual(set(instance.C.data()), set([('A1',1), ('A1',2), ('A1',3), ('A2',1), ('A2',2), ('A2',3), ('A3',1), ('A3',2), ('A3',3)]))
-        os.remove(currdir+'loadC.dat')
+        instance = model.create_instance(currdir + 'loadC.dat')
+        self.assertEqual(
+            set(instance.C.data()),
+            set(
+                [
+                    ('A1', 1),
+                    ('A1', 2),
+                    ('A1', 3),
+                    ('A2', 1),
+                    ('A2', 2),
+                    ('A2', 3),
+                    ('A3', 1),
+                    ('A3', 2),
+                    ('A3', 3),
+                ]
+            ),
+        )
+        os.remove(currdir + 'loadC.dat')
 
     def test_tableD(self):
         # Importing a 2D array of data as a set.
         self.check_skiplist('tableD')
-        with capture_output(currdir+'loadD.dat'):
-            print("load "+self.filename('D')+" format=set_array : C ;")
-        model=AbstractModel()
+        with capture_output(currdir + 'loadD.dat'):
+            print("load " + self.filename('D') + " format=set_array : C ;")
+        model = AbstractModel()
         model.C = Set(dimen=2)
-        instance = model.create_instance(currdir+'loadD.dat')
-        self.assertEqual(set(instance.C.data()), set([('A1',1), ('A2',2), ('A3',3)]))
-        os.remove(currdir+'loadD.dat')
+        instance = model.create_instance(currdir + 'loadD.dat')
+        self.assertEqual(set(instance.C.data()), set([('A1', 1), ('A2', 2), ('A3', 3)]))
+        os.remove(currdir + 'loadD.dat')
 
     def test_tableZ(self):
         # Importing a single parameter
         self.check_skiplist('tableZ')
-        with capture_output(currdir+'loadZ.dat'):
-            print("load "+self.filename('Z')+" : Z ;")
-        model=AbstractModel()
+        with capture_output(currdir + 'loadZ.dat'):
+            print("load " + self.filename('Z') + " : Z ;")
+        model = AbstractModel()
         model.Z = Param(default=99.0)
-        instance = model.create_instance(currdir+'loadZ.dat')
+        instance = model.create_instance(currdir + 'loadZ.dat')
         self.assertEqual(instance.Z, 1.01)
-        os.remove(currdir+'loadZ.dat')
+        os.remove(currdir + 'loadZ.dat')
 
     def test_tableY(self):
         # Same as tableXW.
         self.check_skiplist('tableY')
-        with capture_output(currdir+'loadY.dat'):
-            print("load "+self.filename('Y')+" : [A] Y;")
-        model=AbstractModel()
-        model.A = Set(initialize=['A1','A2','A3','A4'])
+        with capture_output(currdir + 'loadY.dat'):
+            print("load " + self.filename('Y') + " : [A] Y;")
+        model = AbstractModel()
+        model.A = Set(initialize=['A1', 'A2', 'A3', 'A4'])
         model.Y = Param(model.A)
-        instance = model.create_instance(currdir+'loadY.dat')
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3','A4']))
-        self.assertEqual(instance.Y.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        os.remove(currdir+'loadY.dat')
+        instance = model.create_instance(currdir + 'loadY.dat')
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3', 'A4']))
+        self.assertEqual(instance.Y.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        os.remove(currdir + 'loadY.dat')
 
     def test_tableXW_1(self):
         # Importing a table, but only reporting the values for the non-index
         # parameter columns.  The first column is assumed to represent an
         # index column.
         self.check_skiplist('tableXW_1')
-        with capture_output(currdir+'loadXW.dat'):
-            print("load "+self.filename('XW')+" : [A] X W;")
-        model=AbstractModel()
-        model.A = Set(initialize=['A1','A2','A3','A4'])
+        with capture_output(currdir + 'loadXW.dat'):
+            print("load " + self.filename('XW') + " : [A] X W;")
+        model = AbstractModel()
+        model.A = Set(initialize=['A1', 'A2', 'A3', 'A4'])
         model.X = Param(model.A)
         model.W = Param(model.A)
-        instance = model.create_instance(currdir+'loadXW.dat')
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3','A4']))
-        self.assertEqual(instance.X.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(instance.W.extract_values(), {'A1':4.3,'A2':4.4,'A3':4.5})
-        os.remove(currdir+'loadXW.dat')
+        instance = model.create_instance(currdir + 'loadXW.dat')
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3', 'A4']))
+        self.assertEqual(instance.X.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(instance.W.extract_values(), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
+        os.remove(currdir + 'loadXW.dat')
 
     def test_tableXW_2(self):
         # Like test_tableXW_1, except that set A is not defined.
         self.check_skiplist('tableXW_2')
-        with capture_output(currdir+'loadXW.dat'):
-            print("load "+self.filename('XW')+" : [A] X W;")
-        model=AbstractModel()
-        model.A = Set(initialize=['A1','A2','A3'])
+        with capture_output(currdir + 'loadXW.dat'):
+            print("load " + self.filename('XW') + " : [A] X W;")
+        model = AbstractModel()
+        model.A = Set(initialize=['A1', 'A2', 'A3'])
         model.X = Param(model.A)
         model.W = Param(model.A)
-        instance = model.create_instance(currdir+'loadXW.dat')
-        self.assertEqual(instance.X.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(instance.W.extract_values(), {'A1':4.3,'A2':4.4,'A3':4.5})
-        os.remove(currdir+'loadXW.dat')
+        instance = model.create_instance(currdir + 'loadXW.dat')
+        self.assertEqual(instance.X.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(instance.W.extract_values(), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
+        os.remove(currdir + 'loadXW.dat')
 
     def test_tableXW_3(self):
         # Like test_tableXW_1, except that set A is defined in the load statment.
         self.check_skiplist('tableXW_3')
-        with capture_output(currdir+'loadXW.dat'):
-            print("load "+self.filename('XW')+" : A=[A] X W;")
-        model=AbstractModel()
+        with capture_output(currdir + 'loadXW.dat'):
+            print("load " + self.filename('XW') + " : A=[A] X W;")
+        model = AbstractModel()
         model.A = Set()
         model.X = Param(model.A)
         model.W = Param(model.A)
-        instance = model.create_instance(currdir+'loadXW.dat')
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3']))
-        self.assertEqual(instance.X.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(instance.W.extract_values(), {'A1':4.3,'A2':4.4,'A3':4.5})
-        os.remove(currdir+'loadXW.dat')
+        instance = model.create_instance(currdir + 'loadXW.dat')
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3']))
+        self.assertEqual(instance.X.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(instance.W.extract_values(), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
+        os.remove(currdir + 'loadXW.dat')
 
     def test_tableXW_4(self):
         # Like test_tableXW_1, except that set A is defined in the load statment and all values are mapped.
         self.check_skiplist('tableXW_4')
-        with capture_output(currdir+'loadXW.dat'):
-            print("load "+self.filename('XW')+" : B=[A] R=X S=W;")
-        model=AbstractModel()
+        with capture_output(currdir + 'loadXW.dat'):
+            print("load " + self.filename('XW') + " : B=[A] R=X S=W;")
+        model = AbstractModel()
         model.B = Set()
         model.R = Param(model.B)
         model.S = Param(model.B)
-        instance = model.create_instance(currdir+'loadXW.dat')
-        self.assertEqual(set(instance.B.data()), set(['A1','A2','A3']))
-        self.assertEqual(instance.R.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(instance.S.extract_values(), {'A1':4.3,'A2':4.4,'A3':4.5})
-        os.remove(currdir+'loadXW.dat')
+        instance = model.create_instance(currdir + 'loadXW.dat')
+        self.assertEqual(set(instance.B.data()), set(['A1', 'A2', 'A3']))
+        self.assertEqual(instance.R.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(instance.S.extract_values(), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
+        os.remove(currdir + 'loadXW.dat')
 
     def test_tableT(self):
         # Importing a 2D array of parameters that are transposed.
         self.check_skiplist('tableT')
-        with capture_output(currdir+'loadT.dat'):
-            print("load "+self.filename('T')+" format=transposed_array : T;")
-        model=AbstractModel()
-        model.B = Set(initialize=['I1','I2','I3','I4'])
-        model.A = Set(initialize=['A1','A2','A3'])
+        with capture_output(currdir + 'loadT.dat'):
+            print("load " + self.filename('T') + " format=transposed_array : T;")
+        model = AbstractModel()
+        model.B = Set(initialize=['I1', 'I2', 'I3', 'I4'])
+        model.A = Set(initialize=['A1', 'A2', 'A3'])
         model.T = Param(model.A, model.B)
-        instance = model.create_instance(currdir+'loadT.dat')
-        self.assertEqual(instance.T.extract_values(), {('A2', 'I1'): 2.3, ('A1', 'I2'): 1.4, ('A1', 'I3'): 1.5, ('A1', 'I4'): 1.6, ('A1', 'I1'): 1.3, ('A3', 'I4'): 3.6, ('A2', 'I4'): 2.6, ('A3', 'I1'): 3.3, ('A2', 'I3'): 2.5, ('A3', 'I2'): 3.4, ('A2', 'I2'): 2.4, ('A3', 'I3'): 3.5})
-        os.remove(currdir+'loadT.dat')
+        instance = model.create_instance(currdir + 'loadT.dat')
+        self.assertEqual(
+            instance.T.extract_values(),
+            {
+                ('A2', 'I1'): 2.3,
+                ('A1', 'I2'): 1.4,
+                ('A1', 'I3'): 1.5,
+                ('A1', 'I4'): 1.6,
+                ('A1', 'I1'): 1.3,
+                ('A3', 'I4'): 3.6,
+                ('A2', 'I4'): 2.6,
+                ('A3', 'I1'): 3.3,
+                ('A2', 'I3'): 2.5,
+                ('A3', 'I2'): 3.4,
+                ('A2', 'I2'): 2.4,
+                ('A3', 'I3'): 3.5,
+            },
+        )
+        os.remove(currdir + 'loadT.dat')
 
     def test_tableU(self):
         # Importing a 2D array of parameters.
         self.check_skiplist('tableU')
-        with capture_output(currdir+'loadU.dat'):
-            print("load "+self.filename('U')+" format=array : U;")
-        model=AbstractModel()
-        model.A = Set(initialize=['I1','I2','I3','I4'])
-        model.B = Set(initialize=['A1','A2','A3'])
+        with capture_output(currdir + 'loadU.dat'):
+            print("load " + self.filename('U') + " format=array : U;")
+        model = AbstractModel()
+        model.A = Set(initialize=['I1', 'I2', 'I3', 'I4'])
+        model.B = Set(initialize=['A1', 'A2', 'A3'])
         model.U = Param(model.A, model.B)
-        instance = model.create_instance(currdir+'loadU.dat')
-        self.assertEqual(instance.U.extract_values(), {('I2', 'A1'): 1.4, ('I3', 'A1'): 1.5, ('I3', 'A2'): 2.5, ('I4', 'A1'): 1.6, ('I3', 'A3'): 3.5, ('I1', 'A2'): 2.3, ('I4', 'A3'): 3.6, ('I1', 'A3'): 3.3, ('I4', 'A2'): 2.6, ('I2', 'A3'): 3.4, ('I1', 'A1'): 1.3, ('I2', 'A2'): 2.4})
-        os.remove(currdir+'loadU.dat')
+        instance = model.create_instance(currdir + 'loadU.dat')
+        self.assertEqual(
+            instance.U.extract_values(),
+            {
+                ('I2', 'A1'): 1.4,
+                ('I3', 'A1'): 1.5,
+                ('I3', 'A2'): 2.5,
+                ('I4', 'A1'): 1.6,
+                ('I3', 'A3'): 3.5,
+                ('I1', 'A2'): 2.3,
+                ('I4', 'A3'): 3.6,
+                ('I1', 'A3'): 3.3,
+                ('I4', 'A2'): 2.6,
+                ('I2', 'A3'): 3.4,
+                ('I1', 'A1'): 1.3,
+                ('I2', 'A2'): 2.4,
+            },
+        )
+        os.remove(currdir + 'loadU.dat')
 
     def test_tableS(self):
         # Importing a table, but only reporting the values for the non-index
         # parameter columns.  The first column is assumed to represent an
         # index column.  A missing value is represented in the column data.
         self.check_skiplist('tableS')
-        with capture_output(currdir+'loadS.dat'):
-            print("load "+self.filename('S')+" : [A] S ;")
-        model=AbstractModel()
-        model.A = Set(initialize=['A1','A2','A3','A4'])
+        with capture_output(currdir + 'loadS.dat'):
+            print("load " + self.filename('S') + " : [A] S ;")
+        model = AbstractModel()
+        model.A = Set(initialize=['A1', 'A2', 'A3', 'A4'])
         model.S = Param(model.A)
-        instance = model.create_instance(currdir+'loadS.dat')
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3','A4']))
-        self.assertEqual(instance.S.extract_values(), {'A1':3.3,'A3':3.5})
-        os.remove(currdir+'loadS.dat')
+        instance = model.create_instance(currdir + 'loadS.dat')
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3', 'A4']))
+        self.assertEqual(instance.S.extract_values(), {'A1': 3.3, 'A3': 3.5})
+        os.remove(currdir + 'loadS.dat')
 
     def test_tablePO(self):
         # Importing a table that has multiple indexing columns
         self.check_skiplist('tablePO')
-        with capture_output(currdir+'loadPO.dat'):
-            print("load "+self.filename('PO')+" : J=[A,B] P O;")
-        model=AbstractModel()
+        with capture_output(currdir + 'loadPO.dat'):
+            print("load " + self.filename('PO') + " : J=[A,B] P O;")
+        model = AbstractModel()
         model.J = Set(dimen=2)
         model.P = Param(model.J)
         model.O = Param(model.J)
-        instance = model.create_instance(currdir+'loadPO.dat')
-        self.assertEqual(set(instance.J.data()), set([('A3', 'B3'), ('A1', 'B1'), ('A2', 'B2')]) )
-        self.assertEqual(instance.P.extract_values(), {('A3', 'B3'): 4.5, ('A1', 'B1'): 4.3, ('A2', 'B2'): 4.4} )
-        self.assertEqual(instance.O.extract_values(), {('A3', 'B3'): 5.5, ('A1', 'B1'): 5.3, ('A2', 'B2'): 5.4})
-        os.remove(currdir+'loadPO.dat')
+        instance = model.create_instance(currdir + 'loadPO.dat')
+        self.assertEqual(
+            set(instance.J.data()), set([('A3', 'B3'), ('A1', 'B1'), ('A2', 'B2')])
+        )
+        self.assertEqual(
+            instance.P.extract_values(),
+            {('A3', 'B3'): 4.5, ('A1', 'B1'): 4.3, ('A2', 'B2'): 4.4},
+        )
+        self.assertEqual(
+            instance.O.extract_values(),
+            {('A3', 'B3'): 5.5, ('A1', 'B1'): 5.3, ('A2', 'B2'): 5.4},
+        )
+        os.remove(currdir + 'loadPO.dat')
 
 
 class TestTextLoad(LoadTests, unittest.TestCase):
@@ -1338,324 +1864,413 @@ class TestXmlLoad(LoadTests, unittest.TestCase):
         # parameter columns.  The first column is assumed to represent an
         # index column.
         self.check_skiplist('tableXW_1')
-        with capture_output(currdir+'loadXW.dat'):
-            print("load "+self.filename('XW_nested1')+" query='./bar/table/*' : [A] X W;")
-        model=AbstractModel()
-        model.A = Set(initialize=['A1','A2','A3','A4'])
+        with capture_output(currdir + 'loadXW.dat'):
+            print(
+                "load "
+                + self.filename('XW_nested1')
+                + " query='./bar/table/*' : [A] X W;"
+            )
+        model = AbstractModel()
+        model.A = Set(initialize=['A1', 'A2', 'A3', 'A4'])
         model.X = Param(model.A)
         model.W = Param(model.A)
-        instance = model.create_instance(currdir+'loadXW.dat')
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3','A4']))
-        self.assertEqual(instance.X.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(instance.W.extract_values(), {'A1':4.3,'A2':4.4,'A3':4.5})
-        os.remove(currdir+'loadXW.dat')
+        instance = model.create_instance(currdir + 'loadXW.dat')
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3', 'A4']))
+        self.assertEqual(instance.X.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(instance.W.extract_values(), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
+        os.remove(currdir + 'loadXW.dat')
 
     def test_tableXW_nested2(self):
         # Importing a table, but only reporting the values for the non-index
         # parameter columns.  The first column is assumed to represent an
         # index column.
         self.check_skiplist('tableXW_1')
-        with capture_output(currdir+'loadXW.dat'):
-            print("load "+self.filename('XW_nested2')+" query='./bar/table/row' : [A] X W;")
-        model=AbstractModel()
-        model.A = Set(initialize=['A1','A2','A3','A4'])
+        with capture_output(currdir + 'loadXW.dat'):
+            print(
+                "load "
+                + self.filename('XW_nested2')
+                + " query='./bar/table/row' : [A] X W;"
+            )
+        model = AbstractModel()
+        model.A = Set(initialize=['A1', 'A2', 'A3', 'A4'])
         model.X = Param(model.A)
         model.W = Param(model.A)
-        instance = model.create_instance(currdir+'loadXW.dat')
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3','A4']))
-        self.assertEqual(instance.X.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(instance.W.extract_values(), {'A1':4.3,'A2':4.4,'A3':4.5})
-        os.remove(currdir+'loadXW.dat')
+        instance = model.create_instance(currdir + 'loadXW.dat')
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3', 'A4']))
+        self.assertEqual(instance.X.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(instance.W.extract_values(), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
+        os.remove(currdir + 'loadXW.dat')
 
 
 class Spreadsheet(LoadTests):
-
     def filename(self, tname):
         if tname == "Z":
-            return os.path.abspath(tutorial_dir+os.sep+self._filename)+" range="+tname+"param"
+            return (
+                os.path.abspath(tutorial_dir + os.sep + self._filename)
+                + " range="
+                + tname
+                + "param"
+            )
         else:
-            return os.path.abspath(tutorial_dir+os.sep+self._filename)+" range="+tname+"table"
+            return (
+                os.path.abspath(tutorial_dir + os.sep + self._filename)
+                + " range="
+                + tname
+                + "table"
+            )
 
 
 @unittest.skipIf(not xls_interface, "No XLS interface available")
 class TestSpreadsheetXLS(Spreadsheet, unittest.TestCase):
 
-    _filename='excel.xls'
+    _filename = 'excel.xls'
 
 
 @unittest.skipIf(not xlsx_interface, "No XLSX interface available")
 class TestSpreadsheetXLSX(Spreadsheet, unittest.TestCase):
 
-    _filename='excel.xlsx'
+    _filename = 'excel.xlsx'
 
 
 @unittest.skipIf(not xlsb_interface, "No XLSB interface available")
 class TestSpreadsheetXLSB(Spreadsheet, unittest.TestCase):
 
-    _filename='excel.xlsb'
+    _filename = 'excel.xlsb'
 
 
 @unittest.skipIf(not xlsm_interface, "No XLSM interface available")
 class TestSpreadsheetXLSM(Spreadsheet, unittest.TestCase):
 
-    _filename='excel.xlsm'
-
+    _filename = 'excel.xlsm'
 
 
 class TestTableCmd(unittest.TestCase):
-
     def test_tableA1_1(self):
         # Importing a single column of data as a set
-        with capture_output(currdir+'loadA1.dat'):
+        with capture_output(currdir + 'loadA1.dat'):
             print("table columns=1 A={1} := A1 A2 A3 ;")
-        model=AbstractModel()
+        model = AbstractModel()
         model.A = Set()
-        instance = model.create_instance(currdir+'loadA1.dat')
+        instance = model.create_instance(currdir + 'loadA1.dat')
         self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3']))
-        os.remove(currdir+'loadA1.dat')
+        os.remove(currdir + 'loadA1.dat')
 
     def test_tableA1_2(self):
         # Importing a single column of data as a set
-        with capture_output(currdir+'loadA1.dat'):
+        with capture_output(currdir + 'loadA1.dat'):
             print("table A={A} : A := A1 A2 A3 ;")
-        model=AbstractModel()
+        model = AbstractModel()
         model.A = Set()
-        instance = model.create_instance(currdir+'loadA1.dat')
+        instance = model.create_instance(currdir + 'loadA1.dat')
         self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3']))
-        os.remove(currdir+'loadA1.dat')
+        os.remove(currdir + 'loadA1.dat')
 
     def test_tableB1_1(self):
         # Same as test_tableA
-        with capture_output(currdir+'loadB.dat'):
+        with capture_output(currdir + 'loadB.dat'):
             print("table columns=1 B={1} := 1 2 3 ;")
-        model=AbstractModel()
+        model = AbstractModel()
         model.B = Set()
-        instance = model.create_instance(currdir+'loadB.dat')
+        instance = model.create_instance(currdir + 'loadB.dat')
         self.assertEqual(set(instance.B.data()), set([1, 2, 3]))
-        os.remove(currdir+'loadB.dat')
+        os.remove(currdir + 'loadB.dat')
 
     def test_tableB1_2(self):
         # Same as test_tableA
-        with capture_output(currdir+'loadB.dat'):
+        with capture_output(currdir + 'loadB.dat'):
             print("table B={B} : B := 1 2 3 ;")
-        model=AbstractModel()
+        model = AbstractModel()
         model.B = Set()
-        instance = model.create_instance(currdir+'loadB.dat')
+        instance = model.create_instance(currdir + 'loadB.dat')
         self.assertEqual(set(instance.B.data()), set([1, 2, 3]))
-        os.remove(currdir+'loadB.dat')
+        os.remove(currdir + 'loadB.dat')
 
     def test_tableC_1(self):
         # Importing a multi-column table, where all columns are
         # treated as values for a set with tuple values.
-        with capture_output(currdir+'loadC.dat'):
-            print("table columns=2 C={1,2} := A1 1 A1 2 A1 3 A2 1 A2 2 A2 3 A3 1 A3 2 A3 3 ;")
-        model=AbstractModel()
+        with capture_output(currdir + 'loadC.dat'):
+            print(
+                "table columns=2 C={1,2} := A1 1 A1 2 A1 3 A2 1 A2 2 A2 3 A3 1 A3 2 A3 3 ;"
+            )
+        model = AbstractModel()
         model.C = Set(dimen=2)
-        instance = model.create_instance(currdir+'loadC.dat')
-        self.assertEqual(set(instance.C.data()), set([('A1',1), ('A1',2), ('A1',3), ('A2',1), ('A2',2), ('A2',3), ('A3',1), ('A3',2), ('A3',3)]))
-        os.remove(currdir+'loadC.dat')
+        instance = model.create_instance(currdir + 'loadC.dat')
+        self.assertEqual(
+            set(instance.C.data()),
+            set(
+                [
+                    ('A1', 1),
+                    ('A1', 2),
+                    ('A1', 3),
+                    ('A2', 1),
+                    ('A2', 2),
+                    ('A2', 3),
+                    ('A3', 1),
+                    ('A3', 2),
+                    ('A3', 3),
+                ]
+            ),
+        )
+        os.remove(currdir + 'loadC.dat')
 
     def test_tableC_2(self):
         # Importing a multi-column table, where all columns are
         # treated as values for a set with tuple values.
-        with capture_output(currdir+'loadC.dat'):
-            print("table C={a,b} : a b := A1 1 A1 2 A1 3 A2 1 A2 2 A2 3 A3 1 A3 2 A3 3 ;")
-        model=AbstractModel()
+        with capture_output(currdir + 'loadC.dat'):
+            print(
+                "table C={a,b} : a b := A1 1 A1 2 A1 3 A2 1 A2 2 A2 3 A3 1 A3 2 A3 3 ;"
+            )
+        model = AbstractModel()
         model.C = Set(dimen=2)
-        instance = model.create_instance(currdir+'loadC.dat')
-        self.assertEqual(set(instance.C.data()), set([('A1',1), ('A1',2), ('A1',3), ('A2',1), ('A2',2), ('A2',3), ('A3',1), ('A3',2), ('A3',3)]))
-        os.remove(currdir+'loadC.dat')
+        instance = model.create_instance(currdir + 'loadC.dat')
+        self.assertEqual(
+            set(instance.C.data()),
+            set(
+                [
+                    ('A1', 1),
+                    ('A1', 2),
+                    ('A1', 3),
+                    ('A2', 1),
+                    ('A2', 2),
+                    ('A2', 3),
+                    ('A3', 1),
+                    ('A3', 2),
+                    ('A3', 3),
+                ]
+            ),
+        )
+        os.remove(currdir + 'loadC.dat')
 
     def test_tableZ(self):
         # Importing a single parameter
-        with capture_output(currdir+'loadZ.dat'):
+        with capture_output(currdir + 'loadZ.dat'):
             print("table Z := 1.01 ;")
-        model=AbstractModel()
+        model = AbstractModel()
         model.Z = Param(default=99.0)
-        instance = model.create_instance(currdir+'loadZ.dat')
+        instance = model.create_instance(currdir + 'loadZ.dat')
         self.assertEqual(instance.Z, 1.01)
-        os.remove(currdir+'loadZ.dat')
+        os.remove(currdir + 'loadZ.dat')
 
     def test_tableY_1(self):
         # Same as tableXW.
-        with capture_output(currdir+'loadY.dat'):
+        with capture_output(currdir + 'loadY.dat'):
             print("table columns=2 Y(1)={2} := A1 3.3 A2 3.4 A3 3.5 ;")
-        model=AbstractModel()
-        model.A = Set(initialize=['A1','A2','A3','A4'])
+        model = AbstractModel()
+        model.A = Set(initialize=['A1', 'A2', 'A3', 'A4'])
         model.Y = Param(model.A)
-        instance = model.create_instance(currdir+'loadY.dat')
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3','A4']))
-        self.assertEqual(instance.Y.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        os.remove(currdir+'loadY.dat')
+        instance = model.create_instance(currdir + 'loadY.dat')
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3', 'A4']))
+        self.assertEqual(instance.Y.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        os.remove(currdir + 'loadY.dat')
 
     def test_tableY_2(self):
         # Same as tableXW.
-        with capture_output(currdir+'loadY.dat'):
+        with capture_output(currdir + 'loadY.dat'):
             print("table Y(A) : A Y := A1 3.3 A2 3.4 A3 3.5 ;")
-        model=AbstractModel()
-        model.A = Set(initialize=['A1','A2','A3','A4'])
+        model = AbstractModel()
+        model.A = Set(initialize=['A1', 'A2', 'A3', 'A4'])
         model.Y = Param(model.A)
-        instance = model.create_instance(currdir+'loadY.dat')
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3','A4']))
-        self.assertEqual(instance.Y.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        os.remove(currdir+'loadY.dat')
+        instance = model.create_instance(currdir + 'loadY.dat')
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3', 'A4']))
+        self.assertEqual(instance.Y.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        os.remove(currdir + 'loadY.dat')
 
     def test_tableXW_1_1(self):
         # Importing a table, but only reporting the values for the non-index
         # parameter columns.  The first column is assumed to represent an
         # index column.
-        with capture_output(currdir+'loadXW.dat'):
-            print("table columns=3 X(1)={2} W(1)={3} := A1 3.3 4.3 A2 3.4 4.4 A3 3.5 4.5 ;")
-        model=AbstractModel()
-        model.A = Set(initialize=['A1','A2','A3','A4'])
+        with capture_output(currdir + 'loadXW.dat'):
+            print(
+                "table columns=3 X(1)={2} W(1)={3} := A1 3.3 4.3 A2 3.4 4.4 A3 3.5 4.5 ;"
+            )
+        model = AbstractModel()
+        model.A = Set(initialize=['A1', 'A2', 'A3', 'A4'])
         model.X = Param(model.A)
         model.W = Param(model.A)
-        instance = model.create_instance(currdir+'loadXW.dat')
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3','A4']))
-        self.assertEqual(instance.X.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(instance.W.extract_values(), {'A1':4.3,'A2':4.4,'A3':4.5})
-        os.remove(currdir+'loadXW.dat')
+        instance = model.create_instance(currdir + 'loadXW.dat')
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3', 'A4']))
+        self.assertEqual(instance.X.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(instance.W.extract_values(), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
+        os.remove(currdir + 'loadXW.dat')
 
     def test_tableXW_1_2(self):
         # Importing a table, but only reporting the values for the non-index
         # parameter columns.  The first column is assumed to represent an
         # index column.
-        with capture_output(currdir+'loadXW.dat'):
+        with capture_output(currdir + 'loadXW.dat'):
             print("table X(A) W(A) : A X W := A1 3.3 4.3 A2 3.4 4.4 A3 3.5 4.5 ;")
-        model=AbstractModel()
-        model.A = Set(initialize=['A1','A2','A3','A4'])
+        model = AbstractModel()
+        model.A = Set(initialize=['A1', 'A2', 'A3', 'A4'])
         model.X = Param(model.A)
         model.W = Param(model.A)
-        instance = model.create_instance(currdir+'loadXW.dat')
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3','A4']))
-        self.assertEqual(instance.X.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(instance.W.extract_values(), {'A1':4.3,'A2':4.4,'A3':4.5})
-        os.remove(currdir+'loadXW.dat')
+        instance = model.create_instance(currdir + 'loadXW.dat')
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3', 'A4']))
+        self.assertEqual(instance.X.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(instance.W.extract_values(), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
+        os.remove(currdir + 'loadXW.dat')
 
     def test_tableXW_3_1(self):
         # Like test_tableXW_1, except that set A is defined in the load statment.
-        with capture_output(currdir+'loadXW.dat'):
-            print("table columns=3 A={1} X(A)={2} W(A)={3} := A1 3.3 4.3 A2 3.4 4.4 A3 3.5 4.5 ;")
-        model=AbstractModel()
+        with capture_output(currdir + 'loadXW.dat'):
+            print(
+                "table columns=3 A={1} X(A)={2} W(A)={3} := A1 3.3 4.3 A2 3.4 4.4 A3 3.5 4.5 ;"
+            )
+        model = AbstractModel()
         model.A = Set()
         model.X = Param(model.A)
         model.W = Param(model.A)
-        instance = model.create_instance(currdir+'loadXW.dat')
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3']))
-        self.assertEqual(instance.X.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(instance.W.extract_values(), {'A1':4.3,'A2':4.4,'A3':4.5})
-        os.remove(currdir+'loadXW.dat')
+        instance = model.create_instance(currdir + 'loadXW.dat')
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3']))
+        self.assertEqual(instance.X.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(instance.W.extract_values(), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
+        os.remove(currdir + 'loadXW.dat')
 
     def test_tableXW_3_2(self):
         # Like test_tableXW_1, except that set A is defined in the load statment.
-        with capture_output(currdir+'loadXW.dat'):
+        with capture_output(currdir + 'loadXW.dat'):
             print("table A={A} X(A) W(A) : A X W := A1 3.3 4.3 A2 3.4 4.4 A3 3.5 4.5 ;")
-        model=AbstractModel()
+        model = AbstractModel()
         model.A = Set()
         model.X = Param(model.A)
         model.W = Param(model.A)
-        instance = model.create_instance(currdir+'loadXW.dat')
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3']))
-        self.assertEqual(instance.X.extract_values(), {'A1':3.3,'A2':3.4,'A3':3.5})
-        self.assertEqual(instance.W.extract_values(), {'A1':4.3,'A2':4.4,'A3':4.5})
-        os.remove(currdir+'loadXW.dat')
+        instance = model.create_instance(currdir + 'loadXW.dat')
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3']))
+        self.assertEqual(instance.X.extract_values(), {'A1': 3.3, 'A2': 3.4, 'A3': 3.5})
+        self.assertEqual(instance.W.extract_values(), {'A1': 4.3, 'A2': 4.4, 'A3': 4.5})
+        os.remove(currdir + 'loadXW.dat')
 
     def test_tableS_1(self):
         # Importing a table, but only reporting the values for the non-index
         # parameter columns.  The first column is assumed to represent an
         # index column.  A missing value is represented in the column data.
-        with capture_output(currdir+'loadS.dat'):
+        with capture_output(currdir + 'loadS.dat'):
             print("table columns=2 S(1)={2} := A1 3.3 A2 . A3 3.5 ;")
-        model=AbstractModel()
-        model.A = Set(initialize=['A1','A2','A3','A4'])
+        model = AbstractModel()
+        model.A = Set(initialize=['A1', 'A2', 'A3', 'A4'])
         model.S = Param(model.A)
-        instance = model.create_instance(currdir+'loadS.dat')
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3','A4']))
-        self.assertEqual(instance.S.extract_values(), {'A1':3.3,'A3':3.5})
-        os.remove(currdir+'loadS.dat')
+        instance = model.create_instance(currdir + 'loadS.dat')
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3', 'A4']))
+        self.assertEqual(instance.S.extract_values(), {'A1': 3.3, 'A3': 3.5})
+        os.remove(currdir + 'loadS.dat')
 
     def test_tableS_2(self):
         # Importing a table, but only reporting the values for the non-index
         # parameter columns.  The first column is assumed to represent an
         # index column.  A missing value is represented in the column data.
-        with capture_output(currdir+'loadS.dat'):
+        with capture_output(currdir + 'loadS.dat'):
             print("table S(A) : A S := A1 3.3 A2 . A3 3.5 ;")
-        model=AbstractModel()
-        model.A = Set(initialize=['A1','A2','A3','A4'])
+        model = AbstractModel()
+        model.A = Set(initialize=['A1', 'A2', 'A3', 'A4'])
         model.S = Param(model.A)
-        instance = model.create_instance(currdir+'loadS.dat')
-        self.assertEqual(set(instance.A.data()), set(['A1','A2','A3','A4']))
-        self.assertEqual(instance.S.extract_values(), {'A1':3.3,'A3':3.5})
-        os.remove(currdir+'loadS.dat')
+        instance = model.create_instance(currdir + 'loadS.dat')
+        self.assertEqual(set(instance.A.data()), set(['A1', 'A2', 'A3', 'A4']))
+        self.assertEqual(instance.S.extract_values(), {'A1': 3.3, 'A3': 3.5})
+        os.remove(currdir + 'loadS.dat')
 
     def test_tablePO_1(self):
         # Importing a table that has multiple indexing columns
-        with capture_output(currdir+'loadPO.dat'):
-            print("table columns=4 J={1,2} P(J)={3} O(J)={4} := A1 B1 4.3 5.3 A2 B2 4.4 5.4 A3 B3 4.5 5.5 ;")
-        model=AbstractModel()
+        with capture_output(currdir + 'loadPO.dat'):
+            print(
+                "table columns=4 J={1,2} P(J)={3} O(J)={4} := A1 B1 4.3 5.3 A2 B2 4.4 5.4 A3 B3 4.5 5.5 ;"
+            )
+        model = AbstractModel()
         model.J = Set(dimen=2)
         model.P = Param(model.J)
         model.O = Param(model.J)
-        instance = model.create_instance(currdir+'loadPO.dat')
-        self.assertEqual(set(instance.J.data()), set([('A3', 'B3'), ('A1', 'B1'), ('A2', 'B2')]) )
-        self.assertEqual(instance.P.extract_values(), {('A3', 'B3'): 4.5, ('A1', 'B1'): 4.3, ('A2', 'B2'): 4.4} )
-        self.assertEqual(instance.O.extract_values(), {('A3', 'B3'): 5.5, ('A1', 'B1'): 5.3, ('A2', 'B2'): 5.4})
-        os.remove(currdir+'loadPO.dat')
+        instance = model.create_instance(currdir + 'loadPO.dat')
+        self.assertEqual(
+            set(instance.J.data()), set([('A3', 'B3'), ('A1', 'B1'), ('A2', 'B2')])
+        )
+        self.assertEqual(
+            instance.P.extract_values(),
+            {('A3', 'B3'): 4.5, ('A1', 'B1'): 4.3, ('A2', 'B2'): 4.4},
+        )
+        self.assertEqual(
+            instance.O.extract_values(),
+            {('A3', 'B3'): 5.5, ('A1', 'B1'): 5.3, ('A2', 'B2'): 5.4},
+        )
+        os.remove(currdir + 'loadPO.dat')
 
     def test_tablePO_2(self):
         # Importing a table that has multiple indexing columns
-        with capture_output(currdir+'loadPO.dat'):
-            print("table J={A,B} P(J) O(J) : A B P O := A1 B1 4.3 5.3 A2 B2 4.4 5.4 A3 B3 4.5 5.5 ;")
-        model=AbstractModel()
+        with capture_output(currdir + 'loadPO.dat'):
+            print(
+                "table J={A,B} P(J) O(J) : A B P O := A1 B1 4.3 5.3 A2 B2 4.4 5.4 A3 B3 4.5 5.5 ;"
+            )
+        model = AbstractModel()
         model.J = Set(dimen=2)
         model.P = Param(model.J)
         model.O = Param(model.J)
-        instance = model.create_instance(currdir+'loadPO.dat')
-        self.assertEqual(set(instance.J.data()), set([('A3', 'B3'), ('A1', 'B1'), ('A2', 'B2')]) )
-        self.assertEqual(instance.P.extract_values(), {('A3', 'B3'): 4.5, ('A1', 'B1'): 4.3, ('A2', 'B2'): 4.4} )
-        self.assertEqual(instance.O.extract_values(), {('A3', 'B3'): 5.5, ('A1', 'B1'): 5.3, ('A2', 'B2'): 5.4})
-        os.remove(currdir+'loadPO.dat')
+        instance = model.create_instance(currdir + 'loadPO.dat')
+        self.assertEqual(
+            set(instance.J.data()), set([('A3', 'B3'), ('A1', 'B1'), ('A2', 'B2')])
+        )
+        self.assertEqual(
+            instance.P.extract_values(),
+            {('A3', 'B3'): 4.5, ('A1', 'B1'): 4.3, ('A2', 'B2'): 4.4},
+        )
+        self.assertEqual(
+            instance.O.extract_values(),
+            {('A3', 'B3'): 5.5, ('A1', 'B1'): 5.3, ('A2', 'B2'): 5.4},
+        )
+        os.remove(currdir + 'loadPO.dat')
 
     def test_complex_1(self):
         # Importing a table with multiple indexing columns
-        with capture_output(currdir+'loadComplex.dat'):
+        with capture_output(currdir + 'loadComplex.dat'):
             print("table columns=8 I={4} J={3,5} A(I)={1} B(J)={7} :=")
             print("A1 x1 J311 I1 J321 y1 B1 z1")
             print("A2 x2 J312 I2 J322 y2 B2 z2")
             print("A3 x3 J313 I3 J323 y3 B3 z3")
             print(";")
-        model=AbstractModel()
+        model = AbstractModel()
         model.I = Set()
         model.J = Set(dimen=2)
         model.A = Param(model.I)
         model.B = Param(model.J)
-        instance = model.create_instance(currdir+'loadComplex.dat')
-        self.assertEqual(set(instance.J.data()), set([('J311', 'J321'), ('J312', 'J322'), ('J313', 'J323')]) )
+        instance = model.create_instance(currdir + 'loadComplex.dat')
+        self.assertEqual(
+            set(instance.J.data()),
+            set([('J311', 'J321'), ('J312', 'J322'), ('J313', 'J323')]),
+        )
         self.assertEqual(set(instance.I.data()), set(['I1', 'I2', 'I3']))
-        self.assertEqual(instance.B.extract_values(), {('J311', 'J321'): 'B1', ('J312', 'J322'): 'B2', ('J313', 'J323'): 'B3'} )
-        self.assertEqual(instance.A.extract_values(), {'I1': 'A1', 'I2': 'A2', 'I3': 'A3'})
-        os.remove(currdir+'loadComplex.dat')
+        self.assertEqual(
+            instance.B.extract_values(),
+            {('J311', 'J321'): 'B1', ('J312', 'J322'): 'B2', ('J313', 'J323'): 'B3'},
+        )
+        self.assertEqual(
+            instance.A.extract_values(), {'I1': 'A1', 'I2': 'A2', 'I3': 'A3'}
+        )
+        os.remove(currdir + 'loadComplex.dat')
 
     def test_complex_2(self):
         # Importing a table with multiple indexing columns
-        with capture_output(currdir+'loadComplex.dat'):
+        with capture_output(currdir + 'loadComplex.dat'):
             print("table I={I} J={J1,J2} A(J) B(I) :")
             print("A  x  J1   I  J2   y  B  z :=")
             print("A1 x1 J311 I1 J321 y1 B1 z1")
             print("A2 x2 J312 I2 J322 y2 B2 z2")
             print("A3 x3 J313 I3 J323 y3 B3 z3")
             print(";")
-        model=AbstractModel()
+        model = AbstractModel()
         model.I = Set()
         model.J = Set(dimen=2)
         model.A = Param(model.J)
         model.B = Param(model.I)
-        instance = model.create_instance(currdir+'loadComplex.dat')
-        self.assertEqual(set(instance.J.data()), set([('J311', 'J321'), ('J312', 'J322'), ('J313', 'J323')]) )
+        instance = model.create_instance(currdir + 'loadComplex.dat')
+        self.assertEqual(
+            set(instance.J.data()),
+            set([('J311', 'J321'), ('J312', 'J322'), ('J313', 'J323')]),
+        )
         self.assertEqual(set(instance.I.data()), set(['I1', 'I2', 'I3']))
-        self.assertEqual(instance.A.extract_values(), {('J311', 'J321'): 'A1', ('J312', 'J322'): 'A2', ('J313', 'J323'): 'A3'} )
-        self.assertEqual(instance.B.extract_values(), {'I1': 'B1', 'I2': 'B2', 'I3': 'B3'})
-        os.remove(currdir+'loadComplex.dat')
+        self.assertEqual(
+            instance.A.extract_values(),
+            {('J311', 'J321'): 'A1', ('J312', 'J322'): 'A2', ('J313', 'J323'): 'A3'},
+        )
+        self.assertEqual(
+            instance.B.extract_values(), {'I1': 'B1', 'I2': 'B2', 'I3': 'B3'}
+        )
+        os.remove(currdir + 'loadComplex.dat')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fixes (Partly) #329 

## Summary/Motivation:
This is the first in a relatively long string of PRs to apply PEP8 standards via `black` to Pyomo. We are following the standard used by IDAES _except_ that we are adding the `-S` option: `Don't normalize string quotes or prefixes` and the `-C` option: `Don't use trailing commas as a reason to split lines.`

**NOTE**: All changes are NFC.

Full command used: `cd pyomo/dataportal && black -S -C .`

## Changes proposed in this PR:
- Apply `black` to the `pyomo/dataportal` directory `py` files

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
