### PR TITLE
Support config domains with either method or attribute domain_name

### DIFF
--- a/pyomo/common/config.py
+++ b/pyomo/common/config.py
@@ -1134,7 +1134,11 @@ def _domain_name(domain):
     if domain is None:
         return ""
     elif hasattr(domain, 'domain_name'):
-        return domain.domain_name()
+        dn = domain.domain_name
+        if hasattr(dn, '__call__'):
+            return dn()
+        else:
+            return dn
     elif domain.__class__ is type:
         return domain.__name__
     elif inspect.isfunction(domain):

--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -3265,6 +3265,41 @@ option_2: int, default=5
             OUT.getvalue().replace('null', 'None'),
         )
 
+    def test_domain_name(self):
+        cfg = ConfigDict()
+
+        cfg.declare('none', ConfigValue())
+        self.assertEqual(cfg.get('none').domain_name(), '')
+
+        def fcn(val):
+            return val
+
+        cfg.declare('fcn', ConfigValue(domain=fcn))
+        self.assertEqual(cfg.get('fcn').domain_name(), 'fcn')
+
+        fcn.domain_name = 'custom fcn'
+        self.assertEqual(cfg.get('fcn').domain_name(), 'custom fcn')
+
+        class functor:
+            def __call__(self, val):
+                return val
+
+        cfg.declare('functor', ConfigValue(domain=functor()))
+        self.assertEqual(cfg.get('functor').domain_name(), 'functor')
+
+        class cfunctor:
+            def __call__(self, val):
+                return val
+
+            def domain_name(self):
+                return 'custom functor'
+
+        cfg.declare('cfunctor', ConfigValue(domain=cfunctor()))
+        self.assertEqual(cfg.get('cfunctor').domain_name(), 'custom functor')
+
+        cfg.declare('type', ConfigValue(domain=int))
+        self.assertEqual(cfg.get('type').domain_name(), 'int')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This is a follow-on to #3126 where we were defining functor domain validators just to be able to define the `domain_name` method.  This simple fix supports retrieving the domain name as either an attribute, property, or method.

## Changes proposed in this PR:
- Support specifying a custom domain name as either a `domain_name` attribute or method

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
