### PR TITLE
Add missing solver dependency flags for OnlineDocs tests

### DIFF
--- a/doc/OnlineDocs/src/test_examples.py
+++ b/doc/OnlineDocs/src/test_examples.py
@@ -35,7 +35,11 @@ class TestOnlineDocExamples(unittest.BaselineTestDriver, unittest.TestCase):
         list(filter(os.path.isdir, glob.glob(os.path.join(currdir, '*'))))
     )
 
-    solver_dependencies = {}
+    solver_dependencies = {
+        'test_data_pyomo_diet1': ['glpk'],
+        'test_data_pyomo_diet2': ['glpk'],
+        'test_kernel_examples': ['glpk'],
+    }
     # Note on package dependencies: two tests actually need
     # pyutilib.excel.spreadsheet; however, the pyutilib importer is
     # broken on Python>=3.12, so instead of checking for spreadsheet, we


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This PR adds flags specifying solver dependencies for OnlineDocs tests so that the Pyomo "nosolvers" build passes.

## Changes proposed in this PR:
- Add GLPK solver dependency flags to OnlineDocs src tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
