### PR TITLE
Add `Preformatted` class for logging preformatted messages

### DIFF
--- a/pyomo/common/log.py
+++ b/pyomo/common/log.py
@@ -107,11 +107,14 @@ class WrappingFormatter(logging.Formatter):
         super(WrappingFormatter, self).__init__(**kwds)
 
     def format(self, record):
+        msg = record.getMessage()
+        if record.msg.__class__ is not str and isinstance(record.msg, Preformatted):
+            return msg
+
         _orig = {
             k: getattr(record, k) for k in ('msg', 'args', 'pathname', 'levelname')
         }
         _id = getattr(record, 'id', None)
-        msg = record.getMessage()
         record.msg = self._flag
         record.args = None
         if _id:
@@ -210,6 +213,19 @@ class StdoutHandler(logging.StreamHandler):
     def emit(self, record):
         self.stream = sys.stdout
         super(StdoutHandler, self).emit(record)
+
+
+class Preformatted(object):
+    __slots__ = ('msg',)
+
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __str__(self):
+        return str(self.msg)
+
+    def __repr__(self):
+        return f'Preformatted({self.msg!r})'
 
 
 class _GlobalLogFilter(object):

--- a/pyomo/common/tests/test_log.py
+++ b/pyomo/common/tests/test_log.py
@@ -544,3 +544,18 @@ class TestLogStream(unittest.TestCase):
                 self.assertEqual(OUT.getvalue(), "INFO: line 1\n")
             # Exiting the context manager flushes the LogStream
             self.assertEqual(OUT.getvalue(), "INFO: line 1\nINFO: line 2\n")
+
+
+class TestPreformatted(unittest.TestCase):
+    def test_preformatted_api(self):
+        ref = 'a message'
+        msg = Preformatted(ref)
+        self.assertIs(msg.msg, ref)
+        self.assertEqual(str(msg), ref)
+        self.assertEqual(repr(msg), "Preformatted('a message')")
+
+        ref = 2
+        msg = Preformatted(ref)
+        self.assertIs(msg.msg, ref)
+        self.assertEqual(str(msg), '2')
+        self.assertEqual(repr(msg), "Preformatted(2)")

--- a/pyomo/common/tests/test_log.py
+++ b/pyomo/common/tests/test_log.py
@@ -283,7 +283,7 @@ class TestLegacyPyomoFormatter(unittest.TestCase):
         msg = """This is a long multi-line message that in normal circumstances \
 would be line-wrapped
         with additional information
-        that normally be combined."""
+        that normally would be combined."""
 
         logger.setLevel(logging.WARNING)
         logger.info(msg)
@@ -297,7 +297,7 @@ would be line-wrapped
         ans += (
             "WARNING: This is a long multi-line message that in normal "
             "circumstances would\n"
-            "be line-wrapped with additional information that normally be combined.\n"
+            "be line-wrapped with additional information that normally would be combined.\n"
         )
         self.assertEqual(self.stream.getvalue(), ans)
 
@@ -316,7 +316,7 @@ would be line-wrapped
         ans += (
             "    This is a long multi-line message that in normal "
             "circumstances would be\n"
-            "    line-wrapped with additional information that normally be combined.\n"
+            "    line-wrapped with additional information that normally would be combined.\n"
         )
         self.assertEqual(self.stream.getvalue(), ans)
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
MindtPy and PyROS both want to emit solver iteration logs and do NOT want those messages to be reformatted or line-wrapped.  Their current solution is to hijack the entire Pyomo logging system to suppress the automatic formatting that the default log handler implements.  This PR simplifies that by defining a `Preformatted` class that users can wrap a preformatted log message in before sending it to the logger.  These messages will then be directly emitted (without being processed by the default formatter).  As `Preformatted` is castable to `str`, it is compatible with other user-defined log handlers / formatters (without requiring any specialized handling).

## Changes proposed in this PR:
- define a `Preformatted` wrapper class for logging preformatted messages
- Update the default Pyomo formatter to ignore / do not reformat Preformatted messages.
- Add tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
