### PR TITLE
Fix RangeSet.__len__ when defined by floats

### DIFF
--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -2668,7 +2668,7 @@ class _FiniteRangeSetData(
             if r.start == r.end:
                 return 1
             else:
-                return (r.end - r.start) // r.step + 1
+                return int((r.end - r.start) // r.step) + 1
         else:
             return sum(1 for _ in self)
 

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -1240,6 +1240,7 @@ class Test_SetOf_and_RangeSet(unittest.TestCase):
 
         # Test floats
         self.assertEqual(RangeSet(0.0, 2.0), RangeSet(0.0, 2.0))
+        self.assertEqual(RangeSet(0.0, 2.0), RangeSet(0, 2))
 
     def test_inequality(self):
         self.assertTrue(SetOf([1, 2, 3]) <= SetOf({1, 2, 3}))

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -1238,6 +1238,9 @@ class Test_SetOf_and_RangeSet(unittest.TestCase):
         # Test types that cannot be case to set
         self.assertNotEqual(SetOf({3}), 3)
 
+        # Test floats
+        self.assertEqual(RangeSet(0.0, 2.0), RangeSet(0.0, 2.0))
+
     def test_inequality(self):
         self.assertTrue(SetOf([1, 2, 3]) <= SetOf({1, 2, 3}))
         self.assertFalse(SetOf([1, 2, 3]) < SetOf({1, 2, 3}))


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This resolves an error where `RangeSet.__len__()` raised an exception when the RangeSet was defined by float endpoints.

## Changes proposed in this PR:
- Ensure that the result from `RangeSet.__len__()` is cast to an int
- Add a test exercising the observed error

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
