### PR TITLE
GDP: Use private_data for all mappings between original and transformed components

### DIFF
--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -61,6 +61,7 @@ logger = logging.getLogger('pyomo.gdp.bigm')
 
 class _BigMData(AutoSlots.Mixin):
     __slots__ = ('bigm_src',)
+
     def __init__(self):
         # we will keep a map of constraints (hashable, ha!) to a tuple to
         # indicate what their M value is and where it came from, of the form:
@@ -74,7 +75,9 @@ class _BigMData(AutoSlots.Mixin):
         # information for both.)
         self.bigm_src = {}
 
+
 Block.register_private_data_initializer(_BigMData)
+
 
 @TransformationFactory.register(
     'gdp.bigm', doc="Relax disjunctive model using big-M terms."

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -94,15 +94,8 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
     name beginning "_pyomo_gdp_bigm_reformulation".  That Block will
     contain an indexed Block named "relaxedDisjuncts", which will hold
     the relaxed disjuncts.  This block is indexed by an integer
-    indicating the order in which the disjuncts were relaxed.
-    Each block has a dictionary "_constraintMap":
-
-        'srcConstraints': ComponentMap(<transformed constraint>:
-                                       <src constraint>)
-        'transformedConstraints': ComponentMap(<src constraint>:
-                                               <transformed constraint>)
-
-    All transformed Disjuncts will have a pointer to the block their transformed
+    indicating the order in which the disjuncts were relaxed. All
+    transformed Disjuncts will have a pointer to the block their transformed
     constraints are on, and all transformed Disjunctions will have a
     pointer to the corresponding 'Or' or 'ExactlyOne' constraint.
 
@@ -279,7 +272,7 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
         # add constraint to the transformation block, we'll transform it there.
         transBlock = disjunct._transformation_block()
         bigm_src = transBlock.bigm_src
-        constraintMap = transBlock._constraintMap
+        constraint_map = transBlock.private_data('pyomo.gdp')
 
         disjunctionRelaxationBlock = transBlock.parent_block()
 
@@ -346,7 +339,7 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
             bigm_src[c] = (lower, upper)
 
             self._add_constraint_expressions(
-                c, i, M, disjunct.binary_indicator_var, newConstraint, constraintMap
+                c, i, M, disjunct.binary_indicator_var, newConstraint, constraint_map
             )
 
             # deactivate because we relaxed

--- a/pyomo/gdp/plugins/bigm_mixin.py
+++ b/pyomo/gdp/plugins/bigm_mixin.py
@@ -254,7 +254,8 @@ class _BigM_MixIn(object):
             M_expr = M[0] * (1 - indicator_var)
             newConstraint.add((name, i, 'lb'), c.lower <= c.body - M_expr)
             constraint_map.transformed_constraints[c].append(
-                newConstraint[name, i, 'lb'])
+                newConstraint[name, i, 'lb']
+            )
             constraint_map.src_constraint[newConstraint[name, i, 'lb']] = c
         if c.upper is not None:
             if M[1] is None:

--- a/pyomo/gdp/plugins/bigm_mixin.py
+++ b/pyomo/gdp/plugins/bigm_mixin.py
@@ -232,7 +232,7 @@ class _BigM_MixIn(object):
         return tuple(M)
 
     def _add_constraint_expressions(
-        self, c, i, M, indicator_var, newConstraint, constraintMap
+        self, c, i, M, indicator_var, newConstraint, constraint_map
     ):
         # Since we are both combining components from multiple blocks and using
         # local names, we need to make sure that the first index for
@@ -253,8 +253,8 @@ class _BigM_MixIn(object):
                 )
             M_expr = M[0] * (1 - indicator_var)
             newConstraint.add((name, i, 'lb'), c.lower <= c.body - M_expr)
-            constraintMap['transformedConstraints'][c] = [newConstraint[name, i, 'lb']]
-            constraintMap['srcConstraints'][newConstraint[name, i, 'lb']] = c
+            constraint_map.transformed_constraint[c] = [newConstraint[name, i, 'lb']]
+            constraint_map.src_constraint[newConstraint[name, i, 'lb']] = c
         if c.upper is not None:
             if M[1] is None:
                 raise GDP_Error(
@@ -263,13 +263,13 @@ class _BigM_MixIn(object):
                 )
             M_expr = M[1] * (1 - indicator_var)
             newConstraint.add((name, i, 'ub'), c.body - M_expr <= c.upper)
-            transformed = constraintMap['transformedConstraints'].get(c)
+            transformed = constraint_map.transformed_constraint.get(c)
             if transformed is not None:
