### PR TITLE
Update magic constant for visitor tests for python 3.11.2

### DIFF
--- a/pyomo/core/tests/unit/test_visitor.py
+++ b/pyomo/core/tests/unit/test_visitor.py
@@ -1810,7 +1810,9 @@ class TestStreamBasedExpressionVisitor_Deep(unittest.TestCase):
             # overflow error
             cases = []
         else:
-            cases = [(0, ""), (3, warn_msg)]
+            # 3 sufficed through Python 3.10, but appeared to need to be
+            # raised to 5 for recent 3.11 builds (3.11.2)
+            cases = [(0, ""), (5, warn_msg)]
 
         head_room = sys.getrecursionlimit() - get_stack_depth()
         for n, msg in cases:


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Python 3.11.2 appears to need a larger "magic constant" to trigger the "unexpected" RecursionError warning.

## Changes proposed in this PR:
- increase the magic constant to trigger the unexpected RecursionError from 3 to 5 (resolves test failures on python 3.11.2)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
