### PR TITLE
Learning to spell 'because'

### DIFF
--- a/pyomo/contrib/fme/tests/test_fourier_motzkin_elimination.py
+++ b/pyomo/contrib/fme/tests/test_fourier_motzkin_elimination.py
@@ -771,7 +771,7 @@ class TestFourierMotzkinElimination(unittest.TestCase):
     def test_numerical_instability_almost_canceling(self):
         # It's possible that we get almost-but-not-quite zero on the variable
         # being eliminated when we are doing this with floating point
-        # arithmetic. This can get ugly later becuase it might get muliplied by
+        # arithmetic. This can get ugly later because it might get muliplied by
         # a large number later and start to "reappear"
         m = ConcreteModel()
         m.x = Var()

--- a/pyomo/gdp/tests/test_partition_disjuncts.py
+++ b/pyomo/gdp/tests/test_partition_disjuncts.py
@@ -455,7 +455,7 @@ class PaperTwoCircleExample(unittest.TestCase, CommonTests):
         self.check_transformation_block_nested_disjunction(m, disj2, m.disj1.x)
 
     def test_transformation_block_nested_disjunction_badly_ordered_targets(self):
-        """This tests that we preprocess targets correctly becuase we don't
+        """This tests that we preprocess targets correctly because we don't
         want to double transform the inner disjunct, which is what would happen
         if we did things in the order given."""
         m = models.makeBetweenStepsPaperExample_Nested()


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

Seems like the latest release of the spell checker is catching 'becuase' as a typo for the first time. This fixes a couple old typos.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
