### PR TITLE
Fix two bugs in incidence analysis

### DIFF
--- a/pyomo/contrib/incidence_analysis/common/dulmage_mendelsohn.py
+++ b/pyomo/contrib/incidence_analysis/common/dulmage_mendelsohn.py
@@ -90,7 +90,8 @@ def dulmage_mendelsohn(bg, top_nodes=None, matching=None):
     _filter.update(b_unmatched)
     _filter.update(b_matched_with_reachable)
     t_other = [t for t in top_nodes if t not in _filter]
-    b_other = [b for b in bot_nodes if b not in _filter]
+    b_other = [matching[t] for t in t_other]
+    #b_other = [b for b in bot_nodes if b not in _filter]
 
     return (
         (t_unmatched, t_reachable, t_matched_with_reachable, t_other),

--- a/pyomo/contrib/incidence_analysis/common/dulmage_mendelsohn.py
+++ b/pyomo/contrib/incidence_analysis/common/dulmage_mendelsohn.py
@@ -91,7 +91,6 @@ def dulmage_mendelsohn(bg, top_nodes=None, matching=None):
     _filter.update(b_matched_with_reachable)
     t_other = [t for t in top_nodes if t not in _filter]
     b_other = [matching[t] for t in t_other]
-    #b_other = [b for b in bot_nodes if b not in _filter]
 
     return (
         (t_unmatched, t_reachable, t_matched_with_reachable, t_other),

--- a/pyomo/contrib/incidence_analysis/dulmage_mendelsohn.py
+++ b/pyomo/contrib/incidence_analysis/dulmage_mendelsohn.py
@@ -70,6 +70,21 @@ def dulmage_mendelsohn(matrix_or_graph, top_nodes=None, matching=None):
     - **overconstrained** - The columns matched with *possibly* unmatched
       rows (unmatched and overconstrained rows)
 
+    While the Dulmage-Mendelsohn decomposition does not specify an order within
+    any of these subsets, the order returned by this function preserves the
+    maximum matching that is used to compute the decomposition. That is, zipping
+    "corresponding" row and column subsets yields pairs in this maximum matching.
+    For example:
+
+    >>> row_dmpartition, col_dmpartition = dulmage_mendelsohn(matrix)
+    >>> rdmp = row_dmpartition
+    >>> cdmp = col_dmpartition
+    >>> matching = list(zip(
+    ...     rdmp.underconstrained + rdmp.square + rdmp.overconstrained,
+    ...     cdmp.underconstrained + cdmp.square + cdmp.overconstrained,
+    ... ))
+    >>> # matching is a valid maximum matching of rows and columns of the matrix!
+
     Parameters
     ----------
     matrix_or_graph: ``scipy.sparse.coo_matrix`` or ``networkx.Graph``

--- a/pyomo/contrib/incidence_analysis/dulmage_mendelsohn.py
+++ b/pyomo/contrib/incidence_analysis/dulmage_mendelsohn.py
@@ -77,7 +77,16 @@ def dulmage_mendelsohn(matrix_or_graph, top_nodes=None, matching=None):
     For example:
 
     .. doctest::
-       :skipif: True
+       :hide:
+       :skipif: not (networkx_available and scipy_available)
+
+       >>> # Hidden code block to make the following example runnable
+       >>> import scipy.sparse as sps
+       >>> from pyomo.contrib.incidence_analysis.dulmage_mendelsohn import dulmage_mendelsohn
+       >>> matrix = sps.identity(3)
+
+    .. doctest::
+       :skipif: not (networkx_available and scipy_available)
 
        >>> row_dmpartition, col_dmpartition = dulmage_mendelsohn(matrix)
        >>> rdmp = row_dmpartition

--- a/pyomo/contrib/incidence_analysis/dulmage_mendelsohn.py
+++ b/pyomo/contrib/incidence_analysis/dulmage_mendelsohn.py
@@ -76,14 +76,17 @@ def dulmage_mendelsohn(matrix_or_graph, top_nodes=None, matching=None):
     "corresponding" row and column subsets yields pairs in this maximum matching.
     For example:
 
-    >>> row_dmpartition, col_dmpartition = dulmage_mendelsohn(matrix)
-    >>> rdmp = row_dmpartition
-    >>> cdmp = col_dmpartition
-    >>> matching = list(zip(
-    ...     rdmp.underconstrained + rdmp.square + rdmp.overconstrained,
-    ...     cdmp.underconstrained + cdmp.square + cdmp.overconstrained,
-    ... ))
-    >>> # matching is a valid maximum matching of rows and columns of the matrix!
+    .. doctest::
+       :skipif: True
+
+       >>> row_dmpartition, col_dmpartition = dulmage_mendelsohn(matrix)
+       >>> rdmp = row_dmpartition
+       >>> cdmp = col_dmpartition
+       >>> matching = list(zip(
+       ...     rdmp.underconstrained + rdmp.square + rdmp.overconstrained,
+       ...     cdmp.underconstrained + cdmp.square + cdmp.overconstrained,
+       ... ))
+       >>> # matching is a valid maximum matching of rows and columns of the matrix!
 
     Parameters
     ----------

--- a/pyomo/contrib/incidence_analysis/incidence.py
+++ b/pyomo/contrib/incidence_analysis/incidence.py
@@ -59,7 +59,7 @@ def _get_incident_via_standard_repn(expr, include_fixed, linear_only):
             linear_vars.append(var)
     if linear_only:
         nl_var_id_set = set(id(var) for var in repn.nonlinear_vars)
-        return [var for var in repn.linear_vars if id(var) not in nl_var_id_set]
+        return [var for var in linear_vars if id(var) not in nl_var_id_set]
     else:
         # Combine linear and nonlinear variables and filter out duplicates. Note
         # that quadratic=False, so we don't need to include repn.quadratic_vars.

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -750,7 +750,18 @@ class IncidenceGraphInterface(object):
         pairs in this maximum matching. For example:
 
         .. doctest::
-           :skipif: True
+           :hide:
+           :skipif: not (networkx_available and scipy_available)
+
+           >>> # Hidden code block creating a dummy model so the following doctest runs
+           >>> import pyomo.environ as pyo
+           >>> from pyomo.contrib.incidence_analysis import IncidenceGraphInterface
+           >>> model = pyo.ConcreteModel()
+           >>> model.x = pyo.Var([1,2,3])
+           >>> model.eq = pyo.Constraint(expr=sum(m.x[:]) == 1)
+
+        .. doctest::
+           :skipif: not (networkx_available and scipy_available)
 
            >>> igraph = IncidenceGraphInterface(model)
            >>> var_dmpartition, con_dmpartition = igraph.dulmage_mendelsohn()

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -743,6 +743,22 @@ class IncidenceGraphInterface(object):
         - **unmatched** - Constraints that were not matched in a particular
           maximum cardinality matching
 
+        While the Dulmage-Mendelsohn decomposition does not specify an order
+        within any of these subsets, the order returned by this function
+        preserves the maximum matching that is used to compute the decomposition.
+        That is, zipping "corresponding" variable and constraint subsets yields
+        pairs in this maximum matching. For example:
+
+        >>> igraph = IncidenceGraphInterface(model)
+        >>> var_dmpartition, con_dmpartition = igraph.dulmage_mendelsohn()
+        >>> vdmp = var_dmpartition
+        >>> cdmp = con_dmpartition
+        >>> matching = list(zip(
+        ...     vdmp.underconstrained + vdmp.square + vdmp.overconstrained,
+        ...     cdmp.underconstrained + cdmp.square + cdmp.overconstrained,
+        >>> ))
+        >>> # matching is a valid maximum matching of variables and constraints!
+
         Returns
         -------
         var_partition: ``ColPartition`` named tuple

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -749,15 +749,18 @@ class IncidenceGraphInterface(object):
         That is, zipping "corresponding" variable and constraint subsets yields
         pairs in this maximum matching. For example:
 
-        >>> igraph = IncidenceGraphInterface(model)
-        >>> var_dmpartition, con_dmpartition = igraph.dulmage_mendelsohn()
-        >>> vdmp = var_dmpartition
-        >>> cdmp = con_dmpartition
-        >>> matching = list(zip(
-        ...     vdmp.underconstrained + vdmp.square + vdmp.overconstrained,
-        ...     cdmp.underconstrained + cdmp.square + cdmp.overconstrained,
-        >>> ))
-        >>> # matching is a valid maximum matching of variables and constraints!
+        .. doctest::
+           :skipif: True
+
+           >>> igraph = IncidenceGraphInterface(model)
+           >>> var_dmpartition, con_dmpartition = igraph.dulmage_mendelsohn()
+           >>> vdmp = var_dmpartition
+           >>> cdmp = con_dmpartition
+           >>> matching = list(zip(
+           ...     vdmp.underconstrained + vdmp.square + vdmp.overconstrained,
+           ...     cdmp.underconstrained + cdmp.square + cdmp.overconstrained,
+           >>> ))
+           >>> # matching is a valid maximum matching of variables and constraints!
 
         Returns
         -------

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -770,7 +770,7 @@ class IncidenceGraphInterface(object):
            >>> matching = list(zip(
            ...     vdmp.underconstrained + vdmp.square + vdmp.overconstrained,
            ...     cdmp.underconstrained + cdmp.square + cdmp.overconstrained,
-           >>> ))
+           ... ))
            >>> # matching is a valid maximum matching of variables and constraints!
 
         Returns

