### PR TITLE
Update handling of `0*` in linear, quadratic walkers

### DIFF
--- a/pyomo/repn/linear.py
+++ b/pyomo/repn/linear.py
@@ -143,9 +143,11 @@ class LinearRepn(object):
         Notes
         -----
         This method assumes that the operator was "+". It is implemented
-        so that we can directly use a LinearRepn() as a data object in
-        the expression walker (thereby avoiding the function call for a
-        custom callback)
+        so that we can directly use a LinearRepn() as a `data` object in
+        the expression walker (thereby allowing us to use the default
+        implementation of acceptChildResult [which calls
+        `data.append()`] and avoid the function call for a custom
+        callback).
 
         """
         # Note that self.multiplier will always be 1 (we only call append()

--- a/pyomo/repn/linear.py
+++ b/pyomo/repn/linear.py
@@ -158,6 +158,10 @@ class LinearRepn(object):
             return
 
         mult = other.multiplier
+        if not mult:
+            # 0 * other, so there is nothing to add/change about
+            # self.  We can just exit now.
+            return
         if other.constant:
             self.constant += mult * other.constant
         if other.linear:

--- a/pyomo/repn/linear.py
+++ b/pyomo/repn/linear.py
@@ -629,7 +629,7 @@ def _before_monomial(visitor, child):
             return True, None
 
     # We want to check / update the var_map before processing "0"
-    # coefficients to that we are consistent with what gets added to the
+    # coefficients so that we are consistent with what gets added to the
     # var_map (e.g., 0*x*y: y is processed by _before_var and will
     # always be added, but x is processed here)
     _id = id(arg2)

--- a/pyomo/repn/quadratic.py
+++ b/pyomo/repn/quadratic.py
@@ -141,7 +141,12 @@ class QuadraticRepn(object):
             return
 
         mult = other.multiplier
-        self.constant += mult * other.constant
+        if not mult:
+            # 0 * other, so there is nothing to add/change about
+            # self.  We can just exit now.
+            return
+        if other.constant:
+            self.constant += mult * other.constant
         if other.linear:
             _merge_dict(self.linear, mult, other.linear)
         if other.quadratic:

--- a/pyomo/repn/tests/test_linear.py
+++ b/pyomo/repn/tests/test_linear.py
@@ -544,15 +544,13 @@ class TestLinear(unittest.TestCase):
         cfg = VisitorConfig()
         with LoggingIntercept() as LOG:
             repn = LinearRepnVisitor(*cfg).walk_expression(param_expr)
-        self.assertIn(
-            "DEPRECATED: Encountered 0*nan in expression tree.", LOG.getvalue()
-        )
+        self.assertEqual(LOG.getvalue(), "")
 
         self.assertEqual(cfg.subexpr, {})
         self.assertEqual(cfg.var_map, {})
         self.assertEqual(cfg.var_order, {})
         self.assertEqual(repn.multiplier, 1)
-        self.assertEqual(repn.constant, 0)
+        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
 
@@ -1608,3 +1606,52 @@ class TestLinear(unittest.TestCase):
         self.assertEqual(str(repn.constant), 'InvalidNumber(array([3, 4]))')
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.nonlinear, None)
+
+    def test_zero_elimination(self):
+        m = ConcreteModel()
+        m.x = Var(range(4))
+
+        e = 0 * m.x[0] + 0 * m.x[1] * m.x[2] + 0 * log(m.x[3])
+
+        cfg = VisitorConfig()
+        repn = LinearRepnVisitor(*cfg).walk_expression(e)
+        self.assertEqual(cfg.subexpr, {})
+        self.assertEqual(
+            cfg.var_map,
+            {
+                id(m.x[0]): m.x[0],
+                id(m.x[1]): m.x[1],
+                id(m.x[2]): m.x[2],
+                id(m.x[3]): m.x[3],
+            },
+        )
+        self.assertEqual(
+            cfg.var_order, {id(m.x[0]): 0, id(m.x[1]): 1, id(m.x[2]): 2, id(m.x[3]): 3}
+        )
+        self.assertEqual(repn.multiplier, 1)
+        self.assertEqual(repn.constant, 0)
+        self.assertEqual(repn.linear, {})
+        self.assertEqual(repn.nonlinear, None)
+
+        m.p = Param(mutable=True, within=Any, initialize=None)
+        e = m.p * m.x[0] + m.p * m.x[1] * m.x[2] + m.p * log(m.x[3])
+
+        cfg = VisitorConfig()
+        repn = LinearRepnVisitor(*cfg).walk_expression(e)
+        self.assertEqual(cfg.subexpr, {})
+        self.assertEqual(
+            cfg.var_map,
+            {
+                id(m.x[0]): m.x[0],
+                id(m.x[1]): m.x[1],
+                id(m.x[2]): m.x[2],
+                id(m.x[3]): m.x[3],
+            },
+        )
+        self.assertEqual(
+            cfg.var_order, {id(m.x[0]): 0, id(m.x[1]): 1, id(m.x[2]): 2, id(m.x[3]): 3}
+        )
+        self.assertEqual(repn.multiplier, 1)
+        self.assertEqual(repn.constant, 0)
+        self.assertEqual(repn.linear, {id(m.x[0]): InvalidNumber(None)})
+        self.assertEqual(repn.nonlinear, InvalidNumber(None))

--- a/pyomo/repn/tests/test_quadratic.py
+++ b/pyomo/repn/tests/test_quadratic.py
@@ -19,8 +19,9 @@ from pyomo.core.expr.numeric_expr import (
     SumExpression,
 )
 from pyomo.repn.quadratic import QuadraticRepnVisitor
+from pyomo.repn.util import InvalidNumber
 
-from pyomo.environ import ConcreteModel, Var
+from pyomo.environ import ConcreteModel, Var, Param, Any, log
 
 
 class VisitorConfig(object):
@@ -291,3 +292,56 @@ class TestQuadratic(unittest.TestCase):
             {(id(m.x), id(m.x)): 9, (id(m.y), id(m.y)): 16, (id(m.x), id(m.y)): 24},
         )
         self.assertEqual(repn.nonlinear, None)
+
+    def test_zero_elimination(self):
+        m = ConcreteModel()
+        m.x = Var(range(4))
+
+        e = 0 * m.x[0] + 0 * m.x[1] * m.x[2] + 0 * log(m.x[3])
+
+        cfg = VisitorConfig()
+        repn = QuadraticRepnVisitor(*cfg).walk_expression(e)
+        self.assertEqual(cfg.subexpr, {})
+        self.assertEqual(
+            cfg.var_map,
+            {
+                id(m.x[0]): m.x[0],
+                id(m.x[1]): m.x[1],
+                id(m.x[2]): m.x[2],
+                id(m.x[3]): m.x[3],
+            },
+        )
+        self.assertEqual(
+            cfg.var_order, {id(m.x[0]): 0, id(m.x[1]): 1, id(m.x[2]): 2, id(m.x[3]): 3}
+        )
+        self.assertEqual(repn.multiplier, 1)
+        self.assertEqual(repn.constant, 0)
+        self.assertEqual(repn.linear, {})
+        self.assertEqual(repn.quadratic, None)
+        self.assertEqual(repn.nonlinear, None)
+
+        m.p = Param(mutable=True, within=Any, initialize=None)
+        e = m.p * m.x[0] + m.p * m.x[1] * m.x[2] + m.p * log(m.x[3])
+
+        cfg = VisitorConfig()
+        repn = QuadraticRepnVisitor(*cfg).walk_expression(e)
+        self.assertEqual(cfg.subexpr, {})
+        self.assertEqual(
+            cfg.var_map,
+            {
+                id(m.x[0]): m.x[0],
+                id(m.x[1]): m.x[1],
+                id(m.x[2]): m.x[2],
+                id(m.x[3]): m.x[3],
+            },
+        )
+        self.assertEqual(
+            cfg.var_order, {id(m.x[0]): 0, id(m.x[1]): 1, id(m.x[2]): 2, id(m.x[3]): 3}
+        )
+        self.assertEqual(repn.multiplier, 1)
+        self.assertEqual(repn.constant, 0)
+        self.assertEqual(repn.linear, {id(m.x[0]): InvalidNumber(None)})
+        self.assertEqual(
+            repn.quadratic, {(id(m.x[1]), id(m.x[2])): InvalidNumber(None)}
+        )
+        self.assertEqual(repn.nonlinear, InvalidNumber(None))


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
@Robbybp pointed out inconsistencies / errors in how `0*` was handled for monomial, linear, quadratic, and general nonlinear terms within the Linear and Quadratic representation visitors.  This PR resolves those inconsistencies and adds tests for the expected behavior.

## Changes proposed in this PR:
- 0*term should result in the term being removed from the representation (for all cases of monomial, linear, quadratic, and general nonlinear)
- Add tests for this behavior.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
