### PR TITLE
Warn for explicit declaration of immutable params with units

### DIFF
--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -313,6 +313,15 @@ class Param(IndexedComponent, IndexedComponent_NDArrayMixin):
         self._dense_initialize = kwd.pop('initialize_as_dense', False)
         self._units = kwd.pop('units', None)
 
+        if self._mutable is None:
+            if self._units is None:
+                self._mutable = Param.DefaultMutable
+            else:
+                # Params with units *must* be mutable, so that
+                # expression simplification does not remove units from
+                # the expression.
+                self._mutable = True
+
         kwd.setdefault('ctype', Param)
         IndexedComponent.__init__(self, *args, **kwd)
 
@@ -768,14 +777,12 @@ class Param(IndexedComponent, IndexedComponent_NDArrayMixin):
 
         if self._units is not None:
             self._units = units.get_units(self._units)
-            if self._mutable is not None and not self._mutable:
+            if not self._mutable:
                 logger.warning(
                     "Params with units must be mutable.  "
                     f"Converting Param '{self.name}' to mutable."
                 )
-            self._mutable = True
-        elif self._mutable is None:
-            self._mutable = Param.DefaultMutable
+                self._mutable = True
 
         try:
             #

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -308,13 +308,10 @@ class Param(IndexedComponent, IndexedComponent_NDArrayMixin):
         _init = self._pop_from_kwargs('Param', kwd, ('rule', 'initialize'), NOTSET)
         _domain_rule = self._pop_from_kwargs('Param', kwd, ('domain', 'within'))
         self._validate = kwd.pop('validate', None)
-        self._mutable = kwd.pop('mutable', Param.DefaultMutable)
+        self._mutable = kwd.pop('mutable', None)
         self._default_val = kwd.pop('default', Param.NoValue)
         self._dense_initialize = kwd.pop('initialize_as_dense', False)
         self._units = kwd.pop('units', None)
-        if self._units is not None:
-            self._units = units.get_units(self._units)
-            self._mutable = True
 
         kwd.setdefault('ctype', Param)
         IndexedComponent.__init__(self, *args, **kwd)
@@ -768,6 +765,17 @@ class Param(IndexedComponent, IndexedComponent_NDArrayMixin):
             logger.debug(
                 "Constructing Param, name=%s, from data=%s" % (self.name, str(data))
             )
+
+        if self._units is not None:
+            self._units = units.get_units(self._units)
+            if self._mutable is not None and not self._mutable:
+                logger.warning(
+                    "Params with units must be mutable.  "
+                    f"Converting Param '{self.name}' to mutable."
+                )
+            self._mutable = True
+        elif self._mutable is None:
+            self._mutable = Param.DefaultMutable
 
         try:
             #

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -1516,6 +1516,25 @@ q : Size=0, Index=None, Domain=Any, Default=None, Mutable=False
         """.strip(),
         )
 
+    @unittest.skipUnless(pint_available, "units test requires pint module")
+    def test_units_and_mutability(self):
+        m = ConcreteModel()
+        with LoggingIntercept() as LOG:
+            m.p = Param(units=units.g)
+        self.assertEqual(LOG.getvalue(), "")
+        self.assertTrue(m.p.mutable)
+        with LoggingIntercept() as LOG:
+            m.q = Param(units=units.g, mutable=True)
+        self.assertEqual(LOG.getvalue(), "")
+        self.assertTrue(m.q.mutable)
+        with LoggingIntercept() as LOG:
+            m.r = Param(units=units.g, mutable=False)
+        self.assertEqual(
+            LOG.getvalue(),
+            "Params with units must be mutable.  Converting Param 'r' to mutable.\n"
+        )
+        self.assertTrue(m.q.mutable)
+
     def test_scalar_get_mutable_when_not_present(self):
         m = ConcreteModel()
         m.p = Param(mutable=True)

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -1533,7 +1533,7 @@ q : Size=0, Index=None, Domain=Any, Default=None, Mutable=False
             LOG.getvalue(),
             "Params with units must be mutable.  Converting Param 'r' to mutable.\n",
         )
-        self.assertTrue(m.q.mutable)
+        self.assertTrue(m.r.mutable)
 
     def test_scalar_get_mutable_when_not_present(self):
         m = ConcreteModel()

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -1531,7 +1531,7 @@ q : Size=0, Index=None, Domain=Any, Default=None, Mutable=False
             m.r = Param(units=units.g, mutable=False)
         self.assertEqual(
             LOG.getvalue(),
-            "Params with units must be mutable.  Converting Param 'r' to mutable.\n"
+            "Params with units must be mutable.  Converting Param 'r' to mutable.\n",
         )
         self.assertTrue(m.q.mutable)
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #3002

## Summary/Motivation:
#3002 pointed out that we silently force Params with units to be mutable, even when the user explicitly sets `mutable=False`.  This PR adds a warning when we convert a Param that was explicitly immutable to being a mutable Param.

## Changes proposed in this PR:
- Issue warning when Param is constructed with units and explicitly set to immutable.
- Test this behavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
