### PR TITLE
Support kwargs in partial objects passed to Initializer()

### DIFF
--- a/pyomo/core/base/initializer.py
+++ b/pyomo/core/base/initializer.py
@@ -157,7 +157,10 @@ def Initializer(
             # 'int').  We will just have to assume this is a "normal"
             # IndexedCallInitializer
             return IndexedCallInitializer(arg)
-        if len(_args.args) - len(arg.args) == 1 and _args.varargs is None:
+        _positional_args = set(_args.args)
+        for key in arg.keywords:
+            _positional_args.discard(key)
+        if len(_positional_args) - len(arg.args) == 1 and _args.varargs is None:
             return ScalarCallInitializer(arg)
         else:
             return IndexedCallInitializer(arg)

--- a/pyomo/core/tests/unit/test_initializer.py
+++ b/pyomo/core/tests/unit/test_initializer.py
@@ -595,6 +595,17 @@ class Test_Initializer(unittest.TestCase):
         self.assertFalse(a.contains_indices())
         self.assertEqual(a(None, None), 572)
 
+        def fcn(m, k, i, j):
+            return i * 100 + j * 10 + k
+
+        part = functools.partial(fcn, i=2, j=5, k=7)
+        a = Initializer(part)
+        self.assertIs(type(a), ScalarCallInitializer)
+        self.assertTrue(a.constant())
+        self.assertFalse(a.verified)
+        self.assertFalse(a.contains_indices())
+        self.assertEqual(a(None, None), 257)
+
     @unittest.skipUnless(pandas_available, "Pandas is not installed")
     def test_dataframe(self):
         d = {'col1': [1, 2, 4]}


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
@dallan-keylogic pointed out that `Initializer()` incorrectly maps `functools.partial` objects to `IndexedCallInitializer` when all the rule arguments are passed to `functools.partial()` as keyword arguments.  This PR corrects this (and adds a test).

## Changes proposed in this PR:
- `Initializer()` should detect positional arguments specified as keyword arguments to partial()
- Add a test of this behavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
