### PR TITLE
Extend `fbbt.ExpressionBoundsVisitor` to handle relational expressions and Expr_if

### DIFF
--- a/pyomo/contrib/fbbt/expression_bounds_walker.py
+++ b/pyomo/contrib/fbbt/expression_bounds_walker.py
@@ -13,6 +13,11 @@ import logging
 from math import pi
 from pyomo.common.collections import ComponentMap
 from pyomo.contrib.fbbt.interval import (
+    Bool,
+    eq,
+    ineq,
+    ranged,
+    if_,
     add,
     acos,
     asin,
@@ -220,6 +225,26 @@ def _handle_UnaryFunctionExpression(visitor, node, arg):
 def _handle_named_expression(visitor, node, arg):
     visitor.leaf_bounds[node] = arg
     return arg
+
+
+def _handle_unknowable_bounds(visitor, node, arg):
+    return -inf, inf
+
+
+def _handle_equality(visitor, node, arg1, arg2):
+    return eq(*arg1, *arg2)
+
+
+def _handle_inequality(visitor, node, arg1, arg2):
+    return ineq(*arg1, *arg2)
+
+
+def _handle_ranged(visitor, node, arg1, arg2, arg3):
+    return ranged(*arg1, *arg2, *arg3)
+
+
+def _handle_expr_if(visitor, node, arg1, arg2, arg3):
+    return if_(*arg1, *arg2, *arg3)
 
 
 _unary_function_dispatcher = {

--- a/pyomo/contrib/fbbt/expression_bounds_walker.py
+++ b/pyomo/contrib/fbbt/expression_bounds_walker.py
@@ -13,7 +13,7 @@ import logging
 from math import pi
 from pyomo.common.collections import ComponentMap
 from pyomo.contrib.fbbt.interval import (
-    Bool,
+    BoolFlag,
     eq,
     ineq,
     ranged,
@@ -81,7 +81,7 @@ class ExpressionBoundsBeforeChildDispatcher(BeforeChildDispatcher):
 
     @staticmethod
     def _before_native_logical(visitor, child):
-        return False, (Bool(child), Bool(child))
+        return False, (BoolFlag(child), BoolFlag(child))
 
     @staticmethod
     def _before_var(visitor, child):
@@ -266,7 +266,7 @@ class ExpressionBoundsExitNodeDispatcher(ExitNodeDispatcher):
         if isinstance(node, NumericExpression):
             ans = -inf, inf
         elif isinstance(node, BooleanExpression):
-            ans = Bool(False), Bool(True)
+            ans = BoolFlag(False), BoolFlag(True)
         else:
             super().unexpected_expression_type(visitor, node, *args)
         logger.warning(

--- a/pyomo/contrib/fbbt/interval.py
+++ b/pyomo/contrib/fbbt/interval.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 inf = float('inf')
 
 
-class bool_(object):
+class _bool_flag(object):
     def __init__(self, val):
         self._val = val
 
@@ -49,11 +49,11 @@ class bool_(object):
     __rpow__ = _op
 
 
-_true = bool_(True)
-_false = bool_(False)
+_true = _bool_flag(True)
+_false = _bool_flag(False)
 
 
-def Bool(val):
+def BoolFlag(val):
     return _true if val else _false
 
 

--- a/pyomo/contrib/fbbt/interval.py
+++ b/pyomo/contrib/fbbt/interval.py
@@ -17,6 +17,95 @@ logger = logging.getLogger(__name__)
 inf = float('inf')
 
 
+class bool_(object):
+    def __init__(self, val):
+        self._val = val
+
+    def __bool__(self):
+        return self._val
+
+    def _op(self, *others):
+        raise ValueError(
+            f"{self._val!r} ({type(self._val).__name__}) is not a valid numeric type. "
+            f"Cannot compute bounds on expression."
+        )
+
+    def __repr__(self):
+        return repr(self._val)
+
+    __float__ = _op
+    __int__ = _op
+    __abs__ = _op
+    __neg__ = _op
+    __add__ = _op
+    __sub__ = _op
+    __mul__ = _op
+    __div__ = _op
+    __pow__ = _op
+    __radd__ = _op
+    __rsub__ = _op
+    __rmul__ = _op
+    __rdiv__ = _op
+    __rpow__ = _op
+
+
+_true = bool_(True)
+_false = bool_(False)
+
+
+def Bool(val):
+    return _true if val else _false
+
+
+def ineq(xl, xu, yl, yu):
+    ans = []
+    if yl < xu:
+        ans.append(_false)
+    if xl <= yu:
+        ans.append(_true)
+    assert ans
+    if len(ans) == 1:
+        ans.append(ans[0])
+    return tuple(ans)
+
+
+def eq(xl, xu, yl, yu):
+    ans = []
+    if xl != xu or yl != yu or xl != yl:
+        ans.append(_false)
+    if xl <= yu and yl <= xu:
+        ans.append(_true)
+    assert ans
+    if len(ans) == 1:
+        ans.append(ans[0])
+    return tuple(ans)
+
+
+def ranged(xl, xu, yl, yu, zl, zu):
+    lb = ineq(xl, xu, yl, yu)
+    ub = ineq(yl, yu, zl, zu)
+    ans = []
+    if not lb[0] or not ub[0]:
+        ans.append(_false)
+    if lb[1] and ub[1]:
+        ans.append(_true)
+    if len(ans) == 1:
+        ans.append(ans[0])
+    return tuple(ans)
+
+
+def if_(il, iu, tl, tu, fl, fu):
+    l = []
+    u = []
+    if iu:
+        l.append(tl)
+        u.append(tu)
+    if not il:
+        l.append(fl)
+        u.append(fu)
+    return min(l), max(u)
+
+
 def add(xl, xu, yl, yu):
     return xl + yl, xu + yu
 

--- a/pyomo/contrib/fbbt/interval.py
+++ b/pyomo/contrib/fbbt/interval.py
@@ -58,6 +58,14 @@ def Bool(val):
 
 
 def ineq(xl, xu, yl, yu):
+    """Compute the "bounds" on an InequalityExpression
+
+    Note this is *not* performing interval arithmetic: we are
+    calculating the "bounds" on a RelationalExpression (whose domain is
+    {True, False}).  Therefore we are determining if `x` can be less
+    than `y`, `x` can not be less than `y`, or both.
+
+    """
     ans = []
     if yl < xu:
         ans.append(_false)
@@ -70,6 +78,14 @@ def ineq(xl, xu, yl, yu):
 
 
 def eq(xl, xu, yl, yu):
+    """Compute the "bounds" on an EqualityExpression
+
+    Note this is *not* performing interval arithmetic: we are
+    calculating the "bounds" on a RelationalExpression (whose domain is
+    {True, False}).  Therefore we are determining if `x` can be equal to
+    `y`, `x` can not be equal to `y`, or both.
+
+    """
     ans = []
     if xl != xu or yl != yu or xl != yl:
         ans.append(_false)
@@ -82,6 +98,14 @@ def eq(xl, xu, yl, yu):
 
 
 def ranged(xl, xu, yl, yu, zl, zu):
+    """Compute the "bounds" on a RangedExpression
+
+    Note this is *not* performing interval arithmetic: we are
+    calculating the "bounds" on a RelationalExpression (whose domain is
+    {True, False}).  Therefore we are determining if `y` can be between
+    `z` and `z`, `y` can be outside the range `x` and `z`, or both.
+
+    """
     lb = ineq(xl, xu, yl, yu)
     ub = ineq(yl, yu, zl, zu)
     ans = []
@@ -128,12 +152,18 @@ def mul(xl, xu, yl, yu):
 
 
 def inv(xl, xu, feasibility_tol):
-    """
-    The case where xl is very slightly positive but should be very slightly negative (or xu is very slightly negative
-    but should be very slightly positive) should not be an issue. Suppose xu is 2 and xl is 1e-15 but should be -1e-15.
-    The bounds obtained from this function will be [0.5, 1e15] or [0.5, inf), depending on the value of
-    feasibility_tol. The true bounds are (-inf, -1e15] U [0.5, inf), where U is union. The exclusion of (-inf, -1e15]
-    should be acceptable. Additionally, it very important to return a non-negative interval when xl is non-negative.
+    """Compute the inverse of an interval
+
+    The case where xl is very slightly positive but should be very
+    slightly negative (or xu is very slightly negative but should be
+    very slightly positive) should not be an issue. Suppose xu is 2 and
+    xl is 1e-15 but should be -1e-15.  The bounds obtained from this
+    function will be [0.5, 1e15] or [0.5, inf), depending on the value
+    of feasibility_tol. The true bounds are (-inf, -1e15] U [0.5, inf),
+    where U is union. The exclusion of (-inf, -1e15] should be
+    acceptable. Additionally, it very important to return a non-negative
+    interval when xl is non-negative.
+
     """
     if xu - xl <= -feasibility_tol:
         raise InfeasibleConstraintException(
@@ -178,9 +208,8 @@ def power(xl, xu, yl, yu, feasibility_tol):
     Compute bounds on x**y.
     """
     if xl > 0:
-        """
-        If x is always positive, things are simple. We only need to worry about the sign of y.
-        """
+        # If x is always positive, things are simple. We only need to
+        # worry about the sign of y.
         if yl < 0 < yu:
             lb = min(xu**yl, xl**yu)
             ub = max(xl**yl, xu**yu)
@@ -270,14 +299,15 @@ def power(xl, xu, yl, yu, feasibility_tol):
 
 
 def _inverse_power1(zl, zu, yl, yu, orig_xl, orig_xu, feasibility_tol):
-    """
-    z = x**y => compute bounds on x.
+    """z = x**y => compute bounds on x.
 
     First, start by computing bounds on x with
 
         x = exp(ln(z) / y)
 
-    However, if y is an integer, then x can be negative, so there are several special cases. See the docs below.
+    However, if y is an integer, then x can be negative, so there are
+    several special cases. See the docs below.
+
     """
     xl, xu = log(zl, zu)
     xl, xu = div(xl, xu, yl, yu, feasibility_tol)
@@ -288,22 +318,31 @@ def _inverse_power1(zl, zu, yl, yu, orig_xl, orig_xu, feasibility_tol):
         y = yl
         if y == 0:
             # Anything to the power of 0 is 1, so if y is 0, then x can be anything
-            # (assuming zl <= 1 <= zu, which is enforced when traversing the tree in the other direction)
+            # (assuming zl <= 1 <= zu, which is enforced when traversing
+            # the tree in the other direction)
             xl = -inf
             xu = inf
         elif y % 2 == 0:
-            """
-            if y is even, then there are two primary cases (note that it is much easier to walk through these
-            while looking at plots):
+            """if y is even, then there are two primary cases (note that it is much
+            easier to walk through these while looking at plots):
+
             case 1: y is positive
-                x**y is convex, positive, and symmetric. The bounds on x depend on the lower bound of z. If zl <= 0,
-                then xl should simply be -xu. However, if zl > 0, then we may be able to say something better. For
-                example, if the original lower bound on x is positive, then we can keep xl computed from
-                x = exp(ln(z) / y). Furthermore, if the original lower bound on x is larger than -xl computed from
-                x = exp(ln(z) / y), then we can still keep the xl computed from x = exp(ln(z) / y). Similar logic
-                applies to the upper bound of x.
+
+                x**y is convex, positive, and symmetric. The bounds on x
+                depend on the lower bound of z. If zl <= 0, then xl
+                should simply be -xu. However, if zl > 0, then we may be
+                able to say something better. For example, if the
+                original lower bound on x is positive, then we can keep
+                xl computed from x = exp(ln(z) / y). Furthermore, if the
+                original lower bound on x is larger than -xl computed
+                from x = exp(ln(z) / y), then we can still keep the xl
+                computed from x = exp(ln(z) / y). Similar logic applies
+                to the upper bound of x.
+
             case 2: y is negative
+
                 The ideas are similar to case 1.
+
             """
             if zu + feasibility_tol < 0:
                 raise InfeasibleConstraintException(
@@ -351,16 +390,25 @@ def _inverse_power1(zl, zu, yl, yu, orig_xl, orig_xu, feasibility_tol):
                 xl = _xl
                 xu = _xu
         else:  # y % 2 == 1
-            """
-            y is odd.
+            """y is odd.
+
             Case 1: y is positive
-                x**y is monotonically increasing. If y is positive, then we can can compute the bounds on x using
-                x = z**(1/y) and the signs on xl and xu depend on the signs of zl and zu.
+
+                x**y is monotonically increasing. If y is positive, then
+                we can can compute the bounds on x using x = z**(1/y)
+                and the signs on xl and xu depend on the signs of zl and
+                zu.
+
             Case 2: y is negative
-                Again, this is easier to visualize with a plot. x**y approaches zero when x approaches -inf or inf.
-                Thus, if zl < 0 < zu, then no bounds can be inferred for x. If z is positive (zl >=0 ) then we can
-                use the bounds computed from x = exp(ln(z) / y). If z is negative (zu <= 0), then we live in the
-                bottom left quadrant, xl depends on zu, and xu depends on zl.
+
+                Again, this is easier to visualize with a plot. x**y
+                approaches zero when x approaches -inf or inf.  Thus, if
+                zl < 0 < zu, then no bounds can be inferred for x. If z
+                is positive (zl >=0 ) then we can use the bounds
+                computed from x = exp(ln(z) / y). If z is negative (zu
+                <= 0), then we live in the bottom left quadrant, xl
+                depends on zu, and xu depends on zl.
+
             """
             if y > 0:
                 xl = abs(zl) ** (1.0 / y)
@@ -387,12 +435,13 @@ def _inverse_power1(zl, zu, yl, yu, orig_xl, orig_xu, feasibility_tol):
 
 
 def _inverse_power2(zl, zu, xl, xu, feasiblity_tol):
-    """
-    z = x**y => compute bounds on y
+    """z = x**y => compute bounds on y
     y = ln(z) / ln(x)
 
-    This function assumes the exponent can be fractional, so x must be positive. This method should not be called
-    if the exponent is an integer.
+    This function assumes the exponent can be fractional, so x must be
+    positive. This method should not be called if the exponent is an
+    integer.
+
     """
     if xu <= 0:
         raise IntervalException(
@@ -480,10 +529,12 @@ def sin(xl, xu):
     ub: float
     """
 
-    # if there is a minimum between xl and xu, then the lower bound is -1. Minimums occur at 2*pi*n - pi/2
-    # find the minimum value of i such that 2*pi*i - pi/2 >= xl. Then round i up. If 2*pi*i - pi/2 is still less
-    # than or equal to xu, then there is a minimum between xl and xu. Thus the lb is -1. Otherwise, the minimum
-    # occurs at either xl or xu
+    # if there is a minimum between xl and xu, then the lower bound is
+    # -1. Minimums occur at 2*pi*n - pi/2 find the minimum value of i
+    # such that 2*pi*i - pi/2 >= xl. Then round i up. If 2*pi*i - pi/2
+    # is still less than or equal to xu, then there is a minimum between
+    # xl and xu. Thus the lb is -1. Otherwise, the minimum occurs at
+    # either xl or xu
     if xl <= -inf or xu >= inf:
         return -1, 1
     pi = math.pi
@@ -495,7 +546,8 @@ def sin(xl, xu):
     else:
         lb = min(math.sin(xl), math.sin(xu))
 
-    # if there is a maximum between xl and xu, then the upper bound is 1. Maximums occur at 2*pi*n + pi/2
+    # if there is a maximum between xl and xu, then the upper bound is
+    # 1. Maximums occur at 2*pi*n + pi/2
     i = (xu - pi / 2) / (2 * pi)
     i = math.floor(i)
     x_at_max = 2 * pi * i + pi / 2
@@ -521,10 +573,12 @@ def cos(xl, xu):
     ub: float
     """
 
-    # if there is a minimum between xl and xu, then the lower bound is -1. Minimums occur at 2*pi*n - pi
-    # find the minimum value of i such that 2*pi*i - pi >= xl. Then round i up. If 2*pi*i - pi/2 is still less
-    # than or equal to xu, then there is a minimum between xl and xu. Thus the lb is -1. Otherwise, the minimum
-    # occurs at either xl or xu
+    # if there is a minimum between xl and xu, then the lower bound is
+    # -1. Minimums occur at 2*pi*n - pi find the minimum value of i such
+    # that 2*pi*i - pi >= xl. Then round i up. If 2*pi*i - pi/2 is still
+    # less than or equal to xu, then there is a minimum between xl and
+    # xu. Thus the lb is -1. Otherwise, the minimum occurs at either xl
+    # or xu
     if xl <= -inf or xu >= inf:
         return -1, 1
     pi = math.pi
@@ -536,7 +590,8 @@ def cos(xl, xu):
     else:
         lb = min(math.cos(xl), math.cos(xu))
 
-    # if there is a maximum between xl and xu, then the upper bound is 1. Maximums occur at 2*pi*n
+    # if there is a maximum between xl and xu, then the upper bound is
+    # 1. Maximums occur at 2*pi*n
     i = (xu) / (2 * pi)
     i = math.floor(i)
     x_at_max = 2 * pi * i
@@ -562,10 +617,12 @@ def tan(xl, xu):
     ub: float
     """
 
-    # tan goes to -inf and inf at every pi*i + pi/2 (integer i). If one of these values is between xl and xu, then
-    # the lb is -inf and the ub is inf. Otherwise the minimum occurs at xl and the maximum occurs at xu.
-    # find the minimum value of i such that pi*i + pi/2 >= xl. Then round i up. If pi*i + pi/2 is still less
-    # than or equal to xu, then there is an undefined point between xl and xu.
+    # tan goes to -inf and inf at every pi*i + pi/2 (integer i). If one
+    # of these values is between xl and xu, then the lb is -inf and the
+    # ub is inf. Otherwise the minimum occurs at xl and the maximum
+    # occurs at xu.  find the minimum value of i such that pi*i + pi/2
+    # >= xl. Then round i up. If pi*i + pi/2 is still less than or equal
+    # to xu, then there is an undefined point between xl and xu.
     if xl <= -inf or xu >= inf:
         return -inf, inf
     pi = math.pi
@@ -609,12 +666,12 @@ def asin(xl, xu, yl, yu, feasibility_tol):
     if yl <= -inf:
         lb = yl
     elif xl <= math.sin(yl) <= xu:
-        # if sin(yl) >= xl then yl satisfies the bounds on x, and the lower bound of y cannot be improved
+        # if sin(yl) >= xl then yl satisfies the bounds on x, and the
+        # lower bound of y cannot be improved
         lb = yl
     elif math.sin(yl) < xl:
-        """
-        we can only push yl up from its current value to the next lowest value such that xl = sin(y). In other words,
-        we need to
+        """we can only push yl up from its current value to the next lowest
+        value such that xl = sin(y). In other words, we need to
 
         min y
         s.t.
@@ -622,19 +679,21 @@ def asin(xl, xu, yl, yu, feasibility_tol):
             y >= yl
 
         globally.
+
         """
-        # first find the next minimum of x = sin(y). Minimums occur at y = 2*pi*n - pi/2 for integer n.
+        # first find the next minimum of x = sin(y). Minimums occur at y
+        # = 2*pi*n - pi/2 for integer n.
         i = (yl + pi / 2) / (2 * pi)
         i1 = math.floor(i)
         i2 = math.ceil(i)
         i1 = 2 * pi * i1 - pi / 2
         i2 = 2 * pi * i2 - pi / 2
-        # now find the next value of y such that xl = sin(y). This can be computed by a distance from the minimum (i).
+        # now find the next value of y such that xl = sin(y). This can
+        # be computed by a distance from the minimum (i).
         y_tmp = math.asin(xl)  # this will give me a value between -pi/2 and pi/2
-        dist = y_tmp - (
-            -pi / 2
-        )  # this is the distance between the minimum of the sin function and a value that
-        # satisfies xl = sin(y)
+        dist = y_tmp - (-pi / 2)
+        # this is the distance between the minimum of the sin function
+        # and a value that satisfies xl = sin(y)
         lb1 = i1 + dist
         lb2 = i2 + dist
         if lb1 >= yl - feasibility_tol:
@@ -722,12 +781,12 @@ def acos(xl, xu, yl, yu, feasibility_tol):
     if yl <= -inf:
         lb = yl
     elif xl <= math.cos(yl) <= xu:
-        # if xl <= cos(yl) <= xu then yl satisfies the bounds on x, and the lower bound of y cannot be improved
+        # if xl <= cos(yl) <= xu then yl satisfies the bounds on x, and
+        # the lower bound of y cannot be improved
         lb = yl
     elif math.cos(yl) < xl:
-        """
-        we can only push yl up from its current value to the next lowest value such that xl = cos(y). In other words,
-        we need to
+        """we can only push yl up from its current value to the next lowest
+        value such that xl = cos(y). In other words, we need to
 
         min y
         s.t.
@@ -735,19 +794,21 @@ def acos(xl, xu, yl, yu, feasibility_tol):
             y >= yl
 
         globally.
+
         """
-        # first find the next minimum of x = cos(y). Minimums occur at y = 2*pi*n - pi for integer n.
+        # first find the next minimum of x = cos(y). Minimums occur at y
+        # = 2*pi*n - pi for integer n.
         i = (yl + pi) / (2 * pi)
         i1 = math.floor(i)
         i2 = math.ceil(i)
         i1 = 2 * pi * i1 - pi
         i2 = 2 * pi * i2 - pi
-        # now find the next value of y such that xl = cos(y). This can be computed by a distance from the minimum (i).
+        # now find the next value of y such that xl = cos(y). This can
+        # be computed by a distance from the minimum (i).
         y_tmp = math.acos(xl)  # this will give me a value between 0 and pi
-        dist = (
-            pi - y_tmp
-        )  # this is the distance between the minimum of the sin function and a value that
-        # satisfies xl = sin(y)
+        dist = pi - y_tmp
+        # this is the distance between the minimum of the sin function
+        # and a value that satisfies xl = sin(y)
         lb1 = i1 + dist
         lb2 = i2 + dist
         if lb1 >= yl - feasibility_tol:

--- a/pyomo/contrib/fbbt/tests/test_expression_bounds_walker.py
+++ b/pyomo/contrib/fbbt/tests/test_expression_bounds_walker.py
@@ -10,10 +10,33 @@
 #  ___________________________________________________________________________
 
 import math
-from pyomo.environ import exp, log, log10, sin, cos, tan, asin, acos, atan, sqrt
 import pyomo.common.unittest as unittest
-from pyomo.contrib.fbbt.expression_bounds_walker import ExpressionBoundsVisitor
-from pyomo.core import Any, ConcreteModel, Expression, Param, Var
+
+from pyomo.environ import (
+    exp,
+    log,
+    log10,
+    sin,
+    cos,
+    tan,
+    asin,
+    acos,
+    atan,
+    sqrt,
+    inequality,
+    Expr_if,
+    Any,
+    ConcreteModel,
+    Expression,
+    Param,
+    Var,
+)
+
+from pyomo.common.errors import DeveloperError
+from pyomo.common.log import LoggingIntercept
+from pyomo.contrib.fbbt.expression_bounds_walker import ExpressionBoundsVisitor, inf
+from pyomo.contrib.fbbt.interval import _true, _false
+from pyomo.core.expr import ExpressionBase, NumericExpression, BooleanExpression
 
 
 class TestExpressionBoundsWalker(unittest.TestCase):

--- a/pyomo/contrib/fbbt/tests/test_expression_bounds_walker.py
+++ b/pyomo/contrib/fbbt/tests/test_expression_bounds_walker.py
@@ -273,11 +273,19 @@ class TestExpressionBoundsWalker(unittest.TestCase):
 
     def test_invalid_numeric_type(self):
         m = self.make_model()
-        m.p = Param(initialize=True, domain=Any)
+        m.p = Param(initialize=True, mutable=True, domain=Any)
         visitor = ExpressionBoundsVisitor()
         with self.assertRaisesRegex(
             ValueError,
-            r"True \(<class 'bool'>\) is not a valid numeric type. "
+            r"True \(bool\) is not a valid numeric type. "
+            r"Cannot compute bounds on expression.",
+        ):
+            lb, ub = visitor.walk_expression(m.p + m.y)
+
+        m.p.set_value(None)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"None \(NoneType\) is not a valid numeric type. "
             r"Cannot compute bounds on expression.",
         ):
             lb, ub = visitor.walk_expression(m.p + m.y)
@@ -288,7 +296,7 @@ class TestExpressionBoundsWalker(unittest.TestCase):
         visitor = ExpressionBoundsVisitor()
         with self.assertRaisesRegex(
             ValueError,
-            r"'True' \(<class 'str'>\) is not a valid numeric type. "
+            r"'True' \(str\) is not a valid numeric type. "
             r"Cannot compute bounds on expression.",
         ):
             lb, ub = visitor.walk_expression(m.p + m.y)

--- a/pyomo/core/expr/__init__.py
+++ b/pyomo/core/expr/__init__.py
@@ -56,6 +56,7 @@ from .logical_expr import (
     #
     BooleanValue,
     BooleanConstant,
+    BooleanExpression,
     BooleanExpressionBase,
     #
     UnaryBooleanExpression,

--- a/pyomo/repn/tests/test_linear.py
+++ b/pyomo/repn/tests/test_linear.py
@@ -1517,7 +1517,7 @@ class TestLinear(unittest.TestCase):
                 bcd.register_dispatcher(visitor, 5), (False, (linear._CONSTANT, 5))
             )
             self.assertEqual(len(bcd), 1)
-            self.assertIs(bcd[int], bcd._before_native)
+            self.assertIs(bcd[int], bcd._before_native_numeric)
             # complex type
             self.assertEqual(
                 bcd.register_dispatcher(visitor, 5j), (False, (linear._CONSTANT, 5j))

--- a/pyomo/repn/tests/test_util.py
+++ b/pyomo/repn/tests/test_util.py
@@ -729,7 +729,6 @@ class TestRepnUtils(unittest.TestCase):
         self.assertEqual(len(end), 10)
         self.assertIn((UnknownExpression, 6, 7), end)
 
-
     def test_BeforeChildDispatcher_registration(self):
         class BeforeChildDispatcherTester(BeforeChildDispatcher):
             @staticmethod

--- a/pyomo/repn/tests/test_util.py
+++ b/pyomo/repn/tests/test_util.py
@@ -750,7 +750,7 @@ class TestRepnUtils(unittest.TestCase):
 
         node = 5
         self.assertEqual(bcd[node.__class__](None, node), (False, (_CONSTANT, 5)))
-        self.assertIs(bcd[int], bcd._before_native)
+        self.assertIs(bcd[int], bcd._before_native_numeric)
         self.assertEqual(len(bcd), 1)
 
         node = 'string'
@@ -787,7 +787,7 @@ class TestRepnUtils(unittest.TestCase):
 
         node = new_int(5)
         self.assertEqual(bcd[node.__class__](None, node), (False, (_CONSTANT, 5)))
-        self.assertIs(bcd[new_int], bcd._before_native)
+        self.assertIs(bcd[new_int], bcd._before_native_numeric)
         self.assertEqual(len(bcd), 5)
 
         node = []

--- a/pyomo/repn/tests/test_util.py
+++ b/pyomo/repn/tests/test_util.py
@@ -757,8 +757,7 @@ class TestRepnUtils(unittest.TestCase):
         ans = bcd[node.__class__](None, node)
         self.assertEqual(ans, (False, (_CONSTANT, InvalidNumber(node))))
         self.assertEqual(
-            ''.join(ans[1][1].causes),
-            "'string' (str) is not a valid numeric type",
+            ''.join(ans[1][1].causes), "'string' (str) is not a valid numeric type"
         )
         self.assertIs(bcd[str], bcd._before_string)
         self.assertEqual(len(bcd), 2)
@@ -767,8 +766,7 @@ class TestRepnUtils(unittest.TestCase):
         ans = bcd[node.__class__](None, node)
         self.assertEqual(ans, (False, (_CONSTANT, InvalidNumber(node))))
         self.assertEqual(
-            ''.join(ans[1][1].causes),
-            "True (bool) is not a valid numeric type",
+            ''.join(ans[1][1].causes), "True (bool) is not a valid numeric type"
         )
         self.assertIs(bcd[bool], bcd._before_native_logical)
         self.assertEqual(len(bcd), 3)

--- a/pyomo/repn/tests/test_util.py
+++ b/pyomo/repn/tests/test_util.py
@@ -717,14 +717,14 @@ class TestRepnUtils(unittest.TestCase):
             DeveloperError, r".*Unexpected expression node type 'UnknownExpression'"
         ):
             end[node.__class__](None, node, *node.args)
-        self.assertEqual(len(end), 8)
+        self.assertEqual(len(end), 9)
 
         node = UnknownExpression((6, 7))
         with self.assertRaisesRegex(
             DeveloperError, r".*Unexpected expression node type 'UnknownExpression'"
         ):
             end[node.__class__, 6, 7](None, node, *node.args)
-        self.assertEqual(len(end), 8)
+        self.assertEqual(len(end), 10)
 
     def test_BeforeChildDispatcher_registration(self):
         class BeforeChildDispatcherTester(BeforeChildDispatcher):
@@ -758,7 +758,7 @@ class TestRepnUtils(unittest.TestCase):
         self.assertEqual(ans, (False, (_CONSTANT, InvalidNumber(node))))
         self.assertEqual(
             ''.join(ans[1][1].causes),
-            "'string' (<class 'str'>) is not a valid numeric type",
+            "'string' (str) is not a valid numeric type",
         )
         self.assertIs(bcd[str], bcd._before_string)
         self.assertEqual(len(bcd), 2)
@@ -768,9 +768,9 @@ class TestRepnUtils(unittest.TestCase):
         self.assertEqual(ans, (False, (_CONSTANT, InvalidNumber(node))))
         self.assertEqual(
             ''.join(ans[1][1].causes),
-            "True (<class 'bool'>) is not a valid numeric type",
+            "True (bool) is not a valid numeric type",
         )
-        self.assertIs(bcd[bool], bcd._before_invalid)
+        self.assertIs(bcd[bool], bcd._before_native_logical)
         self.assertEqual(len(bcd), 3)
 
         node = 1j
@@ -794,7 +794,7 @@ class TestRepnUtils(unittest.TestCase):
         ans = bcd[node.__class__](None, node)
         self.assertEqual(ans, (False, (_CONSTANT, InvalidNumber([]))))
         self.assertEqual(
-            ''.join(ans[1][1].causes), "[] (<class 'list'>) is not a valid numeric type"
+            ''.join(ans[1][1].causes), "[] (list) is not a valid numeric type"
         )
         self.assertIs(bcd[list], bcd._before_invalid)
         self.assertEqual(len(bcd), 6)

--- a/pyomo/repn/tests/test_util.py
+++ b/pyomo/repn/tests/test_util.py
@@ -699,6 +699,7 @@ class TestRepnUtils(unittest.TestCase):
 
         self.assertEqual(end[node.__class__, 3, 4, 5, 6](None, node, *node.args), 6)
         self.assertEqual(len(end), 7)
+        # We don't cache etypes with more than 3 arguments
         self.assertNotIn((SumExpression, 3, 4, 5, 6), end)
 
         class NewProductExpression(ProductExpression):
@@ -718,6 +719,7 @@ class TestRepnUtils(unittest.TestCase):
         ):
             end[node.__class__](None, node, *node.args)
         self.assertEqual(len(end), 9)
+        self.assertIn(UnknownExpression, end)
 
         node = UnknownExpression((6, 7))
         with self.assertRaisesRegex(
@@ -725,6 +727,8 @@ class TestRepnUtils(unittest.TestCase):
         ):
             end[node.__class__, 6, 7](None, node, *node.args)
         self.assertEqual(len(end), 10)
+        self.assertIn((UnknownExpression, 6, 7), end)
+
 
     def test_BeforeChildDispatcher_registration(self):
         class BeforeChildDispatcherTester(BeforeChildDispatcher):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #3083 .

## Summary/Motivation:
This is an extended implementation of #3086 that switches the handling of unrecognized types from generating exceptions to emitting warnings.  It also fixes #3083 by adding support for relational expressions and `Expr_if`.

I think it would be worth a future PR to revisit the design of the BeforeChildDispatcher to simplify the amount of custom code required between the LinearRepnVisitor / AMPLRepnVisitor and the ExpressionBoundsVisitor.

## Changes proposed in this PR:
- Extend `ExpressionBoundsVisitor` to support relational and `Expr_if` expression s
- `ExpressionBoundsVisitor` should not raise exceptions for unrecognized numeric / logical expressions (instead just emit a warning)
- Clean up some error messages (and make them a little more user friendly)
- Cover additional edge cases where Var / Param can inject invalid values into the bounds processing

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
