### PR TITLE
Remove incorrect use of identity (is) comparisons

### DIFF
--- a/pyomo/neos/plugins/NEOS.py
+++ b/pyomo/neos/plugins/NEOS.py
@@ -50,7 +50,7 @@ class NEOSRemoteSolver(SystemCallSolver):
                 logger.info("Solver log file: '%s'" % (self._log_file,))
             if self._soln_file is not None:
                 logger.info("Solver solution file: '%s'" % (self._soln_file,))
-            if self._problem_files is not []:
+            if self._problem_files != []:
                 logger.info("Solver problem files: %s" % (self._problem_files,))
 
         return Bunch(cmd="", log_file=self._log_file, env="")

--- a/pyomo/opt/base/convert.py
+++ b/pyomo/opt/base/convert.py
@@ -55,7 +55,7 @@ def convert_problem(
         if os.sep in fname:  # pragma:nocover
             fname = tmp.split(os.sep)[-1]
         source_ptype = [guess_format(fname)]
-        if source_ptype is [None]:
+        if source_ptype == [None]:
             raise ConverterError("Unknown suffix type: " + tmp)
     else:
         source_ptype = args[0].valid_problem_types()

--- a/pyomo/opt/solver/shellcmd.py
+++ b/pyomo/opt/solver/shellcmd.py
@@ -260,7 +260,7 @@ class SystemCallSolver(OptSolver):
                 print("Solver log file: '%s'" % self._log_file)
             if self._soln_file is not None:
                 print("Solver solution file: '%s'" % self._soln_file)
-            if self._problem_files is not []:
+            if self._problem_files != []:
                 print("Solver problem files: %s" % str(self._problem_files))
 
         sys.stdout.flush()


### PR DESCRIPTION
# Details

While triaging your project, our bug-fixing tool generated the following message(s)-

> In files: [convert.py, method: convert_problem](https://github.com/Pyomo/pyomo/blob/main/pyomo/opt/base/convert.py#L58), [shellcmd.py, method: _apply_solver](https://github.com/Pyomo/pyomo/blob/main/pyomo/opt/solver/shellcmd.py#L263), and [NEOS.py, method: create_command_line](https://github.com/Pyomo/pyomo/blob/main/pyomo/neos/plugins/NEOS.py#L53) a logical expression uses the identity operator. A new object is created inside the identity check operation and then used for matching identity. Since this is a distinct, new object, it will not match with anything else. As a result, the identity check will have a logical short circuit and the program may have unintended behavior. iCR suggested that the logical operation should be reviewed for correctness.

In this first case, the line 58 of the file [convert.py, method: convert_problem](https://github.com/Pyomo/pyomo/blob/main/pyomo/opt/base/convert.py#L58) is as follows:

```python
if source_ptype is [None]:
```

In this second case, the line 263 of the file [shellcmd.py, method: _apply_solver](https://github.com/Pyomo/pyomo/blob/main/pyomo/opt/solver/shellcmd.py#L263) is as follows:

```python
if self._problem_files is not []:
```

In this third case, the line 53 of the file [NEOS.py, method: create_command_line](https://github.com/Pyomo/pyomo/blob/main/pyomo/neos/plugins/NEOS.py#L53) is as follows:

```python
if self._problem_files is not []:
```

In python, the `is` operator checks for identity, not equality. This means that the `is` operator checks whether the two operands refer to the same object or not. In the mentioned cases, `[None]` is a list with None element and `[]` is an empty list. However, the `[None]` is a new object and is not the same as the `source_ptype` variable being compared with. Similarly, `[]` is not the same as the `self._problem_files` variable. As a result, the `is` operator will always evaluate to False, and `is not` will always evaluate to True. We can test this scenerio by running the following code in python:

```python
a = [None]
b = []
print(a is [None]) # This will print False
print(a == [None]) # This will print True
print(b is []) # This will print False
print(b == []) # This will print True
```
Here, the `is` operator evaluates the expression to return `False`. However, it should have returned `True`.

# Changes

- To ensure logical correctness, in the line 58 of the file [convert.py, method: convert_problem](https://github.com/Pyomo/pyomo/blob/main/pyomo/opt/base/convert.py#L58), the `is` operator is replaced with `==` operator. Similarly, in the line 263 of the file [shellcmd.py, method: _apply_solver](https://github.com/Pyomo/pyomo/blob/main/pyomo/opt/solver/shellcmd.py#L263) and the line 53 of the file [NEOS.py, method: create_command_line](https://github.com/Pyomo/pyomo/blob/main/pyomo/neos/plugins/NEOS.py#L53), the `is not` operators are replaced with `!=` operators.

```python
if source_ptype == [None]:
```
```python
if self._problem_files != []:
```
```python
if self._problem_files != []:
```

Suggestions related to these changes are welcomed. 


# CLA Requirements

This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.

All contributed commits are already automatically signed off.

The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).

[Git Commit SignOff documentation](https://developercertificate.org/)


# Sponsorship and Support

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.