### PR TITLE
Xpress: fix NLP results processing for Xpress 9.2.0

### DIFF
--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -448,7 +448,9 @@ class XpressDirect(DirectSolver):
         optimal = False  # *globally* optimal?
         if status == xp.nlp_unstarted:
             results.solver.status = SolverStatus.unknown
-            results.solver.termination_message = "Non-convex model solve was not start"
+            results.solver.termination_message = (
+                "Non-convex model solve was not started"
+            )
             results.solver.termination_condition = TerminationCondition.unknown
             soln.status = SolutionStatus.unknown
         elif status == xp.nlp_locally_optimal:
@@ -490,7 +492,7 @@ class XpressDirect(DirectSolver):
         elif status == xp.nlp_infeasible:
             results.solver.status = SolverStatus.ok
             results.solver.termination_message = (
-                "Non-conex model was proven to be infeasible"
+                "Non-convex model was proven to be infeasible"
             )
             results.solver.termination_condition = TerminationCondition.infeasible
             soln.status = SolutionStatus.infeasible

--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -436,7 +436,7 @@ class XpressDirect(DirectSolver):
             # was convex
             if (xprob_attrs.originalmipents > 0) or (xprob_attrs.originalsets > 0):
                 return self._get_mip_results(results, soln)
-            elif not xprob_attrs.xslp_nlpstatus:
+            elif xprob_attrs.lpstatus and not xprob_attrs.xslp_nlpstatus:
                 # If there is no NLP solver status, process the result
                 # using the LP results processor.
                 return self._get_lp_results(results, soln)
@@ -448,9 +448,7 @@ class XpressDirect(DirectSolver):
         optimal = False  # *globally* optimal?
         if status == xp.nlp_unstarted:
             results.solver.status = SolverStatus.unknown
-            results.solver.termination_message = (
-                "Non-convex model solve was not start"
-            )
+            results.solver.termination_message = "Non-convex model solve was not start"
             results.solver.termination_condition = TerminationCondition.unknown
             soln.status = SolutionStatus.unknown
         elif status == xp.nlp_locally_optimal:
@@ -498,9 +496,7 @@ class XpressDirect(DirectSolver):
             soln.status = SolutionStatus.infeasible
         elif status == xp.nlp_unbounded:  # locally unbounded!
             results.solver.status = SolverStatus.ok
-            results.solver.termination_message = (
-                "Non-convex model is locally unbounded"
-            )
+            results.solver.termination_message = "Non-convex model is locally unbounded"
             results.solver.termination_condition = TerminationCondition.unbounded
             soln.status = SolutionStatus.unbounded
         elif status == xp.nlp_unfinished:
@@ -513,8 +509,8 @@ class XpressDirect(DirectSolver):
             have_soln = True
         else:
             results.solver.status = SolverStatus.error
-            results.solver.termination_message = (
-                "Error for non-convex model: " + str(status)
+            results.solver.termination_message = "Error for non-convex model: " + str(
+                status
             )
             results.solver.termination_condition = TerminationCondition.error
             soln.status = SolutionStatus.error


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Xpress 9.2.0 appears to return infeasible status differently than previous versions.  In previous versions, infeasible nonlinear problems solved using the Xpress optimizer returned solution status via `LPSTATUS`.  Beginning in 9.2, it appears that the problem status is now returned in `XSLP_NLPSTATUS`.  This PR updates the results processor to only fall back on the LP results processor if `LPRESULTS` is nonzero (and `XSLP_NLPSTATUS` is 0)

@djunglas, am I interpreting the change in Xpress behavior correctly?

## Changes proposed in this PR:
- Update processing of NLP results to only use the LP results processor if there the NLP results status is not set.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
