### PR TITLE
Prevent duplicate entries in ConfigDict declaration order

### DIFF
--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -2383,11 +2383,7 @@ class ConfigDict(ConfigBase, Mapping):
 
     content_filters = {None, 'all', 'userdata'}
 
-    __slots__ = (
-        '_declared',
-        '_implicit_declaration',
-        '_implicit_domain',
-    )
+    __slots__ = ('_declared', '_implicit_declaration', '_implicit_domain')
     _all_slots = set(__slots__ + ConfigBase.__slots__)
 
     def __init__(
@@ -2608,9 +2604,7 @@ class ConfigDict(ConfigBase, Mapping):
     def value(self, accessValue=True):
         if accessValue:
             self._userAccessed = True
-        return {
-            cfg._name: cfg.value(accessValue) for cfg in self._data.values()
-        }
+        return {cfg._name: cfg.value(accessValue) for cfg in self._data.values()}
 
     def set_value(self, value, skip_implicit=False):
         if value is None:

--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -31,6 +31,8 @@ import sys
 import textwrap
 import types
 
+from operator import attrgetter
+
 from pyomo.common.collections import Sequence, Mapping
 from pyomo.common.deprecation import (
     deprecated,
@@ -1688,11 +1690,9 @@ class ConfigBase(object):
             ans.reset()
         else:
             # Copy over any Dict definitions
-            for k in self._decl_order:
+            for k, v in self._data.items():
                 if preserve_implicit or k in self._declared:
-                    v = self._data[k]
                     ans._data[k] = _tmp = v(preserve_implicit=preserve_implicit)
-                    ans._decl_order.append(k)
                     if k in self._declared:
                         ans._declared.add(k)
                     _tmp._parent = ans
@@ -2384,7 +2384,6 @@ class ConfigDict(ConfigBase, Mapping):
     content_filters = {None, 'all', 'userdata'}
 
     __slots__ = (
-        '_decl_order',
         '_declared',
         '_implicit_declaration',
         '_implicit_domain',
@@ -2399,7 +2398,6 @@ class ConfigDict(ConfigBase, Mapping):
         implicit_domain=None,
         visibility=0,
     ):
-        self._decl_order = []
         self._declared = set()
         self._implicit_declaration = implicit
         if (
@@ -2478,7 +2476,6 @@ class ConfigDict(ConfigBase, Mapping):
         _key = str(key).replace(' ', '_')
         del self._data[_key]
         # Clean up the other data structures
-        self._decl_order.remove(_key)
         self._declared.discard(_key)
 
     def __contains__(self, key):
@@ -2486,10 +2483,10 @@ class ConfigDict(ConfigBase, Mapping):
         return _key in self._data
 
     def __len__(self):
-        return self._decl_order.__len__()
+        return len(self._data)
 
     def __iter__(self):
-        return (self._data[key]._name for key in self._decl_order)
+        return map(attrgetter('_name'), self._data.values())
 
     def __getattr__(self, name):
         # Note: __getattr__ is only called after all "usual" attribute
@@ -2526,13 +2523,12 @@ class ConfigDict(ConfigBase, Mapping):
 
     def values(self):
         self._userAccessed = True
-        for key in self._decl_order:
-            yield self[key]
+        return map(self.__getitem__, self._data)
 
     def items(self):
         self._userAccessed = True
-        for key in self._decl_order:
-            yield (self._data[key]._name, self[key])
+        for key, val in self._data.items():
+            yield (val._name, self[key])
 
     @deprecated('The iterkeys method is deprecated. Use dict.keys().', version='6.0')
     def iterkeys(self):
@@ -2561,7 +2557,6 @@ class ConfigDict(ConfigBase, Mapping):
                 % (name, self.name(True))
             )
         self._data[_name] = config
-        self._decl_order.append(_name)
         config._parent = self
         config._name = name
         return config
@@ -2614,8 +2609,7 @@ class ConfigDict(ConfigBase, Mapping):
         if accessValue:
             self._userAccessed = True
         return {
-            cfg._name: cfg.value(accessValue)
-            for cfg in map(self._data.__getitem__, self._decl_order)
+            cfg._name: cfg.value(accessValue) for cfg in self._data.values()
         }
 
     def set_value(self, value, skip_implicit=False):
@@ -2636,7 +2630,7 @@ class ConfigDict(ConfigBase, Mapping):
             _key = str(key).replace(' ', '_')
             if _key in self._data:
                 # str(key) may not be key... store the mapping so that
-                # when we later iterate over the _decl_order, we can map
+                # when we later iterate over the _data, we can map
                 # the local keys back to the incoming value keys.
                 _decl_map[_key] = key
             else:
@@ -2659,7 +2653,7 @@ class ConfigDict(ConfigBase, Mapping):
             # We want to set the values in declaration order (so that
             # things are deterministic and in case a validation depends
             # on the order)
-            for key in self._decl_order:
+            for key in self._data:
                 if key in _decl_map:
                     self[key] = value[_decl_map[key]]
             # implicit data is declared at the end (in sorted order)
@@ -2675,16 +2669,11 @@ class ConfigDict(ConfigBase, Mapping):
     def reset(self):
         # Reset the values in the order they were declared.  This
         # allows reset functions to have a deterministic ordering.
-        def _keep(self, key):
-            keep = key in self._declared
-            if keep:
-                self._data[key].reset()
+        for key, val in list(self._data.items()):
+            if key in self._declared:
+                val.reset()
             else:
                 del self._data[key]
-            return keep
-
-        # this is an in-place slice of a list...
-        self._decl_order[:] = [x for x in self._decl_order if _keep(self, x)]
         self._userAccessed = False
         self._userSet = False
 
@@ -2695,8 +2684,7 @@ class ConfigDict(ConfigBase, Mapping):
             yield (level, prefix, None, self)
             if level is not None:
                 level += 1
-        for key in self._decl_order:
-            cfg = self._data[key]
+        for cfg in self._data.values():
             yield from cfg._data_collector(level, cfg._name + ': ', visibility, docMode)
 
 

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -3027,6 +3027,46 @@ option_2: int, default=5
             self.assertEqual(add_docstring_list("", ExampleClass.CONFIG), ref)
         self.assertIn('add_docstring_list is deprecated', LOG.getvalue())
 
+    def test_declaration_in_init(self):
+        class CustomConfig(ConfigDict):
+            def __init__(
+                    self,
+                    description=None,
+                    doc=None,
+                    implicit=False,
+                    implicit_domain=None,
+                    visibility=0,
+            ):
+                super().__init__(
+                    description=description,
+                    doc=doc,
+                    implicit=implicit,
+                    implicit_domain=implicit_domain,
+                    visibility=visibility,
+                )
+
+                self.declare('time_limit', ConfigValue(domain=NonNegativeFloat))
+                self.declare('stream_solver', ConfigValue(domain=bool))
+
+        cfg = CustomConfig()
+        OUT = StringIO()
+        cfg.display(ostream=OUT)
+        self.assertEqual(
+            "time_limit: None\nstream_solver: None\n",
+            OUT.getvalue()
+        )
+
+        # Test that creating a copy of a ConfigDict with declared fields
+        # in the __init__ does not result in duplicate outputs in the
+        # display (reported in PR #3113)
+        cfg2 = cfg({'time_limit': 10, 'stream_solver': 0})
+        OUT = StringIO()
+        cfg2.display(ostream=OUT)
+        self.assertEqual(
+            "time_limit: 10.0\nstream_solver: false\n",
+            OUT.getvalue()
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -3030,12 +3030,12 @@ option_2: int, default=5
     def test_declaration_in_init(self):
         class CustomConfig(ConfigDict):
             def __init__(
-                    self,
-                    description=None,
-                    doc=None,
-                    implicit=False,
-                    implicit_domain=None,
-                    visibility=0,
+                self,
+                description=None,
+                doc=None,
+                implicit=False,
+                implicit_domain=None,
+                visibility=0,
             ):
                 super().__init__(
                     description=description,
@@ -3051,10 +3051,7 @@ option_2: int, default=5
         cfg = CustomConfig()
         OUT = StringIO()
         cfg.display(ostream=OUT)
-        self.assertEqual(
-            "time_limit: None\nstream_solver: None\n",
-            OUT.getvalue()
-        )
+        self.assertEqual("time_limit: None\nstream_solver: None\n", OUT.getvalue())
 
         # Test that creating a copy of a ConfigDict with declared fields
         # in the __init__ does not result in duplicate outputs in the
@@ -3062,10 +3059,7 @@ option_2: int, default=5
         cfg2 = cfg({'time_limit': 10, 'stream_solver': 0})
         OUT = StringIO()
         cfg2.display(ostream=OUT)
-        self.assertEqual(
-            "time_limit: 10.0\nstream_solver: false\n",
-            OUT.getvalue()
-        )
+        self.assertEqual("time_limit: 10.0\nstream_solver: false\n", OUT.getvalue())
 
 
 if __name__ == "__main__":

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -3051,7 +3051,11 @@ option_2: int, default=5
         cfg = CustomConfig()
         OUT = StringIO()
         cfg.display(ostream=OUT)
-        self.assertEqual("time_limit: None\nstream_solver: None\n", OUT.getvalue())
+        # Note: pypy outputs "None" as "null"
+        self.assertEqual(
+            "time_limit: None\nstream_solver: None\n",
+            OUT.getvalue().replace('null', 'None'),
+        )
 
         # Test that creating a copy of a ConfigDict with declared fields
         # in the __init__ does not result in duplicate outputs in the
@@ -3059,7 +3063,10 @@ option_2: int, default=5
         cfg2 = cfg({'time_limit': 10, 'stream_solver': 0})
         OUT = StringIO()
         cfg2.display(ostream=OUT)
-        self.assertEqual("time_limit: 10.0\nstream_solver: false\n", OUT.getvalue())
+        self.assertEqual(
+            "time_limit: 10.0\nstream_solver: false\n",
+            OUT.getvalue().replace('null', 'None'),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #N/A, supersedes #3113

## Summary/Motivation:
#3113 pointed out that ConfigDict instances that declared attributes in the `__init__` could end up with duplicate entries in the `_decl_order` list, resulting in, e.g., duplicate entries in the `display()` output.  `_decl_order` was only added to resolve non-determinism in `dict` for Python before 3.7.  As we no longer support those versions of Python, the entire `_decl_order` logic can be removed (and implicitly resolves the problem reported in #3113).

## Changes proposed in this PR:
- Remove `_decl_order` from `ConfigDict`
- Add a test for the `display()` behavior observed in #3113.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
