### PR TITLE
NLv2: only raise exception for empty models in the legacy API

### DIFF
--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -346,6 +346,17 @@ class NLWriter(object):
             row_fname
         ) as ROWFILE, _open(col_fname) as COLFILE:
             info = self.write(model, FILE, ROWFILE, COLFILE, config=config)
+        if not info.variables:
+            # This exception is included for compatibility with the
+            # original NL writer v1.
+            os.remove(filename)
+            os.remove(row_filename)
+            os.remove(col_filename)
+            raise ValueError(
+                "No variables appear in the Pyomo model constraints or"
+                " objective. This is not supported by the NL file interface"
+            )
+
         # Historically, the NL writer communicated the external function
         # libraries back to the ASL interface through the PYOMO_AMPLFUNC
         # environment variable.
@@ -854,13 +865,6 @@ class _NLWriter_impl(object):
         con_vars = con_vars_linear | con_vars_nonlinear
         all_vars = con_vars | obj_vars
         n_vars = len(all_vars)
-        if n_vars < 1:
-            # TODO: Remove this.  This exception is included for
-            # compatibility with the original NL writer v1.
-            raise ValueError(
-                "No variables appear in the Pyomo model constraints or"
-                " objective. This is not supported by the NL file interface"
-            )
 
         continuous_vars = set()
         binary_vars = set()

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -350,8 +350,8 @@ class NLWriter(object):
             # This exception is included for compatibility with the
             # original NL writer v1.
             os.remove(filename)
-            os.remove(row_filename)
-            os.remove(col_filename)
+            os.remove(row_fname)
+            os.remove(col_fname)
             raise ValueError(
                 "No variables appear in the Pyomo model constraints or"
                 " objective. This is not supported by the NL file interface"

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -350,8 +350,9 @@ class NLWriter(object):
             # This exception is included for compatibility with the
             # original NL writer v1.
             os.remove(filename)
-            os.remove(row_fname)
-            os.remove(col_fname)
+            if config.symbolic_solver_labels:
+                os.remove(row_fname)
+                os.remove(col_fname)
             raise ValueError(
                 "No variables appear in the Pyomo model constraints or"
                 " objective. This is not supported by the NL file interface"


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #3131  .

## Summary/Motivation:
This updates the NLv2 writer to only raise an exception for empty models (no variables in either objectives or constraints) when it is called using the legacy "call" interface.  The new recommended interface will not raise an exception and instead rely on the caller (the solver interface) to inspect the returned list of variables and do the correct thing when that list is empty.

## Changes proposed in this PR:
- Move the exception for an empty model from the core writer method and into the logacy `__call__` interface.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
