### PR TITLE
Resolve symbolic differentiation infinite loop under pypy

### DIFF
--- a/pyomo/core/expr/calculus/diff_with_pyomo.py
+++ b/pyomo/core/expr/calculus/diff_with_pyomo.py
@@ -378,7 +378,11 @@ def _numeric_apply_operation(node, values):
 
 
 def _symbolic_apply_operation(node, values):
-    return node
+    # Note that it important to create a new node using the (new) list
+    # built by the walker.  Doing so decouples the derivative
+    # expressions from the original expression thereby avoiding some
+    # possible infinite loops due to expression entangling (see #3096)
+    return node.create_node_with_local_data(values)
 
 
 class _LeafToRootVisitor(ExpressionValueVisitor):

--- a/pyomo/core/tests/unit/test_derivs.py
+++ b/pyomo/core/tests/unit/test_derivs.py
@@ -322,6 +322,18 @@ class TestDerivs(unittest.TestCase):
         self.assertAlmostEqual(derivs[m.y], pyo.value(symbolic[m.y]), tol + 3)
         self.assertAlmostEqual(derivs[m.y], approx_deriv(e, m.y), tol)
 
+    def test_linear_exprs_issue_3096(self):
+        m = pyo.ConcreteModel()
+        m.y1 = pyo.Var(initialize=10)
+        m.y2 = pyo.Var(initialize=100)
+        e = (m.y1 - 0.5) * (m.y1 - 0.5) + (m.y2 - 0.5) * (m.y2 - 0.5)
+        derivs = reverse_ad(e)
+        self.assertEqual(derivs[m.y1], 19)
+        self.assertEqual(derivs[m.y2], 199)
+        symbolic = reverse_sd(e)
+        self.assertExpressionsEqual(symbolic[m.y1], m.y1 - 0.5 + m.y1 - 0.5)
+        self.assertExpressionsEqual(symbolic[m.y2], m.y2 - 0.5 + m.y2 - 0.5)
+
 
 class TestDifferentiate(unittest.TestCase):
     @unittest.skipUnless(sympy_available, "test requires sympy")


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #3096 .

## Summary/Motivation:
This resolves an infinite loop that was observed in symbolic differentiation when run under PyPy (#3096) by ensuring that the derivative expressions are detangled from the original expressions.  As the walker is already creating the new lists, this change should have minimal impact on the walker's performance.

## Changes proposed in this PR:
- Ensure derivative expressions are detangled from original expression
- Add test of the behavior observed in #3096.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
