### PR TITLE
Remove presolve-eliminated variables from named expressions

### DIFF
--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -1685,6 +1685,15 @@ class _NLWriter_impl(object):
         if not self.config.linear_presolve:
             return eliminated_cons, eliminated_vars
 
+        # We need to record all named expressions with linear components
+        # so that any eliminated variables are removed from them.
+        for expr, info, _ in self.subexpression_cache.values():
+            if not info.linear:
+                continue
+            expr_id = id(expr)
+            for _id in info.linear:
+                comp_by_linear_var[_id].append((expr_id, info))
+
         fixed_vars = [
             _id for _id, (lb, ub) in var_bounds.items() if lb == ub and lb is not None
         ]

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -1480,7 +1480,6 @@ G0 1
         # Note: bounds on x[1] are:
         #   min(22/3, 82/17, 23/4, -39/-6) == 4.823529411764706
         #   max(2/3, 62/17, 3/4, -19/-6) == 3.6470588235294117
-        print(OUT.getvalue())
         self.assertEqual(
             *nl_diff(
                 """g3 1 1 0	# problem unknown
@@ -1743,7 +1742,7 @@ G0 3
         self.assertEqual(LOG.getvalue(), "")
 
         nl2 = OUT.getvalue()
-        print(nl2)
+
         self.assertEqual(
             *nl_diff(
                 """g3 1 1 0	# problem unknown
@@ -1837,7 +1836,7 @@ G0 3
 
         OUT = io.StringIO()
         nl_writer.NLWriter().write(m, OUT, symbolic_solver_labels=True)
-        print(OUT.getvalue())
+
         self.assertEqual(
             *nl_diff(
                 """g3 1 1 0	# problem unknown

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -1565,18 +1565,17 @@ G0 1
         m.eq = pyo.Constraint(pyo.Integers)
         m.eq[1] = m.x[1] == 7
         m.eq[2] = m.x[3] == 0.1 * m.subexpr[1] * m.x[2]
-        m.obj = pyo.Objective(expr=m.x[1]**2 + m.x[2]**2 + m.x[3]**3)
+        m.obj = pyo.Objective(expr=m.x[1] ** 2 + m.x[2] ** 2 + m.x[3] ** 3)
 
         OUT = io.StringIO()
         with LoggingIntercept() as LOG:
-            nlinfo = nl_writer.NLWriter().write(m, OUT, symbolic_solver_labels=True, linear_presolve=True)
+            nlinfo = nl_writer.NLWriter().write(
+                m, OUT, symbolic_solver_labels=True, linear_presolve=True
+            )
         self.assertEqual(LOG.getvalue(), "")
 
         self.assertEqual(
-            nlinfo.eliminated_vars,
-            [
-                (m.x[1], nl_writer.AMPLRepn(7, {}, None)),
-            ],
+            nlinfo.eliminated_vars, [(m.x[1], nl_writer.AMPLRepn(7, {}, None))]
         )
 
         self.assertEqual(
@@ -1633,7 +1632,6 @@ G0 2	#obj
                 OUT.getvalue(),
             )
         )
-
 
     def test_scaling(self):
         m = pyo.ConcreteModel()


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #3055 .

## Summary/Motivation:
#3055 pointed out that any variables eliminated by the linear presolve were not being removed from the linear portion of named expressions, allowing them to be emitted to the solver.  This resolves the issue and adds a test for the example from the issue.

## Changes proposed in this PR:
- Ensure that named expressions with linear components are included in the `comp_by_linear_var` map, thereby ensuring that they are updated with the results of variable elimination.
- Add the model from #3055 as a test.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
