### PR TITLE
Add `Block.register_private_data_initializer()`

### DIFF
--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -14,13 +14,13 @@ import logging
 import sys
 import weakref
 import textwrap
-from contextlib import contextmanager
 
+from collections import defaultdict
+from contextlib import contextmanager
 from inspect import isclass, currentframe
+from io import StringIO
 from itertools import filterfalse, chain
 from operator import itemgetter, attrgetter
-from io import StringIO
-from pyomo.common.pyomo_typing import overload
 
 from pyomo.common.autoslots import AutoSlots
 from pyomo.common.collections import Mapping
@@ -28,6 +28,7 @@ from pyomo.common.deprecation import deprecated, deprecation_warning, RenamedCla
 from pyomo.common.formatting import StreamIndenter
 from pyomo.common.gc_manager import PauseGC
 from pyomo.common.log import is_debug_set
+from pyomo.common.pyomo_typing import overload
 from pyomo.common.timing import ConstructionTimer
 from pyomo.core.base.component import (
     Component,
@@ -1986,7 +1987,7 @@ Components must now specify their rules explicitly using 'rule=' keywords."""
         if self._private_data is None:
             self._private_data = {}
         if scope not in self._private_data:
-            self._private_data[scope] = {}
+            self._private_data[scope] = Block._private_data_initializers[scope]()
         return self._private_data[scope]
 
 
@@ -2004,6 +2005,7 @@ class Block(ActiveIndexedComponent):
     """
 
     _ComponentDataClass = _BlockData
+    _private_data_initializers = defaultdict(lambda: dict)
 
     def __new__(cls, *args, **kwds):
         if cls != Block:
@@ -2206,6 +2208,23 @@ class Block(ActiveIndexedComponent):
 
         for key in sorted(self):
             _BlockData.display(self[key], filename, ostream, prefix)
+
+    @staticmethod
+    def register_private_data_initializer(initializer, scope=None):
+        mod = currentframe().f_back.f_globals['__name__']
+        if scope is None:
+            scope = mod
+        elif not mod.startswith(scope):
+            raise ValueError(
+                "'private_data' scope must be substrings of the caller's module name. "
+                f"Received '{scope}' when calling register_private_data_initializer()."
+            )
+        if scope in Block._private_data_initializers:
+            raise RuntimeError(
+                "Duplicate initializer registration for 'private_data' dictionary "
+                f"(scope={scope})"
+            )
+        Block._private_data_initializers[scope] = initializer
 
 
 class ScalarBlock(_BlockData, Block):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This provides a way for `Block.private_data()` to define a standard callback that should be used to initialize their private data attribute.  The need for this became apparent when reviewing #3143.

## Changes proposed in this PR:
- add `Block.register_private_data_initializer()` for modules to define the callback to use to create their private data object.
- add tests exercising this new functionality

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
