### PR TITLE
Apply `black` to `duality`, `mpec`, and `environ` directory `py` files

### DIFF
--- a/pyomo/duality/collect.py
+++ b/pyomo/duality/collect.py
@@ -12,7 +12,7 @@
 # Routines to collect data in a structured format
 
 from pyomo.common.collections import Bunch
-from pyomo.core.base import  Var, Constraint, Objective, maximize, minimize
+from pyomo.core.base import Var, Constraint, Objective, maximize, minimize
 from pyomo.repn.standard_repn import generate_standard_repn
 
 
@@ -23,10 +23,14 @@ def collect_linear_terms(block, unfixed):
     #
     vnames = set()
     for obj in block.component_objects(Constraint, active=True):
-        vnames.add((obj.getname(fully_qualified=True, relative_to=block), obj.is_indexed()))
+        vnames.add(
+            (obj.getname(fully_qualified=True, relative_to=block), obj.is_indexed())
+        )
     cnames = set(unfixed)
     for obj in block.component_objects(Var, active=True):
-        cnames.add((obj.getname(fully_qualified=True, relative_to=block), obj.is_indexed()))
+        cnames.add(
+            (obj.getname(fully_qualified=True, relative_to=block), obj.is_indexed())
+        )
     #
     A = {}
     b_coef = {}
@@ -40,13 +44,15 @@ def collect_linear_terms(block, unfixed):
     for odata in block.component_objects(Objective, active=True):
         for ndx in odata:
             if odata[ndx].sense == maximize:
-                o_terms = generate_standard_repn(-1*odata[ndx].expr, compute_values=False)
+                o_terms = generate_standard_repn(
+                    -1 * odata[ndx].expr, compute_values=False
+                )
                 d_sense = minimize
             else:
                 o_terms = generate_standard_repn(odata[ndx].expr, compute_values=False)
                 d_sense = maximize
             for var, coef in zip(o_terms.linear_vars, o_terms.linear_coefs):
-                c_rhs[ var.parent_component().local_name, var.index() ] = coef
+                c_rhs[var.parent_component().local_name, var.index()] = coef
         # Stop after the first objective
         break
     #
@@ -62,23 +68,43 @@ def collect_linear_terms(block, unfixed):
                 # If a constraint has a fixed body, then don't collect it.
                 #
                 continue
-            lower_terms = generate_standard_repn(con.lower, compute_values=False) if not con.lower is None else None
-            upper_terms = generate_standard_repn(con.upper, compute_values=False) if not con.upper is None else None
+            lower_terms = (
+                generate_standard_repn(con.lower, compute_values=False)
+                if not con.lower is None
+                else None
+            )
+            upper_terms = (
+                generate_standard_repn(con.upper, compute_values=False)
+                if not con.upper is None
+                else None
+            )
             #
             if not lower_terms is None and not lower_terms.is_constant():
-                raise(RuntimeError, "Error during dualization:  Constraint '%s' has a lower bound that is non-constant")
+                raise (
+                    RuntimeError,
+                    "Error during dualization:  Constraint '%s' has a lower bound that is non-constant",
+                )
             if not upper_terms is None and not upper_terms.is_constant():
-                raise(RuntimeError, "Error during dualization:  Constraint '%s' has an upper bound that is non-constant")
+                raise (
+                    RuntimeError,
+                    "Error during dualization:  Constraint '%s' has an upper bound that is non-constant",
+                )
             #
             for var, coef in zip(body_terms.linear_vars, body_terms.linear_coefs):
                 try:
                     # The variable is in the subproblem
-                    varname = var.parent_component().getname(fully_qualified=True, relative_to=block)
+                    varname = var.parent_component().getname(
+                        fully_qualified=True, relative_to=block
+                    )
                 except:
                     # The variable is somewhere else in the model
-                    varname = var.parent_component().getname(fully_qualified=True, relative_to=block.model())
+                    varname = var.parent_component().getname(
+                        fully_qualified=True, relative_to=block.model()
+                    )
                 varndx = var.index()
-                A.setdefault(varname, {}).setdefault(varndx,[]).append( Bunch(coef=coef, var=name, ndx=ndx) )
+                A.setdefault(varname, {}).setdefault(varndx, []).append(
+                    Bunch(coef=coef, var=name, ndx=ndx)
+                )
             #
             if not con.equality:
                 #
@@ -89,13 +115,13 @@ def collect_linear_terms(block, unfixed):
                     # body <= upper
                     #
                     v_domain[name, ndx] = -1
-                    b_coef[name,ndx] = upper_terms.constant - body_terms.constant
+                    b_coef[name, ndx] = upper_terms.constant - body_terms.constant
                 elif upper_terms is None:
                     #
                     # lower <= body
                     #
                     v_domain[name, ndx] = 1
-                    b_coef[name,ndx] = lower_terms.constant - body_terms.constant
+                    b_coef[name, ndx] = lower_terms.constant - body_terms.constant
                 else:
                     #
                     # lower <= body <= upper
@@ -104,19 +130,19 @@ def collect_linear_terms(block, unfixed):
                     #
                     ndx_ = tuple(list(ndx).append('lb'))
                     v_domain[name, ndx_] = 1
-                    b_coef[name,ndx] = lower_terms.constant - body_terms.constant
+                    b_coef[name, ndx] = lower_terms.constant - body_terms.constant
                     #
                     # Dual for upper bound
                     #
                     ndx_ = tuple(list(ndx).append('ub'))
                     v_domain[name, ndx_] = -1
-                    b_coef[name,ndx] = upper_terms.constant - body_terms.constant
+                    b_coef[name, ndx] = upper_terms.constant - body_terms.constant
             else:
                 #
                 # Equality constraint
                 #
                 v_domain[name, ndx] = 0
-                b_coef[name,ndx] = lower_terms.constant - body_terms.constant
+                b_coef[name, ndx] = lower_terms.constant - body_terms.constant
     #
     # Collect bound constraints
     #
@@ -151,59 +177,75 @@ def collect_linear_terms(block, unfixed):
             var = data[ndx]
             bounds = var.bounds
             if bounds[0] is None and bounds[1] is None:
-                c_sense[name,ndx] = 'e'
+                c_sense[name, ndx] = 'e'
             elif bounds[0] is None:
                 if bounds[1] == 0.0:
-                    c_sense[name,ndx] = 'g'
+                    c_sense[name, ndx] = 'g'
                 else:
-                    c_sense[name,ndx] = 'e'
+                    c_sense[name, ndx] = 'e'
                     #
                     # Add constraint that defines the upper bound
                     #
                     name_ = name + "_upper_"
-                    varname = data.parent_component().getname(fully_qualified=True, relative_to=block)
+                    varname = data.parent_component().getname(
+                        fully_qualified=True, relative_to=block
+                    )
                     varndx = data[ndx].index()
-                    A.setdefault(varname, {}).setdefault(varndx,[]).append( Bunch(coef=1.0, var=name_, ndx=ndx) )
+                    A.setdefault(varname, {}).setdefault(varndx, []).append(
+                        Bunch(coef=1.0, var=name_, ndx=ndx)
+                    )
                     #
-                    v_domain[name_,ndx] = -1
-                    b_coef[name_,ndx] = bounds[1]
+                    v_domain[name_, ndx] = -1
+                    b_coef[name_, ndx] = bounds[1]
             elif bounds[1] is None:
                 if bounds[0] == 0.0:
-                    c_sense[name,ndx] = 'l'
+                    c_sense[name, ndx] = 'l'
                 else:
-                    c_sense[name,ndx] = 'e'
+                    c_sense[name, ndx] = 'e'
                     #
                     # Add constraint that defines the lower bound
                     #
                     name_ = name + "_lower_"
-                    varname = data.parent_component().getname(fully_qualified=True, relative_to=block)
+                    varname = data.parent_component().getname(
+                        fully_qualified=True, relative_to=block
+                    )
                     varndx = data[ndx].index()
-                    A.setdefault(varname, {}).setdefault(varndx,[]).append( Bunch(coef=1.0, var=name_, ndx=ndx) )
+                    A.setdefault(varname, {}).setdefault(varndx, []).append(
+                        Bunch(coef=1.0, var=name_, ndx=ndx)
+                    )
                     #
-                    v_domain[name_,ndx] = 1
-                    b_coef[name_,ndx] = bounds[0]
+                    v_domain[name_, ndx] = 1
+                    b_coef[name_, ndx] = bounds[0]
             else:
                 # Bounded above and below
-                c_sense[name,ndx] = 'e'
+                c_sense[name, ndx] = 'e'
                 #
                 # Add constraint that defines the upper bound
                 #
                 name_ = name + "_upper_"
-                varname = data.parent_component().getname(fully_qualified=True, relative_to=block)
+                varname = data.parent_component().getname(
+                    fully_qualified=True, relative_to=block
+                )
                 varndx = data[ndx].index()
-                A.setdefault(varname, {}).setdefault(varndx,[]).append( Bunch(coef=1.0, var=name_, ndx=ndx) )
+                A.setdefault(varname, {}).setdefault(varndx, []).append(
+                    Bunch(coef=1.0, var=name_, ndx=ndx)
+                )
                 #
-                v_domain[name_,ndx] = -1
-                b_coef[name_,ndx] = bounds[1]
+                v_domain[name_, ndx] = -1
+                b_coef[name_, ndx] = bounds[1]
                 #
                 # Add constraint that defines the lower bound
                 #
                 name_ = name + "_lower_"
-                varname = data.parent_component().getname(fully_qualified=True, relative_to=block)
+                varname = data.parent_component().getname(
+                    fully_qualified=True, relative_to=block
+                )
                 varndx = data[ndx].index()
-                A.setdefault(varname, {}).setdefault(varndx,[]).append( Bunch(coef=1.0, var=name_, ndx=ndx) )
+                A.setdefault(varname, {}).setdefault(varndx, []).append(
+                    Bunch(coef=1.0, var=name_, ndx=ndx)
+                )
                 #
-                v_domain[name_,ndx] = 1
-                b_coef[name_,ndx] = bounds[0]
+                v_domain[name_, ndx] = 1
+                b_coef[name_, ndx] = bounds[0]
     #
     return (A, b_coef, c_rhs, c_sense, d_sense, vnames, cnames, v_domain)

--- a/pyomo/duality/plugins.py
+++ b/pyomo/duality/plugins.py
@@ -12,22 +12,26 @@
 import logging
 
 from pyomo.common.deprecation import deprecated
-from pyomo.core.base import (Transformation,
-                             TransformationFactory,
-                             Var,
-                             Constraint,
-                             Objective,
-                             minimize,
-                             NonNegativeReals,
-                             NonPositiveReals,
-                             Reals,
-                             Block,
-                             Model,
-                             ConcreteModel)
+from pyomo.core.base import (
+    Transformation,
+    TransformationFactory,
+    Var,
+    Constraint,
+    Objective,
+    minimize,
+    NonNegativeReals,
+    NonPositiveReals,
+    Reals,
+    Block,
+    Model,
+    ConcreteModel,
+)
 from pyomo.duality.collect import collect_linear_terms
+
 
 def load():
     pass
+
 
 logger = logging.getLogger('pyomo.core')
 
@@ -39,22 +43,23 @@ logger = logging.getLogger('pyomo.core')
 # This returns a new Block object.
 #
 @TransformationFactory.register(
-    'duality.linear_dual', doc="[DEPRECATED] Dualize a linear model")
+    'duality.linear_dual', doc="[DEPRECATED] Dualize a linear model"
+)
 @deprecated(
     "Use of the pyomo.duality package is deprecated. There are known bugs "
     "in pyomo.duality, and we do not recommend the use of this code. "
     "Development of dualization capabilities has been shifted to "
     "the Pyomo Adversarial Optimization (PAO) library. Please contact "
     "William Hart for further details (wehart@sandia.gov).",
-    version='5.6.2')
+    version='5.6.2',
+)
 class LinearDual_PyomoTransformation(Transformation):
-
     def __init__(self):
         super(LinearDual_PyomoTransformation, self).__init__()
 
     def _create_using(self, instance, **kwds):
         options = kwds.pop('options', {})
-        bname = options.get('block',None)
+        bname = options.get('block', None)
         #
         # Iterate over the model collecting variable data,
         # until the block is found.
@@ -67,7 +72,7 @@ class LinearDual_PyomoTransformation(Transformation):
                 if name == bname:
                     block = instance
         if block is None:
-            raise RuntimeError("Missing block: "+bname)
+            raise RuntimeError("Missing block: " + bname)
         #
         # Generate the dual
         #
@@ -82,7 +87,16 @@ class LinearDual_PyomoTransformation(Transformation):
         #
         # Collect linear terms from the block
         #
-        A, b_coef, c_rhs, c_sense, d_sense, vnames, cnames, v_domain = collect_linear_terms(block, unfixed)
+        (
+            A,
+            b_coef,
+            c_rhs,
+            c_sense,
+            d_sense,
+            vnames,
+            cnames,
+            v_domain,
+        ) = collect_linear_terms(block, unfixed)
         ##print(A)
         ##print(vnames)
         ##print(cnames)
@@ -100,26 +114,36 @@ class LinearDual_PyomoTransformation(Transformation):
             dual = Block()
         dual.construct()
         _vars = {}
+
         def getvar(name, ndx=None):
-            v = _vars.get((name,ndx), None)
+            v = _vars.get((name, ndx), None)
             if v is None:
                 v = Var()
                 if ndx is None:
                     v_name = name
                 elif type(ndx) is tuple:
