### PR TITLE
NLv2: resolve NPV constants in LinearExpressions

### DIFF
--- a/pyomo/core/expr/numeric_expr.py
+++ b/pyomo/core/expr/numeric_expr.py
@@ -937,11 +937,11 @@ class LinearExpression(NumericExpression):
                 len(args) % 2 == 1
                 and all(
                     arg.__class__ in native_types or not arg.is_potentially_variable()
-                    for arg in args[: 1 + 1 + len(args) // 2]
+                    for arg in args[: 1 + len(args) // 2]
                 )
                 and not any(
                     arg.__class__ in native_types or not arg.is_potentially_variable()
-                    for arg in args[1 + 1 + len(args) // 2 :]
+                    for arg in args[1 + len(args) // 2 :]
                 )
             ):
                 deprecation_warning(

--- a/pyomo/core/expr/numeric_expr.py
+++ b/pyomo/core/expr/numeric_expr.py
@@ -933,14 +933,16 @@ class LinearExpression(NumericExpression):
                     "Cannot specify both args and any of "
                     "{constant, linear_coeffs, or linear_vars}"
                 )
-            if len(args) % 2 == 1 and all(
-                arg.__class__ in native_types
-                or not arg.is_potentially_variable()
-                for arg in args[ : 1 + 1 + len(args) // 2]
-            ) and not any(
-                arg.__class__ in native_types
-                or not arg.is_potentially_variable()
-                for arg in args[1 + 1 + len(args) // 2 : ]
+            if (
+                len(args) % 2 == 1
+                and all(
+                    arg.__class__ in native_types or not arg.is_potentially_variable()
+                    for arg in args[: 1 + 1 + len(args) // 2]
+                )
+                and not any(
+                    arg.__class__ in native_types or not arg.is_potentially_variable()
+                    for arg in args[1 + 1 + len(args) // 2 :]
+                )
             ):
                 deprecation_warning(
                     "LinearExpression has been updated to expect args= to "

--- a/pyomo/core/expr/numeric_expr.py
+++ b/pyomo/core/expr/numeric_expr.py
@@ -933,9 +933,14 @@ class LinearExpression(NumericExpression):
                     "Cannot specify both args and any of "
                     "{constant, linear_coeffs, or linear_vars}"
                 )
-            if len(args) > 1 and (
-                args[1].__class__ in native_types
-                or not args[1].is_potentially_variable()
+            if len(args) % 2 == 1 and all(
+                arg.__class__ in native_types
+                or not arg.is_potentially_variable()
+                for arg in args[ : 1 + 1 + len(args) // 2]
+            ) and not any(
+                arg.__class__ in native_types
+                or not arg.is_potentially_variable()
+                for arg in args[1 + 1 + len(args) // 2 : ]
             ):
                 deprecation_warning(
                     "LinearExpression has been updated to expect args= to "
@@ -988,22 +993,17 @@ class LinearExpression(NumericExpression):
     @_args_.setter
     def _args_(self, value):
         self._args_cache_ = list(value)
+        self.constant = 0
+        self.linear_coefs = []
+        self.linear_vars = []
         if not self._args_cache_:
-            self.constant = 0
-            self.linear_coefs = []
-            self.linear_vars = []
             return
-        if self._args_cache_[0].__class__ is not MonomialTermExpression:
-            self.constant = value[0]
-            first_var = 1
-        else:
-            self.constant = 0
-            first_var = 0
-        self.linear_coefs, self.linear_vars = zip(
-            *map(attrgetter('args'), value[first_var:])
-        )
-        self.linear_coefs = list(self.linear_coefs)
-        self.linear_vars = list(self.linear_vars)
+        for arg in self._args_cache_:
+            if arg.__class__ is not MonomialTermExpression:
+                self.constant += arg
+            else:
+                self.linear_coefs.append(arg.arg(0))
+                self.linear_vars.append(arg.arg(1))
 
     def create_node_with_local_data(self, args, classtype=None):
         if classtype is not None:

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -73,13 +73,6 @@ from pyomo.opt import WriterFactory
 
 from pyomo.repn.plugins.ampl.ampl_ import set_pyomo_amplfunc_env
 
-if sys.version_info[:2] >= (3, 7):
-    _deterministic_dict = dict
-else:
-    from pyomo.common.collections import OrderedDict
-
-    _deterministic_dict = OrderedDict
-
 ### FIXME: Remove the following as soon as non-active components no
 ### longer report active==True
 from pyomo.core.base import Set, RangeSet
@@ -516,7 +509,7 @@ class _NLWriter_impl(object):
         self.subexpression_order = []
         self.external_functions = {}
         self.used_named_expressions = set()
-        self.var_map = _deterministic_dict()
+        self.var_map = {}
         self.visitor = AMPLRepnVisitor(
             self.template,
             self.subexpression_cache,

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -2446,6 +2446,8 @@ def _before_linear(visitor, child):
     # the original expression tree.
     var_map = visitor.var_map
     const = child.constant
+    if const.__class__ not in native_types:
+        const = const()
     linear = {}
     for v, c in zip(child.linear_vars, child.linear_coefs):
         if c.__class__ not in native_types:

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -481,10 +481,15 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
 
         info = INFO()
         with LoggingIntercept() as LOG:
-            repn = info.visitor.walk_expression((
-                LinearExpression(args=[1, m.p, m.p*m.x, (m.p+2)*m.y, 3*m.z, m.p*m.z]),
-                None, None
-            ))
+            repn = info.visitor.walk_expression(
+                (
+                    LinearExpression(
+                        args=[1, m.p, m.p * m.x, (m.p + 2) * m.y, 3 * m.z, m.p * m.z]
+                    ),
+                    None,
+                    None,
+                )
+            )
         self.assertEqual(LOG.getvalue(), "")
         self.assertEqual(repn.nl, None)
         self.assertEqual(repn.mult, 1)
@@ -911,15 +916,18 @@ class Test_NLWriter(unittest.TestCase):
     def test_linear_constraint_npv_const(self):
         # This tests an error possibly reported by #2810
         m = ConcreteModel()
-        m.x = Var([1,2])
+        m.x = Var([1, 2])
         m.p = Param(initialize=5, mutable=True)
         m.o = Objective(expr=1)
-        m.c = Constraint(expr=LinearExpression([m.p**2, 5*m.x[1], 10*m.x[2]]) == 0)
+        m.c = Constraint(
+            expr=LinearExpression([m.p**2, 5 * m.x[1], 10 * m.x[2]]) == 0
+        )
 
         OUT = io.StringIO()
         nl_writer.NLWriter().write(m, OUT)
-        self.assertEqual(*nl_diff(
-            """g3 1 1 0	# problem unknown
+        self.assertEqual(
+            *nl_diff(
+                """g3 1 1 0	# problem unknown
  2 1 1 0 1 	# vars, constraints, objectives, ranges, eqns
  0 0 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
  0 0	# network constraints: nonlinear, linear
@@ -945,5 +953,6 @@ J0 2
 0 5
 1 10
 """,
-            OUT.getvalue(),
-        ))
+                OUT.getvalue(),
+            )
+        )

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -472,6 +472,26 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
+    def test_linearexpression_npv(self):
+        m = ConcreteModel()
+        m.x = Var(initialize=4)
+        m.y = Var(initialize=4)
+        m.z = Var(initialize=4)
+        m.p = Param(initialize=5, mutable=True)
+
+        info = INFO()
+        with LoggingIntercept() as LOG:
+            repn = info.visitor.walk_expression((
+                LinearExpression(args=[1, m.p, m.p*m.x, (m.p+2)*m.y, 3*m.z, m.p*m.z]),
+                None, None
+            ))
+        self.assertEqual(LOG.getvalue(), "")
+        self.assertEqual(repn.nl, None)
+        self.assertEqual(repn.mult, 1)
+        self.assertEqual(repn.const, 6)
+        self.assertEqual(repn.linear, {id(m.x): 5, id(m.y): 7, id(m.z): 8})
+        self.assertEqual(repn.nonlinear, None)
+
     def test_eval_pow(self):
         m = ConcreteModel()
         m.x = Var(initialize=4)

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -45,7 +45,7 @@ class INFO(object):
         self.subexpression_cache = {}
         self.subexpression_order = []
         self.external_functions = {}
-        self.var_map = nl_writer._deterministic_dict()
+        self.var_map = {}
         self.used_named_expressions = set()
         self.symbolic_solver_labels = symbolic
 


### PR DESCRIPTION
## Fixes 

## Summary/Motivation:
This resolves an issue where the NLv2 writer failed to resolve NPV expressions in the constant portion of `LinearExpression` objects to an int/float.  This resulted in emitting the `repr` of the NPV expression in the "r" section of the NL file.

This ~~*may* fix~~ fixes #2810 (in that it fixes **a** source of the observed NL output, but there is not sufficient information in the issue to know is this error was what the user was hitting).

## Changes proposed in this PR:
- Ensure that constant portions of `LinearExpression` objects are resolved to native types in the NLv2 visitor.
- Improve (deprecated) logic for creating `LinearExpression` objects
- Remove unnecessary code (only needed for Python < 3.7)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
