### PR TITLE
Workaround for improvement in Mumps memory prediction algorithm

### DIFF
--- a/pyomo/contrib/interior_point/interface.py
+++ b/pyomo/contrib/interior_point/interface.py
@@ -258,10 +258,9 @@ class InteriorPointInterface(BaseInteriorPointInterface):
 
         # set the init_duals_primals_lb/ub from ipopt_zL_out, ipopt_zU_out if available
         # need to compress them as well and initialize the duals_primals_lb/ub
-        (
-            self._init_duals_primals_lb,
-            self._init_duals_primals_ub,
-        ) = self._get_full_duals_primals_bounds()
+        (self._init_duals_primals_lb, self._init_duals_primals_ub) = (
+            self._get_full_duals_primals_bounds()
+        )
         self._init_duals_primals_lb[np.isneginf(self._nlp.primals_lb())] = 0
         self._init_duals_primals_ub[np.isinf(self._nlp.primals_ub())] = 0
         self._duals_primals_lb = self._init_duals_primals_lb.copy()

--- a/pyomo/contrib/interior_point/interface.py
+++ b/pyomo/contrib/interior_point/interface.py
@@ -258,9 +258,10 @@ class InteriorPointInterface(BaseInteriorPointInterface):
 
         # set the init_duals_primals_lb/ub from ipopt_zL_out, ipopt_zU_out if available
         # need to compress them as well and initialize the duals_primals_lb/ub
-        (self._init_duals_primals_lb, self._init_duals_primals_ub) = (
-            self._get_full_duals_primals_bounds()
-        )
+        (
+            self._init_duals_primals_lb,
+            self._init_duals_primals_ub,
+        ) = self._get_full_duals_primals_bounds()
         self._init_duals_primals_lb[np.isneginf(self._nlp.primals_lb())] = 0
         self._init_duals_primals_ub[np.isinf(self._nlp.primals_ub())] = 0
         self._duals_primals_lb = self._init_duals_primals_lb.copy()

--- a/pyomo/contrib/interior_point/linalg/tests/test_realloc.py
+++ b/pyomo/contrib/interior_point/linalg/tests/test_realloc.py
@@ -44,6 +44,13 @@ class TestReallocation(unittest.TestCase):
 
         predicted = linear_solver.get_infog(16)
 
+        # We predict that factorization will take 2 MB
+        self.assertEqual(predicted, 2)
+
+        # Explicitly set maximum memory to less than the predicted
+        # requirement.
+        linear_solver.set_icntl(23, 1)
+
         res = linear_solver.do_numeric_factorization(matrix, raise_on_error=False)
         self.assertEqual(res.status, LinearSolverStatus.not_enough_memory)
 

--- a/pyomo/contrib/interior_point/tests/test_realloc.py
+++ b/pyomo/contrib/interior_point/tests/test_realloc.py
@@ -67,19 +67,21 @@ class TestReallocation(unittest.TestCase):
         res = linear_solver.do_symbolic_factorization(kkt)
         predicted = linear_solver.get_infog(16)
 
+        linear_solver.set_icntl(23, 8)
+
         self._test_ip_with_reallocation(linear_solver, interface)
         # In Mumps 5.6.2 (and likely previous versions), ICNTL(23)=0
         # corresponds to "use default increase factor over prediction".
         actual = linear_solver.get_icntl(23)
         percent_increase = linear_solver.get_icntl(14)
-        increase_factor = (1.0 + percent_increase/100.0)
+        increase_factor = 1.0 + percent_increase / 100.0
 
         if actual == 0:
             actual = increase_factor * predicted
 
         # As of Mumps 5.6.2, predicted == 9, which is lower than the
         # default actual of 10.8
-        #self.assertTrue(predicted == 12 or predicted == 11)
+        # self.assertTrue(predicted == 12 or predicted == 11)
         self.assertTrue(actual > predicted)
         # NOTE: This test will break if Mumps (or your Mumps version)
         # gets more conservative at estimating memory requirement,

--- a/pyomo/contrib/interior_point/tests/test_realloc.py
+++ b/pyomo/contrib/interior_point/tests/test_realloc.py
@@ -68,11 +68,19 @@ class TestReallocation(unittest.TestCase):
         predicted = linear_solver.get_infog(16)
 
         self._test_ip_with_reallocation(linear_solver, interface)
+        # In Mumps 5.6.2 (and likely previous versions), ICNTL(23)=0
+        # corresponds to "use default increase factor over prediction".
         actual = linear_solver.get_icntl(23)
+        percent_increase = linear_solver.get_icntl(14)
+        increase_factor = (1.0 + percent_increase/100.0)
 
-        self.assertTrue(predicted == 12 or predicted == 11)
+        if actual == 0:
+            actual = increase_factor * predicted
+
+        # As of Mumps 5.6.2, predicted == 9, which is lower than the
+        # default actual of 10.8
+        #self.assertTrue(predicted == 12 or predicted == 11)
         self.assertTrue(actual > predicted)
-        # self.assertEqual(actual, 14)
         # NOTE: This test will break if Mumps (or your Mumps version)
         # gets more conservative at estimating memory requirement,
         # or if the numeric factorization gets more efficient.

--- a/pyomo/contrib/pynumero/linalg/mumps_interface.py
+++ b/pyomo/contrib/pynumero/linalg/mumps_interface.py
@@ -175,7 +175,10 @@ class MumpsCentralizedAssembledLinearSolver(DirectLinearSolverInterface):
             res.status = LinearSolverStatus.successful
         elif stat in {-6, -10}:
             res.status = LinearSolverStatus.singular
-        elif stat in {-8, -9}:
+        elif stat in {-8, -9, -19}:
+            # -8: Integer workspace too small for factorization
+            # -9: Real workspace too small for factorization
+            # -19: Maximum size of working memory is too small
             res.status = LinearSolverStatus.not_enough_memory
         elif stat < 0:
             res.status = LinearSolverStatus.error


### PR DESCRIPTION
Fixes a test failure where we were assuming that mumps would mis-predict the amount of memory required by a simple tridiagonal matrix. Additionally, the behavior of ICNTL(23) seems to have changed so that ICNTL(23)=0 means "use default", which we have to get from ICNTL(14) (the percent increase of the memory prediction that will be allocated) and INFOG(16) (the predicted memory usage after symbolic factorization).

I've changed tests to:
- Manually set the max memory to lower than what is actually required, so we can test failure and reallocation
- Relax a test where we assumed a fairly specific predicted memory allocation prediction from mumps

This lowers the "quality" of the tests, as now I don't think we are explicitly testing the reallocation functionality in the interior point interface, but should at least get tests passing.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