-                constraintMap['transformedConstraints'][c].append(
+                constraint_map.transformed_constraint[c].append(
                     newConstraint[name, i, 'ub']
                 )
             else:
-                constraintMap['transformedConstraints'][c] = [
+                constraint_map.transformed_constraint[c] = [
                     newConstraint[name, i, 'ub']
                 ]
-            constraintMap['srcConstraints'][newConstraint[name, i, 'ub']] = c
+            constraint_map.src_constraint[newConstraint[name, i, 'ub']] = c

--- a/pyomo/gdp/plugins/bigm_mixin.py
+++ b/pyomo/gdp/plugins/bigm_mixin.py
@@ -253,7 +253,8 @@ class _BigM_MixIn(object):
                 )
             M_expr = M[0] * (1 - indicator_var)
             newConstraint.add((name, i, 'lb'), c.lower <= c.body - M_expr)
-            constraint_map.transformed_constraint[c] = [newConstraint[name, i, 'lb']]
+            constraint_map.transformed_constraints[c].append(
+                newConstraint[name, i, 'lb'])
             constraint_map.src_constraint[newConstraint[name, i, 'lb']] = c
         if c.upper is not None:
             if M[1] is None:
@@ -263,13 +264,7 @@ class _BigM_MixIn(object):
                 )
             M_expr = M[1] * (1 - indicator_var)
             newConstraint.add((name, i, 'ub'), c.body - M_expr <= c.upper)
-            transformed = constraint_map.transformed_constraint.get(c)
-            if transformed is not None:
-                constraint_map.transformed_constraint[c].append(
-                    newConstraint[name, i, 'ub']
-                )
-            else:
-                constraint_map.transformed_constraint[c] = [
-                    newConstraint[name, i, 'ub']
-                ]
+            constraint_map.transformed_constraints[c].append(
+                newConstraint[name, i, 'ub']
+            )
             constraint_map.src_constraint[newConstraint[name, i, 'ub']] = c

--- a/pyomo/gdp/plugins/binary_multiplication.py
+++ b/pyomo/gdp/plugins/binary_multiplication.py
@@ -156,7 +156,7 @@ class GDPBinaryMultiplicationTransformation(GDP_to_MIP_Transformation):
         # over the constraint indices, but I don't think it matters a lot.)
         unique = len(newConstraint)
         name = c.local_name + "_%s" % unique
-        transformed = constraint_map.transformed_constraint[c] = []
+        transformed = constraint_map.transformed_constraints[c]
 
         lb, ub = c.lower, c.upper
         if (c.equality or lb is ub) and lb is not None:

--- a/pyomo/gdp/plugins/binary_multiplication.py
+++ b/pyomo/gdp/plugins/binary_multiplication.py
@@ -121,7 +121,7 @@ class GDPBinaryMultiplicationTransformation(GDP_to_MIP_Transformation):
     def _transform_constraint(self, obj, disjunct):
         # add constraint to the transformation block, we'll transform it there.
         transBlock = disjunct._transformation_block()
-        constraintMap = transBlock._constraintMap
+        constraint_map = transBlock.private_data('pyomo.gdp')
 
         disjunctionRelaxationBlock = transBlock.parent_block()
 
@@ -137,14 +137,14 @@ class GDPBinaryMultiplicationTransformation(GDP_to_MIP_Transformation):
                 continue
 
             self._add_constraint_expressions(
-                c, i, disjunct.binary_indicator_var, newConstraint, constraintMap
+                c, i, disjunct.binary_indicator_var, newConstraint, constraint_map
             )
 
             # deactivate because we relaxed
             c.deactivate()
 
     def _add_constraint_expressions(
-        self, c, i, indicator_var, newConstraint, constraintMap
+        self, c, i, indicator_var, newConstraint, constraint_map
     ):
         # Since we are both combining components from multiple blocks and using
         # local names, we need to make sure that the first index for
@@ -156,21 +156,21 @@ class GDPBinaryMultiplicationTransformation(GDP_to_MIP_Transformation):
         # over the constraint indices, but I don't think it matters a lot.)
         unique = len(newConstraint)
         name = c.local_name + "_%s" % unique
-        transformed = constraintMap['transformedConstraints'][c] = []
+        transformed = constraint_map.transformed_constraint[c] = []
 
         lb, ub = c.lower, c.upper
         if (c.equality or lb is ub) and lb is not None:
             # equality
             newConstraint.add((name, i, 'eq'), (c.body - lb) * indicator_var == 0)
             transformed.append(newConstraint[name, i, 'eq'])
