### PR TITLE
NLv2: Bugfix for shared named expressions

### DIFF
--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -1696,7 +1696,7 @@ class AMPLRepn(object):
         ans.nl = self.nl
         ans.mult = self.mult
         ans.const = self.const
-        ans.linear = self.linear
+        ans.linear = None if self.linear is None else dict(self.linear)
         ans.nonlinear = self.nonlinear
         ans.named_exprs = self.named_exprs
         return ans

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -31,6 +31,7 @@ from pyomo.environ import (
     ExternalFunction,
     Suffix,
     Constraint,
+    Expression,
 )
 
 
@@ -733,6 +734,36 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
         self.assertEqual(repn.const, 0)
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, ('o24\no3\nn1\nv%s\nn0\n', [id(m.x)]))
+
+    def test_duplicate_shared_linear_expressions(self):
+        # This tests an issue where AMPLRepn.duplicate() was not copying
+        # the linear dict, allowing certain operations (like finalizing
+        # a bare expression multiplied by something other than 1) to
+        # change the compiled shared expression
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var()
+        m.e = Expression(expr=2*m.x + 3*m.y)
+
+        expr1 = 10*m.e
+        expr2 = m.e + 100*m.x + 100*m.y
+
+        info = INFO()
+        with LoggingIntercept() as LOG:
+            repn1 = info.visitor.walk_expression((expr1, None, None))
+            repn2 = info.visitor.walk_expression((expr2, None, None))
+        self.assertEqual(LOG.getvalue(), "")
+        self.assertEqual(repn1.nl, None)
+        self.assertEqual(repn1.mult, 1)
+        self.assertEqual(repn1.const, 0)
+        self.assertEqual(repn1.linear, {id(m.x): 20, id(m.y): 30})
+        self.assertEqual(repn1.nonlinear, None)
+
+        self.assertEqual(repn2.nl, None)
+        self.assertEqual(repn2.mult, 1)
+        self.assertEqual(repn2.const, 0)
+        self.assertEqual(repn2.linear, {id(m.x): 102, id(m.y): 103})
+        self.assertEqual(repn2.nonlinear, None)
 
 
 class Test_NLWriter(unittest.TestCase):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This resolves an issue reported by @andrewlee94 introduced in #2769 where shared compiled named `Expressions` were being modified by the NL writer to allow subsequent operations (like multiplication by a constant) to bleed into and alter the compiled representation of the base shared expression.

## Changes proposed in this PR:
- `AMPLReon.duplicate()`: (shallow copy) the linear coefficient dict
- add test verifying that the observed bug is resolved

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
