### PR TITLE
Re-enable `contrib.viewer.tests.test_qt.py`

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -194,6 +194,9 @@ jobs:
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils
         sudo chmod -R 777 ${GITHUB_WORKSPACE}/cache/os
+        sudo apt-get -qq install libxcb-xinerama0 pyqt5-dev-tools
+        # start xvfb in the background
+        sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
 
     - name: Update Windows
       if: matrix.TARGET == 'win'

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -22,7 +22,7 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
-  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels pytest-qt
+  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
@@ -75,7 +75,7 @@ jobs:
           python: 3.9
           TARGET: win
           PYENV: conda
-          PACKAGES: glpk
+          PACKAGES: glpk pytest-qt
 
         - os: ubuntu-latest
           python: '3.11'
@@ -83,7 +83,7 @@ jobs:
           skip_doctest: 1
           TARGET: linux
           PYENV: conda
-          PACKAGES:
+          PACKAGES: pytest-qt
 
         - os: ubuntu-latest
           python: 3.9
@@ -126,7 +126,7 @@ jobs:
         # Note: pandas 1.0.3 causes gams 29.1.0 import to fail in python 3.8
         EXTRAS=tests
         if test -z "${{matrix.slim}}"; then
-            EXTRAS="$EXTRAS,tests_optional,docs,optional"
+            EXTRAS="$EXTRAS,docs,optional"
         fi
         echo "EXTRAS=$EXTRAS" >> $GITHUB_ENV
         PYTHON_PACKAGES="${{matrix.PACKAGES}}"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -213,7 +213,10 @@ jobs:
         auto-update-conda: false
         python-version: ${{ matrix.python }}
 
-    - name: Set up headless display
+    # This is necessary for qt (UI) tests; the package utilized here does not
+    # have support for OSX, but we don't do any OSX/conda testing inherently.
+    # This is just to protect us in case we do add that into the matrix someday.
+    - name: Set up UI testing infrastructure
       if: ${{ matrix.PYENV == 'conda' && matrix.TARGET != 'osx' }}
       uses: pyvista/setup-headless-display-action@v2
       with:
@@ -354,7 +357,7 @@ jobs:
                 if test -n "$_BUILDS"; then
                     _ISPY=$(echo "$_BUILDS" | grep "^py") \
                         || echo "\nINFO: No python build detected."
-                    _PYOK=$(echo "$_BUILDS" | grep "^($PYVER|pyh)") \
+                    _PYOK=$(echo "$_BUILDS" | grep -E "^($PYVER|pyh)") \
                         || echo "INFO: No python build matching $PYVER detected."
                     if test -z "$_ISPY" -o -n "$_PYOK"; then
                         echo "\n... INSTALLING $PKG"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -334,7 +334,7 @@ jobs:
         echo "*** Install Pyomo dependencies ***"
         # Note: this will fail the build if any installation fails (or
         # possibly if it outputs messages to stderr)
-        conda install --update-deps -q -y $CONDA_DEPENDENCIES pytest-qt
+        conda install --update-deps -q -y $CONDA_DEPENDENCIES qtconsole pint pytest-qt
         if test -z "${{matrix.slim}}"; then
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -217,7 +217,7 @@ jobs:
     # have support for OSX, but we don't do any OSX/conda testing inherently.
     # This is just to protect us in case we do add that into the matrix someday.
     - name: Set up UI testing infrastructure
-      if: ${{ matrix.PYENV == 'conda' && matrix.TARGET != 'osx' }}
+      if: ${{ matrix.TARGET != 'osx' }}
       uses: pyvista/setup-headless-display-action@v2
       with:
         qt: true

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -22,7 +22,7 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
-  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels PyQt6
+  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels PyQt6 pytest-qt
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -27,8 +27,8 @@ env:
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
   # Display must be available globally for linux to know where xvfb is
-  DISPLAY: ":99.0"
-  QT_SELECT: "qt6"
+  # DISPLAY: ":99.0"
+  # QT_SELECT: "qt6"
 
 jobs:
   lint:
@@ -197,10 +197,10 @@ jobs:
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils
         sudo chmod -R 777 ${GITHUB_WORKSPACE}/cache/os
-        sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0 libglib2.0-0 libgl1-mesa-dev
-        sudo apt-get install '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
-        # start xvfb in the background
-        sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
+        # sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0 libglib2.0-0 libgl1-mesa-dev
+        # sudo apt-get install '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
+        # # start xvfb in the background
+        # sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
 
     - name: Update Windows
       if: matrix.TARGET == 'win'
@@ -219,6 +219,12 @@ jobs:
       with:
         auto-update-conda: false
         python-version: ${{ matrix.python }}
+
+    - name: Set up headless display
+      if: matrix.PYENV == 'conda'
+      uses: pyvista/setup-headless-display-action@v2
+      with:
+        qt: true
 
     # GitHub actions is very fragile when it comes to setting up various
     # Python interpreters, expecially the setup-miniconda interface.

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -215,8 +215,7 @@ jobs:
         python-version: ${{ matrix.python }}
 
     # This is necessary for qt (UI) tests; the package utilized here does not
-    # have support for OSX, but we don't do any OSX testing inherently.
-    # This is just to protect us in case we do add that into the matrix someday.
+    # have support for OSX.
     - name: Set up UI testing infrastructure
       if: ${{ matrix.TARGET != 'osx' }}
       uses: pyvista/setup-headless-display-action@v2

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -22,7 +22,7 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
-  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
+  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels PyQt6
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -194,7 +194,8 @@ jobs:
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils
         sudo chmod -R 777 ${GITHUB_WORKSPACE}/cache/os
