### PR TITLE
Fix bugs of the documentation of Pyomo.DoE

### DIFF
--- a/doc/OnlineDocs/contributed_packages/doe/doe.rst
+++ b/doc/OnlineDocs/contributed_packages/doe/doe.rst
@@ -266,7 +266,7 @@ It allows users to define any number of design decisions. Heatmaps can be drawn 
 The function ``run_grid_search`` enumerates over the design space, each MBDoE problem accomplished by ``compute_FIM`` method.
 Therefore, ``run_grid_search`` supports only two modes: ``sequential_finite`` and ``direct_kaug``.
 
-.. literalinclude:: ../../../../pyomo/contrib/doe/examples/reactor_compute_FIM.py 
+.. literalinclude:: ../../../../pyomo/contrib/doe/examples/reactor_grid_search.py 
     :language: python 
     :pyobject: main
 
@@ -284,7 +284,7 @@ Pyomo.DoE accomplishes gradient-based optimization with the ``stochastic_program
 
 This function solves twice: It solves the square version of the MBDoE problem first, and then unfixes the design variables as degree of freedoms and solves again. In this way the optimization problem can be well initialized.
 
-.. literalinclude:: ../../../../pyomo/contrib/doe/examples/reactor_compute_FIM.py 
+.. literalinclude:: ../../../../pyomo/contrib/doe/examples/reactor_optimize_doe.py 
     :language: python 
     :pyobject: main 
 


### PR DESCRIPTION
## Summary/Motivation:

This fixes the problem that in the documentation, step 4: enumeration and step 5: gradient-based optimization, show the same code. 

## Changes proposed in this PR:
- in `doe.rst` step 4 enumeration, change the code included in this part to `reactor_grid_search.py`
- in `doe.rst` step 5 optimization, change the code included in this part to `reactor_optimize_doe.py` 

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
