### PR TITLE
Resolve `FileDownloader.get_os_version` exception for missing `lsb_release`

### DIFF
--- a/pyomo/common/download.py
+++ b/pyomo/common/download.py
@@ -15,6 +15,7 @@ import logging
 import os
 import platform
 import re
+import shutil
 import sys
 import subprocess
 
@@ -99,14 +100,15 @@ class FileDownloader(object):
 
     @classmethod
     def _get_distver_from_lsb_release(cls):
+        lsb_release = shutil.which('lsb_release')
         dist = subprocess.run(
-            ['lsb_release', '-si'],
+            [lsb_release, '-si'],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,
         )
         ver = subprocess.run(
-            ['lsb_release', '-sr'],
+            [lsb_release, '-sr'],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,
@@ -152,14 +154,7 @@ class FileDownloader(object):
                 dist, ver = cls._get_distver_from_distro()
             elif os.path.exists('/etc/redhat-release'):
                 dist, ver = cls._get_distver_from_redhat_release()
-            elif (
-                subprocess.run(
-                    ['lsb_release'],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                ).returncode
-                == 0
-            ):
+            elif shutil.which('lsb_release'):
                 dist, ver = cls._get_distver_from_lsb_release()
             elif os.path.exists('/etc/os-release'):
                 # Note that (at least on centos), os_release is an


### PR DESCRIPTION
## Fixes IDAES/idaes-pse#1221

## Summary/Motivation:
`FileDownloader.get_os_version()` will generate `FileNotFoundError` exceptions on Linux platforms that are missing `lsb_release` in the `PATH`.  This resolves that exception by first checking for the existence of the executable using `shutil.which()` (the approach recommended for locating executables in the [`subprocess.Popen`](https://docs.python.org/3/library/subprocess.html#subprocess.Popen) documentation)

## Changes proposed in this PR:
- use `shutil.which` to locate / check for the existence of `lsb_release`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