--- a/pyomo/contrib/incidence_analysis/tests/test_dulmage_mendelsohn.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_dulmage_mendelsohn.py
@@ -120,6 +120,27 @@ class TestGasExpansionDMMatrixInterface(unittest.TestCase):
         potentially_unmatched_set = set(range(len(variables)))
         self.assertEqual(set(potentially_unmatched), potentially_unmatched_set)
 
+    def test_recover_matching(self):
+        N_model = 4
+        m = make_gas_expansion_model(N_model)
+        variables = list(m.component_data_objects(pyo.Var))
+        constraints = list(m.component_data_objects(pyo.Constraint))
+        imat = get_structural_incidence_matrix(variables, constraints)
+        rdmp, cdmp = dulmage_mendelsohn(imat)
+        rmatch = rdmp.underconstrained + rdmp.square + rdmp.overconstrained
+        cmatch = cdmp.underconstrained + cdmp.square + cdmp.overconstrained
+        matching = list(zip(rmatch, cmatch))
+        rmatch = [r for (r, c) in matching]
+        cmatch = [c for (r, c) in matching]
+        # Assert that the matched rows and columns contain no duplicates
+        self.assertEqual(len(set(rmatch)), len(rmatch))
+        self.assertEqual(len(set(cmatch)), len(cmatch))
+        entry_set = set(zip(imat.row, imat.col))
+        for (i, j) in matching:
+            # Assert that each pair in the matching is a valid entry
+            # in the matrix
+            self.assertIn((i, j), entry_set)
+
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
 @unittest.skipUnless(scipy_available, "scipy is not available.")

