### PR TITLE
[contrib] Use standard repn for incidence graph generation

### DIFF
--- a/doc/OnlineDocs/contributed_packages/incidence/api.rst
+++ b/doc/OnlineDocs/contributed_packages/incidence/api.rst
@@ -4,6 +4,8 @@ API Reference
 =============
 
 .. toctree::
+   incidence.rst
+   config.rst
    interface.rst
    matching.rst
    connected.rst

--- a/doc/OnlineDocs/contributed_packages/incidence/config.rst
+++ b/doc/OnlineDocs/contributed_packages/incidence/config.rst
@@ -1,0 +1,5 @@
+Incidence Options
+=================
+
+.. automodule:: pyomo.contrib.incidence_analysis.config
+   :members:

--- a/doc/OnlineDocs/contributed_packages/incidence/incidence.rst
+++ b/doc/OnlineDocs/contributed_packages/incidence/incidence.rst
@@ -1,0 +1,5 @@
+Incident Variables
+==================
+
+.. automodule:: pyomo.contrib.incidence_analysis.incidence
+   :members:

--- a/doc/OnlineDocs/contributed_packages/incidence/tutorial.dm.rst
+++ b/doc/OnlineDocs/contributed_packages/incidence/tutorial.dm.rst
@@ -53,8 +53,7 @@ with fields for each of the four subsets defined by the partition:
 If any variables or constraints are unmatched, the (Jacobian of the) model
 is structurally singular.
 
-.. doctest::
-   :skipif: not scipy_available or not networkx_available or not asl_available
+.. code-block:: python
 
    >>> for var in var_dm_partition.unmatched:
    ...     print(f"  {var.name}")

--- a/doc/OnlineDocs/contributed_packages/incidence/tutorial.dm.rst
+++ b/doc/OnlineDocs/contributed_packages/incidence/tutorial.dm.rst
@@ -97,9 +97,10 @@ And display the variables and constraints contained in each:
 
 .. code-block:: python
 
-   >>> # Overconstrained subsystem
    >>> # Note that while these variables/constraints are uniquely determined,
    >>> # their order is not!
+
+   >>> # Overconstrained subsystem
    >>> for var in oc_var:
    >>>     print(var.name)
    x[1]

--- a/doc/OnlineDocs/contributed_packages/incidence/tutorial.dm.rst
+++ b/doc/OnlineDocs/contributed_packages/incidence/tutorial.dm.rst
@@ -55,17 +55,22 @@ is structurally singular.
 
 .. code-block:: python
 
+   >>> # Note that the unmatched variables/constraints are not mathematically
+   >>> # unique and could change with implementation!
    >>> for var in var_dm_partition.unmatched:
-   ...     print(f"  {var.name}")
+   ...     print(var.name)
    flow_comp[1]
    >>> for con in con_dm_partition.unmatched:
-   ...     print(f"  {con.name}")
+   ...     print(con.name)
    density_eqn
 
 This model has one unmatched constraint and one unmatched variable, so it is
 structurally singular. However, the unmatched variable and constraint are not
 unique. For example, ``flow_comp[2]`` could have been unmatched instead of
-``flow_comp[1]``.
+``flow_comp[1]``. The exact variables and constraints that are unmatched depends
+on both the order in which variables are identified in Pyomo expressions and
+the implementation of the matching algorithm. For a given implementation,
+however, these variables and constraints should be deterministic.
 
 Unique subsets of variables and constraints that are useful when debugging a
 structural singularity are the underconstrained and overconstrained subsystems.
@@ -93,14 +98,16 @@ And display the variables and constraints contained in each:
 .. code-block:: python
 
    >>> # Overconstrained subsystem
+   >>> # Note that while these variables/constraints are uniquely determined,
+   >>> # their order is not!
    >>> for var in oc_var:
-   >>>     print(f"  {var.name}")
+   >>>     print(var.name)
    x[1]
    density
    x[2]
    x[3]
    >>> for con in oc_con:
-   >>>     print(f"  {con.name}")
+   >>>     print(con.name)
    sum_eqn
    holdup_eqn[1]
    holdup_eqn[2]
@@ -109,13 +116,13 @@ And display the variables and constraints contained in each:
 
    >>> # Underconstrained subsystem
    >>> for var in uc_var:
-   >>>     print(f"  {var.name}")
+   >>>     print(var.name)
    flow_comp[1]
    flow
    flow_comp[2]
    flow_comp[3]
    >>> for con in uc_con:
-   >>>     print(f"  {con.name}")
+   >>>     print(con.name)
    flow_eqn[1]
    flow_eqn[2]
    flow_eqn[3]

--- a/pyomo/contrib/incidence_analysis/__init__.py
+++ b/pyomo/contrib/incidence_analysis/__init__.py
@@ -5,3 +5,5 @@ from .scc_solver import (
     generate_strongly_connected_components,
     solve_strongly_connected_components,
 )
+from .incidence import get_incident_variables
+from .config import IncidenceMethod

