### PR TITLE
Remove usage of `__all__`

### DIFF
--- a/pyomo/common/_command.py
+++ b/pyomo/common/_command.py
@@ -13,8 +13,6 @@
 Management of Pyomo commands
 """
 
-__all__ = ['pyomo_command', 'get_pyomo_commands']
-
 import logging
 
 logger = logging.getLogger('pyomo.common')

--- a/pyomo/contrib/pynumero/interfaces/ampl_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/ampl_nlp.py
@@ -27,10 +27,8 @@ import numpy as np
 from pyomo.common.deprecation import deprecated
 from pyomo.contrib.pynumero.interfaces.nlp import ExtendedNLP
 
-__all__ = ['AslNLP', 'AmplNLP']
 
-
-# ToDo: need to add support for modifying bounds.
+# TODO: need to add support for modifying bounds.
 # support for changing variable bounds seems possible.
 # support for changing inequality bounds would require more work. (this is less frequent?)
 # TODO: check performance impacts of caching - memory and computational time.

--- a/pyomo/contrib/pynumero/interfaces/nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/nlp.py
@@ -50,9 +50,8 @@ evaluate_jacobian_ineq.
 .. rubric:: Contents
 
 """
-import abc
 
-__all__ = ['NLP']
+import abc
 
 
 class NLP(object, metaclass=abc.ABCMeta):

--- a/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
+++ b/pyomo/contrib/pynumero/interfaces/pyomo_nlp.py
@@ -28,9 +28,6 @@ from pyomo.contrib.pynumero.interfaces.nlp import NLP
 from .external_grey_box import ExternalGreyBoxBlock
 
 
-__all__ = ['PyomoNLP']
-
-
 # TODO: There are todos in the code below
 class PyomoNLP(AslNLP):
     def __init__(self, pyomo_model, nl_file_options=None):

--- a/pyomo/contrib/pynumero/sparse/block_matrix.py
+++ b/pyomo/contrib/pynumero/sparse/block_matrix.py
@@ -31,8 +31,6 @@ import numpy as np
 import logging
 import warnings
 
-__all__ = ['BlockMatrix', 'NotFullyDefinedBlockMatrixError']
-
 
 logger = logging.getLogger(__name__)
 

--- a/pyomo/contrib/pynumero/sparse/block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/block_vector.py
@@ -27,8 +27,6 @@ import operator
 from ..dependencies import numpy as np
 from .base_block import BaseBlockVector
 
-__all__ = ['BlockVector', 'NotFullyDefinedBlockVectorError']
-
 
 class NotFullyDefinedBlockVectorError(Exception):
     pass

--- a/pyomo/contrib/pynumero/sparse/mpi_block_matrix.py
+++ b/pyomo/contrib/pynumero/sparse/mpi_block_matrix.py
@@ -32,8 +32,6 @@ import numpy as np
 from scipy.sparse import coo_matrix
 import operator
 
-__all__ = ['MPIBlockMatrix']
-
 
 def assert_block_structure(mat: MPIBlockMatrix):
     if mat.has_undefined_row_sizes() or mat.has_undefined_col_sizes():

--- a/pyomo/contrib/pynumero/sparse/mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/mpi_block_vector.py
@@ -17,8 +17,6 @@ from .block_vector import assert_block_structure as block_vector_assert_block_st
 import numpy as np
 import operator
 
-__all__ = ['MPIBlockVector']
-
 
 def assert_block_structure(vec):
     if vec.has_none:

--- a/pyomo/core/base/PyomoModel.py
+++ b/pyomo/core/base/PyomoModel.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['Model', 'ConcreteModel', 'AbstractModel', 'global_option']
-
 import logging
 import sys
 from weakref import ref as weakref_ref
@@ -20,7 +18,7 @@ import math
 from pyomo.common import timing
 from pyomo.common.collections import Bunch
 from pyomo.common.dependencies import pympler, pympler_available
