### PR TITLE
Update Gurobi license checks in tests

### DIFF
--- a/pyomo/contrib/cp/tests/test_logical_to_disjunctive.py
+++ b/pyomo/contrib/cp/tests/test_logical_to_disjunctive.py
@@ -45,7 +45,10 @@ from pyomo.environ import (
     TransformationFactory,
 )
 
-gurobi_available = SolverFactory('gurobi').available(exception_flag=False)
+gurobi_available = (
+    SolverFactory('gurobi').available(exception_flag=False) and
+    SolverFactory('gurobi').license_is_valid()
+)
 
 
 class TestLogicalToDisjunctiveVisitor(unittest.TestCase):

--- a/pyomo/contrib/cp/tests/test_logical_to_disjunctive.py
+++ b/pyomo/contrib/cp/tests/test_logical_to_disjunctive.py
@@ -46,8 +46,8 @@ from pyomo.environ import (
 )
 
 gurobi_available = (
-    SolverFactory('gurobi').available(exception_flag=False) and
-    SolverFactory('gurobi').license_is_valid()
+    SolverFactory('gurobi').available(exception_flag=False)
+    and SolverFactory('gurobi').license_is_valid()
 )
 
 

--- a/pyomo/contrib/gdpopt/tests/test_enumerate.py
+++ b/pyomo/contrib/gdpopt/tests/test_enumerate.py
@@ -26,6 +26,7 @@ from pyomo.environ import (
 from pyomo.gdp import Disjunction
 import pyomo.gdp.tests.models as models
 
+
 @unittest.skipUnless(SolverFactory('gurobi').available(), 'Gurobi not available')
 @unittest.skipUnless(SolverFactory('gurobi').license_is_valid(), 'Gurobi not licensed')
 class TestGDPoptEnumerate(unittest.TestCase):

--- a/pyomo/contrib/gdpopt/tests/test_enumerate.py
+++ b/pyomo/contrib/gdpopt/tests/test_enumerate.py
@@ -26,8 +26,8 @@ from pyomo.environ import (
 from pyomo.gdp import Disjunction
 import pyomo.gdp.tests.models as models
 
-
 @unittest.skipUnless(SolverFactory('gurobi').available(), 'Gurobi not available')
+@unittest.skipUnless(SolverFactory('gurobi').license_is_valid(), 'Gurobi not licensed')
 class TestGDPoptEnumerate(unittest.TestCase):
     def test_solve_two_term_disjunction(self):
         m = models.makeTwoTermDisj()
@@ -144,18 +144,6 @@ class TestGDPoptEnumerate(unittest.TestCase):
             results.solver.termination_condition, TerminationCondition.maxIterations
         )
 
-    @unittest.skipUnless(SolverFactory('ipopt').available(), 'Ipopt not available')
-    def test_infeasible_GDP(self):
-        m = models.make_infeasible_gdp_model()
-
-        results = SolverFactory('gdpopt.enumerate').solve(m)
-
-        self.assertEqual(results.solver.iterations, 2)
-        self.assertEqual(
-            results.solver.termination_condition, TerminationCondition.infeasible
-        )
-        self.assertEqual(results.problem.lower_bound, float('inf'))
-
     def test_unbounded_GDP(self):
         m = ConcreteModel()
         m.x = Var(bounds=(-1, 10))
@@ -173,7 +161,20 @@ class TestGDPoptEnumerate(unittest.TestCase):
         self.assertEqual(results.problem.lower_bound, -float('inf'))
         self.assertEqual(results.problem.upper_bound, -float('inf'))
 
-    @unittest.skipUnless(SolverFactory('ipopt').available(), 'Ipopt not available')
+
+@unittest.skipUnless(SolverFactory('ipopt').available(), 'Ipopt not available')
+class TestGDPoptEnumerate_ipopt_tests(unittest.TestCase):
+    def test_infeasible_GDP(self):
+        m = models.make_infeasible_gdp_model()
+
+        results = SolverFactory('gdpopt.enumerate').solve(m)
+
+        self.assertEqual(results.solver.iterations, 2)
+        self.assertEqual(
+            results.solver.termination_condition, TerminationCondition.infeasible
+        )
+        self.assertEqual(results.problem.lower_bound, float('inf'))
+
     def test_algorithm_specified_to_solve(self):
         m = models.twoDisj_twoCircles_easy()
 

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -72,6 +72,11 @@ license_available = (
     else False
 )
 
+gurobi_available = (
+    SolverFactory('gurobi').available(exception_flag=False) and
+    SolverFactory('gurobi').license_is_valid()
+)
+
 
 class TestGDPoptUnit(unittest.TestCase):
     """Real unit tests for GDPopt"""
@@ -129,7 +134,7 @@ class TestGDPoptUnit(unittest.TestCase):
             self.assertAlmostEqual(results.problem.lower_bound, 1)
             self.assertAlmostEqual(results.problem.upper_bound, 1)
 
-    @unittest.skipUnless(SolverFactory('gurobi').available(), 'Gurobi not available')
+    @unittest.skipUnless(gurobi_available, 'Gurobi not available')
     def test_solve_nlp(self):
         m = ConcreteModel()
         m.x = Var(bounds=(-5, 5))
@@ -222,7 +227,7 @@ class TestGDPoptUnit(unittest.TestCase):
         with self.assertRaisesRegex(NotImplementedError, "Found active disjunct"):
             is_feasible(m, GDP_LOA_Solver.CONFIG())
 
-    @unittest.skipUnless(SolverFactory('gurobi').available(), 'Gurobi not available')
+    @unittest.skipUnless(gurobi_available, 'Gurobi not available')
     def test_infeasible_or_unbounded_mip_termination(self):
         m = ConcreteModel()
         m.x = Var()
@@ -461,9 +466,7 @@ class TestGDPopt(unittest.TestCase):
     # [ESJ 5/16/22]: Using Gurobi for this test because glpk seems to get angry
     # on Windows when the MIP is arbitrarily bounded with the large bounds. And
     # I think I blame glpk...
-    @unittest.skipUnless(
-        SolverFactory('gurobi').available(), "Gurobi solver not available"
-    )
+    @unittest.skipUnless(gurobi_available, "Gurobi solver not available")
     def test_GDP_nonlinear_objective(self):
         m = ConcreteModel()
         m.x = Var(bounds=(-1, 10))
@@ -1672,7 +1675,7 @@ class TestConfigOptions(unittest.TestCase):
         return m
 
     @unittest.skipIf(not mcpp_available(), "MC++ is not available")
-    @unittest.skipUnless(SolverFactory('gurobi').available(), 'Gurobi not available')
+    @unittest.skipUnless(gurobi_available, 'Gurobi not available')
     def test_set_options_on_config_block(self):
         m = self.make_model()
 
@@ -1711,7 +1714,7 @@ class TestConfigOptions(unittest.TestCase):
         self.assertAlmostEqual(value(m.obj), -0.25)
 
     @unittest.skipIf(not mcpp_available(), "MC++ is not available")
-    @unittest.skipUnless(SolverFactory('gurobi').available(), 'Gurobi not available')
+    @unittest.skipUnless(gurobi_available, 'Gurobi not available')
     def test_set_options_in_init(self):
         m = self.make_model()
 
@@ -1735,7 +1738,7 @@ class TestConfigOptions(unittest.TestCase):
         self.assertAlmostEqual(value(m.obj), -0.25)
         self.assertEqual(opt.config.mip_solver, 'gurobi')
 
-    @unittest.skipUnless(SolverFactory('gurobi').available(), 'Gurobi not available')
+    @unittest.skipUnless(gurobi_available, 'Gurobi not available')
     def test_no_default_algorithm(self):
         m = self.make_model()
 

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -73,8 +73,8 @@ license_available = (
 )
 
 gurobi_available = (
-    SolverFactory('gurobi').available(exception_flag=False) and
-    SolverFactory('gurobi').license_is_valid()
+    SolverFactory('gurobi').available(exception_flag=False)
+    and SolverFactory('gurobi').license_is_valid()
 )
 
 

--- a/pyomo/contrib/piecewise/tests/test_inner_repn_gdp.py
+++ b/pyomo/contrib/piecewise/tests/test_inner_repn_gdp.py
@@ -167,6 +167,7 @@ class TestTransformPiecewiseModelToInnerRepnGDP(unittest.TestCase):
         )
 
     @unittest.skipUnless(SolverFactory('gurobi').available(), 'Gurobi is not available')
