### PR TITLE
Update Release Wheel Builder Action

### DIFF
--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           name: native_wheels
           path: dist/*.whl
+          overwrite: true
 
   alternative_wheels:
     name: Build wheels (${{ matrix.wheel-version }}) on ${{ matrix.os }} for aarch64
@@ -76,6 +77,7 @@ jobs:
         with:
           name: alt_wheels
           path: dist/*.whl
+          overwrite: true
 
   generictarball:
     name: ${{ matrix.TARGET }}
@@ -106,4 +108,5 @@ jobs:
       with:
         name: generictarball
         path: dist
+        overwrite: true
 

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -43,9 +43,9 @@ jobs:
             CIBW_CONFIG_SETTINGS: '--global-option="--with-cython --with-distributable-extensions"'
       - uses: actions/upload-artifact@v4
         with:
-          name: native_wheels
+          name: alt_wheels-${{ matrix.os }}-${{ matrix.wheel-version }}
           path: dist/*.whl
-          merge-multiple: true
+          overwrite: true
 
   alternative_wheels:
     name: Build wheels (${{ matrix.wheel-version }}) on ${{ matrix.os }} for aarch64
@@ -75,9 +75,9 @@ jobs:
             CIBW_CONFIG_SETTINGS: '--global-option="--with-cython --with-distributable-extensions"'
       - uses: actions/upload-artifact@v4
         with:
-          name: alt_wheels
+          name: alt_wheels-${{ matrix.os }}-${{ matrix.wheel-version }}
           path: dist/*.whl
-          merge-multiple: true
+          overwrite: true
 
   generictarball:
     name: ${{ matrix.TARGET }}
@@ -108,5 +108,5 @@ jobs:
       with:
         name: generictarball
         path: dist
-        merge-multiple: true
+        overwrite: true
 

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2
+        uses: pypa/cibuildwheel@v2.16.5
         with:
           output-dir: dist
         env:
@@ -63,7 +63,7 @@ jobs:
         with:
           platforms: all
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2
+        uses: pypa/cibuildwheel@v2.16.5
         with:
           output-dir: dist
         env:

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2
         with:
           output-dir: dist
         env:
@@ -63,7 +63,7 @@ jobs:
         with:
           platforms: all
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2
         with:
           output-dir: dist
         env:

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           name: native_wheels
           path: dist/*.whl
-          overwrite: true
+          merge-multiple: true
 
   alternative_wheels:
     name: Build wheels (${{ matrix.wheel-version }}) on ${{ matrix.os }} for aarch64
@@ -77,7 +77,7 @@ jobs:
         with:
           name: alt_wheels
           path: dist/*.whl
-          overwrite: true
+          merge-multiple: true
 
   generictarball:
     name: ${{ matrix.TARGET }}
@@ -108,5 +108,5 @@ jobs:
       with:
         name: generictarball
         path: dist
-        overwrite: true
+        merge-multiple: true
 

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -22,10 +22,23 @@ jobs:
     name: Build wheels (${{ matrix.wheel-version }}) on ${{ matrix.os }} for native and cross-compiled architecture
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: true
       matrix:
         os: [ubuntu-22.04, windows-latest, macos-latest]
         arch: [all]
         wheel-version: ['cp38*', 'cp39*', 'cp310*', 'cp311*', 'cp312*']
+
+        include:
+        - wheel-version: 'cp38*'
+          TARGET: 'py38'
+        - wheel-version: 'cp39*'
+          TARGET: 'py39'
+        - wheel-version: 'cp310*'
+          TARGET: 'py310'
+        - wheel-version: 'cp311*'
+          TARGET: 'py311'
+        - wheel-version: 'cp312*'
+          TARGET: 'py312'
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -43,7 +56,7 @@ jobs:
             CIBW_CONFIG_SETTINGS: '--global-option="--with-cython --with-distributable-extensions"'
       - uses: actions/upload-artifact@v4
         with:
-          name: alt_wheels-${{ matrix.os }}-${{ matrix.wheel-version }}
+          name: alt_wheels-${{ matrix.os }}-${{ matrix.TARGET }}
           path: dist/*.whl
           overwrite: true
 
@@ -75,7 +88,7 @@ jobs:
             CIBW_CONFIG_SETTINGS: '--global-option="--with-cython --with-distributable-extensions"'
       - uses: actions/upload-artifact@v4
         with:
-          name: alt_wheels-${{ matrix.os }}-${{ matrix.wheel-version }}
+          name: alt_wheels-${{ matrix.os }}-${{ matrix.TARGET }}
           path: dist/*.whl
           overwrite: true
 


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
@blnicho discovered that the release builder action was failing when bumping the IDAES tag. This PR fixes the failures.

NOTE: The changes to `upload-artifact` in `v4` mean that we need to individually name artifacts now and they cannot be bundled.

## Changes proposed in this PR:
- Update `cibuildwheel` to most recent version
- Adjust `upload-artifact` choices to reflect `v4` changes

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
