### PR TITLE
Remove automatic numpy import

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -18,7 +18,6 @@ import warnings
 
 from .deprecation import deprecated, deprecation_warning, in_testing_environment
 from .errors import DeferredImportError
-from . import numeric_types
 
 
 SUPPRESS_DEPENDENCY_WARNINGS = False
@@ -784,6 +783,8 @@ def _finalize_matplotlib(module, available):
 def _finalize_numpy(np, available):
     if not available:
         return
+    from . import numeric_types
+
     # Register ndarray as a native type to prevent 1-element ndarrays
     # from accidentally registering ndarray as a native_numeric_type.
     numeric_types.native_types.add(np.ndarray)

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -743,6 +743,12 @@ def _finalize_yaml(module, available):
         yaml_load_args['Loader'] = module.SafeLoader
 
 
+def _finalize_ctypes(module, available):
+    # ctypes.util must be explicitly imported (and fileutils assumes
+    # this has already happened)
+    import ctypes.util
+
+
 def _finalize_scipy(module, available):
     if available:
         # Import key subpackages that we will want to assume are present
@@ -835,6 +841,14 @@ def _pyutilib_importer():
     return importlib.import_module('pyutilib')
 
 
+# Standard libraries that are slower to import and not strictly required
+# on all platforms / situations.
+ctypes, _ = attempt_import(
+    'ctypes', deferred_submodules=['util'], callback=_finalize_ctypes
+)
+random, _ = attempt_import('random')
+
+# Commonly-used optional dependencies
 dill, dill_available = attempt_import('dill')
 mpi4py, mpi4py_available = attempt_import('mpi4py')
 networkx, networkx_available = attempt_import('networkx')

--- a/pyomo/common/env.py
+++ b/pyomo/common/env.py
@@ -9,9 +9,9 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import ctypes
 import os
 
+from .dependencies import ctypes
 
 def _as_bytes(val):
     """Helper function to coerce a string to a bytes() object"""

--- a/pyomo/common/env.py
+++ b/pyomo/common/env.py
@@ -13,6 +13,7 @@ import os
 
 from .dependencies import ctypes
 
+
 def _as_bytes(val):
     """Helper function to coerce a string to a bytes() object"""
     if isinstance(val, bytes):

--- a/pyomo/common/fileutils.py
+++ b/pyomo/common/fileutils.py
@@ -32,7 +32,6 @@
    PathData
 """
 
-import ctypes.util
 import glob
 import inspect
 import logging
@@ -42,6 +41,7 @@ import importlib.util
 import sys
 
 from . import envvar
+from .dependencies import ctypes
 from .deprecation import deprecated, relocated_module_attribute
 
 relocated_module_attribute('StreamIndenter', 'pyomo.common.formatting', version='6.2')

--- a/pyomo/common/modeling.py
+++ b/pyomo/common/modeling.py
@@ -9,8 +9,8 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from random import random
 import sys
+from .dependencies import random
 
 
 def randint(a, b):
@@ -21,7 +21,7 @@ def randint(a, b):
     can support deterministic testing (i.e., setting the random.seed and
     expecting the same sequence), we will implement a simple, but stable
     version of randint()."""
-    return int((b - a + 1) * random())
+    return int((b - a + 1) * random.random())
 
 
 def unique_component_name(instance, name):

--- a/pyomo/common/numeric_types.py
+++ b/pyomo/common/numeric_types.py
@@ -12,6 +12,7 @@
 import logging
 import sys
 
+from pyomo.common.dependencies import numpy_available
 from pyomo.common.deprecation import deprecated, relocated_module_attribute
 from pyomo.common.errors import TemplateExpressionError
 
@@ -206,6 +207,13 @@ def check_if_numeric_type(obj):
     # Do not re-evaluate known native types
     if obj_class in native_types:
         return obj_class in native_numeric_types
+
+    if 'numpy' in obj_class.__module__:
+        # trigger the resolution of numpy_available and check if this
+        # type was automatically registered
+        bool(numpy_available)
+        if obj_class in native_numeric_types:
+            return True
 
     try:
         obj_plus_0 = obj + 0

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -21,14 +21,13 @@ from copy import deepcopy
 
 import pyomo.core.expr as EXPR
 import pyomo.core.base as BASE
-from pyomo.core.expr.numeric_expr import NumericNDArray
-from pyomo.core.expr.numvalue import native_types
 from pyomo.core.base.indexed_component_slice import IndexedComponent_slice
 from pyomo.core.base.initializer import Initializer
 from pyomo.core.base.component import Component, ActiveComponent
 from pyomo.core.base.config import PyomoOptions
 from pyomo.core.base.enums import SortComponents
 from pyomo.core.base.global_set import UnindexedComponent_set
