### PR TITLE
Prevent multiple applications of the scaling transform

### DIFF
--- a/examples/doc/samples/case_studies/network_flow/README.txt
+++ b/examples/doc/samples/case_studies/network_flow/README.txt
@@ -109,7 +109,7 @@ def supplyDemandRule(nn, model):
 model.supplyDemand = Constraint(model.places, rule=supplyDemandRule)
 }}}
 
-What we did was just construct a few additional variables; this wasn't required but makes reading and understanding the code much, much simpler.  The variable "amountIn" looks at each route to find ones that end in this location, then adds the amount on each of those routes together to determine how much flows to each location.  The "amountOut" variable functions similarly for the flow out.  Then we just create an "input" and "output" and ensure they're equal.  Like in some of the previous constraints, we feed the set of places into the constraint as an arguement so it will index over that set, and thus this rule functions for all the places in our network.
+What we did was just construct a few additional variables; this wasn't required but makes reading and understanding the code much, much simpler.  The variable "amountIn" looks at each route to find ones that end in this location, then adds the amount on each of those routes together to determine how much flows to each location.  The "amountOut" variable functions similarly for the flow out.  Then we just create an "input" and "output" and ensure they're equal.  Like in some of the previous constraints, we feed the set of places into the constraint as an argument so it will index over that set, and thus this rule functions for all the places in our network.
 
 We have now finished creating the model.  Save this as a .py file before continuing.
 

--- a/examples/doc/samples/case_studies/network_flow/networkFlow1.tex
+++ b/examples/doc/samples/case_studies/network_flow/networkFlow1.tex
@@ -172,7 +172,7 @@ def supplyDemandRule(nn, model):
 model.supplyDemand = Constraint(model.places, rule=supplyDemandRule)
 \end{verbatim}
 
-What we did was just construct a few additional variables; this wasn't required but makes reading and understanding the code much, much simpler.  The variable ``amountIn'' looks at each route to find ones that end in this location, then adds the amount on each of those routes together to determine how much flows to each location.  The ``amountOut'' variable functions similarly for the flow out.  Then we just create an ``input'' and ``output'' and ensure they're equal.  As in some of the previous constraints, we feed the set of places into the constraint as an arguement so it will index over that set, and thus this rule functions for all the places in our network.
+What we did was just construct a few additional variables; this wasn't required but makes reading and understanding the code much, much simpler.  The variable ``amountIn'' looks at each route to find ones that end in this location, then adds the amount on each of those routes together to determine how much flows to each location.  The ``amountOut'' variable functions similarly for the flow out.  Then we just create an ``input'' and ``output'' and ensure they're equal.  As in some of the previous constraints, we feed the set of places into the constraint as an argument so it will index over that set, and thus this rule functions for all the places in our network.
 
 We have now finished creating the model.  Save this as a .py file before continuing.
 

--- a/pyomo/core/plugins/transform/scaling.py
+++ b/pyomo/core/plugins/transform/scaling.py
@@ -178,7 +178,7 @@ class ScaleModel(Transformation):
         # to variable_substitution_dict (key: id() of component)
         # ToDo: We should change replace_expressions to accept a ComponentMap as well
         variable_substitution_dict = {
-            id(k): variable_substitution_map[k] for k in variable_substitution_map
+            id(k): v for k, v in variable_substitution_map.items()
         }
 
         already_scaled = set()

--- a/pyomo/core/plugins/transform/scaling.py
+++ b/pyomo/core/plugins/transform/scaling.py
@@ -225,15 +225,16 @@ class ScaleModel(Transformation):
                 ]
             )
 
-        # scale the variable bounds and values and build the variable substitution map
-        # for scaling vars in constraints
+        # scale the variable bounds and values and build the variable
+        # substitution map for scaling vars in constraints
         variable_substitution_map = ComponentMap()
         already_scaled = set()
         for variable in [
             var for var in model.component_objects(ctype=Var, descend_into=True)
         ]:
             if variable.is_reference():
-                # Skip any references - these should get picked up when handling the actual variable
+                # Skip any references - these should get picked up when
+                # handling the actual variable
                 continue
 
             # set the bounds/value for the scaled variable
@@ -277,7 +278,8 @@ class ScaleModel(Transformation):
             ctype=(Constraint, Objective), descend_into=True
         ):
             if component.is_reference():
