### PR TITLE
Log which suffix values were skipped at the DEBUG level

### DIFF
--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -470,12 +470,22 @@ class _SuffixData(object):
                 "not exported as part of the NL file.  "
                 "Skipping."
             )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "Skipped component keys:\n\t"
+                    + "\n\t".join(sorted(map(str, missing_component_data)))
+                )
         if unknown_data:
             logger.warning(
                 f"model contains export suffix '{self.name}' that "
                 f"contains {len(unknown_data)} keys that are not "
                 "Var, Constraint, Objective, or the model.  Skipping."
             )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "Skipped component keys:\n\t"
+                    + "\n\t".join(sorted(map(str, unknown_data)))
+                )
 
 
 class CachingNumericSuffixFinder(SuffixFinder):

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -13,6 +13,7 @@
 import pyomo.common.unittest as unittest
 
 import io
+import logging
 import math
 import os
 
@@ -949,6 +950,14 @@ class Test_NLWriter(unittest.TestCase):
             "keys that are not exported as part of the NL file.  Skipping.\n",
             LOG.getvalue(),
         )
+        with LoggingIntercept(level=logging.DEBUG) as LOG:
+            nl_writer.NLWriter().write(m, OUT)
+        self.assertEqual(
+            "model contains export suffix 'junk' that contains 1 component "
+            "keys that are not exported as part of the NL file.  Skipping.\n"
+            "Skipped component keys:\n\ty\n",
+            LOG.getvalue(),
+        )
 
         m.junk[m.z] = 1
         with LoggingIntercept() as LOG:
@@ -956,6 +965,14 @@ class Test_NLWriter(unittest.TestCase):
         self.assertEqual(
             "model contains export suffix 'junk' that contains 3 component "
             "keys that are not exported as part of the NL file.  Skipping.\n",
+            LOG.getvalue(),
+        )
+        with LoggingIntercept(level=logging.DEBUG) as LOG:
+            nl_writer.NLWriter().write(m, OUT)
+        self.assertEqual(
+            "model contains export suffix 'junk' that contains 3 component "
+            "keys that are not exported as part of the NL file.  Skipping.\n"
+            "Skipped component keys:\n\ty\n\tz[1]\n\tz[3]\n",
             LOG.getvalue(),
         )
 
@@ -986,6 +1003,17 @@ class Test_NLWriter(unittest.TestCase):
             "model contains export suffix 'junk' that contains 1 "
             "keys that are not Var, Constraint, Objective, or the model.  "
             "Skipping.\n",
+            LOG.getvalue(),
+        )
+        with LoggingIntercept(level=logging.DEBUG) as LOG:
+            nl_writer.NLWriter().write(m, OUT)
+        self.assertEqual(
+            "model contains export suffix 'junk' that contains 6 component "
+            "keys that are not exported as part of the NL file.  Skipping.\n"
+            "Skipped component keys:\n\tc\n\td[1]\n\td[3]\n\ty\n\tz[1]\n\tz[3]\n"
+            "model contains export suffix 'junk' that contains 1 keys that "
+            "are not Var, Constraint, Objective, or the model.  Skipping.\n"
+            "Skipped component keys:\n\t5\n",
             LOG.getvalue(),
         )
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
Updates to the NL writer have silenced a lot of the warnings that were previously generated for declared export suffixes that were not emitted as part of the NL file.  This adds additional logging (so you can get the component / data names for the skipped suffixes at the DEBUG level.

## Changes proposed in this PR:
- Restore logging of the names of skipped export suffix datas, but only at the DEBUG level
- Add a test of this behavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
