### PR TITLE
LP writer: warn user for ignored suffixes

### DIFF
--- a/pyomo/core/kernel/suffix.py
+++ b/pyomo/core/kernel/suffix.py
@@ -102,13 +102,11 @@ class suffix(ISuffix):
     # Interface
     #
 
-    @property
     def export_enabled(self):
         """Returns :const:`True` when this suffix is enabled
         for export to solvers."""
         return bool(self._direction & suffix.EXPORT)
 
-    @property
     def import_enabled(self):
         """Returns :const:`True` when this suffix is enabled
         for import from solutions."""
@@ -233,7 +231,7 @@ def export_suffix_generator(blk, datatype=_noarg, active=True, descend_into=True
     """
     for suf in filter(
         lambda x: (
-            x.export_enabled and ((datatype is _noarg) or (x.datatype is datatype))
+            x.export_enabled() and ((datatype is _noarg) or (x.datatype is datatype))
         ),
         blk.components(ctype=suffix._ctype, active=active, descend_into=descend_into),
     ):
@@ -267,7 +265,7 @@ def import_suffix_generator(blk, datatype=_noarg, active=True, descend_into=True
     """
     for suf in filter(
         lambda x: (
-            x.import_enabled and ((datatype is _noarg) or (x.datatype is datatype))
+            x.import_enabled() and ((datatype is _noarg) or (x.datatype is datatype))
         ),
         blk.components(ctype=suffix._ctype, active=active, descend_into=descend_into),
     ):

--- a/pyomo/core/tests/unit/kernel/test_suffix.py
+++ b/pyomo/core/tests/unit/kernel/test_suffix.py
@@ -111,20 +111,20 @@ class Test_suffix(unittest.TestCase):
         s = suffix()
         s.direction = suffix.LOCAL
         self.assertEqual(s.direction, suffix.LOCAL)
-        self.assertEqual(s.export_enabled, False)
-        self.assertEqual(s.import_enabled, False)
+        self.assertEqual(s.export_enabled(), False)
+        self.assertEqual(s.import_enabled(), False)
         s.direction = suffix.IMPORT
         self.assertEqual(s.direction, suffix.IMPORT)
-        self.assertEqual(s.export_enabled, False)
-        self.assertEqual(s.import_enabled, True)
+        self.assertEqual(s.export_enabled(), False)
+        self.assertEqual(s.import_enabled(), True)
         s.direction = suffix.EXPORT
         self.assertEqual(s.direction, suffix.EXPORT)
-        self.assertEqual(s.export_enabled, True)
-        self.assertEqual(s.import_enabled, False)
+        self.assertEqual(s.export_enabled(), True)
+        self.assertEqual(s.import_enabled(), False)
         s.direction = suffix.IMPORT_EXPORT
         self.assertEqual(s.direction, suffix.IMPORT_EXPORT)
-        self.assertEqual(s.export_enabled, True)
-        self.assertEqual(s.import_enabled, True)
+        self.assertEqual(s.export_enabled(), True)
+        self.assertEqual(s.import_enabled(), True)
         with self.assertRaises(ValueError):
             s.direction = 'export'
 

--- a/pyomo/repn/plugins/lp_writer.py
+++ b/pyomo/repn/plugins/lp_writer.py
@@ -320,6 +320,27 @@ class _LPWriter_impl(object):
 
         timer.toc('Initialized column order', level=logging.DEBUG)
 
+        # We don't export any suffix information to the LP file
+        #
+        if component_map[Suffix]:
+            suffixesByName = {}
+            for block in component_map[Suffix]:
+                for suffix in block.component_objects(
+                    Suffix, active=True, descend_into=False, sort=sorter
+                ):
+                    if not (suffix.direction & Suffix.EXPORT):
+                        continue
+                    if suffix.name in suffixesByName:
+                        suffixesByName[suffix.name].append(suffix)
+                    else:
+                        suffixesByName[suffix.name] = [suffix]
+            for name, suffixes in suffixesByName.items():
+                logger.warning(
+                    f"EXPORT Suffix {name} found on {len(suffixes)} blocks:\n\t"
+                    + "\n\t".join(s.name for s in suffixes)
+                    + "LP writer cannot export suffixes to LP file.  Skipping."
+                )
+
         ostream.write(f"\\* Source Pyomo model name={model.name} *\\\n\n")
 
         #

--- a/pyomo/repn/plugins/lp_writer.py
+++ b/pyomo/repn/plugins/lp_writer.py
@@ -330,10 +330,11 @@ class _LPWriter_impl(object):
                 ):
                     if not suffix.export_enabled() or not suffix:
                         continue
