### PR TITLE
Ensure constants written correctly to LP/NL files

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -778,6 +778,7 @@ def _finalize_matplotlib(module, available):
 def _finalize_numpy(np, available):
     if not available:
         return
+    numeric_types.native_types.add(np.ndarray)
     numeric_types.RegisterLogicalType(np.bool_)
     for t in (
         np.int_,

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -187,12 +187,12 @@ class _ConstraintData(ActiveComponentData):
     def has_lb(self):
         """Returns :const:`False` when the lower bound is
         :const:`None` or negative infinity"""
-        return self.lower is not None
+        return self.lb is not None
 
     def has_ub(self):
         """Returns :const:`False` when the upper bound is
         :const:`None` or positive infinity"""
-        return self.upper is not None
+        return self.ub is not None
 
     def lslack(self):
         """
@@ -338,50 +338,39 @@ class _GeneralConstraintData(_ConstraintData):
         """Access the body of a constraint expression."""
         if self._body is not None:
             return self._body
-        else:
-            # The incoming RangedInequality had a potentially variable
-            # bound.  The "body" is fine, but the bounds may not be
-            # (although the responsibility for those checks lies with the
-            # lower/upper properties)
-            body = self._expr.arg(1)
-            if body.__class__ in native_types and body is not None:
-                return as_numeric(body)
-            return body
+        # The incoming RangedInequality had a potentially variable
+        # bound.  The "body" is fine, but the bounds may not be
+        # (although the responsibility for those checks lies with the
+        # lower/upper properties)
+        body = self._expr.arg(1)
+        if body.__class__ in native_types and body is not None:
+            return as_numeric(body)
+        return body
 
-    def _lb(self):
-        if self._body is not None:
-            bound = self._lower
-        elif self._expr is None:
+    def _get_range_bound(self, range_arg):
+        # Equalities and simple inequalities can always be (directly)
+        # reformulated at construction time to force constant bounds.
+        # The only time we need to defer the determination of bounds is
+        # for ranged inequalities that contain non-constant bounds (so
+        # we *know* that the expr will have 3 args)
+        #
+        # It is possible that there is no expression at all (so catch that)
+        if self._expr is None:
             return None
-        else:
-            bound = self._expr.arg(0)
-            if not is_fixed(bound):
-                raise ValueError(
-                    "Constraint '%s' is a Ranged Inequality with a "
-                    "variable %s bound.  Cannot normalize the "
-                    "constraint or send it to a solver." % (self.name, 'lower')
-                )
-        return bound
-
-    def _ub(self):
-        if self._body is not None:
-            bound = self._upper
-        elif self._expr is None:
-            return None
-        else:
-            bound = self._expr.arg(2)
-            if not is_fixed(bound):
-                raise ValueError(
-                    "Constraint '%s' is a Ranged Inequality with a "
-                    "variable %s bound.  Cannot normalize the "
-                    "constraint or send it to a solver." % (self.name, 'upper')
-                )
+        bound = self._expr.arg(range_arg)
+        if not is_fixed(bound):
+            raise ValueError(
+                "Constraint '%s' is a Ranged Inequality with a "
+                "variable %s bound.  Cannot normalize the "
+                "constraint or send it to a solver."
+                % (self.name, {0: 'lower', 2: 'upper'}[range_arg])
+            )
         return bound
 
     @property
     def lower(self):
         """Access the lower bound of a constraint expression."""
-        bound = self._lb()
+        bound = self._lower if self._body is not None else self._get_range_bound(0)
         # Historically, constraint.lower was guaranteed to return a type
         # derived from Pyomo NumericValue (or None).  Replicate that
         # functionality, although clients should in almost all cases
@@ -395,7 +384,7 @@ class _GeneralConstraintData(_ConstraintData):
     @property
     def upper(self):
         """Access the upper bound of a constraint expression."""
-        bound = self._ub()
+        bound = self._upper if self._body is not None else self._get_range_bound(2)
         # Historically, constraint.upper was guaranteed to return a type
         # derived from Pyomo NumericValue (or None).  Replicate that
         # functionality, although clients should in almost all cases
@@ -409,9 +398,11 @@ class _GeneralConstraintData(_ConstraintData):
     @property
     def lb(self):
         """Access the value of the lower bound of a constraint expression."""
-        bound = self._lb()
-        if bound.__class__ not in native_types:
-            bound = value(bound)
+        bound = self._lower if self._body is not None else self._get_range_bound(0)
+        if bound.__class__ not in native_numeric_types:
+            if bound is None:
+                return None
+            bound = float(value(bound))
         if bound in _nonfinite_values or bound != bound:
             # Note that "bound != bound" catches float('nan')
             if bound == -_inf:
@@ -426,9 +417,11 @@ class _GeneralConstraintData(_ConstraintData):
     @property
     def ub(self):
         """Access the value of the upper bound of a constraint expression."""
-        bound = self._ub()
-        if bound.__class__ not in native_types:
-            bound = value(bound)
+        bound = self._upper if self._body is not None else self._get_range_bound(2)
+        if bound.__class__ not in native_numeric_types:
+            if bound is None:
+                return None
+            bound = float(value(bound))
         if bound in _nonfinite_values or bound != bound:
             # Note that "bound != bound" catches float('nan')
             if bound == _inf:

--- a/pyomo/repn/plugins/lp_writer.py
+++ b/pyomo/repn/plugins/lp_writer.py
@@ -45,6 +45,7 @@ from pyomo.repn.util import (
     FileDeterminism_to_SortComponents,
     categorize_valid_components,
     initialize_var_map_from_column_order,
+    int_float,
     ordered_active_constraints,
 )
 
@@ -383,7 +384,18 @@ class _LPWriter_impl(object):
                 timer.toc('Constraint %s', last_parent, level=logging.DEBUG)
                 last_parent = con.parent_component()
             lb = con.lb
+            if lb is not None:
+                if lb.__class__ not in int_float:
+                    lb = float(lb)
+                if lb == neg_inf:
+                    lb = None
             ub = con.ub
+            if ub is not None:
+                if ub.__class__ not in int_float:
+                    ub = float(ub)
+                if ub == inf:
+                    ub = None
+
             if lb is None and ub is None:
                 # Note: you *cannot* output trivial (unbounded)
                 # constraints in LP format.  I suppose we could add a
@@ -399,6 +411,8 @@ class _LPWriter_impl(object):
 
             # Pull out the constant: we will move it to the bounds
             offset = repn.constant
+            if offset.__class__ not in int_float:
+                offset = float(offset)
             repn.constant = 0
 
             if repn.linear or getattr(repn, 'quadratic', None):
@@ -423,14 +437,20 @@ class _LPWriter_impl(object):
                 repn.linear[id(ONE_VAR_CONSTANT)] = 0
 
             symbol = labeler(con)
-            if lb == ub and lb is not None:
-                label = f'c_e_{symbol}_'
-                addSymbol(con, label)
-                ostream.write(f'\n{label}:\n')
-                self.write_expression(ostream, repn, False)
-                ostream.write(f'= {(lb - offset)!r}\n')
-            elif lb is not None and lb != neg_inf:
-                if ub is not None and ub != inf:
+            if lb is not None:
+                if ub is None:
+                    label = f'c_l_{symbol}_'
+                    addSymbol(con, label)
+                    ostream.write(f'\n{label}:\n')
+                    self.write_expression(ostream, repn, False)
+                    ostream.write(f'>= {(lb - offset)!r}\n')
+                elif lb == ub:
+                    label = f'c_e_{symbol}_'
+                    addSymbol(con, label)
+                    ostream.write(f'\n{label}:\n')
+                    self.write_expression(ostream, repn, False)
+                    ostream.write(f'= {(lb - offset)!r}\n')
+                else:
                     # We will need the constraint body twice.  Generate
                     # in a buffer so we only have to do that once.
                     buf = StringIO()
@@ -447,13 +467,7 @@ class _LPWriter_impl(object):
                     ostream.write(f'\n{label}:\n')
                     ostream.write(buf)
                     ostream.write(f'<= {(ub - offset)!r}\n')
-                else:
-                    label = f'c_l_{symbol}_'
-                    addSymbol(con, label)
-                    ostream.write(f'\n{label}:\n')
-                    self.write_expression(ostream, repn, False)
-                    ostream.write(f'>= {(lb - offset)!r}\n')
-            elif ub is not None and ub != inf:
+            elif ub is not None:
                 label = f'c_u_{symbol}_'
                 addSymbol(con, label)
                 ostream.write(f'\n{label}:\n')
@@ -496,8 +510,24 @@ class _LPWriter_impl(object):
                 integer_vars.append(v_symbol)
 
             lb, ub = v.bounds
-            lb = '-inf' if lb is None else repr(lb)
-            ub = '+inf' if ub is None or ub == inf else repr(ub)
+            if lb is None:
+                lb = '-inf'
+            else:
+                if lb.__class__ not in int_float:
+                    lb = float(lb)
+                if lb == neg_inf:
+                    lb = '-inf'
+                else:
+                    lb = repr(lb)
+            if ub is None:
+                ub = '+inf'
+            else:
+                if ub.__class__ not in int_float:
+                    ub = float(ub)
+                if ub == inf:
+                    ub = '+inf'
+                else:
+                    ub = repr(ub)
             ostream.write(f"\n   {lb} <= {v_symbol} <= {ub}")
 
         if integer_vars:
@@ -532,6 +562,8 @@ class _LPWriter_impl(object):
             for soscon in sos:
                 ostream.write(f'\n{getSymbol(soscon)}: S{soscon.level}::\n')
                 for v, w in getattr(soscon, 'get_items', soscon.items)():
+                    if w.__class__ not in int_float:
+                        w = float(f)
                     ostream.write(f"  {getSymbol(v)}:{w!r}\n")
 
         ostream.write("\nend\n")
@@ -550,6 +582,8 @@ class _LPWriter_impl(object):
             for vid, coef in sorted(
                 expr.linear.items(), key=lambda x: getVarOrder(x[0])
             ):
+                if coef.__class__ not in int_float:
+                    coef = float(coef)
                 if coef < 0:
                     ostream.write(f'{coef!r} {getSymbol(getVar(vid))}\n')
                 else:
@@ -571,6 +605,8 @@ class _LPWriter_impl(object):
                 else:
                     col = c1, c2
                     sym = f' {getSymbol(getVar(vid1))} * {getSymbol(getVar(vid2))}\n'
+                if coef.__class__ not in int_float:
+                    coef = float(coef)
                 if coef < 0:
                     return col, repr(coef) + sym
                 else:

--- a/pyomo/repn/plugins/lp_writer.py
+++ b/pyomo/repn/plugins/lp_writer.py
@@ -383,18 +383,10 @@ class _LPWriter_impl(object):
             if with_debug_timing and con.parent_component() is not last_parent:
                 timer.toc('Constraint %s', last_parent, level=logging.DEBUG)
                 last_parent = con.parent_component()
+            # Note: Constraint.lb/ub guarantee a return value ther is
+            # either a (finite) native_numeric_type, or None
             lb = con.lb
-            if lb is not None:
-                if lb.__class__ not in int_float:
-                    lb = float(lb)
-                if lb == neg_inf:
-                    lb = None
             ub = con.ub
-            if ub is not None:
-                if ub.__class__ not in int_float:
-                    ub = float(ub)
-                if ub == inf:
-                    ub = None
 
             if lb is None and ub is None:
                 # Note: you *cannot* output trivial (unbounded)
@@ -509,25 +501,11 @@ class _LPWriter_impl(object):
             elif v.is_integer():
                 integer_vars.append(v_symbol)
 
+            # Note: Var.bounds guarantees the values are either (finite)
+            # native_numeric_types or None
             lb, ub = v.bounds
-            if lb is None:
-                lb = '-inf'
-            else:
-                if lb.__class__ not in int_float:
-                    lb = float(lb)
-                if lb == neg_inf:
-                    lb = '-inf'
-                else:
-                    lb = repr(lb)
-            if ub is None:
-                ub = '+inf'
-            else:
-                if ub.__class__ not in int_float:
-                    ub = float(ub)
-                if ub == inf:
-                    ub = '+inf'
-                else:
-                    ub = repr(ub)
+            lb = '-inf' if lb is None else repr(lb)
+            ub = '+inf' if ub is None else repr(ub)
             ostream.write(f"\n   {lb} <= {v_symbol} <= {ub}")
 
         if integer_vars:

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -563,22 +563,17 @@ class _NLWriter_impl(object):
             expr = visitor.walk_expression((con.body, con, 0))
             if expr.named_exprs:
                 self._record_named_expression_usage(expr.named_exprs, con, 0)
+            # Note: Constraint.lb/ub guarantee a return value ther is
+            # either a (finite) native_numeric_type, or None
+            const = expr.const
+            if const.__class__ not in int_float:
+                const = float(const)
             lb = con.lb
             if lb is not None:
-                if lb.__class__ not in int_float:
-                    lb = float(lb)
-                if lb == minus_inf:
-                    lb = None
-                else:
-                    lb = repr(lb - expr.const)
+                lb = repr(lb - const)
             ub = con.ub
             if ub is not None:
-                if ub.__class__ not in int_float:
-                    ub = float(ub)
-                if ub == inf:
-                    ub = None
-                else:
-                    ub = repr(ub - expr.const)
+                ub = repr(ub - const)
             _type = _RANGE_TYPE(lb, ub)
             if _type == 4:
                 n_equality += 1
@@ -816,21 +811,13 @@ class _NLWriter_impl(object):
         self.column_order = column_order = {_id: i for i, _id in enumerate(variables)}
         for idx, _id in enumerate(variables):
             v = var_map[_id]
+            # Note: Var.bounds guarantees the values are either (finite)
+            # native_numeric_types or None
             lb, ub = v.bounds
             if lb is not None:
-                if lb.__class__ not in int_float:
-                    lb = float(lb)
-                if lb == minus_inf:
-                    lb = None
-                else:
-                    lb = repr(lb)
+                lb = repr(lb)
             if ub is not None:
-                if ub.__class__ not in int_float:
-                    ub = float(ub)
-                if ub == inf:
-                    ub = None
-                else:
-                    ub = repr(ub)
+                ub = repr(ub)
             variables[idx] = (v, _id, _RANGE_TYPE(lb, ub), lb, ub)
         timer.toc("Computed variable bounds", level=logging.DEBUG)
 

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -95,7 +95,6 @@ TOL = 1e-8
 inf = float('inf')
 minus_inf = -inf
 
-
 _CONSTANT = ExprType.CONSTANT
 _MONOMIAL = ExprType.MONOMIAL
 _GENERAL = ExprType.GENERAL
@@ -1242,8 +1241,12 @@ class _NLWriter_impl(object):
             'x%d%s\n'
             % (len(_init_lines), "\t# initial guess" if symbolic_solver_labels else '')
         )
-        ostream.write(''.join(f'{var_idx} {val!r}{col_comments[var_idx]}\n'
-                              for var_idx, val in _init_lines))
+        ostream.write(
+            ''.join(
+                f'{var_idx} {val!r}{col_comments[var_idx]}\n'
+                for var_idx, val in _init_lines
+            )
+        )
 
         #
         # "r" lines (constraint bounds)
@@ -1504,10 +1507,28 @@ class _NLWriter_impl(object):
             if include_const and repn.const:
                 # Add the constant to the NL expression.  AMPL adds the
                 # constant as the second argument, so we will too.
-                nl = self.template.binary_sum + nl + (self.template.const % (repn.const if repn.const.__class__ in int_float else float(repn.const)))
+                nl = (
+                    self.template.binary_sum
+                    + nl
+                    + (
+                        self.template.const
+                        % (
+                            repn.const
+                            if repn.const.__class__ in int_float
+                            else float(repn.const)
+                        )
+                    )
+                )
             self.ostream.write(nl % tuple(map(self.var_id_to_nl.__getitem__, args)))
         elif include_const:
-            self.ostream.write(self.template.const % (repn.const if repn.const.__class__ in int_float else float(repn.const)))
+            self.ostream.write(
+                self.template.const
+                % (
+                    repn.const
+                    if repn.const.__class__ in int_float
+                    else float(repn.const)
+                )
+            )
         else:
             self.ostream.write(self.template.const % 0)
 
@@ -1655,7 +1676,9 @@ class AMPLRepn(object):
                 args.extend(self.nonlinear[1])
         if self.const:
             nterms += 1
-            nl_sum += template.const % (self.const if self.const.__class__ in int_float else float(self.const))
+            nl_sum += template.const % (
+                self.const if self.const.__class__ in int_float else float(self.const)
+            )
 
         if nterms > 2:
             return (prefix + (template.nary_sum % nterms) + nl_sum, args, named_exprs)

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -20,6 +20,7 @@ import pyomo.repn.util as repn_util
 import pyomo.repn.plugins.nl_writer as nl_writer
 from pyomo.repn.tests.nl_diff import nl_diff
 
+from pyomo.common.dependencies import numpy, numpy_available
 from pyomo.common.log import LoggingIntercept
 from pyomo.common.tempfiles import TempfileManager
 from pyomo.core.expr import Expr_if, inequality, LinearExpression
@@ -1026,6 +1027,79 @@ G0 4    #OBJ
 1 2
 2 3
 3 1
+""",
+                OUT.getvalue(),
+            )
+        )
+
+    @unittest.skipUnless(numpy_available, "test requires numpy")
+    def test_nonfloat_constants(self):
+        import pyomo.environ as pyo
+
+        v = numpy.array([[8], [3], [6], [11]])
+        w = numpy.array([[5], [7], [4], [3]])
+        # Create model
+        m = pyo.ConcreteModel()
+        m.I = pyo.Set(initialize=range(4))
+        # Variables: note initialization with non-numeric value
+        m.zero = pyo.Param(initialize=numpy.array([0]), mutable=True)
+        m.one = pyo.Param(initialize=numpy.array([1]), mutable=True)
+        m.x = pyo.Var(m.I, bounds=(m.zero, m.one), domain=pyo.Integers, initialize=True)
+        # Params: initialize with 1-member ndarrays
+        m.limit = pyo.Param(initialize=numpy.array([14]), mutable=True)
+        m.v = pyo.Param(m.I, initialize=v, mutable=True)
+        m.w = pyo.Param(m.I, initialize=w, mutable=True)
+        # Objective: note use of numpy in coefficients
+        m.value = pyo.Objective(expr=pyo.sum_product(m.v, m.x), sense=pyo.maximize)
+        # Constraint: note use of numpy in coefficients and RHS
+        m.weight = pyo.Constraint(expr=pyo.sum_product(m.w, m.x) <= m.limit)
+
+        OUT = io.StringIO()
+        with LoggingIntercept() as LOG:
+            nl_writer.NLWriter().write(m, OUT, symbolic_solver_labels=True)
+        self.assertEqual(LOG.getvalue(), "")
+        self.assertEqual(
+            *nl_diff(
+                """g3 1 1 0       #problem unknown
+ 4 1 1 0 0     #vars, constraints, objectives, ranges, eqns
+ 0 0 0 0 0 0   #nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0   #network constraints: nonlinear, linear
+ 0 0 0 #nonlinear vars in constraints, objectives, both
+ 0 0 0 1       #linear network variables; functions; arith, flags
+ 0 4 0 0 0     #discrete variables: binary, integer, nonlinear (b,c,o)
+ 4 4   #nonzeros in Jacobian, obj. gradient
+ 6 4   #max name lengths: constraints, variables
+ 0 0 0 0 0     #common exprs: b,c,o,c1,o1
+C0     #weight
+n0
+O0 1   #value
+n0
+x4     #initial guess
+0 1.0  #x[0]
+1 1.0  #x[1]
+2 1.0  #x[2]
+3 1.0  #x[3]
+r      #1 ranges (rhs's)
+1 14.0 #weight
+b      #4 bounds (on variables)
+0 0 1  #x[0]
+0 0 1  #x[1]
+0 0 1  #x[2]
+0 0 1  #x[3]
+k3     #intermediate Jacobian column lengths
+1
+2
+3
+J0 4   #weight
+0 5
+1 7
+2 4
+3 3
+G0 4   #value
+0 8
+1 3
+2 6
+3 11
 """,
                 OUT.getvalue(),
             )

--- a/pyomo/repn/util.py
+++ b/pyomo/repn/util.py
@@ -38,6 +38,7 @@ valid_active_ctypes_minlp = {Block, Constraint, Objective, Suffix}
 
 HALT_ON_EVALUATION_ERROR = False
 nan = float('nan')
+int_float = {int, float}
 
 
 class ExprType(enum.IntEnum):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #2927, 2928 .

## Summary/Motivation:
The LP and NL writers were more flexible in the data types they accepted, but introduced cases where non-int/float data types were written out to the NL or LP files.  This PR goes through and ensures that all numeric constants are mapped to either int or float being written out to the file.

Note that this restores the original behavior reported in the issue, but does not fix the slightly more egregious error of permitting the use of `Boolean` as a domain for (numeric) `Constraint`s.

## Changes proposed in this PR:
- ensure all numeric constants are either `int` or `float` before writing them out to the LP/NL file
- standardize processing of `Var` and `Constraint` `lb/`ub` properties to ensure that the returned vales are either native numeric types or `None`.  This also ensures that ``inf` / `-inf` are mapped to None before returning them to the user
- minor performance improvements (~2% for LP writer, NL writer, and model generation)
- Add a test to exercise issues originally reported in #2927 and #2928.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
