### PR TITLE
Fix appsi auto-update when unfixing a variable and changing its bound

### DIFF
--- a/pyomo/contrib/appsi/base.py
+++ b/pyomo/contrib/appsi/base.py
@@ -1406,17 +1406,17 @@ class PersistentBase(abc.ABC):
             vars_to_update = list()
             for v in vars_to_check:
                 _v, lb, ub, fixed, domain_interval, value = self._vars[id(v)]
-                if lb is not v._lb:
-                    vars_to_update.append(v)
-                elif ub is not v._ub:
-                    vars_to_update.append(v)
-                elif (fixed is not v.fixed) or (fixed and (value != v.value)):
+                if (fixed is not v.fixed) or (fixed and (value != v.value)):
                     vars_to_update.append(v)
                     if self.update_config.treat_fixed_vars_as_params:
                         for c in self._referenced_variables[id(v)][0]:
                             cons_to_remove_and_add[c] = None
                         if self._referenced_variables[id(v)][2] is not None:
                             need_to_set_objective = True
+                elif lb is not v._lb:
+                    vars_to_update.append(v)
+                elif ub is not v._ub:
+                    vars_to_update.append(v)
                 elif domain_interval != v.domain.get_interval():
                     vars_to_update.append(v)
             self.update_variables(vars_to_update)

--- a/pyomo/contrib/appsi/base.py
+++ b/pyomo/contrib/appsi/base.py
@@ -1406,7 +1406,7 @@ class PersistentBase(abc.ABC):
             vars_to_update = list()
             for v in vars_to_check:
                 _v, lb, ub, fixed, domain_interval, value = self._vars[id(v)]
-                if (fixed is not v.fixed) or (fixed and (value != v.value)):
+                if (fixed != v.fixed) or (fixed and (value != v.value)):
                     vars_to_update.append(v)
                     if self.update_config.treat_fixed_vars_as_params:
                         for c in self._referenced_variables[id(v)][0]:

--- a/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
@@ -1292,17 +1292,17 @@ class TestSolvers(unittest.TestCase):
             if not opt.available():
                 raise unittest.SkipTest
             opt.update_config.treat_fixed_vars_as_params = fixed_var_option
-            
+
             m = pe.ConcreteModel()
             m.x = pe.Var(bounds=(-10, 10))
             m.y = pe.Var()
-            m.obj = pe.Objective(expr=3*m.y - m.x)
+            m.obj = pe.Objective(expr=3 * m.y - m.x)
             m.c = pe.Constraint(expr=m.y >= m.x)
-            
+
             m.x.fix(1)
             res = opt.solve(m)
             self.assertAlmostEqual(res.best_feasible_objective, 2, 5)
-            
+
             m.x.unfix()
             m.x.setlb(-9)
             m.x.setub(9)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Summary/Motivation:
This PR fixes a bug in appsi. The bug occurs when both unfixing a variable and changing its bound. Because of the ordering of some if statements, we were not hitting some code that we should. As a result, objectives/constraints that used the fixed variable were not getting updated correctly.


## Changes proposed in this PR:
- fix the bug
- add a test

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
