### PR TITLE
BUGFIX: Loading Scalar Param from `.dat` file

### DIFF
--- a/pyomo/dataportal/process_data.py
+++ b/pyomo/dataportal/process_data.py
@@ -343,7 +343,8 @@ def _process_param(cmd, _model, _data, _default, index=None, param=None, ncolumn
                         _dim = _guess_set_dimen(_param.index_set())
                     finaldata = _process_data_list(pname, _dim, cmd)
                 else:
-                    finaldata = _process_data_list(pname, 1, cmd)
+                    _dim = 1 if len(cmd) > 1 else 0
+                    finaldata = _process_data_list(pname, _dim, cmd)
                 for key in finaldata:
                     _data[pname][key] = finaldata[key]
             else:

--- a/pyomo/dataportal/tests/data17.dat
+++ b/pyomo/dataportal/tests/data17.dat
@@ -1,0 +1,10 @@
+param A := 1;
+
+param B := a 1;
+
+param C := 
+a 1
+b 2
+c 3;
+
+table D := 1; 

--- a/pyomo/dataportal/tests/test_dataportal.py
+++ b/pyomo/dataportal/tests/test_dataportal.py
@@ -675,7 +675,7 @@ class PyomoDataPortal(unittest.TestCase):
 
         md = DataPortal()
         md.load(filename=currdir + "data17.dat")
-        
+
         self.assertEqual(md['A'], 1)
         self.assertEqual(md['B'], {'a': 1})
         self.assertEqual(md['C'], {'a': 1, 'b': 2, 'c': 3})

--- a/pyomo/dataportal/tests/test_dataportal.py
+++ b/pyomo/dataportal/tests/test_dataportal.py
@@ -669,6 +669,20 @@ class PyomoDataPortal(unittest.TestCase):
         except IOError:
             pass
 
+    def test_md18(self):
+        cwd = os.getcwd()
+        os.chdir(currdir)
+
+        md = DataPortal()
+        md.load(filename=currdir + "data17.dat")
+        
+        self.assertEqual(md['A'], 1)
+        self.assertEqual(md['B'], {'a': 1})
+        self.assertEqual(md['C'], {'a': 1, 'b': 2, 'c': 3})
+        self.assertEqual(md['D'], 1)
+
+        os.chdir(cwd)
+
     def test_dat_type_conversion(self):
         model = AbstractModel()
         model.I = Set()


### PR DESCRIPTION
## Fixes #120  .

## Summary/Motivation:

Loading scalar `param` from `.dat` files failes when not providing a `model` to the `load` method. 
The function `_process_data_list` from module `pyomo/dataportal/process_data.py` is called with `dim=1` instead of `dim=0`. 
Thus an indexed parameter is expected instead of a scalar one. 
This PR adds a check to pass the correct value for `dim`

## Changes proposed in this PR:
- `pyomo/dataportal/process_data.py`  line 346: added `_dim = 1 if len(cmd) > 1 else 0` to check for the correct value of dim.
- `pyomo/dataportal/process_data.py`  line 347: changed to `finaldata = _process_data_list(pname, _dim, cmd)` from `finaldata = _process_data_list(pname, 1, cmd)` 
- a unit test `test_md18` was added to `pyomo/blob/bugfix-no120/pyomo/dataportal/tests/test_dataportal.py` along with a data file `https://github.com/marvin-meck/pyomo/blob/bugfix-no120/pyomo/dataportal/tests/data17.dat`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