-                # Skip any references - these should get picked up when handling the actual component
+                # Skip any references - these should get picked up when
+                # handling the actual component
                 continue
 
             for k in component:
@@ -325,7 +327,8 @@ class ScaleModel(Transformation):
                     )
                 else:
                     raise NotImplementedError(
-                        'Unknown object type found when applying scaling factors in ScaleModel transformation - Internal Error'
+                        'Unknown object type found when applying scaling factors '
+                        'in ScaleModel transformation - Internal Error'
                     )
 
         model.component_scaling_factor_map = component_scaling_factor_map
@@ -336,12 +339,14 @@ class ScaleModel(Transformation):
         return model
 
     def propagate_solution(self, scaled_model, original_model):
-        """
-        This method takes the solution in scaled_model and maps it back to the original model.
+        """This method takes the solution in scaled_model and maps it back to
+        the original model.
 
-        It will also transform duals and reduced costs if the suffixes 'dual' and/or 'rc' are present.
-        The :code:`scaled_model` argument must be a model that was already scaled using this transformation
-        as it expects data from the transformation to perform the back mapping.
+        It will also transform duals and reduced costs if the suffixes
+        'dual' and/or 'rc' are present.  The :code:`scaled_model`
+        argument must be a model that was already scaled using this
+        transformation as it expects data from the transformation to
+        perform the back mapping.
 
         Parameters
         ----------
@@ -353,15 +358,17 @@ class ScaleModel(Transformation):
         """
         if not hasattr(scaled_model, 'component_scaling_factor_map'):
             raise AttributeError(
-                'ScaleModel:propagate_solution called with scaled_model that does not '
-                'have a component_scaling_factor_map. It is possible this method was called '
-                'using a model that was not scaled with the ScaleModel transformation'
+                'ScaleModel:propagate_solution called with scaled_model that does '
+                'not have a component_scaling_factor_map. It is possible this '
+                'method was called using a model that was not scaled with the '
+                'ScaleModel transformation'
             )
         if not hasattr(scaled_model, 'scaled_component_to_original_name_map'):
             raise AttributeError(
-                'ScaleModel:propagate_solution called with scaled_model that does not '
-                'have a scaled_component_to_original_name_map. It is possible this method was called '
-                'using a model that was not scaled with the ScaleModel transformation'
+                'ScaleModel:propagate_solution called with scaled_model that does '
+                'not have a scaled_component_to_original_name_map. It is possible '
+                'this method was called using a model that was not scaled with '
+                'the ScaleModel transformation'
             )
 
         component_scaling_factor_map = scaled_model.component_scaling_factor_map
@@ -385,7 +392,8 @@ class ScaleModel(Transformation):
             )
             if len(scaled_objectives) != 1:
                 raise NotImplementedError(
-                    'ScaleModel.propagate_solution requires a single active objective function, but %d objectives found.'
+                    'ScaleModel.propagate_solution requires a single active '
+                    'objective function, but %d objectives found.'
                     % (len(scaled_objectives))
                 )
             else:

--- a/pyomo/core/plugins/transform/scaling.py
+++ b/pyomo/core/plugins/transform/scaling.py
@@ -244,6 +244,12 @@ class ScaleModel(Transformation):
             scaled_component_to_original_name_map
         )
 
+        # Now that we have scaled the model, deactivate the relevant
+        # scaling suffixes so that we don't accidentally (later)
+        # double-scale.
+        for s in self._suffix_finder.all_suffixes:
+            s.deactivate()
+
         return model
 
     def propagate_solution(self, scaled_model, original_model):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
@andrewlee94 noted that the scaling transform caused problems because the `scaling_factor` Suffix was not deactivated after applying the transformation, which caused the resulting model to be doubly-scaled when written out to Ipopt.  This updates the transformation to deactivate the `scaling_factor` Suffixes on the transformed model at the conclusion of the transformation.

In addition, this PR refactors the logic for finding the suffixes into a general-purpose `pyomo.core.base.suffix.SuffixFinder` class (so that it can easily be reused elsewhere, e.g. in GDP).  It also removes the require ment that the scaling factor suffix values are forcibly converted to floats so that clients can use other data structures (in particular, mutable Params).

## Changes proposed in this PR:
- Refactor the scaling transformation to promote the suffix finder as a general utility
- Deactivate `scaling_factor` suffixes after the transformation
- Remove the restriction that all scaling factors are casted to `float` before using them to update constraints.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
