### PR TITLE
fix division by zero error in linear presolve

### DIFF
--- a/pyomo/contrib/solver/tests/solvers/test_solvers.py
+++ b/pyomo/contrib/solver/tests/solvers/test_solvers.py
@@ -1508,6 +1508,71 @@ class TestSolvers(unittest.TestCase):
             res = opt.solve(m)
             self.assertAlmostEqual(res.incumbent_objective, -18, 5)
 
+    @parameterized.expand(input=_load_tests(nl_solvers))
+    def test_presolve_with_zero_coef(
+        self, name: str, opt_class: Type[SolverBase], use_presolve: bool
+    ):
+        opt: SolverBase = opt_class()
+        if not opt.available():
+            raise unittest.SkipTest(f'Solver {opt.name} not available.')
+        if use_presolve:
+            opt.config.writer_config.linear_presolve = True
+        else:
+            opt.config.writer_config.linear_presolve = False
+
+        """
+        when c2 gets presolved out, c1 becomes 
+        x - y + y = 0 which becomes
+        x - 0*y == 0 which is the zero we are testing for
+        """
+        m = pe.ConcreteModel()
+        m.x = pe.Var()
+        m.y = pe.Var()
+        m.z = pe.Var()
+        m.obj = pe.Objective(expr=m.x**2 + m.y**2 + m.z**2)
+        m.c1 = pe.Constraint(expr=m.x == m.y + m.z + 1.5)
+        m.c2 = pe.Constraint(expr=m.z == -m.y)
+
+        res = opt.solve(m)
+        self.assertAlmostEqual(res.incumbent_objective, 2.25)
+        self.assertAlmostEqual(m.x.value, 1.5)
+        self.assertAlmostEqual(m.y.value, 0)
+        self.assertAlmostEqual(m.z.value, 0)
+
+        m.x.setlb(2)
+        res = opt.solve(
+            m, load_solutions=False, raise_exception_on_nonoptimal_result=False
+        )
+        if use_presolve:
+            exp = TerminationCondition.provenInfeasible
+        else:
+            exp = TerminationCondition.locallyInfeasible
+        self.assertEqual(res.termination_condition, exp)
+
+        m = pe.ConcreteModel()
+        m.w = pe.Var()
+        m.x = pe.Var()
+        m.y = pe.Var()
+        m.z = pe.Var()
+        m.obj = pe.Objective(expr=m.x**2 + m.y**2 + m.z**2 + m.w**2)
+        m.c1 = pe.Constraint(expr=m.x + m.w == m.y + m.z)
+        m.c2 = pe.Constraint(expr=m.z == -m.y)
+        m.c3 = pe.Constraint(expr=m.x == -m.w)
+
+        res = opt.solve(m)
+        self.assertAlmostEqual(res.incumbent_objective, 0)
+        self.assertAlmostEqual(m.w.value, 0)
+        self.assertAlmostEqual(m.x.value, 0)
+        self.assertAlmostEqual(m.y.value, 0)
+        self.assertAlmostEqual(m.z.value, 0)
+
+        del m.c1
+        m.c1 = pe.Constraint(expr=m.x + m.w == m.y + m.z + 1.5)
+        res = opt.solve(
+            m, load_solutions=False, raise_exception_on_nonoptimal_result=False
+        )
+        self.assertEqual(res.termination_condition, exp)
+
     @parameterized.expand(input=_load_tests(all_solvers))
     def test_scaling(self, name: str, opt_class: Type[SolverBase], use_presolve: bool):
         opt: SolverBase = opt_class()

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -1760,7 +1760,7 @@ class _NLWriter_impl(object):
                 id2_isdiscrete = var_map[id2].domain.isdiscrete()
                 if var_map[_id].domain.isdiscrete() ^ id2_isdiscrete:
                     # if only one variable is discrete, then we need to
-                    # substiitute out the other
+                    # substitute out the other
                     if id2_isdiscrete:
                         _id, id2 = id2, _id
                         coef, coef2 = coef2, coef

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -1833,7 +1833,7 @@ class _NLWriter_impl(object):
                             if abs(expr_info.const) > TOL:
                                 # constraint is trivially infeasible
                                 raise InfeasibleConstraintException(
-                                    "model contains a trivially infeasible constrint "
+                                    "model contains a trivially infeasible constraint "
                                     f"{expr_info.const} == {coef}*{var_map[x]}"
                                 )
                             # constraint is trivially feasible

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -1829,15 +1829,6 @@ class _NLWriter_impl(object):
                     if expr_info.linear[x] == 0:
                         nnz -= 1
                         coef = expr_info.linear.pop(x)
