### PR TITLE
Fixing a 'that' vs. 'which' mistake in error about bounds crossing

### DIFF
--- a/pyomo/contrib/fbbt/fbbt.py
+++ b/pyomo/contrib/fbbt/fbbt.py
@@ -1138,7 +1138,7 @@ class _FBBTVisitorLeafToRoot(ExpressionValueVisitor):
                     ub = interval.inf
                 if lb - self.feasibility_tol > ub:
                     raise InfeasibleConstraintException(
-                        'Variable has a lower bound which is larger than its upper bound: {0}'.format(
+                        'Variable has a lower bound that is larger than its upper bound: {0}'.format(
                             str(node)
                         )
                     )


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

One-word change to fix a grammar mistake in an error message.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