-                    v_name = "%s[%s]" % (name, ','.join(map(str,ndx)))
+                    v_name = "%s[%s]" % (name, ','.join(map(str, ndx)))
                 else:
                     v_name = "%s[%s]" % (name, str(ndx))
                 setattr(dual, v_name, v)
-                _vars[name,ndx] = v
+                _vars[name, ndx] = v
             return v
+
         #
         # Construct the objective
         #
         if d_sense == minimize:
-            dual.o = Objective(expr=sum(- b_coef[name,ndx]*getvar(name,ndx) for name,ndx in b_coef), sense=d_sense)
+            dual.o = Objective(
+                expr=sum(
+                    -b_coef[name, ndx] * getvar(name, ndx) for name, ndx in b_coef
+                ),
+                sense=d_sense,
+            )
         else:
-            dual.o = Objective(expr=sum(b_coef[name,ndx]*getvar(name,ndx) for name,ndx in b_coef), sense=d_sense)
+            dual.o = Objective(
+                expr=sum(b_coef[name, ndx] * getvar(name, ndx) for name, ndx in b_coef),
+                sense=d_sense,
+            )
         #
         # Construct the constraints
         #
@@ -131,16 +155,16 @@ class LinearDual_PyomoTransformation(Transformation):
                 if not (cname, ndx) in c_rhs:
                     c_rhs[cname, ndx] = 0.0
                 if c_sense[cname, ndx] == 'e':
-                    e = expr - c_rhs[cname,ndx] == 0
+                    e = expr - c_rhs[cname, ndx] == 0
                 elif c_sense[cname, ndx] == 'l':
-                    e = expr - c_rhs[cname,ndx] <= 0
+                    e = expr - c_rhs[cname, ndx] <= 0
                 else:
-                    e = expr - c_rhs[cname,ndx] >= 0
+                    e = expr - c_rhs[cname, ndx] >= 0
                 c = Constraint(expr=e)
                 if ndx is None:
                     c_name = cname
                 elif type(ndx) is tuple:
-                    c_name = "%s[%s]" % (cname, ','.join(map(str,ndx)))
+                    c_name = "%s[%s]" % (cname, ','.join(map(str, ndx)))
                 else:
                     c_name = "%s[%s]" % (cname, str(ndx))
                 setattr(dual, c_name, c)

--- a/pyomo/duality/tests/test_linear_dual.py
+++ b/pyomo/duality/tests/test_linear_dual.py
@@ -16,7 +16,7 @@ import os
 from os.path import abspath, dirname, normpath, join
 
 currdir = dirname(abspath(__file__))
-exdir = normpath(join(currdir,'..','..','..','examples','pyomo','core'))
+exdir = normpath(join(currdir, '..', '..', '..', 'examples', 'pyomo', 'core'))
 
 from filecmp import cmp
 import pyomo.common.unittest as unittest
@@ -27,6 +27,8 @@ import pyomo.scripting.pyomo_main as main
 
 
 solver = None
+
+
 class CommonTests(object):
 
     solve = True
@@ -34,7 +36,7 @@ class CommonTests(object):
     def run_bilevel(self, *_args, **kwds):
         if self.solve:
             args = ['solve']
-            _solver = kwds.get('solver','glpk')
+            _solver = kwds.get('solver', 'glpk')
             args.append('--solver=%s' % _solver)
             args.append('--save-results=result.yml')
             args.append('--results-format=json')
@@ -48,7 +50,7 @@ class CommonTests(object):
 
         if False:
             args.append('--stream-solver')
-            args.append('--tempdir='+currdir)
+            args.append('--tempdir=' + currdir)
             args.append('--keepfiles')
             args.append('--debug')
             args.append('--logging=verbose')
@@ -57,7 +59,7 @@ class CommonTests(object):
         os.chdir(currdir)
 
         print('***')
-        #print(' '.join(args))
+        # print(' '.join(args))
         output = main.main(args)
         try:
             output = main.main(args)
@@ -71,7 +73,7 @@ class CommonTests(object):
         pass
 
     def referenceFile(self, problem, solver):
-        return join(currdir, problem+'.txt')
+        return join(currdir, problem + '.txt')
 
     def getObjective(self, fname):
         FILE = open(fname)
@@ -86,98 +88,104 @@ class CommonTests(object):
     def updateDocStrings(self):
         for key in dir(self):
             if key.startswith('test'):
-                getattr(self,key).__doc__ = " (%s)" % getattr(self,key).__name__
+                getattr(self, key).__doc__ = " (%s)" % getattr(self, key).__name__
 
     def test_t5(self):
-        self.problem='test_t5'
-        self.run_bilevel(join(exdir,'t5.py'))
-        self.check( 't5', 'linear_dual' )
+        self.problem = 'test_t5'
+        self.run_bilevel(join(exdir, 't5.py'))
+        self.check('t5', 'linear_dual')
 
     def test_t1(self):
-        self.problem='test_t1'
-        self.run_bilevel(join(exdir,'t1.py'))
-        self.check( 't1', 'linear_dual' )
+        self.problem = 'test_t1'
+        self.run_bilevel(join(exdir, 't1.py'))
+        self.check('t1', 'linear_dual')
 
 
 class Reformulate(unittest.TestCase, CommonTests):
 
-    solve=False
+    solve = False
 
     def tearDown(self):
-        if os.path.exists(os.path.join(currdir,'result.yml')):
-            os.remove(os.path.join(currdir,'result.yml'))
+        if os.path.exists(os.path.join(currdir, 'result.yml')):
+            os.remove(os.path.join(currdir, 'result.yml'))
 
     @classmethod
     def setUpClass(cls):
         import pyomo.environ
 
-    def run_bilevel(self,  *args, **kwds):
+    def run_bilevel(self, *args, **kwds):
         args = list(args)
-        args.append('--output='+self.problem+'_result.lp')
+        args.append('--output=' + self.problem + '_result.lp')
         kwds['transform'] = 'duality.linear_dual'
         CommonTests.run_bilevel(self, *args, **kwds)
 
     def referenceFile(self, problem, solver):
-        return join(currdir, problem+"_"+solver+'.lp')
+        return join(currdir, problem + "_" + solver + '.lp')
 
     def check(self, problem, solver):
-        _prob, _solv = join(currdir,self.problem+'_result.lp'), self.referenceFile(problem,solver)
-        self.assertTrue(cmp(_prob, _solv),
-                        msg="Files %s and %s differ" % (_prob, _solv))
+        _prob, _solv = join(currdir, self.problem + '_result.lp'), self.referenceFile(
+            problem, solver
+        )
+        self.assertTrue(
+            cmp(_prob, _solv), msg="Files %s and %s differ" % (_prob, _solv)
+        )
 
 
 class Solver(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         import pyomo.environ
 
     def tearDown(self):
-        if os.path.exists(os.path.join(currdir,'result.yml')):
-            os.remove(os.path.join(currdir,'result.yml'))
+        if os.path.exists(os.path.join(currdir, 'result.yml')):
+            os.remove(os.path.join(currdir, 'result.yml'))
 
     def check(self, problem, solver):
-        refObj = self.getObjective(self.referenceFile(problem,solver))
-        ansObj = self.getObjective(join(currdir,'result.yml'))
+        refObj = self.getObjective(self.referenceFile(problem, solver))
+        ansObj = self.getObjective(join(currdir, 'result.yml'))
         self.assertEqual(len(refObj), len(ansObj))
         for i in range(len(refObj)):
             self.assertEqual(len(refObj[i]), len(ansObj[i]))
-            for key,val in refObj[i].items():
-                self.assertAlmostEqual(val['Value'], ansObj[i].get(key,None)['Value'], places=3)
+            for key, val in refObj[i].items():
+                self.assertAlmostEqual(
+                    val['Value'], ansObj[i].get(key, None)['Value'], places=3
+                )
 
 
 class Solve_GLPK(Solver, CommonTests):
-
     @classmethod
     def setUpClass(cls):
         global solvers
         import pyomo.environ
+
         solvers = pyomo.opt.check_available_solvers('glpk')
 
     def setUp(self):
         if (not yaml_available) or (not 'glpk' in solvers):
-            self.skipTest("YAML is not available or "
-                          "the 'glpk' executable is not available")
+            self.skipTest(
+                "YAML is not available or the 'glpk' executable is not available"
+            )
 
-    def run_bilevel(self,  *args, **kwds):
+    def run_bilevel(self, *args, **kwds):
         kwds['solver'] = 'glpk'
         CommonTests.run_bilevel(self, *args, **kwds)
 
 
 class Solve_CPLEX(Solver, CommonTests):
-
     @classmethod
     def setUpClass(cls):
         global solvers
         import pyomo.environ
+
         solvers = pyomo.opt.check_available_solvers('cplex')
 
     def setUp(self):
         if (not yaml_available) or (not 'cplex' in solvers):
-            self.skipTest("YAML is not available or "
-                          "the 'cplex' executable is not available")
+            self.skipTest(
+                "YAML is not available or the 'cplex' executable is not available"
+            )
 
-    def run_bilevel(self,  *args, **kwds):
+    def run_bilevel(self, *args, **kwds):
         kwds['solver'] = 'cplex'
         CommonTests.run_bilevel(self, *args, **kwds)
 

--- a/pyomo/environ/__init__.py
+++ b/pyomo/environ/__init__.py
@@ -12,8 +12,11 @@
 import sys as _sys
 
 import importlib
+
+
 def _do_import(pkg_name):
-        importlib.import_module(pkg_name)
+    importlib.import_module(pkg_name)
+
 
 #
 # These packages contain plugins that need to be loaded
@@ -62,10 +65,12 @@ def _import_packages():
         except ImportError:
             exctype, err, tb = _sys.exc_info()  # BUG?
             import traceback
-            msg = "pyomo.environ failed to import %s:\nOriginal %s: %s\n" \
-                  "Traceback:\n%s" \
-                  % (pname, exctype.__name__, err,
-                     ''.join(traceback.format_tb(tb)),)
+
+            msg = (
+                "pyomo.environ failed to import %s:\nOriginal %s: %s\n"
+                "Traceback:\n%s"
+                % (pname, exctype.__name__, err, ''.join(traceback.format_tb(tb)))
+            )
             # clear local variables to remove circular references
             exctype = err = tb = None
             # TODO: Should this just log an error and re-raise the
@@ -89,72 +94,183 @@ import pyomo.core.base.util
 from pyomo.core import expr, base, kernel, plugins
 from pyomo.core.base import util
 
-from pyomo.core import (numvalue, numeric_expr, boolean_value,
-                             current, symbol_map, sympy_tools,
-                             taylor_series, visitor, expr_common, expr_errors,
-                             calculus, native_types,
-                             linear_expression, nonlinear_expression,
-                             land, lor, equivalent, exactly,
-                             atleast, atmost, implies, lnot,
-                             xor, inequality, log, log10, sin, cos, tan, cosh,
-                             sinh, tanh, asin, acos, atan, exp, sqrt, asinh, acosh,
-                             atanh, ceil, floor, Expr_if, differentiate,
-                             taylor_series_expansion, SymbolMap, PyomoObject,
-                             nonpyomo_leaf_types, native_numeric_types,
-                             value, is_constant, is_fixed, is_variable_type,
-                             is_potentially_variable, polynomial_degree,
-                             NumericValue, ZeroConstant, as_boolean, BooleanConstant,
-                             BooleanValue, native_logical_values, minimize,
-                             maximize, PyomoOptions, Expression, CuidLabeler,
-                             CounterLabeler, NumericLabeler,
-                             CNameLabeler, TextLabeler,
-                             AlphaNumericTextLabeler, NameLabeler, ShortNameLabeler,
-                             name, Component, ComponentUID, BuildAction,
-                             BuildCheck, Set, SetOf, simple_set_rule, RangeSet,
-                             Param, Var, VarList, ScalarVar,
-                             BooleanVar, BooleanVarList, ScalarBooleanVar,
-                             logical_expr, simple_constraint_rule,
-                             simple_constraintlist_rule, ConstraintList,
-                             Constraint, LogicalConstraint,
-                             LogicalConstraintList, simple_objective_rule,
-                             simple_objectivelist_rule, Objective,
-                             ObjectiveList, Connector, SOSConstraint,
-                             Piecewise, active_export_suffix_generator,
-                             active_import_suffix_generator, Suffix,
-                             ExternalFunction, symbol_map_from_instance,
-                             Reference, Reals, PositiveReals, NonPositiveReals,
-                             NegativeReals, NonNegativeReals, Integers,
-                             PositiveIntegers, NonPositiveIntegers,
-                             NegativeIntegers, NonNegativeIntegers,
-                             Boolean, Binary, Any, AnyWithNone, EmptySet,
-                             UnitInterval, PercentFraction, RealInterval,
-                             IntegerInterval, display, SortComponents,
-                             TraversalStrategy, Block, ScalarBlock,
-                             active_components, components,
-                             active_components_data, components_data,
-                             global_option, Model, ConcreteModel,
-                             AbstractModel,
-                             ModelComponentFactory, Transformation,
-                             TransformationFactory, instance2dat,
-                             set_options, RealSet, IntegerSet, BooleanSet,
-                             prod, quicksum, sum_product, dot_product,
-                             summation, sequence)
+from pyomo.core import (
+    numvalue,
+    numeric_expr,
+    boolean_value,
+    current,
+    symbol_map,
+    sympy_tools,
+    taylor_series,
+    visitor,
+    expr_common,
+    expr_errors,
+    calculus,
+    native_types,
+    linear_expression,
+    nonlinear_expression,
+    land,
+    lor,
+    equivalent,
+    exactly,
+    atleast,
+    atmost,
+    implies,
+    lnot,
+    xor,
+    inequality,
+    log,
+    log10,
+    sin,
+    cos,
+    tan,
+    cosh,
+    sinh,
+    tanh,
+    asin,
+    acos,
+    atan,
+    exp,
+    sqrt,
+    asinh,
+    acosh,
+    atanh,
+    ceil,
+    floor,
+    Expr_if,
+    differentiate,
+    taylor_series_expansion,
+    SymbolMap,
+    PyomoObject,
+    nonpyomo_leaf_types,
+    native_numeric_types,
+    value,
+    is_constant,
+    is_fixed,
+    is_variable_type,
+    is_potentially_variable,
+    polynomial_degree,
+    NumericValue,
+    ZeroConstant,
+    as_boolean,
+    BooleanConstant,
+    BooleanValue,
+    native_logical_values,
+    minimize,
+    maximize,
+    PyomoOptions,
+    Expression,
+    CuidLabeler,
+    CounterLabeler,
+    NumericLabeler,
+    CNameLabeler,
+    TextLabeler,
+    AlphaNumericTextLabeler,
+    NameLabeler,
+    ShortNameLabeler,
+    name,
+    Component,
+    ComponentUID,
+    BuildAction,
+    BuildCheck,
+    Set,
+    SetOf,
+    simple_set_rule,
+    RangeSet,
+    Param,
+    Var,
+    VarList,
+    ScalarVar,
+    BooleanVar,
+    BooleanVarList,
+    ScalarBooleanVar,
+    logical_expr,
+    simple_constraint_rule,
+    simple_constraintlist_rule,
+    ConstraintList,
+    Constraint,
+    LogicalConstraint,
+    LogicalConstraintList,
+    simple_objective_rule,
+    simple_objectivelist_rule,
+    Objective,
+    ObjectiveList,
+    Connector,
+    SOSConstraint,
+    Piecewise,
+    active_export_suffix_generator,
+    active_import_suffix_generator,
+    Suffix,
+    ExternalFunction,
+    symbol_map_from_instance,
+    Reference,
+    Reals,
+    PositiveReals,
+    NonPositiveReals,
+    NegativeReals,
+    NonNegativeReals,
+    Integers,
+    PositiveIntegers,
+    NonPositiveIntegers,
+    NegativeIntegers,
+    NonNegativeIntegers,
+    Boolean,
+    Binary,
+    Any,
+    AnyWithNone,
+    EmptySet,
+    UnitInterval,
+    PercentFraction,
+    RealInterval,
+    IntegerInterval,
+    display,
+    SortComponents,
+    TraversalStrategy,
+    Block,
+    ScalarBlock,
+    active_components,
+    components,
+    active_components_data,
+    components_data,
+    global_option,
+    Model,
+    ConcreteModel,
+    AbstractModel,
+    ModelComponentFactory,
+    Transformation,
+    TransformationFactory,
+    instance2dat,
+    set_options,
+    RealSet,
+    IntegerSet,
+    BooleanSet,
+    prod,
+    quicksum,
+    sum_product,
+    dot_product,
+    summation,
+    sequence,
+)
 
 from pyomo.opt import (
-    SolverFactory, SolverManagerFactory, UnknownSolver,
-    TerminationCondition, SolverStatus, check_optimal_termination,
-    assert_optimal_termination
-    )
+    SolverFactory,
+    SolverManagerFactory,
+    UnknownSolver,
+    TerminationCondition,
+    SolverStatus,
+    check_optimal_termination,
+    assert_optimal_termination,
+)
 from pyomo.core.base.units_container import units, as_quantity
 
 # These APIs are deprecated and should be removed in the near future
 from pyomo.common.deprecation import relocated_module_attribute
