### PR TITLE
Fix documentation of `linear_only` argument in `get_incident_variables`

### DIFF
--- a/pyomo/contrib/incidence_analysis/config.py
+++ b/pyomo/contrib/incidence_analysis/config.py
@@ -39,11 +39,10 @@ _include_fixed = ConfigValue(
 _linear_only = ConfigValue(
     default=False,
     domain=bool,
-    description="Identify variables that participate linearly",
+    description="Identify only variables that participate linearly",
     doc=(
         "Flag indicating whether only variables that participate linearly should"
-        " be included. Note that these are included even if they participate"
-        " nonlinearly as well."
+        " be included."
     ),
 )
 
@@ -61,8 +60,7 @@ IncidenceConfig = ConfigDict()
 - ``include_fixed`` -- Flag indicating whether fixed variables should be included
   in the incidence graph
 - ``linear_only`` -- Flag indicating whether only variables that participate linearly
-  should be included. Note that these are included even if they participate
-  nonlinearly as well
+  should be included.
 - ``method`` -- Method used to identify incident variables. Must be a value of the
   ``IncidenceMethod`` enum.
 


### PR DESCRIPTION
## Fixes
Discrepancy between documentation and behavior

## Summary/Motivation:
In https://github.com/Pyomo/pyomo/pull/2883, I fixed the behavior of the `linear_only` argument in `get_incident_variables`, and claimed that the old behavior (identifying variables that participate linearly even if they also participate nonlinearly) was not my intention. Funnily enough, the documentation of the `linear_only` option clearly states that variables that are "both linear and nonlinear" will be returned (even though this is mathematically incorrect). This PR fixes the documentation.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
