### PR TITLE
Enforce expression immutability in `expr.args`

### DIFF
--- a/pyomo/core/expr/numeric_expr.py
+++ b/pyomo/core/expr/numeric_expr.py
@@ -1162,12 +1162,29 @@ class SumExpression(NumericExpression):
 
     @property
     def args(self):
-        if len(self._args_) != self._nargs:
-            self._args_ = self._args_[: self._nargs]
-        return self._args_
+        # We unconditionally make a copy of the args to isolate the user
+        # from future possible updates to the underlying list
+        return self._args_[:self._nargs]
 
     def getname(self, *args, **kwds):
         return 'sum'
+
+    def _trunc_append(self, other):
+        _args = self._args_
+        if len(_args) > self._nargs:
+            _args = _args[:self._nargs]
+        _args.append(other)
+        return self.__class__(_args)
+
+    def _trunc_extend(self, other):
+        _args = self._args_
+        if len(_args) > self._nargs:
+            _args = _args[:self._nargs]
+        if len(other._args_) == other._nargs:
+            _args.extend(other._args_)
+        else:
+            _args.extend(other._args_[:other._nargs])
+        return self.__class__(_args)
 
     def _apply_operation(self, result):
         return sum(result)
@@ -1821,17 +1838,13 @@ def _add_native_monomial(a, b):
 def _add_native_linear(a, b):
     if not a:
         return b
-    args = b.args
-    args.append(a)
-    return b.__class__(args)
+    return b._trunc_append(a)
 
 
 def _add_native_sum(a, b):
     if not a:
         return b
-    args = b.args
-    args.append(a)
-    return b.__class__(args)
+    return b._trunc_append(a)
 
 
 def _add_native_other(a, b):
@@ -1872,15 +1885,11 @@ def _add_npv_monomial(a, b):
 
 
 def _add_npv_linear(a, b):
-    args = b.args
-    args.append(a)
-    return b.__class__(args)
+    return b._trunc_append(a)
 
 
 def _add_npv_sum(a, b):
-    args = b.args
-    args.append(a)
-    return b.__class__(args)
+    return b._trunc_append(a)
 
 
 def _add_npv_other(a, b):
@@ -1942,9 +1951,7 @@ def _add_param_linear(a, b):
         a = a.value
         if not a:
             return b
-    args = b.args
-    args.append(a)
-    return b.__class__(args)
+    return b._trunc_append(a)
 
 
 def _add_param_sum(a, b):
@@ -1952,9 +1959,7 @@ def _add_param_sum(a, b):
         a = value(a)
         if not a:
             return b
-    args = b.args
-    args.append(a)
-    return b.__class__(args)
+    return b._trunc_append(a)
 
 
 def _add_param_other(a, b):
@@ -1999,15 +2004,11 @@ def _add_var_monomial(a, b):
 
 
 def _add_var_linear(a, b):
-    args = b.args
-    args.append(MonomialTermExpression((1, a)))
-    return b.__class__(args)
+    return b._trunc_append(MonomialTermExpression((1, a)))
 
 
 def _add_var_sum(a, b):
-    args = b.args
-    args.append(a)
-    return b.__class__(args)
+    return b._trunc_append(a)
 
 
 def _add_var_other(a, b):
@@ -2046,15 +2047,11 @@ def _add_monomial_monomial(a, b):
 
 
 def _add_monomial_linear(a, b):
-    args = b.args
-    args.append(a)
-    return b.__class__(args)
+    return b._trunc_append(a)
 
 
 def _add_monomial_sum(a, b):
-    args = b.args
-    args.append(a)
-    return b.__class__(args)
+    return b._trunc_append(a)
 
 
 def _add_monomial_other(a, b):
@@ -2069,15 +2066,11 @@ def _add_monomial_other(a, b):
 def _add_linear_native(a, b):
     if not b:
         return a
-    args = a.args
-    args.append(b)
-    return a.__class__(args)
+    return a._trunc_append(b)
 
 
 def _add_linear_npv(a, b):
-    args = a.args
-    args.append(b)
-    return a.__class__(args)
+    return a._trunc_append(b)
 
 
 def _add_linear_param(a, b):
