### PR TITLE
Resolve kernel pickle/clone errors

### DIFF
--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -117,13 +117,17 @@ class _ComponentBase(PyomoObject):
             _scope = memo['__block_scope__']
             _new = None
             tmp = self.parent_block()
+            # "Floating" components should be in scope by default (we
+            # will handle 'global' components like GlobalSets in the
+            # components)
+            _in_scope = tmp is None
             # Note: normally we would need to check that tmp does not
             # end up being None.  However, since clone() inserts
             # id(None) into the __block_scope__ dictionary, we are safe
             while id(tmp) not in _scope:
                 _new = (_new, id(tmp))
                 tmp = tmp.parent_block()
-            _in_scope = _scope[id(tmp)]
+            _in_scope |= _scope[id(tmp)]
 
             # Remember whether all newly-encountered blocks are in or
             # out of scope (prevent duplicate work)

--- a/pyomo/core/kernel/expression.py
+++ b/pyomo/core/kernel/expression.py
@@ -9,6 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+from pyomo.common.deprecation import deprecated
 from pyomo.common.modeling import NOTSET
 from pyomo.core.expr import current as EXPR
 from pyomo.core.kernel.base import ICategorizedObject, _abstract_readwrite_property
@@ -160,70 +161,23 @@ class IIdentityExpression(NumericValue):
         raise NotImplementedError  # pragma:nocover
 
 
-class noclone(IIdentityExpression):
-    """
-    A helper factory class for creating an expression with
-    cloning disabled. This allows the expression to be used
-    in two or more parent expressions without causing a copy
-    to be generated. If it is initialized with a value that
-    is not an instance of NumericValue, that value is simply
-    returned.
-    """
-
-    __slots__ = ("_expr",)
-
-    def __new__(cls, expr=NOTSET):
-        if expr is NOTSET or isinstance(expr, NumericValue):
-            if not is_potentially_variable(expr):
-                return super().__new__(npv_noclone)
-            else:
-                return super().__new__(cls)
-        else:
+@deprecated(
+    "noclone() is deprecated and can be omitted: "
+    "Pyomo expressions natively support shared subexpressions.",
+    version='6.6.2.dev0',
+)
+def noclone(expr):
+    try:
+        if expr.is_potentially_variable():
+            return expression(expr)
+    except AttributeError:
+        pass
+    try:
+        if is_constant(expr):
             return expr
-
-    def __init__(self, expr):
-        self._expr = expr
-
-    def __getnewargs__(self):
-        return (self._expr,)
-
-    def __getstate__(self):
-        return (self._expr,)
-
-    def __setstate__(self, state):
-        assert len(state) == 1
-        self._expr = state[0]
-
-    def __str__(self):
-        return "{%s}" % EXPR.expression_to_string(self)
-
-    #
-    # Override some of the NumericValue methods implemented
-    # by the base class
-    #
-
-    def is_constant(self):
-        """A boolean indicating whether this expression is constant."""
-        return is_constant(self._expr)
-
-    def is_potentially_variable(self):
-        """A boolean indicating whether this expression can
-        reference variables."""
-        return True
-
-    def clone(self):
-        """Return a clone of this expression (no-op)."""
-        return self
-
-
-class npv_noclone(noclone):
-    def is_potentially_variable(self):
-        """A boolean indicating whether this expression can
-        reference variables."""
-        return False
-
-    def potentially_variable_base_class(self):
-        return noclone
+    except:
+        return expr
+    return data_expression(expr)
 
 
 class IExpression(ICategorizedObject, IIdentityExpression):

--- a/pyomo/core/tests/unit/kernel/test_expression.py
+++ b/pyomo/core/tests/unit/kernel/test_expression.py
@@ -101,7 +101,6 @@ class Test_noclone(unittest.TestCase):
         ):
             self.assertTrue(isinstance(noclone(obj), NumericValue))
             self.assertTrue(isinstance(noclone(obj), IIdentityExpression))