--- a/pyomo/contrib/incidence_analysis/config.py
+++ b/pyomo/contrib/incidence_analysis/config.py
@@ -1,0 +1,51 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import enum
+from pyomo.common.config import ConfigBlock, ConfigValue, InEnum
+
+
+class IncidenceMethod(enum.Enum):
+    identify_variables = 0
+    standard_repn = 1
+
+
+IncidenceConfig = ConfigBlock()
+
+
+IncidenceConfig.declare(
+    "include_fixed",
+    ConfigValue(
+        default=False,
+        domain=bool,
+        description="Include fixed variables",
+    ),
+)
+
+
+IncidenceConfig.declare(
+    "linear_only",
+    ConfigValue(
+        default=False,
+        domain=bool,
+        description="Only identify variables that participate linearly",
+    ),
+)
+
+
+IncidenceConfig.declare(
+    "method",
+    ConfigValue(
+        default=IncidenceMethod.standard_repn,
+        domain=InEnum(IncidenceMethod),
+        description="Method used to identify incident variables",
+    ),
+)

--- a/pyomo/contrib/incidence_analysis/config.py
+++ b/pyomo/contrib/incidence_analysis/config.py
@@ -8,6 +8,8 @@
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
+"""Configuration options for incidence graph generation
+"""
 
 import enum
 from pyomo.common.config import ConfigBlock, ConfigValue, InEnum
@@ -23,11 +25,7 @@ IncidenceConfig = ConfigBlock()
 
 IncidenceConfig.declare(
     "include_fixed",
-    ConfigValue(
-        default=False,
-        domain=bool,
-        description="Include fixed variables",
-    ),
+    ConfigValue(default=False, domain=bool, description="Include fixed variables"),
 )
 
 

--- a/pyomo/contrib/incidence_analysis/config.py
+++ b/pyomo/contrib/incidence_analysis/config.py
@@ -12,38 +12,68 @@
 """
 
 import enum
-from pyomo.common.config import ConfigBlock, ConfigValue, InEnum
+from pyomo.common.config import ConfigDict, ConfigValue, InEnum
 
 
 class IncidenceMethod(enum.Enum):
+    """Methods for identifying variables that participate in expressions
+
+    """
     identify_variables = 0
+    """Use ``pyomo.core.expr.visitor.identify_variables``"""
+
     standard_repn = 1
+    """Use ``pyomo.repn.standard_repn.generate_standard_repn``"""
 
 
-IncidenceConfig = ConfigBlock()
-
-
-IncidenceConfig.declare(
-    "include_fixed",
-    ConfigValue(default=False, domain=bool, description="Include fixed variables"),
-)
-
-
-IncidenceConfig.declare(
-    "linear_only",
-    ConfigValue(
-        default=False,
-        domain=bool,
-        description="Only identify variables that participate linearly",
+_include_fixed = ConfigValue(
+    default=False,
+    domain=bool,
+    description="Include fixed variables",
+    doc=(
+        "Flag indicating whether fixed variables should be included in the"
+        " incidence graph"
     ),
 )
 
 
-IncidenceConfig.declare(
-    "method",
-    ConfigValue(
-        default=IncidenceMethod.standard_repn,
-        domain=InEnum(IncidenceMethod),
-        description="Method used to identify incident variables",
+_linear_only = ConfigValue(
+    default=False,
+    domain=bool,
+    description="Identify variables that participate linearly",
+    doc=(
+        "Flag indicating whether only variables that participate linearly should"
+        " be included. Note that these are included even if they participate"
+        " nonlinearly as well."
     ),
 )
+
+
+_method = ConfigValue(
+    default=IncidenceMethod.standard_repn,
+    domain=InEnum(IncidenceMethod),
+    description="Method used to identify incident variables",
+)
+
+
+IncidenceConfig = ConfigDict()
+"""Options for incidence graph generation
+
+- ``include_fixed`` -- Flag indicating whether fixed variables should be included
+  in the incidence graph
+- ``linear_only`` -- Flag indicating whether only variables that participate linearly
+  should be included. Note that these are included even if they participate
+  nonlinearly as well
+- ``method`` -- Method used to identify incident variables. Must be a value of the
+  ``IncidenceMethod`` enum.
+
+"""
+
+
+IncidenceConfig.declare("include_fixed", _include_fixed)
+
+
+IncidenceConfig.declare("linear_only", _linear_only)
+
+
+IncidenceConfig.declare("method", _method)

--- a/pyomo/contrib/incidence_analysis/config.py
+++ b/pyomo/contrib/incidence_analysis/config.py
@@ -16,9 +16,8 @@ from pyomo.common.config import ConfigDict, ConfigValue, InEnum
 
 
 class IncidenceMethod(enum.Enum):
-    """Methods for identifying variables that participate in expressions
+    """Methods for identifying variables that participate in expressions"""
 