+
 relocated_module_attribute(
-    'SimpleBlock', 'pyomo.core.base.block.SimpleBlock', version='6.0')
+    'SimpleBlock', 'pyomo.core.base.block.SimpleBlock', version='6.0'
+)
+relocated_module_attribute('SimpleVar', 'pyomo.core.base.var.SimpleVar', version='6.0')
 relocated_module_attribute(
-    'SimpleVar', 'pyomo.core.base.var.SimpleVar', version='6.0')
-relocated_module_attribute(
-    'SimpleBooleanVar', 'pyomo.core.base.boolean_var.SimpleBooleanVar',
-    version='6.0'
+    'SimpleBooleanVar', 'pyomo.core.base.boolean_var.SimpleBooleanVar', version='6.0'
 )
 del relocated_module_attribute

--- a/pyomo/environ/tests/standalone_minimal_pyomo_driver.py
+++ b/pyomo/environ/tests/standalone_minimal_pyomo_driver.py
@@ -37,31 +37,35 @@ bounds
 end
 """
 
+
 def _check_log_and_out(LOG, OUT, offset, msg=None):
     sys.stdout.flush()
     sys.stderr.flush()
     msg = str(msg) + ': ' if msg else ''
     if LOG.getvalue():
         raise RuntimeError(
-            "FAIL: %sMessage logged to the Logger:\n>>>\n%s<<<" % (
-                msg, LOG.getvalue(),))
+            "FAIL: %sMessage logged to the Logger:\n>>>\n%s<<<" % (msg, LOG.getvalue())
+        )
 
     if OUT.getvalue():
         raise RuntimeError(
-            "FAIL: %sMessage sent to stdout/stderr:\n>>>\n%s<<<" % (
-                msg, OUT.getvalue(),))
+            "FAIL: %sMessage sent to stdout/stderr:\n>>>\n%s<<<" % (msg, OUT.getvalue())
+        )
 
 
 def import_pyomo_environ():
     with LoggingIntercept() as LOG, capture_output(capture_fd=True) as OUT:
         import pyomo.environ as pyo
+
         globals()['pyo'] = pyo
     _check_log_and_out(LOG, OUT, 0)
+
 
 def run_writer_test():
     with LoggingIntercept() as LOG, capture_output(capture_fd=True) as OUT:
         # Enumerate the writers...
         from pyomo.opt import WriterFactory
+
         info = []
         for writer in sorted(WriterFactory):
             info.append("  %s: %s" % (writer, WriterFactory.doc(writer)))
@@ -79,16 +83,21 @@ def run_writer_test():
         m.o = pyo.Objective(expr=m.x**2)
 
         from pyomo.common.tempfiles import TempfileManager
+
         with TempfileManager:
             fname = TempfileManager.create_tempfile(suffix='pyomo.lp')
             m.write(fname)
             with open(fname, 'r') as FILE:
                 data = FILE.read()
 
-    if not all(d.strip() == b.strip() for d,b in zip(
-            data.strip().splitlines(), _baseline.strip().splitlines())):
-        print("Result did not match baseline.\nRESULT:\n%s\nBASELINE:\n%s"
-              % (data, _baseline))
+    if not all(
+        d.strip() == b.strip()
+        for d, b in zip(data.strip().splitlines(), _baseline.strip().splitlines())
+    ):
+        print(
+            "Result did not match baseline.\nRESULT:\n%s\nBASELINE:\n%s"
+            % (data, _baseline)
+        )
         print(data.strip().splitlines())
         print(_baseline.strip().splitlines())
         sys.exit(2)
@@ -97,12 +106,7 @@ def run_writer_test():
 
 
 def run_solverfactory_test():
-    skip_solvers = {
-        'py',
-        'xpress',
-        '_xpress_shell',
-        '_mock_xpress',
-    }
+    skip_solvers = {'py', 'xpress', '_xpress_shell', '_mock_xpress'}
 
     with LoggingIntercept() as LOG, capture_output(capture_fd=True) as OUT:
         info = []
@@ -115,7 +119,7 @@ def run_solverfactory_test():
             else:
                 _avail = str(pyo.SolverFactory(solver).available(False))
             info.append("   %s(%s): %s" % (solver, _avail, _doc))
-            #_check_log_and_out(LOG, OUT, 20, solver)
+            # _check_log_and_out(LOG, OUT, 20, solver)
 
         glpk = pyo.SolverFactory('glpk')
 
@@ -143,15 +147,13 @@ def run_transformationfactory_test():
 
         bigm = pyo.TransformationFactory('gdp.bigm')
 
-
     print("")
     print("Pyomo Transformations")
     print("---------------------")
     print('\n'.join(info))
 
     if not isinstance(bigm, pyo.Transformation):
-        print("TransformationFactory(gdp.bigm) did not return a "
-              "transformation")
+        print("TransformationFactory(gdp.bigm) did not return a transformation")
         sys.exit(4)
 
     _check_log_and_out(LOG, OUT, 30)

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -21,7 +21,9 @@ from collections import namedtuple
 import pyomo.common.unittest as unittest
 
 from pyomo.common.dependencies import numpy_available, attempt_import
+
 pyro4, pyro4_available = attempt_import('Pyro4')
+
 
 class ImportData(object):
     def __init__(self):
@@ -32,84 +34,104 @@ class ImportData(object):
         self.tpl.update(other.tpl)
         self.pyomo.update(other.pyomo)
 
+
 def collect_import_time(module):
-        output = subprocess.check_output(
-            [sys.executable, '-X', 'importtime', '-c', 'import %s' % (module,)],
-            stderr=subprocess.STDOUT)
-        # Note: test only runs in PY3
-        output = output.decode()
-        line_re = re.compile(r'.*:\s*(\d+) \|\s*(\d+) \| ( *)([^ ]+)')
-        data = []
-        for line in output.splitlines():
-            g = line_re.match(line)
-            if not g:
-                continue
-            _self = int(g.group(1))
-            _cumul = int(g.group(2))
-            _level = len(g.group(3)) // 2
-            _module = g.group(4)
-            #print("%6d %8d %2d %s" % (_self, _cumul, _level, _module))
-            while len(data) < _level+1:
-                data.append(ImportData())
-            if len(data) > _level+1:
-                assert len(data) == _level+2
-                inner = data.pop()
-                inner.tpl = {
-                    (k if '(from' in k else "%s (from %s)" % (k, _module),
-                     v) for k,v in inner.tpl.items() }
-                if _module.startswith('pyomo'):
-                    data[_level].update(inner)
-                    data[_level].pyomo[_module] = _self
-                else:
-                    if _level > 0:
-                        data[_level].tpl[_module] = _cumul
-            elif _module.startswith('pyomo'):
+    output = subprocess.check_output(
+        [sys.executable, '-X', 'importtime', '-c', 'import %s' % (module,)],
+        stderr=subprocess.STDOUT,
+    )
+    # Note: test only runs in PY3
+    output = output.decode()
+    line_re = re.compile(r'.*:\s*(\d+) \|\s*(\d+) \| ( *)([^ ]+)')
+    data = []
+    for line in output.splitlines():
+        g = line_re.match(line)
+        if not g:
+            continue
+        _self = int(g.group(1))
+        _cumul = int(g.group(2))
+        _level = len(g.group(3)) // 2
+        _module = g.group(4)
+        # print("%6d %8d %2d %s" % (_self, _cumul, _level, _module))
+        while len(data) < _level + 1:
+            data.append(ImportData())
+        if len(data) > _level + 1:
+            assert len(data) == _level + 2
+            inner = data.pop()
+            inner.tpl = {
+                (k if '(from' in k else "%s (from %s)" % (k, _module), v)
+                for k, v in inner.tpl.items()
+            }
+            if _module.startswith('pyomo'):
+                data[_level].update(inner)
                 data[_level].pyomo[_module] = _self
-            elif _level > 0:
-                data[_level].tpl[_module] = _self
-        assert len(data) == 1
-        return data[0]
+            else:
+                if _level > 0:
+                    data[_level].tpl[_module] = _cumul
+        elif _module.startswith('pyomo'):
+            data[_level].pyomo[_module] = _self
+        elif _level > 0:
+            data[_level].tpl[_module] = _self
+    assert len(data) == 1
+    return data[0]
 
 
 class TestPyomoEnviron(unittest.TestCase):
-
     def test_not_auto_imported(self):
-        rc = subprocess.call([
-                sys.executable, '-c', 
+        rc = subprocess.call(
+            [
+                sys.executable,
+                '-c',
                 'import pyomo.core, sys; '
-                'sys.exit( 1 if "pyomo.environ" in sys.modules else 0 )'])
+                'sys.exit( 1 if "pyomo.environ" in sys.modules else 0 )',
+            ]
+        )
         if rc:
-            self.fail("Importing pyomo.core automatically imports "
-                      "pyomo.environ and it should not.")
+            self.fail(
+                "Importing pyomo.core automatically imports "
+                "pyomo.environ and it should not."
+            )
 
-
-    @unittest.skipIf(sys.version_info[:2] < (3,7),
-                     "Import timing introduced in python 3.7")
-    @unittest.skipIf('pypy_version_info' in dir(sys),
-                     "PyPy does not support '-X importtime")
+    @unittest.skipIf(
+        sys.version_info[:2] < (3, 7), "Import timing introduced in python 3.7"
+    )
+    @unittest.skipIf(
+        'pypy_version_info' in dir(sys), "PyPy does not support '-X importtime"
+    )
     def test_tpl_import_time(self):
         data = collect_import_time('pyomo.environ')
         pyomo_time = sum(data.pyomo.values())
         tpl_time = sum(data.tpl.values())
         total = float(pyomo_time + tpl_time)
         print("Pyomo (by module time):")
-        print("\n".join("   %s: %s" % i for i in sorted(
-            data.pyomo.items(), key=lambda x: x[1])))
+        print(
+            "\n".join(
+                "   %s: %s" % i for i in sorted(data.pyomo.items(), key=lambda x: x[1])
+            )
+        )
         print("TPLS:")
         _line_fmt = "   %%%ds: %%6d %%s" % (
-            max(len(k[:k.find(' ')]) for k in data.tpl),)
-        print("\n".join(_line_fmt % (k[:k.find(' ')], v, k[k.find(' '):])
-                        for k,v in sorted(data.tpl.items())))
+            max(len(k[: k.find(' ')]) for k in data.tpl),
+        )
+        print(
+            "\n".join(
+                _line_fmt % (k[: k.find(' ')], v, k[k.find(' ') :])
+                for k, v in sorted(data.tpl.items())
+            )
+        )
         tpl = {}
         for k, v in data.tpl.items():
-            _mod = k[:k.find(' ')].split('.')[0]
-            tpl[_mod] = tpl.get(_mod,0) + v
+            _mod = k[: k.find(' ')].split('.')[0]
+            tpl[_mod] = tpl.get(_mod, 0) + v
         tpl_by_time = sorted(tpl.items(), key=lambda x: x[1])
         print("TPLS (by package time):")
-        print("\n".join("   %12s: %6d (%4.1f%%)" % (
-            m, t, 100*t/total) for m, t in tpl_by_time))
-        print("Pyomo:    %6d (%4.1f%%)" % (
-            pyomo_time, 100 * pyomo_time / total))
+        print(
+            "\n".join(
+                "   %12s: %6d (%4.1f%%)" % (m, t, 100 * t / total)
+                for m, t in tpl_by_time
+            )
+        )
+        print("Pyomo:    %6d (%4.1f%%)" % (pyomo_time, 100 * pyomo_time / total))
         print("TPL:      %6d (%4.1f%%)" % (tpl_time, 100 * tpl_time / total))
         # Arbitrarily choose a threshold 10% more than the expected
         # value (at time of writing, TPL imports were 52-57% of the
@@ -121,30 +143,30 @@ class TestPyomoEnviron(unittest.TestCase):
         ref = {
             '__future__',
             'argparse',
-            'ast',       # Imported on Windows
-            'base64',    # Imported on Windows
+            'ast',  # Imported on Windows
+            'base64',  # Imported on Windows
             'cPickle',
             'csv',
             'ctypes',
             'decimal',
-            'gc',        # Imported on MacOS, Windows; Linux in 3.10
+            'gc',  # Imported on MacOS, Windows; Linux in 3.10
             'glob',
-            'heapq',     # Added in Python 3.10
-            'importlib', # Imported on Windows
+            'heapq',  # Added in Python 3.10
+            'importlib',  # Imported on Windows
             'inspect',
-            'json',      # Imported on Windows
-            'locale',    # Added in Python 3.9
+            'json',  # Imported on Windows
+            'locale',  # Added in Python 3.9
             'logging',
             'pickle',
             'platform',
-            'random',    # Imported on MacOS, Windows
+            'random',  # Imported on MacOS, Windows
             'shlex',
-            'socket',    # Imported on MacOS, Windows; Linux in 3.10
+            'socket',  # Imported on MacOS, Windows; Linux in 3.10
             'tempfile',  # Imported on MacOS, Windows
             'textwrap',
             'typing',
-            'win32file', # Imported on Windows
-            'win32pipe', # Imported on Windows
+            'win32file',  # Imported on Windows
+            'win32pipe',  # Imported on Windows
         }
         # Non-standard-library TPLs that Pyomo will load unconditionally
         ref.add('ply')
@@ -153,8 +175,8 @@ class TestPyomoEnviron(unittest.TestCase):
             ref.add('numpy')
         diff = set(_[0] for _ in tpl_by_time[-5:]).difference(ref)
         self.assertEqual(
-            diff, set(),
-            "Unexpected module found in 5 slowest-loading TPL modules")
+            diff, set(), "Unexpected module found in 5 slowest-loading TPL modules"
+        )
 
 
 if __name__ == "__main__":

--- a/pyomo/environ/tests/test_package_layout.py
+++ b/pyomo/environ/tests/test_package_layout.py
@@ -41,6 +41,7 @@ _NON_MODULE_DIRS = {
     join('solvers', 'tests', 'piecewise_linear', 'problems'),
 }
 
+
 class TestPackageLayout(unittest.TestCase):
     def test_for_init_files(self):
         _NMD = set(_NON_MODULE_DIRS)
@@ -48,7 +49,7 @@ class TestPackageLayout(unittest.TestCase):
         module_dir = os.path.join(PYOMO_ROOT_DIR, 'pyomo')
         for path, subdirs, files in os.walk(module_dir):
             assert path.startswith(module_dir)
-            relpath = path[1+len(module_dir):]
+            relpath = path[1 + len(module_dir) :]
             # Skip all __pycache__ directories
             try:
                 subdirs.remove('__pycache__')
@@ -77,5 +78,3 @@ class TestPackageLayout(unittest.TestCase):
                 "or unexpectedly contain a __init__.py file:\n\t"
                 + "\n\t".join(sorted(_NMD))
             )
-
-

--- a/pyomo/mpec/complementarity.py
+++ b/pyomo/mpec/complementarity.py
@@ -22,10 +22,13 @@ from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.block import _BlockData
 from pyomo.core.base.disable_methods import disable_methods
 from pyomo.core.base.initializer import (
-    Initializer, IndexedCallInitializer, CountedCallInitializer,
+    Initializer,
+    IndexedCallInitializer,
+    CountedCallInitializer,
 )
 
 import logging
+
 logger = logging.getLogger('pyomo.core')
 
 
@@ -36,12 +39,11 @@ ComplementarityTuple = namedtuple('ComplementarityTuple', ('arg0', 'arg1'))
 
 
 def complements(a, b):
-    """ Return a named 2-tuple """
-    return ComplementarityTuple(a,b)
+    """Return a named 2-tuple"""
+    return ComplementarityTuple(a, b)
 
 
 class _ComplementarityData(_BlockData):
-
     def _canonical_expression(self, e):
         # Note: as the complimentarity component maintains references to
         # the original expression (e), it is NOT safe or valid to bypass
@@ -56,16 +58,16 @@ class _ComplementarityData(_BlockData):
             # The first argument of an equality is never fixed
             #
             else:
-                _e = ( ZeroConstant, e.arg(0) - e.arg(1))
+                _e = (ZeroConstant, e.arg(0) - e.arg(1))
         elif e.__class__ is EXPR.InequalityExpression:
             if e.arg(1).__class__ in native_numeric_types or e.arg(1).is_fixed():
                 _e = (None, e.arg(0), e.arg(1))
             elif e.arg(0).__class__ in native_numeric_types or e.arg(0).is_fixed():
                 _e = (e.arg(0), e.arg(1), None)
             else:
-                _e = ( ZeroConstant, e.arg(1) - e.arg(0), None )
+                _e = (ZeroConstant, e.arg(1) - e.arg(0), None)
         elif e.__class__ is EXPR.RangedExpression:
-                _e = (e.arg(0), e.arg(1), e.arg(2))
+            _e = (e.arg(0), e.arg(1), e.arg(2))
         else:
             _e = (None, e, None)
         return _e
@@ -104,8 +106,13 @@ class _ComplementarityData(_BlockData):
             self.c = Constraint(expr=_e2)
             return
         #
-        if (_e1[0] is None) + (_e1[2] is None) + (_e2[0] is None) + (_e2[2] is None) != 2:
-            raise RuntimeError("Complementarity condition %s must have exactly two finite bounds" % self.name)
+        if (_e1[0] is None) + (_e1[2] is None) + (_e2[0] is None) + (
+            _e2[2] is None
+        ) != 2:
+            raise RuntimeError(
+                "Complementarity condition %s must have exactly two finite bounds"
+                % self.name
+            )
         #
         if _e1[0] is None and _e1[2] is None:
             # Only e2 will be an unconstrained expression
@@ -118,14 +125,18 @@ class _ComplementarityData(_BlockData):
             self.c = Constraint(expr=_e2[0] <= _e2[1])
             self.c._complementarity_type = 1
         elif _e2[0] is None:
-            self.c = Constraint(expr=- _e2[2] <= - _e2[1])
+            self.c = Constraint(expr=-_e2[2] <= -_e2[1])
             self.c._complementarity_type = 1
         #
         if not _e1[0] is None and not _e1[2] is None:
             if not (_e1[0].__class__ in native_numeric_types or _e1[0].is_constant()):
-                raise RuntimeError("Cannot express a complementarity problem of the form L < v < U _|_ g(x) where L is not a constant value")
+                raise RuntimeError(
+                    "Cannot express a complementarity problem of the form L < v < U _|_ g(x) where L is not a constant value"
+                )
             if not (_e1[2].__class__ in native_numeric_types or _e1[2].is_constant()):
-                raise RuntimeError("Cannot express a complementarity problem of the form L < v < U _|_ g(x) where U is not a constant value")
+                raise RuntimeError(
+                    "Cannot express a complementarity problem of the form L < v < U _|_ g(x) where U is not a constant value"
+                )
             self.v = Var(bounds=(_e1[0], _e1[2]))
             self.ve = Constraint(expr=self.v == _e1[1])
         elif _e1[2] is None:
@@ -145,13 +156,14 @@ class _ComplementarityData(_BlockData):
             # The ComplementarityTuple has a fixed length, so we initialize
             # the _args component and return
             #
-            self._args = ( cc.arg0, cc.arg1 )
+            self._args = (cc.arg0, cc.arg1)
         #
         elif cc.__class__ is tuple:
             if len(cc) != 2:
                 raise ValueError(
                     "Invalid tuple for Complementarity %s (expected 2-tuple):"
-                    "\n\t%s" % (self.name, cc) )
+                    "\n\t%s" % (self.name, cc)
+                )
             self._args = cc
         elif cc is Complementarity.Skip:
             del self.parent_component()[self.index()]
@@ -163,8 +175,8 @@ class _ComplementarityData(_BlockData):
             return self.set_value(tuple(cc))
         else:
             raise ValueError(
-                "Unexpected value for Complementarity %s:\n\t%s"
-                % (self.name, cc) )
+                "Unexpected value for Complementarity %s:\n\t%s" % (self.name, cc)
+            )
 
 
 @ModelComponentFactory.register("Complementarity conditions.")
@@ -187,25 +199,34 @@ class Complementarity(Block):
             return
         cc = _rule(b.parent_block(), idx)
         if cc is None:
-            raise ValueError("""
+            raise ValueError(
+                """
 Invalid complementarity condition.  The complementarity condition
 is None instead of a 2-tuple.  Please modify your rule to return
 Complementarity.Skip instead of None.
 
-Error thrown for Complementarity "%s".""" % ( b.name, ) )
+Error thrown for Complementarity "%s"."""
+                % (b.name,)
+            )
         b.set_value(cc)
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ctype', Complementarity)
         kwargs.setdefault('dense', False)
-        _init = tuple( _arg for _arg in (
-            kwargs.pop('initialize', None),
-            kwargs.pop('rule', None),
-            kwargs.pop('expr', None) ) if _arg is not None )
+        _init = tuple(
+            _arg
+            for _arg in (
+                kwargs.pop('initialize', None),
+                kwargs.pop('rule', None),
+                kwargs.pop('expr', None),
+            )
+            if _arg is not None
+        )
         if len(_init) > 1:
             raise ValueError(
                 "Duplicate initialization: Complementarity() only accepts "
-                "one of 'initialize=', 'rule=', and 'expr='")
+                "one of 'initialize=', 'rule=', and 'expr='"
+            )
         elif _init:
             _init = _init[0]
         else:
@@ -222,10 +243,11 @@ Error thrown for Complementarity "%s".""" % ( b.name, ) )
         # HACK to make the "counted call" syntax work.  We wait until
         # after the base class is set up so that is_indexed() is
         # reliable.
