### PR TITLE
Improve NaN handling in LP, NL writers

### DIFF
--- a/pyomo/repn/linear.py
+++ b/pyomo/repn/linear.py
@@ -42,20 +42,18 @@ from pyomo.core.base.objective import ScalarObjective, _GeneralObjectiveData
 import pyomo.core.kernel as kernel
 from pyomo.repn.util import (
     ExprType,
+    InvalidNumber,
     apply_node_operation,
     complex_number_error,
-    InvalidNumber,
+    nan,
+    sum_like_expression_types,
 )
 
 logger = logging.getLogger(__name__)
 
-nan = float("nan")
-
 _CONSTANT = ExprType.CONSTANT
 _LINEAR = ExprType.LINEAR
 _GENERAL = ExprType.GENERAL
-
-_SumLikeExpression = {SumExpression, LinearExpression, NPV_SumExpression}
 
 
 def _merge_dict(dest_dict, mult, src_dict):
@@ -879,7 +877,7 @@ class LinearRepnVisitor(StreamBasedExpressionVisitor):
     def enterNode(self, node):
         # SumExpression are potentially large nary operators.  Directly
         # populate the result
-        if node.__class__ in _SumLikeExpression:
+        if node.__class__ in sum_like_expression_types:
             return node.args, self.Result()
         else:
             return node.args, []

--- a/pyomo/repn/linear.py
+++ b/pyomo/repn/linear.py
@@ -576,6 +576,12 @@ def _before_native(visitor, child):
     return False, (_CONSTANT, child)
 
 
+def _before_invalid(visitor, child):
+    return False, (
+        _CONSTANT, InvalidNumber(child, "'{child}' is not a valid numeric type")
+    )
+
+
 def _before_complex(visitor, child):
     return False, (_CONSTANT, complex_number_error(child, visitor, child))
 
@@ -734,6 +740,8 @@ def _register_new_before_child_dispatcher(visitor, child):
             dispatcher[child_type] = _before_complex
         else:
             dispatcher[child_type] = _before_native
+    elif child_type in native_types:
+        dispatcher[child_type] = _before_invalid
     elif not child.is_expression_type():
         if child.is_potentially_variable():
             dispatcher[child_type] = _before_var

