### PR TITLE
Improve `calculate_variable_from_constraint` error messages

### DIFF
--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -134,6 +134,7 @@ class IterationLimitError(PyomoException, RuntimeError):
 
     """
 
+
 class IntervalException(PyomoException, ValueError):
     """
     Exception class used for errors in interval arithmetic.

--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -124,6 +124,16 @@ class InvalidValueError(PyomoException, ValueError):
     pass
 
 
+class IterationLimitError(PyomoException, RuntimeError):
+    """A subclass of :py:class:`RuntimeError`, raised by an iterative method
+    when the iteration limit is reached.
+
+    TODO: currently solvers currently do not raise this exception, but
+    probably should (at least when non-normal termination conditions are
+    mapped to exceptions)
+
+    """
+
 class IntervalException(PyomoException, ValueError):
     """
     Exception class used for errors in interval arithmetic.

--- a/pyomo/common/errors.py
+++ b/pyomo/common/errors.py
@@ -128,9 +128,9 @@ class IterationLimitError(PyomoException, RuntimeError):
     """A subclass of :py:class:`RuntimeError`, raised by an iterative method
     when the iteration limit is reached.
 
-    TODO: currently solvers currently do not raise this exception, but
-    probably should (at least when non-normal termination conditions are
-    mapped to exceptions)
+    TODO: solvers currently do not raise this exception, but probably
+    should (at least when non-normal termination conditions are mapped
+    to exceptions)
 
     """
 

--- a/pyomo/util/calc_var_value.py
+++ b/pyomo/util/calc_var_value.py
@@ -89,7 +89,7 @@ def calculate_variable_from_constraint(
     upper = constraint.ub
 
     if lower != upper:
-        raise ValueError("Constraint must be an equality constraint")
+        raise ValueError(f"Constraint '{constraint}' must be an equality constraint")
 
     if variable.value is None:
         # Note that we use "skip_validation=True" here as well, as the
@@ -201,7 +201,10 @@ def calculate_variable_from_constraint(
                 raise
 
         if type(expr_deriv) in native_numeric_types and expr_deriv == 0:
-            raise ValueError("Variable derivative == 0, cannot solve for variable")
+            raise ValueError(
+                f"Variable '{variable}' derivative == 0 in constraint "
+                f"'{constraint}', cannot solve for variable"
+            )
 
     if expr_deriv is None:
         fp0 = differentiate(expr, wrt=variable, mode=diff_mode)
@@ -210,8 +213,9 @@ def calculate_variable_from_constraint(
 
     if abs(value(fp0)) < 1e-12:
         raise RuntimeError(
-            'Initial value for variable results in a derivative value that is '
-            'very close to zero.\n\tPlease provide a different initial guess.'
+            f"Initial value for variable '{variable}' results in a derivative "
+            f"value for constraint '{constraint}' that is very close to zero.\n"
+            "\tPlease provide a different initial guess."
         )
 
     iter_left = iterlim
@@ -220,7 +224,8 @@ def calculate_variable_from_constraint(
         iter_left -= 1
         if not iter_left:
             raise RuntimeError(
-                "Iteration limit (%s) reached; remaining residual = %s"
+                f"Iteration limit (%s) reached solving for variable '{variable}' "
+                f"using constraint '{constraint}'; remaining residual = %s"
                 % (iterlim, value(expr))
             )
 
@@ -235,8 +240,8 @@ def calculate_variable_from_constraint(
             # the line search is turned off)
             logger.error(
                 "Newton's method encountered an error evaluating the "
-                "expression.\n\tPlease provide a different initial guess "
-                "or enable the linesearch if you have not."
+                f"expression for constraint '{constraint}'.\n\tPlease provide a "
+                "different initial guess or enable the linesearch if you have not."
             )
             raise
 
@@ -247,7 +252,8 @@ def calculate_variable_from_constraint(
 
         if abs(fpk) < 1e-12:
             raise RuntimeError(
-                "Newton's method encountered a derivative that was too "
+                "Newton's method encountered a derivative of constraint "
+                f"'{constraint}' with respect to variable '{variable}' that was too "
                 "close to zero.\n\tPlease provide a different initial guess "
                 "or enable the linesearch if you have not."
             )
@@ -283,8 +289,9 @@ def calculate_variable_from_constraint(
                 if residual is None or type(residual) is complex:
                     residual = "{function evaluation error}"
                 raise RuntimeError(
-                    "Linesearch iteration limit reached; remaining "
-                    "residual = %s." % (residual,)
+                    f"Linesearch iteration limit reached solving for "
+                    f"variable '{variable}' using constraint '{constraint}'; "
+                    f"remaining residual = {residual}."
                 )
     #
     # Re-set the variable value to trigger any warnings WRT the final

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -14,6 +14,7 @@ from io import StringIO
 
 import pyomo.common.unittest as unittest
 
+from pyomo.common.errors import IterationLimitError
 from pyomo.common.log import LoggingIntercept
 from pyomo.environ import (
     ConcreteModel,
@@ -152,7 +153,7 @@ class Test_calc_var(unittest.TestCase):
         for mode in all_diff_modes:
             m.x.set_value(1.25)  # set the initial value
             with self.assertRaisesRegex(
-                RuntimeError, r'Iteration limit \(10\) reached'
+                IterationLimitError, r'Iteration limit \(10\) reached'
             ):
                 calculate_variable_from_constraint(
                     m.x, m.d, iterlim=10, linesearch=False, diff_mode=mode
@@ -162,7 +163,7 @@ class Test_calc_var(unittest.TestCase):
         for mode in all_diff_modes:
             m.x.set_value(1.25)  # set the initial value
             with self.assertRaisesRegex(
-                RuntimeError, "Linesearch iteration limit reached"
+                    IterationLimitError, "Linesearch iteration limit reached"
             ):
                 calculate_variable_from_constraint(
                     m.x, m.d, iterlim=10, linesearch=True, diff_mode=mode
@@ -172,7 +173,7 @@ class Test_calc_var(unittest.TestCase):
         for mode in all_diff_modes:
             m.x = 0
             with self.assertRaisesRegex(
-                RuntimeError,
+                ValueError,
                 "Initial value for variable 'x' results in a "
                 "derivative value for constraint 'c' that is very close to zero.",
             ):
@@ -185,7 +186,7 @@ class Test_calc_var(unittest.TestCase):
                 # numeric differentiation should not be used to check if a
                 # derivative is always zero
                 with self.assertRaisesRegex(
-                    RuntimeError,
+                    ValueError,
                     "Initial value for variable 'y' results in a "
                     "derivative value for constraint 'c' that is very close to zero.",
                 ):
@@ -314,7 +315,7 @@ class Test_calc_var(unittest.TestCase):
         m.c = Constraint(expr=m.x**0.5 == -1e-8)
         m.x = 1e-8  # 197.932807183
         with self.assertRaisesRegex(
-            RuntimeError,
+            IterationLimitError,
             "Linesearch iteration limit reached solving for variable 'x' using "
             "constraint 'c'; remaining residual = {function evaluation error}",
         ):

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -96,7 +96,7 @@ class Test_calc_var(unittest.TestCase):
 
         m.lt = Constraint(expr=m.x <= m.y)
         with self.assertRaisesRegex(
-            ValueError, "Constraint must be an equality constraint"
+            ValueError, "Constraint 'lt' must be an equality constraint"
         ):
             calculate_variable_from_constraint(m.x, m.lt)
 
@@ -173,8 +173,8 @@ class Test_calc_var(unittest.TestCase):
             m.x = 0
             with self.assertRaisesRegex(
                 RuntimeError,
-                "Initial value for variable results in a "
-                "derivative value that is very close to zero.",
+                "Initial value for variable 'x' results in a "
+                "derivative value for constraint 'c' that is very close to zero.",
             ):
                 calculate_variable_from_constraint(m.x, m.c, diff_mode=mode)
 
@@ -186,12 +186,14 @@ class Test_calc_var(unittest.TestCase):
                 # derivative is always zero
                 with self.assertRaisesRegex(
                     RuntimeError,
-                    "Initial value for variable results in a "
-                    "derivative value that is very close to zero.",
+                    "Initial value for variable 'y' results in a "
+                    "derivative value for constraint 'c' that is very close to zero.",
                 ):
                     calculate_variable_from_constraint(m.y, m.c, diff_mode=mode)
             else:
-                with self.assertRaisesRegex(ValueError, "Variable derivative == 0"):
+                with self.assertRaisesRegex(
+                    ValueError, "Variable 'y' derivative == 0 in constraint 'c'"
+                ):
                     calculate_variable_from_constraint(m.y, m.c, diff_mode=mode)
 
         # should succeed with or without a linesearch
@@ -224,8 +226,8 @@ class Test_calc_var(unittest.TestCase):
             m.x.set_value(3.0)
             with self.assertRaisesRegex(
                 RuntimeError,
-                "Newton's method encountered a derivative "
-                "that was too close to zero",
+                "Newton's method encountered a derivative of constraint 'f' "
+                "with respect to variable 'x' that was too close to zero",
             ):
                 calculate_variable_from_constraint(
                     m.x, m.f, linesearch=False, diff_mode=mode
@@ -299,7 +301,8 @@ class Test_calc_var(unittest.TestCase):
                 # calculate_variable_from_constraint
                 calculate_variable_from_constraint(m.x, m.c, linesearch=False)
         self.assertIn(
-            "Newton's method encountered an error evaluating the expression.",
+            "Newton's method encountered an error evaluating the expression for "
+            "constraint 'c'.",
             output.getvalue(),
         )
 
@@ -312,8 +315,8 @@ class Test_calc_var(unittest.TestCase):
         m.x = 1e-8  # 197.932807183
         with self.assertRaisesRegex(
             RuntimeError,
-            "Linesearch iteration limit reached; "
-            "remaining residual = {function evaluation error}",
+            "Linesearch iteration limit reached solving for variable 'x' using "
+            "constraint 'c'; remaining residual = {function evaluation error}",
         ):
             calculate_variable_from_constraint(m.x, m.c, linesearch=True, alpha_min=0.5)
 

--- a/pyomo/util/tests/test_calc_var_value.py
+++ b/pyomo/util/tests/test_calc_var_value.py
@@ -163,7 +163,7 @@ class Test_calc_var(unittest.TestCase):
         for mode in all_diff_modes:
             m.x.set_value(1.25)  # set the initial value
             with self.assertRaisesRegex(
-                    IterationLimitError, "Linesearch iteration limit reached"
+                IterationLimitError, "Linesearch iteration limit reached"
             ):
                 calculate_variable_from_constraint(
                     m.x, m.d, iterlim=10, linesearch=True, diff_mode=mode


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Debugging an IDAES model pointed out that the errors raised by `calculate_variable_from_constraint` are less informative than they could be.  This improves those errors.

## Changes proposed in this PR:
- Add variable / constraint names to the exception messages raised by `calculate_variable_from_constraint`
- Add `IterationLimitError` (subclass of `RuntimeError`) to provide more informative exceptions
- Switch errors raised due to a poor initial guess (derivative too close to 0) from `RuntimeError` to `ValueError`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
