### PR TITLE
Add Explicit Linting Instructions to PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 <!-- ##################################################################### -->
 <!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->
 
-<!-- All changes must adhere to PEP8 standards, applied using [`black`](https://black.readthedocs.io/en/stable/). -->
+<!-- All changes must adhere to PEP8 standards, applied using `black`: https://black.readthedocs.io/en/stable/. -->
 <!-- If your changes do NOT adhere, the test suite will fail. -->
-<!-- Please read our [Contributing guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) for instructions on how to apply these standards. -->
+<!-- Please read our Contributing guide (https://pyomo.readthedocs.io/en/stable/contribution_guide.html) for instructions on how to apply these standards. -->
 <!-- ##################################################################### -->
 
 ## Fixes # .

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,11 @@
+<!-- ##################################################################### -->
+<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->
+
+<!-- All changes must adhere to PEP8 standards, applied using [`black`](https://black.readthedocs.io/en/stable/). -->
+<!-- If your changes do NOT adhere, the test suite will fail. -->
+<!-- Please read our [Contributing guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) for instructions on how to apply these standards. -->
+<!-- ##################################################################### -->
+
 ## Fixes # .
 
 ## Summary/Motivation:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,10 @@
 <!-- ##################################################################### -->
 <!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->
 
-<!-- All changes must adhere to PEP8 standards, applied using `black`: https://black.readthedocs.io/en/stable/. -->
+<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
 <!-- If your changes do NOT adhere, the test suite will fail. -->
-<!-- Please read our Contributing guide (https://pyomo.readthedocs.io/en/stable/contribution_guide.html) for instructions on how to apply these standards. -->
+<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
+<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
 <!-- ##################################################################### -->
 
 ## Fixes # .


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes NA

## Summary/Motivation:
We have been getting a lot of external contributions lately, and we need to highlight the `black` requirement so PRs do not fail the linting checks as often.

## Changes proposed in this PR:
- Add warning / reminder message at the top of the PR template
- **NOTE**: These changes do NOT render (by design). They are meant as a reminder/"quiet-loud" note to PR submitters

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