-            constraintMap['srcConstraints'][newConstraint[name, i, 'eq']] = c
+            constraint_map.src_constraint[newConstraint[name, i, 'eq']] = c
         else:
             # inequality
             if lb is not None:
                 newConstraint.add((name, i, 'lb'), 0 <= (c.body - lb) * indicator_var)
                 transformed.append(newConstraint[name, i, 'lb'])
-                constraintMap['srcConstraints'][newConstraint[name, i, 'lb']] = c
+                constraint_map.src_constraint[newConstraint[name, i, 'lb']] = c
             if ub is not None:
                 newConstraint.add((name, i, 'ub'), (c.body - ub) * indicator_var <= 0)
                 transformed.append(newConstraint[name, i, 'ub'])
-                constraintMap['srcConstraints'][newConstraint[name, i, 'ub']] = c
+                constraint_map.src_constraint[newConstraint[name, i, 'ub']] = c

--- a/pyomo/gdp/plugins/gdp_to_mip_transformation.py
+++ b/pyomo/gdp/plugins/gdp_to_mip_transformation.py
@@ -11,6 +11,7 @@
 
 from functools import wraps
 
+from pyomo.common.autoslots import AutoSlots
 from pyomo.common.collections import ComponentMap
 from pyomo.common.log import is_debug_set
 from pyomo.common.modeling import unique_component_name
@@ -46,6 +47,16 @@ from pyomo.gdp.util import (
 from pyomo.network import Port
 
 from weakref import ref as weakref_ref
+
+
+class _GDPTransformationData(AutoSlots.Mixin):
+    __slots__ = ('src_constraint', 'transformed_constraint')
+    def __init__(self):
+        self.src_constraint = ComponentMap()
+        self.transformed_constraint = ComponentMap()
+
+
+Block.register_private_data_initializer(_GDPTransformationData, scope='pyomo.gdp')
 
 
 class GDP_to_MIP_Transformation(Transformation):

--- a/pyomo/gdp/plugins/gdp_to_mip_transformation.py
+++ b/pyomo/gdp/plugins/gdp_to_mip_transformation.py
@@ -51,6 +51,7 @@ from weakref import ref as weakref_ref
 
 class _GDPTransformationData(AutoSlots.Mixin):
     __slots__ = ('src_constraint', 'transformed_constraint')
+
     def __init__(self):
         self.src_constraint = ComponentMap()
         self.transformed_constraint = ComponentMap()

--- a/pyomo/gdp/plugins/gdp_to_mip_transformation.py
+++ b/pyomo/gdp/plugins/gdp_to_mip_transformation.py
@@ -12,7 +12,7 @@
 from functools import wraps
 
 from pyomo.common.autoslots import AutoSlots
-from pyomo.common.collections import ComponentMap
+from pyomo.common.collections import ComponentMap, DefaultComponentMap
 from pyomo.common.log import is_debug_set
 from pyomo.common.modeling import unique_component_name
 
@@ -50,11 +50,11 @@ from weakref import ref as weakref_ref
 
 
 class _GDPTransformationData(AutoSlots.Mixin):
-    __slots__ = ('src_constraint', 'transformed_constraint')
+    __slots__ = ('src_constraint', 'transformed_constraints')
 
     def __init__(self):
         self.src_constraint = ComponentMap()
-        self.transformed_constraint = ComponentMap()
+        self.transformed_constraints = DefaultComponentMap(list)
 
 
 Block.register_private_data_initializer(_GDPTransformationData, scope='pyomo.gdp')

--- a/pyomo/gdp/plugins/gdp_to_mip_transformation.py
+++ b/pyomo/gdp/plugins/gdp_to_mip_transformation.py
@@ -254,14 +254,7 @@ class GDP_to_MIP_Transformation(Transformation):
         relaxationBlock = relaxedDisjuncts[len(relaxedDisjuncts)]
 
         relaxationBlock.transformedConstraints = Constraint(Any)
-
         relaxationBlock.localVarReferences = Block()
-        # add the map that will link back and forth between transformed
-        # constraints and their originals.
-        relaxationBlock._constraintMap = {
-            'srcConstraints': ComponentMap(),
-            'transformedConstraints': ComponentMap(),
-        }
 
         # add mappings to source disjunct (so we'll know we've relaxed)
         disjunct._transformation_block = weakref_ref(relaxationBlock)

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -752,7 +752,8 @@ class Hull_Reformulation(GDP_to_MIP_Transformation):
                     newConstraint.add((name, i, 'eq'), newConsExpr)
                     # map the _ConstraintDatas (we mapped the container above)
                     constraint_map.transformed_constraints[c].append(
-                        newConstraint[name, i, 'eq'])
+                        newConstraint[name, i, 'eq']
+                    )
                     constraint_map.src_constraint[newConstraint[name, i, 'eq']] = c
                 else:
                     newConstraint.add((name, 'eq'), newConsExpr)

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -58,8 +58,12 @@ logger = logging.getLogger('pyomo.gdp.hull')
 
 
 class _HullTransformationData(AutoSlots.Mixin):
