### PR TITLE
Resolve testing in Python 3.12 (manage `pyutilib`, `distutils` dependencies)

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -592,8 +592,8 @@ jobs:
         echo "COVERAGE_PROCESS_START=$COVERAGE_RC" >> $GITHUB_ENV
         cp ${GITHUB_WORKSPACE}/.coveragerc ${COVERAGE_RC}
         echo "data_file=${COVERAGE_BASE}age" >> ${COVERAGE_RC}
-        SITE_PACKAGES=$($PYTHON_EXE -c "from distutils.sysconfig import \
-            get_python_lib; print(get_python_lib())")
+        SITE_PACKAGES=$($PYTHON_EXE -c \
+            "import sysconfig; print(sysconfig.get_path('purelib'))")
         echo "Python site-packages: $SITE_PACKAGES"
         echo 'import coverage; coverage.process_startup()' \
             > ${SITE_PACKAGES}/run_coverage_at_startup.pth

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -622,8 +622,8 @@ jobs:
         echo "COVERAGE_PROCESS_START=$COVERAGE_RC" >> $GITHUB_ENV
         cp ${GITHUB_WORKSPACE}/.coveragerc ${COVERAGE_RC}
         echo "data_file=${COVERAGE_BASE}age" >> ${COVERAGE_RC}
-        SITE_PACKAGES=$($PYTHON_EXE -c "from distutils.sysconfig import \
-            get_python_lib; print(get_python_lib())")
+        SITE_PACKAGES=$($PYTHON_EXE -c \
+            "import sysconfig; print(sysconfig.get_path('purelib'))")
         echo "Python site-packages: $SITE_PACKAGES"
         echo 'import coverage; coverage.process_startup()' \
             > ${SITE_PACKAGES}/run_coverage_at_startup.pth

--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -77,7 +77,7 @@ if test -z "$MODE" -o "$MODE" == setup; then
     source python/bin/activate
     # Because modules set the PYTHONPATH, we need to make sure that the
     # virtualenv appears first
-    LOCAL_SITE_PACKAGES=`python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`
+    LOCAL_SITE_PACKAGES=`python -c "import sysconfig; print(sysconfig.get_path('purelib'))"`
     export PYTHONPATH="$LOCAL_SITE_PACKAGES:$PYTHONPATH"
 
     # Set up Pyomo checkouts

--- a/pyomo/common/cmake_builder.py
+++ b/pyomo/common/cmake_builder.py
@@ -32,11 +32,8 @@ def handleReadonly(function, path, excinfo):
 def build_cmake_project(
     targets, package_name=None, description=None, user_args=[], parallel=None
 ):
-    # Note: setuptools must be imported before distutils to avoid
-    # warnings / errors with recent setuptools distributions
-    from setuptools import Extension
-    import distutils.core
-    from distutils.command.build_ext import build_ext
+    from setuptools import Extension, Distribution
+    from setuptools.command.build_ext import build_ext
 
     class _CMakeBuild(build_ext, object):
         def run(self):
@@ -122,7 +119,7 @@ def build_cmake_project(
         'ext_modules': ext_modules,
         'cmdclass': {'build_ext': _CMakeBuild},
     }
-    dist = distutils.core.Distribution(package_config)
+    dist = Distribution(package_config)
     basedir = os.path.abspath(os.path.curdir)
     try:
         tmpdir = os.path.abspath(tempfile.mkdtemp())

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -831,10 +831,8 @@ def _pyutilib_importer():
     # second-level module is imported.  We will arbitrarily choose to
     # check pyutilib.component (as that is the path exercised by the
     # pyomo.common.tempfiles deprecation path)
-    import pyutilib
-    import pyutilib.component
-
-    return pyutilib
+    importlib.import_module('pyutilib.component')
+    return importlib.import_module('pyutilib')
 
 
 dill, dill_available = attempt_import('dill')

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -828,7 +828,7 @@ def _finalize_numpy(np, available):
 
 def _pyutilib_importer():
     # On newer Pythons, PyUtilib import will fail, but only if a
-    # second-level module is imported.  We will arbirtarily choose to
+    # second-level module is imported.  We will arbitrarily choose to
     # check pyutilib.component (as that is the path exercised by the
     # pyomo.common.tempfiles deprecation path)
     import pyutilib

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -826,6 +826,17 @@ def _finalize_numpy(np, available):
         numeric_types.RegisterComplexType(t)
 
 
+def _pyutilib_importer():
+    # On newer Pythons, PyUtilib import will fail, but only if a
+    # second-level module is imported.  We will arbirtarily choose to
+    # check pyutilib.component (as that is the path exercised by the
+    # pyomo.common.tempfiles deprecation path)
+    import pyutilib
+    import pyutilib.component
+
+    return pyutilib
+
+
 dill, dill_available = attempt_import('dill')
 mpi4py, mpi4py_available = attempt_import('mpi4py')
 networkx, networkx_available = attempt_import('networkx')
