### PR TITLE
QuadraticRepnVisitor: Improve nonlinear expression expansion

### DIFF
--- a/pyomo/repn/quadratic.py
+++ b/pyomo/repn/quadratic.py
@@ -274,7 +274,7 @@ def _handle_product_nonlinear(visitor, node, arg1, arg2):
         x1.quadratic = None
     x2.linear = {}
     # [BC] + [BD]
-    if x1_lin:
+    if x1_lin and (x2.nonlinear is not None or x2.quadratic):
         x1.linear = x1_lin
         ans.nonlinear += x1.to_expression(visitor) * x2.to_expression(visitor)
     # [AD]

--- a/pyomo/repn/quadratic.py
+++ b/pyomo/repn/quadratic.py
@@ -222,7 +222,6 @@ def _handle_product_nonlinear(visitor, node, arg1, arg2):
     # We are multiplying (A + Bx + Cx^2 + D(x)) * (A + Bx + Cx^2 + Dx))
     _, x1 = arg1
     _, x2 = arg2
-    ans = visitor.Result()
     ans.multiplier = x1.multiplier * x2.multiplier
     x1.multiplier = x2.multiplier = 1
     # x1.const * x2.const [AA]

--- a/pyomo/repn/quadratic.py
+++ b/pyomo/repn/quadratic.py
@@ -294,6 +294,9 @@ _exit_node_handlers[ProductExpression].update(
         (_QUADRATIC, _GENERAL): _handle_product_nonlinear,
         # Replace handler from the linear walker
         (_LINEAR, _LINEAR): _handle_product_linear_linear,
+        (_GENERAL, _GENERAL): _handle_product_nonlinear,
+        (_GENERAL, _LINEAR): _handle_product_nonlinear,
+        (_LINEAR, _GENERAL): _handle_product_nonlinear,
     }
 )
 

--- a/pyomo/repn/tests/test_quadratic.py
+++ b/pyomo/repn/tests/test_quadratic.py
@@ -126,8 +126,6 @@ class TestQuadratic(unittest.TestCase):
         self.assertEqual(repn.constant, 0)
         self.assertEqual(repn.linear, {})
         self.assertEqual(repn.quadratic, None)
-        print(repn.nonlinear)
-        print(NL)
         assertExpressionsEqual(self, repn.nonlinear, NL)
 
         e = (1 + 2 * m.x + 3 * m.y) * (4 + 5 * m.x + 6 * m.y)
@@ -146,6 +144,70 @@ class TestQuadratic(unittest.TestCase):
             {(id(m.x), id(m.x)): 10, (id(m.y), id(m.y)): 18, (id(m.x), id(m.y)): 27},
         )
         assertExpressionsEqual(self, repn.nonlinear, None)
+
+        e = (m.x + m.y + log(m.x)) * m.x
+
+        cfg = VisitorConfig()
+        visitor = QuadraticRepnVisitor(*cfg)
+        visitor.expand_nonlinear_products = False
+        repn = visitor.walk_expression(e)
+
+        NL = (log(m.x) + (m.x + m.y)) * m.x
+
+        self.assertEqual(cfg.subexpr, {})
+        self.assertEqual(cfg.var_map, {id(m.x): m.x, id(m.y): m.y})
+        self.assertEqual(cfg.var_order, {id(m.x): 0, id(m.y): 1})
+        self.assertEqual(repn.multiplier, 1)
+        self.assertEqual(repn.constant, 0)
+        self.assertEqual(repn.linear, {})
+        self.assertEqual(repn.quadratic, None)
+        assertExpressionsEqual(self, repn.nonlinear, NL)
+
+        visitor.expand_nonlinear_products = True
+        repn = visitor.walk_expression(e)
+
+        NL = log(m.x) * m.x
+
+        self.assertEqual(cfg.subexpr, {})
+        self.assertEqual(cfg.var_map, {id(m.x): m.x, id(m.y): m.y})
+        self.assertEqual(cfg.var_order, {id(m.x): 0, id(m.y): 1})
+        self.assertEqual(repn.multiplier, 1)
+        self.assertEqual(repn.constant, 0)
+        self.assertEqual(repn.linear, {})
+        self.assertEqual(repn.quadratic, {(id(m.x), id(m.x)): 1, (id(m.x), id(m.y)): 1})
+        assertExpressionsEqual(self, repn.nonlinear, NL)
+
+        e = m.x * (m.x + m.y + log(m.x) + 2)
+
+        cfg = VisitorConfig()
+        visitor = QuadraticRepnVisitor(*cfg)
+        visitor.expand_nonlinear_products = False
+        repn = visitor.walk_expression(e)
+
+        NL = m.x * (log(m.x) + (m.x + m.y) + 2)
+
+        self.assertEqual(cfg.subexpr, {})
+        self.assertEqual(cfg.var_map, {id(m.x): m.x, id(m.y): m.y})
+        self.assertEqual(cfg.var_order, {id(m.x): 0, id(m.y): 1})
+        self.assertEqual(repn.multiplier, 1)
+        self.assertEqual(repn.constant, 0)
+        self.assertEqual(repn.linear, {})
+        self.assertEqual(repn.quadratic, None)
+        assertExpressionsEqual(self, repn.nonlinear, NL)
+
+        visitor.expand_nonlinear_products = True
+        repn = visitor.walk_expression(e)
+
+        NL = m.x * log(m.x)
+
+        self.assertEqual(cfg.subexpr, {})
+        self.assertEqual(cfg.var_map, {id(m.x): m.x, id(m.y): m.y})
+        self.assertEqual(cfg.var_order, {id(m.x): 0, id(m.y): 1})
+        self.assertEqual(repn.multiplier, 1)
+        self.assertEqual(repn.constant, 0)
+        self.assertEqual(repn.linear, {id(m.x): 2})
+        self.assertEqual(repn.quadratic, {(id(m.x), id(m.x)): 1, (id(m.x), id(m.y)): 1})
+        assertExpressionsEqual(self, repn.nonlinear, NL)
 
     def test_sum(self):
         m = ConcreteModel()


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #2275 .

## Summary/Motivation:
This resolves some issues in the `QuadraticRepnVisitor` nonlinear term expansion logic.  In particular, it needed specialized handlers for LINEAR * GENERAL and GENERAL * GENERAL so that nonlinear terms are correctly expanded when `expand_nonlinear_products` is True.

## Changes proposed in this PR:
- Register handlers for LINEAR * GENERAL, GENERAL * LINEAR, and GENERAL * GENERAL
- Add a trap to prevent the unnecessary inclusion of "`0*`" terms in expanded products
- Add tests for the examples from #2275

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
