### PR TITLE
Improve Disjunction construction error for invalid types

### DIFF
--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -564,16 +564,18 @@ class _DisjunctionData(ActiveComponentData):
             # IndexedDisjunct indexed by Any which has already been transformed,
             # the new Disjuncts are Blocks already. This catches them for who
             # they are anyway.
-            if isinstance(e, _DisjunctData):
-                self.disjuncts.append(e)
-                continue
-            # The user was lazy and gave us a single constraint
-            # expression or an iterable of expressions
-            expressions = []
-            if hasattr(e, '__iter__'):
+            if hasattr(e, 'is_component_type') and e.is_component_type():
+                if e.ctype == Disjunct and not e.is_indexed():
+                    self.disjuncts.append(e)
+                    continue
+                e_iter = [e]
+            elif hasattr(e, '__iter__'):
                 e_iter = e
             else:
                 e_iter = [e]
+            # The user was lazy and gave us a single constraint
+            # expression or an iterable of expressions
+            expressions = []
             for _tmpe in e_iter:
                 try:
                     if _tmpe.is_expression_type():
@@ -581,13 +583,12 @@ class _DisjunctionData(ActiveComponentData):
                         continue
                 except AttributeError:
                     pass
-                msg = "\n\tin %s" % (type(e),) if e_iter is e else ""
+                msg = " in '%s'" % (type(e).__name__,) if e_iter is e else ""
                 raise ValueError(
-                    "Unexpected term for Disjunction %s.\n"
-                    "\tExpected a Disjunct object, relational expression, "
-                    "or iterable of\n"
-                    "\trelational expressions but got %s%s"
-                    % (self.name, type(_tmpe), msg)
+                    "Unexpected term for Disjunction '%s'.\n"
+                    "    Expected a Disjunct object, relational expression, "
+                    "or iterable of\n    relational expressions but got '%s'%s"
+                    % (self.name, type(_tmpe).__name__, msg)
                 )
 
             comp = self.parent_component()

--- a/pyomo/gdp/tests/test_disjunct.py
+++ b/pyomo/gdp/tests/test_disjunct.py
@@ -108,6 +108,31 @@ class TestDisjunction(unittest.TestCase):
         self.assertEqual(len(disjuncts[0].parent_component().name), 11)
         self.assertEqual(disjuncts[0].name, "f_disjuncts[0]")
 
+    def test_construct_invalid_component(self):
+        m = ConcreteModel()
+        m.d = Disjunct([1, 2])
+        with self.assertRaisesRegex(
+            ValueError,
+            "Unexpected term for Disjunction 'dd'.\n    "
+            "Expected a Disjunct object, relational expression, or iterable of\n"
+            "    relational expressions but got 'IndexedDisjunct'",
+        ):
+            m.dd = Disjunction(expr=[m.d])
+        with self.assertRaisesRegex(
+            ValueError,
+            "Unexpected term for Disjunction 'ee'.\n    "
+            "Expected a Disjunct object, relational expression, or iterable of\n"
+            "    relational expressions but got 'str' in 'list'",
+        ):
+            m.ee = Disjunction(expr=[['a']])
+        with self.assertRaisesRegex(
+            ValueError,
+            "Unexpected term for Disjunction 'ff'.\n    "
+            "Expected a Disjunct object, relational expression, or iterable of\n"
+            "    relational expressions but got 'str'",
+        ):
+            m.ff = Disjunction(expr=['a'])
+
 
 class TestDisjunct(unittest.TestCase):
     def test_deactivate(self):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This addresses some confusion raised on SO, due to a poor error message generated when an IndexedDisjunct as part of the list of Disjuncts in a Disjunction rule.  This improves the error message and adds tests.

## Changes proposed in this PR:
- Generate a sensible error message when returning non-DisjunctData components as part of a Disjunction rule
- Add test of this behavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
