### PR TITLE
Appsi logging

### DIFF
--- a/pyomo/contrib/appsi/solvers/gurobi.py
+++ b/pyomo/contrib/appsi/solvers/gurobi.py
@@ -3,12 +3,13 @@ import logging
 import math
 from typing import List, Dict, Optional
 from pyomo.common.collections import ComponentSet, ComponentMap, OrderedSet
+from pyomo.common.log import LogStream
 from pyomo.common.dependencies import attempt_import
 from pyomo.common.errors import PyomoException
-from pyomo.common.tee import capture_output
+from pyomo.common.tee import capture_output, TeeStream
 from pyomo.common.timing import HierarchicalTimer
 from pyomo.common.shutdown import python_is_shutting_down
-from pyomo.common.config import ConfigValue
+from pyomo.common.config import ConfigValue, NonNegativeInt
 from pyomo.core.kernel.objective import minimize, maximize
 from pyomo.core.base import SymbolMap, NumericLabeler, TextLabeler
 from pyomo.core.base.var import Var, _GeneralVarData
@@ -26,6 +27,7 @@ from pyomo.contrib.appsi.base import (
 )
 from pyomo.contrib.appsi.cmodel import cmodel, cmodel_available
 from pyomo.core.staleflag import StaleFlagManager
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +66,12 @@ class GurobiConfig(MIPSolverConfig):
                                            visibility=visibility)
 
         self.declare('logfile', ConfigValue(domain=str))
+        self.declare('solver_output_logger', ConfigValue())
+        self.declare('log_level', ConfigValue(domain=NonNegativeInt))
+        
         self.logfile = ''
+        self.solver_output_logger = logger
+        self.log_level = logging.INFO
 
 
 class GurobiSolutionLoader(PersistentSolutionLoader):
@@ -317,24 +324,30 @@ class Gurobi(PersistentBase, PersistentSolver):
         return self._symbol_map
 
     def _solve(self, timer: HierarchicalTimer):
-        config = self.config
-        options = self.gurobi_options
-        if config.stream_solver:
-            self._solver_model.setParam('LogToConsole', 1)
-        else:
-            self._solver_model.setParam('LogToConsole', 0)
-        self._solver_model.setParam('LogFile', config.logfile)
+        ostreams = [LogStream(level=self.config.log_level, logger=self.config.solver_output_logger)]
+        if self.config.stream_solver:
+            ostreams.append(sys.stdout)
 
-        if config.time_limit is not None:
-            self._solver_model.setParam('TimeLimit', config.time_limit)
-        if config.mip_gap is not None:
-            self._solver_model.setParam('MIPGap', config.mip_gap)
+        with TeeStream(*ostreams) as t:
+            with capture_output(output=t.STDOUT, capture_fd=False):
+                config = self.config
+                options = self.gurobi_options
+                
+                self._solver_model.setParam('LogToConsole', 1)
+                self._solver_model.setParam('LogFile', config.logfile)
+                
+                if config.time_limit is not None:
+                    self._solver_model.setParam('TimeLimit', config.time_limit)
+                if config.mip_gap is not None:
+                    self._solver_model.setParam('MIPGap', config.mip_gap)
+                
+                for key, option in options.items():
+                    self._solver_model.setParam(key, option)
+                
+                timer.start('optimize')
+                self._solver_model.optimize(self._callback)
+                timer.stop('optimize')
 
-        for key, option in options.items():
-            self._solver_model.setParam(key, option)
-        timer.start('optimize')
-        self._solver_model.optimize(self._callback)
-        timer.stop('optimize')
         self._needs_updated = False
         return self._postsolve(timer)
 

--- a/pyomo/contrib/appsi/solvers/highs.py
+++ b/pyomo/contrib/appsi/solvers/highs.py
@@ -4,7 +4,9 @@ from pyomo.common.collections import ComponentMap
 from pyomo.common.dependencies import attempt_import
 from pyomo.common.errors import PyomoException
 from pyomo.common.timing import HierarchicalTimer
-from pyomo.common.config import ConfigValue
+from pyomo.common.config import ConfigValue, NonNegativeInt
+from pyomo.common.tee import TeeStream, capture_output
+from pyomo.common.log import LogStream
 from pyomo.core.kernel.objective import minimize, maximize
 from pyomo.core.base import SymbolMap
 from pyomo.core.base.var import _GeneralVarData
@@ -23,6 +25,7 @@ from pyomo.contrib.appsi.base import (
 from pyomo.contrib.appsi.cmodel import cmodel, cmodel_available
 from pyomo.common.dependencies import numpy as np
 from pyomo.core.staleflag import StaleFlagManager
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +49,13 @@ class HighsConfig(MIPSolverConfig):
                                           implicit_domain=implicit_domain,
                                           visibility=visibility)
 
-        self.logfile: str = self.declare('logfile', ConfigValue(domain=str, default=''))
+        self.declare('logfile', ConfigValue(domain=str))
+        self.declare('solver_output_logger', ConfigValue())
+        self.declare('log_level', ConfigValue(domain=NonNegativeInt))
+        
+        self.logfile = ''
+        self.solver_output_logger = logger
+        self.log_level = logging.INFO
 
 
 class HighsResults(Results):
@@ -187,23 +196,28 @@ class Highs(PersistentBase, PersistentSolver):
     def _solve(self, timer: HierarchicalTimer):
         config = self.config
         options = self.highs_options
-        if config.stream_solver:
-            self._solver_model.setOptionValue('log_to_console', True)
-        else:
-            self._solver_model.setOptionValue('log_to_console', False)
-        if config.logfile != '':
-            self._solver_model.setOptionValue('log_file', config.logfile)
 
-        if config.time_limit is not None:
-            self._solver_model.setOptionValue('time_limit', config.time_limit)
-        if config.mip_gap is not None:
-            self._solver_model.setOptionValue('mip_rel_gap', config.mip_gap)
+        ostreams = [LogStream(level=self.config.log_level, logger=self.config.solver_output_logger)]
+        if self.config.stream_solver:
+            ostreams.append(sys.stdout)
 
-        for key, option in options.items():
-            self._solver_model.setOptionValue(key, option)
-        timer.start('optimize')
-        self._solver_model.run()
-        timer.stop('optimize')
+        with TeeStream(*ostreams) as t:
+            with capture_output(output=t.STDOUT, capture_fd=True):
+                self._solver_model.setOptionValue('log_to_console', True)
+                if config.logfile != '':
+                    self._solver_model.setOptionValue('log_file', config.logfile)
+
+                if config.time_limit is not None:
+                    self._solver_model.setOptionValue('time_limit', config.time_limit)
+                if config.mip_gap is not None:
+                    self._solver_model.setOptionValue('mip_rel_gap', config.mip_gap)
+
+                for key, option in options.items():
+                    self._solver_model.setOptionValue(key, option)
+                timer.start('optimize')
+                self._solver_model.run()
+                timer.stop('optimize')
+
         return self._postsolve(timer)
 
     def solve(self, model, timer: HierarchicalTimer = None) -> Results:


### PR DESCRIPTION
## Changes proposed in this PR:
- Use `capture_output` and `TeeStream` to make solver output control consistent across subprocess-based and python-based solver interfaces in appsi. In particular, this makes the Gurobi and Highs interfaces work better with logging.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
