### PR TITLE
contrib.gdpopt: Adding missing import for gdpopt.enumerate

### DIFF
--- a/pyomo/contrib/gdpopt/plugins.py
+++ b/pyomo/contrib/gdpopt/plugins.py
@@ -16,3 +16,4 @@ def load():
     import pyomo.contrib.gdpopt.branch_and_bound
     import pyomo.contrib.gdpopt.loa
     import pyomo.contrib.gdpopt.ric
+    import pyomo.contrib.gdpopt.enumerate


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

One-line fix: We weren't registering `gdpopt.enumerate` when the rest of gdpopt is imported. This will make it so that now we are.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