-                        if not nnz:
-                            if abs(expr_info.const) > TOL:
-                                # constraint is trivially infeasible
-                                raise InfeasibleConstraintException(
-                                    "model contains a trivially infeasible constraint "
-                                    f"{expr_info.const} == {coef}*{var_map[x]}"
-                                )
-                            # constraint is trivially feasible
-                            eliminated_cons.add(con_id)
                 elif a:
                     expr_info.linear[x] = c * a
                     # replacing _id with x... NNZ is not changing,
@@ -1847,6 +1838,15 @@ class _NLWriter_impl(object):
                     continue
                 _old = lcon_by_linear_nnz[old_nnz]
                 if con_id in _old:
+                    if not nnz:
+                        if abs(expr_info.const) > TOL:
+                            # constraint is trivially infeasible
+                            raise InfeasibleConstraintException(
+                                "model contains a trivially infeasible constraint "
+                                f"{expr_info.const} == {coef}*{var_map[x]}"
+                            )
+                        # constraint is trivially feasible
+                        eliminated_cons.add(con_id)
                     lcon_by_linear_nnz[nnz][con_id] = _old.pop(con_id)
             # If variables were replaced by the variable that
             # we are currently eliminating, then we need to update

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -1688,6 +1688,131 @@ G0 2	#obj
             )
         )
 