-        sudo apt-get -qq install libxcb-xinerama0 pyqt5-dev-tools
+        sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0 libglib2.0-0 libgl1-mesa-dev
+        sudo apt-get install '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
         # start xvfb in the background
         sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
 

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -321,7 +321,7 @@ jobs:
         if test "${{matrix.TARGET}}" == linux; then
             EXCLUDE="casadi numdifftools pyqt6 $EXCLUDE"
         fi
-        EXCLUDE=`echo "$EXCLUDE" | xargs`
+        EXCLUDE=`echo "$EXCLUDE PyQt6 pyqt6" | xargs`
         if test -n "$EXCLUDE"; then
             for WORD in $EXCLUDE; do
                 PACKAGES=${PACKAGES//$WORD / }

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -53,8 +53,6 @@ jobs:
     name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.other }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
-    env:
-      DISPLAY: ':99.0'
     strategy:
       fail-fast: false
       matrix:
@@ -197,11 +195,7 @@ jobs:
         #  - contrib.viewer needs: libg1l libegl1
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils
-        sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
-            install -y xvfb x11-utils libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 xdotool
         sudo chmod -R 777 ${GITHUB_WORKSPACE}/cache/os
-        # start xvfb in the background
-        sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
 
     - name: Update Windows
       if: matrix.TARGET == 'win'
@@ -220,6 +214,15 @@ jobs:
       with:
         auto-update-conda: false
         python-version: ${{ matrix.python }}
+
+    # This is necessary for qt (UI) tests; the package utilized here does not
+    # have support for OSX.
+    - name: Set up UI testing infrastructure
+      if: ${{ matrix.TARGET != 'osx' }}
+      uses: pyvista/setup-headless-display-action@v2
+      with:
+        qt: true
+        pyvista: false
 
     # GitHub actions is very fragile when it comes to setting up various
     # Python interpreters, expecially the setup-miniconda interface.

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -55,7 +55,6 @@ jobs:
     timeout-minutes: 120
     env:
       DISPLAY: ':99.0'
-      QT_SELECT: 'qt6'
     strategy:
       fail-fast: false
       matrix:
@@ -199,7 +198,7 @@ jobs:
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
-            install -y xvfb x11-utils libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 xdotool libegl1
+            install -y xvfb x11-utils libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 xdotool
         sudo chmod -R 777 ${GITHUB_WORKSPACE}/cache/os
         # start xvfb in the background
         sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -331,7 +331,7 @@ jobs:
         if test -z "${{matrix.slim}}"; then
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
-            for PKG in 'cplex>=12.10' docplex 'gurobi=10.0.3' xpress cyipopt pymumps scip; do
+            for PKG in 'cplex>=12.10' docplex 'gurobi=10.0.3' xpress cyipopt pymumps scip pytest-qt; do
                 echo ""
                 echo "*** Install $PKG ***"
                 # conda can literally take an hour to determine that a

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -199,7 +199,7 @@ jobs:
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
-            install -y xvfb x11-utils libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 xdotool
+            install -y xvfb x11-utils libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 xdotool libegl1
         sudo chmod -R 777 ${GITHUB_WORKSPACE}/cache/os
         # start xvfb in the background
         sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -319,7 +319,7 @@ jobs:
         fi
         # HACK: Remove problem packages on conda+Linux
         if test "${{matrix.TARGET}}" == linux; then
-            EXCLUDE="casadi numdifftools pint $EXCLUDE"
+            EXCLUDE="casadi numdifftools $EXCLUDE"
         fi
         EXCLUDE=`echo "$EXCLUDE" | xargs`
         if test -n "$EXCLUDE"; then
@@ -329,6 +329,7 @@ jobs:
         fi
         for PKG in $PACKAGES; do
             if [[ " $PYPI_ONLY " == *" $PKG "* ]]; then
+                echo "Skipping $PKG"
                 PYPI_DEPENDENCIES="$PYPI_DEPENDENCIES $PKG"
             else
                 CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $PKG"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -194,7 +194,7 @@ jobs:
         #  - ipopt needs: libopenblas-dev gfortran liblapack-dev
         #  - contrib.viewer needs: libg1l libegl1
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
-            install libopenblas-dev gfortran liblapack-dev glpk-utils libgl1 libegl1
+            install libopenblas-dev gfortran liblapack-dev glpk-utils
         sudo chmod -R 777 ${GITHUB_WORKSPACE}/cache/os
 
     - name: Update Windows
@@ -222,7 +222,7 @@ jobs:
       uses: pyvista/setup-headless-display-action@v2
       with:
         qt: true
-        pyvista: false
+        pyvista: true
 
     # GitHub actions is very fragile when it comes to setting up various
     # Python interpreters, expecially the setup-miniconda interface.

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -22,8 +22,7 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
-  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels pytest-qt PyQt5
-  CONDA_EXCLUDE: PyQt5 pyqt5
+  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels pytest-qt
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
@@ -321,7 +320,7 @@ jobs:
         if test "${{matrix.TARGET}}" == linux; then
             EXCLUDE="casadi numdifftools $EXCLUDE"
         fi