-    __slots__ = ('disaggregated_var_map', 'original_var_map', 'bigm_constraint_map',
-                 'disaggregation_constraint_map')
+    __slots__ = (
+        'disaggregated_var_map',
+        'original_var_map',
+        'bigm_constraint_map',
+        'disaggregation_constraint_map',
+    )
 
     def __init__(self):
         self.disaggregated_var_map = DefaultComponentMap(ComponentMap)
@@ -315,7 +319,9 @@ class Hull_Reformulation(GDP_to_MIP_Transformation):
         )
 
         disaggregationConstraint = transBlock.disaggregationConstraints
-        disaggregationConstraintMap = transBlock.private_data().disaggregation_constraint_map
+        disaggregationConstraintMap = (
+            transBlock.private_data().disaggregation_constraint_map
+        )
         disaggregatedVars = transBlock._disaggregatedVars
         disaggregated_var_bounds = transBlock._boundsConstraints
 
@@ -910,8 +916,11 @@ class Hull_Reformulation(GDP_to_MIP_Transformation):
             )
 
         try:
-            cons = transBlock.parent_block().private_data().disaggregation_constraint_map[
-                original_var][disjunction]
+            cons = (
+                transBlock.parent_block()
+                .private_data()
+                .disaggregation_constraint_map[original_var][disjunction]
+            )
         except:
             if raise_exception:
                 logger.error(

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -742,7 +742,7 @@ class Hull_Reformulation(GDP_to_MIP_Transformation):
                         # this variable, so I'm going to return
                         # it. Alternatively we could return an empty list, but I
                         # think I like this better.
-                        constraint_map.transformed_constraint[c] = [v[0]]
+                        constraint_map.transformed_constraints[c].append(v[0])
                         # Reverse map also (this is strange)
                         constraint_map.src_constraint[v[0]] = c
                         continue
@@ -751,9 +751,8 @@ class Hull_Reformulation(GDP_to_MIP_Transformation):
                 if obj.is_indexed():
                     newConstraint.add((name, i, 'eq'), newConsExpr)
                     # map the _ConstraintDatas (we mapped the container above)
-                    constraint_map.transformed_constraint[c] = [
-                        newConstraint[name, i, 'eq']
-                    ]
+                    constraint_map.transformed_constraints[c].append(
+                        newConstraint[name, i, 'eq'])
                     constraint_map.src_constraint[newConstraint[name, i, 'eq']] = c
                 else:
                     newConstraint.add((name, 'eq'), newConsExpr)
@@ -764,9 +763,9 @@ class Hull_Reformulation(GDP_to_MIP_Transformation):
                     # IndexedConstraints, we can map the container to the
                     # container, but more importantly, we are mapping the
                     # _ConstraintDatas to each other above)
-                    constraint_map.transformed_constraint[c] = [
+                    constraint_map.transformed_constraints[c].append(
                         newConstraint[name, 'eq']
-                    ]
+                    )
                     constraint_map.src_constraint[newConstraint[name, 'eq']] = c
 
                 continue
@@ -782,15 +781,15 @@ class Hull_Reformulation(GDP_to_MIP_Transformation):
 
                 if obj.is_indexed():
                     newConstraint.add((name, i, 'lb'), newConsExpr)
-                    constraint_map.transformed_constraint[c] = [
+                    constraint_map.transformed_constraints[c].append(
                         newConstraint[name, i, 'lb']
-                    ]
+                    )
                     constraint_map.src_constraint[newConstraint[name, i, 'lb']] = c
                 else:
                     newConstraint.add((name, 'lb'), newConsExpr)
-                    constraint_map.transformed_constraint[c] = [
+                    constraint_map.transformed_constraints[c].append(
                         newConstraint[name, 'lb']
-                    ]
+                    )
                     constraint_map.src_constraint[newConstraint[name, 'lb']] = c
 
             if c.upper is not None:
@@ -806,23 +805,15 @@ class Hull_Reformulation(GDP_to_MIP_Transformation):
                     newConstraint.add((name, i, 'ub'), newConsExpr)
                     # map (have to account for fact we might have created list
                     # above
-                    transformed = constraint_map.transformed_constraint.get(c)
-                    if transformed is not None:
-                        transformed.append(newConstraint[name, i, 'ub'])
-                    else:
-                        constraint_map.transformed_constraint[c] = [
-                            newConstraint[name, i, 'ub']
-                        ]
+                    constraint_map.transformed_constraints[c].append(
+                        newConstraint[name, i, 'ub']
+                    )
                     constraint_map.src_constraint[newConstraint[name, i, 'ub']] = c
                 else:
                     newConstraint.add((name, 'ub'), newConsExpr)
-                    transformed = constraint_map.transformed_constraint.get(c)
-                    if transformed is not None:
-                        transformed.append(newConstraint[name, 'ub'])
-                    else:
-                        constraint_map.transformed_constraint[c] = [
-                            newConstraint[name, 'ub']
-                        ]
+                    constraint_map.transformed_constraints[c].append(
+                        newConstraint[name, 'ub']
+                    )
                     constraint_map.src_constraint[newConstraint[name, 'ub']] = c
 
         # deactivate now that we have transformed

--- a/pyomo/gdp/plugins/multiple_bigm.py
+++ b/pyomo/gdp/plugins/multiple_bigm.py
@@ -528,32 +528,25 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
             idx = i + offset
             if len(lower_dict) > 0:
                 transformed.add((idx, 'lb'), v >= lower_rhs)
-                constraint_map.src_constraint[
-                    transformed[idx, 'lb']
-                ] = []
+                constraint_map.src_constraint[transformed[idx, 'lb']] = []
                 for c, disj in lower_bound_constraints_by_var[v]:
-                    constraint_map.src_constraint[
-                        transformed[idx, 'lb']
-                    ].append(c)
+                    constraint_map.src_constraint[transformed[idx, 'lb']].append(c)
                     disj.transformation_block.private_data(
-                        'pyomo.gdp').transformed_constraint[
-                        c
-                    ] = [transformed[idx, 'lb']]
+                        'pyomo.gdp'
+                    ).transformed_constraint[c] = [transformed[idx, 'lb']]
             if len(upper_dict) > 0:
                 transformed.add((idx, 'ub'), v <= upper_rhs)
