### PR TITLE
Update `pyomo.common` documentation

### DIFF
--- a/doc/OnlineDocs/developer_reference/deprecation.rst
+++ b/doc/OnlineDocs/developer_reference/deprecation.rst
@@ -11,22 +11,33 @@ Deprecation
 We offer a set of tools to help with deprecation in
 ``pyomo.common.deprecation``.
 
-By policy, when deprecating or moving an existing capability,
-one of the following functions should be imported. In use,
-the ``version`` option should be set to current development
-version. This can be found by running ``pyomo --version`` on
-your local fork/branch.
+By policy, when deprecating or moving an existing capability, one of the
+following utilities should be leveraged.  Each has a required
+``version`` argument that should be set to current development version (e.g.,
+``"6.6.2.dev0"``).  This version will be updated to the next actual
+release as part of the Pyomo release process.  The current development version
+can be found by running ``pyomo --version`` on your local fork/branch.
 
-.. autoclass:: pyomo.common.deprecation.deprecated
+.. currentmodule:: pyomo.common.deprecation
+
+.. autosummary::
+
+   deprecated
+   deprecation_warning
+   relocated_module
+   relocated_module_attribute
+   RenamedClass
+
+.. autodecorator:: pyomo.common.deprecation.deprecated
    :noindex:
 
-.. autoclass:: pyomo.common.deprecation.deprecation_warning
+.. autofunction:: pyomo.common.deprecation.deprecation_warning
    :noindex:
 
-.. autoclass:: pyomo.common.deprecation.relocated_module
+.. autofunction:: pyomo.common.deprecation.relocated_module
    :noindex:
 
-.. autoclass:: pyomo.common.deprecation.relocated_module_attribute
+.. autofunction:: pyomo.common.deprecation.relocated_module_attribute
    :noindex:
 
 .. autoclass:: pyomo.common.deprecation.RenamedClass

--- a/doc/OnlineDocs/library_reference/common/errors.rst
+++ b/doc/OnlineDocs/library_reference/common/errors.rst
@@ -1,0 +1,6 @@
+pyomo.common.errors
+===================
+
+.. automodule:: pyomo.common.errors
+   :members:
+   :member-order: bysource

--- a/doc/OnlineDocs/library_reference/common/index.rst
+++ b/doc/OnlineDocs/library_reference/common/index.rst
@@ -11,6 +11,7 @@ or rely on any other parts of Pyomo.
    config.rst
    dependencies.rst
    deprecation.rst
+   errors.rst
    fileutils.rst
    formatting.rst
    tempfiles.rst

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -17,14 +17,11 @@ import sys
 import warnings
 
 from .deprecation import deprecated, deprecation_warning, in_testing_environment
+from .errors import DeferredImportError
 from . import numeric_types
 
 
 SUPPRESS_DEPENDENCY_WARNINGS = False
-
-
-class DeferredImportError(ImportError):
-    pass
 
 
 class ModuleUnavailable(object):

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -25,11 +25,11 @@ SUPPRESS_DEPENDENCY_WARNINGS = False
 
 
 class ModuleUnavailable(object):
-    """Mock object that raises a DeferredImportError upon attribute access
+    """Mock object that raises :py:class:`.DeferredImportError` upon attribute access
 
     This object is returned by :py:func:`attempt_import()` in lieu of
     the module in the case that the module import fails.  Any attempts
-    to access attributes on this object will raise a DeferredImportError
+    to access attributes on this object will raise a :py:class:`.DeferredImportError`
     exception.
 
     Parameters
@@ -131,7 +131,7 @@ class DeferredImportModule(object):
     ``defer_check=True``.  Any attempts to access attributes on this
     object will trigger the actual module import and return either the
     appropriate module attribute or else if the module import fails,
-    raise a DeferredImportError exception.
+    raise a :py:class:`.DeferredImportError` exception.
 
     """
 
@@ -275,11 +275,11 @@ class DeferredImportIndicator(_DeferredImportIndicatorBase):
 
     This object serves as a placeholder for the Boolean indicator if a
     deferred module import was successful.  Casting this instance to
-    bool will cause the import to be attempted.  The actual import logic
-    is here and not in the DeferredImportModule to reduce the number of
-    attributes on the DeferredImportModule.
+    `bool` will cause the import to be attempted.  The actual import logic
+    is here and not in the :py:class:`DeferredImportModule` to reduce the number of
+    attributes on the :py:class:`DeferredImportModule`.
 
-    ``DeferredImportIndicator`` supports limited logical expressions
+    :py:class:`DeferredImportIndicator` supports limited logical expressions
     using the ``&`` (and) and ``|`` (or) binary operators.  Creating
     these expressions does not trigger the import of the corresponding
     :py:class:`DeferredImportModule` instances, although casting the
@@ -524,8 +524,8 @@ def attempt_import(
     defer_check: bool, optional
         If True (the default), then the attempted import is deferred
         until the first use of either the module or the availability
-        flag.  The method will return instances of DeferredImportModule
-        and DeferredImportIndicator.
+        flag.  The method will return instances of :py:class:`DeferredImportModule`
+        and :py:class:`DeferredImportIndicator`.
 
     deferred_submodules: Iterable[str], optional
         If provided, an iterable of submodule names within this module
@@ -673,7 +673,7 @@ def _perform_import(
 
 
 def declare_deferred_modules_as_importable(globals_dict):
-    """Make all DeferredImportModules in ``globals_dict`` importable
+    """Make all :py:class:`DeferredImportModules` in ``globals_dict`` importable
 
     This function will go throughout the specified ``globals_dict``
     dictionary and add any instances of :py:class:`DeferredImportModule`

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -235,6 +235,7 @@ def UnavailableClass(unavailable_module):
        named 'bogus_unavailable_class')
 
     """
