### PR TITLE
Improve GHA conda env package setup

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -336,9 +336,12 @@ jobs:
                 _BUILDS=$(echo "$_PKGLIST" | grep "^$_BASE " \
                     | sed -r 's/\s+/ /g' | cut -d\  -f3)
                 if test -n "$_BUILDS"; then
-                    _ISPY=$(echo "$_BUILDS" | grep "^py")
-                    _PYOK=$(echo "$_BUILDS" | grep "^$PYVER")
+                    _ISPY=$(echo "$_BUILDS" | grep "^py") \
+                        || echo "No python build detected"
+                    _PYOK=$(echo "$_BUILDS" | grep "^$PYVER") \
+                        || echo "No python build matching $PYVER detected"
                     if test -z "$_ISPY" -o -n "$_PYOK"; then
+                        echo "... INSTALLING $PKG"
                         conda install -y "$PKG" || _BUILDS=""
                     fi
                 fi

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -330,7 +330,8 @@ jobs:
                 # attempting an install.
                 # NOTE: conda search will attempt approximate matches.
                 conda search -f "$PKG"
-                OK=$(conda search -f "$PKG" |& grep "^$PKG " | grep " $PYVER" | wc -l)
+                BASE=$(echo "$PKG" | sed 's/[=<>].*//')
+                OK=$(conda search -f "$PKG" |& grep "^$BASE " | grep " $PYVER" | wc -l)
                 if test "$OK" -gt 0; then
                     conda install -q -y "$PKG"
                     if test "$?" -ne 0; then

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -329,16 +329,22 @@ jobs:
                 # if the package is available for this interpreter before
                 # attempting an install.
                 # NOTE: conda search will attempt approximate matches.
-                conda search -f "$PKG"
-                BASE=$(echo "$PKG" | sed 's/[=<>].*//')
-                OK=$(conda search -f "$PKG" |& grep "^$BASE " | grep " $PYVER" | wc -l)
-                if test "$OK" -gt 0; then
-                    conda install -q -y "$PKG"
-                    if test "$?" -ne 0; then
-                        OK=0
+                _PKGLIST=$(conda search -f "$PKG")
+                echo "$_PKGLIST"
+                _BASE=$(echo "$PKG" | sed 's/[=<>].*//')
+                _BUILDS=$(echo "$_PKGLIST" | grep "^$_BASE " \
+                    | sed -r 's/\s+/ /g' | cut -d\  -f3)
+                if test -n "$_BUILDS"; then
+                    _PY=$(echo "_$BUILDS" | grep "^py")
+                    _PYOK=$(echo "$_BUILDS" | grep "^$PYVER")
+                    test -z "$_PY" -o -n "$_PYOK"; then
+                        conda install -q -y "$PKG"
+                        if test "$?" -ne 0; then
+                            _BUILDS=""
+                        fi
                     fi
                 fi
-                if test "$OK" -eq 0; then
+                if test -z "$_BUILDS" -eq 0; then
                     echo "WARNING: $PKG is not available"
                 fi
             done

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -320,7 +320,8 @@ jobs:
         echo "*** Install Pyomo dependencies ***"
         conda install --update-deps -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
-            PYVER=$(echo "py${{matrix.python}}" | sed 's|\.||g')
+            PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
+            echo "Installing for $PYVER"
             for PKG in 'cplex>=12.10' docplex gurobi xpress cyipopt pymumps scip; do
                 echo ""
                 echo "*** Install $PKG ***"
@@ -335,13 +336,10 @@ jobs:
                 _BUILDS=$(echo "$_PKGLIST" | grep "^$_BASE " \
                     | sed -r 's/\s+/ /g' | cut -d\  -f3)
                 if test -n "$_BUILDS"; then
-                    _PY=$(echo "$_BUILDS" | grep "^py")
+                    _ISPY=$(echo "$_BUILDS" | grep "^py")
                     _PYOK=$(echo "$_BUILDS" | grep "^$PYVER")
-                    if test -z "$_PY" -o -n "$_PYOK"; then
-                        conda install -q -y "$PKG"
-                        if test "$?" -ne 0; then
-                            _BUILDS=""
-                        fi
+                    if test -z "$_ISPY" -o -n "$_PYOK"; then
+                        conda install -y "$PKG" || _BUILDS=""
                     fi
                 fi
                 if test -z "$_BUILDS"; then

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -320,7 +320,7 @@ jobs:
         echo "*** Install Pyomo dependencies ***"
         conda install --update-deps -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
