### PR TITLE
Replace deprecated `numpy.math` alias with standard library `math` module

### DIFF
--- a/pyomo/dae/plugins/colloc.py
+++ b/pyomo/dae/plugins/colloc.py
@@ -10,6 +10,7 @@
 #  ___________________________________________________________________________
 
 import logging
+import math
 
 # If the user has numpy then the collocation points and the a matrix for
 # the Runge-Kutta basis formulation will be calculated as needed.
@@ -156,7 +157,7 @@ def conv(a, b):
 
 def calc_cp(alpha, beta, k):
     gamma = []
-    factorial = numpy.math.factorial
+    factorial = math.factorial
 
     for i in range(k + 1):
         num = factorial(alpha + k) * factorial(alpha + beta + k + i)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
Currently, the following warning is raised:

```
~/pyomo/dae/plugins/colloc.py:159: DeprecationWarning: `np.math` is a deprecated alias for the standard library `math` module (Deprecated Numpy 1.25). Replace usages of `np.math` with `math`
    factorial = numpy.math.factorial
```

## Changes proposed in this PR:
- Replace usages of `numpy.math` with `math`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
