### PR TITLE
Update intersphinx links, remove docs for nonfunctional code

### DIFF
--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -57,8 +57,8 @@ intersphinx_mapping = {
     'numpy': ('https://numpy.org/doc/stable/', None),
     'pandas': ('https://pandas.pydata.org/docs/', None),
     'scikit-learn': ('https://scikit-learn.org/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
-    'Sphinx': ('https://www.sphinx-doc.org/en/stable/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+    'Sphinx': ('https://www.sphinx-doc.org/en/master/', None),
 }
 
 # -- General configuration ------------------------------------------------

--- a/doc/OnlineDocs/library_reference/expressions/context_managers.rst
+++ b/doc/OnlineDocs/library_reference/expressions/context_managers.rst
@@ -8,6 +8,3 @@ Context Managers
 .. autoclass:: pyomo.core.expr.linear_expression
     :members:
 
-.. autoclass:: pyomo.core.expr.current.clone_counter
-    :members:
-


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This silences some InterSphinx warnings for moved inventories, as well as removing the documentation for functionality that has been removed from Pyomo.

## Changes proposed in this PR:
- update intersphinx links for `scipy` and `sphinx-doc`
- remove documentation of `clone_counter`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
