### PR TITLE
Update indentation handling in `config.StringFormatter`

### DIFF
--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -1307,7 +1307,6 @@ def _formatter_str_to_item_callback(pattern, formatter):
         else:
             self.out.write(_doc + '\n')
 
-
     return types.MethodType(_item_body_cb, formatter)
 
 

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -1293,7 +1293,7 @@ def _formatter_str_to_item_callback(pattern, formatter):
         if not _doc:
             return ''
         wraplines = '\n ' not in _doc
-        _doc = _item_body_formatter(_doc).strip()
+        _doc = _item_body_formatter(_doc).rstrip()
         if not _doc:
             return ''
         _indent = indent + ' ' * self.indent_spacing
@@ -1302,8 +1302,11 @@ def _formatter_str_to_item_callback(pattern, formatter):
                 _doc, self.width, initial_indent=_indent, subsequent_indent=_indent
             )
             self.out.write(('\n'.join(doc_lines)).rstrip() + '\n')
+        elif _doc.lstrip() == _doc:
+            self.out.write(_indent + _doc + '\n')
         else:
-            self.out.write(_doc.rstrip() + '\n')
+            self.out.write(_doc + '\n')
+
 
     return types.MethodType(_item_body_cb, formatter)
 

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -2037,7 +2037,7 @@ endBlock{}
             width=66,
         )
 
-        #print(doc)
+        # print(doc)
         ref = """    option_1
         The first configuration option
 
@@ -2074,7 +2074,7 @@ endBlock{}
 """
         self.assertEqual(
             [_.rstrip() for _ in ref.splitlines()],
-            [_.rstrip() for _ in doc.splitlines()]
+            [_.rstrip() for _ in doc.splitlines()],
         )
 
     def test_block_get(self):

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -2022,7 +2022,8 @@ endBlock{}
 
     def test_generate_documentation_StringFormatter(self):
         # This test verifies behavior with simple StringFormatters (in
-        # particular, the handling of newlines and indentation)
+        # particular, the handling of newlines and indentation reported
+        # in #IDAES/idaes-pse#1191)
         CONFIG = ExampleConfig()
         doc = CONFIG.generate_documentation(
             format=String_ConfigFormatter(


### PR DESCRIPTION
## Fixes #IDAES/idaes-pse#1191

## Summary/Motivation:
#IDAES/idaes-pse#1191 noted a change in how the (legacy) `StringFormatter` handled the indentation on the first line of the item body.  This PR proposes a compromise between restoring the original pre #2754 behavior (i.e., ignore all indenting when outputting an item body with internal formatting) and ensuring that the first line of the item body is indented to the correct level.  Here we will use the `doc`'s indentation if the first line starts with *any* whitespace, and if the `doc` does not begin with any whitespace, then we will prepend the current indent.

## Changes proposed in this PR:
- Partially revert changes how the StringFormatter indents "item body" sections 
- Add tests to explicitly test the behavior from #IDAES/idaes-pse#1191

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
