### PR TITLE
contrib.piecewise: Adding tolerance when filtering degenerate simplices

### DIFF
--- a/pyomo/contrib/piecewise/piecewise_linear_function.py
+++ b/pyomo/contrib/piecewise/piecewise_linear_function.py
@@ -295,7 +295,7 @@ class PiecewiseLinearFunction(Block):
         # there if any were coplanar.
         obj._points = [pt for pt in map(tuple, triangulation.points)]
         obj._simplices = []
-        for idx, simplex in enumerate(triangulation.simplices):
+        for simplex in triangulation.simplices:
             # For each simplex, check whether or not the simplex is
             # degenerate. If it is, we will just drop it.
 

--- a/pyomo/contrib/piecewise/piecewise_linear_function.py
+++ b/pyomo/contrib/piecewise/piecewise_linear_function.py
@@ -295,16 +295,25 @@ class PiecewiseLinearFunction(Block):
         # there if any were coplanar.
         obj._points = [pt for pt in map(tuple, triangulation.points)]
         obj._simplices = []
-        for simplex in triangulation.simplices:
-            # Check whether or not the simplex is degenerate. If it is, we will
-            # just drop it.
+        for idx, simplex in enumerate(triangulation.simplices):
+            # For each simplex, check whether or not the simplex is
+            # degenerate. If it is, we will just drop it.
+
+            # We have n + 1 points in n dimensions.
+            # We put them in a n x (n + 1) matrix: [p_0 p_1 ... p_n]
             points = triangulation.points[simplex].transpose()
+            # The question is if they span R^n: We construct the square matrix
+            # [p_1 - p_0  p_2 - p_1  ...  p_n - p_{n-1}] and check if it is full
+            # rank. Note that we use numpy's matrix_rank function rather than
+            # checking the determinant because matrix_rank will by default calculate a
+            # tolerance based on the input to account for numerical errors in the
+            # SVD computation.
             if (
-                np.linalg.det(
+                np.linalg.matrix_rank(
                     points[:, 1:]
                     - np.append(points[:, : dimension - 1], points[:, [0]], axis=1)
                 )
-                != 0
+                == dimension
             ):
                 obj._simplices.append(tuple(sorted(simplex)))
 
@@ -416,7 +425,7 @@ class PiecewiseLinearFunction(Block):
                 # code...
                 raise DeveloperError(
                     msg
-                    + "and that it should have been filtered out of the triangulation"
+                    + " and that it should have been filtered out of the triangulation"
                 )
 
             obj._linear_functions.append(_multivariate_linear_functor(normal))

--- a/pyomo/contrib/piecewise/tests/test_piecewise_linear_function.py
+++ b/pyomo/contrib/piecewise/tests/test_piecewise_linear_function.py
@@ -21,7 +21,7 @@ from pyomo.core.expr.compare import (
     assertExpressionsEqual,
     assertExpressionsStructurallyEqual,
 )
-from pyomo.environ import ConcreteModel, Constraint, log, Reals, Var
+from pyomo.environ import ConcreteModel, Constraint, log, Var
 
 np, numpy_available = attempt_import('numpy')
 scipy, scipy_available = attempt_import('scipy')

--- a/pyomo/contrib/piecewise/tests/test_piecewise_linear_function.py
+++ b/pyomo/contrib/piecewise/tests/test_piecewise_linear_function.py
@@ -21,7 +21,7 @@ from pyomo.core.expr.compare import (
     assertExpressionsEqual,
     assertExpressionsStructurallyEqual,
 )
-from pyomo.environ import ConcreteModel, Constraint, log, Var
+from pyomo.environ import ConcreteModel, Constraint, log, Reals, Var
 
 np, numpy_available = attempt_import('numpy')
 scipy, scipy_available = attempt_import('scipy')
@@ -499,3 +499,85 @@ class TestTriangulationProducesDegenerateSimplices(unittest.TestCase):
                 ],
                 function=m.f,
             )