-        if self._init_rule is not None \
-           and self._init_rule.__class__ is IndexedCallInitializer:
+        if (
+            self._init_rule is not None
+            and self._init_rule.__class__ is IndexedCallInitializer
+        ):
             self._init_rule = CountedCallInitializer(self, self._init_rule)
-
 
     def add(self, index, cc):
         """
@@ -241,9 +263,7 @@ Error thrown for Complementarity "%s".""" % ( b.name, ) )
         """
         Return data that will be printed for this component.
         """
-        _table_data = lambda k, v: [
-            v._args[0], v._args[1], v.active,
-        ]
+        _table_data = lambda k, v: [v._args[0], v._args[1], v.active]
 
         # This is a bit weird, but is being implemented to preserve
         # backwards compatibility.  The Complementarity transformation
@@ -262,23 +282,24 @@ Error thrown for Complementarity "%s".""" % ( b.name, ) )
         # updates and a check that we do not break anything in the
         # Book).
         _transformed = not issubclass(self.ctype, Complementarity)
+
         def _conditional_block_printer(ostream, idx, data):
             if _transformed or len(data.component_map()):
                 self._pprint_callback(ostream, idx, data)
 
         return (
-            [("Size", len(self)),
-             ("Index", self._index_set if self.is_indexed() else None),
-             ("Active", self.active),
-             ],
+            [
+                ("Size", len(self)),
+                ("Index", self._index_set if self.is_indexed() else None),
+                ("Active", self.active),
+            ],
             self._data.items(),
-            ( "Arg0","Arg1","Active" ),
+            ("Arg0", "Arg1", "Active"),
             (_table_data, _conditional_block_printer),
-            )
+        )
 
 
 class ScalarComplementarity(_ComplementarityData, Complementarity):
-
     def __init__(self, *args, **kwds):
         _ComplementarityData.__init__(self, self)
         Complementarity.__init__(self, *args, **kwds)
@@ -313,7 +334,7 @@ class ComplementarityList(IndexedComplementarity):
     an index value is not specified.
     """
 
-    End             = (1003,)
+    End = (1003,)
 
     def __init__(self, **kwargs):
         """Constructor"""
