### PR TITLE
Silence deprecation warnings emitted by Pyomo tests

### DIFF
--- a/doc/OnlineDocs/contributed_packages/gdpopt.rst
+++ b/doc/OnlineDocs/contributed_packages/gdpopt.rst
@@ -175,7 +175,10 @@ To use the GDPopt-LBB solver, define your Pyomo GDP model as usual:
   >>> m.djn = Disjunction(expr=[m.y1, m.y2])
 
   Invoke the GDPopt-LBB solver
+
   >>> results = SolverFactory('gdpopt.lbb').solve(m)
+  WARNING: 09/06/22: The GDPopt LBB algorithm currently has known issues. Please
+      use the results with caution and report any bugs!
 
   >>> print(results)  # doctest: +SKIP
   >>> print(results.solver.status)

--- a/doc/OnlineDocs/developer_reference/expressions/managing.rst
+++ b/doc/OnlineDocs/developer_reference/expressions/managing.rst
@@ -86,20 +86,6 @@ a consistent ordering of terms that should make it easier to interpret
 expressions.
 
 
-Cloning Expressions
--------------------
-
-Expressions are automatically cloned only during certain expression
-transformations.  Since this can be an expensive operation, the
-:data:`clone_counter <pyomo.core.expr.clone_counter>` context
-manager object is provided to track the number of times the
-:func:`clone_expression <pyomo.core.expr.clone_expression>`
-function is executed.
-
-For example:
-
-.. literalinclude:: ../../tests/expr/managing_ex4.spy
-
 Evaluating Expressions
 ----------------------
 

--- a/doc/OnlineDocs/library_reference/expressions/context_managers.rst
+++ b/doc/OnlineDocs/library_reference/expressions/context_managers.rst
@@ -8,6 +8,6 @@ Context Managers
 .. autoclass:: pyomo.core.expr.linear_expression
     :members:
 
-.. autoclass:: pyomo.core.expr.clone_counter
+.. autoclass:: pyomo.core.expr.current.clone_counter
     :members:
 

