### PR TITLE
Skip MOSEK tests on NEOS (due to unknown NEOS error)

### DIFF
--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -146,6 +146,7 @@ class RunAllNEOSSolvers(object):
     def test_minto(self):
         self._run('minto')
 
+    @unittest.skip('[23 May 23] MOSEK Jobs have inexplicably started failing')
     def test_mosek(self):
         self._run('mosek')
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This skips testing MOSEK on NEOS because the NEOS server has started returning unknown errors when sending models to MOSEK.

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