@@ -342,7 +363,7 @@ class ComplementarityList(IndexedComplementarity):
         if self._constructed:
             return
         timer = ConstructionTimer(self)
-        self._constructed=True
+        self._constructed = True
 
         if self._init_rule is not None:
             _init = self._init_rule(self.parent_block(), ())
@@ -354,4 +375,3 @@ class ComplementarityList(IndexedComplementarity):
                 self.add(cc)
 
         timer.report()
-

--- a/pyomo/mpec/plugins/__init__.py
+++ b/pyomo/mpec/plugins/__init__.py
@@ -9,6 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+
 def load():
     import pyomo.mpec.plugins.mpec1
     import pyomo.mpec.plugins.mpec2
@@ -17,4 +18,3 @@ def load():
     import pyomo.mpec.plugins.solver1
     import pyomo.mpec.plugins.solver2
     import pyomo.mpec.plugins.pathampl
-

--- a/pyomo/mpec/plugins/mpec2.py
+++ b/pyomo/mpec/plugins/mpec2.py
@@ -12,12 +12,14 @@
 import logging
 
 from pyomo.core.expr import inequality
-from pyomo.core.base import (Transformation,
-                             TransformationFactory,
-                             Constraint,
-                             Block,
-                             SortComponents,
-                             ComponentUID)
+from pyomo.core.base import (
+    Transformation,
+    TransformationFactory,
+    Constraint,
+    Block,
+    SortComponents,
+    ComponentUID,
+)
 from pyomo.mpec.complementarity import Complementarity
 from pyomo.gdp.disjunct import Disjunct, Disjunction
 
@@ -25,10 +27,11 @@ from pyomo.gdp.disjunct import Disjunct, Disjunction
 logger = logging.getLogger('pyomo.core')
 
 
-@TransformationFactory.register('mpec.simple_disjunction', doc="Disjunctive transformations of complementarity conditions when all variables are non-negative")
+@TransformationFactory.register(
+    'mpec.simple_disjunction',
+    doc="Disjunctive transformations of complementarity conditions when all variables are non-negative",
+)
 class MPEC2_Transformation(Transformation):
-
-
     def __init__(self):
         super(MPEC2_Transformation, self).__init__()
 
@@ -41,9 +44,12 @@ class MPEC2_Transformation(Transformation):
         #
         # Iterate over the model finding Complementarity components
         #
-        for complementarity in instance.component_objects(Complementarity, active=True,
-                                                          descend_into=(Block, Disjunct),
-                                                          sort=SortComponents.deterministic):
+        for complementarity in instance.component_objects(
+            Complementarity,
+            active=True,
+            descend_into=(Block, Disjunct),
+            sort=SortComponents.deterministic,
+        ):
             block = complementarity.parent_block()
 
             for index in sorted(complementarity.keys()):
@@ -53,11 +59,22 @@ class MPEC2_Transformation(Transformation):
                 #
                 _e1 = _data._canonical_expression(_data._args[0])
                 _e2 = _data._canonical_expression(_data._args[1])
-                if len(_e1)==3 and len(_e2) == 3 and (_e1[0] is None) + (_e1[2] is None) + (_e2[0] is None) + (_e2[2] is None) != 2:
-                    raise RuntimeError("Complementarity condition %s must have exactly two finite bounds" % _data.name)
+                if (
+                    len(_e1) == 3
+                    and len(_e2) == 3
+                    and (_e1[0] is None)
+                    + (_e1[2] is None)
+                    + (_e2[0] is None)
+                    + (_e2[2] is None)
+                    != 2
+                ):
+                    raise RuntimeError(
+                        "Complementarity condition %s must have exactly two finite bounds"
+                        % _data.name
+                    )
                 if len(_e1) == 3 and _e1[0] is None and _e1[2] is None:
                     #
-                    # Swap _e1 and _e2.  The ensures that 
+                    # Swap _e1 and _e2.  The ensures that
                     # only e2 will be an unconstrained expression
                     #
                     _e1, _e2 = _e2, _e1
@@ -66,17 +83,21 @@ class MPEC2_Transformation(Transformation):
                         _data.c = Constraint(expr=_e1)
                     else:
                         _data.expr1 = Disjunct()
-                        _data.expr1.c0 = Constraint(expr= _e1[0] == _e1[1])
-                        _data.expr1.c1 = Constraint(expr= _e2[1] >= 0)
+                        _data.expr1.c0 = Constraint(expr=_e1[0] == _e1[1])
+                        _data.expr1.c1 = Constraint(expr=_e2[1] >= 0)
                         #
                         _data.expr2 = Disjunct()
-                        _data.expr2.c0 = Constraint(expr= _e1[1] == _e1[2])
-                        _data.expr2.c1 = Constraint(expr= _e2[1] <= 0)
+                        _data.expr2.c0 = Constraint(expr=_e1[1] == _e1[2])
+                        _data.expr2.c1 = Constraint(expr=_e2[1] <= 0)
                         #
                         _data.expr3 = Disjunct()
-                        _data.expr3.c0 = Constraint(expr= inequality(_e1[0], _e1[1], _e1[2]))
-                        _data.expr3.c1 = Constraint(expr= _e2[1] == 0)
-                        _data.complements = Disjunction(expr=(_data.expr1, _data.expr2, _data.expr3))
+                        _data.expr3.c0 = Constraint(
+                            expr=inequality(_e1[0], _e1[1], _e1[2])
+                        )
+                        _data.expr3.c1 = Constraint(expr=_e2[1] == 0)
+                        _data.complements = Disjunction(
+                            expr=(_data.expr1, _data.expr2, _data.expr3)
+                        )
                 else:
                     if _e1[0] is None:
                         tmp1 = _e1[2] - _e1[1]
@@ -87,13 +108,13 @@ class MPEC2_Transformation(Transformation):
                     else:
                         tmp2 = _e2[1] - _e2[0]
                     _data.expr1 = Disjunct()
-                    _data.expr1.c0 = Constraint(expr= tmp1 >= 0)
-                    _data.expr1.c1 = Constraint(expr= tmp2 == 0)
+                    _data.expr1.c0 = Constraint(expr=tmp1 >= 0)
+                    _data.expr1.c1 = Constraint(expr=tmp2 == 0)
                     #
                     _data.expr2 = Disjunct()
-                    _data.expr2.c0 = Constraint(expr= tmp1 == 0)
-                    _data.expr2.c1 = Constraint(expr= tmp2 >= 0)
+                    _data.expr2.c0 = Constraint(expr=tmp1 == 0)
+                    _data.expr2.c1 = Constraint(expr=tmp2 >= 0)
                     #
                     _data.complements = Disjunction(expr=(_data.expr1, _data.expr2))
-            tdata.compl_cuids.append( ComponentUID(complementarity) )
+            tdata.compl_cuids.append(ComponentUID(complementarity))
             block.reclassify_component_type(complementarity, Block)

--- a/pyomo/mpec/plugins/mpec3.py
+++ b/pyomo/mpec/plugins/mpec3.py
@@ -11,10 +11,7 @@
 
 import logging
 
-from pyomo.core.base import (Transformation,
-                             TransformationFactory,
-                             Block,
-                             SortComponents)
+from pyomo.core.base import Transformation, TransformationFactory, Block, SortComponents
 from pyomo.mpec.complementarity import Complementarity
 from pyomo.gdp import Disjunct
 
@@ -22,13 +19,13 @@ logger = logging.getLogger('pyomo.core')
 
 
 #
-# This transformation reworks each Complementarity block to 
+# This transformation reworks each Complementarity block to
 # setup a standard form.
 #
-@TransformationFactory.register('mpec.standard_form', doc="Standard reformulation of complementarity condition")
+@TransformationFactory.register(
+    'mpec.standard_form', doc="Standard reformulation of complementarity condition"
+)
 class MPEC3_Transformation(Transformation):
-
-
     def __init__(self):
         super(MPEC3_Transformation, self).__init__()
 
@@ -36,9 +33,12 @@ class MPEC3_Transformation(Transformation):
         #
         # Iterate over the model finding Complementarity components
         #
-        for complementarity in instance.component_objects(Complementarity, active=True,
-                                                          descend_into=(Block, Disjunct),
-                                                          sort=SortComponents.deterministic):
+        for complementarity in instance.component_objects(
+            Complementarity,
+            active=True,
+            descend_into=(Block, Disjunct),
+            sort=SortComponents.deterministic,
+        ):
             block = complementarity.parent_block()
             for index in sorted(complementarity.keys()):
                 _data = complementarity[index]

--- a/pyomo/mpec/plugins/mpec4.py
+++ b/pyomo/mpec/plugins/mpec4.py
@@ -11,27 +11,29 @@
 
 import logging
 
-from pyomo.core.base import (Transformation,
-                             TransformationFactory,
-                             Constraint,
-                             Var,
-                             Block,
-                             ComponentUID,
-                             SortComponents,
-                             value)
+from pyomo.core.base import (
+    Transformation,
+    TransformationFactory,
+    Constraint,
+    Var,
+    Block,
+    ComponentUID,
+    SortComponents,
+    value,
+)
 from pyomo.mpec.complementarity import Complementarity
 from pyomo.gdp import Disjunct
 
 logger = logging.getLogger('pyomo.core')
 
 #
-# This transformation reworks each Complementarity block to 
+# This transformation reworks each Complementarity block to
 # create a mixed-complementarity problem that can be written to an NL file.
 #
-@TransformationFactory.register('mpec.nl', doc="Transform a MPEC into a form suitable for the NL writer")
+@TransformationFactory.register(
+    'mpec.nl', doc="Transform a MPEC into a form suitable for the NL writer"
+)
 class MPEC4_Transformation(Transformation):
-
-
     def __init__(self):
         super(MPEC4_Transformation, self).__init__()
 
@@ -42,18 +44,24 @@ class MPEC4_Transformation(Transformation):
         free_vars = {}
         id_list = []
         # [ESJ 07/12/2019] Look on the whole model in case instance is a Block or a Disjunct
-        for vdata in instance.model().component_data_objects(Var, active=True,
-                                                             sort=SortComponents.deterministic,
-                                                             descend_into=(Block, Disjunct)):
-            id_list.append( id(vdata) )
+        for vdata in instance.model().component_data_objects(
+            Var,
+            active=True,
+            sort=SortComponents.deterministic,
+            descend_into=(Block, Disjunct),
+        ):
+            id_list.append(id(vdata))
             free_vars[id(vdata)] = vdata
         #
         # Iterate over the Complementarity components
         #
         cobjs = []
-        for cobj in instance.component_objects(Complementarity, active=True,
-                                               descend_into=(Block, Disjunct),
-                                               sort=SortComponents.deterministic):
+        for cobj in instance.component_objects(
+            Complementarity,
+            active=True,
+            descend_into=(Block, Disjunct),
+            sort=SortComponents.deterministic,
+        ):
             cobjs.append(cobj)
             for index in sorted(cobj.keys()):
                 _cdata = cobj[index]
@@ -67,13 +75,13 @@ class MPEC4_Transformation(Transformation):
         tdata = instance._transformation_data['mpec.nl']
         tdata.compl_cuids = []
         for cobj in cobjs:
-            tdata.compl_cuids.append( ComponentUID(cobj) )
+            tdata.compl_cuids.append(ComponentUID(cobj))
             cobj.parent_block().reclassify_component_type(cobj, Block)
 
-    #instance.pprint()
-    #self.print_nl_form(instance)
+    # instance.pprint()
+    # self.print_nl_form(instance)
 
-    def print_nl_form(self, instance):          #pragma:nocover
+    def print_nl_form(self, instance):  # pragma:nocover
         """
         Summarize the complementarity relations in this problem.
         """
@@ -81,9 +89,24 @@ class MPEC4_Transformation(Transformation):
         for vdata in instance.component_data_objects(Var, active=True):
             vmap[id(vdata)] = vdata
         print("-------------------- Complementary Relations ----------------------")
-        for bdata in instance.block_data_objects(active=True, sort=SortComponents.            deterministic):
-            for cobj in bdata.component_data_objects(Constraint, active=True,                 descend_into=False):
-                print("%s %s\t\t\t%s" % (getattr(cobj, '_complementarity', None), str(cobj.   lower)+" < "+str(cobj.body)+" < "+str(cobj.upper) , vmap.get(getattr(cobj, '_vid', None),     None)))
+        for bdata in instance.block_data_objects(
+            active=True, sort=SortComponents.deterministic
+        ):
+            for cobj in bdata.component_data_objects(
+                Constraint, active=True, descend_into=False
+            ):
+                print(
+                    "%s %s\t\t\t%s"
+                    % (
+                        getattr(cobj, '_complementarity', None),
+                        str(cobj.lower)
+                        + " < "
+                        + str(cobj.body)
+                        + " < "
+                        + str(cobj.upper),
+                        vmap.get(getattr(cobj, '_vid', None), None),
+                    )
+                )
         print("-------------------- Complementary Relations ----------------------")
 
     def to_common_form(self, cdata, free_vars):