@@ -2085,33 +2078,23 @@ def _add_linear_param(a, b):
         b = b.value
         if not b:
             return a
-    args = a.args
-    args.append(b)
-    return a.__class__(args)
+    return a._trunc_append(b)
 
 
 def _add_linear_var(a, b):
-    args = a.args
-    args.append(MonomialTermExpression((1, b)))
-    return a.__class__(args)
+    return a._trunc_append(MonomialTermExpression((1, b)))
 
 
 def _add_linear_monomial(a, b):
-    args = a.args
-    args.append(b)
-    return a.__class__(args)
+    return a._trunc_append(b)
 
 
 def _add_linear_linear(a, b):
-    args = a.args
-    args.extend(b.args)
-    return a.__class__(args)
+    return a._trunc_extend(b)
 
 
 def _add_linear_sum(a, b):
-    args = b.args
-    args.append(a)
-    return b.__class__(args)
+    return b._trunc_append(a)
 
 
 def _add_linear_other(a, b):
@@ -2126,15 +2109,11 @@ def _add_linear_other(a, b):
 def _add_sum_native(a, b):
     if not b:
         return a
-    args = a.args
-    args.append(b)
-    return a.__class__(args)
+    return a._trunc_append(b)
 
 
 def _add_sum_npv(a, b):
-    args = a.args
-    args.append(b)
-    return a.__class__(args)
+    return a._trunc_append(b)
 
 
 def _add_sum_param(a, b):
@@ -2142,39 +2121,27 @@ def _add_sum_param(a, b):
         b = b.value
         if not b:
             return a
-    args = a.args
-    args.append(b)
-    return a.__class__(args)
+    return a._trunc_append(b)
 
 
 def _add_sum_var(a, b):
-    args = a.args
-    args.append(b)
-    return a.__class__(args)
+    return a._trunc_append(b)
 
 
 def _add_sum_monomial(a, b):
-    args = a.args
-    args.append(b)
-    return a.__class__(args)
+    return a._trunc_append(b)
 
 
 def _add_sum_linear(a, b):
-    args = a.args
-    args.append(b)
-    return a.__class__(args)
+    return a._trunc_append(b)
 
 
 def _add_sum_sum(a, b):
-    args = a.args
-    args.extend(b.args)
-    return a.__class__(args)
+    return a._trunc_extend(b)
 
 
 def _add_sum_other(a, b):
-    args = a.args
-    args.append(b)
-    return a.__class__(args)
+    return a._trunc_append(b)
 
 
 #
@@ -2213,9 +2180,7 @@ def _add_other_linear(a, b):
 
 
 def _add_other_sum(a, b):
-    args = b.args
-    args.append(a)
-    return b.__class__(args)
+    return b._trunc_append(a)
 
 
 def _add_other_other(a, b):
@@ -2628,8 +2593,8 @@ def _neg_var(a):
 
 
 def _neg_monomial(a):
-    args = a.args
-    return MonomialTermExpression((-args[0], args[1]))
+    coef, var = a.args
+    return MonomialTermExpression((-coef, var))
 
 
 def _neg_sum(a):

--- a/pyomo/core/expr/numeric_expr.py
+++ b/pyomo/core/expr/numeric_expr.py
@@ -1164,7 +1164,7 @@ class SumExpression(NumericExpression):
     def args(self):
         # We unconditionally make a copy of the args to isolate the user
         # from future possible updates to the underlying list
-        return self._args_[:self._nargs]
+        return self._args_[: self._nargs]
 
     def getname(self, *args, **kwds):
         return 'sum'
@@ -1172,18 +1172,18 @@ class SumExpression(NumericExpression):
     def _trunc_append(self, other):
         _args = self._args_
         if len(_args) > self._nargs:
-            _args = _args[:self._nargs]
+            _args = _args[: self._nargs]
         _args.append(other)
         return self.__class__(_args)
 
     def _trunc_extend(self, other):
         _args = self._args_
         if len(_args) > self._nargs:
-            _args = _args[:self._nargs]
+            _args = _args[: self._nargs]
         if len(other._args_) == other._nargs:
             _args.extend(other._args_)
         else:
-            _args.extend(other._args_[:other._nargs])
+            _args.extend(other._args_[: other._nargs])
         return self.__class__(_args)
 
     def _apply_operation(self, result):

--- a/pyomo/core/tests/unit/test_derivs.py
+++ b/pyomo/core/tests/unit/test_derivs.py
@@ -322,6 +322,18 @@ class TestDerivs(unittest.TestCase):
         self.assertAlmostEqual(derivs[m.y], pyo.value(symbolic[m.y]), tol + 3)
         self.assertAlmostEqual(derivs[m.y], approx_deriv(e, m.y), tol)
 
+    def test_linear_exprs_issue_3096(self):
+        m = pyo.ConcreteModel()
+        m.y1 = pyo.Var(initialize=10)
+        m.y2 = pyo.Var(initialize=100)
+        e = (m.y1 - 0.5) * (m.y1 - 0.5) + (m.y2 - 0.5) * (m.y2 - 0.5)
+        derivs = reverse_ad(e)
+        self.assertEqual(derivs[m.y1], 19)
+        self.assertEqual(derivs[m.y2], 199)
+        symbolic = reverse_sd(e)
+        self.assertExpressionsEqual(symbolic[m.y1], m.y1 - 0.5 + m.y1 - 0.5)
+        self.assertExpressionsEqual(symbolic[m.y2], m.y2 - 0.5 + m.y2 - 0.5)
+
 
 class TestDifferentiate(unittest.TestCase):
     @unittest.skipUnless(sympy_available, "test requires sympy")

--- a/pyomo/core/tests/unit/test_numeric_expr.py
+++ b/pyomo/core/tests/unit/test_numeric_expr.py
@@ -1618,9 +1618,9 @@ class TestGenerate_ProductExpression(unittest.TestCase):
             ),
         )
         # Verify shared args...
-        self.assertIsNot(e1._args_, e2._args_)
-        self.assertIs(e1._args_, e3._args_)
-        self.assertIs(e1._args_, e.arg(1)._args_)
+        self.assertIs(e1._args_, e2._args_)
+        self.assertIsNot(e1._args_, e3._args_)
+        self.assertIs(e1._args_, e.arg(0)._args_)
         self.assertIs(e.arg(0).arg(0), e.arg(1).arg(0))
         self.assertIs(e.arg(0).arg(1), e.arg(1).arg(1))
 

--- a/pyomo/core/tests/unit/test_numeric_expr_api.py
+++ b/pyomo/core/tests/unit/test_numeric_expr_api.py
@@ -950,7 +950,14 @@ class TestExpressionDuplicateAPI(unittest.TestCase):
         f = e.create_node_with_local_data(e.args)
         self.assertIsNot(f, e)
         self.assertIs(type(f), type(e))
-        self.assertIs(f.args, e.args)
+        self.assertIsNot(f._args_, e._args_)
+        self.assertIsNot(f.args, e.args)
+
+        f = e.create_node_with_local_data(e._args_)
+        self.assertIsNot(f, e)
+        self.assertIs(type(f), type(e))
+        self.assertIs(f._args_, e._args_)
+        self.assertIsNot(f.args, e.args)
 
         f = e.create_node_with_local_data((m.x, 2, 3))
         self.assertIsNot(f, e)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #3096, superceeds #3098 

## Summary/Motivation:
This resolves #3096 by closing a loophole in the "immutability" of expressions.  For efficiency, `SumExpression` makes use of a mutable data structure (list) for storing the node arguments.  Prior to this PR, we would return the raw underlying argument list from `SumExpression.args`.  There are, however, edge cases where modifying either the expression or an entangled expression can cause that list to change.  This PR changes the SumExpression API so that SumExpression.args *always* makes a copy of the `_args_` list, thereby ensuring that the interface preserves the immutability that users expect.

Note that this PR has a negative effect on performance in the form of a ~1% slow-down on LP and NL writers (as observed in the performance test suite).

## Changes proposed in this PR:
- `SumExpression.args` now always returns a copy of the underlying argument list
- Add a test for #3096 
- Clean up some of the expression API (remove redundant code)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