-    """
     identify_variables = 0
     """Use ``pyomo.core.expr.visitor.identify_variables``"""
 

--- a/pyomo/contrib/incidence_analysis/incidence.py
+++ b/pyomo/contrib/incidence_analysis/incidence.py
@@ -21,7 +21,6 @@ from pyomo.contrib.incidence_analysis.config import IncidenceMethod, IncidenceCo
 #
 # Handlers for different methods of generating the incidence graph
 #
-
 def _get_incident_via_identify_variables(expr, include_fixed):
     # Note that identify_variables will not identify the same variable
     # more than once.
@@ -66,6 +65,28 @@ def _get_incident_via_standard_repn(expr, include_fixed, linear_only):
 
 
 def get_incident_variables(expr, **kwds):
+    """Get variables that participate in an expression
+
+    The exact variables returned depends on the method used to determine incidence.
+    For example, ``method=IncidenceMethod.identify_variables`` will return all
+    variables participating in the expression, while
+    ``method=IncidenceMethod.standard_repn`` will return only the variables
+    identified by ``generate_standard_repn`` which ignores variables that only
+    appear multiplied by a constant factor of zero.
+
+    Keyword arguments must be valid options for ``IncidenceConfig``.
+
+    Parameters
+    ----------
+    expr: ``NumericExpression``
+        Expression to search for variables
+
+    Returns
+    -------
+    list of VarData
+        List containing the variables that participate in the expression
+
+    """
     config = IncidenceConfig(kwds)
     method = config.method
     include_fixed = config.include_fixed

--- a/pyomo/contrib/incidence_analysis/incidence.py
+++ b/pyomo/contrib/incidence_analysis/incidence.py
@@ -8,8 +8,7 @@
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
-"""Functionality for identifying variables that are incident on expressions
-
+"""Functionality for identifying variables that are "incident on" expressions
 """
 import enum
 from pyomo.core.expr.visitor import identify_variables
@@ -43,10 +42,15 @@ def _get_incident_via_standard_repn(expr, include_fixed, linear_only):
         repn = generate_standard_repn(expr, compute_values=False)
 
     linear_vars = list(repn.linear_vars)
+    # TODO: Check coefficients
+    # This is only necessary when handling mutable parameters and fixed
+    # variables as coefficients, which we're punting on for now. Variables
+    # with constant coefficients of zero don't appear here.
     if linear_only:
-        # TODO: Check coefficients
         return linear_vars
     else:
+        # Combine linear, quadratic, and nonlinear variables and filter out
+        # duplicates
         variables = linear_vars
         for var1, var2 in repn.quadratic_vars:
             variables.extend((var1, var2))

--- a/pyomo/contrib/incidence_analysis/incidence.py
+++ b/pyomo/contrib/incidence_analysis/incidence.py
@@ -30,8 +30,7 @@ def _get_incident_via_identify_variables(expr, include_fixed):
 def _get_incident_via_standard_repn(expr, include_fixed, linear_only):
     if include_fixed:
         to_unfix = [
-            var for var in identify_variables(expr, include_fixed=True)
-            if var.fixed
+            var for var in identify_variables(expr, include_fixed=True) if var.fixed
         ]
         context = TemporarySubsystemManager(to_unfix=to_unfix)
     else:

--- a/pyomo/contrib/incidence_analysis/incidence.py
+++ b/pyomo/contrib/incidence_analysis/incidence.py
@@ -15,11 +15,7 @@ from pyomo.core.expr.visitor import identify_variables
 from pyomo.repn import generate_standard_repn
 from pyomo.common.backports import nullcontext
 from pyomo.util.subsystems import TemporarySubsystemManager
-
-
-class IncidenceMethod(enum.Enum):
-    identify_variables = 0
-    standard_repn = 1
+from pyomo.contrib.incidence_analysis.config import IncidenceMethod, IncidenceConfig
 
 
 #
@@ -69,13 +65,11 @@ def _get_incident_via_standard_repn(expr, include_fixed, linear_only):
         return unique_variables
 
 
