### PR TITLE
Use `SetInitializer` for initializing `Param` domains; reinitializing `IndexedVar` domains

### DIFF
--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -1016,6 +1016,10 @@ class IndexedVar(Var):
                 domain = domain_rule(self.parent_block(), None)
                 for vardata in self.values():
                     vardata._domain = domain
+            elif domain_rule.contains_indices():
+                parent = self.parent_block()
+                for index in domain_rule.indices():
+                    self[index]._domain = domain_rule(parent, index)
             else:
                 parent = self.parent_block()
                 for index, vardata in self.items():

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -1010,11 +1010,7 @@ class IndexedVar(Var):
     @domain.setter
     def domain(self, domain):
         """Sets the domain for all variables in this container."""
-        # TODO: Ideally we would pass valid arguments to the initializer
-        # that we just created.  However at the moment, getting the
-        # index() is expensive (see #1228).  As a result, for the moment
-        # we will only support constant initializers
-        domain = SetInitializer(domain)(None, None)
+        domain = SetInitializer(domain)(self.parent_block(), self.index())
         for vardata in self.values():
             vardata.domain = domain
 

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -436,7 +436,7 @@ class _GeneralVarData(_VarData):
     @domain.setter
     def domain(self, domain):
         try:
-            self._domain = SetInitializer(domain)(None, None)
+            self._domain = SetInitializer(domain)(self.parent_block(), self.index())
         except:
             logger.error(
                 "%s is not a valid domain. Variable domains must be an "

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -66,6 +66,7 @@ from pyomo.common.errors import PyomoException
 from pyomo.common.log import LoggingIntercept
 from pyomo.common.tempfiles import TempfileManager
 from pyomo.core.base.param import _ParamData
+from pyomo.core.base.set import _SetData
 from pyomo.core.base.units_container import units, pint_available, UnitsError
 
 from io import StringIO
@@ -1480,6 +1481,13 @@ q : Size=0, Index=None, Domain=Any, Default=None, Mutable=False
         self.assertIsNot(m.p.domain, i.p.domain)
         self.assertIs(m.p.domain._owner(), m.p)
         self.assertIs(i.p.domain._owner(), i.p)
+
+    def test_domain_set_initializer(self):
+        m = ConcreteModel()
+        m.I = Set(initialize=[1, 2, 3])
+        param_vals = {1: 1, 2: 1, 3: -1}
+        m.p = Param(m.I, initialize=param_vals, domain={-1, 1})
+        self.assertIsInstance(m.p.domain, _SetData)
 
     @unittest.skipUnless(pint_available, "units test requires pint module")
     def test_set_value_units(self):

--- a/pyomo/core/tests/unit/test_var.py
+++ b/pyomo/core/tests/unit/test_var.py
@@ -817,6 +817,10 @@ class TestArrayVar(TestSimpleVar):
         self.assertIs(m.x[1].domain, Integers)
         self.assertIs(m.x[2].domain, Integers)
         self.assertIs(m.x[3].domain, Integers)
+        m.x.domain = lambda m, i: PositiveReals
+        self.assertIs(m.x[1].domain, PositiveReals)
+        self.assertIs(m.x[2].domain, PositiveReals)
+        self.assertIs(m.x[3].domain, PositiveReals)
         m.x.domain = {1: Reals, 2: NonPositiveReals, 3: NonNegativeReals}
         self.assertIs(m.x[1].domain, Reals)
         self.assertIs(m.x[2].domain, NonPositiveReals)

--- a/pyomo/core/tests/unit/test_var.py
+++ b/pyomo/core/tests/unit/test_var.py
@@ -807,6 +807,38 @@ class TestArrayVar(TestSimpleVar):
         self.assertEqual(type(tmp), int)
         self.assertEqual(tmp, 3)
 
+    def test_var_domain_setter(self):
+        m = ConcreteModel()
+        m.x = Var([1, 2, 3])
+        self.assertIs(m.x[1].domain, Reals)
+        self.assertIs(m.x[2].domain, Reals)
+        self.assertIs(m.x[3].domain, Reals)
+        m.x.domain = Integers
+        self.assertIs(m.x[1].domain, Integers)
+        self.assertIs(m.x[2].domain, Integers)
+        self.assertIs(m.x[3].domain, Integers)
+        m.x.domain = {1: Reals, 2: NonPositiveReals, 3: NonNegativeReals}
+        self.assertIs(m.x[1].domain, Reals)
+        self.assertIs(m.x[2].domain, NonPositiveReals)
+        self.assertIs(m.x[3].domain, NonNegativeReals)
+        m.x.domain = {2: Integers}
+        self.assertIs(m.x[1].domain, Reals)
+        self.assertIs(m.x[2].domain, Integers)
+        self.assertIs(m.x[3].domain, NonNegativeReals)
+        with LoggingIntercept() as LOG, self.assertRaisesRegex(
+            TypeError,
+            'Cannot create a Set from data that does not support __contains__.  '
+            'Expected set-like object supporting collections.abc.Collection '
+            "interface, but received 'NoneType'",
+        ):
+            m.x.domain = {1: None, 2: None, 3: None}
+        self.assertIn(
+            '{1: None, 2: None, 3: None} is not a valid domain. '
+            'Variable domains must be an instance of a Pyomo Set or '
+            'convertible to a Pyomo Set.',
+            LOG.getvalue(),
+        )
+
 
 class TestVarList(PyomoModel):
     def setUp(self):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
@emma58 pointed out that the following simple code produces an exception:
```python
from pyomo.environ import *
m = ConcreteModel()
m.I = Set(initialize=[1, 2, 3])
param_vals = {1: 1, 2: 1, 3: -1}
m.p = Param(m.I, initialize=param_vals, domain={-1, 1})
m.pprint()
```

This was happening because the Python `set` that was passed in as the Param domain was not being converted to a Pyomo `Set`.  This PR corrects that error and ensures that Param domain values are passed through `SetInitializer` to ensure that they are "proper" Pyomo `Set` objects.

## Changes proposed in this PR:
- Use `SetInitializer` to process non-None Param domains
- Remove a TODO from Var's domain setter now that #2351 is merged

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