+    def test_presolve_zero_coef(self):
+        m = ConcreteModel()
+        m.x = Var()
+        m.y = Var()
+        m.z = Var()
+        m.obj = Objective(expr=m.x**2 + m.y**2 + m.z**2)
+        m.c1 = Constraint(expr=m.x == m.y + m.z + 1.5)
+        m.c2 = Constraint(expr=m.z == -m.y)
+
+        OUT = io.StringIO()
+        with LoggingIntercept() as LOG:
+            nlinfo = nl_writer.NLWriter().write(
+                m, OUT, symbolic_solver_labels=True, linear_presolve=True
+            )
+        self.assertEqual(LOG.getvalue(), "")
+
+        self.assertEqual(nlinfo.eliminated_vars[0], (m.x, 1.5))
+        self.assertIs(nlinfo.eliminated_vars[1][0], m.y)
+        self.assertExpressionsEqual(
+            nlinfo.eliminated_vars[1][1], LinearExpression([-1.0 * m.z])
+        )
+
+        self.assertEqual(
+            *nl_diff(
+                """g3 1 1 0	# problem unknown
+ 1 0 1 0 0	#vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	#nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	#network constraints: nonlinear, linear
+ 0 1 0	#nonlinear vars in constraints, objectives, both
+ 0 0 0 1	#linear network variables; functions; arith, flags
+ 0 0 0 0 0	#discrete variables: binary, integer, nonlinear (b,c,o)
+ 0 1	#nonzeros in Jacobian, obj. gradient
+ 3 1	#max name lengths: constraints, variables
+ 0 0 0 0 0	#common exprs: b,c,o,c1,o1
+O0 0	#obj
+o54	#sumlist
+3	#(n)
+o5	#^
+n1.5
+n2
+o5	#^
+o16	#-
+v0	#z
+n2
+o5	#^
+v0	#z
+n2
+x0	#initial guess
+r	#0 ranges (rhs's)
+b	#1 bounds (on variables)
+3	#z
+k0	#intermediate Jacobian column lengths
+G0 1	#obj
+0 0
+""",
+                OUT.getvalue(),
+            )
+        )
+
+        m.c3 = Constraint(expr=m.x == 2)
+        OUT = io.StringIO()
+        with LoggingIntercept() as LOG:
+            with self.assertRaisesRegex(
+                nl_writer.InfeasibleConstraintException,
+                r"model contains a trivially infeasible constraint 0.5 == 0.0\*y",
+            ):
+                nlinfo = nl_writer.NLWriter().write(
+                    m, OUT, symbolic_solver_labels=True, linear_presolve=True
+                )
+        self.assertEqual(LOG.getvalue(), "")
+
+        m.c1.set_value(m.x >= m.y + m.z + 1.5)
+        OUT = io.StringIO()
+        with LoggingIntercept() as LOG:
+            nlinfo = nl_writer.NLWriter().write(
+                m, OUT, symbolic_solver_labels=True, linear_presolve=True
+            )
+        self.assertEqual(LOG.getvalue(), "")
+
+        self.assertIs(nlinfo.eliminated_vars[0][0], m.y)
+        self.assertExpressionsEqual(
+            nlinfo.eliminated_vars[0][1], LinearExpression([-1.0 * m.z])
+        )
+        self.assertEqual(nlinfo.eliminated_vars[1], (m.x, 2))
+
+        self.assertEqual(
+            *nl_diff(
+                """g3 1 1 0	# problem unknown
+ 1 1 1 0 0	#vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	#nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	#network constraints: nonlinear, linear
+ 0 1 0	#nonlinear vars in constraints, objectives, both
+ 0 0 0 1	#linear network variables; functions; arith, flags
+ 0 0 0 0 0	#discrete variables: binary, integer, nonlinear (b,c,o)
+ 0 1	#nonzeros in Jacobian, obj. gradient
+ 3 1	#max name lengths: constraints, variables
+ 0 0 0 0 0	#common exprs: b,c,o,c1,o1
+C0	#c1
+n0
+O0 0	#obj
+o54	#sumlist
+3	#(n)
+o5	#^
+n2
+n2
+o5	#^
+o16	#-
+v0	#z
+n2
+o5	#^
+v0	#z
+n2
+x0	#initial guess
+r	#1 ranges (rhs's)
+1 0.5	#c1
+b	#1 bounds (on variables)
+3	#z
+k0	#intermediate Jacobian column lengths
+G0 1	#obj
+0 0
+""",
+                OUT.getvalue(),
+            )
+        )
+
     def test_scaling(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var(initialize=0)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Summary/Motivation:
```
In [1]: import pyomo.environ as pe
   ...: from pyomo.repn.plugins.nl_writer import NLWriter
   ...: import io
   ...: m = pe.ConcreteModel()
   ...: m.x = pe.Var()
   ...: m.y = pe.Var()
   ...: m.z = pe.Var()
   ...: m.obj = pe.Objective(expr=m.x**2 + m.y**2 + m.z**2)
   ...: m.c1 = pe.Constraint(expr=m.x == m.y + m.z + 1.5)
   ...: m.c2 = pe.Constraint(expr=m.z == -m.y)
   ...: writer = NLWriter()
   ...: out = io.StringIO()
   ...: writer.write(m, out)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In [1], line 13
     11 writer = NLWriter()
     12 out = io.StringIO()
---> 13 writer.write(m, out)

File /.../pyomo/repn/plugins/nl_writer.py:409, in NLWriter.write(self, model, ostream, rowstream, colstream, **options)
    405 # Pause the GC, as the walker that generates the compiled NL
    406 # representation generates (and disposes of) a large number of
    407 # small objects.
    408 with _NLWriter_impl(ostream, rowstream, colstream, config) as impl:
--> 409     return impl.write(model)

File /.../pyomo/repn/plugins/nl_writer.py:775, in _NLWriter_impl.write(self, model)
    769 # This may fetch more bounds than needed, but only in the cases
    770 # where variables were completely eliminated while walking the
    771 # expressions, or when users provide superfluous variables in
    772 # the column ordering.
    773 var_bounds = {_id: v.bounds for _id, v in var_map.items()}
--> 775 eliminated_cons, eliminated_vars = self._linear_presolve(
    776     comp_by_linear_var, lcon_by_linear_nnz, var_bounds
    777 )
    778 del comp_by_linear_var
    779 del lcon_by_linear_nnz

File /.../pyomo/repn/plugins/nl_writer.py:1771, in _NLWriter_impl._linear_presolve(self, comp_by_linear_var, lcon_by_linear_nnz, var_bounds)
   1766         coef, coef2 = coef2, coef
   1767 else:
   1768     # In an attempt to improve numerical stability, we will
   1769     # solve for (and substitute out) the variable with the
   1770     # coefficient closer to +/-1)
-> 1771     log_coef = _log10(abs(coef))
   1772     log_coef2 = _log10(abs(coef2))
   1773     if abs(log_coef2) < abs(log_coef) or (
   1774         log_coef2 == -log_coef and log_coef2 < log_coef
   1775     ):

ValueError: math domain error
```

## Changes proposed in this PR:
- Check for division by zero in NL writer's linear presolve

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
