### PR TITLE
Add `CITATION` file to main repository

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,32 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - name: "Pyomo contributors"
+title: "Pyomo: a Python-based, open-source optimization modeling language with a diverse set of optimization capabilities"
+url: "https://github.com/Pyomo/pyomo"
+license-url: "https://github.com/Pyomo/pyomo/blob/main/LICENSE.md"
+version: 6.6.2
+date-released: "2023-08-23"
+preferred-citation:
+  type: book
+  authors:
+    - family-names: "Bynum"
+      given-names: "Michael L"
+    - family-names: "Hackebeil"
+      given-names: "Gabriel A"
+    - family-names: "Hart"
+      given-names: "William E"
+    - family-names: "Laird"
+      given-names: "Carl D"
+    - family-names: "Nicholson"
+      given-names: "Bethany L"
+    - family-names: "Siirola"
+      given-names: "John D"
+    - family-names: "Watson"
+      given-names: "Jean-Paul"
+    - family-names: "Woodruff"
+      given-names: "David L"
+  title: "Pyomo-optimization modeling in python"
+  publisher: "Springer"
+  volume: 67
+  year: 2021

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,7 +24,7 @@ preferred-citation:
       given-names: "Jean-Paul"
     - family-names: "Woodruff"
       given-names: "David L"
-  title: "Pyomo - optimization modeling in python, 3rd edition"
+  title: "Pyomo - optimization modeling in Python, 3rd Edition"
   publisher: "Springer"
   volume: 67
   year: 2021

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,7 +24,8 @@ preferred-citation:
       given-names: "Jean-Paul"
     - family-names: "Woodruff"
       given-names: "David L"
-  title: "Pyomo-optimization modeling in python"
+  title: "Pyomo - optimization modeling in python"
   publisher: "Springer"
   volume: 67
   year: 2021
+  edition: "3rd"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,6 @@ authors:
 title: "Pyomo: a Python-based, open-source optimization modeling language with a diverse set of optimization capabilities"
 url: "https://github.com/Pyomo/pyomo"
 license-url: "https://github.com/Pyomo/pyomo/blob/main/LICENSE.md"
-version: 6.6.2
-date-released: "2023-08-23"
 preferred-citation:
   type: book
   authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,8 +24,8 @@ preferred-citation:
       given-names: "Jean-Paul"
     - family-names: "Woodruff"
       given-names: "David L"
-  title: "Pyomo - optimization modeling in python"
+  title: "Pyomo - optimization modeling in python, 3rd edition"
   publisher: "Springer"
   volume: 67
   year: 2021
-  edition: "3rd"
+  doi: "10.1007/978-3-030-68928-5"


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
There was a suggestion to add the citation to the repository such that GitHub will render it on the main repo page. This citation file includes the software information itself, but renders to the user as the Pyomo book as the preferred citation path.

## Changes proposed in this PR:
- `CITATION.rff` file
- See [my fork](https://github.com/mrmundt/pyomo) for how it looks in practice

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
