### PR TITLE
DAE: Improve error message when attempting to discretize models with circular references

### DIFF
--- a/pyomo/dae/misc.py
+++ b/pyomo/dae/misc.py
@@ -18,6 +18,7 @@ from pyomo.core import Expression, Param
 from pyomo.core.base.misc import apply_indexed_rule
 from pyomo.core.base.block import IndexedBlock, SortComponents
 from pyomo.dae import ContinuousSet, DAE_Error
+from pyomo.common.formatting import tostr
 
 from io import StringIO
 
@@ -165,7 +166,7 @@ def expand_components(block):
                         "components %s. Reformulate your model to"
                         " remove circular references or apply a "
                         "discretization transformation before "
-                        "linking blocks together." % (block, str(redo_expansion))
+                        "linking blocks together." % (block, tostr(redo_expansion))
                     )
 
                 N = len(redo_expansion)


### PR DESCRIPTION
## Summary/Motivation:
This PR fixes an issue in a Pyomo.DAE error message that was reporting component types instead of component names. Thanks to @dallan-keylogic for pointing this out and testing this fix on his IDAES model. I didn't add a test because I was having trouble coming up with a small example model that hits this issue of circular references. 

## Changes proposed in this PR:
- log component names instead of component types in DAE error message related to circular references

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
