### PR TITLE
Fix `range_difference` for Sets with nonzero anchor points

### DIFF
--- a/pyomo/core/base/range.py
+++ b/pyomo/core/base/range.py
@@ -557,9 +557,14 @@ class NumericRange(object):
                             NumericRange(t.start, start, 0, (t.closed[0], False))
                         )
                     if s.step:  # i.e., not a single point
-                        for i in range(int(start // s.step), int(end // s.step)):
+                        for i in range(int((end - start) // s.step)):
                             _new_subranges.append(
-                                NumericRange(i * s.step, (i + 1) * s.step, 0, '()')
+                                NumericRange(
+                                    start + i * s.step,
+                                    start + (i + 1) * s.step,
+                                    0,
+                                    '()',
+                                )
                             )
                     if t.end > end:
                         _new_subranges.append(
@@ -605,7 +610,7 @@ class NumericRange(object):
                         )
                     elif t_max == s_max and t_c[1] and not s_c[1]:
                         _new_subranges.append(NumericRange(t_max, t_max, 0))
-                _this = _new_subranges
+            _this = _new_subranges
         return _this
 
     def range_intersection(self, other_ranges):

--- a/pyomo/core/base/range.py
+++ b/pyomo/core/base/range.py
@@ -208,7 +208,7 @@ class NumericRange(object):
                 return False
 
         if self.step:
-            _dir = math.copysign(1, self.step)
+            _dir = int(math.copysign(1, self.step))
             _from_start = value - self.start
             return (
                 0 <= _dir * _from_start <= _dir * (self.end - self.start)
@@ -411,14 +411,13 @@ class NumericRange(object):
 
         assert new_step >= abs(cnr.step)
         assert new_step % cnr.step == 0
-        _dir = math.copysign(1, cnr.step)
+        _dir = int(math.copysign(1, cnr.step))
         _subranges = []
         for i in range(int(abs(new_step // cnr.step))):
             if _dir * (cnr.start + i * cnr.step) > _dir * cnr.end:
                 # Once we walk past the end of the range, we are done
                 # (all remaining offsets will be farther past the end)
                 break
-
             _subranges.append(
                 NumericRange(cnr.start + i * cnr.step, cnr.end, _dir * new_step)
             )
@@ -458,7 +457,7 @@ class NumericRange(object):
             else:
                 # one of the steps was 0: add to preserve the non-zero step
                 a += b
-        return abs(a)
+        return int(abs(a))
 
     def _push_to_discrete_element(self, val, push_to_next_larger_value):
         if not self.step or val in _infinite:

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -2663,12 +2663,16 @@ A : Size=1, Index=None, Ordered=True
 
         self.assertEqual(
             list(x.ranges()),
-            list(RangeSet(ranges=[
-                NR(0, 1, 0, (True, False)),
-                NR(1, 3, 0, (False, False)),
-                NR(3, 5, 0, (False, False)),
-                NR(5, 6, 0, (False, True)),
-            ]).ranges()),
+            list(
+                RangeSet(
+                    ranges=[
+                        NR(0, 1, 0, (True, False)),
+                        NR(1, 3, 0, (False, False)),
+                        NR(3, 5, 0, (False, False)),
+                        NR(5, 6, 0, (False, True)),
+                    ]
+                ).ranges()
+            ),
         )
 
 

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -2647,6 +2647,30 @@ A : Size=1, Index=None, Ordered=True
             list(RangeSet(ranges=[NR(0, 2, 0, (True, False))]).ranges()),
         )
 
+        x = RangeSet(0, 6, 0) - RangeSet(1, 5, 2)
+        self.assertIs(type(x), SetDifference_InfiniteSet)
+        self.assertFalse(x.isfinite())
+        self.assertFalse(x.isordered())
+
+        self.assertIn(0, x)
+        self.assertNotIn(1, x)
+        self.assertIn(2, x)
+        self.assertNotIn(3, x)
+        self.assertIn(4, x)
+        self.assertNotIn(5, x)
+        self.assertIn(6, x)
+        self.assertNotIn(7, x)
+
+        self.assertEqual(
+            list(x.ranges()),
+            list(RangeSet(ranges=[
+                NR(0, 1, 0, (True, False)),
+                NR(1, 3, 0, (False, False)),
+                NR(3, 5, 0, (False, False)),
+                NR(5, 6, 0, (False, True)),
+            ]).ranges()),
+        )
+
 
 class TestSetSymmetricDifference(unittest.TestCase):
     def test_pickle(self):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This resolves a bug in the `range_difference` method when the two ranges do not share a common (0) anchor point.  

This includes a test for the use case that originally highlighted the bug:
```python
>>> from pyomo.environ import *
>>> x = RangeSet(0, 6, 0) - RangeSet(1, 5, 2)
>>> list(x.ranges())
[[0..1), (0..2), (2..4), (5..6]]
```
With this PR, we now see:
```python
>>> from pyomo.environ import *
>>> x = RangeSet(0, 6, 0) - RangeSet(1, 5, 2)
>>> list(x.ranges())
[[0..1), (1..3), (3..5), (5..6]]
```

## Changes proposed in this PR:
- Resolve `range_difference` bug when the range is not anchored at 0
- Add a test for the observed (previously incorrect) behavior

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