@@ -92,7 +115,7 @@ class MPEC4_Transformation(Transformation):
         """
         _e1 = cdata._canonical_expression(cdata._args[0])
         _e2 = cdata._canonical_expression(cdata._args[1])
-        if False:                       #pragma:nocover
+        if False:  # pragma:nocover
             if _e1[0] is None:
                 print(None)
             else:
@@ -125,8 +148,13 @@ class MPEC4_Transformation(Transformation):
         if len(_e2) == 2:
             cdata.c = Constraint(expr=_e2)
             return
-        if (_e1[0] is None) + (_e1[2] is None) + (_e2[0] is None) + (_e2[2] is None) != 2:
-            raise RuntimeError("Complementarity condition %s must have exactly two finite bounds" % cdata.name)
+        if (_e1[0] is None) + (_e1[2] is None) + (_e2[0] is None) + (
+            _e2[2] is None
+        ) != 2:
+            raise RuntimeError(
+                "Complementarity condition %s must have exactly two finite bounds"
+                % cdata.name
+            )
         #
         # Swap if the body of the second constraint is not a free variable
         #
@@ -179,4 +207,3 @@ class MPEC4_Transformation(Transformation):
             if var.ub is None or value(_e2[2]) > value(var.ub):
                 var.setub(_e2[2])
             cdata.c._complementarity += 2
-      

--- a/pyomo/mpec/plugins/pathampl.py
+++ b/pyomo/mpec/plugins/pathampl.py
@@ -38,9 +38,11 @@ class PATHAMPL(ASL):
 
     def _default_executable(self):
         executable = Executable("pathampl")
-        if not executable:                      #pragma:nocover
-            logger.warning("Could not locate the 'pathampl' executable, "
-                           "which is required for solver %s" % self.name)
+        if not executable:  # pragma:nocover
+            logger.warning(
+                "Could not locate the 'pathampl' executable, "
+                "which is required for solver %s" % self.name
+            )
             self.enable = False
             return None
         return executable.path()

--- a/pyomo/mpec/plugins/solver1.py
+++ b/pyomo/mpec/plugins/solver1.py
@@ -16,13 +16,13 @@ from pyomo.core import TransformationFactory
 from pyomo.common.collections import Bunch
 
 
-@SolverFactory.register('mpec_nlp', doc='MPEC solver that optimizes a nonlinear transformation')
+@SolverFactory.register(
+    'mpec_nlp', doc='MPEC solver that optimizes a nonlinear transformation'
+)
 class MPEC_Solver1(pyomo.opt.OptSolver):
-
-
     def __init__(self, **kwds):
         kwds['type'] = 'mpec_nlp'
-        pyomo.opt.OptSolver.__init__(self,**kwds)
+        pyomo.opt.OptSolver.__init__(self, **kwds)
         self._metasolver = True
 
     def _presolve(self, *args, **kwds):
@@ -43,7 +43,7 @@ class MPEC_Solver1(pyomo.opt.OptSolver):
         # Solve with a specified solver
         #
         solver = self.options.solver
-        if not self.options.solver:                 #pragma:nocover
+        if not self.options.solver:  # pragma:nocover
             self.options.solver = solver = 'ipopt'
 
         # use the with block here so that deactivation of the
@@ -53,7 +53,7 @@ class MPEC_Solver1(pyomo.opt.OptSolver):
             self.results = []
             epsilon_final = self.options.get('epsilon_final', 1e-7)
             epsilon = self.options.get('epsilon_initial', epsilon_final)
-            while (True):
+            while True:
                 self._instance.mpec_bound.set_value(epsilon)
                 #
                 # **NOTE: It would be better to override _presolve on the
@@ -63,9 +63,9 @@ class MPEC_Solver1(pyomo.opt.OptSolver):
                 #         io_options are getting relayed to the subsolver
                 #         here).
                 #
-                res = opt.solve(self._instance,
-                                tee=self._tee,
-                                timelimit=self._timelimit)
+                res = opt.solve(
+                    self._instance, tee=self._tee, timelimit=self._timelimit
+                )
                 self.results.append(res)
                 epsilon /= 10.0
                 if epsilon < epsilon_final:
@@ -74,7 +74,10 @@ class MPEC_Solver1(pyomo.opt.OptSolver):
             # Reclassify the Complementarity components
             #
             from pyomo.mpec import Complementarity
-            for cuid in self._instance._transformation_data['mpec.simple_nonlinear'].compl_cuids:
+
+            for cuid in self._instance._transformation_data[
+                'mpec.simple_nonlinear'
+            ].compl_cuids:
                 cobj = cuid.find_component_on(self._instance)
                 cobj.parent_block().reclassify_component_type(cobj, Complementarity)
             #
@@ -85,8 +88,7 @@ class MPEC_Solver1(pyomo.opt.OptSolver):
             #
             # Return the sub-solver return condition value and log
             #
-            return Bunch(rc=getattr(opt,'_rc', None),
-                                       log=getattr(opt,'_log',None))
+            return Bunch(rc=getattr(opt, '_rc', None), log=getattr(opt, '_log', None))
 
     def _postsolve(self):
         #
@@ -100,12 +102,12 @@ class MPEC_Solver1(pyomo.opt.OptSolver):
         solv.name = self.options.subsolver
         solv.wallclock_time = self.wall_time
         cpu_ = []
-        for res in self.results:                    #pragma:nocover
+        for res in self.results:  # pragma:nocover
             if not getattr(res.solver, 'cpu_time', None) is None:
-                cpu_.append( res.solver.cpu_time )
-        if len(cpu_) > 0:                           #pragma:nocover
+                cpu_.append(res.solver.cpu_time)
+        if len(cpu_) > 0:  # pragma:nocover
             solv.cpu_time = sum(cpu_)
-        #solv.termination_condition = pyomo.opt.TerminationCondition.maxIterations
+        # solv.termination_condition = pyomo.opt.TerminationCondition.maxIterations
         #
         # PROBLEM
         #
@@ -114,9 +116,15 @@ class MPEC_Solver1(pyomo.opt.OptSolver):
         prob.name = self._instance.name
         prob.number_of_constraints = self._instance.statistics.number_of_constraints
         prob.number_of_variables = self._instance.statistics.number_of_variables
-        prob.number_of_binary_variables = self._instance.statistics.number_of_binary_variables
-        prob.number_of_integer_variables = self._instance.statistics.number_of_integer_variables
-        prob.number_of_continuous_variables = self._instance.statistics.number_of_continuous_variables
+        prob.number_of_binary_variables = (
+            self._instance.statistics.number_of_binary_variables
+        )
+        prob.number_of_integer_variables = (
+            self._instance.statistics.number_of_integer_variables
+        )
+        prob.number_of_continuous_variables = (
+            self._instance.statistics.number_of_continuous_variables
+        )
         prob.number_of_objectives = self._instance.statistics.number_of_objectives
         #
         # SOLUTION(S)

--- a/pyomo/mpec/plugins/solver2.py
+++ b/pyomo/mpec/plugins/solver2.py
@@ -18,11 +18,9 @@ from pyomo.common.collections import Bunch
 
 @SolverFactory.register('mpec_minlp', doc='MPEC solver transforms to a MINLP')
 class MPEC_Solver2(pyomo.opt.OptSolver):
-
-
     def __init__(self, **kwds):
         kwds['type'] = 'mpec_minlp'
-        pyomo.opt.OptSolver.__init__(self,**kwds)
+        pyomo.opt.OptSolver.__init__(self, **kwds)
         self._metasolver = True
 
     def _presolve(self, *args, **kwds):
@@ -41,12 +39,12 @@ class MPEC_Solver2(pyomo.opt.OptSolver):
         xfrm.apply_to(self._instance)
 
         xfrm = TransformationFactory('gdp.bigm')
-        xfrm.apply_to(self._instance, bigM=self.options.get('bigM',10**6))
+        xfrm.apply_to(self._instance, bigM=self.options.get('bigM', 10**6))
         #
         # Solve with a specified solver
         #
         solver = self.options.solver
-        if not self.options.solver:                     #pragma:nocover
+        if not self.options.solver:  # pragma:nocover
             self.options.solver = solver = 'glpk'
 
         # use the with block here so that deactivation of the
@@ -61,14 +59,17 @@ class MPEC_Solver2(pyomo.opt.OptSolver):
             #         io_options are getting relayed to the subsolver
             #         here).
             #
-            self.results = opt.solve(self._instance,
-                                     tee=self._tee,
-                                     timelimit=self._timelimit)
+            self.results = opt.solve(
+                self._instance, tee=self._tee, timelimit=self._timelimit
+            )
             #
             # Reclassify the Complementarity components
             #
             from pyomo.mpec import Complementarity
-            for cuid in self._instance._transformation_data['mpec.simple_disjunction'].compl_cuids:
+
+            for cuid in self._instance._transformation_data[
+                'mpec.simple_disjunction'
+            ].compl_cuids:
                 cobj = cuid.find_component_on(self._instance)
                 cobj.parent_block().reclassify_component_type(cobj, Complementarity)
             #
@@ -84,8 +85,7 @@ class MPEC_Solver2(pyomo.opt.OptSolver):
             #
             # Return the sub-solver return condition value and log
             #
-            return Bunch(rc=getattr(opt,'_rc', None),
-                                       log=getattr(opt,'_log',None))
+            return Bunch(rc=getattr(opt, '_rc', None), log=getattr(opt, '_log', None))
 
     def _postsolve(self):
         #
@@ -106,4 +106,3 @@ class MPEC_Solver2(pyomo.opt.OptSolver):
         # Return the results
         #
         return self.results
-

--- a/pyomo/mpec/tests/test_complementarity.py
+++ b/pyomo/mpec/tests/test_complementarity.py
@@ -25,8 +25,13 @@ from pyomo.common.fileutils import this_file_dir
 from pyomo.common.tee import capture_output
 from pyomo.common.tempfiles import TempfileManager
 from pyomo.core import (
-    ConcreteModel, Var, Constraint, TransformationFactory, Objective,
-    Block, inequality
+    ConcreteModel,
+    Var,
+    Constraint,
+    TransformationFactory,
+    Objective,
+    Block,
+    inequality,
 )
 from pyomo.gdp import Disjunct, Disjunction
 from pyomo.mpec import Complementarity, complements, ComplementarityList
@@ -36,8 +41,8 @@ from pyomo.repn.tests.ampl.nl_diff import load_and_compare_nl_baseline
 
 currdir = this_file_dir()
 
-class CCTests(object):
 
+class CCTests(object):
     @classmethod
     def setUpClass(cls):
         import pyomo.environ
@@ -63,8 +68,9 @@ class CCTests(object):
             with capture_output(ofile):
                 self._print(M)
             try:
-                self.assertTrue(cmp(ofile, bfile),
-                                msg="Files %s and %s differ" % (ofile, bfile))
+                self.assertTrue(
+                    cmp(ofile, bfile), msg="Files %s and %s differ" % (ofile, bfile)
+                )
             except:
                 with open(ofile, 'r') as f1, open(bfile, 'r') as f2:
                     f1_contents = list(filter(None, f1.read().split()))
@@ -75,22 +81,27 @@ class CCTests(object):
         # y + x1 >= 0  _|_  x1 + 2*x2 + 3*x3 >= 1
         M = self._setup()
         M.c = Constraint(expr=M.y + M.x3 >= M.x2)
-        M.cc = Complementarity(expr=complements(M.y + M.x1 >= 0, M.x1 + 2*M.x2 + 3*M.x3 >= 1))
+        M.cc = Complementarity(
+            expr=complements(M.y + M.x1 >= 0, M.x1 + 2 * M.x2 + 3 * M.x3 >= 1)
+        )
         self._test("t1a", M)
 
     def test_t1b(self):
         # Reversing the expressions in test t1a:
         #    x1 + 2*x2 + 3*x3 >= 1  _|_  y + x1 >= 0
         M = self._setup()
-        M.cc = Complementarity(expr=complements(M.x1 + 2*M.x2 + 3*M.x3 >= 1, M.y + M.x1 >= 0))
+        M.cc = Complementarity(
+            expr=complements(M.x1 + 2 * M.x2 + 3 * M.x3 >= 1, M.y + M.x1 >= 0)
+        )
         self._test("t1b", M)
 
     def test_t1c(self):
         # y >= - x1  _|_  x1 + 2*x2 >= 1 - 3*x3
         M = self._setup()
-        M.cc = Complementarity(expr=complements(M.y >= - M.x1, M.x1 + 2*M.x2 >= 1 - 3*M.x3))
+        M.cc = Complementarity(
+            expr=complements(M.y >= -M.x1, M.x1 + 2 * M.x2 >= 1 - 3 * M.x3)
+        )
         self._test("t1c", M)
-
 
     def test_t2a(self):
         # y + x2 >= 0  _|_  x2 - x3 <= -1
@@ -105,7 +116,6 @@ class CCTests(object):
         M.cc = Complementarity(expr=complements(M.x2 - M.x3 <= -1, M.y + M.x2 >= 0))
         self._test("t2b", M)
 
-
     def test_t3a(self):
         # y + x3 >= 0  _|_  x1 + x2 >= -1
         M = self._setup()
@@ -119,37 +129,43 @@ class CCTests(object):
         M.cc = Complementarity(expr=complements(M.x1 + M.x2 >= -1, M.y + M.x3 >= 0))
         self._test("t3b", M)
 
-
     def test_t4a(self):
         # x1 + 2*x2 + 3*x3 = 1  _|_  y + x3
         M = self._setup()
-        M.cc = Complementarity(expr=complements(M.x1 + 2*M.x2 + 3*M.x3 == 1, M.y + M.x3))
+        M.cc = Complementarity(
+            expr=complements(M.x1 + 2 * M.x2 + 3 * M.x3 == 1, M.y + M.x3)
+        )
         self._test("t4a", M)
 
     def test_t4b(self):
         # Reversing the expressions in test t7b:
         #    y + x3  _|_  x1 + 2*x2 + 3*x3 = 1
         M = self._setup()
-        M.cc = Complementarity(expr=complements(M.y + M.x3, M.x1 + 2*M.x2 + 3*M.x3 == 1))
+        M.cc = Complementarity(
+            expr=complements(M.y + M.x3, M.x1 + 2 * M.x2 + 3 * M.x3 == 1)
+        )
         self._test("t4b", M)
 
     def test_t4c(self):
         # 1 = x1 + 2*x2 + 3*x3  _|_  y + x3
         M = self._setup()
-        M.cc = Complementarity(expr=complements(1 == M.x1 + 2*M.x2 + 3*M.x3, M.y + M.x3))
+        M.cc = Complementarity(
+            expr=complements(1 == M.x1 + 2 * M.x2 + 3 * M.x3, M.y + M.x3)
+        )
         self._test("t4c", M)
 
     def test_t4d(self):
         # x1 + 2*x2 == 1 - 3*x3  _|_  y + x3
         M = self._setup()
-        M.cc = Complementarity(expr=complements(M.x1 + 2*M.x2 == 1 - 3*M.x3, M.y + M.x3))
+        M.cc = Complementarity(
+            expr=complements(M.x1 + 2 * M.x2 == 1 - 3 * M.x3, M.y + M.x3)
+        )
         self._test("t4d", M)
-
 
     def test_t9(self):
         # Testing that we can skip deactivated complementarity conditions
         M = self._setup()
-        M.cc = Complementarity(expr=complements(M.y + M.x3, M.x1 + 2*M.x2 == 1))
+        M.cc = Complementarity(expr=complements(M.y + M.x3, M.x1 + 2 * M.x2 == 1))
         M.cc.deactivate()
         # AMPL needs at least one variable in the problem therefore
         # we need to have a constraint that keeps them around
@@ -159,9 +175,11 @@ class CCTests(object):
     def test_t10(self):
         # Testing that we can skip an array of deactivated complementarity conditions
         M = self._setup()
+
         def f(model, i):
-            return complements(M.y + M.x3, M.x1 + 2*M.x2 == i)
-        M.cc = Complementarity([0,1,2], rule=f)
+            return complements(M.y + M.x3, M.x1 + 2 * M.x2 == i)
+
+        M.cc = Complementarity([0, 1, 2], rule=f)
         M.cc[1].deactivate()
         self._test("t10", M)
 
@@ -180,47 +198,55 @@ class CCTests(object):
     def test_t13(self):
         # Testing that we can skip an array of deactivated complementarity conditions
         M = self._setup()
+
         def f(model, i):
             if i == 0:
-                return complements(M.y + M.x3, M.x1 + 2*M.x2 == 0)
+                return complements(M.y + M.x3, M.x1 + 2 * M.x2 == 0)
             if i == 1:
                 return Complementarity.Skip
             if i == 2:
-                return complements(M.y + M.x3, M.x1 + 2*M.x2 == 2)
-        M.cc = Complementarity([0,1,2], rule=f)
+                return complements(M.y + M.x3, M.x1 + 2 * M.x2 == 2)
+
+        M.cc = Complementarity([0, 1, 2], rule=f)
         self._test("t13", M)
 
     def test_cov2(self):
         # Testing warning for no rule"""
         M = self._setup()
