### PR TITLE
Update `ExitNodeDispatcher` to support subclasses, improved customization

### DIFF
--- a/pyomo/repn/util.py
+++ b/pyomo/repn/util.py
@@ -387,42 +387,49 @@ class ExitNodeDispatcher(collections.defaultdict):
         super().__init__(None, *args, **kwargs)
 
     def __missing__(self, key):
-        return functools.partial(self.register_dispatcher, key=key)
-
-    def register_dispatcher(self, visitor, node, *data, key=None):
+        if type(key) is tuple:
+            node_class = key[0]
+        else:
+            node_class = key
+        bases = node_class.__mro__
+        # Note: if we add an `etype`, then this special-case can be removed
         if (
-            isinstance(node, _named_subexpression_types)
-            or type(node) is kernel.expression.noclone
+            issubclass(node_class, _named_subexpression_types)
+            or node_class is kernel.expression.noclone
         ):
-            base_type = Expression
-        elif not node.is_potentially_variable():
-            base_type = node.potentially_variable_base_class()
-        else:
-            base_type = node.__class__
-        if isinstance(key, tuple):
-            base_key = (base_type,) + key[1:]
-            # Only cache handlers for unary, binary and ternary operators
-            cache = len(key) <= 4
-        else:
-            base_key = base_type
-            cache = True
-        if base_key in self:
-            fcn = self[base_key]
-        elif base_type in self:
-            fcn = self[base_type]
-        elif any((k[0] if k.__class__ is tuple else k) is base_type for k in self):
+            bases = [Expression]
+        fcn = None
+        for base_type in bases:
+            if isinstance(key, tuple):
+                base_key = (base_type,) + key[1:]
+                # Only cache handlers for unary, binary and ternary operators
+                cache = len(key) <= 4
+            else:
+                base_key = base_type
+                cache = True
+            if base_key in self:
+                fcn = self[base_key]
+            elif base_type in self:
+                fcn = self[base_type]
+            elif any((k[0] if type(k) is tuple else k) is base_type for k in self):
+                raise DeveloperError(
+                    f"Base expression key '{base_key}' not found when inserting "
+                    f"dispatcher for node '{node_class.__name__}' while walking "
+                    "expression tree."
+                )
+        if fcn is None:
+            if type(key) is tuple:
+                node_class = key[0]
+            else:
+                node_class = key
             raise DeveloperError(
-                f"Base expression key '{base_key}' not found when inserting dispatcher"
-                f" for node '{type(node).__name__}' while walking expression tree."
+                f"Unexpected expression node type '{node_class.__name__}' "
+                f"found while walking expression tree."
             )
-        else:
-            raise DeveloperError(
-                f"Unexpected expression node type '{type(node).__name__}' "
-                "found while walking expression tree."
-            )
+            return self.unexpected_expression_type(key)
         if cache:
             self[key] = fcn
-        return fcn(visitor, node, *data)
+        return fcn
 
 
 def apply_node_operation(node, args):

--- a/pyomo/repn/util.py
+++ b/pyomo/repn/util.py
@@ -418,18 +418,20 @@ class ExitNodeDispatcher(collections.defaultdict):
                     "expression tree."
                 )
         if fcn is None:
-            if type(key) is tuple:
-                node_class = key[0]
-            else:
-                node_class = key
-            raise DeveloperError(
-                f"Unexpected expression node type '{node_class.__name__}' "
-                f"found while walking expression tree."
-            )
             return self.unexpected_expression_type(key)
         if cache:
             self[key] = fcn
         return fcn
+
+    def unexpected_expression_type(self, key):
+        if type(key) is tuple:
+            node_class = key[0]
+        else:
+            node_class = key
+        raise DeveloperError(
+            f"Unexpected expression node type '{node_class.__name__}' "
+            f"found while walking expression tree."
+        )
 
 
 def apply_node_operation(node, args):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This PR updates the `ExitNodeDispatcher` to better support extensibility:
- Automatically handle derived classes using known base class handlers
- Provide a hook to change the behavior for unknown classes

Note that this does not address #3111 (although these changes are compatible with adding an `etype` class attribute).

## Changes proposed in this PR:
- Support automatic handling of derived expression classes using known base class handlers
- Provide `unexpected_expression_type()` method so derived dispatchers can change the behavior for unbknown expression types (enables simpler implementation of #3086)
- Add tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
