### PR TITLE
Fix PyROS DR polishing optimality constraint under nominal objective focus

### DIFF
--- a/pyomo/contrib/pyros/master_problem_methods.py
+++ b/pyomo/contrib/pyros/master_problem_methods.py
@@ -352,7 +352,7 @@ def minimize_dr_vars(model_data, config):
     nom_block = polishing_model.scenarios[0, 0]
     if config.objective_focus == ObjectiveType.nominal:
         obj_val = value(
-            this_iter.second_stage_objective + this_iter.first_stage_objective
+            nom_block.second_stage_objective + nom_block.first_stage_objective
         )
         polishing_model.scenarios[0, 0].polishing_constraint = Constraint(
             expr=obj_val


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Summary/Motivation:

Ensure optimality of decision rules (DR) with respect to the PyROS master problem is properly enforced for problems with a nominal objective focus (i.e. `objective_focus=ObjectiveType.nominal` passed to the PyROS solver).

Let $k \in \\{0, 1, \dots\\}$ denote the index of the current PyROS iteration. Let $x^\star$ denote the optimal master first-stage variable values for the current iteration. For each $r = 0, 1, \dots, k$, let $z^{r,\star}, y^{r,\star}$ denote the optimal second-stage and state variable values for block $r$ of the master problem of the current iteration. Now let

$$F^{r} = f_1(x^\star) + f_2(x^\star, z^{r,\star}, y^{r,\star}, q^{r}), \qquad r = 0, 1, \dots, k$$

where $f_1$ and $f_2$ are the first-stage and second-stage objective functions, respectively; and $q^0, q^1, \dots, q^k$ are the uncertain parameter realizations of the current master problem. Under a nominal objective focus, the optimality constraint of the DR polishing problem of the current iteration should be

$$F^{0} \geq f_1(x^\star) + f_2(x^\star, z^0, y^0; q^0)$$

in which $z^0, y^0$ are the nominal second-stage and state variables for block 0 of the polishing problem. However, PyROS currently implements

$$F^{k} \geq f_1(x^\star) + f_2(x^\star, z^0, y^0; q^0)$$

which may result in suboptimal polished decision rules.

## Changes proposed in this PR:
- Fix DR polishing problem optimality constraint under nominal objective focus

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
