### PR TITLE
Correctly Process Objective Bounds from Gurobi for Nonconvex QCPs

### DIFF
--- a/pyomo/contrib/appsi/solvers/gurobi.py
+++ b/pyomo/contrib/appsi/solvers/gurobi.py
@@ -905,21 +905,18 @@ class Gurobi(PersistentBase, PersistentSolver):
         results.best_feasible_objective = None
         results.best_objective_bound = None
         if self._objective is not None:
-            if gprob.SolCount > 0:
-                try:
-                    results.best_feasible_objective = gprob.ObjVal
-                except (gurobipy.GurobiError, AttributeError):
-                    results.best_feasible_objective = None
             try:
-                if gprob.NumBinVars + gprob.NumIntVars == 0:
-                    results.best_objective_bound = gprob.ObjVal
-                else:
-                    results.best_objective_bound = gprob.ObjBound
+                results.best_feasible_objective = gprob.ObjVal
+            except (gurobipy.GurobiError, AttributeError):
+                results.best_feasible_objective = None
+            try:
+                results.best_objective_bound = gprob.ObjBound
             except (gurobipy.GurobiError, AttributeError):
                 if self._objective.sense == minimize:
                     results.best_objective_bound = -math.inf
                 else:
                     results.best_objective_bound = math.inf
+
             if results.best_feasible_objective is not None and not math.isfinite(
                 results.best_feasible_objective
             ):

--- a/pyomo/contrib/appsi/solvers/tests/test_gurobi_persistent.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_gurobi_persistent.py
@@ -179,6 +179,45 @@ class TestGurobiPersistentSimpleLPUpdates(unittest.TestCase):
 
 
 class TestGurobiPersistent(unittest.TestCase):
+    def test_nonconvex_qcp_objective_bound_1(self):
+        # the goal of this test is to ensure we can get an objective bound
+        # for nonconvex but continuous problems even if a feasible solution
+        # is not found
+        #
+        # This is a fragile test because it could fail if Gurobi's algorithms improve
+        # (e.g., a heuristic solution is found before an objective bound of -8 is reached
+        m = pe.ConcreteModel()
+        m.x = pe.Var(bounds=(-5, 5))
+        m.y = pe.Var(bounds=(-5, 5))
+        m.obj = pe.Objective(expr=-m.x**2 - m.y)
+        m.c1 = pe.Constraint(expr=m.y <= -2*m.x + 1)
+        m.c2 = pe.Constraint(expr=m.y <= m.x - 2)
+        opt = Gurobi()
+        opt.gurobi_options['nonconvex'] = 2
+        opt.gurobi_options['BestBdStop'] = -8
+        opt.config.load_solution = False
+        res = opt.solve(m)
+        self.assertEqual(res.best_feasible_objective, None)
+        self.assertAlmostEqual(res.best_objective_bound, -8)
+
+    def test_nonconvex_qcp_objective_bound_2(self):
+        # the goal of this test is to ensure we can best_objective_bound properly
+        # for nonconvex but continuous problems when the solver terminates with a nonzero gap
+        #
+        # This is a fragile test because it could fail if Gurobi's algorithms change
+        m = pe.ConcreteModel()
+        m.x = pe.Var(bounds=(-5, 5))
+        m.y = pe.Var(bounds=(-5, 5))
+        m.obj = pe.Objective(expr=-m.x**2 - m.y)
+        m.c1 = pe.Constraint(expr=m.y <= -2*m.x + 1)
+        m.c2 = pe.Constraint(expr=m.y <= m.x - 2)
+        opt = Gurobi()
+        opt.gurobi_options['nonconvex'] = 2
+        opt.gurobi_options['MIPGap'] = 0.5
+        res = opt.solve(m)
+        self.assertAlmostEqual(res.best_feasible_objective, -4)
+        self.assertAlmostEqual(res.best_objective_bound, -6)
+
     def test_range_constraints(self):
         m = pe.ConcreteModel()
         m.x = pe.Var()


### PR DESCRIPTION
## Summary/Motivation:
Currently, the appsi interface to Gurobi does not correctly set `results.best_objective_bound` for nonconvex QCPs when Gurobi terminates with a nonzero gap. This PR fixes that.

The tests I added are rather fragile, but I can't think of a better way to test this. If anyone has ideas, please let me know.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
