### PR TITLE
Ensure templatize_constraint returns an expression

### DIFF
--- a/pyomo/core/expr/relational_expr.py
+++ b/pyomo/core/expr/relational_expr.py
@@ -458,3 +458,10 @@ def _generate_relational_expression(etype, lhs, rhs):
             )
     else:
         return InequalityExpression((lhs, rhs), _relational_op[etype][2])
+
+
+def tuple_to_relational_expr(args):
+    if len(args) == 2:
+        return EqualityExpression(args)
+    else:
+        return inequality(*args)

--- a/pyomo/core/expr/template_expr.py
+++ b/pyomo/core/expr/template_expr.py
@@ -25,6 +25,7 @@ from pyomo.core.expr.numeric_expr import (
     Numeric_NPV_Mixin,
     register_arg_type,
     ARG_TYPE,
+    _balanced_parens,
 )
 from pyomo.core.expr.numvalue import (
     NumericValue,

--- a/pyomo/core/expr/template_expr.py
+++ b/pyomo/core/expr/template_expr.py
@@ -34,6 +34,7 @@ from pyomo.core.expr.numvalue import (
     value,
     is_constant,
 )
+from pyomo.core.expr.relational_expr import tuple_to_relational_expr
 from pyomo.core.expr.visitor import (
     ExpressionReplacementVisitor,
     StreamBasedExpressionVisitor,
@@ -1173,4 +1174,7 @@ def templatize_rule(block, rule, index_set):
 
 
 def templatize_constraint(con):
-    return templatize_rule(con.parent_block(), con.rule, con.index_set())
+    expr, indices = templatize_rule(con.parent_block(), con.rule, con.index_set())
+    if expr.__class__ is tuple:
+        expr = tuple_to_relational_expr(expr)
+    return expr, indices

--- a/pyomo/core/tests/unit/test_template_expr.py
+++ b/pyomo/core/tests/unit/test_template_expr.py
@@ -353,6 +353,53 @@ class TestTemplatizeRule(unittest.TestCase):
         indices[0].set_value(2)
         self.assertEqual(str(resolve_template(template)), 'x[2]  <=  0')
 
+    def test_tuple_rules(self):
+        m = ConcreteModel()
+        m.I = RangeSet(3)
+        m.x = Var(m.I)
+
+        @m.Constraint(m.I)
+        def c(m, i):
+            return (None, m.x[i], 0)
+
+        template, indices = templatize_constraint(m.c)
+        self.assertEqual(len(indices), 1)
+        self.assertIs(indices[0]._set, m.I)
+        self.assertEqual(str(template), "x[_1]  <=  0")
+        # Test that the RangeSet iterator was put back
+        self.assertEqual(list(m.I), list(range(1, 4)))
+        # Evaluate the template
+        indices[0].set_value(2)
+        self.assertEqual(str(resolve_template(template)), 'x[2]  <=  0')
+
+        @m.Constraint(m.I)
+        def d(m, i):
+            return (0, m.x[i], 10)
+
+        template, indices = templatize_constraint(m.d)
+        self.assertEqual(len(indices), 1)
+        self.assertIs(indices[0]._set, m.I)
+        self.assertEqual(str(template), "0  <=  x[_1]  <=  10")
+        # Test that the RangeSet iterator was put back
+        self.assertEqual(list(m.I), list(range(1, 4)))
+        # Evaluate the template
+        indices[0].set_value(2)
+        self.assertEqual(str(resolve_template(template)), '0  <=  x[2]  <=  10')
+
+        @m.Constraint(m.I)
+        def e(m, i):
+            return (m.x[i], 0)
+
+        template, indices = templatize_constraint(m.e)
+        self.assertEqual(len(indices), 1)
+        self.assertIs(indices[0]._set, m.I)
+        self.assertEqual(str(template), "x[_1]  ==  0")
+        # Test that the RangeSet iterator was put back
+        self.assertEqual(list(m.I), list(range(1, 4)))
+        # Evaluate the template
+        indices[0].set_value(2)
+        self.assertEqual(str(resolve_template(template)), 'x[2]  ==  0')
+
     def test_simple_rule_nonfinite_set(self):
         m = ConcreteModel()
         m.x = Var(Integers, dense=False)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
@codykarcher reported two errors with `templatize_constraint`: first, the templatized expression was not guaranteed to be an expression (it could contain a tuple), and the other was a missing import.  This PR resolves both of those issues.

## Changes proposed in this PR:
- Ensure that the first return value from `templatize_constraint` is always an expression
- Add tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