+from pyomo.core.expr.numeric_expr import _ndarray
 from pyomo.core.pyomoobject import PyomoObject
 from pyomo.common import DeveloperError
 from pyomo.common.autoslots import fast_deepcopy
@@ -36,6 +35,7 @@ from pyomo.common.dependencies import numpy as np, numpy_available
 from pyomo.common.deprecation import deprecated, deprecation_warning
 from pyomo.common.errors import DeveloperError, TemplateExpressionError
 from pyomo.common.modeling import NOTSET
+from pyomo.common.numeric_types import native_types
 from pyomo.common.sorting import sorted_robust
 
 from collections.abc import Sequence
@@ -1216,7 +1216,7 @@ class IndexedComponent_NDArrayMixin(object):
 
     def __array__(self, dtype=None):
         if not self.is_indexed():
-            ans = NumericNDArray(shape=(1,), dtype=object)
+            ans = _ndarray.NumericNDArray(shape=(1,), dtype=object)
             ans[0] = self
             return ans
 
@@ -1236,10 +1236,12 @@ class IndexedComponent_NDArrayMixin(object):
                 % (self, bounds[0], bounds[1])
             )
         shape = tuple(b + 1 for b in bounds[1])
-        ans = NumericNDArray(shape=shape, dtype=object)
+        ans = _ndarray.NumericNDArray(shape=shape, dtype=object)
         for k, v in self.items():
             ans[k] = v
         return ans
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        return NumericNDArray.__array_ufunc__(None, ufunc, method, *inputs, **kwargs)
+        return _ndarray.NumericNDArray.__array_ufunc__(
+            None, ufunc, method, *inputs, **kwargs
+        )

--- a/pyomo/core/expr/ndarray.py
+++ b/pyomo/core/expr/ndarray.py
@@ -1,0 +1,39 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+from pyomo.common.dependencies import numpy as np, numpy_available
+
+
+#
+# Note: the "if numpy_available" in the class definition also ensures
+# that the numpy types are registered if numpy is in fact available
+#
+class NumericNDArray(np.ndarray if numpy_available else object):
+    """An ndarray subclass that stores Pyomo numeric expressions"""
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        if method == '__call__':
+            # Convert all incoming types to ndarray (to prevent recursion)
+            args = [np.asarray(i) for i in inputs]
+            # Set the return type to be an 'object'.  This prevents the
+            # logical operators from casting the result to a bool.  This
+            # requires numpy >= 1.6
+            kwargs['dtype'] = object
+
+        # Delegate to the base ufunc, but return an instance of this
+        # class so that additional operators hit this method.
+        ans = getattr(ufunc, method)(*args, **kwargs)
+        if isinstance(ans, np.ndarray):
+            if ans.size == 1:
+                return ans[0]
+            return ans.view(NumericNDArray)
+        else:
+            return ans

--- a/pyomo/core/tests/unit/test_numpy_expr.py
+++ b/pyomo/core/tests/unit/test_numpy_expr.py
@@ -29,7 +29,7 @@ from pyomo.environ import (
     Reals,
 )
 from pyomo.core.expr import MonomialTermExpression
-from pyomo.core.expr.numeric_expr import NumericNDArray
+from pyomo.core.expr.ndarray import NumericNDArray
 from pyomo.core.expr.numvalue import as_numeric
 from pyomo.core.expr.compare import compare_expressions
 from pyomo.core.expr.relational_expr import InequalityExpression

--- a/pyomo/core/tests/unit/test_numvalue.py
+++ b/pyomo/core/tests/unit/test_numvalue.py
@@ -12,8 +12,12 @@
 # Unit Tests for Python numeric values
 #
 
+import subprocess
+import sys
 from math import nan, inf
+
 import pyomo.common.unittest as unittest