-            PYVER=`echo "${{matrix.python}}" | sed 's|\.||g'`
+            PYVER=$(echo "py${{matrix.python}}" | sed 's|\.||g')
             for PKG in 'cplex>=12.10' docplex gurobi xpress cyipopt pymumps scip; do
                 echo ""
                 echo "*** Install $PKG ***"
@@ -328,8 +328,9 @@ jobs:
                 # package is not available.  Perform a quick search to see
                 # if the package is available for this interpreter before
                 # attempting an install.
-                # NOTE: conda search will attempt approximatches.
-                OK=$(conda search "$PKG" |& grep "^$PKG " | grep " py$PYVER" | wc -l)
+                # NOTE: conda search will attempt approximate matches.
+                conda search -f "$PKG"
+                OK=$(conda search -f "$PKG" |& grep "^$PKG " | grep " $PYVER" | wc -l)
                 if test "$OK" -gt 0; then
                     conda install -q -y "$PKG"
                     if test "$?" -ne 0; then

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -344,7 +344,7 @@ jobs:
                         fi
                     fi
                 fi
-                if test -z "$_BUILDS" -eq 0; then
+                if test -z "$_BUILDS"; then
                     echo "WARNING: $PKG is not available"
                 fi
             done

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -330,7 +330,7 @@ jobs:
                 # if the package is available for this interpreter before
                 # attempting an install.
                 # NOTE: conda search will attempt approximate matches.
-                _PKGLIST=$(conda search -f "$PKG")
+                _PKGLIST=$(conda search -f "$PKG") || echo "Package $PKG not found"
                 echo "$_PKGLIST"
                 _BASE=$(echo "$PKG" | sed 's/[=<>].*//')
                 _BUILDS=$(echo "$_PKGLIST" | grep "^$_BASE " \

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -328,9 +328,12 @@ jobs:
                 # package is not available.  Perform a quick search to see
                 # if the package is available for this interpreter before
                 # attempting an install.
-                OK=`conda search "$PKG" |& grep " py$PYVER" | wc -l`
+                OK=$(conda search "$PKG" |& grep " py$PYVER" | wc -l)
                 if test "$OK" -gt 0; then
-                    conda install -q -y $PKG || OK=0
+                    conda install -q -y "$PKG"
+                    if test "$?" -ne 0; then
+                        OK=0
+                    fi
                 fi
                 if test "$OK" -eq 0; then
                     echo "WARNING: $PKG is not available"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -334,7 +334,7 @@ jobs:
                 echo "$_PKGLIST"
                 _BASE=$(echo "$PKG" | sed 's/[=<>].*//')
                 _BUILDS=$(echo "$_PKGLIST" | grep "^$_BASE " \
-                    | sed -r 's/\s+/ /g' | cut -d\  -f3)
+                    | sed -r 's/\s+/ /g' | cut -d\  -f3) || echo ""x
                 if test -n "$_BUILDS"; then
                     _ISPY=$(echo "$_BUILDS" | grep "^py") \
                         || echo "No python build detected"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -335,9 +335,9 @@ jobs:
                 _BUILDS=$(echo "$_PKGLIST" | grep "^$_BASE " \
                     | sed -r 's/\s+/ /g' | cut -d\  -f3)
                 if test -n "$_BUILDS"; then
-                    _PY=$(echo "_$BUILDS" | grep "^py")
+                    _PY=$(echo "$_BUILDS" | grep "^py")
                     _PYOK=$(echo "$_BUILDS" | grep "^$PYVER")
-                    test -z "$_PY" -o -n "$_PYOK"; then
+                    if test -z "$_PY" -o -n "$_PYOK"; then
                         conda install -q -y "$PKG"
                         if test "$?" -ne 0; then
                             _BUILDS=""

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -328,7 +328,8 @@ jobs:
                 # package is not available.  Perform a quick search to see
                 # if the package is available for this interpreter before
                 # attempting an install.
-                OK=$(conda search "$PKG" |& grep " py$PYVER" | wc -l)
+                # NOTE: conda search will attempt approximatches.
+                OK=$(conda search "$PKG" |& grep "^$PKG " | grep " py$PYVER" | wc -l)
                 if test "$OK" -gt 0; then
                     conda install -q -y "$PKG"
                     if test "$?" -ne 0; then

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -320,19 +320,21 @@ jobs:
         echo "*** Install Pyomo dependencies ***"
         conda install --update-deps -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
