### PR TITLE
Improve conversions between Pyomo and Sympy expressions

### DIFF
--- a/pyomo/core/expr/cnf_walker.py
+++ b/pyomo/core/expr/cnf_walker.py
@@ -9,7 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-
 from pyomo.common import DeveloperError
 from pyomo.common.collections import ComponentMap
 from pyomo.common.dependencies import attempt_import
@@ -42,9 +41,11 @@ class CNF_Pyomo2SympyVisitor(Pyomo2SympyVisitor):
 def to_cnf(expr, bool_varlist=None, bool_var_to_special_atoms=None):
     """Converts a Pyomo logical constraint to CNF form.
 
-    Note: the atoms AtMostExpression, AtLeastExpression, and ExactlyExpression
-    require special treatment if they are not the root node, or if their children are not atoms,
-    e.g. atmost(2, Y1, Y1 | Y2, Y2, Y3)
+    Note: the atoms AtMostExpression, AtLeastExpression, and
+    ExactlyExpression require special treatment if they are not the root
+    node, or if their children are not atoms, e.g.
+
+        atmost(2, Y1, Y1 | Y2, Y2, Y3)
 
     As a result, the model may need to be augmented with
     additional boolean indicator variables and logical propositions.
@@ -85,14 +86,14 @@ def to_cnf(expr, bool_varlist=None, bool_var_to_special_atoms=None):
     sympy_expr = visitor.walk_expression(expr)
 
     new_statements = []
-    # If visitor encountered any special atoms in non-root node, ensure that their children are literals:
+    # If visitor encountered any special atoms in non-root node, ensure
+    # that their children are literals:
     for indicator_var, special_atom in visitor.special_atom_map.items():
         atom_cnf = _convert_children_to_literals(
             special_atom, bool_varlist, bool_var_to_special_atoms
         )
         bool_var_to_special_atoms[indicator_var] = atom_cnf[0]
         new_statements.extend(atom_cnf[1:])
-
     cnf_form = sympy.to_cnf(sympy_expr)
     return [
         sympy2pyomo_expression(cnf_form, pyomo_sympy_map)
@@ -102,7 +103,8 @@ def to_cnf(expr, bool_varlist=None, bool_var_to_special_atoms=None):
 def _convert_children_to_literals(
     special_atom, bool_varlist, bool_var_to_special_atoms
 ):
-    """If the child logical constraints are not literals, substitute augmented boolean variables.
+    """If the child logical constraints are not literals, substitute
+    augmented boolean variables.
 
     Same return types as to_cnf() function.
 

--- a/pyomo/core/expr/sympy_tools.py
+++ b/pyomo/core/expr/sympy_tools.py
@@ -191,15 +191,16 @@ class Pyomo2SympyVisitor(EXPR.StreamBasedExpressionVisitor):
         if type(child) in native_types:
             return False, child
         #
-        # We will descend into all expressions...
-        #
-        if child.is_expression_type():
-            return True, None
-        #
         # Replace pyomo variables with sympy variables
         #
         if child.is_potentially_variable():
-            return False, self.object_map.getSympySymbol(child)
+            #
+            # We will descend into all expressions...
+            #
+            if child.is_expression_type():
+                return True, None
+            else:
+                return False, self.object_map.getSympySymbol(child)
         #
         # Everything else is a constant...
         #

--- a/pyomo/core/expr/sympy_tools.py
+++ b/pyomo/core/expr/sympy_tools.py
@@ -8,12 +8,14 @@
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
+import operator
+import sys
 
 from pyomo.common import DeveloperError
 from pyomo.common.collections import ComponentMap
 from pyomo.common.dependencies import attempt_import
 from pyomo.common.errors import NondifferentiableError
-from pyomo.core.expr import current as EXPR, native_types
+from pyomo.core.expr import current as EXPR, logical_expr as LEXPR, native_types
 from pyomo.core.expr.numvalue import value
 
 #
@@ -32,38 +34,54 @@ def _configure_sympy(sympy, available):
 
     _operatorMap.update(
         {
-            sympy.Add: _sum,
+            sympy.Add: sum,
             sympy.Mul: _prod,
-            sympy.Pow: lambda x, y: x**y,
-            sympy.exp: lambda x: EXPR.exp(x),
-            sympy.log: lambda x: EXPR.log(x),
-            sympy.sin: lambda x: EXPR.sin(x),
-            sympy.asin: lambda x: EXPR.asin(x),
-            sympy.sinh: lambda x: EXPR.sinh(x),
-            sympy.asinh: lambda x: EXPR.asinh(x),
-            sympy.cos: lambda x: EXPR.cos(x),
-            sympy.acos: lambda x: EXPR.acos(x),
-            sympy.cosh: lambda x: EXPR.cosh(x),
-            sympy.acosh: lambda x: EXPR.acosh(x),
-            sympy.tan: lambda x: EXPR.tan(x),
-            sympy.atan: lambda x: EXPR.atan(x),
-            sympy.tanh: lambda x: EXPR.tanh(x),
-            sympy.atanh: lambda x: EXPR.atanh(x),
-            sympy.ceiling: lambda x: EXPR.ceil(x),
-            sympy.floor: lambda x: EXPR.floor(x),
-            sympy.sqrt: lambda x: EXPR.sqrt(x),
-            sympy.Abs: lambda x: abs(x),
+            sympy.Pow: lambda x: operator.pow(*x),
+            sympy.exp: lambda x: EXPR.exp(*x),
+            sympy.log: lambda x: EXPR.log(*x),
+            sympy.sin: lambda x: EXPR.sin(*x),
+            sympy.asin: lambda x: EXPR.asin(*x),
+            sympy.sinh: lambda x: EXPR.sinh(*x),
+            sympy.asinh: lambda x: EXPR.asinh(*x),
+            sympy.cos: lambda x: EXPR.cos(*x),
+            sympy.acos: lambda x: EXPR.acos(*x),
+            sympy.cosh: lambda x: EXPR.cosh(*x),
+            sympy.acosh: lambda x: EXPR.acosh(*x),
+            sympy.tan: lambda x: EXPR.tan(*x),
+            sympy.atan: lambda x: EXPR.atan(*x),
+            sympy.tanh: lambda x: EXPR.tanh(*x),
+            sympy.atanh: lambda x: EXPR.atanh(*x),
+            sympy.ceiling: lambda x: EXPR.ceil(*x),
+            sympy.floor: lambda x: EXPR.floor(*x),
+            sympy.sqrt: lambda x: EXPR.sqrt(*x),
+            sympy.Abs: lambda x: abs(*x),
             sympy.Derivative: _nondifferentiable,
-            sympy.Tuple: lambda *x: x,
+            sympy.Tuple: lambda x: x,
+            sympy.Or: lambda x: LEXPR.lor(*x),
+            sympy.And: lambda x: LEXPR.land(*x),
+            sympy.Implies: lambda x: LEXPR.implies(*x),
+            sympy.Equivalent: lambda x: LEXPR.equivalents(*x),
+            sympy.Not: lambda x: LEXPR.lnot(*x),
+            sympy.LessThan: lambda x: operator.le(*x),
+            sympy.StrictLessThan: lambda x: operator.lt(*x),
+            sympy.GreaterThan: lambda x: operator.ge(*x),
+            sympy.StrictGreaterThan: lambda x: operator.gt(*x),
+            sympy.Equality: lambda x: operator.eq(*x),
         }
     )
 
     _pyomo_operator_map.update(
         {
             EXPR.SumExpression: sympy.Add,
+            EXPR.LinearExpression: sympy.Add,
             EXPR.ProductExpression: sympy.Mul,
-            EXPR.NPV_ProductExpression: sympy.Mul,
             EXPR.MonomialTermExpression: sympy.Mul,
+            LEXPR.AndExpression: sympy.And,
+            LEXPR.OrExpression: sympy.Or,
+            LEXPR.ImplicationExpression: sympy.Implies,
+            LEXPR.EquivalenceExpression: sympy.Equivalent,
+            LEXPR.XorExpression: sympy.Xor,
+            LEXPR.NotExpression: sympy.Not,
         }
     )
 
@@ -94,18 +112,19 @@ def _configure_sympy(sympy, available):
 sympy, sympy_available = attempt_import('sympy', callback=_configure_sympy)
 
 
-def _prod(*x):
-    ans = x[0]
-    for i in x[1:]:
-        ans *= i
-    return ans
+if sys.version_info[:2] < (3, 8):
+
+    def _prod(args):
+        ans = 1
+        for arg in args:
+            ans *= arg
+        return ans
+
+else:
+    from math import prod as _prod
 
 
-def _sum(*x):
-    return sum(x_ for x_ in x)
-
-
-def _nondifferentiable(*x):
+def _nondifferentiable(x):
     if type(x[1]) is tuple:
         # sympy >= 1.3 returns tuples (var, order)
         wrt = x[1][0]
@@ -208,7 +227,7 @@ class Sympy2PyomoVisitor(EXPR.StreamBasedExpressionVisitor):
                 "sympy expression type '%s' not found in the operator "
                 "map" % type(_sympyOp)
             )
-        return _op(*tuple(values))
+        return _op(tuple(values))
 
     def beforeChild(self, node, child, child_idx):
         if not child._args:

--- a/pyomo/core/expr/sympy_tools.py
+++ b/pyomo/core/expr/sympy_tools.py
@@ -76,6 +76,7 @@ def _configure_sympy(sympy, available):
             EXPR.LinearExpression: sympy.Add,
             EXPR.ProductExpression: sympy.Mul,
             EXPR.MonomialTermExpression: sympy.Mul,
+            EXPR.ExternalFunctionExpression: _external_fcn,
             LEXPR.AndExpression: sympy.And,
             LEXPR.OrExpression: sympy.Or,
             LEXPR.ImplicationExpression: sympy.Implies,
@@ -133,6 +134,13 @@ def _nondifferentiable(x):
         wrt = x[1]
     raise NondifferentiableError(
         "The sub-expression '%s' is not differentiable with respect to %s" % (x[0], wrt)
+    )
+
+
+def _external_fcn(x):
+    raise ValueError(
+        "Expressions containing external functions are not convertible to "
+        f"sympy expressions (found 'f{x}')"
     )
 
 

--- a/pyomo/core/expr/sympy_tools.py
+++ b/pyomo/core/expr/sympy_tools.py
@@ -137,7 +137,7 @@ def _nondifferentiable(x):
     )
 
 
-def _external_fcn(x):
+def _external_fcn(*x):
     raise ValueError(
         "Expressions containing external functions are not convertible to "
         f"sympy expressions (found 'f{x}')"

--- a/pyomo/core/expr/sympy_tools.py
+++ b/pyomo/core/expr/sympy_tools.py
@@ -216,21 +216,19 @@ class Sympy2PyomoVisitor(EXPR.StreamBasedExpressionVisitor):
         return self.beforeChild(None, expr, None)
 
     def enterNode(self, node):
-        return (node._args, [])
+        return (node.args, [])
 
     def exitNode(self, node, values):
         """Visit nodes that have been expanded"""
-        _sympyOp = node
-        _op = _operatorMap.get(type(_sympyOp), None)
+        _op = _operatorMap.get(node.func, None)
         if _op is None:
             raise DeveloperError(
-                "sympy expression type '%s' not found in the operator "
-                "map" % type(_sympyOp)
+                "sympy expression type %s not found in the operator " "map" % node.func
             )
         return _op(tuple(values))
 
     def beforeChild(self, node, child, child_idx):
-        if not child._args:
+        if not child.args:
             item = self.object_map.getPyomoSymbol(child, None)
             if item is None:
                 item = float(child.evalf())

--- a/pyomo/core/plugins/transform/logical_to_linear.py
+++ b/pyomo/core/plugins/transform/logical_to_linear.py
@@ -361,7 +361,7 @@ class CnfToLinearVisitor(StreamBasedExpressionVisitor):
 
         # Only thing left should be _BooleanVarData
         #
-        # TODO: Aftter the expr_multiple_dispatch is merged, this should
+        # TODO: After the expr_multiple_dispatch is merged, this should
         # be switched to using as_numeric.
         if hasattr(child, 'get_associated_binary'):
             return False, child.get_associated_binary()

--- a/pyomo/core/plugins/transform/logical_to_linear.py
+++ b/pyomo/core/plugins/transform/logical_to_linear.py
@@ -1,6 +1,7 @@
 """Transformation from BooleanVar and LogicalConstraint to Binary and
 Constraints."""
 from pyomo.common.collections import ComponentMap
+from pyomo.common.errors import MouseTrap, DeveloperError
 from pyomo.common.modeling import unique_component_name
 from pyomo.common.config import ConfigBlock, ConfigValue
 from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
@@ -335,7 +336,17 @@ class CnfToLinearVisitor(StreamBasedExpressionVisitor):
                     + (-(rhs_lb - 1) + num_args) * (1 - less_than_binary),
                     sum_values >= values[0] + 1 - (rhs_ub + 1) * (1 - more_than_binary),
                 ]
-            pass
+        if type(node) in _numeric_relational_types:
+            raise MouseTrap(
+                "core.logical_to_linear does not support transforming "
+                "LogicalConstraints with embedded relational expressions.  "
+                f"Found '{node}'."
+            )
+        else:
+            raise DeveloperError(
+                f"Unsupported node type {type(node)} encountered when "
+                f"transforming a CNF expression to its linear equivalent ({node})."
+            )
 
     def beforeChild(self, node, child, child_idx):
         if type(node) in special_boolean_atom_types and child is node.args[0]:
@@ -349,7 +360,13 @@ class CnfToLinearVisitor(StreamBasedExpressionVisitor):
             return True, None
 
         # Only thing left should be _BooleanVarData
-        return False, child.get_associated_binary()
+        #
+        # TODO: Aftter the expr_multiple_dispatch is merged, this should
+        # be switched to using as_numeric.
+        if hasattr(child, 'get_associated_binary'):
+            return False, child.get_associated_binary()
+        else:
+            return False, child
 
     def finalizeResult(self, result):
         if type(result) is list:

--- a/pyomo/core/tests/unit/test_logical_to_linear.py
+++ b/pyomo/core/tests/unit/test_logical_to_linear.py
@@ -10,6 +10,7 @@
 #  ___________________________________________________________________________
 
 import pyomo.common.unittest as unittest
+from pyomo.common.errors import MouseTrap, DeveloperError
 from pyomo.common.log import LoggingIntercept
 import logging
 
@@ -21,14 +22,16 @@ from pyomo.environ import (
     ConcreteModel,
     BooleanVar,
     LogicalConstraint,
-    lor,
     TransformationFactory,
     RangeSet,
     Var,
     Constraint,
+    ExternalFunction,
     ComponentMap,
     value,
     BooleanSet,
+    land,
+    lor,
     atleast,
     atmost,
     exactly,
@@ -826,6 +829,36 @@ class TestLogicalToLinearTransformation(unittest.TestCase):
             r"\n\tReceived <class 'int'>",
         ):
             TransformationFactory('core.logical_to_linear').apply_to(m, targets=1)
+
+    def test_mixed_logical_relational_expressions(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = BooleanVar([1, 2])
+        m.c = LogicalConstraint(expr=(land(m.y[1], m.y[2]).implies(m.x >= 0)))
+        with self.assertRaisesRegex(
+            MouseTrap,
+            "core.logical_to_linear does not support transforming "
+            "LogicalConstraints with embedded relational expressions. "
+            "Found '0.0 <= x'.",
+            normalize_whitespace=True,
+        ):
+            TransformationFactory('core.logical_to_linear').apply_to(m)
+
+    def test_external_function(self):
+        def _fcn(*args):
+            raise RuntimeError('unreachable')
+
+        m = ConcreteModel()
+        m.x = Var()
+        m.f = ExternalFunction(_fcn)
+        m.y = BooleanVar()
+        m.c = LogicalConstraint(expr=(m.y.implies(m.f(m.x))))
+        with self.assertRaisesRegex(
+            ValueError,
+            "Expressions containing external functions are not convertible "
+            r"to sympy expressions \(found 'f\(x1",
+        ):
+            TransformationFactory('core.logical_to_linear').apply_to(m)
 
 
 @unittest.skipUnless(sympy_available, "Sympy not available")

--- a/pyomo/core/tests/unit/test_symbolic.py
+++ b/pyomo/core/tests/unit/test_symbolic.py
@@ -397,7 +397,8 @@ class SymbolicDerivatives(unittest.TestCase):
 
         class bogus(object):
             def __init__(self):
-                self._args = (obj_map.getSympySymbol(m.x),)
+                self.args = (obj_map.getSympySymbol(m.x),)
+                self.func = type(self)
 
         self.assertRaisesRegex(
             DeveloperError,

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -144,6 +144,7 @@ class TestPyomoEnviron(unittest.TestCase):
             '__future__',
             'argparse',
             'ast',  # Imported on Windows
+            'backports_abc',  # Imported by cython on Linux
             'base64',  # Imported on Windows
             'cPickle',
             'csv',


### PR DESCRIPTION
## Fixes #2802, fixes #2803.

## Summary/Motivation:
This PR improves support for converting Pyomo expressions to/from Sympy expressions.  In particular:
- Remove the redundant code from `cnf_walker`: the CNF walker now builds on the general walker from `sympy_tools` (eliminates a significant amount of repeated code)
- Generate an exception when attempting to convert a Pyomo expression with an ExternalFunction expression node into a Sympy expression (fixes #2803)
- Remove use of private sympy attributes
- Improve handling of NPV expressions

This also improves error checking in the `core.logical_to_linear` transformation.  In particular, attempts to transform LogicalConstraints containing relational expressions will generate an exception (fixes #2802).

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
