### PR TITLE
Infrastructure Fix: New Mac Version Failure

### DIFF
--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -229,9 +229,14 @@ class TestFileUtils(unittest.TestCase):
             os.path.join(subdir, subdir_name),
         )
 
+    # TODO: Remove this when Python 3.7 is no longer supported
     @unittest.skipIf(
-        sys.version_info[:2] < (3, 8) and platform.mac_ver()[0].startswith('10.16'),
-        "find_library has known bugs in Big Sur for Python<3.8",
+        sys.version_info[:2] < (3, 8)
+        and (
+            platform.mac_ver()[0].startswith('10.16')
+            or platform.mac_ver()[0].startswith('12.6')
+        ),
+        "find_library has known bugs in Big Sur/Monterey for Python<3.8",
     )
     def test_find_library_system(self):
         # Find a system library (before we muck with the PATH)


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:

GitHub Actions bumped the `macos-latest` version from 12.6.5 to 12.6.6, and that changed what prints out when one runs `platform.mac_ver()` in Python. A test that is supposed to be skipped is being run. This adds a hack to make the skip work, to be removed after the next Pyomo release.

## Changes proposed in this PR:
- HACK to make `osx/3.7` work again

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