-def get_incident_variables(
-    expr,
-    include_fixed=False,
-    method=IncidenceMethod.standard_repn,
-    #method=IncidenceMethod.identify_variables,
-    linear_only=False,
-):
+def get_incident_variables(expr, **kwds):
+    config = IncidenceConfig(kwds)
+    method = config.method
+    include_fixed = config.include_fixed
+    linear_only = config.linear_only
     if linear_only and method is IncidenceMethod.identify_variables:
         raise RuntimeError(
             "linear_only=True is not supported when using identify_variables"

--- a/pyomo/contrib/incidence_analysis/incidence.py
+++ b/pyomo/contrib/incidence_analysis/incidence.py
@@ -37,22 +37,18 @@ def _get_incident_via_standard_repn(expr, include_fixed, linear_only):
         context = nullcontext()
 
     with context:
-        repn = generate_standard_repn(expr, compute_values=False)
+        repn = generate_standard_repn(expr, compute_values=False, quadratic=False)
 
-    linear_vars = list(repn.linear_vars)
-    # TODO: Check coefficients
+    # TODO: Check coefficients of linear variables.
     # This is only necessary when handling mutable parameters and fixed
     # variables as coefficients, which we're punting on for now. Variables
     # with constant coefficients of zero don't appear here.
     if linear_only:
-        return linear_vars
+        return list(repn.linear_vars)
     else:
-        # Combine linear, quadratic, and nonlinear variables and filter out
-        # duplicates
-        variables = linear_vars
-        for var1, var2 in repn.quadratic_vars:
-            variables.extend((var1, var2))
-        variables.extend(repn.nonlinear_vars)
+        # Combine linear and nonlinear variables and filter out duplicates. Note
+        # that quadratic=False, so we don't need to include repn.quadratic_vars.
+        variables = repn.linear_vars + repn.nonlinear_vars
         unique_variables = []
         id_set = set()
         for var in variables:

--- a/pyomo/contrib/incidence_analysis/incidence.py
+++ b/pyomo/contrib/incidence_analysis/incidence.py
@@ -1,0 +1,81 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+"""Functionality for identifying variables that are incident on expressions
+
+"""
+import enum
+from pyomo.core.expr.visitor import identify_variables
+from pyomo.repn import generate_standard_repn
+from pyomo.common.backports import nullcontext
+from pyomo.util.subsystems import TemporarySubsystemManager
+
+
+class IncidenceMethod(enum.Enum):
+    identify_variables = 0
+    standard_repn = 1
+
+
+def _get_incident_via_identify_variables(expr, include_fixed):
+    # Note that identify_variables will not identify the same variable
+    # more than once.
+    return list(identify_variables(expr, include_fixed=include_fixed))
+
+
+def _get_incident_via_standard_repn(expr, include_fixed, linear_only):
+    if include_fixed:
+        to_unfix = [
+            var for var in identify_variables(expr, include_fixed=True)
+            if var.fixed
+        ]
+        context = TemporarySubsystemManager(to_unfix=to_unfix)
+    else:
+        context = nullcontext()
+
+    with context:
+        repn = generate_standard_repn(expr, compute_values=False)
+
+    linear_vars = list(repn.linear_vars)
+    if linear_only:
+        # TODO: Check coefficients
+        return linear_vars
+    else:
+        variables = repn.linear_vars + repn.quadratic_vars + repn.nonlinear_vars
+        unique_variables = []
+        id_set = set()
+        for var in variables:
+            v_id = id(var)
+            if v_id not in id_set:
+                id_set.add(v_id)
+                unique_variables.append(var)
+        return unique_variables
+
+
+def get_incident_variables(
+    expr,
+    include_fixed=False,
+    method=IncidenceMethod.standard_repn,
+    #method=IncidenceMethod.identify_variables,
+    linear_only=False,
+):
+    if linear_only and method is IncidenceMethod.identify_variables:
+        raise RuntimeError(
+            "linear_only=True is not supported when using identify_variables"
+        )
+    if method is IncidenceMethod.identify_variables:
+        return _get_incident_via_identify_variables(expr, include_fixed)
+    elif method is IncidenceMethod.standard_repn:
+        return _get_incident_via_standard_repn(expr, include_fixed, linear_only)
+    else:
+        raise ValueError(
+            f"Unrecognized value {method} for the method used to identify incident"
+            f" variables. Valid options are {IncidenceMethod.identify_variables}"
+            f" and {IncidenceMethod.standard_repn}."
+        )

--- a/pyomo/contrib/incidence_analysis/incidence.py
+++ b/pyomo/contrib/incidence_analysis/incidence.py
@@ -22,6 +22,10 @@ class IncidenceMethod(enum.Enum):
     standard_repn = 1
 
 
+#
+# Handlers for different methods of generating the incidence graph
+#
+
 def _get_incident_via_identify_variables(expr, include_fixed):
     # Note that identify_variables will not identify the same variable
     # more than once.

--- a/pyomo/contrib/incidence_analysis/incidence.py
+++ b/pyomo/contrib/incidence_analysis/incidence.py
@@ -89,7 +89,6 @@ def get_incident_variables(expr, **kwds):
     -------
 
     .. doctest::
-       :skipif: not networkx_available
 
        >>> import pyomo.environ as pyo
        >>> from pyomo.contrib.incidence_analysis import get_incident_variables

--- a/pyomo/contrib/incidence_analysis/incidence.py
+++ b/pyomo/contrib/incidence_analysis/incidence.py
@@ -85,6 +85,22 @@ def get_incident_variables(expr, **kwds):
     list of VarData
         List containing the variables that participate in the expression
 
+    Example
+    -------
+
+    .. doctest::
+       :skipif: not networkx_available
+
+       >>> import pyomo.environ as pyo
+       >>> from pyomo.contrib.incidence_analysis import get_incident_variables
+       >>> m = pyo.ConcreteModel()
+       >>> m.x = pyo.Var([1, 2, 3])
+       >>> expr = m.x[1] + 2*m.x[2] + 3*m.x[3]**2
+       >>> print([v.name for v in get_incident_variables(expr)])
+       ['x[1]', 'x[2]', 'x[3]']
+       >>> print([v.name for v in get_incident_variables(expr, linear_only=True)])
+       ['x[1]', 'x[2]']
+
     """
     config = IncidenceConfig(kwds)
     method = config.method

--- a/pyomo/contrib/incidence_analysis/incidence.py
+++ b/pyomo/contrib/incidence_analysis/incidence.py
@@ -8,7 +8,7 @@
 #  rights in this software.
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
-"""Functionality for identifying variables that are "incident on" expressions
+"""Functionality for identifying variables that participate in expressions
 """
 import enum
 from pyomo.core.expr.visitor import identify_variables

--- a/pyomo/contrib/incidence_analysis/incidence.py
+++ b/pyomo/contrib/incidence_analysis/incidence.py
@@ -47,7 +47,10 @@ def _get_incident_via_standard_repn(expr, include_fixed, linear_only):
         # TODO: Check coefficients
         return linear_vars
     else:
-        variables = repn.linear_vars + repn.quadratic_vars + repn.nonlinear_vars
+        variables = linear_vars
+        for var1, var2 in repn.quadratic_vars:
+            variables.extend((var1, var2))
+        variables.extend(repn.nonlinear_vars)
         unique_variables = []
         id_set = set()
         for var in variables:

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -307,12 +307,18 @@ class IncidenceGraphInterface(object):
                     "nl interface (PyomoNLP).\nPlease set the `active` flag "
                     "to True."
                 )