--- a/pyomo/contrib/incidence_analysis/tests/test_dulmage_mendelsohn.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_dulmage_mendelsohn.py
@@ -136,7 +136,7 @@ class TestGasExpansionDMMatrixInterface(unittest.TestCase):
         self.assertEqual(len(set(rmatch)), len(rmatch))
         self.assertEqual(len(set(cmatch)), len(cmatch))
         entry_set = set(zip(imat.row, imat.col))
-        for (i, j) in matching:
+        for i, j in matching:
             # Assert that each pair in the matching is a valid entry
             # in the matrix
             self.assertIn((i, j), entry_set)

--- a/pyomo/contrib/incidence_analysis/tests/test_incidence.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_incidence.py
@@ -148,6 +148,17 @@ class TestIncidenceStandardRepn(unittest.TestCase, _TestIncidence):
         variables = self._get_incident_variables(expr)
         self.assertEqual(ComponentSet(variables), ComponentSet([m.x[1], m.x[2]]))
 
+    def test_fixed_zero_coefficient_linear_only(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var([1, 2, 3])
+        expr = m.x[1] * m.x[2] + 2 * m.x[3]
+        m.x[2].fix(0)
+        variables = get_incident_variables(
+            expr, method=IncidenceMethod.standard_repn, linear_only=True
+        )
+        self.assertEqual(len(variables), 1)
+        self.assertIs(variables[0], m.x[3])
+
     def test_fixed_none_linear_coefficient(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var([1, 2, 3])

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -1323,6 +1323,22 @@ class TestDulmageMendelsohnInterface(unittest.TestCase):
         self.assertEqual(N_new, N - len(cons_to_remove))
         self.assertEqual(M_new, M - len(vars_to_remove))
 
+    def test_recover_matching_from_dulmage_mendelsohn(self):
+        m = make_degenerate_solid_phase_model()
+        igraph = IncidenceGraphInterface(m)
+        vdmp, cdmp = igraph.dulmage_mendelsohn()
+        vmatch = vdmp.underconstrained + vdmp.square + vdmp.overconstrained
+        cmatch = cdmp.underconstrained + cdmp.square + cdmp.overconstrained
+        # Assert no duplicates in matched variables and constraints
+        self.assertEqual(len(ComponentSet(vmatch)), len(vmatch))
+        self.assertEqual(len(ComponentSet(cmatch)), len(cmatch))
+        matching = list(zip(vmatch, cmatch))
+        # Assert each matched pair contains a variable that participates
+        # in the constraint.
+        for var, con in matching:
+            var_in_con = ComponentSet(igraph.get_adjacent_to(con))
+            self.assertIn(var, var_in_con)
+
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
 class TestConnectedComponents(unittest.TestCase):


### PR DESCRIPTION
## Fixes #3040

## Summary/Motivation:
- The subsets returned by the Dulmage-Mendelsohn decomposition should be ordered so that zipping the constraint and variable subsets allows us to recover a maximum matching.
- `get_incident_variables(expr, linear_only=True)` should correctly filter out variables that have coefficients of zero

## Changes proposed in this PR:
- Change the order of nodes returned in the "square subset" of the second bipartite set in `pyomo.contrib.common.dulmage_mendelsohn` 
- Fix bug in behavior with `linear_only=True`

Re-running the motivating example in #3040,
```python
from run_distill import instance
from pyomo.contrib.incidence_analysis import IncidenceGraphInterface
from pyomo.contrib.incidence_analysis.interface import get_structural_incidence_matrix
from pyomo.common.collections import ComponentSet
import matplotlib.pyplot as plt 

igraph = IncidenceGraphInterface(instance, include_inequality=False, linear_only=True)
var_dmp, con_dmp = igraph.dulmage_mendelsohn()
vorder = sum(var_dmp, []) 
corder = sum(con_dmp, []) 

vmatch = var_dmp.underconstrained + var_dmp.square + var_dmp.overconstrained
cmatch = con_dmp.underconstrained + con_dmp.square + con_dmp.overconstrained

matching = zip(vmatch, cmatch)
# Assert that zipping the subsets gives us a valid matching
assert len(vmatch) == len(ComponentSet(vmatch))
assert len(cmatch) == len(ComponentSet(cmatch))
for var, con in matching:
    assert var in ComponentSet(igraph.get_adjacent_to(con))

# My intention is for this to have a non-zero diagonal
imat = get_structural_incidence_matrix(vorder, corder, linear_only=True)
fig, ax = plt.subplots()
ax.spy(imat, markersize=1)
plt.show()
```
we get:
![distill_imat](https://github.com/Pyomo/pyomo/assets/8885032/5baaada7-6043-4fbe-a150-cde59fc5cfd0)


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