-        M.cc = Complementarity([0,1,2])
+        M.cc = Complementarity([0, 1, 2])
         # AMPL needs at least one variable in the problem therefore
         # we need to have a constraint that keeps them around
-        M.keep_var_con = Constraint(expr=M.x1 == 0.5)        
+        M.keep_var_con = Constraint(expr=M.x1 == 0.5)
         self._test("cov2", M)
 
     def test_cov4(self):
         # Testing construction with no indexing and a rule
         M = self._setup()
+
         def f(model):
-            return complements(M.y + M.x3, M.x1 + 2*M.x2 == 1)
+            return complements(M.y + M.x3, M.x1 + 2 * M.x2 == 1)
+
         M.cc = Complementarity(rule=f)
         self._test("cov4", M)
 
     def test_cov5(self):
         # Testing construction with rules that generate an exception
         M = self._setup()
+
         def f(model):
             raise IOError("cov5 error")
+
         try:
             M.cc1 = Complementarity(rule=f)
             self.fail("Expected an IOError")
         except IOError:
             pass
+
         def f(model, i):
             raise IOError("cov5 error")
+
         try:
-            M.cc2 = Complementarity([0,1], rule=f)
+            M.cc2 = Complementarity([0, 1], rule=f)
             self.fail("Expected an IOError")
         except IOError:
             pass
@@ -228,29 +254,34 @@ class CCTests(object):
     def test_cov6(self):
         # Testing construction with indexing and an expression
         M = self._setup()
-        with self.assertRaisesRegex(
-                ValueError, "Invalid tuple for Complementarity"):
-            M.cc = Complementarity([0,1], expr=())
+        with self.assertRaisesRegex(ValueError, "Invalid tuple for Complementarity"):
+            M.cc = Complementarity([0, 1], expr=())
 
     def test_cov7(self):
         # Testing error checking with return value
         M = self._setup()
+
         def f(model):
             return ()
+
         try:
             M.cc = Complementarity(rule=f)
             self.fail("Expected ValueError")
         except ValueError:
             pass
+
         def f(model):
             return
+
         try:
             M.cc = Complementarity(rule=f)
             self.fail("Expected ValueError")
         except ValueError:
             pass
+
         def f(model):
             return {}
+
         try:
             M.cc = Complementarity(rule=f)
             self.fail("Expected ValueError")
@@ -260,16 +291,20 @@ class CCTests(object):
     def test_cov8(self):
         # Testing construction with a list
         M = self._setup()
+
         def f(model):
-            return [M.y + M.x3, M.x1 + 2*M.x2 == 1]
+            return [M.y + M.x3, M.x1 + 2 * M.x2 == 1]
+
         M.cc = Complementarity(rule=f)
         self._test("cov8", M)
 
     def test_cov9(self):
         # Testing construction with a tuple
         M = self._setup()
+
         def f(model):
-            return (M.y + M.x3, M.x1 + 2*M.x2 == 1)
+            return (M.y + M.x3, M.x1 + 2 * M.x2 == 1)
+
         M.cc = Complementarity(rule=f)
         self._test("cov8", M)
 
@@ -296,44 +331,47 @@ class CCTests(object):
     def test_list1(self):
         M = self._setup()
         M.cc = ComplementarityList()
-        M.cc.add( complements(M.y + M.x3, M.x1 + 2*M.x2 == 0) )
-        M.cc.add( complements(M.y + M.x3, M.x1 + 2*M.x2 == 2) )
+        M.cc.add(complements(M.y + M.x3, M.x1 + 2 * M.x2 == 0))
+        M.cc.add(complements(M.y + M.x3, M.x1 + 2 * M.x2 == 2))
         self._test("list1", M)
 
     def test_list2(self):
         M = self._setup()
         M.cc = ComplementarityList()
-        M.cc.add( complements(M.y + M.x3, M.x1 + 2*M.x2 == 0) )
-        M.cc.add( complements(M.y + M.x3, M.x1 + 2*M.x2 == 1) )
-        M.cc.add( complements(M.y + M.x3, M.x1 + 2*M.x2 == 2) )
+        M.cc.add(complements(M.y + M.x3, M.x1 + 2 * M.x2 == 0))
+        M.cc.add(complements(M.y + M.x3, M.x1 + 2 * M.x2 == 1))
+        M.cc.add(complements(M.y + M.x3, M.x1 + 2 * M.x2 == 2))
         M.cc[2].deactivate()
         self._test("list2", M)
 
     def test_list3(self):
         M = self._setup()
+
         def f(M, i):
             if i == 1:
-                return complements(M.y + M.x3, M.x1 + 2*M.x2 == 0)
+                return complements(M.y + M.x3, M.x1 + 2 * M.x2 == 0)
             elif i == 2:
-                return complements(M.y + M.x3, M.x1 + 2*M.x2 == 2)
+                return complements(M.y + M.x3, M.x1 + 2 * M.x2 == 2)
             return ComplementarityList.End
+
         M.cc = ComplementarityList(rule=f)
         self._test("list1", M)
 
     def test_list4(self):
         M = self._setup()
+
         def f(M):
-            yield complements(M.y + M.x3, M.x1 + 2*M.x2 == 0)
-            yield complements(M.y + M.x3, M.x1 + 2*M.x2 == 2)
+            yield complements(M.y + M.x3, M.x1 + 2 * M.x2 == 0)
+            yield complements(M.y + M.x3, M.x1 + 2 * M.x2 == 2)
             yield ComplementarityList.End
+
         M.cc = ComplementarityList(rule=f)
         self._test("list1", M)
 
     def test_list5(self):
         M = self._setup()
         M.cc = ComplementarityList(
-            rule=( complements(M.y + M.x3, M.x1 + 2*M.x2 == i)
-                   for i in range(3) )
+            rule=(complements(M.y + M.x3, M.x1 + 2 * M.x2 == i) for i in range(3))
         )
         self._test("list5", M)
 
@@ -347,16 +385,20 @@ class CCTests(object):
 
     def test_list7(self):
         M = self._setup()
+
         def f(M):
             return None
+
         try:
             M.cc = ComplementarityList(rule=f)
             self.fail("Expected a ValueError")
         except:
             pass
         M = self._setup()
+
         def f(M):
             yield None
+
         try:
             M.cc = ComplementarityList(rule=f)
             self.fail("Expected a ValueError")
@@ -403,13 +445,11 @@ class CCTests_nl_nlxfrm(CCTests):
             M.write(
                 ofile,
                 format=self._nl_version,
-                io_options={
-                    'symbolic_solver_labels': False,
-                    'file_determinism': fd,
-                }
+                io_options={'symbolic_solver_labels': False, 'file_determinism': fd},
             )
-            self.assertEqual(*load_and_compare_nl_baseline(
-                bfile, ofile, self._nl_version))
+            self.assertEqual(
+                *load_and_compare_nl_baseline(bfile, ofile, self._nl_version)
+            )
 
 
 class CCTests_nl_nlxfrm_nlv1(CCTests_nl_nlxfrm, unittest.TestCase):
@@ -428,7 +468,7 @@ class DescendIntoDisjunct(unittest.TestCase):
         m.obj = Objective(expr=m.x)
 
         m.disjunct1 = Disjunct()
-        m.disjunct1.comp = Complementarity(expr=complements(m.x >= 0, 4*m.x - 3 >= 0))
+        m.disjunct1.comp = Complementarity(expr=complements(m.x >= 0, 4 * m.x - 3 >= 0))
         m.disjunct2 = Disjunct()
         m.disjunct2.cons = Constraint(expr=m.x >= 2)
 
@@ -453,7 +493,7 @@ class DescendIntoDisjunct(unittest.TestCase):
         m = self.get_model()
         TransformationFactory('mpec.simple_disjunction').apply_to(m.disjunct1)
         self.check_simple_disjunction(m)
-    
+
     def check_simple_nonlinear(self, m):
         # check that we have what we expect on disjunct1
         compBlock = m.disjunct1.component('comp')
@@ -470,6 +510,7 @@ class DescendIntoDisjunct(unittest.TestCase):
 
     def test_simple_nonlinear_on_disjunct(self):
         m = self.get_model()
+
     def check_standard_form(self, m):
         # check that we have what we expect on disjunct1
         compBlock = m.disjunct1.component('comp')
@@ -504,6 +545,7 @@ class DescendIntoDisjunct(unittest.TestCase):
         m = self.get_model()
         TransformationFactory('mpec.nl').apply_to(m.disjunct1)
         self.check_nl(m)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/mpec/tests/test_minlp.py
+++ b/pyomo/mpec/tests/test_minlp.py
@@ -15,8 +15,9 @@
 
 import os
 from os.path import abspath, dirname, normpath, join
+
 currdir = dirname(abspath(__file__))
-exdir = normpath(join(currdir,'..','..','..','examples','mpec'))
+exdir = normpath(join(currdir, '..', '..', '..', 'examples', 'mpec'))
 
 import pyomo.common.unittest as unittest
 
@@ -27,17 +28,18 @@ from pyomo.scripting.util import cleanup
 
 solvers = pyomo.opt.check_available_solvers('cplex', 'glpk')
 
+
 class CommonTests:
 
     solve = True
-    solver='mpec_minlp'
+    solver = 'mpec_minlp'
 
     def run_solver(self, *_args, **kwds):
         if self.solve:
             args = ['solve']
             if 'solver' in kwds:
-                _solver = kwds.get('solver','glpk')
-                args.append('--solver='+self.solver)
+                _solver = kwds.get('solver', 'glpk')
+                args.append('--solver=' + self.solver)
                 args.append('--solver-options="solver=%s"' % _solver)
             args.append('--save-results=result.yml')
             args.append('--results-format=yaml')
@@ -47,12 +49,12 @@ class CommonTests:
 
         # These were being ignored by the solvers for this package,
         # which now causes a helpful error message.
-        #args.append('--symbolic-solver-labels')
-        #args.append('--file-determinism=2')
+        # args.append('--symbolic-solver-labels')
+        # args.append('--file-determinism=2')
 
         if False:
             args.append('--stream-solver')
-            args.append('--tempdir='+currdir)
+            args.append('--tempdir=' + currdir)
             args.append('--keepfiles')
             args.append('--logging=debug')
 
@@ -60,7 +62,7 @@ class CommonTests:
         os.chdir(currdir)
 
         print('***')
-        #print(' '.join(args))
+        # print(' '.join(args))
         try:
             output = pyomo_main.main(args)
         except SystemExit:
@@ -73,10 +75,10 @@ class CommonTests:
         return output
 
     def referenceFile(self, problem, solver):
-        return join(currdir, problem+'.txt')
+        return join(currdir, problem + '.txt')
 
     def getObjective(self, fname):
