### PR TITLE
Add support for tuples in `ComponentMap`; add `DefaultComponentMap`

### DIFF
--- a/pyomo/common/autoslots.py
+++ b/pyomo/common/autoslots.py
@@ -29,7 +29,7 @@ def _deepcopy_tuple(obj, memo, _id):
             unchanged = False
     if unchanged:
         # Python does not duplicate "unchanged" tuples (i.e. allows the
-        # original objecct to be returned from deepcopy()).  We will
+        # original object to be returned from deepcopy()).  We will
         # preserve that behavior here.
         #
         # It also appears to be faster *not* to cache the fact that this

--- a/pyomo/common/collections/__init__.py
+++ b/pyomo/common/collections/__init__.py
@@ -14,6 +14,6 @@ from collections.abc import MutableMapping, MutableSet, Mapping, Set, Sequence
 from collections import UserDict
 
 from .orderedset import OrderedDict, OrderedSet
-from .component_map import ComponentMap
+from .component_map import ComponentMap, DefaultComponentMap
 from .component_set import ComponentSet
 from .bunch import Bunch

--- a/pyomo/common/collections/component_map.py
+++ b/pyomo/common/collections/component_map.py
@@ -179,3 +179,32 @@ class ComponentMap(AutoSlots.Mixin, collections.abc.MutableMapping):
         else:
             self[key] = default
         return default
