### PR TITLE
Test indexed block in Incidence Analysis

### DIFF
--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -344,7 +344,8 @@ class IncidenceGraphInterface(object):
         else:
             raise TypeError(
                 "Unsupported type for incidence matrix. Expected "
-                "%s or %s but got %s." % (pyomo_nlp.PyomoNLP, Block, type(model))
+                "%s or %s but got %s."
+                % (pyomo_nlp.PyomoNLP, _BlockData, type(model))
             )
 
     @property

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -1671,5 +1671,22 @@ class TestInterface(unittest.TestCase):
         igraph.plot(title='test plot', show=False)
 
 
+@unittest.skipUnless(networkx_available, "networkx is not available.")
+class TestIndexedBlock(unittest.TestCase):
+
+    def test_block_data_obj(self):
+        m = pyo.ConcreteModel()
+        m.block = pyo.Block([1, 2, 3])
+        m.block[1].subblock = make_degenerate_solid_phase_model()
+        igraph = IncidenceGraphInterface(m.block[1])
+        var_dmp, con_dmp = igraph.dulmage_mendelsohn()
+        self.assertEqual(len(var_dmp.unmatched), 1)
+        self.assertEqual(len(con_dmp.unmatched), 1)
+
+        msg = "Unsupported type.*_BlockData"
+        with self.assertRaisesRegex(TypeError, msg):
+            igraph = IncidenceGraphInterface(m.block)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary/Motivation:
`IncidenceGraphInterface` does not support being given indexed blocks as the "model" (only `PyomoNLP` or `_BlockData`). This PR updates an error message to indicate that `_BlockData` is supported (rather than `Block`, which may imply that `IndexedBlock` is supported). It also adds a test to make sure we get the correct error message when an `IndexedBlock` is provided and that `IncidenceGraphInterface` can be constructed from a non-`Block` `_BlockData` (i.e. a data object of an `IndexedBlock`).


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
