### PR TITLE
Allow CyIpopt to solve problems without objectives

### DIFF
--- a/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
@@ -24,6 +24,8 @@ import abc
 from pyomo.common.deprecation import relocated_module_attribute
 from pyomo.common.dependencies import attempt_import, numpy as np, numpy_available
 from pyomo.common.tee import redirect_fd, TeeStream
+from pyomo.common.modeling import unique_component_name
+from pyomo.core.base.objective import Objective
 
 # Because pynumero.interfaces requires numpy, we will leverage deferred
 # imports here so that the solver can be registered even when numpy is
@@ -332,11 +334,22 @@ class PyomoCyIpoptSolver(object):
         grey_box_blocks = list(
             model.component_data_objects(egb.ExternalGreyBoxBlock, active=True)
         )
-        if grey_box_blocks:
-            # nlp = pyomo_nlp.PyomoGreyBoxNLP(model)
-            nlp = pyomo_grey_box.PyomoNLPWithGreyBoxBlocks(model)
-        else:
-            nlp = pyomo_nlp.PyomoNLP(model)
+        # if there is no objective, add one temporarily so we can construct an NLP
+        objectives = list(model.component_data_objects(Objective, active=True))
+        if not objectives:
+            objname = unique_component_name(model, "_obj")
+            objective = model.add_component(objname, Objective(expr=0.0))
+        try:
+            if grey_box_blocks:
+                # nlp = pyomo_nlp.PyomoGreyBoxNLP(model)
+                nlp = pyomo_grey_box.PyomoNLPWithGreyBoxBlocks(model)
+            else:
+                nlp = pyomo_nlp.PyomoNLP(model)
+        finally:
+            # We only need the objective to construct the NLP, so we delete
+            # it from the model ASAP
+            if not objectives:
+                model.del_component(objective)
 
         problem = cyipopt_interface.CyIpoptNLP(
             nlp,

--- a/pyomo/contrib/pynumero/algorithms/solvers/tests/test_cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/tests/test_cyipopt_solver.py
@@ -316,3 +316,13 @@ class TestCyIpoptSolver(unittest.TestCase):
         msg = "Error in AMPL evaluation"
         with self.assertRaisesRegex(PyNumeroEvaluationError, msg):
             res = solver.solve(m, tee=True)
+
+    def test_solve_without_objective(self):
+        m = create_model1()
+        m.o.deactivate()
+        m.x[2].fix(0.0)
+        m.x[3].fix(4.0)
+        solver = pyo.SolverFactory("cyipopt")
+        res = solver.solve(m, tee=True)
+        pyo.assert_optimal_termination(res)
+        self.assertAlmostEqual(m.x[1].value, 9.0)


### PR DESCRIPTION
## Fixes 
CyIpopt can't solve problems without objectives because it fails to create the PyomoNLP that it needs to construct the CyIpoptProblemInterface

## Summary/Motivation:
Use CyIpopt as a solver for square problems in various contexts.

## Changes proposed in this PR:
- In `PyomoCyIpoptSolver.solve`, check the model for active objectives. If none, add a dummy objective with value zero that is removed after the NLP object is created.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