-            echo "*** Install CPLEX ***"
-            conda install -q -y 'cplex>=12.10' docplex \
-                || echo "WARNING: CPLEX Community Edition is not available"
-            echo "*** Install Gurobi ***"
-            conda install -q -y gurobi \
-                || echo "WARNING: Gurobi is not available"
-            echo "*** Install Xpress ***"
-            conda install -q -y xpress \
-                || echo "WARNING: Xpress Community Edition is not available"
-            for PKG in cyipopt pymumps scip; do
+            PYVER=`echo "${{matrix.python}}" | sed 's|\.||g'`
+            for PKG in 'cplex>=12.10' docplex gurobi xpress cyipopt pymumps scip; do
+                echo ""
                 echo "*** Install $PKG ***"
-                conda install -q -y $PKG \
-                    || echo "WARNING: $PKG is not available"
+                # conda can literally take an hour to determine that a
+                # package is not available.  Perform a quick search to see
+                # if the package is available for this interpreter before
+                # attempting an install.
+                OK=`conda search "$PKG" |& grep " py$PYVER" | wc -l`
+                if test "$OK" -gt 0; then
+                    conda install -q -y $PKG || OK=0
+                fi
+                if test "$OK" -eq 0; then
+                    echo "WARNING: $PKG is not available"
+                fi
             done
             # TODO: This is a hack to stop test_qt.py from running until we
             # can better troubleshoot why it fails on GHA

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -350,7 +350,7 @@ jobs:
         echo "*** Install Pyomo dependencies ***"
         conda install --update-deps -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
-            PYVER=`echo "${{matrix.python}}" | sed 's|\.||g'`
+            PYVER=$(echo "py${{matrix.python}}" | sed 's|\.||g')
             for PKG in 'cplex>=12.10' docplex gurobi xpress cyipopt pymumps scip; do
                 echo ""
                 echo "*** Install $PKG ***"
@@ -358,8 +358,9 @@ jobs:
                 # package is not available.  Perform a quick search to see
                 # if the package is available for this interpreter before
                 # attempting an install.
-                # NOTE: conda search will attempt approximatches.
-                OK=$(conda search "$PKG" |& grep "^$PKG " | grep " py$PYVER" | wc -l)
+                # NOTE: conda search will attempt approximate matches.
+                conda search -f "$PKG"
+                OK=$(conda search -f "$PKG" |& grep "^$PKG " | grep " $PYVER" | wc -l)
                 if test "$OK" -gt 0; then
                     conda install -q -y "$PKG"
                     if test "$?" -ne 0; then

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -360,7 +360,7 @@ jobs:
                 # if the package is available for this interpreter before
                 # attempting an install.
                 # NOTE: conda search will attempt approximate matches.
