### PR TITLE
Improve formatting for DeveloperError, MouseTrap messages

### DIFF
--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -163,8 +163,9 @@ class MouseTrap(PyomoException, NotImplementedError):
             repr(super().__str__()),
             prolog="Sorry, mouse, no cookies here!",
             epilog="This is functionality we think may be rational to "
-            "support, but is not yet implemented since it might go "
-            "beyond what can practically be solved. However, please "
-            "feed the mice: pull requests are always welcome!",
+            "support, but is not yet implemented (possibly due to developer "
+            "availability, complexity of edge cases, or general practicality "
+            "or tractability). However, please feed the mice: "
+            "pull requests are always welcome!",
             exception=self,
         )

--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -45,7 +45,7 @@ def format_exception(msg, prolog=None, epilog=None, exception=None, width=76):
                 break_long_words=False,
                 break_on_hyphens=False,
             ).lstrip()
-        # If the prolog line-wrapped, endure that the message is
+        # If the prolog line-wrapped, ensure that the message is
         # indented an additional level.
         if '\n' in prolog:
             indent = ' ' * 8

--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -9,14 +9,85 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import inspect
+import textwrap
+
+
+def format_exception(msg, prolog=None, epilog=None, exception=None, width=76):
+    fields = []
+
+    if epilog:
+        indent = ' ' * 8
+    else:
+        indent = ' ' * 4
+
+    if exception is None:
+        # default to the length of 'NotImplementedError: ', the longest
+        # built-in name that we commonly raise
+        initial_indent = ' ' * 21
+    else:
+        if not inspect.isclass(exception):
+            exception = exception.__class__
+        initial_indent = ' ' * (len(exception.__name__) + 2)
+        if exception.__module__ != 'builtins':
+            initial_indent += ' ' * (len(exception.__module__) + 1)
+
+    if prolog is not None:
+        if '\n' not in prolog:
+            # We want to strip off the leading indent that we added as a
+            # placeholder for the string representation of the exception
+            # class name.
+            prolog = textwrap.fill(
+                prolog,
+                width=width,
+                initial_indent=initial_indent,
+                subsequent_indent=' ' * 4,
+                break_long_words=False,
+                break_on_hyphens=False,
+            ).lstrip()
+        # If the prolog line-wrapped, endure that the message is
+        # indented an additional level.
+        if '\n' in prolog:
+            indent = ' ' * 8
+        fields.append(prolog)
+        initial_indent = indent
+
+    if '\n' not in msg:
+        msg = textwrap.fill(
+            msg,
+            width=width,
+            initial_indent=initial_indent,
+            subsequent_indent=indent,
+            break_long_words=False,
+            break_on_hyphens=False,
+        )
+        if not fields:
+            # We want to strip off the leading indent that we just
+            # added, but only if there is no prolog
+            msg = msg.lstrip()
+    fields.append(msg)
+
+    if epilog is not None:
+        if '\n' not in epilog:
+            epilog = textwrap.fill(
+                epilog,
+                width=width,
+                initial_indent=' ' * 4,
+                subsequent_indent=' ' * 4,
+                break_long_words=False,
+                break_on_hyphens=False,
+            )
+        fields.append(epilog)
+
+    return '\n'.join(fields)
+
 
 class ApplicationError(Exception):
     """
     An exception used when an external application generates an error.
     """
 
-    def __init__(self, *args, **kargs):
-        Exception.__init__(self, *args, **kargs)  # pragma:nocover
+    pass
 
 
 class PyomoException(Exception):
@@ -36,13 +107,12 @@ class DeveloperError(PyomoException, NotImplementedError):
     component not declaring a 'ctype').
     """
 
-    def __init__(self, val):
-        self.parameter = val
-
     def __str__(self):
-        return (
-            "Internal Pyomo implementation error:\n\t%s\n"
-            "\tPlease report this to the Pyomo Developers." % (repr(self.parameter),)
+        return format_exception(
+            repr(super().__str__()),
+            prolog="Internal Pyomo implementation error:",
+            epilog="Please report this to the Pyomo Developers.",
+            exception=self,
         )
 
 
@@ -88,14 +158,13 @@ class MouseTrap(PyomoException, NotImplementedError):
     want a glass of milk too?)
     """
 
-    def __init__(self, val):
-        self.parameter = val
-
     def __str__(self):
-        return (
-            "Sorry, mouse, no cookies here!\n\t%s\n"
-            "\tThis is functionality we think may be rational to "
+        return format_exception(
+            repr(super().__str__()),
+            prolog="Sorry, mouse, no cookies here!",
+            epilog="This is functionality we think may be rational to "
             "support, but is not yet implemented since it might go "
             "beyond what can practically be solved. However, please "
-            "feed the mice: pull requests are always welcome!" % (repr(self.parameter),)
+            "feed the mice: pull requests are always welcome!",
+            exception=self,
         )

--- a/pyomo/common/tests/test_deprecated.py
+++ b/pyomo/common/tests/test_deprecated.py
@@ -657,6 +657,7 @@ class TestRenamedClass(unittest.TestCase):
             "Declaring class 'DeprecatedClass' using the "
             "RenamedClass metaclass, but without specifying the "
             "__renamed__version__ class attribute",
+            normalize_whitespace=True,
         ):
 
             class DeprecatedClass(metaclass=RenamedClass):

