### PR TITLE
Update Performance Plot URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ subproblems using Python parallel communication libraries.
 * [About Pyomo](http://www.pyomo.org/about)
 * [Download](http://www.pyomo.org/installation/)
 * [Documentation](http://www.pyomo.org/documentation/)
-* [Performance Plots](https://software.sandia.gov/downloads/pub/pyomo/performance/index.html)
+* [Performance Plots](https://pyomo.github.io/performance/)
 
 Pyomo was formerly released as the Coopr software library.
 


### PR DESCRIPTION
## Fixes NA

## Summary/Motivation:
We moved the performance plot portal to GitHub pages. This updates the URL in the README.

The new website is here: https://pyomo.github.io/performance/ 

## Changes proposed in this PR:
- Update URL for Performance Plots

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
