### PR TITLE
Fix lbb solve_data bug

### DIFF
--- a/pyomo/contrib/gdpopt/branch_and_bound.py
+++ b/pyomo/contrib/gdpopt/branch_and_bound.py
@@ -230,12 +230,12 @@ class GDP_LBB_Solver(_GDPoptAlgorithm):
                 no_feasible_soln = float('inf')
                 self.LB = (
                     node_data.obj_lb
-                    if solve_data.objective_sense == minimize
+                    if self.objective_sense == minimize
                     else -no_feasible_soln
                 )
                 self.UB = (
                     no_feasible_soln
-                    if solve_data.objective_sense == minimize
+                    if self.objective_sense == minimize
                     else -node_data.obj_lb
                 )
                 config.logger.info(


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #3132 .

## Summary/Motivation:
The `solve_data` was designed to be removed in both `gdpopt` and `mindtpy`. This pull request addresses the omission by removing two instances of `solve_data` from the `gdpopt.lbb` code.


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
