### PR TITLE
Remove HTML4 Forcing in Online Docs

### DIFF
--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -146,13 +146,6 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 html_theme = 'sphinx_rtd_theme'
 
-# Force HTML4: If we don't explicitly force HTML4, then the background
-# of the Parameters/Returns/Return type headers is shaded the same as the
-# method prototype (tested 15 April 21 with Sphinx=3.5.4 and
-# sphinx-rtd-theme=0.5.2).
-html4_writer = True
-# html5_writer = True
-
 if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme
 


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
We have been forcing HTML4 ReadTheDocs configuration due to an issue from 2021; however, that issue has been resolved.

## Changes proposed in this PR:
- Allow RTD to render HTML in whatever format it likes

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