-                _PKGLIST=$(conda search -f "$PKG")
+                _PKGLIST=$(conda search -f "$PKG") || echo "Package $PKG not found"
                 echo "$_PKGLIST"
                 _BASE=$(echo "$PKG" | sed 's/[=<>].*//')
                 _BUILDS=$(echo "$_PKGLIST" | grep "^$_BASE " \

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -359,16 +359,22 @@ jobs:
                 # if the package is available for this interpreter before
                 # attempting an install.
                 # NOTE: conda search will attempt approximate matches.
-                conda search -f "$PKG"
-                BASE=$(echo "$PKG" | sed 's/[=<>].*//')
-                OK=$(conda search -f "$PKG" |& grep "^$BASE " | grep " $PYVER" | wc -l)
-                if test "$OK" -gt 0; then
-                    conda install -q -y "$PKG"
-                    if test "$?" -ne 0; then
-                        OK=0
+                _PKGLIST=$(conda search -f "$PKG")
+                echo "$_PKGLIST"
+                _BASE=$(echo "$PKG" | sed 's/[=<>].*//')
+                _BUILDS=$(echo "$_PKGLIST" | grep "^$_BASE " \
+                    | sed -r 's/\s+/ /g' | cut -d\  -f3)
+                if test -n "$_BUILDS"; then
+                    _PY=$(echo "$_BUILDS" | grep "^py")
+                    _PYOK=$(echo "$_BUILDS" | grep "^$PYVER")
+                    test -z "$_PY" -o -n "$_PYOK"; then
+                        conda install -q -y "$PKG"
+                        if test "$?" -ne 0; then
+                            _BUILDS=""
+                        fi
                     fi
                 fi
-                if test "$OK" -eq 0; then
+                if test -z "$_BUILDS" -eq 0; then
                     echo "WARNING: $PKG is not available"
                 fi
             done

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -348,7 +348,6 @@ jobs:
             fi
         done
         echo "*** Install Pyomo dependencies ***"
-        set -x
         conda install --update-deps -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
@@ -367,8 +366,10 @@ jobs:
                 _BUILDS=$(echo "$_PKGLIST" | grep "^$_BASE " \
                     | sed -r 's/\s+/ /g' | cut -d\  -f3)
                 if test -n "$_BUILDS"; then
-                    _ISPY=$(echo "$_BUILDS" | grep "^py")
-                    _PYOK=$(echo "$_BUILDS" | grep "^$PYVER")
+                    _ISPY=$(echo "$_BUILDS" | grep "^py") \
+                        || echo "No python build detected"
+                    _PYOK=$(echo "$_BUILDS" | grep "^$PYVER") \
+                        || echo "No python build matching $PYVER detected"
                     if test -z "$_ISPY" -o -n "$_PYOK"; then
                         echo "... INSTALLING $PKG"
                         conda install -y "$PKG" || _BUILDS=""
@@ -377,9 +378,7 @@ jobs:
                 if test -z "$_BUILDS"; then
                     echo "WARNING: $PKG is not available"
                 fi
-                echo "... DONE with $PKG"
             done
-            echo "DONE installing"
             # TODO: This is a hack to stop test_qt.py from running until we
             # can better troubleshoot why it fails on GHA
             for QTPACKAGE in qt pyqt; do

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -37,6 +37,10 @@ jobs:
     steps:
     - name: Checkout Pyomo source
       uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
     - name: Black Formatting Check
       run: |
         pip install black
@@ -346,19 +350,21 @@ jobs:
         echo "*** Install Pyomo dependencies ***"
         conda install --update-deps -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
-            echo "*** Install CPLEX ***"
-            conda install -q -y 'cplex>=12.10' docplex \
-                || echo "WARNING: CPLEX Community Edition is not available"
-            echo "*** Install Gurobi ***"
-            conda install -q -y gurobi \
-                || echo "WARNING: Gurobi is not available"
-            echo "*** Install Xpress ***"
-            conda install -q -y xpress \
-                || echo "WARNING: Xpress Community Edition is not available"
-            for PKG in cyipopt pymumps scip; do
+            PYVER=`echo "${{matrix.python}}" | sed 's|\.||g'`
+            for PKG in 'cplex>=12.10' docplex gurobi xpress cyipopt pymumps scip; do
+                echo ""
                 echo "*** Install $PKG ***"
-                conda install -q -y $PKG \
-                    || echo "WARNING: $PKG is not available"
+                # conda can literally take an hour to determine that a
+                # package is not available.  Perform a quick search to see
+                # if the package is available for this interpreter before
+                # attempting an install.
+                OK=`conda search "$PKG" |& grep " py$PYVER" | wc -l`
+                if test "$OK" -gt 0; then
+                    conda install -q -y $PKG || OK=0
+                fi
+                if test "$OK" -eq 0; then
+                    echo "WARNING: $PKG is not available"
+                fi
             done
             # TODO: This is a hack to stop test_qt.py from running until we
             # can better troubleshoot why it fails on GHA

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -364,7 +364,7 @@ jobs:
                 echo "$_PKGLIST"
                 _BASE=$(echo "$PKG" | sed 's/[=<>].*//')
                 _BUILDS=$(echo "$_PKGLIST" | grep "^$_BASE " \
-                    | sed -r 's/\s+/ /g' | cut -d\  -f3)
+                    | sed -r 's/\s+/ /g' | cut -d\  -f3) || echo ""
                 if test -n "$_BUILDS"; then
                     _ISPY=$(echo "$_BUILDS" | grep "^py") \
                         || echo "No python build detected"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -348,6 +348,7 @@ jobs:
             fi
         done
         echo "*** Install Pyomo dependencies ***"
+        set -x
         conda install --update-deps -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
@@ -369,13 +370,16 @@ jobs:
                     _ISPY=$(echo "$_BUILDS" | grep "^py")
                     _PYOK=$(echo "$_BUILDS" | grep "^$PYVER")
                     if test -z "$_ISPY" -o -n "$_PYOK"; then
+                        echo "... INSTALLING $PKG"
                         conda install -y "$PKG" || _BUILDS=""
                     fi
                 fi
                 if test -z "$_BUILDS"; then
                     echo "WARNING: $PKG is not available"
                 fi
+                echo "... DONE with $PKG"
             done
+            echo "DONE installing"
             # TODO: This is a hack to stop test_qt.py from running until we
             # can better troubleshoot why it fails on GHA
             for QTPACKAGE in qt pyqt; do

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -374,7 +374,7 @@ jobs:
                         fi
                     fi
                 fi
