### PR TITLE
PyNumero: Fix typo in docstring

### DIFF
--- a/pyomo/contrib/pynumero/interfaces/external_grey_box.py
+++ b/pyomo/contrib/pynumero/interfaces/external_grey_box.py
@@ -33,7 +33,7 @@ logger = logging.getLogger('pyomo.contrib.pynumero')
 This module is used for interfacing an external model as
 a block in a Pyomo model.
 
-An ExternalGreyBoxModel is model is a model that does not
+An ExternalGreyBoxModel is a model that does not
 provide constraints explicitly as algebraic expressions, but
 instead provides a set of methods that can compute the residuals
 of the constraints (or outputs) and their derivatives.


### PR DESCRIPTION
## Summary/Motivation:
Fix a small typo in a PyNumero docstring

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
