### PR TITLE
Update report_timing() to support context manager API

### DIFF
--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -608,8 +608,6 @@ class _NLWriter_impl(object):
                     if name not in suffix_data:
                         suffix_data[name] = _SuffixData(name)
                     suffix_data[name].update(suffix)
-            timer.toc("Collected suffixes", level=logging.DEBUG)
-
         #
         # Data structures to support variable/constraint scaling
         #
@@ -620,6 +618,8 @@ class _NLWriter_impl(object):
         else:
             scaling_factor = _NoScalingFactor()
         scale_model = scaling_factor.scale
+
+        timer.toc("Collected suffixes", level=logging.DEBUG)
 
         #
         # Data structures to support presolve
@@ -641,7 +641,10 @@ class _NLWriter_impl(object):
         last_parent = None
         for obj in model.component_data_objects(Objective, active=True, sort=sorter):
             if with_debug_timing and obj.parent_component() is not last_parent:
-                timer.toc('Objective %s', last_parent, level=logging.DEBUG)
+                if last_parent is None:
+                    timer.toc(None)
+                else:
+                    timer.toc('Objective %s', last_parent, level=logging.DEBUG)
                 last_parent = obj.parent_component()
             expr_info = visitor.walk_expression((obj.expr, obj, 1, scaling_factor(obj)))
             if expr_info.named_exprs:
@@ -657,6 +660,8 @@ class _NLWriter_impl(object):
         if with_debug_timing:
             # report the last objective
             timer.toc('Objective %s', last_parent, level=logging.DEBUG)
+        else:
+            timer.toc('Processed %s objectives', len(objectives))
 
         # Order the objectives, moving all nonlinear objectives to
         # the beginning
@@ -676,9 +681,13 @@ class _NLWriter_impl(object):
         n_complementarity_range = 0
         n_complementarity_nz_var_lb = 0
         #
+        last_parent = None
         for con in ordered_active_constraints(model, self.config):
             if with_debug_timing and con.parent_component() is not last_parent:
-                timer.toc('Constraint %s', last_parent, level=logging.DEBUG)
+                if last_parent is None:
+                    timer.toc(None)
+                else:
+                    timer.toc('Constraint %s', last_parent, level=logging.DEBUG)
                 last_parent = con.parent_component()
             scale = scaling_factor(con)
             expr_info = visitor.walk_expression((con.body, con, 0, scale))
@@ -723,6 +732,8 @@ class _NLWriter_impl(object):
         if with_debug_timing:
             # report the last constraint
             timer.toc('Constraint %s', last_parent, level=logging.DEBUG)
+        else:
+            timer.toc('Processed %s constraints', len(constraints))
 
         # This may fetch more bounds than needed, but only in the cases
         # where variables were completely eliminated while walking the
@@ -912,8 +923,8 @@ class _NLWriter_impl(object):
             linear_binary_vars = linear_integer_vars = set()
         assert len(variables) == n_vars
         timer.toc(
-            'Set row / column ordering: %s variables [%s, %s, %s R/B/Z], '
-            '%s constraints [%s, %s L/NL]',
+            'Set row / column ordering: %s var [%s, %s, %s R/B/Z], '
+            '%s con [%s, %s L/NL]',
             n_vars,
             len(continuous_vars),
             len(binary_vars),

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -13,8 +13,10 @@
 import pyomo.common.unittest as unittest
 
 import io
+import logging
 import math
 import os
+import re
 
 import pyomo.repn.util as repn_util
 import pyomo.repn.plugins.nl_writer as nl_writer
@@ -23,7 +25,9 @@ from pyomo.repn.tests.nl_diff import nl_diff
 
 from pyomo.common.dependencies import numpy, numpy_available
 from pyomo.common.log import LoggingIntercept
+from pyomo.common.tee import capture_output
 from pyomo.common.tempfiles import TempfileManager
+from pyomo.common.timing import report_timing
 from pyomo.core.expr import Expr_if, inequality, LinearExpression
 from pyomo.core.base.expression import ScalarExpression
 from pyomo.environ import (
@@ -987,6 +991,40 @@ class Test_NLWriter(unittest.TestCase):
             "keys that are not Var, Constraint, Objective, or the model.  "
             "Skipping.\n",
             LOG.getvalue(),
+        )
+
+    def test_log_timing(self):
+        # This tests an error possibly reported by #2810
+        m = ConcreteModel()
+        m.x = Var(range(6))
+        m.x[0].domain = pyo.Binary
+        m.x[1].domain = pyo.Integers
+        m.x[2].domain = pyo.Integers
+        m.p = Param(initialize=5, mutable=True)
+        m.o1 = Objective([1, 2], rule=lambda m, i: 1)
+        m.o2 = Objective(expr=m.x[1] * m.x[2])
+        m.c1 = Constraint([1, 2], rule=lambda m, i: sum(m.x.values()) == 1)
+        m.c2 = Constraint(expr=m.p * m.x[1] ** 2 + m.x[2] ** 3 <= 100)
+
+        self.maxDiff = None
+        OUT = io.StringIO()
+        with capture_output() as LOG:
+            with report_timing(level=logging.DEBUG):
+                nl_writer.NLWriter().write(m, OUT)
+        self.assertEqual(
+            """      [+   #.##] Initialized column order
+      [+   #.##] Collected suffixes
+      [+   #.##] Objective o1
+      [+   #.##] Objective o2
+      [+   #.##] Constraint c1
+      [+   #.##] Constraint c2
+      [+   #.##] Categorized model variables: 14 nnz
+      [+   #.##] Set row / column ordering: 6 var [3, 1, 2 R/B/Z], 3 con [2, 1 L/NL]
+      [+   #.##] Generated row/col labels & comments
+      [+   #.##] Wrote NL stream
+      [    #.##] Generated NL representation
+""",
+            re.sub(r'\d\.\d\d\]', '#.##]', LOG.getvalue()),
         )
 
     def test_linear_constraint_npv_const(self):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This updates the old `report_timing()` function so that it can be used as a context manager.  When used as a context manager, it will undo the changes that it made to the timing loggers upon exit from the context.  Among other things, this prevents side effects from enabling report_timing in `model.create_instance()` and makes it easier to exercise the timing statements in the transformations and writers.

This also adds a test that exercises the timing reporting for the NLv2 (which was the original motivation)

## Changes proposed in this PR:
- Convert `report_timing()` to support use as a context manager
- Use `report_timing()` context manager in `Model.create_instance()`
- Add test exercising timing in NLv2 writer

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
