### PR TITLE
Create contributors data gathering script

### DIFF
--- a/scripts/admin/README.md
+++ b/scripts/admin/README.md
@@ -1,0 +1,28 @@
+# Contributors Script
+
+The `contributors.py` script is intended to be used to determine contributors
+to a public GitHub repository within a given time frame.
+
+## Requirements
+
+1. Python 3.7+
+1. [PyGithub](https://pypi.org/project/PyGithub/)
+1. A [GitHub Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with `repo` access, exported to the environment variable `GH_TOKEN`
+
+## Usage
+
+```
+Usage: contributors.py <Org/Repo> <start_date> <end_date>
+   <Org/Repo>   : the GitHub organization/repository combo (e.g., Pyomo/pyomo)
+   <start_date> : date from which to start exploring contributors in YYYY-MM-DD
+   <end_date>   : date at which to stop exploring contributors in YYYY-MM-DD
+
+ALSO REQUIRED: Please generate a GitHub token (with repo permissions) and export to the environment variable GH_TOKEN.
+   Visit GitHub's official documentation for more details.
+```
+
+## Results
+
+A list of contributors will print to the terminal upon completion. More detailed
+information, including authors, committers, reviewers, and pull requests, can
+be found in the `contributors-start_date-end_date.json` generated file. 

--- a/scripts/admin/contributors.py
+++ b/scripts/admin/contributors.py
@@ -231,3 +231,4 @@ if __name__ == '__main__':
     json_filename = f"contributors-{sys.argv[2]}-{sys.argv[3]}.json"
     with open(json_filename, 'w') as file:
         json.dump(contrib_info, file, default=set_default)
+    print(f"\nDetailed information can be found in {json_filename}.")


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
This adds a small script that can assist with gathering relevant contributor information for a given repository during a given timeframe. It was requested as part of an IDAES technical meeting.

## Changes proposed in this PR:
- New useful contributor script

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
