### PR TITLE
[Docs] Update ReadtheDocs Configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 sphinx:
    configuration: doc/OnlineDocs/conf.py
 
@@ -12,7 +17,6 @@ formats: all
 
 # Set the version of Python and requirements required to build the docs
 python:
-   version: 3
    install:
      - method: pip
        path: .


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
The configuration option we are using for ReadtheDocs is deprecated, which became obvious today when it spontaneously stopped working. This updates us to the new version so we hopefully don't run into this issue again.

## Changes proposed in this PR:
- Use preferred configuration: https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