@@ -833,7 +844,7 @@ numpy, numpy_available = attempt_import('numpy', callback=_finalize_numpy)
 pandas, pandas_available = attempt_import('pandas')
 plotly, plotly_available = attempt_import('plotly')
 pympler, pympler_available = attempt_import('pympler', callback=_finalize_pympler)
-pyutilib, pyutilib_available = attempt_import('pyutilib')
+pyutilib, pyutilib_available = attempt_import('pyutilib', importer=_pyutilib_importer)
 scipy, scipy_available = attempt_import(
     'scipy',
     callback=_finalize_scipy,

--- a/pyomo/common/tempfiles.py
+++ b/pyomo/common/tempfiles.py
@@ -23,14 +23,14 @@ import logging
 import shutil
 import weakref
 
-from pyomo.common.dependencies import pyutilib_available
+from pyomo.common.dependencies import attempt_import, pyutilib_available
 from pyomo.common.deprecation import deprecated, deprecation_warning
 from pyomo.common.errors import TempfileContextError
 from pyomo.common.multithread import MultiThreadWrapperWithMain
 
 deletion_errors_are_fatal = True
 logger = logging.getLogger(__name__)
-pyutilib_mngr = None
+pyutilib_tempfiles, _ = attempt_import('pyutilib.component.config.tempfiles')
 
 
 class TempfileManagerClass(object):
@@ -430,11 +430,7 @@ class TempfileContext:
         elif TempfileManager.main_thread.tempdir is not None:
             return TempfileManager.main_thread.tempdir
         elif pyutilib_available:
-            if pyutilib_mngr is None:
-                from pyutilib.component.config.tempfiles import (
-                    TempfileManager as pyutilib_mngr,
-                )
-            if pyutilib_mngr.tempdir is not None:
+            if pyutilib_tempfiles.TempfileManager.tempdir is not None:
                 deprecation_warning(
                     "The use of the PyUtilib TempfileManager.tempdir "
                     "to specify the default location for Pyomo "
@@ -443,7 +439,7 @@ class TempfileContext:
                     "pyomo.common.tempfiles",
                     version='5.7.2',
                 )
-                return pyutilib_mngr.tempdir
+                return pyutilib_tempfiles.TempfileManager.tempdir
         return None
 
     def _remove_filesystem_object(self, name):

--- a/pyomo/common/tests/test_tempfile.py
+++ b/pyomo/common/tests/test_tempfile.py
@@ -30,17 +30,13 @@ import pyomo.common.unittest as unittest
 
 import pyomo.common.tempfiles as tempfiles
 
+from pyomo.common.dependencies import pyutilib_available
 from pyomo.common.log import LoggingIntercept
 from pyomo.common.tempfiles import (
     TempfileManager,
     TempfileManagerClass,
     TempfileContextError,
 )
-
-try:
-    from pyutilib.component.config.tempfiles import TempfileManager as pyutilib_mngr
-except ImportError:
-    pyutilib_mngr = None
 
 old_tempdir = TempfileManager.tempdir
 tempdir = None
@@ -528,7 +524,7 @@ class Test_TempfileManager(unittest.TestCase):
             f.close()
             os.remove(fname)
 
-    @unittest.skipIf(pyutilib_mngr is None, "deprecation test requires pyutilib")
+    @unittest.skipUnless(pyutilib_available, "deprecation test requires pyutilib")
     def test_deprecated_tempdir(self):
         self.TM.push()
         try:

--- a/pyomo/common/tests/test_tempfile.py
+++ b/pyomo/common/tests/test_tempfile.py
@@ -529,8 +529,8 @@ class Test_TempfileManager(unittest.TestCase):
         self.TM.push()
         try:
             tmpdir = self.TM.create_tempdir()
-            _orig = pyutilib_mngr.tempdir
-            pyutilib_mngr.tempdir = tmpdir
+            _orig = tempfiles.pyutilib_tempfiles.TempfileManager.tempdir
+            tempfiles.pyutilib_tempfiles.TempfileManager.tempdir = tmpdir
             self.TM.tempdir = None
 
             with LoggingIntercept() as LOG:
@@ -552,7 +552,7 @@ class Test_TempfileManager(unittest.TestCase):
             )
         finally:
             self.TM.pop()
