### PR TITLE
Fix typo in FBBT (GeneralExpression)

### DIFF
--- a/pyomo/contrib/fbbt/fbbt.py
+++ b/pyomo/contrib/fbbt/fbbt.py
@@ -444,7 +444,7 @@ def _prop_bnds_leaf_to_root_GeneralExpression(node, bnds_dict, feasibility_tol):
         is more conservative).
     """
     if node.expr.__class__ in native_types:
-        expr_lb = expr_up = node.expr
+        expr_lb = expr_ub = node.expr
     else:
         expr_lb, expr_ub = bnds_dict[node.expr]
     bnds_dict[node] = (expr_lb, expr_ub)

--- a/pyomo/contrib/fbbt/tests/test_fbbt.py
+++ b/pyomo/contrib/fbbt/tests/test_fbbt.py
@@ -1331,6 +1331,7 @@ class FbbtTestBase(object):
         self.assertAlmostEqual(m.x.lb, 2)
         self.assertAlmostEqual(m.x.ub, 3)
 
+
 class TestFBBT(FbbtTestBase, unittest.TestCase):
     def setUp(self) -> None:
         self.tightener = fbbt

--- a/pyomo/contrib/fbbt/tests/test_fbbt.py
+++ b/pyomo/contrib/fbbt/tests/test_fbbt.py
@@ -1317,6 +1317,19 @@ class FbbtTestBase(object):
         self.assertAlmostEqual(m.y.lb, 0)
         self.assertAlmostEqual(m.y.ub, 3)
 
+    def test_named_expr(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(bounds=(0, None))
+        m.y = pyo.Var(bounds=(1, 6))
+        m.e_const = pyo.Expression(expr=3)
+        m.e_var = pyo.Expression(expr=m.y + m.e_const)
+
+        m.c = pyo.Constraint(expr=m.x**2 == m.e_var)
+
+        self.tightener(m)
+        self.tightener(m)
+        self.assertAlmostEqual(m.x.lb, 2)
+        self.assertAlmostEqual(m.x.ub, 3)
 
 class TestFBBT(FbbtTestBase, unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Fixes #2846

## Summary/Motivation:
This fixes a typo in FBBT, and adds a test to exercise the code.

## Changes proposed in this PR:
- Fix typo, add test

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
