### PR TITLE
Generalize the simple_constraint_rule decorator

### DIFF
--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -90,7 +90,7 @@ def simple_constraint_rule(rule):
     for l_type in native_logical_types:
         result_map[l_type(True)] = Constraint.Feasible
         result_map[l_type(False)] = Constraint.Infeasible
-    # Note: some logical types has the same as bool (e.g., np.bool_), so
+    # Note: some logical types hash the same as bool (e.g., np.bool_), so
     # we will pass the set of all logical types in addition to the
     # result_map
     return rule_wrapper(rule, result_map, map_types=map_types)
@@ -116,7 +116,7 @@ def simple_constraintlist_rule(rule):
     for l_type in native_logical_types:
         result_map[l_type(True)] = Constraint.Feasible
         result_map[l_type(False)] = Constraint.Infeasible
-    # Note: some logical types has the same as bool (e.g., np.bool_), so
+    # Note: some logical types hash the same as bool (e.g., np.bool_), so
     # we will pass the set of all logical types in addition to the
     # result_map
     return rule_wrapper(rule, result_map, map_types=map_types)

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -27,6 +27,7 @@ from pyomo.core.expr.numvalue import (
     as_numeric,
     is_fixed,
     native_numeric_types,
+    native_logical_types,
     native_types,
 )
 from pyomo.core.expr import (
@@ -84,14 +85,14 @@ def simple_constraint_rule(rule):
 
     model.c = Constraint(rule=simple_constraint_rule(...))
     """
-    return rule_wrapper(
-        rule,
-        {
-            None: Constraint.Skip,
-            True: Constraint.Feasible,
-            False: Constraint.Infeasible,
-        },
-    )
+    result_map = {None: Constraint.Skip}
+    for l_type in native_logical_types:
+        result_map[l_type(True)] = Constraint.Feasible
+        result_map[l_type(False)] = Constraint.Infeasible
+    # Note: some logical types has the same as bool (e.g., np.bool_), so
+    # we will pass the set of all logical types in addition to the
+    # result_map
+    return rule_wrapper(rule, result_map, map_types=native_logical_types)
 
 
 def simple_constraintlist_rule(rule):
@@ -109,14 +110,14 @@ def simple_constraintlist_rule(rule):
 
     model.c = ConstraintList(expr=simple_constraintlist_rule(...))
     """
-    return rule_wrapper(
-        rule,
-        {
-            None: ConstraintList.End,
-            True: Constraint.Feasible,
-            False: Constraint.Infeasible,
-        },
-    )
+    result_map = {None: ConstraintList.End}
+    for l_type in native_logical_types:
+        result_map[l_type(True)] = Constraint.Feasible
+        result_map[l_type(False)] = Constraint.Infeasible
+    # Note: some logical types has the same as bool (e.g., np.bool_), so
+    # we will pass the set of all logical types in addition to the
+    # result_map
+    return rule_wrapper(rule, result_map, map_types=native_logical_types)
 
 
 #

--- a/pyomo/core/base/constraint.py
+++ b/pyomo/core/base/constraint.py
@@ -85,6 +85,7 @@ def simple_constraint_rule(rule):
 
     model.c = Constraint(rule=simple_constraint_rule(...))
     """
+    map_types = set([type(None)]) | native_logical_types
     result_map = {None: Constraint.Skip}
     for l_type in native_logical_types:
         result_map[l_type(True)] = Constraint.Feasible
@@ -92,7 +93,7 @@ def simple_constraint_rule(rule):
     # Note: some logical types has the same as bool (e.g., np.bool_), so
     # we will pass the set of all logical types in addition to the
     # result_map
-    return rule_wrapper(rule, result_map, map_types=native_logical_types)
+    return rule_wrapper(rule, result_map, map_types=map_types)
 
 
 def simple_constraintlist_rule(rule):
@@ -110,6 +111,7 @@ def simple_constraintlist_rule(rule):
 
     model.c = ConstraintList(expr=simple_constraintlist_rule(...))
     """
+    map_types = set([type(None)]) | native_logical_types
     result_map = {None: ConstraintList.End}
     for l_type in native_logical_types:
         result_map[l_type(True)] = Constraint.Feasible
@@ -117,7 +119,7 @@ def simple_constraintlist_rule(rule):
     # Note: some logical types has the same as bool (e.g., np.bool_), so
     # we will pass the set of all logical types in addition to the
     # result_map
-    return rule_wrapper(rule, result_map, map_types=native_logical_types)
+    return rule_wrapper(rule, result_map, map_types=map_types)
 
 
 #

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -160,9 +160,12 @@ include the "return" statement at the end of your rule.
 """
 
 
-def rule_result_substituter(result_map):
+def rule_result_substituter(result_map, map_types):
     _map = result_map
-    _map_types = set(type(key) for key in result_map)
+    if map_types is None:
+        _map_types = set(type(key) for key in result_map)
+    else:
+        _map_types = map_types
 
     def rule_result_substituter_impl(rule, *args, **kwargs):
         if rule.__class__ in _map_types:
@@ -203,7 +206,7 @@ _map_rule_funcdef = """def wrapper_function%s:
 """
 
 
-def rule_wrapper(rule, wrapping_fcn, positional_arg_map=None):
+def rule_wrapper(rule, wrapping_fcn, positional_arg_map=None, map_types=None):
     """Wrap a rule with another function
 
     This utility method provides a way to wrap a function (rule) with
@@ -230,7 +233,7 @@ def rule_wrapper(rule, wrapping_fcn, positional_arg_map=None):
 
     """
     if isinstance(wrapping_fcn, dict):
-        wrapping_fcn = rule_result_substituter(wrapping_fcn)
+        wrapping_fcn = rule_result_substituter(wrapping_fcn, map_types)
         if not inspect.isfunction(rule):
             return wrapping_fcn(rule)
     # Because some of our processing of initializer functions relies on


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #3092 .

## Summary/Motivation:
This PR generalizes the `simple_constraint_rule` decorator so that it has a better chance of correctly handling `numpy.bool_` return types.  Note that this is not perfect, as it will not trigger automatic type registration - so if this is the first time a numpy type has been "seen" by Pyomo, it will still generate the normal exception.

## Changes proposed in this PR:
- Generate the constraint result map based on the current value of `native_logical_types`
- Support passing the map_types set as an argument (for cases like numpy.bool_ where instances hash the same as other types)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