-                constraint_map.src_constraint[
-                    transformed[idx, 'ub']
-                ] = []
+                constraint_map.src_constraint[transformed[idx, 'ub']] = []
                 for c, disj in upper_bound_constraints_by_var[v]:
-                    constraint_map.src_constraint[
-                        transformed[idx, 'ub']
-                    ].append(c)
+                    constraint_map.src_constraint[transformed[idx, 'ub']].append(c)
                     # might already be here if it had an upper bound
                     disj_constraint_map = disj.transformation_block.private_data(
-                        'pyomo.gdp')
+                        'pyomo.gdp'
+                    )
                     if c in disj_constraint_map.transformed_constraint:
                         disj_constraint_map.transformed_constraint[c].append(
-                            transformed[idx, 'ub'])
+                            transformed[idx, 'ub']
+                        )
                     else:
                         disj_constraint_map.transformed_constraint[c] = [
                             transformed[idx, 'ub']

--- a/pyomo/gdp/plugins/multiple_bigm.py
+++ b/pyomo/gdp/plugins/multiple_bigm.py
@@ -378,7 +378,7 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
                 continue
 
             if not self._config.only_mbigm_bound_constraints:
-                transformed = []
+                transformed = constraint_map.transformed_constraints[c]
                 if c.lower is not None:
                     rhs = sum(
                         Ms[c, disj][0] * disj.indicator_var.get_associated_binary()
@@ -398,7 +398,6 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
                     transformed.append(newConstraint[i, 'ub'])
                 for c_new in transformed:
                     constraint_map.src_constraint[c_new] = [c]
-                constraint_map.transformed_constraint[c] = transformed
             else:
                 lower = (None, None, None)
                 upper = (None, None, None)
@@ -533,7 +532,7 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
                     constraint_map.src_constraint[transformed[idx, 'lb']].append(c)
                     disj.transformation_block.private_data(
                         'pyomo.gdp'
-                    ).transformed_constraint[c] = [transformed[idx, 'lb']]
+                    ).transformed_constraints[c].append(transformed[idx, 'lb'])
             if len(upper_dict) > 0:
                 transformed.add((idx, 'ub'), v <= upper_rhs)
                 constraint_map.src_constraint[transformed[idx, 'ub']] = []
@@ -543,14 +542,9 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
                     disj_constraint_map = disj.transformation_block.private_data(
                         'pyomo.gdp'
                     )
-                    if c in disj_constraint_map.transformed_constraint:
-                        disj_constraint_map.transformed_constraint[c].append(
-                            transformed[idx, 'ub']
-                        )
-                    else:
-                        disj_constraint_map.transformed_constraint[c] = [
-                            transformed[idx, 'ub']
-                        ]
+                    disj_constraint_map.transformed_constraints[c].append(
+                        transformed[idx, 'ub']
+                    )
 
         return transformed_constraints
 

--- a/pyomo/gdp/plugins/multiple_bigm.py
+++ b/pyomo/gdp/plugins/multiple_bigm.py
@@ -359,7 +359,7 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
     def _transform_constraint(self, obj, disjunct, active_disjuncts, Ms):
         # we will put a new transformed constraint on the relaxation block.
         relaxationBlock = disjunct._transformation_block()
-        constraintMap = relaxationBlock._constraintMap
+        constraint_map = relaxationBlock.private_data('pyomo.gdp')
         transBlock = relaxationBlock.parent_block()
 
         # Though rare, it is possible to get naming conflicts here
@@ -397,8 +397,8 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
                     newConstraint.add((i, 'ub'), c.body - c.upper <= rhs)
                     transformed.append(newConstraint[i, 'ub'])
                 for c_new in transformed:
-                    constraintMap['srcConstraints'][c_new] = [c]
-                constraintMap['transformedConstraints'][c] = transformed
+                    constraint_map.src_constraint[c_new] = [c]
+                constraint_map.transformed_constraint[c] = transformed
             else:
                 lower = (None, None, None)
                 upper = (None, None, None)
@@ -427,7 +427,7 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
                     M,
                     disjunct.indicator_var.get_associated_binary(),
                     newConstraint,
-                    constraintMap,
+                    constraint_map,
                 )
 
             # deactivate now that we have transformed