-        EXCLUDE=`echo "$EXCLUDE $CONDA_EXCLUDE" | xargs`
+        EXCLUDE=`echo "$EXCLUDE" | xargs`
         if test -n "$EXCLUDE"; then
             for WORD in $EXCLUDE; do
                 PACKAGES=${PACKAGES//$WORD / }

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -327,11 +327,11 @@ jobs:
         echo "*** Install Pyomo dependencies ***"
         # Note: this will fail the build if any installation fails (or
         # possibly if it outputs messages to stderr)
-        conda install --update-deps -q -y $CONDA_DEPENDENCIES
+        conda install --update-deps -q -y $CONDA_DEPENDENCIES pytest-qt
         if test -z "${{matrix.slim}}"; then
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
-            for PKG in 'cplex>=12.10' docplex 'gurobi=10.0.3' xpress cyipopt pymumps scip pytest-qt; do
+            for PKG in 'cplex>=12.10' docplex 'gurobi=10.0.3' xpress cyipopt pymumps scip; do
                 echo ""
                 echo "*** Install $PKG ***"
                 # conda can literally take an hour to determine that a

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -22,8 +22,8 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
-  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels pytest-qt PySide6
-  CONDA_EXCLUDE: PySide6 pyside6
+  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels pytest-qt PyQt5
+  CONDA_EXCLUDE: PyQt5 pyqt5
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -53,6 +53,9 @@ jobs:
     name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.other }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
+    env:
+      DISPLAY: ':99.0'
+      QT_SELECT: 'qt6'
     strategy:
       fail-fast: false
       matrix:
@@ -195,7 +198,11 @@ jobs:
         #  - contrib.viewer needs: libg1l libegl1
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils
+        sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
+            install -y xvfb x11-utils libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 xdotool
         sudo chmod -R 777 ${GITHUB_WORKSPACE}/cache/os
+        # start xvfb in the background
+        sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
 
     - name: Update Windows
       if: matrix.TARGET == 'win'
@@ -214,15 +221,6 @@ jobs:
       with:
         auto-update-conda: false
         python-version: ${{ matrix.python }}
-
-    # This is necessary for qt (UI) tests; the package utilized here does not
-    # have support for OSX.
-    - name: Set up UI testing infrastructure
-      if: ${{ matrix.TARGET != 'osx' }}
-      uses: pyvista/setup-headless-display-action@v2
-      with:
-        qt: true
-        pyvista: true
 
     # GitHub actions is very fragile when it comes to setting up various
     # Python interpreters, expecially the setup-miniconda interface.

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -360,16 +360,16 @@ jobs:
             done
             # TODO: This is a hack to stop test_qt.py from running until we
             # can better troubleshoot why it fails on GHA
-            for QTPACKAGE in qt pyqt; do
-                # Because conda is insane, removing packages can cause
-                # unrelated packages to be updated (breaking version
-                # specifications specified previously, e.g., in
-                # setup.py).  There doesn't appear to be a good
-                # workaround, so we will just force-remove (recognizing
-                # that it may break other conda cruft).
-                conda remove --force-remove $QTPACKAGE \
-                    || echo "$QTPACKAGE not in this environment"
-            done
+            # for QTPACKAGE in qt pyqt; do
+            #     # Because conda is insane, removing packages can cause
+            #     # unrelated packages to be updated (breaking version
+            #     # specifications specified previously, e.g., in
+            #     # setup.py).  There doesn't appear to be a good
+            #     # workaround, so we will just force-remove (recognizing
+            #     # that it may break other conda cruft).
+            #     conda remove --force-remove $QTPACKAGE \
+            #         || echo "$QTPACKAGE not in this environment"
+            # done
         fi
         # Re-try Pyomo (optional) dependencies with pip
         if test -n "$PYPI_DEPENDENCIES"; then

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -337,7 +337,7 @@ jobs:
         echo "*** Install Pyomo dependencies ***"
         # Note: this will fail the build if any installation fails (or
         # possibly if it outputs messages to stderr)
-        conda install --update-deps -q -y $CONDA_DEPENDENCIES qtconsole pint pytest-qt
+        conda install --update-deps -q -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"
@@ -360,7 +360,8 @@ jobs:
                     _PYOK=$(echo "$_BUILDS" | grep -E "^($PYVER|pyh)") \
                         || echo "INFO: No python build matching $PYVER detected."
                     if test -z "$_ISPY" -o -n "$_PYOK"; then
-                        echo "\n... INSTALLING $PKG"
+                        echo ""
+                        echo "... INSTALLING $PKG"
                         conda install -y "$PKG" || _BUILDS=""
                     fi
                 fi

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -191,6 +191,7 @@ jobs:
         # Notes:
         #  - install glpk
         #  - ipopt needs: libopenblas-dev gfortran liblapack-dev
+        #  - contrib.viewer needs: libg1l libegl1
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils libgl1 libegl1
         sudo chmod -R 777 ${GITHUB_WORKSPACE}/cache/os
@@ -214,7 +215,7 @@ jobs:
         python-version: ${{ matrix.python }}
 
     # This is necessary for qt (UI) tests; the package utilized here does not
-    # have support for OSX, but we don't do any OSX/conda testing inherently.
+    # have support for OSX, but we don't do any OSX testing inherently.
     # This is just to protect us in case we do add that into the matrix someday.
     - name: Set up UI testing infrastructure
       if: ${{ matrix.TARGET != 'osx' }}
@@ -319,7 +320,7 @@ jobs:
         fi
         # HACK: Remove problem packages on conda+Linux
         if test "${{matrix.TARGET}}" == linux; then
