### PR TITLE
Additional fixes for LinearRepn

### DIFF
--- a/pyomo/repn/linear.py
+++ b/pyomo/repn/linear.py
@@ -36,7 +36,7 @@ from pyomo.core.expr.relational_expr import (
     RangedExpression,
 )
 from pyomo.core.expr.visitor import StreamBasedExpressionVisitor, _EvaluationVisitor
-from pyomo.core.expr import is_fixed
+from pyomo.core.expr import is_fixed, value
 from pyomo.core.base.expression import ScalarExpression, _GeneralExpressionData
 from pyomo.core.base.objective import ScalarObjective, _GeneralObjectiveData
 import pyomo.core.kernel as kernel
@@ -756,7 +756,7 @@ def _register_new_before_child_dispatcher(visitor, child):
     dispatcher = _before_child_dispatcher
     child_type = child.__class__
     if child_type in native_numeric_types:
-        if isinstance(child_type, complex):
+        if issubclass(child_type, complex):
             _complex_types.add(child_type)
             dispatcher[child_type] = _before_complex
         else:
@@ -775,7 +775,7 @@ def _register_new_before_child_dispatcher(visitor, child):
         if pv_base_type not in dispatcher:
             try:
                 child.__class__ = pv_base_type
-                _register_new_before_child_dispatcher(self, child)
+                _register_new_before_child_dispatcher(visitor, child)
             finally:
                 child.__class__ = child_type
         if pv_base_type in visitor.exit_node_handlers:


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This is a follow-up to $2863 to address a few additional errors in the `LinearRepn` (and to expand the suite of unit tests.

## Changes proposed in this PR:
- Resolve additional errors in `LinearRepn` and `_register_new_before_child_dispatcher()`
- Expand unit tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
