### PR TITLE
Silence deprecation warnings

### DIFF
--- a/pyomo/common/tests/test_deprecated.py
+++ b/pyomo/common/tests/test_deprecated.py
@@ -59,7 +59,7 @@ class TestDeprecated(unittest.TestCase):
 
     def test_no_version_exception(self):
         with self.assertRaisesRegex(
-            DeveloperError, "@deprecated\(\): missing 'version' argument"
+            DeveloperError, r"@deprecated\(\): missing 'version' argument"
         ):
 
             @deprecated()
@@ -67,7 +67,7 @@ class TestDeprecated(unittest.TestCase):
                 pass
 
         with self.assertRaisesRegex(
-            DeveloperError, "@deprecated\(\): missing 'version' argument"
+            DeveloperError, r"@deprecated\(\): missing 'version' argument"
         ):
 
             @deprecated()
@@ -262,7 +262,7 @@ class TestDeprecated(unittest.TestCase):
         self.assertIs(type(foo), type)
         self.assertRegex(
             foo.__doc__,
-            r'.. deprecated:: test\n' r'   This class \(.*\.foo\) has been deprecated',
+            r'.. deprecated:: test\n   This class \(.*\.foo\) has been deprecated',
         )
 
         # Test the default argument

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -468,7 +468,7 @@ class _AssertRaisesContext_NormalizeWhitespace(_unittest.case._AssertRaisesConte
         finally:
             self.expected_regex = _save_re
 
-        exc_value = re.sub('(?s)\s+', ' ', str(exc_value))
+        exc_value = re.sub(r'(?s)\s+', ' ', str(exc_value))
         if not _save_re.search(exc_value):
             self._raiseFailure(
                 '"{}" does not match "{}"'.format(_save_re.pattern, exc_value)

--- a/pyomo/contrib/doe/doe.py
+++ b/pyomo/contrib/doe/doe.py
@@ -1035,7 +1035,7 @@ class DesignOfExperiments:
             return m.trace == sum(m.fim[j, j] for j in m.regression_parameters)
 
         def det_general(m):
-            """Calculate determinant. Can be applied to FIM of any size.
+            r"""Calculate determinant. Can be applied to FIM of any size.
             det(A) = sum_{\sigma \in \S_n} (sgn(\sigma) * \Prod_{i=1}^n a_{i,\sigma_i})
             Use permutation() to get permutations, sgn() to get signature
             """

--- a/pyomo/contrib/mindtpy/util.py
+++ b/pyomo/contrib/mindtpy/util.py
@@ -153,7 +153,8 @@ def generate_norm2sq_objective_function(model, setpoint_model, discrete_only=Fal
     setpoint_model : Pyomo model
         The model that provides the base point for us to calculate the distance.
     discrete_only : bool, optional
-        Whether to only optimize on distance between the discrete variables, by default False.
+        Whether to only optimize on distance between the discrete
+        variables, by default False.
 
     Returns
     -------
@@ -208,12 +209,14 @@ def generate_norm1_objective_function(model, setpoint_model, discrete_only=False
     setpoint_model : Pyomo model
         The model that provides the base point for us to calculate the distance.
     discrete_only : bool, optional
-        Whether to only optimize on distance between the discrete variables, by default False.
+        Whether to only optimize on distance between the discrete
+        variables, by default False.
 
     Returns
     -------
     Objective
         The norm1 objective function.
+
     """
     # skip objective_value variable and slack_var variables
     var_filter = (
@@ -453,7 +456,9 @@ def generate_norm1_norm_constraint(model, setpoint_model, config, discrete_only=
     config : ConfigBlock
         The specific configurations for MindtPy.
     discrete_only : bool, optional
-        Whether to only optimize on distance between the discrete variables, by default True.
+        Whether to only optimize on distance between the discrete
+        variables, by default True.
+
     """
     var_filter = (lambda v: v.is_integer()) if discrete_only else (lambda v: True)
     model_vars = list(filter(var_filter, model.MindtPy_utils.variable_list))

--- a/pyomo/contrib/mindtpy/util.py
+++ b/pyomo/contrib/mindtpy/util.py
@@ -141,7 +141,8 @@ def add_var_bound(model, config):
 
 
 def generate_norm2sq_objective_function(model, setpoint_model, discrete_only=False):
-    """This function generates objective (FP-NLP subproblem) for minimum euclidean distance to setpoint_model.
+    r"""This function generates objective (FP-NLP subproblem) for minimum
+    euclidean distance to setpoint_model.
 
     L2 distance of (x,y) = \sqrt{\sum_i (x_i - y_i)^2}.
 
@@ -195,7 +196,8 @@ def generate_norm2sq_objective_function(model, setpoint_model, discrete_only=Fal
 
 
 def generate_norm1_objective_function(model, setpoint_model, discrete_only=False):
-    """This function generates objective (PF-OA main problem) for minimum Norm1 distance to setpoint_model.
+    r"""This function generates objective (PF-OA main problem) for minimum
+    Norm1 distance to setpoint_model.
 
     Norm1 distance of (x,y) = \sum_i |x_i - y_i|.
 
@@ -433,9 +435,12 @@ def generate_lag_objective_function(
 
 
 def generate_norm1_norm_constraint(model, setpoint_model, config, discrete_only=True):
-    """This function generates constraint (PF-OA main problem) for minimum Norm1 distance to setpoint_model.
+    r"""This function generates constraint (PF-OA main problem) for minimum
+    Norm1 distance to setpoint_model.
 
-    Norm constraint is used to guarantees the monotonicity of the norm objective value sequence of all iterations
+    Norm constraint is used to guarantees the monotonicity of the norm
+    objective value sequence of all iterations.
+
     Norm1 distance of (x,y) = \sum_i |x_i - y_i|.
     Ref: Paper 'A storm of feasibility pumps for nonconvex MINLP' Eq. (16).
 

--- a/pyomo/contrib/parmest/parmest.py
+++ b/pyomo/contrib/parmest/parmest.py
@@ -1234,7 +1234,7 @@ class Estimator(object):
     def likelihood_ratio_test(
         self, obj_at_theta, obj_value, alphas, return_thresholds=False
     ):
-        """
+        r"""
         Likelihood ratio test to identify theta values within a confidence
         region using the :math:`\chi^2` distribution
 

--- a/pyomo/core/base/sos.py
+++ b/pyomo/core/base/sos.py
@@ -131,7 +131,7 @@ class SOSConstraint(ActiveIndexedComponent):
       model = AbstractModel()
       model.A = Set()
       model.B = Set(A)
-      model.X = Set(B)
+      model.X = Var(B)
 
       model.C1 = SOSConstraint(model.A, var=model.X, set=model.B, sos=1)
 


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This PR silences some deprecation warnings by using raw strings for strings containing backslashes.

## Changes proposed in this PR:
- convert certain strings to raw strings
- minor docstring reformatting
- correct error in SOSConstraint docs

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