-                    if suffix.name in suffixesByName:
-                        suffixesByName[suffix.name].append(suffix)
+                    name = suffix.local_name
+                    if name in suffixesByName:
+                        suffixesByName[name].append(suffix)
                     else:
-                        suffixesByName[suffix.name] = [suffix]
+                        suffixesByName[name] = [suffix]
             for name, suffixes in suffixesByName.items():
                 logger.warning(
                     f"EXPORT Suffix {name} found on {len(suffixes)} blocks:\n\t"

--- a/pyomo/repn/plugins/lp_writer.py
+++ b/pyomo/repn/plugins/lp_writer.py
@@ -328,7 +328,7 @@ class _LPWriter_impl(object):
                 for suffix in block.component_objects(
                     Suffix, active=True, descend_into=False, sort=sorter
                 ):
-                    if not (suffix.direction & Suffix.EXPORT):
+                    if not suffix.export_enabled() or not suffix:
                         continue
                     if suffix.name in suffixesByName:
                         suffixesByName[suffix.name].append(suffix)

--- a/pyomo/repn/plugins/lp_writer.py
+++ b/pyomo/repn/plugins/lp_writer.py
@@ -336,10 +336,12 @@ class _LPWriter_impl(object):
                     else:
                         suffixesByName[name] = [suffix]
             for name, suffixes in suffixesByName.items():
+                n = len(suffixes)
+                plural = 's' if n > 1 else ''
                 logger.warning(
-                    f"EXPORT Suffix {name} found on {len(suffixes)} blocks:\n\t"
-                    + "\n\t".join(s.name for s in suffixes)
-                    + "LP writer cannot export suffixes to LP file.  Skipping."
+                    f"EXPORT Suffix '{name}' found on {n} block{plural}:\n    "
+                    + "\n    ".join(s.name for s in suffixes)
+                    + "\nLP writer cannot export suffixes to LP files.  Skipping."
                 )
 
         ostream.write(f"\\* Source Pyomo model name={model.name} *\\\n\n")

--- a/pyomo/repn/tests/cpxlp/test_lpv2.py
+++ b/pyomo/repn/tests/cpxlp/test_lpv2.py
@@ -18,18 +18,19 @@ from pyomo.environ import ConcreteModel, Block, Constraint, Var, Objective, Suff
 
 from pyomo.repn.plugins.lp_writer import LPWriter
 
+
 class TestLPv2(unittest.TestCase):
     def test_warn_export_suffixes(self):
         m = ConcreteModel()
         m.x = Var()
         m.obj = Objective(expr=m.x)
-        m.con = Constraint(expr=m.x>=2)
+        m.con = Constraint(expr=m.x >= 2)
         m.b = Block()
         m.ignored = Suffix(direction=Suffix.IMPORT)
         m.duals = Suffix(direction=Suffix.IMPORT_EXPORT)
         m.b.duals = Suffix(direction=Suffix.IMPORT_EXPORT)
         m.b.scaling = Suffix(direction=Suffix.EXPORT)
-        
+
         # Empty suffixes are ignored
         writer = LPWriter()
         with LoggingIntercept() as LOG:
@@ -44,13 +45,16 @@ class TestLPv2(unittest.TestCase):
         writer = LPWriter()
         with LoggingIntercept() as LOG:
             writer.write(m, StringIO())
-        self.assertEqual(LOG.getvalue(), """EXPORT Suffix 'duals' found on 1 block:
+        self.assertEqual(
+            LOG.getvalue(),
+            """EXPORT Suffix 'duals' found on 1 block:
     duals
 LP writer cannot export suffixes to LP files.  Skipping.
 EXPORT Suffix 'scaling' found on 1 block:
     b.scaling
 LP writer cannot export suffixes to LP files.  Skipping.
-""")
+""",
+        )
 
         # Counting works correctly
         m.b.duals[m.x] = 7
@@ -58,11 +62,14 @@ LP writer cannot export suffixes to LP files.  Skipping.
         writer = LPWriter()
         with LoggingIntercept() as LOG:
             writer.write(m, StringIO())
-        self.assertEqual(LOG.getvalue(), """EXPORT Suffix 'duals' found on 2 blocks:
+        self.assertEqual(
+            LOG.getvalue(),
+            """EXPORT Suffix 'duals' found on 2 blocks:
     duals
     b.duals
 LP writer cannot export suffixes to LP files.  Skipping.
 EXPORT Suffix 'scaling' found on 1 block:
     b.scaling
 LP writer cannot export suffixes to LP files.  Skipping.
-""")
+""",
+        )

--- a/pyomo/repn/tests/cpxlp/test_lpv2.py
+++ b/pyomo/repn/tests/cpxlp/test_lpv2.py
@@ -1,0 +1,68 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+from io import StringIO
+
+import pyomo.common.unittest as unittest
+
+from pyomo.common.log import LoggingIntercept
+from pyomo.environ import ConcreteModel, Block, Constraint, Var, Objective, Suffix
+
+from pyomo.repn.plugins.lp_writer import LPWriter
+
+class TestLPv2(unittest.TestCase):
+    def test_warn_export_suffixes(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.obj = Objective(expr=m.x)
+        m.con = Constraint(expr=m.x>=2)
+        m.b = Block()
+        m.ignored = Suffix(direction=Suffix.IMPORT)
+        m.duals = Suffix(direction=Suffix.IMPORT_EXPORT)
+        m.b.duals = Suffix(direction=Suffix.IMPORT_EXPORT)
+        m.b.scaling = Suffix(direction=Suffix.EXPORT)
+        
+        # Empty suffixes are ignored
+        writer = LPWriter()
+        with LoggingIntercept() as LOG:
+            writer.write(m, StringIO())
+        self.assertEqual(LOG.getvalue(), "")
+
+        # Import are ignored, export and import/export are warned
+        m.duals[m.con] = 5
+        m.ignored[m.x] = 6
+        m.b.scaling[m.x] = 7
+
+        writer = LPWriter()
+        with LoggingIntercept() as LOG:
+            writer.write(m, StringIO())
+        self.assertEqual(LOG.getvalue(), """EXPORT Suffix 'duals' found on 1 block:
+    duals
+LP writer cannot export suffixes to LP files.  Skipping.
+EXPORT Suffix 'scaling' found on 1 block:
+    b.scaling
+LP writer cannot export suffixes to LP files.  Skipping.
+""")
+
+        # Counting works correctly
+        m.b.duals[m.x] = 7
+
+        writer = LPWriter()
+        with LoggingIntercept() as LOG:
+            writer.write(m, StringIO())
+        self.assertEqual(LOG.getvalue(), """EXPORT Suffix 'duals' found on 2 blocks:
+    duals
+    b.duals
+LP writer cannot export suffixes to LP files.  Skipping.
+EXPORT Suffix 'scaling' found on 1 block:
+    b.scaling
+LP writer cannot export suffixes to LP files.  Skipping.
+""")

--- a/pyomo/solvers/tests/models/base.py
+++ b/pyomo/solvers/tests/models/base.py
@@ -142,12 +142,7 @@ class _BaseTestModel(object):
             (suffix, getattr(model, suffix)) for suffix in kwds.pop('suffixes', [])
         )
         for suf in suffixes.values():
-            if isinstance(self.model, IBlock):
-                assert isinstance(suf, pmo.suffix)
-                assert suf.import_enabled
-            else:
-                assert isinstance(suf, Suffix)
-                assert suf.import_enabled()
+            assert suf.import_enabled()
 
         with open(filename, 'w') as f:
             #
@@ -197,12 +192,7 @@ class _BaseTestModel(object):
         )
         exclude = kwds.pop('exclude_suffixes', set())
         for suf in suffixes.values():
-            if isinstance(self.model, IBlock):
-                assert isinstance(suf, pmo.suffix)
-                assert suf.import_enabled
-            else:
-                assert isinstance(suf, Suffix)
-                assert suf.import_enabled()
+            assert suf.import_enabled()
         solution = None
         error_str = (
             "Difference in solution for {0}.{1}:\n\tBaseline - {2}\n\tCurrent - {3}"


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
The LP writer cannot export suffixes to LP files .  This PR updates the writer to warn the user for any non-empty EXPORT Suffixes that it has implicitly ignored.

This also resolved an inconsistency between the AML and Kernel APIs for Suffixes: `export_inabled` and `import_enabled` were methods in the AML and properties in Kernel.  This resolves that inconsistency by standardizing on method.  (@ghackebeil, please note this breaking change; it was not at all clear how to maintain backwards compatibility with both modeling environments)

## Changes proposed in this PR:
- Generate warnings for any non-empty EXPORT Suffixes on the model
- make `ISuffix.export_enabled` and `ISuffix.import_enabled` methods
- Add tests of the warning logic

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
