### PR TITLE
Resolve error categorizing some Var discrete domains as "integer"

### DIFF
--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -174,7 +174,16 @@ class _VarData(ComponentData, NumericValue):
         if _id in _known_global_real_domains:
             return not _known_global_real_domains[_id]
         _interval = self.domain.get_interval()
-        return _interval is not None and _interval[2] == 1
+        if _interval is None:
+            return False
+        # Note: it is not sufficient to just check the step: the
+        # starting / ending points must be integers (or not specified)
+        start, stop, step = _interval
+        return (
+            step == 1
+            and (start is None or int(start) == start)
+            and (stop is None or int(stop) == stop)
+        )
 
     def is_binary(self):
         """Returns True when the domain is restricted to Binary values."""

--- a/pyomo/core/tests/unit/test_var.py
+++ b/pyomo/core/tests/unit/test_var.py
@@ -1678,6 +1678,45 @@ class MiscVarTests(unittest.TestCase):
         self.assertTrue(i.y.stale)
         self.assertFalse(i.z.stale)
 
+    def test_domain_categories(self):
+        """Test domain attribute"""
+        x = Var()
+        x.construct()
+        self.assertEqual(x.is_integer(), False)
+        self.assertEqual(x.is_binary(), False)
+        self.assertEqual(x.is_continuous(), True)
+        self.assertEqual(x.bounds, (None, None))
+        x.domain = Integers
+        self.assertEqual(x.is_integer(), True)
+        self.assertEqual(x.is_binary(), False)
+        self.assertEqual(x.is_continuous(), False)
+        self.assertEqual(x.bounds, (None, None))
+        x.domain = Binary
+        self.assertEqual(x.is_integer(), True)
+        self.assertEqual(x.is_binary(), True)
+        self.assertEqual(x.is_continuous(), False)
+        self.assertEqual(x.bounds, (0, 1))
+        x.domain = RangeSet(0, 10, 0)
+        self.assertEqual(x.is_integer(), False)
+        self.assertEqual(x.is_binary(), False)
+        self.assertEqual(x.is_continuous(), True)
+        self.assertEqual(x.bounds, (0, 10))
+        x.domain = RangeSet(0, 10, 1)
+        self.assertEqual(x.is_integer(), True)
+        self.assertEqual(x.is_binary(), False)
+        self.assertEqual(x.is_continuous(), False)
+        self.assertEqual(x.bounds, (0, 10))
+        x.domain = RangeSet(0.5, 10, 1)
+        self.assertEqual(x.is_integer(), False)
+        self.assertEqual(x.is_binary(), False)
+        self.assertEqual(x.is_continuous(), False)
+        self.assertEqual(x.bounds, (0.5, 9.5))
+        x.domain = RangeSet(0, 1, 1)
+        self.assertEqual(x.is_integer(), True)
+        self.assertEqual(x.is_binary(), True)
+        self.assertEqual(x.is_continuous(), False)
+        self.assertEqual(x.bounds, (0, 1))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
Variables with domains defined with a domain with step 1, but not starting at an integer value were being categorized as "integer" domains.  This updates `is_integer()` to correctly report `False` for discrete domains that are not rooted (start or stop) at integer values.  This adds a test to exercise / verify the expected behavior.

## Changes proposed in this PR:
- `is_integer()` should only be `True` if the range starts/ends at an integer
- Add tests verifying the correct behavior.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