-            self.assertTrue(isinstance(noclone(obj), noclone))
             self.assertIs(noclone(obj).expr, obj)
 
     def test_pprint(self):
@@ -134,10 +133,10 @@ class Test_noclone(unittest.TestCase):
     def test_pickle(self):
         v = variable()
         e = noclone(v)
-        self.assertEqual(type(e), noclone)
+        self.assertEqual(type(e), expression)
         self.assertIs(type(e.expr), variable)
         eup = pickle.loads(pickle.dumps(e))
-        self.assertEqual(type(eup), noclone)
+        self.assertEqual(type(eup), expression)
         self.assertTrue(e is not eup)
         self.assertIs(type(eup.expr), variable)
         self.assertIs(type(e.expr), variable)
@@ -291,15 +290,17 @@ class Test_noclone(unittest.TestCase):
         p = parameter()
         e = noclone(p**2)
         self.assertEqual(str(e.expr), "<parameter>**2")
-        self.assertEqual(str(e), "{(<parameter>**2)}")
+        self.assertEqual(str(e), "<data_expression>")
         self.assertEqual(e.to_string(), "(<parameter>**2)")
         self.assertEqual(e.to_string(verbose=False), "(<parameter>**2)")
-        self.assertEqual(e.to_string(verbose=True), "{pow(<parameter>, 2)}")
+        self.assertEqual(
+            e.to_string(verbose=True), "<data_expression>{pow(<parameter>, 2)}"
+        )
         b.e = e
         b.p = p
         self.assertNotEqual(p.name, None)
-        self.assertEqual(e.to_string(verbose=True), "{pow(" + p.name + ", 2)}")
-        self.assertEqual(e.to_string(verbose=True), "{pow(p, 2)}")
+        self.assertEqual(e.to_string(verbose=True), "e{pow(" + p.name + ", 2)}")
+        self.assertEqual(e.to_string(verbose=True), "e{pow(p, 2)}")
         del b.e
         del b.p
 

--- a/pyomo/solvers/tests/checks/test_pickle.py
+++ b/pyomo/solvers/tests/checks/test_pickle.py
@@ -169,15 +169,7 @@ for model in all_models():
 for key, value in generate_scenarios(lambda c: c.test_pickling):
     model, solver, io = key
     cls = driver[model]
-    # July 19, 2023: There is an issue with certain GAMS cases that is
-    # causing failures. This is not universal, however, so we cannot add
-    # the cases directly to testcases.py.
-    if (
-        (solver == 'gams')
-        and (io in ['gms', 'python'])
-        and ('.LP_simple_kernel' in str(value.model))
-    ):
-        value.status = 'expected failure'
+
     # Symbolic labels
     test_name = "test_" + solver + "_" + io + "_symbolic_labels"
     test_method = create_method(model, solver, io, value, True)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This resolves errors cloning Kernel models that used the `noclone` class.  `noclone` appears to not have been safe to pickle / deepcopy for quite a while, but the error was only highlighted by a mostly unrelated test that started failing after updating GAMS.  This PR removes the `noclone` class and replaces it with a deprecated function that mimics the old behavior (but is correctly picklable / clonable).

As part of resolving this, it became apparent that we needed to change the default deepcopy "scope" rules for Components not attached to blocks.  The previous behavior defaulted to `memo['__block_scope__'][None]` (usually "_don't clone_").  This changes the behavior to default to cloning components not attached to blocks.  Global components (like `GlobalSet` instances) will still not be cloned, as they override the deepcopy / pickle semantics to ensure their global nature.

## Changes proposed in this PR:
- Deprecate `pyomo.core.kernel.expression.noclone`
- Switch default handling of cloning components not attached to blocks to "always clone"
- Rework kernel's block scoping scheme to use the same memo entry as the core AML's
- Restore the tests marked "expected failure" by #2913

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