+
+    @unittest.skipUnless(
+        scipy_available and numpy_available, "scipy and/or numpy are not available"
+    )
+    def test_simplex_not_numerically_full_rank_but_determinant_nonzero(self):
+        m = ConcreteModel()
+
+        def f(x3, x6, x9, x4):
+            return -x6 * (0.01 * x4 * x9 + x3) + 0.98 * x3
+
+        points = [
+            (0, 0.85, 1.2, 0),
+            (0.07478, 0.86396, 1.8668, 5),
+            (0, 0.85, 1.8668, 0),
+            (0.07478, 0.86396, 2.18751, 5),
+            (0, 0.86396, 1.2, 0),
+            (0.07478, 0.87971, 2.18751, 5),
+            (0, 0.87971, 1.2, 0),
+            (0.07478, 0.89001, 2.18751, 5),
+            (0.07478, 0.85, 1.2, 0),
+            (0.28333, 0.86396, 2.18751, 5),
+            (0.07478, 0.86396, 1.2, 0),
+            (0.28333, 0.89001, 2.18751, 5),
+            (0.28333, 0.85, 1.2, 0),
+            (0.31332, 0.89001, 2.18751, 5),
+            (0.31332, 0.85, 1.2, 0),
+            (1.2, 0.89001, 2.18751, 5),
+            (0, 0.89001, 1.2, 0),
+            (0.07478, 0.91727, 1.8668, 5),
+            (0, 0.89001, 1.8668, 0),
+            (0.07478, 0.91727, 2.18751, 5),
+            (0, 0.91727, 1.2, 0),
+            (0.07478, 0.93, 2.18751, 5),
+            (0.07478, 0.89001, 1.2, 0),
+            (0.28333, 0.91727, 2.18751, 5),
+            (0.07478, 0.91727, 1.2, 0),
+            (0.28333, 0.93, 2.18751, 5),
+            (0.28333, 0.89001, 1.2, 0),
+            (0.31332, 0.93, 2.18751, 5),
+            (0.31332, 0.89001, 1.2, 0),
+            (1.2, 0.93, 2.18751, 5),
+            (0, 0.85, 2.18751, 0),
+            (0.07478, 0.86396, 3.49134, 5),
+            (0, 0.85, 3.49134, 0),
+            (0.07478, 0.86396, 4, 5),
+            (0, 0.86396, 2.18751, 0),
+            (0.07478, 0.87971, 4, 5),
+            (0, 0.87971, 2.18751, 0),
+            (0.07478, 0.89001, 4, 5),
+            (0.07478, 0.85, 2.18751, 0),
+            (0.28333, 0.86396, 4, 5),
+            (0.07478, 0.86396, 2.18751, 0),
+            (0.28333, 0.89001, 4, 5),
+            (0.28333, 0.85, 2.18751, 0),
+            (0.31332, 0.89001, 4, 5),
+            (0.31332, 0.85, 2.18751, 0),
+            (1.2, 0.89001, 4, 5),
+            (0, 0.89001, 2.18751, 0),
+            (0.07478, 0.91727, 3.49134, 5),
+            (0, 0.89001, 3.49134, 0),
+            (0.07478, 0.91727, 4, 5),
+            (0, 0.91727, 2.18751, 0),
+            (0.07478, 0.93, 3.49134, 5),
+            (0, 0.91727, 3.49134, 0),
+            (0.07478, 0.93, 4, 5),
+            (0.07478, 0.89001, 2.18751, 0),
+            (0.28333, 0.91727, 4, 5),
+            (0.07478, 0.91727, 2.18751, 0),
+            (0.28333, 0.93, 4, 5),
+            (0.28333, 0.89001, 2.18751, 0),
+            (0.31332, 0.93, 4, 5),
+            (0.31332, 0.89001, 2.18751, 0),
+            (1.2, 0.93, 4, 5),
+        ]
+        m.pw = PiecewiseLinearFunction(points=points, function=f)
+
+        # The big win is if the above runs, but we'll check the approximation
+        # computationally at least, to make sure that at all the points we gave,
+        # the pw linear approximation evaluates to the same value as the
+        # original nonlinear function.
+        for pt in points:
+            self.assertAlmostEqual(m.pw(*pt), f(*pt))


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

When constructing a `PiecewiseLinearFunction` from a set of user-given points, we use scipy to calculate a triangulation of those points. This can create degenerate simplices that need to be filtered out before we calculate the linear functions. Previously, when checking if simplices were full-dimensional, we were checking for a non-zero determinant with no numerical tolerance whatsoever. Unsurprisingly, that doesn't work. This switches to using numpy's `matrix_rank` function which has a default implementation to account for numerical error in the SVD calculation. (We could alternatively add our own tolerance on the determinant, but I think that the numpy implementation is more clever than we would be, though we may someday need to extend and allow for a user to pass their own tolerance through to the numpy function.)

## Changes proposed in this PR:
- Switches from filtering simplices using determinant to using `matrix_rank`
- Adds some documentation of the simplex filtering so that I might believe my past self more quickly in the future
- Adds a kind of ugly test (more of an integration test) that was hitting numerical issues in the determinant calculation

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