-            pyutilib_mngr.tempdir = _orig
+            tempfiles.pyutilib_tempfiles.TempfileManager.tempdir = _orig
 
     def test_context(self):
         with self.assertRaisesRegex(

--- a/pyomo/contrib/appsi/build.py
+++ b/pyomo/contrib/appsi/build.py
@@ -63,8 +63,7 @@ def get_appsi_extension(in_setup=False, appsi_root=None):
 
 def build_appsi(args=[]):
     print('\n\n**** Building APPSI ****')
-    import setuptools
-    from distutils.dist import Distribution
+    from setuptools import Distribution
     from pybind11.setup_helpers import build_ext
     import pybind11.setup_helpers
     from pyomo.common.envvar import PYOMO_CONFIG_DIR

--- a/pyomo/contrib/mcpp/build.py
+++ b/pyomo/contrib/mcpp/build.py
@@ -64,8 +64,8 @@ def _generate_configuration():
 
 
 def build_mcpp():
-    import distutils.core
-    from distutils.command.build_ext import build_ext
+    from setuptools import Distribution
+    from setuptools.command.build_ext import build_ext
 
     class _BuildWithoutPlatformInfo(build_ext, object):
         # Python3.x puts platform information into the generated SO file
@@ -87,7 +87,7 @@ def build_mcpp():
     print("\n**** Building MCPP library ****")
     package_config = _generate_configuration()
     package_config['cmdclass'] = {'build_ext': _BuildWithoutPlatformInfo}
-    dist = distutils.core.Distribution(package_config)
+    dist = Distribution(package_config)
     install_dir = os.path.join(envvar.PYOMO_CONFIG_DIR, 'lib')
     dist.get_command_obj('install_lib').install_dir = install_dir
     try:

--- a/pyomo/dataportal/plugins/__init__.py
+++ b/pyomo/dataportal/plugins/__init__.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from pyomo.common.dependencies import pyutilib, pyutilib_available
-
 
 def load():
     import pyomo.dataportal.plugins.csv_table
@@ -19,6 +17,4 @@ def load():
     import pyomo.dataportal.plugins.json_dict
     import pyomo.dataportal.plugins.text
     import pyomo.dataportal.plugins.xml_table
-
-    if pyutilib_available:
-        import pyomo.dataportal.plugins.sheet
+    import pyomo.dataportal.plugins.sheet

--- a/pyomo/dataportal/plugins/sheet.py
+++ b/pyomo/dataportal/plugins/sheet.py
@@ -18,9 +18,18 @@ from pyomo.dataportal import TableData
 # )
 from pyomo.dataportal.factory import DataManagerFactory
 from pyomo.common.errors import ApplicationError
-from pyomo.common.dependencies import attempt_import
+from pyomo.common.dependencies import attempt_import, importlib, pyutilib
 
-spreadsheet, spreadsheet_available = attempt_import('pyutilib.excel.spreadsheet')
+
+def _spreadsheet_importer():
+    # verify pyutilib imported correctly the first time
+    pyutilib.component
+    return importlib.import_module('pyutilib.excel.spreadsheet')
+
+
+spreadsheet, spreadsheet_available = attempt_import(
+    'pyutilib.excel.spreadsheet', importer=_spreadsheet_importer
+)
 
 
 def _attempt_open_excel():

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -168,7 +168,6 @@ class TestPyomoEnviron(unittest.TestCase):
         }
         # Non-standard-library TPLs that Pyomo will load unconditionally
         ref.add('ply')
-        ref.add('pyutilib')
         if numpy_available:
             ref.add('numpy')
         diff = set(_[0] for _ in tpl_by_time[-5:]).difference(ref)

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,10 @@ import sys
 from setuptools import setup, find_packages, Command
 
 try:
+    # This works beginning in setuptools 40.7.0 (27 Jan 2019)
     from setuptools import DistutilsOptionError
 except ImportError:
+    # Needed for setuptools prior to 40.7.0
     from distutils.errors import DistutilsOptionError
 
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This resolves an error first observed in Python 3.12 where PyUtilib installs but no longer imports cleanly (due to an `import imp`).  This was causing an issue in Pyomo where the TempfileManager logic thought that PyUtilib was not available, but the tests found it to be present.  This PR updates all checks for PyUtilib to go through `pyomo.common.dependencies`, so that everyone uses the same "truth" value for PyUtilib's availability.

As part of this rework, the new structure removes the pyutilib import from the module scope.  As a result, PyUtilib is no longer imported as part of `pyomo.environ`.  This (slightly) speeds up `import pyomo.environ` (~5%), and the PR removes `pyutilib` from the expected list of TPLs in the environment after the `pyomo.environ` import.

## Changes proposed in this PR:
- Rework `pyomo.common.tempfiles` to use `pyomo.common.dependencies` to check for PyUtilib
- Remove import of pyutilib from `pyomo.common.tempfiles` module scope
- Remove `pyutilib` from the list of expected TPLs importedby `pyomo.environ`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
