### PR TITLE
Update to Parmest for pandas 2.0.0 release

### DIFF
--- a/pyomo/contrib/doe/result.py
+++ b/pyomo/contrib/doe/result.py
@@ -31,6 +31,7 @@ from pyomo.common.dependencies import (
     pandas as pd, pandas_available,
     matplotlib as plt, matplotlib_available,
 )
+from pyomo.core.expr.numvalue import value
 
 from itertools import product
 import logging

--- a/pyomo/contrib/parmest/graphics.py
+++ b/pyomo/contrib/parmest/graphics.py
@@ -76,7 +76,7 @@ def _get_data_slice(xvar,yvar,columns,data,theta_star):
                 temp[col] = temp[col] + data[col].mean()/10
             else:
                 temp[col] = temp[col] + data[col].std()
-            data = data.append(temp, ignore_index=True)
+            data = data.concat(temp, ignore_index=True)
     
     data_slice['obj'] = scipy.interpolate.griddata(
         np.array(data[columns]),
@@ -167,9 +167,9 @@ def _add_obj_contour(x,y,color,columns,data,theta_star,label=None):
         print('Objective contour plot for', xvar, yvar,'slice failed')
 
 def _set_axis_limits(g, axis_limits, theta_vals, theta_star):
-    
+
     if theta_star is not None:
-        theta_vals = theta_vals.append(theta_star, ignore_index=True)
+        theta_vals = theta_vals.concat(theta_star, ignore_index=True)
         
     if axis_limits is None:
         axis_limits = {}

--- a/pyomo/contrib/parmest/graphics.py
+++ b/pyomo/contrib/parmest/graphics.py
@@ -76,7 +76,7 @@ def _get_data_slice(xvar,yvar,columns,data,theta_star):
                 temp[col] = temp[col] + data[col].mean()/10
             else:
                 temp[col] = temp[col] + data[col].std()
-            data = data.concat(temp, ignore_index=True)
+            data = pd.concat([data, temp], ignore_index=True)
     
     data_slice['obj'] = scipy.interpolate.griddata(
         np.array(data[columns]),
@@ -169,7 +169,7 @@ def _add_obj_contour(x,y,color,columns,data,theta_star,label=None):
 def _set_axis_limits(g, axis_limits, theta_vals, theta_star):
 
     if theta_star is not None:
-        theta_vals = theta_vals.concat(theta_star, ignore_index=True)
+        theta_vals = pd.concat([theta_vals, theta_star], ignore_index=True)
         
     if axis_limits is None:
         axis_limits = {}


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
`pandas 2.0.0` released this morning, which introduced the removal of deprecated functionality that will break several parmest tests.

## Changes proposed in this PR:
- Small bug fix in `DoE`
- Move to [preferred functionality](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.append.html) to replace `DataFrame.append`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
