### PR TITLE
Resolve error identifying vars in indexed SOS

### DIFF
--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -684,7 +684,7 @@ class _NLWriter_impl(object):
         # variable order because the SOS constraint *could* reference a
         # variable not yet seen in the model.
         for block in component_map[SOSConstraint]:
-            for sos in block.component_objects(
+            for sos in block.component_data_objects(
                 SOSConstraint, active=True, descend_into=False, sort=sorter
             ):
                 for v in sos.variables:

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -989,8 +989,6 @@ J0 2
         OUT = io.StringIO()
         with LoggingIntercept() as LOG:
             nl_writer.NLWriter().write(m, OUT, symbolic_solver_labels=True)
-        m.pprint()
-        print(OUT.getvalue())
         self.assertEqual(LOG.getvalue(), "")
         self.assertEqual(
             *nl_diff(


### PR DESCRIPTION
## Fixes #2827

## Summary/Motivation:
The NLv2 writer incorrectly handled iterating over `SOSConstraint` components when identifying model variables.  This PR fixes the issue and adds a test exercising the correct behavior.

## Changes proposed in this PR:
- Resolve error iterating over `SOSConstraint` component data.
- Add test

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