+    @unittest.skipUnless(SolverFactory('gurobi').license_is_valid(), 'No license')
     def test_solve_disaggregated_convex_combo_model(self):
         m = models.make_log_x_model()
         TransformationFactory(

--- a/pyomo/contrib/piecewise/tests/test_outer_repn_gdp.py
+++ b/pyomo/contrib/piecewise/tests/test_outer_repn_gdp.py
@@ -171,10 +171,9 @@ class TestTransformPiecewiseModelToOuterRepnGDP(unittest.TestCase):
             self, 'contrib.piecewise.outer_repn_gdp'
         )
 
-    @unittest.skipUnless(
-        SolverFactory('gurobi').available() and scipy_available,
-        'Gurobi and/or scipy is not available',
-    )
+    @unittest.skipUnless(scipy_available, "scipy is not available")
+    @unittest.skipUnless(SolverFactory('gurobi').available(), 'Gurobi is not available')
+    @unittest.skipUnless(SolverFactory('gurobi').license_is_valid(), 'No license')
     def test_solve_multiple_choice_model(self):
         m = models.make_log_x_model()
         TransformationFactory('contrib.piecewise.multiple_choice').apply_to(m)

--- a/pyomo/contrib/piecewise/tests/test_reduced_inner_repn.py
+++ b/pyomo/contrib/piecewise/tests/test_reduced_inner_repn.py
@@ -248,6 +248,7 @@ class TestTransformPiecewiseModelToReducedInnerRepnGDP(unittest.TestCase):
         )
 
     @unittest.skipUnless(SolverFactory('gurobi').available(), 'Gurobi is not available')