-from pyomo.common.deprecation import deprecated, deprecation_warning
+from pyomo.common.deprecation import deprecated
 from pyomo.common.gc_manager import PauseGC
 from pyomo.common.log import is_debug_set
 from pyomo.common.numeric_types import value
@@ -34,11 +32,10 @@ from pyomo.core.base.suffix import active_import_suffix_generator
 from pyomo.core.base.block import ScalarBlock
 from pyomo.core.base.set import Set
 from pyomo.core.base.componentuid import ComponentUID
-from pyomo.core.base.transformation import TransformationFactory
 from pyomo.core.base.label import CNameLabeler, CuidLabeler
 from pyomo.dataportal.DataPortal import DataPortal
 
-from pyomo.opt.results import SolverResults, Solution, SolverStatus, UndefinedData
+from pyomo.opt.results import Solution, SolverStatus, UndefinedData
 
 from contextlib import nullcontext
 from io import StringIO

--- a/pyomo/core/base/action.py
+++ b/pyomo/core/base/action.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['BuildAction']
-
 import logging
 import types
 
@@ -24,7 +22,8 @@ logger = logging.getLogger('pyomo.core')
 
 
 @ModelComponentFactory.register(
-    "A component that performs arbitrary actions during model construction.  The action rule is applied to every index value."
+    "A component that performs arbitrary actions during model construction.  "
+    "The action rule is applied to every index value."
 )
 class BuildAction(IndexedComponent):
     """A build action, which executes a rule for all valid indices.

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -9,20 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = [
-    'Block',
-    'TraversalStrategy',
-    'SortComponents',
-    'active_components',
-    'components',
-    'active_components_data',
-    'components_data',
-    'SimpleBlock',
-    'ScalarBlock',
-]
-
 import copy
-import enum
 import logging
 import sys
 import weakref
@@ -41,7 +28,6 @@ from pyomo.common.deprecation import deprecated, deprecation_warning, RenamedCla
 from pyomo.common.formatting import StreamIndenter
 from pyomo.common.gc_manager import PauseGC
 from pyomo.common.log import is_debug_set
-from pyomo.common.sorting import sorted_robust
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base.component import (
     Component,

--- a/pyomo/core/base/blockutil.py
+++ b/pyomo/core/base/blockutil.py
@@ -12,8 +12,6 @@
 # the purpose of this file is to collect all utility methods that compute
 # attributes of blocks, based on their contents.
 
-__all__ = ['has_discrete_variables']
-
 from pyomo.common import deprecated
 from pyomo.core.base import Var
 

--- a/pyomo/core/base/check.py
+++ b/pyomo/core/base/check.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['BuildCheck']
-
 import logging
 import types
 

--- a/pyomo/core/base/component_order.py
+++ b/pyomo/core/base/component_order.py
@@ -9,9 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-
-__all__ = ['items', 'display_items', 'display_name']
-
 from pyomo.core.base.set import Set, RangeSet
 from pyomo.core.base.param import Param
 from pyomo.core.base.var import Var

--- a/pyomo/core/base/connector.py
+++ b/pyomo/core/base/connector.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['Connector']
-
 import logging
 import sys
 from weakref import ref as weakref_ref
@@ -26,7 +24,6 @@ from pyomo.core.base.component import ComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import IndexedComponent
 from pyomo.core.base.misc import apply_indexed_rule
-from pyomo.core.base.transformation import TransformationFactory
 
 logger = logging.getLogger('pyomo.core')
 

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -9,18 +9,8 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = [
-    'Constraint',
-    '_ConstraintData',
-    'ConstraintList',
-    'simple_constraint_rule',
-    'simple_constraintlist_rule',
-]
-
-import io
 import sys
 import logging
-import math
 from weakref import ref as weakref_ref
 from pyomo.common.pyomo_typing import overload
 

--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -9,15 +9,13 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['Expression', '_ExpressionData']
-
 import sys
 import logging
 from weakref import ref as weakref_ref
 from pyomo.common.pyomo_typing import overload
 
 from pyomo.common.log import is_debug_set
-from pyomo.common.deprecation import deprecated, RenamedClass
+from pyomo.common.deprecation import RenamedClass
 from pyomo.common.modeling import NOTSET
 from pyomo.common.formatting import tabular_writer
 from pyomo.common.timing import ConstructionTimer
@@ -32,7 +30,6 @@ import pyomo.core.expr.numeric_expr as numeric_expr
 from pyomo.core.base.component import ComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index
 from pyomo.core.base.indexed_component import IndexedComponent, UnindexedComponent_set
-from pyomo.core.base.misc import apply_indexed_rule
 from pyomo.core.expr.numvalue import as_numeric
 from pyomo.core.base.initializer import Initializer
 

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -43,8 +43,6 @@ import pyomo.core.expr as EXPR
 from pyomo.core.base.component import Component
 from pyomo.core.base.units_container import units
 
-__all__ = ('ExternalFunction',)
-
 logger = logging.getLogger('pyomo.core')
 nan = float('nan')
 

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -9,15 +9,10 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['IndexedComponent', 'ActiveIndexedComponent']
-
-import enum
 import inspect
 import logging
 import sys
 import textwrap
-
-from copy import deepcopy
 
 import pyomo.core.expr as EXPR
 import pyomo.core.base as BASE
@@ -32,9 +27,8 @@ from pyomo.core.pyomoobject import PyomoObject
 from pyomo.common import DeveloperError
 from pyomo.common.autoslots import fast_deepcopy
 from pyomo.common.collections import ComponentSet
-from pyomo.common.dependencies import numpy as np, numpy_available
 from pyomo.common.deprecation import deprecated, deprecation_warning
-from pyomo.common.errors import DeveloperError, TemplateExpressionError
+from pyomo.common.errors import TemplateExpressionError
 from pyomo.common.modeling import NOTSET
 from pyomo.common.numeric_types import native_types
 from pyomo.common.sorting import sorted_robust

--- a/pyomo/core/base/instance2dat.py
+++ b/pyomo/core/base/instance2dat.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['instance2dat']
-
 import types
 from pyomo.core.base import Set, Param, value
 

--- a/pyomo/core/base/label.py
+++ b/pyomo/core/base/label.py
@@ -9,17 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = [
-    'CounterLabeler',
-    'NumericLabeler',
-    'CNameLabeler',
-    'TextLabeler',
-    'AlphaNumericTextLabeler',
-    'NameLabeler',
-    'CuidLabeler',
-    'ShortNameLabeler',
-]
-
 import re
 
 from pyomo.common.deprecation import deprecated

--- a/pyomo/core/base/logical_constraint.py
+++ b/pyomo/core/base/logical_constraint.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['LogicalConstraint', '_LogicalConstraintData', 'LogicalConstraintList']
-
 import inspect
 import sys
 import logging
@@ -22,7 +20,6 @@ from pyomo.common.log import is_debug_set
 from pyomo.common.modeling import NOTSET
 from pyomo.common.timing import ConstructionTimer
 
-from pyomo.core.base.constraint import Constraint
 from pyomo.core.expr.boolean_value import as_boolean, BooleanConstant
 from pyomo.core.expr.numvalue import native_types, native_logical_types
 from pyomo.core.base.component import ActiveComponentData, ModelComponentFactory

--- a/pyomo/core/base/misc.py
+++ b/pyomo/core/base/misc.py
@@ -9,14 +9,10 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['display']
-
 import logging
 import sys
-import types
 
 from pyomo.common.deprecation import relocated_module_attribute
-from pyomo.core.expr import native_numeric_types
 
 logger = logging.getLogger('pyomo.core')
 

--- a/pyomo/core/base/objective.py
+++ b/pyomo/core/base/objective.py
@@ -9,16 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = (
-    'Objective',
-    'simple_objective_rule',
-    '_ObjectiveData',
-    'minimize',
-    'maximize',
-    'simple_objectivelist_rule',
-    'ObjectiveList',
-)
-
 import sys
 import logging
 from weakref import ref as weakref_ref

--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['Param']
-
 import sys
 import types
 import logging

--- a/pyomo/core/base/piecewise.py
+++ b/pyomo/core/base/piecewise.py
@@ -32,9 +32,6 @@ Possible Extensions
 *) piecewise for functions of the form y = f(x1,x2,...)
 """
 
