### PR TITLE
reference bug in highs interface

### DIFF
--- a/pyomo/contrib/appsi/solvers/highs.py
+++ b/pyomo/contrib/appsi/solvers/highs.py
@@ -462,9 +462,9 @@ class Highs(PersistentBase, PersistentSolver):
         self._pyomo_con_to_solver_con_map.clear()
         self._pyomo_con_to_solver_con_map.update(new_con_map)
         self._solver_con_to_pyomo_con_map.clear()
-        self._solver_con_to_pyomo_con_map.update({
-            v: k for k, v in self._pyomo_con_to_solver_con_map.items()
-        })
+        self._solver_con_to_pyomo_con_map.update(
+            {v: k for k, v in self._pyomo_con_to_solver_con_map.items()}
+        )
 
     def _remove_sos_constraints(self, cons: List[_SOSConstraintData]):
         if cons:

--- a/pyomo/contrib/appsi/solvers/highs.py
+++ b/pyomo/contrib/appsi/solvers/highs.py
@@ -459,10 +459,12 @@ class Highs(PersistentBase, PersistentSolver):
         for c in self._pyomo_con_to_solver_con_map.keys():
             new_con_map[c] = con_ndx
             con_ndx += 1
-        self._pyomo_con_to_solver_con_map = new_con_map
-        self._solver_con_to_pyomo_con_map = {
+        self._pyomo_con_to_solver_con_map.clear()
+        self._pyomo_con_to_solver_con_map.update(new_con_map)
+        self._solver_con_to_pyomo_con_map.clear()
+        self._solver_con_to_pyomo_con_map.update({
             v: k for k, v in self._pyomo_con_to_solver_con_map.items()
-        }
+        })
 
     def _remove_sos_constraints(self, cons: List[_SOSConstraintData]):
         if cons:
@@ -480,6 +482,7 @@ class Highs(PersistentBase, PersistentSolver):
             v_ndx = self._pyomo_var_to_solver_var_map.pop(v_id)
             indices_to_remove.append(v_ndx)
             self._mutable_bounds.pop(v_id, None)
+        indices_to_remove.sort()
         self._solver_model.deleteVars(
             len(indices_to_remove), np.array(indices_to_remove)
         )
@@ -488,7 +491,8 @@ class Highs(PersistentBase, PersistentSolver):
         for v_id in self._pyomo_var_to_solver_var_map.keys():
             new_var_map[v_id] = v_ndx
             v_ndx += 1
-        self._pyomo_var_to_solver_var_map = new_var_map
+        self._pyomo_var_to_solver_var_map.clear()
+        self._pyomo_var_to_solver_var_map.update(new_var_map)
 
     def _remove_params(self, params: List[_ParamData]):
         pass

--- a/pyomo/contrib/appsi/solvers/tests/test_highs_persistent.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_highs_persistent.py
@@ -17,7 +17,7 @@ class TestBugs(unittest.TestCase):
 
         m.p1 = pe.Param(mutable=True)
         m.p2 = pe.Param(mutable=True)
-        
+
         m.obj = pe.Objective(expr=m.y)
         m.c1 = pe.Constraint(expr=m.y >= m.x + m.p1)
         m.c2 = pe.Constraint(expr=m.y >= -m.x + m.p2)
@@ -44,7 +44,7 @@ class TestBugs(unittest.TestCase):
 
         m.y.setlb(m.p1)
         m.y.setub(m.p2)
-        
+
         m.obj = pe.Objective(expr=m.y)
         m.c1 = pe.Constraint(expr=m.y >= m.x + 1)
         m.c2 = pe.Constraint(expr=m.y >= -m.x + 1)

--- a/pyomo/contrib/appsi/solvers/tests/test_highs_persistent.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_highs_persistent.py
@@ -1,0 +1,64 @@
+import pyomo.common.unittest as unittest
+import pyomo.environ as pe
+from pyomo.contrib.appsi.solvers.highs import Highs
+from pyomo.contrib.appsi.base import TerminationCondition
+
+
+opt = Highs()
+if not opt.available():
+    raise unittest.SkipTest
+
+
+class TestBugs(unittest.TestCase):
+    def test_mutable_params_with_remove_cons(self):
+        m = pe.ConcreteModel()
+        m.x = pe.Var(bounds=(-10, 10))
+        m.y = pe.Var()
+
+        m.p1 = pe.Param(mutable=True)
+        m.p2 = pe.Param(mutable=True)
+        
+        m.obj = pe.Objective(expr=m.y)
+        m.c1 = pe.Constraint(expr=m.y >= m.x + m.p1)
+        m.c2 = pe.Constraint(expr=m.y >= -m.x + m.p2)
+
+        m.p1.value = 1
+        m.p2.value = 1
+
+        opt = Highs()
+        res = opt.solve(m)
+        self.assertAlmostEqual(res.best_feasible_objective, 1)
+
+        del m.c1
+        m.p2.value = 2
+        res = opt.solve(m)
+        self.assertAlmostEqual(res.best_feasible_objective, -8)
+
+    def test_mutable_params_with_remove_vars(self):
+        m = pe.ConcreteModel()
+        m.x = pe.Var()
+        m.y = pe.Var()
+
+        m.p1 = pe.Param(mutable=True)
+        m.p2 = pe.Param(mutable=True)
+
+        m.y.setlb(m.p1)
+        m.y.setub(m.p2)
+        
+        m.obj = pe.Objective(expr=m.y)
+        m.c1 = pe.Constraint(expr=m.y >= m.x + 1)
+        m.c2 = pe.Constraint(expr=m.y >= -m.x + 1)
+
+        m.p1.value = -10
+        m.p2.value = 10
+
+        opt = Highs()
+        res = opt.solve(m)
+        self.assertAlmostEqual(res.best_feasible_objective, 1)
+
+        del m.c1
+        del m.c2
+        m.p1.value = -9
+        m.p2.value = 9
+        res = opt.solve(m)
+        self.assertAlmostEqual(res.best_feasible_objective, -9)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Summary/Motivation:
This PR fixes a bug in the HiGHS interface. The updates that happen to account for changes in mutable parameters rely on references to dictionaries. These dictionaries were being replaced and modified instead of modified in place, leading to inconsistencies.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
