### PR TITLE
Apply `black` to `kernel` and `gdp` directory `py` files

### DIFF
--- a/pyomo/gdp/__init__.py
+++ b/pyomo/gdp/__init__.py
@@ -13,6 +13,5 @@ from pyomo.gdp.disjunct import GDP_Error, Disjunct, Disjunction
 
 # Do not import these files: importing them registers the transformation
 # plugins with the pyomo script so that they get automatically invoked.
-#import pyomo.gdp.bigm
-#import pyomo.gdp.hull
-
+# import pyomo.gdp.bigm
+# import pyomo.gdp.hull

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -23,11 +23,21 @@ from pyomo.common.log import is_debug_set
 from pyomo.common.modeling import unique_component_name, NOTSET
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core import (
-    ModelComponentFactory, Binary, Block, ConstraintList, Any,
-    LogicalConstraintList, BooleanValue, ScalarBooleanVar, ScalarVar,
-    value)
+    ModelComponentFactory,
+    Binary,
+    Block,
+    ConstraintList,
+    Any,
+    LogicalConstraintList,
+    BooleanValue,
+    ScalarBooleanVar,
+    ScalarVar,
+    value,
+)
 from pyomo.core.base.component import (
-    ActiveComponent, ActiveComponentData, ComponentData
+    ActiveComponent,
+    ActiveComponentData,
+    ComponentData,
 )
 from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.numvalue import native_types
@@ -45,6 +55,7 @@ individual expressions, or Disjunction.Skip.  The most common cause of
 this error is forgetting to include the "return" statement at the end of
 your rule.
 """
+
 
 class GDP_Error(PyomoException):
     """Exception raised while processing GDP Models"""
@@ -86,7 +97,8 @@ class AutoLinkedBinaryVar(ScalarVar):
             bool_val = bool(int(val + 0.5))
         # (Setting _propagate_value prevents infinite recursion.)
         self.get_associated_boolean().set_value(
-            bool_val, skip_validation, _propagate_value=False)
+            bool_val, skip_validation, _propagate_value=False
+        )
 
     def fix(self, value=NOTSET, skip_validation=False):
         super().fix(value, skip_validation)
@@ -137,8 +149,9 @@ class AutoLinkedBooleanVar(ScalarBooleanVar):
             "binary variable is deprecated and will be removed.  "
             "Either express constraints on indicator_var using "
             "LogicalConstraints or work with the associated binary "
-            "variable from indicator_var.get_associated_binary()"
-            % (self.name,), version='6.0')
+            "variable from indicator_var.get_associated_binary()" % (self.name,),
+            version='6.0',
+        )
         return self.get_associated_binary()
 
     def set_value(self, val, skip_validation=False, _propagate_value=True):
@@ -154,7 +167,8 @@ class AutoLinkedBooleanVar(ScalarBooleanVar):
             val = int(val)
         # (Setting _propagate_value prevents infinite recursion.)
         self.get_associated_binary().set_value(
-            val, skip_validation, _propagate_value=False)
+            val, skip_validation, _propagate_value=False
+        )
 
     def fix(self, value=NOTSET, skip_validation=False):
         super().fix(value, skip_validation)
@@ -199,82 +213,118 @@ class AutoLinkedBooleanVar(ScalarBooleanVar):
 
     def __abs__(self):
         return self.as_binary().__abs__()
+
     def __float__(self):
         return self.as_binary().__float__()
+
     def __int__(self):
         return self.as_binary().__int__()
+
     def __neg__(self):
         return self.as_binary().__neg__()
+
     def __bool__(self):
         return self.as_binary().__bool__()
+
     def __pos__(self):
         return self.as_binary().__pos__()
+
     def get_units(self):
         return self.as_binary().get_units()
+
     def has_lb(self):
         return self.as_binary().has_lb()
+
     def has_ub(self):
         return self.as_binary().has_ub()
+
     def is_binary(self):
         return self.as_binary().is_binary()
+
     def is_continuous(self):
         return self.as_binary().is_continuous()
+
     def is_integer(self):
         return self.as_binary().is_integer()
+
     def polynomial_degree(self):
         return self.as_binary().polynomial_degree()
 
     def __le__(self, arg):
         return self.as_binary().__le__(arg)
+
     def __lt__(self, arg):
         return self.as_binary().__lt__(arg)
+
     def __ge__(self, arg):
         return self.as_binary().__ge__(arg)
+
     def __gt__(self, arg):
         return self.as_binary().__gt__(arg)
+
     def __eq__(self, arg):
         return self.as_binary().__eq__(arg)
+
     def __ne__(self, arg):
         return self.as_binary().__ne__(arg)
 
     def __add__(self, arg):
         return self.as_binary().__add__(arg)
+
     def __div__(self, arg):
         return self.as_binary().__div__(arg)
+
     def __mul__(self, arg):
         return self.as_binary().__mul__(arg)
+
     def __pow__(self, arg):
         return self.as_binary().__pow__(arg)
+
     def __sub__(self, arg):
         return self.as_binary().__sub__(arg)
+
     def __truediv__(self, arg):
         return self.as_binary().__truediv__(arg)
+
     def __iadd__(self, arg):
         return self.as_binary().__iadd__(arg)
+
     def __idiv__(self, arg):
         return self.as_binary().__idiv__(arg)
+
     def __imul__(self, arg):
         return self.as_binary().__imul__(arg)
+
     def __ipow__(self, arg):
         return self.as_binary().__ipow__(arg)
+
     def __isub__(self, arg):
         return self.as_binary().__isub__(arg)
+
     def __itruediv__(self, arg):
         return self.as_binary().__itruediv__(arg)
+
     def __radd__(self, arg):
         return self.as_binary().__radd__(arg)
+
     def __rdiv__(self, arg):
         return self.as_binary().__rdiv__(arg)
+
     def __rmul__(self, arg):
         return self.as_binary().__rmul__(arg)
+
     def __rpow__(self, arg):
         return self.as_binary().__rpow__(arg)
+
     def __rsub__(self, arg):
         return self.as_binary().__rsub__(arg)
+
     def __rtruediv__(self, arg):
         return self.as_binary().__rtruediv__(arg)
+
     def setlb(self, arg):
         return self.as_binary().setlb(arg)
+
     def setub(self, arg):
         return self.as_binary().setub(arg)
 
@@ -318,8 +368,9 @@ class _DisjunctData(_BlockData):
 
     @property
     def transformation_block(self):
-        return None if self._transformation_block is None else \
-            self._transformation_block()
+        return (
+            None if self._transformation_block is None else self._transformation_block()
+        )
 
     def __init__(self, component):
         _BlockData.__init__(self, component)
@@ -371,7 +422,7 @@ class Disjunct(Block):
 
     # For the time being, this method is not needed.
     #
-    #def _deactivate_without_fixing_indicator(self):
+    # def _deactivate_without_fixing_indicator(self):
     #    # Ideally, this would be a super call from this class.  However,
     #    # doing that would trigger a call to deactivate() on all the
     #    # _DisjunctData objects (exactly what we want to aviod!)
@@ -395,7 +446,6 @@ class Disjunct(Block):
 
 
 class ScalarDisjunct(_DisjunctData, Disjunct):
-
     def __init__(self, *args, **kwds):
         ## FIXME: This is a HACK to get around a chicken-and-egg issue
         ## where _BlockData creates the indicator_var *before*
@@ -434,8 +484,9 @@ class _DisjunctionData(ActiveComponentData):
 
     @property
     def algebraic_constraint(self):
-        return None if self._algebraic_constraint is None else \
-            self._algebraic_constraint()
+        return (
+            None if self._algebraic_constraint is None else self._algebraic_constraint()
+        )
 
     def __init__(self, component=None):
         #
@@ -444,8 +495,7 @@ class _DisjunctionData(ActiveComponentData):
         #   - _ConstraintData,
         #   - ActiveComponentData
         #   - ComponentData
-        self._component = weakref_ref(component) if (component is not None) \
-                          else None
+        self._component = weakref_ref(component) if (component is not None) else None
         self._index = NOTSET
         self._active = True
         self.disjuncts = []
@@ -463,7 +513,7 @@ class _DisjunctionData(ActiveComponentData):
             # the new Disjuncts are Blocks already. This catches them for who
             # they are anyway.
             if isinstance(e, _DisjunctData):
-            #if hasattr(e, 'type') and e.ctype == Disjunct:
+                # if hasattr(e, 'type') and e.ctype == Disjunct:
                 self.disjuncts.append(e)
                 continue
             # The user was lazy and gave us a single constraint
@@ -486,7 +536,8 @@ class _DisjunctionData(ActiveComponentData):
                     "\tExpected a Disjunct object, relational expression, "
                     "or iterable of\n"
                     "\trelational expressions but got %s%s"
-                    % (self.name, type(_tmpe), msg) )
+                    % (self.name, type(_tmpe), msg)
+                )
 
             comp = self.parent_component()
             if comp._autodisjuncts is None:
@@ -494,7 +545,8 @@ class _DisjunctionData(ActiveComponentData):
                 comp._autodisjuncts = Disjunct(Any)
                 b.add_component(
                     unique_component_name(b, comp.local_name + "_disjuncts"),
-                    comp._autodisjuncts )
+                    comp._autodisjuncts,
+                )
                 # TODO: I am not at all sure why we need to
                 # explicitly construct this block - that should
                 # happen automatically.
@@ -511,7 +563,8 @@ class _DisjunctionData(ActiveComponentData):
                     raise RuntimeError(
                         "Unsupported expression type on Disjunct "
                         f"{disjunct.name}: expected either relational or "
-                        f"logical expression, found {e.__class__.__name__}")
+                        f"logical expression, found {e.__class__.__name__}"
+                    )
             self.disjuncts.append(disjunct)
 
 
@@ -537,8 +590,8 @@ class Disjunction(ActiveIndexedComponent):
 
         if self._init_expr is not None and self._init_rule is not None:
             raise ValueError(
-                "Cannot specify both rule= and expr= for Disjunction %s"
-                % ( self.name, ))
+                "Cannot specify both rule= and expr= for Disjunction %s" % (self.name,)
+            )
 
     #
     # TODO: Ideally we would not override these methods and instead add
@@ -562,37 +615,38 @@ class Disjunction(ActiveIndexedComponent):
             return None
         else:
             ans = super(Disjunction, self)._setitem_when_not_present(
-                index=index, value=value)
+                index=index, value=value
+            )
             self._initialize_members((index,))
             return ans
 
     def _initialize_members(self, init_set):
-        if self._init_xor[0] == _Initializer.value: # POD data
+        if self._init_xor[0] == _Initializer.value:  # POD data
             val = self._init_xor[1]
             for key in init_set:
                 self._data[key].xor = val
-        elif self._init_xor[0] == _Initializer.deferred_value: # Param data
-            val = bool(value( self._init_xor[1] ))
+        elif self._init_xor[0] == _Initializer.deferred_value:  # Param data
+            val = bool(value(self._init_xor[1]))
             for key in init_set:
                 self._data[key].xor = val
-        elif self._init_xor[0] == _Initializer.function: # rule
+        elif self._init_xor[0] == _Initializer.function:  # rule
             fcn = self._init_xor[1]
             for key in init_set:
-                self._data[key].xor = bool(value(apply_indexed_rule(
-                    self, fcn, self._parent(), key)))
-        elif self._init_xor[0] == _Initializer.dict_like: # dict-like thing
+                self._data[key].xor = bool(
+                    value(apply_indexed_rule(self, fcn, self._parent(), key))
+                )
+        elif self._init_xor[0] == _Initializer.dict_like:  # dict-like thing
             val = self._init_xor[1]
             for key in init_set:
                 self._data[key].xor = bool(value(val[key]))
 
     def construct(self, data=None):
         if is_debug_set(logger):
-            logger.debug("Constructing disjunction %s"
-                         % (self.name))
+            logger.debug("Constructing disjunction %s" % (self.name))
         if self._constructed:
             return
         timer = ConstructionTimer(self)
-        self._constructed=True
+        self._constructed = True
 
         _self_parent = self.parent_block()
         if not self.is_indexed():
@@ -605,38 +659,33 @@ class Disjunction(ActiveIndexedComponent):
                 return
 
             if expr is None:
-                raise ValueError( _rule_returned_none_error % (self.name,) )
+                raise ValueError(_rule_returned_none_error % (self.name,))
             if expr is Disjunction.Skip:
                 timer.report()
                 return
             self._data[None] = self
-            self._setitem_when_not_present( None, expr )
+            self._setitem_when_not_present(None, expr)
         elif self._init_expr is not None:
             raise IndexError(
                 "Disjunction '%s': Cannot initialize multiple indices "
-                "of a disjunction with a single disjunction list" %
-                (self.name,) )
+                "of a disjunction with a single disjunction list" % (self.name,)
+            )
         elif self._init_rule is not None:
             _init_rule = self._init_rule
             for ndx in self._index_set:
                 try:
-                    expr = apply_indexed_rule(self,
-                                             _init_rule,
-                                             _self_parent,
-                                             ndx)
+                    expr = apply_indexed_rule(self, _init_rule, _self_parent, ndx)
                 except Exception:
                     err = sys.exc_info()[1]
                     logger.error(
                         "Rule failed when generating expression for "
                         "disjunction %s with index %s:\n%s: %s"
-                        % (self.name,
-                           str(ndx),
-                           type(err).__name__,
-                           err))
+                        % (self.name, str(ndx), type(err).__name__, err)
+                    )
                     raise
                 if expr is None:
                     _name = "%s[%s]" % (self.name, str(ndx))
-                    raise ValueError( _rule_returned_none_error % (_name,) )
+                    raise ValueError(_rule_returned_none_error % (_name,))
                 if expr is Disjunction.Skip:
                     continue
                 self._setitem_when_not_present(ndx, expr)
@@ -647,18 +696,18 @@ class Disjunction(ActiveIndexedComponent):
         Return data that will be printed for this component.
         """
         return (
-            [("Size", len(self)),
-             ("Index", self._index_set if self.is_indexed() else None),
-             ("Active", self.active),
-             ],
+            [
+                ("Size", len(self)),
+                ("Index", self._index_set if self.is_indexed() else None),
+                ("Active", self.active),
+            ],
             self.items(),
-            ( "Disjuncts", "Active", "XOR" ),
-            lambda k, v: [ [x.name for x in v.disjuncts], v.active, v.xor]
-            )
+            ("Disjuncts", "Active", "XOR"),
+            lambda k, v: [[x.name for x in v.disjuncts], v.active, v.xor],
+        )
 
 
 class ScalarDisjunction(_DisjunctionData, Disjunction):
-
     def __init__(self, *args, **kwds):
         _DisjunctionData.__init__(self, component=self)
         Disjunction.__init__(self, *args, **kwds)
@@ -681,8 +730,8 @@ class ScalarDisjunction(_DisjunctionData, Disjunction):
             raise ValueError(
                 "Setting the value of disjunction '%s' "
                 "before the Disjunction has been constructed (there "
-                "is currently no object to set)."
-                % (self.name))
+                "is currently no object to set)." % (self.name)
+            )
 
         if len(self._data) == 0:
             self._data[None] = self

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -513,7 +513,6 @@ class _DisjunctionData(ActiveComponentData):
             # the new Disjuncts are Blocks already. This catches them for who
             # they are anyway.
             if isinstance(e, _DisjunctData):
-                # if hasattr(e, 'type') and e.ctype == Disjunct:
                 self.disjuncts.append(e)
                 continue
             # The user was lazy and gave us a single constraint

--- a/pyomo/gdp/plugins/__init__.py
+++ b/pyomo/gdp/plugins/__init__.py
@@ -9,6 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+
 def load():
     import pyomo.gdp.plugins.bigm
     import pyomo.gdp.plugins.hull

--- a/pyomo/gdp/plugins/between_steps.py
+++ b/pyomo/gdp/plugins/between_steps.py
@@ -17,17 +17,20 @@ Relaxations between big-M and Convex Hull Reformulations," 2021.
 """
 from pyomo.core import Transformation, TransformationFactory
 
-@TransformationFactory.register('gdp.between_steps',
-                                doc="Reformulates a convex disjunctive model "
-                                "by splitting additively separable constraints"
-                                "on P sets of variables, then taking hull "
-                                "reformulation.")
+
+@TransformationFactory.register(
+    'gdp.between_steps',
+    doc="Reformulates a convex disjunctive model "
+    "by splitting additively separable constraints"
+    "on P sets of variables, then taking hull "
+    "reformulation.",
+)
 class BetweenSteps_Transformation(Transformation):
     """
     Transform disjunctive model to equivalent MI(N)LP using the between steps
     transformation from Konqvist et al. 2021 [1].
 
-    This transformation first calls the 'gdp.partition_disjuncts' 
+    This transformation first calls the 'gdp.partition_disjuncts'
     transformation, resulting in an equivalent GDP with the constraints
     partitioned, and then takes the hull reformulation of that model to get
     an algebraic model.
@@ -37,10 +40,10 @@ class BetweenSteps_Transformation(Transformation):
         [1] J. Kronqvist, R. Misener, and C. Tsay, "Between Steps: Intermediate
             Relaxations between big-M and Convex Hull Reformulations," 2021.
     """
+
     def __init__(self):
         super(BetweenSteps_Transformation, self).__init__()
 
     def _apply_to(self, instance, **kwds):
-        TransformationFactory('gdp.partition_disjuncts').apply_to(instance,
-                                                                  **kwds)
+        TransformationFactory('gdp.partition_disjuncts').apply_to(instance, **kwds)
         TransformationFactory('gdp.hull').apply_to(instance)

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -18,21 +18,37 @@ from pyomo.common.config import ConfigDict, ConfigValue
 from pyomo.common.modeling import unique_component_name
 from pyomo.common.deprecation import deprecated, deprecation_warning
 from pyomo.contrib.cp.transform.logical_to_disjunctive_program import (
-    LogicalToDisjunctive)
+    LogicalToDisjunctive,
+)
 from pyomo.core import (
-    Block, BooleanVar, Connector, Constraint, Param, Set, SetOf, Var,
-    Expression, SortComponents, TraversalStrategy, value, RangeSet,
-    NonNegativeIntegers, Binary, Any)
+    Block,
+    BooleanVar,
+    Connector,
+    Constraint,
+    Param,
+    Set,
+    SetOf,
+    Var,
+    Expression,
+    SortComponents,
+    TraversalStrategy,
+    value,
+    RangeSet,
+    NonNegativeIntegers,
+    Binary,
+    Any,
+)
 from pyomo.core.base import TransformationFactory, Reference
 import pyomo.core.expr.current as EXPR
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 from pyomo.gdp.plugins.bigm_mixin import (
-    _BigM_MixIn, _get_bigM_suffix_list, _warn_for_unused_bigM_args)
-from pyomo.gdp.plugins.gdp_to_mip_transformation import (
-    GDP_to_MIP_Transformation)
+    _BigM_MixIn,
+    _get_bigM_suffix_list,
+    _warn_for_unused_bigM_args,
+)
+from pyomo.gdp.plugins.gdp_to_mip_transformation import GDP_to_MIP_Transformation
 from pyomo.gdp.transformed_disjunct import _TransformedDisjunct
-from pyomo.gdp.util import (
-    is_child_of, _get_constraint_transBlock, _to_dict)
+from pyomo.gdp.util import is_child_of, _get_constraint_transBlock, _to_dict
 from pyomo.core.util import target_list
 from pyomo.network import Port
 from pyomo.repn import generate_standard_repn
@@ -40,8 +56,10 @@ from weakref import ref as weakref_ref, ReferenceType
 
 logger = logging.getLogger('pyomo.gdp.bigm')
 
-@TransformationFactory.register('gdp.bigm', doc="Relax disjunctive model using "
-                                "big-M terms.")
+
+@TransformationFactory.register(
+    'gdp.bigm', doc="Relax disjunctive model using big-M terms."
+)
 class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
     """Relax disjunctive model using big-M terms.
 
@@ -90,35 +108,43 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
     """
 
     CONFIG = ConfigDict("gdp.bigm")
-    CONFIG.declare('targets', ConfigValue(
-        default=None,
-        domain=target_list,
-        description="target or list of targets that will be relaxed",
-        doc="""
+    CONFIG.declare(
+        'targets',
+        ConfigValue(
+            default=None,
+            domain=target_list,
+            description="target or list of targets that will be relaxed",
+            doc="""
 
         This specifies the list of components to relax. If None (default), the
         entire model is transformed. Note that if the transformation is done out
         of place, the list of targets should be attached to the model before it
         is cloned, and the list will specify the targets on the cloned
-        instance."""
-    ))
-    CONFIG.declare('bigM', ConfigValue(
-        default=None,
-        domain=_to_dict,
-        description="Big-M value used for constraint relaxation",
-        doc="""
+        instance.""",
+        ),
+    )
+    CONFIG.declare(
+        'bigM',
+        ConfigValue(
+            default=None,
+            domain=_to_dict,
+            description="Big-M value used for constraint relaxation",
+            doc="""
 
         A user-specified value, dict, or ComponentMap of M values that override
         M-values found through model Suffixes or that would otherwise be
-        calculated using variable domains."""
-    ))
-    CONFIG.declare('assume_fixed_vars_permanent', ConfigValue(
-        default=False,
-        domain=bool,
-        description="Boolean indicating whether or not to transform so that "
-        "the transformed model will still be valid when fixed Vars are "
-        "unfixed.",
-        doc="""
+        calculated using variable domains.""",
+        ),
+    )
+    CONFIG.declare(
+        'assume_fixed_vars_permanent',
+        ConfigValue(
+            default=False,
+            domain=bool,
+            description="Boolean indicating whether or not to transform so that "
+            "the transformed model will still be valid when fixed Vars are "
+            "unfixed.",
+            doc="""
         This is only relevant when the transformation will be estimating values
         for M. If True, the transformation will calculate M values assuming that
         fixed variables will always be fixed to their current values. This means
@@ -128,20 +154,21 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
         future and will use their bounds to calculate the M value rather than
         their value. Note that this could make for a weaker LP relaxation
         while the variables remain fixed.
-        """
-    ))
+        """,
+        ),
+    )
     transformation_name = 'bigm'
 
     def __init__(self):
         super().__init__(logger)
 
     def _apply_to(self, instance, **kwds):
-        self.used_args = ComponentMap() # If everything was sure to go well,
-                                        # this could be a dictionary. But if
-                                        # someone messes up and gives us a Var
-                                        # as a key in bigMargs, I need the error
-                                        # not to be when I try to put it into
-                                        # this map!
+        self.used_args = ComponentMap()  # If everything was sure to go well,
+        # this could be a dictionary. But if
+        # someone messes up and gives us a Var
+        # as a key in bigMargs, I need the error
+        # not to be when I try to put it into
+        # this map!
         try:
             self._apply_to_impl(instance, **kwds)
         finally:
@@ -166,29 +193,32 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
         for t in preprocessed_targets:
             if t.ctype is Disjunction:
                 self._transform_disjunctionData(
-                    t, t.index(), parent_disjunct=gdp_tree.parent(t),
-                    root_disjunct=gdp_tree.root_disjunct(t))
-            else:# We know t is a Disjunct after preprocessing
+                    t,
+                    t.index(),
+                    parent_disjunct=gdp_tree.parent(t),
+                    root_disjunct=gdp_tree.root_disjunct(t),
+                )
+            else:  # We know t is a Disjunct after preprocessing
                 self._transform_disjunct(
-                    t, bigM, root_disjunct=gdp_tree.root_disjunct(t))
+                    t, bigM, root_disjunct=gdp_tree.root_disjunct(t)
+                )
 
         # issue warnings about anything that was in the bigM args dict that we
         # didn't use
         _warn_for_unused_bigM_args(bigM, self.used_args, logger)
 
-    def _transform_disjunctionData(self, obj, index, parent_disjunct=None,
-                                   root_disjunct=None):
+    def _transform_disjunctionData(
+        self, obj, index, parent_disjunct=None, root_disjunct=None
+    ):
 
-        (transBlock,
-         xorConstraint) = self._setup_transform_disjunctionData(obj,
-                                                                root_disjunct)
+        (transBlock, xorConstraint) = self._setup_transform_disjunctionData(
+            obj, root_disjunct
+        )
 
         # add or (or xor) constraint
-        or_expr = sum(disjunct.binary_indicator_var for disjunct in
-                      obj.disjuncts)
+        or_expr = sum(disjunct.binary_indicator_var for disjunct in obj.disjuncts)
 
-        rhs = 1 if parent_disjunct is None else \
-              parent_disjunct.binary_indicator_var
+        rhs = 1 if parent_disjunct is None else parent_disjunct.binary_indicator_var
         if obj.xor:
             xorConstraint[index] = or_expr == rhs
         else:
@@ -201,14 +231,16 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
         obj.deactivate()
 
     def _transform_disjunct(self, obj, bigM, root_disjunct):
-        root = root_disjunct.parent_block() if root_disjunct is not None else \
-               obj.parent_block()
+        root = (
+            root_disjunct.parent_block()
+            if root_disjunct is not None
+            else obj.parent_block()
+        )
         transBlock = self._add_transformation_block(root)[0]
         suffix_list = _get_bigM_suffix_list(obj)
         arg_list = self._get_bigM_arg_list(bigM, obj)
 
-        relaxationBlock = self._get_disjunct_transformation_block(obj,
-                                                                  transBlock)
+        relaxationBlock = self._get_disjunct_transformation_block(obj, transBlock)
 
         # we will keep a map of constraints (hashable, ha!) to a tuple to
         # indicate what their M value is and where it came from, of the form:
@@ -236,8 +268,9 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
         # deactivate disjunct to keep the writers happy
         obj._deactivate_without_fixing_indicator()
 
-    def _transform_constraint(self, obj, disjunct, bigMargs, arg_list,
-                              disjunct_suffix_list):
+    def _transform_constraint(
+        self, obj, disjunct, bigMargs, arg_list, disjunct_suffix_list
+    ):
         # add constraint to the transformation block, we'll transform it there.
         transBlock = disjunct._transformation_block()
         bigm_src = transBlock.bigm_src
@@ -261,32 +294,35 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
 
             # first, we see if an M value was specified in the arguments.
             # (This returns None if not)
-            lower, upper = self._get_M_from_args(c, bigMargs, arg_list, lower,
-                                                 upper)
+            lower, upper = self._get_M_from_args(c, bigMargs, arg_list, lower, upper)
             M = (lower[0], upper[0])
 
             if self._generate_debug_messages:
-                logger.debug("GDP(BigM): The value for M for constraint '%s' "
-                             "from the BigM argument is %s." % (c.name,
-                                                                str(M)))
+                logger.debug(
+                    "GDP(BigM): The value for M for constraint '%s' "
+                    "from the BigM argument is %s." % (c.name, str(M))
+                )
 
             # if we didn't get something we need from args, try suffixes:
-            if (M[0] is None and c.lower is not None) or \
-               (M[1] is None and c.upper is not None):
+            if (M[0] is None and c.lower is not None) or (
+                M[1] is None and c.upper is not None
+            ):
                 # first get anything parent to c but below disjunct
                 suffix_list = _get_bigM_suffix_list(
-                    c.parent_block(),
-                    stopping_block=disjunct)
+                    c.parent_block(), stopping_block=disjunct
+                )
                 # prepend that to what we already collected for the disjunct.
                 suffix_list.extend(disjunct_suffix_list)
-                lower, upper = self._update_M_from_suffixes(c, suffix_list,
-                                                            lower, upper)
+                lower, upper = self._update_M_from_suffixes(
+                    c, suffix_list, lower, upper
+                )
                 M = (lower[0], upper[0])
 
             if self._generate_debug_messages:
-                logger.debug("GDP(BigM): The value for M for constraint '%s' "
-                             "after checking suffixes is %s." % (c.name,
-                                                                 str(M)))
+                logger.debug(
+                    "GDP(BigM): The value for M for constraint '%s' "
+                    "after checking suffixes is %s." % (c.name, str(M))
+                )
 
             if c.lower is not None and M[0] is None:
                 M = (self._estimate_M(c.body, c)[0] - c.lower, M[1])
@@ -296,16 +332,17 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
                 upper = (M[1], None, None)
 
             if self._generate_debug_messages:
-                logger.debug("GDP(BigM): The value for M for constraint '%s' "
-                             "after estimating (if needed) is %s." %
-                             (c.name, str(M)))
+                logger.debug(
+                    "GDP(BigM): The value for M for constraint '%s' "
+                    "after estimating (if needed) is %s." % (c.name, str(M))
+                )
 
             # save the source information
             bigm_src[c] = (lower, upper)
 
-            self._add_constraint_expressions(c, i, M,
-                                             disjunct.binary_indicator_var,
-                                             newConstraint, constraintMap)
+            self._add_constraint_expressions(
+                c, i, M, disjunct.binary_indicator_var, newConstraint, constraintMap
+            )
 
             # deactivate because we relaxed
             c.deactivate()
@@ -321,12 +358,16 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
         for bigm in suffix_list:
             if constraint in bigm:
                 M = bigm[constraint]
-                (lower, upper,
-                 need_lower,
-                 need_upper) = self._process_M_value(M, lower, upper,
-                                                     need_lower, need_upper,
-                                                     bigm, constraint,
-                                                     constraint)
+                (lower, upper, need_lower, need_upper) = self._process_M_value(
+                    M,
+                    lower,
+                    upper,
+                    need_lower,
+                    need_upper,
+                    bigm,
+                    constraint,
+                    constraint,
+                )
                 if not need_lower and not need_upper:
                     return lower, upper
 
@@ -334,11 +375,9 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
             if constraint.parent_component() in bigm:
                 parent = constraint.parent_component()
                 M = bigm[parent]
-                (lower, upper,
-                 need_lower,
-                 need_upper) = self._process_M_value(M, lower, upper,
-                                                     need_lower, need_upper,
-                                                     bigm, parent, constraint)
+                (lower, upper, need_lower, need_upper) = self._process_M_value(
+                    M, lower, upper, need_lower, need_upper, bigm, parent, constraint
+                )
                 if not need_lower and not need_upper:
                     return lower, upper
 
@@ -348,30 +387,38 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
             for bigm in suffix_list:
                 if None in bigm:
                     M = bigm[None]
-                    (lower, upper,
-                     need_lower,
-                     need_upper) = self._process_M_value(M, lower, upper,
-                                                         need_lower, need_upper,
-                                                         bigm, None, constraint)
+                    (lower, upper, need_lower, need_upper) = self._process_M_value(
+                        M, lower, upper, need_lower, need_upper, bigm, None, constraint
+                    )
                 if not need_lower and not need_upper:
                     return lower, upper
         return lower, upper
 
-    @deprecated("The get_m_value_src function is deprecated. Use "
-                "the get_M_value_src function if you need source "
-                "information or the get_M_value function if you "
-                "only need values.", version='5.7.1')
+    @deprecated(
+        "The get_m_value_src function is deprecated. Use "
+        "the get_M_value_src function if you need source "
+        "information or the get_M_value function if you "
+        "only need values.",
+        version='5.7.1',
+    )
     def get_m_value_src(self, constraint):
         transBlock = _get_constraint_transBlock(constraint)
-        ((lower_val, lower_source, lower_key),
-         (upper_val, upper_source, upper_key)) = transBlock.bigm_src[constraint]
+        (
+            (lower_val, lower_source, lower_key),
+            (upper_val, upper_source, upper_key),
+        ) = transBlock.bigm_src[constraint]
 
-        if constraint.lower is not None and constraint.upper is not None and \
-           (not lower_source is upper_source or not lower_key is upper_key):
-            raise GDP_Error("This is why this method is deprecated: The lower "
-                            "and upper M values for constraint %s came from "
-                            "different sources, please use the get_M_value_src "
-                            "method." % constraint.name)
+        if (
+            constraint.lower is not None
+            and constraint.upper is not None
+            and (not lower_source is upper_source or not lower_key is upper_key)
+        ):
+            raise GDP_Error(
+                "This is why this method is deprecated: The lower "
+                "and upper M values for constraint %s came from "
+                "different sources, please use the get_M_value_src "
+                "method." % constraint.name
+            )
         # if source and key are equal for the two, this is representable in the
         # old format.
         if constraint.lower is not None and lower_source is not None:
@@ -442,9 +489,8 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
         """
         m_values = {}
         for disj in model.component_data_objects(
-                Disjunct,
-                active=None,
-                descend_into=(Block, Disjunct)):
+            Disjunct, active=None, descend_into=(Block, Disjunct)
+        ):
             transBlock = disj.transformation_block
             # First check if it was transformed at all.
             if transBlock is not None:
@@ -461,5 +507,7 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
         ----------
         model: A GDP model that has been transformed with BigM
         """
-        return max(max(abs(m) for m in m_values if m is not None) for m_values
-                   in self.get_all_M_values_by_constraint(model).values())
+        return max(
+            max(abs(m) for m in m_values if m is not None)
+            for m_values in self.get_all_M_values_by_constraint(model).values()
+        )

--- a/pyomo/gdp/plugins/bilinear.py
+++ b/pyomo/gdp/plugins/bilinear.py
@@ -11,16 +11,27 @@
 
 import logging
 
-from pyomo.core import TransformationFactory, Transformation, Block, VarList, Set, SortComponents, Objective, Constraint
+from pyomo.core import (
+    TransformationFactory,
+    Transformation,
+    Block,
+    VarList,
+    Set,
+    SortComponents,
+    Objective,
+    Constraint,
+)
 from pyomo.gdp import Disjunct, Disjunction
 from pyomo.repn import generate_standard_repn
 
 logger = logging.getLogger('pyomo.gdp')
 
 
-@TransformationFactory.register('gdp.bilinear', doc="Creates a disjunctive model where bilinear terms are replaced with disjunctive expressions.")
+@TransformationFactory.register(
+    'gdp.bilinear',
+    doc="Creates a disjunctive model where bilinear terms are replaced with disjunctive expressions.",
+)
 class Bilinear_Transformation(Transformation):
-
     def __init__(self):
         super(Bilinear_Transformation, self).__init__()
 
@@ -32,7 +43,9 @@ class Bilinear_Transformation(Transformation):
             instance.bilinear_data_.vlist = VarList()
             instance.bilinear_data_.vlist_boolean = []
             instance.bilinear_data_.IDX = Set()
-            instance.bilinear_data_.disjuncts_   = Disjunct(instance.bilinear_data_.IDX*[0,1])
+            instance.bilinear_data_.disjuncts_ = Disjunct(
+                instance.bilinear_data_.IDX * [0, 1]
+            )
             instance.bilinear_data_.disjunction_data = {}
             instance.bilinear_data_.o_expr = {}
             instance.bilinear_data_.c_body = {}
@@ -40,23 +53,31 @@ class Bilinear_Transformation(Transformation):
         # Iterate over all blocks
         #
         for block in instance.block_data_objects(
-                active=True, sort=SortComponents.deterministic ):
+            active=True, sort=SortComponents.deterministic
+        ):
             self._transformBlock(block, instance)
         #
         # WEH: I wish I had a DisjunctList and DisjunctionList object...
         #
         def rule(block, i):
             return instance.bilinear_data_.disjunction_data[i]
-        instance.bilinear_data_.disjunction_ = Disjunction(instance.bilinear_data_.IDX, rule=rule)
+
+        instance.bilinear_data_.disjunction_ = Disjunction(
+            instance.bilinear_data_.IDX, rule=rule
+        )
 
     def _transformBlock(self, block, instance):
-        for component in block.component_objects(Objective, active=True, descend_into=False):
+        for component in block.component_objects(
+            Objective, active=True, descend_into=False
+        ):
             expr = self._transformExpression(component.expr, instance)
-            instance.bilinear_data_.o_expr[ id(component) ] = component.expr
+            instance.bilinear_data_.o_expr[id(component)] = component.expr
             component.expr = expr
-        for component in block.component_data_objects(Constraint, active=True, descend_into=False):
+        for component in block.component_data_objects(
+            Constraint, active=True, descend_into=False
+        ):
             expr = self._transformExpression(component.body, instance)
-            instance.bilinear_data_.c_body[ id(component) ] = component.body
+            instance.bilinear_data_.c_body[id(component)] = component.body
             component._body = expr
 
     def _transformExpression(self, expr, instance):
@@ -81,7 +102,9 @@ class Bilinear_Transformation(Transformation):
             for vars_, coef_ in zip(terms.quadratic_vars, terms.quadratic_coefs):
                 #
                 if vars_[0].is_binary():
-                    v = instance.bilinear_data_.cache.get( (id(vars_[0]),id(vars_[1])), None )
+                    v = instance.bilinear_data_.cache.get(
+                        (id(vars_[0]), id(vars_[1])), None
+                    )
                     if v is None:
                         instance.bilinear_data_.vlist_boolean.append(vars_[0])
                         v = instance.bilinear_data_.vlist.add()
@@ -92,21 +115,29 @@ class Bilinear_Transformation(Transformation):
                         id_ = len(instance.bilinear_data_.vlist)
                         instance.bilinear_data_.IDX.add(id_)
                         # First disjunct
-                        d0 = instance.bilinear_data_.disjuncts_[id_,0]
+                        d0 = instance.bilinear_data_.disjuncts_[id_, 0]
                         d0.c1 = Constraint(expr=vars_[0] == 1)
                         d0.c2 = Constraint(expr=v == vars_[1])
                         # Second disjunct
-                        d1 = instance.bilinear_data_.disjuncts_[id_,1]
+                        d1 = instance.bilinear_data_.disjuncts_[id_, 1]
                         d1.c1 = Constraint(expr=vars_[0] == 0)
                         d1.c2 = Constraint(expr=v == 0)
                         # Disjunction
-                        instance.bilinear_data_.disjunction_data[id_] = [instance.bilinear_data_.disjuncts_[id_,0], instance.bilinear_data_.disjuncts_[id_,1]]
-                        instance.bilinear_data_.disjunction_data[id_] = [instance.bilinear_data_.disjuncts_[id_,0], instance.bilinear_data_.disjuncts_[id_,1]]
+                        instance.bilinear_data_.disjunction_data[id_] = [
+                            instance.bilinear_data_.disjuncts_[id_, 0],
+                            instance.bilinear_data_.disjuncts_[id_, 1],
+                        ]
+                        instance.bilinear_data_.disjunction_data[id_] = [
+                            instance.bilinear_data_.disjuncts_[id_, 0],
+                            instance.bilinear_data_.disjuncts_[id_, 1],
+                        ]
                     # The disjunctive variable is the expression
-                    e += coef_*v
+                    e += coef_ * v
                 #
                 elif vars_[1].is_binary():
-                    v = instance.bilinear_data_.cache.get( (id(vars_[1]),id(vars_[0])), None )
+                    v = instance.bilinear_data_.cache.get(
+                        (id(vars_[1]), id(vars_[0])), None
+                    )
                     if v is None:
                         instance.bilinear_data_.vlist_boolean.append(vars_[1])
                         v = instance.bilinear_data_.vlist.add()
@@ -117,20 +148,22 @@ class Bilinear_Transformation(Transformation):
                         id_ = len(instance.bilinear_data_.vlist)
                         instance.bilinear_data_.IDX.add(id_)
                         # First disjunct
-                        d0 = instance.bilinear_data_.disjuncts_[id_,0]
+                        d0 = instance.bilinear_data_.disjuncts_[id_, 0]
                         d0.c1 = Constraint(expr=vars_[1] == 1)
                         d0.c2 = Constraint(expr=v == vars_[0])
                         # Second disjunct
-                        d1 = instance.bilinear_data_.disjuncts_[id_,1]
+                        d1 = instance.bilinear_data_.disjuncts_[id_, 1]
                         d1.c1 = Constraint(expr=vars_[1] == 0)
                         d1.c2 = Constraint(expr=v == 0)
                         # Disjunction
-                        instance.bilinear_data_.disjunction_data[id_] = [instance.bilinear_data_.disjuncts_[id_,0], instance.bilinear_data_.disjuncts_[id_,1]]
+                        instance.bilinear_data_.disjunction_data[id_] = [
+                            instance.bilinear_data_.disjuncts_[id_, 0],
+                            instance.bilinear_data_.disjuncts_[id_, 1],
+                        ]
                     # The disjunctive variable is the expression
-                    e += coef_*v
+                    e += coef_ * v
                 else:
                     # If neither variable is boolean, just reinsert the original bilinear term
-                    e += coef_*vars_[0]*vars_[1]
+                    e += coef_ * vars_[0] * vars_[1]
         #
         return e
-            

--- a/pyomo/gdp/plugins/chull.py
+++ b/pyomo/gdp/plugins/chull.py
@@ -10,9 +10,11 @@
 #  ___________________________________________________________________________
 
 from pyomo.common.deprecation import deprecation_warning
+
 deprecation_warning(
     'The pyomo.gdp.plugins.chull module is deprecated.  '
     'Import the Hull reformulation objects from pyomo.gdp.plugins.hull.',
-    version='5.7')
+    version='5.7',
+)
 
 from .hull import _Deprecated_Name_Hull as ConvexHull_Transformation

--- a/pyomo/gdp/plugins/cuttingplane.py
+++ b/pyomo/gdp/plugins/cuttingplane.py
@@ -17,41 +17,67 @@ convex GDPs.
 """
 from __future__ import division
 
-from pyomo.common.config import (ConfigBlock, ConfigValue,
-                                 NonNegativeFloat, PositiveInt, In)
+from pyomo.common.config import (
+    ConfigBlock,
+    ConfigValue,
+    NonNegativeFloat,
+    PositiveInt,
+    In,
+)
 from pyomo.common.modeling import unique_component_name
-from pyomo.core import ( Any, Block, Constraint, Objective, Param, Var,
-                         SortComponents, Transformation, TransformationFactory,
-                         value, NonNegativeIntegers, Reals, NonNegativeReals,
-                         Suffix, ComponentMap )
+from pyomo.core import (
+    Any,
+    Block,
+    Constraint,
+    Objective,
+    Param,
+    Var,
+    SortComponents,
+    Transformation,
+    TransformationFactory,
+    value,
+    NonNegativeIntegers,
+    Reals,
+    NonNegativeReals,
+    Suffix,
+    ComponentMap,
+)
 from pyomo.core.expr import differentiate
 from pyomo.common.collections import ComponentSet
 from pyomo.opt import SolverFactory
 from pyomo.repn import generate_standard_repn
 
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
-from pyomo.gdp.util import ( verify_successful_solve, NORMAL,
-                             clone_without_expression_components )
+from pyomo.gdp.util import (
+    verify_successful_solve,
+    NORMAL,
+    clone_without_expression_components,
+)
 
-from pyomo.contrib.fme.fourier_motzkin_elimination import \
-    Fourier_Motzkin_Elimination_Transformation
+from pyomo.contrib.fme.fourier_motzkin_elimination import (
+    Fourier_Motzkin_Elimination_Transformation,
+)
 
 import logging
 
 logger = logging.getLogger('pyomo.gdp.cuttingplane')
 
+
 def do_not_tighten(m):
     return m
 
+
 def _get_constraint_exprs(constraints, hull_to_bigm_map):
-    """Returns a list of expressions which are constrain.expr translated 
+    """Returns a list of expressions which are constrain.expr translated
     into the bigm space, for each constraint in constraints.
     """
     cuts = []
     for cons in constraints:
-        cuts.append(clone_without_expression_components( 
-            cons.expr, substitute=hull_to_bigm_map))
+        cuts.append(
+            clone_without_expression_components(cons.expr, substitute=hull_to_bigm_map)
+        )
     return cuts
+
 
 def _constraint_tight(model, constraint, TOL):
     """
@@ -74,24 +100,22 @@ def _constraint_tight(model, constraint, TOL):
 
     return ans
 
+
 def _get_linear_approximation_expr(normal_vec, point):
     """Returns constraint linearly approximating constraint normal to normal_vec
     at point"""
     body = 0
     for coef, v in zip(point, normal_vec):
-        body -= coef*v
-    return body >= -sum(normal_vec[idx]*v.value for (idx, v) in
-                       enumerate(point))
+        body -= coef * v
+    return body >= -sum(normal_vec[idx] * v.value for (idx, v) in enumerate(point))
 
-def _precompute_potentially_useful_constraints(transBlock_rHull,
-                                               disaggregated_vars):
+
+def _precompute_potentially_useful_constraints(transBlock_rHull, disaggregated_vars):
     instance_rHull = transBlock_rHull.model()
     constraints = transBlock_rHull.constraints_for_FME = []
     for constraint in instance_rHull.component_data_objects(
-            Constraint,
-            active=True,
-            descend_into=Block,
-            sort=SortComponents.deterministic):
+        Constraint, active=True, descend_into=Block, sort=SortComponents.deterministic
+    ):
         # we don't care about anything that does not involve at least one
         # disaggregated variable.
         repn = generate_standard_repn(constraint.body)
@@ -101,31 +125,41 @@ def _precompute_potentially_useful_constraints(transBlock_rHull,
                 constraints.append(constraint)
                 break
 
-def create_cuts_fme(transBlock_rHull, var_info, hull_to_bigm_map,
-                    rBigM_linear_constraints, rHull_vars, disaggregated_vars,
-                    norm, cut_threshold, zero_tolerance, integer_arithmetic,
-                    constraint_tolerance):
+
+def create_cuts_fme(
+    transBlock_rHull,
+    var_info,
+    hull_to_bigm_map,
+    rBigM_linear_constraints,
+    rHull_vars,
+    disaggregated_vars,
+    norm,
+    cut_threshold,
+    zero_tolerance,
+    integer_arithmetic,
+    constraint_tolerance,
+):
     """Returns a cut which removes x* from the relaxed bigm feasible region.
 
-    Finds all the constraints which are tight at xhat (assumed to be the 
+    Finds all the constraints which are tight at xhat (assumed to be the
     solution currently in instance_rHull), and calculates a composite normal
     vector by summing the vectors normal to each of these constraints. Then
     Fourier-Motzkin elimination is used to project the disaggregated variables
-    out of the polyhedron formed by the composite normal and the collection 
+    out of the polyhedron formed by the composite normal and the collection
     of tight constraints. This results in multiple cuts, of which we select
     one that cuts of x* by the greatest margin, as long as that margin is
-    more than cut_threshold. If no cut satisfies the margin specified by 
+    more than cut_threshold. If no cut satisfies the margin specified by
     cut_threshold, we return None.
 
     Parameters
     -----------
     transBlock_rHull: transformation blcok on relaxed hull instance
     var_info: List of tuples (rBigM_var, rHull_var, xstar_param)
-    hull_to_bigm_map: For expression substition, maps id(hull_var) to 
+    hull_to_bigm_map: For expression substition, maps id(hull_var) to
                       coresponding bigm var
     rBigM_linear_constraints: list of linear constraints in relaxed bigM
     rHull_vars: list of all variables in relaxed hull
-    disaggregated_vars: ComponentSet of disaggregated variables in hull 
+    disaggregated_vars: ComponentSet of disaggregated variables in hull
                         reformulation
     norm: norm used in the separation problem
     cut_threshold: Amount x* needs to be infeasible in generated cut in order
@@ -133,9 +167,9 @@ def create_cuts_fme(transBlock_rHull, var_info, hull_to_bigm_map,
     zero_tolerance: Tolerance at which a float will be treated as 0 during
                     Fourier-Motzkin elimination
     integer_arithmetic: boolean, whether or not to require Fourier-Motzkin
-                        Elimination does integer arithmetic. Only possible 
+                        Elimination does integer arithmetic. Only possible
                         when all data is integer.
-    constraint_tolerance: Tolerance at which we will consider a constraint 
+    constraint_tolerance: Tolerance at which we will consider a constraint
                           tight.
     """
     instance_rHull = transBlock_rHull.model()
@@ -143,31 +177,31 @@ def create_cuts_fme(transBlock_rHull, var_info, hull_to_bigm_map,
     # ever be interesting: Everything that involves at least one disaggregated
     # variable.
     if transBlock_rHull.component("constraints_for_FME") is None:
-        _precompute_potentially_useful_constraints( transBlock_rHull,
-                                                    disaggregated_vars)
+        _precompute_potentially_useful_constraints(transBlock_rHull, disaggregated_vars)
 
     tight_constraints = Block()
-    conslist = tight_constraints.constraints = Constraint(
-        NonNegativeIntegers)
+    conslist = tight_constraints.constraints = Constraint(NonNegativeIntegers)
     conslist.construct()
     something_interesting = False
     for constraint in transBlock_rHull.constraints_for_FME:
-        multipliers = _constraint_tight(instance_rHull, constraint,
-                                        constraint_tolerance)
+        multipliers = _constraint_tight(
+            instance_rHull, constraint, constraint_tolerance
+        )
         for multiplier in multipliers:
             if multiplier:
                 something_interesting = True
                 f = constraint.body
                 firstDerivs = differentiate(f, wrt_list=rHull_vars)
-                normal_vec = [multiplier*value(_) for _ in firstDerivs]
+                normal_vec = [multiplier * value(_) for _ in firstDerivs]
                 # check if constraint is linear
                 if f.polynomial_degree() == 1:
                     conslist[len(conslist)] = constraint.expr
-                else: 
+                else:
                     # we will use the linear approximation of this constraint at
                     # x_hat
                     conslist[len(conslist)] = _get_linear_approximation_expr(
-                        normal_vec, rHull_vars)
+                        normal_vec, rHull_vars
+                    )
 
     # NOTE: we now have all the tight Constraints (in the pyomo sense of the
     # word "Constraint"), but we are missing some variable bounds. The ones for
@@ -181,14 +215,17 @@ def create_cuts_fme(transBlock_rHull, var_info, hull_to_bigm_map,
         return None
 
     tight_constraints.construct()
-    logger.info("Calling FME transformation on %s constraints to eliminate"
-                " %s variables" % (len(tight_constraints.constraints),
-                                   len(disaggregated_vars)))
-    TransformationFactory('contrib.fourier_motzkin_elimination').\
-        apply_to(tight_constraints, vars_to_eliminate=disaggregated_vars,
-                 zero_tolerance=zero_tolerance,
-                 do_integer_arithmetic=integer_arithmetic,
-                 projected_constraints_name="fme_constraints")
+    logger.info(
+        "Calling FME transformation on %s constraints to eliminate"
+        " %s variables" % (len(tight_constraints.constraints), len(disaggregated_vars))
+    )
+    TransformationFactory('contrib.fourier_motzkin_elimination').apply_to(
+        tight_constraints,
+        vars_to_eliminate=disaggregated_vars,
+        zero_tolerance=zero_tolerance,
+        do_integer_arithmetic=integer_arithmetic,
+        projected_constraints_name="fme_constraints",
+    )
     fme_results = tight_constraints.fme_constraints
     projected_constraints = [cons for i, cons in fme_results.items()]
 
@@ -212,7 +249,7 @@ def create_cuts_fme(transBlock_rHull, var_info, hull_to_bigm_map,
             logger.info("FME:\t Doesn't cut off x*")
             continue
         # we have found a constraint which cuts of x* by some convincing amount
-        # and is not already in rBigM. 
+        # and is not already in rBigM.
         cuts_to_keep.append(i)
         # We know cut is lb <= expr and that it's violated
         assert len(cut.args) == 2
@@ -232,14 +269,23 @@ def create_cuts_fme(transBlock_rHull, var_info, hull_to_bigm_map,
 
     return None
 
-def create_cuts_normal_vector(transBlock_rHull, var_info, hull_to_bigm_map,
-                              rBigM_linear_constraints, rHull_vars,
-                              disaggregated_vars, norm, cut_threshold,
-                              zero_tolerance, integer_arithmetic,
-                              constraint_tolerance):
+
+def create_cuts_normal_vector(
+    transBlock_rHull,
+    var_info,
+    hull_to_bigm_map,
+    rBigM_linear_constraints,
+    rHull_vars,
+    disaggregated_vars,
+    norm,
+    cut_threshold,
+    zero_tolerance,
+    integer_arithmetic,
+    constraint_tolerance,
+):
     """Returns a cut which removes x* from the relaxed bigm feasible region.
 
-    Ignores all parameters except var_info and cut_threshold, and constructs 
+    Ignores all parameters except var_info and cut_threshold, and constructs
     a cut at x_hat, the projection of the relaxed bigM solution x* onto the hull,
     which is perpendicular to the vector from x* to x_hat.
 
@@ -252,12 +298,12 @@ def create_cuts_normal_vector(transBlock_rHull, var_info, hull_to_bigm_map,
     transBlock_rHull: transformation blcok on relaxed hull instance. Ignored by
                       this callback.
     var_info: List of tuples (rBigM_var, rHull_var, xstar_param)
-    hull_to_bigm_map: For expression substition, maps id(hull_var) to 
+    hull_to_bigm_map: For expression substition, maps id(hull_var) to
                       coresponding bigm var. Ignored by this callback
     rBigM_linear_constraints: list of linear constraints in relaxed bigM.
                               Ignored by this callback.
     rHull_vars: list of all variables in relaxed hull. Ignored by this callback.
-    disaggregated_vars: ComponentSet of disaggregated variables in hull 
+    disaggregated_vars: ComponentSet of disaggregated variables in hull
                         reformulation. Ignored by this callback
     norm: The norm used in the separation problem, will be used to calculate
           the subgradient used to generate the cut
@@ -273,37 +319,42 @@ def create_cuts_normal_vector(transBlock_rHull, var_info, hull_to_bigm_map,
     cutexpr = 0
     if norm == 2:
         for x_rbigm, x_hull, x_star in var_info:
-            cutexpr += (x_hull.value - x_star.value)*(x_rbigm - x_hull.value)
+            cutexpr += (x_hull.value - x_star.value) * (x_rbigm - x_hull.value)
     elif norm == float('inf'):
         duals = transBlock_rHull.model().dual
         if len(duals) == 0:
-            raise GDP_Error("No dual information in the separation problem! "
-                            "To use the infinity norm and the "
-                            "create_cuts_normal_vector method, you must use "
-                            "a solver which provides dual information.")
+            raise GDP_Error(
+                "No dual information in the separation problem! "
+                "To use the infinity norm and the "
+                "create_cuts_normal_vector method, you must use "
+                "a solver which provides dual information."
+            )
         i = 0
         for x_rbigm, x_hull, x_star in var_info:
             # ESJ: We wrote this so duals will be nonnegative
             mu_plus = value(duals[transBlock_rHull.inf_norm_linearization[i]])
-            mu_minus = value(duals[transBlock_rHull.inf_norm_linearization[i+1]])
+            mu_minus = value(duals[transBlock_rHull.inf_norm_linearization[i + 1]])
             assert mu_plus >= 0
             assert mu_minus >= 0
-            cutexpr += (mu_plus - mu_minus)*(x_rbigm - x_hull.value)
+            cutexpr += (mu_plus - mu_minus) * (x_rbigm - x_hull.value)
             i += 2
 
     # make sure we're cutting off x* by enough.
     if value(cutexpr) < -cut_threshold:
         return [cutexpr >= 0]
-    logger.warning("Generated cut did not remove relaxed BigM solution by more "
-                   "than the specified threshold of %s. Stopping cut "
-                   "generation." % cut_threshold)
+    logger.warning(
+        "Generated cut did not remove relaxed BigM solution by more "
+        "than the specified threshold of %s. Stopping cut "
+        "generation." % cut_threshold
+    )
     return None
 
-def back_off_constraint_with_calculated_cut_violation(cut, transBlock_rHull,
-                                                      bigm_to_hull_map, opt,
-                                                      stream_solver, TOL):
+
+def back_off_constraint_with_calculated_cut_violation(
+    cut, transBlock_rHull, bigm_to_hull_map, opt, stream_solver, TOL
+):
     """Calculates the maximum violation of cut subject to the relaxed hull
-    constraints. Increases this violation by TOL (to account for optimality 
+    constraints. Increases this violation by TOL (to account for optimality
     tolerance in solving the problem), and, if it finds that cut can be violated
     up to this tolerance, makes it more conservative such that it no longer can.
 
@@ -311,7 +362,7 @@ def back_off_constraint_with_calculated_cut_violation(cut, transBlock_rHull,
     ----------
     cut: The cut to be made more conservative, a Constraint
     transBlock_rHull: the relaxed hull model's transformation Block
-    bigm_to_hull_map: Dictionary mapping ids of bigM variables to the 
+    bigm_to_hull_map: Dictionary mapping ids of bigM variables to the
                       corresponding variables on the relaxed hull instance
     opt: SolverFactory object for solving the maximum violation problem
     stream_solver: Whether or not to set tee=True while solving the maximum
@@ -328,15 +379,17 @@ def back_off_constraint_with_calculated_cut_violation(cut, transBlock_rHull,
     transBlock_rHull.separation_objective.deactivate()
 
     transBlock_rHull.infeasibility_objective = Objective(
-        expr=clone_without_expression_components(cut.body,
-                                                 substitute=bigm_to_hull_map))
+        expr=clone_without_expression_components(cut.body, substitute=bigm_to_hull_map)
+    )
 
     results = opt.solve(instance_rHull, tee=stream_solver, load_solutions=False)
     if verify_successful_solve(results) is not NORMAL:
-        logger.warning("Problem to determine how much to "
-                       "back off the new cut "
-                       "did not solve normally. Leaving the constraint as is, "
-                       "which could lead to numerical trouble%s" % (results,))
+        logger.warning(
+            "Problem to determine how much to "
+            "back off the new cut "
+            "did not solve normally. Leaving the constraint as is, "
+            "which could lead to numerical trouble%s" % (results,)
+        )
         # restore the objective
         transBlock_rHull.del_component(transBlock_rHull.infeasibility_objective)
         transBlock_rHull.separation_objective.activate()
@@ -352,9 +405,10 @@ def back_off_constraint_with_calculated_cut_violation(cut, transBlock_rHull,
     transBlock_rHull.del_component(transBlock_rHull.infeasibility_objective)
     transBlock_rHull.separation_objective.activate()
 
-def back_off_constraint_by_fixed_tolerance(cut, transBlock_rHull,
-                                           bigm_to_hull_map, opt, stream_solver,
-                                           TOL):
+
+def back_off_constraint_by_fixed_tolerance(
+    cut, transBlock_rHull, bigm_to_hull_map, opt, stream_solver, TOL
+):
     """Makes cut more conservative by absolute tolerance TOL
 
     Parameters
@@ -362,7 +416,7 @@ def back_off_constraint_by_fixed_tolerance(cut, transBlock_rHull,
     cut: the cut to be made more conservative, a Constraint
     transBlock_rHull: the relaxed hull model's transformation Block. Ignored by
                       this callback
-    bigm_to_hull_map: Dictionary mapping ids of bigM variables to the 
+    bigm_to_hull_map: Dictionary mapping ids of bigM variables to the
                       corresponding variables on the relaxed hull instance.
                       Ignored by this callback.
     opt: SolverFactory object. Ignored by this callback
@@ -372,10 +426,13 @@ def back_off_constraint_by_fixed_tolerance(cut, transBlock_rHull,
     """
     cut._body += TOL
 
-@TransformationFactory.register('gdp.cuttingplane',
-                                doc="Relaxes a linear disjunctive model by "
-                                "adding cuts from convex hull to Big-M "
-                                "reformulation.")
+
+@TransformationFactory.register(
+    'gdp.cuttingplane',
+    doc="Relaxes a linear disjunctive model by "
+    "adding cuts from convex hull to Big-M "
+    "reformulation.",
+)
 class CuttingPlane_Transformation(Transformation):
     """Relax convex disjunctive model by forming the bigm relaxation and then
     iteratively adding cuts from the hull relaxation (or the hull relaxation
@@ -386,7 +443,7 @@ class CuttingPlane_Transformation(Transformation):
     after transformation will very likely result in an invalid model.
 
     This transformation accepts the following keyword arguments:
-    
+
     Parameters
     ----------
     solver : Solver name (as string) to use to solve relaxed BigM and separation
@@ -397,21 +454,21 @@ class CuttingPlane_Transformation(Transformation):
     cuts_name : Optional name for the IndexedConstraint containing the projected
                 cuts (must be a unique name with respect to the instance)
     minimum_improvement_threshold : Stopping criterion based on improvement in
-                                    Big-M relaxation. This is the minimum 
+                                    Big-M relaxation. This is the minimum
                                     difference in relaxed BigM objective
                                     values between consecutive iterations
-    separation_objective_threshold : Stopping criterion based on separation 
-                                     objective. If separation objective is not 
-                                     at least this large, cut generation will 
+    separation_objective_threshold : Stopping criterion based on separation
+                                     objective. If separation objective is not
+                                     at least this large, cut generation will
                                      terminate.
-    cut_filtering_threshold : Stopping criterion based on effectiveness of the 
-                              generated cut: This is the amount by which 
-                              a cut must be violated at the relaxed bigM 
+    cut_filtering_threshold : Stopping criterion based on effectiveness of the
+                              generated cut: This is the amount by which
+                              a cut must be violated at the relaxed bigM
                               solution in order to be added to the bigM model
     max_number_of_cuts : The maximum number of cuts to add to the big-M model
     norm : norm to use in the objective of the separation problem
-    tighten_relaxation : callback to modify the GDP model before the hull 
-                         relaxation is taken (e.g. could be used to perform 
+    tighten_relaxation : callback to modify the GDP model before the hull
+                         relaxation is taken (e.g. could be used to perform
                          basic steps)
     create_cuts : callback to create cuts using the solved relaxed bigM and hull
                   problems
@@ -428,79 +485,92 @@ class CuttingPlane_Transformation(Transformation):
 
     By default, the callbacks will be set such that the algorithm performed is
     as presented in [1], but with an additional post-processing procedure to
-    reduce numerical error, which calculates the maximum violation of the cut 
-    subject to the relaxed hull constraints, and then pads the constraint by 
+    reduce numerical error, which calculates the maximum violation of the cut
+    subject to the relaxed hull constraints, and then pads the constraint by
     this violation plus an additional user-specified tolerance.
 
     In addition, the create_cuts_fme function provides an (exponential time)
-    method of generating cuts which reduces numerical error (and can eliminate 
-    it if all data is integer). It collects the hull constraints which are 
-    tight at the solution of the separation problem. It creates a cut in the 
-    extended space perpendicular to  a composite normal vector created by 
-    summing the directions normal to these constraints. It then performs 
+    method of generating cuts which reduces numerical error (and can eliminate
+    it if all data is integer). It collects the hull constraints which are
+    tight at the solution of the separation problem. It creates a cut in the
+    extended space perpendicular to  a composite normal vector created by
+    summing the directions normal to these constraints. It then performs
     fourier-motzkin elimination on the collection of constraints and the cut
     to project out the disaggregated variables. The resulting constraint which
     is most violated by the relaxed bigM solution is then returned.
 
     References
     ----------
-        [1] Sawaya, N. W., Grossmann, I. E. (2005). A cutting plane method for 
+        [1] Sawaya, N. W., Grossmann, I. E. (2005). A cutting plane method for
         solving linear generalized disjunctive programming problems. Computers
-        and Chemical Engineering, 29, 1891-1913 
+        and Chemical Engineering, 29, 1891-1913
     """
 
     CONFIG = ConfigBlock("gdp.cuttingplane")
-    CONFIG.declare('solver', ConfigValue(
-        default='ipopt',
-        domain=str,
-        description="""Solver to use for relaxed BigM problem and the separation
+    CONFIG.declare(
+        'solver',
+        ConfigValue(
+            default='ipopt',
+            domain=str,
+            description="""Solver to use for relaxed BigM problem and the separation
         problem""",
-        doc="""
+            doc="""
         This specifies the solver which will be used to solve LP relaxation
         of the BigM problem and the separation problem. Note that this solver
         must be able to handle a quadratic objective because of the separation
         problem.
-        """
-    ))
-    CONFIG.declare('minimum_improvement_threshold', ConfigValue(
-        default=0.01,
-        domain=NonNegativeFloat,
-        description="Threshold value for difference in relaxed bigM problem "
-        "objectives used to decide when to stop adding cuts",
-        doc="""
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'minimum_improvement_threshold',
+        ConfigValue(
+            default=0.01,
+            domain=NonNegativeFloat,
+            description="Threshold value for difference in relaxed bigM problem "
+            "objectives used to decide when to stop adding cuts",
+            doc="""
         If the difference between the objectives in two consecutive iterations is
         less than this value, the algorithm terminates without adding the cut
         generated in the last iteration.  
-        """
-    ))
-    CONFIG.declare('separation_objective_threshold', ConfigValue(
-        default=0.01,
-        domain=NonNegativeFloat,
-        description="Threshold value used to decide when to stop adding cuts: "
-        "If separation problem objective is not at least this quantity, cut "
-        "generation will terminate.",
-        doc="""
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'separation_objective_threshold',
+        ConfigValue(
+            default=0.01,
+            domain=NonNegativeFloat,
+            description="Threshold value used to decide when to stop adding cuts: "
+            "If separation problem objective is not at least this quantity, cut "
+            "generation will terminate.",
+            doc="""
         If the separation problem objective (distance between relaxed bigM 
         solution and its projection onto the relaxed hull feasible region)
         does not exceed this threshold, the algorithm will terminate.
-        """
-    ))
-    CONFIG.declare('max_number_of_cuts', ConfigValue(
-        default=100,
-        domain=PositiveInt,
-        description="The maximum number of cuts to add before the algorithm "
-        "terminates.",
-        doc="""
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'max_number_of_cuts',
+        ConfigValue(
+            default=100,
+            domain=PositiveInt,
+            description="The maximum number of cuts to add before the algorithm "
+            "terminates.",
+            doc="""
         If the algorithm does not terminate due to another criterion first,
         cut generation will stop after adding this many cuts.
-        """
-    ))
-    CONFIG.declare('norm', ConfigValue(
-        default=2,
-        domain=In([2, float('inf')]),
-        description="Norm to use in the separation problem: 2, or "
-        "float('inf')",
-        doc="""
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'norm',
+        ConfigValue(
+            default=2,
+            domain=In([2, float('inf')]),
+            description="Norm to use in the separation problem: 2, or float('inf')",
+            doc="""
         Norm used to calculate distance in the objective of the separation 
         problem which finds the nearest point on the hull relaxation region
         to the current solution of the relaxed bigm problem.
@@ -508,39 +578,51 @@ class CuttingPlane_Transformation(Transformation):
         Supported norms are the Euclidean norm (specify 2) and the infinity 
         norm (specify float('inf')). Note that the first makes the separation 
         problem objective quadratic and the latter makes it linear.
-        """
-    ))
-    CONFIG.declare('verbose', ConfigValue(
-        default=False,
-        domain=bool,
-        description="Flag to enable verbose output",
-        doc="""
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'verbose',
+        ConfigValue(
+            default=False,
+            domain=bool,
+            description="Flag to enable verbose output",
+            doc="""
         If True, prints subproblem solutions, as well as potential and added cuts
         during algorithm.
 
         If False, only the relaxed BigM objective and minimal information about 
         cuts is logged.
-        """
-    ))
-    CONFIG.declare('stream_solver', ConfigValue(
-        default=False,
-        domain=bool,
-        description="""If true, sets tee=True for every solve performed over
-        "the course of the algorithm"""
-    ))
-    CONFIG.declare('solver_options', ConfigBlock(
-        implicit=True,
-        description="Dictionary of solver options",
-        doc="""
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'stream_solver',
+        ConfigValue(
+            default=False,
+            domain=bool,
+            description="""If true, sets tee=True for every solve performed over
+        "the course of the algorithm""",
+        ),
+    )
+    CONFIG.declare(
+        'solver_options',
+        ConfigBlock(
+            implicit=True,
+            description="Dictionary of solver options",
+            doc="""
         Dictionary of solver options that will be set for the solver for both the
         relaxed BigM and separation problem solves.
-        """
-    ))
-    CONFIG.declare('tighten_relaxation', ConfigValue(
-        default=do_not_tighten,
-        description="Callback which takes the GDP formulation and returns a "
-        "GDP formulation with a tighter hull relaxation",
-        doc="""
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'tighten_relaxation',
+        ConfigValue(
+            default=do_not_tighten,
+            description="Callback which takes the GDP formulation and returns a "
+            "GDP formulation with a tighter hull relaxation",
+            doc="""
         Function which accepts the GDP formulation of the problem and returns
         a GDP formulation which the transformation will then take the hull
         reformulation of.
@@ -548,14 +630,17 @@ class CuttingPlane_Transformation(Transformation):
         Most typically, this callback would be used to apply basic steps before
         taking the hull reformulation, but anything which tightens the GDP can 
         be performed here.
-        """
-    ))
-    CONFIG.declare('create_cuts', ConfigValue(
-        default=create_cuts_normal_vector,
-        description="Callback which generates a list of cuts, given the solved "
-        "relaxed bigM and relaxed hull solutions. If no cuts can be "
-        "generated, returns None",
-        doc="""
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'create_cuts',
+        ConfigValue(
+            default=create_cuts_normal_vector,
+            description="Callback which generates a list of cuts, given the solved "
+            "relaxed bigM and relaxed hull solutions. If no cuts can be "
+            "generated, returns None",
+            doc="""
         Callback to generate cuts to be added to the bigM problem based on 
         solutions to the relaxed bigM problem and the separation problem.
 
@@ -578,14 +663,17 @@ class CuttingPlane_Transformation(Transformation):
         -------
         list of cuts to be added to bigM problem (and relaxed bigM problem),
         represented as expressions using variables from the bigM model
-        """
-    ))
-    CONFIG.declare('post_process_cut', ConfigValue(
-        default=back_off_constraint_with_calculated_cut_violation,
-        description="Callback which takes a generated cut and post processes "
-        "it, presumably to back it off in the case of numerical error. Set to "
-        "None if not post-processing is desired.",
-        doc="""
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'post_process_cut',
+        ConfigValue(
+            default=back_off_constraint_with_calculated_cut_violation,
+            description="Callback which takes a generated cut and post processes "
+            "it, presumably to back it off in the case of numerical error. Set to "
+            "None if not post-processing is desired.",
+            doc="""
         Callback to adjust a cut returned from create_cuts before adding it to
         the model, presumably to make it more conservative in case of numerical
         error.
@@ -603,62 +691,77 @@ class CuttingPlane_Transformation(Transformation):
         Returns
         -------
         None, modifies the cut in place
-        """
-    ))
+        """,
+        ),
+    )
     # back off problem tolerance (on top of the solver's (sometimes))
-    CONFIG.declare('back_off_problem_tolerance', ConfigValue(
-        default=1e-8,
-        domain=NonNegativeFloat,
-        description="Tolerance to pass to the post_process_cut callback.",
-        doc="""
+    CONFIG.declare(
+        'back_off_problem_tolerance',
+        ConfigValue(
+            default=1e-8,
+            domain=NonNegativeFloat,
+            description="Tolerance to pass to the post_process_cut callback.",
+            doc="""
         Tolerance passed to the post_process_cut callback.
 
         Depending on the callback, different values could make sense, but 
         something on the order of the solver's optimality or constraint 
         tolerances is appropriate.
-        """
-    ))
-    CONFIG.declare('cut_filtering_threshold', ConfigValue(
-        default=0.001,
-        domain=NonNegativeFloat,
-        description="Tolerance used to decide if a cut removes x* from the "
-        "relaxed BigM problem by enough to be added to the bigM problem.",
-        doc="""
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'cut_filtering_threshold',
+        ConfigValue(
+            default=0.001,
+            domain=NonNegativeFloat,
+            description="Tolerance used to decide if a cut removes x* from the "
+            "relaxed BigM problem by enough to be added to the bigM problem.",
+            doc="""
         Absolute tolerance used to decide whether to keep a cut. We require
         that, when evaluated at x* (the relaxed BigM optimal solution), the 
         cut be infeasible by at least this tolerance.
-        """
-    ))
-    CONFIG.declare('zero_tolerance', ConfigValue(
-        default=1e-9,
-        domain=NonNegativeFloat,
-        description="Tolerance at which floats are assumed to be 0 while "
-        "performing Fourier-Motzkin elimination",
-        doc="""
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'zero_tolerance',
+        ConfigValue(
+            default=1e-9,
+            domain=NonNegativeFloat,
+            description="Tolerance at which floats are assumed to be 0 while "
+            "performing Fourier-Motzkin elimination",
+            doc="""
         Only relevant when create_cuts=create_cuts_fme, this sets the 
         zero_tolerance option for the Fourier-Motzkin elimination transformation.
-        """
-    ))
-    CONFIG.declare('do_integer_arithmetic', ConfigValue(
-        default=False,
-        domain=bool,
-        description="Only relevant if using Fourier-Motzkin Elimination (FME) "
-        "and if all problem data is integer, requires FME transformation to "
-        "perform integer arithmetic to eliminate numerical error.",
-        doc="""
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'do_integer_arithmetic',
+        ConfigValue(
+            default=False,
+            domain=bool,
+            description="Only relevant if using Fourier-Motzkin Elimination (FME) "
+            "and if all problem data is integer, requires FME transformation to "
+            "perform integer arithmetic to eliminate numerical error.",
+            doc="""
         Only relevant when create_cuts=create_cuts_fme and if all problem data 
         is integer, this sets the do_integer_arithmetic flag to true for the 
         FME transformation, meaning that the projection to the big-M space 
         can be done with exact precision.
-        """
-    ))
-    CONFIG.declare('cuts_name', ConfigValue(
-        default=None,
-        domain=str,
-        description="Optional name for the IndexedConstraint containing the "
-        "projected cuts. Must be a unique name with respect to the "
-        "instance.",
-        doc="""
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'cuts_name',
+        ConfigValue(
+            default=None,
+            domain=str,
+            description="Optional name for the IndexedConstraint containing the "
+            "projected cuts. Must be a unique name with respect to the "
+            "instance.",
+            doc="""
         Optional name for the IndexedConstraint containing the projected 
         constraints. If not specified, the cuts will be stored on a 
         private block created by the transformation, so if you want access 
@@ -666,22 +769,27 @@ class CuttingPlane_Transformation(Transformation):
 
         Must be a string which is a unique component name with respect to the 
         Block on which the transformation is called.
-        """
-    ))
-    CONFIG.declare('tight_constraint_tolerance', ConfigValue(
-        default=1e-6, # Gurobi constraint tolerance
-        domain=NonNegativeFloat,
-        description="Tolerance at which a constraint is considered tight for "
-        "the Fourier-Motzkin cut generation procedure.",
-        doc="""
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'tight_constraint_tolerance',
+        ConfigValue(
+            default=1e-6,  # Gurobi constraint tolerance
+            domain=NonNegativeFloat,
+            description="Tolerance at which a constraint is considered tight for "
+            "the Fourier-Motzkin cut generation procedure.",
+            doc="""
         For a constraint a^Tx <= b, the Fourier-Motzkin cut generation procedure
         will consider the constraint tight (and add it to the set of constraints
         being projected) when a^Tx - b is less than this tolerance. 
 
         It is recommended to set this tolerance to the constraint tolerance of
         the solver being used.
-        """
-    ))
+        """,
+        ),
+    )
+
     def __init__(self):
         super(CuttingPlane_Transformation, self).__init__()
 
@@ -700,18 +808,22 @@ class CuttingPlane_Transformation(Transformation):
             else:
                 self.verbose = False
 
-            (instance_rBigM, cuts_obj, instance_rHull, var_info, 
-             transBlockName) = self._setup_subproblems( instance, bigM,
-                                                        self._config.\
-                                                        tighten_relaxation)
+            (
+                instance_rBigM,
+                cuts_obj,
+                instance_rHull,
+                var_info,
+                transBlockName,
+            ) = self._setup_subproblems(instance, bigM, self._config.tighten_relaxation)
 
-            self._generate_cuttingplanes( instance_rBigM, cuts_obj,
-                                          instance_rHull, var_info,
-                                          transBlockName)
+            self._generate_cuttingplanes(
+                instance_rBigM, cuts_obj, instance_rHull, var_info, transBlockName
+            )
 
             # restore integrality
-            TransformationFactory('core.relax_integer_vars').apply_to(instance,
-                                                                      undo=True)
+            TransformationFactory('core.relax_integer_vars').apply_to(
+                instance, undo=True
+            )
         finally:
             del self._config
             del self.verbose
@@ -725,10 +837,13 @@ class CuttingPlane_Transformation(Transformation):
         # We store a list of all vars so that we can efficiently
         # generate maps among the subproblems
 
-        transBlock.all_vars = list(v for v in instance.component_data_objects(
-            Var,
-            descend_into=(Block, Disjunct),
-            sort=SortComponents.deterministic) if not v.is_fixed())
+        transBlock.all_vars = list(
+            v
+            for v in instance.component_data_objects(
+                Var, descend_into=(Block, Disjunct), sort=SortComponents.deterministic
+            )
+            if not v.is_fixed()
+        )
 
         # we'll store all the cuts we add together
         nm = self._config.cuts_name
@@ -737,9 +852,11 @@ class CuttingPlane_Transformation(Transformation):
         else:
             # check that this really is an available name
             if instance.component(nm) is not None:
-                raise GDP_Error("cuts_name was specified as '%s', but this is "
-                                "already a component on the instance! Please "
-                                "specify a unique name." % nm)
+                raise GDP_Error(
+                    "cuts_name was specified as '%s', but this is "
+                    "already a component on the instance! Please "
+                    "specify a unique name." % nm
+                )
             instance.add_component(nm, Constraint(NonNegativeIntegers))
             cuts_obj = instance.component(nm)
 
@@ -754,8 +871,7 @@ class CuttingPlane_Transformation(Transformation):
         #
         tighter_instance = tighten_relaxation_callback(instance)
         instance_rHull = hullRelaxation.create_using(tighter_instance)
-        relaxIntegrality.apply_to(instance_rHull,
-                                  transform_deactivated_blocks=True)
+        relaxIntegrality.apply_to(instance_rHull, transform_deactivated_blocks=True)
 
         #
         # Reformulate the instance using the BigM relaxation (this will
@@ -777,8 +893,9 @@ class CuttingPlane_Transformation(Transformation):
         # this will hold the solution to rbigm each time we solve it. We
         # add it to the transformation block so that we don't have to
         # worry about name conflicts.
-        transBlock_rHull.xstar = Param( range(len(transBlock.all_vars)),
-                                        mutable=True, default=0, within=Reals)
+        transBlock_rHull.xstar = Param(
+            range(len(transBlock.all_vars)), mutable=True, default=0, within=Reals
+        )
 
         # we will add a block that we will deactivate to use to store the
         # extended space cuts. We never need to solve these, but we need them to
@@ -792,10 +909,13 @@ class CuttingPlane_Transformation(Transformation):
         # instances and the xstar parameter.
         #
         var_info = [
-            (v, # this is the bigM variable
-             transBlock_rHull.all_vars[i],
-             transBlock_rHull.xstar[i])
-            for i,v in enumerate(transBlock.all_vars)]
+            (
+                v,  # this is the bigM variable
+                transBlock_rHull.all_vars[i],
+                transBlock_rHull.xstar[i],
+            )
+            for i, v in enumerate(transBlock.all_vars)
+        ]
 
         # NOTE: we wait to add the separation objective to the rHull problem
         # because it is best to do it in the first iteration, so that we can
@@ -806,37 +926,37 @@ class CuttingPlane_Transformation(Transformation):
     # this is the map that I need to translate my projected cuts and add
     # them to bigM
     def _create_hull_to_bigm_substitution_map(self, var_info):
-        return dict((id(var_info[i][1]), var_info[i][0]) for i in
-                    range(len(var_info)))
+        return dict((id(var_info[i][1]), var_info[i][0]) for i in range(len(var_info)))
 
     # this map is needed to solve the back-off problem for post-processing
     def _create_bigm_to_hull_substition_map(self, var_info):
-        return dict((id(var_info[i][0]), var_info[i][1]) for i in
-                    range(len(var_info)))
+        return dict((id(var_info[i][0]), var_info[i][1]) for i in range(len(var_info)))
 
     def _get_disaggregated_vars(self, hull):
         disaggregatedVars = ComponentSet()
-        for disjunction in hull.component_data_objects( Disjunction,
-                                                        descend_into=(Disjunct,
-                                                                      Block)):
+        for disjunction in hull.component_data_objects(
+            Disjunction, descend_into=(Disjunct, Block)
+        ):
             for disjunct in disjunction.disjuncts:
                 transBlock = disjunct.transformation_block
                 if transBlock is not None:
-                    for v in transBlock.disaggregatedVars.\
-                        component_data_objects(Var):
+                    for v in transBlock.disaggregatedVars.component_data_objects(Var):
                         disaggregatedVars.add(v)
-                
+
         return disaggregatedVars
 
     def _get_rBigM_obj_and_constraints(self, instance_rBigM):
         # We try to grab the first active objective. If there is more
         # than one, the writer will yell when we try to solve below. If
         # there are 0, we will yell here.
-        rBigM_obj = next(instance_rBigM.component_data_objects(
-            Objective, active=True), None)
+        rBigM_obj = next(
+            instance_rBigM.component_data_objects(Objective, active=True), None
+        )
         if rBigM_obj is None:
-            raise GDP_Error("Cannot apply cutting planes transformation "
-                            "without an active objective in the model!")
+            raise GDP_Error(
+                "Cannot apply cutting planes transformation "
+                "without an active objective in the model!"
+            )
 
         #
         # Collect all of the linear constraints that are in the rBigM
@@ -848,10 +968,11 @@ class CuttingPlane_Transformation(Transformation):
         fme = TransformationFactory('contrib.fourier_motzkin_elimination')
         rBigM_linear_constraints = []
         for cons in instance_rBigM.component_data_objects(
-                Constraint,
-                descend_into=Block,
-                sort=SortComponents.deterministic,
-                active=True):
+            Constraint,
+            descend_into=Block,
+            sort=SortComponents.deterministic,
+            active=True,
+        ):
             body = cons.body
             if body.polynomial_degree() != 1:
                 # We will never get a nonlinear constraint out of FME, so we
@@ -868,8 +989,9 @@ class CuttingPlane_Transformation(Transformation):
 
         return rBigM_obj, rBigM_linear_constraints
 
-    def _generate_cuttingplanes( self, instance_rBigM, cuts_obj, instance_rHull,
-                                 var_info, transBlockName):
+    def _generate_cuttingplanes(
+        self, instance_rBigM, cuts_obj, instance_rHull, var_info, transBlockName
+    ):
 
         opt = SolverFactory(self._config.solver)
         stream_solver = self._config.stream_solver
@@ -882,32 +1004,35 @@ class CuttingPlane_Transformation(Transformation):
 
         transBlock_rHull = instance_rHull.component(transBlockName)
 
-        rBigM_obj, rBigM_linear_constraints = self.\
-                                              _get_rBigM_obj_and_constraints(
-                                                  instance_rBigM)
+        rBigM_obj, rBigM_linear_constraints = self._get_rBigM_obj_and_constraints(
+            instance_rBigM
+        )
 
         # Get list of all variables in the rHull model which we will use when
         # calculating the composite normal vector.
-        rHull_vars = [i for i in instance_rHull.component_data_objects(
-            Var,
-            descend_into=Block,
-            sort=SortComponents.deterministic)]
+        rHull_vars = [
+            i
+            for i in instance_rHull.component_data_objects(
+                Var, descend_into=Block, sort=SortComponents.deterministic
+            )
+        ]
 
         # collect a list of disaggregated variables.
-        disaggregated_vars = self._get_disaggregated_vars( instance_rHull)
+        disaggregated_vars = self._get_disaggregated_vars(instance_rHull)
 
         hull_to_bigm_map = self._create_hull_to_bigm_substitution_map(var_info)
         bigm_to_hull_map = self._create_bigm_to_hull_substition_map(var_info)
         xhat = ComponentMap()
 
-        while (improving):
+        while improving:
             # solve rBigM, solution is xstar
-            results = opt.solve(instance_rBigM, tee=stream_solver,
-                                load_solutions=False)
+            results = opt.solve(instance_rBigM, tee=stream_solver, load_solutions=False)
             if verify_successful_solve(results) is not NORMAL:
-                logger.warning("Relaxed BigM subproblem "
-                               "did not solve normally. Stopping cutting "
-                               "plane generation.\n\n%s" % (results,))
+                logger.warning(
+                    "Relaxed BigM subproblem "
+                    "did not solve normally. Stopping cutting "
+                    "plane generation.\n\n%s" % (results,)
+                )
                 return
             instance_rBigM.solutions.load_from(results)
 
@@ -922,7 +1047,7 @@ class CuttingPlane_Transformation(Transformation):
             #
             if transBlock_rHull.component("separation_objective") is None:
                 self._add_separation_objective(var_info, transBlock_rHull)
-            
+
             # copy over xstar
             logger.info("x* is:")
             for x_rbigm, x_hull, x_star in var_info:
@@ -931,9 +1056,10 @@ class CuttingPlane_Transformation(Transformation):
                     # initialize the X values
                     x_hull.set_value(x_rbigm.value, skip_validation=True)
                 if self.verbose:
-                    logger.info("\t%s = %s" % 
-                                (x_rbigm.getname(fully_qualified=True),
-                                 x_rbigm.value))
+                    logger.info(
+                        "\t%s = %s"
+                        % (x_rbigm.getname(fully_qualified=True), x_rbigm.value)
+                    )
 
             # compare objectives: check absolute difference close to 0, relative
             # difference further from 0.
@@ -941,20 +1067,26 @@ class CuttingPlane_Transformation(Transformation):
                 improving = True
             else:
                 obj_diff = prev_obj - rBigM_objVal
-                improving = ( abs(obj_diff) > epsilon if abs(rBigM_objVal) < 1
-                             else abs(obj_diff/prev_obj) > epsilon )
+                improving = (
+                    abs(obj_diff) > epsilon
+                    if abs(rBigM_objVal) < 1
+                    else abs(obj_diff / prev_obj) > epsilon
+                )
 
             # solve separation problem to get xhat.
-            results = opt.solve(instance_rHull, tee=stream_solver,
-                                load_solutions=False)
+            results = opt.solve(instance_rHull, tee=stream_solver, load_solutions=False)
             if verify_successful_solve(results) is not NORMAL:
-                logger.warning("Hull separation subproblem "
-                               "did not solve normally. Stopping cutting "
-                               "plane generation.\n\n%s" % (results,))
+                logger.warning(
+                    "Hull separation subproblem "
+                    "did not solve normally. Stopping cutting "
+                    "plane generation.\n\n%s" % (results,)
+                )
                 return
             instance_rHull.solutions.load_from(results)
-            logger.warning("separation problem objective value: %s" %
-                           value(transBlock_rHull.separation_objective))
+            logger.warning(
+                "separation problem objective value: %s"
+                % value(transBlock_rHull.separation_objective)
+            )
 
             # save xhat to initialize rBigM with in the next iteration
             if self.verbose:
@@ -962,43 +1094,53 @@ class CuttingPlane_Transformation(Transformation):
             for x_rbigm, x_hull, x_star in var_info:
                 xhat[x_rbigm] = value(x_hull)
                 if self.verbose:
-                    logger.info("\t%s = %s" % 
-                                (x_hull.getname(fully_qualified=True), 
-                                 x_hull.value))
+                    logger.info(
+                        "\t%s = %s"
+                        % (x_hull.getname(fully_qualified=True), x_hull.value)
+                    )
 
             # [JDS 19 Dec 18] Note: we check that the separation objective was
             # significantly nonzero.  If it is too close to zero, either the
             # rBigM solution was in the convex hull, or the separation vector is
             # so close to zero that the resulting cut is likely to have
             # numerical issues.
-            if value(transBlock_rHull.separation_objective) < \
-               self._config.separation_objective_threshold:
-                logger.warning("Separation problem objective below threshold of"
-                               " %s: Stopping cut generation." %
-                               self._config.separation_objective_threshold)
+            if (
+                value(transBlock_rHull.separation_objective)
+                < self._config.separation_objective_threshold
+            ):
+                logger.warning(
+                    "Separation problem objective below threshold of"
+                    " %s: Stopping cut generation."
+                    % self._config.separation_objective_threshold
+                )
                 break
 
-            cuts = self._config.create_cuts(transBlock_rHull, var_info,
-                                            hull_to_bigm_map,
-                                            rBigM_linear_constraints,
-                                            rHull_vars, disaggregated_vars,
-                                            self._config.norm,
-                                            self._config.cut_filtering_threshold,
-                                            self._config.zero_tolerance,
-                                            self._config.do_integer_arithmetic,
-                                            self._config.\
-                                            tight_constraint_tolerance)
-           
+            cuts = self._config.create_cuts(
+                transBlock_rHull,
+                var_info,
+                hull_to_bigm_map,
+                rBigM_linear_constraints,
+                rHull_vars,
+                disaggregated_vars,
+                self._config.norm,
+                self._config.cut_filtering_threshold,
+                self._config.zero_tolerance,
+                self._config.do_integer_arithmetic,
+                self._config.tight_constraint_tolerance,
+            )
+
             # We are done if the cut generator couldn't return a valid cut
             if cuts is None:
-                logger.warning("Did not generate a valid cut, stopping cut "
-                               "generation.")
+                logger.warning(
+                    "Did not generate a valid cut, stopping cut generation."
+                )
                 break
             if not improving:
-                logger.warning("Difference in relaxed BigM problem objective "
-                               "values from past two iterations is below "
-                               "threshold of %s: Stopping cut generation." %
-                               epsilon)
+                logger.warning(
+                    "Difference in relaxed BigM problem objective "
+                    "values from past two iterations is below "
+                    "threshold of %s: Stopping cut generation." % epsilon
+                )
                 break
 
             for cut in cuts:
@@ -1008,14 +1150,18 @@ class CuttingPlane_Transformation(Transformation):
                 cuts_obj.add(cut_number, cut)
                 if self._config.post_process_cut is not None:
                     self._config.post_process_cut(
-                        cuts_obj[cut_number], transBlock_rHull,
-                        bigm_to_hull_map, opt, stream_solver,
-                        self._config.back_off_problem_tolerance)
+                        cuts_obj[cut_number],
+                        transBlock_rHull,
+                        bigm_to_hull_map,
+                        opt,
+                        stream_solver,
+                        self._config.back_off_problem_tolerance,
+                    )
 
             if cut_number + 1 == self._config.max_number_of_cuts:
                 logger.warning("Reached maximum number of cuts.")
                 break
-                
+
             prev_obj = rBigM_objVal
 
             # Initialize rbigm with xhat (for the next iteration)
@@ -1026,12 +1172,11 @@ class CuttingPlane_Transformation(Transformation):
         # creates transformation block with a unique name based on name, adds it
         # to instance, and returns it.
         transBlockName = unique_component_name(
-            instance,
-            '_pyomo_gdp_cuttingplane_transformation')
+            instance, '_pyomo_gdp_cuttingplane_transformation'
+        )
         transBlock = Block()
         instance.add_component(transBlockName, transBlock)
         return transBlockName, transBlock
-
 
     def _add_separation_objective(self, var_info, transBlock_rHull):
         # creates the separation objective. That is just adding an objective for
@@ -1051,37 +1196,40 @@ class CuttingPlane_Transformation(Transformation):
             obj_expr = 0
             for i, (x_rbigm, x_hull, x_star) in enumerate(var_info):
                 if not x_rbigm.stale:
-                    obj_expr += (x_hull - x_star)**2
+                    obj_expr += (x_hull - x_star) ** 2
                 else:
                     if self.verbose:
-                        logger.info("The variable %s will not be included in "
-                                    "the separation problem: It was stale in "
-                                    "the rBigM solve." % x_rbigm.getname(
-                                        fully_qualified=True))
+                        logger.info(
+                            "The variable %s will not be included in "
+                            "the separation problem: It was stale in "
+                            "the rBigM solve." % x_rbigm.getname(fully_qualified=True)
+                        )
                     to_delete.append(i)
         elif norm == float('inf'):
             u = transBlock_rHull.u = Var(domain=NonNegativeReals)
             inf_cons = transBlock_rHull.inf_norm_linearization = Constraint(
-                NonNegativeIntegers)
+                NonNegativeIntegers
+            )
             i = 0
             for j, (x_rbigm, x_hull, x_star) in enumerate(var_info):
                 if not x_rbigm.stale:
                     # NOTE: these are written as >= constraints so that we know
                     # the duals will come back nonnegative.
-                    inf_cons[i] = u  - x_hull >= - x_star
-                    inf_cons[i+1] = u + x_hull >= x_star
+                    inf_cons[i] = u - x_hull >= -x_star
+                    inf_cons[i + 1] = u + x_hull >= x_star
                     i += 2
                 else:
                     if self.verbose:
-                        logger.info("The variable %s will not be included in "
-                                    "the separation problem: It was stale in "
-                                    "the rBigM solve." % x_rbigm.getname(
-                                        fully_qualified=True))
+                        logger.info(
+                            "The variable %s will not be included in "
+                            "the separation problem: It was stale in "
+                            "the rBigM solve." % x_rbigm.getname(fully_qualified=True)
+                        )
                     to_delete.append(j)
             # we'll need the duals of these to get the subgradient
             self._add_dual_suffix(transBlock_rHull.model())
             obj_expr = u
-        
+
         # delete the unneeded x_stars so that we don't add cuts involving
         # useless variables later.
         for i in sorted(to_delete, reverse=True):

--- a/pyomo/gdp/plugins/fix_disjuncts.py
+++ b/pyomo/gdp/plugins/fix_disjuncts.py
@@ -5,8 +5,9 @@ import logging
 from math import fabs
 
 from pyomo.common.config import ConfigDict, ConfigValue, NonNegativeFloat
-from pyomo.contrib.cp.transform .logical_to_disjunctive_program import (
-    LogicalToDisjunctive)
+from pyomo.contrib.cp.transform.logical_to_disjunctive_program import (
+    LogicalToDisjunctive,
+)
 from pyomo.core.base import Transformation, TransformationFactory
 from pyomo.core.base.block import Block
 from pyomo.core.expr.numvalue import value
@@ -15,19 +16,23 @@ from pyomo.gdp.disjunct import Disjunct, Disjunction
 
 logger = logging.getLogger('pyomo.gdp.fix_disjuncts')
 
+
 def _is_transformation(transformation_name):
     xform = TransformationFactory(transformation_name)
     if xform is None:
         raise ValueError(
             "Expected valid name for a registered Pyomo transformation. "
-            "\n\tRecieved: %s" % transformation_name)
+            "\n\tRecieved: %s" % transformation_name
+        )
     return transformation_name
+
 
 @TransformationFactory.register(
     'gdp.fix_disjuncts',
     doc="""Fix disjuncts to their current Boolean values and transforms any
     LogicalConstraints and BooleanVars so that the resulting model is a
-    (MI)(N)LP.""")
+    (MI)(N)LP.""",
+)
 class GDP_Disjunct_Fixer(Transformation):
     """Fix disjuncts to their current Boolean values.
 
@@ -45,21 +50,26 @@ class GDP_Disjunct_Fixer(Transformation):
         super(GDP_Disjunct_Fixer, self).__init__(**kwargs)
 
     CONFIG = ConfigDict("gdp.fix_disjuncts")
-    CONFIG.declare("GDP_to_MIP_transformation", ConfigValue(
-        default='gdp.bigm',
-        domain=_is_transformation,
-        description="The name of the transformation to call after the "
-        "'logical_to_disjunctive' transformation in order to finish "
-        "transforming to a MI(N)LP.",
-        doc="""
+    CONFIG.declare(
+        "GDP_to_MIP_transformation",
+        ConfigValue(
+            default='gdp.bigm',
+            domain=_is_transformation,
+            description="The name of the transformation to call after the "
+            "'logical_to_disjunctive' transformation in order to finish "
+            "transforming to a MI(N)LP.",
+            doc="""
         If there are no logical constraints on the model being transformed,
         this option is not used. However, if there are logical constraints
         that involve mixtures of Boolean and integer variables, this option
         specifies the transformation to use to transform the model with fixed
         Disjuncts to a MI(N)LP. Uses 'gdp.bigm' by default.
-        """))
+        """,
+        ),
+    )
+
     def _apply_to(self, model, **kwds):
-        """Fix all disjuncts in the given model and reclassify them to 
+        """Fix all disjuncts in the given model and reclassify them to
         Blocks."""
         config = self.config = self.CONFIG(kwds.pop('options', {}))
         config.set_value(kwds)
@@ -67,11 +77,12 @@ class GDP_Disjunct_Fixer(Transformation):
         self._transformContainer(model)
 
         # Reclassify all disjuncts
-        for disjunct_object in model.component_objects(Disjunct,
-                                                       descend_into=(Block,
-                                                                     Disjunct)):
+        for disjunct_object in model.component_objects(
+            Disjunct, descend_into=(Block, Disjunct)
+        ):
             disjunct_object.parent_block().reclassify_component_type(
-                disjunct_object, Block)
+                disjunct_object, Block
+            )
 
         # Transform any remaining logical stuff
         TransformationFactory('contrib.logical_to_disjunctive').apply_to(model)
@@ -80,14 +91,17 @@ class GDP_Disjunct_Fixer(Transformation):
 
     def _transformContainer(self, obj):
         """Find all disjuncts in the container and transform them."""
-        for disjunct in obj.component_data_objects(ctype=Disjunct, active=True,
-                                                   descend_into=True):
+        for disjunct in obj.component_data_objects(
+            ctype=Disjunct, active=True, descend_into=True
+        ):
             _bool = disjunct.indicator_var
             if _bool.value is None:
-                raise GDP_Error("The value of the indicator_var of "
-                                "Disjunct '%s' is None. All indicator_vars "
-                                "must have values before calling "
-                                "'fix_disjuncts'." % disjunct.name)
+                raise GDP_Error(
+                    "The value of the indicator_var of "
+                    "Disjunct '%s' is None. All indicator_vars "
+                    "must have values before calling "
+                    "'fix_disjuncts'." % disjunct.name
+                )
             elif _bool.value:
                 disjunct.indicator_var.fix(True)
                 self._transformContainer(disjunct)
@@ -95,16 +109,17 @@ class GDP_Disjunct_Fixer(Transformation):
                 # Deactivating fixes the indicator_var to False
                 disjunct.deactivate()
 
-        for disjunction in obj.component_data_objects(ctype=Disjunction,
-                                                      active=True,
-                                                      descend_into=True):
+        for disjunction in obj.component_data_objects(
+            ctype=Disjunction, active=True, descend_into=True
+        ):
             self._transformDisjunctionData(disjunction)
 
     def _transformDisjunctionData(self, disjunction):
         # the sum of all the indicator variable values of disjuncts in the
         # disjunction
-        logical_sum = sum(value(disj.binary_indicator_var)
-                          for disj in disjunction.disjuncts)
+        logical_sum = sum(
+            value(disj.binary_indicator_var) for disj in disjunction.disjuncts
+        )
 
         # Check that the disjunctions are not being fixed to an infeasible
         # realization.
@@ -113,14 +128,16 @@ class GDP_Disjunct_Fixer(Transformation):
             raise GDP_Error(
                 "Disjunction %s violated. "
                 "Expected 1 disjunct to be active, but %s were active."
-                % (disjunction.name, logical_sum))
+                % (disjunction.name, logical_sum)
+            )
         elif not logical_sum >= 1:
             # for non-XOR disjunctions, the sum of all disjunct values should
             # be at least 1
             raise GDP_Error(
                 "Disjunction %s violated. "
                 "Expected at least 1 disjunct to be active, "
-                "but none were active.")
+                "but none were active."
+            )
         else:
             # disjunction is in feasible realization. Deactivate it.
             disjunction.deactivate()

--- a/pyomo/gdp/plugins/gdp_var_mover.py
+++ b/pyomo/gdp/plugins/gdp_var_mover.py
@@ -23,9 +23,9 @@ from pyomo.core.base.indexed_component import ActiveIndexedComponent
 from pyomo.common.deprecation import deprecated
 
 logger = logging.getLogger('pyomo.gdp')
-                
-@TransformationFactory.register('gdp.reclassify',
-          doc="Reclassify Disjuncts to Blocks.")
+
+
+@TransformationFactory.register('gdp.reclassify', doc="Reclassify Disjuncts to Blocks.")
 class HACK_GDP_Disjunct_Reclassifier(Transformation):
     """Reclassify Disjuncts to Blocks.
 
@@ -33,38 +33,48 @@ class HACK_GDP_Disjunct_Reclassifier(Transformation):
     can find the variables
 
     """
-    @deprecated(msg="The gdp.reclasify transformation has been deprecated in "
-                "favor of the gdp transformations creating References to "
-                "variables local to each Disjunct during the transformation. "
-                "Validation that the model has been completely transformed "
-                "to an algebraic model has been moved to the "
-                "check_model_algebraic function in gdp.util.",
-                version='5.7')
+
+    @deprecated(
+        msg="The gdp.reclasify transformation has been deprecated in "
+        "favor of the gdp transformations creating References to "
+        "variables local to each Disjunct during the transformation. "
+        "Validation that the model has been completely transformed "
+        "to an algebraic model has been moved to the "
+        "check_model_algebraic function in gdp.util.",
+        version='5.7',
+    )
     def _apply_to(self, instance, **kwds):
         assert not kwds  # no keywords expected to the transformation
         disjunct_generator = instance.component_objects(
-            Disjunct, descend_into=(Block, Disjunct),
-            descent_order=TraversalStrategy.PostfixDFS)
+            Disjunct,
+            descend_into=(Block, Disjunct),
+            descent_order=TraversalStrategy.PostfixDFS,
+        )
         for disjunct_component in disjunct_generator:
             # Check that the disjuncts being reclassified are all relaxed or
             # are not on an active block.
             for disjunct in disjunct_component.values():
-                if (disjunct.active and
-                        self._disjunct_not_relaxed(disjunct) and
-                        self._disjunct_on_active_block(disjunct) and
-                        self._disjunct_not_fixed_true(disjunct)):
+                if (
+                    disjunct.active
+                    and self._disjunct_not_relaxed(disjunct)
+                    and self._disjunct_on_active_block(disjunct)
+                    and self._disjunct_not_fixed_true(disjunct)
+                ):
 
                     # First, do a couple checks in order to give a more
                     # useful error message
-                    disjunction_set = {i for i in
-                                       instance.component_data_objects(
-                                           Disjunction, descend_into=True,
-                                           active=None)}
-                    active_disjunction_set = {i for i in
-                                              instance.component_data_objects(
-                                                  Disjunction,
-                                                  descend_into=True,
-                                                  active=True)}
+                    disjunction_set = {
+                        i
+                        for i in instance.component_data_objects(
+                            Disjunction, descend_into=True, active=None
+                        )
+                    }
+                    active_disjunction_set = {
+                        i
+                        for i in instance.component_data_objects(
+                            Disjunction, descend_into=True, active=True
+                        )
+                    }
                     disjuncts_in_disjunctions = set()
                     for i in disjunction_set:
                         disjuncts_in_disjunctions.update(i.disjuncts)
@@ -73,30 +83,38 @@ class HACK_GDP_Disjunct_Reclassifier(Transformation):
                         disjuncts_in_active_disjunctions.update(i.disjuncts)
 
                     if disjunct not in disjuncts_in_disjunctions:
-                        raise GDP_Error('Disjunct "%s" is currently active, '
-                                        'but was not found in any Disjunctions. '
-                                        'This is generally an error as the model '
-                                        'has not been fully relaxed to a '
-                                        'pure algebraic form.' % (disjunct.name,))
+                        raise GDP_Error(
+                            'Disjunct "%s" is currently active, '
+                            'but was not found in any Disjunctions. '
+                            'This is generally an error as the model '
+                            'has not been fully relaxed to a '
+                            'pure algebraic form.' % (disjunct.name,)
+                        )
                     elif disjunct not in disjuncts_in_active_disjunctions:
-                        raise GDP_Error('Disjunct "%s" is currently active. While '
-                                        'it participates in a Disjunction, '
-                                        'that Disjunction is currently deactivated. '
-                                        'This is generally an error as the '
-                                        'model has not been fully relaxed to a pure '
-                                        'algebraic form. Did you deactivate '
-                                        'the Disjunction without addressing the '
-                                        'individual Disjuncts?' % (disjunct.name,))
+                        raise GDP_Error(
+                            'Disjunct "%s" is currently active. While '
+                            'it participates in a Disjunction, '
+                            'that Disjunction is currently deactivated. '
+                            'This is generally an error as the '
+                            'model has not been fully relaxed to a pure '
+                            'algebraic form. Did you deactivate '
+                            'the Disjunction without addressing the '
+                            'individual Disjuncts?' % (disjunct.name,)
+                        )
                     else:
-                        raise GDP_Error("""
+                        raise GDP_Error(
+                            """
                         Reclassifying active Disjunct "%s" as a Block.  This
                         is generally an error as it indicates that the model
                         was not completely relaxed before applying the
-                        gdp.reclassify transformation""" % (disjunct.name,))
+                        gdp.reclassify transformation"""
+                            % (disjunct.name,)
+                        )
 
             # Reclassify this disjunct as a block
             disjunct_component.parent_block().reclassify_component_type(
-                disjunct_component, Block)
+                disjunct_component, Block
+            )
             # HACK: activate teh block, but do not activate the
             # _BlockData objects
             super(ActiveIndexedComponent, disjunct_component).activate()
@@ -116,19 +134,19 @@ class HACK_GDP_Disjunct_Reclassifier(Transformation):
                     disjunct._activate_without_unfixing_indicator()
 
                 cons_in_disjunct = disjunct.component_objects(
-                    Constraint, descend_into=Block, active=True)
+                    Constraint, descend_into=Block, active=True
+                )
                 for con in cons_in_disjunct:
                     con.deactivate()
 
     def _disjunct_not_fixed_true(self, disjunct):
         # Return true if the disjunct indicator variable is not fixed to True
-        return not (disjunct.indicator_var.fixed and
-                    disjunct.indicator_var.value)
+        return not (disjunct.indicator_var.fixed and disjunct.indicator_var.value)
 
     def _disjunct_not_relaxed(self, disjunct):
         # Return True if the disjunct was not relaxed by a transformation.
         return disjunct.transformation_block is None
-        
+
     def _disjunct_on_active_block(self, disjunct):
         # Check first to make sure that the disjunct is not a
         # descendent of an inactive Block or fixed and deactivated
@@ -137,9 +155,12 @@ class HACK_GDP_Disjunct_Reclassifier(Transformation):
         while parent_block is not None:
             if parent_block.ctype is Block and not parent_block.active:
                 return False
-            elif (parent_block.ctype is Disjunct and not parent_block.active
-                  and parent_block.indicator_var.value == False
-                  and parent_block.indicator_var.fixed):
+            elif (
+                parent_block.ctype is Disjunct
+                and not parent_block.active
+                and parent_block.indicator_var.value == False
+                and parent_block.indicator_var.fixed
+            ):
                 return False
             else:
                 # Step up one level in the hierarchy

--- a/pyomo/gdp/plugins/partition_disjuncts.py
+++ b/pyomo/gdp/plugins/partition_disjuncts.py
@@ -23,12 +23,33 @@ from pyomo.common.config import (
     document_kwargs_from_configdict,
 )
 from pyomo.common.modeling import unique_component_name
-from pyomo.core import ( Block, Constraint, Var, SortComponents, Transformation,
-                         TransformationFactory, TraversalStrategy,
-                         NonNegativeIntegers, value, ConcreteModel, Objective,
-                         ComponentMap, BooleanVar, LogicalConstraint, Connector,
-                         Expression, Suffix, Param, Set, SetOf, RangeSet,
-                         Reference, Binary, LogicalConstraintList, maximize)
+from pyomo.core import (
+    Block,
+    Constraint,
+    Var,
+    SortComponents,
+    Transformation,
+    TransformationFactory,
+    TraversalStrategy,
+    NonNegativeIntegers,
+    value,
+    ConcreteModel,
+    Objective,
+    ComponentMap,
+    BooleanVar,
+    LogicalConstraint,
+    Connector,
+    Expression,
+    Suffix,
+    Param,
+    Set,
+    SetOf,
+    RangeSet,
+    Reference,
+    Binary,
+    LogicalConstraintList,
+    maximize,
+)
 from pyomo.core.base.external import ExternalFunction
 from pyomo.network import Port
 from pyomo.common.collections import ComponentSet
@@ -38,9 +59,15 @@ from pyomo.opt import SolverFactory
 from pyomo.util.vars_from_expressions import get_vars_from_components
 
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
-from pyomo.gdp.util import (is_child_of, _to_dict, verify_successful_solve,
-                            NORMAL, clone_without_expression_components,
-                            _warn_for_active_disjunct, get_gdp_tree)
+from pyomo.gdp.util import (
+    is_child_of,
+    _to_dict,
+    verify_successful_solve,
+    NORMAL,
+    clone_without_expression_components,
+    _warn_for_active_disjunct,
+    get_gdp_tree,
+)
 from pyomo.core.util import target_list
 from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
 from weakref import ref as weakref_ref
@@ -48,24 +75,31 @@ from weakref import ref as weakref_ref
 from math import floor
 
 import logging
+
 logger = logging.getLogger('pyomo.gdp.partition_disjuncts')
+
 
 def _generate_additively_separable_repn(nonlinear_part):
     if nonlinear_part.__class__ is not EXPR.SumExpression:
         # This isn't separable, so we just have the one expression
-        return {'nonlinear_vars': [tuple(v for v in EXPR.identify_variables(
-            nonlinear_part))], 'nonlinear_exprs': [nonlinear_part]}
+        return {
+            'nonlinear_vars': [
+                tuple(v for v in EXPR.identify_variables(nonlinear_part))
+            ],
+            'nonlinear_exprs': [nonlinear_part],
+        }
 
     # else, it was a SumExpression, and we will break it into the summands,
     # recording which variables are there.
-    nonlinear_decomp = {'nonlinear_vars': [],
-                        'nonlinear_exprs': []}
+    nonlinear_decomp = {'nonlinear_vars': [], 'nonlinear_exprs': []}
     for summand in nonlinear_part.args:
         nonlinear_decomp['nonlinear_exprs'].append(summand)
         nonlinear_decomp['nonlinear_vars'].append(
-            tuple(v for v in EXPR.identify_variables(summand)))
+            tuple(v for v in EXPR.identify_variables(summand))
+        )
 
     return nonlinear_decomp
+
 
 def arbitrary_partition(disjunction, P):
     """
@@ -83,14 +117,16 @@ def arbitrary_partition(disjunction, P):
     # collect variables
     v_set = ComponentSet()
     for disj in disjunction.disjuncts:
-        v_set.update(get_vars_from_components(disj, Constraint,
-                                              descend_into=Block, active=True))
+        v_set.update(
+            get_vars_from_components(disj, Constraint, descend_into=Block, active=True)
+        )
     # assign them to partitions
     partitions = [ComponentSet() for i in range(P)]
     for i, v in enumerate(v_set):
         partitions[i % P].add(v)
 
     return partitions
+
 
 def compute_optimal_bounds(expr, global_constraints, opt):
     """
@@ -109,21 +145,26 @@ def compute_optimal_bounds(expr, global_constraints, opt):
           opt will need to be capable of optimizing nonconvex problems.
     """
     if opt is None:
-        raise GDP_Error("No solver was specified to optimize the "
-                        "subproblems for computing expression bounds! "
-                        "Please specify a configured solver in the "
-                        "'compute_bounds_solver' argument if using "
-                        "'compute_optimal_bounds.'")
+        raise GDP_Error(
+            "No solver was specified to optimize the "
+            "subproblems for computing expression bounds! "
+            "Please specify a configured solver in the "
+            "'compute_bounds_solver' argument if using "
+            "'compute_optimal_bounds.'"
+        )
 
     # add temporary objective and calculate bounds
     obj = Objective(expr=expr)
-    global_constraints.add_component(unique_component_name(global_constraints,
-                                                           "tmp_obj"), obj)
+    global_constraints.add_component(
+        unique_component_name(global_constraints, "tmp_obj"), obj
+    )
     # Solve first minimizing, to get a lower bound
     results = opt.solve(global_constraints)
     if verify_successful_solve(results) is not NORMAL:
-        logger.warning("Problem to find lower bound for expression %s"
-                       "did not solve normally.\n\n%s" % (expr, results))
+        logger.warning(
+            "Problem to find lower bound for expression %s"
+            "did not solve normally.\n\n%s" % (expr, results)
+        )
         LB = None
     else:
         # This has some risks, if you're using a solver the gives a lower bound,
@@ -133,8 +174,10 @@ def compute_optimal_bounds(expr, global_constraints, opt):
     obj.sense = maximize
     results = opt.solve(global_constraints)
     if verify_successful_solve(results) is not NORMAL:
-        logger.warning("Problem to find upper bound for expression %s"
-                       "did not solve normally.\n\n%s" % (expr, results))
+        logger.warning(
+            "Problem to find upper bound for expression %s"
+            "did not solve normally.\n\n%s" % (expr, results)
+        )
         UB = None
     else:
         UB = value(obj.expr)
@@ -145,6 +188,7 @@ def compute_optimal_bounds(expr, global_constraints, opt):
 
     return (LB, UB)
 
+
 def compute_fbbt_bounds(expr, global_constraints, opt):
     """
     Calls fbbt on expr and returns the lower and upper bounds on the expression
@@ -153,10 +197,13 @@ def compute_fbbt_bounds(expr, global_constraints, opt):
     """
     return compute_bounds_on_expr(expr)
 
-@TransformationFactory.register('gdp.partition_disjuncts',
-                                doc="Reformulates a convex disjunctive model "
-                                "into a new GDP by splitting additively "
-                                "separable constraints on P sets of variables")
+
+@TransformationFactory.register(
+    'gdp.partition_disjuncts',
+    doc="Reformulates a convex disjunctive model "
+    "into a new GDP by splitting additively "
+    "separable constraints on P sets of variables",
+)
 @document_kwargs_from_configdict('CONFIG')
 class PartitionDisjuncts_Transformation(Transformation):
     """
@@ -185,12 +232,15 @@ class PartitionDisjuncts_Transformation(Transformation):
             Relaxations between big-M and Convex Hull Reformulations," 2021.
 
     """
+
     CONFIG = ConfigBlock("gdp.partition_disjuncts")
-    CONFIG.declare('targets', ConfigValue(
-        default=None,
-        domain=target_list,
-        description="""target or list of targets that will be relaxed""",
-        doc="""
+    CONFIG.declare(
+        'targets',
+        ConfigValue(
+            default=None,
+            domain=target_list,
+            description="""target or list of targets that will be relaxed""",
+            doc="""
         Specifies the target or list of targets to relax as either a
         component or a list of components. 
 
@@ -198,16 +248,19 @@ class PartitionDisjuncts_Transformation(Transformation):
         transformation is done out of place, the list of targets should be 
         attached to the model before it is cloned, and the list will specify 
         the targets on the cloned instance.
-        """
-    ))
-    CONFIG.declare('variable_partitions', ConfigValue(
-        default=None,
-        domain=_to_dict,
-        description="""Set of sets of variables which define valid partitions
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'variable_partitions',
+        ConfigValue(
+            default=None,
+            domain=_to_dict,
+            description="""Set of sets of variables which define valid partitions
         (i.e., the constraints are additively separable across these
         partitions). These can be specified globally (for all active
         Disjunctions), or by Disjunction.""",
-        doc="""
+            doc="""
         Specified variable partitions, either globally or per Disjunction.
 
         Expects either a set of disjoint ComponentSets whose union is all the
@@ -223,15 +276,18 @@ class PartitionDisjuncts_Transformation(Transformation):
         Last, note that in the case of constraints containing partially
         additively separable functions, it is required that the user specify
         the variable parition(s).
-        """
-    ))
-    CONFIG.declare('num_partitions', ConfigValue(
-        default=None,
-        domain=_to_dict,
-        description="""Number of partitions of variables, if variable_partitions
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'num_partitions',
+        ConfigValue(
+            default=None,
+            domain=_to_dict,
+            description="""Number of partitions of variables, if variable_partitions
         is not specifed. Can be specified separately for specific Disjunctions
         if desired.""",
-        doc="""
+            doc="""
         Either a single value so that all Disjunctions will have variables
         partitioned into P sets, or a map of Disjunctions to a value of P
         for each active Disjunction. Mapping None to a value of P will specify
@@ -241,14 +297,17 @@ class PartitionDisjuncts_Transformation(Transformation):
         Note that if any constraints contain partially additively separable
         functions, the partitions for the Disjunctions with these Constraints
         must be specified in the variable_partitions argument.
-        """
-    ))
-    CONFIG.declare('variable_partitioning_method', ConfigValue(
-        default=arbitrary_partition,
-        domain=_to_dict,
-        description="""Method to partition the variables. By default, the
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'variable_partitioning_method',
+        ConfigValue(
+            default=arbitrary_partition,
+            domain=_to_dict,
+            description="""Method to partition the variables. By default, the
         partitioning will be done arbitrarily.""",
-        doc="""
+            doc="""
         A function which takes a Disjunction object and a number P and return
         a valid partitioning of the variables that appear in the disjunction
         into P partitions.
@@ -260,15 +319,18 @@ class PartitionDisjuncts_Transformation(Transformation):
         functions, the partitions for the Disjunctions cannot be calculated
         automatically. Please specify the partitions for the Disjunctions with
         these Constraints in the variable_partitions argument.
-        """
-    ))
-    CONFIG.declare('assume_fixed_vars_permanent', ConfigValue(
-        default=False,
-        domain=bool,
-        description="""Boolean indicating whether or not to transform so that
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'assume_fixed_vars_permanent',
+        ConfigValue(
+            default=False,
+            domain=bool,
+            description="""Boolean indicating whether or not to transform so that
         the transformed model will still be valid when fixed Vars are
         unfixed.""",
-        doc="""
+            doc="""
         If True, the transformation will create a correct model even if fixed
         variables are later unfixed. That is, bounds will be calculated based
         on fixed variables' bounds, not their values. However, if fixed
@@ -278,14 +340,17 @@ class PartitionDisjuncts_Transformation(Transformation):
         Note that this has no effect on fixed BooleanVars, including the
         indicator variables of Disjuncts. The transformation is always correct
         whether or not these remain fixed.
-        """
-    ))
-    CONFIG.declare('compute_bounds_method', ConfigValue(
-        default=compute_fbbt_bounds,
-        description="""Function that takes an expression, a Block containing
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'compute_bounds_method',
+        ConfigValue(
+            default=compute_fbbt_bounds,
+            description="""Function that takes an expression, a Block containing
         the global constraints of the original problem, and a configured
         solver, and returns both a lower and upper bound for the expression.""",
-        doc="""
+            doc="""
         Callback for computing bounds on expressions, in order to bound
         the auxiliary variables created by the transformation. 
 
@@ -296,47 +361,53 @@ class PartitionDisjuncts_Transformation(Transformation):
         a model containing the variables and global constraints of the original
         instance, and a configured solver and returns a tuple (LB, UB) where
         either element can be None if no valid bound could be found.
-        """
-    ))
-    CONFIG.declare('compute_bounds_solver', ConfigValue(
-        default=None,
-        description="""Solver object to pass to compute_bounds_method.
+        """,
+        ),
+    )
+    CONFIG.declare(
+        'compute_bounds_solver',
+        ConfigValue(
+            default=None,
+            description="""Solver object to pass to compute_bounds_method.
         This is required if you are using 'compute_optimal_bounds'.""",
-        doc="""
+            doc="""
         Configured solver object for use in the compute_bounds_method.
 
         In particular, if compute_bounds_method is 'compute_optimal_bounds',
         this will be used to solve the subproblems, so needs to handle
         non-convex problems if any Disjunctions contain nonlinear constraints.
-        """
-    ))
+        """,
+        ),
+    )
+
     def __init__(self):
         super(PartitionDisjuncts_Transformation, self).__init__()
         self.handlers = {
-            Constraint:  self._transform_constraint,
-            Var:         False, # these will be already dealt with--we add
-                                # references to them before we call handlers.
-            BooleanVar:  False,
-            Connector:   False,
-            Expression:  False,
-            Suffix:      False,
-            Param:       False,
-            Set:         False,
-            SetOf:       False,
-            RangeSet:    False,
-            Disjunct:    self._warn_for_active_disjunct,
-            Block:       False,
+            Constraint: self._transform_constraint,
+            Var: False,  # these will be already dealt with--we add
+            # references to them before we call handlers.
+            BooleanVar: False,
+            Connector: False,
+            Expression: False,
+            Suffix: False,
+            Param: False,
+            Set: False,
+            SetOf: False,
+            RangeSet: False,
+            Disjunct: self._warn_for_active_disjunct,
+            Block: False,
             ExternalFunction: False,
-            Port:        False, # not Arcs, because those are deactivated after
-                                # the network.expand_arcs transformation
+            Port: False,  # not Arcs, because those are deactivated after
+            # the network.expand_arcs transformation
         }
 
     def _apply_to(self, instance, **kwds):
         if not instance.ctype in (Block, Disjunct):
-            raise GDP_Error("Transformation called on %s of type %s. 'instance'"
-                            " must be a ConcreteModel, Block, or Disjunct (in "
-                            "the case of nested disjunctions)." %
-                            (instance.name, instance.ctype))
+            raise GDP_Error(
+                "Transformation called on %s of type %s. 'instance'"
+                " must be a ConcreteModel, Block, or Disjunct (in "
+                "the case of nested disjunctions)." % (instance.name, instance.ctype)
+            )
         try:
             self._config = self.CONFIG(kwds.pop('options', {}))
             self._config.set_value(kwds)
@@ -344,11 +415,13 @@ class PartitionDisjuncts_Transformation(Transformation):
 
             if not self._config.assume_fixed_vars_permanent:
                 fixed_vars = ComponentMap()
-                for v in get_vars_from_components(instance, Constraint,
-                                                  include_fixed=True,
-                                                  active=True,
-                                                  descend_into=(Block,
-                                                                Disjunct)):
+                for v in get_vars_from_components(
+                    instance,
+                    Constraint,
+                    include_fixed=True,
+                    active=True,
+                    descend_into=(Block, Disjunct),
+                ):
                     if v.fixed:
                         fixed_vars[v] = value(v)
                         v.fixed = False
@@ -365,9 +438,11 @@ class PartitionDisjuncts_Transformation(Transformation):
             del self._transformation_blocks
 
     def _apply_to_impl(self, instance):
-        self.variable_partitions = self._config.variable_partitions if \
-                                   self._config.variable_partitions is not \
-                                   None else {}
+        self.variable_partitions = (
+            self._config.variable_partitions
+            if self._config.variable_partitions is not None
+            else {}
+        )
         self.partitioning_method = self._config.variable_partitioning_method
 
         # create a model to store the global constraints on that we will pass to
@@ -375,24 +450,33 @@ class PartitionDisjuncts_Transformation(Transformation):
         # separate model because we don't need it again
         global_constraints = ConcreteModel()
         for cons in instance.component_objects(
-                Constraint, active=True, descend_into=Block,
-                sort=SortComponents.deterministic):
-            global_constraints.add_component(unique_component_name(
-                global_constraints, cons.getname(fully_qualified=True)),
-                                             Reference(cons))
+            Constraint,
+            active=True,
+            descend_into=Block,
+            sort=SortComponents.deterministic,
+        ):
+            global_constraints.add_component(
+                unique_component_name(
+                    global_constraints, cons.getname(fully_qualified=True)
+                ),
+                Reference(cons),
+            )
         for var in instance.component_objects(
-                Var, descend_into=(Block, Disjunct),
-                sort=SortComponents.deterministic):
-            global_constraints.add_component(unique_component_name(
-                global_constraints, var.getname(fully_qualified=True)),
-                                             Reference(var))
+            Var, descend_into=(Block, Disjunct), sort=SortComponents.deterministic
+        ):
+            global_constraints.add_component(
+                unique_component_name(
+                    global_constraints, var.getname(fully_qualified=True)
+                ),
+                Reference(var),
+            )
         self._global_constraints = global_constraints
 
         # we can support targets as usual.
         targets = self._config.targets
         knownBlocks = {}
         if targets is None:
-            targets = ( instance, )
+            targets = (instance,)
         # Disjunctions in targets will transform their Disjuncts which will in
         # turn transform all the GDP components declared on themselves. So we
         # only need to list root nodes of the GDP tree as targets, and
@@ -402,7 +486,7 @@ class PartitionDisjuncts_Transformation(Transformation):
             if t.ctype is Disjunction:
                 # After preprocessing, we know that this is not indexed.
                 self._transform_disjunctionData(t, t.index())
-            else: # We know this is a DisjunctData after preprocessing
+            else:  # We know this is a DisjunctData after preprocessing
                 self._transform_blockData(t)
 
     def _preprocess_targets(self, targets, instance, knownBlocks):
@@ -429,12 +513,14 @@ class PartitionDisjuncts_Transformation(Transformation):
         self._transformation_blocks[block] = transformation_block = Block()
         block.add_component(
             unique_component_name(
-                block,
-                '_pyomo_gdp_partition_disjuncts_reformulation'),
-            transformation_block)
+                block, '_pyomo_gdp_partition_disjuncts_reformulation'
+            ),
+            transformation_block,
+        )
 
         transformation_block.indicator_var_equalities = LogicalConstraint(
-            NonNegativeIntegers)
+            NonNegativeIntegers
+        )
 
         return transformation_block
 
@@ -445,29 +531,32 @@ class PartitionDisjuncts_Transformation(Transformation):
         # Transform every (active) disjunction in the block. Don't descend into
         # Disjuncts because we'll transform what's on them recursively.
         for disjunction in obj.component_data_objects(
-                Disjunction,
-                active=True,
-                sort=SortComponents.deterministic,
-                descend_into=Block):
+            Disjunction,
+            active=True,
+            sort=SortComponents.deterministic,
+            descend_into=Block,
+        ):
             to_transform.append(disjunction)
 
         for disjunction in to_transform:
             self._transform_disjunctionData(disjunction, disjunction.index())
 
-    def _transform_disjunctionData(self, obj, idx, transBlock=None,
-                                   transformed_parent_disjunct=None):
+    def _transform_disjunctionData(
+        self, obj, idx, transBlock=None, transformed_parent_disjunct=None
+    ):
         if not obj.active:
             return
 
         # Just because it's unlikely this is what someone meant to do...
         if len(obj.disjuncts) == 0:
-            raise GDP_Error("Disjunction '%s' is empty. This is "
-                            "likely indicative of a modeling error."  %
-                            obj.getname(fully_qualified=True))
+            raise GDP_Error(
+                "Disjunction '%s' is empty. This is "
+                "likely indicative of a modeling error."
+                % obj.getname(fully_qualified=True)
+            )
 
         if transBlock is None and transformed_parent_disjunct is not None:
-            transBlock = self._get_transformation_block(
-                transformed_parent_disjunct)
+            transBlock = self._get_transformation_block(transformed_parent_disjunct)
         if transBlock is None:
             transBlock = self._get_transformation_block(obj.parent_block())
 
@@ -499,11 +588,13 @@ class PartitionDisjuncts_Transformation(Transformation):
                     if P is None:
                         P = self._config.num_partitions.get(None)
                 if P is None:
-                    raise GDP_Error("No value for P was given for disjunction "
-                                    "%s! Please specify a value of P "
-                                    "(number of "
-                                    "partitions), if you do not specify the "
-                                    "partitions directly." % obj.name)
+                    raise GDP_Error(
+                        "No value for P was given for disjunction "
+                        "%s! Please specify a value of P "
+                        "(number of "
+                        "partitions), if you do not specify the "
+                        "partitions directly." % obj.name
+                    )
                 # it's this method's job to scream if it can't handle what's
                 # here, we can only assume it worked for now, since it's a
                 # callback.
@@ -513,24 +604,27 @@ class PartitionDisjuncts_Transformation(Transformation):
 
         transformed_disjuncts = []
         for disjunct in obj.disjuncts:
-            transformed_disjunct = self._transform_disjunct(disjunct, partition,
-                                                            transBlock)
+            transformed_disjunct = self._transform_disjunct(
+                disjunct, partition, transBlock
+            )
             if transformed_disjunct is not None:
                 transformed_disjuncts.append(transformed_disjunct)
                 # These require transformation, but that's okay because we are
                 # going to a GDP
                 transBlock.indicator_var_equalities[
-                    len(transBlock.indicator_var_equalities)] = \
-                        disjunct.indicator_var.equivalent_to(
-                            transformed_disjunct.indicator_var)
+                    len(transBlock.indicator_var_equalities)
+                ] = disjunct.indicator_var.equivalent_to(
+                    transformed_disjunct.indicator_var
+                )
 
         # make a new disjunction with the transformed guys
-        transformed_disjunction = Disjunction(expr=[disj for disj in
-                                                    transformed_disjuncts])
+        transformed_disjunction = Disjunction(
+            expr=[disj for disj in transformed_disjuncts]
+        )
         transBlock.add_component(
-            unique_component_name(transBlock,
-                                  obj.getname(fully_qualified=True)),
-            transformed_disjunction)
+            unique_component_name(transBlock, obj.getname(fully_qualified=True)),
+            transformed_disjunction,
+        )
         obj._algebraic_constraint = weakref_ref(transformed_disjunction)
 
         obj.deactivate()
@@ -555,55 +649,61 @@ class PartitionDisjuncts_Transformation(Transformation):
                     raise GDP_Error(
                         "The disjunct '%s' is deactivated, but the "
                         "indicator_var is fixed to %s. This makes no sense."
-                        % ( disjunct.name, value(disjunct.indicator_var) ))
+                        % (disjunct.name, value(disjunct.indicator_var))
+                    )
             if disjunct._transformation_block is None:
                 raise GDP_Error(
                     "The disjunct '%s' is deactivated, but the "
                     "indicator_var is not fixed and the disjunct does not "
                     "appear to have been relaxed. This makes no sense. "
                     "(If the intent is to deactivate the disjunct, fix its "
-                    "indicator_var to False.)"
-                    % ( disjunct.name, ))
+                    "indicator_var to False.)" % (disjunct.name,)
+                )
 
         if disjunct._transformation_block is not None:
             # we've transformed it, which means this is the second time it's
             # appearing in a Disjunction
             raise GDP_Error(
-                    "The disjunct '%s' has been transformed, but a disjunction "
-                    "it appears in has not. Putting the same disjunct in "
-                    "multiple disjunctions is not supported." % disjunct.name)
+                "The disjunct '%s' has been transformed, but a disjunction "
+                "it appears in has not. Putting the same disjunct in "
+                "multiple disjunctions is not supported." % disjunct.name
+            )
 
         transformed_disjunct = Disjunct()
         disjunct._transformation_block = weakref_ref(transformed_disjunct)
         transBlock.add_component(
-            unique_component_name(transBlock, disjunct.getname(
-                fully_qualified=True)), transformed_disjunct)
+            unique_component_name(transBlock, disjunct.getname(fully_qualified=True)),
+            transformed_disjunct,
+        )
         # If the original has an indicator_var fixed to something, fix this one
         # too.
         if disjunct.indicator_var.fixed:
-            transformed_disjunct.indicator_var.fix(
-                value(disjunct.indicator_var))
+            transformed_disjunct.indicator_var.fix(value(disjunct.indicator_var))
 
         # need to transform inner Disjunctions first (before we complain about
         # active Disjuncts)
         for disjunction in disjunct.component_data_objects(
-                Disjunction,
-                active=True,
-                sort=SortComponents.deterministic,
-                descend_into=Block):
-            self._transform_disjunctionData(disjunction, disjunction.index(),
-                                            None, transformed_disjunct)
+            Disjunction,
+            active=True,
+            sort=SortComponents.deterministic,
+            descend_into=Block,
+        ):
+            self._transform_disjunctionData(
+                disjunction, disjunction.index(), None, transformed_disjunct
+            )
 
         # create references to any variables declared here on the transformed
         # Disjunct (this will include the indicator_var) NOTE that we will not
         # have to do this when #1032 is implemented for the writers. But right
         # now, we are going to deactivate this and hide it from the active
         # subtree, so we need to be safe.
-        for var in disjunct.component_objects(Var, descend_into=Block,
-                                              active=None):
-            transformed_disjunct.add_component(unique_component_name(
-                transformed_disjunct, var.getname(fully_qualified=True)),
-                                           Reference(var))
+        for var in disjunct.component_objects(Var, descend_into=Block, active=None):
+            transformed_disjunct.add_component(
+                unique_component_name(
+                    transformed_disjunct, var.getname(fully_qualified=True)
+                ),
+                Reference(var),
+            )
 
         # Since this transformation is GDP -> GDP and it is based on
         # partitioning algebraic expressions, we will copy over
@@ -614,11 +714,13 @@ class PartitionDisjuncts_Transformation(Transformation):
         # who their parent block is, we would like these constraints to answer
         # that it is the transformed Disjunct.
         logical_constraints = LogicalConstraintList()
-        transformed_disjunct.add_component(unique_component_name(
-            transformed_disjunct, 'logical_constraints'), logical_constraints)
-        for cons in disjunct.component_data_objects(LogicalConstraint,
-                                                    descend_into=Block,
-                                                    active=None):
+        transformed_disjunct.add_component(
+            unique_component_name(transformed_disjunct, 'logical_constraints'),
+            logical_constraints,
+        )
+        for cons in disjunct.component_data_objects(
+            LogicalConstraint, descend_into=Block, active=None
+        ):
             # Add a copy of it on the new Disjunct
             logical_constraints.add(cons.expr)
 
@@ -628,9 +730,8 @@ class PartitionDisjuncts_Transformation(Transformation):
 
         # transform everything else
         for obj in disjunct.component_data_objects(
-                active=True,
-                sort=SortComponents.deterministic,
-                descend_into=Block):
+            active=True, sort=SortComponents.deterministic, descend_into=Block
+        ):
             handler = self.handlers.get(obj.ctype, None)
             if not handler:
                 if handler is None:
@@ -640,7 +741,8 @@ class PartitionDisjuncts_Transformation(Transformation):
                         "for modeling components of type %s. If your "
                         "disjuncts contain non-GDP Pyomo components that "
                         "require transformation, please transform them first."
-                        % obj.ctype)
+                        % obj.ctype
+                    )
                 continue
             # we are really only transforming constraints and checking for
             # anything nutty (active Disjuncts, etc) here, so pass through what
@@ -650,24 +752,31 @@ class PartitionDisjuncts_Transformation(Transformation):
         disjunct._deactivate_without_fixing_indicator()
         return transformed_disjunct
 
-    def _transform_constraint(self, cons, disjunct, transformed_disjunct,
-                              transBlock, partition):
+    def _transform_constraint(
+        self, cons, disjunct, transformed_disjunct, transBlock, partition
+    ):
         instance = disjunct.model()
         cons_name = cons.getname(fully_qualified=True)
 
         # create place on transformed Disjunct for the new constraint and
         # for the auxiliary variables
         transformed_constraint = Constraint(NonNegativeIntegers)
-        transformed_disjunct.add_component(unique_component_name(
-            transformed_disjunct, cons_name), transformed_constraint)
+        transformed_disjunct.add_component(
+            unique_component_name(transformed_disjunct, cons_name),
+            transformed_constraint,
+        )
         aux_vars = Var(NonNegativeIntegers, dense=False)
-        transformed_disjunct.add_component(unique_component_name(
-            transformed_disjunct, cons_name + "_aux_vars"), aux_vars)
+        transformed_disjunct.add_component(
+            unique_component_name(transformed_disjunct, cons_name + "_aux_vars"),
+            aux_vars,
+        )
 
         # create a place on the transBlock for the split constraints
         split_constraints = Constraint(NonNegativeIntegers)
-        transBlock.add_component(unique_component_name(
-            transBlock, cons_name + "_split_constraints"), split_constraints)
+        transBlock.add_component(
+            unique_component_name(transBlock, cons_name + "_split_constraints"),
+            split_constraints,
+        )
 
         # this is a list which might have two constraints in it if we had
         # both a lower and upper value.
@@ -677,13 +786,13 @@ class PartitionDisjuncts_Transformation(Transformation):
             nonlinear_repn = None
             if repn.nonlinear_expr is not None:
                 nonlinear_repn = _generate_additively_separable_repn(
-                    repn.nonlinear_expr)
+                    repn.nonlinear_expr
+                )
             split_exprs = []
             split_aux_vars = []
-            vars_not_accounted_for = ComponentSet(v for v in
-                                                  EXPR.identify_variables(
-                                                      body,
-                                                      include_fixed=False))
+            vars_not_accounted_for = ComponentSet(
+                v for v in EXPR.identify_variables(body, include_fixed=False)
+            )
             vars_accounted_for = ComponentSet()
             for idx, var_list in enumerate(partition):
                 # we are going to recreate the piece of the expression
@@ -692,27 +801,27 @@ class PartitionDisjuncts_Transformation(Transformation):
                 expr = split_exprs[-1]
                 for i, v in enumerate(repn.linear_vars):
                     if v in var_list:
-                        expr += repn.linear_coefs[i]*v
+                        expr += repn.linear_coefs[i] * v
                         vars_accounted_for.add(v)
                 for i, (v1, v2) in enumerate(repn.quadratic_vars):
                     if v1 in var_list:
                         if v2 not in var_list:
-                            raise GDP_Error("Variables '%s' and '%s' are "
-                                            "multiplied in Constraint '%s', "
-                                            "but they are in different "
-                                            "partitions! Please ensure that "
-                                            "all the constraints in the "
-                                            "disjunction are "
-                                            "additively separable with "
-                                            "respect to the specified "
-                                            "partition." % (v1.name, v2.name,
-                                                            cons.name))
-                        expr += repn.quadratic_coefs[i]*v1*v2
+                            raise GDP_Error(
+                                "Variables '%s' and '%s' are "
+                                "multiplied in Constraint '%s', "
+                                "but they are in different "
+                                "partitions! Please ensure that "
+                                "all the constraints in the "
+                                "disjunction are "
+                                "additively separable with "
+                                "respect to the specified "
+                                "partition." % (v1.name, v2.name, cons.name)
+                            )
+                        expr += repn.quadratic_coefs[i] * v1 * v2
                         vars_accounted_for.add(v1)
                         vars_accounted_for.add(v2)
                 if nonlinear_repn is not None:
-                    for i, expr_var_set in enumerate(
-                            nonlinear_repn['nonlinear_vars']):
+                    for i, expr_var_set in enumerate(nonlinear_repn['nonlinear_vars']):
                         # check if v_list is a subset of var_list. If it is
                         # not and there is no intersection, we move on. If
                         # it is not and there is an intersection, we raise
@@ -725,40 +834,41 @@ class PartitionDisjuncts_Transformation(Transformation):
                                 vars_accounted_for.add(var)
                         # intersection?
                         elif len(ComponentSet(expr_var_set) & var_list) != 0:
-                            raise GDP_Error("Variables which appear in the "
-                                            "expression %s are in different "
-                                            "partitions, but this "
-                                            "expression doesn't appear "
-                                            "additively separable. Please "
-                                            "expand it if it is additively "
-                                            "separable or, more likely, "
-                                            "ensure that all the "
-                                            "constraints in the disjunction "
-                                            "are additively separable with "
-                                            "respect to the specified "
-                                            "partition. If you did not "
-                                            "specify a partition, only "
-                                            "a value of P, note that to "
-                                            "automatically partition the "
-                                            "variables, we assume all the "
-                                            "expressions are additively "
-                                            "separable." %
-                                            nonlinear_repn[
-                                                'nonlinear_exprs'][i])
+                            raise GDP_Error(
+                                "Variables which appear in the "
+                                "expression %s are in different "
+                                "partitions, but this "
+                                "expression doesn't appear "
+                                "additively separable. Please "
+                                "expand it if it is additively "
+                                "separable or, more likely, "
+                                "ensure that all the "
+                                "constraints in the disjunction "
+                                "are additively separable with "
+                                "respect to the specified "
+                                "partition. If you did not "
+                                "specify a partition, only "
+                                "a value of P, note that to "
+                                "automatically partition the "
+                                "variables, we assume all the "
+                                "expressions are additively "
+                                "separable." % nonlinear_repn['nonlinear_exprs'][i]
+                            )
 
                 expr_lb, expr_ub = self._config.compute_bounds_method(
-                    expr, self._global_constraints,
-                    self._config.compute_bounds_solver)
+                    expr, self._global_constraints, self._config.compute_bounds_solver
+                )
                 if expr_lb is None or expr_ub is None:
-                    raise GDP_Error("Expression %s from constraint '%s' "
-                                    "is unbounded! Please ensure all "
-                                    "variables that appear "
-                                    "in the constraint are bounded or "
-                                    "specify compute_bounds_method="
-                                    "compute_optimal_bounds"
-                                    " if the expression is bounded by the "
-                                    "global constraints." %
-                                    (expr, cons.name))
+                    raise GDP_Error(
+                        "Expression %s from constraint '%s' "
+                        "is unbounded! Please ensure all "
+                        "variables that appear "
+                        "in the constraint are bounded or "
+                        "specify compute_bounds_method="
+                        "compute_optimal_bounds"
+                        " if the expression is bounded by the "
+                        "global constraints." % (expr, cons.name)
+                    )
                 # if the expression was empty wrt the partition, we don't
                 # need to bother with any of this. The aux_var doesn't need
                 # to exist because it would be 0.
@@ -767,30 +877,34 @@ class PartitionDisjuncts_Transformation(Transformation):
                     aux_var.setlb(expr_lb)
                     aux_var.setub(expr_ub)
                     split_aux_vars.append(aux_var)
-                    split_constraints[
-                        len(split_constraints)] = expr <= aux_var
+                    split_constraints[len(split_constraints)] = expr <= aux_var
 
             if len(vars_accounted_for) < len(vars_not_accounted_for):
-                    orphans = vars_not_accounted_for - vars_accounted_for
-                    orphan_string = ""
-                    for v in orphans:
-                        orphan_string += "'%s', " % v.name
-                    orphan_string = orphan_string[:-2]
-                    raise GDP_Error("Partition specified for disjunction "
-                                    "containing Disjunct '%s' does not "
-                                    "include all the variables that appear "
-                                    "in the disjunction. The following "
-                                    "variables are not assigned to any part "
-                                    "of the partition: %s" % (disjunct.name,
-                                                              orphan_string))
-            transformed_constraint[
-                len(transformed_constraint)] = sum(v for v in
-                                                   split_aux_vars) <= \
-                rhs - repn.constant
+                orphans = vars_not_accounted_for - vars_accounted_for
+                orphan_string = ""
+                for v in orphans:
+                    orphan_string += "'%s', " % v.name
+                orphan_string = orphan_string[:-2]
+                raise GDP_Error(
+                    "Partition specified for disjunction "
+                    "containing Disjunct '%s' does not "
+                    "include all the variables that appear "
+                    "in the disjunction. The following "
+                    "variables are not assigned to any part "
+                    "of the partition: %s" % (disjunct.name, orphan_string)
+                )
+            transformed_constraint[len(transformed_constraint)] = (
+                sum(v for v in split_aux_vars) <= rhs - repn.constant
+            )
         # deactivate the constraint since we've transformed it
         cons.deactivate()
 
-    def _warn_for_active_disjunct(self, disjunct, parent_disjunct,
-                                  transformed_parent_disjunct, transBlock,
-                                  partition):
+    def _warn_for_active_disjunct(
+        self,
+        disjunct,
+        parent_disjunct,
+        transformed_parent_disjunct,
+        transBlock,
+        partition,
+    ):
         _warn_for_active_disjunct(disjunct, parent_disjunct)

--- a/pyomo/gdp/tests/common_tests.py
+++ b/pyomo/gdp/tests/common_tests.py
@@ -13,9 +13,19 @@ import pickle
 from pyomo.common.dependencies import dill
 
 from pyomo.environ import (
-    TransformationFactory, ConcreteModel, Constraint, Var, Objective,
-    Block, Any, RangeSet, Expression, value, BooleanVar, SolverFactory,
-    TerminationCondition
+    TransformationFactory,
+    ConcreteModel,
+    Constraint,
+    Var,
+    Objective,
+    Block,
+    Any,
+    RangeSet,
+    Expression,
+    value,
+    BooleanVar,
+    SolverFactory,
+    TerminationCondition,
 )
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 from pyomo.core.base import constraint, ComponentUID
@@ -27,10 +37,10 @@ import random
 
 import pyomo.opt
 
-linear_solvers = pyomo.opt.check_available_solvers(
-    'glpk','cbc','gurobi','cplex')
+linear_solvers = pyomo.opt.check_available_solvers('glpk', 'cbc', 'gurobi', 'cplex')
 
 # utility functions
+
 
 def check_linear_coef(self, repn, var, coef):
     # Map logical variables to their Boolean counterparts
@@ -39,26 +49,27 @@ def check_linear_coef(self, repn, var, coef):
 
     # utility used to check a variable-coefficient pair in a standard_repn
     var_id = None
-    for i,v in enumerate(repn.linear_vars):
+    for i, v in enumerate(repn.linear_vars):
         if v is var:
             var_id = i
     self.assertIsNotNone(var_id)
     self.assertAlmostEqual(repn.linear_coefs[var_id], coef)
 
+
 def check_squared_term_coef(self, repn, var, coef):
     var_id = None
-    for i,(v1, v2) in enumerate(repn.quadratic_vars):
+    for i, (v1, v2) in enumerate(repn.quadratic_vars):
         if v1 is var and v2 is var:
             var_id = i
             break
     self.assertIsNotNone(var_id)
     self.assertEqual(repn.quadratic_coefs[var_id], coef)
 
+
 def diff_apply_to_and_create_using(self, model, transformation, **kwargs):
     # compares the pprint from the transformed model after using both apply_to
     # and create_using to make sure the two do the same thing
-    modelcopy = TransformationFactory(transformation).create_using(model,
-                                                                   **kwargs)
+    modelcopy = TransformationFactory(transformation).create_using(model, **kwargs)
     modelcopy_buf = StringIO()
     modelcopy.pprint(ostream=modelcopy_buf)
     modelcopy_output = modelcopy_buf.getvalue()
@@ -70,6 +81,7 @@ def diff_apply_to_and_create_using(self, model, transformation, **kwargs):
     model.pprint(ostream=model_buf)
     model_output = model_buf.getvalue()
     self.assertMultiLineEqual(modelcopy_output, model_output)
+
 
 def check_obj_in_active_tree(self, obj, root=None):
     # Utility for checking that transformed components are indeed on the new
@@ -85,6 +97,7 @@ def check_obj_in_active_tree(self, obj, root=None):
         self.assertTrue(blk.active)
         blk = blk.parent_block()
 
+
 def check_relaxation_block(self, m, name, numdisjuncts):
     # utility for checking the transformation block (this method is generic to
     # bigm and hull though there is more on the hull transformation block, and
@@ -94,12 +107,13 @@ def check_relaxation_block(self, m, name, numdisjuncts):
     self.assertIsInstance(transBlock.component("relaxedDisjuncts"), Block)
     self.assertEqual(len(transBlock.relaxedDisjuncts), numdisjuncts)
 
+
 def checkb0TargetsInactive(self, m):
     self.assertTrue(m.disjunct1.active)
-    self.assertTrue(m.disjunct1[1,0].active)
-    self.assertTrue(m.disjunct1[1,1].active)
-    self.assertTrue(m.disjunct1[2,0].active)
-    self.assertTrue(m.disjunct1[2,1].active)
+    self.assertTrue(m.disjunct1[1, 0].active)
+    self.assertTrue(m.disjunct1[1, 1].active)
+    self.assertTrue(m.disjunct1[2, 0].active)
+    self.assertTrue(m.disjunct1[2, 1].active)
 
     self.assertFalse(m.b[0].disjunct.active)
     self.assertFalse(m.b[0].disjunct[0].active)
@@ -107,33 +121,39 @@ def checkb0TargetsInactive(self, m):
     self.assertTrue(m.b[1].disjunct0.active)
     self.assertTrue(m.b[1].disjunct1.active)
 
+
 def checkb0TargetsTransformed(self, m, transformation):
     trans = TransformationFactory('gdp.%s' % transformation)
-    disjBlock = m.b[0].component(
-        "_pyomo_gdp_%s_reformulation" % transformation).relaxedDisjuncts
+    disjBlock = (
+        m.b[0]
+        .component("_pyomo_gdp_%s_reformulation" % transformation)
+        .relaxedDisjuncts
+    )
     self.assertEqual(len(disjBlock), 2)
-    self.assertIs(trans.get_transformed_constraints(
-        m.b[0].disjunct[0].c)[0].parent_block(), disjBlock[0])
-    self.assertIs(trans.get_transformed_constraints(
-        m.b[0].disjunct[1].c)[0].parent_block(), disjBlock[1])
+    self.assertIs(
+        trans.get_transformed_constraints(m.b[0].disjunct[0].c)[0].parent_block(),
+        disjBlock[0],
+    )
+    self.assertIs(
+        trans.get_transformed_constraints(m.b[0].disjunct[1].c)[0].parent_block(),
+        disjBlock[1],
+    )
 
     # This relies on the disjunctions being transformed in the same order
     # every time. This dictionary maps the block index to the list of
     # pairs of (originalDisjunctIndex, transBlockIndex)
-    pairs = [
-            (0,0),
-            (1,1),
-    ]
+    pairs = [(0, 0), (1, 1)]
     for i, j in pairs:
-        self.assertIs(m.b[0].disjunct[i].transformation_block,
-                      disjBlock[j])
-        self.assertIs(trans.get_src_disjunct(disjBlock[j]),
-                      m.b[0].disjunct[i])
+        self.assertIs(m.b[0].disjunct[i].transformation_block, disjBlock[j])
+        self.assertIs(trans.get_src_disjunct(disjBlock[j]), m.b[0].disjunct[i])
+
 
 # active status checks
 
-def check_user_deactivated_disjuncts(self, transformation,
-                                     check_trans_block=True, **kwargs):
+
+def check_user_deactivated_disjuncts(
+    self, transformation, check_trans_block=True, **kwargs
+):
     # check that we do not transform a deactivated DisjunctData
     m = models.makeTwoTermDisj()
     m.d[0].deactivate()
@@ -150,6 +170,7 @@ def check_user_deactivated_disjuncts(self, transformation,
         self.assertIs(disjBlock[0], m.d[1].transformation_block)
         self.assertIs(transform.get_src_disjunct(disjBlock[0]), m.d[1])
 
+
 def check_improperly_deactivated_disjuncts(self, transformation, **kwargs):
     # check that if a Disjunct is deactivated but its indicator variable is not
     # fixed to 0, we express our confusion.
@@ -164,20 +185,22 @@ def check_improperly_deactivated_disjuncts(self, transformation, **kwargs):
         r"indicator_var is fixed to True. This makes no sense.",
         TransformationFactory('gdp.%s' % transformation).apply_to,
         m,
-        **kwargs)
+        **kwargs
+    )
+
 
 def check_indexed_disjunction_not_transformed(self, m, transformation):
     # no transformation block, nothing transformed
-    self.assertIsNone(m.component("_pyomo_gdp_%s_transformation"
-                                  % transformation))
+    self.assertIsNone(m.component("_pyomo_gdp_%s_transformation" % transformation))
     for idx in m.disjunct:
         self.assertIsNone(m.disjunct[idx].transformation_block)
     for idx in m.disjunction:
         self.assertIsNone(m.disjunction[idx].algebraic_constraint)
 
-def check_do_not_transform_userDeactivated_indexedDisjunction(self,
-                                                              transformation,
-                                                              **kwargs):
+
+def check_do_not_transform_userDeactivated_indexedDisjunction(
+    self, transformation, **kwargs
+):
     # check that we do not transform a deactivated disjunction
     m = models.makeTwoTermIndexedDisjunction()
     # If you truly want to transform nothing, deactivate everything
@@ -185,32 +208,35 @@ def check_do_not_transform_userDeactivated_indexedDisjunction(self,
     for idx in m.disjunct:
         m.disjunct[idx].deactivate()
     directly = TransformationFactory('gdp.%s' % transformation).create_using(
-        m, **kwargs)
+        m, **kwargs
+    )
     check_indexed_disjunction_not_transformed(self, directly, transformation)
 
     targets = TransformationFactory('gdp.%s' % transformation).create_using(
-        m, targets=(m.disjunction), **kwargs)
+        m, targets=(m.disjunction), **kwargs
+    )
     check_indexed_disjunction_not_transformed(self, targets, transformation)
+
 
 def check_disjunction_deactivated(self, transformation, **kwargs):
     # check that we deactivate disjunctions after we transform them
     m = models.makeTwoTermDisj()
-    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=(m,),
-                                                              **kwargs)
+    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=(m,), **kwargs)
 
     oldblock = m.component("disjunction")
     self.assertIsInstance(oldblock, Disjunction)
     self.assertFalse(oldblock.active)
 
+
 def check_disjunctDatas_deactivated(self, transformation, **kwargs):
     # check that we deactivate disjuncts after we transform them
     m = models.makeTwoTermDisj()
-    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=(m,),
-                                                              **kwargs)
+    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=(m,), **kwargs)
 
     oldblock = m.component("disjunction")
     self.assertFalse(oldblock.disjuncts[0].active)
     self.assertFalse(oldblock.disjuncts[1].active)
+
 
 def check_deactivated_constraints(self, transformation, **kwargs):
     # test that we deactivate constraints after we transform them
@@ -230,23 +256,23 @@ def check_deactivated_constraints(self, transformation, **kwargs):
     self.assertIsInstance(oldc, Constraint)
     self.assertFalse(oldc.active)
 
+
 def check_deactivated_disjuncts(self, transformation, **kwargs):
     # another test that we deactivated transformed Disjuncts, but this one
     # includes a SimpleDisjunct as well
     m = models.makeTwoTermMultiIndexedDisjunction()
-    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=(m,),
-                                                              **kwargs)
+    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=(m,), **kwargs)
     # all the disjuncts got transformed, so all should be deactivated
     for i in m.disjunct.index_set():
         self.assertFalse(m.disjunct[i].active)
     self.assertFalse(m.disjunct.active)
 
+
 def check_deactivated_disjunctions(self, transformation, **kwargs):
     # another test that we deactivated transformed Disjunctions, but including a
     # SimpleDisjunction
     m = models.makeTwoTermMultiIndexedDisjunction()
-    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=(m,),
-                                                              **kwargs)
+    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=(m,), **kwargs)
 
     # all the disjunctions got transformed, so they should be
     # deactivated too
@@ -254,8 +280,8 @@ def check_deactivated_disjunctions(self, transformation, **kwargs):
         self.assertFalse(m.disjunction[i].active)
     self.assertFalse(m.disjunction.active)
 
-def check_do_not_transform_twice_if_disjunction_reactivated(self,
-                                                            transformation):
+
+def check_do_not_transform_twice_if_disjunction_reactivated(self, transformation):
     # test that if an already-transformed disjunction is reactivated, we will
     # not retransform it in a subsequent call to the transformation.
     m = models.makeTwoTermDisj()
@@ -285,10 +311,11 @@ def check_do_not_transform_twice_if_disjunction_reactivated(self,
         r"a disjunction it appears in, has not. Putting the same disjunct in "
         r"multiple disjunctions is not supported.",
         TransformationFactory('gdp.%s' % transformation).apply_to,
-        m)
+        m,
+    )
 
-def check_constraints_deactivated_indexedDisjunction(self, transformation,
-                                                     **kwargs):
+
+def check_constraints_deactivated_indexedDisjunction(self, transformation, **kwargs):
     # check that we deactivate transformed constraints
     m = models.makeTwoTermMultiIndexedDisjunction()
     TransformationFactory('gdp.%s' % transformation).apply_to(m, **kwargs)
@@ -296,10 +323,12 @@ def check_constraints_deactivated_indexedDisjunction(self, transformation,
     for i in m.disjunct.index_set():
         self.assertFalse(m.disjunct[i].c.active)
 
+
 def check_partial_deactivate_indexed_disjunction(self, transformation):
     """Test for partial deactivation of an indexed disjunction."""
     m = ConcreteModel()
     m.x = Var(bounds=(0, 10))
+
     @m.Disjunction([0, 1])
     def disj(m, i):
         if i == 0:
@@ -313,11 +342,15 @@ def check_partial_deactivate_indexed_disjunction(self, transformation):
     TransformationFactory('gdp.%s' % transformation).apply_to(m)
     transBlock = m.component("_pyomo_gdp_%s_reformulation" % transformation)
     self.assertEqual(
-        len(transBlock.disj_xor), 1,
-        "There should only be one XOR constraint generated. Found %s." %
-        len(transBlock.disj_xor))
+        len(transBlock.disj_xor),
+        1,
+        "There should only be one XOR constraint generated. Found %s."
+        % len(transBlock.disj_xor),
+    )
+
 
 # transformation block
+
 
 def check_transformation_block_name_collision(self, transformation):
     # make sure that if the model already has a block called
@@ -340,10 +373,13 @@ def check_transformation_block_name_collision(self, transformation):
     self.assertIs(m.d[1].transformation_block, disjBlock[1])
 
     # we didn't add to the block that wasn't ours
-    self.assertEqual(len(m.component("_pyomo_gdp_%s_reformulation" %
-                                     transformation)), 0)
+    self.assertEqual(
+        len(m.component("_pyomo_gdp_%s_reformulation" % transformation)), 0
+    )
+
 
 # XOR constraints
+
 
 def check_indicator_vars(self, transformation):
     # particularly paranoid test checking that the indicator_vars are intact
@@ -362,6 +398,7 @@ def check_indicator_vars(self, transformation):
     self.assertTrue(_binary1.active)
     self.assertTrue(_binary1.is_binary())
 
+
 def check_two_term_disjunction_xor(self, xor, disj1, disj2):
     self.assertIsInstance(xor, Constraint)
     self.assertEqual(len(xor), 1)
@@ -375,6 +412,7 @@ def check_two_term_disjunction_xor(self, xor, disj1, disj2):
     self.assertEqual(xor.lower, 1)
     self.assertEqual(xor.upper, 1)
 
+
 def check_xor_constraint(self, transformation):
     # verify xor constraint for a SimpleDisjunction
     m = models.makeTwoTermDisj()
@@ -385,41 +423,41 @@ def check_xor_constraint(self, transformation):
     xor = rBlock.component("disjunction_xor")
     check_two_term_disjunction_xor(self, xor, m.d[0], m.d[1])
 
+
 def check_indexed_xor_constraints(self, transformation):
     # verify xor constraint for an IndexedDisjunction
     m = models.makeTwoTermMultiIndexedDisjunction()
     TransformationFactory('gdp.%s' % transformation).apply_to(m)
 
-    xor = m.component("_pyomo_gdp_%s_reformulation" % transformation).\
-          component("disjunction_xor")
+    xor = m.component("_pyomo_gdp_%s_reformulation" % transformation).component(
+        "disjunction_xor"
+    )
     self.assertIsInstance(xor, Constraint)
     for i in m.disjunction.index_set():
         repn = generate_standard_repn(xor[i].body)
         self.assertEqual(repn.constant, 0)
         self.assertTrue(repn.is_linear())
         self.assertEqual(len(repn.linear_vars), 2)
-        check_linear_coef(
-            self, repn, m.disjunction[i].disjuncts[0].indicator_var, 1)
-        check_linear_coef(
-            self, repn, m.disjunction[i].disjuncts[1].indicator_var, 1)
+        check_linear_coef(self, repn, m.disjunction[i].disjuncts[0].indicator_var, 1)
+        check_linear_coef(self, repn, m.disjunction[i].disjuncts[1].indicator_var, 1)
         self.assertEqual(xor[i].lower, 1)
         self.assertEqual(xor[i].upper, 1)
+
 
 def check_indexed_xor_constraints_with_targets(self, transformation):
     # check that when we use targets to specfy some DisjunctionDatas in an
     # IndexedDisjunction, the xor constraint is indexed correctly
     m = models.makeTwoTermIndexedDisjunction_BoundedVars()
     TransformationFactory('gdp.%s' % transformation).apply_to(
-        m,
-        targets=[m.disjunction[1],
-                 m.disjunction[3]])
+        m, targets=[m.disjunction[1], m.disjunction[3]]
+    )
 
     xorC = m.disjunction[1].algebraic_constraint.parent_component()
     self.assertIsInstance(xorC, Constraint)
     self.assertEqual(len(xorC), 2)
 
     # check the constraints
-    for i in [1,3]:
+    for i in [1, 3]:
         self.assertEqual(xorC[i].lower, 1)
         self.assertEqual(xorC[i].upper, 1)
         repn = generate_standard_repn(xorC[i].body)
@@ -428,14 +466,16 @@ def check_indexed_xor_constraints_with_targets(self, transformation):
         check_linear_coef(self, repn, m.disjunct[i, 0].indicator_var, 1)
         check_linear_coef(self, repn, m.disjunct[i, 1].indicator_var, 1)
 
+
 def check_three_term_xor_constraint(self, transformation):
     # check that the xor constraint has all the indicator variables from a
     # three-term disjunction
     m = models.makeThreeTermIndexedDisj()
     TransformationFactory('gdp.%s' % transformation).apply_to(m)
 
-    xor = m.component("_pyomo_gdp_%s_reformulation" % transformation).\
-          component("disjunction_xor")
+    xor = m.component("_pyomo_gdp_%s_reformulation" % transformation).component(
+        "disjunction_xor"
+    )
     self.assertIsInstance(xor, Constraint)
     self.assertEqual(xor[1].lower, 1)
     self.assertEqual(xor[1].upper, 1)
@@ -447,17 +487,18 @@ def check_three_term_xor_constraint(self, transformation):
     self.assertEqual(repn.constant, 0)
     self.assertEqual(len(repn.linear_vars), 3)
     for i in range(3):
-        check_linear_coef(self, repn, m.disjunct[i,1].indicator_var, 1)
+        check_linear_coef(self, repn, m.disjunct[i, 1].indicator_var, 1)
 
     repn = generate_standard_repn(xor[2].body)
     self.assertTrue(repn.is_linear())
     self.assertEqual(repn.constant, 0)
     self.assertEqual(len(repn.linear_vars), 3)
     for i in range(3):
-        check_linear_coef(self, repn, m.disjunct[i,2].indicator_var, 1)
+        check_linear_coef(self, repn, m.disjunct[i, 2].indicator_var, 1)
 
 
 # mappings
+
 
 def check_xor_constraint_mapping(self, transformation):
     # test that we correctly map between disjunctions and XOR constraints
@@ -466,10 +507,8 @@ def check_xor_constraint_mapping(self, transformation):
     trans.apply_to(m)
 
     transBlock = m.component("_pyomo_gdp_%s_reformulation" % transformation)
-    self.assertIs(trans.get_src_disjunction(transBlock.disjunction_xor),
-                  m.disjunction)
-    self.assertIs(m.disjunction.algebraic_constraint,
-                  transBlock.disjunction_xor)
+    self.assertIs(trans.get_src_disjunction(transBlock.disjunction_xor), m.disjunction)
+    self.assertIs(m.disjunction.algebraic_constraint, transBlock.disjunction_xor)
 
 
 def check_xor_constraint_mapping_two_disjunctions(self, transformation):
@@ -480,13 +519,11 @@ def check_xor_constraint_mapping_two_disjunctions(self, transformation):
     trans.apply_to(m)
 
     transBlock = m.component("_pyomo_gdp_%s_reformulation" % transformation)
-    self.assertIs( trans.get_src_disjunction(transBlock.disjunction_xor),
-                   m.disjunction)
+    self.assertIs(trans.get_src_disjunction(transBlock.disjunction_xor), m.disjunction)
 
-    self.assertIs(m.disjunction.algebraic_constraint,
-                  transBlock.disjunction_xor)
-    self.assertIs(m.disjunction2.algebraic_constraint,
-                  transBlock.disjunction2_xor)
+    self.assertIs(m.disjunction.algebraic_constraint, transBlock.disjunction_xor)
+    self.assertIs(m.disjunction2.algebraic_constraint, transBlock.disjunction2_xor)
+
 
 def check_disjunct_mapping(self, transformation):
     # check that we correctly map between Disjuncts and their transformation
@@ -495,24 +532,26 @@ def check_disjunct_mapping(self, transformation):
     trans = TransformationFactory('gdp.%s' % transformation)
     trans.apply_to(m)
 
-    disjBlock = m.component("_pyomo_gdp_%s_reformulation" % transformation).\
-                relaxedDisjuncts
+    disjBlock = m.component(
+        "_pyomo_gdp_%s_reformulation" % transformation
+    ).relaxedDisjuncts
 
     # the disjuncts will always be transformed in the same order,
     # and d[0] goes first, so we can check in a loop.
-    for i in [0,1]:
+    for i in [0, 1]:
         self.assertIs(disjBlock[i]._src_disjunct(), m.d[i])
         self.assertIs(trans.get_src_disjunct(disjBlock[i]), m.d[i])
 
+
 # targets
+
 
 def check_only_targets_inactive(self, transformation, **kwargs):
     # test that we only transform targets (by checking active status)
     m = models.makeTwoSimpleDisjunctions()
     TransformationFactory('gdp.%s' % transformation).apply_to(
-        m,
-        targets=[m.disjunction1],
-        **kwargs)
+        m, targets=[m.disjunction1], **kwargs
+    )
 
     self.assertFalse(m.disjunction1.active)
     # disjunction2 still active
@@ -525,29 +564,27 @@ def check_only_targets_inactive(self, transformation, **kwargs):
     self.assertTrue(m.disjunct2[1].active)
     self.assertTrue(m.disjunct2.active)
 
+
 def check_only_targets_get_transformed(self, transformation):
     # test that we only transform targets (by checking the actual components)
     m = models.makeTwoSimpleDisjunctions()
     trans = TransformationFactory('gdp.%s' % transformation)
-    trans.apply_to(
-        m,
-        targets=[m.disjunction1])
+    trans.apply_to(m, targets=[m.disjunction1])
 
-    disjBlock = m.component("_pyomo_gdp_%s_reformulation" % transformation).\
-                relaxedDisjuncts
+    disjBlock = m.component(
+        "_pyomo_gdp_%s_reformulation" % transformation
+    ).relaxedDisjuncts
     # only two disjuncts relaxed
     self.assertEqual(len(disjBlock), 2)
 
-    pairs = [
-        (0, 0),
-        (1, 1)
-    ]
+    pairs = [(0, 0), (1, 1)]
     for i, j in pairs:
         self.assertIs(disjBlock[i], m.disjunct1[j].transformation_block)
         self.assertIs(trans.get_src_disjunct(disjBlock[i]), m.disjunct1[j])
 
     self.assertIsNone(m.disjunct2[0].transformation_block)
     self.assertIsNone(m.disjunct2[1].transformation_block)
+
 
 def check_target_not_a_component_error(self, transformation, **kwargs):
     # test error message for crazy targets
@@ -559,7 +596,10 @@ def check_target_not_a_component_error(self, transformation, **kwargs):
         "Target 'block' is not a component on instance 'unknown'!",
         TransformationFactory('gdp.%s' % transformation).apply_to,
         m,
-        targets=[decoy.block], **kwargs)
+        targets=[decoy.block],
+        **kwargs
+    )
+
 
 def check_targets_cannot_be_cuids(self, transformation):
     # check that we scream if targets are cuids
@@ -573,23 +613,25 @@ def check_targets_cannot_be_cuids(self, transformation):
         r"\n\tReceived %s" % type(ComponentUID(m.disjunction)),
         TransformationFactory('gdp.%s' % transformation).apply_to,
         m,
-        targets=[ComponentUID(m.disjunction)])
+        targets=[ComponentUID(m.disjunction)],
+    )
+
 
 def check_indexedDisj_targets_inactive(self, transformation, **kwargs):
     # check that targets are deactivated (when target is IndexedDisjunction)
     m = models.makeDisjunctionsOnIndexedBlock()
     TransformationFactory('gdp.%s' % transformation).apply_to(
-        m,
-        targets=[m.disjunction1], **kwargs)
+        m, targets=[m.disjunction1], **kwargs
+    )
 
     self.assertFalse(m.disjunction1.active)
     self.assertFalse(m.disjunction1[1].active)
     self.assertFalse(m.disjunction1[2].active)
 
-    self.assertFalse(m.disjunct1[1,0].active)
-    self.assertFalse(m.disjunct1[1,1].active)
-    self.assertFalse(m.disjunct1[2,0].active)
-    self.assertFalse(m.disjunct1[2,1].active)
+    self.assertFalse(m.disjunct1[1, 0].active)
+    self.assertFalse(m.disjunct1[1, 1].active)
+    self.assertFalse(m.disjunct1[2, 0].active)
+    self.assertFalse(m.disjunct1[2, 1].active)
     self.assertFalse(m.disjunct1.active)
 
     self.assertTrue(m.b[0].disjunct[0].active)
@@ -597,80 +639,96 @@ def check_indexedDisj_targets_inactive(self, transformation, **kwargs):
     self.assertTrue(m.b[1].disjunct0.active)
     self.assertTrue(m.b[1].disjunct1.active)
 
+
 def check_indexedDisj_only_targets_transformed(self, transformation):
     # check that only the targets are transformed (with IndexedDisjunction as
     # target)
     m = models.makeDisjunctionsOnIndexedBlock()
     trans = TransformationFactory('gdp.%s' % transformation)
-    trans.apply_to(
-        m,
-        targets=[m.disjunction1])
+    trans.apply_to(m, targets=[m.disjunction1])
 
-    disjBlock = m.component("_pyomo_gdp_%s_reformulation" % transformation).\
-                relaxedDisjuncts
+    disjBlock = m.component(
+        "_pyomo_gdp_%s_reformulation" % transformation
+    ).relaxedDisjuncts
     self.assertEqual(len(disjBlock), 4)
     if transformation == 'bigm':
-        self.assertIs(trans.get_transformed_constraints(
-            m.disjunct1[1, 0].c)[0].parent_block(), disjBlock[0])
-        self.assertIs(trans.get_transformed_constraints(
-            m.disjunct1[1, 1].c)[0].parent_block(), disjBlock[1])
-        self.assertIs(trans.get_transformed_constraints(
-            m.disjunct1[2, 0].c)[0].parent_block(), disjBlock[2])
-        self.assertIs(trans.get_transformed_constraints(
-            m.disjunct1[2, 1].c)[0].parent_block(), disjBlock[3])
+        self.assertIs(
+            trans.get_transformed_constraints(m.disjunct1[1, 0].c)[0].parent_block(),
+            disjBlock[0],
+        )
+        self.assertIs(
+            trans.get_transformed_constraints(m.disjunct1[1, 1].c)[0].parent_block(),
+            disjBlock[1],
+        )
+        self.assertIs(
+            trans.get_transformed_constraints(m.disjunct1[2, 0].c)[0].parent_block(),
+            disjBlock[2],
+        )
+        self.assertIs(
+            trans.get_transformed_constraints(m.disjunct1[2, 1].c)[0].parent_block(),
+            disjBlock[3],
+        )
     elif transformation == 'hull':
         # In the disaggregated var bounds
-        self.assertIs(trans.get_transformed_constraints(
-            m.disjunct1[1, 0].c)[0].parent_block().parent_block(),
-                      disjBlock[2])
-        self.assertIs(trans.get_transformed_constraints(
-            m.disjunct1[1, 1].c)[0].parent_block(), disjBlock[3])
+        self.assertIs(
+            trans.get_transformed_constraints(m.disjunct1[1, 0].c)[0]
+            .parent_block()
+            .parent_block(),
+            disjBlock[2],
+        )
+        self.assertIs(
+            trans.get_transformed_constraints(m.disjunct1[1, 1].c)[0].parent_block(),
+            disjBlock[3],
+        )
         # In the disaggregated var bounds
-        self.assertIs(trans.get_transformed_constraints(
-            m.disjunct1[2, 0].c)[0].parent_block().parent_block(), disjBlock[0])
-        self.assertIs(trans.get_transformed_constraints(
-            m.disjunct1[2, 1].c)[0].parent_block(), disjBlock[1])
+        self.assertIs(
+            trans.get_transformed_constraints(m.disjunct1[2, 0].c)[0]
+            .parent_block()
+            .parent_block(),
+            disjBlock[0],
+        )
+        self.assertIs(
+            trans.get_transformed_constraints(m.disjunct1[2, 1].c)[0].parent_block(),
+            disjBlock[1],
+        )
 
     # This relies on the disjunctions being transformed in the same order
     # every time. These are the mappings between the indices of the original
     # disjuncts and the indices on the indexed block on the transformation
     # block.
     if transformation == 'bigm':
-        pairs = [
-            ((1,0), 0),
-            ((1,1), 1),
-            ((2,0), 2),
-            ((2,1), 3),
-        ]
+        pairs = [((1, 0), 0), ((1, 1), 1), ((2, 0), 2), ((2, 1), 3)]
     elif transformation == 'hull':
-        pairs = [
-            ((2,0), 0),
-            ((2,1), 1),
-            ((1,0), 2),
-            ((1,1), 3),
-        ]
+        pairs = [((2, 0), 0), ((2, 1), 1), ((1, 0), 2), ((1, 1), 3)]
 
     for i, j in pairs:
         self.assertIs(trans.get_src_disjunct(disjBlock[j]), m.disjunct1[i])
         self.assertIs(disjBlock[j], m.disjunct1[i].transformation_block)
 
+
 def check_warn_for_untransformed(self, transformation, **kwargs):
     # Check that we complain if we find an untransformed Disjunct inside of
     # another Disjunct we are transforming
     m = models.makeDisjunctionsOnIndexedBlock()
+
     def innerdisj_rule(d, flag):
         m = d.model()
         if flag:
             d.c = Constraint(expr=m.a[1] <= 2)
         else:
             d.c = Constraint(expr=m.a[1] >= 65)
-    m.disjunct1[1,1].innerdisjunct = Disjunct([0,1], rule=innerdisj_rule)
-    m.disjunct1[1,1].innerdisjunction = Disjunction([0],
-        rule=lambda a,i: [m.disjunct1[1,1].innerdisjunct[0],
-                          m.disjunct1[1,1].innerdisjunct[1]])
+
+    m.disjunct1[1, 1].innerdisjunct = Disjunct([0, 1], rule=innerdisj_rule)
+    m.disjunct1[1, 1].innerdisjunction = Disjunction(
+        [0],
+        rule=lambda a, i: [
+            m.disjunct1[1, 1].innerdisjunct[0],
+            m.disjunct1[1, 1].innerdisjunct[1],
+        ],
+    )
     # if the disjunction doesn't drive the transformation of the Disjuncts, we
     # get the error
-    m.disjunct1[1,1].innerdisjunction.deactivate()
+    m.disjunct1[1, 1].innerdisjunction.deactivate()
     # This test relies on the order that the component objects of
     # the disjunct get considered. In this case, the disjunct
     # causes the error, but in another world, it could be the
@@ -682,28 +740,29 @@ def check_warn_for_untransformed(self, transformation, **kwargs):
         TransformationFactory('gdp.%s' % transformation).create_using,
         m,
         targets=[m.disjunction1[1]],
-        **kwargs)
-    m.disjunct1[1,1].innerdisjunction.activate()
+        **kwargs
+    )
+    m.disjunct1[1, 1].innerdisjunction.activate()
+
 
 def check_disjData_targets_inactive(self, transformation, **kwargs):
     # check targets deactivated with DisjunctionData is the target
     m = models.makeDisjunctionsOnIndexedBlock()
     TransformationFactory('gdp.%s' % transformation).apply_to(
-        m,
-        targets=[m.disjunction1[2]],
-        **kwargs)
+        m, targets=[m.disjunction1[2]], **kwargs
+    )
 
     self.assertFalse(m.disjunction1[2].active)
 
     self.assertTrue(m.disjunct1.active)
-    self.assertTrue(m.disjunct1[1,0].active)
-    self.assertIsNone(m.disjunct1[1,0]._transformation_block)
-    self.assertTrue(m.disjunct1[1,1].active)
-    self.assertIsNone(m.disjunct1[1,1]._transformation_block)
-    self.assertFalse(m.disjunct1[2,0].active)
-    self.assertIsNotNone(m.disjunct1[2,0]._transformation_block)
-    self.assertFalse(m.disjunct1[2,1].active)
-    self.assertIsNotNone(m.disjunct1[2,1]._transformation_block)
+    self.assertTrue(m.disjunct1[1, 0].active)
+    self.assertIsNone(m.disjunct1[1, 0]._transformation_block)
+    self.assertTrue(m.disjunct1[1, 1].active)
+    self.assertIsNone(m.disjunct1[1, 1]._transformation_block)
+    self.assertFalse(m.disjunct1[2, 0].active)
+    self.assertIsNotNone(m.disjunct1[2, 0]._transformation_block)
+    self.assertFalse(m.disjunct1[2, 1].active)
+    self.assertIsNotNone(m.disjunct1[2, 1]._transformation_block)
 
     self.assertTrue(m.b[0].disjunct.active)
     self.assertTrue(m.b[0].disjunct[0].active)
@@ -715,56 +774,60 @@ def check_disjData_targets_inactive(self, transformation, **kwargs):
     self.assertTrue(m.b[1].disjunct1.active)
     self.assertIsNone(m.b[1].disjunct1._transformation_block)
 
+
 def check_disjData_only_targets_transformed(self, transformation):
     # check that targets are transformed when DisjunctionData is the target
     m = models.makeDisjunctionsOnIndexedBlock()
     trans = TransformationFactory('gdp.%s' % transformation)
-    trans.apply_to(
-        m,
-        targets=[m.disjunction1[2]])
+    trans.apply_to(m, targets=[m.disjunction1[2]])
 
-    disjBlock = m.component("_pyomo_gdp_%s_reformulation" % transformation).\
-                relaxedDisjuncts
+    disjBlock = m.component(
+        "_pyomo_gdp_%s_reformulation" % transformation
+    ).relaxedDisjuncts
     self.assertEqual(len(disjBlock), 2)
     if transformation == 'bigm':
-        self.assertIs(trans.get_transformed_constraints(
-            m.disjunct1[2, 0].c)[0].parent_block(), disjBlock[0])
+        self.assertIs(
+            trans.get_transformed_constraints(m.disjunct1[2, 0].c)[0].parent_block(),
+            disjBlock[0],
+        )
     elif transformation == 'hull':
-            self.assertIs(trans.get_transformed_constraints(
-                m.disjunct1[2, 0].c)[0].parent_block().parent_block(),
-                          disjBlock[0])
-    self.assertIs(trans.get_transformed_constraints(
-        m.disjunct1[2, 1].c)[0].parent_block(), disjBlock[1])
+        self.assertIs(
+            trans.get_transformed_constraints(m.disjunct1[2, 0].c)[0]
+            .parent_block()
+            .parent_block(),
+            disjBlock[0],
+        )
+    self.assertIs(
+        trans.get_transformed_constraints(m.disjunct1[2, 1].c)[0].parent_block(),
+        disjBlock[1],
+    )
 
     # This relies on the disjunctions being transformed in the same order
     # every time. These are the mappings between the indices of the original
     # disjuncts and the indices on the indexed block on the transformation
     # block.
-    pairs = [
-        ((2,0), 0),
-        ((2,1), 1),
-    ]
+    pairs = [((2, 0), 0), ((2, 1), 1)]
     for i, j in pairs:
         self.assertIs(m.disjunct1[i].transformation_block, disjBlock[j])
         self.assertIs(trans.get_src_disjunct(disjBlock[j]), m.disjunct1[i])
+
 
 def check_indexedBlock_targets_inactive(self, transformation, **kwargs):
     # check that targets are deactivated when target is an IndexedBlock
     m = models.makeDisjunctionsOnIndexedBlock()
     TransformationFactory('gdp.%s' % transformation).apply_to(
-        m,
-        targets=[m.b],
-        **kwargs)
+        m, targets=[m.b], **kwargs
+    )
 
     self.assertTrue(m.disjunct1.active)
-    self.assertTrue(m.disjunct1[1,0].active)
-    self.assertTrue(m.disjunct1[1,1].active)
-    self.assertTrue(m.disjunct1[2,0].active)
-    self.assertTrue(m.disjunct1[2,1].active)
-    self.assertIsNone(m.disjunct1[1,0].transformation_block)
-    self.assertIsNone(m.disjunct1[1,1].transformation_block)
-    self.assertIsNone(m.disjunct1[2,0].transformation_block)
-    self.assertIsNone(m.disjunct1[2,1].transformation_block)
+    self.assertTrue(m.disjunct1[1, 0].active)
+    self.assertTrue(m.disjunct1[1, 1].active)
+    self.assertTrue(m.disjunct1[2, 0].active)
+    self.assertTrue(m.disjunct1[2, 1].active)
+    self.assertIsNone(m.disjunct1[1, 0].transformation_block)
+    self.assertIsNone(m.disjunct1[1, 1].transformation_block)
+    self.assertIsNone(m.disjunct1[2, 0].transformation_block)
+    self.assertIsNone(m.disjunct1[2, 1].transformation_block)
 
     self.assertFalse(m.b[0].disjunct.active)
     self.assertFalse(m.b[0].disjunct[0].active)
@@ -772,44 +835,49 @@ def check_indexedBlock_targets_inactive(self, transformation, **kwargs):
     self.assertFalse(m.b[1].disjunct0.active)
     self.assertFalse(m.b[1].disjunct1.active)
 
+
 def check_indexedBlock_only_targets_transformed(self, transformation):
     # check that targets are transformed when target is an IndexedBlock
     m = models.makeDisjunctionsOnIndexedBlock()
     trans = TransformationFactory('gdp.%s' % transformation)
-    trans.apply_to(
-        m,
-        targets=[m.b])
+    trans.apply_to(m, targets=[m.b])
 
-    disjBlock1 = m.b[0].component(
-        "_pyomo_gdp_%s_reformulation" % transformation).relaxedDisjuncts
+    disjBlock1 = (
+        m.b[0]
+        .component("_pyomo_gdp_%s_reformulation" % transformation)
+        .relaxedDisjuncts
+    )
     self.assertEqual(len(disjBlock1), 2)
-    self.assertIs(trans.get_transformed_constraints(
-        m.b[0].disjunct[0].c)[0].parent_block(), disjBlock1[0])
-    self.assertIs(trans.get_transformed_constraints(
-        m.b[0].disjunct[1].c)[0].parent_block(), disjBlock1[1])
+    self.assertIs(
+        trans.get_transformed_constraints(m.b[0].disjunct[0].c)[0].parent_block(),
+        disjBlock1[0],
+    )
+    self.assertIs(
+        trans.get_transformed_constraints(m.b[0].disjunct[1].c)[0].parent_block(),
+        disjBlock1[1],
+    )
 
-    disjBlock2 = m.b[1].component(
-        "_pyomo_gdp_%s_reformulation" % transformation).relaxedDisjuncts
+    disjBlock2 = (
+        m.b[1]
+        .component("_pyomo_gdp_%s_reformulation" % transformation)
+        .relaxedDisjuncts
+    )
     self.assertEqual(len(disjBlock2), 2)
-    self.assertIs(trans.get_transformed_constraints(
-        m.b[1].disjunct0.c)[0].parent_block(), disjBlock2[0])
-    self.assertIs(trans.get_transformed_constraints(
-        m.b[1].disjunct1.c)[0].parent_block(), disjBlock2[1])
+    self.assertIs(
+        trans.get_transformed_constraints(m.b[1].disjunct0.c)[0].parent_block(),
+        disjBlock2[0],
+    )
+    self.assertIs(
+        trans.get_transformed_constraints(m.b[1].disjunct1.c)[0].parent_block(),
+        disjBlock2[1],
+    )
 
     # This relies on the disjunctions being transformed in the same order
     # every time. This dictionary maps the block index to the list of
     # pairs of (originalDisjunctIndex, transBlockIndex)
     pairs = {
-        0:
-        [
-            ('disjunct',0,0),
-            ('disjunct',1,1),
-        ],
-        1:
-        [
-            ('disjunct0',None,0),
-            ('disjunct1',None,1),
-        ]
+        0: [('disjunct', 0, 0), ('disjunct', 1, 1)],
+        1: [('disjunct0', None, 0), ('disjunct1', None, 1)],
     }
 
     for blocknum, lst in pairs.items():
@@ -822,23 +890,23 @@ def check_indexedBlock_only_targets_transformed(self, transformation):
             self.assertIs(original[i].transformation_block, disjBlock[j])
             self.assertIs(trans.get_src_disjunct(disjBlock[j]), original[i])
 
+
 def check_blockData_targets_inactive(self, transformation, **kwargs):
     # test that BlockData target is deactivated
     m = models.makeDisjunctionsOnIndexedBlock()
     TransformationFactory('gdp.%s' % transformation).apply_to(
-        m,
-        targets=[m.b[0]],
-        **kwargs)
+        m, targets=[m.b[0]], **kwargs
+    )
 
     checkb0TargetsInactive(self, m)
+
 
 def check_blockData_only_targets_transformed(self, transformation):
     # test that BlockData target is transformed
     m = models.makeDisjunctionsOnIndexedBlock()
-    TransformationFactory('gdp.%s' % transformation).apply_to(
-        m,
-        targets=[m.b[0]])
+    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=[m.b[0]])
     checkb0TargetsTransformed(self, m, transformation)
+
 
 def check_do_not_transform_deactivated_targets(self, transformation):
     # test that if a deactivated component is given as a target, we don't
@@ -849,11 +917,12 @@ def check_do_not_transform_deactivated_targets(self, transformation):
     m = models.makeDisjunctionsOnIndexedBlock()
     m.b[1].deactivate()
     TransformationFactory('gdp.%s' % transformation).apply_to(
-        m,
-        targets=[m.b[0], m.b[1]])
+        m, targets=[m.b[0], m.b[1]]
+    )
 
     checkb0TargetsInactive(self, m)
     checkb0TargetsTransformed(self, m, transformation)
+
 
 def check_disjunction_data_target(self, transformation):
     # test that if we transform DisjunctionDatas one at a time, we get what we
@@ -861,26 +930,30 @@ def check_disjunction_data_target(self, transformation):
     # the xor constraint.
     m = models.makeThreeTermIndexedDisj()
     TransformationFactory('gdp.%s' % transformation).apply_to(
-        m, targets=[m.disjunction[2]])
+        m, targets=[m.disjunction[2]]
+    )
 
     # we got a transformation block on the model
     transBlock = m.component("_pyomo_gdp_%s_reformulation" % transformation)
     self.assertIsInstance(transBlock, Block)
-    self.assertIsInstance(transBlock.component("disjunction_xor"),
-                          Constraint)
-    self.assertIsInstance(transBlock.disjunction_xor[2],
-                          constraint._GeneralConstraintData)
+    self.assertIsInstance(transBlock.component("disjunction_xor"), Constraint)
+    self.assertIsInstance(
+        transBlock.disjunction_xor[2], constraint._GeneralConstraintData
+    )
     self.assertIsInstance(transBlock.component("relaxedDisjuncts"), Block)
     self.assertEqual(len(transBlock.relaxedDisjuncts), 3)
 
     # suppose we transform the next one separately
     TransformationFactory('gdp.%s' % transformation).apply_to(
-        m, targets=[m.disjunction[1]])
-    self.assertIsInstance(m.disjunction[1].algebraic_constraint,
-                          constraint._GeneralConstraintData)
+        m, targets=[m.disjunction[1]]
+    )
+    self.assertIsInstance(
+        m.disjunction[1].algebraic_constraint, constraint._GeneralConstraintData
+    )
     transBlock = m.component("_pyomo_gdp_%s_reformulation_4" % transformation)
     self.assertIsInstance(transBlock, Block)
     self.assertEqual(len(transBlock.relaxedDisjuncts), 3)
+
 
 def check_disjunction_data_target_any_index(self, transformation):
     # check the same as the above, but that it still works when the Disjunction
@@ -889,25 +962,30 @@ def check_disjunction_data_target_any_index(self, transformation):
     m.x = Var(bounds=(-100, 100))
     m.disjunct3 = Disjunct(Any)
     m.disjunct4 = Disjunct(Any)
-    m.disjunction2=Disjunction(Any)
+    m.disjunction2 = Disjunction(Any)
     for i in range(2):
         m.disjunct3[i].cons = Constraint(expr=m.x == 2)
         m.disjunct4[i].cons = Constraint(expr=m.x <= 3)
         m.disjunction2[i] = [m.disjunct3[i], m.disjunct4[i]]
 
         TransformationFactory('gdp.%s' % transformation).apply_to(
-            m, targets=[m.disjunction2[i]])
+            m, targets=[m.disjunction2[i]]
+        )
 
         if i == 0:
-            check_relaxation_block(self, m, "_pyomo_gdp_%s_reformulation" %
-                                   transformation, 2)
+            check_relaxation_block(
+                self, m, "_pyomo_gdp_%s_reformulation" % transformation, 2
+            )
         if i == 2:
-            check_relaxation_block(self, m, "_pyomo_gdp_%s_reformulation" %
-                                   transformation, 4)
+            check_relaxation_block(
+                self, m, "_pyomo_gdp_%s_reformulation" % transformation, 4
+            )
+
 
 # tests that we treat disjunctions on blocks correctly (the main issue here is
 # that if you were to solve that block post-transformation that you would have
 # the whole transformed model)
+
 
 def check_xor_constraint_added(self, transformation):
     # test we put the xor on the transformation block
@@ -915,8 +993,12 @@ def check_xor_constraint_added(self, transformation):
     TransformationFactory('gdp.%s' % transformation).apply_to(m)
 
     self.assertIsInstance(
-        m.b.component("_pyomo_gdp_%s_reformulation" % transformation).\
-        component(m.b.disjunction.algebraic_constraint.local_name), Constraint)
+        m.b.component("_pyomo_gdp_%s_reformulation" % transformation).component(
+            m.b.disjunction.algebraic_constraint.local_name
+        ),
+        Constraint,
+    )
+
 
 def check_trans_block_created(self, transformation):
     # check we put the transformation block on the parent block of the
@@ -931,43 +1013,44 @@ def check_trans_block_created(self, transformation):
     self.assertIsInstance(disjBlock, Block)
     self.assertEqual(len(disjBlock), 2)
     # and that it didn't get created on the model
-    self.assertIsNone(
-        m.component('_pyomo_gdp_%s_reformulation' % transformation))
+    self.assertIsNone(m.component('_pyomo_gdp_%s_reformulation' % transformation))
 
 
 # disjunction generation tests: These all suppose that you are doing some sort
 # of column and constraint generation algorithm, but you are in fact generating
 # Disjunctions and retransforming the model after each addition.
 
-def check_iteratively_adding_to_indexed_disjunction_on_block(self,
-                                                             transformation):
+
+def check_iteratively_adding_to_indexed_disjunction_on_block(self, transformation):
     # check that we can iteratively add to an IndexedDisjunction and transform
     # the block it lives on
     m = ConcreteModel()
     m.b = Block()
     m.b.x = Var(bounds=(-100, 100))
-    m.b.firstTerm = Disjunct([1,2])
+    m.b.firstTerm = Disjunct([1, 2])
     m.b.firstTerm[1].cons = Constraint(expr=m.b.x == 0)
     m.b.firstTerm[2].cons = Constraint(expr=m.b.x == 2)
-    m.b.secondTerm = Disjunct([1,2])
+    m.b.secondTerm = Disjunct([1, 2])
     m.b.secondTerm[1].cons = Constraint(expr=m.b.x >= 2)
     m.b.secondTerm[2].cons = Constraint(expr=m.b.x >= 3)
     m.b.disjunctionList = Disjunction(Any)
 
     m.b.obj = Objective(expr=m.b.x)
 
-    for i in range(1,3):
+    for i in range(1, 3):
         m.b.disjunctionList[i] = [m.b.firstTerm[i], m.b.secondTerm[i]]
 
-        TransformationFactory('gdp.%s' % transformation).apply_to(m,
-                                                                  targets=[m.b])
+        TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=[m.b])
 
         if i == 1:
-            check_relaxation_block(self, m.b, "_pyomo_gdp_%s_reformulation" %
-                                   transformation, 2)
+            check_relaxation_block(
+                self, m.b, "_pyomo_gdp_%s_reformulation" % transformation, 2
+            )
         if i == 2:
-             check_relaxation_block(self, m.b, "_pyomo_gdp_%s_reformulation_4" %
-                                    transformation, 2)
+            check_relaxation_block(
+                self, m.b, "_pyomo_gdp_%s_reformulation_4" % transformation, 2
+            )
+
 
 def check_simple_disjunction_of_disjunct_datas(self, transformation):
     # This is actually a reasonable use case if you are generating
@@ -979,15 +1062,13 @@ def check_simple_disjunction_of_disjunct_datas(self, transformation):
 
     self.check_trans_block_disjunctions_of_disjunct_datas(m)
     transBlock = m.component("_pyomo_gdp_%s_reformulation" % transformation)
-    self.assertIsInstance( transBlock.component("disjunction_xor"),
-                           Constraint)
-    self.assertIsInstance( transBlock.component("disjunction2_xor"),
-                           Constraint)
+    self.assertIsInstance(transBlock.component("disjunction_xor"), Constraint)
+    self.assertIsInstance(transBlock.component("disjunction2_xor"), Constraint)
+
 
 # these tests have different checks for what ends up on the model between bigm
 # and hull, but they have the same structure
-def check_iteratively_adding_disjunctions_transform_container(self,
-                                                              transformation):
+def check_iteratively_adding_disjunctions_transform_container(self, transformation):
     # Check that we can play the same game with iteratively adding Disjunctions,
     # but this time just specify the IndexedDisjunction as the argument. Note
     # that the success of this depends on our rebellion regarding the active
@@ -999,25 +1080,27 @@ def check_iteratively_adding_disjunctions_transform_container(self,
     for i in range(2):
         firstTermName = "firstTerm[%s]" % i
         model.add_component(firstTermName, Disjunct())
-        model.component(firstTermName).cons = Constraint(
-            expr=model.x == 2*i)
+        model.component(firstTermName).cons = Constraint(expr=model.x == 2 * i)
         secondTermName = "secondTerm[%s]" % i
         model.add_component(secondTermName, Disjunct())
-        model.component(secondTermName).cons = Constraint(
-            expr=model.x >= i + 2)
-        model.disjunctionList[i] = [model.component(firstTermName),
-                                    model.component(secondTermName)]
+        model.component(secondTermName).cons = Constraint(expr=model.x >= i + 2)
+        model.disjunctionList[i] = [
+            model.component(firstTermName),
+            model.component(secondTermName),
+        ]
 
         # we're lazy and we just transform the disjunctionList (and in
         # theory we are transforming at every iteration because we are
         # solving at every iteration)
         TransformationFactory('gdp.%s' % transformation).apply_to(
-            model, targets=[model.disjunctionList])
+            model, targets=[model.disjunctionList]
+        )
         if i == 0:
             self.check_first_iteration(model)
 
         if i == 1:
             self.check_second_iteration(model)
+
 
 def check_disjunction_and_disjuncts_indexed_by_any(self, transformation):
     # check that we can play the same game when the Disjuncts also are indexed
@@ -1032,7 +1115,7 @@ def check_disjunction_and_disjuncts_indexed_by_any(self, transformation):
     model.obj = Objective(expr=model.x)
 
     for i in range(2):
-        model.firstTerm[i].cons = Constraint(expr=model.x == 2*i)
+        model.firstTerm[i].cons = Constraint(expr=model.x == 2 * i)
         model.secondTerm[i].cons = Constraint(expr=model.x >= i + 2)
         model.disjunctionList[i] = [model.firstTerm[i], model.secondTerm[i]]
 
@@ -1044,6 +1127,7 @@ def check_disjunction_and_disjuncts_indexed_by_any(self, transformation):
         if i == 1:
             self.check_second_iteration(model)
 
+
 def check_iteratively_adding_disjunctions_transform_model(self, transformation):
     # Same as above, but transforming whole model in every iteration
     model = ConcreteModel()
@@ -1053,14 +1137,14 @@ def check_iteratively_adding_disjunctions_transform_model(self, transformation):
     for i in range(2):
         firstTermName = "firstTerm[%s]" % i
         model.add_component(firstTermName, Disjunct())
-        model.component(firstTermName).cons = Constraint(
-            expr=model.x == 2*i)
+        model.component(firstTermName).cons = Constraint(expr=model.x == 2 * i)
         secondTermName = "secondTerm[%s]" % i
         model.add_component(secondTermName, Disjunct())
-        model.component(secondTermName).cons = Constraint(
-            expr=model.x >= i + 2)
-        model.disjunctionList[i] = [model.component(firstTermName),
-                                    model.component(secondTermName)]
+        model.component(secondTermName).cons = Constraint(expr=model.x >= i + 2)
+        model.disjunctionList[i] = [
+            model.component(firstTermName),
+            model.component(secondTermName),
+        ]
 
         # we're lazy and we just transform the model (and in
         # theory we are transforming at every iteration because we are
@@ -1072,6 +1156,7 @@ def check_iteratively_adding_disjunctions_transform_model(self, transformation):
         if i == 1:
             self.check_second_iteration(model)
 
+
 # transforming blocks
 
 # If you transform a block as if it is a model, the transformation should
@@ -1082,70 +1167,76 @@ def check_transformation_simple_block(self, transformation, **kwargs):
     TransformationFactory('gdp.%s' % transformation).apply_to(m.b, **kwargs)
 
     # transformation block not on m
-    self.assertIsNone(
-        m.component("_pyomo_gdp_%s_reformulation" % transformation))
+    self.assertIsNone(m.component("_pyomo_gdp_%s_reformulation" % transformation))
 
     # transformation block on m.b
-    self.assertIsInstance(m.b.component("_pyomo_gdp_%s_reformulation" %
-                                        transformation), Block)
+    self.assertIsInstance(
+        m.b.component("_pyomo_gdp_%s_reformulation" % transformation), Block
+    )
+
 
 def check_transform_block_data(self, transformation, **kwargs):
     m = models.makeDisjunctionsOnIndexedBlock()
     TransformationFactory('gdp.%s' % transformation).apply_to(m.b[0], **kwargs)
 
-    self.assertIsNone(
-        m.component("_pyomo_gdp_%s_reformulation" % transformation))
+    self.assertIsNone(m.component("_pyomo_gdp_%s_reformulation" % transformation))
 
-    self.assertIsInstance(m.b[0].component("_pyomo_gdp_%s_reformulation" %
-                                           transformation), Block)
+    self.assertIsInstance(
+        m.b[0].component("_pyomo_gdp_%s_reformulation" % transformation), Block
+    )
+
 
 def check_simple_block_target(self, transformation, **kwargs):
     m = models.makeTwoTermDisjOnBlock()
-    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=[m.b],
-                                                              **kwargs)
+    TransformationFactory('gdp.%s' % transformation).apply_to(
+        m, targets=[m.b], **kwargs
+    )
 
     # transformation block not on m
-    self.assertIsNone(
-        m.component("_pyomo_gdp_%s_reformulation" % transformation))
+    self.assertIsNone(m.component("_pyomo_gdp_%s_reformulation" % transformation))
 
     # transformation block on m.b
-    self.assertIsInstance(m.b.component("_pyomo_gdp_%s_reformulation" %
-                                        transformation), Block)
+    self.assertIsInstance(
+        m.b.component("_pyomo_gdp_%s_reformulation" % transformation), Block
+    )
+
 
 def check_block_data_target(self, transformation, **kwargs):
     m = models.makeDisjunctionsOnIndexedBlock()
-    TransformationFactory('gdp.%s' % transformation).apply_to(m,
-                                                              targets=[m.b[0]],
-                                                              **kwargs)
+    TransformationFactory('gdp.%s' % transformation).apply_to(
+        m, targets=[m.b[0]], **kwargs
+    )
 
-    self.assertIsNone(
-        m.component("_pyomo_gdp_%s_reformulation" % transformation))
+    self.assertIsNone(m.component("_pyomo_gdp_%s_reformulation" % transformation))
 
-    self.assertIsInstance(m.b[0].component("_pyomo_gdp_%s_reformulation" %
-                                           transformation), Block)
+    self.assertIsInstance(
+        m.b[0].component("_pyomo_gdp_%s_reformulation" % transformation), Block
+    )
+
 
 def check_indexed_block_target(self, transformation, **kwargs):
     m = models.makeDisjunctionsOnIndexedBlock()
-    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=[m.b],
-                                                              **kwargs)
+    TransformationFactory('gdp.%s' % transformation).apply_to(
+        m, targets=[m.b], **kwargs
+    )
 
     # We expect the transformation block on each of the BlockDatas. Because
     # it is always going on the parent block of the disjunction.
 
-    self.assertIsNone(
-        m.component("_pyomo_gdp_%s_reformulation" % transformation))
+    self.assertIsNone(m.component("_pyomo_gdp_%s_reformulation" % transformation))
 
-    for i in [0,1]:
-        self.assertIsInstance( m.b[i].component("_pyomo_gdp_%s_reformulation" %
-                                                transformation), Block)
+    for i in [0, 1]:
+        self.assertIsInstance(
+            m.b[i].component("_pyomo_gdp_%s_reformulation" % transformation), Block
+        )
+
 
 def check_block_targets_inactive(self, transformation, **kwargs):
     m = models.makeTwoTermDisjOnBlock()
     m = models.add_disj_not_on_block(m)
     TransformationFactory('gdp.%s' % transformation).apply_to(
-        m,
-        targets=[m.b],
-        **kwargs)
+        m, targets=[m.b], **kwargs
+    )
 
     self.assertFalse(m.b.disjunct[0].active)
     self.assertFalse(m.b.disjunct[1].active)
@@ -1153,41 +1244,45 @@ def check_block_targets_inactive(self, transformation, **kwargs):
     self.assertTrue(m.simpledisj.active)
     self.assertTrue(m.simpledisj2.active)
 
+
 def check_block_only_targets_transformed(self, transformation):
     m = models.makeTwoTermDisjOnBlock()
     m = models.add_disj_not_on_block(m)
     trans = TransformationFactory('gdp.%s' % transformation)
-    trans.apply_to(
-        m,
-        targets=[m.b])
+    trans.apply_to(m, targets=[m.b])
 
-    disjBlock = m.b.component("_pyomo_gdp_%s_reformulation" % transformation).\
-                relaxedDisjuncts
+    disjBlock = m.b.component(
+        "_pyomo_gdp_%s_reformulation" % transformation
+    ).relaxedDisjuncts
     self.assertEqual(len(disjBlock), 2)
     if transformation == 'bigm':
-        self.assertIs(disjBlock[0],
-                      trans.get_transformed_constraints(
-                          m.b.disjunct[0].c)[0].parent_block())
+        self.assertIs(
+            disjBlock[0],
+            trans.get_transformed_constraints(m.b.disjunct[0].c)[0].parent_block(),
+        )
     elif transformation == 'hull':
         # this constraint is on the bounds of the disaggregated var
-        self.assertIs(disjBlock[0],
-                      trans.get_transformed_constraints(
-                          m.b.disjunct[0].c)[0].parent_block().parent_block())
-    self.assertIs(disjBlock[1],
-                  trans.get_transformed_constraints(
-                      m.b.disjunct[1].c)[0].parent_block())
+        self.assertIs(
+            disjBlock[0],
+            trans.get_transformed_constraints(m.b.disjunct[0].c)[0]
+            .parent_block()
+            .parent_block(),
+        )
+    self.assertIs(
+        disjBlock[1],
+        trans.get_transformed_constraints(m.b.disjunct[1].c)[0].parent_block(),
+    )
 
     # this relies on the disjuncts being transformed in the same order every
     # time
-    pairs = [
-        (0,0),
-        (1,1),
-    ]
+    pairs = [(0, 0), (1, 1)]
     for i, j in pairs:
         self.assertIs(m.b.disjunct[i].transformation_block, disjBlock[j])
         self.assertIs(trans.get_src_disjunct(disjBlock[j]), m.b.disjunct[i])
 
+
 # common error messages
+
 
 def check_transform_empty_disjunction(self, transformation, **kwargs):
     m = ConcreteModel()
@@ -1198,12 +1293,14 @@ def check_transform_empty_disjunction(self, transformation, **kwargs):
         "Disjunction 'empty' is empty. This is likely indicative of a "
         "modeling error.*",
         TransformationFactory('gdp.%s' % transformation).apply_to,
-        m, **kwargs)
+        m,
+        **kwargs
+    )
 
-def check_deactivated_disjunct_nonzero_indicator_var(self, transformation,
-                                                     **kwargs):
+
+def check_deactivated_disjunct_nonzero_indicator_var(self, transformation, **kwargs):
     m = ConcreteModel()
-    m.x = Var(bounds=(0,8))
+    m.x = Var(bounds=(0, 8))
     m.disjunction = Disjunction(expr=[m.x == 0, m.x >= 4])
 
     m.disjunction.disjuncts[0].deactivate()
@@ -1214,12 +1311,14 @@ def check_deactivated_disjunct_nonzero_indicator_var(self, transformation,
         r"The disjunct 'disjunction_disjuncts\[0\]' is deactivated, but the "
         r"indicator_var is fixed to True. This makes no sense.",
         TransformationFactory('gdp.%s' % transformation).apply_to,
-        m, **kwargs)
+        m,
+        **kwargs
+    )
 
-def check_deactivated_disjunct_unfixed_indicator_var(self, transformation,
-                                                     **kwargs):
+
+def check_deactivated_disjunct_unfixed_indicator_var(self, transformation, **kwargs):
     m = ConcreteModel()
-    m.x = Var(bounds=(0,8))
+    m.x = Var(bounds=(0, 8))
     m.disjunction = Disjunction(expr=[m.x == 0, m.x >= 4])
 
     m.disjunction.disjuncts[0].deactivate()
@@ -1233,7 +1332,10 @@ def check_deactivated_disjunct_unfixed_indicator_var(self, transformation,
         r"\(If the intent is to deactivate the disjunct, fix its "
         r"indicator_var to False.\)",
         TransformationFactory('gdp.%s' % transformation).apply_to,
-        m, **kwargs)
+        m,
+        **kwargs
+    )
+
 
 def check_retrieving_nondisjunctive_components(self, transformation):
     m = models.makeTwoTermDisj()
@@ -1246,36 +1348,41 @@ def check_retrieving_nondisjunctive_components(self, transformation):
 
     self.assertRaisesRegex(
         GDP_Error,
-        "Constraint 'b.global_cons' is not on a disjunct and so was not "
-        "transformed",
+        "Constraint 'b.global_cons' is not on a disjunct and so was not transformed",
         trans.get_transformed_constraints,
-        m.b.global_cons)
+        m.b.global_cons,
+    )
 
     self.assertRaisesRegex(
         GDP_Error,
         "Constraint 'b.global_cons' is not a transformed constraint",
         trans.get_src_constraint,
-        m.b.global_cons)
+        m.b.global_cons,
+    )
 
     self.assertRaisesRegex(
         GDP_Error,
         "Constraint 'another_global_cons' is not a transformed constraint",
         trans.get_src_constraint,
-        m.another_global_cons)
+        m.another_global_cons,
+    )
 
     self.assertRaisesRegex(
         GDP_Error,
         "Block 'b' doesn't appear to be a transformation block for a "
         "disjunct. No source disjunct found.",
         trans.get_src_disjunct,
-        m.b)
+        m.b,
+    )
 
     self.assertRaisesRegex(
         GDP_Error,
         "It appears that 'another_global_cons' is not an XOR or OR"
         " constraint resulting from transforming a Disjunction.",
         trans.get_src_disjunction,
-        m.another_global_cons)
+        m.another_global_cons,
+    )
+
 
 def check_silly_target(self, transformation, **kwargs):
     m = models.makeTwoTermDisj()
@@ -1287,10 +1394,14 @@ def check_silly_target(self, transformation, **kwargs):
         r"can't be transformed.",
         TransformationFactory('gdp.%s' % transformation).apply_to,
         m,
-        targets=[m.d[1].c1], **kwargs)
+        targets=[m.d[1].c1],
+        **kwargs
+    )
+
 
 def check_ask_for_transformed_constraint_from_untransformed_disjunct(
-        self, transformation):
+    self, transformation
+):
     m = models.makeTwoTermIndexedDisjunction()
     trans = TransformationFactory('gdp.%s' % transformation)
     trans.apply_to(m, targets=m.disjunction[1])
@@ -1300,10 +1411,13 @@ def check_ask_for_transformed_constraint_from_untransformed_disjunct(
         r"Constraint 'disjunct\[2,b\].cons_b' is on a disjunct which has "
         r"not been transformed",
         trans.get_transformed_constraints,
-        m.disjunct[2, 'b'].cons_b)
+        m.disjunct[2, 'b'].cons_b,
+    )
 
-def check_error_for_same_disjunct_in_multiple_disjunctions(self, transformation,
-                                                           **kwargs):
+
+def check_error_for_same_disjunct_in_multiple_disjunctions(
+    self, transformation, **kwargs
+):
     m = models.makeDisjunctInMultipleDisjunctions()
     self.assertRaisesRegex(
         GDP_Error,
@@ -1311,10 +1425,12 @@ def check_error_for_same_disjunct_in_multiple_disjunctions(self, transformation,
         r"but 'disjunction2', a disjunction it appears in, has not. "
         r"Putting the same disjunct in multiple disjunctions is not supported.",
         TransformationFactory('gdp.%s' % transformation).apply_to,
-        m, **kwargs)
+        m,
+        **kwargs
+    )
 
-def check_cannot_call_transformation_on_disjunction(self, transformation,
-                                                    **kwargs):
+
+def check_cannot_call_transformation_on_disjunction(self, transformation, **kwargs):
     m = models.makeTwoTermIndexedDisjunction()
     trans = TransformationFactory('gdp.%s' % transformation)
     self.assertRaisesRegex(
@@ -1329,18 +1445,19 @@ def check_cannot_call_transformation_on_disjunction(self, transformation,
         **kwargs
     )
 
+
 # This is really neurotic, but test that we will create an infeasible XOR
 # constraint. We have to because in the case of nested disjunctions, our model
 # is not necessarily infeasible because of this. It just might make a Disjunct
 # infeasible.
-def setup_infeasible_xor_because_all_disjuncts_deactivated(self,
-                                                           transformation):
+def setup_infeasible_xor_because_all_disjuncts_deactivated(self, transformation):
     m = ConcreteModel()
-    m.x = Var(bounds=(0,8))
-    m.y = Var(bounds=(0,7))
+    m.x = Var(bounds=(0, 8))
+    m.y = Var(bounds=(0, 7))
     m.disjunction = Disjunction(expr=[m.x == 0, m.x >= 4])
     m.disjunction_disjuncts[0].nestedDisjunction = Disjunction(
-        expr=[m.y == 6, m.y <= 1])
+        expr=[m.y == 6, m.y <= 1]
+    )
     # Note that this fixes the indicator variables to 0, but since the
     # disjunction is still active, the XOR constraint will be created. So we
     # will have to land in the second disjunct of m.disjunction
@@ -1348,8 +1465,8 @@ def setup_infeasible_xor_because_all_disjuncts_deactivated(self,
     m.disjunction.disjuncts[0].nestedDisjunction.disjuncts[1].deactivate()
     # This should create a 0 = 1 XOR constraint, actually...
     TransformationFactory('gdp.%s' % transformation).apply_to(
-        m,
-        targets=m.disjunction.disjuncts[0].nestedDisjunction)
+        m, targets=m.disjunction.disjuncts[0].nestedDisjunction
+    )
 
     # check that our XOR is the bad thing it should be.
     xor = m.disjunction_disjuncts[0].nestedDisjunction.algebraic_constraint
@@ -1366,6 +1483,7 @@ def setup_infeasible_xor_because_all_disjuncts_deactivated(self,
 
     return m
 
+
 def check_disjunction_target_err(self, transformation, **kwargs):
     m = models.makeNestedDisjunctions()
     # deactivate the disjunction that would transform the nested Disjuncts so
@@ -1378,16 +1496,17 @@ def check_disjunction_target_err(self, transformation, **kwargs):
         TransformationFactory('gdp.%s' % transformation).apply_to,
         m,
         targets=[m.disjunction],
-        **kwargs)
+        **kwargs
+    )
 
 
 # nested disjunctions: hull and bigm have very different handling for nested
 # disjunctions, but these tests check *that* everything is transformed, not how
 
+
 def check_disjuncts_inactive_nested(self, transformation, **kwargs):
     m = models.makeNestedDisjunctions()
-    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=(m,),
-                                                              **kwargs)
+    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=(m,), **kwargs)
 
     self.assertFalse(m.disjunction.active)
     self.assertFalse(m.simpledisjunct.active)
@@ -1395,15 +1514,15 @@ def check_disjuncts_inactive_nested(self, transformation, **kwargs):
     self.assertFalse(m.disjunct[1].active)
     self.assertFalse(m.disjunct.active)
 
-def check_deactivated_disjunct_leaves_nested_disjunct_active(self,
-                                                             transformation,
-                                                             **kwargs):
+
+def check_deactivated_disjunct_leaves_nested_disjunct_active(
+    self, transformation, **kwargs
+):
     m = models.makeNestedDisjunctions_FlatDisjuncts()
     m.d1.deactivate()
     # Specifying 'targets' prevents the HACK_GDP_Disjunct_Reclassifier
     # transformation of Disjuncts to Blocks
-    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=[m],
-                                                              **kwargs)
+    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=[m], **kwargs)
 
     self.assertFalse(m.d1.active)
     self.assertTrue(m.d1.indicator_var.fixed)
@@ -1422,8 +1541,7 @@ def check_deactivated_disjunct_leaves_nested_disjunct_active(self,
     m.d1.deactivate()
     # Specifying 'targets' prevents the HACK_GDP_Disjunct_Reclassifier
     # transformation of Disjuncts to Blocks
-    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=[m],
-                                                              **kwargs)
+    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=[m], **kwargs)
 
     self.assertFalse(m.d1.active)
     self.assertTrue(m.d1.indicator_var.fixed)
@@ -1438,12 +1556,12 @@ def check_deactivated_disjunct_leaves_nested_disjunct_active(self,
     self.assertTrue(m.d1.d4.active)
     self.assertFalse(m.d1.d4.indicator_var.fixed)
 
+
 def check_disjunct_targets_inactive(self, transformation, **kwargs):
     m = models.makeNestedDisjunctions()
     TransformationFactory('gdp.%s' % transformation).apply_to(
-        m,
-        targets=[m.simpledisjunct],
-        **kwargs)
+        m, targets=[m.simpledisjunct], **kwargs
+    )
 
     self.assertTrue(m.disjunct.active)
     self.assertTrue(m.disjunct[0].active)
@@ -1459,42 +1577,54 @@ def check_disjunct_targets_inactive(self, transformation, **kwargs):
     self.assertFalse(m.simpledisjunct.innerdisjunct0.active)
     self.assertFalse(m.simpledisjunct.innerdisjunct1.active)
 
+
 def check_disjunct_only_targets_transformed(self, transformation):
     m = models.makeNestedDisjunctions()
     transform = TransformationFactory('gdp.%s' % transformation)
-    transform.apply_to(
-        m,
-        targets=[m.simpledisjunct])
+    transform.apply_to(m, targets=[m.simpledisjunct])
 
-    disjBlock = m.simpledisjunct.component("_pyomo_gdp_%s_reformulation" %
-                                           transformation).relaxedDisjuncts
+    disjBlock = m.simpledisjunct.component(
+        "_pyomo_gdp_%s_reformulation" % transformation
+    ).relaxedDisjuncts
     self.assertEqual(len(disjBlock), 2)
-    self.assertIs(transform.get_transformed_constraints(
-        m.simpledisjunct.innerdisjunct0.c)[0].parent_block(), disjBlock[0])
-    self.assertIs(transform.get_transformed_constraints(
-        m.simpledisjunct.innerdisjunct0.c)[0].parent_block(), disjBlock[0])
-    self.assertIs(transform.get_transformed_constraints(
-        m.simpledisjunct.innerdisjunct1.c)[0].parent_block(), disjBlock[1])
+    self.assertIs(
+        transform.get_transformed_constraints(m.simpledisjunct.innerdisjunct0.c)[
+            0
+        ].parent_block(),
+        disjBlock[0],
+    )
+    self.assertIs(
+        transform.get_transformed_constraints(m.simpledisjunct.innerdisjunct0.c)[
+            0
+        ].parent_block(),
+        disjBlock[0],
+    )
+    self.assertIs(
+        transform.get_transformed_constraints(m.simpledisjunct.innerdisjunct1.c)[
+            0
+        ].parent_block(),
+        disjBlock[1],
+    )
 
     # This also relies on the disjuncts being transformed in the same
     # order every time.
-    pairs = [
-        (0,0),
-        (1,1),
-    ]
+    pairs = [(0, 0), (1, 1)]
     for i, j in pairs:
-        self.assertIs(m.simpledisjunct.component('innerdisjunct%d'%i),
-                      transform.get_src_disjunct(disjBlock[j]))
-        self.assertIs(disjBlock[j],
-                      m.simpledisjunct.component(
-                          'innerdisjunct%d'%i).transformation_block)
+        self.assertIs(
+            m.simpledisjunct.component('innerdisjunct%d' % i),
+            transform.get_src_disjunct(disjBlock[j]),
+        )
+        self.assertIs(
+            disjBlock[j],
+            m.simpledisjunct.component('innerdisjunct%d' % i).transformation_block,
+        )
+
 
 def check_disjunctData_targets_inactive(self, transformation, **kwargs):
     m = models.makeNestedDisjunctions()
     TransformationFactory('gdp.%s' % transformation).apply_to(
-        m,
-        targets=[m.disjunct[1]],
-        **kwargs)
+        m, targets=[m.disjunct[1]], **kwargs
+    )
 
     self.assertTrue(m.disjunct[0].active)
     self.assertTrue(m.disjunct[1].active)
@@ -1507,40 +1637,51 @@ def check_disjunctData_targets_inactive(self, transformation, **kwargs):
     self.assertTrue(m.simpledisjunct.innerdisjunct0.active)
     self.assertTrue(m.simpledisjunct.innerdisjunct1.active)
 
+
 def check_disjunctData_only_targets_transformed(self, transformation):
     m = models.makeNestedDisjunctions()
     # This is so convoluted, but you can treat a disjunct like a block:
     transform = TransformationFactory('gdp.%s' % transformation)
-    transform.apply_to(
-        m,
-        targets=[m.disjunct[1]])
+    transform.apply_to(m, targets=[m.disjunct[1]])
 
-    disjBlock = m.disjunct[1].component("_pyomo_gdp_%s_reformulation" %
-                                        transformation).relaxedDisjuncts
+    disjBlock = (
+        m.disjunct[1]
+        .component("_pyomo_gdp_%s_reformulation" % transformation)
+        .relaxedDisjuncts
+    )
     self.assertEqual(len(disjBlock), 2)
     if transformation == 'bigm':
-        self.assertIs(transform.get_transformed_constraints(
-            m.disjunct[1].innerdisjunct[0].c)[0].parent_block(), disjBlock[0])
+        self.assertIs(
+            transform.get_transformed_constraints(m.disjunct[1].innerdisjunct[0].c)[
+                0
+            ].parent_block(),
+            disjBlock[0],
+        )
     elif transformation == 'hull':
         # This constraint is on Block deeper because it is in the bounds of a
         # disaggregated var
-        self.assertIs(transform.get_transformed_constraints(
-            m.disjunct[1].innerdisjunct[0].c)[0].parent_block().parent_block(),
-                      disjBlock[0])
-    self.assertIs(transform.get_transformed_constraints(
-        m.disjunct[1].innerdisjunct[1].c)[0].parent_block(), disjBlock[1])
+        self.assertIs(
+            transform.get_transformed_constraints(m.disjunct[1].innerdisjunct[0].c)[0]
+            .parent_block()
+            .parent_block(),
+            disjBlock[0],
+        )
+    self.assertIs(
+        transform.get_transformed_constraints(m.disjunct[1].innerdisjunct[1].c)[
+            0
+        ].parent_block(),
+        disjBlock[1],
+    )
 
     # This also relies on the disjuncts being transformed in the same
     # order every time.
-    pairs = [
-        (0,0),
-        (1,1),
-    ]
+    pairs = [(0, 0), (1, 1)]
     for i, j in pairs:
-        self.assertIs(transform.get_src_disjunct(disjBlock[j]),
-                      m.disjunct[1].innerdisjunct[i])
-        self.assertIs(m.disjunct[1].innerdisjunct[i].transformation_block,
-                      disjBlock[j])
+        self.assertIs(
+            transform.get_src_disjunct(disjBlock[j]), m.disjunct[1].innerdisjunct[i]
+        )
+        self.assertIs(m.disjunct[1].innerdisjunct[i].transformation_block, disjBlock[j])
+
 
 def check_all_components_transformed(self, m):
     # checks that all the disjunctive components claim to be transformed in the
@@ -1551,6 +1692,7 @@ def check_all_components_transformed(self, m):
     self.assertIsInstance(m.d2.transformation_block, _BlockData)
     self.assertIsInstance(m.d1.d3.transformation_block, _BlockData)
     self.assertIsInstance(m.d1.d4.transformation_block, _BlockData)
+
 
 def check_transformation_blocks_nestedDisjunctions(self, m, transformation):
     disjunctionTransBlock = m.disj.algebraic_constraint.parent_block()
@@ -1567,6 +1709,7 @@ def check_transformation_blocks_nestedDisjunctions(self, m, transformation):
         self.assertIs(transBlocks[0], m.d1.transformation_block)
         self.assertIs(transBlocks[1], m.d2.transformation_block)
 
+
 def check_nested_disjunction_target(self, transformation):
     m = models.makeNestedDisjunctions_NestedDisjuncts()
     transform = TransformationFactory('gdp.%s' % transformation)
@@ -1578,6 +1721,7 @@ def check_nested_disjunction_target(self, transformation):
     check_all_components_transformed(self, m)
     check_transformation_blocks_nestedDisjunctions(self, m, transformation)
 
+
 def check_target_appears_twice(self, transformation):
     m = models.makeNestedDisjunctions_NestedDisjuncts()
     # Because of the way we preprocess targets, the result here will be that
@@ -1585,7 +1729,8 @@ def check_target_appears_twice(self, transformation):
     # the transformation will not try to retransform anything that has already
     # been transformed.
     m1 = TransformationFactory('gdp.%s' % transformation).create_using(
-        m, targets=[m.d1, m.disj])
+        m, targets=[m.d1, m.disj]
+    )
 
     check_all_components_transformed(self, m1)
     # check we have correct number of transformation blocks
@@ -1593,11 +1738,10 @@ def check_target_appears_twice(self, transformation):
 
     # Now check the same thing, but if the already-transformed disjunct appears
     # after its disjunction.
-    TransformationFactory('gdp.%s' % transformation).apply_to( m,
-                                                               targets=[m.disj,
-                                                                        m.d1])
+    TransformationFactory('gdp.%s' % transformation).apply_to(m, targets=[m.disj, m.d1])
     check_all_components_transformed(self, m)
     check_transformation_blocks_nestedDisjunctions(self, m, transformation)
+
 
 def check_unique_reference_to_nested_indicator_var(self, transformation):
     m = models.makeNestedDisjunctions_NestedDisjuncts()
@@ -1613,18 +1757,22 @@ def check_unique_reference_to_nested_indicator_var(self, transformation):
     self.assertEqual(num_references_d3, 1)
     self.assertEqual(num_references_d4, 1)
 
+
 # checks for handling of benign types that could be on disjuncts we're
 # transforming
+
 
 def check_RangeSet(self, transformation, **kwargs):
     m = models.makeDisjunctWithRangeSet()
     TransformationFactory('gdp.%s' % transformation).apply_to(m, **kwargs)
     self.assertIsInstance(m.d1.s, RangeSet)
 
+
 def check_Expression(self, transformation, **kwargs):
     m = models.makeDisjunctWithExpression()
     TransformationFactory('gdp.%s' % transformation).apply_to(m, **kwargs)
     self.assertIsInstance(m.d1.e, Expression)
+
 
 def check_untransformed_network_raises_GDPError(self, transformation, **kwargs):
     m = models.makeNetworkDisjunction()
@@ -1635,18 +1783,21 @@ def check_untransformed_network_raises_GDPError(self, transformation, **kwargs):
         "your disjuncts contain non-GDP Pyomo components that require "
         "transformation, please transform them first." % transformation,
         TransformationFactory('gdp.%s' % transformation).apply_to,
-        m, **kwargs)
+        m,
+        **kwargs
+    )
+
 
 def check_network_disjuncts(self, minimize, transformation, **kwds):
     m = models.makeExpandedNetworkDisjunction(minimize=minimize)
     TransformationFactory('gdp.%s' % transformation).apply_to(m, **kwds)
     results = SolverFactory(linear_solvers[0]).solve(m)
-    self.assertEqual(results.solver.termination_condition,
-                     TerminationCondition.optimal)
+    self.assertEqual(results.solver.termination_condition, TerminationCondition.optimal)
     if minimize:
         self.assertAlmostEqual(value(m.dest.x), 0.42)
     else:
         self.assertAlmostEqual(value(m.dest.x), 0.84)
+
 
 def check_solution_obeys_logical_constraints(self, transformation, m):
     # m is expected to either by models.makeLogicalConstraintsOnDisjuncts or
@@ -1659,8 +1810,7 @@ def check_solution_obeys_logical_constraints(self, transformation, m):
     no_logic = trans.create_using(m)
 
     results = SolverFactory(linear_solvers[0]).solve(no_logic)
-    self.assertEqual(results.solver.termination_condition,
-                     TerminationCondition.optimal)
+    self.assertEqual(results.solver.termination_condition, TerminationCondition.optimal)
     self.assertAlmostEqual(value(no_logic.x), 2.5)
 
     # with logical constraints
@@ -1668,11 +1818,12 @@ def check_solution_obeys_logical_constraints(self, transformation, m):
     m.bwahaha.activate()
     trans.apply_to(m)
     results = SolverFactory(linear_solvers[0]).solve(m)
-    self.assertEqual(results.solver.termination_condition,
-                     TerminationCondition.optimal)
+    self.assertEqual(results.solver.termination_condition, TerminationCondition.optimal)
     self.assertAlmostEqual(value(m.x), 8)
 
+
 # test pickling transformed models
+
 
 def check_pprint_equal(self, m, unpickle):
     # This is almost the same as in the diff_apply_to_and_create_using test but
@@ -1686,6 +1837,7 @@ def check_pprint_equal(self, m, unpickle):
     unpickle_output = unpickle_buf.getvalue()
     self.assertMultiLineEqual(m_output, unpickle_output)
 
+
 def check_transformed_model_pickles(self, transformation):
     # Do a model where we'll have to call logical_to_disjunctive too.
     m = models.makeLogicalConstraintsOnDisjuncts_NonlinearConvex()
@@ -1696,6 +1848,7 @@ def check_transformed_model_pickles(self, transformation):
     unpickle = pickle.loads(pickle.dumps(m))
 
     check_pprint_equal(self, m, unpickle)
+
 
 def check_transformed_model_pickles_with_dill(self, transformation):
     m = models.makeLogicalConstraintsOnDisjuncts_NonlinearConvex()

--- a/pyomo/gdp/tests/models.py
+++ b/pyomo/gdp/tests/models.py
@@ -1,22 +1,38 @@
-from pyomo.core import (Block, ConcreteModel, Constraint, Objective, Param, Set,
-                        Var, inequality, RangeSet, Any, Expression, maximize,
-                        TransformationFactory, BooleanVar, LogicalConstraint,
-                        exactly)
+from pyomo.core import (
+    Block,
+    ConcreteModel,
+    Constraint,
+    Objective,
+    Param,
+    Set,
+    Var,
+    inequality,
+    RangeSet,
+    Any,
+    Expression,
+    maximize,
+    TransformationFactory,
+    BooleanVar,
+    LogicalConstraint,
+    exactly,
+)
 from pyomo.core.expr.current import sqrt
 from pyomo.gdp import Disjunct, Disjunction
 
 import pyomo.network as ntwk
 
+
 def oneVarDisj_2pts():
     m = ConcreteModel()
     m.x = Var(bounds=(0, 10))
     m.disj1 = Disjunct()
-    m.disj1.xTrue = Constraint(expr=m.x==1)
+    m.disj1.xTrue = Constraint(expr=m.x == 1)
     m.disj2 = Disjunct()
-    m.disj2.xFalse = Constraint(expr=m.x==0)
+    m.disj2.xFalse = Constraint(expr=m.x == 0)
     m.disjunction = Disjunction(expr=[m.disj1, m.disj2])
     m.obj = Objective(expr=m.x)
     return m
+
 
 def twoSegments_SawayaGrossmann():
     m = ConcreteModel()
@@ -33,9 +49,9 @@ def twoSegments_SawayaGrossmann():
 
     return m
 
+
 def makeTwoTermDisj():
-    """Single two-term disjunction which has all of ==, <=, and >= constraints
-    """
+    """Single two-term disjunction which has all of ==, <=, and >= constraints"""
     m = ConcreteModel()
     m.a = Var(bounds=(2, 7))
     m.x = Var(bounds=(4, 9))
@@ -47,13 +63,14 @@ def makeTwoTermDisj():
             disjunct.c2 = Constraint(expr=m.x <= 7)
         else:
             disjunct.c = Constraint(expr=m.a >= 5)
+
     m.d = Disjunct([0, 1], rule=d_rule)
     m.disjunction = Disjunction(expr=[m.d[0], m.d[1]])
     return m
 
 
 def makeTwoTermDisj_Nonlinear():
-    """Single two-term disjunction which has all of ==, <=, and >= and 
+    """Single two-term disjunction which has all of ==, <=, and >= and
     one nonlinear constraint.
     """
     m = ConcreteModel()
@@ -69,14 +86,15 @@ def makeTwoTermDisj_Nonlinear():
             disjunct.c3 = Constraint(expr=(1, m.x, 3))
         else:
             disjunct.c = Constraint(expr=m.x + m.y**2 <= 14)
+
     m.d = Disjunct([0, 1], rule=d_rule)
     m.disjunction = Disjunction(expr=[m.d[0], m.d[1]])
     return m
 
 
 def makeTwoTermDisj_IndexedConstraints():
-    """Single two-term disjunction with IndexedConstraints on both disjuncts.  
-    Does not bound the variables, so cannot be transformed by hull at all and 
+    """Single two-term disjunction with IndexedConstraints on both disjuncts.
+    Does not bound the variables, so cannot be transformed by hull at all and
     requires specifying m values in bigm.
     """
     m = ConcreteModel()
@@ -89,7 +107,9 @@ def makeTwoTermDisj_IndexedConstraints():
 
         def c_rule(d, s):
             return m.a[s] == 0
+
         disjunct.c = Constraint(m.s, rule=c_rule)
+
     m.b.simpledisj1 = Disjunct(rule=disj1_rule)
 
     def disj2_rule(disjunct):
@@ -97,15 +117,16 @@ def makeTwoTermDisj_IndexedConstraints():
 
         def c_rule(d, s):
             return m.a[s] <= 3
+
         disjunct.c = Constraint(m.s, rule=c_rule)
+
     m.b.simpledisj2 = Disjunct(rule=disj2_rule)
     m.b.disjunction = Disjunction(expr=[m.b.simpledisj1, m.b.simpledisj2])
     return m
 
 
 def makeTwoTermDisj_IndexedConstraints_BoundedVars():
-    """Single two-term disjunction with IndexedConstraints on both disjuncts. 
-    """
+    """Single two-term disjunction with IndexedConstraints on both disjuncts."""
     m = ConcreteModel()
     m.s = Set(initialize=[1, 2])
     m.lbs = Param(m.s, initialize={1: 2, 2: 4})
@@ -113,6 +134,7 @@ def makeTwoTermDisj_IndexedConstraints_BoundedVars():
 
     def bounds_rule(m, s):
         return (m.lbs[s], m.ubs[s])
+
     m.a = Var(m.s, bounds=bounds_rule)
 
     def d_rule(disjunct, flag):
@@ -123,13 +145,16 @@ def makeTwoTermDisj_IndexedConstraints_BoundedVars():
 
         def false_rule(d, s):
             return m.a[s] >= 5
+
         if flag:
             disjunct.c = Constraint(m.s, rule=true_rule)
         else:
             disjunct.c = Constraint(m.s, rule=false_rule)
+
     m.disjunct = Disjunct([0, 1], rule=d_rule)
     m.disjunction = Disjunction(expr=[m.disjunct[0], m.disjunct[1]])
     return m
+
 
 def localVar():
     """Two-term disjunction which declares a local variable y on one of the
@@ -140,13 +165,13 @@ def localVar():
     """
     # y appears in a global constraint and a single disjunct.
     m = ConcreteModel()
-    m.x = Var(bounds=(0,3))
+    m.x = Var(bounds=(0, 3))
 
     m.disj1 = Disjunct()
     m.disj1.cons = Constraint(expr=m.x >= 1)
 
     m.disj2 = Disjunct()
-    m.disj2.y = Var(bounds=(1,3))
+    m.disj2.y = Var(bounds=(1, 3))
     m.disj2.cons = Constraint(expr=m.x + m.disj2.y == 3)
 
     m.disjunction = Disjunction(expr=[m.disj1, m.disj2])
@@ -159,9 +184,7 @@ def localVar():
 def make_infeasible_gdp_model():
     m = ConcreteModel()
     m.x = Var(bounds=(0, 2))
-    m.d = Disjunction(expr=[
-        [m.x ** 2 >= 3, m.x >= 3],
-        [m.x ** 2 <= -1, m.x <= -1]])
+    m.d = Disjunction(expr=[[m.x**2 >= 3, m.x >= 3], [m.x**2 <= -1, m.x <= -1]])
     m.o = Objective(expr=m.x)
 
     return m
@@ -181,18 +204,21 @@ def makeThreeTermIndexedDisj():
             disjunct.c = Constraint(expr=m.a[s] >= 5)
         else:
             disjunct.c = Constraint(expr=inequality(2, m.a[s], 4))
+
     m.disjunct = Disjunct([0, 1, 2], m.s, rule=d_rule)
 
     def disj_rule(m, s):
         return [m.disjunct[0, s], m.disjunct[1, s], m.disjunct[2, s]]
+
     m.disjunction = Disjunction(m.s, rule=disj_rule)
     return m
 
 
 def makeTwoTermDisj_boxes():
     m = ConcreteModel()
-    m.x = Var(bounds=(0,5))
-    m.y = Var(bounds=(0,5))
+    m.x = Var(bounds=(0, 5))
+    m.y = Var(bounds=(0, 5))
+
     def d_rule(disjunct, flag):
         m = disjunct.model()
         if flag:
@@ -201,11 +227,14 @@ def makeTwoTermDisj_boxes():
         else:
             disjunct.c1 = Constraint(expr=inequality(3, m.x, 4))
             disjunct.c2 = Constraint(expr=inequality(1, m.y, 2))
-    m.d = Disjunct([0,1], rule=d_rule)
+
+    m.d = Disjunct([0, 1], rule=d_rule)
+
     def disj_rule(m):
         return [m.d[0], m.d[1]]
+
     m.disjunction = Disjunction(rule=disj_rule)
-    m.obj = Objective(expr=m.x + 2*m.y)
+    m.obj = Objective(expr=m.x + 2 * m.y)
     return m
 
 
@@ -222,6 +251,7 @@ def makeThreeTermDisj_IndexedConstraints():
     def d_rule(d, j):
         m = d.model()
         d.c = Constraint(m.I[:j], rule=c_rule)
+
     m.d = Disjunct(m.I, rule=d_rule)
     m.disjunction = Disjunction(expr=[m.d[i] for i in m.I])
     return m
@@ -240,10 +270,12 @@ def makeTwoTermIndexedDisjunction():
             d.cons_a = Constraint(expr=m.x[i] >= 5)
         if k == 'b':
             d.cons_b = Constraint(expr=m.x[i] <= 0)
+
     m.disjunct = Disjunct(m.A, m.B, rule=disjunct_rule)
 
     def disj_rule(m, i):
         return [m.disjunct[i, k] for k in m.B]
+
     m.disjunction = Disjunction(m.A, rule=disj_rule)
     return m
 
@@ -261,10 +293,12 @@ def makeTwoTermIndexedDisjunction_BoundedVars():
             d.c = Constraint(expr=m.a[s] >= 6)
         else:
             d.c = Constraint(expr=m.a[s] <= 3)
+
     m.disjunct = Disjunct(m.s, [0, 1], rule=disjunct_rule)
 
     def disjunction_rule(m, s):
         return [m.disjunct[s, flag] for flag in [0, 1]]
+
     m.disjunction = Disjunction(m.s, rule=disjunction_rule)
     return m
 
@@ -273,18 +307,20 @@ def makeIndexedDisjunction_SkipIndex():
     """Two-term indexed disjunction where one of the two indices is skipped"""
     m = ConcreteModel()
     m.x = Var(bounds=(0, 10))
-    @m.Disjunct([0,1])
+
+    @m.Disjunct([0, 1])
     def disjuncts(d, i):
         m = d.model()
         d.cons = Constraint(expr=m.x == i)
 
-    @m.Disjunction([0,1])
+    @m.Disjunction([0, 1])
     def disjunctions(m, i):
         if i == 0:
             return Disjunction.Skip
         return [m.disjuncts[i], m.disjuncts[0]]
 
     return m
+
 
 def makeTwoTermMultiIndexedDisjunction():
     """Two-term indexed disjunction with tuple indices"""
@@ -299,10 +335,12 @@ def makeTwoTermMultiIndexedDisjunction():
             disjunct.c = Constraint(expr=m.a[s, t] == 0)
         else:
             disjunct.c = Constraint(expr=m.a[s, t] >= 5)
+
     m.disjunct = Disjunct([0, 1], m.s, m.t, rule=d_rule)
 
     def disj_rule(m, s, t):
         return [m.disjunct[0, s, t], m.disjunct[1, s, t]]
+
     m.disjunction = Disjunction(m.s, m.t, rule=disj_rule)
     return m
 
@@ -327,17 +365,22 @@ def makeTwoTermDisjOnBlock():
 
     return m
 
+
 def add_disj_not_on_block(m):
     def simpdisj_rule(disjunct):
         m = disjunct.model()
         disjunct.c = Constraint(expr=m.a >= 3)
+
     m.simpledisj = Disjunct(rule=simpdisj_rule)
+
     def simpledisj2_rule(disjunct):
         m = disjunct.model()
         disjunct.c = Constraint(expr=m.a <= 3.5)
+
     m.simpledisj2 = Disjunct(rule=simpledisj2_rule)
     m.disjunction2 = Disjunction(expr=[m.simpledisj, m.simpledisj2])
     return m
+
 
 def makeDisjunctionsOnIndexedBlock():
     """Two disjunctions (one indexed and one not), each on a separate
@@ -357,6 +400,7 @@ def makeDisjunctionsOnIndexedBlock():
 
     def disjunction1_rule(m, s):
         return [m.disjunct1[s, flag] for flag in [0, 1]]
+
     m.disjunction1 = Disjunction(m.s, rule=disjunction1_rule)
 
     m.b = Block([0, 1])
@@ -367,10 +411,12 @@ def makeDisjunctionsOnIndexedBlock():
             disjunct.c = Constraint(expr=m.b[0].x <= 0)
         else:
             disjunct.c = Constraint(expr=m.b[0].x >= 0)
+
     m.b[0].disjunct = Disjunct([0, 1], rule=disjunct2_rule)
 
     def disjunction(b, i):
         return [b.disjunct[0], b.disjunct[1]]
+
     m.b[0].disjunction = Disjunction([0], rule=disjunction)
 
     m.b[1].y = Var(bounds=(-3, 3))
@@ -378,8 +424,7 @@ def makeDisjunctionsOnIndexedBlock():
     m.b[1].disjunct0.c = Constraint(expr=m.b[1].y <= 0)
     m.b[1].disjunct1 = Disjunct()
     m.b[1].disjunct1.c = Constraint(expr=m.b[1].y >= 0)
-    m.b[1].disjunction = Disjunction(
-        expr=[m.b[1].disjunct0, m.b[1].disjunct1])
+    m.b[1].disjunction = Disjunction(expr=[m.b[1].disjunct0, m.b[1].disjunct1])
     return m
 
 
@@ -402,6 +447,7 @@ def makeTwoTermDisj_BlockOnDisj():
             d.bb[1].c = Constraint(expr=m.x == 0)
         else:
             d.c = Constraint(expr=m.x >= 80)
+
     m.evil = Disjunct([0, 1], rule=disj_rule)
     m.disjunction = Disjunction(expr=[m.evil[0], m.evil[1]])
     return m
@@ -425,20 +471,24 @@ def makeNestedDisjunctions():
     def disjunct_rule(disjunct, flag):
         m = disjunct.model()
         if flag:
+
             def innerdisj_rule(disjunct, flag):
                 m = disjunct.model()
                 if flag:
                     disjunct.c = Constraint(expr=m.z >= 5)
                 else:
                     disjunct.c = Constraint(expr=m.z == 0)
+
             disjunct.innerdisjunct = Disjunct([0, 1], rule=innerdisj_rule)
 
             @disjunct.Disjunction([0])
             def innerdisjunction(b, i):
                 return [b.innerdisjunct[0], b.innerdisjunct[1]]
+
             disjunct.c = Constraint(expr=m.a <= 2)
         else:
             disjunct.c = Constraint(expr=m.x == 2)
+
     m.disjunct = Disjunct([0, 1], rule=disjunct_rule)
     # I want a SimpleDisjunct with a disjunction in it too
 
@@ -454,10 +504,11 @@ def makeNestedDisjunctions():
             disjunct.c = Constraint(expr=m.x >= 4)
 
         disjunct.innerdisjunction = Disjunction(
-            expr=[disjunct.innerdisjunct0, disjunct.innerdisjunct1])
+            expr=[disjunct.innerdisjunct0, disjunct.innerdisjunct1]
+        )
+
     m.simpledisjunct = Disjunct(rule=simpledisj_rule)
-    m.disjunction = Disjunction(
-        expr=[m.simpledisjunct, m.disjunct[0], m.disjunct[1]])
+    m.disjunction = Disjunction(expr=[m.simpledisjunct, m.disjunct[0], m.disjunct[1]])
     return m
 
 
@@ -510,6 +561,7 @@ def makeTwoSimpleDisjunctions():
             disjunct.c = Constraint(expr=m.a == 0)
         else:
             disjunct.c = Constraint(expr=m.a >= 5)
+
     m.disjunct1 = Disjunct([0, 1], rule=d1_rule)
 
     def d2_rule(disjunct, flag):
@@ -517,6 +569,7 @@ def makeTwoSimpleDisjunctions():
             disjunct.c = Constraint(expr=m.a >= 30)
         else:
             disjunct.c = Constraint(expr=m.a == 100)
+
     m.disjunct2 = Disjunct([0, 1], rule=d2_rule)
 
     m.disjunction1 = Disjunction(expr=[m.disjunct1[0], m.disjunct1[1]])
@@ -537,6 +590,7 @@ def makeDisjunctInMultipleDisjunctions():
             disjunct.c = Constraint(expr=m.a == 0)
         else:
             disjunct.c = Constraint(expr=m.a >= 5)
+
     m.disjunct1 = Disjunct([0, 1], rule=d1_rule)
 
     def d2_rule(disjunct, flag):
@@ -544,6 +598,7 @@ def makeDisjunctInMultipleDisjunctions():
             disjunct.c = Constraint(expr=m.a >= 30)
         else:
             disjunct.c = Constraint(expr=m.a == 100)
+
     m.disjunct2 = Disjunct([0, 1], rule=d2_rule)
 
     m.disjunction1 = Disjunction(expr=[m.disjunct1[0], m.disjunct1[1]])
@@ -564,23 +619,28 @@ def makeDuplicatedNestedDisjunction():
     def outerdisj_rule(d, flag):
         m = d.model()
         if flag:
+
             def innerdisj_rule(d, flag):
                 m = d.model()
                 if flag:
                     d.c = Constraint(expr=m.x >= 2)
                 else:
                     d.c = Constraint(expr=m.x == 0)
+
             d.innerdisjunct = Disjunct([0, 1], rule=innerdisj_rule)
-            d.innerdisjunction = Disjunction(expr=[d.innerdisjunct[0],
-                                                   d.innerdisjunct[1]])
-            d.duplicateddisjunction = Disjunction(expr=[d.innerdisjunct[0],
-                                                        d.innerdisjunct[1]])
+            d.innerdisjunction = Disjunction(
+                expr=[d.innerdisjunct[0], d.innerdisjunct[1]]
+            )
+            d.duplicateddisjunction = Disjunction(
+                expr=[d.innerdisjunct[0], d.innerdisjunct[1]]
+            )
         else:
             d.c = Constraint(expr=m.x == 8)
+
     m.outerdisjunct = Disjunct([0, 1], rule=outerdisj_rule)
-    m.disjunction = Disjunction(expr=[m.outerdisjunct[0],
-                                      m.outerdisjunct[1]])
+    m.disjunction = Disjunction(expr=[m.outerdisjunct[0], m.outerdisjunct[1]])
     return m
+
 
 def makeDisjunctWithRangeSet():
     """Two-term SimpleDisjunction where one of the disjuncts contains a
@@ -594,13 +654,15 @@ def makeDisjunctWithRangeSet():
     m.disj = Disjunction(expr=[m.d1, m.d2])
     return m
 
+
 ##########################
 # Grossmann lecture models
 ##########################
 
+
 def grossmann_oneDisj():
     m = ConcreteModel()
-    m.x = Var(bounds=(0,20))
+    m.x = Var(bounds=(0, 20))
     m.y = Var(bounds=(0, 20))
     m.disjunct1 = Disjunct()
     m.disjunct1.constraintx = Constraint(expr=inequality(0, m.x, 2))
@@ -612,9 +674,10 @@ def grossmann_oneDisj():
 
     m.disjunction = Disjunction(expr=[m.disjunct1, m.disjunct2])
 
-    m.objective = Objective(expr=m.x + 2*m.y, sense=maximize)
+    m.objective = Objective(expr=m.x + 2 * m.y, sense=maximize)
 
     return m
+
 
 def to_break_constraint_tolerances():
     m = ConcreteModel()
@@ -630,9 +693,10 @@ def to_break_constraint_tolerances():
 
     m.disjunction = Disjunction(expr=[m.disjunct1, m.disjunct2])
 
-    m.objective = Objective(expr=m.x + 2*m.y, sense=maximize)
+    m.objective = Objective(expr=m.x + 2 * m.y, sense=maximize)
 
     return m
+
 
 def grossmann_twoDisj():
     m = grossmann_oneDisj()
@@ -649,20 +713,22 @@ def grossmann_twoDisj():
 
     return m
 
+
 def twoDisj_twoCircles_easy():
     m = ConcreteModel()
-    m.x = Var(bounds=(0,8))
-    m.y = Var(bounds=(0,10))
+    m.x = Var(bounds=(0, 8))
+    m.y = Var(bounds=(0, 10))
 
     m.upper_circle = Disjunct()
-    m.upper_circle.cons = Constraint(expr=(m.x - 1)**2 + (m.y - 6)**2 <= 2)
+    m.upper_circle.cons = Constraint(expr=(m.x - 1) ** 2 + (m.y - 6) ** 2 <= 2)
     m.lower_circle = Disjunct()
-    m.lower_circle.cons = Constraint(expr=(m.x - 4)**2 + (m.y - 2)**2 <= 2)
+    m.lower_circle.cons = Constraint(expr=(m.x - 4) ** 2 + (m.y - 2) ** 2 <= 2)
 
     m.disjunction = Disjunction(expr=[m.upper_circle, m.lower_circle])
 
     m.obj = Objective(expr=m.x + m.y, sense=maximize)
     return m
+
 
 def fourCircles():
     m = twoDisj_twoCircles_easy()
@@ -670,14 +736,15 @@ def fourCircles():
     # and add two more overlapping circles, a la the Grossmann test case with
     # the rectangles. (but not change my nice integral optimal solution...)
     m.upper_circle2 = Disjunct()
-    m.upper_circle2.cons = Constraint(expr=(m.x - 2)**2 + (m.y - 7)**2 <= 1)
+    m.upper_circle2.cons = Constraint(expr=(m.x - 2) ** 2 + (m.y - 7) ** 2 <= 1)
 
     m.lower_circle2 = Disjunct()
-    m.lower_circle2.cons = Constraint(expr=(m.x - 5)**2 + (m.y - 3)**2 <= 2)
+    m.lower_circle2.cons = Constraint(expr=(m.x - 5) ** 2 + (m.y - 3) ** 2 <= 2)
 
     m.disjunction2 = Disjunction(expr=[m.upper_circle2, m.lower_circle2])
 
     return m
+
 
 def makeDisjunctWithExpression():
     """Two-term SimpleDisjunction where one of the disjuncts contains an
@@ -692,6 +759,7 @@ def makeDisjunctWithExpression():
     m.disj = Disjunction(expr=[m.d1, m.d2])
     return m
 
+
 def makeDisjunctionOfDisjunctDatas():
     """Two SimpleDisjunctions, where each are disjunctions of DisjunctDatas.
     This adds nothing to makeTwoSimpleDisjunctions but exists for convenience
@@ -703,7 +771,7 @@ def makeDisjunctionOfDisjunctDatas():
 
     m.obj = Objective(expr=m.x)
 
-    m.idx = Set(initialize=[1,2])
+    m.idx = Set(initialize=[1, 2])
     m.firstTerm = Disjunct(m.idx)
     m.firstTerm[1].cons = Constraint(expr=m.x == 0)
     m.firstTerm[2].cons = Constraint(expr=m.x == 2)
@@ -714,6 +782,7 @@ def makeDisjunctionOfDisjunctDatas():
     m.disjunction = Disjunction(expr=[m.firstTerm[1], m.secondTerm[1]])
     m.disjunction2 = Disjunction(expr=[m.firstTerm[2], m.secondTerm[2]])
     return m
+
 
 def makeAnyIndexedDisjunctionOfDisjunctDatas():
     """An IndexedDisjunction indexed by Any, with two two-term DisjunctionDatas
@@ -728,7 +797,7 @@ def makeAnyIndexedDisjunctionOfDisjunctDatas():
 
     m.obj = Objective(expr=m.x)
 
-    m.idx = Set(initialize=[1,2])
+    m.idx = Set(initialize=[1, 2])
     m.firstTerm = Disjunct(m.idx)
     m.firstTerm[1].cons = Constraint(expr=m.x == 0)
     m.firstTerm[2].cons = Constraint(expr=m.x == 2)
@@ -741,8 +810,9 @@ def makeAnyIndexedDisjunctionOfDisjunctDatas():
     m.disjunction[2] = [m.firstTerm[2], m.secondTerm[2]]
     return m
 
+
 def makeNetworkDisjunction(minimize=True):
-    """ creates a GDP model with pyomo.network components """
+    """creates a GDP model with pyomo.network components"""
     m = ConcreteModel()
 
     m.feed = feed = Block()
@@ -752,33 +822,31 @@ def makeNetworkDisjunction(minimize=True):
     m.orange = orange = Disjunct()
     m.blue = blue = Disjunct()
 
-    m.orange_or_blue = Disjunction(expr=[orange,blue])
+    m.orange_or_blue = Disjunction(expr=[orange, blue])
 
     blue.blue_box = blue_box = Block()
 
-    feed.x = Var(bounds=(0,1))
-    wkbx.x = Var(bounds=(0,1))
-    dest.x = Var(bounds=(0,1))
+    feed.x = Var(bounds=(0, 1))
+    wkbx.x = Var(bounds=(0, 1))
+    dest.x = Var(bounds=(0, 1))
 
-    wkbx.inlet = ntwk.Port(initialize={"x":wkbx.x})
-    wkbx.outlet = ntwk.Port(initialize={"x":wkbx.x})
+    wkbx.inlet = ntwk.Port(initialize={"x": wkbx.x})
+    wkbx.outlet = ntwk.Port(initialize={"x": wkbx.x})
 
-    feed.outlet = ntwk.Port(initialize={"x":feed.x})
-    dest.inlet = ntwk.Port(initialize={"x":dest.x})
+    feed.outlet = ntwk.Port(initialize={"x": feed.x})
+    dest.inlet = ntwk.Port(initialize={"x": dest.x})
 
-    blue_box.x = Var(bounds=(0,1))
-    blue_box.x_wkbx = Var(bounds=(0,1))
-    blue_box.x_dest = Var(bounds=(0,1))
+    blue_box.x = Var(bounds=(0, 1))
+    blue_box.x_wkbx = Var(bounds=(0, 1))
+    blue_box.x_dest = Var(bounds=(0, 1))
 
+    blue_box.inlet_feed = ntwk.Port(initialize={"x": blue_box.x})
+    blue_box.outlet_wkbx = ntwk.Port(initialize={"x": blue_box.x})
 
-    blue_box.inlet_feed = ntwk.Port(initialize={"x":blue_box.x})
-    blue_box.outlet_wkbx = ntwk.Port(initialize={"x":blue_box.x})
+    blue_box.inlet_wkbx = ntwk.Port(initialize={"x": blue_box.x_wkbx})
+    blue_box.outlet_dest = ntwk.Port(initialize={"x": blue_box.x_dest})
 
-    blue_box.inlet_wkbx = ntwk.Port(initialize={"x":blue_box.x_wkbx})
-    blue_box.outlet_dest = ntwk.Port(initialize={"x":blue_box.x_dest})
-
-    blue_box.multiplier_constr = Constraint(expr=blue_box.x_dest == \
-                                            2*blue_box.x_wkbx)
+    blue_box.multiplier_constr = Constraint(expr=blue_box.x_dest == 2 * blue_box.x_wkbx)
 
     # orange arcs
     orange.a1 = ntwk.Arc(source=feed.outlet, destination=wkbx.inlet)
@@ -801,10 +869,12 @@ def makeNetworkDisjunction(minimize=True):
 
     return m
 
+
 def makeExpandedNetworkDisjunction(minimize=True):
     m = makeNetworkDisjunction(minimize)
     TransformationFactory('network.expand_arcs').apply_to(m)
     return m
+
 
 def makeThreeTermDisjunctionWithOneVarInOneDisjunct():
     """This is to make sure hull doesn't create more disaggregated variables
@@ -813,8 +883,8 @@ def makeThreeTermDisjunctionWithOneVarInOneDisjunct():
     free if either of the second two Disjuncts is active and 0 otherwise.
     """
     m = ConcreteModel()
-    m.x = Var(bounds=(-2,8))
-    m.y = Var(bounds=(3,4))
+    m.x = Var(bounds=(-2, 8))
+    m.y = Var(bounds=(3, 4))
     m.d1 = Disjunct()
     m.d1.c1 = Constraint(expr=m.x <= 3)
     m.d1.c2 = Constraint(expr=m.y >= 3.5)
@@ -827,6 +897,7 @@ def makeThreeTermDisjunctionWithOneVarInOneDisjunct():
 
     return m
 
+
 def makeNestedNonlinearModel():
     """This is actually a disjunction between two points, but it's written
     as a nested disjunction over four circles!"""
@@ -835,91 +906,106 @@ def makeNestedNonlinearModel():
     m.y = Var(bounds=(-10, 10))
     m.d1 = Disjunct()
     m.d1.lower_circle = Constraint(expr=m.x**2 + m.y**2 <= 1)
-    m.disj = Disjunction(expr=[[m.x == 10], [(sqrt(2) - m.x)**2 + (sqrt(2) -
-                                                                   m.y)**2 <=
-                                             1]])
+    m.disj = Disjunction(
+        expr=[[m.x == 10], [(sqrt(2) - m.x) ** 2 + (sqrt(2) - m.y) ** 2 <= 1]]
+    )
     m.d2 = Disjunct()
-    m.d2.upper_circle = Constraint(expr=(3 - m.x)**2 + (3 - m.y)**2 <= 1)
-    m.d2.inner = Disjunction(expr=[[m.y == 10], [(sqrt(2) - m.x)**2 + (sqrt(2) -
-                                                                       m.y)**2
-                                                 <= 1]])
+    m.d2.upper_circle = Constraint(expr=(3 - m.x) ** 2 + (3 - m.y) ** 2 <= 1)
+    m.d2.inner = Disjunction(
+        expr=[[m.y == 10], [(sqrt(2) - m.x) ** 2 + (sqrt(2) - m.y) ** 2 <= 1]]
+    )
     m.outer = Disjunction(expr=[m.d1, m.d2])
     m.obj = Objective(expr=m.x + m.y)
 
     return m
 
+
 ##
 # Variations on the example from the Kronqvist et al. Between Steps paper
 ##
 
+
 def makeBetweenStepsPaperExample():
     """Original example model, implicit disjunction"""
     m = ConcreteModel()
-    m.I = RangeSet(1,4)
-    m.x = Var(m.I, bounds=(-2,6))
+    m.I = RangeSet(1, 4)
+    m.x = Var(m.I, bounds=(-2, 6))
 
-    m.disjunction = Disjunction(expr=[[sum(m.x[i]**2 for i in m.I) <= 1],
-                                      [sum((3 - m.x[i])**2 for i in m.I) <=
-                                       1]])
+    m.disjunction = Disjunction(
+        expr=[
+            [sum(m.x[i] ** 2 for i in m.I) <= 1],
+            [sum((3 - m.x[i]) ** 2 for i in m.I) <= 1],
+        ]
+    )
 
     m.obj = Objective(expr=m.x[2] - m.x[1], sense=maximize)
 
     return m
+
 
 def makeBetweenStepsPaperExample_DeclareVarOnDisjunct():
     """Exactly the same model as above, but declaring the Disjuncts explicitly
     and declaring the variables on one of them.
     """
     m = ConcreteModel()
-    m.I = RangeSet(1,4)
+    m.I = RangeSet(1, 4)
     m.disj1 = Disjunct()
-    m.disj1.x = Var(m.I, bounds=(-2,6))
-    m.disj1.c = Constraint(expr=sum(m.disj1.x[i]**2 for i in m.I) <= 1)
+    m.disj1.x = Var(m.I, bounds=(-2, 6))
+    m.disj1.c = Constraint(expr=sum(m.disj1.x[i] ** 2 for i in m.I) <= 1)
     m.disj2 = Disjunct()
-    m.disj2.c = Constraint(expr=sum((3 - m.disj1.x[i])**2 for i in m.I) <=
-                           1)
+    m.disj2.c = Constraint(expr=sum((3 - m.disj1.x[i]) ** 2 for i in m.I) <= 1)
     m.disjunction = Disjunction(expr=[m.disj1, m.disj2])
 
     m.obj = Objective(expr=m.disj1.x[2] - m.disj1.x[1], sense=maximize)
 
     return m
 
+
 def makeBetweenStepsPaperExample_Nested():
     """Mathematically, this is really dumb, but I am nesting this model on
     itself because it makes writing tests simpler (I can recycle.)"""
     m = makeBetweenStepsPaperExample_DeclareVarOnDisjunct()
     m.disj2.disjunction = Disjunction(
-        expr=[[sum(m.disj1.x[i]**2 for i in m.I) <= 1],
-              [sum((3 - m.disj1.x[i])**2 for i in m.I) <= 1]])
+        expr=[
+            [sum(m.disj1.x[i] ** 2 for i in m.I) <= 1],
+            [sum((3 - m.disj1.x[i]) ** 2 for i in m.I) <= 1],
+        ]
+    )
 
     return m
+
 
 def instantiate_hierarchical_nested_model(m):
     """helper function to instantiate a nested version of the model with
     the Disjuncts and Disjunctions on blocks"""
     m.disj1 = Disjunct()
     m.disjunct_block.disj2 = Disjunct()
-    m.disj1.c = Constraint(expr=sum(m.x[i]**2 for i in m.I) <= 1)
-    m.disjunct_block.disj2.c = Constraint(expr=sum((3 - m.x[i])**2 for i in
-                                                   m.I) <= 1)
+    m.disj1.c = Constraint(expr=sum(m.x[i] ** 2 for i in m.I) <= 1)
+    m.disjunct_block.disj2.c = Constraint(expr=sum((3 - m.x[i]) ** 2 for i in m.I) <= 1)
     m.disjunct_block.disj2.disjunction = Disjunction(
-        expr=[[sum(m.x[i]**2 for i in m.I) <= 1],
-              [sum((3 - m.x[i])**2 for i in m.I) <= 1]])
+        expr=[
+            [sum(m.x[i] ** 2 for i in m.I) <= 1],
+            [sum((3 - m.x[i]) ** 2 for i in m.I) <= 1],
+        ]
+    )
     m.disjunction_block.disjunction = Disjunction(
-        expr=[m.disj1, m.disjunct_block.disj2])
+        expr=[m.disj1, m.disjunct_block.disj2]
+    )
+
 
 def makeHierarchicalNested_DeclOrderMatchesInstantationOrder():
     """Here, we put the disjunctive components on Blocks, but we do it in the
     same order that we declared the blocks, that is, on each block, decl order
     matches instantiation order."""
     m = ConcreteModel()
-    m.I = RangeSet(1,4)
-    m.x = Var(m.I, bounds=(-2,6))
+    m.I = RangeSet(1, 4)
+    m.x = Var(m.I, bounds=(-2, 6))
     m.disjunct_block = Block()
     m.disjunction_block = Block()
     instantiate_hierarchical_nested_model(m)
 
     return m
+
 
 def makeHierarchicalNested_DeclOrderOppositeInstantationOrder():
     """Here, we declare the Blocks in the opposite order. This means that
@@ -927,37 +1013,49 @@ def makeHierarchicalNested_DeclOrderOppositeInstantationOrder():
     can break our targets preprocessing without even using targets if we
     are not correctly identifying what is nested in what!"""
     m = ConcreteModel()
-    m.I = RangeSet(1,4)
-    m.x = Var(m.I, bounds=(-2,6))
+    m.I = RangeSet(1, 4)
+    m.x = Var(m.I, bounds=(-2, 6))
     m.disjunction_block = Block()
     m.disjunct_block = Block()
     instantiate_hierarchical_nested_model(m)
 
     return m
 
+
 def makeNonQuadraticNonlinearGDP():
     """We use this in testing between steps--Needed non-quadratic and not
     additively separable constraint expressions on a Disjunct."""
     m = ConcreteModel()
-    m.I = RangeSet(1,4)
-    m.I1 = RangeSet(1,2)
-    m.I2 = RangeSet(3,4)
-    m.x = Var(m.I, bounds=(-2,6))
+    m.I = RangeSet(1, 4)
+    m.I1 = RangeSet(1, 2)
+    m.I2 = RangeSet(3, 4)
+    m.x = Var(m.I, bounds=(-2, 6))
 
     # sum of 4-norms...
     m.disjunction = Disjunction(
-        expr=[[sum(m.x[i]**4 for i in m.I1)**(1/4) + \
-               sum(m.x[i]**4 for i in m.I2)**(1/4) <= 1],
-              [sum((3 - m.x[i])**4 for i in m.I1)**(1/4) +
-               sum((3 - m.x[i])**4 for i in m.I2)**(1/4) <= 1]])
+        expr=[
+            [
+                sum(m.x[i] ** 4 for i in m.I1) ** (1 / 4)
+                + sum(m.x[i] ** 4 for i in m.I2) ** (1 / 4)
+                <= 1
+            ],
+            [
+                sum((3 - m.x[i]) ** 4 for i in m.I1) ** (1 / 4)
+                + sum((3 - m.x[i]) ** 4 for i in m.I2) ** (1 / 4)
+                <= 1
+            ],
+        ]
+    )
 
     m.obj = Objective(expr=m.x[2] - m.x[1], sense=maximize)
 
     return m
 
+
 #
 # Logical Constraints on Disjuncts
 #
+
 
 def makeLogicalConstraintsOnDisjuncts():
     m = ConcreteModel()
@@ -978,12 +1076,12 @@ def makeLogicalConstraintsOnDisjuncts():
     m.o = Objective(expr=m.x)
 
     # Add the logical proposition
-    m.p = LogicalConstraint(
-        expr=m.d[1].indicator_var.implies(m.d[4].indicator_var))
+    m.p = LogicalConstraint(expr=m.d[1].indicator_var.implies(m.d[4].indicator_var))
     # Use the logical stuff to make choosing d1 and d4 infeasible:
     m.bwahaha = LogicalConstraint(expr=m.Y[1].xor(m.Y[2]))
 
     return m
+
 
 def makeLogicalConstraintsOnDisjuncts_NonlinearConvex():
     # same game as the previous model, but include some nonlinear
@@ -1012,6 +1110,7 @@ def makeLogicalConstraintsOnDisjuncts_NonlinearConvex():
 
     return m
 
+
 def makeBooleanVarsOnDisjuncts():
     # same as linear model above, but declare the BooleanVar on one of the
     # Disjuncts, just to make sure we make references and stuff correctly.
@@ -1028,14 +1127,12 @@ def makeBooleanVarsOnDisjuncts():
     m.d[1].logical = LogicalConstraint(expr=~m.d[1].Y[1])
     m.d[2].c = Constraint(expr=m.x >= 3)
     m.d[3].c = Constraint(expr=m.x >= 8)
-    m.d[4].logical = LogicalConstraint(
-        expr=m.d[1].Y[1].equivalent_to(m.d[1].Y[2]))
+    m.d[4].logical = LogicalConstraint(expr=m.d[1].Y[1].equivalent_to(m.d[1].Y[2]))
     m.d[4].c = Constraint(expr=m.x == 2.5)
     m.o = Objective(expr=m.x)
 
     # Add the logical proposition
-    m.p = LogicalConstraint(
-        expr=m.d[1].indicator_var.implies(m.d[4].indicator_var))
+    m.p = LogicalConstraint(expr=m.d[1].indicator_var.implies(m.d[4].indicator_var))
     # Use the logical stuff to make choosing d1 and d4 infeasible:
     m.bwahaha = LogicalConstraint(expr=m.d[1].Y[1].xor(m.d[1].Y[2]))
 

--- a/pyomo/gdp/tests/test_basic_step.py
+++ b/pyomo/gdp/tests/test_basic_step.py
@@ -20,6 +20,7 @@ import pyomo.gdp.tests.common_tests as ct
 from pyomo.common.fileutils import import_file
 
 from os.path import abspath, dirname, normpath, join
+
 currdir = dirname(abspath(__file__))
 exdir = normpath(join(currdir, '..', '..', '..', 'examples', 'gdp'))
 
@@ -28,48 +29,33 @@ class TestBasicStep(unittest.TestCase):
     """Tests disjunctive basic steps."""
 
     def test_improper_basic_step(self):
-        model_builder = import_file(
-            join(exdir, 'two_rxn_lee', 'two_rxn_model.py'))
+        model_builder = import_file(join(exdir, 'two_rxn_lee', 'two_rxn_model.py'))
         m = model_builder.build_model()
         m.basic_step = apply_basic_step([m.reactor_choice, m.max_demand])
         for disj in m.basic_step.disjuncts.values():
-            self.assertEqual(
-                disj.improper_constraints[1].body.polynomial_degree(), 2)
-            self.assertEqual(
-                disj.improper_constraints[1].lower, None)
-            self.assertEqual(
-                disj.improper_constraints[1].upper, 2)
-            self.assertEqual(
-                len(disj.improper_constraints), 1)
+            self.assertEqual(disj.improper_constraints[1].body.polynomial_degree(), 2)
+            self.assertEqual(disj.improper_constraints[1].lower, None)
+            self.assertEqual(disj.improper_constraints[1].upper, 2)
+            self.assertEqual(len(disj.improper_constraints), 1)
         self.assertFalse(m.max_demand.active)
 
     def test_improper_basic_step_linear(self):
-        model_builder = import_file(
-            join(exdir, 'two_rxn_lee', 'two_rxn_model.py'))
+        model_builder = import_file(join(exdir, 'two_rxn_lee', 'two_rxn_model.py'))
         m = model_builder.build_model(use_mccormick=True)
-        m.basic_step = apply_basic_step([
-            m.reactor_choice, m.max_demand, m.mccormick_1, m.mccormick_2])
+        m.basic_step = apply_basic_step(
+            [m.reactor_choice, m.max_demand, m.mccormick_1, m.mccormick_2]
+        )
         for disj in m.basic_step.disjuncts.values():
-            self.assertIs(
-                disj.improper_constraints[1].body, m.P)
-            self.assertEqual(
-                disj.improper_constraints[1].lower, None)
-            self.assertEqual(
-                disj.improper_constraints[1].upper, 2)
-            self.assertEqual(
-                disj.improper_constraints[2].body.polynomial_degree(), 1)
-            self.assertEqual(
-                disj.improper_constraints[2].lower, None)
-            self.assertEqual(
-                disj.improper_constraints[2].upper, 0)
-            self.assertEqual(
-                disj.improper_constraints[3].body.polynomial_degree(), 1)
-            self.assertEqual(
-                disj.improper_constraints[3].lower, None)
-            self.assertEqual(
-                disj.improper_constraints[3].upper, 0)
-            self.assertEqual(
-                len(disj.improper_constraints), 3)
+            self.assertIs(disj.improper_constraints[1].body, m.P)
+            self.assertEqual(disj.improper_constraints[1].lower, None)
+            self.assertEqual(disj.improper_constraints[1].upper, 2)
+            self.assertEqual(disj.improper_constraints[2].body.polynomial_degree(), 1)
+            self.assertEqual(disj.improper_constraints[2].lower, None)
+            self.assertEqual(disj.improper_constraints[2].upper, 0)
+            self.assertEqual(disj.improper_constraints[3].body.polynomial_degree(), 1)
+            self.assertEqual(disj.improper_constraints[3].lower, None)
+            self.assertEqual(disj.improper_constraints[3].upper, 0)
+            self.assertEqual(len(disj.improper_constraints), 3)
         self.assertFalse(m.max_demand.active)
         self.assertFalse(m.mccormick_1.active)
         self.assertFalse(m.mccormick_2.active)
@@ -101,19 +87,21 @@ class TestBasicStep(unittest.TestCase):
 
     def test_improper_basic_step_constraintData(self):
         m = models.makeTwoTermDisj()
+
         @m.Constraint([1, 2])
         def indexed(m, i):
             return m.x <= m.a + i
 
         m.basic_step = apply_basic_step([m.disjunction, m.indexed[1]])
         self.check_after_improper_basic_step(m)
-        
+
         self.assertFalse(m.indexed[1].active)
         self.assertTrue(m.indexed[2].active)
         self.assertFalse(m.disjunction.active)
 
     def test_improper_basic_step_indexedConstraint(self):
         m = models.makeTwoTermDisj()
+
         @m.Constraint([1, 2])
         def indexed(m, i):
             return m.x <= m.a + i
@@ -133,8 +121,12 @@ class TestBasicStep(unittest.TestCase):
 
         m.basic_step = apply_basic_step([m.disjunction, m.simple])
 
-        refs = [v for v in m.basic_step.component_data_objects(
-            BooleanVar, sort=SortComponents.deterministic)]
+        refs = [
+            v
+            for v in m.basic_step.component_data_objects(
+                BooleanVar, sort=SortComponents.deterministic
+            )
+        ]
         self.assertEqual(len(refs), 2)
         self.assertIs(refs[0][None], m.d[0].indicator_var)
         self.assertIs(refs[1][None], m.d[1].indicator_var)
@@ -144,12 +136,15 @@ class TestBasicStep(unittest.TestCase):
         m.simple = Constraint(expr=m.x <= m.a + 1)
 
         with self.assertRaisesRegex(
-                ValueError, 'apply_basic_step only accepts a list containing '
-                'Disjunctions or Constraints'):
+            ValueError,
+            'apply_basic_step only accepts a list containing '
+            'Disjunctions or Constraints',
+        ):
             apply_basic_step([m.disjunction, m.simple, m.x])
         with self.assertRaisesRegex(
-                ValueError, 'apply_basic_step: argument list must contain at '
-                'least one Disjunction'):
+            ValueError,
+            'apply_basic_step: argument list must contain at least one Disjunction',
+        ):
             apply_basic_step([m.simple, m.simple])
 
 

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -13,13 +13,24 @@ from pyomo.common.dependencies import dill_available
 import pyomo.common.unittest as unittest
 from pyomo.common.deprecation import RenamedClass
 
-from pyomo.environ import (TransformationFactory, Block, Set, Constraint,
-                           ComponentMap, Suffix, ConcreteModel, Var,
-                           Any, value)
+from pyomo.environ import (
+    TransformationFactory,
+    Block,
+    Set,
+    Constraint,
+    ComponentMap,
+    Suffix,
+    ConcreteModel,
+    Var,
+    Any,
+    value,
+)
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 from pyomo.core.base import constraint, _ConstraintData
 from pyomo.core.expr.compare import (
-    assertExpressionsEqual, assertExpressionsStructurallyEqual)
+    assertExpressionsEqual,
+    assertExpressionsStructurallyEqual,
+)
 from pyomo.repn import generate_standard_repn
 from pyomo.common.log import LoggingIntercept
 import logging
@@ -33,9 +44,11 @@ import random
 
 from io import StringIO
 
+
 class CommonTests:
     def diff_apply_to_and_create_using(self, model):
         ct.diff_apply_to_and_create_using(self, model, 'gdp.bigm')
+
 
 class TwoTermDisj(unittest.TestCase, CommonTests):
     def setUp(self):
@@ -88,7 +101,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
         # we are counting on the fact that the disjuncts get relaxed in the
         # same order every time.
-        for i in [0,1]:
+        for i in [0, 1]:
             self.assertIs(oldblock[i].transformation_block, disjBlock[i])
             self.assertIs(bigm.get_src_disjunct(disjBlock[i]), oldblock[i])
 
@@ -154,8 +167,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         ct.check_improperly_deactivated_disjuncts(self, 'bigm')
 
     def test_do_not_transform_userDeactivated_IndexedDisjunction(self):
-        ct.check_do_not_transform_userDeactivated_indexedDisjunction(self,
-                                                                     'bigm')
+        ct.check_do_not_transform_userDeactivated_indexedDisjunction(self, 'bigm')
 
     # helper method to check the M values in all of the transformed
     # constraints (m, M) is the tuple for M.  This also relies on the
@@ -300,7 +312,8 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
             "and upper sides of the constraint respectively.*",
             TransformationFactory('gdp.bigm').apply_to,
             m,
-            bigM=(-18, 19.2, 3))
+            bigM=(-18, 19.2, 3),
+        )
 
     def test_singleArg_M_list(self):
         m = models.makeTwoTermDisj()
@@ -327,7 +340,8 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
             r"tuple or list of length two*",
             TransformationFactory('gdp.bigm').apply_to,
             m,
-            bigM=[-18, 19.2, 3])
+            bigM=[-18, 19.2, 3],
+        )
 
     def test_arg_M_simpleConstraint(self):
         m = models.makeTwoTermDisj()
@@ -341,21 +355,14 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
         # give an arg
         bigm = TransformationFactory('gdp.bigm')
-        bigm.apply_to(
-            m,
-            bigM={None: 19,
-                  m.d[0].c: 18,
-                  m.d[1].c1: 17,
-                  m.d[1].c2: 16})
+        bigm.apply_to(m, bigM={None: 19, m.d[0].c: 18, m.d[1].c1: 17, m.d[1].c2: 16})
         self.checkMs(m, bigm, -18, -17, 17, 16)
 
     def test_tuple_M_arg(self):
         m = models.makeTwoTermDisj()
         # give a tuple arg
         bigm = TransformationFactory('gdp.bigm')
-        bigm.apply_to(
-            m,
-            bigM={None: (-20,19)})
+        bigm.apply_to(m, bigM={None: (-20, 19)})
         self.checkMs(m, bigm, -20, -20, 19, 19)
 
     def test_tuple_M_suffix(self):
@@ -370,9 +377,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         m = models.makeTwoTermDisj()
         # give a tuple arg
         bigm = TransformationFactory('gdp.bigm')
-        bigm.apply_to(
-            m,
-            bigM={None: [-20,19]})
+        bigm.apply_to(m, bigM={None: [-20, 19]})
         self.checkMs(m, bigm, -20, -20, 19, 19)
 
     def test_list_M_suffix(self):
@@ -385,7 +390,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
     def test_tuple_wrong_length_err(self):
         m = models.makeTwoTermDisj()
-        M = (-20,19, 32)
+        M = (-20, 19, 32)
         self.assertRaisesRegex(
             GDP_Error,
             r"Big-M \(-20, 19, 32\) for constraint d\[0\].c is not of "
@@ -393,7 +398,8 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
             r"tuple or list of length two*",
             TransformationFactory('gdp.bigm').apply_to,
             m,
-            bigM={None: M})
+            bigM={None: M},
+        )
 
     def test_list_wrong_length_err(self):
         m = models.makeTwoTermDisj()
@@ -405,7 +411,8 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
             r"tuple or list of length two*",
             TransformationFactory('gdp.bigm').apply_to,
             m,
-            bigM={None: M})
+            bigM={None: M},
+        )
 
     def test_create_using(self):
         m = models.makeTwoTermDisj()
@@ -413,14 +420,17 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
     def test_indexed_constraints_in_disjunct(self):
         m = ConcreteModel()
-        m.I = [1,2,3]
-        m.x = Var(m.I, bounds=(0,10))
-        def c_rule(b,i):
+        m.I = [1, 2, 3]
+        m.x = Var(m.I, bounds=(0, 10))
+
+        def c_rule(b, i):
             m = b.model()
             return m.x[i] >= i
-        def d_rule(d,j):
+
+        def d_rule(d, j):
             m = d.model()
             d.c = Constraint(m.I[:j], rule=c_rule)
+
         m.d = Disjunct(m.I, rule=d_rule)
         m.disjunction = Disjunction(expr=[m.d[i] for i in m.I])
 
@@ -428,31 +438,29 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         transBlock = m._pyomo_gdp_bigm_reformulation
 
         # 2 blocks: the original Disjunct and the transformation block
-        self.assertEqual(
-            len(list(m.component_objects(Block, descend_into=False))), 1)
-        self.assertEqual(
-            len(list(m.component_objects(Disjunct))), 1)
+        self.assertEqual(len(list(m.component_objects(Block, descend_into=False))), 1)
+        self.assertEqual(len(list(m.component_objects(Disjunct))), 1)
 
         # Each relaxed disjunct should have 1 var (the reference to the
         # indicator var), and i "d[i].c" Constraints
-        for i in [1,2,3]:
-            relaxed = transBlock.relaxedDisjuncts[i-1]
+        for i in [1, 2, 3]:
+            relaxed = transBlock.relaxedDisjuncts[i - 1]
             self.assertEqual(len(list(relaxed.component_objects(Var))), 1)
             self.assertEqual(len(list(relaxed.component_data_objects(Var))), 1)
-            self.assertEqual(
-                len(list(relaxed.component_objects(Constraint))), 1)
-            self.assertEqual(
-                len(list(relaxed.component_data_objects(Constraint))), i)
+            self.assertEqual(len(list(relaxed.component_objects(Constraint))), 1)
+            self.assertEqual(len(list(relaxed.component_data_objects(Constraint))), i)
 
     def test_virtual_indexed_constraints_in_disjunct(self):
         m = ConcreteModel()
-        m.I = [1,2,3]
-        m.x = Var(m.I, bounds=(0,10))
-        def d_rule(d,j):
+        m.I = [1, 2, 3]
+        m.x = Var(m.I, bounds=(0, 10))
+
+        def d_rule(d, j):
             m = d.model()
             d.c = Constraint(Any)
             for k in range(j):
-                d.c[k+1] = m.x[k+1] >= k+1
+                d.c[k + 1] = m.x[k + 1] >= k + 1
+
         m.d = Disjunct(m.I, rule=d_rule)
         m.disjunction = Disjunction(expr=[m.d[i] for i in m.I])
 
@@ -460,21 +468,17 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         transBlock = m._pyomo_gdp_bigm_reformulation
 
         # 2 blocks: the original Disjunct and the transformation block
-        self.assertEqual(
-            len(list(m.component_objects(Block, descend_into=False))), 1)
-        self.assertEqual(
-            len(list(m.component_objects(Disjunct))), 1)
+        self.assertEqual(len(list(m.component_objects(Block, descend_into=False))), 1)
+        self.assertEqual(len(list(m.component_objects(Disjunct))), 1)
 
         # Each relaxed disjunct should have 1 var (the reference to the
         # indicator var), and i "d[i].c" Constraints
-        for i in [1,2,3]:
-            relaxed = transBlock.relaxedDisjuncts[i-1]
+        for i in [1, 2, 3]:
+            relaxed = transBlock.relaxedDisjuncts[i - 1]
             self.assertEqual(len(list(relaxed.component_objects(Var))), 1)
             self.assertEqual(len(list(relaxed.component_data_objects(Var))), 1)
-            self.assertEqual(
-                len(list(relaxed.component_objects(Constraint))), 1)
-            self.assertEqual(
-                len(list(relaxed.component_data_objects(Constraint))), i)
+            self.assertEqual(len(list(relaxed.component_objects(Constraint))), 1)
+            self.assertEqual(len(list(relaxed.component_data_objects(Constraint))), i)
 
     def test_local_var(self):
         m = models.localVar()
@@ -493,6 +497,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         repn = generate_standard_repn(ub.body)
         self.assertTrue(repn.is_linear())
         ct.check_linear_coef(self, repn, m.disj2.indicator_var, 3)
+
 
 class TwoTermDisjNonlinear(unittest.TestCase, CommonTests):
     def test_nonlinear_bigM(self):
@@ -524,16 +529,19 @@ class TwoTermDisjNonlinear(unittest.TestCase, CommonTests):
             r"expressions.\n\t\(found while processing "
             r"constraint 'd\[0\].c'\)",
             TransformationFactory('gdp.bigm').apply_to,
-            m)
+            m,
+        )
 
     def test_nonlinear_disjoint(self):
         m = ConcreteModel()
         x = m.x = Var(bounds=(-4, 4))
         y = m.y = Var(bounds=(-10, 10))
-        m.disj = Disjunction(expr=[
-            [x**2 + y**2 <= 2, x**3 + y**2 + x * y >= 1.0/2.0],
-            [(x - 3)**2 + (y - 3)**2 <= 1]
-        ])
+        m.disj = Disjunction(
+            expr=[
+                [x**2 + y**2 <= 2, x**3 + y**2 + x * y >= 1.0 / 2.0],
+                [(x - 3) ** 2 + (y - 3) ** 2 <= 1],
+            ]
+        )
         bigm = TransformationFactory('gdp.bigm')
         bigm.apply_to(m)
         disjBlock = m._pyomo_gdp_bigm_reformulation.relaxedDisjuncts
@@ -547,8 +555,7 @@ class TwoTermDisjNonlinear(unittest.TestCase, CommonTests):
         self.assertEqual(len(repn.linear_vars), 1)
         ct.check_linear_coef(self, repn, m.disj_disjuncts[0].indicator_var, 114)
         self.assertEqual(repn.constant, -114)
-        self.assertEqual(c_ub.upper,
-                         m.disj_disjuncts[0].constraint[1].upper)
+        self.assertEqual(c_ub.upper, m.disj_disjuncts[0].constraint[1].upper)
         self.assertIsNone(c_ub.lower)
         # first disjunct, second constraint
         c = bigm.get_transformed_constraints(m.disj_disjuncts[0].constraint[2])
@@ -557,11 +564,9 @@ class TwoTermDisjNonlinear(unittest.TestCase, CommonTests):
         repn = generate_standard_repn(c_lb.body)
         self.assertFalse(repn.is_linear())
         self.assertEqual(len(repn.linear_vars), 1)
-        ct.check_linear_coef(self, repn, m.disj_disjuncts[0].indicator_var,
-                             -104.5)
+        ct.check_linear_coef(self, repn, m.disj_disjuncts[0].indicator_var, -104.5)
         self.assertEqual(repn.constant, 104.5)
-        self.assertEqual(c_lb.lower,
-                         m.disj_disjuncts[0].constraint[2].lower)
+        self.assertEqual(c_lb.lower, m.disj_disjuncts[0].constraint[2].lower)
         self.assertIsNone(c_lb.upper)
         # second disjunct, first constraint
         c = bigm.get_transformed_constraints(m.disj_disjuncts[1].constraint[1])
@@ -574,8 +579,7 @@ class TwoTermDisjNonlinear(unittest.TestCase, CommonTests):
         ct.check_linear_coef(self, repn, m.y, -6)
         ct.check_linear_coef(self, repn, m.disj_disjuncts[1].indicator_var, 217)
         self.assertEqual(repn.constant, -199)
-        self.assertEqual(c_ub.upper,
-                         m.disj_disjuncts[1].constraint[1].upper)
+        self.assertEqual(c_ub.upper, m.disj_disjuncts[1].constraint[1].upper)
         self.assertIsNone(c_ub.lower)
 
 
@@ -588,14 +592,14 @@ class TwoTermIndexedDisj(unittest.TestCase, CommonTests):
         # block. This is needed in multiple tests, so I am storing it
         # here.
         self.pairs = [
-            ( (0,1,'A'), 0 ),
-            ( (1,1,'A'), 1 ),
-            ( (0,1,'B'), 2 ),
-            ( (1,1,'B'), 3 ),
-            ( (0,2,'A'), 4 ),
-            ( (1,2,'A'), 5 ),
-            ( (0,2,'B'), 6 ),
-            ( (1,2,'B'), 7 ),
+            ((0, 1, 'A'), 0),
+            ((1, 1, 'A'), 1),
+            ((0, 1, 'B'), 2),
+            ((1, 1, 'B'), 3),
+            ((0, 2, 'A'), 4),
+            ((1, 2, 'A'), 5),
+            ((0, 2, 'B'), 6),
+            ((1, 2, 'B'), 7),
         ]
 
     def test_xor_constraints(self):
@@ -615,7 +619,7 @@ class TwoTermIndexedDisj(unittest.TestCase, CommonTests):
         self.assertEqual(len(disjBlock), 8)
 
         # check that all 8 blocks have exactly one constraint on them.
-        for i,j in self.pairs:
+        for i, j in self.pairs:
             self.assertEqual(len(disjBlock[j].component_map(Constraint)), 1)
 
     def test_disjunct_and_constraint_maps(self):
@@ -632,10 +636,8 @@ class TwoTermIndexedDisj(unittest.TestCase, CommonTests):
         for src, dest in self.pairs:
             srcDisjunct = oldblock[src]
             transformedDisjunct = disjBlock[dest]
-            self.assertIs(bigm.get_src_disjunct(transformedDisjunct),
-                          srcDisjunct)
-            self.assertIs(transformedDisjunct,
-                          srcDisjunct.transformation_block)
+            self.assertIs(bigm.get_src_disjunct(transformedDisjunct), srcDisjunct)
+            self.assertIs(transformedDisjunct, srcDisjunct.transformation_block)
 
             transformed = bigm.get_transformed_constraints(srcDisjunct.c)
             if src[0]:
@@ -643,17 +645,14 @@ class TwoTermIndexedDisj(unittest.TestCase, CommonTests):
                 self.assertEqual(len(transformed), 2)
                 self.assertIsInstance(transformed[0], _ConstraintData)
                 self.assertIsInstance(transformed[1], _ConstraintData)
-                self.assertIs(bigm.get_src_constraint(transformed[0]),
-                              srcDisjunct.c)
-                self.assertIs(bigm.get_src_constraint(transformed[1]),
-                              srcDisjunct.c)
+                self.assertIs(bigm.get_src_constraint(transformed[0]), srcDisjunct.c)
+                self.assertIs(bigm.get_src_constraint(transformed[1]), srcDisjunct.c)
             else:
                 # >=
                 self.assertEqual(len(transformed), 1)
                 self.assertIsInstance(transformed[0], _ConstraintData)
                 # check reverse map from the container
-                self.assertIs(bigm.get_src_constraint(transformed[0]),
-                              srcDisjunct.c)
+                self.assertIs(bigm.get_src_constraint(transformed[0]), srcDisjunct.c)
 
     def test_deactivated_disjuncts(self):
         ct.check_deactivated_disjuncts(self, 'bigm')
@@ -664,6 +663,7 @@ class TwoTermIndexedDisj(unittest.TestCase, CommonTests):
     def test_create_using(self):
         m = models.makeTwoTermMultiIndexedDisjunction()
         self.diff_apply_to_and_create_using(m)
+
 
 class DisjOnBlock(unittest.TestCase, CommonTests):
     # when the disjunction is on a block, we want all of the stuff created by
@@ -686,13 +686,11 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         repn = generate_standard_repn(lb.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(repn.constant, -disj1c1lb)
-        ct.check_linear_coef(
-            self, repn, model.b.disjunct[0].indicator_var, disj1c1lb)
+        ct.check_linear_coef(self, repn, model.b.disjunct[0].indicator_var, disj1c1lb)
         repn = generate_standard_repn(ub.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(repn.constant, -disj1c1ub)
-        ct.check_linear_coef(
-            self, repn, model.b.disjunct[0].indicator_var, disj1c1ub)
+        ct.check_linear_coef(self, repn, model.b.disjunct[0].indicator_var, disj1c1ub)
 
         c2 = bigm.get_transformed_constraints(model.b.disjunct[1].c)
         self.assertEqual(len(c2), 1)
@@ -700,8 +698,7 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         repn = generate_standard_repn(ub.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(repn.constant, -disj1c2)
-        ct.check_linear_coef(
-            self, repn, model.b.disjunct[1].indicator_var, disj1c2)
+        ct.check_linear_coef(self, repn, model.b.disjunct[1].indicator_var, disj1c2)
 
     def checkMs(self, model, disj1c1lb, disj1c1ub, disj1c2, disj2c1, disj2c2):
         bigm = TransformationFactory('gdp.bigm')
@@ -713,8 +710,7 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         repn = generate_standard_repn(lb.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(repn.constant, -disj2c1)
-        ct.check_linear_coef(
-            self, repn, model.simpledisj.indicator_var, disj2c1)
+        ct.check_linear_coef(self, repn, model.simpledisj.indicator_var, disj2c1)
 
         c = bigm.get_transformed_constraints(model.simpledisj2.c)
         self.assertEqual(len(c), 1)
@@ -722,8 +718,7 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         repn = generate_standard_repn(ub.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(repn.constant, -disj2c2)
-        ct.check_linear_coef(
-            self, repn, model.simpledisj2.indicator_var, disj2c2)
+        ct.check_linear_coef(self, repn, model.simpledisj2.indicator_var, disj2c2)
 
     def test_suffix_M_onBlock(self):
         m = models.makeTwoTermDisjOnBlock()
@@ -739,8 +734,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.checkMs(m, -34, 34, 34, -3, 1.5)
 
         # check the source of the values
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.simpledisj.c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.simpledisj.c
+        )
         self.assertIsNone(l_src)
         self.assertIsNone(u_src)
         self.assertIsNone(l_key)
@@ -751,8 +747,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -3)
         self.assertIsNone(u_val)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.simpledisj2.c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.simpledisj2.c
+        )
         self.assertIsNone(l_src)
         self.assertIsNone(u_src)
         self.assertIsNone(l_key)
@@ -763,8 +760,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertIsNone(l_val)
         self.assertEqual(u_val, 1.5)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.b.disjunct[0].c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.b.disjunct[0].c
+        )
         self.assertIs(l_src, m.b.BigM)
         self.assertIs(u_src, m.b.BigM)
         self.assertIsNone(l_key)
@@ -775,8 +773,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -34)
         self.assertEqual(u_val, 34)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.b.disjunct[1].c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.b.disjunct[1].c
+        )
         self.assertIsNone(l_src)
         self.assertIs(u_src, m.b.BigM)
         self.assertIsNone(l_key)
@@ -796,8 +795,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.checkMs(m, -100, 100, 13, -3, 1.5)
 
         # check the source of the values
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.simpledisj.c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.simpledisj.c
+        )
         self.assertIsNone(l_src)
         self.assertIsNone(u_src)
         self.assertIsNone(l_key)
@@ -808,8 +808,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -3)
         self.assertIsNone(u_val)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.simpledisj2.c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.simpledisj2.c
+        )
         self.assertIsNone(l_src)
         self.assertIsNone(u_src)
         self.assertIsNone(l_key)
@@ -820,8 +821,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertIsNone(l_val)
         self.assertEqual(u_val, 1.5)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.b.disjunct[0].c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.b.disjunct[0].c
+        )
         self.assertIs(l_src, bigms)
         self.assertIs(u_src, bigms)
         self.assertIs(l_key, m.b)
@@ -832,8 +834,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -100)
         self.assertEqual(u_val, 100)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.b.disjunct[1].c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.b.disjunct[1].c
+        )
         self.assertIsNone(l_src)
         self.assertIs(u_src, bigms)
         self.assertIsNone(l_key)
@@ -853,8 +856,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.checkMs(m, -100, 100, 13, -3, 1.5)
 
         # check the source of the values
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.simpledisj.c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.simpledisj.c
+        )
         self.assertIsNone(l_src)
         self.assertIsNone(u_src)
         self.assertIsNone(l_key)
@@ -865,8 +869,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -3)
         self.assertIsNone(u_val)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.simpledisj2.c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.simpledisj2.c
+        )
         self.assertIsNone(l_src)
         self.assertIsNone(u_src)
         self.assertIsNone(l_key)
@@ -877,8 +882,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertIsNone(l_val)
         self.assertEqual(u_val, 1.5)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.b.disjunct[0].c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.b.disjunct[0].c
+        )
         self.assertIs(l_src, bigms)
         self.assertIs(u_src, bigms)
         self.assertIs(l_key, m.b)
@@ -889,8 +895,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -100)
         self.assertEqual(u_val, 100)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.b.disjunct[1].c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.b.disjunct[1].c
+        )
         self.assertIsNone(l_src)
         self.assertIs(u_src, bigms)
         self.assertIsNone(l_key)
@@ -905,14 +912,19 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         m = models.makeTwoTermDisjOnBlock()
         m = models.add_disj_not_on_block(m)
         bigm = TransformationFactory('gdp.bigm')
-        bigms = {m.b: 100, m.b.disjunct[1].c: 13,
-                 m.b.disjunct[0].c: (None, 50), None: 34}
+        bigms = {
+            m.b: 100,
+            m.b.disjunct[1].c: 13,
+            m.b.disjunct[0].c: (None, 50),
+            None: 34,
+        }
         bigm.apply_to(m, bigM=bigms)
         self.checkMs(m, -100, 50, 13, -34, 34)
 
         # check the source of the values
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.simpledisj.c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.simpledisj.c
+        )
         self.assertIs(l_src, bigms)
         self.assertIsNone(u_src)
         self.assertIsNone(l_key)
@@ -923,8 +935,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -34)
         self.assertIsNone(u_val)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.simpledisj2.c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.simpledisj2.c
+        )
         self.assertIsNone(l_src)
         self.assertIs(u_src, bigms)
         self.assertIsNone(l_key)
@@ -935,8 +948,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertIsNone(l_val)
         self.assertEqual(u_val, 34)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.b.disjunct[0].c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.b.disjunct[0].c
+        )
         self.assertIs(l_src, bigms)
         self.assertIs(u_src, bigms)
         self.assertIs(l_key, m.b)
@@ -947,8 +961,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -100)
         self.assertEqual(u_val, 50)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.b.disjunct[1].c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.b.disjunct[1].c
+        )
         self.assertIsNone(l_src)
         self.assertIs(u_src, bigms)
         self.assertIsNone(l_key)
@@ -965,9 +980,8 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         out = StringIO()
         with LoggingIntercept(out, 'pyomo.gdp.bigm'):
             TransformationFactory('gdp.bigm').apply_to(
-                m,
-                bigM={m: 100,
-                      m.b.disjunct[1].c: 13})
+                m, bigM={m: 100, m.b.disjunct[1].c: 13}
+            )
         self.checkMs(m, -100, 100, 13, -100, 100)
         # make sure we didn't get any warnings when we used all the args
         self.assertEqual(out.getvalue(), '')
@@ -978,15 +992,15 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         out = StringIO()
         with LoggingIntercept(out, 'pyomo.gdp.bigm'):
             TransformationFactory('gdp.bigm').apply_to(
-                m,
-                bigM={m: 100,
-                      m.b.disjunct[1].c: 13,
-                      None: 34})
+                m, bigM={m: 100, m.b.disjunct[1].c: 13, None: 34}
+            )
         self.checkMs(m, -100, 100, 13, -100, 100)
-        self.assertEqual(out.getvalue(),
-                         "Unused arguments in the bigM map! "
-                         "These arguments were not used by the "
-                         "transformation:\n\tNone\n\n")
+        self.assertEqual(
+            out.getvalue(),
+            "Unused arguments in the bigM map! "
+            "These arguments were not used by the "
+            "transformation:\n\tNone\n\n",
+        )
 
     def test_warning_for_crazy_bigm_args(self):
         m = models.makeTwoTermDisjOnBlock()
@@ -996,12 +1010,14 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         # this is silly
         bigM[m.a] = 34
         with LoggingIntercept(out, 'pyomo.gdp.bigm'):
-            TransformationFactory('gdp.bigm').apply_to( m, bigM=bigM)
+            TransformationFactory('gdp.bigm').apply_to(m, bigM=bigM)
         self.checkMs(m, -100, 100, 13, -100, 100)
-        self.assertEqual(out.getvalue(),
-                         "Unused arguments in the bigM map! "
-                         "These arguments were not used by the "
-                         "transformation:\n\ta\n\n")
+        self.assertEqual(
+            out.getvalue(),
+            "Unused arguments in the bigM map! "
+            "These arguments were not used by the "
+            "transformation:\n\ta\n\n",
+        )
 
     def test_use_above_scope_m_value(self):
         m = models.makeTwoTermDisjOnBlock()
@@ -1011,7 +1027,7 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         # transform just the block. We expect to use the M value specified on
         # the model, and we should comment on nothing.
         with LoggingIntercept(out, 'pyomo.gdp.bigm'):
-            TransformationFactory('gdp.bigm').apply_to( m.b, bigM=bigM)
+            TransformationFactory('gdp.bigm').apply_to(m.b, bigM=bigM)
         self.checkFirstDisjMs(m, -100, 100, 13)
         self.assertEqual(out.getvalue(), '')
 
@@ -1027,19 +1043,19 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         out = StringIO()
         with LoggingIntercept(out, 'pyomo.gdp.bigm'):
             TransformationFactory('gdp.bigm').apply_to(
-                m.b,
-                bigM={m: 100,
-                      m.b: 13,
-                      m.simpledisj2.c: 10})
+                m.b, bigM={m: 100, m.b: 13, m.simpledisj2.c: 10}
+            )
 
         self.checkFirstDisjMs(m, -13, 13, 13)
 
         # The order these get printed depends on a dictionary order, so test
         # this way...
-        self.assertIn("Unused arguments in the bigM map! "
-                      "These arguments were not used by the "
-                      "transformation:",
-                      out.getvalue())
+        self.assertIn(
+            "Unused arguments in the bigM map! "
+            "These arguments were not used by the "
+            "transformation:",
+            out.getvalue(),
+        )
         self.assertIn("simpledisj2.c", out.getvalue())
         self.assertIn("unknown", out.getvalue())
 
@@ -1056,8 +1072,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.checkMs(m, -20, 20, 20, -45, 20)
 
         # check source of the m values
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.simpledisj.c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.simpledisj.c
+        )
         self.assertIs(l_src, m.simpledisj.BigM)
         self.assertIsNone(u_src)
         self.assertIsNone(l_key)
@@ -1068,8 +1085,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -45)
         self.assertIsNone(u_val)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.simpledisj2.c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.simpledisj2.c
+        )
         self.assertIsNone(l_src)
         self.assertIs(u_src, m.BigM)
         self.assertIsNone(l_key)
@@ -1080,8 +1098,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertIsNone(l_val)
         self.assertEqual(u_val, 20)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.b.disjunct[0].c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.b.disjunct[0].c
+        )
         self.assertIs(l_src, m.BigM)
         self.assertIs(u_src, m.BigM)
         self.assertIsNone(l_key)
@@ -1092,8 +1111,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -20)
         self.assertEqual(u_val, 20)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.b.disjunct[1].c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.b.disjunct[1].c
+        )
         self.assertIsNone(l_src)
         self.assertIs(u_src, m.BigM)
         self.assertIsNone(l_key)
@@ -1139,8 +1159,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.checkMs(m, -15, 20, 20, -87, 20)
 
         # check source of the m values
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.simpledisj.c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.simpledisj.c
+        )
         self.assertIs(l_src, m.simpledisj.BigM)
         self.assertIsNone(u_src)
         self.assertIs(l_key, m.simpledisj.c)
@@ -1151,8 +1172,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -87)
         self.assertIsNone(u_val)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.simpledisj2.c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.simpledisj2.c
+        )
         self.assertIsNone(l_src)
         self.assertIs(u_src, m.BigM)
         self.assertIsNone(l_key)
@@ -1163,8 +1185,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertIsNone(l_val)
         self.assertEqual(u_val, 20)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.b.disjunct[0].c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.b.disjunct[0].c
+        )
         self.assertIs(l_src, bigms)
         self.assertIs(u_src, m.BigM)
         self.assertIs(l_key, m.b.disjunct[0].c)
@@ -1175,8 +1198,9 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -15)
         self.assertEqual(u_val, 20)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.b.disjunct[1].c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.b.disjunct[1].c
+        )
         self.assertIsNone(l_src)
         self.assertIs(u_src, m.BigM)
         self.assertIsNone(l_key)
@@ -1215,7 +1239,8 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
             r"came from different sources, please use the "
             r"get_M_value_src method.",
             bigm.get_m_value_src,
-            m.b.disjunct[0].c)
+            m.b.disjunct[0].c,
+        )
         (src, key) = bigm.get_m_value_src(m.b.disjunct[1].c)
         self.assertIs(src, m.BigM)
         self.assertIsNone(key)
@@ -1284,10 +1309,12 @@ class ScalarDisjIndexedConstraints(unittest.TestCase, CommonTests):
                 KeyError,
                 r".*b.simpledisj1.c\[1\]",
                 bigm.get_transformed_constraints,
-                m.b.simpledisj1.c[1])
-        self.assertRegex(log.getvalue(),
-                         r".*Constraint 'b.simpledisj1.c\[1\]' "
-                         r"has not been transformed.")
+                m.b.simpledisj1.c[1],
+            )
+        self.assertRegex(
+            log.getvalue(),
+            r".*Constraint 'b.simpledisj1.c\[1\]' " r"has not been transformed.",
+        )
 
         # and the rest of the container was transformed
         cons_list = bigm.get_transformed_constraints(m.b.simpledisj1.c[2])
@@ -1297,8 +1324,9 @@ class ScalarDisjIndexedConstraints(unittest.TestCase, CommonTests):
         self.assertIsInstance(lb, constraint._GeneralConstraintData)
         self.assertIsInstance(ub, constraint._GeneralConstraintData)
 
-    def checkMs(self, m, disj1c1lb, disj1c1ub, disj1c2lb, disj1c2ub, disj2c1ub,
-                disj2c2ub):
+    def checkMs(
+        self, m, disj1c1lb, disj1c1ub, disj1c2lb, disj1c2ub, disj2c1ub, disj2c2ub
+    ):
         bigm = TransformationFactory('gdp.bigm')
         m_values = bigm.get_all_M_values_by_constraint(m)
 
@@ -1309,13 +1337,11 @@ class ScalarDisjIndexedConstraints(unittest.TestCase, CommonTests):
         repn = generate_standard_repn(lb.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(repn.constant, -disj1c1lb)
-        ct.check_linear_coef(
-            self, repn, m.b.simpledisj1.indicator_var, disj1c1lb)
+        ct.check_linear_coef(self, repn, m.b.simpledisj1.indicator_var, disj1c1lb)
         repn = generate_standard_repn(ub.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(repn.constant, -disj1c1ub)
-        ct.check_linear_coef(
-            self, repn, m.b.simpledisj1.indicator_var, disj1c1ub)
+        ct.check_linear_coef(self, repn, m.b.simpledisj1.indicator_var, disj1c1ub)
         self.assertIn(m.b.simpledisj1.c[1], m_values.keys())
         self.assertEqual(m_values[m.b.simpledisj1.c[1]][0], disj1c1lb)
         self.assertEqual(m_values[m.b.simpledisj1.c[1]][1], disj1c1ub)
@@ -1327,13 +1353,11 @@ class ScalarDisjIndexedConstraints(unittest.TestCase, CommonTests):
         repn = generate_standard_repn(lb.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(repn.constant, -disj1c2lb)
-        ct.check_linear_coef(
-            self, repn, m.b.simpledisj1.indicator_var, disj1c2lb)
+        ct.check_linear_coef(self, repn, m.b.simpledisj1.indicator_var, disj1c2lb)
         repn = generate_standard_repn(ub.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(repn.constant, -disj1c2ub)
-        ct.check_linear_coef(
-            self, repn, m.b.simpledisj1.indicator_var, disj1c2ub)
+        ct.check_linear_coef(self, repn, m.b.simpledisj1.indicator_var, disj1c2ub)
         self.assertIn(m.b.simpledisj1.c[2], m_values.keys())
         self.assertEqual(m_values[m.b.simpledisj1.c[2]][0], disj1c2lb)
         self.assertEqual(m_values[m.b.simpledisj1.c[2]][1], disj1c2ub)
@@ -1344,8 +1368,7 @@ class ScalarDisjIndexedConstraints(unittest.TestCase, CommonTests):
         repn = generate_standard_repn(ub.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(repn.constant, -disj2c1ub)
-        ct.check_linear_coef(
-            self, repn, m.b.simpledisj2.indicator_var, disj2c1ub)
+        ct.check_linear_coef(self, repn, m.b.simpledisj2.indicator_var, disj2c1ub)
         self.assertIn(m.b.simpledisj2.c[1], m_values.keys())
         self.assertEqual(m_values[m.b.simpledisj2.c[1]][1], disj2c1ub)
         self.assertIsNone(m_values[m.b.simpledisj2.c[1]][0])
@@ -1356,8 +1379,7 @@ class ScalarDisjIndexedConstraints(unittest.TestCase, CommonTests):
         repn = generate_standard_repn(ub.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(repn.constant, -disj2c2ub)
-        ct.check_linear_coef(
-            self, repn, m.b.simpledisj2.indicator_var, disj2c2ub)
+        ct.check_linear_coef(self, repn, m.b.simpledisj2.indicator_var, disj2c2ub)
         self.assertIn(m.b.simpledisj2.c[2], m_values.keys())
         self.assertEqual(m_values[m.b.simpledisj2.c[2]][1], disj2c2ub)
         self.assertIsNone(m_values[m.b.simpledisj2.c[2]][0])
@@ -1414,7 +1436,8 @@ class ScalarDisjIndexedConstraints(unittest.TestCase, CommonTests):
             r"or ensure all variables that appear in the "
             r"constraint are bounded.",
             TransformationFactory('gdp.bigm').apply_to,
-            m)
+            m,
+        )
 
     def test_create_using(self):
         m = models.makeTwoTermDisj_IndexedConstraints()
@@ -1546,9 +1569,8 @@ class IndexedConstraintsInDisj(unittest.TestCase, CommonTests):
 
         # give an arg
         TransformationFactory('gdp.bigm').apply_to(
-            m,
-            bigM={None: 19, m.disjunct[0].c[1]: 17,
-                  m.disjunct[0].c[2]: 18})
+            m, bigM={None: 19, m.disjunct[0].c[1]: 17, m.disjunct[0].c[2]: 18}
+        )
 
         # check that m values are what we expect
         self.checkMs(m, -17, -18, -19, 19, -19, 19)
@@ -1563,8 +1585,8 @@ class IndexedConstraintsInDisj(unittest.TestCase, CommonTests):
 
         # give an arg. Doing this one as a ComponentMap, just to make sure.
         TransformationFactory('gdp.bigm').apply_to(
-            m,
-            bigM=ComponentMap({None: 19, m.disjunct[0].c: 17}))
+            m, bigM=ComponentMap({None: 19, m.disjunct[0].c: 17})
+        )
         self.checkMs(m, -17, -17, -19, 19, -19, 19)
 
     def test_suffix_M_None_on_indexedConstraint(self):
@@ -1644,6 +1666,7 @@ class TestTargets_SingleDisjunction(unittest.TestCase, CommonTests):
     #     # No error, and we've transformed the whole model
     #     m.pprint()
 
+
 class TestTargets_IndexedDisjunction(unittest.TestCase, CommonTests):
     def test_indexedDisj_targets_inactive(self):
         ct.check_indexedDisj_targets_inactive(self, 'bigm')
@@ -1689,11 +1712,9 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         ct.check_disjuncts_inactive_nested(self, 'bigm')
 
     def test_deactivated_disjunct_leaves_nested_disjuncts_active(self):
-        ct.check_deactivated_disjunct_leaves_nested_disjunct_active(self,
-                                                                    'bigm')
+        ct.check_deactivated_disjunct_leaves_nested_disjunct_active(self, 'bigm')
 
-    def check_disjunction_transformation_block_structure(self, transBlock,
-                                                         pairs):
+    def check_disjunction_transformation_block_structure(self, transBlock, pairs):
         self.assertIsInstance(transBlock, Block)
 
         disjBlock = transBlock.relaxedDisjuncts
@@ -1709,7 +1730,8 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
             for comp in j:
                 self.assertIs(
                     bigm.get_transformed_constraints(comp)[0].parent_block(),
-                    disjBlock[i])
+                    disjBlock[i],
+                )
 
     def test_transformation_block_structure(self):
         m = models.makeNestedDisjunctions()
@@ -1720,23 +1742,21 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         pairs = [
             (0, [m.simpledisjunct.innerdisjunct0.c]),
             (1, [m.simpledisjunct.innerdisjunct1.c]),
-            (2, []),# No constraints, just a reference to simpledisjunct's
-                    # indicator_var
+            (2, []),  # No constraints, just a reference to simpledisjunct's
+            # indicator_var
             (3, [m.disjunct[0].c]),
             (4, [m.disjunct[1].innerdisjunct[0].c]),
             (5, [m.disjunct[1].innerdisjunct[1].c]),
-            (6, []),# Again no constraints, just indicator var ref
+            (6, []),  # Again no constraints, just indicator var ref
         ]
         self.check_disjunction_transformation_block_structure(transBlock, pairs)
         # we have the XOR constraints for both the outer and inner disjunctions
-        self.assertIsInstance(transBlock.component("disjunction_xor"),
-                              Constraint)
+        self.assertIsInstance(transBlock.component("disjunction_xor"), Constraint)
 
     def test_transformation_block_on_inner_disjunct_empty(self):
         m = models.makeNestedDisjunctions()
         TransformationFactory('gdp.bigm').apply_to(m)
-        self.assertIsNone(m.disjunct[1].component(
-            "_pyomo_gdp_bigm_reformulation"))
+        self.assertIsNone(m.disjunct[1].component("_pyomo_gdp_bigm_reformulation"))
 
     def test_mappings_between_disjunctions_and_xors(self):
         m = models.makeNestedDisjunctions()
@@ -1747,10 +1767,8 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
 
         disjunctionPairs = [
             (m.disjunction, transBlock1.disjunction_xor),
-            (m.disjunct[1].innerdisjunction[0],
-             transBlock1.innerdisjunction_xor_4[0]),
-            (m.simpledisjunct.innerdisjunction,
-             transBlock1.innerdisjunction_xor)
+            (m.disjunct[1].innerdisjunction[0], transBlock1.innerdisjunction_xor_4[0]),
+            (m.simpledisjunct.innerdisjunction, transBlock1.innerdisjunction_xor),
         ]
 
         # check disjunction mappings
@@ -1767,25 +1785,29 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
 
         # I want to check that I correctly updated the pointers to the
         # transformation blocks on the inner Disjuncts.
-        self.assertIs(m.disjunct[1].innerdisjunct[0].transformation_block,
-                      disjunctBlocks[4])
-        self.assertIs(disjunctBlocks[4]._src_disjunct(),
-                      m.disjunct[1].innerdisjunct[0])
+        self.assertIs(
+            m.disjunct[1].innerdisjunct[0].transformation_block, disjunctBlocks[4]
+        )
+        self.assertIs(disjunctBlocks[4]._src_disjunct(), m.disjunct[1].innerdisjunct[0])
 
-        self.assertIs(m.disjunct[1].innerdisjunct[1].transformation_block,
-                      disjunctBlocks[5])
-        self.assertIs(disjunctBlocks[5]._src_disjunct(),
-                      m.disjunct[1].innerdisjunct[1])
+        self.assertIs(
+            m.disjunct[1].innerdisjunct[1].transformation_block, disjunctBlocks[5]
+        )
+        self.assertIs(disjunctBlocks[5]._src_disjunct(), m.disjunct[1].innerdisjunct[1])
 
-        self.assertIs(m.simpledisjunct.innerdisjunct0.transformation_block,
-                      disjunctBlocks[0])
-        self.assertIs(disjunctBlocks[0]._src_disjunct(),
-                      m.simpledisjunct.innerdisjunct0)
+        self.assertIs(
+            m.simpledisjunct.innerdisjunct0.transformation_block, disjunctBlocks[0]
+        )
+        self.assertIs(
+            disjunctBlocks[0]._src_disjunct(), m.simpledisjunct.innerdisjunct0
+        )
 
-        self.assertIs(m.simpledisjunct.innerdisjunct1.transformation_block,
-                      disjunctBlocks[1])
-        self.assertIs(disjunctBlocks[1]._src_disjunct(),
-                      m.simpledisjunct.innerdisjunct1)
+        self.assertIs(
+            m.simpledisjunct.innerdisjunct1.transformation_block, disjunctBlocks[1]
+        )
+        self.assertIs(
+            disjunctBlocks[1]._src_disjunct(), m.simpledisjunct.innerdisjunct1
+        )
 
     def test_m_value_mappings(self):
         m = models.makeNestedDisjunctions()
@@ -1796,9 +1818,9 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         bigms = {m.disjunct[1].innerdisjunct[0]: 89}
         bigm.apply_to(m, bigM=bigms)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(
-             m.disjunct[1].innerdisjunct[0].c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.disjunct[1].innerdisjunct[0].c
+        )
         self.assertIs(l_src, bigms)
         self.assertIs(u_src, bigms)
         self.assertIs(l_key, m.disjunct[1].innerdisjunct[0])
@@ -1806,9 +1828,9 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -89)
         self.assertEqual(u_val, 89)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(
-             m.disjunct[1].innerdisjunct[1].c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.disjunct[1].innerdisjunct[1].c
+        )
         self.assertIsNone(l_src)
         self.assertIsNone(u_src)
         self.assertIsNone(l_key)
@@ -1816,8 +1838,9 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -5)
         self.assertIsNone(u_val)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.disjunct[0].c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.disjunct[0].c
+        )
         self.assertIsNone(l_src)
         self.assertIsNone(u_src)
         self.assertIsNone(l_key)
@@ -1825,8 +1848,9 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         self.assertEqual(l_val, -11)
         self.assertEqual(u_val, 7)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(m.disjunct[1].c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.disjunct[1].c
+        )
         self.assertIsNone(l_src)
         self.assertIsNone(u_src)
         self.assertIsNone(l_key)
@@ -1834,9 +1858,9 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         self.assertIsNone(l_val)
         self.assertEqual(u_val, 21)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(
-             m.simpledisjunct.innerdisjunct0.c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.simpledisjunct.innerdisjunct0.c
+        )
         self.assertIsNone(l_src)
         self.assertIs(u_src, m.simpledisjunct.BigM)
         self.assertIsNone(l_key)
@@ -1844,9 +1868,9 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         self.assertIsNone(l_val)
         self.assertEqual(u_val, 42)
 
-        ((l_val, l_src, l_key),
-         (u_val, u_src, u_key)) = bigm.get_M_value_src(
-             m.simpledisjunct.innerdisjunct1.c)
+        ((l_val, l_src, l_key), (u_val, u_src, u_key)) = bigm.get_M_value_src(
+            m.simpledisjunct.innerdisjunct1.c
+        )
         self.assertIs(l_src, m.simpledisjunct.BigM)
         self.assertIsNone(u_src)
         self.assertIsNone(l_key)
@@ -1864,8 +1888,9 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         ct.check_linear_coef(self, repn, variable, 1)
         ct.check_linear_coef(self, repn, indicator_var, M)
 
-    def check_inner_xor_constraint(self, inner_disjunction, outer_disjunct,
-                                   inner_disjuncts):
+    def check_inner_xor_constraint(
+        self, inner_disjunction, outer_disjunct, inner_disjuncts
+    ):
         self.assertIsNotNone(inner_disjunction.algebraic_constraint)
         cons = inner_disjunction.algebraic_constraint
         self.assertEqual(cons.lower, 0)
@@ -1874,9 +1899,8 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         self.assertTrue(repn.is_linear())
         self.assertEqual(repn.constant, 0)
         for disj in inner_disjuncts:
-            ct.check_linear_coef( self, repn, disj.binary_indicator_var, 1)
-        ct.check_linear_coef(self, repn, outer_disjunct.binary_indicator_var,
-                             -1)
+            ct.check_linear_coef(self, repn, disj.binary_indicator_var, 1)
+        ct.check_linear_coef(self, repn, outer_disjunct.binary_indicator_var, -1)
 
     def test_transformed_constraints(self):
         # We'll check all the transformed constraints to make sure
@@ -1886,8 +1910,7 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         m = models.makeNestedDisjunctions()
         bigm = TransformationFactory('gdp.bigm')
         bigm.apply_to(m)
-        cons1 = bigm.get_transformed_constraints(
-            m.disjunct[1].innerdisjunct[0].c)
+        cons1 = bigm.get_transformed_constraints(m.disjunct[1].innerdisjunct[0].c)
         self.assertEqual(len(cons1), 2)
         cons1lb = cons1[0]
         cons1ub = cons1[1]
@@ -1896,46 +1919,46 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         self.assertIs(cons1lb.body, m.z)
         self.assertIsNone(cons1ub.lower)
         self.assertEqual(cons1ub.upper, 0)
-        self.check_bigM_constraint(cons1ub, m.z, 10,
-                                   m.disjunct[1].innerdisjunct[0].indicator_var)
+        self.check_bigM_constraint(
+            cons1ub, m.z, 10, m.disjunct[1].innerdisjunct[0].indicator_var
+        )
 
-        cons2 = bigm.get_transformed_constraints(
-            m.disjunct[1].innerdisjunct[1].c)
+        cons2 = bigm.get_transformed_constraints(m.disjunct[1].innerdisjunct[1].c)
         self.assertEqual(len(cons2), 1)
         cons2lb = cons2[0]
         self.assertEqual(cons2lb.lower, 5)
         self.assertIsNone(cons2lb.upper)
-        self.check_bigM_constraint(cons2lb, m.z, -5,
-                                   m.disjunct[1].innerdisjunct[1].indicator_var)
+        self.check_bigM_constraint(
+            cons2lb, m.z, -5, m.disjunct[1].innerdisjunct[1].indicator_var
+        )
 
-        cons3 = bigm.get_transformed_constraints(
-            m.simpledisjunct.innerdisjunct0.c)
+        cons3 = bigm.get_transformed_constraints(m.simpledisjunct.innerdisjunct0.c)
         self.assertEqual(len(cons3), 1)
         cons3ub = cons3[0]
         self.assertEqual(cons3ub.upper, 2)
         self.assertIsNone(cons3ub.lower)
         self.check_bigM_constraint(
-            cons3ub, m.x, 7,
-            m.simpledisjunct.innerdisjunct0.indicator_var)
+            cons3ub, m.x, 7, m.simpledisjunct.innerdisjunct0.indicator_var
+        )
 
-        cons4 = bigm.get_transformed_constraints(
-            m.simpledisjunct.innerdisjunct1.c)
+        cons4 = bigm.get_transformed_constraints(m.simpledisjunct.innerdisjunct1.c)
         self.assertEqual(len(cons4), 1)
         cons4lb = cons4[0]
         self.assertEqual(cons4lb.lower, 4)
         self.assertIsNone(cons4lb.upper)
         self.check_bigM_constraint(
-            cons4lb, m.x, -13,
-            m.simpledisjunct.innerdisjunct1.indicator_var)
+            cons4lb, m.x, -13, m.simpledisjunct.innerdisjunct1.indicator_var
+        )
 
         # Here we check that the xor constraint from
         # simpledisjunct.innerdisjunction is transformed.
         cons5 = m.simpledisjunct.innerdisjunction.algebraic_constraint
         self.assertIsNotNone(cons5)
-        self.check_inner_xor_constraint(m.simpledisjunct.innerdisjunction,
-                                        m.simpledisjunct,
-                                        [m.simpledisjunct.innerdisjunct0,
-                                         m.simpledisjunct.innerdisjunct1])
+        self.check_inner_xor_constraint(
+            m.simpledisjunct.innerdisjunction,
+            m.simpledisjunct,
+            [m.simpledisjunct.innerdisjunct0, m.simpledisjunct.innerdisjunct1],
+        )
         self.assertIsInstance(cons5, Constraint)
         self.assertEqual(cons5.lower, 0)
         self.assertEqual(cons5.upper, 0)
@@ -1943,19 +1966,19 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         self.assertTrue(repn.is_linear())
         self.assertEqual(repn.constant, 0)
         ct.check_linear_coef(
-            self, repn, m.simpledisjunct.innerdisjunct0.binary_indicator_var, 1)
+            self, repn, m.simpledisjunct.innerdisjunct0.binary_indicator_var, 1
+        )
         ct.check_linear_coef(
-            self, repn, m.simpledisjunct.innerdisjunct1.binary_indicator_var, 1)
-        ct.check_linear_coef(self, repn, m.simpledisjunct.binary_indicator_var,
-                             -1)
+            self, repn, m.simpledisjunct.innerdisjunct1.binary_indicator_var, 1
+        )
+        ct.check_linear_coef(self, repn, m.simpledisjunct.binary_indicator_var, -1)
 
         cons6 = bigm.get_transformed_constraints(m.disjunct[0].c)
         self.assertEqual(len(cons6), 2)
         cons6lb = cons6[0]
         self.assertIsNone(cons6lb.upper)
         self.assertEqual(cons6lb.lower, 2)
-        self.check_bigM_constraint(cons6lb, m.x, -11,
-                                   m.disjunct[0].indicator_var)
+        self.check_bigM_constraint(cons6lb, m.x, -11, m.disjunct[0].indicator_var)
         cons6ub = cons6[1]
         self.assertIsNone(cons6ub.lower)
         self.assertEqual(cons6ub.upper, 2)
@@ -1963,18 +1986,18 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
 
         # now we check that the xor constraint from disjunct[1].innerdisjunction
         # is correct.
-        self.check_inner_xor_constraint(m.disjunct[1].innerdisjunction[0],
-                                        m.disjunct[1],
-                                        [m.disjunct[1].innerdisjunct[0],
-                                         m.disjunct[1].innerdisjunct[1]])
+        self.check_inner_xor_constraint(
+            m.disjunct[1].innerdisjunction[0],
+            m.disjunct[1],
+            [m.disjunct[1].innerdisjunct[0], m.disjunct[1].innerdisjunct[1]],
+        )
 
         cons8 = bigm.get_transformed_constraints(m.disjunct[1].c)
         self.assertEqual(len(cons8), 1)
         cons8ub = cons8[0]
         self.assertIsNone(cons8ub.lower)
         self.assertEqual(cons8ub.upper, 2)
-        self.check_bigM_constraint(cons8ub, m.a, 21,
-                                   m.disjunct[1].indicator_var)
+        self.check_bigM_constraint(cons8ub, m.a, 21, m.disjunct[1].indicator_var)
 
     def test_unique_reference_to_nested_indicator_var(self):
         ct.check_unique_reference_to_nested_indicator_var(self, 'bigm')
@@ -2015,11 +2038,13 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         # the second time.
         m = ConcreteModel()
         m.d1 = Disjunct()
-        m.d1.indexedDisjunct1 = Disjunct([0,1])
-        m.d1.indexedDisjunct2 = Disjunct([0,1])
-        @m.d1.Disjunction([0,1])
+        m.d1.indexedDisjunct1 = Disjunct([0, 1])
+        m.d1.indexedDisjunct2 = Disjunct([0, 1])
+
+        @m.d1.Disjunction([0, 1])
         def innerIndexed(d, i):
             return [d.indexedDisjunct1[i], d.indexedDisjunct2[i]]
+
         m.d2 = Disjunct()
         m.outer = Disjunction(expr=[m.d1, m.d2])
 
@@ -2027,12 +2052,19 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
 
         # we check that they all ended up on the same Block in the end (I don't
         # really care in what order for this test)
-        disjuncts = [m.d1, m.d2, m.d1.indexedDisjunct1[0],
-                     m.d1.indexedDisjunct1[1], m.d1.indexedDisjunct2[0],
-                     m.d1.indexedDisjunct2[1]]
+        disjuncts = [
+            m.d1,
+            m.d2,
+            m.d1.indexedDisjunct1[0],
+            m.d1.indexedDisjunct1[1],
+            m.d1.indexedDisjunct2[0],
+            m.d1.indexedDisjunct2[1],
+        ]
         for disjunct in disjuncts:
-            self.assertIs(disjunct.transformation_block.parent_component(),
-                          m._pyomo_gdp_bigm_reformulation.relaxedDisjuncts)
+            self.assertIs(
+                disjunct.transformation_block.parent_component(),
+                m._pyomo_gdp_bigm_reformulation.relaxedDisjuncts,
+            )
 
     def check_first_disjunct_constraint(self, disj1c, x, ind_var):
         self.assertEqual(len(disj1c), 1)
@@ -2057,7 +2089,7 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         self.assertTrue(repn.is_quadratic())
         self.assertEqual(len(repn.linear_vars), 5)
         self.assertEqual(len(repn.quadratic_vars), 4)
-        self.assertEqual(repn.constant, -63) # M = 99, so this is 36 - 99
+        self.assertEqual(repn.constant, -63)  # M = 99, so this is 36 - 99
         ct.check_linear_coef(self, repn, ind_var, 99)
         for i in range(1, 5):
             ct.check_squared_term_coef(self, repn, x[i], 1)
@@ -2065,8 +2097,9 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
 
     def check_hierarchical_nested_model(self, m, bigm):
         outer_xor = m.disjunction_block.disjunction.algebraic_constraint
-        ct.check_two_term_disjunction_xor(self, outer_xor, m.disj1,
-                                          m.disjunct_block.disj2)
+        ct.check_two_term_disjunction_xor(
+            self, outer_xor, m.disj1, m.disjunct_block.disj2
+        )
 
         inner_xor = m.disjunct_block.disj2.disjunction.algebraic_constraint
         self.assertEqual(inner_xor.lower, 0)
@@ -2075,39 +2108,49 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         self.assertTrue(repn.is_linear())
         self.assertEqual(len(repn.linear_vars), 3)
         self.assertEqual(repn.constant, 0)
-        ct.check_linear_coef(self, repn,
-                             m.disjunct_block.disj2.disjunction_disjuncts[0].\
-                             binary_indicator_var, 1)
-        ct.check_linear_coef(self, repn,
-                             m.disjunct_block.disj2.disjunction_disjuncts[1].\
-                             binary_indicator_var, 1)
-        ct.check_linear_coef(self, repn,
-                             m.disjunct_block.disj2.binary_indicator_var, -1)
+        ct.check_linear_coef(
+            self,
+            repn,
+            m.disjunct_block.disj2.disjunction_disjuncts[0].binary_indicator_var,
+            1,
+        )
+        ct.check_linear_coef(
+            self,
+            repn,
+            m.disjunct_block.disj2.disjunction_disjuncts[1].binary_indicator_var,
+            1,
+        )
+        ct.check_linear_coef(
+            self, repn, m.disjunct_block.disj2.binary_indicator_var, -1
+        )
 
         # outer disjunction constraints
         disj1c = bigm.get_transformed_constraints(m.disj1.c)
-        self.check_first_disjunct_constraint(disj1c, m.x,
-                                             m.disj1.binary_indicator_var)
+        self.check_first_disjunct_constraint(disj1c, m.x, m.disj1.binary_indicator_var)
 
         disj2c = bigm.get_transformed_constraints(m.disjunct_block.disj2.c)
         self.check_second_disjunct_constraint(
-            disj2c, m.x,
-            m.disjunct_block.disj2.binary_indicator_var)
+            disj2c, m.x, m.disjunct_block.disj2.binary_indicator_var
+        )
 
         # inner disjunction constraints
         innerd1c = bigm.get_transformed_constraints(
-            m.disjunct_block.disj2.disjunction_disjuncts[0].constraint[1])
+            m.disjunct_block.disj2.disjunction_disjuncts[0].constraint[1]
+        )
         self.check_first_disjunct_constraint(
-            innerd1c, m.x,
-            m.disjunct_block.disj2.disjunction_disjuncts[0].\
-            binary_indicator_var)
+            innerd1c,
+            m.x,
+            m.disjunct_block.disj2.disjunction_disjuncts[0].binary_indicator_var,
+        )
 
         innerd2c = bigm.get_transformed_constraints(
-            m.disjunct_block.disj2.disjunction_disjuncts[1].constraint[1])
+            m.disjunct_block.disj2.disjunction_disjuncts[1].constraint[1]
+        )
         self.check_second_disjunct_constraint(
-            innerd2c, m.x,
-            m.disjunct_block.disj2.disjunction_disjuncts[1].\
-            binary_indicator_var)
+            innerd2c,
+            m.x,
+            m.disjunct_block.disj2.disjunction_disjuncts[1].binary_indicator_var,
+        )
 
     def test_hierarchical_badly_ordered_targets(self):
         m = models.makeHierarchicalNested_DeclOrderMatchesInstantationOrder()
@@ -2130,6 +2173,7 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         # the same check to make sure everything is transformed correctly.
         self.check_hierarchical_nested_model(m, bigm)
 
+
 class IndexedDisjunction(unittest.TestCase):
     # this tests that if the targets are a subset of the
     # _DisjunctDatas in an IndexedDisjunction that the xor constraint
@@ -2139,6 +2183,7 @@ class IndexedDisjunction(unittest.TestCase):
 
     def test_partial_deactivate_indexed_disjunction(self):
         ct.check_partial_deactivate_indexed_disjunction(self, 'bigm')
+
 
 class BlocksOnDisjuncts(unittest.TestCase):
     # ESJ: All of these tests are specific to bigm because they check how much
@@ -2202,10 +2247,12 @@ class BlocksOnDisjuncts(unittest.TestCase):
                 KeyError,
                 r".*.evil\[1\].b.anotherblock.c",
                 bigm.get_transformed_constraints,
-                m.evil[1].b.anotherblock.c)
-        self.assertRegex(out.getvalue(),
-                         r".*Constraint 'evil\[1\].b.anotherblock.c' "
-                         r"has not been transformed.")
+                m.evil[1].b.anotherblock.c,
+            )
+        self.assertRegex(
+            out.getvalue(),
+            r".*Constraint 'evil\[1\].b.anotherblock.c' " r"has not been transformed.",
+        )
         evil1 = bigm.get_transformed_constraints(m.evil[1].bb[1].c)
         self.assertEqual(len(evil1), 2)
         self.assertIs(evil1[0].parent_block(), disjBlock[1])
@@ -2250,7 +2297,7 @@ class BlocksOnDisjuncts(unittest.TestCase):
         m.b.d = Disjunct()
         m.b.d.foo = Block()
 
-        m.b.d.c = Constraint(expr=m.x>=9)
+        m.b.d.c = Constraint(expr=m.x >= 9)
 
         m.b.BigM = Suffix()
         m.b.BigM[None] = 10
@@ -2277,12 +2324,14 @@ class BlocksOnDisjuncts(unittest.TestCase):
         self.assertIs(repn.linear_vars[1], m.b.d.binary_indicator_var)
         self.assertEqual(repn.linear_coefs[1], -10)
 
+
 class UntransformableObjectsOnDisjunct(unittest.TestCase):
     def test_RangeSet(self):
         ct.check_RangeSet(self, 'bigm')
 
     def test_Expression(self):
         ct.check_Expression(self, 'bigm')
+
 
 class TransformABlock(unittest.TestCase):
     def test_transformation_simple_block(self):
@@ -2300,6 +2349,7 @@ class TransformABlock(unittest.TestCase):
     def test_indexed_block_target(self):
         ct.check_indexed_block_target(self, 'bigm')
 
+
 class IndexedDisjunctions(unittest.TestCase):
     def setUp(self):
         # set seed so we can test name collisions predictably
@@ -2309,7 +2359,7 @@ class IndexedDisjunctions(unittest.TestCase):
         ct.check_disjunction_data_target(self, 'bigm')
 
     def test_disjunction_data_target_any_index(self):
-       ct.check_disjunction_data_target_any_index(self, 'bigm')
+        ct.check_disjunction_data_target_any_index(self, 'bigm')
 
     # ESJ: This and the following tests are *very* similar to those in hull,
     # but I actually bothered to check the additional transformed objects in
@@ -2324,20 +2374,16 @@ class IndexedDisjunctions(unittest.TestCase):
         bigm = TransformationFactory('gdp.bigm')
         self.assertEqual(len(transBlock1.relaxedDisjuncts), 4)
         firstTerm1 = bigm.get_transformed_constraints(m.firstTerm[1].cons)
-        self.assertIs(firstTerm1[0].parent_block(),
-                      transBlock1.relaxedDisjuncts[0])
+        self.assertIs(firstTerm1[0].parent_block(), transBlock1.relaxedDisjuncts[0])
         self.assertEqual(len(firstTerm1), 2)
         secondTerm1 = bigm.get_transformed_constraints(m.secondTerm[1].cons)
-        self.assertIs(secondTerm1[0].parent_block(),
-                      transBlock1.relaxedDisjuncts[1])
+        self.assertIs(secondTerm1[0].parent_block(), transBlock1.relaxedDisjuncts[1])
         self.assertEqual(len(secondTerm1), 1)
         firstTerm2 = bigm.get_transformed_constraints(m.firstTerm[2].cons)
-        self.assertIs(firstTerm2[0].parent_block(),
-                      transBlock1.relaxedDisjuncts[2])
+        self.assertIs(firstTerm2[0].parent_block(), transBlock1.relaxedDisjuncts[2])
         self.assertEqual(len(firstTerm2), 2)
         secondTerm2 = bigm.get_transformed_constraints(m.secondTerm[2].cons)
-        self.assertIs(secondTerm2[0].parent_block(),
-                      transBlock1.relaxedDisjuncts[3])
+        self.assertIs(secondTerm2[0].parent_block(), transBlock1.relaxedDisjuncts[3])
         self.assertEqual(len(secondTerm2), 1)
 
     def test_simple_disjunction_of_disjunct_datas(self):
@@ -2353,37 +2399,30 @@ class IndexedDisjunctions(unittest.TestCase):
         self.assertIsInstance(transBlock.component("relaxedDisjuncts"), Block)
         self.assertEqual(len(transBlock.relaxedDisjuncts), 4)
         firstTerm1 = bigm.get_transformed_constraints(m.firstTerm[1].cons)
-        self.assertIs(firstTerm1[0].parent_block(),
-                      transBlock.relaxedDisjuncts[0])
+        self.assertIs(firstTerm1[0].parent_block(), transBlock.relaxedDisjuncts[0])
         self.assertEqual(len(firstTerm1), 2)
         secondTerm1 = bigm.get_transformed_constraints(m.secondTerm[1].cons)
-        self.assertIs(secondTerm1[0].parent_block(),
-                      transBlock.relaxedDisjuncts[1])
+        self.assertIs(secondTerm1[0].parent_block(), transBlock.relaxedDisjuncts[1])
         self.assertEqual(len(secondTerm1), 1)
         firstTerm2 = bigm.get_transformed_constraints(m.firstTerm[2].cons)
-        self.assertIs(firstTerm2[0].parent_block(),
-                      transBlock.relaxedDisjuncts[2])
+        self.assertIs(firstTerm2[0].parent_block(), transBlock.relaxedDisjuncts[2])
         self.assertEqual(len(firstTerm1), 2)
         secondTerm2 = bigm.get_transformed_constraints(m.secondTerm[2].cons)
-        self.assertIs(secondTerm2[0].parent_block(),
-                      transBlock.relaxedDisjuncts[3])
+        self.assertIs(secondTerm2[0].parent_block(), transBlock.relaxedDisjuncts[3])
         self.assertEqual(len(secondTerm1), 1)
 
         self.assertIsInstance(
-            m.disjunction[1].algebraic_constraint.parent_component(),
-            Constraint)
+            m.disjunction[1].algebraic_constraint.parent_component(), Constraint
+        )
         self.assertIsInstance(
-            m.disjunction[2].algebraic_constraint.parent_component(),
-            Constraint)
+            m.disjunction[2].algebraic_constraint.parent_component(), Constraint
+        )
 
     def check_first_iteration(self, model):
         transBlock = model.component("_pyomo_gdp_bigm_reformulation")
         self.assertIsInstance(transBlock, Block)
-        self.assertIsInstance(
-            transBlock.component("disjunctionList_xor"),
-            Constraint)
-        self.assertEqual(
-            len(transBlock.disjunctionList_xor), 1)
+        self.assertIsInstance(transBlock.component("disjunctionList_xor"), Constraint)
+        self.assertEqual(len(transBlock.disjunctionList_xor), 1)
         self.assertFalse(model.disjunctionList[0].active)
 
     def check_second_iteration(self, model):
@@ -2401,21 +2440,19 @@ class IndexedDisjunctions(unittest.TestCase):
             secondTerm1 = model.secondTerm[1]
 
         firstTerm = bigm.get_transformed_constraints(firstTerm1.cons)
-        self.assertIs(firstTerm[0].parent_block(),
-                      transBlock.relaxedDisjuncts[0])
+        self.assertIs(firstTerm[0].parent_block(), transBlock.relaxedDisjuncts[0])
         self.assertEqual(len(firstTerm), 2)
 
         secondTerm = bigm.get_transformed_constraints(secondTerm1.cons)
-        self.assertIs(secondTerm[0].parent_block(),
-                      transBlock.relaxedDisjuncts[1])
+        self.assertIs(secondTerm[0].parent_block(), transBlock.relaxedDisjuncts[1])
         self.assertEqual(len(secondTerm), 1)
 
         self.assertIsInstance(
-            model.disjunctionList[1].algebraic_constraint.parent_component(),
-            Constraint)
+            model.disjunctionList[1].algebraic_constraint.parent_component(), Constraint
+        )
         self.assertIsInstance(
-            model.disjunctionList[0].algebraic_constraint.parent_component(),
-            Constraint)
+            model.disjunctionList[0].algebraic_constraint.parent_component(), Constraint
+        )
         self.assertFalse(model.disjunctionList[1].active)
         self.assertFalse(model.disjunctionList[0].active)
 
@@ -2423,40 +2460,37 @@ class IndexedDisjunctions(unittest.TestCase):
         ct.check_disjunction_and_disjuncts_indexed_by_any(self, 'bigm')
 
     def test_iteratively_adding_disjunctions_transform_container(self):
-        ct.check_iteratively_adding_disjunctions_transform_container(self,
-                                                                     'bigm')
+        ct.check_iteratively_adding_disjunctions_transform_container(self, 'bigm')
 
     def test_iteratively_adding_disjunctions_transform_model(self):
         ct.check_iteratively_adding_disjunctions_transform_model(self, 'bigm')
 
     def test_iteratively_adding_to_indexed_disjunction_on_block(self):
-        ct.check_iteratively_adding_to_indexed_disjunction_on_block(self,
-                                                                    'bigm')
+        ct.check_iteratively_adding_to_indexed_disjunction_on_block(self, 'bigm')
+
 
 class TestErrors(unittest.TestCase):
     def test_transform_empty_disjunction(self):
         ct.check_transform_empty_disjunction(self, 'bigm')
 
     def test_deactivated_disjunct_nonzero_indicator_var(self):
-        ct.check_deactivated_disjunct_nonzero_indicator_var(self,
-                                                            'bigm')
+        ct.check_deactivated_disjunct_nonzero_indicator_var(self, 'bigm')
 
     def test_deactivated_disjunct_unfixed_indicator_var(self):
         ct.check_deactivated_disjunct_unfixed_indicator_var(self, 'bigm')
 
     def test_infeasible_xor_because_all_disjuncts_deactivated(self):
-        m = ct.setup_infeasible_xor_because_all_disjuncts_deactivated(self,
-                                                                      'bigm')
+        m = ct.setup_infeasible_xor_because_all_disjuncts_deactivated(self, 'bigm')
         bigm = TransformationFactory('gdp.bigm')
 
         transBlock = m.component("_pyomo_gdp_bigm_reformulation")
         self.assertIsInstance(transBlock, Block)
         self.assertEqual(len(transBlock.relaxedDisjuncts), 2)
-        self.assertIsInstance(transBlock.component("disjunction_xor"),
-                              Constraint)
+        self.assertIsInstance(transBlock.component("disjunction_xor"), Constraint)
         disjunct1 = transBlock.relaxedDisjuncts[0]
         relaxed_xor = bigm.get_transformed_constraints(
-            m.disjunction_disjuncts[0].nestedDisjunction.algebraic_constraint)
+            m.disjunction_disjuncts[0].nestedDisjunction.algebraic_constraint
+        )
         # It was an equality
         self.assertEqual(len(relaxed_xor), 2)
         self.assertIsInstance(relaxed_xor[0].parent_component(), Constraint)
@@ -2467,24 +2501,21 @@ class TestErrors(unittest.TestCase):
         self.assertIsNone(relaxed_xor_lb.upper)
         # the other variables got eaten in the constant because they are fixed.
         self.assertEqual(len(repn.linear_vars), 1)
-        ct.check_linear_coef(self, repn,
-                             m.disjunction.disjuncts[0].indicator_var, -1)
+        ct.check_linear_coef(self, repn, m.disjunction.disjuncts[0].indicator_var, -1)
         self.assertEqual(repn.constant, 1)
         repn = generate_standard_repn(relaxed_xor_ub.body)
         self.assertIsNone(relaxed_xor_ub.lower)
         self.assertEqual(value(relaxed_xor_ub.upper), 1)
         self.assertEqual(len(repn.linear_vars), 1)
-        ct.check_linear_coef(self, repn,
-                             m.disjunction.disjuncts[0].indicator_var, 1)
+        ct.check_linear_coef(self, repn, m.disjunction.disjuncts[0].indicator_var, 1)
 
         # and last check that the other constraints here look fine
-        x0 = bigm.get_transformed_constraints(
-            m.disjunction_disjuncts[0].constraint[1])
+        x0 = bigm.get_transformed_constraints(m.disjunction_disjuncts[0].constraint[1])
         self.assertEqual(len(x0), 2)
         lb = x0[0]
         ub = x0[1]
         self.assertIsInstance(lb.parent_component(), Constraint)
-        #lb = x0[(1, 'lb')]
+        # lb = x0[(1, 'lb')]
         self.assertEqual(value(lb.lower), 0)
         self.assertIsNone(lb.upper)
         repn = generate_standard_repn(lb.body)
@@ -2499,21 +2530,22 @@ class TestErrors(unittest.TestCase):
         self.assertEqual(repn.constant, -8)
         self.assertEqual(len(repn.linear_vars), 2)
         ct.check_linear_coef(self, repn, m.x, 1)
-        ct.check_linear_coef(self, repn,
-                             m.disjunction_disjuncts[0].indicator_var, 8)
+        ct.check_linear_coef(self, repn, m.disjunction_disjuncts[0].indicator_var, 8)
 
     def test_retrieving_nondisjunctive_components(self):
         ct.check_retrieving_nondisjunctive_components(self, 'bigm')
 
     def test_ask_for_transformed_constraint_from_untransformed_disjunct(self):
         ct.check_ask_for_transformed_constraint_from_untransformed_disjunct(
-            self, 'bigm')
+            self, 'bigm'
+        )
 
     def test_silly_target(self):
         ct.check_silly_target(self, 'bigm')
 
     def test_untransformed_arcs(self):
         ct.check_untransformed_network_raises_GDPError(self, 'bigm')
+
 
 class EstimatingMwithFixedVars(unittest.TestCase):
     def test_tighter_Ms_when_vars_fixed_forever(self):
@@ -2555,8 +2587,8 @@ class EstimatingMwithFixedVars(unittest.TestCase):
         ct.check_linear_coef(self, repn, promise.x, 1)
         ct.check_linear_coef(self, repn, promise.d.indicator_var, 7)
 
-class NetworkDisjuncts(unittest.TestCase, CommonTests):
 
+class NetworkDisjuncts(unittest.TestCase, CommonTests):
     @unittest.skipIf(not ct.linear_solvers, "No linear solver available")
     def test_solution_maximize(self):
         ct.check_network_disjuncts(self, minimize=False, transformation='bigm')
@@ -2564,6 +2596,7 @@ class NetworkDisjuncts(unittest.TestCase, CommonTests):
     @unittest.skipIf(not ct.linear_solvers, "No linear solver available")
     def test_solution_minimize(self):
         ct.check_network_disjuncts(self, minimize=True, transformation='bigm')
+
 
 class LogicalConstraintsOnDisjuncts(unittest.TestCase):
     def test_logical_constraints_transformed(self):
@@ -2578,7 +2611,8 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
 
         # first d[1]:
         cons = bigm.get_transformed_constraints(
-            m.d[1]._logical_to_disjunctive.transformed_constraints[1])
+            m.d[1]._logical_to_disjunctive.transformed_constraints[1]
+        )
         # big-M transformation of z = 1 - y1:
         #     z <= 1 - y1 + (1 - d[1].indicator_var)
         #     z >= 1 - y1 - (1 - d[1].indicator_var)
@@ -2590,31 +2624,32 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(leq.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            z + y1 - m.d[1].binary_indicator_var)
+            self, simplified, z + y1 - m.d[1].binary_indicator_var
+        )
         geq = cons[1]
         self.assertEqual(geq.upper, 0)
         self.assertIsNone(geq.lower)
         repn = generate_standard_repn(geq.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            z + y1 + m.d[1].binary_indicator_var - 2)
+            self, simplified, z + y1 + m.d[1].binary_indicator_var - 2
+        )
 
         # then d[4]:
         z1 = m.d[4]._logical_to_disjunctive.auxiliary_vars[1]
         z2 = m.d[4]._logical_to_disjunctive.auxiliary_vars[2]
-        z3 = m.d[4]._logical_to_disjunctive.auxiliary_vars[3] # fixed True
+        z3 = m.d[4]._logical_to_disjunctive.auxiliary_vars[3]  # fixed True
         cons = bigm.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[1])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[1]
+        )
         self.assertEqual(len(cons), 1)
         c = cons[0]
         # (1 - z1) + (1 - y1) + y2 >= 1 - (1 - d4.ind_var)
@@ -2623,14 +2658,15 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(c.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            -z1 - y1 + y2 - m.d[4].binary_indicator_var + 3)
+            self, simplified, -z1 - y1 + y2 - m.d[4].binary_indicator_var + 3
+        )
         cons = bigm.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[2])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[2]
+        )
         self.assertEqual(len(cons), 1)
         c = cons[0]
         # z1 + 1 - (1 - y1) >= 1 - (1 - d4.ind_var)
@@ -2639,14 +2675,15 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(c.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            y1 + z1 - m.d[4].binary_indicator_var + 1)
+            self, simplified, y1 + z1 - m.d[4].binary_indicator_var + 1
+        )
         cons = bigm.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[3])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[3]
+        )
         self.assertEqual(len(cons), 1)
         c = cons[0]
         # z1 + (1 - y2) >= 1 - (1 - d4.ind_var)
@@ -2655,14 +2692,15 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(c.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            - y2 + z1 - m.d[4].binary_indicator_var + 2)
+            self, simplified, -y2 + z1 - m.d[4].binary_indicator_var + 2
+        )
         cons = bigm.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[4])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[4]
+        )
         self.assertEqual(len(cons), 1)
         c = cons[0]
         # (1 - z2) + y1 + (1 - y2) >= 1 - (1 - d4.ind_var)
@@ -2671,14 +2709,15 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(c.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            -z2 - y2 + y1 - m.d[4].binary_indicator_var + 3)
+            self, simplified, -z2 - y2 + y1 - m.d[4].binary_indicator_var + 3
+        )
         cons = bigm.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[5])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[5]
+        )
         self.assertEqual(len(cons), 1)
         c = cons[0]
         # z2 + (1 - y1) >= 1 - (1 - d4.ind_var)
@@ -2687,14 +2726,15 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(c.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            - y1 + z2 - m.d[4].binary_indicator_var + 2)
+            self, simplified, -y1 + z2 - m.d[4].binary_indicator_var + 2
+        )
         cons = bigm.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[6])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[6]
+        )
         self.assertEqual(len(cons), 1)
         c = cons[0]
         # z2 + 1 - (1 - y2) >= 1 - (1 - d4.ind_var)
@@ -2703,14 +2743,15 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(c.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            y2 + z2 - m.d[4].binary_indicator_var + 1)
+            self, simplified, y2 + z2 - m.d[4].binary_indicator_var + 1
+        )
         cons = bigm.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[7])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[7]
+        )
         self.assertEqual(len(cons), 1)
         c = cons[0]
         # z3 <= z1 + (1 - d4.ind_var)
@@ -2719,14 +2760,15 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(c.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            z3 - z1 + m.d[4].binary_indicator_var - 1)
+            self, simplified, z3 - z1 + m.d[4].binary_indicator_var - 1
+        )
         cons = bigm.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[8])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[8]
+        )
         self.assertEqual(len(cons), 1)
         c = cons[0]
         # z3 <= z2 + (1 - d4.ind_var)
@@ -2735,12 +2777,12 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(c.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            z3 - z2 + m.d[4].binary_indicator_var - 1)
+            self, simplified, z3 - z2 + m.d[4].binary_indicator_var - 1
+        )
 
         # check that the global logical constraints were also transformed.
         self.assertFalse(m.p.active)
@@ -2764,6 +2806,7 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
     @unittest.skipIf(not dill_available, "Dill is not available")
     def test_dill_pickle(self):
         ct.check_transformed_model_pickles_with_dill(self, 'bigm')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyomo/gdp/tests/test_cuttingplane.py
+++ b/pyomo/gdp/tests/test_cuttingplane.py
@@ -11,10 +11,18 @@
 
 import pyomo.common.unittest as unittest
 
-from pyomo.environ import (Var, Constraint, Objective, Block,
-                           TransformationFactory, value, maximize, Suffix)
+from pyomo.environ import (
+    Var,
+    Constraint,
+    Objective,
+    Block,
+    TransformationFactory,
+    value,
+    maximize,
+    Suffix,
+)
 from pyomo.gdp import GDP_Error
-from pyomo.gdp.plugins.cuttingplane import create_cuts_fme 
+from pyomo.gdp.plugins.cuttingplane import create_cuts_fme
 
 import pyomo.opt
 import pyomo.gdp.tests.models as models
@@ -24,11 +32,13 @@ from pyomo.gdp.tests.common_tests import diff_apply_to_and_create_using
 
 solvers = pyomo.opt.check_available_solvers('ipopt', 'gurobi')
 
+
 def check_validity(self, body, lower, upper, TOL=0):
     if lower is not None:
         self.assertGreaterEqual(value(body), value(lower) - TOL)
     if upper is not None:
         self.assertLessEqual(value(body), value(upper) + TOL)
+
 
 class OneVarDisj(unittest.TestCase):
     def check_no_cuts_for_optimal_m(self, m):
@@ -103,9 +113,7 @@ class OneVarDisj(unittest.TestCase):
         m = models.oneVarDisj_2pts()
 
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, 
-            create_cuts=create_cuts_fme,
-            post_process_cut=None
+            m, create_cuts=create_cuts_fme, post_process_cut=None
         )
         self.check_no_cuts_for_optimal_m(m)
 
@@ -114,9 +122,7 @@ class OneVarDisj(unittest.TestCase):
         m = models.oneVarDisj_2pts()
 
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, 
-            norm=float('inf'),
-            post_process_cut=None
+            m, norm=float('inf'), post_process_cut=None
         )
         self.check_no_cuts_for_optimal_m(m)
 
@@ -125,32 +131,31 @@ class OneVarDisj(unittest.TestCase):
         m = models.twoSegments_SawayaGrossmann()
         # have to make M big for the bigm relaxation to be the box 0 <= x <= 3,
         # 0 <= Y <= 1 (in the limit)
-        TransformationFactory('gdp.cuttingplane').apply_to(m, bigM=1e6,
-                                                           verbose=True)
+        TransformationFactory('gdp.cuttingplane').apply_to(m, bigM=1e6, verbose=True)
         self.check_expected_two_segment_cut(m)
-    
+
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_expected_two_segment_cut_fme(self):
         m = models.twoSegments_SawayaGrossmann()
         # have to make M big for the bigm relaxation to be the box 0 <= x <= 3,
         # 0 <= Y <= 1 (in the limit)
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, create_cuts=create_cuts_fme,
-            post_process_cut=None)
+            m, bigM=1e6, create_cuts=create_cuts_fme, post_process_cut=None
+        )
         self.check_expected_two_segment_cut(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_expected_two_segment_cut_inf_norm(self):
         m = models.twoSegments_SawayaGrossmann()
-        
+
         # make sure this is fine if dual Suffix is already on model
         m.dual = Suffix(direction=Suffix.IMPORT)
 
         # have to make M big for the bigm relaxation to be the box 0 <= x <= 3,
         # 0 <= Y <= 1 (in the limit)
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, norm=float('inf'),
-            post_process_cut=None)
+            m, bigM=1e6, norm=float('inf'), post_process_cut=None
+        )
         self.check_expected_two_segment_cut(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
@@ -159,22 +164,25 @@ class OneVarDisj(unittest.TestCase):
         # have to make M big for the bigm relaxation to be the box 0 <= x <= 3,
         # 0 <= Y <= 1 (in the limit)
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, norm=float('inf'), create_cuts=create_cuts_fme,
-            post_process_cut=None, verbose=True)
+            m,
+            bigM=1e6,
+            norm=float('inf'),
+            create_cuts=create_cuts_fme,
+            post_process_cut=None,
+            verbose=True,
+        )
         self.check_expected_two_segment_cut(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_deactivated_objectives_ignored(self):
         m = models.twoSegments_SawayaGrossmann()
         # add an opposite direction objective, but deactivate it
-        m.another_obj = Objective(expr=m.x - m.disj2.indicator_var,
-                                  sense=maximize)
+        m.another_obj = Objective(expr=m.x - m.disj2.indicator_var, sense=maximize)
         m.another_obj.deactivate()
 
         # have to make M big for the bigm relaxation to be the box 0 <= x <= 3,
         # 0 <= Y <= 1 (in the limit)
-        TransformationFactory('gdp.cuttingplane').apply_to(m, bigM=1e6,
-                                                           verbose=True)
+        TransformationFactory('gdp.cuttingplane').apply_to(m, bigM=1e6, verbose=True)
         self.check_expected_two_segment_cut(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
@@ -196,8 +204,8 @@ class OneVarDisj(unittest.TestCase):
         # have to make M big for the bigm relaxation to be the box 0 <= x <= 3,
         # 0 <= Y <= 1 (in the limit)
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, create_cuts=create_cuts_fme,
-            post_process_cut=None)
+            m, bigM=1e6, create_cuts=create_cuts_fme, post_process_cut=None
+        )
 
         self.check_two_segment_cuts_valid(m)
 
@@ -217,7 +225,8 @@ class OneVarDisj(unittest.TestCase):
         # This one has to post process, but it is correct with the default
         # settings.
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, norm=float('inf'))
+            m, bigM=1e6, norm=float('inf')
+        )
 
         self.check_two_segment_cuts_valid(m)
 
@@ -250,8 +259,12 @@ class OneVarDisj(unittest.TestCase):
         # have to make M big for the bigm relaxation to be the box 0 <= x <= 3,
         # 0 <= Y <= 1 (in the limit)
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, create_cuts=create_cuts_fme,
-            post_process_cut=None, do_integer_arithmetic=True)
+            m,
+            bigM=1e6,
+            create_cuts=create_cuts_fme,
+            post_process_cut=None,
+            do_integer_arithmetic=True,
+        )
         cuts = m._pyomo_gdp_cuttingplane_transformation.cuts
 
         self.check_expected_two_segment_cut_exact(cuts)
@@ -262,8 +275,13 @@ class OneVarDisj(unittest.TestCase):
         # have to make M big for the bigm relaxation to be the box 0 <= x <= 3,
         # 0 <= Y <= 1 (in the limit)
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, create_cuts=create_cuts_fme, norm=float('inf'),
-            post_process_cut=None, do_integer_arithmetic=True)
+            m,
+            bigM=1e6,
+            create_cuts=create_cuts_fme,
+            norm=float('inf'),
+            post_process_cut=None,
+            do_integer_arithmetic=True,
+        )
         cuts = m._pyomo_gdp_cuttingplane_transformation.cuts
 
         self.check_expected_two_segment_cut_exact(cuts)
@@ -277,8 +295,12 @@ class OneVarDisj(unittest.TestCase):
         # have to make M big for the bigm relaxation to be the box 0 <= x <= 3,
         # 0 <= Y <= 1 (in the limit)
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, create_cuts=create_cuts_fme,
-            post_process_cut=None, do_integer_arithmetic=True)
+            m,
+            bigM=1e6,
+            create_cuts=create_cuts_fme,
+            post_process_cut=None,
+            do_integer_arithmetic=True,
+        )
         cuts = m._pyomo_gdp_cuttingplane_transformation.cuts
 
         self.check_expected_two_segment_cut_exact(cuts)
@@ -289,12 +311,16 @@ class OneVarDisj(unittest.TestCase):
         # have to make M big for the bigm relaxation to be the box 0 <= x <= 3,
         # 0 <= Y <= 1 (in the limit)
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, create_cuts=create_cuts_fme, cuts_name="perfect_cuts",
-            post_process_cut=None, do_integer_arithmetic=True)
+            m,
+            bigM=1e6,
+            create_cuts=create_cuts_fme,
+            cuts_name="perfect_cuts",
+            post_process_cut=None,
+            do_integer_arithmetic=True,
+        )
         cuts = m.component("perfect_cuts")
         self.assertIsInstance(cuts, Constraint)
-        self.assertIsNone(
-            m._pyomo_gdp_cuttingplane_transformation.component("cuts"))
+        self.assertIsNone(m._pyomo_gdp_cuttingplane_transformation.component("cuts"))
 
         self.check_expected_two_segment_cut_exact(cuts)
 
@@ -308,18 +334,20 @@ class OneVarDisj(unittest.TestCase):
             "specify a unique name.",
             TransformationFactory('gdp.cuttingplane').apply_to,
             m,
-            cuts_name="disj1")
-   
+            cuts_name="disj1",
+        )
+
+
 class TwoTermDisj(unittest.TestCase):
     extreme_points = [
-        (1,0,4,1),
-        (1,0,4,2),
-        (1,0,3,1),
-        (1,0,3,2),
-        (0,1,1,3),
-        (0,1,1,4),
-        (0,1,2,3),
-        (0,1,2,4)
+        (1, 0, 4, 1),
+        (1, 0, 4, 2),
+        (1, 0, 3, 1),
+        (1, 0, 3, 2),
+        (0, 1, 1, 3),
+        (0, 1, 1, 4),
+        (0, 1, 2, 3),
+        (0, 1, 2, 4),
     ]
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
@@ -351,7 +379,8 @@ class TwoTermDisj(unittest.TestCase):
     def test_cuts_valid_for_optimal_fme(self):
         m = models.makeTwoTermDisj_boxes()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, create_cuts=create_cuts_fme, post_process_cut=None)
+            m, create_cuts=create_cuts_fme, post_process_cut=None
+        )
 
         self.check_cuts_valid_for_optimal(m, TOL=0)
 
@@ -359,15 +388,15 @@ class TwoTermDisj(unittest.TestCase):
     def test_cuts_valid_for_optimal_with_tolerance(self):
         m = models.makeTwoTermDisj_boxes()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, back_off_problem_tolerance=1e-7)
+            m, back_off_problem_tolerance=1e-7
+        )
 
         self.check_cuts_valid_for_optimal(m, TOL=1e-8)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_cuts_valid_for_optimal_inf_norm(self):
         m = models.makeTwoTermDisj_boxes()
-        TransformationFactory('gdp.cuttingplane').apply_to( m,
-                                                            norm=float('inf'))
+        TransformationFactory('gdp.cuttingplane').apply_to(m, norm=float('inf'))
         # same tolerance as the l-2 norm version:
         self.check_cuts_valid_for_optimal(m, TOL=1e-8)
 
@@ -389,7 +418,8 @@ class TwoTermDisj(unittest.TestCase):
     def test_cuts_valid_on_hull_vertices_fme(self):
         m = models.makeTwoTermDisj_boxes()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, create_cuts=create_cuts_fme, post_process_cut=None)
+            m, create_cuts=create_cuts_fme, post_process_cut=None
+        )
 
         self.check_cuts_valid_on_hull_vertices(m, TOL=0)
 
@@ -397,7 +427,8 @@ class TwoTermDisj(unittest.TestCase):
     def test_cuts_valid_on_hull_vertices_with_tolerance(self):
         m = models.makeTwoTermDisj_boxes()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, back_off_problem_tolerance=2e-8, verbose=True)
+            m, back_off_problem_tolerance=2e-8, verbose=True
+        )
 
         self.check_cuts_valid_on_hull_vertices(m, TOL=1e-8)
 
@@ -407,16 +438,17 @@ class TwoTermDisj(unittest.TestCase):
         # we actually don't have to adjust the back-off problem tolerance for
         # this norm.
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, norm=float('inf'), verbose=True)
+            m, norm=float('inf'), verbose=True
+        )
 
         self.check_cuts_valid_on_hull_vertices(m, TOL=1e-8)
-        
+
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_cuts_are_correct_facets_fme(self):
         m = models.makeTwoTermDisj_boxes()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, create_cuts=create_cuts_fme, post_process_cut=None, 
-            zero_tolerance=0)
+            m, create_cuts=create_cuts_fme, post_process_cut=None, zero_tolerance=0
+        )
         # This would also be a valid cut, it just doesn't happen to be what we
         # choose.
         # facet_extreme_pts = [
@@ -425,13 +457,8 @@ class TwoTermDisj(unittest.TestCase):
         #     (0,1,1,3),
         #     (0,1,1,4)
         # ]
-        facet_extreme_pts = [
-            (0,1,1,3),
-            (0,1,2,3),
-            (1,0,3,1),
-            (1,0,4,1)
-        ]
-        
+        facet_extreme_pts = [(0, 1, 1, 3), (0, 1, 2, 3), (1, 0, 3, 1), (1, 0, 4, 1)]
+
         cuts = m._pyomo_gdp_cuttingplane_transformation.cuts
         # Here, we get just one facet
         self.assertEqual(len(cuts), 1)
@@ -450,14 +477,8 @@ class TwoTermDisj(unittest.TestCase):
                 self.assertEqual(value(upper), value(cut_expr))
 
     def check_cuts_are_correct_facets(self, m):
-        cut1_tight_pts = [
-            (1,0,3,1),
-            (0,1,1,3)
-        ]
-        facet2_extreme_pts = [
-            (1,0,3,1),
-            (1,0,4,1)
-        ]
+        cut1_tight_pts = [(1, 0, 3, 1), (0, 1, 1, 3)]
+        facet2_extreme_pts = [(1, 0, 3, 1), (1, 0, 4, 1)]
         cuts = m._pyomo_gdp_cuttingplane_transformation.cuts
         # ESJ: In this version, we don't get the facets, but we still get two
         # cuts, and we check they are tight at points on the relevant facets.
@@ -505,7 +526,7 @@ class TwoTermDisj(unittest.TestCase):
         m = models.makeTwoTermDisj_boxes()
         TransformationFactory('gdp.cuttingplane').apply_to(m, norm=float('inf'))
         self.check_cuts_are_correct_facets(m)
-   
+
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_create_using(self):
         m = models.makeTwoTermDisj_boxes()
@@ -520,7 +541,7 @@ class TwoTermDisj(unittest.TestCase):
             "Cannot apply cutting planes transformation without an active "
             "objective in the model*",
             TransformationFactory('gdp.cuttingplane').apply_to,
-            m
+            m,
         )
 
     # I'm doing this test with Gurobi because ipopt doesn't really catch this
@@ -536,14 +557,18 @@ class TwoTermDisj(unittest.TestCase):
         TransformationFactory('gdp.cuttingplane').apply_to(
             m,
             create_cuts=create_cuts_fme,
-            post_process_cut=None, verbose=True, solver='gurobi',
+            post_process_cut=None,
+            verbose=True,
+            solver='gurobi',
             # don't actually need this, but taking the excuse to set solver
             # options
             solver_options={'FeasibilityTol': 1e-8},
-            cuts_name="cuts", bigM=5)
+            cuts_name="cuts",
+            bigM=5,
+        )
 
         # rBigM first iteration solve will give (x = 3, Y = 0.6). If we don't
-        # catch equality constraints, we don't get a cut. But we need to get 
+        # catch equality constraints, we don't get a cut. But we need to get
         # x + Y <= 1. (Where Y is the indicator that x = 0).
         self.assertEqual(len(m.cuts), 1)
         cut = m.cuts[0]
@@ -557,17 +582,18 @@ class TwoTermDisj(unittest.TestCase):
         self.assertIs(repn.linear_vars[1], m.x)
         self.assertEqual(repn.linear_coefs[1], -1)
 
+
 class Grossmann_TestCases(unittest.TestCase):
     def check_cuts_valid_at_extreme_pts(self, m):
         extreme_points = [
-            (1,0,2,10),
-            (1,0,0,10),
-            (1,0,0,7),
-            (1,0,2,7),
-            (0,1,8,0),
-            (0,1,8,3),
-            (0,1,10,0),
-            (0,1,10,3)
+            (1, 0, 2, 10),
+            (1, 0, 0, 10),
+            (1, 0, 0, 7),
+            (1, 0, 2, 7),
+            (0, 1, 8, 0),
+            (0, 1, 8, 3),
+            (0, 1, 10, 0),
+            (0, 1, 10, 3),
         ]
 
         cuts = m._pyomo_gdp_cuttingplane_transformation.cuts
@@ -588,7 +614,8 @@ class Grossmann_TestCases(unittest.TestCase):
     def test_cut_valid_at_extreme_pts_fme(self):
         m = models.grossmann_oneDisj()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, create_cuts=create_cuts_fme, post_process_cut=None)
+            m, create_cuts=create_cuts_fme, post_process_cut=None
+        )
 
         self.check_cuts_valid_at_extreme_pts(m)
 
@@ -612,7 +639,8 @@ class Grossmann_TestCases(unittest.TestCase):
     def test_cut_is_correct_facet_fme(self):
         m = models.grossmann_oneDisj()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, create_cuts=create_cuts_fme, post_process_cut=None)
+            m, create_cuts=create_cuts_fme, post_process_cut=None
+        )
         cuts = m._pyomo_gdp_cuttingplane_transformation.cuts
         # ESJ: Again, for FME, we don't mind getting both the possible facets,
         # as long as they are beautiful.
@@ -620,16 +648,16 @@ class Grossmann_TestCases(unittest.TestCase):
         # similar to the two boxes example, this is on the line where two facets
         # intersect
         facet2_extreme_points = [
-            (1,0,2,10),
-            (1,0,2,7),
-            (0,1,10,0),
-            (0,1,10,3)
+            (1, 0, 2, 10),
+            (1, 0, 2, 7),
+            (0, 1, 10, 0),
+            (0, 1, 10, 3),
         ]
         facet_extreme_points = [
-            (1,0,2,10),
-            (1,0,0,10),
-            (0,1,8,3),
-            (0,1,10,3)
+            (1, 0, 2, 10),
+            (1, 0, 0, 10),
+            (0, 1, 8, 3),
+            (0, 1, 10, 3),
         ]
 
         for pt in facet_extreme_points:
@@ -652,29 +680,21 @@ class Grossmann_TestCases(unittest.TestCase):
         # similar to the two boxes example, this is on the line where two facets
         # intersect, we get cuts which intersect the two facets from FME. This
         # makes sense because these are angled.
-        cut1_tight_points = [
-            (1,0,2,10),
-            (0,1,10,3)
-        ]
-        cut2_tight_points = [
-            (1,0,2,10),
-            (1,0,0,10)
-        ]
+        cut1_tight_points = [(1, 0, 2, 10), (0, 1, 10, 3)]
+        cut2_tight_points = [(1, 0, 2, 10), (1, 0, 0, 10)]
 
         for pt in cut1_tight_points:
             m.x.fix(pt[2])
             m.y.fix(pt[3])
             m.disjunct1.binary_indicator_var.fix(pt[0])
             m.disjunct2.binary_indicator_var.fix(pt[1])
-            self.assertAlmostEqual(value(cuts[0].lower), value(cuts[0].body),
-                                   places=6)
+            self.assertAlmostEqual(value(cuts[0].lower), value(cuts[0].body), places=6)
         for pt in cut2_tight_points:
             m.x.fix(pt[2])
             m.y.fix(pt[3])
             m.disjunct1.binary_indicator_var.fix(pt[0])
             m.disjunct2.binary_indicator_var.fix(pt[1])
-            self.assertAlmostEqual(value(cuts[1].lower), value(cuts[1].body),
-                                   places=6)
+            self.assertAlmostEqual(value(cuts[1].lower), value(cuts[1].body), places=6)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_cut_is_correct_facet_projection(self):
@@ -689,19 +709,20 @@ class Grossmann_TestCases(unittest.TestCase):
         # whcih is also tight where cut 2 is. It doesn't improve the objective
         # by much at all, so it's redundant.
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, norm=float('inf'), cut_filtering_threshold=0.2)
+            m, norm=float('inf'), cut_filtering_threshold=0.2
+        )
         self.check_cut_is_correct_facet(m)
 
     def check_cuts_valid_at_extreme_pts_rescaled(self, m):
         extreme_points = [
-            (1,0,2,127),
-            (1,0,0,127),
-            (1,0,0,117),
-            (1,0,2,117),
-            (0,1,118,0),
-            (0,1,118,3),
-            (0,1,120,0),
-            (0,1,120,3)
+            (1, 0, 2, 127),
+            (1, 0, 0, 127),
+            (1, 0, 0, 117),
+            (1, 0, 2, 117),
+            (0, 1, 118, 0),
+            (0, 1, 118, 3),
+            (0, 1, 120, 0),
+            (0, 1, 120, 3),
         ]
 
         cuts = m._pyomo_gdp_cuttingplane_transformation.cuts
@@ -722,7 +743,8 @@ class Grossmann_TestCases(unittest.TestCase):
     def test_cuts_valid_at_extreme_pts_rescaled_fme(self):
         m = models.to_break_constraint_tolerances()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, create_cuts=create_cuts_fme, post_process_cut=None)
+            m, create_cuts=create_cuts_fme, post_process_cut=None
+        )
         self.check_cuts_valid_at_extreme_pts_rescaled(m)
 
     # Again, this actually passes without tolerance, so leaving it for now...
@@ -738,27 +760,26 @@ class Grossmann_TestCases(unittest.TestCase):
         # this cuts off by a little more than 1e-8 without the adjusted back-off
         # problem tolerance
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, norm=float('inf'), back_off_problem_tolerance=1e-7, verbose=True)
+            m, norm=float('inf'), back_off_problem_tolerance=1e-7, verbose=True
+        )
         self.check_cuts_valid_at_extreme_pts_rescaled(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_cut_is_correct_facet_rescaled_fme(self):
         m = models.to_break_constraint_tolerances()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, create_cuts=create_cuts_fme, post_process_cut=None)
+            m, create_cuts=create_cuts_fme, post_process_cut=None
+        )
 
         cuts = m._pyomo_gdp_cuttingplane_transformation.cuts
         self.assertEqual(len(cuts), 1)
-        
+
         # we don't get a whole facet. We get 0 <= 129y_1 + 123y_2 - x - y, which
-        # is the sum of two facets: 
-        # 0 <= 2y_1 + 120y_2 - x and 
+        # is the sum of two facets:
+        # 0 <= 2y_1 + 120y_2 - x and
         # 0 <= 127y_1 + 3y_2 - y
         # But this is valid and the only cut needed, so we won't complain.
-        cut_extreme_points = [
-            (1,0,2,127),
-            (0,1,120,3)
-        ]
+        cut_extreme_points = [(1, 0, 2, 127), (0, 1, 120, 3)]
 
         for pt in cut_extreme_points:
             m.x.fix(pt[2])
@@ -772,11 +793,8 @@ class Grossmann_TestCases(unittest.TestCase):
     def check_cut_is_correct_facet_rescaled(self, m):
         cuts = m._pyomo_gdp_cuttingplane_transformation.cuts
         self.assertEqual(len(cuts), 1)
-        
-        cut_tight_points = [
-            (1,0,2,127),
-            (0,1,120,3)
-        ]
+
+        cut_tight_points = [(1, 0, 2, 127), (0, 1, 120, 3)]
 
         for pt in cut_tight_points:
             m.x.fix(pt[2])
@@ -786,14 +804,13 @@ class Grossmann_TestCases(unittest.TestCase):
             # ESJ: 5 places is not ideal... But it's in the direction of valid,
             # so I think that's just the price we pay. This test still seems
             # useful to me as a sanity check that the cut is where it should be.
-            self.assertAlmostEqual(value(cuts[0].lower), value(cuts[0].body),
-                                   places=5)
+            self.assertAlmostEqual(value(cuts[0].lower), value(cuts[0].body), places=5)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_cut_is_correct_facet_rescaled_projection(self):
         m = models.to_break_constraint_tolerances()
         TransformationFactory('gdp.cuttingplane').apply_to(m)
-        self.check_cut_is_correct_facet_rescaled(m)        
+        self.check_cut_is_correct_facet_rescaled(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_cut_is_correct_facet_rescaled_inf_norm(self):
@@ -801,19 +818,20 @@ class Grossmann_TestCases(unittest.TestCase):
         # This would give two cuts, the second improving by about 0.05, without
         # the tighter threshold.
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, norm=float('inf'), cut_filtering_threshold=0.1)
+            m, norm=float('inf'), cut_filtering_threshold=0.1
+        )
         self.check_cut_is_correct_facet_rescaled(m)
 
     def check_2disj_cuts_valid_for_extreme_pts(self, m):
         extreme_points = [
-            (1,0,1,0,1,7),
-            (1,0,1,0,1,8),
-            (1,0,1,0,2,7),
-            (1,0,1,0,2,8),
-            (0,1,0,1,9,2),
-            (0,1,0,1,9,3),
-            (0,1,0,1,10,2),
-            (0,1,0,1,10,3)
+            (1, 0, 1, 0, 1, 7),
+            (1, 0, 1, 0, 1, 8),
+            (1, 0, 1, 0, 2, 7),
+            (1, 0, 1, 0, 2, 8),
+            (0, 1, 0, 1, 9, 2),
+            (0, 1, 0, 1, 9, 3),
+            (0, 1, 0, 1, 10, 2),
+            (0, 1, 0, 1, 10, 3),
         ]
 
         cuts = m._pyomo_gdp_cuttingplane_transformation.cuts
@@ -835,7 +853,8 @@ class Grossmann_TestCases(unittest.TestCase):
     def test_2disj_cuts_valid_for_extreme_pts_fme(self):
         m = models.grossmann_twoDisj()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, create_cuts=create_cuts_fme, post_process_cut=None)
+            m, create_cuts=create_cuts_fme, post_process_cut=None
+        )
 
         self.check_2disj_cuts_valid_for_extreme_pts(m)
 
@@ -854,10 +873,11 @@ class Grossmann_TestCases(unittest.TestCase):
 
         self.check_2disj_cuts_valid_for_extreme_pts(m)
 
+
 class NonlinearConvex_TwoCircles(unittest.TestCase):
     def check_cuts_valid_for_optimal(self, m):
         cuts = m._pyomo_gdp_cuttingplane_transformation.cuts
-        self.assertGreaterEqual(len(cuts), 1) # we should get at least one.
+        self.assertGreaterEqual(len(cuts), 1)  # we should get at least one.
 
         m.x.fix(2)
         m.y.fix(7)
@@ -877,7 +897,8 @@ class NonlinearConvex_TwoCircles(unittest.TestCase):
     def test_cuts_valid_for_optimal_fme(self):
         m = models.twoDisj_twoCircles_easy()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, create_cuts=create_cuts_fme, verbose=True)
+            m, bigM=1e6, create_cuts=create_cuts_fme, verbose=True
+        )
 
         self.check_cuts_valid_for_optimal(m)
 
@@ -885,13 +906,14 @@ class NonlinearConvex_TwoCircles(unittest.TestCase):
     def test_cuts_valid_for_optimal_inf_norm(self):
         m = models.twoDisj_twoCircles_easy()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, norm=float('inf'), verbose=True)
+            m, bigM=1e6, norm=float('inf'), verbose=True
+        )
 
         self.check_cuts_valid_for_optimal(m)
 
     def check_cuts_valid_on_facet_containing_optimal(self, m):
         cuts = m._pyomo_gdp_cuttingplane_transformation.cuts
-        self.assertGreaterEqual(len(cuts), 1) # we should get at least one.
+        self.assertGreaterEqual(len(cuts), 1)  # we should get at least one.
 
         m.x.fix(5)
         m.y.fix(3)
@@ -910,19 +932,21 @@ class NonlinearConvex_TwoCircles(unittest.TestCase):
     def test_cuts_valid_on_facet_containing_optimal_fme(self):
         m = models.twoDisj_twoCircles_easy()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, create_cuts=create_cuts_fme, verbose=True)
+            m, bigM=1e6, create_cuts=create_cuts_fme, verbose=True
+        )
         self.check_cuts_valid_on_facet_containing_optimal(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_cuts_valid_on_facet_containing_optimal_inf_norm(self):
         m = models.twoDisj_twoCircles_easy()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, norm=float('inf'), verbose=True)
+            m, bigM=1e6, norm=float('inf'), verbose=True
+        )
         self.check_cuts_valid_on_facet_containing_optimal(m)
 
     def check_cuts_valid_for_other_extreme_points(self, m):
         cuts = m._pyomo_gdp_cuttingplane_transformation.cuts
-        self.assertGreaterEqual(len(cuts), 1) # we should get at least one.
+        self.assertGreaterEqual(len(cuts), 1)  # we should get at least one.
 
         m.x.fix(3)
         m.y.fix(1)
@@ -956,7 +980,8 @@ class NonlinearConvex_TwoCircles(unittest.TestCase):
         # confidence about in the case of numerical difficulties...)
         m = models.twoDisj_twoCircles_easy()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, create_cuts=create_cuts_fme, verbose=True)
+            m, bigM=1e6, create_cuts=create_cuts_fme, verbose=True
+        )
         self.check_cuts_valid_for_other_extreme_points(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
@@ -967,9 +992,10 @@ class NonlinearConvex_TwoCircles(unittest.TestCase):
         # confidence about in the case of numerical difficulties...)
         m = models.twoDisj_twoCircles_easy()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, norm=float('inf'), cut_filtering_threshold=0.5)
+            m, bigM=1e6, norm=float('inf'), cut_filtering_threshold=0.5
+        )
         self.check_cuts_valid_for_other_extreme_points(m)
-            
+
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_cuts_valid_for_optimal_tighter_m(self):
         m = models.twoDisj_twoCircles_easy()
@@ -983,8 +1009,9 @@ class NonlinearConvex_TwoCircles(unittest.TestCase):
         m = models.twoDisj_twoCircles_easy()
 
         # this M comes from the fact that y \in (0,8) and x \in (0,6)
-        TransformationFactory('gdp.cuttingplane').apply_to(m, bigM=83,
-                                                           norm=float('inf'))
+        TransformationFactory('gdp.cuttingplane').apply_to(
+            m, bigM=83, norm=float('inf')
+        )
         self.check_cuts_valid_for_optimal(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
@@ -993,7 +1020,8 @@ class NonlinearConvex_TwoCircles(unittest.TestCase):
 
         # this M comes from the fact that y \in (0,8) and x \in (0,6)
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=83, create_cuts=create_cuts_fme)
+            m, bigM=83, create_cuts=create_cuts_fme
+        )
         self.check_cuts_valid_for_optimal(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
@@ -1010,7 +1038,8 @@ class NonlinearConvex_TwoCircles(unittest.TestCase):
 
         # this M comes from the fact that y \in (0,8) and x \in (0,6)
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=83, create_cuts=create_cuts_fme)
+            m, bigM=83, create_cuts=create_cuts_fme
+        )
         self.check_cuts_valid_on_facet_containing_optimal(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
@@ -1019,7 +1048,8 @@ class NonlinearConvex_TwoCircles(unittest.TestCase):
 
         # this M comes from the fact that y \in (0,8) and x \in (0,6)
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=83, norm=float('inf'))
+            m, bigM=83, norm=float('inf')
+        )
         self.check_cuts_valid_on_facet_containing_optimal(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
@@ -1032,21 +1062,24 @@ class NonlinearConvex_TwoCircles(unittest.TestCase):
     def test_cuts_valid_for_other_extreme_points_tighter_m_fme(self):
         m = models.twoDisj_twoCircles_easy()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=83, create_cuts=create_cuts_fme)
+            m, bigM=83, create_cuts=create_cuts_fme
+        )
         self.check_cuts_valid_for_other_extreme_points(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_cuts_valid_for_other_extreme_points_tighter_m_inf_norm(self):
         m = models.twoDisj_twoCircles_easy()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=83, norm=float('inf'), cut_filtering_threshold=0.5)
+            m, bigM=83, norm=float('inf'), cut_filtering_threshold=0.5
+        )
         self.check_cuts_valid_for_other_extreme_points(m)
-        
-class NonlinearConvex_OverlappingCircles(unittest.TestCase):  
+
+
+class NonlinearConvex_OverlappingCircles(unittest.TestCase):
     def check_cuts_valid_for_optimal(self, m):
         cuts = m._pyomo_gdp_cuttingplane_transformation.cuts
-        self.assertGreaterEqual(len(cuts), 1) # we should get at least one.
-        
+        self.assertGreaterEqual(len(cuts), 1)  # we should get at least one.
+
         m.x.fix(2)
         m.y.fix(7)
         m.upper_circle.indicator_var.fix(True)
@@ -1055,30 +1088,32 @@ class NonlinearConvex_OverlappingCircles(unittest.TestCase):
         m.lower_circle2.indicator_var.fix(False)
         for i in range(len(cuts)):
             self.assertGreaterEqual(value(cuts[i].body), 0)
-      
+
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_cuts_valid_for_optimal(self):
         m = models.fourCircles()
         TransformationFactory('gdp.cuttingplane').apply_to(m, bigM=1e6)
         self.check_cuts_valid_for_optimal(m)
-        
+
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_cuts_valid_for_optimal_fme(self):
         m = models.fourCircles()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, create_cuts=create_cuts_fme)
+            m, bigM=1e6, create_cuts=create_cuts_fme
+        )
         self.check_cuts_valid_for_optimal(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_cuts_valid_for_optimal_inf_norm(self):
         m = models.fourCircles()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, norm=float('inf'))
+            m, bigM=1e6, norm=float('inf')
+        )
         self.check_cuts_valid_for_optimal(m)
 
     def check_cuts_valid_on_facet_containing_optimal(self, m):
         cuts = m._pyomo_gdp_cuttingplane_transformation.cuts
-        self.assertGreaterEqual(len(cuts), 1) # we should get at least one.
+        self.assertGreaterEqual(len(cuts), 1)  # we should get at least one.
 
         m.x.fix(5)
         m.y.fix(3)
@@ -1099,14 +1134,16 @@ class NonlinearConvex_OverlappingCircles(unittest.TestCase):
     def test_cuts_valid_on_facet_containing_optimal_fme(self):
         m = models.fourCircles()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6,create_cuts=create_cuts_fme)
+            m, bigM=1e6, create_cuts=create_cuts_fme
+        )
         self.check_cuts_valid_on_facet_containing_optimal(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_cuts_valid_on_facet_containing_optimal_inf_norm(self):
         m = models.fourCircles()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, norm=float('inf'))
+            m, bigM=1e6, norm=float('inf')
+        )
         self.check_cuts_valid_on_facet_containing_optimal(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
@@ -1119,14 +1156,16 @@ class NonlinearConvex_OverlappingCircles(unittest.TestCase):
     def test_cuts_valid_for_optimal_tightM_fme(self):
         m = models.fourCircles()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6,create_cuts=create_cuts_fme)
+            m, bigM=1e6, create_cuts=create_cuts_fme
+        )
         self.check_cuts_valid_for_optimal(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_cuts_valid_for_optimal_tightM_inf_norm(self):
         m = models.fourCircles()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, norm=float('inf'))
+            m, bigM=1e6, norm=float('inf')
+        )
         self.check_cuts_valid_for_optimal(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
@@ -1139,12 +1178,14 @@ class NonlinearConvex_OverlappingCircles(unittest.TestCase):
     def test_cuts_valid_on_facet_containing_optimal_tightM_fme(self):
         m = models.fourCircles()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6,create_cuts=create_cuts_fme)
+            m, bigM=1e6, create_cuts=create_cuts_fme
+        )
         self.check_cuts_valid_on_facet_containing_optimal(m)
 
     @unittest.skipIf('ipopt' not in solvers, "Ipopt solver not available")
     def test_cuts_valid_on_facet_containing_optimal_tightM_inf_norm(self):
         m = models.fourCircles()
         TransformationFactory('gdp.cuttingplane').apply_to(
-            m, bigM=1e6, norm=float('inf'))
+            m, bigM=1e6, norm=float('inf')
+        )
         self.check_cuts_valid_on_facet_containing_optimal(m)

--- a/pyomo/gdp/tests/test_disjunct.py
+++ b/pyomo/gdp/tests/test_disjunct.py
@@ -33,7 +33,7 @@ class TestDisjunction(unittest.TestCase):
         self.assertEqual(len(m.x1), 1)
         self.assertEqual(m.x1.disjuncts, [m.d, m.e])
 
-        m.x2 = Disjunction([1,2,3,4])
+        m.x2 = Disjunction([1, 2, 3, 4])
         self.assertEqual(len(m.x2), 0)
 
         m.x2[2] = [m.d, m.e]
@@ -44,7 +44,7 @@ class TestDisjunction(unittest.TestCase):
         m = ConcreteModel()
         m.x = Var()
         m.y = Var()
-        m.d = Disjunction(expr=[m.x<=0, m.y>=1])
+        m.d = Disjunction(expr=[m.x <= 0, m.y >= 1])
         self.assertEqual(len(m.component_map(Disjunction)), 1)
         self.assertEqual(len(m.component_map(Disjunct)), 1)
 
@@ -59,7 +59,7 @@ class TestDisjunction(unittest.TestCase):
 
         # Test that the implicit disjuncts get a unique name
         m.add_component('e_disjuncts', Var())
-        m.e = Disjunction(expr=[m.y<=0, m.x>=1])
+        m.e = Disjunction(expr=[m.y <= 0, m.x >= 1])
         self.assertEqual(len(m.component_map(Disjunction)), 2)
         self.assertEqual(len(m.component_map(Disjunct)), 2)
         implicit_disjuncts = list(m.component_map(Disjunct).keys())
@@ -75,14 +75,10 @@ class TestDisjunction(unittest.TestCase):
 
         # Test that the implicit disjuncts can be lists/tuples/generators
         def _gen():
-            yield m.y<=4
-            yield m.x>=5
-        m.f = Disjunction(expr=[
-            [ m.y<=0,
-              m.x>=1 ],
-            ( m.y<=2,
-              m.x>=3 ),
-            _gen() ])
+            yield m.y <= 4
+            yield m.x >= 5
+
+        m.f = Disjunction(expr=[[m.y <= 0, m.x >= 1], (m.y <= 2, m.x >= 3), _gen()])
         self.assertEqual(len(m.component_map(Disjunction)), 3)
         self.assertEqual(len(m.component_map(Disjunct)), 3)
         implicit_disjuncts = list(m.component_map(Disjunct).keys())
@@ -116,8 +112,8 @@ class TestDisjunct(unittest.TestCase):
         m = ConcreteModel()
         m.x = Var()
         m.d1 = Disjunct()
-        m.d1.constraint = Constraint(expr=m.x<=0)
-        m.d = Disjunction(expr=[m.d1, m.x>=1, m.x>=5])
+        m.d1.constraint = Constraint(expr=m.x <= 0)
+        m.d = Disjunction(expr=[m.d1, m.x >= 1, m.x >= 5])
         d2 = m.d.disjuncts[1].parent_component()
         self.assertEqual(len(m.component_map(Disjunction)), 1)
         self.assertEqual(len(m.component_map(Disjunct)), 2)
@@ -196,8 +192,8 @@ class TestDisjunct(unittest.TestCase):
         m = ConcreteModel()
         m.x = Var()
         m.d1 = Disjunct()
-        m.d1.constraint = Constraint(expr=m.x<=0)
-        m.d = Disjunction(expr=[m.d1, m.x>=1, m.x>=5])
+        m.d1.constraint = Constraint(expr=m.x <= 0)
+        m.d = Disjunction(expr=[m.d1, m.x >= 1, m.x >= 5])
         d2 = m.d.disjuncts[1].parent_component()
         self.assertEqual(len(m.component_map(Disjunction)), 1)
         self.assertEqual(len(m.component_map(Disjunct)), 2)
@@ -235,6 +231,7 @@ class TestDisjunct(unittest.TestCase):
     def test_indexed_disjunct_active_property(self):
         m = ConcreteModel()
         m.x = Var(bounds=(0, 12))
+
         @m.Disjunct([0, 1, 2])
         def disjunct(d, i):
             m = d.model()
@@ -261,9 +258,10 @@ class TestDisjunct(unittest.TestCase):
     def test_indexed_disjunction_active_property(self):
         m = ConcreteModel()
         m.x = Var(bounds=(0, 12))
+
         @m.Disjunction([0, 1, 2])
         def disjunction(m, i):
-            return [m.x == i*5, m.x == i*5 + 1]
+            return [m.x == i * 5, m.x == i * 5 + 1]
 
         self.assertTrue(m.disjunction.active)
         m.disjunction[2].deactivate()
@@ -277,6 +275,7 @@ class TestDisjunct(unittest.TestCase):
         self.assertFalse(m.disjunction.active)
         for i in range(3):
             self.assertFalse(m.disjunction[i].active)
+
 
 class TestAutoVars(unittest.TestCase):
     def test_synchronize_value(self):
@@ -379,8 +378,10 @@ class TestAutoVars(unittest.TestCase):
 
         with LoggingIntercept() as LOG:
             m.biv.fix(0.5)
-        self.assertEqual(LOG.getvalue().strip(), "Setting Var 'biv' to a "
-                         "value `0.5` (float) not in domain Binary.")
+        self.assertEqual(
+            LOG.getvalue().strip(),
+            "Setting Var 'biv' to a value `0.5` (float) not in domain Binary.",
+        )
         self.assertEqual(m.iv.value, None)
         self.assertEqual(m.biv.value, 0.5)
 
@@ -398,11 +399,14 @@ class TestAutoVars(unittest.TestCase):
 
         # Note that fixing to a near-True value will toggle the iv
         with LoggingIntercept() as LOG:
-            m.biv.fix(1-eps)
-        self.assertEqual(LOG.getvalue().strip(), "Setting Var 'biv' to a "
-                         "value `%s` (float) not in domain Binary." % (1-eps))
+            m.biv.fix(1 - eps)
+        self.assertEqual(
+            LOG.getvalue().strip(),
+            "Setting Var 'biv' to a "
+            "value `%s` (float) not in domain Binary." % (1 - eps),
+        )
         self.assertEqual(m.iv.value, True)
-        self.assertEqual(m.biv.value, 1-eps)
+        self.assertEqual(m.biv.value, 1 - eps)
 
         with LoggingIntercept() as LOG:
             m.biv.fix(eps, True)
@@ -456,8 +460,7 @@ class TestAutoVars(unittest.TestCase):
 
         m.biv = 1
 
-        deprecation_msg = (
-            "Implicit conversion of the Boolean indicator_var 'iv'")
+        deprecation_msg = "Implicit conversion of the Boolean indicator_var 'iv'"
 
         out = StringIO()
         with LoggingIntercept(out):
@@ -471,7 +474,7 @@ class TestAutoVars(unittest.TestCase):
 
         out = StringIO()
         with LoggingIntercept(out):
-            self.assertEqual(m.iv.bounds, (0,1))
+            self.assertEqual(m.iv.bounds, (0, 1))
         self.assertIn(deprecation_msg, out.getvalue())
 
         out = StringIO()
@@ -486,7 +489,7 @@ class TestAutoVars(unittest.TestCase):
 
         out = StringIO()
         with LoggingIntercept(out):
-            m.iv.bounds = (1,1)
+            m.iv.bounds = (1, 1)
         self.assertIn(deprecation_msg, out.getvalue())
 
         out = StringIO()
@@ -511,24 +514,27 @@ class TestAutoVars(unittest.TestCase):
         out = StringIO()
         with LoggingIntercept(out):
             with self.assertRaisesRegex(
-                    PyomoException, r"Cannot convert non-constant Pyomo "
-                    r"numeric value \(biv\) to bool"):
+                PyomoException,
+                r"Cannot convert non-constant Pyomo " r"numeric value \(biv\) to bool",
+            ):
                 bool(m.iv)
         self.assertIn(deprecation_msg, out.getvalue())
 
         out = StringIO()
         with LoggingIntercept(out):
             with self.assertRaisesRegex(
-                    TypeError, r"Implicit conversion of Pyomo numeric "
-                    r"value \(biv\) to float"):
+                TypeError,
+                r"Implicit conversion of Pyomo numeric " r"value \(biv\) to float",
+            ):
                 float(m.iv)
         self.assertIn(deprecation_msg, out.getvalue())
 
         out = StringIO()
         with LoggingIntercept(out):
             with self.assertRaisesRegex(
-                    TypeError, r"Implicit conversion of Pyomo numeric "
-                    r"value \(biv\) to int"):
+                TypeError,
+                r"Implicit conversion of Pyomo numeric " r"value \(biv\) to int",
+            ):
                 int(m.iv)
         self.assertIn(deprecation_msg, out.getvalue())
 
@@ -597,7 +603,6 @@ class TestAutoVars(unittest.TestCase):
             self.assertIs((m.iv > 0).args[1], m.biv)
         self.assertIn(deprecation_msg, out.getvalue())
 
-
         out = StringIO()
         with LoggingIntercept(out):
             self.assertIs((m.iv + 1).args[0], m.biv)
@@ -620,9 +625,8 @@ class TestAutoVars(unittest.TestCase):
 
         out = StringIO()
         with LoggingIntercept(out):
-            self.assertIs((m.iv ** 2).args[0], m.biv)
+            self.assertIs((m.iv**2).args[0], m.biv)
         self.assertIn(deprecation_msg, out.getvalue())
-
 
         out = StringIO()
         with LoggingIntercept(out):
@@ -646,9 +650,8 @@ class TestAutoVars(unittest.TestCase):
 
         out = StringIO()
         with LoggingIntercept(out):
-            self.assertIs((2 ** m.iv).args[1], m.biv)
+            self.assertIs((2**m.iv).args[1], m.biv)
         self.assertIn(deprecation_msg, out.getvalue())
-
 
         out = StringIO()
         with LoggingIntercept(out):
@@ -686,7 +689,5 @@ class TestAutoVars(unittest.TestCase):
         self.assertIn(deprecation_msg, out.getvalue())
 
 
-
 if __name__ == '__main__':
     unittest.main()
-

--- a/pyomo/gdp/tests/test_fix_disjuncts.py
+++ b/pyomo/gdp/tests/test_fix_disjuncts.py
@@ -14,13 +14,24 @@
 """Tests disjunct fixing."""
 import pyomo.common.unittest as unittest
 from pyomo.environ import (
-    Block, Constraint, ConcreteModel, TransformationFactory, NonNegativeReals,
-    BooleanVar, LogicalConstraint, SolverFactory, Objective, value, Var,
-    implies)
+    Block,
+    Constraint,
+    ConcreteModel,
+    TransformationFactory,
+    NonNegativeReals,
+    BooleanVar,
+    LogicalConstraint,
+    SolverFactory,
+    Objective,
+    value,
+    Var,
+    implies,
+)
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 from pyomo.opt import check_available_solvers
 
 solvers = check_available_solvers('gurobi')
+
 
 class TestFixDisjuncts(unittest.TestCase):
     """Tests fixing of disjuncts."""
@@ -74,11 +85,12 @@ class TestFixDisjuncts(unittest.TestCase):
         m.d1.binary_indicator_var.set_value(0.5)
         m.d2.binary_indicator_var.set_value(0.5)
         with self.assertRaisesRegex(
-                GDP_Error, 
-                "The value of the indicator_var of "
-                "Disjunct 'd1' is None. All indicator_vars "
-                "must have values before calling "
-                "'fix_disjuncts'."):
+            GDP_Error,
+            "The value of the indicator_var of "
+            "Disjunct 'd1' is None. All indicator_vars "
+            "must have values before calling "
+            "'fix_disjuncts'.",
+        ):
             TransformationFactory('gdp.fix_disjuncts').apply_to(m)
 
     def test_disjuncts_partially_fixed(self):
@@ -94,11 +106,12 @@ class TestFixDisjuncts(unittest.TestCase):
         m.d2.indicator_var.set_value(False)
 
         with self.assertRaisesRegex(
-                GDP_Error,
-                "The value of the indicator_var of "
-                "Disjunct 'another1' is None. All indicator_vars "
-                "must have values before calling "
-                "'fix_disjuncts'."):
+            GDP_Error,
+            "The value of the indicator_var of "
+            "Disjunct 'another1' is None. All indicator_vars "
+            "must have values before calling "
+            "'fix_disjuncts'.",
+        ):
             TransformationFactory('gdp.fix_disjuncts').apply_to(m)
 
     @unittest.skipIf('gurobi' not in solvers, "Gurobi solver not available")
@@ -115,7 +128,8 @@ class TestFixDisjuncts(unittest.TestCase):
         m.Y = BooleanVar()
         m.global_logical = LogicalConstraint(expr=m.Y.xor(m.d1.indicator_var))
         m.d1.logical = LogicalConstraint(
-            expr=implies(~m.Y, m.another.disjuncts[0].indicator_var))
+            expr=implies(~m.Y, m.another.disjuncts[0].indicator_var)
+        )
         m.obj = Objective(expr=m.x)
 
         m.d1.indicator_var.set_value(True)
@@ -127,10 +141,15 @@ class TestFixDisjuncts(unittest.TestCase):
 
         # Make sure there are no active LogicalConstraints
         self.assertEqual(
-            len(list(m.component_data_objects(LogicalConstraint,
-                                              active=True,
-                                              descend_into=(Block,
-                                                            Disjunct)))), 0)
+            len(
+                list(
+                    m.component_data_objects(
+                        LogicalConstraint, active=True, descend_into=(Block, Disjunct)
+                    )
+                )
+            ),
+            0,
+        )
         # See that it solves as expected
         SolverFactory('gurobi').solve(m)
         self.assertTrue(value(m.d1.indicator_var))
@@ -147,7 +166,7 @@ class TestFixDisjuncts(unittest.TestCase):
         m.d[1].deactivate()
         m.d[2].indicator_var = True
         m.d[3].indicator_var = False
-        
+
         TransformationFactory('gdp.fix_disjuncts').apply_to(m)
 
         self.assertTrue(m.d[1].indicator_var.fixed)
@@ -163,6 +182,7 @@ class TestFixDisjuncts(unittest.TestCase):
         self.assertFalse(m.d[3].active)
         self.assertEqual(m.d[1].ctype, Block)
         self.assertEqual(m.d[2].ctype, Block)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyomo/gdp/tests/test_gdp.py
+++ b/pyomo/gdp/tests/test_gdp.py
@@ -17,8 +17,9 @@ import os
 import sys
 from os.path import abspath, dirname, normpath, join
 from pyomo.common.fileutils import import_file
+
 currdir = dirname(abspath(__file__))
-exdir = normpath(join(currdir,'..','..','..','examples', 'gdp'))
+exdir = normpath(join(currdir, '..', '..', '..', 'examples', 'gdp'))
 
 try:
     import new
@@ -32,18 +33,23 @@ from pyomo.common.dependencies import yaml, yaml_available, yaml_load_args
 import pyomo.opt
 from pyomo.environ import SolverFactory, TransformationFactory
 
-solvers = pyomo.opt.check_available_solvers('cplex', 'glpk','gurobi')
+solvers = pyomo.opt.check_available_solvers('cplex', 'glpk', 'gurobi')
 
 
 if False:
-    if os.path.exists(sys.exec_prefix+os.sep+'bin'+os.sep+'coverage'):
-        executable=sys.exec_prefix+os.sep+'bin'+os.sep+'coverage -x '
+    if os.path.exists(sys.exec_prefix + os.sep + 'bin' + os.sep + 'coverage'):
+        executable = sys.exec_prefix + os.sep + 'bin' + os.sep + 'coverage -x '
     else:
-        executable=sys.executable
+        executable = sys.executable
 
     def copyfunc(func):
-        return new.function(func.__code__, func.func_globals, func.func_name,
-                            func.func_defaults, func.func_closure)
+        return new.function(
+            func.__code__,
+            func.func_globals,
+            func.func_name,
+            func.func_defaults,
+            func.func_closure,
+        )
 
     class Labeler(type):
         def __new__(meta, name, bases, attrs):
@@ -53,8 +59,7 @@ if False:
                         original = getattr(base, key, None)
                         if original is not None:
                             copy = copyfunc(original)
-                            copy.__doc__ = attrs[key].__doc__ + \
-                                           " (%s)" % copy.__name__
+                            copy.__doc__ = attrs[key].__doc__ + " (%s)" % copy.__name__
                             attrs[key] = copy
                             break
             for base in bases:
@@ -68,10 +73,10 @@ if False:
 
 
 class CommonTests:
-    #__metaclass__ = Labeler
+    # __metaclass__ = Labeler
 
-    solve=True
-    
+    solve = True
+
     def pyomo(self, *args, **kwds):
         exfile = import_file(join(exdir, 'jobshop.py'))
         m_jobshop = exfile.build_model()
@@ -84,8 +89,10 @@ class CommonTests:
             transformation = kwds['preprocess']
 
         TransformationFactory('gdp.%s' % transformation).apply_to(m)
-        m.write(join(currdir, '%s_result.lp' % self.problem),
-                io_options={'symbolic_solver_labels': True})
+        m.write(
+            join(currdir, '%s_result.lp' % self.problem),
+            io_options={'symbolic_solver_labels': True},
+        )
 
         if self.solve:
             solver = 'glpk'
@@ -99,7 +106,7 @@ class CommonTests:
         pass
 
     def referenceFile(self, problem, solver):
-        return join(currdir, problem+'.txt')
+        return join(currdir, problem + '.txt')
 
     def getObjective(self, fname):
         FILE = open(fname)
@@ -114,122 +121,119 @@ class CommonTests:
     def updateDocStrings(self):
         for key in dir(self):
             if key.startswith('test'):
-                getattr(self,key).__doc__ = " (%s)" % getattr(self,key).__name__
+                getattr(self, key).__doc__ = " (%s)" % getattr(self, key).__name__
 
     def test_bigm_jobshop_small(self):
-        self.problem='test_bigm_jobshop_small'
+        self.problem = 'test_bigm_jobshop_small'
         # Run the small jobshop example using the BigM transformation
         self.pyomo('jobshop-small.dat', preprocess='bigm')
         # ESJ: TODO: Right now the indicator variables have names they won't
         # have when they don't have to be reclassified. So I think this LP file
         # will need to change again.
-        self.check( 'jobshop_small', 'bigm' )
+        self.check('jobshop_small', 'bigm')
 
     def test_bigm_jobshop_large(self):
-        self.problem='test_bigm_jobshop_large'
+        self.problem = 'test_bigm_jobshop_large'
         # Run the large jobshop example using the BigM transformation
         self.pyomo('jobshop.dat', preprocess='bigm')
         # ESJ: TODO: this LP file also will need to change with the
         # indicator variable change.
-        self.check( 'jobshop_large', 'bigm' )
+        self.check('jobshop_large', 'bigm')
 
     # def test_bigm_constrained_layout(self):
     #     self.problem='test_bigm_constrained_layout'
     #     # Run the constrained layout example with the bigm transformation
-    #     self.pyomo( join(exdir,'ConstrainedLayout.py'), 
-    #                 join(exdir,'ConstrainedLayout_BigM.dat'), 
+    #     self.pyomo( join(exdir,'ConstrainedLayout.py'),
+    #                 join(exdir,'ConstrainedLayout_BigM.dat'),
     #                 preprocess='bigm', solver='cplex')
     #     self.check( 'constrained_layout', 'bigm')
 
     def test_hull_jobshop_small(self):
-        self.problem='test_hull_jobshop_small'
+        self.problem = 'test_hull_jobshop_small'
         # Run the small jobshop example using the Hull transformation
         self.pyomo('jobshop-small.dat', preprocess='hull')
-        self.check( 'jobshop_small', 'hull' )
+        self.check('jobshop_small', 'hull')
 
     def test_hull_jobshop_large(self):
-        self.problem='test_hull_jobshop_large'
+        self.problem = 'test_hull_jobshop_large'
         # Run the large jobshop example using the Hull transformation
         self.pyomo('jobshop.dat', preprocess='hull')
-        self.check( 'jobshop_large', 'hull' )
+        self.check('jobshop_large', 'hull')
 
     @unittest.skip("cutting plane LP file tests are too fragile")
     @unittest.skipIf('gurobi' not in solvers, 'Gurobi solver not available')
     def test_cuttingplane_jobshop_small(self):
-        self.problem='test_cuttingplane_jobshop_small'
+        self.problem = 'test_cuttingplane_jobshop_small'
         self.pyomo('jobshop-small.dat', preprocess='cuttingplane')
-        self.check( 'jobshop_small', 'cuttingplane' )
+        self.check('jobshop_small', 'cuttingplane')
 
     @unittest.skip("cutting plane LP file tests are too fragile")
     @unittest.skipIf('gurobi' not in solvers, 'Gurobi solver not available')
     def test_cuttingplane_jobshop_large(self):
-        self.problem='test_cuttingplane_jobshop_large'
+        self.problem = 'test_cuttingplane_jobshop_large'
         self.pyomo('jobshop.dat', preprocess='cuttingplane')
-        self.check( 'jobshop_large', 'cuttingplane' )
+        self.check('jobshop_large', 'cuttingplane')
 
 
 class Reformulate(unittest.TestCase, CommonTests):
 
-    solve=False
+    solve = False
 
     def tearDown(self):
-        if os.path.exists(os.path.join(currdir,'result.yml')):
-            os.remove(os.path.join(currdir,'result.yml'))
+        if os.path.exists(os.path.join(currdir, 'result.yml')):
+            os.remove(os.path.join(currdir, 'result.yml'))
 
-    def pyomo(self,  *args, **kwds):
+    def pyomo(self, *args, **kwds):
         args = list(args)
-        args.append('--output='+self.problem+'_result.lp')
+        args.append('--output=' + self.problem + '_result.lp')
         CommonTests.pyomo(self, *args, **kwds)
 
     def referenceFile(self, problem, solver):
-        return join(currdir, problem+"_"+solver+'.lp')
+        return join(currdir, problem + "_" + solver + '.lp')
 
     def check(self, problem, solver):
-        _prob, _solv = join(currdir,self.problem+'_result.lp'), self.referenceFile(problem,solver)
-        self.assertTrue(cmp(_prob, _solv),
-                        msg="Files %s and %s differ" % (_prob, _solv))
-        if os.path.exists(join(currdir,self.problem+'_result.lp')):
-           os.remove(join(currdir,self.problem+'_result.lp'))
+        _prob, _solv = join(currdir, self.problem + '_result.lp'), self.referenceFile(
+            problem, solver
+        )
+        self.assertTrue(
+            cmp(_prob, _solv), msg="Files %s and %s differ" % (_prob, _solv)
+        )
+        if os.path.exists(join(currdir, self.problem + '_result.lp')):
+            os.remove(join(currdir, self.problem + '_result.lp'))
 
 
 class Solver(unittest.TestCase):
-
     def tearDown(self):
-        if os.path.exists(os.path.join(currdir,'result.yml')):
-            os.remove(os.path.join(currdir,'result.yml'))
+        if os.path.exists(os.path.join(currdir, 'result.yml')):
+            os.remove(os.path.join(currdir, 'result.yml'))
 
     def check(self, problem, solver):
-        refObj = self.getObjective(self.referenceFile(problem,solver))
-        ansObj = self.getObjective(join(currdir,'result.yml'))
+        refObj = self.getObjective(self.referenceFile(problem, solver))
+        ansObj = self.getObjective(join(currdir, 'result.yml'))
         self.assertEqual(len(refObj), len(ansObj))
         for i in range(len(refObj)):
             self.assertEqual(len(refObj[i]), len(ansObj[i]))
-            for key,val in refObj[i].items():
+            for key, val in refObj[i].items():
                 self.assertAlmostEqual(
-                    val.get('Value', None),
-                    ansObj[i].get(key,{}).get('Value', None),
-                    6
+                    val.get('Value', None), ansObj[i].get(key, {}).get('Value', None), 6
                 )
         # Clean up test files
-        if os.path.exists(join(currdir,self.problem+'_result.lp')):
-           os.remove(join(currdir,self.problem+'_result.lp'))
+        if os.path.exists(join(currdir, self.problem + '_result.lp')):
+            os.remove(join(currdir, self.problem + '_result.lp'))
 
 
 @unittest.skipIf(not yaml_available, "YAML is not available")
 @unittest.skipIf(not 'glpk' in solvers, "The 'glpk' executable is not available")
 class Solve_GLPK(Solver, CommonTests):
-
-    def pyomo(self,  *args, **kwds):
+    def pyomo(self, *args, **kwds):
         kwds['solver'] = 'glpk'
         CommonTests.pyomo(self, *args, **kwds)
 
 
 @unittest.skipIf(not yaml_available, "YAML is not available")
-@unittest.skipIf(not 'cplex' in solvers, 
-                 "The 'cplex' executable is not available")
+@unittest.skipIf(not 'cplex' in solvers, "The 'cplex' executable is not available")
 class Solve_CPLEX(Solver, CommonTests):
-
-    def pyomo(self,  *args, **kwds):
+    def pyomo(self, *args, **kwds):
         kwds['solver'] = 'cplex'
         CommonTests.pyomo(self, *args, **kwds)
 

--- a/pyomo/gdp/tests/test_gdp_reclassification_error.py
+++ b/pyomo/gdp/tests/test_gdp_reclassification_error.py
@@ -32,8 +32,7 @@ class TestGDPReclassificationError(unittest.TestCase):
         log = StringIO()
         with LoggingIntercept(log, 'pyomo.gdp', logging.WARNING):
             check_model_algebraic(m)
-        self.assertRegex( log.getvalue(), 
-                                  '.*not found in any Disjunctions.*')
+        self.assertRegex(log.getvalue(), '.*not found in any Disjunctions.*')
 
     def test_disjunct_not_in_active_disjunction(self):
         m = pyo.ConcreteModel()
@@ -48,6 +47,8 @@ class TestGDPReclassificationError(unittest.TestCase):
         log = StringIO()
         with LoggingIntercept(log, 'pyomo.gdp', logging.WARNING):
             check_model_algebraic(m)
-        self.assertRegex(log.getvalue(), 
-                                 '.*While it participates in a Disjunction, '
-                                 'that Disjunction is currently deactivated.*')
+        self.assertRegex(
+            log.getvalue(),
+            '.*While it participates in a Disjunction, '
+            'that Disjunction is currently deactivated.*',
+        )

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -14,10 +14,26 @@ import pyomo.common.unittest as unittest
 from pyomo.common.log import LoggingIntercept
 import logging
 
-from pyomo.environ import (TransformationFactory, Block, Set, Constraint, Var,
-                           RealSet, ComponentMap, value, log, ConcreteModel,
-                           Any, Suffix, SolverFactory, RangeSet, Param,
-                           Objective, TerminationCondition, Reference)
+from pyomo.environ import (
+    TransformationFactory,
+    Block,
+    Set,
+    Constraint,
+    Var,
+    RealSet,
+    ComponentMap,
+    value,
+    log,
+    ConcreteModel,
+    Any,
+    Suffix,
+    SolverFactory,
+    RangeSet,
+    Param,
+    Objective,
+    TerminationCondition,
+    Reference,
+)
 from pyomo.core.expr.compare import assertExpressionsStructurallyEqual
 from pyomo.core.base import constraint
 from pyomo.repn import generate_standard_repn
@@ -30,11 +46,13 @@ import random
 from io import StringIO
 import os
 from os.path import abspath, dirname, join
+
 currdir = dirname(abspath(__file__))
 from filecmp import cmp
 
 EPS = TransformationFactory('gdp.hull').CONFIG.EPS
 linear_solvers = ct.linear_solvers
+
 
 class CommonTests:
     def setUp(self):
@@ -43,6 +61,7 @@ class CommonTests:
 
     def diff_apply_to_and_create_using(self, model):
         ct.diff_apply_to_and_create_using(self, model, 'gdp.hull')
+
 
 class TwoTermDisj(unittest.TestCase, CommonTests):
     def setUp(self):
@@ -73,13 +92,13 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         transBlock = m._pyomo_gdp_hull_reformulation
         disjBlock = transBlock.relaxedDisjuncts
         # same on both disjuncts
-        for i in [0,1]:
+        for i in [0, 1]:
             relaxationBlock = disjBlock[i]
             x = relaxationBlock.disaggregatedVars.x
-            if i == 1: # this disjunct as x, w, and no y
+            if i == 1:  # this disjunct as x, w, and no y
                 w = relaxationBlock.disaggregatedVars.w
                 y = transBlock._disaggregatedVars[0]
-            elif i == 0: # this disjunct as x, y, and no w
+            elif i == 0:  # this disjunct as x, y, and no w
                 y = relaxationBlock.disaggregatedVars.y
                 w = transBlock._disaggregatedVars[1]
             # variables created (w and y can be Vars or VarDatas depending on
@@ -125,7 +144,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         self.assertEqual(len(repn.linear_vars), 1)
         # This is a weak test, but as good as any to ensure that the
         # substitution was done correctly
-        EPS_1 = 1-EPS
+        EPS_1 = 1 - EPS
         self.assertEqual(
             str(cons.body),
             "(%s*d[0].binary_indicator_var + %s)*("
@@ -135,8 +154,8 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
             "(_pyomo_gdp_hull_reformulation.relaxedDisjuncts[0]."
             "disaggregatedVars.y/"
             "(%s*d[0].binary_indicator_var + %s))**2) - "
-            "14.0*d[0].binary_indicator_var"
-            % (EPS_1, EPS, EPS_1, EPS, EPS_1, EPS))
+            "14.0*d[0].binary_indicator_var" % (EPS_1, EPS, EPS_1, EPS, EPS_1, EPS),
+        )
 
     def test_transformed_constraints_linear(self):
         m = models.makeTwoTermDisj_Nonlinear()
@@ -201,8 +220,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         ct.check_linear_coef(self, repn, m.d[1].indicator_var, -3)
         self.assertEqual(repn.constant, 0)
 
-    def check_bound_constraints_on_disjBlock(self, cons, disvar, indvar, lb,
-                                             ub):
+    def check_bound_constraints_on_disjBlock(self, cons, disvar, indvar, lb, ub):
         self.assertIsInstance(cons, Constraint)
 
         # both lb and ub
@@ -227,8 +245,9 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         ct.check_linear_coef(self, repn, indvar, -ub)
         ct.check_linear_coef(self, repn, disvar, 1)
 
-    def check_bound_constraints_on_disjunctionBlock(self, varlb, varub, disvar,
-                                                    indvar, lb, ub):
+    def check_bound_constraints_on_disjunctionBlock(
+        self, varlb, varub, disvar, indvar, lb, ub
+    ):
         self.assertIsNone(varlb.lower)
         self.assertEqual(varlb.upper, 0)
         repn = generate_standard_repn(varlb.body)
@@ -253,33 +272,48 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
         transBlock = m._pyomo_gdp_hull_reformulation
         disjBlock = transBlock.relaxedDisjuncts
-        for i in [0,1]:
+        for i in [0, 1]:
             # check bounds constraints for each variable on each of the two
             # disjuncts.
             self.check_bound_constraints_on_disjBlock(
                 disjBlock[i].x_bounds,
                 disjBlock[i].disaggregatedVars.x,
-                m.d[i].indicator_var, 1, 8)
-            if i == 1: # this disjunct has x, w, and no y
+                m.d[i].indicator_var,
+                1,
+                8,
+            )
+            if i == 1:  # this disjunct has x, w, and no y
                 self.check_bound_constraints_on_disjBlock(
                     disjBlock[i].w_bounds,
                     disjBlock[i].disaggregatedVars.w,
-                    m.d[i].indicator_var, 2, 7)
+                    m.d[i].indicator_var,
+                    2,
+                    7,
+                )
                 self.check_bound_constraints_on_disjunctionBlock(
-                    transBlock._boundsConstraints[0,'lb'],
-                    transBlock._boundsConstraints[0,'ub'],
+                    transBlock._boundsConstraints[0, 'lb'],
+                    transBlock._boundsConstraints[0, 'ub'],
                     transBlock._disaggregatedVars[0],
-                    m.d[0].indicator_var, -10, -3)
-            elif i == 0: # this disjunct has x, y, and no w
+                    m.d[0].indicator_var,
+                    -10,
+                    -3,
+                )
+            elif i == 0:  # this disjunct has x, y, and no w
                 self.check_bound_constraints_on_disjBlock(
                     disjBlock[i].y_bounds,
                     disjBlock[i].disaggregatedVars.y,
-                    m.d[i].indicator_var, -10, -3)
+                    m.d[i].indicator_var,
+                    -10,
+                    -3,
+                )
                 self.check_bound_constraints_on_disjunctionBlock(
-                    transBlock._boundsConstraints[1,'lb'],
-                    transBlock._boundsConstraints[1,'ub'],
+                    transBlock._boundsConstraints[1, 'lb'],
+                    transBlock._boundsConstraints[1, 'ub'],
                     transBlock._disaggregatedVars[1],
-                    m.d[1].indicator_var, 2, 7)
+                    m.d[1].indicator_var,
+                    2,
+                    7,
+                )
 
     def test_error_for_or(self):
         m = models.makeTwoTermDisj_Nonlinear()
@@ -290,7 +324,8 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
             "Cannot do hull reformulation for Disjunction "
             "'disjunction' with OR constraint.  Must be an XOR!*",
             TransformationFactory('gdp.hull').apply_to,
-            m)
+            m,
+        )
 
     def check_disaggregation_constraint(self, cons, var, disvar1, disvar2):
         repn = generate_standard_repn(cons.body)
@@ -309,14 +344,23 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         disjBlock = transBlock.relaxedDisjuncts
 
         self.check_disaggregation_constraint(
-            hull.get_disaggregation_constraint(m.w, m.disjunction), m.w,
-            disjBlock[1].disaggregatedVars.w, transBlock._disaggregatedVars[1])
+            hull.get_disaggregation_constraint(m.w, m.disjunction),
+            m.w,
+            disjBlock[1].disaggregatedVars.w,
+            transBlock._disaggregatedVars[1],
+        )
         self.check_disaggregation_constraint(
-            hull.get_disaggregation_constraint(m.x, m.disjunction), m.x,
-            disjBlock[0].disaggregatedVars.x, disjBlock[1].disaggregatedVars.x)
+            hull.get_disaggregation_constraint(m.x, m.disjunction),
+            m.x,
+            disjBlock[0].disaggregatedVars.x,
+            disjBlock[1].disaggregatedVars.x,
+        )
         self.check_disaggregation_constraint(
-            hull.get_disaggregation_constraint(m.y, m.disjunction), m.y,
-            disjBlock[0].disaggregatedVars.y, transBlock._disaggregatedVars[0])
+            hull.get_disaggregation_constraint(m.y, m.disjunction),
+            m.y,
+            disjBlock[0].disaggregatedVars.y,
+            transBlock._disaggregatedVars[0],
+        )
 
     def test_xor_constraint_mapping(self):
         ct.check_xor_constraint_mapping(self, 'hull')
@@ -383,13 +427,13 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         transBlock = m._pyomo_gdp_hull_reformulation
         disjBlock = transBlock.relaxedDisjuncts
 
-        for i in [0,1]:
+        for i in [0, 1]:
             mappings = ComponentMap()
             mappings[m.x] = disjBlock[i].disaggregatedVars.x
-            if i == 1: # this disjunct as x, w, and no y
+            if i == 1:  # this disjunct as x, w, and no y
                 mappings[m.w] = disjBlock[i].disaggregatedVars.w
                 mappings[m.y] = transBlock._disaggregatedVars[0]
-            elif i == 0: # this disjunct as x, y, and no w
+            elif i == 0:  # this disjunct as x, y, and no w
                 mappings[m.y] = disjBlock[i].disaggregatedVars.y
                 mappings[m.w] = transBlock._disaggregatedVars[1]
 
@@ -405,21 +449,21 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         transBlock = m._pyomo_gdp_hull_reformulation
         disjBlock = transBlock.relaxedDisjuncts
 
-        for i in [0,1]:
+        for i in [0, 1]:
             mappings = ComponentMap()
             mappings[disjBlock[i].disaggregatedVars.x] = disjBlock[i].x_bounds
-            if i == 1: # this disjunct has x, w, and no y
-                mappings[disjBlock[i].disaggregatedVars.w] = disjBlock[i].\
-                                                             w_bounds
+            if i == 1:  # this disjunct has x, w, and no y
+                mappings[disjBlock[i].disaggregatedVars.w] = disjBlock[i].w_bounds
                 mappings[transBlock._disaggregatedVars[0]] = Reference(
-                    transBlock._boundsConstraints[0,...])
-            elif i == 0: # this disjunct has x, y, and no w
-                mappings[disjBlock[i].disaggregatedVars.y] = disjBlock[i].\
-                                                             y_bounds
+                    transBlock._boundsConstraints[0, ...]
+                )
+            elif i == 0:  # this disjunct has x, y, and no w
+                mappings[disjBlock[i].disaggregatedVars.y] = disjBlock[i].y_bounds
                 mappings[transBlock._disaggregatedVars[1]] = Reference(
-                    transBlock._boundsConstraints[1,...])
+                    transBlock._boundsConstraints[1, ...]
+                )
             for var, cons in mappings.items():
-                returned_cons =  hull.get_var_bounds_constraint(var)
+                returned_cons = hull.get_var_bounds_constraint(var)
                 # This sometimes refers a reference to the right part of a
                 # larger indexed constraint, so the indexed constraints
                 # themselves might not be the same object. The ConstraintDatas
@@ -443,8 +487,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
         # check that we used the bounds on the local variable as if they are
         # global. Which means checking the bounds constraints...
-        y_disagg = m.disj2.transformation_block.disaggregatedVars.component(
-            "disj2.y")
+        y_disagg = m.disj2.transformation_block.disaggregatedVars.component("disj2.y")
         cons = hull.get_var_bounds_constraint(y_disagg)
         lb = cons['lb']
         self.assertIsNone(lb.lower)
@@ -471,12 +514,12 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         # two birds one stone: test the mappings too
         disj1y = hull.get_disaggregated_var(m.disj2.y, m.disj1)
         disj2y = hull.get_disaggregated_var(m.disj2.y, m.disj2)
-        self.assertIs(disj1y,
-                      m.disj1.transformation_block.parent_block().\
-                      _disaggregatedVars[0])
-        self.assertIs(disj2y,
-                      m.disj2.transformation_block.disaggregatedVars.\
-                      component("disj2.y"))
+        self.assertIs(
+            disj1y, m.disj1.transformation_block.parent_block()._disaggregatedVars[0]
+        )
+        self.assertIs(
+            disj2y, m.disj2.transformation_block.disaggregatedVars.component("disj2.y")
+        )
         self.assertIs(hull.get_src_var(disj1y), m.disj2.y)
         self.assertIs(hull.get_src_var(disj2y), m.disj2.y)
 
@@ -516,8 +559,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         disj = m.disj1
         transBlock = disj.transformation_block
         varBlock = transBlock.disaggregatedVars
-        self.assertEqual(len([v for v in
-                              varBlock.component_data_objects(Var)]), 2)
+        self.assertEqual(len([v for v in varBlock.component_data_objects(Var)]), 2)
         x = varBlock.component("disj1.x")
         y = varBlock.component("disj1.y")
         self.assertIsInstance(x, Var)
@@ -530,8 +572,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         for disj in [m.disj2, m.disj4]:
             transBlock = disj.transformation_block
             varBlock = transBlock.disaggregatedVars
-            self.assertEqual(len([v for v in
-                                  varBlock.component_data_objects(Var)]), 1)
+            self.assertEqual(len([v for v in varBlock.component_data_objects(Var)]), 1)
             y = varBlock.component("disj1.y")
             self.assertIsInstance(y, Var)
             self.assertIs(hull.get_disaggregated_var(m.disj1.y, disj), y)
@@ -540,24 +581,20 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         disj = m.disj3
         transBlock = disj.transformation_block
         varBlock = transBlock.disaggregatedVars
-        self.assertEqual(len([v for v in
-                              varBlock.component_data_objects(Var)]), 1)
+        self.assertEqual(len([v for v in varBlock.component_data_objects(Var)]), 1)
         x = varBlock.component("disj1.x")
         self.assertIsInstance(x, Var)
         self.assertIs(hull.get_disaggregated_var(m.disj1.x, disj), x)
         self.assertIs(hull.get_src_var(x), m.disj1.x)
 
         # there is a spare x on disjunction1's block
-        x2 = m.disjunction1.algebraic_constraint.parent_block().\
-             _disaggregatedVars[2]
+        x2 = m.disjunction1.algebraic_constraint.parent_block()._disaggregatedVars[2]
         self.assertIs(hull.get_disaggregated_var(m.disj1.x, m.disj2), x2)
         self.assertIs(hull.get_src_var(x2), m.disj1.x)
 
         # and both a spare x and y on disjunction2's block
-        x2 = m.disjunction2.algebraic_constraint.parent_block().\
-             _disaggregatedVars[0]
-        y1 = m.disjunction2.algebraic_constraint.parent_block().\
-             _disaggregatedVars[1]
+        x2 = m.disjunction2.algebraic_constraint.parent_block()._disaggregatedVars[0]
+        y1 = m.disjunction2.algebraic_constraint.parent_block()._disaggregatedVars[1]
         self.assertIs(hull.get_disaggregated_var(m.disj1.x, m.disj4), x2)
         self.assertIs(hull.get_src_var(x2), m.disj1.x)
         self.assertIs(hull.get_disaggregated_var(m.disj1.y, m.disj3), y1)
@@ -567,8 +604,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         hull = TransformationFactory('gdp.hull')
         transBlock = disj.transformation_block
         varBlock = transBlock.disaggregatedVars
-        self.assertEqual(len([v for v in
-                              varBlock.component_data_objects(Var)]), 2)
+        self.assertEqual(len([v for v in varBlock.component_data_objects(Var)]), 2)
         # ESJ: This is not what I expected. *Can* we still get name collisions,
         # if we're using a fully qualified name here?
         x2 = varBlock.component("'disj1.x'")
@@ -617,8 +653,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         ct.check_improperly_deactivated_disjuncts(self, 'hull')
 
     def test_do_not_transform_userDeactivated_IndexedDisjunction(self):
-        ct.check_do_not_transform_userDeactivated_indexedDisjunction(self,
-                                                                     'hull')
+        ct.check_do_not_transform_userDeactivated_indexedDisjunction(self, 'hull')
 
     def test_disjunction_deactivated(self):
         ct.check_disjunction_deactivated(self, 'hull')
@@ -630,8 +665,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         ct.check_deactivated_constraints(self, 'hull')
 
     def check_no_double_transformation(self):
-        ct.check_do_not_transform_twice_if_disjunction_reactivated(self,
-                                                                   'hull')
+        ct.check_do_not_transform_twice_if_disjunction_reactivated(self, 'hull')
 
     def test_indicator_vars(self):
         ct.check_indicator_vars(self, 'hull')
@@ -650,41 +684,40 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
             "bounded in order to use the hull "
             "transformation! Missing bound for w.*",
             TransformationFactory('gdp.hull').apply_to,
-            m)
+            m,
+        )
 
     def check_threeTermDisj_IndexedConstraints(self, m, lb):
         transBlock = m._pyomo_gdp_hull_reformulation
         hull = TransformationFactory('gdp.hull')
 
         # 2 blocks: the original Disjunct and the transformation block
-        self.assertEqual(
-            len(list(m.component_objects(Block, descend_into=False))), 1)
-        self.assertEqual(
-            len(list(m.component_objects(Disjunct))), 1)
+        self.assertEqual(len(list(m.component_objects(Block, descend_into=False))), 1)
+        self.assertEqual(len(list(m.component_objects(Disjunct))), 1)
 
         # Each relaxed disjunct should have i disaggregated vars and i "d[i].c"
         # Constraints
-        for i in [1,2,3]:
-            relaxed = transBlock.relaxedDisjuncts[i-1]
+        for i in [1, 2, 3]:
+            relaxed = transBlock.relaxedDisjuncts[i - 1]
             self.assertEqual(
-                len(list(relaxed.disaggregatedVars.component_objects( Var))), i)
+                len(list(relaxed.disaggregatedVars.component_objects(Var))), i
+            )
             self.assertEqual(
-                len(list(relaxed.disaggregatedVars.component_data_objects(
-                    Var))), i)
+                len(list(relaxed.disaggregatedVars.component_data_objects(Var))), i
+            )
             # we always have the x[1] bounds constraint, then however many
             # original constraints were on the Disjunct
-            self.assertEqual(
-                len(list(relaxed.component_objects(Constraint))), 1 + i)
+            self.assertEqual(len(list(relaxed.component_objects(Constraint))), 1 + i)
             if lb == 0:
                 # i bounds constraints and i transformed constraints
                 self.assertEqual(
-                    len(list(relaxed.component_data_objects(Constraint))),
-                    i + i)
+                    len(list(relaxed.component_data_objects(Constraint))), i + i
+                )
             else:
                 # 2*i bounds constraints and i transformed constraints
                 self.assertEqual(
-                    len(list(relaxed.component_data_objects(Constraint))),
-                    2*i + i)
+                    len(list(relaxed.component_data_objects(Constraint))), 2 * i + i
+                )
 
             # Check that there are i transformed constraints on relaxed:
             for j in range(1, i + 1):
@@ -694,24 +727,43 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
         # the remaining disaggregated variables are on the disjunction
         # transformation block
-        self.assertEqual(len(list(transBlock.component_objects(
-            Var, descend_into=False))), 1)
-        self.assertEqual(len(list(transBlock.component_data_objects(
-            Var, descend_into=False))), 2)
+        self.assertEqual(
+            len(list(transBlock.component_objects(Var, descend_into=False))), 1
+        )
+        self.assertEqual(
+            len(list(transBlock.component_data_objects(Var, descend_into=False))), 2
+        )
         # as are the XOR, reaggregation and their bounds constraints
-        self.assertEqual(len(list(transBlock.component_objects(
-            Constraint, descend_into=False))), 3)
+        self.assertEqual(
+            len(list(transBlock.component_objects(Constraint, descend_into=False))), 3
+        )
 
         if lb == 0:
             # 3 reaggregation + 2 bounds + 1 xor (because one bounds constraint
             # is on the parent transformation block, and we don't need lb
             # constraints if lb = 0)
-            self.assertEqual(len(list(transBlock.component_data_objects(
-                Constraint, descend_into=False))), 6)
+            self.assertEqual(
+                len(
+                    list(
+                        transBlock.component_data_objects(
+                            Constraint, descend_into=False
+                        )
+                    )
+                ),
+                6,
+            )
         else:
             # 3 reaggregation + 4 bounds + 1 xor
-            self.assertEqual(len(list(transBlock.component_data_objects(
-                Constraint, descend_into=False))), 8)
+            self.assertEqual(
+                len(
+                    list(
+                        transBlock.component_data_objects(
+                            Constraint, descend_into=False
+                        )
+                    )
+                ),
+                8,
+            )
 
     def test_indexed_constraints_in_disjunct(self):
         m = models.makeThreeTermDisj_IndexedConstraints()
@@ -722,13 +774,15 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
 
     def test_virtual_indexed_constraints_in_disjunct(self):
         m = ConcreteModel()
-        m.I = [1,2,3]
-        m.x = Var(m.I, bounds=(-1,10))
-        def d_rule(d,j):
+        m.I = [1, 2, 3]
+        m.x = Var(m.I, bounds=(-1, 10))
+
+        def d_rule(d, j):
             m = d.model()
             d.c = Constraint(Any)
             for k in range(j):
-                d.c[k+1] = m.x[k+1] >= k+1
+                d.c[k + 1] = m.x[k + 1] >= k + 1
+
         m.d = Disjunct(m.I, rule=d_rule)
         m.disjunction = Disjunction(expr=[m.d[i] for i in m.I])
 
@@ -752,10 +806,12 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
                 KeyError,
                 r".*b.simpledisj1.c\[1\]",
                 hull.get_transformed_constraints,
-                m.b.simpledisj1.c[1])
-        self.assertRegex(log.getvalue(),
-                         r".*Constraint 'b.simpledisj1.c\[1\]' has not "
-                         r"been transformed.")
+                m.b.simpledisj1.c[1],
+            )
+        self.assertRegex(
+            log.getvalue(),
+            r".*Constraint 'b.simpledisj1.c\[1\]' has not " r"been transformed.",
+        )
 
         # this fixes a[2] to 0, so we should get the disggregated var
         transformed = hull.get_transformed_constraints(m.b.simpledisj1.c[2])
@@ -769,14 +825,16 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         transformed = hull.get_transformed_constraints(m.b.simpledisj2.c[1])
         # simpledisj2.c[1] is a <= constraint
         self.assertEqual(len(transformed), 1)
-        self.assertIs(transformed[0].parent_block(),
-                      m.b.simpledisj2.transformation_block)
+        self.assertIs(
+            transformed[0].parent_block(), m.b.simpledisj2.transformation_block
+        )
 
         transformed = hull.get_transformed_constraints(m.b.simpledisj2.c[2])
         # simpledisj2.c[2] is a <= constraint
         self.assertEqual(len(transformed), 1)
-        self.assertIs(transformed[0].parent_block(),
-                      m.b.simpledisj2.transformation_block)
+        self.assertIs(
+            transformed[0].parent_block(), m.b.simpledisj2.transformation_block
+        )
 
 
 class MultiTermDisj(unittest.TestCase, CommonTests):
@@ -798,8 +856,7 @@ class MultiTermDisj(unittest.TestCase, CommonTests):
         self.assertEqual(x1.ub, 8)
         self.assertIs(hull.get_src_var(x1), m.x)
 
-        x2 = m.disjunction.algebraic_constraint.parent_block().\
-             _disaggregatedVars[0]
+        x2 = m.disjunction.algebraic_constraint.parent_block()._disaggregatedVars[0]
         self.assertIs(hull.get_src_var(x2), m.x)
         self.assertIs(hull.get_disaggregated_var(m.x, m.d2), x2)
         self.assertIs(hull.get_disaggregated_var(m.x, m.d3), x2)
@@ -814,8 +871,7 @@ class MultiTermDisj(unittest.TestCase, CommonTests):
         self.assertTrue(repn.is_linear())
         self.assertEqual(len(repn.linear_vars), 2)
         self.assertIs(repn.linear_vars[1], x2)
-        self.assertIs(repn.linear_vars[0],
-                      m.d1.indicator_var.get_associated_binary())
+        self.assertIs(repn.linear_vars[0], m.d1.indicator_var.get_associated_binary())
         self.assertEqual(repn.linear_coefs[0], 2)
         self.assertEqual(repn.linear_coefs[1], -1)
         self.assertEqual(repn.constant, -2)
@@ -826,8 +882,7 @@ class MultiTermDisj(unittest.TestCase, CommonTests):
         self.assertTrue(repn.is_linear())
         self.assertEqual(len(repn.linear_vars), 2)
         self.assertIs(repn.linear_vars[0], x2)
-        self.assertIs(repn.linear_vars[1],
-                      m.d1.indicator_var.get_associated_binary())
+        self.assertIs(repn.linear_vars[1], m.d1.indicator_var.get_associated_binary())
         self.assertEqual(repn.linear_coefs[1], 8)
         self.assertEqual(repn.linear_coefs[0], 1)
         self.assertEqual(repn.constant, -8)
@@ -847,6 +902,7 @@ class MultiTermDisj(unittest.TestCase, CommonTests):
         self.assertEqual(repn.linear_coefs[2], -1)
         self.assertEqual(repn.constant, 0)
 
+
 class IndexedDisjunction(unittest.TestCase, CommonTests):
     def setUp(self):
         # set seed so we can test name collisions predictably
@@ -859,17 +915,22 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         relaxedDisjuncts = m._pyomo_gdp_hull_reformulation.relaxedDisjuncts
 
         disaggregatedVars = {
-            1: [hull.get_disaggregated_var(m.x[1], m.disjunct[1, 'a']),
-                hull.get_disaggregated_var(m.x[1], m.disjunct[1, 'b'])],
-            2: [hull.get_disaggregated_var(m.x[2], m.disjunct[2, 'a']),
-                hull.get_disaggregated_var(m.x[2], m.disjunct[2, 'b'])],
-            3: [hull.get_disaggregated_var(m.x[3], m.disjunct[3, 'a']),
-                hull.get_disaggregated_var(m.x[3], m.disjunct[3, 'b'])],
+            1: [
+                hull.get_disaggregated_var(m.x[1], m.disjunct[1, 'a']),
+                hull.get_disaggregated_var(m.x[1], m.disjunct[1, 'b']),
+            ],
+            2: [
+                hull.get_disaggregated_var(m.x[2], m.disjunct[2, 'a']),
+                hull.get_disaggregated_var(m.x[2], m.disjunct[2, 'b']),
+            ],
+            3: [
+                hull.get_disaggregated_var(m.x[3], m.disjunct[3, 'a']),
+                hull.get_disaggregated_var(m.x[3], m.disjunct[3, 'b']),
+            ],
         }
 
         for i, disVars in disaggregatedVars.items():
-            cons = hull.get_disaggregation_constraint(m.x[i],
-                                                       m.disjunction[i])
+            cons = hull.get_disaggregation_constraint(m.x[i], m.disjunction[i])
             self.assertEqual(cons.lower, 0)
             self.assertEqual(cons.upper, 0)
             repn = generate_standard_repn(cons.body)
@@ -887,23 +948,26 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         relaxedDisjuncts = m._pyomo_gdp_hull_reformulation.relaxedDisjuncts
 
         disaggregatedVars = {
-            (1,'A'):
-            [hull.get_disaggregated_var(m.a[1,'A'], m.disjunct[0,1,'A']),
-             hull.get_disaggregated_var(m.a[1,'A'], m.disjunct[1,1,'A'])],
-            (1,'B'):
-            [hull.get_disaggregated_var(m.a[1,'B'], m.disjunct[0,1,'B']),
-             hull.get_disaggregated_var(m.a[1,'B'], m.disjunct[1,1,'B'])],
-            (2,'A'):
-            [hull.get_disaggregated_var(m.a[2,'A'], m.disjunct[0,2,'A']),
-             hull.get_disaggregated_var(m.a[2,'A'], m.disjunct[1,2,'A'])],
-            (2,'B'):
-            [hull.get_disaggregated_var(m.a[2,'B'], m.disjunct[0,2,'B']),
-             hull.get_disaggregated_var(m.a[2,'B'], m.disjunct[1,2,'B'])],
+            (1, 'A'): [
+                hull.get_disaggregated_var(m.a[1, 'A'], m.disjunct[0, 1, 'A']),
+                hull.get_disaggregated_var(m.a[1, 'A'], m.disjunct[1, 1, 'A']),
+            ],
+            (1, 'B'): [
+                hull.get_disaggregated_var(m.a[1, 'B'], m.disjunct[0, 1, 'B']),
+                hull.get_disaggregated_var(m.a[1, 'B'], m.disjunct[1, 1, 'B']),
+            ],
+            (2, 'A'): [
+                hull.get_disaggregated_var(m.a[2, 'A'], m.disjunct[0, 2, 'A']),
+                hull.get_disaggregated_var(m.a[2, 'A'], m.disjunct[1, 2, 'A']),
+            ],
+            (2, 'B'): [
+                hull.get_disaggregated_var(m.a[2, 'B'], m.disjunct[0, 2, 'B']),
+                hull.get_disaggregated_var(m.a[2, 'B'], m.disjunct[1, 2, 'B']),
+            ],
         }
 
         for i, disVars in disaggregatedVars.items():
-            cons = hull.get_disaggregation_constraint(m.a[i],
-                                                       m.disjunction[i])
+            cons = hull.get_disaggregation_constraint(m.a[i], m.disjunction[i])
             self.assertEqual(cons.lower, 0)
             self.assertEqual(cons.upper, 0)
             # NOTE: fixed variables are evaluated here.
@@ -961,7 +1025,7 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.assertIs(firstTerm2, m.firstTerm[2].transformation_block)
         self.assertIsInstance(firstTerm2.disaggregatedVars.component("x"), Var)
         constraints = hull.get_transformed_constraints(m.firstTerm[2].cons)
-        self.assertEqual(len(constraints), 1) # one equality constraint
+        self.assertEqual(len(constraints), 1)  # one equality constraint
         cons = constraints[0]
         self.assertIs(cons.parent_block(), firstTerm2)
         # also check for the bounds constraints for x
@@ -1027,58 +1091,50 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         self.check_trans_block_disjunctions_of_disjunct_datas(m)
 
         transBlock = m.component("_pyomo_gdp_hull_reformulation")
-        self.assertIsInstance(transBlock.component("disjunction_xor"),
-                              Constraint)
+        self.assertIsInstance(transBlock.component("disjunction_xor"), Constraint)
         self.assertEqual(len(transBlock.component("disjunction_xor")), 2)
 
     def check_first_iteration(self, model):
         transBlock = model.component("_pyomo_gdp_hull_reformulation")
         self.assertIsInstance(transBlock, Block)
-        self.assertIsInstance(
-            transBlock.component("disjunctionList_xor"), Constraint)
+        self.assertIsInstance(transBlock.component("disjunctionList_xor"), Constraint)
         self.assertEqual(len(transBlock.disjunctionList_xor), 1)
         self.assertFalse(model.disjunctionList[0].active)
         hull = TransformationFactory('gdp.hull')
 
         if model.component('firstTerm') is None:
             firstTerm_cons = hull.get_transformed_constraints(
-                model.component("firstTerm[0]").cons)
+                model.component("firstTerm[0]").cons
+            )
             secondTerm_cons = hull.get_transformed_constraints(
-                model.component("secondTerm[0]").cons)
+                model.component("secondTerm[0]").cons
+            )
 
         else:
-            firstTerm_cons = hull.get_transformed_constraints(
-                model.firstTerm[0].cons)
-            secondTerm_cons = hull.get_transformed_constraints(
-                model.secondTerm[0].cons)
+            firstTerm_cons = hull.get_transformed_constraints(model.firstTerm[0].cons)
+            secondTerm_cons = hull.get_transformed_constraints(model.secondTerm[0].cons)
 
         self.assertIsInstance(transBlock.relaxedDisjuncts, Block)
         self.assertEqual(len(transBlock.relaxedDisjuncts), 2)
 
-        self.assertIsInstance(transBlock.relaxedDisjuncts[0].\
-                              disaggregatedVars.x, Var)
-        self.assertTrue(transBlock.relaxedDisjuncts[0].disaggregatedVars.x.\
-                        is_fixed())
-        self.assertEqual(value(transBlock.relaxedDisjuncts[0].\
-                               disaggregatedVars.x), 0)
+        self.assertIsInstance(transBlock.relaxedDisjuncts[0].disaggregatedVars.x, Var)
+        self.assertTrue(transBlock.relaxedDisjuncts[0].disaggregatedVars.x.is_fixed())
+        self.assertEqual(value(transBlock.relaxedDisjuncts[0].disaggregatedVars.x), 0)
         self.assertEqual(len(firstTerm_cons), 1)
-        self.assertIs(firstTerm_cons[0].parent_block(),
-                      # It fixes a var to 0
-                      transBlock.relaxedDisjuncts[0].disaggregatedVars)
-        self.assertIsInstance(transBlock.relaxedDisjuncts[0].x_bounds,
-                              Constraint)
+        self.assertIs(
+            firstTerm_cons[0].parent_block(),
+            # It fixes a var to 0
+            transBlock.relaxedDisjuncts[0].disaggregatedVars,
+        )
+        self.assertIsInstance(transBlock.relaxedDisjuncts[0].x_bounds, Constraint)
         self.assertEqual(len(transBlock.relaxedDisjuncts[0].x_bounds), 2)
 
-        self.assertIsInstance(transBlock.relaxedDisjuncts[1].\
-                              disaggregatedVars.x, Var)
-        self.assertFalse(transBlock.relaxedDisjuncts[1].disaggregatedVars.\
-                         x.is_fixed())
+        self.assertIsInstance(transBlock.relaxedDisjuncts[1].disaggregatedVars.x, Var)
+        self.assertFalse(transBlock.relaxedDisjuncts[1].disaggregatedVars.x.is_fixed())
 
         self.assertEqual(len(secondTerm_cons), 1)
-        self.assertIs(secondTerm_cons[0].parent_block(),
-                      transBlock.relaxedDisjuncts[1])
-        self.assertIsInstance(transBlock.relaxedDisjuncts[1].x_bounds,
-                              Constraint)
+        self.assertIs(secondTerm_cons[0].parent_block(), transBlock.relaxedDisjuncts[1])
+        self.assertIsInstance(transBlock.relaxedDisjuncts[1].x_bounds, Constraint)
         self.assertEqual(len(transBlock.relaxedDisjuncts[1].x_bounds), 2)
 
     def check_second_iteration(self, model):
@@ -1090,28 +1146,30 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
 
         if model.component('firstTerm') is None:
             firstTerm_cons = hull.get_transformed_constraints(
-                model.component("firstTerm[1]").cons)
+                model.component("firstTerm[1]").cons
+            )
             secondTerm_cons = hull.get_transformed_constraints(
-                model.component("secondTerm[1]").cons)
+                model.component("secondTerm[1]").cons
+            )
 
         else:
-            firstTerm_cons = hull.get_transformed_constraints(
-                model.firstTerm[1].cons)
-            secondTerm_cons = hull.get_transformed_constraints(
-                model.secondTerm[1].cons)
+            firstTerm_cons = hull.get_transformed_constraints(model.firstTerm[1].cons)
+            secondTerm_cons = hull.get_transformed_constraints(model.secondTerm[1].cons)
 
         self.assertEqual(len(firstTerm_cons), 1)
-        self.assertIs(firstTerm_cons[0].parent_block(),
-                      transBlock.relaxedDisjuncts[0])
+        self.assertIs(firstTerm_cons[0].parent_block(), transBlock.relaxedDisjuncts[0])
         self.assertEqual(len(secondTerm_cons), 1)
-        self.assertIs(secondTerm_cons[0].parent_block(),
-                      transBlock.relaxedDisjuncts[1])
+        self.assertIs(secondTerm_cons[0].parent_block(), transBlock.relaxedDisjuncts[1])
 
         orig = model.component("_pyomo_gdp_hull_reformulation")
-        self.assertIsInstance(model.disjunctionList[1].algebraic_constraint,
-                              constraint._GeneralConstraintData)
-        self.assertIsInstance(model.disjunctionList[0].algebraic_constraint,
-                              constraint._GeneralConstraintData)
+        self.assertIsInstance(
+            model.disjunctionList[1].algebraic_constraint,
+            constraint._GeneralConstraintData,
+        )
+        self.assertIsInstance(
+            model.disjunctionList[0].algebraic_constraint,
+            constraint._GeneralConstraintData,
+        )
         self.assertFalse(model.disjunctionList[1].active)
         self.assertFalse(model.disjunctionList[0].active)
 
@@ -1119,15 +1177,14 @@ class IndexedDisjunction(unittest.TestCase, CommonTests):
         ct.check_disjunction_and_disjuncts_indexed_by_any(self, 'hull')
 
     def test_iteratively_adding_disjunctions_transform_container(self):
-        ct.check_iteratively_adding_disjunctions_transform_container(self,
-                                                                     'hull')
+        ct.check_iteratively_adding_disjunctions_transform_container(self, 'hull')
 
     def test_iteratively_adding_disjunctions_transform_model(self):
         ct.check_iteratively_adding_disjunctions_transform_model(self, 'hull')
 
     def test_iteratively_adding_to_indexed_disjunction_on_block(self):
-        ct.check_iteratively_adding_to_indexed_disjunction_on_block(self,
-                                                                    'hull')
+        ct.check_iteratively_adding_to_indexed_disjunction_on_block(self, 'hull')
+
 
 class TestTargets_SingleDisjunction(unittest.TestCase, CommonTests):
     def test_only_targets_inactive(self):
@@ -1141,6 +1198,7 @@ class TestTargets_SingleDisjunction(unittest.TestCase, CommonTests):
 
     def test_targets_cannot_be_cuids(self):
         ct.check_targets_cannot_be_cuids(self, 'hull')
+
 
 class TestTargets_IndexedDisjunction(unittest.TestCase, CommonTests):
     # There are a couple tests for targets above, but since I had the patience
@@ -1180,6 +1238,7 @@ class TestTargets_IndexedDisjunction(unittest.TestCase, CommonTests):
         m = models.makeDisjunctionsOnIndexedBlock()
         ct.diff_apply_to_and_create_using(self, m, 'gdp.hull')
 
+
 class DisaggregatedVarNamingConflict(unittest.TestCase):
     @staticmethod
     def makeModel():
@@ -1187,14 +1246,16 @@ class DisaggregatedVarNamingConflict(unittest.TestCase):
         m.b = Block()
         m.b.x = Var(bounds=(0, 10))
         m.add_component("b.x", Var(bounds=(-9, 9)))
+
         def disjunct_rule(d, i):
             m = d.model()
             if i:
                 d.cons_block = Constraint(expr=m.b.x >= 5)
-                d.cons_model = Constraint(expr=m.component("b.x")==0)
+                d.cons_model = Constraint(expr=m.component("b.x") == 0)
             else:
                 d.cons_model = Constraint(expr=m.component("b.x") <= -5)
-        m.disjunct = Disjunct([0,1], rule=disjunct_rule)
+
+        m.disjunct = Disjunct([0, 1], rule=disjunct_rule)
         m.disjunction = Disjunction(expr=[m.disjunct[0], m.disjunct[1]])
 
         return m
@@ -1204,20 +1265,23 @@ class DisaggregatedVarNamingConflict(unittest.TestCase):
         hull = TransformationFactory('gdp.hull')
         hull.apply_to(m)
 
-        disaggregationConstraints = m._pyomo_gdp_hull_reformulation.\
-                                    disaggregationConstraints
+        disaggregationConstraints = (
+            m._pyomo_gdp_hull_reformulation.disaggregationConstraints
+        )
         consmap = [
             (m.component("b.x"), disaggregationConstraints[0]),
-            (m.b.x, disaggregationConstraints[1])
+            (m.b.x, disaggregationConstraints[1]),
         ]
 
         for v, cons in consmap:
             disCons = hull.get_disaggregation_constraint(v, m.disjunction)
             self.assertIs(disCons, cons)
 
+
 class DisjunctInMultipleDisjunctions(unittest.TestCase, CommonTests):
     def test_error_for_same_disjunct_in_multiple_disjunctions(self):
         ct.check_error_for_same_disjunct_in_multiple_disjunctions(self, 'hull')
+
 
 class NestedDisjunction(unittest.TestCase, CommonTests):
     def setUp(self):
@@ -1228,8 +1292,7 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         ct.check_disjuncts_inactive_nested(self, 'hull')
 
     def test_deactivated_disjunct_leaves_nested_disjuncts_active(self):
-        ct.check_deactivated_disjunct_leaves_nested_disjunct_active(self,
-                                                                    'hull')
+        ct.check_deactivated_disjunct_leaves_nested_disjunct_active(self, 'hull')
 
     def test_mappings_between_disjunctions_and_xors(self):
         # This test is nearly identical to the one in bigm, but because of
@@ -1243,10 +1306,8 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
 
         disjunctionPairs = [
             (m.disjunction, transBlock.disjunction_xor),
-            (m.disjunct[1].innerdisjunction[0],
-             transBlock.innerdisjunction_xor[0]),
-            (m.simpledisjunct.innerdisjunction,
-             transBlock.innerdisjunction_xor_4)
+            (m.disjunct[1].innerdisjunction[0], transBlock.innerdisjunction_xor[0]),
+            (m.simpledisjunct.innerdisjunction, transBlock.innerdisjunction_xor_4),
         ]
 
         # check disjunction mappings
@@ -1286,17 +1347,17 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         solver = SolverFactory(linear_solvers[0])
 
         cases = [
-            (1,1,1,1,None),
-            (0,0,0,0,None),
-            (1,0,0,0,None),
-            (0,1,0,0,1.1),
-            (0,0,1,0,None),
-            (0,0,0,1,None),
-            (1,1,0,0,None),
-            (1,0,1,0,1.2),
-            (1,0,0,1,1.3),
-            (1,0,1,1,None),
-            ]
+            (1, 1, 1, 1, None),
+            (0, 0, 0, 0, None),
+            (1, 0, 0, 0, None),
+            (0, 1, 0, 0, 1.1),
+            (0, 0, 1, 0, None),
+            (0, 0, 0, 1, None),
+            (1, 1, 0, 0, None),
+            (1, 0, 1, 0, 1.2),
+            (1, 0, 0, 1, 1.3),
+            (1, 0, 1, 1, None),
+        ]
         for case in cases:
             m.d1.indicator_var.fix(case[0])
             m.d2.indicator_var.fix(case[1])
@@ -1304,11 +1365,14 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
             m.d4.indicator_var.fix(case[3])
             results = solver.solve(m)
             if case[4] is None:
-                self.assertEqual(results.solver.termination_condition,
-                                 TerminationCondition.infeasible)
+                self.assertEqual(
+                    results.solver.termination_condition,
+                    TerminationCondition.infeasible,
+                )
             else:
-                self.assertEqual(results.solver.termination_condition,
-                                 TerminationCondition.optimal)
+                self.assertEqual(
+                    results.solver.termination_condition, TerminationCondition.optimal
+                )
                 self.assertEqual(value(m.obj), case[4])
 
     @unittest.skipIf(not linear_solvers, "No linear solver available")
@@ -1324,17 +1388,17 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         solver = SolverFactory(linear_solvers[0])
 
         cases = [
-            (1,1,1,1,None),
-            (0,0,0,0,None),
-            (1,0,0,0,None),
-            (0,1,0,0,1.1),
-            (0,0,1,0,None),
-            (0,0,0,1,None),
-            (1,1,0,0,None),
-            (1,0,1,0,1.2),
-            (1,0,0,1,1.3),
-            (1,0,1,1,None),
-            ]
+            (1, 1, 1, 1, None),
+            (0, 0, 0, 0, None),
+            (1, 0, 0, 0, None),
+            (0, 1, 0, 0, 1.1),
+            (0, 0, 1, 0, None),
+            (0, 0, 0, 1, None),
+            (1, 1, 0, 0, None),
+            (1, 0, 1, 0, 1.2),
+            (1, 0, 0, 1, 1.3),
+            (1, 0, 1, 1, None),
+        ]
         for case in cases:
             m.d1.indicator_var.fix(case[0])
             m.d2.indicator_var.fix(case[1])
@@ -1342,19 +1406,21 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
             m.d4.indicator_var.fix(case[3])
             results = solver.solve(m)
             if case[4] is None:
-                self.assertEqual(results.solver.termination_condition,
-                                 TerminationCondition.infeasible)
+                self.assertEqual(
+                    results.solver.termination_condition,
+                    TerminationCondition.infeasible,
+                )
             else:
-                self.assertEqual(results.solver.termination_condition,
-                                 TerminationCondition.optimal)
+                self.assertEqual(
+                    results.solver.termination_condition, TerminationCondition.optimal
+                )
                 self.assertEqual(value(m.obj), case[4])
 
     def test_create_using(self):
         m = models.makeNestedDisjunctions_FlatDisjuncts()
         self.diff_apply_to_and_create_using(m)
 
-    def check_outer_disaggregation_constraint(self, cons, var, disj1, disj2,
-                                              rhs=None):
+    def check_outer_disaggregation_constraint(self, cons, var, disj1, disj2, rhs=None):
         if rhs is None:
             rhs = var
         hull = TransformationFactory('gdp.hull')
@@ -1365,10 +1431,8 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         self.assertTrue(repn.is_linear())
         self.assertEqual(repn.constant, 0)
         ct.check_linear_coef(self, repn, rhs, 1)
-        ct.check_linear_coef(self, repn, hull.get_disaggregated_var(var, disj1),
-                             -1)
-        ct.check_linear_coef(self, repn, hull.get_disaggregated_var(var, disj2),
-                             -1)
+        ct.check_linear_coef(self, repn, hull.get_disaggregated_var(var, disj1), -1)
+        ct.check_linear_coef(self, repn, hull.get_disaggregated_var(var, disj2), -1)
 
     def check_bounds_constraint_ub(self, constraint, ub, dis_var, ind_var):
         hull = TransformationFactory('gdp.hull')
@@ -1450,10 +1514,9 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         self.check_outer_disaggregation_constraint(dis[0], m.x, m.d1, m.d2)
         self.assertIs(hull.get_disaggregation_constraint(m.x, m.disj), dis[0])
         self.check_outer_disaggregation_constraint(
-            dis[1], m.x, m.d1.d3, m.d1.d4,
-            rhs=hull.get_disaggregated_var(m.x, m.d1))
-        self.assertIs(hull.get_disaggregation_constraint(m.x,
-                                                         m.d1.disj2),dis[1])
+            dis[1], m.x, m.d1.d3, m.d1.d4, rhs=hull.get_disaggregated_var(m.x, m.d1)
+        )
+        self.assertIs(hull.get_disaggregation_constraint(m.x, m.d1.disj2), dis[1])
 
         # we should have four disjunct transformation blocks
         disjBlocks = transBlock.relaxedDisjuncts
@@ -1470,17 +1533,17 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         self.assertIsInstance(disj1.disaggregatedVars.x, Var)
         self.assertEqual(disj1.disaggregatedVars.x.lb, 0)
         self.assertEqual(disj1.disaggregatedVars.x.ub, 2)
-        self.assertIs(disj1.disaggregatedVars.x,
-                      hull.get_disaggregated_var(m.x, m.d1))
+        self.assertIs(disj1.disaggregatedVars.x, hull.get_disaggregated_var(m.x, m.d1))
         self.assertIs(m.x, hull.get_src_var(disj1.disaggregatedVars.x))
         # check the bounds constraints
-        self.check_bounds_constraint_ub(disj1.x_bounds, 2,
-                                        disj1.disaggregatedVars.x,
-                                        m.d1.indicator_var)
+        self.check_bounds_constraint_ub(
+            disj1.x_bounds, 2, disj1.disaggregatedVars.x, m.d1.indicator_var
+        )
         # transformed constraint x >= 1
         cons = hull.get_transformed_constraints(m.d1.c)
-        self.check_transformed_constraint(cons, disj1.disaggregatedVars.x, 1,
-                                          m.d1.indicator_var)
+        self.check_transformed_constraint(
+            cons, disj1.disaggregatedVars.x, 1, m.d1.indicator_var
+        )
 
         ## d2's transformation block
 
@@ -1497,12 +1560,10 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         self.assertIs(hull.get_src_var(x2), m.x)
         # bounds constraint
         x_bounds = disj2.x_bounds
-        self.check_bounds_constraint_ub(x_bounds, 2, x2,
-                                        m.d2.binary_indicator_var)
+        self.check_bounds_constraint_ub(x_bounds, 2, x2, m.d2.binary_indicator_var)
         # transformed constraint x >= 1.1
         cons = hull.get_transformed_constraints(m.d2.c)
-        self.check_transformed_constraint(cons, x2, 1.1,
-                                          m.d2.binary_indicator_var)
+        self.check_transformed_constraint(cons, x2, 1.1, m.d2.binary_indicator_var)
 
         ## d1.d3's transformation block
 
@@ -1518,12 +1579,12 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         self.assertIs(hull.get_disaggregated_var(m.x, m.d1.d3), x3)
         self.assertIs(hull.get_src_var(x3), m.x)
         # bounds constraints
-        self.check_bounds_constraint_ub(disj3.x_bounds, 2, x3,
-                                        m.d1.d3.binary_indicator_var)
+        self.check_bounds_constraint_ub(
+            disj3.x_bounds, 2, x3, m.d1.d3.binary_indicator_var
+        )
         # transformed x >= 1.2
         cons = hull.get_transformed_constraints(m.d1.d3.c)
-        self.check_transformed_constraint(cons, x3, 1.2,
-                                          m.d1.d3.binary_indicator_var)
+        self.check_transformed_constraint(cons, x3, 1.2, m.d1.d3.binary_indicator_var)
 
         ## d1.d4's transformation block
 
@@ -1539,12 +1600,12 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         self.assertIs(hull.get_disaggregated_var(m.x, m.d1.d4), x4)
         self.assertIs(hull.get_src_var(x4), m.x)
         # bounds constraints
-        self.check_bounds_constraint_ub(disj4.x_bounds, 2, x4,
-                                        m.d1.d4.binary_indicator_var)
+        self.check_bounds_constraint_ub(
+            disj4.x_bounds, 2, x4, m.d1.d4.binary_indicator_var
+        )
         # transformed x >= 1.3
         cons = hull.get_transformed_constraints(m.d1.d4.c)
-        self.check_transformed_constraint(cons, x4, 1.3,
-                                          m.d1.d4.binary_indicator_var)
+        self.check_transformed_constraint(cons, x4, 1.3, m.d1.d4.binary_indicator_var)
 
     @unittest.skipIf(not linear_solvers, "No linear solver available")
     def test_solve_nested_model(self):
@@ -1587,8 +1648,9 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         m.d4.indicator_var.fix(0)
 
         results = SolverFactory(linear_solvers[0]).solve(m)
-        self.assertEqual(results.solver.termination_condition,
-                         TerminationCondition.optimal)
+        self.assertEqual(
+            results.solver.termination_condition, TerminationCondition.optimal
+        )
         self.assertEqual(value(m.x), 1.1)
 
         self.assertEqual(value(hull.get_disaggregated_var(m.x, m.d1)), 0)
@@ -1603,8 +1665,9 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         m.d4.indicator_var.fix(0)
 
         results = SolverFactory(linear_solvers[0]).solve(m)
-        self.assertEqual(results.solver.termination_condition,
-                         TerminationCondition.optimal)
+        self.assertEqual(
+            results.solver.termination_condition, TerminationCondition.optimal
+        )
         self.assertEqual(value(m.x), 1.2)
 
         self.assertEqual(value(hull.get_disaggregated_var(m.x, m.d1)), 1.2)
@@ -1612,13 +1675,14 @@ class NestedDisjunction(unittest.TestCase, CommonTests):
         self.assertEqual(value(hull.get_disaggregated_var(m.x, m.d3)), 1.2)
         self.assertEqual(value(hull.get_disaggregated_var(m.x, m.d4)), 0)
 
+
 class TestSpecialCases(unittest.TestCase):
     def test_local_vars(self):
-        """ checks that if nothing is marked as local, we assume it is all
+        """checks that if nothing is marked as local, we assume it is all
         global. We disaggregate everything to be safe."""
         m = ConcreteModel()
-        m.x = Var(bounds=(5,100))
-        m.y = Var(bounds=(0,100))
+        m.x = Var(bounds=(5, 100))
+        m.y = Var(bounds=(0, 100))
         m.d1 = Disjunct()
         m.d1.c = Constraint(expr=m.y >= m.x)
         m.d2 = Disjunct()
@@ -1630,13 +1694,15 @@ class TestSpecialCases(unittest.TestCase):
             GDP_Error,
             ".*Missing bound for d2.z.*",
             TransformationFactory('gdp.hull').create_using,
-            m)
+            m,
+        )
         m.d2.z.setlb(7)
         self.assertRaisesRegex(
             GDP_Error,
             ".*Missing bound for d2.z.*",
             TransformationFactory('gdp.hull').create_using,
-            m)
+            m,
+        )
         m.d2.z.setub(9)
 
         i = TransformationFactory('gdp.hull').create_using(m)
@@ -1645,15 +1711,15 @@ class TestSpecialCases(unittest.TestCase):
         # z should be disaggregated because we can't be sure it's not somewhere
         # else on the model. (Note however that the copy of x corresponding to
         # this disjunct is on the disjunction block)
-        self.assertEqual(sorted(varBlock.component_map(Var)), ['d2.z','y'])
+        self.assertEqual(sorted(varBlock.component_map(Var)), ['d2.z', 'y'])
         # constraint on the disjunction block
         self.assertEqual(len(rd.component_map(Constraint)), 3)
         # bounds haven't changed on original
-        self.assertEqual(i.d2.z.bounds, (7,9))
+        self.assertEqual(i.d2.z.bounds, (7, 9))
         # check disaggregated variable
         z = varBlock.component('d2.z')
         self.assertIsInstance(z, Var)
-        self.assertEqual(z.bounds, (0,9))
+        self.assertEqual(z.bounds, (0, 9))
         z_bounds = rd.component("d2.z_bounds")
         self.assertEqual(len(z_bounds), 2)
         self.assertEqual(z_bounds['lb'].lower, None)
@@ -1670,14 +1736,14 @@ class TestSpecialCases(unittest.TestCase):
         i = TransformationFactory('gdp.hull').create_using(m)
         rd = i._pyomo_gdp_hull_reformulation.relaxedDisjuncts[1]
         varBlock = rd.disaggregatedVars
-        self.assertEqual(sorted(varBlock.component_map(Var)), ['d2.z','y'])
+        self.assertEqual(sorted(varBlock.component_map(Var)), ['d2.z', 'y'])
         self.assertEqual(len(rd.component_map(Constraint)), 3)
         # original bounds unchanged
-        self.assertEqual(i.d2.z.bounds, (-9,-7))
+        self.assertEqual(i.d2.z.bounds, (-9, -7))
         # check disaggregated variable
         z = varBlock.component("d2.z")
         self.assertIsInstance(z, Var)
-        self.assertEqual(z.bounds, (-9,0))
+        self.assertEqual(z.bounds, (-9, 0))
         z_bounds = rd.component("d2.z_bounds")
         self.assertEqual(len(z_bounds), 2)
         self.assertEqual(z_bounds['lb'].lower, None)
@@ -1693,8 +1759,8 @@ class TestSpecialCases(unittest.TestCase):
         hull = TransformationFactory('gdp.hull')
 
         model = ConcreteModel()
-        model.x = Var(bounds=(5,100))
-        model.y = Var(bounds=(0,100))
+        model.x = Var(bounds=(5, 100))
+        model.y = Var(bounds=(0, 100))
         model.d1 = Disjunct()
         model.d1.c = Constraint(expr=model.y >= model.x)
         model.d2 = Disjunct()
@@ -1706,11 +1772,9 @@ class TestSpecialCases(unittest.TestCase):
         m = hull.create_using(model)
         self.assertEqual(m.d2.z.lb, -9)
         self.assertEqual(m.d2.z.ub, -7)
-        z_disaggregated = m.d2.transformation_block.disaggregatedVars.\
-                          component("d2.z")
+        z_disaggregated = m.d2.transformation_block.disaggregatedVars.component("d2.z")
         self.assertIsInstance(z_disaggregated, Var)
-        self.assertIs(z_disaggregated,
-                      hull.get_disaggregated_var(m.d2.z, m.d2))
+        self.assertIs(z_disaggregated, hull.get_disaggregated_var(m.d2.z, m.d2))
 
         # we do declare z local
         model.d2.LocalVars = Suffix(direction=Suffix.LOCAL)
@@ -1724,8 +1788,8 @@ class TestSpecialCases(unittest.TestCase):
         # it is its own disaggregated variable
         self.assertIs(hull.get_disaggregated_var(m.d2.z, m.d2), m.d2.z)
         # it does not exist on the transformation block
-        self.assertIsNone(m.d2.transformation_block.disaggregatedVars.\
-                          component("z"))
+        self.assertIsNone(m.d2.transformation_block.disaggregatedVars.component("z"))
+
 
 class UntransformableObjectsOnDisjunct(unittest.TestCase):
     def test_RangeSet(self):
@@ -1733,6 +1797,7 @@ class UntransformableObjectsOnDisjunct(unittest.TestCase):
 
     def test_Expression(self):
         ct.check_Expression(self, 'hull')
+
 
 class TransformABlock(unittest.TestCase, CommonTests):
     def test_transformation_simple_block(self):
@@ -1760,6 +1825,7 @@ class TransformABlock(unittest.TestCase, CommonTests):
         m = models.makeTwoTermDisjOnBlock()
         ct.diff_apply_to_and_create_using(self, m, 'gdp.hull')
 
+
 class DisjOnBlock(unittest.TestCase, CommonTests):
     # when the disjunction is on a block, we want all of the stuff created by
     # the transformation to go on that block also so that solving the block
@@ -1771,6 +1837,7 @@ class DisjOnBlock(unittest.TestCase, CommonTests):
     def test_trans_block_created(self):
         ct.check_trans_block_created(self, 'hull')
 
+
 class TestErrors(unittest.TestCase):
     def setUp(self):
         # set seed so we can test name collisions predictably
@@ -1778,7 +1845,8 @@ class TestErrors(unittest.TestCase):
 
     def test_ask_for_transformed_constraint_from_untransformed_disjunct(self):
         ct.check_ask_for_transformed_constraint_from_untransformed_disjunct(
-            self, 'hull')
+            self, 'hull'
+        )
 
     def test_silly_target(self):
         ct.check_silly_target(self, 'hull')
@@ -1790,44 +1858,50 @@ class TestErrors(unittest.TestCase):
         ct.check_transform_empty_disjunction(self, 'hull')
 
     def test_deactivated_disjunct_nonzero_indicator_var(self):
-        ct.check_deactivated_disjunct_nonzero_indicator_var(self,
-                                                            'hull')
+        ct.check_deactivated_disjunct_nonzero_indicator_var(self, 'hull')
 
     def test_deactivated_disjunct_unfixed_indicator_var(self):
         ct.check_deactivated_disjunct_unfixed_indicator_var(self, 'hull')
 
     def test_infeasible_xor_because_all_disjuncts_deactivated(self):
-        m = ct.setup_infeasible_xor_because_all_disjuncts_deactivated(self,
-                                                                      'hull')
+        m = ct.setup_infeasible_xor_because_all_disjuncts_deactivated(self, 'hull')
         hull = TransformationFactory('gdp.hull')
         transBlock = m.component("_pyomo_gdp_hull_reformulation")
         self.assertIsInstance(transBlock, Block)
         self.assertEqual(len(transBlock.relaxedDisjuncts), 2)
-        self.assertIsInstance(transBlock.component("disjunction_xor"),
-                              Constraint)
+        self.assertIsInstance(transBlock.component("disjunction_xor"), Constraint)
         disjunct1 = transBlock.relaxedDisjuncts[0]
         # we disaggregated the (deactivated) indicator variables
-        d3_ind = m.disjunction_disjuncts[0].nestedDisjunction_disjuncts[0].\
-                 binary_indicator_var
-        d4_ind = m.disjunction_disjuncts[0].nestedDisjunction_disjuncts[1].\
-                 binary_indicator_var
+        d3_ind = (
+            m.disjunction_disjuncts[0]
+            .nestedDisjunction_disjuncts[0]
+            .binary_indicator_var
+        )
+        d4_ind = (
+            m.disjunction_disjuncts[0]
+            .nestedDisjunction_disjuncts[1]
+            .binary_indicator_var
+        )
         d3_ind_dis = disjunct1.disaggregatedVars.component(
             "disjunction_disjuncts[0].nestedDisjunction_"
-            "disjuncts[0].binary_indicator_var")
-        self.assertIs(hull.get_disaggregated_var(d3_ind,
-                                                 m.disjunction_disjuncts[0]),
-                      d3_ind_dis)
+            "disjuncts[0].binary_indicator_var"
+        )
+        self.assertIs(
+            hull.get_disaggregated_var(d3_ind, m.disjunction_disjuncts[0]), d3_ind_dis
+        )
         self.assertIs(hull.get_src_var(d3_ind_dis), d3_ind)
         d4_ind_dis = disjunct1.disaggregatedVars.component(
             "disjunction_disjuncts[0].nestedDisjunction_"
-            "disjuncts[1].binary_indicator_var")
-        self.assertIs(hull.get_disaggregated_var(d4_ind,
-                                                 m.disjunction_disjuncts[0]),
-                      d4_ind_dis)
+            "disjuncts[1].binary_indicator_var"
+        )
+        self.assertIs(
+            hull.get_disaggregated_var(d4_ind, m.disjunction_disjuncts[0]), d4_ind_dis
+        )
         self.assertIs(hull.get_src_var(d4_ind_dis), d4_ind)
 
         relaxed_xor = hull.get_transformed_constraints(
-            m.disjunction_disjuncts[0].nestedDisjunction.algebraic_constraint)
+            m.disjunction_disjuncts[0].nestedDisjunction.algebraic_constraint
+        )
         self.assertEqual(len(relaxed_xor), 1)
         relaxed_xor = relaxed_xor[0]
         repn = generate_standard_repn(relaxed_xor.body)
@@ -1837,12 +1911,9 @@ class TestErrors(unittest.TestCase):
         self.assertEqual(len(repn.linear_vars), 3)
         # constraint says that the disaggregated indicator variables of the
         # nested disjuncts sum to the indicator variable of the outer disjunct.
-        ct.check_linear_coef(
-            self, repn, m.disjunction.disjuncts[0].indicator_var, -1)
-        ct.check_linear_coef(
-            self, repn, d3_ind_dis, 1)
-        ct.check_linear_coef(
-            self, repn, d4_ind_dis, 1)
+        ct.check_linear_coef(self, repn, m.disjunction.disjuncts[0].indicator_var, -1)
+        ct.check_linear_coef(self, repn, d3_ind_dis, 1)
+        ct.check_linear_coef(self, repn, d4_ind_dis, 1)
         self.assertEqual(repn.constant, 0)
 
         # but the disaggregation constraints are going to force them to 0 (which
@@ -1864,8 +1935,8 @@ class TestErrors(unittest.TestCase):
         self.assertTrue(repn.is_linear())
         self.assertEqual(len(repn.linear_vars), 2)
         self.assertEqual(repn.constant, 0)
-        ct.check_linear_coef( self, repn, d4_ind_dis, -1)
-        ct.check_linear_coef( self, repn, transBlock._disaggregatedVars[1], -1)
+        ct.check_linear_coef(self, repn, d4_ind_dis, -1)
+        ct.check_linear_coef(self, repn, transBlock._disaggregatedVars[1], -1)
 
     def test_mapping_method_errors(self):
         m = models.makeTwoTermDisj_Nonlinear()
@@ -1878,12 +1949,14 @@ class TestErrors(unittest.TestCase):
                 AttributeError,
                 "'NoneType' object has no attribute 'parent_block'",
                 hull.get_var_bounds_constraint,
-                m.w)
+                m.w,
+            )
         self.assertRegex(
             log.getvalue(),
             ".*Either 'w' is not a disaggregated variable, "
             "or the disjunction that disaggregates it has "
-            "not been properly transformed.")
+            "not been properly transformed.",
+        )
 
         log = StringIO()
         with LoggingIntercept(log, 'pyomo.gdp.hull', logging.ERROR):
@@ -1893,12 +1966,16 @@ class TestErrors(unittest.TestCase):
                 r"disaggregatedVars.w",
                 hull.get_disaggregation_constraint,
                 m.d[1].transformation_block.disaggregatedVars.w,
-                m.disjunction)
-        self.assertRegex(log.getvalue(), ".*It doesn't appear that "
-                         r"'_pyomo_gdp_hull_reformulation."
-                         r"relaxedDisjuncts\[1\].disaggregatedVars.w' "
-                         r"is a variable that was disaggregated by "
-                         r"Disjunction 'disjunction'")
+                m.disjunction,
+            )
+        self.assertRegex(
+            log.getvalue(),
+            ".*It doesn't appear that "
+            r"'_pyomo_gdp_hull_reformulation."
+            r"relaxedDisjuncts\[1\].disaggregatedVars.w' "
+            r"is a variable that was disaggregated by "
+            r"Disjunction 'disjunction'",
+        )
 
         log = StringIO()
         with LoggingIntercept(log, 'pyomo.gdp.hull', logging.ERROR):
@@ -1906,10 +1983,11 @@ class TestErrors(unittest.TestCase):
                 AttributeError,
                 "'NoneType' object has no attribute 'parent_block'",
                 hull.get_src_var,
-                m.w)
+                m.w,
+            )
         self.assertRegex(
-            log.getvalue(),
-            ".*'w' does not appear to be a disaggregated variable")
+            log.getvalue(), ".*'w' does not appear to be a disaggregated variable"
+        )
 
         log = StringIO()
         with LoggingIntercept(log, 'pyomo.gdp.hull', logging.ERROR):
@@ -1919,13 +1997,16 @@ class TestErrors(unittest.TestCase):
                 r"disaggregatedVars.w",
                 hull.get_disaggregated_var,
                 m.d[1].transformation_block.disaggregatedVars.w,
-                m.d[1])
-        self.assertRegex(log.getvalue(),
-                         r".*It does not appear "
-                         r"'_pyomo_gdp_hull_reformulation."
-                         r"relaxedDisjuncts\[1\].disaggregatedVars.w' "
-                         r"is a variable that appears in disjunct "
-                         r"'d\[1\]'")
+                m.d[1],
+            )
+        self.assertRegex(
+            log.getvalue(),
+            r".*It does not appear "
+            r"'_pyomo_gdp_hull_reformulation."
+            r"relaxedDisjuncts\[1\].disaggregatedVars.w' "
+            r"is a variable that appears in disjunct "
+            r"'d\[1\]'",
+        )
 
         m.random_disjunction = Disjunction(expr=[m.w == 2, m.w >= 7])
         self.assertRaisesRegex(
@@ -1934,7 +2015,8 @@ class TestErrors(unittest.TestCase):
             "transformed: None of its disjuncts are transformed.",
             hull.get_disaggregation_constraint,
             m.w,
-            m.random_disjunction)
+            m.random_disjunction,
+        )
 
         self.assertRaisesRegex(
             GDP_Error,
@@ -1942,10 +2024,12 @@ class TestErrors(unittest.TestCase):
             r"transformed",
             hull.get_disaggregated_var,
             m.w,
-            m.random_disjunction.disjuncts[0])
+            m.random_disjunction.disjuncts[0],
+        )
 
     def test_untransformed_arcs(self):
         ct.check_untransformed_network_raises_GDPError(self, 'hull')
+
 
 class BlocksOnDisjuncts(unittest.TestCase):
     def setUp(self):
@@ -1981,12 +2065,24 @@ class BlocksOnDisjuncts(unittest.TestCase):
         # Just make sure exactly the expected number of constraints are here and
         # that they are mapped to the correct original components.
         self.assertEqual(len(transBlock.component_map(Constraint)), 3)
-        self.assertIs(hull.get_transformed_constraints(
-            m.disj1.b.any_index['local'])[0].parent_block(), transBlock)
-        self.assertIs(hull.get_transformed_constraints(
-            m.disj1.b.any_index['nonlin-ub'])[0].parent_block(), transBlock)
-        self.assertIs(hull.get_transformed_constraints(
-            m.disj1.component('b.any_index'))[0].parent_block(), transBlock)
+        self.assertIs(
+            hull.get_transformed_constraints(m.disj1.b.any_index['local'])[
+                0
+            ].parent_block(),
+            transBlock,
+        )
+        self.assertIs(
+            hull.get_transformed_constraints(m.disj1.b.any_index['nonlin-ub'])[
+                0
+            ].parent_block(),
+            transBlock,
+        )
+        self.assertIs(
+            hull.get_transformed_constraints(m.disj1.component('b.any_index'))[
+                0
+            ].parent_block(),
+            transBlock,
+        )
 
     def test_local_var_handled_correctly(self):
         m = self.makeModel()
@@ -1998,10 +2094,10 @@ class BlocksOnDisjuncts(unittest.TestCase):
         self.assertIs(hull.get_disaggregated_var(m.x, m.disj1), m.x)
         self.assertEqual(m.x.lb, 0)
         self.assertEqual(m.x.ub, 5)
-        self.assertIsNone(m.disj1.transformation_block.disaggregatedVars.\
-                          component("x"))
-        self.assertIsInstance(m.disj1.transformation_block.disaggregatedVars.\
-                              component("y"), Var)
+        self.assertIsNone(m.disj1.transformation_block.disaggregatedVars.component("x"))
+        self.assertIsInstance(
+            m.disj1.transformation_block.disaggregatedVars.component("y"), Var
+        )
 
     # this doesn't require the block, I'm just coopting this test to make sure
     # of some nonlinear expressions.
@@ -2013,22 +2109,24 @@ class BlocksOnDisjuncts(unittest.TestCase):
 
         # test the transformed nonlinear constraints
         nonlin_ub_list = hull.get_transformed_constraints(
-            m.disj1.b.any_index['nonlin-ub'])
+            m.disj1.b.any_index['nonlin-ub']
+        )
         self.assertEqual(len(nonlin_ub_list), 1)
         cons = nonlin_ub_list[0]
         self.assertIs(cons.ctype, Constraint)
         self.assertIsNone(cons.lower)
         self.assertEqual(value(cons.upper), 0)
         repn = generate_standard_repn(cons.body)
-        self.assertEqual(str(repn.nonlinear_expr),
-                         "(0.9999*disj1.binary_indicator_var + 0.0001)*"
-                         "(_pyomo_gdp_hull_reformulation.relaxedDisjuncts[0]."
-                         "disaggregatedVars.y/"
-                         "(0.9999*disj1.binary_indicator_var + 0.0001))**2")
+        self.assertEqual(
+            str(repn.nonlinear_expr),
+            "(0.9999*disj1.binary_indicator_var + 0.0001)*"
+            "(_pyomo_gdp_hull_reformulation.relaxedDisjuncts[0]."
+            "disaggregatedVars.y/"
+            "(0.9999*disj1.binary_indicator_var + 0.0001))**2",
+        )
         self.assertEqual(len(repn.nonlinear_vars), 2)
         self.assertIs(repn.nonlinear_vars[0], m.disj1.binary_indicator_var)
-        self.assertIs(repn.nonlinear_vars[1],
-                      hull.get_disaggregated_var(m.y, m.disj1))
+        self.assertIs(repn.nonlinear_vars[1], hull.get_disaggregated_var(m.y, m.disj1))
         self.assertEqual(repn.constant, 0)
         self.assertEqual(len(repn.linear_vars), 1)
         self.assertIs(repn.linear_vars[0], m.disj1.binary_indicator_var)
@@ -2041,20 +2139,22 @@ class BlocksOnDisjuncts(unittest.TestCase):
         self.assertIsNone(cons.lower)
         self.assertEqual(value(cons.upper), 0)
         repn = generate_standard_repn(cons.body)
-        self.assertEqual(str(repn.nonlinear_expr),
-                         "- ((0.9999*disj2.binary_indicator_var + 0.0001)*"
-                         "log(1 + "
-                         "_pyomo_gdp_hull_reformulation.relaxedDisjuncts[1]."
-                         "disaggregatedVars.y/"
-                         "(0.9999*disj2.binary_indicator_var + 0.0001)))")
+        self.assertEqual(
+            str(repn.nonlinear_expr),
+            "- ((0.9999*disj2.binary_indicator_var + 0.0001)*"
+            "log(1 + "
+            "_pyomo_gdp_hull_reformulation.relaxedDisjuncts[1]."
+            "disaggregatedVars.y/"
+            "(0.9999*disj2.binary_indicator_var + 0.0001)))",
+        )
         self.assertEqual(len(repn.nonlinear_vars), 2)
         self.assertIs(repn.nonlinear_vars[0], m.disj2.binary_indicator_var)
-        self.assertIs(repn.nonlinear_vars[1],
-                      hull.get_disaggregated_var(m.y, m.disj2))
+        self.assertIs(repn.nonlinear_vars[1], hull.get_disaggregated_var(m.y, m.disj2))
         self.assertEqual(repn.constant, 0)
         self.assertEqual(len(repn.linear_vars), 1)
         self.assertIs(repn.linear_vars[0], m.disj2.binary_indicator_var)
         self.assertEqual(repn.linear_coefs[0], 1)
+
 
 class DisaggregatingFixedVars(unittest.TestCase):
     def test_disaggregate_fixed_variables(self):
@@ -2065,8 +2165,9 @@ class DisaggregatingFixedVars(unittest.TestCase):
         # check that we did indeed disaggregate x
         transBlock = m.d[1].transformation_block
         self.assertIsInstance(transBlock.disaggregatedVars.component("x"), Var)
-        self.assertIs(hull.get_disaggregated_var(m.x, m.d[1]),
-                      transBlock.disaggregatedVars.x)
+        self.assertIs(
+            hull.get_disaggregated_var(m.x, m.d[1]), transBlock.disaggregatedVars.x
+        )
         self.assertIs(hull.get_src_var(transBlock.disaggregatedVars.x), m.x)
 
     def test_do_not_disaggregate_fixed_variables(self):
@@ -2078,15 +2179,18 @@ class DisaggregatingFixedVars(unittest.TestCase):
         transBlock = m.d[1].transformation_block
         self.assertIsNone(transBlock.disaggregatedVars.component("x"))
 
+
 class NameDeprecationTest(unittest.TestCase):
     def test_name_deprecated(self):
         m = models.makeTwoTermDisj()
         output = StringIO()
         with LoggingIntercept(output, 'pyomo.gdp', logging.WARNING):
             TransformationFactory('gdp.chull').apply_to(m)
-        self.assertIn("DEPRECATED: The 'gdp.chull' name is deprecated. "
-                      "Please use the more apt 'gdp.hull' instead.",
-                      output.getvalue().replace('\n', ' '))
+        self.assertIn(
+            "DEPRECATED: The 'gdp.chull' name is deprecated. "
+            "Please use the more apt 'gdp.hull' instead.",
+            output.getvalue().replace('\n', ' '),
+        )
 
     def test_hull_chull_equivalent(self):
         m = models.makeTwoTermDisj()
@@ -2098,32 +2202,35 @@ class NameDeprecationTest(unittest.TestCase):
         m2.pprint(ostream=out2)
         self.assertMultiLineEqual(out1.getvalue(), out2.getvalue())
 
+
 class KmeansTest(unittest.TestCase):
-    @unittest.skipIf('gurobi' not in linear_solvers,
-                     "Gurobi solver not available")
+    @unittest.skipIf('gurobi' not in linear_solvers, "Gurobi solver not available")
     def test_optimal_soln_feasible(self):
         m = ConcreteModel()
         m.Points = RangeSet(3)
         m.Centroids = RangeSet(2)
 
-        m.X = Param(m.Points, initialize={1:0.3672, 2:0.8043, 3:0.3059})
+        m.X = Param(m.Points, initialize={1: 0.3672, 2: 0.8043, 3: 0.3059})
 
-        m.cluster_center = Var(m.Centroids, bounds=(0,2))
-        m.distance = Var(m.Points, bounds=(0,2))
-        m.t = Var(m.Points, m.Centroids, bounds=(0,2))
+        m.cluster_center = Var(m.Centroids, bounds=(0, 2))
+        m.distance = Var(m.Points, bounds=(0, 2))
+        m.t = Var(m.Points, m.Centroids, bounds=(0, 2))
 
         @m.Disjunct(m.Points, m.Centroids)
         def AssignPoint(d, i, k):
             m = d.model()
             d.LocalVars = Suffix(direction=Suffix.LOCAL)
-            d.LocalVars[d] = [m.t[i,k]]
+            d.LocalVars[d] = [m.t[i, k]]
+
             def distance1(d):
-                return m.t[i,k] >= m.X[i] - m.cluster_center[k]
+                return m.t[i, k] >= m.X[i] - m.cluster_center[k]
+
             def distance2(d):
-                return m.t[i,k] >= - (m.X[i] - m.cluster_center[k])
+                return m.t[i, k] >= -(m.X[i] - m.cluster_center[k])
+
             d.dist1 = Constraint(rule=distance1)
             d.dist2 = Constraint(rule=distance2)
-            d.define_distance = Constraint(expr=m.distance[i] == m.t[i,k])
+            d.define_distance = Constraint(expr=m.distance[i] == m.t[i, k])
 
         @m.Disjunction(m.Points)
         def OneCentroidPerPt(m, i):
@@ -2134,12 +2241,12 @@ class KmeansTest(unittest.TestCase):
         TransformationFactory('gdp.hull').apply_to(m)
 
         # fix an optimal solution
-        m.AssignPoint[1,1].indicator_var.fix(1)
-        m.AssignPoint[1,2].indicator_var.fix(0)
-        m.AssignPoint[2,1].indicator_var.fix(0)
-        m.AssignPoint[2,2].indicator_var.fix(1)
-        m.AssignPoint[3,1].indicator_var.fix(1)
-        m.AssignPoint[3,2].indicator_var.fix(0)
+        m.AssignPoint[1, 1].indicator_var.fix(1)
+        m.AssignPoint[1, 2].indicator_var.fix(0)
+        m.AssignPoint[2, 1].indicator_var.fix(0)
+        m.AssignPoint[2, 2].indicator_var.fix(1)
+        m.AssignPoint[3, 1].indicator_var.fix(1)
+        m.AssignPoint[3, 2].indicator_var.fix(0)
 
         m.cluster_center[1].fix(0.3059)
         m.cluster_center[2].fix(0.8043)
@@ -2148,17 +2255,18 @@ class KmeansTest(unittest.TestCase):
         m.distance[2].fix(0)
         m.distance[3].fix(0)
 
-        m.t[1,1].fix(0.0613)
-        m.t[1,2].fix(0)
-        m.t[2,1].fix(0)
-        m.t[2,2].fix(0)
-        m.t[3,1].fix(0)
-        m.t[3,2].fix(0)
+        m.t[1, 1].fix(0.0613)
+        m.t[1, 2].fix(0)
+        m.t[2, 1].fix(0)
+        m.t[2, 2].fix(0)
+        m.t[3, 1].fix(0)
+        m.t[3, 2].fix(0)
 
         results = SolverFactory('gurobi').solve(m)
 
-        self.assertEqual(results.solver.termination_condition,
-                         TerminationCondition.optimal)
+        self.assertEqual(
+            results.solver.termination_condition, TerminationCondition.optimal
+        )
 
         TOL = 1e-8
         for c in m.component_data_objects(Constraint, active=True):
@@ -2167,8 +2275,8 @@ class KmeansTest(unittest.TestCase):
             if c.upper is not None:
                 self.assertLessEqual(value(c.body) - TOL, value(c.upper))
 
-class NetworkDisjuncts(unittest.TestCase, CommonTests):
 
+class NetworkDisjuncts(unittest.TestCase, CommonTests):
     @unittest.skipIf(not ct.linear_solvers, "No linear solver available")
     def test_solution_maximize(self):
         ct.check_network_disjuncts(self, minimize=False, transformation='hull')
@@ -2176,6 +2284,7 @@ class NetworkDisjuncts(unittest.TestCase, CommonTests):
     @unittest.skipIf(not ct.linear_solvers, "No linear solver available")
     def test_solution_minimize(self):
         ct.check_network_disjuncts(self, minimize=True, transformation='hull')
+
 
 class LogicalConstraintsOnDisjuncts(unittest.TestCase):
     def test_logical_constraints_transformed(self):
@@ -2190,9 +2299,11 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
 
         # first d[1]:
         cons = hull.get_transformed_constraints(
-            m.d[1]._logical_to_disjunctive.transformed_constraints[1])
+            m.d[1]._logical_to_disjunctive.transformed_constraints[1]
+        )
         dis_z1 = hull.get_disaggregated_var(
-            m.d[1]._logical_to_disjunctive.auxiliary_vars[1], m.d[1])
+            m.d[1]._logical_to_disjunctive.auxiliary_vars[1], m.d[1]
+        )
         dis_y1 = hull.get_disaggregated_var(y1, m.d[1])
 
         self.assertEqual(len(cons), 1)
@@ -2205,35 +2316,41 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(c.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            dis_z1 + dis_y1 - m.d[1].binary_indicator_var)
+            self, simplified, dis_z1 + dis_y1 - m.d[1].binary_indicator_var
+        )
 
         cons = hull.get_transformed_constraints(
-            m.d[1]._logical_to_disjunctive.transformed_constraints[2])
+            m.d[1]._logical_to_disjunctive.transformed_constraints[2]
+        )
         self.assertEqual(len(cons), 1)
         c = cons[0]
         # hull transformation of z1 >= 1
-        assertExpressionsStructurallyEqual(self, c.expr, dis_z1 >=
-                                           m.d[1].binary_indicator_var)
+        assertExpressionsStructurallyEqual(
+            self, c.expr, dis_z1 >= m.d[1].binary_indicator_var
+        )
 
         # then d[4]:
         y1d = hull.get_disaggregated_var(y1, m.d[4])
         y2d = hull.get_disaggregated_var(y2, m.d[4])
         z1d = hull.get_disaggregated_var(
-            m.d[4]._logical_to_disjunctive.auxiliary_vars[1], m.d[4])
+            m.d[4]._logical_to_disjunctive.auxiliary_vars[1], m.d[4]
+        )
         z2d = hull.get_disaggregated_var(
-            m.d[4]._logical_to_disjunctive.auxiliary_vars[2], m.d[4])
+            m.d[4]._logical_to_disjunctive.auxiliary_vars[2], m.d[4]
+        )
         z3d = hull.get_disaggregated_var(
-            m.d[4]._logical_to_disjunctive.auxiliary_vars[3], m.d[4])
+            m.d[4]._logical_to_disjunctive.auxiliary_vars[3], m.d[4]
+        )
 
         # hull transformation of (1 - z1) + (1 - y1) + y2 >= 1:
         # dz1 + dy1 - dy2 <= m.d[4].ind_var
         cons = hull.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[1])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[1]
+        )
         # these also are simple because it's really an equality, and since both
         # disaggregated variables will be 0 when the disjunct isn't selected, it
         # doesn't even need big-Ming.
@@ -2244,17 +2361,18 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(cons.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            - m.d[4].binary_indicator_var + z1d + y1d - y2d)
+            self, simplified, -m.d[4].binary_indicator_var + z1d + y1d - y2d
+        )
 
         # hull transformation of z1 + 1 - (1 - y1) >= 1
         # -y1d - z1d <= -d[4].ind_var
         cons = hull.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[2])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[2]
+        )
         self.assertEqual(len(cons), 1)
         cons = cons[0]
         self.assertIsNone(cons.lower)
@@ -2262,17 +2380,18 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(cons.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            m.d[4].binary_indicator_var - y1d - z1d)
+            self, simplified, m.d[4].binary_indicator_var - y1d - z1d
+        )
 
         # hull transformation of z1 + (1 - y2) >= 1
         # y2d - z1d <= 0
         cons = hull.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[3])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[3]
+        )
         self.assertEqual(len(cons), 1)
         cons = cons[0]
         self.assertIsNone(cons.lower)
@@ -2280,17 +2399,16 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(cons.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
-        assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            y2d - z1d)
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
+        assertExpressionsStructurallyEqual(self, simplified, y2d - z1d)
 
         # hull transformation of (1 - z2) + y1 + (1 - y2) >= 1
         # z2d - y1d + y2d <= m.d[4].ind_var
         cons = hull.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[4])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[4]
+        )
         self.assertEqual(len(cons), 1)
         cons = cons[0]
         self.assertIsNone(cons.lower)
@@ -2298,17 +2416,18 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(cons.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            - m.d[4].binary_indicator_var + z2d + y2d - y1d)
+            self, simplified, -m.d[4].binary_indicator_var + z2d + y2d - y1d
+        )
 
         # hull transformation of z2 + (1 - y1) >= 1
         # y1d - z2d <= 0
         cons = hull.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[5])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[5]
+        )
         self.assertEqual(len(cons), 1)
         cons = cons[0]
         self.assertIsNone(cons.lower)
@@ -2316,17 +2435,16 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(cons.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
-        assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            y1d - z2d)
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
+        assertExpressionsStructurallyEqual(self, simplified, y1d - z2d)
 
         # hull transformation of z2 + 1 - (1 - y2) >= 1
         # -y2d - z2d <= -d[4].ind_var
         cons = hull.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[6])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[6]
+        )
         self.assertEqual(len(cons), 1)
         cons = cons[0]
         self.assertIsNone(cons.lower)
@@ -2334,17 +2452,18 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(cons.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            m.d[4].binary_indicator_var - y2d - z2d)
+            self, simplified, m.d[4].binary_indicator_var - y2d - z2d
+        )
 
         # hull transformation of z3 <= z1
         # z3d - z1d <= 0
         cons = hull.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[7])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[7]
+        )
         self.assertEqual(len(cons), 1)
         cons = cons[0]
         self.assertIsNone(cons.lower)
@@ -2352,17 +2471,16 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(cons.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
-        assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            z3d - z1d)
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
+        assertExpressionsStructurallyEqual(self, simplified, z3d - z1d)
 
         # hull transformation of z3 <= z2
         # z3d - z2d <= 0
         cons = hull.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[8])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[8]
+        )
         self.assertEqual(len(cons), 1)
         cons = cons[0]
         self.assertIsNone(cons.lower)
@@ -2370,20 +2488,20 @@ class LogicalConstraintsOnDisjuncts(unittest.TestCase):
         repn = generate_standard_repn(cons.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
-        assertExpressionsStructurallyEqual(
-            self,
-            simplified,
-            z3d - z2d)
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
+        assertExpressionsStructurallyEqual(self, simplified, z3d - z2d)
 
         # hull transformation of z3 >= 1
         cons = hull.get_transformed_constraints(
-            m.d[4]._logical_to_disjunctive.transformed_constraints[9])
+            m.d[4]._logical_to_disjunctive.transformed_constraints[9]
+        )
         self.assertEqual(len(cons), 1)
         cons = cons[0]
         assertExpressionsStructurallyEqual(
-            self, cons.expr, z3d >= m.d[4].binary_indicator_var)
+            self, cons.expr, z3d >= m.d[4].binary_indicator_var
+        )
 
         self.assertFalse(m.bwahaha.active)
         self.assertFalse(m.p.active)

--- a/pyomo/gdp/tests/test_mbigm.py
+++ b/pyomo/gdp/tests/test_mbigm.py
@@ -17,21 +17,33 @@ from pyomo.common.fileutils import import_file, PYOMO_ROOT_DIR
 from pyomo.common.log import LoggingIntercept
 import pyomo.common.unittest as unittest
 from pyomo.core.expr.compare import (
-    assertExpressionsEqual, assertExpressionsStructurallyEqual
+    assertExpressionsEqual,
+    assertExpressionsStructurallyEqual,
 )
 
 from pyomo.environ import (
-    BooleanVar, ConcreteModel, Constraint, LogicalConstraint,
-    NonNegativeIntegers, SolverFactory, Suffix, TransformationFactory,
-    value, Var
+    BooleanVar,
+    ConcreteModel,
+    Constraint,
+    LogicalConstraint,
+    NonNegativeIntegers,
+    SolverFactory,
+    Suffix,
+    TransformationFactory,
+    value,
+    Var,
 )
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 from pyomo.gdp.tests.common_tests import (
-    check_linear_coef, check_obj_in_active_tree, check_pprint_equal)
+    check_linear_coef,
+    check_obj_in_active_tree,
+    check_pprint_equal,
+)
 from pyomo.repn import generate_standard_repn
 
 gurobi_available = SolverFactory('gurobi').available()
 exdir = normpath(join(PYOMO_ROOT_DIR, 'examples', 'gdp'))
+
 
 class LinearModelDecisionTreeExample(unittest.TestCase):
     def make_model(self):
@@ -48,12 +60,12 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         m.d2 = Disjunct()
         m.d2.x1_bounds = Constraint(expr=(0.65, m.x1, 3))
         m.d2.x2_bounds = Constraint(expr=(3, m.x2, 10))
-        m.d2.func = Constraint(expr=2*m.x1 + 4*m.x2 + 7 == m.d)
+        m.d2.func = Constraint(expr=2 * m.x1 + 4 * m.x2 + 7 == m.d)
 
         m.d3 = Disjunct()
         m.d3.x1_bounds = Constraint(expr=(2, m.x1, 10))
         m.d3.x2_bounds = Constraint(expr=(0.55, m.x2, 1))
-        m.d3.func = Constraint(expr=m.x1 - 5*m.x2 - 3 == m.d)
+        m.d3.func = Constraint(expr=m.x1 - 5 * m.x2 - 3 == m.d)
 
         m.disjunction = Disjunction(expr=[m.d1, m.d2, m.d3])
 
@@ -61,29 +73,29 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
 
     def get_Ms(self, m):
         return {
-            (m.d1.x1_bounds, m.d2) : (0.15, 1),
-            (m.d1.x2_bounds, m.d2) : (2.25, 7),
-            (m.d1.x1_bounds, m.d3) : (1.5, 8),
-            (m.d1.x2_bounds, m.d3) : (-0.2, -2),
-            (m.d2.x1_bounds, m.d1) : (-0.15, -1),
-            (m.d2.x2_bounds, m.d1) : (-2.25, -7),
-            (m.d2.x1_bounds, m.d3) : (1.35, 7),
-            (m.d2.x2_bounds, m.d3) : (-2.45, -9),
-            (m.d3.x1_bounds, m.d1) : (-1.5, -8),
-            (m.d3.x2_bounds, m.d1) : (0.2, 2),
-            (m.d3.x1_bounds, m.d2) : (-1.35, -7),
-            (m.d3.x2_bounds, m.d2) : (2.45, 9),
-            (m.d1.func, m.d2) : (-40, -16.65),
-            (m.d1.func, m.d3) : (6.3, 9),
-            (m.d2.func, m.d1) : (9.75, 18),
-            (m.d2.func, m.d3) : (16.95, 29),
-            (m.d3.func, m.d1) : (-21, -7.5),
-            (m.d3.func, m.d2) : (-103, -37.65),
-            }
+            (m.d1.x1_bounds, m.d2): (0.15, 1),
+            (m.d1.x2_bounds, m.d2): (2.25, 7),
+            (m.d1.x1_bounds, m.d3): (1.5, 8),
+            (m.d1.x2_bounds, m.d3): (-0.2, -2),
+            (m.d2.x1_bounds, m.d1): (-0.15, -1),
+            (m.d2.x2_bounds, m.d1): (-2.25, -7),
+            (m.d2.x1_bounds, m.d3): (1.35, 7),
+            (m.d2.x2_bounds, m.d3): (-2.45, -9),
+            (m.d3.x1_bounds, m.d1): (-1.5, -8),
+            (m.d3.x2_bounds, m.d1): (0.2, 2),
+            (m.d3.x1_bounds, m.d2): (-1.35, -7),
+            (m.d3.x2_bounds, m.d2): (2.45, 9),
+            (m.d1.func, m.d2): (-40, -16.65),
+            (m.d1.func, m.d3): (6.3, 9),
+            (m.d2.func, m.d1): (9.75, 18),
+            (m.d2.func, m.d3): (16.95, 29),
+            (m.d3.func, m.d1): (-21, -7.5),
+            (m.d3.func, m.d2): (-103, -37.65),
+        }
 
-    def check_untightened_bounds_constraint(self, cons, var, parent_disj,
-                                            disjunction, Ms, lower=None,
-                                            upper=None):
+    def check_untightened_bounds_constraint(
+        self, cons, var, parent_disj, disjunction, Ms, lower=None, upper=None
+    ):
         repn = generate_standard_repn(cons.body)
         self.assertTrue(repn.is_linear())
         self.assertEqual(len(repn.linear_vars), 3)
@@ -94,15 +106,17 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
             check_linear_coef(self, repn, var, -1)
             for disj in disjunction.disjuncts:
                 if disj is not parent_disj:
-                    check_linear_coef(self, repn, disj.binary_indicator_var,
-                                      Ms[disj] - lower)
+                    check_linear_coef(
+                        self, repn, disj.binary_indicator_var, Ms[disj] - lower
+                    )
         if upper is not None:
             self.assertEqual(repn.constant, -upper)
             check_linear_coef(self, repn, var, 1)
             for disj in disjunction.disjuncts:
                 if disj is not parent_disj:
-                    check_linear_coef(self, repn, disj.binary_indicator_var,
-                                       - Ms[disj] + upper)
+                    check_linear_coef(
+                        self, repn, disj.binary_indicator_var, -Ms[disj] + upper
+                    )
 
     def check_all_untightened_bounds_constraints(self, m, mbm):
         # d1.x1_bounds
@@ -110,94 +124,88 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         self.assertEqual(len(cons), 2)
         lower = cons[0]
         check_obj_in_active_tree(self, lower)
-        self.check_untightened_bounds_constraint(lower, m.x1, m.d1,
-                                                 m.disjunction, {m.d2: 0.65,
-                                                                 m.d3: 2},
-                                                 lower=0.5)
+        self.check_untightened_bounds_constraint(
+            lower, m.x1, m.d1, m.disjunction, {m.d2: 0.65, m.d3: 2}, lower=0.5
+        )
         upper = cons[1]
         check_obj_in_active_tree(self, upper)
-        self.check_untightened_bounds_constraint(upper, m.x1, m.d1,
-                                                 m.disjunction, {m.d2: 3, m.d3:
-                                                                 10}, upper=2)
+        self.check_untightened_bounds_constraint(
+            upper, m.x1, m.d1, m.disjunction, {m.d2: 3, m.d3: 10}, upper=2
+        )
 
         # d1.x2_bounds
         cons = mbm.get_transformed_constraints(m.d1.x2_bounds)
         self.assertEqual(len(cons), 2)
         lower = cons[0]
         check_obj_in_active_tree(self, lower)
-        self.check_untightened_bounds_constraint(lower, m.x2, m.d1,
-                                                 m.disjunction, {m.d2: 3,
-                                                                 m.d3: 0.55},
-                                                 lower=0.75)
+        self.check_untightened_bounds_constraint(
+            lower, m.x2, m.d1, m.disjunction, {m.d2: 3, m.d3: 0.55}, lower=0.75
+        )
         upper = cons[1]
         check_obj_in_active_tree(self, upper)
-        self.check_untightened_bounds_constraint(upper, m.x2, m.d1,
-                                                 m.disjunction, {m.d2: 10, m.d3:
-                                                                 1}, upper=3)
+        self.check_untightened_bounds_constraint(
+            upper, m.x2, m.d1, m.disjunction, {m.d2: 10, m.d3: 1}, upper=3
+        )
 
         # d2.x1_bounds
         cons = mbm.get_transformed_constraints(m.d2.x1_bounds)
         self.assertEqual(len(cons), 2)
         lower = cons[0]
         check_obj_in_active_tree(self, lower)
-        self.check_untightened_bounds_constraint(lower, m.x1, m.d2,
-                                                 m.disjunction, {m.d1: 0.5,
-                                                                 m.d3: 2},
-                                                 lower=0.65)
+        self.check_untightened_bounds_constraint(
+            lower, m.x1, m.d2, m.disjunction, {m.d1: 0.5, m.d3: 2}, lower=0.65
+        )
         upper = cons[1]
         check_obj_in_active_tree(self, upper)
-        self.check_untightened_bounds_constraint(upper, m.x1, m.d2,
-                                                 m.disjunction, {m.d1: 2, m.d3:
-                                                                 10}, upper=3)
+        self.check_untightened_bounds_constraint(
+            upper, m.x1, m.d2, m.disjunction, {m.d1: 2, m.d3: 10}, upper=3
+        )
 
-        #d2.x2_bounds
+        # d2.x2_bounds
         cons = mbm.get_transformed_constraints(m.d2.x2_bounds)
         self.assertEqual(len(cons), 2)
         lower = cons[0]
         check_obj_in_active_tree(self, lower)
-        self.check_untightened_bounds_constraint(lower, m.x2, m.d2,
-                                                 m.disjunction, {m.d1: 0.75,
-                                                                 m.d3: 0.55},
-                                                 lower=3)
+        self.check_untightened_bounds_constraint(
+            lower, m.x2, m.d2, m.disjunction, {m.d1: 0.75, m.d3: 0.55}, lower=3
+        )
         upper = cons[1]
-        self.check_untightened_bounds_constraint(upper, m.x2, m.d2,
-                                                 m.disjunction, {m.d1: 3, m.d3:
-                                                                 1}, upper=10)
+        self.check_untightened_bounds_constraint(
+            upper, m.x2, m.d2, m.disjunction, {m.d1: 3, m.d3: 1}, upper=10
+        )
 
         # d3.x1_bounds
         cons = mbm.get_transformed_constraints(m.d3.x1_bounds)
         self.assertEqual(len(cons), 2)
         lower = cons[0]
-        self.check_untightened_bounds_constraint(lower, m.x1, m.d3,
-                                                 m.disjunction, {m.d1: 0.5,
-                                                                 m.d2: 0.65},
-                                                 lower=2)
+        self.check_untightened_bounds_constraint(
+            lower, m.x1, m.d3, m.disjunction, {m.d1: 0.5, m.d2: 0.65}, lower=2
+        )
         upper = cons[1]
         check_obj_in_active_tree(self, upper)
-        self.check_untightened_bounds_constraint(upper, m.x1, m.d3,
-                                                 m.disjunction, {m.d1: 2, m.d2:
-                                                                 3}, upper=10)
+        self.check_untightened_bounds_constraint(
+            upper, m.x1, m.d3, m.disjunction, {m.d1: 2, m.d2: 3}, upper=10
+        )
 
-        #d3.x2_bounds
+        # d3.x2_bounds
         cons = mbm.get_transformed_constraints(m.d3.x2_bounds)
         self.assertEqual(len(cons), 2)
         lower = cons[0]
         check_obj_in_active_tree(self, lower)
-        self.check_untightened_bounds_constraint(lower, m.x2, m.d3,
-                                                 m.disjunction, {m.d1: 0.75,
-                                                                 m.d2: 3},
-                                                 lower=0.55)
+        self.check_untightened_bounds_constraint(
+            lower, m.x2, m.d3, m.disjunction, {m.d1: 0.75, m.d2: 3}, lower=0.55
+        )
         upper = cons[1]
         check_obj_in_active_tree(self, upper)
-        self.check_untightened_bounds_constraint(upper, m.x2, m.d3,
-                                                 m.disjunction, {m.d1: 3, m.d2:
-                                                                 10}, upper=1)
+        self.check_untightened_bounds_constraint(
+            upper, m.x2, m.d3, m.disjunction, {m.d1: 3, m.d2: 10}, upper=1
+        )
 
     def check_linear_func_constraints(self, m, mbm, Ms=None):
         if Ms is None:
             Ms = self.get_Ms(m)
 
-        #d1.func
+        # d1.func
         cons = mbm.get_transformed_constraints(m.d1.func)
         self.assertEqual(len(cons), 2)
         lower = cons[0]
@@ -211,10 +219,8 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         check_linear_coef(self, repn, m.x1, -1)
         check_linear_coef(self, repn, m.x2, -1)
         check_linear_coef(self, repn, m.d, 1)
-        check_linear_coef(self, repn, m.d2.binary_indicator_var, Ms[m.d1.func,
-                                                                    m.d2][0])
-        check_linear_coef(self, repn, m.d3.binary_indicator_var, Ms[m.d1.func,
-                                                                    m.d3][0])
+        check_linear_coef(self, repn, m.d2.binary_indicator_var, Ms[m.d1.func, m.d2][0])
+        check_linear_coef(self, repn, m.d3.binary_indicator_var, Ms[m.d1.func, m.d3][0])
         upper = cons[1]
         check_obj_in_active_tree(self, upper)
         self.assertEqual(value(upper.upper), 0)
@@ -226,12 +232,14 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         check_linear_coef(self, repn, m.x1, 1)
         check_linear_coef(self, repn, m.x2, 1)
         check_linear_coef(self, repn, m.d, -1)
-        check_linear_coef(self, repn, m.d2.binary_indicator_var, -Ms[m.d1.func,
-                                                                     m.d2][1])
-        check_linear_coef(self, repn, m.d3.binary_indicator_var, -Ms[m.d1.func,
-                                                                     m.d3][1])
+        check_linear_coef(
+            self, repn, m.d2.binary_indicator_var, -Ms[m.d1.func, m.d2][1]
+        )
+        check_linear_coef(
+            self, repn, m.d3.binary_indicator_var, -Ms[m.d1.func, m.d3][1]
+        )
 
-        #d2.func
+        # d2.func
         cons = mbm.get_transformed_constraints(m.d2.func)
         self.assertEqual(len(cons), 2)
         lower = cons[0]
@@ -245,10 +253,8 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         check_linear_coef(self, repn, m.x1, -2)
         check_linear_coef(self, repn, m.x2, -4)
         check_linear_coef(self, repn, m.d, 1)
-        check_linear_coef(self, repn, m.d1.binary_indicator_var, Ms[m.d2.func,
-                                                                    m.d1][0])
-        check_linear_coef(self, repn, m.d3.binary_indicator_var, Ms[m.d2.func,
-                                                                    m.d3][0])
+        check_linear_coef(self, repn, m.d1.binary_indicator_var, Ms[m.d2.func, m.d1][0])
+        check_linear_coef(self, repn, m.d3.binary_indicator_var, Ms[m.d2.func, m.d3][0])
         upper = cons[1]
         check_obj_in_active_tree(self, upper)
         self.assertEqual(value(upper.upper), 0)
@@ -260,12 +266,14 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         check_linear_coef(self, repn, m.x1, 2)
         check_linear_coef(self, repn, m.x2, 4)
         check_linear_coef(self, repn, m.d, -1)
-        check_linear_coef(self, repn, m.d1.binary_indicator_var, -Ms[m.d2.func,
-                                                                     m.d1][1])
-        check_linear_coef(self, repn, m.d3.binary_indicator_var, -Ms[m.d2.func,
-                                                                     m.d3][1])
+        check_linear_coef(
+            self, repn, m.d1.binary_indicator_var, -Ms[m.d2.func, m.d1][1]
+        )
+        check_linear_coef(
+            self, repn, m.d3.binary_indicator_var, -Ms[m.d2.func, m.d3][1]
+        )
 
-        #d3.func
+        # d3.func
         cons = mbm.get_transformed_constraints(m.d3.func)
         self.assertEqual(len(cons), 2)
         lower = cons[0]
@@ -279,10 +287,8 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         check_linear_coef(self, repn, m.x1, -1)
         check_linear_coef(self, repn, m.x2, 5)
         check_linear_coef(self, repn, m.d, 1)
-        check_linear_coef(self, repn, m.d1.binary_indicator_var, Ms[m.d3.func,
-                                                                    m.d1][0])
-        check_linear_coef(self, repn, m.d2.binary_indicator_var, Ms[m.d3.func,
-                                                                    m.d2][0])
+        check_linear_coef(self, repn, m.d1.binary_indicator_var, Ms[m.d3.func, m.d1][0])
+        check_linear_coef(self, repn, m.d2.binary_indicator_var, Ms[m.d3.func, m.d2][0])
         upper = cons[1]
         check_obj_in_active_tree(self, upper)
         self.assertEqual(value(upper.upper), 0)
@@ -294,10 +300,12 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         check_linear_coef(self, repn, m.x1, 1)
         check_linear_coef(self, repn, m.x2, -5)
         check_linear_coef(self, repn, m.d, -1)
-        check_linear_coef(self, repn, m.d1.binary_indicator_var, -Ms[m.d3.func,
-                                                                     m.d1][1])
-        check_linear_coef(self, repn, m.d2.binary_indicator_var, -Ms[m.d3.func,
-                                                                     m.d2][1])
+        check_linear_coef(
+            self, repn, m.d1.binary_indicator_var, -Ms[m.d3.func, m.d1][1]
+        )
+        check_linear_coef(
+            self, repn, m.d2.binary_indicator_var, -Ms[m.d3.func, m.d2][1]
+        )
 
     @unittest.skipUnless(gurobi_available, "Gurobi is not available")
     def test_calculated_Ms_correct(self):
@@ -310,8 +318,7 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         self.check_all_untightened_bounds_constraints(m, mbm)
         self.check_linear_func_constraints(m, mbm)
 
-        self.assertStructuredAlmostEqual(mbm.get_all_M_values(m),
-                                         self.get_Ms(m))
+        self.assertStructuredAlmostEqual(mbm.get_all_M_values(m), self.get_Ms(m))
 
     def test_transformed_constraints_correct_Ms_specified(self):
         m = self.make_model()
@@ -347,8 +354,7 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
                 original_cons = disj.component(comp)
                 transformed = mbm.get_transformed_constraints(original_cons)
                 for cons in transformed:
-                    self.assertIn(original_cons,
-                                  mbm.get_src_constraints(cons))
+                    self.assertIn(original_cons, mbm.get_src_constraints(cons))
 
     def test_algebraic_constraints(self):
         m = self.make_model()
@@ -405,11 +411,12 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         self.assertIs(sameagain[0], cons[0])
         self.assertIs(sameagain[1], cons[1])
 
-        self.check_pretty_bound_constraints(cons[0], m.x1, {m.d1: 0.5, m.d2:
-                                                            0.65, m.d3: 2},
-                                            lb=True)
-        self.check_pretty_bound_constraints(cons[1], m.x1, {m.d1: 2, m.d2: 3,
-                                                            m.d3: 10}, lb=False)
+        self.check_pretty_bound_constraints(
+            cons[0], m.x1, {m.d1: 0.5, m.d2: 0.65, m.d3: 2}, lb=True
+        )
+        self.check_pretty_bound_constraints(
+            cons[1], m.x1, {m.d1: 2, m.d2: 3, m.d3: 10}, lb=False
+        )
 
         cons = mbm.get_transformed_constraints(m.d1.x2_bounds)
         self.assertEqual(len(cons), 2)
@@ -422,11 +429,12 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         self.assertIs(sameagain[0], cons[0])
         self.assertIs(sameagain[1], cons[1])
 
-        self.check_pretty_bound_constraints(cons[0], m.x2, {m.d1: 0.75, m.d2: 3,
-                                                            m.d3: 0.55},
-                                            lb=True)
-        self.check_pretty_bound_constraints(cons[1], m.x2, {m.d1: 3, m.d2: 10,
-                                                            m.d3: 1}, lb=False)
+        self.check_pretty_bound_constraints(
+            cons[0], m.x2, {m.d1: 0.75, m.d2: 3, m.d3: 0.55}, lb=True
+        )
+        self.check_pretty_bound_constraints(
+            cons[1], m.x2, {m.d1: 3, m.d2: 10, m.d3: 1}, lb=False
+        )
 
     def test_bound_constraints_correct_with_redundant_constraints(self):
         m = self.make_model()
@@ -437,19 +445,21 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
 
         cons = mbm.get_transformed_constraints(m.d1.x1_bounds)
         self.assertEqual(len(cons), 2)
-        self.check_pretty_bound_constraints(cons[0], m.x1, {m.d1: 0.5, m.d2:
-                                                            0.65, m.d3: 2},
-                                            lb=True)
-        self.check_pretty_bound_constraints(cons[1], m.x1, {m.d1: 2, m.d2: 3,
-                                                            m.d3: 10}, lb=False)
+        self.check_pretty_bound_constraints(
+            cons[0], m.x1, {m.d1: 0.5, m.d2: 0.65, m.d3: 2}, lb=True
+        )
+        self.check_pretty_bound_constraints(
+            cons[1], m.x1, {m.d1: 2, m.d2: 3, m.d3: 10}, lb=False
+        )
 
         cons = mbm.get_transformed_constraints(m.d1.x2_bounds)
         self.assertEqual(len(cons), 2)
-        self.check_pretty_bound_constraints(cons[0], m.x2, {m.d1: 0.75, m.d2: 3,
-                                                            m.d3: 0.55},
-                                            lb=True)
-        self.check_pretty_bound_constraints(cons[1], m.x2, {m.d1: 3, m.d2: 10,
-                                                            m.d3: 1}, lb=False)
+        self.check_pretty_bound_constraints(
+            cons[0], m.x2, {m.d1: 0.75, m.d2: 3, m.d3: 0.55}, lb=True
+        )
+        self.check_pretty_bound_constraints(
+            cons[1], m.x2, {m.d1: 3, m.d2: 10, m.d3: 1}, lb=False
+        )
 
     def test_Ms_specified_as_args_honored(self):
         m = self.make_model()
@@ -472,14 +482,12 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         # bound not the value of M. So the logic here is that if we want M to
         # turn out to be -100, we need b - 3 = -100, so we pretend the bound was
         # b=-97. The same logic holds for the next one too.
-        self.check_untightened_bounds_constraint(cons[0], m.x2, m.d2,
-                                                 m.disjunction, {m.d1: 0.75,
-                                                                 m.d3: -97},
-                                                 lower=3)
-        self.check_untightened_bounds_constraint(cons[1], m.x2, m.d2,
-                                                 m.disjunction, {m.d1: 3,
-                                                                 m.d3: 110},
-                                                 upper=10)
+        self.check_untightened_bounds_constraint(
+            cons[0], m.x2, m.d2, m.disjunction, {m.d1: 0.75, m.d3: -97}, lower=3
+        )
+        self.check_untightened_bounds_constraint(
+            cons[1], m.x2, m.d2, m.disjunction, {m.d1: 3, m.d3: 110}, upper=10
+        )
 
     # TODO: If Suffixes allow tuple keys then we can support them and it will
     # look something like this:
@@ -559,21 +567,26 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
             mbm.apply_to(m, bigM=self.get_Ms(m), reduce_bound_constraints=True)
 
         warnings = out.getvalue()
-        self.assertIn("Unused arguments in the bigM map! "
-                      "These arguments were not used by the "
-                      "transformation:", warnings)
-        for (cons, disj) in [(m.d1.x1_bounds, m.d2),
-                             (m.d1.x2_bounds, m.d2),
-                             (m.d1.x1_bounds, m.d3),
-                             (m.d1.x2_bounds, m.d3),
-                             (m.d2.x1_bounds, m.d1),
-                             (m.d2.x2_bounds, m.d1),
-                             (m.d2.x1_bounds, m.d3),
-                             (m.d2.x2_bounds, m.d3),
-                             (m.d3.x1_bounds, m.d1),
-                             (m.d3.x2_bounds, m.d1),
-                             (m.d3.x1_bounds, m.d2),
-                             (m.d3.x2_bounds, m.d2)]:
+        self.assertIn(
+            "Unused arguments in the bigM map! "
+            "These arguments were not used by the "
+            "transformation:",
+            warnings,
+        )
+        for (cons, disj) in [
+            (m.d1.x1_bounds, m.d2),
+            (m.d1.x2_bounds, m.d2),
+            (m.d1.x1_bounds, m.d3),
+            (m.d1.x2_bounds, m.d3),
+            (m.d2.x1_bounds, m.d1),
+            (m.d2.x2_bounds, m.d1),
+            (m.d2.x1_bounds, m.d3),
+            (m.d2.x2_bounds, m.d3),
+            (m.d3.x1_bounds, m.d1),
+            (m.d3.x2_bounds, m.d1),
+            (m.d3.x1_bounds, m.d2),
+            (m.d3.x2_bounds, m.d2),
+        ]:
             self.assertIn("(%s, %s)" % (cons.name, disj.name), warnings)
 
         # check that the bounds constraints are right
@@ -584,12 +597,12 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         self.assertEqual(len(sameish), 1)
         self.assertIs(sameish[0], cons[1])
 
-        self.check_pretty_bound_constraints(cons[1], m.x1, {m.d1: 2, m.d2: 3,
-                                                            m.d3: 10, m.d4: 8},
-                                            lb=False)
-        self.check_pretty_bound_constraints(cons[0], m.x1, {m.d1: 0.5, m.d2:
-                                                            0.65, m.d3: 2, m.d4:
-                                                            -10}, lb=True)
+        self.check_pretty_bound_constraints(
+            cons[1], m.x1, {m.d1: 2, m.d2: 3, m.d3: 10, m.d4: 8}, lb=False
+        )
+        self.check_pretty_bound_constraints(
+            cons[0], m.x1, {m.d1: 0.5, m.d2: 0.65, m.d3: 2, m.d4: -10}, lb=True
+        )
 
         # and for x2:
         cons = mbm.get_transformed_constraints(m.d1.x2_bounds)
@@ -598,22 +611,23 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         self.assertEqual(len(sameish), 1)
         self.assertIs(sameish[0], cons[0])
 
-        self.check_pretty_bound_constraints(cons[1], m.x2, {m.d1: 3, m.d2: 10,
-                                                            m.d3: 1, m.d4: 20},
-                                            lb=False)
-        self.check_pretty_bound_constraints(cons[0], m.x2, {m.d1: 0.75, m.d2: 3,
-                                                            m.d3: 0.55, m.d4:
-                                                            -5}, lb=True)
+        self.check_pretty_bound_constraints(
+            cons[1], m.x2, {m.d1: 3, m.d2: 10, m.d3: 1, m.d4: 20}, lb=False
+        )
+        self.check_pretty_bound_constraints(
+            cons[0], m.x2, {m.d1: 0.75, m.d2: 3, m.d3: 0.55, m.d4: -5}, lb=True
+        )
 
     def test_nested_gdp_error(self):
         m = self.make_model()
         m.d1.disjunction = Disjunction(expr=[m.x1 >= 5, m.x1 <= 4])
         with self.assertRaisesRegex(
-                GDP_Error,
-                "Found nested Disjunction 'd1.disjunction'. The multiple bigm "
-                "transformation does not support nested GDPs. "
-                "Please flatten the model before calling the "
-                "transformation"):
+            GDP_Error,
+            "Found nested Disjunction 'd1.disjunction'. The multiple bigm "
+            "transformation does not support nested GDPs. "
+            "Please flatten the model before calling the "
+            "transformation",
+        ):
             TransformationFactory('gdp.mbigm').apply_to(m)
 
     @unittest.skipUnless(gurobi_available, "Gurobi is not available")
@@ -633,7 +647,8 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         # MbigM transformation of: (1 - z1) + (1 - y) + z >= 1
         # (1 - z1) + (1 - y) + z >= 1 - d2.ind_var - d3.ind_var
         transformed = mbm.get_transformed_constraints(
-            m.d1._logical_to_disjunctive.transformed_constraints[1])
+            m.d1._logical_to_disjunctive.transformed_constraints[1]
+        )
         self.assertEqual(len(transformed), 1)
         c = transformed[0]
         check_obj_in_active_tree(self, c)
@@ -642,18 +657,20 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         repn = generate_standard_repn(c.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
             self,
             simplified,
-            - m.d2.binary_indicator_var - m.d3.binary_indicator_var + z1 +
-            y - z - 1)
+            -m.d2.binary_indicator_var - m.d3.binary_indicator_var + z1 + y - z - 1,
+        )
 
         # MbigM transformation of: z1 + 1 - (1 - y) >= 1
         # z1 + y >= 1 - d2.ind_var - d3.ind_var
         transformed = mbm.get_transformed_constraints(
-            m.d1._logical_to_disjunctive.transformed_constraints[2])
+            m.d1._logical_to_disjunctive.transformed_constraints[2]
+        )
         self.assertEqual(len(transformed), 1)
         c = transformed[0]
         check_obj_in_active_tree(self, c)
@@ -662,18 +679,20 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         repn = generate_standard_repn(c.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
             self,
             simplified,
-            - m.d2.binary_indicator_var - m.d3.binary_indicator_var - y - z1 +
-            1)
+            -m.d2.binary_indicator_var - m.d3.binary_indicator_var - y - z1 + 1,
+        )
 
         # MbigM transformation of: z1 + 1 - z >= 1
         # z1 + 1 - z >= 1 - d2.ind_var - d3.ind_var
         transformed = mbm.get_transformed_constraints(
-            m.d1._logical_to_disjunctive.transformed_constraints[3])
+            m.d1._logical_to_disjunctive.transformed_constraints[3]
+        )
         self.assertEqual(len(transformed), 1)
         c = transformed[0]
         check_obj_in_active_tree(self, c)
@@ -682,20 +701,25 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         repn = generate_standard_repn(c.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
         assertExpressionsStructurallyEqual(
             self,
             simplified,
-            - m.d2.binary_indicator_var - m.d3.binary_indicator_var + z - z1)
+            -m.d2.binary_indicator_var - m.d3.binary_indicator_var + z - z1,
+        )
 
     def check_traditionally_bigmed_constraints(self, m, mbm, Ms):
         cons = mbm.get_transformed_constraints(m.d1.func)
         self.assertEqual(len(cons), 2)
         lb = cons[0]
         ub = cons[1]
-        assertExpressionsEqual(self, lb.expr, 0.0 <= m.x1 + m.x2 - m.d -
-                               Ms[m.d1][0]*(1 - m.d1.binary_indicator_var))
+        assertExpressionsEqual(
+            self,
+            lb.expr,
+            0.0 <= m.x1 + m.x2 - m.d - Ms[m.d1][0] * (1 - m.d1.binary_indicator_var),
+        )
         # [ESJ 11/23/22]: It's really hard to use assertExpressionsEqual on the
         # ub constraints because SumExpressions are sharing args, I think. So
         # when they get constructed in the transformation (because they come
@@ -707,45 +731,78 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
         repn = generate_standard_repn(ub.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
-        assertExpressionsEqual(self, simplified, m.x1 + m.x2 - m.d +
-                               Ms[m.d1][1]*m.d1.binary_indicator_var -
-                               Ms[m.d1][1])
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
+        assertExpressionsEqual(
+            self,
+            simplified,
+            m.x1 + m.x2 - m.d + Ms[m.d1][1] * m.d1.binary_indicator_var - Ms[m.d1][1],
+        )
 
         cons = mbm.get_transformed_constraints(m.d2.func)
         self.assertEqual(len(cons), 2)
         lb = cons[0]
         ub = cons[1]
-        assertExpressionsEqual(self, lb.expr, 0.0 <= 2*m.x1 + 4*m.x2 + 7 - m.d -
-                               Ms[m.d2][0]*(1 - m.d2.binary_indicator_var))
+        assertExpressionsEqual(
+            self,
+            lb.expr,
+            0.0
+            <= 2 * m.x1
+            + 4 * m.x2
+            + 7
+            - m.d
+            - Ms[m.d2][0] * (1 - m.d2.binary_indicator_var),
+        )
         self.assertIsNone(ub.lower)
         self.assertEqual(ub.upper, 0)
         repn = generate_standard_repn(ub.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
-        assertExpressionsEqual(self, simplified, 2*m.x1 + 4*m.x2 - m.d +
-                               Ms[m.d2][1]*m.d2.binary_indicator_var -
-                               (Ms[m.d2][1] - 7))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
+        assertExpressionsEqual(
+            self,
+            simplified,
+            2 * m.x1
+            + 4 * m.x2
+            - m.d
+            + Ms[m.d2][1] * m.d2.binary_indicator_var
+            - (Ms[m.d2][1] - 7),
+        )
 
         cons = mbm.get_transformed_constraints(m.d3.func)
         self.assertEqual(len(cons), 2)
         lb = cons[0]
         ub = cons[1]
-        assertExpressionsEqual(self, lb.expr, 0.0 <= m.x1 - 5*m.x2 - 3 - m.d -
-                               Ms[m.d3][0]*(1 - m.d3.binary_indicator_var))
+        assertExpressionsEqual(
+            self,
+            lb.expr,
+            0.0
+            <= m.x1
+            - 5 * m.x2
+            - 3
+            - m.d
+            - Ms[m.d3][0] * (1 - m.d3.binary_indicator_var),
+        )
         self.assertIsNone(ub.lower)
         self.assertEqual(ub.upper, 0)
         repn = generate_standard_repn(ub.body)
         self.assertTrue(repn.is_linear())
         simplified = repn.constant + sum(
-            repn.linear_coefs[i]*repn.linear_vars[i]
-            for i in range(len(repn.linear_vars)))
-        assertExpressionsEqual(self, simplified, m.x1 - 5*m.x2 - m.d +
-                               Ms[m.d3][1]*m.d3.binary_indicator_var -
-                               (Ms[m.d3][1] + 3))
+            repn.linear_coefs[i] * repn.linear_vars[i]
+            for i in range(len(repn.linear_vars))
+        )
+        assertExpressionsEqual(
+            self,
+            simplified,
+            m.x1
+            - 5 * m.x2
+            - m.d
+            + Ms[m.d3][1] * m.d3.binary_indicator_var
+            - (Ms[m.d3][1] + 3),
+        )
 
     def test_only_multiple_bigm_bound_constraints(self):
         m = self.make_model()
@@ -754,26 +811,27 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
 
         cons = mbm.get_transformed_constraints(m.d1.x1_bounds)
         self.assertEqual(len(cons), 2)
-        self.check_pretty_bound_constraints(cons[0], m.x1, {m.d1: 0.5, m.d2:
-                                                            0.65, m.d3: 2},
-                                            lb=True)
-        self.check_pretty_bound_constraints(cons[1], m.x1, {m.d1: 2, m.d2: 3,
-                                                            m.d3: 10}, lb=False)
+        self.check_pretty_bound_constraints(
+            cons[0], m.x1, {m.d1: 0.5, m.d2: 0.65, m.d3: 2}, lb=True
+        )
+        self.check_pretty_bound_constraints(
+            cons[1], m.x1, {m.d1: 2, m.d2: 3, m.d3: 10}, lb=False
+        )
 
         cons = mbm.get_transformed_constraints(m.d1.x2_bounds)
         self.assertEqual(len(cons), 2)
-        self.check_pretty_bound_constraints(cons[0], m.x2, {m.d1: 0.75, m.d2: 3,
-                                                            m.d3: 0.55},
-                                            lb=True)
-        self.check_pretty_bound_constraints(cons[1], m.x2, {m.d1: 3, m.d2: 10,
-                                                            m.d3: 1}, lb=False)
+        self.check_pretty_bound_constraints(
+            cons[0], m.x2, {m.d1: 0.75, m.d2: 3, m.d3: 0.55}, lb=True
+        )
+        self.check_pretty_bound_constraints(
+            cons[1], m.x2, {m.d1: 3, m.d2: 10, m.d3: 1}, lb=False
+        )
 
         self.check_traditionally_bigmed_constraints(
             m,
             mbm,
-            {m.d1: (-1030.0, 1030.0),
-             m.d2: (-1093.0, 1107.0),
-             m.d3: (-1113.0, 1107.0)})
+            {m.d1: (-1030.0, 1030.0), m.d2: (-1093.0, 1107.0), m.d3: (-1113.0, 1107.0)},
+        )
 
     def test_only_multiple_bigm_bound_constraints_arg_Ms(self):
         m = self.make_model()
@@ -783,23 +841,22 @@ class LinearModelDecisionTreeExample(unittest.TestCase):
 
         cons = mbm.get_transformed_constraints(m.d1.x1_bounds)
         self.assertEqual(len(cons), 2)
-        self.check_pretty_bound_constraints(cons[0], m.x1, {m.d1: 0.5, m.d2:
-                                                            0.65, m.d3: 2},
-                                            lb=True)
-        self.check_pretty_bound_constraints(cons[1], m.x1, {m.d1: 2, m.d2: 3,
-                                                            m.d3: 10}, lb=False)
+        self.check_pretty_bound_constraints(
+            cons[0], m.x1, {m.d1: 0.5, m.d2: 0.65, m.d3: 2}, lb=True
+        )
+        self.check_pretty_bound_constraints(
+            cons[1], m.x1, {m.d1: 2, m.d2: 3, m.d3: 10}, lb=False
+        )
 
         cons = mbm.get_transformed_constraints(m.d1.x2_bounds)
         self.assertEqual(len(cons), 2)
-        self.check_pretty_bound_constraints(cons[0], m.x2, {m.d1: 0.75, m.d2: 3,
-                                                            m.d3: 0.55},
-                                            lb=True)
-        self.check_pretty_bound_constraints(cons[1], m.x2, {m.d1: 3, m.d2: 10,
-                                                            m.d3: 1}, lb=False)
+        self.check_pretty_bound_constraints(
+            cons[0], m.x2, {m.d1: 0.75, m.d2: 3, m.d3: 0.55}, lb=True
+        )
+        self.check_pretty_bound_constraints(
+            cons[1], m.x2, {m.d1: 3, m.d2: 10, m.d3: 1}, lb=False
+        )
 
         self.check_traditionally_bigmed_constraints(
-            m,
-            mbm,
-            {m.d1: (-1050, 1050),
-             m.d2: (-2000, 1200),
-             m.d3: (-4000, 4000)})
+            m, mbm, {m.d1: (-1050, 1050), m.d2: (-2000, 1200), m.d3: (-4000, 4000)}
+        )

--- a/pyomo/gdp/tests/test_partition_disjuncts.py
+++ b/pyomo/gdp/tests/test_partition_disjuncts.py
@@ -11,15 +11,31 @@
 
 import pyomo.common.unittest as unittest
 from pyomo.environ import (
-    TransformationFactory, Constraint, ConcreteModel, Var, RangeSet, Objective,
-    maximize, SolverFactory, Any, Reference, LogicalConstraint)
+    TransformationFactory,
+    Constraint,
+    ConcreteModel,
+    Var,
+    RangeSet,
+    Objective,
+    maximize,
+    SolverFactory,
+    Any,
+    Reference,
+    LogicalConstraint,
+)
 from pyomo.core.expr.logical_expr import (
-    EquivalenceExpression, NotExpression, AndExpression, ExactlyExpression
+    EquivalenceExpression,
+    NotExpression,
+    AndExpression,
+    ExactlyExpression,
 )
 from pyomo.gdp import Disjunct, Disjunction
 from pyomo.gdp.util import GDP_Error, check_model_algebraic
 from pyomo.gdp.plugins.partition_disjuncts import (
-    arbitrary_partition, compute_optimal_bounds, compute_fbbt_bounds)
+    arbitrary_partition,
+    compute_optimal_bounds,
+    compute_fbbt_bounds,
+)
 from pyomo.core import Block, value
 from pyomo.core.expr import current as EXPR
 import pyomo.gdp.tests.common_tests as ct
@@ -30,10 +46,13 @@ from pyomo.opt import check_available_solvers
 
 solvers = check_available_solvers('gurobi_direct')
 
+
 class CommonTests:
     def diff_apply_to_and_create_using(self, model, **kwargs):
-        ct.diff_apply_to_and_create_using(self, model,
-                                          'gdp.partition_disjuncts', **kwargs)
+        ct.diff_apply_to_and_create_using(
+            self, model, 'gdp.partition_disjuncts', **kwargs
+        )
+
 
 class PaperTwoCircleExample(unittest.TestCase, CommonTests):
     def check_disj_constraint(self, c1, upper, auxVar1, auxVar2):
@@ -86,9 +105,19 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         self.assertIs(repn.quadratic_vars[1][1], var2)
         self.assertIsNone(repn.nonlinear_expr)
 
-    def check_aux_var_bounds(self, aux_vars1, aux_vars2, aux11lb, aux11ub,
-                             aux12lb, aux12ub, aux21lb, aux21ub, aux22lb,
-                             aux22ub):
+    def check_aux_var_bounds(
+        self,
+        aux_vars1,
+        aux_vars2,
+        aux11lb,
+        aux11ub,
+        aux12lb,
+        aux12ub,
+        aux21lb,
+        aux21ub,
+        aux22lb,
+        aux22ub,
+    ):
         self.assertEqual(len(aux_vars1), 2)
         # Gurobi default constraint tolerance is 1e-6, so let's say that's
         # our goal too. Have to tighten Gurobi's tolerance to even get here
@@ -105,7 +134,8 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         self.assertAlmostEqual(aux_vars2[1].ub, aux22ub, places=6)
 
     def check_transformation_block_disjuncts_and_constraints(
-            self, m, original_disjunction, disjunction_name=None):
+        self, m, original_disjunction, disjunction_name=None
+    ):
         b = m.component("_pyomo_gdp_partition_disjuncts_reformulation")
         self.assertIsInstance(b, Block)
 
@@ -133,10 +163,11 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         self.assertIsInstance(equivalence, LogicalConstraint)
         self.assertEqual(len(equivalence), 2)
         for i, variables in enumerate(
-                [(original_disjunction.disjuncts[0].indicator_var,
-                  disj1.indicator_var),
-                 (original_disjunction.disjuncts[1].indicator_var,
-                  disj2.indicator_var)]):
+            [
+                (original_disjunction.disjuncts[0].indicator_var, disj1.indicator_var),
+                (original_disjunction.disjuncts[1].indicator_var, disj2.indicator_var),
+            ]
+        ):
             cons = equivalence[i]
             self.assertIsInstance(cons.body, EquivalenceExpression)
             self.assertIs(cons.body.args[0], variables[0])
@@ -144,26 +175,32 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
 
         return b, disj1, disj2
 
-    def check_transformation_block_structure(self, m, aux11lb, aux11ub, aux12lb,
-                                             aux12ub, aux21lb, aux21ub, aux22lb,
-                                             aux22ub):
-        (b, disj1,
-         disj2) = self.check_transformation_block_disjuncts_and_constraints(
-             m,
-             m.disjunction)
+    def check_transformation_block_structure(
+        self, m, aux11lb, aux11ub, aux12lb, aux12ub, aux21lb, aux21ub, aux22lb, aux22ub
+    ):
+        (b, disj1, disj2) = self.check_transformation_block_disjuncts_and_constraints(
+            m, m.disjunction
+        )
 
         # each Disjunct has two variables declared on it (aux vars and indicator
         # var), plus a reference to the indicator_var from the original Disjunct
         self.assertEqual(len(disj1.component_map(Var)), 3)
         self.assertEqual(len(disj2.component_map(Var)), 3)
 
-        aux_vars1 = disj1.component(
-            "disjunction_disjuncts[0].constraint[1]_aux_vars")
-        aux_vars2 = disj2.component(
-            "disjunction_disjuncts[1].constraint[1]_aux_vars")
-        self.check_aux_var_bounds(aux_vars1, aux_vars2, aux11lb, aux11ub,
-                                  aux12lb, aux12ub, aux21lb, aux21ub, aux22lb,
-                                  aux22ub)
+        aux_vars1 = disj1.component("disjunction_disjuncts[0].constraint[1]_aux_vars")
+        aux_vars2 = disj2.component("disjunction_disjuncts[1].constraint[1]_aux_vars")
+        self.check_aux_var_bounds(
+            aux_vars1,
+            aux_vars2,
+            aux11lb,
+            aux11ub,
+            aux12lb,
+            aux12ub,
+            aux21lb,
+            aux21ub,
+            aux22lb,
+            aux22ub,
+        )
 
         return b, disj1, disj2, aux_vars1, aux_vars2
 
@@ -177,42 +214,53 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         c2 = c[0]
         self.check_disj_constraint(c2, -35, aux_vars2[0], aux_vars2[1])
 
-    def check_transformation_block(self, m, aux11lb, aux11ub, aux12lb, aux12ub,
-                                   aux21lb, aux21ub, aux22lb, aux22ub,
-                                   partitions):
-        (b, disj1, disj2,
-         aux_vars1,
-         aux_vars2) = self.check_transformation_block_structure( m, aux11lb,
-                                                                 aux11ub,
-                                                                 aux12lb,
-                                                                 aux12ub,
-                                                                 aux21lb,
-                                                                 aux21ub,
-                                                                 aux22lb,
-                                                                 aux22ub)
+    def check_transformation_block(
+        self,
+        m,
+        aux11lb,
+        aux11ub,
+        aux12lb,
+        aux12ub,
+        aux21lb,
+        aux21ub,
+        aux22lb,
+        aux22ub,
+        partitions,
+    ):
+        (
+            b,
+            disj1,
+            disj2,
+            aux_vars1,
+            aux_vars2,
+        ) = self.check_transformation_block_structure(
+            m, aux11lb, aux11ub, aux12lb, aux12ub, aux21lb, aux21ub, aux22lb, aux22ub
+        )
 
         self.check_disjunct_constraints(disj1, disj2, aux_vars1, aux_vars2)
 
         # check the global constraints
-        c = b.component(
-            "disjunction_disjuncts[0].constraint[1]_split_constraints")
+        c = b.component("disjunction_disjuncts[0].constraint[1]_split_constraints")
         self.assertEqual(len(c), 2)
         c1 = c[0]
-        self.check_global_constraint_disj1(c1, aux_vars1[0], partitions[0][0],
-                                           partitions[0][1])
+        self.check_global_constraint_disj1(
+            c1, aux_vars1[0], partitions[0][0], partitions[0][1]
+        )
         c2 = c[1]
-        self.check_global_constraint_disj1(c2, aux_vars1[1], partitions[1][0],
-                                           partitions[1][1])
+        self.check_global_constraint_disj1(
+            c2, aux_vars1[1], partitions[1][0], partitions[1][1]
+        )
 
-        c = b.component(
-            "disjunction_disjuncts[1].constraint[1]_split_constraints")
+        c = b.component("disjunction_disjuncts[1].constraint[1]_split_constraints")
         self.assertEqual(len(c), 2)
         c1 = c[0]
-        self.check_global_constraint_disj2(c1, aux_vars2[0], partitions[0][0],
-                                           partitions[0][1])
+        self.check_global_constraint_disj2(
+            c1, aux_vars2[0], partitions[0][0], partitions[0][1]
+        )
         c2 = c[1]
-        self.check_global_constraint_disj2(c2, aux_vars2[1], partitions[1][0],
-                                           partitions[1][1])
+        self.check_global_constraint_disj2(
+            c2, aux_vars2[1], partitions[1][0], partitions[1][1]
+        )
 
     def test_transformation_block_fbbt_bounds(self):
         m = models.makeBetweenStepsPaperExample()
@@ -220,17 +268,28 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         TransformationFactory('gdp.partition_disjuncts').apply_to(
             m,
             variable_partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
-            compute_bounds_method=compute_fbbt_bounds)
+            compute_bounds_method=compute_fbbt_bounds,
+        )
 
-        self.check_transformation_block(m, 0, 72, 0, 72, -72, 96, -72, 96,
-                                        partitions=[[m.x[1], m.x[2]], [m.x[3],
-                                                                       m.x[4]]])
+        self.check_transformation_block(
+            m,
+            0,
+            72,
+            0,
+            72,
+            -72,
+            96,
+            -72,
+            96,
+            partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
+        )
 
     def check_transformation_block_indexed_var_on_disjunct(
-            self, m, original_disjunction):
-        (b, disj1,
-         disj2) = self.check_transformation_block_disjuncts_and_constraints(
-             m, original_disjunction)
+        self, m, original_disjunction
+    ):
+        (b, disj1, disj2) = self.check_transformation_block_disjuncts_and_constraints(
+            m, original_disjunction
+        )
 
         # Has it's own indicator var, a Reference to the original Disjunct's
         # indicator var, the aux vars, and the Reference to x
@@ -240,8 +299,7 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
 
         aux_vars1 = disj1.component("disj1.c_aux_vars")
         aux_vars2 = disj2.component("disj2.c_aux_vars")
-        self.check_aux_var_bounds(aux_vars1, aux_vars2, 0, 72, 0, 72, -72, 96,
-                                  -72, 96)
+        self.check_aux_var_bounds(aux_vars1, aux_vars2, 0, 72, 0, 72, -72, 96, -72, 96)
 
         # check the transformed constraints on the disjuncts
         c = disj1.component("disj1.c")
@@ -257,20 +315,16 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         c = b.component("disj1.c_split_constraints")
         self.assertEqual(len(c), 2)
         c1 = c[0]
-        self.check_global_constraint_disj1(c1, aux_vars1[0], m.disj1.x[1],
-                                           m.disj1.x[2])
+        self.check_global_constraint_disj1(c1, aux_vars1[0], m.disj1.x[1], m.disj1.x[2])
         c2 = c[1]
-        self.check_global_constraint_disj1(c2, aux_vars1[1], m.disj1.x[3],
-                                           m.disj1.x[4])
+        self.check_global_constraint_disj1(c2, aux_vars1[1], m.disj1.x[3], m.disj1.x[4])
 
         c = b.component("disj2.c_split_constraints")
         self.assertEqual(len(c), 2)
         c1 = c[0]
-        self.check_global_constraint_disj2(c1, aux_vars2[0], m.disj1.x[1],
-                                           m.disj1.x[2])
+        self.check_global_constraint_disj2(c1, aux_vars2[0], m.disj1.x[1], m.disj1.x[2])
         c2 = c[1]
-        self.check_global_constraint_disj2(c2, aux_vars2[1], m.disj1.x[3],
-                                           m.disj1.x[4])
+        self.check_global_constraint_disj2(c2, aux_vars2[1], m.disj1.x[3], m.disj1.x[4])
 
         return b, disj1, disj2
 
@@ -279,64 +333,76 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
 
         TransformationFactory('gdp.partition_disjuncts').apply_to(
             m,
-            variable_partitions=[[m.disj1.x[1], m.disj1.x[2]], \
-                                 [m.disj1.x[3], m.disj1.x[4]]],
-            compute_bounds_method=compute_fbbt_bounds)
+            variable_partitions=[
+                [m.disj1.x[1], m.disj1.x[2]],
+                [m.disj1.x[3], m.disj1.x[4]],
+            ],
+            compute_bounds_method=compute_fbbt_bounds,
+        )
 
-        self.check_transformation_block_indexed_var_on_disjunct(m,
-                                                                m.disjunction)
+        self.check_transformation_block_indexed_var_on_disjunct(m, m.disjunction)
 
-    def check_transformation_block_nested_disjunction(self, m, disj2, x,
-                                                      disjunction_block=None):
+    def check_transformation_block_nested_disjunction(
+        self, m, disj2, x, disjunction_block=None
+    ):
         if disjunction_block is None:
             block_prefix = ""
             disjunction_parent = m
         else:
             block_prefix = disjunction_block + "."
             disjunction_parent = m.component(disjunction_block)
-        (inner_b, inner_disj1,
-         inner_disj2) = self.\
-                        check_transformation_block_disjuncts_and_constraints(
-                            disj2, disjunction_parent.disj2.disjunction,
-                            "%sdisj2.disjunction" % block_prefix)
+        (
+            inner_b,
+            inner_disj1,
+            inner_disj2,
+        ) = self.check_transformation_block_disjuncts_and_constraints(
+            disj2,
+            disjunction_parent.disj2.disjunction,
+            "%sdisj2.disjunction" % block_prefix,
+        )
 
         # Has it's own indicator var, the aux vars, and the Reference to the
         # original indicator_var
         self.assertEqual(len(inner_disj1.component_map(Var)), 3)
         self.assertEqual(len(inner_disj2.component_map(Var)), 3)
 
-        aux_vars1 = inner_disj1.component("%sdisj2.disjunction_disjuncts[0]."
-                                          "constraint[1]_aux_vars" %
-                                          block_prefix)
-        aux_vars2 = inner_disj2.component("%sdisj2.disjunction_disjuncts[1]."
-                                          "constraint[1]_aux_vars" %
-                                          block_prefix)
-        self.check_aux_var_bounds(aux_vars1, aux_vars2, 0, 72, 0, 72, -72, 96,
-                                  -72, 96)
+        aux_vars1 = inner_disj1.component(
+            "%sdisj2.disjunction_disjuncts[0].constraint[1]_aux_vars" % block_prefix
+        )
+        aux_vars2 = inner_disj2.component(
+            "%sdisj2.disjunction_disjuncts[1].constraint[1]_aux_vars" % block_prefix
+        )
+        self.check_aux_var_bounds(aux_vars1, aux_vars2, 0, 72, 0, 72, -72, 96, -72, 96)
 
         # check the transformed constraints on the disjuncts
         c = inner_disj1.component(
-            "%sdisj2.disjunction_disjuncts[0].constraint[1]" % block_prefix)
+            "%sdisj2.disjunction_disjuncts[0].constraint[1]" % block_prefix
+        )
         self.assertEqual(len(c), 1)
         c1 = c[0]
         self.check_disj_constraint(c1, 1, aux_vars1[0], aux_vars1[1])
         c = inner_disj2.component(
-            "%sdisj2.disjunction_disjuncts[1].constraint[1]" % block_prefix)
+            "%sdisj2.disjunction_disjuncts[1].constraint[1]" % block_prefix
+        )
         self.assertEqual(len(c), 1)
         c2 = c[0]
         self.check_disj_constraint(c2, -35, aux_vars2[0], aux_vars2[1])
 
         # check the global constraints
-        c = inner_b.component("%sdisj2.disjunction_disjuncts[0].constraint[1]"
-                              "_split_constraints" % block_prefix)
+        c = inner_b.component(
+            "%sdisj2.disjunction_disjuncts[0].constraint[1]"
+            "_split_constraints" % block_prefix
+        )
         self.assertEqual(len(c), 2)
         c1 = c[0]
         self.check_global_constraint_disj1(c1, aux_vars1[0], x[1], x[2])
         c2 = c[1]
         self.check_global_constraint_disj1(c2, aux_vars1[1], x[3], x[4])
 
-        c = inner_b.component("%sdisj2.disjunction_disjuncts[1].constraint[1]"
-                              "_split_constraints" % block_prefix)
+        c = inner_b.component(
+            "%sdisj2.disjunction_disjuncts[1].constraint[1]"
+            "_split_constraints" % block_prefix
+        )
         self.assertEqual(len(c), 2)
         c1 = c[0]
         self.check_global_constraint_disj2(c1, aux_vars2[0], x[1], x[2])
@@ -348,21 +414,23 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
 
         TransformationFactory('gdp.partition_disjuncts').apply_to(
             m,
-            variable_partitions=[[m.disj1.x[1], m.disj1.x[2]],
-                                 [m.disj1.x[3], m.disj1.x[4]]],
-            compute_bounds_method=compute_fbbt_bounds)
+            variable_partitions=[
+                [m.disj1.x[1], m.disj1.x[2]],
+                [m.disj1.x[3], m.disj1.x[4]],
+            ],
+            compute_bounds_method=compute_fbbt_bounds,
+        )
 
         # everything for the outer disjunction should look exactly the same as
         # the test above:
-        (b, disj1,
-         disj2) = self.check_transformation_block_indexed_var_on_disjunct(
-             m, m.disjunction)
+        (b, disj1, disj2) = self.check_transformation_block_indexed_var_on_disjunct(
+            m, m.disjunction
+        )
 
         # AND, we should have a transformed inner disjunction on disj2:
         self.check_transformation_block_nested_disjunction(m, disj2, m.disj1.x)
 
-    def test_transformation_block_nested_disjunction_outer_disjunction_target(
-            self):
+    def test_transformation_block_nested_disjunction_outer_disjunction_target(self):
         """We should get identical behavior to the previous test if we
         specify the outer disjunction as the target"""
         m = models.makeBetweenStepsPaperExample_Nested()
@@ -370,21 +438,23 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         TransformationFactory('gdp.partition_disjuncts').apply_to(
             m,
             targets=m.disjunction,
-            variable_partitions=[[m.disj1.x[1], m.disj1.x[2]],
-                                 [m.disj1.x[3], m.disj1.x[4]]],
-            compute_bounds_method=compute_fbbt_bounds)
+            variable_partitions=[
+                [m.disj1.x[1], m.disj1.x[2]],
+                [m.disj1.x[3], m.disj1.x[4]],
+            ],
+            compute_bounds_method=compute_fbbt_bounds,
+        )
 
         # everything for the outer disjunction should look exactly the same as
         # the test above:
-        (b, disj1,
-         disj2) = self.check_transformation_block_indexed_var_on_disjunct(
-             m, m.disjunction)
+        (b, disj1, disj2) = self.check_transformation_block_indexed_var_on_disjunct(
+            m, m.disjunction
+        )
 
         # AND, we should have a transformed inner disjunction on disj2:
         self.check_transformation_block_nested_disjunction(m, disj2, m.disj1.x)
 
-    def test_transformation_block_nested_disjunction_badly_ordered_targets(
-            self):
+    def test_transformation_block_nested_disjunction_badly_ordered_targets(self):
         """This tests that we preprocess targets correctly becuase we don't
         want to double transform the inner disjunct, which is what would happen
         if we did things in the order given."""
@@ -393,24 +463,28 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         TransformationFactory('gdp.partition_disjuncts').apply_to(
             m,
             targets=[m.disj2, m.disjunction],
-            variable_partitions=[[m.disj1.x[1], m.disj1.x[2]],
-                                 [m.disj1.x[3], m.disj1.x[4]]],
-            compute_bounds_method=compute_fbbt_bounds)
+            variable_partitions=[
+                [m.disj1.x[1], m.disj1.x[2]],
+                [m.disj1.x[3], m.disj1.x[4]],
+            ],
+            compute_bounds_method=compute_fbbt_bounds,
+        )
 
         # everything for the outer disjunction should look exactly the same as
         # the test above:
-        (b, disj1,
-         disj2) = self.check_transformation_block_indexed_var_on_disjunct(
-             m, m.disjunction)
+        (b, disj1, disj2) = self.check_transformation_block_indexed_var_on_disjunct(
+            m, m.disjunction
+        )
 
         # AND, we should have a transformed inner disjunction on disj2:
         self.check_transformation_block_nested_disjunction(m, disj2, m.disj1.x)
 
     def check_hierarchical_nested_model(self, m):
-        (b, disj1,
-         disj2) = self.check_transformation_block_disjuncts_and_constraints(
-             m.disjunction_block, m.disjunction_block.disjunction,
-             "disjunction_block.disjunction")
+        (b, disj1, disj2) = self.check_transformation_block_disjuncts_and_constraints(
+            m.disjunction_block,
+            m.disjunction_block.disjunction,
+            "disjunction_block.disjunction",
+        )
         # each Disjunct has two variables declared on it (aux vars and indicator
         # var), plus a reference to the indicator_var from the original Disjunct
         self.assertEqual(len(disj1.component_map(Var)), 3)
@@ -418,8 +492,7 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
 
         aux_vars1 = disj1.component("disj1.c_aux_vars")
         aux_vars2 = disj2.component("disjunct_block.disj2.c_aux_vars")
-        self.check_aux_var_bounds(aux_vars1, aux_vars2, 0, 72, 0, 72, -72, 96,
-                                  -72, 96)
+        self.check_aux_var_bounds(aux_vars1, aux_vars2, 0, 72, 0, 72, -72, 96, -72, 96)
         # check the transformed constraints on the disjuncts
         c = disj1.component("disj1.c")
         self.assertEqual(len(c), 1)
@@ -446,8 +519,9 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         self.check_global_constraint_disj2(c2, aux_vars2[1], m.x[3], m.x[4])
 
         # check the inner disjunction
-        self.check_transformation_block_nested_disjunction(m, disj2, m.x,
-                                                           "disjunct_block")
+        self.check_transformation_block_nested_disjunction(
+            m, disj2, m.x, "disjunct_block"
+        )
 
     def test_hierarchical_nested_badly_ordered_targets(self):
         m = models.makeHierarchicalNested_DeclOrderMatchesInstantationOrder()
@@ -463,7 +537,8 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
             m,
             targets=[m.disjunction_block, m.disjunct_block.disj2],
             variable_partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
-            compute_bounds_method=compute_fbbt_bounds)
+            compute_bounds_method=compute_fbbt_bounds,
+        )
 
         self.check_hierarchical_nested_model(m)
 
@@ -472,7 +547,8 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         TransformationFactory('gdp.partition_disjuncts').apply_to(
             m,
             variable_partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
-            compute_bounds_method=compute_fbbt_bounds)
+            compute_bounds_method=compute_fbbt_bounds,
+        )
 
         self.check_hierarchical_nested_model(m)
 
@@ -482,12 +558,14 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         TransformationFactory('gdp.partition_disjuncts').apply_to(
             m,
             targets=m.disj2.disjunction,
-            variable_partitions=[[m.disj1.x[1], m.disj1.x[2]],
-                                 [m.disj1.x[3], m.disj1.x[4]]],
-            compute_bounds_method=compute_fbbt_bounds)
+            variable_partitions=[
+                [m.disj1.x[1], m.disj1.x[2]],
+                [m.disj1.x[3], m.disj1.x[4]],
+            ],
+            compute_bounds_method=compute_fbbt_bounds,
+        )
 
-        self.check_transformation_block_nested_disjunction(m, m.disj2,
-                                                           m.disj1.x)
+        self.check_transformation_block_nested_disjunction(m, m.disj2, m.disj1.x)
         # NOTE: If you then transformed the whole model (or the outer
         # disjunction), you would double-transform in the sense that you would
         # again transform the Disjunction this creates. But I think it serves
@@ -496,8 +574,9 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         # for us to know. It is confusing though since bigm and hull need to go
         # from the leaves up and this is opposite.
 
-    @unittest.skipIf('gurobi_direct' not in solvers,
-                     'Gurobi direct solver not available')
+    @unittest.skipIf(
+        'gurobi_direct' not in solvers, 'Gurobi direct solver not available'
+    )
     def test_transformation_block_optimized_bounds(self):
         m = models.makeBetweenStepsPaperExample()
 
@@ -509,35 +588,49 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
             m,
             variable_partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
             compute_bounds_solver=SolverFactory('gurobi_direct'),
-            compute_bounds_method=compute_optimal_bounds)
+            compute_bounds_method=compute_optimal_bounds,
+        )
 
-        self.check_transformation_block(m, 0, 72, 0, 72, -18, 32, -18, 32,
-                                        partitions=[[m.x[1], m.x[2]], [m.x[3],
-                                                                       m.x[4]]])
+        self.check_transformation_block(
+            m,
+            0,
+            72,
+            0,
+            72,
+            -18,
+            32,
+            -18,
+            32,
+            partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
+        )
 
     def test_no_solver_error(self):
         m = models.makeBetweenStepsPaperExample()
 
-        with self.assertRaisesRegex(GDP_Error,
-                                    "No solver was specified to optimize the "
-                                    "subproblems for computing expression "
-                                    "bounds! "
-                                    "Please specify a configured solver in the "
-                                    "'compute_bounds_solver' argument if using "
-                                    "'compute_optimal_bounds.'"):
+        with self.assertRaisesRegex(
+            GDP_Error,
+            "No solver was specified to optimize the "
+            "subproblems for computing expression "
+            "bounds! "
+            "Please specify a configured solver in the "
+            "'compute_bounds_solver' argument if using "
+            "'compute_optimal_bounds.'",
+        ):
             TransformationFactory('gdp.partition_disjuncts').apply_to(
                 m,
                 variable_partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
-                compute_bounds_method=compute_optimal_bounds)
+                compute_bounds_method=compute_optimal_bounds,
+            )
 
-    @unittest.skipIf('gurobi_direct' not in solvers,
-                     'Gurobi direct solver not available')
+    @unittest.skipIf(
+        'gurobi_direct' not in solvers, 'Gurobi direct solver not available'
+    )
     def test_transformation_block_better_bounds_in_global_constraints(self):
         m = models.makeBetweenStepsPaperExample()
-        m.c1 = Constraint(expr=m.x[1]**2 + m.x[2]**2 <= 32)
-        m.c2 = Constraint(expr=m.x[3]**2 + m.x[4]**2 <= 32)
-        m.c3 = Constraint(expr=(3 - m.x[1])**2 + (3 - m.x[2])**2 <= 32)
-        m.c4 = Constraint(expr=(3 - m.x[3])**2 + (3 - m.x[4])**2 <= 32)
+        m.c1 = Constraint(expr=m.x[1] ** 2 + m.x[2] ** 2 <= 32)
+        m.c2 = Constraint(expr=m.x[3] ** 2 + m.x[4] ** 2 <= 32)
+        m.c3 = Constraint(expr=(3 - m.x[1]) ** 2 + (3 - m.x[2]) ** 2 <= 32)
+        m.c4 = Constraint(expr=(3 - m.x[3]) ** 2 + (3 - m.x[4]) ** 2 <= 32)
         opt = SolverFactory('gurobi_direct')
         opt.options['NonConvex'] = 2
         opt.options['FeasibilityTol'] = 1e-8
@@ -546,14 +639,25 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
             m,
             variable_partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
             compute_bounds_solver=opt,
-            compute_bounds_method=compute_optimal_bounds)
+            compute_bounds_method=compute_optimal_bounds,
+        )
 
-        self.check_transformation_block(m, 0, 32, 0, 32, -18, 14, -18, 14,
-                                        partitions=[[m.x[1], m.x[2]], [m.x[3],
-                                                                       m.x[4]]])
+        self.check_transformation_block(
+            m,
+            0,
+            32,
+            0,
+            32,
+            -18,
+            14,
+            -18,
+            14,
+            partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
+        )
 
-    @unittest.skipIf('gurobi_direct' not in solvers,
-                     'Gurobi direct solver not available')
+    @unittest.skipIf(
+        'gurobi_direct' not in solvers, 'Gurobi direct solver not available'
+    )
     def test_transformation_block_arbitrary_even_partition(self):
         m = models.makeBetweenStepsPaperExample()
 
@@ -565,14 +669,25 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
             m,
             num_partitions=2,
             compute_bounds_solver=SolverFactory('gurobi_direct'),
-            compute_bounds_method=compute_optimal_bounds)
+            compute_bounds_method=compute_optimal_bounds,
+        )
         # The above will partition as [[x[1], x[3]], [x[2], x[4]]]
-        self.check_transformation_block(m, 0, 72, 0, 72, -18, 32, -18, 32,
-                                        partitions=[[m.x[1], m.x[3]], [m.x[2],
-                                                                       m.x[4]]])
+        self.check_transformation_block(
+            m,
+            0,
+            72,
+            0,
+            72,
+            -18,
+            32,
+            -18,
+            32,
+            partitions=[[m.x[1], m.x[3]], [m.x[2], m.x[4]]],
+        )
 
-    @unittest.skipIf('gurobi_direct' not in solvers,
-                     'Gurobi direct solver not available')
+    @unittest.skipIf(
+        'gurobi_direct' not in solvers, 'Gurobi direct solver not available'
+    )
     def test_assume_fixed_vars_not_permanent(self):
         m = models.makeBetweenStepsPaperExample()
         m.x[1].fix(0)
@@ -587,7 +702,8 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
             variable_partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
             assume_fixed_vars_permanent=False,
             compute_bounds_solver=SolverFactory('gurobi_direct'),
-            compute_bounds_method=compute_optimal_bounds)
+            compute_bounds_method=compute_optimal_bounds,
+        )
 
         self.assertTrue(m.x[1].fixed)
         self.assertEqual(value(m.x[1]), 0)
@@ -596,12 +712,22 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
 
         m.x[1].fixed = False
         # should be identical to the case where x[1] was not fixed
-        self.check_transformation_block(m, 0, 72, 0, 72, -18, 32, -18, 32,
-                                        partitions=[[m.x[1], m.x[2]], [m.x[3],
-                                                                       m.x[4]]])
+        self.check_transformation_block(
+            m,
+            0,
+            72,
+            0,
+            72,
+            -18,
+            32,
+            -18,
+            32,
+            partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
+        )
 
-    @unittest.skipIf('gurobi_direct' not in solvers,
-                     'Gurobi direct solver not available')
+    @unittest.skipIf(
+        'gurobi_direct' not in solvers, 'Gurobi direct solver not available'
+    )
     def test_assume_fixed_vars_permanent(self):
         m = models.makeBetweenStepsPaperExample()
         m.x[1].fix(0)
@@ -616,7 +742,8 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
             variable_partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
             assume_fixed_vars_permanent=True,
             compute_bounds_solver=SolverFactory('gurobi_direct'),
-            compute_bounds_method=compute_optimal_bounds)
+            compute_bounds_method=compute_optimal_bounds,
+        )
 
         # Fixing BooleanVars is the same either way. We just check that it was
         # maintained through the transformation.
@@ -626,18 +753,20 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         # This actually changes the structure of the model because fixed vars
         # move to the constants. I think this is fair, and we should allow it
         # because it will allow for a tighter relaxation.
-        (b, disj1, disj2,
-         aux_vars1,
-         aux_vars2) = self.check_transformation_block_structure(m, 0, 36, 0, 72,
-                                                                -9, 16, -18, 32)
+        (
+            b,
+            disj1,
+            disj2,
+            aux_vars1,
+            aux_vars2,
+        ) = self.check_transformation_block_structure(m, 0, 36, 0, 72, -9, 16, -18, 32)
 
         # check disjunct constraints
         self.check_disjunct_constraints(disj1, disj2, aux_vars1, aux_vars2)
 
         # now we can check the global constraints--these are what is different
         # because x[1] is gone.
-        c = b.component(
-            "disjunction_disjuncts[0].constraint[1]_split_constraints")
+        c = b.component("disjunction_disjuncts[0].constraint[1]_split_constraints")
         self.assertEqual(len(c), 2)
         c1 = c[0]
         self.assertIsNone(c1.lower)
@@ -655,8 +784,7 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         c2 = c[1]
         self.check_global_constraint_disj1(c2, aux_vars1[1], m.x[3], m.x[4])
 
-        c = b.component(
-            "disjunction_disjuncts[1].constraint[1]_split_constraints")
+        c = b.component("disjunction_disjuncts[1].constraint[1]_split_constraints")
         self.assertEqual(len(c), 2)
         c1 = c[0]
         self.assertIsNone(c1.lower)
@@ -676,8 +804,9 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         c2 = c[1]
         self.check_global_constraint_disj2(c2, aux_vars2[1], m.x[3], m.x[4])
 
-    @unittest.skipIf('gurobi_direct' not in solvers,
-                     'Gurobi direct solver not available')
+    @unittest.skipIf(
+        'gurobi_direct' not in solvers, 'Gurobi direct solver not available'
+    )
     def test_transformation_block_arbitrary_odd_partition(self):
         m = models.makeBetweenStepsPaperExample()
 
@@ -689,11 +818,12 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
             m,
             num_partitions=3,
             compute_bounds_solver=SolverFactory('gurobi_direct'),
-            compute_bounds_method=compute_optimal_bounds)
+            compute_bounds_method=compute_optimal_bounds,
+        )
 
-        (b, disj1,
-         disj2) = self.check_transformation_block_disjuncts_and_constraints(
-             m, m.disjunction)
+        (b, disj1, disj2) = self.check_transformation_block_disjuncts_and_constraints(
+            m, m.disjunction
+        )
 
         # each Disjunct has three variables declared on it (aux vars and
         # indicator var), plus a reference to the indicator_var of the original
@@ -701,8 +831,7 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         self.assertEqual(len(disj1.component_map(Var)), 3)
         self.assertEqual(len(disj2.component_map(Var)), 3)
 
-        aux_vars1 = disj1.component(
-            "disjunction_disjuncts[0].constraint[1]_aux_vars")
+        aux_vars1 = disj1.component("disjunction_disjuncts[0].constraint[1]_aux_vars")
         self.assertEqual(len(aux_vars1), 3)
         self.assertEqual(aux_vars1[0].lb, 0)
         self.assertEqual(aux_vars1[0].ub, 72)
@@ -710,8 +839,7 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         self.assertEqual(aux_vars1[1].ub, 36)
         self.assertEqual(aux_vars1[2].lb, 0)
         self.assertEqual(aux_vars1[2].ub, 36)
-        aux_vars2 = disj2.component(
-            "disjunction_disjuncts[1].constraint[1]_aux_vars")
+        aux_vars2 = disj2.component("disjunction_disjuncts[1].constraint[1]_aux_vars")
         self.assertEqual(len(aux_vars2), 3)
         # min and max of x1^2 - 6x1 + x2^2 - 6x2
         self.assertEqual(aux_vars2[0].lb, -18)
@@ -756,8 +884,7 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         self.assertEqual(repn.linear_coefs[2], 1)
 
         # check the global constraints
-        c = b.component(
-            "disjunction_disjuncts[0].constraint[1]_split_constraints")
+        c = b.component("disjunction_disjuncts[0].constraint[1]_split_constraints")
         self.assertEqual(len(c), 3)
         c.pprint()
         c1 = c[0]
@@ -790,8 +917,7 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         self.assertIs(repn.quadratic_vars[0][1], m.x[3])
         self.assertIsNone(repn.nonlinear_expr)
 
-        c = b.component(
-            "disjunction_disjuncts[1].constraint[1]_split_constraints")
+        c = b.component("disjunction_disjuncts[1].constraint[1]_split_constraints")
         self.assertEqual(len(c), 3)
         c1 = c[0]
         self.check_global_constraint_disj2(c1, aux_vars2[0], m.x[1], m.x[4])
@@ -834,13 +960,16 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         TransformationFactory('gdp.partition_disjuncts').apply_to(
             m,
             variable_partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
-            compute_bounds_method=compute_fbbt_bounds)
+            compute_bounds_method=compute_fbbt_bounds,
+        )
 
         b = m.component("_pyomo_gdp_partition_disjuncts_reformulation")
-        self.assertIs(m.disjunction.disjuncts[0].transformation_block,
-                      b.disjunction.disjuncts[0])
-        self.assertIs(m.disjunction.disjuncts[1].transformation_block,
-                      b.disjunction.disjuncts[1])
+        self.assertIs(
+            m.disjunction.disjuncts[0].transformation_block, b.disjunction.disjuncts[0]
+        )
+        self.assertIs(
+            m.disjunction.disjuncts[1].transformation_block, b.disjunction.disjuncts[1]
+        )
 
     def test_transformed_disjunctions_mapped_correctly(self):
         # we map disjunctions to disjunctions because this is a GDP -> GDP
@@ -850,7 +979,8 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         TransformationFactory('gdp.partition_disjuncts').apply_to(
             m,
             variable_partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
-            compute_bounds_method=compute_fbbt_bounds)
+            compute_bounds_method=compute_fbbt_bounds,
+        )
 
         b = m.component("_pyomo_gdp_partition_disjuncts_reformulation")
         self.assertIs(m.disjunction.algebraic_constraint, b.disjunction)
@@ -858,9 +988,12 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
     def add_disjunction(self, b):
         m = b.model()
         b.another_disjunction = Disjunction(
-            expr=[[(m.x[1] - 1)**2 + m.x[2]**2 <= 1],
-                  # writing this constraint backwards to test the flipping logic
-                  [-(m.x[1] - 2)**2 - (m.x[2] - 3)**2 >= -1]])
+            expr=[
+                [(m.x[1] - 1) ** 2 + m.x[2] ** 2 <= 1],
+                # writing this constraint backwards to test the flipping logic
+                [-((m.x[1] - 2) ** 2) - (m.x[2] - 3) ** 2 >= -1],
+            ]
+        )
 
     def make_model_with_added_disjunction_on_block(self):
         m = models.makeBetweenStepsPaperExample()
@@ -962,22 +1095,31 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
             m,
             variable_partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
             compute_bounds_method=compute_fbbt_bounds,
-            targets=[m.disjunction])
+            targets=[m.disjunction],
+        )
 
         # should be the same as before
-        self.check_transformation_block(m, 0, 72, 0, 72, -72, 96, -72, 96,
-                                        partitions=[[m.x[1], m.x[2]], [m.x[3],
-                                                                       m.x[4]]])
+        self.check_transformation_block(
+            m,
+            0,
+            72,
+            0,
+            72,
+            -72,
+            96,
+            -72,
+            96,
+            partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
+        )
 
         # and another_disjunction should be untransformed
         self.assertIsNone(m.b.another_disjunction.algebraic_constraint)
-        self.assertIsNone(
-            m.b.another_disjunction.disjuncts[0].transformation_block)
-        self.assertIsNone(
-            m.b.another_disjunction.disjuncts[1].transformation_block)
+        self.assertIsNone(m.b.another_disjunction.disjuncts[0].transformation_block)
+        self.assertIsNone(m.b.another_disjunction.disjuncts[1].transformation_block)
 
-    @unittest.skipIf('gurobi_direct' not in solvers,
-                     'Gurobi direct solver not available')
+    @unittest.skipIf(
+        'gurobi_direct' not in solvers, 'Gurobi direct solver not available'
+    )
     def test_block_target(self):
         m = self.make_model_with_added_disjunction_on_block()
 
@@ -986,7 +1128,8 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
             variable_partitions=[[m.x[1]], [m.x[2]]],
             compute_bounds_solver=SolverFactory('gurobi_direct'),
             compute_bounds_method=compute_optimal_bounds,
-            targets=[m.b])
+            targets=[m.b],
+        )
 
         # we didn't transform the disjunction not on b
         self.assertIsNone(m.disjunction.algebraic_constraint)
@@ -999,8 +1142,8 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         # check we declared the right things
         self.assertEqual(len(b.component_map(Disjunction)), 1)
         self.assertEqual(len(b.component_map(Disjunct)), 2)
-        self.assertEqual(len(b.component_map(Constraint)), 2)# global
-                                                             # constraints
+        self.assertEqual(len(b.component_map(Constraint)), 2)  # global
+        # constraints
 
         disjunction = b.component("b.another_disjunction")
         self.assertIsInstance(disjunction, Disjunction)
@@ -1017,10 +1160,12 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         self.assertEqual(len(disj2.component_map(Var)), 3)
 
         aux_vars1 = disj1.component(
-            "b.another_disjunction_disjuncts[0].constraint[1]_aux_vars")
+            "b.another_disjunction_disjuncts[0].constraint[1]_aux_vars"
+        )
 
         aux_vars2 = disj2.component(
-            "b.another_disjunction_disjuncts[1].constraint[1]_aux_vars")
+            "b.another_disjunction_disjuncts[1].constraint[1]_aux_vars"
+        )
         self.check_second_disjunction_aux_vars(aux_vars1, aux_vars2)
 
         # check constraints on disjuncts
@@ -1034,18 +1179,18 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
 
         # check global constraints
         c = b.component(
-            "b.another_disjunction_disjuncts[0].constraint[1]"
-            "_split_constraints")
+            "b.another_disjunction_disjuncts[0].constraint[1]_split_constraints"
+        )
         self.check_second_disjunction_global_constraint_disj1(c, aux_vars1)
 
         c = b.component(
-            "b.another_disjunction_disjuncts[1].constraint[1]"
-            "_split_constraints")
+            "b.another_disjunction_disjuncts[1].constraint[1]_split_constraints"
+        )
         self.check_second_disjunction_global_constraint_disj2(c, aux_vars2)
 
-
-    @unittest.skipIf('gurobi_direct' not in solvers,
-                     'Gurobi direct solver not available')
+    @unittest.skipIf(
+        'gurobi_direct' not in solvers, 'Gurobi direct solver not available'
+    )
     def test_indexed_block_target(self):
         m = ConcreteModel()
         m.b = Block(Any)
@@ -1057,10 +1202,12 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
             m,
             variable_partitions={
                 m.b[1].another_disjunction: [[m.x[1]], [m.x[2]]],
-                m.b[0].disjunction: [[m.x[1], m.x[2]], [m.x[3], m.x[4]]]},
+                m.b[0].disjunction: [[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
+            },
             compute_bounds_solver=SolverFactory('gurobi_direct'),
             compute_bounds_method=compute_optimal_bounds,
-            targets=[m.b])
+            targets=[m.b],
+        )
 
         b0 = m.b[0].component("_pyomo_gdp_partition_disjuncts_reformulation")
         self.assertIsInstance(b0, Block)
@@ -1068,16 +1215,16 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         # check we declared the right things
         self.assertEqual(len(b0.component_map(Disjunction)), 1)
         self.assertEqual(len(b0.component_map(Disjunct)), 2)
-        self.assertEqual(len(b0.component_map(Constraint)), 2) # global
-                                                               # constraints
+        self.assertEqual(len(b0.component_map(Constraint)), 2)  # global
+        # constraints
         b1 = m.b[1].component("_pyomo_gdp_partition_disjuncts_reformulation")
         self.assertIsInstance(b1, Block)
 
         # check we declared the right things
         self.assertEqual(len(b1.component_map(Disjunction)), 1)
         self.assertEqual(len(b1.component_map(Disjunct)), 2)
-        self.assertEqual(len(b1.component_map(Constraint)), 2) # global
-                                                               # constraints
+        self.assertEqual(len(b1.component_map(Constraint)), 2)  # global
+        # constraints
 
         ############################
         # Check the added disjunction
@@ -1097,29 +1244,31 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         self.assertEqual(len(disj2.component_map(Var)), 3)
 
         aux_vars1 = disj1.component(
-            "b[1].another_disjunction_disjuncts[0].constraint[1]_aux_vars")
+            "b[1].another_disjunction_disjuncts[0].constraint[1]_aux_vars"
+        )
         aux_vars2 = disj2.component(
-            "b[1].another_disjunction_disjuncts[1].constraint[1]_aux_vars")
+            "b[1].another_disjunction_disjuncts[1].constraint[1]_aux_vars"
+        )
         self.check_second_disjunction_aux_vars(aux_vars1, aux_vars2)
 
         # check constraints on disjuncts
-        c1 = disj1.component(
-            "b[1].another_disjunction_disjuncts[0].constraint[1]")
+        c1 = disj1.component("b[1].another_disjunction_disjuncts[0].constraint[1]")
         self.assertEqual(len(c1), 1)
         self.check_disj_constraint(c1[0], 0, aux_vars1[0], aux_vars1[1])
 
-        c2 = disj2.component(
-            "b[1].another_disjunction_disjuncts[1].constraint[1]")
+        c2 = disj2.component("b[1].another_disjunction_disjuncts[1].constraint[1]")
         self.assertEqual(len(c2), 1)
         self.check_disj_constraint(c2[0], -12, aux_vars2[0], aux_vars2[1])
 
         # check global constraints
-        c = b1.component("b[1].another_disjunction_disjuncts[0]."
-                        "constraint[1]_split_constraints")
+        c = b1.component(
+            "b[1].another_disjunction_disjuncts[0].constraint[1]_split_constraints"
+        )
         self.check_second_disjunction_global_constraint_disj1(c, aux_vars1)
 
-        c = b1.component("b[1].another_disjunction_disjuncts[1]."
-                        "constraint[1]_split_constraints")
+        c = b1.component(
+            "b[1].another_disjunction_disjuncts[1].constraint[1]_split_constraints"
+        )
         self.check_second_disjunction_global_constraint_disj2(c, aux_vars2)
 
         ############################
@@ -1140,11 +1289,12 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         self.assertEqual(len(disj2.component_map(Var)), 3)
 
         aux_vars1 = disj1.component(
-            "b[0].disjunction_disjuncts[0].constraint[1]_aux_vars")
+            "b[0].disjunction_disjuncts[0].constraint[1]_aux_vars"
+        )
         aux_vars2 = disj2.component(
-            "b[0].disjunction_disjuncts[1].constraint[1]_aux_vars")
-        self.check_aux_var_bounds(aux_vars1, aux_vars2, 0, 72, 0, 72, -18, 32,
-                                  -18, 32)
+            "b[0].disjunction_disjuncts[1].constraint[1]_aux_vars"
+        )
+        self.check_aux_var_bounds(aux_vars1, aux_vars2, 0, 72, 0, 72, -18, 32, -18, 32)
 
         # check constraints on disjuncts
         c1 = disj1.component("b[0].disjunction_disjuncts[0].constraint[1]")
@@ -1157,7 +1307,8 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
 
         # check global constraints
         c = b0.component(
-            "b[0].disjunction_disjuncts[0].constraint[1]_split_constraints")
+            "b[0].disjunction_disjuncts[0].constraint[1]_split_constraints"
+        )
         self.assertEqual(len(c), 2)
         c1 = c[0]
         self.check_global_constraint_disj1(c1, aux_vars1[0], m.x[1], m.x[2])
@@ -1165,32 +1316,40 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         self.check_global_constraint_disj1(c2, aux_vars1[1], m.x[3], m.x[4])
 
         c = b0.component(
-            "b[0].disjunction_disjuncts[1].constraint[1]_split_constraints")
+            "b[0].disjunction_disjuncts[1].constraint[1]_split_constraints"
+        )
         self.assertEqual(len(c), 2)
         c1 = c[0]
         self.check_global_constraint_disj2(c1, aux_vars2[0], m.x[1], m.x[2])
         c2 = c[1]
         self.check_global_constraint_disj2(c2, aux_vars2[1], m.x[3], m.x[4])
 
-    @unittest.skipIf('gurobi_direct' not in solvers,
-                     'Gurobi direct solver not available')
+    @unittest.skipIf(
+        'gurobi_direct' not in solvers, 'Gurobi direct solver not available'
+    )
     def test_indexed_disjunction_target(self):
         m = ConcreteModel()
-        m.I = RangeSet(1,4)
-        m.x = Var(m.I, bounds=(-2,6))
+        m.I = RangeSet(1, 4)
+        m.x = Var(m.I, bounds=(-2, 6))
         m.indexed = Disjunction(Any)
-        m.indexed[1] = [[sum(m.x[i]**2 for i in m.I) <= 1],
-                        [sum((3 - m.x[i])**2 for i in m.I) <= 1]]
-        m.indexed[0] = [[(m.x[1] - 1)**2 + m.x[2]**2 <= 1],
-                        [-(m.x[1] - 2)**2 - (m.x[2] - 3)**2 >= -1]]
+        m.indexed[1] = [
+            [sum(m.x[i] ** 2 for i in m.I) <= 1],
+            [sum((3 - m.x[i]) ** 2 for i in m.I) <= 1],
+        ]
+        m.indexed[0] = [
+            [(m.x[1] - 1) ** 2 + m.x[2] ** 2 <= 1],
+            [-((m.x[1] - 2) ** 2) - (m.x[2] - 3) ** 2 >= -1],
+        ]
         TransformationFactory('gdp.partition_disjuncts').apply_to(
             m,
             variable_partitions={
                 m.indexed[0]: [[m.x[1]], [m.x[2]]],
-                m.indexed[1]: [[m.x[1], m.x[2]], [m.x[3], m.x[4]]]},
+                m.indexed[1]: [[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
+            },
             compute_bounds_solver=SolverFactory('gurobi_direct'),
             compute_bounds_method=compute_optimal_bounds,
-            targets=[m.indexed])
+            targets=[m.indexed],
+        )
 
         b = m.component("_pyomo_gdp_partition_disjuncts_reformulation")
         self.assertIsInstance(b, Block)
@@ -1198,8 +1357,8 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         # check we declared the right things
         self.assertEqual(len(b.component_map(Disjunction)), 2)
         self.assertEqual(len(b.component_map(Disjunct)), 4)
-        self.assertEqual(len(b.component_map(Constraint)), 4) # global
-                                                              # constraints
+        self.assertEqual(len(b.component_map(Constraint)), 4)  # global
+        # constraints
         ############################
         # Check the added disjunction
         #############################
@@ -1216,30 +1375,24 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         # Disjunct
         self.assertEqual(len(disj1.component_map(Var)), 3)
         self.assertEqual(len(disj2.component_map(Var)), 3)
-        aux_vars1 = disj1.component(
-            "indexed_disjuncts[2].constraint[1]_aux_vars")
-        aux_vars2 = disj2.component(
-            "indexed_disjuncts[3].constraint[1]_aux_vars")
+        aux_vars1 = disj1.component("indexed_disjuncts[2].constraint[1]_aux_vars")
+        aux_vars2 = disj2.component("indexed_disjuncts[3].constraint[1]_aux_vars")
         self.check_second_disjunction_aux_vars(aux_vars1, aux_vars2)
 
         # check constraints on disjuncts
-        c1 = disj1.component(
-            "indexed_disjuncts[2].constraint[1]")
+        c1 = disj1.component("indexed_disjuncts[2].constraint[1]")
         self.assertEqual(len(c1), 1)
         self.check_disj_constraint(c1[0], 0, aux_vars1[0], aux_vars1[1])
 
-        c2 = disj2.component(
-            "indexed_disjuncts[3].constraint[1]")
+        c2 = disj2.component("indexed_disjuncts[3].constraint[1]")
         self.assertEqual(len(c2), 1)
         self.check_disj_constraint(c2[0], -12, aux_vars2[0], aux_vars2[1])
 
         # check global constraints
-        c = b.component("indexed_disjuncts[2]."
-                        "constraint[1]_split_constraints")
+        c = b.component("indexed_disjuncts[2].constraint[1]_split_constraints")
         self.check_second_disjunction_global_constraint_disj1(c, aux_vars1)
 
-        c = b.component("indexed_disjuncts[3]."
-                        "constraint[1]_split_constraints")
+        c = b.component("indexed_disjuncts[3].constraint[1]_split_constraints")
         self.check_second_disjunction_global_constraint_disj2(c, aux_vars2)
 
         ############################
@@ -1259,12 +1412,9 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         self.assertEqual(len(disj1.component_map(Var)), 3)
         self.assertEqual(len(disj2.component_map(Var)), 3)
 
-        aux_vars1 = disj1.component(
-            "indexed_disjuncts[0].constraint[1]_aux_vars")
-        aux_vars2 = disj2.component(
-            "indexed_disjuncts[1].constraint[1]_aux_vars")
-        self.check_aux_var_bounds(aux_vars1, aux_vars2, 0, 72, 0, 72, -18, 32,
-                                  -18, 32)
+        aux_vars1 = disj1.component("indexed_disjuncts[0].constraint[1]_aux_vars")
+        aux_vars2 = disj2.component("indexed_disjuncts[1].constraint[1]_aux_vars")
+        self.check_aux_var_bounds(aux_vars1, aux_vars2, 0, 72, 0, 72, -18, 32, -18, 32)
 
         # check constraints on disjuncts
         c1 = disj1.component("indexed_disjuncts[0].constraint[1]")
@@ -1276,16 +1426,14 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         self.check_disj_constraint(c2[0], -35, aux_vars2[0], aux_vars2[1])
 
         # check global constraints
-        c = b.component(
-            "indexed_disjuncts[0].constraint[1]_split_constraints")
+        c = b.component("indexed_disjuncts[0].constraint[1]_split_constraints")
         self.assertEqual(len(c), 2)
         c1 = c[0]
         self.check_global_constraint_disj1(c1, aux_vars1[0], m.x[1], m.x[2])
         c2 = c[1]
         self.check_global_constraint_disj1(c2, aux_vars1[1], m.x[3], m.x[4])
 
-        c = b.component(
-            "indexed_disjuncts[1].constraint[1]_split_constraints")
+        c = b.component("indexed_disjuncts[1].constraint[1]_split_constraints")
         self.assertEqual(len(c), 2)
         c1 = c[0]
         self.check_global_constraint_disj2(c1, aux_vars2[0], m.x[1], m.x[2])
@@ -1305,7 +1453,8 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
             TransformationFactory('gdp.partition_disjuncts').apply_to,
             m,
             variable_partitions=[[m.x[1]], [m.x[2]]],
-            compute_bounds_method=compute_fbbt_bounds)
+            compute_bounds_method=compute_fbbt_bounds,
+        )
 
     def test_unbounded_expression_error(self):
         m = models.makeBetweenStepsPaperExample()
@@ -1322,21 +1471,24 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
             TransformationFactory('gdp.partition_disjuncts').apply_to,
             m,
             variable_partitions=[[m.x[1]], [m.x[2]], [m.x[3], m.x[4]]],
-            compute_bounds_method=compute_fbbt_bounds)
+            compute_bounds_method=compute_fbbt_bounds,
+        )
 
     def test_no_value_for_P_error(self):
         m = models.makeBetweenStepsPaperExample()
         with self.assertRaisesRegex(
-                GDP_Error,
-                "No value for P was given for disjunction "
-                "disjunction! Please specify a value of P "
-                r"\(number of partitions\), if you do not specify the "
-                "partitions directly."):
+            GDP_Error,
+            "No value for P was given for disjunction "
+            "disjunction! Please specify a value of P "
+            r"\(number of partitions\), if you do not specify the "
+            "partitions directly.",
+        ):
             TransformationFactory('gdp.partition_disjuncts').apply_to(m)
 
     def test_create_using(self):
         m = models.makeBetweenStepsPaperExample()
         self.diff_apply_to_and_create_using(m, num_partitions=2)
+
 
 class NonQuadraticNonlinear(unittest.TestCase, CommonTests):
     def check_transformation_block(self, m, aux1lb, aux1ub, aux2lb, aux2ub):
@@ -1368,23 +1520,22 @@ class NonQuadraticNonlinear(unittest.TestCase, CommonTests):
         self.assertIsInstance(equivalence, LogicalConstraint)
         self.assertEqual(len(equivalence), 2)
         for i, variables in enumerate(
-                [(m.disjunction.disjuncts[0].indicator_var,
-                  disj1.indicator_var),
-                 (m.disjunction.disjuncts[1].indicator_var,
-                  disj2.indicator_var)]):
+            [
+                (m.disjunction.disjuncts[0].indicator_var, disj1.indicator_var),
+                (m.disjunction.disjuncts[1].indicator_var, disj2.indicator_var),
+            ]
+        ):
             cons = equivalence[i]
             self.assertIsInstance(cons.body, EquivalenceExpression)
             self.assertEqual(cons.body.args, variables)
 
-        aux_vars1 = disj1.component(
-            "disjunction_disjuncts[0].constraint[1]_aux_vars")
+        aux_vars1 = disj1.component("disjunction_disjuncts[0].constraint[1]_aux_vars")
         self.assertEqual(len(aux_vars1), 2)
         self.assertEqual(aux_vars1[0].lb, aux1lb)
         self.assertEqual(aux_vars1[0].ub, aux1ub)
         self.assertEqual(aux_vars1[1].lb, aux1lb)
         self.assertEqual(aux_vars1[1].ub, aux1ub)
-        aux_vars2 = disj2.component(
-            "disjunction_disjuncts[1].constraint[1]_aux_vars")
+        aux_vars2 = disj2.component("disjunction_disjuncts[1].constraint[1]_aux_vars")
         self.assertEqual(len(aux_vars2), 2)
         self.assertEqual(aux_vars2[0].lb, aux2lb)
         self.assertEqual(aux_vars2[0].ub, aux2ub)
@@ -1421,8 +1572,7 @@ class NonQuadraticNonlinear(unittest.TestCase, CommonTests):
         self.assertEqual(repn.linear_coefs[1], 1)
 
         # check the global constraints
-        c = b.component(
-            "disjunction_disjuncts[0].constraint[1]_split_constraints")
+        c = b.component("disjunction_disjuncts[0].constraint[1]_split_constraints")
         self.assertEqual(len(c), 2)
         c1 = c[0]
         self.assertIsNone(c1.lower)
@@ -1439,10 +1589,8 @@ class NonQuadraticNonlinear(unittest.TestCase, CommonTests):
         self.assertEqual(repn.nonlinear_expr.args[1], 0.25)
         self.assertIsInstance(repn.nonlinear_expr.args[0], EXPR.SumExpression)
         self.assertEqual(len(repn.nonlinear_expr.args[0].args), 2)
-        self.assertIsInstance(repn.nonlinear_expr.args[0].args[0],
-                              EXPR.PowExpression)
-        self.assertIsInstance(repn.nonlinear_expr.args[0].args[1],
-                              EXPR.PowExpression)
+        self.assertIsInstance(repn.nonlinear_expr.args[0].args[0], EXPR.PowExpression)
+        self.assertIsInstance(repn.nonlinear_expr.args[0].args[1], EXPR.PowExpression)
         self.assertIs(repn.nonlinear_expr.args[0].args[0].args[0], m.x[1])
         self.assertEqual(repn.nonlinear_expr.args[0].args[0].args[1], 4)
         self.assertIs(repn.nonlinear_expr.args[0].args[1].args[0], m.x[2])
@@ -1462,17 +1610,14 @@ class NonQuadraticNonlinear(unittest.TestCase, CommonTests):
         self.assertEqual(repn.nonlinear_expr.args[1], 0.25)
         self.assertIsInstance(repn.nonlinear_expr.args[0], EXPR.SumExpression)
         self.assertEqual(len(repn.nonlinear_expr.args[0].args), 2)
-        self.assertIsInstance(repn.nonlinear_expr.args[0].args[0],
-                              EXPR.PowExpression)
-        self.assertIsInstance(repn.nonlinear_expr.args[0].args[1],
-                              EXPR.PowExpression)
+        self.assertIsInstance(repn.nonlinear_expr.args[0].args[0], EXPR.PowExpression)
+        self.assertIsInstance(repn.nonlinear_expr.args[0].args[1], EXPR.PowExpression)
         self.assertIs(repn.nonlinear_expr.args[0].args[0].args[0], m.x[3])
         self.assertEqual(repn.nonlinear_expr.args[0].args[0].args[1], 4)
         self.assertIs(repn.nonlinear_expr.args[0].args[1].args[0], m.x[4])
         self.assertEqual(repn.nonlinear_expr.args[0].args[1].args[1], 4)
 
-        c = b.component(
-            "disjunction_disjuncts[1].constraint[1]_split_constraints")
+        c = b.component("disjunction_disjuncts[1].constraint[1]_split_constraints")
         self.assertEqual(len(c), 2)
         c1 = c[0]
         self.assertIsNone(c1.lower)
@@ -1489,10 +1634,8 @@ class NonQuadraticNonlinear(unittest.TestCase, CommonTests):
         self.assertEqual(repn.nonlinear_expr.args[1], 0.25)
         self.assertIsInstance(repn.nonlinear_expr.args[0], EXPR.SumExpression)
         self.assertEqual(len(repn.nonlinear_expr.args[0].args), 2)
-        self.assertIsInstance(repn.nonlinear_expr.args[0].args[0],
-                              EXPR.PowExpression)
-        self.assertIsInstance(repn.nonlinear_expr.args[0].args[1],
-                              EXPR.PowExpression)
+        self.assertIsInstance(repn.nonlinear_expr.args[0].args[0], EXPR.PowExpression)
+        self.assertIsInstance(repn.nonlinear_expr.args[0].args[1], EXPR.PowExpression)
         sum_expr = repn.nonlinear_expr.args[0].args[0].args[0]
         self.assertIsInstance(sum_expr, EXPR.SumExpression)
         sum_repn = generate_standard_repn(sum_expr)
@@ -1502,8 +1645,7 @@ class NonQuadraticNonlinear(unittest.TestCase, CommonTests):
         self.assertEqual(sum_repn.linear_coefs[0], -1)
         self.assertIs(sum_repn.linear_vars[0], m.x[1])
         self.assertEqual(repn.nonlinear_expr.args[0].args[0].args[1], 4)
-        self.assertIsInstance(repn.nonlinear_expr.args[0].args[1],
-                              EXPR.PowExpression)
+        self.assertIsInstance(repn.nonlinear_expr.args[0].args[1], EXPR.PowExpression)
         sum_expr = repn.nonlinear_expr.args[0].args[1].args[0]
         self.assertIsInstance(sum_expr, EXPR.SumExpression)
         sum_repn = generate_standard_repn(sum_expr)
@@ -1529,10 +1671,8 @@ class NonQuadraticNonlinear(unittest.TestCase, CommonTests):
         self.assertEqual(repn.nonlinear_expr.args[1], 0.25)
         self.assertIsInstance(repn.nonlinear_expr.args[0], EXPR.SumExpression)
         self.assertEqual(len(repn.nonlinear_expr.args[0].args), 2)
-        self.assertIsInstance(repn.nonlinear_expr.args[0].args[0],
-                              EXPR.PowExpression)
-        self.assertIsInstance(repn.nonlinear_expr.args[0].args[1],
-                              EXPR.PowExpression)
+        self.assertIsInstance(repn.nonlinear_expr.args[0].args[0], EXPR.PowExpression)
+        self.assertIsInstance(repn.nonlinear_expr.args[0].args[1], EXPR.PowExpression)
         sum_expr = repn.nonlinear_expr.args[0].args[0].args[0]
         self.assertIsInstance(sum_expr, EXPR.SumExpression)
         sum_repn = generate_standard_repn(sum_expr)
@@ -1542,8 +1682,7 @@ class NonQuadraticNonlinear(unittest.TestCase, CommonTests):
         self.assertEqual(sum_repn.linear_coefs[0], -1)
         self.assertIs(sum_repn.linear_vars[0], m.x[3])
         self.assertEqual(repn.nonlinear_expr.args[0].args[0].args[1], 4)
-        self.assertIsInstance(repn.nonlinear_expr.args[0].args[1],
-                              EXPR.PowExpression)
+        self.assertIsInstance(repn.nonlinear_expr.args[0].args[1], EXPR.PowExpression)
         sum_expr = repn.nonlinear_expr.args[0].args[1].args[0]
         self.assertIsInstance(sum_expr, EXPR.SumExpression)
         sum_repn = generate_standard_repn(sum_expr)
@@ -1560,9 +1699,12 @@ class NonQuadraticNonlinear(unittest.TestCase, CommonTests):
         TransformationFactory('gdp.partition_disjuncts').apply_to(
             m,
             variable_partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
-            compute_bounds_method=compute_fbbt_bounds)
+            compute_bounds_method=compute_fbbt_bounds,
+        )
 
-        self.check_transformation_block(m, 0, (2*6**4)**0.25, 0, (2*5**4)**0.25)
+        self.check_transformation_block(
+            m, 0, (2 * 6**4) ** 0.25, 0, (2 * 5**4) ** 0.25
+        )
 
     def test_invalid_partition_error(self):
         m = models.makeNonQuadraticNonlinearGDP()
@@ -1582,31 +1724,35 @@ class NonQuadraticNonlinear(unittest.TestCase, CommonTests):
             TransformationFactory('gdp.partition_disjuncts').apply_to,
             m,
             variable_partitions=[[m.x[3], m.x[2]], [m.x[1], m.x[4]]],
-            compute_bounds_method=compute_fbbt_bounds)
+            compute_bounds_method=compute_fbbt_bounds,
+        )
 
     def test_invalid_partition_error_multiply_vars_in_different_partition(self):
         m = ConcreteModel()
-        m.x = Var(bounds=(-10,10))
-        m.y = Var(bounds=(-60,56))
+        m.x = Var(bounds=(-10, 10))
+        m.y = Var(bounds=(-60, 56))
         m.d1 = Disjunct()
-        m.d1.c = Constraint(expr=m.x**2 + m.x*m.y + m.y**2 <= 32)
+        m.d1.c = Constraint(expr=m.x**2 + m.x * m.y + m.y**2 <= 32)
         m.d2 = Disjunct()
         m.d2.c = Constraint(expr=m.x**2 + m.y**2 <= 3)
         m.disjunction = Disjunction(expr=[m.d1, m.d2])
-        with self.assertRaisesRegex(GDP_Error,
-                                    "Variables 'x' and 'y' are "
-                                    "multiplied in Constraint 'd1.c', "
-                                    "but they are in different "
-                                    "partitions! Please ensure that "
-                                    "all the constraints in the "
-                                    "disjunction are "
-                                    "additively separable with "
-                                    "respect to the specified "
-                                    "partition."):
+        with self.assertRaisesRegex(
+            GDP_Error,
+            "Variables 'x' and 'y' are "
+            "multiplied in Constraint 'd1.c', "
+            "but they are in different "
+            "partitions! Please ensure that "
+            "all the constraints in the "
+            "disjunction are "
+            "additively separable with "
+            "respect to the specified "
+            "partition.",
+        ):
             TransformationFactory('gdp.partition_disjuncts').apply_to(
                 m,
                 variable_partitions=[[m.x], [m.y]],
-                compute_bounds_method=compute_fbbt_bounds)
+                compute_bounds_method=compute_fbbt_bounds,
+            )
 
     def test_non_additively_separable_expression(self):
         m = models.makeNonQuadraticNonlinearGDP()
@@ -1616,12 +1762,14 @@ class NonQuadraticNonlinear(unittest.TestCase, CommonTests):
         # how things work when part of the expression is empty for one part in
         # the partition.
         m.disjunction.disjuncts[0].another_constraint = Constraint(
-            expr=m.x[1]**3 <= 0.5)
+            expr=m.x[1] ** 3 <= 0.5
+        )
 
         TransformationFactory('gdp.partition_disjuncts').apply_to(
             m,
             variable_partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]],
-            compute_bounds_method=compute_fbbt_bounds)
+            compute_bounds_method=compute_fbbt_bounds,
+        )
 
         # we just need to check the first Disjunct's transformation
         b = m.component("_pyomo_gdp_partition_disjuncts_reformulation")
@@ -1633,12 +1781,12 @@ class NonQuadraticNonlinear(unittest.TestCase, CommonTests):
         self.assertEqual(len(disj1.component_map(Var)), 4)
         self.assertEqual(len(disj1.component_map(Constraint)), 2)
 
-        aux_vars1 = disj1.component(
-            "disjunction_disjuncts[0].constraint[1]_aux_vars")
+        aux_vars1 = disj1.component("disjunction_disjuncts[0].constraint[1]_aux_vars")
         # we check these in test_transformation_block_fbbt_bounds
 
         aux_vars2 = disj1.component(
-            "disjunction_disjuncts[0].another_constraint_aux_vars")
+            "disjunction_disjuncts[0].another_constraint_aux_vars"
+        )
         self.assertEqual(len(aux_vars2), 1)
         self.assertEqual(aux_vars2[0].lb, -8)
         self.assertEqual(aux_vars2[0].ub, 216)
@@ -1658,7 +1806,8 @@ class NonQuadraticNonlinear(unittest.TestCase, CommonTests):
 
         # now check the global constraint
         cons = b.component(
-            "disjunction_disjuncts[0].another_constraint_split_constraints")
+            "disjunction_disjuncts[0].another_constraint_split_constraints"
+        )
         self.assertEqual(len(cons), 1)
         cons = cons[0]
         self.assertIsNone(cons.lower)
@@ -1677,10 +1826,9 @@ class NonQuadraticNonlinear(unittest.TestCase, CommonTests):
 
     def test_create_using(self):
         m = models.makeNonQuadraticNonlinearGDP()
-        self.diff_apply_to_and_create_using(m, variable_partitions=[[m.x[1],
-                                                                     m.x[2]],
-                                                                    [m.x[3],
-                                                                     m.x[4]]])
+        self.diff_apply_to_and_create_using(
+            m, variable_partitions=[[m.x[1], m.x[2]], [m.x[3], m.x[4]]]
+        )
 
     def test_infeasible_value_of_P(self):
         m = models.makeNonQuadraticNonlinearGDP()
@@ -1708,154 +1856,159 @@ class NonQuadraticNonlinear(unittest.TestCase, CommonTests):
             "separable.",
             TransformationFactory('gdp.partition_disjuncts').apply_to,
             m,
-            num_partitions=3)
+            num_partitions=3,
+        )
+
 
 # This is just a pile of tests that are structural that we use for bigm and
 # hull, so might as well for this too.
 class CommonModels(unittest.TestCase, CommonTests):
     def test_user_deactivated_disjuncts(self):
-        ct.check_user_deactivated_disjuncts(self, 'partition_disjuncts',
-                                            check_trans_block=False,
-                                            num_partitions=2)
+        ct.check_user_deactivated_disjuncts(
+            self, 'partition_disjuncts', check_trans_block=False, num_partitions=2
+        )
 
     def test_improperly_deactivated_disjuncts(self):
-        ct.check_improperly_deactivated_disjuncts(self, 'partition_disjuncts',
-                                                  num_partitions=2)
+        ct.check_improperly_deactivated_disjuncts(
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     def test_do_not_transform_userDeactivated_indexedDisjunction(self):
         ct.check_do_not_transform_userDeactivated_indexedDisjunction(
-            self, 'partition_disjuncts', num_partitions=2)
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     def test_disjunction_deactivated(self):
-        ct.check_disjunction_deactivated(self, 'partition_disjuncts',
-                                         num_partitions=2)
+        ct.check_disjunction_deactivated(self, 'partition_disjuncts', num_partitions=2)
 
     def test_disjunctDatas_deactivated(self):
-        ct.check_disjunctDatas_deactivated(self, 'partition_disjuncts',
-                                           num_partitions=2)
+        ct.check_disjunctDatas_deactivated(
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     def test_deactivated_constraints(self):
-        ct.check_deactivated_constraints(self, 'partition_disjuncts',
-                                         num_partitions=2)
+        ct.check_deactivated_constraints(self, 'partition_disjuncts', num_partitions=2)
 
     def test_deactivated_disjuncts(self):
-        ct.check_deactivated_disjuncts(self, 'partition_disjuncts',
-                                       num_partitions=2)
+        ct.check_deactivated_disjuncts(self, 'partition_disjuncts', num_partitions=2)
 
     def test_deactivated_disjunctions(self):
-        ct.check_deactivated_disjunctions(self, 'partition_disjuncts',
-                                          num_partitions=2)
+        ct.check_deactivated_disjunctions(self, 'partition_disjuncts', num_partitions=2)
 
     def test_constraints_deactivated_indexedDisjunction(self):
         ct.check_constraints_deactivated_indexedDisjunction(
-            self,
-            'partition_disjuncts', num_partitions=2)
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     # targets
 
     def test_only_targets_inactive(self):
-        ct.check_only_targets_inactive(self, 'partition_disjuncts',
-                                       num_partitions=2)
+        ct.check_only_targets_inactive(self, 'partition_disjuncts', num_partitions=2)
 
     def test_target_not_a_component_error(self):
-        ct.check_target_not_a_component_error(self, 'partition_disjuncts',
-                                              num_partitions=2)
+        ct.check_target_not_a_component_error(
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     def test_indexedDisj_targets_inactive(self):
-        ct.check_indexedDisj_targets_inactive(self, 'partition_disjuncts',
-                                              num_partitions=2)
+        ct.check_indexedDisj_targets_inactive(
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     def test_warn_for_untransformed(self):
-        ct.check_warn_for_untransformed(self, 'partition_disjuncts',
-                                        num_partitions=2)
+        ct.check_warn_for_untransformed(self, 'partition_disjuncts', num_partitions=2)
 
     def test_disjData_targets_inactive(self):
-        ct.check_disjData_targets_inactive(self, 'partition_disjuncts',
-                                           num_partitions=2)
+        ct.check_disjData_targets_inactive(
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     def test_indexedBlock_targets_inactive(self):
-        ct.check_indexedBlock_targets_inactive(self, 'partition_disjuncts',
-                                               num_partitions=2)
+        ct.check_indexedBlock_targets_inactive(
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     def test_blockData_targets_inactive(self):
-        ct.check_blockData_targets_inactive(self, 'partition_disjuncts',
-                                            num_partitions=2)
+        ct.check_blockData_targets_inactive(
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     # transforming blocks
 
     def test_transformation_simple_block(self):
-        ct.check_transformation_simple_block(self, 'partition_disjuncts',
-                                             num_partitions=2)
+        ct.check_transformation_simple_block(
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     def test_transform_block_data(self):
-        ct.check_transform_block_data(self, 'partition_disjuncts',
-                                      num_partitions=2)
+        ct.check_transform_block_data(self, 'partition_disjuncts', num_partitions=2)
 
     def test_simple_block_target(self):
-        ct.check_simple_block_target(self, 'partition_disjuncts',
-                                     num_partitions=2)
+        ct.check_simple_block_target(self, 'partition_disjuncts', num_partitions=2)
 
     def test_block_data_target(self):
-        ct.check_block_data_target(self, 'partition_disjuncts',
-                                   num_partitions=2)
+        ct.check_block_data_target(self, 'partition_disjuncts', num_partitions=2)
 
     def test_indexed_block_target(self):
-        ct.check_indexed_block_target(self, 'partition_disjuncts',
-                                      num_partitions=2)
+        ct.check_indexed_block_target(self, 'partition_disjuncts', num_partitions=2)
 
     def test_block_targets_inactive(self):
-        ct.check_block_targets_inactive(self, 'partition_disjuncts',
-                                        num_partitions=2)
+        ct.check_block_targets_inactive(self, 'partition_disjuncts', num_partitions=2)
 
     # common error messages
 
     def test_transform_empty_disjunction(self):
-        ct.check_transform_empty_disjunction(self, 'partition_disjuncts',
-                                             num_partitions=2)
+        ct.check_transform_empty_disjunction(
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     def test_deactivated_disjunct_nonzero_indicator_var(self):
         ct.check_deactivated_disjunct_nonzero_indicator_var(
-            self,
-            'partition_disjuncts', num_partitions=2)
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     def test_deactivated_disjunct_unfixed_indicator_var(self):
         ct.check_deactivated_disjunct_unfixed_indicator_var(
-            self,
-            'partition_disjuncts', num_partitions=2)
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     def test_silly_target(self):
         ct.check_silly_target(self, 'partition_disjuncts', num_partitions=2)
 
     def test_error_for_same_disjunct_in_multiple_disjunctions(self):
         ct.check_error_for_same_disjunct_in_multiple_disjunctions(
-            self, 'partition_disjuncts', num_partitions=2)
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     def test_cannot_call_transformation_on_disjunction(self):
         ct.check_cannot_call_transformation_on_disjunction(
-            self,
-            'partition_disjuncts', num_partitions=2)
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     def test_disjunction_target_err(self):
-        ct.check_disjunction_target_err(self, 'partition_disjuncts',
-                                        num_partitions=2)
+        ct.check_disjunction_target_err(self, 'partition_disjuncts', num_partitions=2)
 
     # nested disjunctions (only checking that everything is transformed)
 
     def test_disjuncts_inactive_nested(self):
-        ct.check_disjuncts_inactive_nested(self, 'partition_disjuncts',
-                                           num_partitions=2)
+        ct.check_disjuncts_inactive_nested(
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     def test_deactivated_disjunct_leaves_nested_disjunct_active(self):
         ct.check_deactivated_disjunct_leaves_nested_disjunct_active(
-            self, 'partition_disjuncts', num_partitions=2)
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     def test_disjunct_targets_inactive(self):
-        ct.check_disjunct_targets_inactive(self, 'partition_disjuncts',
-                                           num_partitions=2)
+        ct.check_disjunct_targets_inactive(
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     def test_disjunctData_targets_inactive(self):
-        ct.check_disjunctData_targets_inactive(self, 'partition_disjuncts',
-                                               num_partitions=2)
+        ct.check_disjunctData_targets_inactive(
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     # check handling for benign types
 
@@ -1866,16 +2019,15 @@ class CommonModels(unittest.TestCase, CommonTests):
         ct.check_Expression(self, 'partition_disjuncts', num_partitions=2)
 
     def test_untransformed_network_raises_GDPError(self):
-        ct.check_untransformed_network_raises_GDPError( self,
-                                                        'partition_disjuncts',
-                                                        num_partitions=2)
+        ct.check_untransformed_network_raises_GDPError(
+            self, 'partition_disjuncts', num_partitions=2
+        )
 
     @unittest.skipUnless(ct.linear_solvers, "Could not find a linear solver")
     def test_network_disjuncts(self):
-        ct.check_network_disjuncts(self, True, 'between_steps',
-                                   num_partitions=2)
-        ct.check_network_disjuncts(self, False, 'between_steps',
-                                   num_partitions=2)
+        ct.check_network_disjuncts(self, True, 'between_steps', num_partitions=2)
+        ct.check_network_disjuncts(self, False, 'between_steps', num_partitions=2)
+
 
 class LogicalExpressions(unittest.TestCase, CommonTests):
     def test_logical_constraints_on_disjunct_copied(self):
@@ -1883,7 +2035,8 @@ class LogicalExpressions(unittest.TestCase, CommonTests):
         TransformationFactory('gdp.partition_disjuncts').apply_to(
             m,
             variable_partitions=[[m.x], [m.y]],
-            compute_bounds_method=compute_fbbt_bounds)
+            compute_bounds_method=compute_fbbt_bounds,
+        )
         d1 = m.d[1].transformation_block
         self.assertEqual(len(d1.component_map(LogicalConstraint)), 1)
         c = d1.component("logical_constraints")
@@ -1948,13 +2101,14 @@ class LogicalExpressions(unittest.TestCase, CommonTests):
     #     self.assertTrue(value(m.d[3].indicator_var))
     #     self.assertFalse(value(m.d[4].indicator_var))
 
-    @unittest.skipIf('gurobi_direct' not in solvers,
-                     'Gurobi direct solver not available')
+    @unittest.skipIf(
+        'gurobi_direct' not in solvers, 'Gurobi direct solver not available'
+    )
     def test_original_indicator_vars_in_logical_constraints(self):
         m = models.makeLogicalConstraintsOnDisjuncts()
         TransformationFactory('gdp.between_steps').apply_to(
-            m, variable_partitions=[[m.x]],
-            compute_bounds_method=compute_fbbt_bounds)
+            m, variable_partitions=[[m.x]], compute_bounds_method=compute_fbbt_bounds
+        )
 
         self.assertTrue(check_model_algebraic(m))
 

--- a/pyomo/gdp/tests/test_reclassify.py
+++ b/pyomo/gdp/tests/test_reclassify.py
@@ -1,7 +1,14 @@
 # -*- coding: UTF-8 -*-
 """Tests disjunct reclassifier transformation."""
 import pyomo.common.unittest as unittest
-from pyomo.core import (Block, ConcreteModel, TransformationFactory, RangeSet, Constraint, Var)
+from pyomo.core import (
+    Block,
+    ConcreteModel,
+    TransformationFactory,
+    RangeSet,
+    Constraint,
+    Var,
+)
 from pyomo.gdp import Disjunct, Disjunction, GDP_Error
 
 
@@ -77,7 +84,8 @@ class TestDisjunctReclassify(unittest.TestCase):
         #     print(disj.name)
         # There should be no active Disjunction objects.
         self.assertIsNone(
-            next(m.component_data_objects(Disjunction, active=True), None))
+            next(m.component_data_objects(Disjunction, active=True), None)
+        )
 
     def test_do_not_reactivate_disjuncts_with_abandon(self):
         m = ConcreteModel()

--- a/pyomo/gdp/tests/test_util.py
+++ b/pyomo/gdp/tests/test_util.py
@@ -14,9 +14,13 @@ import pyomo.common.unittest as unittest
 from pyomo.core import ConcreteModel, Var, Expression, Block, RangeSet, Any
 import pyomo.core.expr.current as EXPR
 from pyomo.core.base.expression import _ExpressionData
-from pyomo.gdp.util import (clone_without_expression_components, is_child_of,
-                            get_gdp_tree)
+from pyomo.gdp.util import (
+    clone_without_expression_components,
+    is_child_of,
+    get_gdp_tree,
+)
 from pyomo.gdp import Disjunct, Disjunction
+
 
 class TestGDPUtils(unittest.TestCase):
     def test_clone_without_expression_components(self):
@@ -30,7 +34,7 @@ class TestGDPUtils(unittest.TestCase):
         self.assertIs(base, test)
         self.assertEqual(base(), test())
         test = clone_without_expression_components(base, {id(m.x): m.y})
-        self.assertEqual(3**2+1, test())
+        self.assertEqual(3**2 + 1, test())
 
         base = m.e
         test = clone_without_expression_components(base, {})
@@ -39,7 +43,7 @@ class TestGDPUtils(unittest.TestCase):
         self.assertIsInstance(base, _ExpressionData)
         self.assertIsInstance(test, EXPR.SumExpression)
         test = clone_without_expression_components(base, {id(m.x): m.y})
-        self.assertEqual(3**2+3-1, test())
+        self.assertEqual(3**2 + 3 - 1, test())
 
         base = m.e + m.x
         test = clone_without_expression_components(base, {})
@@ -50,22 +54,24 @@ class TestGDPUtils(unittest.TestCase):
         self.assertIsInstance(base.arg(0), _ExpressionData)
         self.assertIsInstance(test.arg(0), EXPR.SumExpression)
         test = clone_without_expression_components(base, {id(m.x): m.y})
-        self.assertEqual(3**2+3-1 + 3, test())
+        self.assertEqual(3**2 + 3 - 1 + 3, test())
 
     def test_is_child_of(self):
         m = ConcreteModel()
         m.b = Block()
-        m.b.b_indexed = Block([1,2])
+        m.b.b_indexed = Block([1, 2])
         m.b_parallel = Block()
-        
+
         knownBlocks = {}
-        self.assertFalse(is_child_of(parent=m.b, child=m.b_parallel,
-                                     knownBlocks=knownBlocks))
+        self.assertFalse(
+            is_child_of(parent=m.b, child=m.b_parallel, knownBlocks=knownBlocks)
+        )
         self.assertEqual(len(knownBlocks), 2)
         self.assertFalse(knownBlocks.get(m))
         self.assertFalse(knownBlocks.get(m.b_parallel))
-        self.assertTrue(is_child_of(parent=m.b, child=m.b.b_indexed[1],
-                                    knownBlocks=knownBlocks))
+        self.assertTrue(
+            is_child_of(parent=m.b, child=m.b.b_indexed[1], knownBlocks=knownBlocks)
+        )
         self.assertEqual(len(knownBlocks), 4)
         self.assertFalse(knownBlocks.get(m))
         self.assertFalse(knownBlocks.get(m.b_parallel))
@@ -83,11 +89,10 @@ class TestGDPUtils(unittest.TestCase):
         m.block.d1.b = Block()
         m.block.d1.b.dd2 = Disjunct()
         m.block.d1.b.dd3 = Disjunct()
-        m.block.d1.disjunction = Disjunction(expr=[m.block.d1.dd1,
-                                                   m.block.d1.b.dd2,
-                                                   m.block.d1.b.dd3])
-        m.block.d1.b.dd2.disjunction = Disjunction(expr=[[m.x >= 1], [m.x <=
-                                                                      -1]])
+        m.block.d1.disjunction = Disjunction(
+            expr=[m.block.d1.dd1, m.block.d1.b.dd2, m.block.d1.b.dd3]
+        )
+        m.block.d1.b.dd2.disjunction = Disjunction(expr=[[m.x >= 1], [m.x <= -1]])
         targets = (m,)
         knownBlocks = {}
         tree = get_gdp_tree(targets, m, knownBlocks)
@@ -95,44 +100,56 @@ class TestGDPUtils(unittest.TestCase):
         # check tree structure first
         vertices = tree.vertices
         self.assertEqual(len(vertices), 10)
-        in_degrees = {m.block.d1 : 1,
-                      m.block.disjunction : 0,
-                      m.disj1 : 1,
-                      m.block.d1.disjunction : 1,
-                      m.block.d1.dd1 : 1,
-                      m.block.d1.b.dd2 : 1,
-                      m.block.d1.b.dd3 : 1,
-                      m.block.d1.b.dd2.disjunction : 1,
-                      m.block.d1.b.dd2.disjunction.disjuncts[0] : 1,
-                      m.block.d1.b.dd2.disjunction.disjuncts[1] : 1
-                      }
+        in_degrees = {
+            m.block.d1: 1,
+            m.block.disjunction: 0,
+            m.disj1: 1,
+            m.block.d1.disjunction: 1,
+            m.block.d1.dd1: 1,
+            m.block.d1.b.dd2: 1,
+            m.block.d1.b.dd3: 1,
+            m.block.d1.b.dd2.disjunction: 1,
+            m.block.d1.b.dd2.disjunction.disjuncts[0]: 1,
+            m.block.d1.b.dd2.disjunction.disjuncts[1]: 1,
+        }
         for key, val in in_degrees.items():
             self.assertEqual(tree.in_degree(key), val)
 
         # This should be deterministic, so we can just check the order
-        topo_sort = [m.block.disjunction, m.disj1, m.block.d1,
-                     m.block.d1.disjunction, m.block.d1.b.dd3, m.block.d1.b.dd2,
-                     m.block.d1.b.dd2.disjunction,
-                     m.block.d1.b.dd2.disjunction.disjuncts[1],
-                     m.block.d1.b.dd2.disjunction.disjuncts[0], m.block.d1.dd1]
+        topo_sort = [
+            m.block.disjunction,
+            m.disj1,
+            m.block.d1,
+            m.block.d1.disjunction,
+            m.block.d1.b.dd3,
+            m.block.d1.b.dd2,
+            m.block.d1.b.dd2.disjunction,
+            m.block.d1.b.dd2.disjunction.disjuncts[1],
+            m.block.d1.b.dd2.disjunction.disjuncts[0],
+            m.block.d1.dd1,
+        ]
         sort = tree.topological_sort()
         for i, node in enumerate(sort):
             self.assertIs(node, topo_sort[i])
 
     def add_indexed_disjunction(self, parent, m):
         parent.indexed = Disjunction(Any)
-        parent.indexed[1] = [[sum(m.x[i]**2 for i in m.I) <= 1],
-                        [sum((3 - m.x[i])**2 for i in m.I) <= 1]]
-        parent.indexed[0] = [[(m.x[1] - 1)**2 + m.x[2]**2 <= 1],
-                        [-(m.x[1] - 2)**2 - (m.x[2] - 3)**2 >= -1]]        
+        parent.indexed[1] = [
+            [sum(m.x[i] ** 2 for i in m.I) <= 1],
+            [sum((3 - m.x[i]) ** 2 for i in m.I) <= 1],
+        ]
+        parent.indexed[0] = [
+            [(m.x[1] - 1) ** 2 + m.x[2] ** 2 <= 1],
+            [-((m.x[1] - 2) ** 2) - (m.x[2] - 3) ** 2 >= -1],
+        ]
 
     def test_gdp_tree_indexed_disjunction(self):
         # This is to check that indexed components never actually appear as
         # nodes in the tree. We should only have DisjunctionDatas and
         # DisjunctDatas.
         m = ConcreteModel()
-        m.I = RangeSet(1,4)
-        m.x = Var(m.I, bounds=(-2,6))
+        m.I = RangeSet(1, 4)
+        m.x = Var(m.I, bounds=(-2, 6))
         self.add_indexed_disjunction(m, m)
 
         targets = (m.indexed,)
@@ -141,26 +158,33 @@ class TestGDPUtils(unittest.TestCase):
 
         vertices = tree.vertices
         self.assertEqual(len(vertices), 6)
-        in_degrees = {m.indexed[0] : 0,
-                      m.indexed[1] : 0,
-                      m.indexed[0].disjuncts[0] : 1,
-                      m.indexed[0].disjuncts[1] : 1,
-                      m.indexed[1].disjuncts[0] : 1,
-                      m.indexed[1].disjuncts[1] : 1}
+        in_degrees = {
+            m.indexed[0]: 0,
+            m.indexed[1]: 0,
+            m.indexed[0].disjuncts[0]: 1,
+            m.indexed[0].disjuncts[1]: 1,
+            m.indexed[1].disjuncts[0]: 1,
+            m.indexed[1].disjuncts[1]: 1,
+        }
         for key, val in in_degrees.items():
             self.assertEqual(tree.in_degree(key), val)
 
-        topo_sort = [m.indexed[0], m.indexed[0].disjuncts[1],
-                     m.indexed[0].disjuncts[0], m.indexed[1],
-                     m.indexed[1].disjuncts[1], m.indexed[1].disjuncts[0]]
+        topo_sort = [
+            m.indexed[0],
+            m.indexed[0].disjuncts[1],
+            m.indexed[0].disjuncts[0],
+            m.indexed[1],
+            m.indexed[1].disjuncts[1],
+            m.indexed[1].disjuncts[0],
+        ]
         sort = tree.topological_sort()
         for i, node in enumerate(sort):
             self.assertIs(node, topo_sort[i])
 
     def test_gdp_tree_nested_indexed_disjunction(self):
         m = ConcreteModel()
-        m.I = RangeSet(1,4)
-        m.x = Var(m.I, bounds=(-2,6))
+        m.I = RangeSet(1, 4)
+        m.x = Var(m.I, bounds=(-2, 6))
         m.disj1 = Disjunct()
         self.add_indexed_disjunction(m.disj1, m)
         m.disj2 = Disjunct()
@@ -175,19 +199,25 @@ class TestGDPUtils(unittest.TestCase):
 
         vertices = tree.vertices
         self.assertEqual(len(vertices), 6)
-        in_degrees = {m.disj1.indexed[0] : 0,
-                      m.disj1.indexed[1] : 0,
-                      m.disj1.indexed[0].disjuncts[0] : 1,
-                      m.disj1.indexed[0].disjuncts[1] : 1,
-                      m.disj1.indexed[1].disjuncts[0] : 1,
-                      m.disj1.indexed[1].disjuncts[1] : 1}
+        in_degrees = {
+            m.disj1.indexed[0]: 0,
+            m.disj1.indexed[1]: 0,
+            m.disj1.indexed[0].disjuncts[0]: 1,
+            m.disj1.indexed[0].disjuncts[1]: 1,
+            m.disj1.indexed[1].disjuncts[0]: 1,
+            m.disj1.indexed[1].disjuncts[1]: 1,
+        }
         for key, val in in_degrees.items():
             self.assertEqual(tree.in_degree(key), val)
 
-        topo_sort = [m.disj1.indexed[0], m.disj1.indexed[0].disjuncts[1],
-                     m.disj1.indexed[0].disjuncts[0], m.disj1.indexed[1],
-                     m.disj1.indexed[1].disjuncts[1],
-                     m.disj1.indexed[1].disjuncts[0]]
+        topo_sort = [
+            m.disj1.indexed[0],
+            m.disj1.indexed[0].disjuncts[1],
+            m.disj1.indexed[0].disjuncts[0],
+            m.disj1.indexed[1],
+            m.disj1.indexed[1].disjuncts[1],
+            m.disj1.indexed[1].disjuncts[0],
+        ]
         sort = tree.topological_sort()
         for i, node in enumerate(sort):
             self.assertIs(node, topo_sort[i])
@@ -208,14 +238,21 @@ class TestGDPUtils(unittest.TestCase):
         for key, val in in_degrees.items():
             self.assertEqual(tree.in_degree(key), val)
 
-        topo_sort = [m.another_disjunction, m.disj2, m.disj1,
-                     m.disj1.indexed[1], m.disj1.indexed[1].disjuncts[1],
-                     m.disj1.indexed[1].disjuncts[0], m.disj1.indexed[0],
-                     m.disj1.indexed[0].disjuncts[1],
-                     m.disj1.indexed[0].disjuncts[0]]
+        topo_sort = [
+            m.another_disjunction,
+            m.disj2,
+            m.disj1,
+            m.disj1.indexed[1],
+            m.disj1.indexed[1].disjuncts[1],
+            m.disj1.indexed[1].disjuncts[0],
+            m.disj1.indexed[0],
+            m.disj1.indexed[0].disjuncts[1],
+            m.disj1.indexed[0].disjuncts[0],
+        ]
         sort = tree.topological_sort()
         for i, node in enumerate(sort):
             self.assertIs(node, topo_sort[i])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyomo/gdp/transformed_disjunct.py
+++ b/pyomo/gdp/transformed_disjunct.py
@@ -11,9 +11,8 @@
 
 from pyomo.common.autoslots import AutoSlots
 from pyomo.core.base.block import _BlockData, IndexedBlock
-from pyomo.core.base.global_set import (
-    UnindexedComponent_index, UnindexedComponent_set
-)
+from pyomo.core.base.global_set import UnindexedComponent_index, UnindexedComponent_set
+
 
 class _TransformedDisjunctData(_BlockData):
     __slots__ = ('_src_disjunct',)
@@ -27,6 +26,7 @@ class _TransformedDisjunctData(_BlockData):
         _BlockData.__init__(self, component)
         # pointer to the Disjunct whose transformation block this is.
         self._src_disjunct = None
+
 
 class _TransformedDisjunct(IndexedBlock):
     _ComponentDataClass = _TransformedDisjunctData

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -15,7 +15,13 @@ from pyomo.gdp.disjunct import _DisjunctData, Disjunct
 import pyomo.core.expr.current as EXPR
 from pyomo.core.base.component import _ComponentBase
 from pyomo.core import (
-    Block, Suffix, TraversalStrategy, SortComponents, LogicalConstraint, value)
+    Block,
+    Suffix,
+    TraversalStrategy,
+    SortComponents,
+    LogicalConstraint,
+    value,
+)
 from pyomo.core.base.block import _BlockData
 from pyomo.common.collections import ComponentMap, ComponentSet, OrderedSet
 from pyomo.opt import TerminationCondition, SolverStatus
@@ -26,20 +32,29 @@ import logging
 
 logger = logging.getLogger('pyomo.gdp')
 
-_acceptable_termination_conditions = set([
-    TerminationCondition.optimal,
-    TerminationCondition.globallyOptimal,
-    TerminationCondition.locallyOptimal,
-])
-_infeasible_termination_conditions = set([
-    TerminationCondition.infeasible,
-    TerminationCondition.invalidProblem,
-])
+_acceptable_termination_conditions = set(
+    [
+        TerminationCondition.optimal,
+        TerminationCondition.globallyOptimal,
+        TerminationCondition.locallyOptimal,
+    ]
+)
+_infeasible_termination_conditions = set(
+    [TerminationCondition.infeasible, TerminationCondition.invalidProblem]
+)
 
 
-class NORMAL(object): pass
-class INFEASIBLE(object): pass
-class NONOPTIMAL(object): pass
+class NORMAL(object):
+    pass
+
+
+class INFEASIBLE(object):
+    pass
+
+
+class NONOPTIMAL(object):
+    pass
+
 
 def verify_successful_solve(results):
     status = results.solver.status
@@ -81,9 +96,11 @@ def clone_without_expression_components(expr, substitute=None):
     if substitute is None:
         substitute = {}
     #
-    visitor = EXPR.ExpressionReplacementVisitor(substitute=substitute,
-                                                remove_named_expressions=True)
+    visitor = EXPR.ExpressionReplacementVisitor(
+        substitute=substitute, remove_named_expressions=True
+    )
     return visitor.walk_expression(expr)
+
 
 def _raise_disjunct_in_multiple_disjunctions_error(disjunct, disjunction):
     # we've transformed it, which means this is the second time it's appearing
@@ -91,8 +108,9 @@ def _raise_disjunct_in_multiple_disjunctions_error(disjunct, disjunction):
     raise GDP_Error(
         "The disjunct '%s' has been transformed, but '%s', a disjunction "
         "it appears in, has not. Putting the same disjunct in "
-        "multiple disjunctions is not supported." % (disjunct.name,
-                                                     disjunction.name))
+        "multiple disjunctions is not supported." % (disjunct.name, disjunction.name)
+    )
+
 
 class GDPTree:
     def __init__(self):
@@ -119,15 +137,17 @@ class GDPTree:
             u : A node in the tree
         """
         if u not in self._vertices:
-            raise ValueError("'%s' is not a vertex in the GDP tree. Cannot "
-                             "retrieve its parent." % u)
+            raise ValueError(
+                "'%s' is not a vertex in the GDP tree. Cannot "
+                "retrieve its parent." % u
+            )
         if u in self._parent:
             return self._parent[u]
         else:
             return None
 
     def root_disjunct(self, u):
-        """ Returns the highest parent Disjunct in the hierarchy, or None if
+        """Returns the highest parent Disjunct in the hierarchy, or None if
         the component is not nested.
 
         Arg:
@@ -191,6 +211,7 @@ def _parent_disjunct(obj):
 
     return None
 
+
 def _check_properly_deactivated(disjunct):
     if disjunct.indicator_var.is_fixed():
         if not value(disjunct.indicator_var):
@@ -201,15 +222,17 @@ def _check_properly_deactivated(disjunct):
             raise GDP_Error(
                 "The disjunct '%s' is deactivated, but the "
                 "indicator_var is fixed to %s. This makes no sense."
-                % ( disjunct.name, value(disjunct.indicator_var) ))
+                % (disjunct.name, value(disjunct.indicator_var))
+            )
     if disjunct._transformation_block is None:
         raise GDP_Error(
             "The disjunct '%s' is deactivated, but the "
             "indicator_var is not fixed and the disjunct does not "
             "appear to have been transformed. This makes no sense. "
             "(If the intent is to deactivate the disjunct, fix its "
-            "indicator_var to False.)"
-            % ( disjunct.name, ))
+            "indicator_var to False.)" % (disjunct.name,)
+        )
+
 
 def _gather_disjunctions(block, gdp_tree, include_root=True):
     if not include_root:
@@ -222,18 +245,20 @@ def _gather_disjunctions(block, gdp_tree, include_root=True):
     while to_explore:
         block = to_explore.pop()
         for disjunction in block.component_data_objects(
-                Disjunction,
-                active=True,
-                sort=SortComponents.deterministic,
-                descend_into=Block):
+            Disjunction,
+            active=True,
+            sort=SortComponents.deterministic,
+            descend_into=Block,
+        ):
             # add the node (because it might be an empty Disjunction and block
             # might be a Block, in case it wouldn't get added below.)
             gdp_tree.add_node(disjunction)
             for disjunct in disjunction.disjuncts:
                 if not disjunct.active:
                     if disjunct.transformation_block is not None:
-                            _raise_disjunct_in_multiple_disjunctions_error(
-                                disjunct, disjunction)
+                        _raise_disjunct_in_multiple_disjunctions_error(
+                            disjunct, disjunction
+                        )
                     _check_properly_deactivated(disjunct)
                     continue
                 gdp_tree.add_edge(disjunction, disjunct)
@@ -245,23 +270,24 @@ def _gather_disjunctions(block, gdp_tree, include_root=True):
 
     return gdp_tree
 
+
 def get_gdp_tree(targets, instance, knownBlocks=None):
     if knownBlocks is None:
         knownBlocks = {}
     gdp_tree = GDPTree()
     for t in targets:
         # first check it's not insane, that is, it is at least on the instance
-        if not is_child_of(parent=instance, child=t,
-                           knownBlocks=knownBlocks):
-            raise GDP_Error("Target '%s' is not a component on instance "
-                            "'%s'!" % (t.name, instance.name))
+        if not is_child_of(parent=instance, child=t, knownBlocks=knownBlocks):
+            raise GDP_Error(
+                "Target '%s' is not a component on instance "
+                "'%s'!" % (t.name, instance.name)
+            )
         if t.ctype is Block or isinstance(t, _BlockData):
             _blocks = t.values() if t.is_indexed() else (t,)
             for block in _blocks:
                 if not block.active:
                     continue
-                gdp_tree = _gather_disjunctions(block, gdp_tree,
-                                                include_root=False)
+                gdp_tree = _gather_disjunctions(block, gdp_tree, include_root=False)
         elif t.ctype is Disjunction:
             parent = _parent_disjunct(t)
             if parent is not None and parent in targets:
@@ -276,7 +302,8 @@ def get_gdp_tree(targets, instance, knownBlocks=None):
                     if not disjunct.active:
                         if disjunct.transformation_block is not None:
                             _raise_disjunct_in_multiple_disjunctions_error(
-                                disjunct, disjunction)
+                                disjunct, disjunction
+                            )
                         _check_properly_deactivated(disjunct)
                         continue
                     gdp_tree.add_edge(disjunction, disjunct)
@@ -286,9 +313,10 @@ def get_gdp_tree(targets, instance, knownBlocks=None):
             # deal with this
             raise GDP_Error(
                 "Target '%s' was not a Block, Disjunct, or Disjunction. "
-                "It was of type %s and can't be transformed."
-                % (t.name, type(t)) )
+                "It was of type %s and can't be transformed." % (t.name, type(t))
+            )
     return gdp_tree
+
 
 def preprocess_targets(targets, instance, knownBlocks, gdp_tree=None):
     if gdp_tree is None:
@@ -296,6 +324,7 @@ def preprocess_targets(targets, instance, knownBlocks, gdp_tree=None):
     # this is for bigm: We need to transform from the leaves up, so we want a
     # reverse of a topological sort: no parent can come before its child.
     return gdp_tree.reverse_topological_sort()
+
 
 # [ESJ 07/09/2019 Should this be a more general utility function elsewhere?  I'm
 #  putting it here for now so that all the gdp transformations can use it.
@@ -310,8 +339,7 @@ def is_child_of(parent, child, knownBlocks=None):
     if knownBlocks is None:
         knownBlocks = {}
     tmp = set()
-    node = child if isinstance(child, (Block, _BlockData)) else \
-           child.parent_block()
+    node = child if isinstance(child, (Block, _BlockData)) else child.parent_block()
     while True:
         known = knownBlocks.get(node)
         if known:
@@ -334,10 +362,12 @@ def is_child_of(parent, child, knownBlocks=None):
         else:
             node = container
 
+
 def _to_dict(val):
     if isinstance(val, (dict, ComponentMap)):
-       return val
+        return val
     return {None: val}
+
 
 def get_src_disjunction(xor_constraint):
     """Return the Disjunction corresponding to xor_constraint
@@ -356,14 +386,17 @@ def get_src_disjunction(xor_constraint):
     # block while we do the transformation. And then this method could query
     # that map.
     m = xor_constraint.model()
-    for disjunction in m.component_data_objects(Disjunction,
-                                                descend_into=(Block, Disjunct)):
+    for disjunction in m.component_data_objects(
+        Disjunction, descend_into=(Block, Disjunct)
+    ):
         if disjunction._algebraic_constraint:
             if disjunction._algebraic_constraint() is xor_constraint:
                 return disjunction
-    raise GDP_Error("It appears that '%s' is not an XOR or OR constraint "
-                    "resulting from transforming a Disjunction."
-                    % xor_constraint.name)
+    raise GDP_Error(
+        "It appears that '%s' is not an XOR or OR constraint "
+        "resulting from transforming a Disjunction." % xor_constraint.name
+    )
+
 
 def get_src_disjunct(transBlock):
     """Return the Disjunct object whose transformed components are on
@@ -374,12 +407,16 @@ def get_src_disjunct(transBlock):
     transBlock: _BlockData which is in the relaxedDisjuncts IndexedBlock
                 on a transformation block.
     """
-    if not hasattr(transBlock, "_src_disjunct") or \
-       type(transBlock._src_disjunct) is not weakref_ref:
-        raise GDP_Error("Block '%s' doesn't appear to be a transformation "
-                        "block for a disjunct. No source disjunct found."
-                        % transBlock.name)
+    if (
+        not hasattr(transBlock, "_src_disjunct")
+        or type(transBlock._src_disjunct) is not weakref_ref
+    ):
+        raise GDP_Error(
+            "Block '%s' doesn't appear to be a transformation "
+            "block for a disjunct. No source disjunct found." % transBlock.name
+        )
     return transBlock._src_disjunct()
+
 
 def get_src_constraint(transformedConstraint):
     """Return the original Constraint whose transformed counterpart is
@@ -396,10 +433,13 @@ def get_src_constraint(transformedConstraint):
     # us the wrong thing. If they happen to also have a _constraintMap then
     # the world is really against us.
     if not hasattr(transBlock, "_constraintMap"):
-        raise GDP_Error("Constraint '%s' is not a transformed constraint"
-                        % transformedConstraint.name)
+        raise GDP_Error(
+            "Constraint '%s' is not a transformed constraint"
+            % transformedConstraint.name
+        )
     # if something goes wrong here, it's a bug in the mappings.
     return transBlock._constraintMap['srcConstraints'][transformedConstraint]
+
 
 def _find_parent_disjunct(constraint):
     # traverse up until we find the disjunct this constraint lives on
@@ -408,10 +448,12 @@ def _find_parent_disjunct(constraint):
         if parent_disjunct is None:
             raise GDP_Error(
                 "Constraint '%s' is not on a disjunct and so was not "
-                "transformed" % constraint.name)
+                "transformed" % constraint.name
+            )
         parent_disjunct = parent_disjunct.parent_block()
 
     return parent_disjunct
+
 
 def _get_constraint_transBlock(constraint):
     parent_disjunct = _find_parent_disjunct(constraint)
@@ -419,12 +461,15 @@ def _get_constraint_transBlock(constraint):
     # so the below is OK
     transBlock = parent_disjunct._transformation_block
     if transBlock is None:
-        raise GDP_Error("Constraint '%s' is on a disjunct which has not been "
-                        "transformed" % constraint.name)
+        raise GDP_Error(
+            "Constraint '%s' is on a disjunct which has not been "
+            "transformed" % constraint.name
+        )
     # if it's not None, it's the weakref we wanted.
     transBlock = transBlock()
 
     return transBlock
+
 
 def get_transformed_constraints(srcConstraint):
     """Return the transformed version of srcConstraint
@@ -435,20 +480,21 @@ def get_transformed_constraints(srcConstraint):
     the subtree of a transformed Disjunct
     """
     if srcConstraint.is_indexed():
-        raise GDP_Error("Argument to get_transformed_constraint should be "
-                        "a ScalarConstraint or _ConstraintData. (If you "
-                        "want the container for all transformed constraints "
-                        "from an IndexedDisjunction, this is the parent "
-                        "component of a transformed constraint originating "
-                        "from any of its _ComponentDatas.)")
+        raise GDP_Error(
+            "Argument to get_transformed_constraint should be "
+            "a ScalarConstraint or _ConstraintData. (If you "
+            "want the container for all transformed constraints "
+            "from an IndexedDisjunction, this is the parent "
+            "component of a transformed constraint originating "
+            "from any of its _ComponentDatas.)"
+        )
     transBlock = _get_constraint_transBlock(srcConstraint)
     try:
-        return transBlock._constraintMap['transformedConstraints'][
-            srcConstraint]
+        return transBlock._constraintMap['transformedConstraints'][srcConstraint]
     except:
-        logger.error("Constraint '%s' has not been transformed."
-                     % srcConstraint.name)
+        logger.error("Constraint '%s' has not been transformed." % srcConstraint.name)
         raise
+
 
 def _warn_for_active_disjunct(innerdisjunct, outerdisjunct):
     assert innerdisjunct.active
@@ -460,13 +506,17 @@ def _warn_for_active_disjunct(innerdisjunct, outerdisjunct):
                 problemdisj = innerdisjunct[i]
                 break
 
-    raise GDP_Error("Found active disjunct '{0}' in disjunct '{1}'! Either {0} "
-                    "is not in a disjunction or the disjunction it is in "
-                    "has not been transformed. {0} needs to be deactivated "
-                    "or its disjunction transformed before {1} can be "
-                    "transformed.".format(
-                        problemdisj.getname(fully_qualified=True),
-                        outerdisjunct.getname(fully_qualified=True)))
+    raise GDP_Error(
+        "Found active disjunct '{0}' in disjunct '{1}'! Either {0} "
+        "is not in a disjunction or the disjunction it is in "
+        "has not been transformed. {0} needs to be deactivated "
+        "or its disjunction transformed before {1} can be "
+        "transformed.".format(
+            problemdisj.getname(fully_qualified=True),
+            outerdisjunct.getname(fully_qualified=True),
+        )
+    )
+
 
 def check_model_algebraic(instance):
     """Checks if there are any active Disjuncts or Disjunctions reachable via
@@ -478,10 +528,18 @@ def check_model_algebraic(instance):
     ----------
     instance: a Model or Block
     """
-    disjunction_set = {i for i in instance.component_data_objects(
-        Disjunction, descend_into=(Block, Disjunct), active=None)}
-    active_disjunction_set = {i for i in instance.component_data_objects(
-        Disjunction, descend_into=(Block, Disjunct), active=True)}
+    disjunction_set = {
+        i
+        for i in instance.component_data_objects(
+            Disjunction, descend_into=(Block, Disjunct), active=None
+        )
+    }
+    active_disjunction_set = {
+        i
+        for i in instance.component_data_objects(
+            Disjunction, descend_into=(Block, Disjunct), active=True
+        )
+    }
     disjuncts_in_disjunctions = set()
     for i in disjunction_set:
         disjuncts_in_disjunctions.update(i.disjuncts)
@@ -490,56 +548,68 @@ def check_model_algebraic(instance):
         disjuncts_in_active_disjunctions.update(i.disjuncts)
 
     for disjunct in instance.component_data_objects(
-            Disjunct, descend_into=(Block,),
-            descent_order=TraversalStrategy.PostfixDFS):
+        Disjunct, descend_into=(Block,), descent_order=TraversalStrategy.PostfixDFS
+    ):
         # check if it's relaxed
         if disjunct.transformation_block is not None:
             continue
         # It's not transformed, check if we should complain
-        elif disjunct.active and _disjunct_not_fixed_true(disjunct) and \
-             _disjunct_on_active_block(disjunct):
+        elif (
+            disjunct.active
+            and _disjunct_not_fixed_true(disjunct)
+            and _disjunct_on_active_block(disjunct)
+        ):
             # If someone thinks they've transformed the whole instance, but
             # there is still an active Disjunct on the model, we will warn
             # them. In the future this should be the writers' job.)
             if disjunct not in disjuncts_in_disjunctions:
-                logger.warning('Disjunct "%s" is currently active, '
-                               'but was not found in any Disjunctions. '
-                               'This is generally an error as the model '
-                               'has not been fully relaxed to a '
-                               'pure algebraic form.' % (disjunct.name,))
+                logger.warning(
+                    'Disjunct "%s" is currently active, '
+                    'but was not found in any Disjunctions. '
+                    'This is generally an error as the model '
+                    'has not been fully relaxed to a '
+                    'pure algebraic form.' % (disjunct.name,)
+                )
                 return False
             elif disjunct not in disjuncts_in_active_disjunctions:
-                logger.warning('Disjunct "%s" is currently active. While '
-                               'it participates in a Disjunction, '
-                               'that Disjunction is currently deactivated. '
-                               'This is generally an error as the '
-                               'model has not been fully relaxed to a pure '
-                               'algebraic form. Did you deactivate '
-                               'the Disjunction without addressing the '
-                               'individual Disjuncts?' % (disjunct.name,))
+                logger.warning(
+                    'Disjunct "%s" is currently active. While '
+                    'it participates in a Disjunction, '
+                    'that Disjunction is currently deactivated. '
+                    'This is generally an error as the '
+                    'model has not been fully relaxed to a pure '
+                    'algebraic form. Did you deactivate '
+                    'the Disjunction without addressing the '
+                    'individual Disjuncts?' % (disjunct.name,)
+                )
                 return False
             else:
-                logger.warning('Disjunct "%s" is currently active. It must be '
-                               'transformed or deactivated before solving the '
-                               'model.' % (disjunct.name,))
+                logger.warning(
+                    'Disjunct "%s" is currently active. It must be '
+                    'transformed or deactivated before solving the '
+                    'model.' % (disjunct.name,)
+                )
                 return False
 
-    for cons in instance.component_data_objects(LogicalConstraint,
-                                                descend_into=Block,
-                                                active=True):
+    for cons in instance.component_data_objects(
+        LogicalConstraint, descend_into=Block, active=True
+    ):
         if cons.active:
-            logger.warning('LogicalConstraint "%s" is currently active. It '
-                           'must be transformed or deactivated before solving '
-                           'the model.' % cons.name)
+            logger.warning(
+                'LogicalConstraint "%s" is currently active. It '
+                'must be transformed or deactivated before solving '
+                'the model.' % cons.name
+            )
             return False
 
     # We didn't find anything bad.
     return True
 
+
 def _disjunct_not_fixed_true(disjunct):
     # Return true if the disjunct indicator variable is not fixed to True
-    return not (disjunct.indicator_var.fixed and
-                disjunct.indicator_var.value)
+    return not (disjunct.indicator_var.fixed and disjunct.indicator_var.value)
+
 
 def _disjunct_on_active_block(disjunct):
     # Check first to make sure that the disjunct is not a descendent of an
@@ -551,9 +621,12 @@ def _disjunct_on_active_block(disjunct):
         if parent_block.ctype is Block and not parent_block.active:
             return False
         # properly deactivated Disjunct
-        elif (parent_block.ctype is Disjunct and not parent_block.active
-              and parent_block.indicator_var.value == False
-              and parent_block.indicator_var.fixed):
+        elif (
+            parent_block.ctype is Disjunct
+            and not parent_block.active
+            and parent_block.indicator_var.value == False
+            and parent_block.indicator_var.fixed
+        ):
             return False
         else:
             # Step up one level in the hierarchy

--- a/pyomo/kernel/__init__.py
+++ b/pyomo/kernel/__init__.py
@@ -16,147 +16,168 @@ from pyomo.version import version_info, __version__
 #
 import pyomo.environ
 import pyomo.opt
-from pyomo.opt import (SolverFactory,
-                       SolverStatus,
-                       TerminationCondition)
+from pyomo.opt import SolverFactory, SolverStatus, TerminationCondition
 
 #
 # Define the modeling namespace
 #
 from pyomo.common.collections import ComponentMap, ComponentSet
 from pyomo.core.expr import (
-    numvalue, numeric_expr, boolean_value, logical_expr, current,
-    calculus, symbol_map, expr_errors, visitor, sympy_tools, taylor_series,
-    expr_common, cnf_walker, template_expr
+    numvalue,
+    numeric_expr,
+    boolean_value,
+    logical_expr,
+    current,
+    calculus,
+    symbol_map,
+    expr_errors,
+    visitor,
+    sympy_tools,
+    taylor_series,
+    expr_common,
+    cnf_walker,
+    template_expr,
 )
 
 
 from pyomo.core.expr.numvalue import (
-    value, is_constant, is_fixed, is_variable_type,
-    is_potentially_variable, NumericValue, ZeroConstant,
-    native_numeric_types, native_types, polynomial_degree,
+    value,
+    is_constant,
+    is_fixed,
+    is_variable_type,
+    is_potentially_variable,
+    NumericValue,
+    ZeroConstant,
+    native_numeric_types,
+    native_types,
+    polynomial_degree,
 )
 
 from pyomo.core.expr.boolean_value import BooleanValue
 
 from pyomo.core.expr.current import (
-    linear_expression, nonlinear_expression,
-    land, lor, equivalent, exactly,
-    atleast, atmost, implies, lnot,
-    xor, inequality,
-    log, log10, sin, cos, tan, cosh, sinh, tanh,
-    asin, acos, atan, exp, sqrt, asinh, acosh,
-    atanh, ceil, floor,
+    linear_expression,
+    nonlinear_expression,
+    land,
+    lor,
+    equivalent,
+    exactly,
+    atleast,
+    atmost,
+    implies,
+    lnot,
+    xor,
+    inequality,
+    log,
+    log10,
+    sin,
+    cos,
+    tan,
+    cosh,
+    sinh,
+    tanh,
+    asin,
+    acos,
+    atan,
+    exp,
+    sqrt,
+    asinh,
+    acosh,
+    atanh,
+    ceil,
+    floor,
     Expr_if,
 )
 
 from pyomo.core.expr.calculus.derivatives import differentiate
 from pyomo.core.expr.taylor_series import taylor_series_expansion
 import pyomo.core.kernel
-from pyomo.kernel.util import (generate_names,
-                               preorder_traversal,
-                               pprint)
-from pyomo.core.kernel.variable import \
-    (variable,
-     variable_tuple,
-     variable_list,
-     variable_dict)
-from pyomo.core.kernel.constraint import \
-    (constraint,
-     linear_constraint,
-     constraint_tuple,
-     constraint_list,
-     constraint_dict)
-from pyomo.core.kernel.matrix_constraint import \
-    matrix_constraint
-import pyomo.core.kernel.conic as conic
-from pyomo.core.kernel.parameter import \
-    (parameter,
-     functional_value,
-     parameter_tuple,
-     parameter_list,
-     parameter_dict)
-from pyomo.core.kernel.expression import \
-    (noclone,
-     expression,
-     data_expression,
-     expression_tuple,
-     expression_list,
-     expression_dict)
-from pyomo.core.kernel.objective import \
-    (maximize,
-     minimize,
-     objective,
-     objective_tuple,
-     objective_list,
-     objective_dict)
-from pyomo.core.kernel.sos import \
-    (sos,
-     sos1,
-     sos2,
-     sos_tuple,
-     sos_list,
-     sos_dict)
-from pyomo.core.kernel.suffix import \
-    (suffix,
-     suffix_dict,
-     export_suffix_generator,
-     import_suffix_generator,
-     local_suffix_generator,
-     suffix_generator)
-from pyomo.core.kernel.block import \
-    (block,
-     block_tuple,
-     block_list,
-     block_dict)
-from pyomo.core.kernel.piecewise_library.transforms import \
-    piecewise
-from pyomo.core.kernel.piecewise_library.transforms_nd import \
-    piecewise_nd
-from pyomo.core.kernel.set_types import \
-    (RealSet,
-     IntegerSet,
-     BooleanSet)
-from pyomo.environ import (
-     Reals,
-     PositiveReals,
-     NonPositiveReals,
-     NegativeReals,
-     NonNegativeReals,
-     PercentFraction,
-     UnitInterval,
-     Integers,
-     PositiveIntegers,
-     NonPositiveIntegers,
-     NegativeIntegers,
-     NonNegativeIntegers,
-     Boolean,
-     Binary,
-     RealInterval,
-     IntegerInterval,
+from pyomo.kernel.util import generate_names, preorder_traversal, pprint
+from pyomo.core.kernel.variable import (
+    variable,
+    variable_tuple,
+    variable_list,
+    variable_dict,
 )
+from pyomo.core.kernel.constraint import (
+    constraint,
+    linear_constraint,
+    constraint_tuple,
+    constraint_list,
+    constraint_dict,
+)
+from pyomo.core.kernel.matrix_constraint import matrix_constraint
+import pyomo.core.kernel.conic as conic
+from pyomo.core.kernel.parameter import (
+    parameter,
+    functional_value,
+    parameter_tuple,
+    parameter_list,
+    parameter_dict,
+)
+from pyomo.core.kernel.expression import (
+    noclone,
+    expression,
+    data_expression,
+    expression_tuple,
+    expression_list,
+    expression_dict,
+)
+from pyomo.core.kernel.objective import (
+    maximize,
+    minimize,
+    objective,
+    objective_tuple,
+    objective_list,
+    objective_dict,
+)
+from pyomo.core.kernel.sos import sos, sos1, sos2, sos_tuple, sos_list, sos_dict
+from pyomo.core.kernel.suffix import (
+    suffix,
+    suffix_dict,
+    export_suffix_generator,
+    import_suffix_generator,
+    local_suffix_generator,
+    suffix_generator,
+)
+from pyomo.core.kernel.block import block, block_tuple, block_list, block_dict
+from pyomo.core.kernel.piecewise_library.transforms import piecewise
+from pyomo.core.kernel.piecewise_library.transforms_nd import piecewise_nd
+from pyomo.core.kernel.set_types import RealSet, IntegerSet, BooleanSet
+from pyomo.environ import (
+    Reals,
+    PositiveReals,
+    NonPositiveReals,
+    NegativeReals,
+    NonNegativeReals,
+    PercentFraction,
+    UnitInterval,
+    Integers,
+    PositiveIntegers,
+    NonPositiveIntegers,
+    NegativeIntegers,
+    NonNegativeIntegers,
+    Boolean,
+    Binary,
+    RealInterval,
+    IntegerInterval,
+)
+
 #
 # allow the use of standard kernel modeling components
 # as the ctype argument for the general iterator method
 #
 
 from pyomo.core.kernel.base import _convert_ctype
-_convert_ctype[block] = \
-    pyomo.core.kernel.block.IBlock
-_convert_ctype[variable] = \
-    pyomo.core.kernel.variable.IVariable
-_convert_ctype[constraint] = \
-    pyomo.core.kernel.constraint.IConstraint
-_convert_ctype[parameter] = \
-    pyomo.core.kernel.parameter.IParameter
-_convert_ctype[expression] = \
-    pyomo.core.kernel.expression.IExpression
-_convert_ctype[objective] = \
-    pyomo.core.kernel.objective.IObjective
-_convert_ctype[sos] = \
-    pyomo.core.kernel.sos.ISOS
-_convert_ctype[suffix] = \
-    pyomo.core.kernel.suffix.ISuffix
+
+_convert_ctype[block] = pyomo.core.kernel.block.IBlock
+_convert_ctype[variable] = pyomo.core.kernel.variable.IVariable
+_convert_ctype[constraint] = pyomo.core.kernel.constraint.IConstraint
+_convert_ctype[parameter] = pyomo.core.kernel.parameter.IParameter
+_convert_ctype[expression] = pyomo.core.kernel.expression.IExpression
+_convert_ctype[objective] = pyomo.core.kernel.objective.IObjective
+_convert_ctype[sos] = pyomo.core.kernel.sos.ISOS
+_convert_ctype[suffix] = pyomo.core.kernel.suffix.ISuffix
 del _convert_ctype
 
 #
@@ -169,29 +190,24 @@ from pyomo.core.kernel.base import _convert_ctype, _kernel_ctype_backmap
 #
 # Set up mappings between AML and Kernel ctypes
 #
-_convert_ctype[pyomo.environ.Block] = \
-    pyomo.core.kernel.block.IBlock
-_convert_ctype[pyomo.environ.Var] = \
-    pyomo.core.kernel.variable.IVariable
-_convert_ctype[pyomo.environ.Constraint] = \
-    pyomo.core.kernel.constraint.IConstraint
-_convert_ctype[pyomo.environ.Param] = \
-    pyomo.core.kernel.parameter.IParameter
-_convert_ctype[pyomo.environ.Expression] = \
-    pyomo.core.kernel.expression.IExpression
-_convert_ctype[pyomo.environ.Objective] = \
-    pyomo.core.kernel.objective.IObjective
-_convert_ctype[pyomo.environ.SOSConstraint] = \
-    pyomo.core.kernel.sos.ISOS
-_convert_ctype[pyomo.environ.Suffix] = \
-    pyomo.core.kernel.suffix.ISuffix
+_convert_ctype[pyomo.environ.Block] = pyomo.core.kernel.block.IBlock
+_convert_ctype[pyomo.environ.Var] = pyomo.core.kernel.variable.IVariable
+_convert_ctype[pyomo.environ.Constraint] = pyomo.core.kernel.constraint.IConstraint
+_convert_ctype[pyomo.environ.Param] = pyomo.core.kernel.parameter.IParameter
+_convert_ctype[pyomo.environ.Expression] = pyomo.core.kernel.expression.IExpression
+_convert_ctype[pyomo.environ.Objective] = pyomo.core.kernel.objective.IObjective
+_convert_ctype[pyomo.environ.SOSConstraint] = pyomo.core.kernel.sos.ISOS
+_convert_ctype[pyomo.environ.Suffix] = pyomo.core.kernel.suffix.ISuffix
 
 #
 # Set up back mappings from Kernel back to AML ctypes
 #
 _kernel_ctype_backmap.update(
-    {v: k for k, v in _convert_ctype.items()
-     if not issubclass(k, pyomo.core.kernel.base.ICategorizedObject)}
+    {
+        v: k
+        for k, v in _convert_ctype.items()
+        if not issubclass(k, pyomo.core.kernel.base.ICategorizedObject)
+    }
 )
 
 del _convert_ctype
@@ -201,8 +217,8 @@ del _kernel_ctype_backmap
 # Now cleanup the namespace a bit
 #
 
-import pyomo.core.kernel.piecewise_library.util as \
-    piecewise_util
+import pyomo.core.kernel.piecewise_library.util as piecewise_util
+
 del util
 del pyomo
 
@@ -210,17 +226,23 @@ del pyomo
 # Ducktyping to work with a solver interfaces. Ideally,
 # everything below here could be deleted one day.
 #
-from pyomo.core.kernel.heterogeneous_container import (heterogeneous_containers,
-                                                       IHeterogeneousContainer)
+from pyomo.core.kernel.heterogeneous_container import (
+    heterogeneous_containers,
+    IHeterogeneousContainer,
+)
+
+
 def _component_data_objects(self, *args, **kwds):
     # this is not yet handled
     kwds.pop('sort', None)
     if 'active' not in kwds:
         kwds['active'] = None
     yield from self.components(*args, **kwds)
-IHeterogeneousContainer.component_data_objects = \
-    _component_data_objects
+
+
+IHeterogeneousContainer.component_data_objects = _component_data_objects
 del _component_data_objects
+
 
 def _component_objects(self, *args, **kwds):
     # this is not yet handled
@@ -229,14 +251,16 @@ def _component_objects(self, *args, **kwds):
     assert kwds.pop('descent_order', None) is None
     active = kwds.pop('active', None)
     descend_into = kwds.pop('descend_into', True)
-    for item in heterogeneous_containers(self,
-                                         active=active,
-                                         descend_into=descend_into):
+    for item in heterogeneous_containers(
+        self, active=active, descend_into=descend_into
+    ):
         yield from item.children(*args, **kwds)
-IHeterogeneousContainer.component_objects = \
-    _component_objects
+
+
+IHeterogeneousContainer.component_objects = _component_objects
 del _component_objects
 del IHeterogeneousContainer
+
 
 def _block_data_objects(self, **kwds):
     # this is not yet handled
@@ -244,18 +268,22 @@ def _block_data_objects(self, **kwds):
     active = kwds.get("active", None)
     assert active in (None, True)
     # if not active, then nothing below is active
-    if (active is not None) and \
-       (not self.active):
+    if (active is not None) and (not self.active):
         return
     yield self
     yield from self.components(ctype=self.ctype, **kwds)
+
+
 block.block_data_objects = _block_data_objects
 del _block_data_objects
 
 # Note sure where this gets used or why we need it
 def _valid_problem_types(self):
     import pyomo.opt
+
     return [pyomo.opt.base.ProblemFormat.pyomo]
+
+
 block.valid_problem_types = _valid_problem_types
 del _valid_problem_types
 

--- a/pyomo/kernel/util.py
+++ b/pyomo/kernel/util.py
@@ -14,18 +14,16 @@ import pprint as _pprint_
 
 from pyomo.common.collections import ComponentMap
 import pyomo.core
-from pyomo.core.expr.numvalue import \
-    NumericValue
-from pyomo.core.kernel.base import \
-    (ICategorizedObject,
-     _no_ctype,
-     _convert_ctype,
-     _convert_descend_into)
+from pyomo.core.expr.numvalue import NumericValue
+from pyomo.core.kernel.base import (
+    ICategorizedObject,
+    _no_ctype,
+    _convert_ctype,
+    _convert_descend_into,
+)
 
-def preorder_traversal(node,
-                       ctype=_no_ctype,
-                       active=True,
-                       descend=True):
+
+def preorder_traversal(node, ctype=_no_ctype, active=True, descend=True):
     """
     A generator that yields each object in the storage tree
     (including the root object) using a preorder traversal.
@@ -57,8 +55,7 @@ def preorder_traversal(node,
     assert active in (None, True)
 
     # if not active, then nothing below is active
-    if (active is not None) and \
-       (not node.active):
+    if (active is not None) and (not node.active):
         return
 
     # convert AML types into Kernel types (hack for the
@@ -68,32 +65,29 @@ def preorder_traversal(node,
     # convert descend to a function
     descend = _convert_descend_into(descend)
 
-    if (ctype is _no_ctype) or \
-       (node.ctype is ctype) or \
-       (node.ctype._is_heterogeneous_container):
+    if (
+        (ctype is _no_ctype)
+        or (node.ctype is ctype)
+        or (node.ctype._is_heterogeneous_container)
+    ):
         yield node
 
-    if (not node._is_container) or \
-        (not descend(node)):
+    if (not node._is_container) or (not descend(node)):
         return
 
     for child in node.children():
         child_ctype = child.ctype
         if not child._is_container:
             # not a container
-            if (active is None) or \
-               child.active:
-                if (ctype is _no_ctype) or \
-                   (child_ctype is ctype):
+            if (active is None) or child.active:
+                if (ctype is _no_ctype) or (child_ctype is ctype):
                     yield child
         elif child._is_heterogeneous_container:
             # a heterogeneous container, so use
             # its traversal method
             for obj in preorder_traversal(
-                    child,
-                    ctype=ctype,
-                    active=active,
-                    descend=descend):
+                child, ctype=ctype, active=active, descend=descend
+            ):
                 yield obj
         else:
             # a homogeneous container
@@ -106,10 +100,8 @@ def preorder_traversal(node,
                         return False
                     else:
                         return descend(obj_)
-                for obj in preorder_traversal(
-                        child,
-                        active=active,
-                        descend=descend_):
+
+                for obj in preorder_traversal(child, active=active, descend=descend_):
                     if not obj._is_heterogeneous_container:
                         yield obj
                     else:
@@ -117,23 +109,15 @@ def preorder_traversal(node,
                         # its traversal method and reapply the
                         # ctype filter
                         for item in preorder_traversal(
-                                obj,
-                                ctype=ctype,
-                                active=active,
-                                descend=descend):
+                            obj, ctype=ctype, active=active, descend=descend
+                        ):
                             yield item
-            elif (ctype is _no_ctype) or \
-                 (child_ctype is ctype):
-                for obj in preorder_traversal(
-                        child,
-                        active=active,
-                        descend=descend):
+            elif (ctype is _no_ctype) or (child_ctype is ctype):
+                for obj in preorder_traversal(child, active=active, descend=descend):
                     yield obj
 
-def generate_names(node,
-                   convert=str,
-                   prefix="",
-                   **kwds):
+
+def generate_names(node, convert=str, prefix="", **kwds):
     """
     Generate names relative to this object for all
     objects stored under it.
@@ -168,16 +152,14 @@ def generate_names(node,
 
     for obj in traversal:
         parent = obj.parent
-        name = (parent._child_storage_entry_string
-                % convert(obj.storage_key))
+        name = parent._child_storage_entry_string % convert(obj.storage_key)
         if parent is not node:
-            names[obj] = (names[parent] +
-                          parent._child_storage_delimiter_string +
-                          name)
+            names[obj] = names[parent] + parent._child_storage_delimiter_string + name
         else:
             names[obj] = prefix + name
 
     return names
+
 
 def pprint(obj, indent=0, stream=sys.stdout):
     """pprint a kernel modeling object"""
@@ -185,65 +167,90 @@ def pprint(obj, indent=0, stream=sys.stdout):
         if isinstance(obj, NumericValue):
             prefix = ""
             if indent > 0:
-                prefix = (" "*indent)+" - "
-            stream.write(prefix+str(obj)+"\n")
+                prefix = (" " * indent) + " - "
+            stream.write(prefix + str(obj) + "\n")
         else:
             assert indent == 0
-            _pprint_.pprint(obj, indent=indent+1, stream=stream)
+            _pprint_.pprint(obj, indent=indent + 1, stream=stream)
         return
     if not obj._is_container:
         prefix = ""
         if indent > 0:
-            prefix = (" "*indent)+" - "
+            prefix = (" " * indent) + " - "
         # not a block
         clsname = obj.__class__.__name__
         if obj.ctype is pyomo.core.kernel.variable.IVariable:
-            stream.write(prefix+"%s: %s(active=%s, value=%s, bounds=(%s,%s), domain_type=%s, fixed=%s, stale=%s)\n"
-                  % (str(obj),
-                     clsname,
-                     obj.active,
-                     obj.value,
-                     obj.lb,
-                     obj.ub,
-                     obj.domain_type.__name__,
-                     obj.fixed,
-                     obj.stale))
+            stream.write(
+                prefix
+                + "%s: %s(active=%s, value=%s, bounds=(%s,%s), domain_type=%s, fixed=%s, stale=%s)\n"
+                % (
+                    str(obj),
+                    clsname,
+                    obj.active,
+                    obj.value,
+                    obj.lb,
+                    obj.ub,
+                    obj.domain_type.__name__,
+                    obj.fixed,
+                    obj.stale,
+                )
+            )
         elif obj.ctype is pyomo.core.kernel.constraint.IConstraint:
-              stream.write(prefix+"%s: %s(active=%s, expr=%s)\n"
-                  % (str(obj),
-                     clsname,
-                     obj.active,
-                     str(obj.expr)))
+            stream.write(
+                prefix
+                + "%s: %s(active=%s, expr=%s)\n"
+                % (str(obj), clsname, obj.active, str(obj.expr))
+            )
         elif obj.ctype is pyomo.core.kernel.objective.IObjective:
-            stream.write(prefix+"%s: %s(active=%s, expr=%s)\n"
-                  % (str(obj), clsname, obj.active, str(obj.expr)))
+            stream.write(
+                prefix
+                + "%s: %s(active=%s, expr=%s)\n"
+                % (str(obj), clsname, obj.active, str(obj.expr))
+            )
         elif obj.ctype is pyomo.core.kernel.expression.IExpression:
-            stream.write(prefix+"%s: %s(active=%s, expr=%s)\n"
-                  % (str(obj), clsname, obj.active, str(obj.expr)))
+            stream.write(
+                prefix
+                + "%s: %s(active=%s, expr=%s)\n"
+                % (str(obj), clsname, obj.active, str(obj.expr))
+            )
         elif obj.ctype is pyomo.core.kernel.parameter.IParameter:
-            stream.write(prefix+"%s: %s(active=%s, value=%s)\n"
-                  % (str(obj), clsname, obj.active, str(obj())))
+            stream.write(
+                prefix
+                + "%s: %s(active=%s, value=%s)\n"
+                % (str(obj), clsname, obj.active, str(obj()))
+            )
         elif obj.ctype is pyomo.core.kernel.sos.ISOS:
-            stream.write(prefix+"%s: %s(active=%s, level=%s, entries=%s)\n"
-                  % (str(obj),
-                     clsname,
-                     obj.active,
-                     obj.level,
-                     str(["(%s,%s)" % (str(v), w)
-                          for v,w in zip(obj.variables,
-                                         obj.weights)])))
+            stream.write(
+                prefix
+                + "%s: %s(active=%s, level=%s, entries=%s)\n"
+                % (
+                    str(obj),
+                    clsname,
+                    obj.active,
+                    obj.level,
+                    str(
+                        [
+                            "(%s,%s)" % (str(v), w)
+                            for v, w in zip(obj.variables, obj.weights)
+                        ]
+                    ),
+                )
+            )
         else:
             assert obj.ctype is pyomo.core.kernel.suffix.ISuffix
-            stream.write(prefix+"%s: %s(active=%s, size=%s)\n"
-                  % (str(obj.name), clsname, obj.active, str(len(obj))))
+            stream.write(
+                prefix
+                + "%s: %s(active=%s, size=%s)\n"
+                % (str(obj.name), clsname, obj.active, str(len(obj)))
+            )
     else:
         prefix = ""
         if indent > 0:
-            prefix = (" "*indent)+" - "
-        stream.write(prefix+"%s: %s(active=%s, ctype=%s)\n"
-                     % (str(obj),
-                        obj.__class__.__name__,
-                        obj.active,
-                        obj.ctype.__name__))
+            prefix = (" " * indent) + " - "
+        stream.write(
+            prefix
+            + "%s: %s(active=%s, ctype=%s)\n"
+            % (str(obj), obj.__class__.__name__, obj.active, obj.ctype.__name__)
+        )
         for c in obj.children():
-            pprint(c, indent=indent+1, stream=stream)
+            pprint(c, indent=indent + 1, stream=stream)


### PR DESCRIPTION
## Fixes (Partly) #329 

## Summary/Motivation:
This is the first in a relatively long string of PRs to apply PEP8 standards via `black` to Pyomo. We are following the standard used by IDAES _except_ that we are adding the `-S` option: `Don't normalize string quotes or prefixes` and the `-C` option: `Don't use trailing commas as a reason to split lines.`

**NOTE**: All changes are NFC.

Full command used: `black -S -C pyomo/gdp && black -S -C pyomo/kernel`

:warning: Please squash this at merge. :warning:

## Changes proposed in this PR:
- Apply `black` to the `gdp` and `kernel` directory `py` files
- Manually fix instances where two lines were merged and left `" "` or `' '`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