+
+
+class DefaultComponentMap(ComponentMap):
+    """A :py:class:`defaultdict` admitting Pyomo Components as keys
+
+    This class is a replacement for defaultdict that allows Pyomo
+    modeling components to be used as entry keys. The base
+    implementation builds on :py:class:`ComponentMap`.
+
+    """
+
+    __slots__ = ('default_factory',)
+
+    def __init__(self, default_factory=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.default_factory = default_factory
+
+    def __missing__(self, key):
+        if self.default_factory is None:
+            raise KeyError(key)
+        self[key] = ans = self.default_factory()
+        return ans
+
+    def __getitem__(self, obj):
+        _key = _hasher[obj.__class__](obj)
+        if _key in self._dict:
+            return self._dict[_key][1]
+        else:
+            return self.__missing__(obj)

--- a/pyomo/common/collections/component_map.py
+++ b/pyomo/common/collections/component_map.py
@@ -80,7 +80,7 @@ class ComponentMap(AutoSlots.Mixin, collections.abc.MutableMapping):
     __autoslot_mappers__ = {'_dict': _rehash_keys}
 
     def __init__(self, *args, **kwds):
-        # maps id(obj) -> (obj,val)
+        # maps id_hash(obj) -> (obj,val)
         self._dict = {}
         # handle the dict-style initialization scenarios
         self.update(*args, **kwds)

--- a/pyomo/common/collections/component_map.py
+++ b/pyomo/common/collections/component_map.py
@@ -9,21 +9,49 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from collections.abc import MutableMapping as collections_MutableMapping
+import collections
 from collections.abc import Mapping as collections_Mapping
 from pyomo.common.autoslots import AutoSlots
 
 
-def _rebuild_ids(encode, val):
+def _rehash_keys(encode, val):
     if encode:
-        return val
+        return list(val.values())
     else:
         # object id() may have changed after unpickling,
         # so we rebuild the dictionary keys
-        return {id(obj): (obj, v) for obj, v in val.values()}
+        return {_hasher[obj.__class__](obj): (obj, v) for obj, v in val}
 
 
-class ComponentMap(AutoSlots.Mixin, collections_MutableMapping):
+class _Hasher(collections.defaultdict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(lambda: self._missing_impl, *args, **kwargs)
+        self[tuple] = self._tuple
+
+    def _missing_impl(self, val):
+        try:
+            hash(val)
+            self[val.__class__] = self._hashable
+        except:
+            self[val.__class__] = self._unhashable
+        return self[val.__class__](val)
+
+    @staticmethod
+    def _hashable(val):
+        return val
+
+    @staticmethod
+    def _unhashable(val):
+        return id(val)
+
+    def _tuple(self, val):
+        return tuple(self[i.__class__](i) for i in val)
+
+
+_hasher = _Hasher()
+
+
+class ComponentMap(AutoSlots.Mixin, collections.abc.MutableMapping):
     """
     This class is a replacement for dict that allows Pyomo
     modeling components to be used as entry keys. The
@@ -49,7 +77,7 @@ class ComponentMap(AutoSlots.Mixin, collections_MutableMapping):
     """
 
     __slots__ = ("_dict",)
-    __autoslot_mappers__ = {'_dict': _rebuild_ids}
+    __autoslot_mappers__ = {'_dict': _rehash_keys}
 
     def __init__(self, *args, **kwds):
         # maps id(obj) -> (obj,val)
@@ -68,18 +96,20 @@ class ComponentMap(AutoSlots.Mixin, collections_MutableMapping):
 
     def __getitem__(self, obj):
         try:
-            return self._dict[id(obj)][1]
+            return self._dict[_hasher[obj.__class__](obj)][1]
         except KeyError:
-            raise KeyError("Component with id '%s': %s" % (id(obj), str(obj)))
+            _id = _hasher[obj.__class__](obj)
+            raise KeyError("Component with id '%s': %s" % (_id, obj))
 
     def __setitem__(self, obj, val):
-        self._dict[id(obj)] = (obj, val)
+        self._dict[_hasher[obj.__class__](obj)] = (obj, val)
 
     def __delitem__(self, obj):
         try:
-            del self._dict[id(obj)]
+            del self._dict[_hasher[obj.__class__](obj)]
         except KeyError:
-            raise KeyError("Component with id '%s': %s" % (id(obj), str(obj)))
+            _id = _hasher[obj.__class__](obj)
+            raise KeyError("Component with id '%s': %s" % (_id, obj))
 
     def __iter__(self):
         return (obj for obj, val in self._dict.values())
@@ -107,7 +137,7 @@ class ComponentMap(AutoSlots.Mixin, collections_MutableMapping):
             return False
         # Note we have already verified the dicts are the same size
         for key, val in other.items():
-            other_id = id(key)
+            other_id = _hasher[key.__class__](key)
             if other_id not in self._dict:
                 return False
             self_val = self._dict[other_id][1]
@@ -130,7 +160,7 @@ class ComponentMap(AutoSlots.Mixin, collections_MutableMapping):
     #
 
     def __contains__(self, obj):
-        return id(obj) in self._dict
+        return _hasher[obj.__class__](obj) in self._dict
 
     def clear(self):
         'D.clear() -> None.  Remove all items from D.'

--- a/pyomo/common/collections/component_map.py
+++ b/pyomo/common/collections/component_map.py
@@ -16,11 +16,11 @@ from pyomo.common.autoslots import AutoSlots
 
 def _rehash_keys(encode, val):
     if encode:
-        return tuple(val.values())
+        return val
     else:
         # object id() may have changed after unpickling,
         # so we rebuild the dictionary keys
-        return {_hasher[obj.__class__](obj): (obj, v) for obj, v in val}
+        return {_hasher[obj.__class__](obj): (obj, v) for obj, v in val.values()}
 
 
 class _Hasher(collections.defaultdict):

--- a/pyomo/common/collections/component_map.py
+++ b/pyomo/common/collections/component_map.py
@@ -16,7 +16,7 @@ from pyomo.common.autoslots import AutoSlots
 
 def _rehash_keys(encode, val):
     if encode:
-        return list(val.values())
+        return tuple(val.values())
     else:
         # object id() may have changed after unpickling,
         # so we rebuild the dictionary keys

--- a/pyomo/common/collections/component_map.py
+++ b/pyomo/common/collections/component_map.py
@@ -87,8 +87,8 @@ class ComponentMap(AutoSlots.Mixin, collections.abc.MutableMapping):
 
     def __str__(self):
         """String representation of the mapping."""
-        tmp = {str(c) + " (id=" + str(id(c)) + ")": v for c, v in self.items()}
-        return "ComponentMap(" + str(tmp) + ")"
+        tmp = {f"{v[0]} (key={k})": v[1] for k, v in self._dict.items()}
+        return f"ComponentMap({tmp})"
 
     #
     # Implement MutableMapping abstract methods
@@ -99,7 +99,7 @@ class ComponentMap(AutoSlots.Mixin, collections.abc.MutableMapping):
             return self._dict[_hasher[obj.__class__](obj)][1]
         except KeyError:
             _id = _hasher[obj.__class__](obj)
-            raise KeyError("Component with id '%s': %s" % (_id, obj))
+            raise KeyError(f"{obj} (key={_id})") from None
 
     def __setitem__(self, obj, val):
         self._dict[_hasher[obj.__class__](obj)] = (obj, val)
@@ -109,7 +109,7 @@ class ComponentMap(AutoSlots.Mixin, collections.abc.MutableMapping):
             del self._dict[_hasher[obj.__class__](obj)]
         except KeyError:
             _id = _hasher[obj.__class__](obj)
-            raise KeyError("Component with id '%s': %s" % (_id, obj))
+            raise KeyError(f"{obj} (key={_id})") from None
 
     def __iter__(self):
         return (obj for obj, val in self._dict.values())

--- a/pyomo/common/collections/component_set.py
+++ b/pyomo/common/collections/component_set.py
@@ -24,7 +24,7 @@ def _rehash_keys(encode, val):
         #
         # here, then we get a strange failure when deepcopying
         # ComponentSets containing an _ImplicitAny domain.  We could
-        # track it down to teh implementation of
+        # track it down to the implementation of
         # autoslots.fast_deepcopy, but couldn't find an obvious bug.
         # There is no error if we just return the original dict, or if
         # we return a tuple(val.values)

--- a/pyomo/common/collections/component_set.py
+++ b/pyomo/common/collections/component_set.py
@@ -63,6 +63,7 @@ class ComponentSet(AutoSlots.Mixin, collections_MutableSet):
     __autoslot_mappers__ = {'_data': _rehash_keys}
 
     def __init__(self, iterable=None):
+        # maps id_hash(obj) -> obj
         self._data = {}
         if iterable is not None:
             self.update(iterable)

--- a/pyomo/common/collections/component_set.py
+++ b/pyomo/common/collections/component_set.py
@@ -18,7 +18,17 @@ from pyomo.common.collections.component_map import _hasher
 
 def _rehash_keys(encode, val):
     if encode:
-        return list(val.values())
+        # TBD [JDS 2/2024]: if we
+        #
+        # return list(val.values())
+        #
+        # here, then we get a strange failure when deepcopying
+        # ComponentSets containing an _ImplicitAny domain.  We could
+        # track it down to teh implementation of
+        # autoslots.fast_deepcopy, but couldn't find an obvious bug.
+        # There is no error if we just return the original dict, or if
+        # we return a tuple(val.values)
+        return tuple(val.values())
     else:
         # object id() may have changed after unpickling,
         # so we rebuild the dictionary keys

--- a/pyomo/common/collections/component_set.py
+++ b/pyomo/common/collections/component_set.py
@@ -70,10 +70,8 @@ class ComponentSet(AutoSlots.Mixin, collections_MutableSet):
 
     def __str__(self):
         """String representation of the mapping."""
-        tmp = []
-        for objid, obj in self._data.items():
-            tmp.append(str(obj) + " (id=" + str(objid) + ")")
-        return "ComponentSet(" + str(tmp) + ")"
+        tmp = [f"{v} (key={k})" for k, v in self._data.items()]
+        return f"ComponentSet({tmp})"
 
     def update(self, iterable):
         """Update a set with the union of itself and others."""
@@ -136,4 +134,4 @@ class ComponentSet(AutoSlots.Mixin, collections_MutableSet):
             del self._data[_hasher[val.__class__](val)]
         except KeyError:
             _id = _hasher[val.__class__](val)
-            raise KeyError("Component with id '%s': %s" % (_id, val))
+            raise KeyError(f"{val} (key={_id})") from None

--- a/pyomo/common/collections/component_set.py
+++ b/pyomo/common/collections/component_set.py
@@ -28,11 +28,11 @@ def _rehash_keys(encode, val):
         # autoslots.fast_deepcopy, but couldn't find an obvious bug.
         # There is no error if we just return the original dict, or if
         # we return a tuple(val.values)
-        return tuple(val.values())
+        return val
     else:
         # object id() may have changed after unpickling,
         # so we rebuild the dictionary keys
-        return {_hasher[obj.__class__](obj): obj for obj in val}
+        return {_hasher[obj.__class__](obj): obj for obj in val.values()}
 
 
 class ComponentSet(AutoSlots.Mixin, collections_MutableSet):

--- a/pyomo/common/collections/orderedset.py
+++ b/pyomo/common/collections/orderedset.py
@@ -9,42 +9,30 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from collections.abc import MutableSet
 from collections import OrderedDict
+from collections.abc import MutableSet
+from pyomo.common.autoslots import AutoSlots
 
 
-class OrderedSet(MutableSet):
+class OrderedSet(AutoSlots.Mixin, MutableSet):
     __slots__ = ('_dict',)
 
     def __init__(self, iterable=None):
         # TODO: Starting in Python 3.7, dict is ordered (and is faster
         # than OrderedDict).  dict began supporting reversed() in 3.8.
-        # We should consider changing the underlying data type here from
-        # OrderedDict to dict.
-        self._dict = OrderedDict()
+        self._dict = {}
         if iterable is not None:
-            if iterable.__class__ is OrderedSet:
-                self._dict.update(iterable._dict)
-            else:
-                self.update(iterable)
+            self.update(iterable)
 
     def __str__(self):
         """String representation of the mapping."""
         return "OrderedSet(%s)" % (', '.join(repr(x) for x in self))
 
     def update(self, iterable):
-        for val in iterable:
-            self.add(val)
-
-    #
-    # This method must be defined for deepcopy/pickling
-    # because this class is slotized.
-    #
-    def __setstate__(self, state):
-        self._dict = state
-
-    def __getstate__(self):
-        return self._dict
+        if isinstance(iterable, OrderedSet):
+            self._dict.update(iterable._dict)
+        else:
+            self._dict.update((val, None) for val in iterable)
 
     #
     # Implement MutableSet abstract methods

--- a/pyomo/common/collections/orderedset.py
+++ b/pyomo/common/collections/orderedset.py
@@ -18,8 +18,8 @@ class OrderedSet(AutoSlots.Mixin, MutableSet):
     __slots__ = ('_dict',)
 
     def __init__(self, iterable=None):
-        # TODO: Starting in Python 3.7, dict is ordered (and is faster
-        # than OrderedDict).  dict began supporting reversed() in 3.8.
+        # Starting in Python 3.7, dict is ordered (and is faster than
+        # OrderedDict).  dict began supporting reversed() in 3.8.
         self._dict = {}
         if iterable is not None:
             self.update(iterable)

--- a/pyomo/common/tests/test_component_map.py
+++ b/pyomo/common/tests/test_component_map.py
@@ -1,7 +1,7 @@
 #  ___________________________________________________________________________
 #
 #  Pyomo: Python Optimization Modeling Objects
-#  Copyright (c) 2008-2022
+#  Copyright (c) 2008-2024
 #  National Technology and Engineering Solutions of Sandia, LLC
 #  Under the terms of Contract DE-NA0003525 with National Technology and
 #  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain

--- a/pyomo/common/tests/test_component_map.py
+++ b/pyomo/common/tests/test_component_map.py
@@ -22,24 +22,24 @@ class TestComponentMap(unittest.TestCase):
         m.c = Constraint(expr=m.v >= 0)
         m.cm = cm = ComponentMap()
 
-        cm[(1,2)] = 5
+        cm[(1, 2)] = 5
         self.assertEqual(len(cm), 1)
-        self.assertIn((1,2), cm)
-        self.assertEqual(cm[1,2], 5)
+        self.assertIn((1, 2), cm)
+        self.assertEqual(cm[1, 2], 5)
 
-        cm[(1,2)] = 50
+        cm[(1, 2)] = 50
         self.assertEqual(len(cm), 1)
-        self.assertIn((1,2), cm)
-        self.assertEqual(cm[1,2], 50)
+        self.assertIn((1, 2), cm)
+        self.assertEqual(cm[1, 2], 50)
 
         cm[(1, (2, m.v))] = 10
         self.assertEqual(len(cm), 2)
-        self.assertIn((1,(2, m.v)), cm)
+        self.assertIn((1, (2, m.v)), cm)
         self.assertEqual(cm[1, (2, m.v)], 10)
 
         cm[(1, (2, m.v))] = 100
         self.assertEqual(len(cm), 2)
-        self.assertIn((1,(2, m.v)), cm)
+        self.assertIn((1, (2, m.v)), cm)
         self.assertEqual(cm[1, (2, m.v)], 100)
 
         i = m.clone()

--- a/pyomo/common/tests/test_component_map.py
+++ b/pyomo/common/tests/test_component_map.py
@@ -1,0 +1,50 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import pyomo.common.unittest as unittest
+
+from pyomo.common.collections import ComponentMap
+from pyomo.environ import ConcreteModel, Var, Constraint
+
+
+class TestComponentMap(unittest.TestCase):
+    def test_tuple(self):
+        m = ConcreteModel()
+        m.v = Var()
+        m.c = Constraint(expr=m.v >= 0)
+        m.cm = cm = ComponentMap()
+
+        cm[(1,2)] = 5
+        self.assertEqual(len(cm), 1)
+        self.assertIn((1,2), cm)
+        self.assertEqual(cm[1,2], 5)
+
+        cm[(1,2)] = 50
+        self.assertEqual(len(cm), 1)
+        self.assertIn((1,2), cm)
+        self.assertEqual(cm[1,2], 50)
+
+        cm[(1, (2, m.v))] = 10
+        self.assertEqual(len(cm), 2)
+        self.assertIn((1,(2, m.v)), cm)
+        self.assertEqual(cm[1, (2, m.v)], 10)
+
+        cm[(1, (2, m.v))] = 100
+        self.assertEqual(len(cm), 2)
+        self.assertIn((1,(2, m.v)), cm)
+        self.assertEqual(cm[1, (2, m.v)], 100)
+
+        i = m.clone()
+        self.assertIn((1, 2), i.cm)
+        self.assertIn((1, (2, i.v)), i.cm)
+        self.assertNotIn((1, (2, i.v)), m.cm)
+        self.assertIn((1, (2, m.v)), m.cm)
+        self.assertNotIn((1, (2, m.v)), i.cm)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
`ComponentMap` / `ComponentSet` historically used the `id()` of the key for all entries.  This prevented the reliable use of tuples as keys in `ComponentMap` / items in `ComponentSet`, as two tuples that contained the same data would potentially have separate ids.  This PR changes the hashing scheme to:
- only replace unhashable elements with their `id()`
- recursively process tuples using the same logic

This also adds a new class `DefaultComponentMap` that provides the `defaultdict` API for `ComponetMap` objects.

While I was looking at things in `collections`, this PR removes support for Python<3.8 in `OrderdSet` and standardizes some of the logic across ComponentMap, ComponentSet, and OrderedSet.

## Changes proposed in this PR:
- change `ComponentMap`/`ComponentSet` hashing cheme to 
   - only use `id()` for unhashable types
   - recursively process tuples
- add the `DefaultComponentMap` class
- update the storage mechanism for OrderedSet to rely on `dict` (now that we only support Python 3.8+)
- add a test for using tuples in `ComponentMap` / `DefaultComponentMap`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