--- a/pyomo/repn/linear.py
+++ b/pyomo/repn/linear.py
@@ -768,18 +768,8 @@ _before_child_dispatcher = collections.defaultdict(
 # complex number types
 _complex_types = set((complex,))
 
-# Register an initial set of known expression types with the "before
-# child" expression handler lookup table.
-for _type in native_numeric_types:
-    _before_child_dispatcher[_type] = _before_native
 # We do not support writing complex numbers out
 _before_child_dispatcher[complex] = _before_complex
-# general operators
-for _type in _exit_node_handlers:
-    _before_child_dispatcher[_type] = _before_general_expression
-# override for named subexpressions
-for _type in _named_subexpression_types:
-    _before_child_dispatcher[_type] = _before_named_expression
 # Special handling for expr_if and external functions: will be handled
 # as terminal nodes from the point of view of the visitor
 _before_child_dispatcher[Expr_ifExpression] = _before_expr_if

--- a/pyomo/repn/linear.py
+++ b/pyomo/repn/linear.py
@@ -821,7 +821,10 @@ class LinearRepnVisitor(StreamBasedExpressionVisitor):
 
     def _eval_fixed(self, obj):
         ans = obj()
-        if ans is None or ans != ans:
+        if ans.__class__ not in native_numeric_types:
+            if ans.__class__ is not InvalidNumber:
+                ans = InvalidNumber(nan if ans is None else ans)
+        elif ans != ans:
             ans = InvalidNumber(nan)
         elif ans.__class__ in _complex_types:
             ans = complex_number_error(ans, self, obj)
@@ -831,9 +834,12 @@ class LinearRepnVisitor(StreamBasedExpressionVisitor):
         ans = self._eval_expr_visitor.dfs_postorder_stack(expr)
         if ans.__class__ not in native_types:
             ans = value(ans)
-        if ans != ans:
-            return InvalidNumber(ans)
-        if ans.__class__ in _complex_types:
+        if ans.__class__ not in native_numeric_types:
+            if ans.__class__ is not InvalidNumber:
+                ans = InvalidNumber(nan if ans is None else ans)
+        elif ans != ans:
+            ans = InvalidNumber(nan)
+        elif ans.__class__ in _complex_types:
             return complex_number_error(ans, self, expr)
         return ans
 

--- a/pyomo/repn/linear.py
+++ b/pyomo/repn/linear.py
@@ -578,7 +578,8 @@ def _before_native(visitor, child):
 
 def _before_invalid(visitor, child):
     return False, (
-        _CONSTANT, InvalidNumber(child, "'{child}' is not a valid numeric type")
+        _CONSTANT,
+        InvalidNumber(child, "'{child}' is not a valid numeric type"),
     )
 
 

--- a/pyomo/repn/linear.py
+++ b/pyomo/repn/linear.py
@@ -810,26 +810,64 @@ class LinearRepnVisitor(StreamBasedExpressionVisitor):
         self._eval_expr_visitor = _EvaluationVisitor(True)
 
     def _eval_fixed(self, obj):
-        ans = obj()
+        ans = obj.value
         if ans.__class__ not in native_numeric_types:
-            if ans.__class__ is not InvalidNumber:
-                ans = InvalidNumber(nan if ans is None else ans)
-        elif ans != ans:
-            ans = InvalidNumber(nan)
-        elif ans.__class__ in _complex_types:
-            ans = complex_number_error(ans, self, obj)
+            # None can be returned from uninitialized Var/Param objects
+            if ans is None:
+                return InvalidNumber(
+                    None, f"'{obj}' contains a nonnumeric value '{ans}'"
+                )
+            if ans.__class__ is InvalidNumber:
+                return ans
+            else:
+                # It is possible to get other non-numeric types.  Most
+                # common are bool and 1-element numpy.array().  We will
+                # attempt to convert the value to a float before
+                # proceeding.
+                #
+                # TODO: we should check bool and warn/error (while bool is
+                # convertible to float in Python, they have very
+                # different semantic meanings in Pyomo).
+                try:
+                    ans = float(ans)
+                except:
+                    return InvalidNumber(
+                        ans, f"'{obj}' contains a nonnumeric value '{ans}'"
+                    )
+        if ans != ans:
+            return InvalidNumber(nan, f"'{obj}' contains a nonnumeric value '{ans}'")
+        if ans.__class__ in _complex_types:
+            return complex_number_error(ans, self, obj)
         return ans
 
     def _eval_expr(self, expr):
         ans = self._eval_expr_visitor.dfs_postorder_stack(expr)
-        if ans.__class__ not in native_types:
-            ans = value(ans)
         if ans.__class__ not in native_numeric_types:
-            if ans.__class__ is not InvalidNumber:
-                ans = InvalidNumber(nan if ans is None else ans)
-        elif ans != ans:
-            ans = InvalidNumber(nan)
-        elif ans.__class__ in _complex_types:
+            # None can be returned from uninitialized Expression objects
+            if ans is None:
+                return InvalidNumber(
+                    ans, f"'{expr}' evaluated to nonnumeric value '{ans}'"
+                )
+            if ans.__class__ is InvalidNumber:
+                return ans
+            else:
+                # It is possible to get other non-numeric types.  Most
+                # common are bool and 1-element numpy.array().  We will
+                # attempt to convert the value to a float before
+                # proceeding.
+                #
+                # TODO: we should check bool and warn/error (while bool is
+                # convertible to float in Python, they have very
+                # different semantic meanings in Pyomo).
+                try:
+                    ans = float(ans)
+                except:
+                    return InvalidNumber(
+                        ans, f"'{expr}' evaluated to nonnumeric value '{ans}'"
+                    )
+        if ans != ans:
+            return InvalidNumber(ans, f"'{expr}' evaluated to nonnumeric value '{ans}'")
+        if ans.__class__ in _complex_types:
             return complex_number_error(ans, self, expr)
         return ans
 

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -2375,9 +2375,9 @@ def _register_new_before_child_handler(visitor, child):
     if child_type in native_numeric_types:
         if isinstance(child_type, complex):
             _complex_types.add(child_type)
-            dispatcher[child_type] = _before_complex
+            handlers[child_type] = _before_complex
         else:
-            dispatcher[child_type] = _before_native
+            handlers[child_type] = _before_native
     elif issubclass(child_type, str):
         handlers[child_type] = _before_string
     elif child_type in native_types:
@@ -2414,28 +2414,10 @@ def _register_new_before_child_handler(visitor, child):
 _before_child_handlers = defaultdict(lambda: _register_new_before_child_handler)
 
 _complex_types = set((complex,))
-# Register an initial set of known expression types with the "before
-# child" expression handler lookup table.
-for _type in native_numeric_types:
-    _before_child_handlers[_type] = _before_native
 _before_child_handlers[complex] = _before_complex
 for _type in native_types:
     if issubclass(_type, str):
         _before_child_handlers[_type] = _before_string
-# general operators
-for _type in _operator_handles:
-    _before_child_handlers[_type] = _before_general_expression
-# named subexpressions
-for _type in (
-    _GeneralExpressionData,
-    ScalarExpression,
-    kernel.expression.expression,
-    kernel.expression.noclone,
-    _GeneralObjectiveData,
-    ScalarObjective,
-    kernel.objective.objective,
-):
-    _before_child_handlers[_type] = _before_named_expression
 # Special linear / summation expressions
 _before_child_handlers[MonomialTermExpression] = _before_monomial
 _before_child_handlers[LinearExpression] = _before_linear

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -2469,7 +2469,10 @@ class AMPLRepnVisitor(StreamBasedExpressionVisitor):
 
     def _eval_fixed(self, obj):
         ans = obj()
-        if ans is None or ans != ans:
+        if ans.__class__ not in native_numeric_types:
+            if ans.__class__ is not InvalidNumber:
+                ans = InvalidNumber(nan if ans is None else ans)
+        elif ans != ans:
             ans = InvalidNumber(nan)
         elif ans.__class__ in _complex_types:
             ans = complex_number_error(ans, self, obj)
@@ -2479,7 +2482,12 @@ class AMPLRepnVisitor(StreamBasedExpressionVisitor):
         ans = self._eval_expr_visitor.dfs_postorder_stack(expr)
         if ans.__class__ not in native_types:
             ans = value(ans)
-        if ans.__class__ in _complex_types:
+        if ans.__class__ not in native_numeric_types:
+            if ans.__class__ is not InvalidNumber:
+                ans = InvalidNumber(nan if ans is None else ans)
+        elif ans != ans:
+            ans = InvalidNumber(nan)
+        elif ans.__class__ in _complex_types:
             return complex_number_error(ans, self, expr)
         return ans
 

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -2312,7 +2312,7 @@ def _before_linear(visitor, child):
                             "tree.  Mapping the NaN result to 0 for compatibility "
                             "with the nl_v1 writer.  In the future, this NaN "
                             "will be preserved/emitted to comply with IEEE-754.",
-                            version='6.6.0',
+                            version='6.4.3',
                         )
                 continue
 

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -2236,23 +2236,13 @@ def _before_var(visitor, child):
     _id = id(child)
     if _id not in visitor.var_map:
         if child.fixed:
-            ans = child()
-            if ans is None or ans != ans:
-                ans = InvalidNumber(nan)
-            elif ans.__class__ in _complex_types:
-                ans = complex_number_error(ans, self, node)
-            return False, (_CONSTANT, ans)
+            return False, (_CONSTANT, visitor._eval_fixed(child))
         visitor.var_map[_id] = child
     return False, (_MONOMIAL, _id, 1)
 
 
 def _before_param(visitor, child):
-    ans = child()
-    if ans is None or ans != ans:
-        ans = InvalidNumber(nan)
-    elif ans.__class__ in _complex_types:
-        ans = complex_number_error(ans, self, child)
-    return False, (_CONSTANT, ans)
+    return False, (_CONSTANT, visitor._eval_fixed(child))
 
 
 def _before_npv(visitor, child):

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -77,6 +77,8 @@ from pyomo.repn.util import (
     complex_number_error,
     initialize_var_map_from_column_order,
     ordered_active_constraints,
+    nan,
+    sum_like_expression_types,
 )
 from pyomo.repn.plugins.ampl.ampl_ import set_pyomo_amplfunc_env
 
@@ -2448,7 +2450,7 @@ class AMPLRepnVisitor(StreamBasedExpressionVisitor):
     def enterNode(self, node):
         # SumExpression are potentially large nary operators.  Directly
         # populate the result