-            EXCLUDE="casadi numdifftools pyqt6 $EXCLUDE"
+            EXCLUDE="casadi numdifftools $EXCLUDE"
         fi
         EXCLUDE=`echo "$EXCLUDE PyQt6 pyqt6" | xargs`
         if test -n "$EXCLUDE"; then

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -26,6 +26,9 @@ env:
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
+  # Display must be available globally for linux to know where xvfb is
+  DISPLAY: ":99.0"
+  QT_SELECT: "qt6"
 
 jobs:
   lint:

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -192,7 +192,6 @@ jobs:
         # Notes:
         #  - install glpk
         #  - ipopt needs: libopenblas-dev gfortran liblapack-dev
-        #  - contrib.viewer needs: libg1l libegl1
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils
         sudo chmod -R 777 ${GITHUB_WORKSPACE}/cache/os

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -192,7 +192,7 @@ jobs:
         #  - install glpk
         #  - ipopt needs: libopenblas-dev gfortran liblapack-dev
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
-            install libopenblas-dev gfortran liblapack-dev glpk-utils libgl1
+            install libopenblas-dev gfortran liblapack-dev glpk-utils libgl1 libegl1
         sudo chmod -R 777 ${GITHUB_WORKSPACE}/cache/os
 
     - name: Update Windows

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -21,7 +21,7 @@ defaults:
 env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
-  PYPI_ONLY: z3-solver PyQt6
+  PYPI_ONLY: z3-solver
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
@@ -319,7 +319,7 @@ jobs:
         fi
         # HACK: Remove problem packages on conda+Linux
         if test "${{matrix.TARGET}}" == linux; then
-            EXCLUDE="casadi numdifftools $EXCLUDE"
+            EXCLUDE="casadi numdifftools PyQt6 $EXCLUDE"
         fi
         EXCLUDE=`echo "$EXCLUDE" | xargs`
         if test -n "$EXCLUDE"; then
@@ -356,7 +356,7 @@ jobs:
                     | sed -r 's/\s+/ /g' | cut -d\  -f3) || echo ""
                 if test -n "$_BUILDS"; then
                     _ISPY=$(echo "$_BUILDS" | grep "^py") \
-                        || echo "\nINFO: No python build detected."
+                        || echo "INFO: No python build detected."
                     _PYOK=$(echo "$_BUILDS" | grep -E "^($PYVER|pyh)") \
                         || echo "INFO: No python build matching $PYVER detected."
                     if test -z "$_ISPY" -o -n "$_PYOK"; then

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -319,7 +319,7 @@ jobs:
         fi
         # HACK: Remove problem packages on conda+Linux
         if test "${{matrix.TARGET}}" == linux; then
-            EXCLUDE="casadi numdifftools PyQt6 $EXCLUDE"
+            EXCLUDE="casadi numdifftools pyqt6 $EXCLUDE"
         fi
         EXCLUDE=`echo "$EXCLUDE" | xargs`
         if test -n "$EXCLUDE"; then

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -353,11 +353,11 @@ jobs:
                     | sed -r 's/\s+/ /g' | cut -d\  -f3) || echo ""
                 if test -n "$_BUILDS"; then
                     _ISPY=$(echo "$_BUILDS" | grep "^py") \
-                        || echo "No python build detected"
-                    _PYOK=$(echo "$_BUILDS" | grep "^$PYVER") \
-                        || echo "No python build matching $PYVER detected"
+                        || echo "\nINFO: No python build detected."
+                    _PYOK=$(echo "$_BUILDS" | grep "^($PYVER|pyh)") \
+                        || echo "INFO: No python build matching $PYVER detected."
                     if test -z "$_ISPY" -o -n "$_PYOK"; then
-                        echo "... INSTALLING $PKG"
+                        echo "\n... INSTALLING $PKG"
                         conda install -y "$PKG" || _BUILDS=""
                     fi
                 fi
@@ -365,18 +365,6 @@ jobs:
                     echo "WARNING: $PKG is not available"
                 fi
             done
-            # TODO: This is a hack to stop test_qt.py from running until we
-            # can better troubleshoot why it fails on GHA
-            # for QTPACKAGE in qt pyqt; do
-            #     # Because conda is insane, removing packages can cause
-            #     # unrelated packages to be updated (breaking version
-            #     # specifications specified previously, e.g., in
-            #     # setup.py).  There doesn't appear to be a good
-            #     # workaround, so we will just force-remove (recognizing
-            #     # that it may break other conda cruft).
-            #     conda remove --force-remove $QTPACKAGE \
-            #         || echo "$QTPACKAGE not in this environment"
-            # done
         fi
         # Re-try Pyomo (optional) dependencies with pip
         if test -n "$PYPI_DEPENDENCIES"; then

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -21,7 +21,7 @@ defaults:
 env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
-  PYPI_ONLY: z3-solver pyqt6
+  PYPI_ONLY: z3-solver PyQt6
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
@@ -328,9 +328,7 @@ jobs:
             done
         fi
         for PKG in $PACKAGES; do
-            echo "######### Analyzing $PKG"
             if [[ " $PYPI_ONLY " == *" $PKG "* ]]; then
-                echo "######## Skipping $PKG"
                 PYPI_DEPENDENCIES="$PYPI_DEPENDENCIES $PKG"
             else
                 CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $PKG"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -328,8 +328,9 @@ jobs:
             done
         fi
         for PKG in $PACKAGES; do