--- a/pyomo/contrib/parmest/graphics.py
+++ b/pyomo/contrib/parmest/graphics.py
@@ -152,7 +152,7 @@ def _add_scipy_dist_CI(
                 data_slice.append(np.array([[theta_star[var]] * ncells] * ncells))
         data_slice = np.dstack(tuple(data_slice))
 
-    elif isinstance(dist, stats.kde.gaussian_kde):
+    elif isinstance(dist, stats.gaussian_kde):
         for var in theta_star.index:
             if var == xvar:
                 data_slice.append(X.ravel())

--- a/pyomo/core/tests/examples/test_kernel_examples.py
+++ b/pyomo/core/tests/examples/test_kernel_examples.py
@@ -44,10 +44,10 @@ testing_solvers['mosek_direct', 'python'] = False
 def setUpModule():
     global testing_solvers
     import pyomo.environ
-    from pyomo.solvers.tests.solvers import test_solver_cases
+    from pyomo.solvers.tests.solvers import test_solver_cases as _test_solver_cases
 
-    for _solver, _io in test_solver_cases():
-        if (_solver, _io) in testing_solvers and test_solver_cases(
+    for _solver, _io in _test_solver_cases():
+        if (_solver, _io) in testing_solvers and _test_solver_cases(
             _solver, _io
         ).available:
             testing_solvers[_solver, _io] = True

--- a/pyomo/dae/plugins/colloc.py
+++ b/pyomo/dae/plugins/colloc.py
@@ -10,6 +10,7 @@
 #  ___________________________________________________________________________
 
 import logging
+import math
 
 # If the user has numpy then the collocation points and the a matrix for
 # the Runge-Kutta basis formulation will be calculated as needed.
@@ -156,7 +157,7 @@ def conv(a, b):
 
 def calc_cp(alpha, beta, k):
     gamma = []
-    factorial = numpy.math.factorial
+    factorial = math.factorial
 
     for i in range(k + 1):
         num = factorial(alpha + k) * factorial(alpha + beta + k + i)

--- a/pyomo/solvers/tests/checks/test_BARON.py
+++ b/pyomo/solvers/tests/checks/test_BARON.py
@@ -20,9 +20,9 @@ from pyomo.environ import ConcreteModel, Constraint, Objective, Var, log10, mini
 from pyomo.opt import SolverFactory, TerminationCondition
 
 # check if BARON is available
-from pyomo.solvers.tests.solvers import test_solver_cases
+from pyomo.solvers.tests.solvers import test_solver_cases as _test_solver_cases
 
-baron_available = test_solver_cases('baron', 'bar').available
+baron_available = _test_solver_cases('baron', 'bar').available
 
 
 @unittest.skipIf(not baron_available, "The 'BARON' solver is not available")

--- a/pyomo/solvers/tests/mip/test_asl.py
+++ b/pyomo/solvers/tests/mip/test_asl.py
@@ -47,9 +47,9 @@ class mock_all(unittest.TestCase):
     def setUpClass(cls):
         global cplexamp_available
         import pyomo.environ
-        from pyomo.solvers.tests.solvers import test_solver_cases
+        from pyomo.solvers.tests.solvers import test_solver_cases as _test_solver_cases
 
-        cplexamp_available = test_solver_cases('cplex', 'nl').available
+        cplexamp_available = _test_solver_cases('cplex', 'nl').available
 
     def setUp(self):
         self.do_setup(False)

--- a/pyomo/solvers/tests/mip/test_ipopt.py
+++ b/pyomo/solvers/tests/mip/test_ipopt.py
@@ -42,9 +42,9 @@ class Test(unittest.TestCase):
     def setUpClass(cls):
         global ipopt_available
         import pyomo.environ
-        from pyomo.solvers.tests.solvers import test_solver_cases
+        from pyomo.solvers.tests.solvers import test_solver_cases as _test_solver_cases
 
-        ipopt_available = test_solver_cases('ipopt', 'nl').available
+        ipopt_available = _test_solver_cases('ipopt', 'nl').available
 
     def setUp(self):
         if not ipopt_available:

--- a/pyomo/solvers/tests/mip/test_scip.py
+++ b/pyomo/solvers/tests/mip/test_scip.py
@@ -33,9 +33,9 @@ class Test(unittest.TestCase):
     def setUpClass(cls):
         global scip_available
         import pyomo.environ
-        from pyomo.solvers.tests.solvers import test_solver_cases
+        from pyomo.solvers.tests.solvers import test_solver_cases as _test_solver_cases
 
-        scip_available = test_solver_cases('scip', 'nl').available
+        scip_available = _test_solver_cases('scip', 'nl').available
 
     def setUp(self):
         if not scip_available:

--- a/pyomo/solvers/tests/piecewise_linear/test_piecewise_linear.py
+++ b/pyomo/solvers/tests/piecewise_linear/test_piecewise_linear.py
@@ -22,7 +22,7 @@ from pyomo.common.fileutils import import_file
 from pyomo.core.base import Var
 from pyomo.core.base.objective import minimize, maximize
 from pyomo.core.base.piecewise import Bound, PWRepn
-from pyomo.solvers.tests.solvers import test_solver_cases
+from pyomo.solvers.tests.solvers import test_solver_cases as _test_solver_cases
 
 smoke_problems = ['convex_var', 'step_var', 'step_vararray']
 
@@ -50,8 +50,8 @@ testing_solvers['gurobi', 'lp'] = False
 # testing_solvers['ipopt','nl'] = False
 # testing_solvers['cplex','python'] = False
 # testing_solvers['_cplex_persistent','python'] = False
-for _solver, _io in test_solver_cases():
-    if (_solver, _io) in testing_solvers and test_solver_cases(_solver, _io).available:
+for _solver, _io in _test_solver_cases():
+    if (_solver, _io) in testing_solvers and _test_solver_cases(_solver, _io).available:
         testing_solvers[_solver, _io] = True
 
 

--- a/pyomo/solvers/tests/piecewise_linear/test_piecewise_linear_kernel.py
+++ b/pyomo/solvers/tests/piecewise_linear/test_piecewise_linear_kernel.py
@@ -19,7 +19,7 @@ import pyomo.common.unittest as unittest
 
 from pyomo.common.fileutils import import_file
 from pyomo.kernel import SolverFactory, variable, maximize, minimize
-from pyomo.solvers.tests.solvers import test_solver_cases
+from pyomo.solvers.tests.solvers import test_solver_cases as _test_solver_cases
 
 problems = ['convex_var', 'concave_var', 'piecewise_var', 'step_var']
 
@@ -30,8 +30,8 @@ testing_solvers['gurobi', 'nl'] = False
 # testing_solvers['ipopt','nl'] = False
 # testing_solvers['cplex','python'] = False
 # testing_solvers['_cplex_persistent','python'] = False
-for _solver, _io in test_solver_cases():
-    if (_solver, _io) in testing_solvers and test_solver_cases(_solver, _io).available:
+for _solver, _io in _test_solver_cases():
+    if (_solver, _io) in testing_solvers and _test_solver_cases(_solver, _io).available:
         testing_solvers[_solver, _io] = True
 
 

--- a/pyomo/solvers/tests/testcases.py
+++ b/pyomo/solvers/tests/testcases.py
@@ -15,7 +15,7 @@ import logging
 from pyomo.common.collections import Bunch
 from pyomo.opt import TerminationCondition
 from pyomo.solvers.tests.models.base import all_models
-from pyomo.solvers.tests.solvers import test_solver_cases
+from pyomo.solvers.tests.solvers import test_solver_cases as _test_solver_cases
 from pyomo.core.kernel.block import IBlock
 
 # For expected failures that appear in all known version
@@ -297,8 +297,8 @@ def generate_scenarios(arg=None):
         _model = all_models(model)
         if not arg is None and not arg(_model):
             continue
-        for solver, io in sorted(test_solver_cases()):
-            _solver_case = test_solver_cases(solver, io)
+        for solver, io in sorted(_test_solver_cases()):
+            _solver_case = _test_solver_cases(solver, io)
             _ver = _solver_case.version
 
             # Skip this test case if the solver doesn't support the


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This PR silences a number of deprecation warnings that are emitted by the Pyomo test harness.

## Changes proposed in this PR:
- Remove outdates references to cloning expressions from Pyomo online documentation
- Update `numpy.math` references in DAE (this was also included in #3074)
- Update `stats..gaussian_kde` references in parmest
- Rename the `test_solver_cases` utility function so pytest does not attempt to run it as a test

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