+
     class UnavailableMeta(type):
         def __getattr__(cls, name):
             raise DeferredImportError(

--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -389,10 +389,6 @@ def relocated_module_attribute(
     object from the new location (on request), as well as emitting the
     deprecation warning.
 
-    It contains backports of the __getattr__ functionality for earlier
-    versions of Python (although the implementation for 3.5+ is more
-    efficient that the implementation for 2.7+)
-
     Parameters
     ----------
     local: str

--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -16,7 +16,7 @@ import textwrap
 def format_exception(msg, prolog=None, epilog=None, exception=None, width=76):
     """Generate a formatted exception message
 
-    This returns a formated exception message, line wrapped for display
+    This returns a formatted exception message, line wrapped for display
     on the console and with optional prolog and epilog messages.
 
     Parameters

--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -155,9 +155,11 @@ class DeveloperError(PyomoException, NotImplementedError):
         )
 
 
-class InvalidValueError(PyomoException, ValueError):
+class InfeasibleConstraintException(PyomoException):
     """
-    Exception class used for for value errors in compiled model representations
+    Exception class used by Pyomo transformations to indicate
+    that an infeasible constraint has been identified (e.g. in
+    the course of range reduction).
     """
 
     pass
@@ -171,26 +173,9 @@ class IntervalException(PyomoException, ValueError):
     pass
 
 
-class InfeasibleConstraintException(PyomoException):
+class InvalidValueError(PyomoException, ValueError):
     """
-    Exception class used by Pyomo transformations to indicate
-    that an infeasible constraint has been identified (e.g. in
-    the course of range reduction).
-    """
-
-    pass
-
-
-class NondifferentiableError(PyomoException, ValueError):
-    """A Pyomo-specific ValueError raised for non-differentiable expressions"""
-
-    pass
-
-
-class TempfileContextError(PyomoException, IndexError):
-    """A Pyomo-specific IndexError raised when attempting to use the
-    TempfileManager when it does not have a currently active context.
-
+    Exception class used for for value errors in compiled model representations
     """
 
     pass
@@ -216,3 +201,18 @@ class MouseTrap(PyomoException, NotImplementedError):
             "pull requests are always welcome!",
             exception=self,
         )
+
+
+class NondifferentiableError(PyomoException, ValueError):
+    """A Pyomo-specific ValueError raised for non-differentiable expressions"""
+
+    pass
+
+
+class TempfileContextError(PyomoException, IndexError):
+    """A Pyomo-specific IndexError raised when attempting to use the
+    TempfileManager when it does not have a currently active context.
+
+    """
+
+    pass

--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -130,6 +130,15 @@ class PyomoException(Exception):
     pass
 
 
+class DeferredImportError(ImportError):
+    """This exception is raised when something attempts to access a module
+    that was imported by :py:func:`.attempt_import`, but the module
+    import failed.
+
+    """
+    pass
+
+
 class DeveloperError(PyomoException, NotImplementedError):
     """
     Exception class used to throw errors that result from Pyomo

--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -122,8 +122,8 @@ class ApplicationError(Exception):
 
 class PyomoException(Exception):
     """
-    Exception class for other pyomo exceptions to inherit from,
-    allowing pyomo exceptions to be caught in a general way
+    Exception class for other Pyomo exceptions to inherit from,
+    allowing Pyomo exceptions to be caught in a general way
     (e.g., in other applications that use Pyomo).
     """
 

--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -176,7 +176,7 @@ class IntervalException(PyomoException, ValueError):
 
 class InvalidValueError(PyomoException, ValueError):
     """
-    Exception class used for for value errors in compiled model representations
+    Exception class used for value errors in compiled model representations
     """
 
     pass

--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -136,6 +136,7 @@ class DeferredImportError(ImportError):
     import failed.
 
     """
+
     pass
 
 

--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -14,6 +14,36 @@ import textwrap
 
 
 def format_exception(msg, prolog=None, epilog=None, exception=None, width=76):
+    """Generate a formatted exception message
+
+    This returns a formated exception message, line wrapped for display
+    on the console and with optional prolog and epilog messages.
+
+    Parameters
+    ----------
+    msg: str
+        The raw exception message
+
+    prolog: str, optional
+        A message to output before the exception message, ``msg``.  If
+        this message is long enough to line wrap, the ``msg`` will be
+        indented a level below the ``prolog`` message.
+
+    epilog: str, optional
+        A message to output after the exception message, ``msg``.  If
+        provided, the ``msg`` will be indented a level below the
+        ``prolog`` / ``epilog`` messages.
+
+    exception: Exception, optional
+        The raw exception being raised (used to improve initial line wrapping).
+
+    width: int, optional
+        The line length to wrap the exception message to.
+
+    Returns
+    -------
+    str
+    """
     fields = []
 
     if epilog:


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
As part of #2897 I realized we added a class with no documentation.  This PR adds that documentation and makes a pass at cleaning up some of the related documentation in `pyomo.common`

## Changes proposed in this PR:
- Add documentation for `UnavailableClass` and `format_exception()`
- Move the `DeferredImportError` into `pyomo.common.errors`
- Add `pyomo.common.errors` to the online documentation library reference
- Update some links, spelling, and remove outdated documentation

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
