### PR TITLE
Restore slice API broken by #2829

### DIFF
--- a/pyomo/core/base/indexed_component_slice.py
+++ b/pyomo/core/base/indexed_component_slice.py
@@ -338,15 +338,15 @@ class IndexedComponent_slice(object):
         _iter = _IndexedComponent_slice_iter(self, iter_over_index=True, sort=sort)
         return (_iter.get_last_index_wildcards() for _ in _iter)
 
-    def wildcard_keys(self, sort):
+    def wildcard_keys(self, sort=SortComponents.UNSORTED):
         _iter = _IndexedComponent_slice_iter(self, sort=sort)
         return (_iter.get_last_index_wildcards() for _ in _iter)
 
-    def wildcard_values(self, sort):
+    def wildcard_values(self, sort=SortComponents.UNSORTED):
         """Return an iterator over this slice"""
         return _IndexedComponent_slice_iter(self, sort=sort)
 
-    def wildcard_items(self, sort):
+    def wildcard_items(self, sort=SortComponents.UNSORTED):
         _iter = _IndexedComponent_slice_iter(self, sort=sort)
         return ((_iter.get_last_index_wildcards(), _) for _ in _iter)
 

--- a/pyomo/core/tests/unit/test_indexed_slice.py
+++ b/pyomo/core/tests/unit/test_indexed_slice.py
@@ -492,9 +492,9 @@ class TestComponentSlices(unittest.TestCase):
         m = self.m
 
         _slice = self.m.x[...]
-        self.assertEqual(list(_slice.wildcard_keys(False)), [7, 8, 9])
+        self.assertEqual(list(_slice.wildcard_keys()), [7, 8, 9])
         self.assertEqual(
-            list(_slice.wildcard_items(False)), [(7, m.x[7]), (8, m.x[8]), (9, m.x[9])]
+            list(_slice.wildcard_items()), [(7, m.x[7]), (8, m.x[8]), (9, m.x[9])]
         )
         self.assertEqual(list(_slice.expanded_keys()), [7, 8, 9])
         self.assertEqual(
@@ -503,11 +503,11 @@ class TestComponentSlices(unittest.TestCase):
 
         _slice = self.m.b[...]
         self.assertEqual(
-            list(_slice.wildcard_keys(False)),
+            list(_slice.wildcard_keys()),
             [(1, 4), (1, 5), (1, 6), (2, 4), (2, 5), (2, 6), (3, 4), (3, 5), (3, 6)],
         )
         self.assertEqual(
-            list(_slice.wildcard_items(False)),
+            list(_slice.wildcard_items()),
             [
                 ((1, 4), m.b[1, 4]),
                 ((1, 5), m.b[1, 5]),


### PR DESCRIPTION
## Fixes #2844.

## Summary/Motivation:
This restores the old (pre6.6.0) slice API.

## Changes proposed in this PR:
- add argument default to restore previous `slice.wildcard_*()` API
- revert change to test to exercise old API

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
