### PR TITLE
Fix differentiation of `Expressions` containing `native_numeric_types`

### DIFF
--- a/pyomo/core/expr/calculus/diff_with_pyomo.py
+++ b/pyomo/core/expr/calculus/diff_with_pyomo.py
@@ -328,7 +328,7 @@ def _diff_GeneralExpression(node, val_dict, der_dict):
     val_dict: ComponentMap
     der_dict: ComponentMap
     """
-    der_dict[node.expr] += der_dict[node]
+    der_dict[node.arg(0)] += der_dict[node]
 
 
 def _diff_ExternalFunctionExpression(node, val_dict, der_dict):

--- a/pyomo/core/tests/unit/test_derivs.py
+++ b/pyomo/core/tests/unit/test_derivs.py
@@ -230,6 +230,17 @@ class TestDerivs(unittest.TestCase):
         symbolic = reverse_sd(m.o.expr)
         self.assertAlmostEqual(derivs[m.x], pyo.value(symbolic[m.x]), tol)
 
+    def test_constant_named_expressions(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(initialize=3)
+        m.e = pyo.Expression(expr=2)
+
+        e = m.x * m.e
+        derivs = reverse_ad(e)
+        symbolic = reverse_sd(e)
+        self.assertAlmostEqual(derivs[m.x], pyo.value(symbolic[m.x]), tol + 3)
+        self.assertAlmostEqual(derivs[m.x], approx_deriv(e, m.x), tol)
+
     def test_multiple_named_expressions(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var()


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #2986

## Summary/Motivation:
Recently, Pyomo changed the Expression object API so that `.expr` would always return a class derived from `NumericValue`, but not necessarily the *same* object each time it was called.  As a result, walkers that key off the expression child need to use `.arg(0)` and not `.expr`.  This PR resolves that bug in the Pyomo `reverse_ad` walker.

## Changes proposed in this PR:
- Use `.arg(0)` and not `.expr` when accessing the child of an `Expression`
- Add a test exercising the behavior reported in #2986

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