@@ -496,6 +496,7 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
                 relaxationBlock = self._get_disjunct_transformation_block(
                     disj, transBlock
                 )
+                constraint_map = relaxationBlock.private_data('pyomo.gdp')
                 if len(lower_dict) > 0:
                     M = lower_dict.get(disj, None)
                     if M is None:
@@ -527,39 +528,36 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
             idx = i + offset
             if len(lower_dict) > 0:
                 transformed.add((idx, 'lb'), v >= lower_rhs)
-                relaxationBlock._constraintMap['srcConstraints'][
+                constraint_map.src_constraint[
                     transformed[idx, 'lb']
                 ] = []
                 for c, disj in lower_bound_constraints_by_var[v]:
-                    relaxationBlock._constraintMap['srcConstraints'][
+                    constraint_map.src_constraint[
                         transformed[idx, 'lb']
                     ].append(c)
-                    disj.transformation_block._constraintMap['transformedConstraints'][
+                    disj.transformation_block.private_data(
+                        'pyomo.gdp').transformed_constraint[
                         c
                     ] = [transformed[idx, 'lb']]
             if len(upper_dict) > 0:
                 transformed.add((idx, 'ub'), v <= upper_rhs)
-                relaxationBlock._constraintMap['srcConstraints'][
+                constraint_map.src_constraint[
                     transformed[idx, 'ub']
                 ] = []
                 for c, disj in upper_bound_constraints_by_var[v]:
-                    relaxationBlock._constraintMap['srcConstraints'][
+                    constraint_map.src_constraint[
                         transformed[idx, 'ub']
                     ].append(c)
                     # might already be here if it had an upper bound
-                    if (
-                        c
-                        in disj.transformation_block._constraintMap[
-                            'transformedConstraints'
-                        ]
-                    ):
-                        disj.transformation_block._constraintMap[
-                            'transformedConstraints'
-                        ][c].append(transformed[idx, 'ub'])
+                    disj_constraint_map = disj.transformation_block.private_data(
+                        'pyomo.gdp')
+                    if c in disj_constraint_map.transformed_constraint:
+                        disj_constraint_map.transformed_constraint[c].append(
+                            transformed[idx, 'ub'])
                     else:
-                        disj.transformation_block._constraintMap[
-                            'transformedConstraints'
-                        ][c] = [transformed[idx, 'ub']]
+                        disj_constraint_map.transformed_constraint[c] = [
+                            transformed[idx, 'ub']
+                        ]
 
         return transformed_constraints
 

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -1316,18 +1316,11 @@ class ScalarDisjIndexedConstraints(unittest.TestCase, CommonTests):
         bigm.apply_to(m)
 
         # the real test: This wasn't transformed
-        log = StringIO()
-        with LoggingIntercept(log, 'pyomo.gdp', logging.ERROR):
-            self.assertRaisesRegex(
-                KeyError,
-                r".*b.simpledisj1.c\[1\]",
-                bigm.get_transformed_constraints,
-                m.b.simpledisj1.c[1],
-            )
-        self.assertRegex(
-            log.getvalue(),
-            r".*Constraint 'b.simpledisj1.c\[1\]' has not been transformed.",
-        )
+        with self.assertRaisesRegex(
+            GDP_Error,
+            r"Constraint 'b.simpledisj1.c\[1\]' has not been transformed."
+        ):
+            bigm.get_transformed_constraints(m.b.simpledisj1.c[1])
 
         # and the rest of the container was transformed
         cons_list = bigm.get_transformed_constraints(m.b.simpledisj1.c[2])
@@ -2272,18 +2265,13 @@ class BlocksOnDisjuncts(unittest.TestCase):
         self.assertEqual(len(evil1), 2)
         self.assertIs(evil1[0].parent_block(), disjBlock[1])
         self.assertIs(evil1[1].parent_block(), disjBlock[1])
-        out = StringIO()
-        with LoggingIntercept(out, 'pyomo.gdp', logging.ERROR):
-            self.assertRaisesRegex(
-                KeyError,
-                r".*.evil\[1\].b.anotherblock.c",
-                bigm.get_transformed_constraints,
-                m.evil[1].b.anotherblock.c,
-            )
-        self.assertRegex(
-            out.getvalue(),
-            r".*Constraint 'evil\[1\].b.anotherblock.c' has not been transformed.",
-        )
+        with self.assertRaisesRegex(
+            GDP_Error,
+            r"Constraint 'evil\[1\].b.anotherblock.c' has not been "
+            r"transformed.",
+        ):
+            bigm.get_transformed_constraints(m.evil[1].b.anotherblock.c)
+
         evil1 = bigm.get_transformed_constraints(m.evil[1].bb[1].c)
         self.assertEqual(len(evil1), 2)
         self.assertIs(evil1[0].parent_block(), disjBlock[1])

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -1317,8 +1317,7 @@ class ScalarDisjIndexedConstraints(unittest.TestCase, CommonTests):
 
         # the real test: This wasn't transformed
         with self.assertRaisesRegex(
-            GDP_Error,
-            r"Constraint 'b.simpledisj1.c\[1\]' has not been transformed."
+            GDP_Error, r"Constraint 'b.simpledisj1.c\[1\]' has not been transformed."
         ):
             bigm.get_transformed_constraints(m.b.simpledisj1.c[1])
 
@@ -2267,8 +2266,7 @@ class BlocksOnDisjuncts(unittest.TestCase):
         self.assertIs(evil1[1].parent_block(), disjBlock[1])
         with self.assertRaisesRegex(
             GDP_Error,
-            r"Constraint 'evil\[1\].b.anotherblock.c' has not been "
-            r"transformed.",
+            r"Constraint 'evil\[1\].b.anotherblock.c' has not been transformed.",
         ):
             bigm.get_transformed_constraints(m.evil[1].b.anotherblock.c)
 

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -897,18 +897,11 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         hull = TransformationFactory('gdp.hull')
         hull.apply_to(m)
         # can't ask for simpledisj1.c[1]: it wasn't transformed
-        log = StringIO()
-        with LoggingIntercept(log, 'pyomo.gdp', logging.ERROR):
-            self.assertRaisesRegex(
-                KeyError,
-                r".*b.simpledisj1.c\[1\]",
-                hull.get_transformed_constraints,
-                m.b.simpledisj1.c[1],
-            )
-        self.assertRegex(
-            log.getvalue(),
-            r".*Constraint 'b.simpledisj1.c\[1\]' has not been transformed.",
-        )
+        with self.assertRaisesRegex(
+            GDP_Error,
+            r"Constraint 'b.simpledisj1.c\[1\]' has not been transformed."
+        ):
+            hull.get_transformed_constraints(m.b.simpledisj1.c[1])
 
         # this fixes a[2] to 0, so we should get the disggregated var
         transformed = hull.get_transformed_constraints(m.b.simpledisj1.c[2])

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -2314,8 +2314,7 @@ class TestErrors(unittest.TestCase):
         with LoggingIntercept(log, 'pyomo.gdp.hull', logging.ERROR):
             self.assertRaisesRegex(
                 KeyError,
-                r".*_pyomo_gdp_hull_reformulation.relaxedDisjuncts\[1\]."
-                r"disaggregatedVars.w",
+                r".*disjunction",
                 hull.get_disaggregation_constraint,
                 m.d[1].transformation_block.disaggregatedVars.w,
                 m.disjunction,

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -898,8 +898,7 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
         hull.apply_to(m)
         # can't ask for simpledisj1.c[1]: it wasn't transformed
         with self.assertRaisesRegex(
-            GDP_Error,
-            r"Constraint 'b.simpledisj1.c\[1\]' has not been transformed."
+            GDP_Error, r"Constraint 'b.simpledisj1.c\[1\]' has not been transformed."
         ):
             hull.get_transformed_constraints(m.b.simpledisj1.c[1])
 

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -540,7 +540,8 @@ def get_transformed_constraints(srcConstraint):
     transBlock = _get_constraint_transBlock(srcConstraint)
     try:
         return transBlock.private_data('pyomo.gdp').transformed_constraint[
-            srcConstraint]
+            srcConstraint
+        ]
     except:
         logger.error("Constraint '%s' has not been transformed." % srcConstraint.name)
         raise

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -539,12 +539,14 @@ def get_transformed_constraints(srcConstraint):
         )
     transBlock = _get_constraint_transBlock(srcConstraint)
     transformed_constraints = transBlock.private_data(
-        'pyomo.gdp').transformed_constraints
+        'pyomo.gdp'
+    ).transformed_constraints
     if srcConstraint in transformed_constraints:
         return transformed_constraints[srcConstraint]
     else:
-        raise GDP_Error("Constraint '%s' has not been transformed." % 
-                        srcConstraint.name)
+        raise GDP_Error(
+            "Constraint '%s' has not been transformed." % srcConstraint.name
+        )
 
 
 def _warn_for_active_disjunct(innerdisjunct, outerdisjunct):

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -477,16 +477,17 @@ def get_src_constraint(transformedConstraint):
     a transformation block
     """
     transBlock = transformedConstraint.parent_block()
+    src_constraints = transBlock.private_data('pyomo.gdp').src_constraint
     # This should be our block, so if it's not, the user messed up and gave
     # us the wrong thing. If they happen to also have a _constraintMap then
     # the world is really against us.
-    if not hasattr(transBlock, "_constraintMap"):
+    if transformedConstraint not in src_constraints:
         raise GDP_Error(
             "Constraint '%s' is not a transformed constraint"
             % transformedConstraint.name
         )
     # if something goes wrong here, it's a bug in the mappings.
-    return transBlock._constraintMap['srcConstraints'][transformedConstraint]
+    return src_constraints[transformedConstraint]
 
 
 def _find_parent_disjunct(constraint):
@@ -538,7 +539,8 @@ def get_transformed_constraints(srcConstraint):
         )
     transBlock = _get_constraint_transBlock(srcConstraint)
     try:
-        return transBlock._constraintMap['transformedConstraints'][srcConstraint]
+        return transBlock.private_data('pyomo.gdp').transformed_constraint[
+            srcConstraint]
     except:
         logger.error("Constraint '%s' has not been transformed." % srcConstraint.name)
         raise

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -538,13 +538,13 @@ def get_transformed_constraints(srcConstraint):
             "from any of its _ComponentDatas.)"
         )
     transBlock = _get_constraint_transBlock(srcConstraint)
-    try:
-        return transBlock.private_data('pyomo.gdp').transformed_constraint[
-            srcConstraint
-        ]
-    except:
-        logger.error("Constraint '%s' has not been transformed." % srcConstraint.name)
-        raise
+    transformed_constraints = transBlock.private_data(
+        'pyomo.gdp').transformed_constraints
+    if srcConstraint in transformed_constraints:
+        return transformed_constraints[srcConstraint]
+    else:
+        raise GDP_Error("Constraint '%s' has not been transformed." % 
+                        srcConstraint.name)
 
 
 def _warn_for_active_disjunct(innerdisjunct, outerdisjunct):


### PR DESCRIPTION

## Fixes # .

## Summary/Motivation:

This moves all of the mappings between original and transformed things in pyomo.gdp onto the new Block `private_data` infrastructure. It's very pretty.

## Changes proposed in this PR:
- Uses private_data for all the mappings in pyomo.gdp
- That changes a couple tests from KeyErrors to GDP_Errors, but that's the most significant change you can see from the outside.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
