### PR TITLE
Fix Linear/QuadraticRepnVisitor handling of `{}**{float}`

### DIFF
--- a/pyomo/repn/linear.py
+++ b/pyomo/repn/linear.py
@@ -336,10 +336,10 @@ def _handle_pow_ANY_constant(visitor, node, arg1, arg2):
     _, exp = arg2
     if exp == 1:
         return arg1
-    elif exp > 0 and exp <= visitor.max_exponential_expansion and int(exp) == exp:
+    elif exp > 1 and exp <= visitor.max_exponential_expansion and int(exp) == exp:
         _type, _arg = arg1
         ans = _type, _arg.duplicate()
-        for i in range(1, exp):
+        for i in range(1, int(exp)):
             ans = visitor.exit_node_dispatcher[(ProductExpression, ans[0], _type)](
                 visitor, None, ans, (_type, _arg.duplicate())
             )

--- a/pyomo/repn/tests/test_quadratic.py
+++ b/pyomo/repn/tests/test_quadratic.py
@@ -262,7 +262,7 @@ class TestQuadratic(unittest.TestCase):
 
         # Check **{int}
         cfg = VisitorConfig()
-        repn = QuadraticRepnVisitor(*cfg).walk_expression((1 + 3*m.x + 4*m.y)**2)
+        repn = QuadraticRepnVisitor(*cfg).walk_expression((1 + 3 * m.x + 4 * m.y) ** 2)
         self.assertEqual(cfg.subexpr, {})
         self.assertEqual(cfg.var_map, {id(m.x): m.x, id(m.y): m.y})
         self.assertEqual(cfg.var_order, {id(m.x): 0, id(m.y): 1})
@@ -277,7 +277,9 @@ class TestQuadratic(unittest.TestCase):
 
         # Check **{int}
         cfg = VisitorConfig()
-        repn = QuadraticRepnVisitor(*cfg).walk_expression((1 + 3*m.x + 4*m.y)**2.0)
+        repn = QuadraticRepnVisitor(*cfg).walk_expression(
+            (1 + 3 * m.x + 4 * m.y) ** 2.0
+        )
         self.assertEqual(cfg.subexpr, {})
         self.assertEqual(cfg.var_map, {id(m.x): m.x, id(m.y): m.y})
         self.assertEqual(cfg.var_order, {id(m.x): 0, id(m.y): 1})

--- a/pyomo/repn/tests/test_quadratic.py
+++ b/pyomo/repn/tests/test_quadratic.py
@@ -254,3 +254,38 @@ class TestQuadratic(unittest.TestCase):
         self.assertEqual(repn.linear, {id(m.x): 1, id(m.y): 2})
         self.assertEqual(repn.quadratic, {(id(m.y), id(m.y)): 1, (id(m.x), id(m.y)): 3})
         assertExpressionsEqual(self, repn.nonlinear, m.y**3 + 2 * m.x**4)
+
+    def test_pow(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var()
+
+        # Check **{int}
+        cfg = VisitorConfig()
+        repn = QuadraticRepnVisitor(*cfg).walk_expression((1 + 3*m.x + 4*m.y)**2)
+        self.assertEqual(cfg.subexpr, {})
+        self.assertEqual(cfg.var_map, {id(m.x): m.x, id(m.y): m.y})
+        self.assertEqual(cfg.var_order, {id(m.x): 0, id(m.y): 1})
+        self.assertEqual(repn.multiplier, 1)
+        self.assertEqual(repn.constant, 1)
+        self.assertEqual(repn.linear, {id(m.x): 6, id(m.y): 8})
+        self.assertEqual(
+            repn.quadratic,
+            {(id(m.x), id(m.x)): 9, (id(m.y), id(m.y)): 16, (id(m.x), id(m.y)): 24},
+        )
+        self.assertEqual(repn.nonlinear, None)
+
+        # Check **{int}
+        cfg = VisitorConfig()
+        repn = QuadraticRepnVisitor(*cfg).walk_expression((1 + 3*m.x + 4*m.y)**2.0)
+        self.assertEqual(cfg.subexpr, {})
+        self.assertEqual(cfg.var_map, {id(m.x): m.x, id(m.y): m.y})
+        self.assertEqual(cfg.var_order, {id(m.x): 0, id(m.y): 1})
+        self.assertEqual(repn.multiplier, 1)
+        self.assertEqual(repn.constant, 1)
+        self.assertEqual(repn.linear, {id(m.x): 6, id(m.y): 8})
+        self.assertEqual(
+            repn.quadratic,
+            {(id(m.x), id(m.x)): 9, (id(m.y), id(m.y)): 16, (id(m.x), id(m.y)): 24},
+        )
+        self.assertEqual(repn.nonlinear, None)


### PR DESCRIPTION
## Fixes #2862

## Summary/Motivation:
This resolves a type error when a constant exponent is a floating point value.

## Changes proposed in this PR:
- Cast exponent to `int` before passing to `range()`
- Add test for `{}**{float}`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