-                if test -z "$_BUILDS" -eq 0; then
+                if test -z "$_BUILDS"; then
                     echo "WARNING: $PKG is not available"
                 fi
             done

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -350,7 +350,8 @@ jobs:
         echo "*** Install Pyomo dependencies ***"
         conda install --update-deps -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
-            PYVER=$(echo "py${{matrix.python}}" | sed 's|\.||g')
+            PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
+            echo "Installing for $PYVER"
             for PKG in 'cplex>=12.10' docplex gurobi xpress cyipopt pymumps scip; do
                 echo ""
                 echo "*** Install $PKG ***"
@@ -365,13 +366,10 @@ jobs:
                 _BUILDS=$(echo "$_PKGLIST" | grep "^$_BASE " \
                     | sed -r 's/\s+/ /g' | cut -d\  -f3)
                 if test -n "$_BUILDS"; then
-                    _PY=$(echo "$_BUILDS" | grep "^py")
+                    _ISPY=$(echo "$_BUILDS" | grep "^py")
                     _PYOK=$(echo "$_BUILDS" | grep "^$PYVER")
-                    if test -z "$_PY" -o -n "$_PYOK"; then
-                        conda install -q -y "$PKG"
-                        if test "$?" -ne 0; then
-                            _BUILDS=""
-                        fi
+                    if test -z "$_ISPY" -o -n "$_PYOK"; then
+                        conda install -y "$PKG" || _BUILDS=""
                     fi
                 fi
                 if test -z "$_BUILDS"; then

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -358,9 +358,12 @@ jobs:
                 # package is not available.  Perform a quick search to see
                 # if the package is available for this interpreter before
                 # attempting an install.
-                OK=`conda search "$PKG" |& grep " py$PYVER" | wc -l`
+                OK=$(conda search "$PKG" |& grep " py$PYVER" | wc -l)
                 if test "$OK" -gt 0; then
-                    conda install -q -y $PKG || OK=0
+                    conda install -q -y "$PKG"
+                    if test "$?" -ne 0; then
+                        OK=0
+                    fi
                 fi
                 if test "$OK" -eq 0; then
                     echo "WARNING: $PKG is not available"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -367,7 +367,7 @@ jobs:
                 if test -n "$_BUILDS"; then
                     _PY=$(echo "$_BUILDS" | grep "^py")
                     _PYOK=$(echo "$_BUILDS" | grep "^$PYVER")
-                    test -z "$_PY" -o -n "$_PYOK"; then
+                    if test -z "$_PY" -o -n "$_PYOK"; then
                         conda install -q -y "$PKG"
                         if test "$?" -ne 0; then
                             _BUILDS=""

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -360,7 +360,8 @@ jobs:
                 # attempting an install.
                 # NOTE: conda search will attempt approximate matches.
                 conda search -f "$PKG"
-                OK=$(conda search -f "$PKG" |& grep "^$PKG " | grep " $PYVER" | wc -l)
+                BASE=$(echo "$PKG" | sed 's/[=<>].*//')
+                OK=$(conda search -f "$PKG" |& grep "^$BASE " | grep " $PYVER" | wc -l)
                 if test "$OK" -gt 0; then
                     conda install -q -y "$PKG"
                     if test "$?" -ne 0; then

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -358,7 +358,8 @@ jobs:
                 # package is not available.  Perform a quick search to see
                 # if the package is available for this interpreter before
                 # attempting an install.
-                OK=$(conda search "$PKG" |& grep " py$PYVER" | wc -l)
+                # NOTE: conda search will attempt approximatches.
+                OK=$(conda search "$PKG" |& grep "^$PKG " | grep " py$PYVER" | wc -l)
                 if test "$OK" -gt 0; then
                     conda install -q -y "$PKG"
                     if test "$?" -ne 0; then


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
Conda environment setup is currently taking over an hour on Windows/Python 3.11.  The bulk of this appears to be determining that `cplex` is not actually available for Python 3.11.  This PR attempts to speed up conda environment setup by using `conda search` to check that optional packages even have a distribution for the active Python interpreter before attempting to call `conda install`.

This also removes a minor inconsistency between the PR/main and Branches workflows (setting up the linting Python environment)

## Changes proposed in this PR:
- use `conda search` to check for optional packages before attempting to install them with `conda install`
- Explicitly set up Python environment for linting job on PR/main workflow (for consistency with the branches workflow)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