-        if node.__class__ is SumExpression:
+        if node.__class__ in sum_like_expression_types:
             data = AMPLRepn(0, {}, None)
             data.nonlinear = []
             return node.args, data

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -18,6 +18,7 @@ import os
 
 import pyomo.repn.util as repn_util
 import pyomo.repn.plugins.nl_writer as nl_writer
+from pyomo.repn.util import InvalidNumber
 from pyomo.repn.tests.nl_diff import nl_diff
 
 from pyomo.common.log import LoggingIntercept
@@ -500,7 +501,7 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
         repn = info.visitor.walk_expression((expr, None, None))
         self.assertEqual(repn.nl, None)
         self.assertEqual(repn.mult, 1)
-        self.assertEqual(str(repn.const), 'InvalidNumber(nan)')
+        self.assertEqual(repn.const, InvalidNumber(None))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -509,16 +510,16 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
         repn = info.visitor.walk_expression((expr, None, None))
         self.assertEqual(repn.nl, None)
         self.assertEqual(repn.mult, 1)
-        self.assertEqual(str(repn.const), 'InvalidNumber(nan)')
-        self.assertEqual(repn.linear, {id(m.z): 10})
+        self.assertEqual(repn.const, 0)
+        self.assertEqual(repn.linear, {id(m.z): 10, id(m.x): InvalidNumber(None)})
         self.assertEqual(repn.nonlinear, None)
 
         expr = m.y * m.x
         repn = info.visitor.walk_expression((expr, None, None))
         self.assertEqual(repn.nl, None)
         self.assertEqual(repn.mult, 1)
-        self.assertEqual(str(repn.const), 'InvalidNumber(nan)')
-        self.assertEqual(repn.linear, {})
+        self.assertEqual(repn.const, 0)
+        self.assertEqual(repn.linear, {id(m.x): InvalidNumber(None)})
         self.assertEqual(repn.nonlinear, None)
 
         m.z = Var([1, 2, 3, 4], initialize=lambda m, i: i - 1)
@@ -528,7 +529,7 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
             repn = info.visitor.walk_expression((expr, None, None))
         self.assertEqual(repn.nl, None)
         self.assertEqual(repn.mult, 1)
-        self.assertEqual(str(repn.const), 'InvalidNumber(nan)')
+        self.assertEqual(repn.const, InvalidNumber(None))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear[0], 'o16\no2\no2\nv%s\nv%s\nv%s\n')
         self.assertEqual(repn.nonlinear[1], [id(m.z[2]), id(m.z[3]), id(m.z[4])])
@@ -538,7 +539,7 @@ class Test_AMPLRepnVisitor(unittest.TestCase):
             repn = info.visitor.walk_expression((expr, None, None))
         self.assertEqual(repn.nl, None)
         self.assertEqual(repn.mult, 1)
-        self.assertEqual(str(repn.const), 'InvalidNumber(nan)')
+        self.assertEqual(repn.const, InvalidNumber(None))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 

--- a/pyomo/repn/tests/test_linear.py
+++ b/pyomo/repn/tests/test_linear.py
@@ -134,7 +134,7 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(cfg.var_map, {})
         self.assertEqual(cfg.var_order, {})
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
+        self.assertEqual(repn.constant, InvalidNumber(None))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -188,7 +188,7 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(cfg.var_map, {})
         self.assertEqual(cfg.var_order, {})
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
+        self.assertEqual(repn.constant, InvalidNumber(None))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -408,7 +408,7 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(cfg.var_order, {id(m.x): 0})
         self.assertEqual(repn.multiplier, 1)
         self.assertEqual(repn.constant, 0)
-        self.assertStructuredAlmostEqual(repn.linear, {id(m.x): InvalidNumber(nan)})
+        self.assertStructuredAlmostEqual(repn.linear, {id(m.x): InvalidNumber(None)})
         self.assertEqual(repn.nonlinear, None)
 
         m.p.set_value(4)
