### PR TITLE
Typos version update

### DIFF
--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -38,4 +38,6 @@ caf = "caf"
 WRONLY = "WRONLY"
 # Ignore the name Hax
 Hax = "Hax"
+# Big Sur
+Sur = "Sur"
 # AS NEEDED: Add More Words Below

--- a/pyomo/contrib/pynumero/sparse/tests/test_intrinsics.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_intrinsics.py
@@ -19,7 +19,7 @@ from pyomo.contrib.pynumero.dependencies import (
 
 if not (numpy_available and scipy_available):
     raise unittest.SkipTest(
-        "Pynumero needs scipy and numpy to run Sparse intrinsict tests"
+        "Pynumero needs scipy and numpy to run Sparse intrinsic tests"
     )
 
 from pyomo.contrib.pynumero.sparse import BlockVector


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
The `typos` tool updated to version 1.16.2, which found new typos (yay).

## Changes proposed in this PR:
- Ignore `Sur` (e.g., `Big Sur`)
- Fix residual typo

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
