### PR TITLE
Add `PyNumeroEvaluationError`

### DIFF
--- a/pyomo/contrib/pynumero/asl.py
+++ b/pyomo/contrib/pynumero/asl.py
@@ -11,6 +11,7 @@
 
 from pyomo.common.fileutils import find_library
 from pyomo.common.dependencies import numpy as np
+from pyomo.contrib.pynumero.exceptions import PyNumeroEvaluationError
 import ctypes
 import logging
 import os
@@ -364,7 +365,8 @@ class AmplInterface(object):
         res = self.ASLib.EXTERNAL_AmplInterface_eval_f(
             self._obj, x, self._nx, ctypes.byref(sol)
         )
-        assert res, "Error in AMPL evaluation"
+        if not res:
+            raise PyNumeroEvaluationError("Error in AMPL evaluation")
         return sol.value
 
     def eval_deriv_f(self, x, df):
@@ -373,7 +375,8 @@ class AmplInterface(object):
             x.dtype == np.double
         ), "Error: array type. Function eval_deriv_f expects an array of type double"
         res = self.ASLib.EXTERNAL_AmplInterface_eval_deriv_f(self._obj, x, df, len(x))
-        assert res, "Error in AMPL evaluation"
+        if not res:
+            raise PyNumeroEvaluationError("Error in AMPL evaluation")
 
     def struct_jac_g(self, irow, jcol):
         irow_p = irow.astype(np.intc, casting='safe', copy=False)
@@ -409,7 +412,8 @@ class AmplInterface(object):
         res = self.ASLib.EXTERNAL_AmplInterface_eval_jac_g(
             self._obj, xeval, self._nx, jac_eval, self._nnz_jac_g
         )
-        assert res, "Error in AMPL evaluation"
+        if not res:
+            raise PyNumeroEvaluationError("Error in AMPL evaluation")
 
     def eval_g(self, x, g):
         assert x.size == self._nx, "Error: Dimension mismatch."
@@ -423,7 +427,8 @@ class AmplInterface(object):
         res = self.ASLib.EXTERNAL_AmplInterface_eval_g(
             self._obj, x, self._nx, g, self._ny
         )
-        assert res, "Error in AMPL evaluation"
+        if not res:
+            raise PyNumeroEvaluationError("Error in AMPL evaluation")
 
     def eval_hes_lag(self, x, lam, hes_lag, obj_factor=1.0):
         assert x.size == self._nx, "Error: Dimension mismatch."
@@ -453,7 +458,8 @@ class AmplInterface(object):
             res = self.ASLib.EXTERNAL_AmplInterface_eval_hes_lag(
                 self._obj, x, self._nx, lam, self._ny, hes_lag, self._nnz_hess
             )
-        assert res, "Error in AMPL evaluation"
+        if not res:
+            raise PyNumeroEvaluationError("Error in AMPL evaluation")
 
     def finalize_solution(self, ampl_solve_status_num, msg, x, lam):
         b_msg = msg.encode('utf-8')

--- a/pyomo/contrib/pynumero/exceptions.py
+++ b/pyomo/contrib/pynumero/exceptions.py
@@ -9,10 +9,12 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+
 class PyNumeroEvaluationError(ArithmeticError):
     """An exception to be raised by PyNumero evaluation backends in the event
     of a failed function evaluation. This should be caught by solver interfaces
     and translated to the solver-specific evaluation error API.
 
     """
+
     pass

--- a/pyomo/contrib/pynumero/exceptions.py
+++ b/pyomo/contrib/pynumero/exceptions.py
@@ -1,0 +1,18 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+class PyNumeroEvaluationError(ArithmeticError):
+    """An exception to be raised by PyNumero evaluation backends in the event
+    of a failed function evaluation. This should be caught by solver interfaces
+    and translated to the solver-specific evaluation error API.
+
+    """
+    pass


### PR DESCRIPTION
## Fixes #2899

Partially.

## Summary/Motivation:
To handle evaluation errors in PyNumero solver interfaces currently, we would have to catch `AssertionErrors`, which seems dangerous.

This is WIP for now as I haven't written any tests.

## Changes proposed in this PR:
- Add `PyNumeroEvaluationError` in a new `pyomo.contrib.pynumero.exceptions` module

This error is currently raised in the `AmplInterface` functions, at the same location the old asserts happened. We could imagine a different API where the low-level evaluation functions return some `EvaluationResult` object that contains error information, then it is the `NLP`'s responsibility to raise the exception (currently the `AmplInterface` evaluation methods don't return anything). This would make it easier to return useful debugging information to the NLP, which has access to the Pyomo variables and constraints needed to display useful information. I've punted on trying to do anything like this for now, but don't think the current design precludes doing this in the future.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
