### PR TITLE
Updating TPL package list due to contrib.solver

### DIFF
--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -140,7 +140,7 @@ class TestPyomoEnviron(unittest.TestCase):
             'cPickle',
             'csv',
             'ctypes',  # mandatory import in core/base/external.py; TODO: fix this
-            'datetime', # imported by contrib.solver
+            'datetime',  # imported by contrib.solver
             'decimal',
             'gc',  # Imported on MacOS, Windows; Linux in 3.10
             'glob',

--- a/pyomo/environ/tests/test_environ.py
+++ b/pyomo/environ/tests/test_environ.py
@@ -140,6 +140,7 @@ class TestPyomoEnviron(unittest.TestCase):
             'cPickle',
             'csv',
             'ctypes',  # mandatory import in core/base/external.py; TODO: fix this
+            'datetime', # imported by contrib.solver
             'decimal',
             'gc',  # Imported on MacOS, Windows; Linux in 3.10
             'glob',


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
`contrib.solver` added an unconditional dependence on `datetime`.  While we could defer that import, it is not a slow import (at least at the moment), and is likely to become pervasive throughout the solver interfaces, to this PR adds to the list of expected TPL imports.

This resolves an occasional test failure that checks the TPL import times.

## Changes proposed in this PR:
- add `datetime` to the list of expected `pyomo.environ` TPL imports

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
