### PR TITLE
Clarify errors raised by accessing Sets by positional index

### DIFF
--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -2021,7 +2021,7 @@ class Set(IndexedComponent):
         filter=None,
         validate=None,
         name=None,
-        doc=None
+        doc=None,
     ):
         ...
 
@@ -2859,7 +2859,7 @@ class RangeSet(Component):
         filter=None,
         validate=None,
         name=None,
-        doc=None
+        doc=None,
     ):
         ...
 
@@ -2876,7 +2876,7 @@ class RangeSet(Component):
         filter=None,
         validate=None,
         name=None,
-        doc=None
+        doc=None,
     ):
         ...
 
@@ -2890,7 +2890,7 @@ class RangeSet(Component):
         filter=None,
         validate=None,
         name=None,
-        doc=None
+        doc=None,
     ):
         ...
 

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -1584,28 +1584,26 @@ class _OrderedSetMixin(object):
         # implementation does not guarantee that the index is valid (it
         # could be outside of abs(i) <= len(self)).
         try:
-            if item != int(item):
-                raise IndexError(
-                    "%s indices must be integers, not %s"
-                    % (self.name, type(item).__name__)
-                )
-            item = int(item)
+            _item = int(item)
+            if item != _item:
+                raise IndexError()
         except:
             raise IndexError(
-                "%s indices must be integers, not %s" % (self.name, type(item).__name__)
-            )
+                f"Set '{self.name}' positional indices must be integers, "
+                f"not {type(item).__name__}"
+            ) from None
 
-        if item >= 1:
-            return item - 1
-        elif item < 0:
-            item += len(self)
-            if item < 0:
-                raise IndexError("%s index out of range" % (self.name,))
-            return item
+        if _item >= 1:
+            return _item - 1
+        elif _item < 0:
+            _item += len(self)
+            if _item < 0:
+                raise IndexError(f"{self.name} index out of range")
+            return _item
         else:
             raise IndexError(
-                "Pyomo Sets are 1-indexed: valid index values for Sets are "
-                "[1 .. len(Set)] or [-1 .. -len(Set)]"
+                "Accessing Pyomo Sets by position is 1-based: valid Set positional "
+                "index values are [1 .. len(Set)] or [-1 .. -len(Set)]"
             )
 
 

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -1681,7 +1681,7 @@ class _OrderedSetData(_OrderedSetMixin, _FiniteSetData):
         try:
             return self._ordered_values[i]
         except IndexError:
-            raise IndexError("%s index out of range" % (self.name))
+            raise IndexError(f"{self.name} index out of range") from None
 
     def ord(self, item):
         """
@@ -2543,7 +2543,7 @@ class OrderedSetOf(_ScalarOrderedSetMixin, _OrderedSetMixin, FiniteSetOf):
         try:
             return self._ref[i]
         except IndexError:
-            raise IndexError("%s index out of range" % (self.name))
+            raise IndexError(f"{self.name} index out of range") from None
 
     def ord(self, item):
         # The bulk of single-value set members are stored as scalars.
@@ -2684,7 +2684,7 @@ class _FiniteRangeSetData(
                 if not idx:
                     return ans
                 idx -= 1
-        raise IndexError("%s index out of range" % (self.name,))
+        raise IndexError(f"{self.name} index out of range")
 
     def ord(self, item):
         if len(self._ranges) == 1:
@@ -3503,7 +3503,7 @@ class SetUnion_OrderedSet(_ScalarOrderedSetMixin, _OrderedSetMixin, SetUnion_Fin
                     if val not in self._sets[0]:
                         idx -= 1
             except StopIteration:
-                raise IndexError("%s index out of range" % (self.name,))
+                raise IndexError(f"{self.name} index out of range") from None
             return val
 
     def ord(self, item):
@@ -3640,7 +3640,7 @@ class SetIntersection_OrderedSet(
                 idx -= 1
             return next(_iter)
         except StopIteration:
-            raise IndexError("%s index out of range" % (self.name,))
+            raise IndexError(f"{self.name} index out of range") from None
 
     def ord(self, item):
         """