-        FILE = open(fname,'r')
+        FILE = open(fname, 'r')
         data = yaml.load(FILE, **yaml_load_args)
         FILE.close()
         solutions = data.get('Solution', [])
@@ -88,37 +90,38 @@ class CommonTests:
     def updateDocStrings(self):
         for key in dir(self):
             if key.startswith('test'):
-                getattr(self,key).__doc__ = " (%s)" % getattr(self,key).__name__
+                getattr(self, key).__doc__ = " (%s)" % getattr(self, key).__name__
 
     def test_linear1(self):
-        self.problem='test_linear1'
-        self.run_solver( join(exdir,'linear1.py') )
-        self.check( 'linear1', self.solver )
+        self.problem = 'test_linear1'
+        self.run_solver(join(exdir, 'linear1.py'))
+        self.check('linear1', self.solver)
 
     def test_scholtes4(self):
-        self.problem='test_scholtes4'
-        self.run_solver( join(exdir,'scholtes4.py') )
-        self.check( 'scholtes4', self.solver )
+        self.problem = 'test_scholtes4'
+        self.run_solver(join(exdir, 'scholtes4.py'))
+        self.check('scholtes4', self.solver)
 
     def check(self, problem, solver):
-        refObj = self.getObjective(self.referenceFile(problem,solver))
-        ansObj = self.getObjective(join(currdir,'result.yml'))
+        refObj = self.getObjective(self.referenceFile(problem, solver))
+        ansObj = self.getObjective(join(currdir, 'result.yml'))
         self.assertEqual(len(refObj), len(ansObj))
         for i in range(len(refObj)):
             self.assertEqual(len(refObj[i]), len(ansObj[i]))
-            for key,val in refObj[i].items():
-                self.assertAlmostEqual(val['Value'], ansObj[i].get(key,None)['Value'], places=3)
+            for key, val in refObj[i].items():
+                self.assertAlmostEqual(
+                    val['Value'], ansObj[i].get(key, None)['Value'], places=3
+                )
 
 
 @unittest.skipIf(not yaml_available, "YAML is not available")
 @unittest.skipIf(not 'glpk' in solvers, "The 'glpk' executable is not available")
 class Solve_GLPK(unittest.TestCase, CommonTests):
-
     def tearDown(self):
-        if os.path.exists(os.path.join(currdir,'result.yml')):
-            os.remove(os.path.join(currdir,'result.yml'))
+        if os.path.exists(os.path.join(currdir, 'result.yml')):
+            os.remove(os.path.join(currdir, 'result.yml'))
 
-    def run_solver(self,  *args, **kwds):
+    def run_solver(self, *args, **kwds):
         kwds['solver'] = 'glpk'
         CommonTests.run_solver(self, *args, **kwds)
 
@@ -126,12 +129,11 @@ class Solve_GLPK(unittest.TestCase, CommonTests):
 @unittest.skipIf(not yaml_available, "YAML is not available")
 @unittest.skipIf(not 'cplex' in solvers, "The 'cplex' executable is not available")
 class Solve_CPLEX(unittest.TestCase, CommonTests):
-
     def tearDown(self):
-        if os.path.exists(os.path.join(currdir,'result.yml')):
-            os.remove(os.path.join(currdir,'result.yml'))
+        if os.path.exists(os.path.join(currdir, 'result.yml')):
+            os.remove(os.path.join(currdir, 'result.yml'))
 
-    def run_solver(self,  *args, **kwds):
+    def run_solver(self, *args, **kwds):
         kwds['solver'] = 'cplex'
         CommonTests.run_solver(self, *args, **kwds)
 

--- a/pyomo/mpec/tests/test_nlp.py
+++ b/pyomo/mpec/tests/test_nlp.py
@@ -15,6 +15,7 @@
 
 import os
 from os.path import abspath, dirname, normpath, join
+
 currdir = dirname(abspath(__file__))
 exdir = normpath(join(currdir, '..', '..', '..', 'examples', 'mpec'))
 
@@ -31,14 +32,14 @@ solvers = pyomo.opt.check_available_solvers('ipopt')
 class CommonTests:
 
     solve = True
-    solver='mpec_nlp'
+    solver = 'mpec_nlp'
 
     def run_solver(self, *_args, **kwds):
         if self.solve:
             args = ['solve']
             if 'solver' in kwds:
-                _solver = kwds.get('solver','glpk')
-                args.append('--solver='+self.solver)
+                _solver = kwds.get('solver', 'glpk')
+                args.append('--solver=' + self.solver)
                 args.append('--solver-options="solver=%s"' % _solver)
             args.append('--save-results=result.yml')
             args.append('--results-format=yaml')
@@ -48,12 +49,12 @@ class CommonTests:
 
         # These were being ignored by the solvers for this package,
         # which now causes a helpful error message.
-        #args.append('--symbolic-solver-labels')
-        #args.append('--file-determinism=2')
+        # args.append('--symbolic-solver-labels')
+        # args.append('--file-determinism=2')
 
         if False:
             args.append('--stream-solver')
-            args.append('--tempdir='+currdir)
+            args.append('--tempdir=' + currdir)
             args.append('--keepfiles')
             args.append('--logging=debug')
 
@@ -61,7 +62,7 @@ class CommonTests:
         os.chdir(currdir)
 
         print('***')
-        #print(' '.join(args))
+        # print(' '.join(args))
         try:
             output = pyomo_main.main(args)
         except SystemExit:
@@ -74,10 +75,10 @@ class CommonTests:
         return output
 
     def referenceFile(self, problem, solver):
-        return join(currdir, problem+'.txt')
+        return join(currdir, problem + '.txt')
 
     def getObjective(self, fname):
-        FILE = open(fname,'r')
+        FILE = open(fname, 'r')
         data = yaml.load(FILE, **yaml_load_args)
         FILE.close()
         solutions = data.get('Solution', [])
@@ -89,42 +90,43 @@ class CommonTests:
     def updateDocStrings(self):
         for key in dir(self):
             if key.startswith('test'):
-                getattr(self,key).__doc__ = " (%s)" % getattr(self,key).__name__
+                getattr(self, key).__doc__ = " (%s)" % getattr(self, key).__name__
 
     def test_linear1(self):
-        self.problem='test_linear1'
-        self.run_solver( join(exdir,'linear1.py') )
-        self.check( 'linear1', self.solver )
+        self.problem = 'test_linear1'
+        self.run_solver(join(exdir, 'linear1.py'))
+        self.check('linear1', self.solver)
 
     def test_bard1(self):
-        self.problem='test_bard1'
-        self.run_solver( join(exdir,'bard1.py') )
-        self.check( 'bard1', self.solver )
+        self.problem = 'test_bard1'
+        self.run_solver(join(exdir, 'bard1.py'))
+        self.check('bard1', self.solver)
 
     def test_scholtes4(self):
-        self.problem='test_scholtes4'
-        self.run_solver( join(exdir,'scholtes4.py') )
-        self.check( 'scholtes4', self.solver )
+        self.problem = 'test_scholtes4'
+        self.run_solver(join(exdir, 'scholtes4.py'))
+        self.check('scholtes4', self.solver)
 
     def check(self, problem, solver):
-        refObj = self.getObjective(self.referenceFile(problem,solver))
-        ansObj = self.getObjective(join(currdir,'result.yml'))
+        refObj = self.getObjective(self.referenceFile(problem, solver))
+        ansObj = self.getObjective(join(currdir, 'result.yml'))
         self.assertEqual(len(refObj), len(ansObj))
         for i in range(len(refObj)):
             self.assertEqual(len(refObj[i]), len(ansObj[i]))
-            for key,val in refObj[i].items():
-                self.assertAlmostEqual(val['Value'], ansObj[i].get(key,None)['Value'], places=2)
+            for key, val in refObj[i].items():
+                self.assertAlmostEqual(
+                    val['Value'], ansObj[i].get(key, None)['Value'], places=2
+                )
 
 
 @unittest.skipIf(not yaml_available, "YAML is not available")
 @unittest.skipIf(not 'ipopt' in solvers, "The 'ipopt' executable is not available")
 class Solve_IPOPT(unittest.TestCase, CommonTests):
-
     def tearDown(self):
-        if os.path.exists(os.path.join(currdir,'result.yml')):
-            os.remove(os.path.join(currdir,'result.yml'))
+        if os.path.exists(os.path.join(currdir, 'result.yml')):
+            os.remove(os.path.join(currdir, 'result.yml'))
 
-    def run_solver(self,  *args, **kwds):
+    def run_solver(self, *args, **kwds):
         kwds['solver'] = 'ipopt'
         CommonTests.run_solver(self, *args, **kwds)
 

--- a/pyomo/mpec/tests/test_path.py
+++ b/pyomo/mpec/tests/test_path.py
@@ -31,15 +31,16 @@ exdir = os.path.join(PYOMO_ROOT_DIR, 'examples', 'mpec')
 
 solvers = pyomo.opt.check_available_solvers('path')
 
+
 class CommonTests:
 
     solve = True
-    solver='path'
+    solver = 'path'
 
     def run_solver(self, *_args, **kwds):
         if self.solve:
             args = ['solve']
-            args.append('--solver='+self.solver)
+            args.append('--solver=' + self.solver)
             args.append('--save-results=result.yml')
             args.append('--results-format=yaml')
             args.append('--solver-options="lemke_start=automatic output_options=yes"')
@@ -51,7 +52,7 @@ class CommonTests:
 
         if False:
             args.append('--stream-solver')
-            args.append('--tempdir='+currdir)
+            args.append('--tempdir=' + currdir)
             args.append('--keepfiles')
             args.append('--logging=debug')
 
@@ -72,10 +73,10 @@ class CommonTests:
         return output
 
     def referenceFile(self, problem, solver):
-        return os.path.join(currdir, problem+'.txt')
+        return os.path.join(currdir, problem + '.txt')
 
     def getObjective(self, fname):
-        FILE = open(fname,'r')
+        FILE = open(fname, 'r')
         data = yaml.load(FILE, **yaml_load_args)
         FILE.close()
         solutions = data.get('Solution', [])
@@ -87,47 +88,48 @@ class CommonTests:
     def updateDocStrings(self):
         for key in dir(self):
             if key.startswith('test'):
-                getattr(self,key).__doc__ = " (%s)" % getattr(self,key).__name__
+                getattr(self, key).__doc__ = " (%s)" % getattr(self, key).__name__
 
     def test_munson1a(self):
-        self.problem='test_munson1a'
-        self.run_solver(os.path.join(exdir,'munson1a.py'))
+        self.problem = 'test_munson1a'
+        self.run_solver(os.path.join(exdir, 'munson1a.py'))
         self.check('munson1a', self.solver)
 
     def test_munson1b(self):
-        self.problem='test_munson1b'
-        self.run_solver(os.path.join(exdir,'munson1b.py'))
+        self.problem = 'test_munson1b'
+        self.run_solver(os.path.join(exdir, 'munson1b.py'))
         self.check('munson1b', self.solver)
 
     def test_munson1c(self):
-        self.problem='test_munson1c'
-        self.run_solver(os.path.join(exdir,'munson1c.py'))
+        self.problem = 'test_munson1c'
+        self.run_solver(os.path.join(exdir, 'munson1c.py'))
         self.check('munson1c', self.solver)
 
     def test_munson1d(self):
-        self.problem='test_munson1d'
-        self.run_solver(os.path.join(exdir,'munson1d.py'))
+        self.problem = 'test_munson1d'
+        self.run_solver(os.path.join(exdir, 'munson1d.py'))
         self.check('munson1d', self.solver)
 
     def check(self, problem, solver):
-        refObj = self.getObjective(self.referenceFile(problem,solver))
-        ansObj = self.getObjective(os.path.join(currdir,'result.yml'))
+        refObj = self.getObjective(self.referenceFile(problem, solver))
+        ansObj = self.getObjective(os.path.join(currdir, 'result.yml'))
         self.assertEqual(len(refObj), len(ansObj))
         for i in range(len(refObj)):
             self.assertEqual(len(refObj[i]), len(ansObj[i]))
             if isinstance(refObj[i], str):
                 continue
-            for key,val in refObj[i].items():
-                self.assertAlmostEqual(val['Value'], ansObj[i].get(key,None)['Value'], places=2)
+            for key, val in refObj[i].items():
+                self.assertAlmostEqual(
+                    val['Value'], ansObj[i].get(key, None)['Value'], places=2
+                )
 
 
 @unittest.skipIf(not yaml_available, "YAML is not available")
 @unittest.skipIf(not 'path' in solvers, "The 'path' executable is not available")
 class Solve_PATH(unittest.TestCase, CommonTests):
-
     def tearDown(self):
-        if os.path.exists(os.path.join(currdir,'result.yml')):
-            os.remove(os.path.join(currdir,'result.yml'))
+        if os.path.exists(os.path.join(currdir, 'result.yml')):
+            os.remove(os.path.join(currdir, 'result.yml'))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fixes (Partly) #329 

## Summary/Motivation:
This is the first in a relatively long string of PRs to apply PEP8 standards via `black` to Pyomo. We are following the standard used by IDAES _except_ that we are adding the `-S` option: `Don't normalize string quotes or prefixes` and the `-C` option: `Don't use trailing commas as a reason to split lines.`

**NOTE**: All changes are NFC.

Full command used: `black -S -C pyomo/duality && black -S -C pyomo/mpec && black -S -C pyomo/environ`

:warning: Please squash this at merge. :warning:

## Changes proposed in this PR:
- Apply `black` to the `duality`, `mpec`, and `environ` directory `py` files
- Manually fix instances where two lines were merged and left `" "` or `' '`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