+            echo "######### Analyzing $PKG"
             if [[ " $PYPI_ONLY " == *" $PKG "* ]]; then
-                echo "Skipping $PKG"
+                echo "######## Skipping $PKG"
                 PYPI_DEPENDENCIES="$PYPI_DEPENDENCIES $PKG"
             else
                 CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $PKG"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -214,7 +214,7 @@ jobs:
         python-version: ${{ matrix.python }}
 
     - name: Set up headless display
-      if: matrix.PYENV == 'conda' && ${{ matrix.TARGET != 'osx' }}
+      if: ${{ matrix.PYENV == 'conda' && matrix.TARGET != 'osx' }}
       uses: pyvista/setup-headless-display-action@v2
       with:
         qt: true

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -21,7 +21,7 @@ defaults:
 env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
-  PYPI_ONLY: z3-solver
+  PYPI_ONLY: z3-solver pyqt6
   PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
@@ -192,7 +192,7 @@ jobs:
         #  - install glpk
         #  - ipopt needs: libopenblas-dev gfortran liblapack-dev
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
-            install libopenblas-dev gfortran liblapack-dev glpk-utils
+            install libopenblas-dev gfortran liblapack-dev glpk-utils libgl1
         sudo chmod -R 777 ${GITHUB_WORKSPACE}/cache/os
 
     - name: Update Windows

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -26,9 +26,6 @@ env:
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
-  # Display must be available globally for linux to know where xvfb is
-  # DISPLAY: ":99.0"
-  # QT_SELECT: "qt6"
 
 jobs:
   lint:
@@ -197,10 +194,6 @@ jobs:
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils
         sudo chmod -R 777 ${GITHUB_WORKSPACE}/cache/os
-        # sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0 libglib2.0-0 libgl1-mesa-dev
-        # sudo apt-get install '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
-        # # start xvfb in the background
-        # sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
 
     - name: Update Windows
       if: matrix.TARGET == 'win'
@@ -221,10 +214,11 @@ jobs:
         python-version: ${{ matrix.python }}
 
     - name: Set up headless display
-      if: matrix.PYENV == 'conda'
+      if: matrix.PYENV == 'conda' && ${{ matrix.TARGET != 'osx' }}
       uses: pyvista/setup-headless-display-action@v2
       with:
         qt: true
+        pyvista: false
 
     # GitHub actions is very fragile when it comes to setting up various
     # Python interpreters, expecially the setup-miniconda interface.

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -22,7 +22,8 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
-  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels PyQt6 pytest-qt
+  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels pytest-qt PySide6
+  CONDA_EXCLUDE: PySide6 pyside6
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
@@ -126,7 +127,7 @@ jobs:
         # Note: pandas 1.0.3 causes gams 29.1.0 import to fail in python 3.8
         EXTRAS=tests
         if test -z "${{matrix.slim}}"; then
-            EXTRAS="$EXTRAS,docs,optional"
+            EXTRAS="$EXTRAS,tests_optional,docs,optional"
         fi
         echo "EXTRAS=$EXTRAS" >> $GITHUB_ENV
         PYTHON_PACKAGES="${{matrix.PACKAGES}}"
@@ -321,7 +322,7 @@ jobs:
         if test "${{matrix.TARGET}}" == linux; then
             EXCLUDE="casadi numdifftools $EXCLUDE"
         fi