-            if self._config.include_fixed:
+            if kwds:
                 raise ValueError(
-                    "Cannot get the Jacobian with respect to fixed variables "
-                    "from the nl interface (PyomoNLP).\nPlease set the "
-                    "`include_fixed` flag to False."
+                    "Incidence graph generation options, e.g. include_fixed, method,"
+                    " and linear_only, are not supported when generating a graph"
+                    " from a PyomoNLP."
                 )
+            #if self._config.include_fixed:
+            #    raise ValueError(
+            #        "Cannot get the Jacobian with respect to fixed variables "
+            #        "from the nl interface (PyomoNLP).\nPlease set the "
+            #        "`include_fixed` flag to False."
+            #    )
             nlp = model
             self._variables = nlp.get_pyomo_variables()
             self._constraints = [

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -65,9 +65,7 @@ def _check_unindexed(complist):
 
 def get_incidence_graph(variables, constraints, **kwds):
     config = IncidenceConfig(kwds)
-    return get_bipartite_incidence_graph(
-        variables, constraints, **config
-    )
+    return get_bipartite_incidence_graph(variables, constraints, **config)
 
 
 def get_bipartite_incidence_graph(variables, constraints, **kwds):
@@ -273,9 +271,7 @@ class IncidenceGraphInterface(object):
 
     """
 
-    def __init__(
-        self, model=None, active=True, include_inequality=True, **kwds
-    ):
+    def __init__(self, model=None, active=True, include_inequality=True, **kwds):
         """Construct an IncidenceGraphInterface object"""
         # If the user gives us a model or an NLP, we assume they want us
         # to cache the incidence graph for fast analysis later on.

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -298,9 +298,7 @@ class IncidenceGraphInterface(object):
                 (con, i) for i, con in enumerate(self._constraints)
             )
             self._incidence_graph = get_bipartite_incidence_graph(
-                self._variables,
-                self._constraints,
-                **self._config,
+                self._variables, self._constraints, **self._config
             )
         elif pyomo_nlp_available and isinstance(model, pyomo_nlp.PyomoNLP):
             if not active:

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -102,7 +102,7 @@ def get_bipartite_incidence_graph(variables, constraints, include_fixed=True):
     var_node_map = ComponentMap((v, M + i) for i, v in enumerate(variables))
     for i, con in enumerate(constraints):
         #for var in identify_variables(con.expr, include_fixed=include_fixed):
-        for var in get_incident_variables(con.expr, include_fixed=include_fixed):
+        for var in get_incident_variables(con.body, include_fixed=include_fixed):
             if var in var_node_map:
                 graph.add_edge(i, var_node_map[var])
     return graph
@@ -168,7 +168,7 @@ def _generate_variables_in_constraints(constraints, include_fixed=False):
     known_vars = ComponentSet()
     for con in constraints:
         #for var in identify_variables(con.expr, include_fixed=include_fixed):
-        for var in get_incident_variables(con.expr, include_fixed=include_fixed):
+        for var in get_incident_variables(con.body, include_fixed=include_fixed):
             if var not in known_vars:
                 known_vars.add(var)
                 yield var
@@ -202,7 +202,7 @@ def get_structural_incidence_matrix(variables, constraints, include_fixed=True):
         cols.extend(
             var_idx_map[v]
             #for v in identify_variables(con.expr, include_fixed=include_fixed)
-            for v in get_incident_variables(con.expr, include_fixed=include_fixed)
+            for v in get_incident_variables(con.body, include_fixed=include_fixed)
             if v in var_idx_map
         )
         rows.extend([i] * (len(cols) - len(rows)))

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -304,8 +304,7 @@ class IncidenceGraphInterface(object):
             self._incidence_graph = get_bipartite_incidence_graph(
                 self._variables,
                 self._constraints,
-                # Note that include_fixed is not necessary here. We have
-                # already checked this condition above.
+                **self._config,
             )
         elif pyomo_nlp_available and isinstance(model, pyomo_nlp.PyomoNLP):
             if not active:

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -313,12 +313,6 @@ class IncidenceGraphInterface(object):
                     " and linear_only, are not supported when generating a graph"
                     " from a PyomoNLP."
                 )
-            #if self._config.include_fixed:
-            #    raise ValueError(
-            #        "Cannot get the Jacobian with respect to fixed variables "
-            #        "from the nl interface (PyomoNLP).\nPlease set the "
-            #        "`include_fixed` flag to False."
-            #    )
             nlp = model
             self._variables = nlp.get_pyomo_variables()
             self._constraints = [

--- a/pyomo/contrib/incidence_analysis/tests/test_incidence.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_incidence.py
@@ -20,9 +20,7 @@ from pyomo.contrib.incidence_analysis.incidence import (
 
 class _TestIncidence(object):
     def _get_incident_variables(self, expr):
-        raise NotImplementedError(
-            "_TestIncidence should not be used directly"
-        )
+        raise NotImplementedError("_TestIncidence should not be used directly")
 
     def test_basic_incidence(self):
         m = pyo.ConcreteModel()
@@ -47,7 +45,7 @@ class _TestIncidence(object):
         expr = m.x[1] + m.p * m.x[1] * m.x[2] + m.x[1] * pyo.exp(m.x[3])
         variables = self._get_incident_variables(expr)
         self.assertEqual(ComponentSet(variables), ComponentSet(m.x[:]))
-        
+
 
 class TestIncidenceStandardRepn(unittest.TestCase, _TestIncidence):
     def _get_incident_variables(self, expr, **kwds):

--- a/pyomo/contrib/incidence_analysis/tests/test_incidence.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_incidence.py
@@ -1,0 +1,101 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import pyomo.environ as pyo
+import pyomo.common.unittest as unittest
+from pyomo.common.collections import ComponentSet
+from pyomo.contrib.incidence_analysis.incidence import (
+    IncidenceMethod,
+    get_incident_variables,
+)
+
+
+class _TestIncidence(object):
+    def _get_incident_variables(self, expr):
+        raise NotImplementedError(
+            "_TestIncidence should not be used directly"
+        )
+
+    def test_basic_incidence(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var([1, 2, 3])
+        expr = m.x[1] + m.x[1] * m.x[2] + m.x[1] * pyo.exp(m.x[3])
+        variables = self._get_incident_variables(expr)
+        self.assertEqual(ComponentSet(variables), ComponentSet(m.x[:]))
+
+    def test_incidence_with_fixed_variable(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var([1, 2, 3])
+        expr = m.x[1] + m.x[1] * m.x[2] + m.x[1] * pyo.exp(m.x[3])
+        m.x[2].fix()
+        variables = self._get_incident_variables(expr)
+        var_set = ComponentSet(variables)
+        self.assertEqual(var_set, ComponentSet([m.x[1], m.x[3]]))
+
+    def test_incidence_with_mutable_parameter(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var([1, 2, 3])
+        m.p = pyo.Param(mutable=True, initialize=None)
+        expr = m.x[1] + m.p * m.x[1] * m.x[2] + m.x[1] * pyo.exp(m.x[3])
+        variables = self._get_incident_variables(expr)
+        self.assertEqual(ComponentSet(variables), ComponentSet(m.x[:]))
+        
+
+class TestIncidenceStandardRepn(unittest.TestCase, _TestIncidence):
+    def _get_incident_variables(self, expr):
+        method = IncidenceMethod.standard_repn
+        return get_incident_variables(expr, method=method)
+
+    def test_zero_coef(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var([1, 2, 3])
+
+        # generate_standard_repn filters subexpressions with zero coefficients
+        expr = 0 * m.x[1] + 0 * m.x[1] * m.x[2] + 0 * pyo.exp(m.x[3])
+        variables = self._get_incident_variables(expr)
+        self.assertEqual(len(variables), 0)
+
+    def test_variable_minus_itself(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var([1, 2, 3])
+        # standard repn will recognize the zero coefficient and filter x[1]
+        expr = m.x[1] + m.x[2] * m.x[3] - m.x[1]
+        variables = self._get_incident_variables(expr)
+        var_set = ComponentSet(variables)
+        self.assertEqual(var_set, ComponentSet([m.x[2], m.x[3]]))
+
+
+class TestIncidenceIdentifyVariables(unittest.TestCase, _TestIncidence):
+    def _get_incident_variables(self, expr):
+        method = IncidenceMethod.identify_variables
+        return get_incident_variables(expr, method=method)
+
+    def test_zero_coef(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var([1, 2, 3])
+
+        # identify_variables does not eliminate expressions times zero
+        expr = 0 * m.x[1] + 0 * m.x[1] * m.x[2] + 0 * pyo.exp(m.x[3])
+        variables = self._get_incident_variables(expr)
+        self.assertEqual(ComponentSet(variables), ComponentSet(m.x[:]))
+
+    def test_variable_minus_itself(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var([1, 2, 3])
+        # identify_variables will not filter x[1]
+        expr = m.x[1] + m.x[2] * m.x[3] - m.x[1]
+        variables = self._get_incident_variables(expr)
+        var_set = ComponentSet(variables)
+        self.assertEqual(var_set, ComponentSet(m.x[:]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyomo/contrib/incidence_analysis/tests/test_incidence.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_incidence.py
@@ -50,9 +50,9 @@ class _TestIncidence(object):
         
 
 class TestIncidenceStandardRepn(unittest.TestCase, _TestIncidence):
-    def _get_incident_variables(self, expr):
+    def _get_incident_variables(self, expr, **kwds):
         method = IncidenceMethod.standard_repn
-        return get_incident_variables(expr, method=method)
+        return get_incident_variables(expr, method=method, **kwds)
 
     def test_zero_coef(self):
         m = pyo.ConcreteModel()
@@ -72,11 +72,19 @@ class TestIncidenceStandardRepn(unittest.TestCase, _TestIncidence):
         var_set = ComponentSet(variables)
         self.assertEqual(var_set, ComponentSet([m.x[2], m.x[3]]))
 
+    def test_linear_only(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var([1, 2, 3])
+
+        expr = 2 * m.x[1] + 4 * m.x[2] * m.x[1] - m.x[1] * pyo.exp(m.x[3])
+        variables = self._get_incident_variables(expr, linear_only=True)
+        self.assertEqual(ComponentSet(variables), ComponentSet([m.x[1]]))
+
 
 class TestIncidenceIdentifyVariables(unittest.TestCase, _TestIncidence):
-    def _get_incident_variables(self, expr):
+    def _get_incident_variables(self, expr, **kwds):
         method = IncidenceMethod.identify_variables
-        return get_incident_variables(expr, method=method)
+        return get_incident_variables(expr, method=method, **kwds)
 
     def test_zero_coef(self):
         m = pyo.ConcreteModel()

--- a/pyomo/contrib/incidence_analysis/tests/test_incidence.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_incidence.py
@@ -24,6 +24,7 @@ class _TestIncidence(object):
     independent of the method used
 
     """
+
     def _get_incident_variables(self, expr):
         raise NotImplementedError("_TestIncidence should not be used directly")
 

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -1753,9 +1753,9 @@ class TestInterface(unittest.TestCase):
     def test_linear_only(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var([1, 2, 3])
-        m.eq1 = pyo.Constraint(expr=m.x[1]**2 + m.x[2]**2 + m.x[3]**2 == 1)
+        m.eq1 = pyo.Constraint(expr=m.x[1] ** 2 + m.x[2] ** 2 + m.x[3] ** 2 == 1)
         m.eq2 = pyo.Constraint(expr=m.x[2] + pyo.sqrt(m.x[1]) + pyo.exp(m.x[3]) == 1)
-        m.eq3 = pyo.Constraint(expr=m.x[3] + m.x[1]**3 + m.x[2] == 1)
+        m.eq3 = pyo.Constraint(expr=m.x[3] + m.x[1] ** 3 + m.x[2] == 1)
 
         igraph = IncidenceGraphInterface(m, linear_only=True)
         self.assertEqual(igraph.n_edges, 3)

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -1421,7 +1421,8 @@ class TestExceptions(unittest.TestCase):
         m.v2.fix(2.0)
         m._obj = pyo.Objective(expr=0.0)
         nlp = PyomoNLP(m)
-        with self.assertRaisesRegex(ValueError, "fixed variables"):
+        msg = "generation options.*are not supported"
+        with self.assertRaisesRegex(ValueError, msg):
             igraph = IncidenceGraphInterface(nlp, include_fixed=True)
 
     @unittest.skipUnless(scipy_available, "scipy is not available.")

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -1750,6 +1750,22 @@ class TestInterface(unittest.TestCase):
         # so we correctly identify that the system is structurally singular
         self.assertGreater(len(var_dmp.unmatched), 0)
 
+    def test_linear_only(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var([1, 2, 3])
+        m.eq1 = pyo.Constraint(expr=m.x[1]**2 + m.x[2]**2 + m.x[3]**2 == 1)
+        m.eq2 = pyo.Constraint(expr=m.x[2] + pyo.sqrt(m.x[1]) + pyo.exp(m.x[3]) == 1)
+        m.eq3 = pyo.Constraint(expr=m.x[3] + m.x[1]**3 + m.x[2] == 1)
+
+        igraph = IncidenceGraphInterface(m, linear_only=True)
+        self.assertEqual(igraph.n_edges, 3)
+        self.assertEqual(ComponentSet(igraph.variables), ComponentSet([m.x[2], m.x[3]]))
+
+        matching = igraph.maximum_matching()
+        self.assertEqual(len(matching), 2)
+        self.assertIs(matching[m.eq2], m.x[2])
+        self.assertIs(matching[m.eq3], m.x[3])
+
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
 class TestIndexedBlock(unittest.TestCase):

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -10,6 +10,7 @@
 #  ___________________________________________________________________________
 
 import pyomo.environ as pyo
+from pyomo.core.expr.visitor import identify_variables
 from pyomo.common.dependencies import (
     networkx_available,
     plotly_available,
@@ -1683,6 +1684,13 @@ class TestGetAdjacent(unittest.TestCase):
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
 class TestInterface(unittest.TestCase):
+    def test_assumed_constraint_behavior(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var([1, 2, 3])
+        m.con = pyo.Constraint(expr=m.x[1] == m.x[2] - pyo.exp(m.x[3]))
+        var_set = ComponentSet(identify_variables(m.con.body))
+        self.assertEqual(var_set, ComponentSet(m.x[:]))
+
     def test_subgraph_with_fewer_var_or_con(self):
         m = pyo.ConcreteModel()
         m.I = pyo.Set(initialize=[1, 2])

--- a/pyomo/util/subsystems.py
+++ b/pyomo/util/subsystems.py
@@ -148,7 +148,7 @@ class TemporarySubsystemManager(object):
 
     """
 
-    def __init__(self, to_fix=None, to_deactivate=None, to_reset=None):
+    def __init__(self, to_fix=None, to_deactivate=None, to_reset=None, to_unfix=None):
         """
         Arguments
         ---------
@@ -164,6 +164,10 @@ class TemporarySubsystemManager(object):
             List of var data objects that should be reset to their
             original values on exit from this object's context context
             manager.
+        to_unfix: List
+            List of var data objects to be temporarily unfixed. These are
+            restored to their original status on exit from this object's
+            context manager.
 
         """
         if to_fix is None:
@@ -172,18 +176,31 @@ class TemporarySubsystemManager(object):
             to_deactivate = []
         if to_reset is None:
             to_reset = []
+        if to_unfix is None:
+            to_unfix = []
+        if not ComponentSet(to_fix).isdisjoint(ComponentSet(to_unfix)):
+            to_unfix_set = ComponentSet(to_unfix)
+            both = [var for var in to_fix if var in to_unfix_set]
+            var_names = "\n" + "\n".join([var.name for var in both])
+            raise RuntimeError(
+                f"Conflicting instructions: The following variables are present"
+                " in both to_fix and to_unfix lists: {var_names}"
+            )
         self._vars_to_fix = to_fix
         self._cons_to_deactivate = to_deactivate
         self._comps_to_set = to_reset
+        self._vars_to_unfix = to_unfix
         self._var_was_fixed = None
         self._con_was_active = None
         self._comp_original_value = None
+        self._var_was_unfixed = None
 
     def __enter__(self):
         to_fix = self._vars_to_fix
         to_deactivate = self._cons_to_deactivate
         to_set = self._comps_to_set
-        self._var_was_fixed = [(var, var.fixed) for var in to_fix]
+        to_unfix = self._vars_to_unfix
+        self._var_was_fixed = [(var, var.fixed) for var in to_fix + to_unfix]
         self._con_was_active = [(con, con.active) for con in to_deactivate]
         self._comp_original_value = [(comp, comp.value) for comp in to_set]
 
@@ -193,11 +210,18 @@ class TemporarySubsystemManager(object):
         for con in self._cons_to_deactivate:
             con.deactivate()
 
+        for var in self._vars_to_unfix:
+            # As of Pyomo 6.5, attempting to unfix an already unfixed var
+            # does not raise an exception. Here we rely on this behavior.
+            var.unfix()
+
         return self
 
     def __exit__(self, ex_type, ex_val, ex_bt):
         for var, was_fixed in self._var_was_fixed:
-            if not was_fixed:
+            if was_fixed:
+                var.fix()
+            else:
                 var.unfix()
         for con, was_active in self._con_was_active:
             if was_active:

--- a/pyomo/util/tests/test_subsystems.py
+++ b/pyomo/util/tests/test_subsystems.py
@@ -468,6 +468,21 @@ class TestTemporarySubsystemManager(unittest.TestCase):
         # Test that we have properly unfixed variables
         self.assertFalse(any(var.fixed for var in m.component_data_objects(pyo.Var)))
 
+    def test_to_unfix(self):
+        m = _make_simple_model()
+        m.v1.fix()
+        m.v3.fix()
+        with TemporarySubsystemManager(to_unfix=[m.v3]):
+            self.assertTrue(m.v1.fixed)
+            self.assertFalse(m.v2.fixed)
+            self.assertFalse(m.v3.fixed)
+            self.assertFalse(m.v4.fixed)
+
+        self.assertTrue(m.v1.fixed)
+        self.assertFalse(m.v2.fixed)
+        self.assertTrue(m.v3.fixed)
+        self.assertFalse(m.v4.fixed)
+
 
 class TestParamSweeper(unittest.TestCase):
     def test_set_values(self):


### PR DESCRIPTION
## Fixes
Variables with zero coefficients appear in incidence graphs

## Summary/Motivation:
Incidence graphs where `0*x` appears as an edge can lead to incorrect results when analyzing singularity or generating decompositions.

## Changes proposed in this PR:
- `get_incident_variables` function, which accepts a `method` argument that can be used to switch between using `identify_variables` and `generate_standard_repn`
- `IncidenceConfig` `ConfigBlock` to consolidate specification of default options for incidence graph generation
- Tests for this new functionality, including a `linear_only` option for incidence graph generation

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