@@ -494,7 +494,7 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(cfg.var_map, {})
         self.assertEqual(cfg.var_order, {})
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
+        self.assertEqual(repn.constant, InvalidNumber(None))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -1357,7 +1357,7 @@ class TestLinear(unittest.TestCase):
         expr = 3 * m.y
         repn = LinearRepnVisitor(*cfg).walk_expression(expr)
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
+        self.assertEqual(repn.constant, InvalidNumber(None))
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -1368,7 +1368,7 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(repn.constant, 0)
         self.assertEqual(len(repn.linear), 2)
         self.assertEqual(repn.linear[id(m.z)], 10)
-        self.assertEqual(str(repn.linear[id(m.x)]), 'InvalidNumber(nan)')
+        self.assertEqual(repn.linear[id(m.x)], InvalidNumber(None))
         self.assertEqual(repn.nonlinear, None)
 
         expr = m.y * m.x
@@ -1376,7 +1376,7 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(repn.multiplier, 1)
         self.assertEqual(repn.constant, 0)
         self.assertEqual(len(repn.linear), 1)
-        self.assertEqual(str(repn.linear[id(m.x)]), 'InvalidNumber(nan)')
+        self.assertEqual(repn.linear[id(m.x)], InvalidNumber(None))
         self.assertEqual(repn.nonlinear, None)
 
         m.z = Var([1, 2, 3, 4], initialize=lambda m, i: i - 1)
@@ -1384,14 +1384,14 @@ class TestLinear(unittest.TestCase):
         expr = m.z[1] - ((m.z[2] * m.z[3]) * m.z[4])
         repn = LinearRepnVisitor(*cfg).walk_expression(expr)
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
+        self.assertEqual(repn.constant, InvalidNumber(None))
         self.assertEqual(repn.linear, {})
         self.assertIsNotNone(repn.nonlinear)
 
         m.z[3].fix(float('nan'))
         repn = LinearRepnVisitor(*cfg).walk_expression(expr)
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
+        self.assertEqual(repn.constant, InvalidNumber(None))
         self.assertEqual(repn.linear, {})
         self.assertIsNotNone(repn.nonlinear)
 

--- a/pyomo/repn/tests/test_linear.py
+++ b/pyomo/repn/tests/test_linear.py
@@ -18,7 +18,16 @@ from pyomo.core.expr import Expr_if, inequality, LinearExpression, NPV_SumExpres
 from pyomo.repn.linear import LinearRepn, LinearRepnVisitor
 from pyomo.repn.util import InvalidNumber
 
-from pyomo.environ import Any, ConcreteModel, Param, Var, Expression, ExternalFunction, cos, log
+from pyomo.environ import (
+    Any,
+    ConcreteModel,
+    Param,
+    Var,
+    Expression,
+    ExternalFunction,
+    cos,
+    log,
+)
 
 nan = float('nan')
 

--- a/pyomo/repn/tests/test_linear.py
+++ b/pyomo/repn/tests/test_linear.py
@@ -1211,7 +1211,7 @@ class TestLinear(unittest.TestCase):
         assertExpressionsEqual(
             self,
             repn.nonlinear,
-            Expr_if(IF=InvalidNumber(False), THEN=m.x, ELSE=m.x**2)
+            Expr_if(IF=InvalidNumber(False), THEN=m.x, ELSE=m.x**2),
         )
 
         cfg = VisitorConfig()
@@ -1225,7 +1225,7 @@ class TestLinear(unittest.TestCase):
         assertExpressionsEqual(
             self,
             repn.nonlinear,
-            Expr_if(IF=InvalidNumber(False), THEN=m.x, ELSE=m.x**2)
+            Expr_if(IF=InvalidNumber(False), THEN=m.x, ELSE=m.x**2),
         )
 
         cfg = VisitorConfig()
@@ -1239,7 +1239,7 @@ class TestLinear(unittest.TestCase):
         assertExpressionsEqual(
             self,
             repn.nonlinear,
-            Expr_if(IF=InvalidNumber(False), THEN=m.x, ELSE=m.x**2)
+            Expr_if(IF=InvalidNumber(False), THEN=m.x, ELSE=m.x**2),
         )
 
         m.y.unfix()