-        EXCLUDE=`echo "$EXCLUDE PyQt6 pyqt6" | xargs`
+        EXCLUDE=`echo "$EXCLUDE $CONDA_EXCLUDE" | xargs`
         if test -n "$EXCLUDE"; then
             for WORD in $EXCLUDE; do
                 PACKAGES=${PACKAGES//$WORD / }

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -25,8 +25,8 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
-  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels pytest-qt PySide6
-  CONDA_EXCLUDE: PySide6 pyside6
+  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels pytest-qt PyQt5
+  CONDA_EXCLUDE: PyQt5 pyqt5
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
@@ -222,7 +222,6 @@ jobs:
         # Notes:
         #  - install glpk
         #  - ipopt needs: libopenblas-dev gfortran liblapack-dev
-        #  - contrib.viewer needs: libg1l libegl1
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
             install libopenblas-dev gfortran liblapack-dev glpk-utils
         sudo chmod -R 777 ${GITHUB_WORKSPACE}/cache/os
@@ -252,7 +251,7 @@ jobs:
       uses: pyvista/setup-headless-display-action@v2
       with:
         qt: true
-        pyvista: true
+        pyvista: false
 
     # GitHub actions is very fragile when it comes to setting up various
     # Python interpreters, expecially the setup-miniconda interface.

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -25,8 +25,7 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
-  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels pytest-qt PyQt5
-  CONDA_EXCLUDE: PyQt5 pyqt5
+  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels pytest-qt
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
@@ -351,7 +350,7 @@ jobs:
         if test "${{matrix.TARGET}}" == linux; then
             EXCLUDE="casadi numdifftools $EXCLUDE"
         fi
-        EXCLUDE=`echo "$EXCLUDE $CONDA_EXCLUDE" | xargs`
+        EXCLUDE=`echo "$EXCLUDE" | xargs`
         if test -n "$EXCLUDE"; then
             for WORD in $EXCLUDE; do
                 PACKAGES=${PACKAGES//$WORD / }

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -25,7 +25,8 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
-  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels PyQt6 pytest-qt
+  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels pytest-qt PySide6
+  CONDA_EXCLUDE: PySide6 pyside6
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
@@ -156,7 +157,7 @@ jobs:
         # Note: pandas 1.0.3 causes gams 29.1.0 import to fail in python 3.8
         EXTRAS=tests
         if test -z "${{matrix.slim}}"; then
-            EXTRAS="$EXTRAS,docs,optional"
+            EXTRAS="$EXTRAS,tests_optional,docs,optional"
         fi
         echo "EXTRAS=$EXTRAS" >> $GITHUB_ENV
         PYTHON_PACKAGES="${{matrix.PACKAGES}}"
@@ -351,7 +352,7 @@ jobs:
         if test "${{matrix.TARGET}}" == linux; then
             EXCLUDE="casadi numdifftools $EXCLUDE"
         fi
-        EXCLUDE=`echo "$EXCLUDE PyQt6 pyqt6" | xargs`
+        EXCLUDE=`echo "$EXCLUDE $CONDA_EXCLUDE" | xargs`
         if test -n "$EXCLUDE"; then
             for WORD in $EXCLUDE; do
                 PACKAGES=${PACKAGES//$WORD / }

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -25,7 +25,7 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
-  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels pytest-qt
+  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}
@@ -76,7 +76,7 @@ jobs:
         - os: windows-latest
           TARGET: win
           PYENV: conda
-          PACKAGES: glpk
+          PACKAGES: glpk pytest-qt
 
         - os: ubuntu-latest
           python: '3.11'
@@ -84,7 +84,7 @@ jobs:
           skip_doctest: 1
           TARGET: linux
           PYENV: conda
-          PACKAGES:
+          PACKAGES: pytest-qt
 
         - os: ubuntu-latest
           python: 3.9
@@ -156,7 +156,7 @@ jobs:
         # Note: pandas 1.0.3 causes gams 29.1.0 import to fail in python 3.8
         EXTRAS=tests
         if test -z "${{matrix.slim}}"; then
-            EXTRAS="$EXTRAS,tests_optional,docs,optional"
+            EXTRAS="$EXTRAS,docs,optional"
         fi
         echo "EXTRAS=$EXTRAS" >> $GITHUB_ENV
         PYTHON_PACKAGES="${{matrix.PACKAGES}}"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -245,8 +245,7 @@ jobs:
         python-version: ${{ matrix.python }}
 
     # This is necessary for qt (UI) tests; the package utilized here does not
-    # have support for OSX, but we don't do any OSX testing inherently.
-    # This is just to protect us in case we do add that into the matrix someday.
+    # have support for OSX.
     - name: Set up UI testing infrastructure
       if: ${{ matrix.TARGET != 'osx' }}
       uses: pyvista/setup-headless-display-action@v2

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -221,8 +221,9 @@ jobs:
         # Notes:
         #  - install glpk
         #  - ipopt needs: libopenblas-dev gfortran liblapack-dev
+        #  - contrib.viewer needs: libg1l libegl1
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
-            install libopenblas-dev gfortran liblapack-dev glpk-utils
+            install libopenblas-dev gfortran liblapack-dev glpk-utils libgl1 libegl1
         sudo chmod -R 777 ${GITHUB_WORKSPACE}/cache/os
 
     - name: Update Windows
@@ -242,6 +243,16 @@ jobs:
       with:
         auto-update-conda: false
         python-version: ${{ matrix.python }}
+
+    # This is necessary for qt (UI) tests; the package utilized here does not
+    # have support for OSX, but we don't do any OSX testing inherently.
+    # This is just to protect us in case we do add that into the matrix someday.
+    - name: Set up UI testing infrastructure
+      if: ${{ matrix.TARGET != 'osx' }}
+      uses: pyvista/setup-headless-display-action@v2
+      with:
+        qt: true
+        pyvista: false
 
     # GitHub actions is very fragile when it comes to setting up various
     # Python interpreters, expecially the setup-miniconda interface.
@@ -339,9 +350,9 @@ jobs:
         fi
         # HACK: Remove problem packages on conda+Linux
         if test "${{matrix.TARGET}}" == linux; then
-            EXCLUDE="casadi numdifftools pint $EXCLUDE"
+            EXCLUDE="casadi numdifftools $EXCLUDE"
         fi
-        EXCLUDE=`echo "$EXCLUDE" | xargs`
+        EXCLUDE=`echo "$EXCLUDE PyQt6 pyqt6" | xargs`
         if test -n "$EXCLUDE"; then
             for WORD in $EXCLUDE; do
                 PACKAGES=${PACKAGES//$WORD / }
@@ -376,10 +387,11 @@ jobs:
                     | sed -r 's/\s+/ /g' | cut -d\  -f3) || echo ""
                 if test -n "$_BUILDS"; then
                     _ISPY=$(echo "$_BUILDS" | grep "^py") \
-                        || echo "No python build detected"
-                    _PYOK=$(echo "$_BUILDS" | grep "^$PYVER") \
-                        || echo "No python build matching $PYVER detected"
+                        || echo "INFO: No python build detected."
+                    _PYOK=$(echo "$_BUILDS" | grep -E "^($PYVER|pyh)") \
+                        || echo "INFO: No python build matching $PYVER detected."
                     if test -z "$_ISPY" -o -n "$_PYOK"; then
+                        echo ""
                         echo "... INSTALLING $PKG"
                         conda install -y "$PKG" || _BUILDS=""
                     fi
@@ -387,18 +399,6 @@ jobs:
                 if test -z "$_BUILDS"; then
                     echo "WARNING: $PKG is not available"
                 fi
-            done
-            # TODO: This is a hack to stop test_qt.py from running until we
-            # can better troubleshoot why it fails on GHA
-            for QTPACKAGE in qt pyqt; do
-                # Because conda is insane, removing packages can cause
-                # unrelated packages to be updated (breaking version
-                # specifications specified previously, e.g., in
-                # setup.py).  There doesn't appear to be a good
-                # workaround, so we will just force-remove (recognizing
-                # that it may break other conda cruft).
-                conda remove --force-remove $QTPACKAGE \
-                    || echo "$QTPACKAGE not in this environment"
             done
         fi
         # Re-try Pyomo (optional) dependencies with pip

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -25,7 +25,7 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
-  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels PyQt6
+  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels PyQt6 pytest-qt
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -224,7 +224,7 @@ jobs:
         #  - ipopt needs: libopenblas-dev gfortran liblapack-dev
         #  - contrib.viewer needs: libg1l libegl1
         sudo apt-get -o Dir::Cache=${GITHUB_WORKSPACE}/cache/os \
-            install libopenblas-dev gfortran liblapack-dev glpk-utils libgl1 libegl1
+            install libopenblas-dev gfortran liblapack-dev glpk-utils
         sudo chmod -R 777 ${GITHUB_WORKSPACE}/cache/os
 
     - name: Update Windows
@@ -252,7 +252,7 @@ jobs:
       uses: pyvista/setup-headless-display-action@v2
       with:
         qt: true
-        pyvista: false
+        pyvista: true
 
     # GitHub actions is very fragile when it comes to setting up various
     # Python interpreters, expecially the setup-miniconda interface.

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -25,7 +25,7 @@ env:
   PYTHONWARNINGS: ignore::UserWarning
   PYTHON_CORE_PKGS: wheel
   PYPI_ONLY: z3-solver
-  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels
+  PYPY_EXCLUDE: scipy numdifftools seaborn statsmodels PyQt6
   CACHE_VER: v221013.1
   NEOS_EMAIL: tests@pyomo.org
   SRC_REF: ${{ github.head_ref || github.ref }}

--- a/setup.py
+++ b/setup.py
@@ -243,16 +243,8 @@ setup_kwargs = dict(
     python_requires='>=3.8',
     install_requires=['ply'],
     extras_require={
-        'tests': [
-            'coverage',
-            'parameterized',
-            'pybind11',
-            'pytest',
-            'pytest-parallel',
-        ],
-        'tests_optional': [
-            'pytest-qt',  # contrib.viewer
-        ],
+        'tests': ['coverage', 'parameterized', 'pybind11', 'pytest', 'pytest-parallel'],
+        'tests_optional': ['pytest-qt'],  # contrib.viewer
         'docs': [
             'Sphinx>4',
             'sphinx-copybutton',

--- a/setup.py
+++ b/setup.py
@@ -243,8 +243,10 @@ setup_kwargs = dict(
     python_requires='>=3.8',
     install_requires=['ply'],
     extras_require={
+        # There are certain tests that also require pytest-qt, but because those
+        # tests are so environment/machine specific, we are leaving these out of
+        # the dependencies.
         'tests': ['coverage', 'parameterized', 'pybind11', 'pytest', 'pytest-parallel'],
-        'tests_optional': ['pytest-qt'],  # contrib.viewer
         'docs': [
             'Sphinx>4',
             'sphinx-copybutton',
@@ -262,7 +264,7 @@ setup_kwargs = dict(
             'matplotlib!=3.6.1',
             # network, incidence_analysis, community_detection
             # Note: networkx 3.2 is Python>-3.9, but there is a broken
-            # 3.2 package on conda-forgethat will get implicitly
+            # 3.2 package on conda-forge that will get implicitly
             # installed on python 3.8
             'networkx<3.2; python_version<"3.9"',
             'networkx; python_version>="3.9"',
@@ -273,6 +275,8 @@ setup_kwargs = dict(
             'plotly',  # incidence_analysis
             'python-louvain',  # community_detection
             'pyyaml',  # core
+            # qtconsole also requires a supported Qt version (PyQt5 or PySide6).
+            # Because those are environment specific, we have left that out here.
             'qtconsole',  # contrib.viewer
             'scipy',
             'sympy',  # differentiation
@@ -286,9 +290,7 @@ setup_kwargs = dict(
             # The following optional dependencies are difficult to
             # install on PyPy (binary wheels are not available), so we
             # will only "require" them on other (CPython) platforms:
-            #
-            # DAE can use casadi
-            'casadi; implementation_name!="pypy"',
+            'casadi; implementation_name!="pypy"',  # dae
             'numdifftools; implementation_name!="pypy"',  # pynumero
             'pandas; implementation_name!="pypy"',
             'seaborn; implementation_name!="pypy"',  # parmest.graphics

--- a/setup.py
+++ b/setup.py
@@ -271,7 +271,6 @@ setup_kwargs = dict(
             #'pathos',   # requested for #963, but PR currently closed
             'pint',  # units
             'plotly',  # incidence_analysis
-            'PyQt5',  # contrib.viewer
             'python-louvain',  # community_detection
             'pyyaml',  # core
             'qtconsole',  # contrib.viewer

--- a/setup.py
+++ b/setup.py
@@ -244,12 +244,14 @@ setup_kwargs = dict(
     install_requires=['ply'],
     extras_require={
         'tests': [
-            #'codecov', # useful for testing infrastructures, but not required
             'coverage',
             'parameterized',
             'pybind11',
             'pytest',
             'pytest-parallel',
+        ],
+        'tests_optional': [
+            'pytest-qt',  # contrib.viewer
         ],
         'docs': [
             'Sphinx>4',
@@ -277,7 +279,7 @@ setup_kwargs = dict(
             #'pathos',   # requested for #963, but PR currently closed
             'pint',  # units
             'plotly',  # incidence_analysis
-            'PyQt6',  # contrib.viewer
+            'PySide6',  # contrib.viewer
             'pytest-qt',  # for testing contrib.viewer
             'python-louvain',  # community_detection
             'pyyaml',  # core

--- a/setup.py
+++ b/setup.py
@@ -278,7 +278,7 @@ setup_kwargs = dict(
             #'pathos',   # requested for #963, but PR currently closed
             'pint',  # units
             'plotly',  # incidence_analysis
-            'PyQt5',  # contrib.viewer
+            'PyQt6',  # contrib.viewer
             'python-louvain',  # community_detection
             'pyyaml',  # core
             'qtconsole',  # contrib.viewer

--- a/setup.py
+++ b/setup.py
@@ -250,7 +250,6 @@ setup_kwargs = dict(
             'pybind11',
             'pytest',
             'pytest-parallel',
-            'pytest-qt',  # for testing contrib.viewer
         ],
         'docs': [
             'Sphinx>4',
@@ -279,6 +278,7 @@ setup_kwargs = dict(
             'pint',  # units
             'plotly',  # incidence_analysis
             'PyQt6',  # contrib.viewer
+            'pytest-qt',  # for testing contrib.viewer
             'python-louvain',  # community_detection
             'pyyaml',  # core
             'qtconsole',  # contrib.viewer

--- a/setup.py
+++ b/setup.py
@@ -278,7 +278,7 @@ setup_kwargs = dict(
             #'pathos',   # requested for #963, but PR currently closed
             'pint',  # units
             'plotly',  # incidence_analysis
-            'PyQt6',  # contrib.viewer
+            'PyQt5',  # contrib.viewer
             'python-louvain',  # community_detection
             'pyyaml',  # core
             'qtconsole',  # contrib.viewer

--- a/setup.py
+++ b/setup.py
@@ -272,7 +272,6 @@ setup_kwargs = dict(
             'pint',  # units
             'plotly',  # incidence_analysis
             'PyQt5',  # contrib.viewer
-            'pytest-qt',  # for testing contrib.viewer
             'python-louvain',  # community_detection
             'pyyaml',  # core
             'qtconsole',  # contrib.viewer

--- a/setup.py
+++ b/setup.py
@@ -271,7 +271,7 @@ setup_kwargs = dict(
             #'pathos',   # requested for #963, but PR currently closed
             'pint',  # units
             'plotly',  # incidence_analysis
-            'PySide6',  # contrib.viewer
+            'PyQt5',  # contrib.viewer
             'pytest-qt',  # for testing contrib.viewer
             'python-louvain',  # community_detection
             'pyyaml',  # core

--- a/setup.py
+++ b/setup.py
@@ -278,10 +278,10 @@ setup_kwargs = dict(
             #'pathos',   # requested for #963, but PR currently closed
             'pint',  # units
             'plotly',  # incidence_analysis
+            'PyQt6',  # contrib.viewer
             'python-louvain',  # community_detection
             'pyyaml',  # core
             'qtconsole',  # contrib.viewer
-            'qtpy',  # contrib.viewer
             'scipy',
             'sympy',  # differentiation
             'xlrd',  # dataportals

--- a/setup.py
+++ b/setup.py
@@ -281,6 +281,7 @@ setup_kwargs = dict(
             'python-louvain',  # community_detection
             'pyyaml',  # core
             'qtconsole',  # contrib.viewer
+            'qtpy',  # contrib.viewer
             'scipy',
             'sympy',  # differentiation
             'xlrd',  # dataportals

--- a/setup.py
+++ b/setup.py
@@ -246,10 +246,11 @@ setup_kwargs = dict(
         'tests': [
             #'codecov', # useful for testing infrastructures, but not required
             'coverage',
-            'pytest',
-            'pytest-parallel',
             'parameterized',
             'pybind11',
+            'pytest',
+            'pytest-parallel',
+            'pytest-qt',  # for testing contrib.viewer
         ],
         'docs': [
             'Sphinx>4',
@@ -279,6 +280,7 @@ setup_kwargs = dict(
             'plotly',  # incidence_analysis
             'python-louvain',  # community_detection
             'pyyaml',  # core
+            'qtconsole',  # contrib.viewer
             'scipy',
             'sympy',  # differentiation
             'xlrd',  # dataportals


### PR DESCRIPTION
## Fixes #2289 

## Summary/Motivation:
In an effort to close EVEN MORE ISSUES - this PR resolves an issue that appeared last year relating to `contrib.viewer` tests that utilize `qt`. This PR introduces infrastructure for "[headless](https://testguild.com/headless-browser-testing-pros-cons/#A1)" UI testing, as well as officially listing `qtconsole`, `pyqt`, and `pytest-qt` as extra dependencies to enable the both the tests and the general functionality.

## Changes proposed in this PR:
- Introduce `setup-headless-display-action` for UI testing
- Add new optional / test dependencies
- Fix small bug in regex processing for conda

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
