### PR TITLE
Remove the 'singletest' job from "branches" builds

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -95,14 +95,6 @@ jobs:
           PACKAGES: mpi4py openmpi
 
         - os: ubuntu-latest
-          python: 3.11
-          other: /singletest
-          category: "-m 'neos or importtest'"
-          skip_doctest: 1
-          TARGET: linux
-          PYENV: pip
-
-        - os: ubuntu-latest
           python: '3.10'
           other: /cython
           setup_options: --with-cython


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This should significantly decrease the load that the Pyomo GHA jobs put on the NEOS servers.  It has no effect on PRs or coverage (the singletest job is still in `test_pr_and_main.yml`)

## Changes proposed in this PR:
- remove the `linux/singletest` job from the branches GHA suite

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
