### PR TITLE
Skip `fileutils` test failure that persists in OSX 12.7

### DIFF
--- a/pyomo/common/tests/test_fileutils.py
+++ b/pyomo/common/tests/test_fileutils.py
@@ -235,6 +235,7 @@ class TestFileUtils(unittest.TestCase):
         and (
             platform.mac_ver()[0].startswith('10.16')
             or platform.mac_ver()[0].startswith('12.6')
+            or platform.mac_ver()[0].startswith('12.7')
         ),
         "find_library has known bugs in Big Sur/Monterey for Python<3.8",
     )


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
A test that fails for Python 3.7 on OSX persists into the new OSX runner (12.7).  Continue to skip the test on that platform / interpreter.

## Changes proposed in this PR:
- Skip `test_find_library_system` test on Python 3.7 / OSX 12.7

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
