### PR TITLE
Fall back on `multiprocessing.dummy` when `multiprocessing.Pool` is not available

### DIFF
--- a/pyomo/common/env.py
+++ b/pyomo/common/env.py
@@ -66,6 +66,7 @@ def _load_dll(name, timeout=10):
         return False, None
 
     import multiprocessing
+
     if _load_dll.pool is None:
         try:
             _load_dll.pool = multiprocessing.Pool(1)
@@ -75,6 +76,7 @@ def _load_dll(name, timeout=10):
             # launched within a dask server).  Fall back on a serial
             # process (and live with the risk that the import hangs).
             import multiprocessing.dummy
+
             _load_dll.pool = multiprocessing.dummy.Pool(1)
     job = _load_dll.pool.apply_async(_attempt_ctypes_cdll, (name,))
     try:


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This resolves an issue reported by a user when running Pyomo within DASK. Dask runs services within a daemonic process, which is not compatible with `multiprocessing.Pool`, raising the following exception:
```
Traceback (most recent call last):
  File "<ipython-input-1-ffd19c2d3298>", 
  [.....]
  File "[...]\Python37\lib\site-packages\pyomo\contrib\pynumero\interfaces\pyomo_grey_box_nlp.py", line 63, in __init__
    self._pyomo_nlp = PyomoNLP(pyomo_model)
  File "[...]\Python37\lib\site-packages\pyomo\contrib\pynumero\interfaces\pyomo_nlp.py", line 107, in __init__
    with CtypesEnviron(AMPLFUNC=amplfunc):
  File "[...]\Python37\lib\site-packages\pyomo\common\env.py", line 445, in __init__
    _RestorableEnvironInterface(dll) for dll in self.DLLs if dll.available()
  File "[...]\Python37\lib\site-packages\pyomo\common\env.py", line 445, in <genexpr>
    _RestorableEnvironInterface(dll) for dll in self.DLLs if dll.available()
  File "[...]\Python37\lib\site-packages\pyomo\common\env.py", line 286, in available
    self._loaded, self.dll = _load_dll(self._libname)
  File "[...]\Python37\lib\site-packages\pyomo\common\env.py", line 69, in _load_dll
    _load_dll.pool = multiprocessing.Pool(1)
  File "[...]\Python37\lib\multiprocessing\context.py", line 119, in Pool
    context=self.get_context())
  File "[...]\Python37\lib\multiprocessing\pool.py", line 176, in __init__
    self._repopulate_pool()
  File "[...]\Python37\lib\multiprocessing\pool.py", line 241, in _repopulate_pool
    w.start()
  File "[...]\Python37\lib\multiprocessing\process.py", line 110, in start
    'daemonic processes are not allowed to have children'
AssertionError: daemonic processes are not allowed to have children
```
This PR avoids that fatal exception by falling back on `multiprocessing.dummy`.

This also updates imports to avoid importing `multiprocessing` as part of `pyomo.environ`.


## Changes proposed in this PR:
- Fall back on `multiprocessing.dummy` in environments where `multiprocessing.Pool` is not supported.
- Defer import of multiprocessing until needed

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