-
-__all__ = ['Piecewise']
-
 import logging
 import math
 import itertools

--- a/pyomo/core/base/plugin.py
+++ b/pyomo/core/base/plugin.py
@@ -21,30 +21,6 @@ deprecation_warning(
     calling_frame=inspect.currentframe().f_back,
 )
 
-__all__ = [
-    'pyomo_callback',
-    'IPyomoExpression',
-    'ExpressionFactory',
-    'ExpressionRegistration',
-    'IPyomoPresolver',
-    'IPyomoPresolveAction',
-    'IParamRepresentation',
-    'ParamRepresentationFactory',
-    'IPyomoScriptPreprocess',
-    'IPyomoScriptCreateModel',
-    'IPyomoScriptCreateDataPortal',
-    'IPyomoScriptModifyInstance',
-    'IPyomoScriptPrintModel',
-    'IPyomoScriptPrintInstance',
-    'IPyomoScriptSaveInstance',
-    'IPyomoScriptPrintResults',
-    'IPyomoScriptSaveResults',
-    'IPyomoScriptPostprocess',
-    'ModelComponentFactory',
-    'Transformation',
-    'TransformationFactory',
-]
-
 from pyomo.core.base.component import ModelComponentFactory
 from pyomo.core.base.transformation import (
     Transformation,

--- a/pyomo/core/base/rangeset.py
+++ b/pyomo/core/base/rangeset.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['RangeSet']
-
 from .set import RangeSet
 
 from pyomo.common.deprecation import deprecation_warning

--- a/pyomo/core/base/sets.py
+++ b/pyomo/core/base/sets.py
@@ -13,8 +13,6 @@
 # . rename 'filter' to something else
 # . confirm that filtering is efficient
 
-__all__ = ['Set', 'set_options', 'simple_set_rule', 'SetOf']
-
 from .set import (
     process_setarg,
     set_options,

--- a/pyomo/core/base/sos.py
+++ b/pyomo/core/base/sos.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['SOSConstraint']
-
 import sys
 import logging
 

--- a/pyomo/core/base/suffix.py
+++ b/pyomo/core/base/suffix.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ('Suffix', 'active_export_suffix_generator', 'active_import_suffix_generator')
-
 import enum
 import logging
 

--- a/pyomo/core/base/var.py
+++ b/pyomo/core/base/var.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['Var', '_VarData', '_GeneralVarData', 'VarList', 'SimpleVar', 'ScalarVar']
-
 import logging
 import sys
 from pyomo.common.pyomo_typing import overload
@@ -29,7 +27,6 @@ from pyomo.core.expr.numvalue import (
     value,
     is_potentially_variable,
     native_numeric_types,
-    native_types,
 )
 from pyomo.core.base.component import ComponentData, ModelComponentFactory
 from pyomo.core.base.global_set import UnindexedComponent_index
@@ -44,7 +41,6 @@ from pyomo.core.base.initializer import (
     DefaultInitializer,
     BoundInitializer,
 )
-from pyomo.core.base.misc import apply_indexed_rule
 from pyomo.core.base.set import (
     Reals,
     Binary,
@@ -54,7 +50,6 @@ from pyomo.core.base.set import (
     integer_global_set_ids,
 )
 from pyomo.core.base.units_container import units
-from pyomo.core.base.util import is_functor
 
 logger = logging.getLogger('pyomo.core')
 

--- a/pyomo/core/beta/dict_objects.py
+++ b/pyomo/core/beta/dict_objects.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ()
-
 import logging
 from weakref import ref as weakref_ref
 

--- a/pyomo/core/beta/list_objects.py
+++ b/pyomo/core/beta/list_objects.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ()
-
 import logging
 from weakref import ref as weakref_ref
 

--- a/pyomo/core/expr/__init__.py
+++ b/pyomo/core/expr/__init__.py
@@ -9,14 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-#
-# The definition of __all__ is a bit funky here, because we want to
-# expose symbols in pyomo.core.expr.current that are not included in
-# pyomo.core.expr.  The idea is that pyomo.core.expr provides symbols
-# that are used by general users, but pyomo.core.expr.current provides
-# symbols that are used by developers.
-#
-
 from . import (
     numvalue,
     visitor,

--- a/pyomo/core/expr/numvalue.py
+++ b/pyomo/core/expr/numvalue.py
@@ -32,6 +32,7 @@ from pyomo.common.numeric_types import (
     check_if_numeric_type,
     value,
 )
+from pyomo.core.pyomoobject import PyomoObject
 
 relocated_module_attribute(
     'native_boolean_types',

--- a/pyomo/core/expr/numvalue.py
+++ b/pyomo/core/expr/numvalue.py
@@ -9,21 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = (
-    'value',
-    'is_constant',
-    'is_fixed',
-    'is_variable_type',
-    'is_potentially_variable',
-    'NumericValue',
-    'ZeroConstant',
-    'native_numeric_types',
-    'native_types',
-    'nonpyomo_leaf_types',
-    'polynomial_degree',
-)
-
-import collections
 import sys
 import logging
 
@@ -34,7 +19,6 @@ from pyomo.common.deprecation import (
 )
 from pyomo.core.expr.expr_common import ExpressionType
 from pyomo.core.expr.numeric_expr import NumericValue
-import pyomo.common.numeric_types as _numeric_types
 
 # TODO: update Pyomo to import these objects from common.numeric_types
 #   (and not from here)
@@ -48,7 +32,6 @@ from pyomo.common.numeric_types import (
     check_if_numeric_type,
     value,
 )
-from pyomo.core.pyomoobject import PyomoObject
 
 relocated_module_attribute(
     'native_boolean_types',

--- a/pyomo/core/util.py
+++ b/pyomo/core/util.py
@@ -13,24 +13,12 @@
 # Utility functions
 #
 
-__all__ = [
-    'sum_product',
-    'summation',
-    'dot_product',
-    'sequence',
-    'prod',
-    'quicksum',
-    'target_list',
-]
-
 from pyomo.common.deprecation import deprecation_warning
 from pyomo.core.expr.numvalue import native_numeric_types
 from pyomo.core.expr.numeric_expr import (
     mutable_expression,
-    nonlinear_expression,
     NPV_SumExpression,
 )
-import pyomo.core.expr as EXPR
 from pyomo.core.base.var import Var
 from pyomo.core.base.expression import Expression
 from pyomo.core.base.component import _ComponentBase

--- a/pyomo/core/util.py
+++ b/pyomo/core/util.py
@@ -15,10 +15,7 @@
 
 from pyomo.common.deprecation import deprecation_warning
 from pyomo.core.expr.numvalue import native_numeric_types
-from pyomo.core.expr.numeric_expr import (
-    mutable_expression,
-    NPV_SumExpression,
-)
+from pyomo.core.expr.numeric_expr import mutable_expression, NPV_SumExpression
 from pyomo.core.base.var import Var
 from pyomo.core.base.expression import Expression
 from pyomo.core.base.component import _ComponentBase

--- a/pyomo/dae/contset.py
+++ b/pyomo/dae/contset.py
@@ -17,7 +17,6 @@ from pyomo.core.base.set import SortedScalarSet
 from pyomo.core.base.component import ModelComponentFactory
 
 logger = logging.getLogger('pyomo.dae')
-__all__ = ['ContinuousSet']
 
 
 @ModelComponentFactory.register(

--- a/pyomo/dae/diffvar.py
+++ b/pyomo/dae/diffvar.py
@@ -16,8 +16,6 @@ from pyomo.core.base.set import UnknownSetDimen
 from pyomo.core.base.var import Var
 from pyomo.dae.contset import ContinuousSet
 
-__all__ = ('DerivativeVar', 'DAE_Error')
-
 
 def create_access_function(var):
     """

--- a/pyomo/dae/integral.py
+++ b/pyomo/dae/integral.py
@@ -21,8 +21,6 @@ from pyomo.core.base.expression import (
 from pyomo.dae.contset import ContinuousSet
 from pyomo.dae.diffvar import DAE_Error
 
-__all__ = ('Integral',)
-
 
 @ModelComponentFactory.register("Integral Expression in a DAE model.")
 class Integral(Expression):

--- a/pyomo/dae/simulator.py
+++ b/pyomo/dae/simulator.py
@@ -17,20 +17,14 @@
 #  the U.S. Government retains certain rights in this software.
 #  This software is distributed under the BSD License.
 #  _________________________________________________________________________
-from pyomo.core.base import Constraint, Param, value, Suffix, Block
+import logging
 
+from pyomo.core.base import Constraint, Param, value, Suffix, Block
 from pyomo.dae import ContinuousSet, DerivativeVar
 from pyomo.dae.diffvar import DAE_Error
-
 import pyomo.core.expr as EXPR
 from pyomo.core.expr.numvalue import native_numeric_types
 from pyomo.core.expr.template_expr import IndexTemplate, _GetItemIndexer
-
-import logging
-
-__all__ = ('Simulator',)
-logger = logging.getLogger('pyomo.core')
-
 from pyomo.common.dependencies import (
     numpy as np,
     numpy_available,
@@ -38,6 +32,8 @@ from pyomo.common.dependencies import (
     scipy_available,
     attempt_import,
 )
+
+logger = logging.getLogger('pyomo.core')
 
 casadi_intrinsic = {}
 

--- a/pyomo/dataportal/DataPortal.py
+++ b/pyomo/dataportal/DataPortal.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['DataPortal']
-
 import logging
 from pyomo.common.log import is_debug_set
 from pyomo.dataportal.factory import DataManagerFactory, UnknownDataManager

--- a/pyomo/dataportal/TableData.py
+++ b/pyomo/dataportal/TableData.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['TableData']
-
 from pyomo.common.collections import Bunch
 from pyomo.dataportal.process_data import _process_data
 

--- a/pyomo/dataportal/factory.py
+++ b/pyomo/dataportal/factory.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['DataManagerFactory', 'UnknownDataManager']
-
 import logging
 from pyomo.common import Factory
 from pyomo.common.plugin_base import PluginError

--- a/pyomo/dataportal/parse_datacmds.py
+++ b/pyomo/dataportal/parse_datacmds.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['parse_data_commands']
-
 import bisect
 import sys
 import logging

--- a/pyomo/network/arc.py
+++ b/pyomo/network/arc.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['Arc']
-
 from pyomo.network.port import Port
 from pyomo.core.base.component import ActiveComponentData, ModelComponentFactory
 from pyomo.core.base.indexed_component import (

--- a/pyomo/network/decomposition.py
+++ b/pyomo/network/decomposition.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['SequentialDecomposition']
-
 from pyomo.network import Port, Arc
 from pyomo.network.foqus_graph import FOQUSGraph
 from pyomo.core import (

--- a/pyomo/network/port.py
+++ b/pyomo/network/port.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['Port']
-
 import logging, sys
 from weakref import ref as weakref_ref
 

--- a/pyomo/opt/base/convert.py
+++ b/pyomo/opt/base/convert.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['convert_problem']
-
 import copy
 import os
 

--- a/pyomo/opt/base/formats.py
+++ b/pyomo/opt/base/formats.py
@@ -9,11 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-#
-# The formats that are supported by Pyomo
-#
-__all__ = ['ProblemFormat', 'ResultsFormat', 'guess_format']
-
 import enum
 
 

--- a/pyomo/opt/base/problem.py
+++ b/pyomo/opt/base/problem.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ["AbstractProblemWriter", "WriterFactory", "BranchDirection"]
-
 from pyomo.common import Factory
 
 

--- a/pyomo/opt/base/results.py
+++ b/pyomo/opt/base/results.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['AbstractResultsReader', 'ReaderFactory']
-
 from pyomo.common import Factory
 
 

--- a/pyomo/opt/base/solvers.py
+++ b/pyomo/opt/base/solvers.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ('OptSolver', 'SolverFactory', 'UnknownSolver', 'check_available_solvers')
-
 import re
 import sys
 import time
@@ -18,12 +16,11 @@ import logging
 import shlex
 
 from pyomo.common import Factory
-from pyomo.common.config import ConfigDict
 from pyomo.common.errors import ApplicationError
 from pyomo.common.collections import Bunch
 
 from pyomo.opt.base.convert import convert_problem
-from pyomo.opt.base.formats import ResultsFormat, ProblemFormat
+from pyomo.opt.base.formats import ResultsFormat
 import pyomo.opt.base.results
 
 logger = logging.getLogger('pyomo.opt')

--- a/pyomo/opt/parallel/async_solver.py
+++ b/pyomo/opt/parallel/async_solver.py
@@ -9,9 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-
-__all__ = ['AsynchronousSolverManager', 'SolverManagerFactory']
-
 from pyomo.common import Factory
 from pyomo.opt.parallel.manager import AsynchronousActionManager
 

--- a/pyomo/opt/parallel/local.py
+++ b/pyomo/opt/parallel/local.py
@@ -9,9 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-
-__all__ = ()
-
 import time
 
 from pyomo.common.collections import OrderedDict

--- a/pyomo/opt/parallel/manager.py
+++ b/pyomo/opt/parallel/manager.py
@@ -9,16 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-
-__all__ = [
-    'ActionManagerError',
-    'ActionHandle',
-    'AsynchronousActionManager',
-    'ActionStatus',
-    'FailedActionHandle',
-    'solve_all_instances',
-]
-
 import enum
 
 

--- a/pyomo/opt/problem/ampl.py
+++ b/pyomo/opt/problem/ampl.py
@@ -14,8 +14,6 @@ Utilities to support the definition of optimization applications that
 can be optimized with the Acro COLIN optimizers.
 """
 
-__all__ = ['AmplModel']
-
 import os
 
 from pyomo.opt.base import ProblemFormat, convert_problem, guess_format

--- a/pyomo/opt/results/container.py
+++ b/pyomo/opt/results/container.py
@@ -16,6 +16,7 @@ from math import inf
 
 from pyomo.common.collections import Bunch
 
+
 class ScalarType(str, enum.Enum):
     int = 'int'
     time = 'time'

--- a/pyomo/opt/results/container.py
+++ b/pyomo/opt/results/container.py
@@ -9,25 +9,12 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = [
-    'UndefinedData',
-    'undefined',
-    'ignore',
-    'ScalarData',
-    'ListContainer',
-    'MapContainer',
-    'default_print_options',
-    'ScalarType',
-]
-
 import copy
-
-from math import inf
-from pyomo.common.collections import Bunch
-
 import enum
 from io import StringIO
+from math import inf
 
+from pyomo.common.collections import Bunch
 
 class ScalarType(str, enum.Enum):
     int = 'int'

--- a/pyomo/opt/results/problem.py
+++ b/pyomo/opt/results/problem.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['ProblemInformation', 'ProblemSense']
-
 import enum
 from pyomo.opt.results.container import MapContainer
 

--- a/pyomo/opt/results/results_.py
+++ b/pyomo/opt/results/results_.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['SolverResults']
-
 import math
 import sys
 import copy
@@ -18,7 +16,7 @@ import json
 import logging
 import os.path
 
-from pyomo.common.dependencies import yaml, yaml_load_args, yaml_available
+from pyomo.common.dependencies import yaml, yaml_load_args
 import pyomo.opt
 from pyomo.opt.results.container import undefined, ignore, ListContainer, MapContainer
 import pyomo.opt.results.solution

--- a/pyomo/opt/results/solution.py
+++ b/pyomo/opt/results/solution.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['SolutionStatus', 'Solution']
-
 import math
 import enum
 from pyomo.opt.results.container import MapContainer, ListContainer, ignore

--- a/pyomo/opt/results/solver.py
+++ b/pyomo/opt/results/solver.py
@@ -9,14 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = [
-    'SolverInformation',
-    'SolverStatus',
-    'TerminationCondition',
-    'check_optimal_termination',
-    'assert_optimal_termination',
-]
-
 import enum
 from pyomo.opt.results.container import MapContainer, ScalarType
 

--- a/pyomo/opt/solver/ilmcmd.py
+++ b/pyomo/opt/solver/ilmcmd.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['ILMLicensedSystemCallSolver']
-
 import re
 import sys
 import os

--- a/pyomo/opt/solver/shellcmd.py
+++ b/pyomo/opt/solver/shellcmd.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['SystemCallSolver']
-
 import os
 import sys
 import time

--- a/pyomo/opt/testing/pyunit.py
+++ b/pyomo/opt/testing/pyunit.py
@@ -9,9 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-
-__all__ = ['TestCase']
-
 import sys
 import os
 import re

--- a/pyomo/repn/beta/matrix.py
+++ b/pyomo/repn/beta/matrix.py
@@ -9,12 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = (
-    "_LinearConstraintData",
-    "MatrixConstraint",
-    "compile_block_linear_constraints",
-)
-
 import time
 import logging
 import array

--- a/pyomo/repn/plugins/ampl/ampl_.py
+++ b/pyomo/repn/plugins/ampl/ampl_.py
@@ -13,8 +13,6 @@
 # AMPL Problem Writer Plugin
 #
 
-__all__ = ['ProblemWriter_nl']
-
 import itertools
 import logging
 import operator

--- a/pyomo/repn/standard_aux.py
+++ b/pyomo/repn/standard_aux.py
@@ -10,9 +10,6 @@
 #  ___________________________________________________________________________
 
 
-__all__ = ['compute_standard_repn']
-
-
 from pyomo.repn.standard_repn import (
     preprocess_block_constraints,
     preprocess_block_objectives,

--- a/pyomo/repn/standard_repn.py
+++ b/pyomo/repn/standard_repn.py
@@ -10,9 +10,6 @@
 #  ___________________________________________________________________________
 
 
-__all__ = ['StandardRepn', 'generate_standard_repn']
-
-
 import sys
 import logging
 import itertools

--- a/pyomo/scripting/convert.py
+++ b/pyomo/scripting/convert.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['pyomo2lp', 'pyomo2nl', 'pyomo2dakota']
-
 import os
 import sys
 

--- a/pyomo/scripting/pyomo_parser.py
+++ b/pyomo/scripting/pyomo_parser.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['add_subparser', 'get_parser', 'subparsers']
-
 import argparse
 import sys
 

--- a/pyomo/solvers/plugins/solvers/CBCplugin.py
+++ b/pyomo/solvers/plugins/solvers/CBCplugin.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['CBC', 'MockCBC']
-
 import os
 import re
 import time

--- a/pyomo/solvers/tests/solvers.py
+++ b/pyomo/solvers/tests/solvers.py
@@ -9,8 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-__all__ = ['test_solver_cases']
-
 import logging
 
 from pyomo.common.collections import Bunch

--- a/pyomo/util/blockutil.py
+++ b/pyomo/util/blockutil.py
@@ -12,8 +12,6 @@
 # the purpose of this file is to collect all utility methods that compute
 # attributes of blocks, based on their contents.
 
-__all__ = ['has_discrete_variables']
-
 import logging
 
 from pyomo.core import Var, Constraint, TraversalStrategy


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:

We have stopped documenting and using `from pyomo.environ import *`. We recommend that people explicitly import the modules and elements they desire or use `import pyomo.environ as pyo`. This removes the usage of `__all__` from the entire codebase.

## Changes proposed in this PR:
- Remove `__all__` from modules
- Removed unused imports

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
