### PR TITLE
Import pandas through pyomo.common.dependencies

### DIFF
--- a/pyomo/contrib/parmest/examples/reactor_design/bootstrap_example.py
+++ b/pyomo/contrib/parmest/examples/reactor_design/bootstrap_example.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pandas as pd
+from pyomo.common.dependencies import pandas as pd
 from os.path import join, abspath, dirname
 import pyomo.contrib.parmest.parmest as parmest
 from pyomo.contrib.parmest.examples.reactor_design.reactor_design import (

--- a/pyomo/contrib/parmest/examples/reactor_design/datarec_example.py
+++ b/pyomo/contrib/parmest/examples/reactor_design/datarec_example.py
@@ -9,8 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import numpy as np
-import pandas as pd
+from pyomo.common.dependencies import numpy as np, pandas as pd
 import pyomo.contrib.parmest.parmest as parmest
 from pyomo.contrib.parmest.examples.reactor_design.reactor_design import (
     reactor_design_model,

--- a/pyomo/contrib/parmest/examples/reactor_design/leaveNout_example.py
+++ b/pyomo/contrib/parmest/examples/reactor_design/leaveNout_example.py
@@ -9,8 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import numpy as np
-import pandas as pd
+from pyomo.common.dependencies import numpy as np, pandas as pd
 from os.path import join, abspath, dirname
 import pyomo.contrib.parmest.parmest as parmest
 from pyomo.contrib.parmest.examples.reactor_design.reactor_design import (

--- a/pyomo/contrib/parmest/examples/reactor_design/likelihood_ratio_example.py
+++ b/pyomo/contrib/parmest/examples/reactor_design/likelihood_ratio_example.py
@@ -9,8 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import numpy as np
-import pandas as pd
+from pyomo.common.dependencies import numpy as np, pandas as pd
 from itertools import product
 from os.path import join, abspath, dirname
 import pyomo.contrib.parmest.parmest as parmest

--- a/pyomo/contrib/parmest/examples/reactor_design/multisensor_data_example.py
+++ b/pyomo/contrib/parmest/examples/reactor_design/multisensor_data_example.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pandas as pd
+from pyomo.common.dependencies import pandas as pd
 from os.path import join, abspath, dirname
 import pyomo.contrib.parmest.parmest as parmest
 from pyomo.contrib.parmest.examples.reactor_design.reactor_design import (

--- a/pyomo/contrib/parmest/examples/reactor_design/parameter_estimation_example.py
+++ b/pyomo/contrib/parmest/examples/reactor_design/parameter_estimation_example.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pandas as pd
+from pyomo.common.dependencies import pandas as pd
 from os.path import join, abspath, dirname
 import pyomo.contrib.parmest.parmest as parmest
 from pyomo.contrib.parmest.examples.reactor_design.reactor_design import (

--- a/pyomo/contrib/parmest/examples/reactor_design/reactor_design.py
+++ b/pyomo/contrib/parmest/examples/reactor_design/reactor_design.py
@@ -12,7 +12,7 @@
 Continuously stirred tank reactor model, based on
 pyomo/examples/doc/pyomobook/nonlinear-ch/react_design/ReactorDesign.py
 """
-import pandas as pd
+from pyomo.common.dependencies import pandas as pd
 from pyomo.environ import (
     ConcreteModel,
     Param,

--- a/pyomo/contrib/parmest/examples/reactor_design/timeseries_data_example.py
+++ b/pyomo/contrib/parmest/examples/reactor_design/timeseries_data_example.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pandas as pd
+from pyomo.common.dependencies import pandas as pd
 from os.path import join, abspath, dirname
 
 import pyomo.contrib.parmest.parmest as parmest

--- a/pyomo/contrib/parmest/examples/rooney_biegler/bootstrap_example.py
+++ b/pyomo/contrib/parmest/examples/rooney_biegler/bootstrap_example.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pandas as pd
+from pyomo.common.dependencies import pandas as pd
 import pyomo.contrib.parmest.parmest as parmest
 from pyomo.contrib.parmest.examples.rooney_biegler.rooney_biegler import (
     rooney_biegler_model,

--- a/pyomo/contrib/parmest/examples/rooney_biegler/likelihood_ratio_example.py
+++ b/pyomo/contrib/parmest/examples/rooney_biegler/likelihood_ratio_example.py
@@ -9,8 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import numpy as np
-import pandas as pd
+from pyomo.common.dependencies import numpy as np, pandas as pd
 from itertools import product
 import pyomo.contrib.parmest.parmest as parmest
 from pyomo.contrib.parmest.examples.rooney_biegler.rooney_biegler import (

--- a/pyomo/contrib/parmest/examples/rooney_biegler/parameter_estimation_example.py
+++ b/pyomo/contrib/parmest/examples/rooney_biegler/parameter_estimation_example.py
@@ -9,7 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pandas as pd
+from pyomo.common.dependencies import pandas as pd
 import pyomo.contrib.parmest.parmest as parmest
 from pyomo.contrib.parmest.examples.rooney_biegler.rooney_biegler import (
     rooney_biegler_model,

--- a/pyomo/contrib/parmest/examples/rooney_biegler/rooney_biegler.py
+++ b/pyomo/contrib/parmest/examples/rooney_biegler/rooney_biegler.py
@@ -15,7 +15,7 @@ model parameter uncertainty using nonlinear confidence regions. AIChE Journal,
 47(8), 1794-1804.
 """
 
-import pandas as pd
+from pyomo.common.dependencies import pandas as pd
 import pyomo.environ as pyo
 
 

--- a/pyomo/contrib/parmest/examples/rooney_biegler/rooney_biegler_with_constraint.py
+++ b/pyomo/contrib/parmest/examples/rooney_biegler/rooney_biegler_with_constraint.py
@@ -15,7 +15,7 @@ model parameter uncertainty using nonlinear confidence regions. AIChE Journal,
 47(8), 1794-1804.
 """
 
-import pandas as pd
+from pyomo.common.dependencies import pandas as pd
 import pyomo.environ as pyo
 
 

--- a/pyomo/contrib/parmest/examples/semibatch/parallel_example.py
+++ b/pyomo/contrib/parmest/examples/semibatch/parallel_example.py
@@ -14,8 +14,7 @@ The following script can be used to run semibatch parameter estimation in
 parallel and save results to files for later analysis and graphics.
 Example command: mpiexec -n 4 python parallel_example.py
 """
-import numpy as np
-import pandas as pd
+from pyomo.common.dependencies import numpy as np, pandas as pd
 from itertools import product
 from os.path import join, abspath, dirname
 import pyomo.contrib.parmest.parmest as parmest

--- a/pyomo/contrib/pynumero/examples/callback/cyipopt_functor_callback.py
+++ b/pyomo/contrib/pynumero/examples/callback/cyipopt_functor_callback.py
@@ -1,6 +1,6 @@
 import pyomo.environ as pyo
 from pyomo.contrib.pynumero.examples.callback.reactor_design import model as m
-import pandas as pd
+from pyomo.common.dependencies import pandas as pd
 
 """
 This example uses an iteration callback with a functor to store

--- a/pyomo/contrib/pynumero/examples/external_grey_box/param_est/generate_data.py
+++ b/pyomo/contrib/pynumero/examples/external_grey_box/param_est/generate_data.py
@@ -1,7 +1,7 @@
 import pyomo.environ as pyo
 import numpy.random as rnd
 import pyomo.contrib.pynumero.examples.external_grey_box.param_est.models as pm
-import pandas as pd
+from pyomo.common.dependencies import pandas as pd
 
 
 def generate_data(N, UA_mean, UA_std, seed=42):

--- a/pyomo/contrib/pynumero/examples/external_grey_box/param_est/perform_estimation.py
+++ b/pyomo/contrib/pynumero/examples/external_grey_box/param_est/perform_estimation.py
@@ -1,7 +1,7 @@
 import sys
 import pyomo.environ as pyo
 import numpy.random as rnd
-import pandas as pd
+from pyomo.common.dependencies import pandas as pd
 import pyomo.contrib.pynumero.examples.external_grey_box.param_est.models as po
 
 

--- a/pyomo/contrib/sensitivity_toolbox/examples/rooney_biegler.py
+++ b/pyomo/contrib/sensitivity_toolbox/examples/rooney_biegler.py
@@ -15,7 +15,7 @@ Rooney Biegler model, based on Rooney, W. C. and Biegler, L. T. (2001). Design f
 model parameter uncertainty using nonlinear confidence regions. AIChE Journal, 
 47(8), 1794-1804.
 """
-import pandas as pd
+from pyomo.common.dependencies import pandas as pd
 import pyomo.environ as pyo
 
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This updates examples to import pandas through `pyomo.common.dependencies`.  

This change was motivated by a deprecation warning that pandas emits upon import that was breaking the Pyomo package layout tests.

## Changes proposed in this PR:
- Import pandas through `pyomo.common.dependencies` and not directly

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
