### PR TITLE
Update cmake builder for recent setuptools

### DIFF
--- a/doc/OnlineDocs/contributed_packages/pynumero/installation.rst
+++ b/doc/OnlineDocs/contributed_packages/pynumero/installation.rst
@@ -10,11 +10,14 @@ https://github.com/Pyomo/pyomo/blob/main/pyomo/contrib/pynumero/build.py
 and
 https://github.com/Pyomo/pyomo/blob/main/pyomo/contrib/pynumero/src/CMakeLists.txt.
 
+Note that you will need a C++ compiler and CMake installed to build the
+PyNumero libraries.
+
 Method 1
 --------
 
 One way to build PyNumero extensions is with the pyomo
-download-extensions and build-extensions subcommands. Note that
+`download-extensions` and `build-extensions` subcommands. Note that
 this approach will build PyNumero without support for the HSL linear
 solvers. ::
 
@@ -27,6 +30,18 @@ Method 2
 If you want PyNumero support for the HSL solvers and you have an IPOPT compilation
 for your machine, you can build PyNumero using the build script ::
 
-  cd pyomo/contrib/pynumero/
-  python build.py -DBUILD_ASL=ON -DBUILD_MA27=ON -DIPOPT_DIR=<path/to/ipopt/build/>
+  python -m pyomo.contrib.pynumero.build -DBUILD_ASL=ON -DBUILD_MA27=ON -DIPOPT_DIR=<path/to/ipopt/build/>
 
+Method 3
+--------
+
+You can build the PyNumero libraries from source using `cmake`.  This
+generally works best when building from a source distribution of Pyomo.
+Assuming that you are starting in the root of the Pyomo source
+distribution, you can follow the normal CMake build process ::
+
+  mkdir build
+  cd build
+  ccmake ../pyomo/contrib/pynumero/src
+  make
+  make install

--- a/pyomo/common/cmake_builder.py
+++ b/pyomo/common/cmake_builder.py
@@ -32,8 +32,10 @@ def handleReadonly(function, path, excinfo):
 def build_cmake_project(
     targets, package_name=None, description=None, user_args=[], parallel=None
 ):
-    import distutils.core
+    # Note: setuptools must be imported before distutils to avoid
+    # warnings / errors with recent setuptools distributions
     from setuptools import Extension
+    import distutils.core
     from distutils.command.build_ext import build_ext
 
     class _CMakeBuild(build_ext, object):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This resolves an error when using the cmake builder directly with recent setuptools distributions.  This resolves errors when attempting to build specific extensions, e.g.,
```
python -m pyomo.contrib.pynumero.build
```

## Changes proposed in this PR:
- Update import order for setuputils/distutils
- Expand PyNumero installation instructions

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
