### PR TITLE
Track changes in PyPy behavior introduced in 7.3.14

### DIFF
--- a/pyomo/core/tests/unit/test_initializer.py
+++ b/pyomo/core/tests/unit/test_initializer.py
@@ -12,6 +12,7 @@
 import functools
 import pickle
 import platform
+import sys
 import types
 
 import pyomo.common.unittest as unittest

--- a/pyomo/core/tests/unit/test_initializer.py
+++ b/pyomo/core/tests/unit/test_initializer.py
@@ -576,9 +576,10 @@ class Test_Initializer(unittest.TestCase):
             # persist through Pyomo's Initializer handling (and not
             # special case it there)
             self.assertIs(type(a), ScalarCallInitializer)
+            self.assertTrue(a.constant())
         else:
             self.assertIs(type(a), IndexedCallInitializer)
-        self.assertFalse(a.constant())
+            self.assertFalse(a.constant())
         self.assertFalse(a.verified)
         self.assertFalse(a.contains_indices())
         # but this is not callable, as int won't accept the 'model'

--- a/pyomo/core/tests/unit/test_initializer.py
+++ b/pyomo/core/tests/unit/test_initializer.py
@@ -11,6 +11,7 @@
 
 import functools
 import pickle
+import platform
 import types
 
 import pyomo.common.unittest as unittest
@@ -35,6 +36,9 @@ from pyomo.core.base.initializer import (
     DefaultInitializer,
 )
 from pyomo.environ import ConcreteModel, Var
+
+
+is_pypy = platform.python_implementation().lower().startswith("pypy")
 
 
 def _init_scalar(m):
@@ -561,11 +565,18 @@ class Test_Initializer(unittest.TestCase):
         self.assertFalse(a.contains_indices())
         self.assertEqual(a('111', 2), 7)
 
-        # Special case: getfullargspec fails on int, so we assume it is
-        # always an IndexedCallInitializer
+        # Special case: getfullargspec fails for int under CPython and
+        # PyPy<7.3.14, so we assume it is an IndexedCallInitializer.
         basetwo = functools.partial(int, '101', base=2)
         a = Initializer(basetwo)
-        self.assertIs(type(a), IndexedCallInitializer)
+        if is_pypy and sys.pypy_version_info[:3] >= (7, 3, 14):
+            # PyPy behavior diverged from CPython in 7.3.14.  Arguably
+            # this is "more correct", so we will allow the difference to
+            # persist through Pyomo's Initializer handling (and not
+            # special case it there)
+            self.assertIs(type(a), ScalarCallInitializer)
+        else:
+            self.assertIs(type(a), IndexedCallInitializer)
         self.assertFalse(a.constant())
         self.assertFalse(a.verified)
         self.assertFalse(a.contains_indices())

--- a/pyomo/core/tests/unit/test_pickle.py
+++ b/pyomo/core/tests/unit/test_pickle.py
@@ -35,7 +35,7 @@ from pyomo.environ import (
 )
 
 
-using_pypy = platform.python_implementation() == "PyPy"
+is_pypy = platform.python_implementation().lower().startswith("pypy")
 
 
 def obj_rule(model):
@@ -322,7 +322,7 @@ class Test(unittest.TestCase):
         model.con = Constraint(rule=rule1)
         model.con2 = Constraint(model.a, rule=rule2)
         instance = model.create_instance()
-        if using_pypy:
+        if is_pypy:
             str_ = pickle.dumps(instance)
             tmp_ = pickle.loads(str_)
         else:


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
PyPy 7.3.14 changed how `inspect` behaves to diverge from CPython's behavior (see https://github.com/pypy/pypy/issues/4839).  This introduced a test failure in Pyomo.  This PR resolves the test failure, by acknowledging that PyPy and CPython behave differently (and does NOT introduce hacks into Pyomo to make both platforms behave similarly)

## Changes proposed in this PR:
- Update tests to recognize / document that we will see different behavior on recent PyPy
- Standardize the check of running under PyPy in other tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
