### PR TITLE
Resolve handling of {}**0 in LinearRepn/QuadraticRepn

### DIFF
--- a/pyomo/repn/linear.py
+++ b/pyomo/repn/linear.py
@@ -344,6 +344,8 @@ def _handle_pow_ANY_constant(visitor, node, arg1, arg2):
                 visitor, None, ans, (_type, _arg.duplicate())
             )
         return ans
+    elif exp == 0:
+        return _CONSTANT, 1
     else:
         return _handle_pow_nonlinear(visitor, node, arg1, arg2)
 

--- a/pyomo/repn/tests/test_linear.py
+++ b/pyomo/repn/tests/test_linear.py
@@ -852,6 +852,18 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(repn.linear, {id(m.x): 1})
         self.assertEqual(repn.nonlinear, None)
 
+        m.p = 0
+
+        cfg = VisitorConfig()
+        repn = LinearRepnVisitor(*cfg).walk_expression(e)
+        self.assertEqual(cfg.subexpr, {})
+        self.assertEqual(cfg.var_map, {id(m.x): m.x})
+        self.assertEqual(cfg.var_order, {id(m.x): 0})
+        self.assertEqual(repn.multiplier, 1)
+        self.assertEqual(repn.constant, 1)
+        self.assertEqual(repn.linear, {})
+        self.assertEqual(repn.nonlinear, None)
+
         m.p = 2
 
         cfg = VisitorConfig()


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This resolves an error we were seeing in the performance tests where x**0 was being categorized as a nonlinear expression instead of resolving it to the constant 1.

## Changes proposed in this PR:
- Compile {}**0 to 1 in `LinearRepnVisitor` / `QuadraticRepnVisitor`
- Update tests to cover this case

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
