### PR TITLE
Fixing a latex_printer vestige in the documentation

### DIFF
--- a/doc/OnlineDocs/model_debugging/index.rst
+++ b/doc/OnlineDocs/model_debugging/index.rst
@@ -7,4 +7,3 @@ Debugging Pyomo Models
    model_interrogation.rst
    FAQ.rst
    getting_help.rst
-   latex_printing.rst


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .
There was a leftover file in the index tree for the latex printer that is no longer correct

## Summary/Motivation:
fixes an issue

## Changes proposed in this PR:
- only removes a single line of documentation

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