+from pyomo.common.dependencies import numpy, numpy_available
 
 from pyomo.environ import (
     value,
@@ -37,13 +41,6 @@ from pyomo.core.expr.numvalue import (
     native_integer_types,
 )
 from pyomo.common.numeric_types import _native_boolean_types
-
-try:
-    import numpy
-
-    numpy_available = True
-except:
-    numpy_available = False
 
 
 class MyBogusType(object):
@@ -541,29 +538,48 @@ class Test_as_numeric(unittest.TestCase):
             native_numeric_types.remove(MyBogusNumericType)
             native_types.remove(MyBogusNumericType)
 
+    @unittest.skipUnless(numpy_available, "This test requires NumPy")
     def test_numpy_basic_float_registration(self):
-        if not numpy_available:
-            self.skipTest("This test requires NumPy")
         self.assertIn(numpy.float_, native_numeric_types)
         self.assertNotIn(numpy.float_, native_integer_types)
         self.assertIn(numpy.float_, _native_boolean_types)
         self.assertIn(numpy.float_, native_types)
 
+    @unittest.skipUnless(numpy_available, "This test requires NumPy")
     def test_numpy_basic_int_registration(self):
-        if not numpy_available:
-            self.skipTest("This test requires NumPy")
         self.assertIn(numpy.int_, native_numeric_types)
         self.assertIn(numpy.int_, native_integer_types)
         self.assertIn(numpy.int_, _native_boolean_types)
         self.assertIn(numpy.int_, native_types)
 
+    @unittest.skipUnless(numpy_available, "This test requires NumPy")
     def test_numpy_basic_bool_registration(self):
-        if not numpy_available:
-            self.skipTest("This test requires NumPy")
         self.assertNotIn(numpy.bool_, native_numeric_types)
         self.assertNotIn(numpy.bool_, native_integer_types)
         self.assertIn(numpy.bool_, _native_boolean_types)
         self.assertIn(numpy.bool_, native_types)
+
+    @unittest.skipUnless(numpy_available, "This test requires NumPy")
+    def test_automatic_numpy_registration(self):
+        cmd = (
+            'import pyomo; from pyomo.core.base import Var; import numpy as np; '
+            'print(np.float64 in pyomo.common.numeric_types.native_numeric_types); '
+            '%s; print(np.float64 in pyomo.common.numeric_types.native_numeric_types)'
+        )
+
+        def _tester(expr):
+            rc = subprocess.run(
+                [sys.executable, '-c', cmd % expr],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            self.assertEqual((rc.returncode, rc.stdout), (0, "False\nTrue\n"))
+
+        _tester('Var() <= np.float64(5)')
+        _tester('np.float64(5) <= Var()')
+        _tester('np.float64(5) + Var()')
+        _tester('Var() + np.float64(5)')
 
 
 if __name__ == "__main__":

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -160,8 +160,6 @@ class TestPyomoEnviron(unittest.TestCase):
         }
         # Non-standard-library TPLs that Pyomo will load unconditionally
         ref.add('ply')
-        if numpy_available:
-            ref.add('numpy')
         diff = set(_[0] for _ in tpl_by_time[-5:]).difference(ref)
         self.assertEqual(
             diff, set(), "Unexpected module found in 5 slowest-loading TPL modules"

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -143,7 +143,7 @@ class TestPyomoEnviron(unittest.TestCase):
             'gc',  # Imported on MacOS, Windows; Linux in 3.10
             'glob',
             'heapq',  # Added in Python 3.10
-            'importlib',  # Imported on Windows
+            'importlib',
             'inspect',
             'json',  # Imported on Windows
             'locale',  # Added in Python 3.9
@@ -152,6 +152,7 @@ class TestPyomoEnviron(unittest.TestCase):
             'platform',
             'shlex',
             'socket',  # Imported on MacOS, Windows; Linux in 3.10
+            'subprocess',
             'tempfile',  # Imported on MacOS, Windows
             'textwrap',
             'typing',

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -16,13 +16,7 @@ import re
 import sys
 import subprocess
 
-from collections import namedtuple
-
 import pyomo.common.unittest as unittest
-
-from pyomo.common.dependencies import numpy_available, attempt_import
-
-pyro4, pyro4_available = attempt_import('Pyro4')
 
 
 class ImportData(object):
@@ -145,7 +139,6 @@ class TestPyomoEnviron(unittest.TestCase):
             'base64',  # Imported on Windows
             'cPickle',
             'csv',
-            'ctypes',
             'decimal',
             'gc',  # Imported on MacOS, Windows; Linux in 3.10
             'glob',
@@ -157,7 +150,6 @@ class TestPyomoEnviron(unittest.TestCase):
             'logging',
             'pickle',
             'platform',
-            'random',  # Imported on MacOS, Windows
             'shlex',
             'socket',  # Imported on MacOS, Windows; Linux in 3.10
             'tempfile',  # Imported on MacOS, Windows

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -139,6 +139,7 @@ class TestPyomoEnviron(unittest.TestCase):
             'base64',  # Imported on Windows
             'cPickle',
             'csv',
+            'ctypes',  # mandatory import in core/base/external.py; TODO: fix this
             'decimal',
             'gc',  # Imported on MacOS, Windows; Linux in 3.10
             'glob',


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
Pyomo has an optional dependency on NumPy, however, because of how we implemented some of the Pyomo/NumPy integration, NumPy would *always* be imported if it was present.  This import accounted for between 33-50% of the time to `import pyomo.environ`.  This PR reorganizes the module structure so that we no longer automatically import NumPy, thereby significantly speeding up the time to start up the Pyomo environment.

## Changes proposed in this PR:
- reorganize modules so that numpy import is not automatically triggered
- begin update to defer the import of the `ctypes` library (`ctypes` is still a required import, but `ctypes.util` is now deferred)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
