### PR TITLE
GHA: lint test is a prereq only for PR/main builds

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -46,9 +46,11 @@ jobs:
       uses: crate-ci/typos@master
       with: 
         config: ./.github/workflows/typos.toml
+
+
   build:
     name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.other }}
-    needs: lint
+    needs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:
@@ -655,7 +657,7 @@ jobs:
 
   bare-python-env:
     name: linux/3.8/bare-env
-    needs: lint
+    needs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -45,6 +45,8 @@ jobs:
       uses: crate-ci/typos@master
       with: 
         config: ./.github/workflows/typos.toml
+
+
   build:
     name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.other }}
     needs: lint


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
The linter test should only be a prerequisite for PRs and the main branch.  User branch builds should proceed even if the linter fails: this should significantly reduce the number of `NFC: apply black` commits during development.

## Changes proposed in this PR:
- Only preemptively fail PR/main builds based on a failed linter job

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