@@ -1282,7 +1282,7 @@ class TestLinear(unittest.TestCase):
             Expr_if(IF=inequality(3, m.y, 5), THEN=m.x, ELSE=m.x**2),
         )
 
-        h = Expr_if(1/m.y >= 1, m.x, m.x**2)
+        h = Expr_if(1 / m.y >= 1, m.x, m.x**2)
 
         cfg = VisitorConfig()
         repn = LinearRepnVisitor(*cfg).walk_expression(h)
@@ -1293,9 +1293,7 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(repn.constant, 0)
         self.assertEqual(repn.linear, {})
         assertExpressionsEqual(
-            self,
-            repn.nonlinear,
-            Expr_if(IF=1/m.y >= 1, THEN=m.x, ELSE=m.x**2),
+            self, repn.nonlinear, Expr_if(IF=1 / m.y >= 1, THEN=m.x, ELSE=m.x**2)
         )
 
         m.y.fix(0)
@@ -1599,7 +1597,7 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
-        m.p = numpy.array([3,4])
+        m.p = numpy.array([3, 4])
 
         cfg = VisitorConfig()
         repn = LinearRepnVisitor(*cfg).walk_expression(m.p)

--- a/pyomo/repn/util.py
+++ b/pyomo/repn/util.py
@@ -29,12 +29,18 @@ from pyomo.core.base import (
 )
 from pyomo.core.base.component import ActiveComponent
 from pyomo.core.expr.numvalue import native_numeric_types, is_fixed, value
+import pyomo.core.expr as EXPR
 import pyomo.core.kernel as kernel
 
 logger = logging.getLogger('pyomo.core')
 
 valid_expr_ctypes_minlp = {Var, Param, Expression, Objective}
 valid_active_ctypes_minlp = {Block, Constraint, Objective, Suffix}
+sum_like_expression_types = {
+    EXPR.SumExpression,
+    EXPR.LinearExpression,
+    EXPR.NPV_SumExpression,
+}
 
 HALT_ON_EVALUATION_ERROR = False
 nan = float('nan')

--- a/pyomo/repn/util.py
+++ b/pyomo/repn/util.py
@@ -179,7 +179,7 @@ class InvalidNumber(object):
 
     def __abs__(self):
         return self._op(operator.abs, self)
- 
+
     def __add__(self, other):
         return self._op(operator.add, self, other)
 

--- a/pyomo/repn/util.py
+++ b/pyomo/repn/util.py
@@ -114,7 +114,7 @@ class InvalidNumber(object):
         causes = []
         real_args = []
         for arg in args:
-            if obj.__class__ is InvalidNumber:
+            if arg.__class__ is InvalidNumber:
                 causes.extend(arg.causes)
                 real_args.append(arg.value)
             else:
@@ -131,14 +131,14 @@ class InvalidNumber(object):
             return False
 
     def _op(self, op, *args):
-        args, causes = self._parse_args(self, other)
+        args, causes = self._parse_args(*args)
         try:
             return InvalidNumber(op(*args), causes)
         except (TypeError, ArithmeticError):
             # TypeError will be raised when operating on incompatible
             # types (e.g., int + None); ArithmeticError can be raised by
             # invalid operations (like divide by zero)
-            return self.value
+            return InvalidNumber(self.value, causes)
 
     def __eq__(self, other):
         return self._cmp(operator.eq, other)


### PR DESCRIPTION
## Fixes #2906

## Summary/Motivation:
#2906 pointed out that the NaN handling in the NL writer was missing an import.  While this PR does add the missing import, it also added tests to check that the NaN handling was functioning correctly (it wasn't).  This resolves certain consistency issues when processing NaN values in the LP and NL writers.  It also ports certain approaches developed in the LP writer that were more efficient than the ones in the NL writer.  This results in a modest performance improvement in the NL writer.

## Changes proposed in this PR:
- standardize the handling of both expression evaluation and fixed variable evaluation in the LP and NL writers
- port use of `defaultdict` from LP writer to NL writer
- improve testing of `nan` values in expressions

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
