### PR TITLE
contrib.piecewise: Fixing a bug with caused by degenerate simplices

### DIFF
--- a/pyomo/contrib/piecewise/piecewise_linear_function.py
+++ b/pyomo/contrib/piecewise/piecewise_linear_function.py
@@ -288,7 +288,7 @@ class PiecewiseLinearFunction(Block):
             raise
 
         # Get the points for the triangulation because they might not all be
-        # there if any where coplanar.
+        # there if any were coplanar.
         obj._points = [pt for pt in map(tuple, triangulation.points)]
         obj._simplices = []
         for simplex in triangulation.simplices:

--- a/pyomo/contrib/piecewise/piecewise_linear_function.py
+++ b/pyomo/contrib/piecewise/piecewise_linear_function.py
@@ -302,14 +302,14 @@ class PiecewiseLinearFunction(Block):
                 )
                 != 0
             ):
-                obj._simplices.append(simplex)
+                obj._simplices.append(tuple(simplex))
 
         # It's possible that qhull dropped some points if there were numerical
         # issues with them (e.g., if they were redundant). We'll be polite and
         # tell the user:
         for pt in triangulation.coplanar:
             logger.info(
-                "The Delaunary triangulation dropped the point with index "
+                "The Delaunay triangulation dropped the point with index "
                 "%s from the triangulation." % pt[0]
             )
 

--- a/pyomo/contrib/piecewise/tests/test_piecewise_linear_function.py
+++ b/pyomo/contrib/piecewise/tests/test_piecewise_linear_function.py
@@ -331,7 +331,7 @@ class TestPiecewiseLinearFunction3D(unittest.TestCase):
         )
         # check it's equal to the original function at all the extreme points of
         # the simplices
-        for (x1, x2) in m.pw._points:
+        for x1, x2 in m.pw._points:
             self.assertAlmostEqual(m.pw(x1, x2), m.g(x1, x2))
         # check some points in the approximation
         self.assertAlmostEqual(m.pw(1, 3), g1(1, 3))


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

When we construct a `PiecewiseLinearFunction` from a set of points, a lot of times users will give us a grid. This means that the Delaunay triangulation is quite degenerate, so we get a lot of degenerate simplices back. This PR adds a check after calling the triangulation to filter out all simplices that are not full-dimensional. 

## Changes proposed in this PR:
- Filter the simplices from `scipy.spatial.Delaunay` and keep only full-dimensional ones
- Log when points were dropped in the triangulation due to numerical issues
- Raise a `DeveloperError` when the linear system solve to find the hyperplane above a simplex is unexpectedly singular: this is a sign that we didn't correctly filter out degenerate simplices (in particular, it's possible we'll need a tolerance rather than keeping anything with a determinant that's not exactly 0.)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