@@ -3734,7 +3734,7 @@ class SetDifference_OrderedSet(
                 idx -= 1
             return next(_iter)
         except StopIteration:
-            raise IndexError("%s index out of range" % (self.name,))
+            raise IndexError(f"{self.name} index out of range") from None
 
     def ord(self, item):
         """
@@ -3844,7 +3844,7 @@ class SetSymmetricDifference_OrderedSet(
                 idx -= 1
             return next(_iter)
         except StopIteration:
-            raise IndexError("%s index out of range" % (self.name,))
+            raise IndexError(f"{self.name} index out of range") from None
 
     def ord(self, item):
         """
@@ -4126,7 +4126,7 @@ class SetProduct_OrderedSet(
             i -= 1
             _ord[i], _idx = _idx % _ord[i], _idx // _ord[i]
         if _idx:
-            raise IndexError("%s index out of range" % (self.name,))
+            raise IndexError(f"{self.name} index out of range")
         ans = tuple(s.at(i + 1) for s, i in zip(self._sets, _ord))
         if FLATTEN_CROSS_PRODUCT and normalize_index.flatten and self.dimen != len(ans):
             return self._flatten_product(ans)

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -4194,7 +4194,9 @@ class TestSet(unittest.TestCase):
             IndexError, "Set 'I' positional indices must be integers, not float"
         ):
             m.I[2.5]
-        with self.assertRaisesRegex(IndexError, "Set 'I' positional indices must be integers, not str"):
+        with self.assertRaisesRegex(
+            IndexError, "Set 'I' positional indices must be integers, not str"
+        ):
             m.I['a']
 
     def test_add_filter_validate(self):

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -1530,8 +1530,8 @@ class Test_SetOf_and_RangeSet(unittest.TestCase):
         self.assertEqual(i[-1], 0)
         with self.assertRaisesRegex(
             IndexError,
-            "valid index values for Sets are "
-            r"\[1 .. len\(Set\)\] or \[-1 .. -len\(Set\)\]",
+            "Accessing Pyomo Sets by position is 1-based: valid Set positional "
+            r"index values are \[1 .. len\(Set\)\] or \[-1 .. -len\(Set\)\]",
         ):
             i[0]
         with self.assertRaisesRegex(IndexError, "OrderedSetOf index out of range"):
@@ -1589,8 +1589,8 @@ class Test_SetOf_and_RangeSet(unittest.TestCase):
         self.assertEqual(i[-1], 0)
         with self.assertRaisesRegex(
             IndexError,
-            "valid index values for Sets are "
-            r"\[1 .. len\(Set\)\] or \[-1 .. -len\(Set\)\]",
+            "Accessing Pyomo Sets by position is 1-based: valid Set positional "
+            r"index values are \[1 .. len\(Set\)\] or \[-1 .. -len\(Set\)\]",
         ):
             i[0]
         with self.assertRaisesRegex(IndexError, "OrderedSetOf index out of range"):
@@ -1752,8 +1752,8 @@ class Test_SetOf_and_RangeSet(unittest.TestCase):
             self.assertEqual(r[i + 1], v)
         with self.assertRaisesRegex(
             IndexError,
-            "valid index values for Sets are "
-            r"\[1 .. len\(Set\)\] or \[-1 .. -len\(Set\)\]",
+            "Accessing Pyomo Sets by position is 1-based: valid Set positional "
+            r"index values are \[1 .. len\(Set\)\] or \[-1 .. -len\(Set\)\]",
         ):
             r[0]
         with self.assertRaisesRegex(
@@ -1769,8 +1769,8 @@ class Test_SetOf_and_RangeSet(unittest.TestCase):
             self.assertEqual(r[i + 1], v)
         with self.assertRaisesRegex(
             IndexError,
-            "valid index values for Sets are "
-            r"\[1 .. len\(Set\)\] or \[-1 .. -len\(Set\)\]",
+            "Accessing Pyomo Sets by position is 1-based: valid Set positional "
+            r"index values are \[1 .. len\(Set\)\] or \[-1 .. -len\(Set\)\]",
         ):
             r[0]
         with self.assertRaisesRegex(
@@ -4191,10 +4191,10 @@ class TestSet(unittest.TestCase):
         m.I = [1, 3, 2]
         self.assertEqual(m.I[2], 3)
         with self.assertRaisesRegex(
-            IndexError, "I indices must be integers, not float"
+            IndexError, "Set 'I' positional indices must be integers, not float"
         ):
             m.I[2.5]
-        with self.assertRaisesRegex(IndexError, "I indices must be integers, not str"):
+        with self.assertRaisesRegex(IndexError, "Set 'I' positional indices must be integers, not str"):
             m.I['a']
 
     def test_add_filter_validate(self):

--- a/pyomo/core/tests/unit/test_sets.py
+++ b/pyomo/core/tests/unit/test_sets.py
@@ -3396,7 +3396,7 @@ class TestSetErrors(PyomoModel):
             a[0]
         a.construct()
         with self.assertRaisesRegex(
-                IndexError, "Accessing Pyomo Sets by position is 1-based"
+            IndexError, "Accessing Pyomo Sets by position is 1-based"
         ):
             a[0]
         self.assertEqual(a[1], 2)

--- a/pyomo/core/tests/unit/test_sets.py
+++ b/pyomo/core/tests/unit/test_sets.py
@@ -3395,7 +3395,9 @@ class TestSetErrors(PyomoModel):
         with self.assertRaisesRegex(RuntimeError, ".*before it has been constructed"):
             a[0]
         a.construct()
-        with self.assertRaisesRegex(IndexError, "Pyomo Sets are 1-indexed"):
+        with self.assertRaisesRegex(
+                IndexError, "Accessing Pyomo Sets by position is 1-based"
+        ):
             a[0]
         self.assertEqual(a[1], 2)
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
A user recently pointed out that the "1-based" indexing for ordered Sets was both surprising and unclear.  We cannot move Pyomo to 0-based indexing until Pyomo 7.  This PR at least attempts to clarify and standardize the `IndexError`s that are raised by Pyomo Sets.

## Changes proposed in this PR:
- Clarify `IndexError` message about Sets being 1-based
- Standardize context raised by (nested) Set exceptions

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
