### PR TITLE
Gams/Baron: ensure negative numbers are parenthesized

### DIFF
--- a/pyomo/repn/plugins/baron_writer.py
+++ b/pyomo/repn/plugins/baron_writer.py
@@ -61,7 +61,7 @@ def _handle_PowExpression(visitor, node, values):
         if type(arg) in native_types:
             pass
         elif arg.is_fixed():
-            values[i] = ftoa(value(arg))
+            values[i] = ftoa(value(arg), True)
         else:
             unfixed_count += 1
 

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -181,7 +181,7 @@ class ToGamsVisitor(EXPR._ToStringVisitor):
         values = [
             self._monomial_to_string(arg)
             if arg.__class__ is EXPR.MonomialTermExpression
-            else ftoa(arg)
+            else ftoa(arg, True)
             for arg in node.args
         ]
         return node._to_string(values, False, self.smap)
@@ -623,20 +623,20 @@ class ProblemWriter_gams(AbstractProblemWriter):
                 constraint_names.append('%s' % cName)
                 ConstraintIO.write(
                     '%s.. %s =e= %s ;\n'
-                    % (constraint_names[-1], con_body_str, ftoa(con.upper))
+                    % (constraint_names[-1], con_body_str, ftoa(con.upper, False))
                 )
             else:
                 if con.has_lb():
                     constraint_names.append('%s_lo' % cName)
                     ConstraintIO.write(
                         '%s.. %s =l= %s ;\n'
-                        % (constraint_names[-1], ftoa(con.lower), con_body_str)
+                        % (constraint_names[-1], ftoa(con.lower, False), con_body_str)
                     )
                 if con.has_ub():
                     constraint_names.append('%s_hi' % cName)
                     ConstraintIO.write(
                         '%s.. %s =l= %s ;\n'
-                        % (constraint_names[-1], con_body_str, ftoa(con.upper))
+                        % (constraint_names[-1], con_body_str, ftoa(con.upper, False))
                     )
 
         obj = list(model.component_data_objects(Objective, active=True, sort=sort))

--- a/pyomo/repn/tests/baron/test_baron.py
+++ b/pyomo/repn/tests/baron/test_baron.py
@@ -260,6 +260,19 @@ class TestToBaronVisitor(unittest.TestCase):
         test = expression_to_string(e, variables, smap)
         self.assertEqual(test, "3 ^ x")
 
+    def test_issue_2819(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.z = Var()
+        t = 0.55
+        m.x.fix(3.5)
+        e = (m.x - 4) ** 2 + (m.z - 1) ** 2 - t
+
+        variables = OrderedSet()
+        smap = SymbolMap()
+        test = expression_to_string(e, variables, smap)
+        self.assertEqual(test, '(-0.5) ^ 2 + (z - 1) ^ 2 + (-0.55)')
+
 
 # class TestBaron_writer(unittest.TestCase):
 class XTestBaron_writer(object):

--- a/pyomo/repn/tests/gams/test_gams.py
+++ b/pyomo/repn/tests/gams/test_gams.py
@@ -457,6 +457,21 @@ class Test(unittest.TestCase):
             expression_to_string(m.c2.body, tc, smap=smap), ("x1 ** (-1.5)", False)
         )
 
+    def test_issue_2819(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.z = Var()
+        t = 0.55
+        m.x.fix(3.5)
+        e = (m.x - 4) ** 2 + (m.z - 1) ** 2 - t
+
+        tc = StorageTreeChecker(m)
+        smap = SymbolMap()
+        test = expression_to_string(e, tc, smap=smap)
+        self.assertEqual(
+            test, ('power((3.5 + (-4)), 2) + power((z + (-1)), 2) + (-0.55)', False)
+        )
+
 
 class TestGams_writer(unittest.TestCase):
     def _cleanup(self, fname):


### PR DESCRIPTION
## Fixes #2819 .

## Summary/Motivation:
This resolves an issue where negative constants were not being parenthesized, which lead to incorrect expressions in certain contexts (like exponentiation)

## Changes proposed in this PR:
- ensure negative constants are always parenthesized
- add test for issue #2819

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