+    @unittest.skipUnless(SolverFactory('gurobi').license_is_valid(), 'No license')
     def test_solve_convex_combo_model(self):
         m = models.make_log_x_model()
         TransformationFactory('contrib.piecewise.convex_combination').apply_to(m)

--- a/pyomo/gdp/tests/test_mbigm.py
+++ b/pyomo/gdp/tests/test_mbigm.py
@@ -41,7 +41,10 @@ from pyomo.gdp.tests.common_tests import (
 )
 from pyomo.repn import generate_standard_repn
 
-gurobi_available = SolverFactory('gurobi').available()
+gurobi_available = (
+    SolverFactory('gurobi').available(exception_flag=False) and
+    SolverFactory('gurobi').license_is_valid()
+)
 exdir = normpath(join(PYOMO_ROOT_DIR, 'examples', 'gdp'))
 
 

--- a/pyomo/gdp/tests/test_mbigm.py
+++ b/pyomo/gdp/tests/test_mbigm.py
@@ -42,8 +42,8 @@ from pyomo.gdp.tests.common_tests import (
 from pyomo.repn import generate_standard_repn
 
 gurobi_available = (
-    SolverFactory('gurobi').available(exception_flag=False) and
-    SolverFactory('gurobi').license_is_valid()
+    SolverFactory('gurobi').available(exception_flag=False)
+    and SolverFactory('gurobi').license_is_valid()
 )
 exdir = normpath(join(PYOMO_ROOT_DIR, 'examples', 'gdp'))
 

--- a/pyomo/solvers/plugins/solvers/GUROBI.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI.py
@@ -86,12 +86,12 @@ class GUROBINL(ASL):
 
     def license_is_valid(self):
         m = ConcreteModel()
-        m.x = Var(bounds=(0, 1))
+        m.x = Var(bounds=(1, 2))
         m.obj = Objective(expr=m.x)
         try:
             with capture_output():
                 self.solve(m)
-            return m.x.value == 0
+            return abs(m.x.value - 1) <= 1e-4
         except:
             return False
 

--- a/pyomo/solvers/plugins/solvers/GUROBI.py
+++ b/pyomo/solvers/plugins/solvers/GUROBI.py
@@ -83,9 +83,10 @@ class GUROBI(OptSolver):
 @SolverFactory.register('_gurobi_nl', doc='NL interface to the Gurobi solver')
 class GUROBINL(ASL):
     """NL interface to gurobi_ampl."""
+
     def license_is_valid(self):
         m = ConcreteModel()
-        m.x = Var(bounds=(0,1))
+        m.x = Var(bounds=(0, 1))
         m.obj = Objective(expr=m.x)
         try:
             with capture_output():

--- a/pyomo/solvers/tests/checks/test_gurobi_direct.py
+++ b/pyomo/solvers/tests/checks/test_gurobi_direct.py
@@ -22,6 +22,7 @@ try:
 except ImportError:
     gurobipy_available = False
 
+gurobi_available = GurobiDirect().available(exception_flag=False)
 
 def clean_up_global_state():
     # Best efforts to dispose any gurobipy objects from previous tests
@@ -79,6 +80,7 @@ class GurobiImportFailedTests(unittest.TestCase):
 
 
 @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
+@unittest.skipIf(not gurobi_available, "gurobi license is not valid")
 class GurobiParameterTests(GurobiBase):
     # Test parameter handling at the model and environment level
 
@@ -158,6 +160,7 @@ class GurobiParameterTests(GurobiBase):
 
 
 @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
+@unittest.skipIf(not gurobi_available, "gurobi license is not valid")
 class GurobiEnvironmentTests(GurobiBase):
     # Test handling of gurobi environments
 
@@ -318,6 +321,7 @@ class GurobiEnvironmentTests(GurobiBase):
 
 
 @unittest.skipIf(not gurobipy_available, "gurobipy is not available")
+@unittest.skipIf(not gurobi_available, "gurobi license is not valid")
 @unittest.skipIf(not single_use_license(), reason="test needs a single use license")
 class GurobiSingleUseTests(GurobiBase):
     # Integration tests for Gurobi single-use licenses (useful for checking all Gurobi

--- a/pyomo/solvers/tests/checks/test_gurobi_direct.py
+++ b/pyomo/solvers/tests/checks/test_gurobi_direct.py
@@ -24,6 +24,7 @@ except ImportError:
 
 gurobi_available = GurobiDirect().available(exception_flag=False)
 
+
 def clean_up_global_state():
     # Best efforts to dispose any gurobipy objects from previous tests
     # which might keep the default environment active


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This resolves test failures that occur when Gurobi is installed, but not properly licensed.

## Changes proposed in this PR:
- Update Gurobi license guards in tests
- Add a custom ASL solver interface for Gurobi that implements a `license_is_valid()` method to enable license checks for the Gurobi NL interface.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