--- a/pyomo/common/tests/test_errors.py
+++ b/pyomo/common/tests/test_errors.py
@@ -1,0 +1,139 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import pyomo.common.unittest as unittest
+from pyomo.common.errors import format_exception
+
+
+class LocalException(Exception):
+    pass
+
+
+class TestFormatException(unittest.TestCase):
+    def test_basic_message(self):
+        self.assertEqual(format_exception("Hello world"), "Hello world")
+
+    def test_formatted_message(self):
+        self.assertEqual(format_exception("Hello\nworld"), "Hello\nworld")
+
+    def test_long_basic_message(self):
+        self.assertEqual(
+            format_exception(
+                "Hello world, this is a very long message that will "
+                "inevitably wrap onto another line."
+            ),
+            "Hello world, this is a very long message that will\n"
+            "    inevitably wrap onto another line.",
+        )
+
+    def test_long_basic_message_exception(self):
+        self.assertEqual(
+            format_exception(
+                "Hello world, this is a very long message that will "
+                "inevitably wrap onto another line.",
+                exception=LocalException(),
+            ),
+            "Hello world, this is a very\n"
+            "    long message that will inevitably wrap onto another line.",
+        )
+
+    def test_long_basic_message_builtin_exception(self):
+        self.assertEqual(
+            format_exception(
+                "Hello world, this is a very long message that will "
+                "inevitably wrap onto another line.",
+                exception=RuntimeError,
+            ),
+            "Hello world, this is a very long message that will inevitably\n"
+            "    wrap onto another line.",
+        )
+
+    def test_basic_message_prolog(self):
+        self.assertEqual(
+            format_exception(
+                "This is a very, very, very long message that will "
+                "inevitably wrap onto another line.",
+                prolog="Hello world:",
+            ),
+            "Hello world:\n"
+            "    This is a very, very, very long message that will inevitably "
+            "wrap onto\n"
+            "    another line.",
+        )
+
+    def test_basic_message_long_prolog(self):
+        msg = format_exception(
+            "This is a very, very, very long message that will "
+            "inevitably wrap onto another line.",
+            prolog="Hello, this is a more verbose prolog that will "
+            "trigger a line wrap:",
+        )
+        self.assertEqual(
+            msg,
+            "Hello, this is a more verbose prolog that will trigger\n"
+            "    a line wrap:\n"
+            "        This is a very, very, very long message that will inevitably "
+            "wrap\n"
+            "        onto another line.",
+        )
+
+    def test_basic_message_formatted_prolog(self):
+        msg = format_exception(
+            "This is a very, very, very long message that will "
+            "inevitably wrap onto another line.",
+            prolog="Hello world:\n    This is a prolog:",
+        )
+        self.assertEqual(
+            msg,
+            "Hello world:\n    This is a prolog:\n"
+            "        This is a very, very, very long message that will inevitably "
+            "wrap\n"
+            "        onto another line.",
+        )
+
+    def test_basic_message_epilog(self):
+        self.assertEqual(
+            format_exception(
+                "This is a very, very, very long message that will "
+                "inevitably wrap onto another line.",
+                epilog="Hello world",
+            ),
+            "This is a very, very, very long message that will\n"
+            "        inevitably wrap onto another line.\n"
+            "    Hello world",
+        )
+
+    def test_basic_message_long_epilog(self):
+        self.assertEqual(
+            format_exception(
+                "This is a very, very, very long message that will "
+                "inevitably wrap onto another line.",
+                epilog="Hello, this is a very, very, very verbose epilog that will "
+                "trigger a line wrap",
+            ),
+            "This is a very, very, very long message that will\n"
+            "        inevitably wrap onto another line.\n"
+            "    Hello, this is a very, very, very verbose epilog that will trigger a\n"
+            "    line wrap",
+        )
+
+    def test_basic_message_formatted_epilog(self):
+        msg = format_exception(
+            "This is a very, very, very long message that will "
+            "inevitably wrap onto another line.",
+            epilog="Hello world:\n    This is an epilog:",
+        )
+        self.assertEqual(
+            msg,
+            "This is a very, very, very long message that will\n"
+            "        inevitably wrap onto another line.\n"
+            "Hello world:\n    This is an epilog:",
+        )

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -510,7 +510,7 @@ class TestCase(_unittest.TestCase):
     def assertRaisesRegex(self, expected_exception, expected_regex, *args, **kwargs):
         """Asserts that the message in a raised exception matches a regex.
 
-        This is a light weight wrapper arounf
+        This is a light weight wrapper around
         :py:meth:`unittest.TestCase.assertRaisesRegex` that adds
         handling of a `normalize_whitespace` keyword argument that
         normalizes all consecutive whitespace in the exception message

--- a/pyomo/contrib/cp/tests/test_logical_to_disjunctive.py
+++ b/pyomo/contrib/cp/tests/test_logical_to_disjunctive.py
@@ -335,6 +335,7 @@ class TestLogicalToDisjunctiveVisitor(unittest.TestCase):
             r"This may be a mathematically coherent expression; However "
             r"it is not yet supported to convert it to a disjunctive "
             r"program.",
+            normalize_whitespace=True,
         ):
             visitor.walk_expression(e)
 
@@ -357,6 +358,7 @@ class TestLogicalToDisjunctiveVisitor(unittest.TestCase):
             r"This may be a mathematically coherent expression; However "
             r"it is not yet supported to convert it to a disjunctive "
             r"program",
+            normalize_whitespace=True,
         ):
             visitor.walk_expression(e)
 
@@ -379,6 +381,7 @@ class TestLogicalToDisjunctiveVisitor(unittest.TestCase):
             r"This may be a mathematically coherent expression; However "
             r"it is not yet supported to convert it to a disjunctive "
             r"program",
+            normalize_whitespace=True,
         ):
             visitor.walk_expression(e)
 
@@ -390,9 +393,10 @@ class TestLogicalToDisjunctiveVisitor(unittest.TestCase):
 
         with self.assertRaisesRegex(
             MouseTrap,
-            "The RelationalExpression '3  <=  x' was used as a Boolean "
+            "The RelationalExpression '3 <= x' was used as a Boolean "
             "term in a logical proposition. This is not yet supported "
             "when transforming to disjunctive form.",
+            normalize_whitespace=True,
         ):
             visitor.walk_expression(e)
 

--- a/pyomo/core/expr/sympy_tools.py
+++ b/pyomo/core/expr/sympy_tools.py
@@ -205,7 +205,7 @@ class Sympy2PyomoVisitor(EXPR.StreamBasedExpressionVisitor):
         _op = _operatorMap.get(type(_sympyOp), None)
         if _op is None:
             raise DeveloperError(
-                "sympy expression type '%s' not found in the operator "
+                "sympy expression type %s not found in the operator "
                 "map" % type(_sympyOp)
             )
         return _op(*tuple(values))

--- a/pyomo/core/tests/unit/test_disable_methods.py
+++ b/pyomo/core/tests/unit/test_disable_methods.py
@@ -231,7 +231,9 @@ class TestDisableMethods(unittest.TestCase):
 
     def test_bad_api(self):
         with self.assertRaisesRegex(
-            DeveloperError, r"Cannot disable method not_there on " r"<class '.*\.foo'>"
+            DeveloperError,
+            r"Cannot disable method not_there on <class '.*\.foo'>",
+            normalize_whitespace=True,
         ):
 
             @disable_methods(('a', 'not_there'))

--- a/pyomo/core/tests/unit/test_indexed.py
+++ b/pyomo/core/tests/unit/test_indexed.py
@@ -302,6 +302,7 @@ class TestIndexedComponent(unittest.TestCase):
             ".*The '_data' dictionary and '_index' attribute are out of "
             "sync for indexed Var 'x': The 2 entry in the '_data' "
             "dictionary does not map back to this component data object.",
+            normalize_whitespace=True,
         ):
             m.x[3].index()
 

--- a/pyomo/core/tests/unit/test_symbolic.py
+++ b/pyomo/core/tests/unit/test_symbolic.py
@@ -401,10 +401,11 @@ class SymbolicDerivatives(unittest.TestCase):
 
         self.assertRaisesRegex(
             DeveloperError,
-            "sympy expression .* not found in the operator map",
+            "sympy expression .*bogus'> not found in the operator map",
             sympy2pyomo_expression,
             bogus(),
             obj_map,
+            normalize_whitespace=True,
         )
 
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This PR improves the formatting for exception messages generated by the `MouseTrap` and `DeveloperError` exceptions.  The formatting is performed by a general-purpose method (`pyomo.common.errors.format_exception()`) that can be used for other messages/exceptions.

To make comparing messages where the formatter introduces newlines or indentation easier, this PR adds a custom implementation of `assertRaisesRegex` that supports a `normalize_whitespace` keyword argument that will take the generated message and replace all consecutive whitespace with single spaces before applying the regex.

## Changes proposed in this PR:
- Improve formatting (line wrapping, indentation) for `DeveloperError` and `MouseTrap`
- Remove unnecessary methods from Pyomo exception classes
- Add a `normalize_whitespace` option for `assertRaisesRegex`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
