### PR TITLE
avoid duplicate entries in config _decl_order

### DIFF
--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -1692,9 +1692,12 @@ class ConfigBase(object):
                 if preserve_implicit or k in self._declared:
                     v = self._data[k]
                     ans._data[k] = _tmp = v(preserve_implicit=preserve_implicit)
-                    ans._decl_order.append(k)
-                    if k in self._declared:
-                        ans._declared.add(k)
+                    if k not in ans._declared:
+                        # the above if statement is needed just in case the options
+                        # were declared in the constructor above
+                        ans._decl_order.append(k)
+                        if k in self._declared:
+                            ans._declared.add(k)
                     _tmp._parent = ans
                     _tmp._name = v._name
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Summary/Motivation:
This fixes a bug that causes `config.display()` to print multiple times.

```

In [1]: from pyomo.common.config import ConfigDict, ConfigValue

In [2]: class Conf(ConfigDict):
   ...:     def __init__(
   ...:         self,
   ...:         description=None,
   ...:         doc=None,
   ...:         implicit=False,
   ...:         implicit_domain=None,
   ...:         visibility=0,
   ...:     ):
   ...:         super().__init__(
   ...:             description=description,
   ...:             doc=doc,
   ...:             implicit=implicit,
   ...:             implicit_domain=implicit_domain,
   ...:             visibility=visibility,
   ...:         )
   ...:         self.foo = self.declare('foo', ConfigValue(default=1))
   ...:

In [3]: c1 = Conf()

In [4]: c1.display()
foo: 1

In [5]: c2 = c1()

In [6]: c2.display()
foo: 1
foo: 1
```

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
