### PR TITLE
Improbve NumPy registration when assigning numpy to Param

### DIFF
--- a/pyomo/common/numeric_types.py
+++ b/pyomo/common/numeric_types.py
@@ -212,8 +212,8 @@ def check_if_numeric_type(obj):
         # trigger the resolution of numpy_available and check if this
         # type was automatically registered
         bool(numpy_available)
-        if obj_class in native_numeric_types:
-            return True
+        if obj_class in native_types:
+            return obj_class in native_numeric_types
 
     try:
         obj_plus_0 = obj + 0

--- a/pyomo/core/tests/unit/test_numvalue.py
+++ b/pyomo/core/tests/unit/test_numvalue.py
@@ -562,7 +562,7 @@ class Test_as_numeric(unittest.TestCase):
     @unittest.skipUnless(numpy_available, "This test requires NumPy")
     def test_automatic_numpy_registration(self):
         cmd = (
-            'import pyomo; from pyomo.core.base import Var; import numpy as np; '
+            'import pyomo; from pyomo.core.base import Var, Param; import numpy as np; '
             'print(np.float64 in pyomo.common.numeric_types.native_numeric_types); '
             '%s; print(np.float64 in pyomo.common.numeric_types.native_numeric_types)'
         )
@@ -580,6 +580,8 @@ class Test_as_numeric(unittest.TestCase):
         _tester('np.float64(5) <= Var()')
         _tester('np.float64(5) + Var()')
         _tester('Var() + np.float64(5)')
+        _tester('v = Var(); v.construct(); v.value = np.float64(5)')
+        _tester('p = Param(mutable=True); p.construct(); p.value = np.float64(5)')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This resolves (for Pyomo) a weakness in the automated numpy type registration system (which is necessary after #3077 removed the mandatory import / registration of NumPy).  This partially addresses #3091 (the remainder will need to be addressed within mpi-sppy).

## Changes proposed in this PR:
- Update NumericRange so that checking membership of a numpy type in the range will trigger numpy type registrations (through the normal `check_if_numeric_type` mechanism)
- Add a test that ensures that assigning a numpy type to a Param will trigger numpy type registration

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
