### PR TITLE
Automate TPL callback registrations

### DIFF
--- a/doc/OnlineDocs/conf.py
+++ b/doc/OnlineDocs/conf.py
@@ -271,7 +271,7 @@ from pyomo.common.dependencies import (
     yaml_available, networkx_available, matplotlib_available,
     pympler_available, dill_available,
 )
-pint_available = attempt_import('pint', defer_check=False)[1]
+pint_available = attempt_import('pint', defer_import=False)[1]
 from pyomo.contrib.parmest.parmest import parmest_available
 
 import pyomo.environ as _pe # (trigger all plugin registrations)

--- a/doc/OnlineDocs/contributed_packages/pyros.rst
+++ b/doc/OnlineDocs/contributed_packages/pyros.rst
@@ -689,7 +689,7 @@ could have been equivalently written as:
   ...     },
   ... )
   ==============================================================================
-  PyROS: The Pyomo Robust Optimization Solver.
+  PyROS: The Pyomo Robust Optimization Solver...
   ...
   ------------------------------------------------------------------------------
   Robust optimal solution identified.

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -964,6 +964,11 @@ def _finalize_matplotlib(module, available):
 def _finalize_numpy(np, available):
     if not available:
         return
+    # scipy has a dependence on numpy.testing, and if we don't import it
+    # as part of resolving numpy, then certain deferred scipy imports
+    # fail when run under pytest.
+    import numpy.testing
+
     from . import numeric_types
 
     # Register ndarray as a native type to prevent 1-element ndarrays

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -485,7 +485,7 @@ class DeferredImportCallbackFinder:
     normal loader returned by ``PathFinder`` with a loader that will
     trigger custom callbacks after the module is loaded.  We use this to
     trigger the post import callbacks registered through
-    :py:fcn:`attempt_import` even when a user imports the target library
+    :py:func:`attempt_import` even when a user imports the target library
     directly (and not through attribute access on the
     :py:class:`DeferredImportModule`.
 
@@ -582,7 +582,8 @@ def attempt_import(
         The message for the exception raised by :py:class:`ModuleUnavailable`
 
     only_catch_importerror: bool, optional
-        DEPRECATED: use catch_exceptions instead or only_catch_importerror.
+        DEPRECATED: use ``catch_exceptions`` instead of ``only_catch_importerror``.
+
         If True (the default), exceptions other than ``ImportError`` raised
         during module import will be reraised.  If False, any exception
         will result in returning a :py:class:`ModuleUnavailable` object.
@@ -593,13 +594,14 @@ def attempt_import(
         ``module.__version__``)
 
     alt_names: list, optional
-        DEPRECATED: alt_names no longer needs to be specified and is ignored.
+        DEPRECATED: ``alt_names`` no longer needs to be specified and is ignored.
+
         A list of common alternate names by which to look for this
         module in the ``globals()`` namespaces.  For example, the alt_names
         for NumPy would be ``['np']``.  (deprecated in version 6.0)
 
     callback: Callable[[ModuleType, bool], None], optional
-        A function with the signature "``fcn(module, available)``" that
+        A function with the signature ``fcn(module, available)`` that
         will be called after the import is first attempted.
 
     importer: function, optional
@@ -609,7 +611,7 @@ def attempt_import(
         want to import/return the first one that is available.
 
     defer_check: bool, optional
-        DEPRECATED: renamed to ``defer_import``
+        DEPRECATED: renamed to ``defer_import`` (deprecated in version 6.7.2.dev0)
 
     defer_import: bool, optional
         If True, then the attempted import is deferred until the first
@@ -783,8 +785,8 @@ def _perform_import(
 
 
 @deprecated(
-    "declare_deferred_modules_as_importable() is dperecated.  "
-    "Use the declare_modules_as_importable() context manager.",
+    "``declare_deferred_modules_as_importable()`` is deprecated.  "
+    "Use the :py:class:`declare_modules_as_importable` context manager.",
     version='6.7.2.dev0',
 )
 def declare_deferred_modules_as_importable(globals_dict):
@@ -837,7 +839,7 @@ class declare_modules_as_importable(object):
 
     This context manager will detect all modules imported into the
     specified ``globals_dict`` environment (either directly or through
-    :py:fcn:`attempt_import`) and will make those modules importable
+    :py:func:`attempt_import`) and will make those modules importable
     from the specified ``globals_dict`` context.  It works by detecting
     changes in the specified ``globals_dict`` dictionary and adding any new
     modules or instances of :py:class:`DeferredImportModule` that it

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -813,6 +813,7 @@ def declare_deferred_modules_as_importable(globals_dict):
        ...     'scipy', callback=_finalize_scipy,
        ...     deferred_submodules=['stats', 'sparse', 'spatial', 'integrate'])
        >>> declare_deferred_modules_as_importable(globals())
+       WARNING: DEPRECATED: ...
 
     Which enables users to use:
 
@@ -851,7 +852,7 @@ class declare_modules_as_importable(object):
 
        >>> from pyomo.common.dependencies import (
        ...     attempt_import, _finalize_scipy, __dict__ as dep_globals,
-       ...     declare_deferred_modules_as_importable, )
+       ...     declare_modules_as_importable, )
        >>> # Sphinx does not provide a proper globals()
        >>> def globals(): return dep_globals
 

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -784,8 +784,8 @@ def _perform_import(
 
 @deprecated(
     "declare_deferred_modules_as_importable() is dperecated.  "
-    "Use the declare_modules_as_importable() context manager."
-    version='6.7.2.dev0'
+    "Use the declare_modules_as_importable() context manager.",
+    version='6.7.2.dev0',
 )
 def declare_deferred_modules_as_importable(globals_dict):
     """Make all :py:class:`DeferredImportModules` in ``globals_dict`` importable
@@ -875,6 +875,7 @@ class declare_modules_as_importable(object):
     :py:class:`ModuleUnavailable` instance.
 
     """
+
     def __init__(self, globals_dict):
         self.globals_dict = globals_dict
         self.init_dict = {}

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -513,9 +513,9 @@ class DeferredImportCallbackFinder:
 
 _DeferredImportCallbackFinder = DeferredImportCallbackFinder()
 # Insert the DeferredImportCallbackFinder at the beginning of the
-# mata_path to that it is found before the standard finders (so that we
-# can correctly inject the resolution of the DeferredImportIndicators --
-# which triggers the needed callbacks)
+# sys.meta_path to that it is found before the standard finders (so that
+# we can correctly inject the resolution of the DeferredImportIndicators
+# -- which triggers the needed callbacks)
 sys.meta_path.insert(0, _DeferredImportCallbackFinder)
 
 

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -597,7 +597,7 @@ def attempt_import(
         module in the ``globals()`` namespaces.  For example, the alt_names
         for NumPy would be ``['np']``.  (deprecated in version 6.0)
 
-    callback: function, optional
+    callback: Callable[[ModuleType, bool], None], optional
         A function with the signature "``fcn(module, available)``" that
         will be called after the import is first attempted.
 

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -513,7 +513,7 @@ class DeferredImportCallbackFinder:
 
 _DeferredImportCallbackFinder = DeferredImportCallbackFinder()
 # Insert the DeferredImportCallbackFinder at the beginning of the
-# sys.meta_path to that it is found before the standard finders (so that
+# sys.meta_path so that it is found before the standard finders (so that
 # we can correctly inject the resolution of the DeferredImportIndicators
 # -- which triggers the needed callbacks)
 sys.meta_path.insert(0, _DeferredImportCallbackFinder)

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -1034,12 +1034,6 @@ def _pyutilib_importer():
     return importlib.import_module('pyutilib')
 
 
-#
-# Note: because we will be calling
-# declare_deferred_modules_as_importable, it is important that the
-# following declarations explicitly defer_import (even if the target
-# module has already been imported)
-#
 with declare_modules_as_importable(globals()):
     # Standard libraries that are slower to import and not strictly required
     # on all platforms / situations.

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -963,6 +963,8 @@ def _finalize_matplotlib(module, available):
     if in_testing_environment():
         module.use('Agg')
     import matplotlib.pyplot
+    import matplotlib.pylab
+    import matplotlib.backends
 
 
 def _finalize_numpy(np, available):
@@ -1069,7 +1071,7 @@ with declare_modules_as_importable(globals()):
     matplotlib, matplotlib_available = attempt_import(
         'matplotlib',
         callback=_finalize_matplotlib,
-        deferred_submodules=['pyplot', 'pylab'],
+        deferred_submodules=['pyplot', 'pylab', 'backends'],
         catch_exceptions=(ImportError, RuntimeError),
     )
 

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -676,6 +676,15 @@ def attempt_import(
         assert defer_import is None
         defer_import = defer_check
 
+    # If the module has already been imported, there is no reason to
+    # further defer things: just import it.
+    if defer_import is None:
+        if name in sys.modules:
+            defer_import = False
+            deferred_submodules = None
+        else:
+            defer_import = True
+
     # If we are going to defer the check until later, return the
     # deferred import module object
     if defer_import:

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -490,6 +490,7 @@ class DeferredImportCallbackFinder:
     :py:class:`DeferredImportModule`.
 
     """
+
     _callbacks = {}
 
     def find_spec(self, fullname, path, target=None):

--- a/pyomo/common/numeric_types.py
+++ b/pyomo/common/numeric_types.py
@@ -12,7 +12,6 @@
 import logging
 import sys
 
-from pyomo.common.dependencies import numpy_available
 from pyomo.common.deprecation import deprecated, relocated_module_attribute
 from pyomo.common.errors import TemplateExpressionError
 
@@ -207,13 +206,6 @@ def check_if_numeric_type(obj):
     # Do not re-evaluate known native types
     if obj_class in native_types:
         return obj_class in native_numeric_types
-
-    if 'numpy' in obj_class.__module__:
-        # trigger the resolution of numpy_available and check if this
-        # type was automatically registered
-        bool(numpy_available)
-        if obj_class in native_types:
-            return obj_class in native_numeric_types
 
     try:
         obj_plus_0 = obj + 0

--- a/pyomo/common/tests/dep_mod.py
+++ b/pyomo/common/tests/dep_mod.py
@@ -13,8 +13,8 @@ from pyomo.common.dependencies import attempt_import
 
 __version__ = '1.5'
 
-numpy, numpy_available = attempt_import('numpy', defer_check=True)
+numpy, numpy_available = attempt_import('numpy', defer_import=True)
 
 bogus_nonexisting_module, bogus_nonexisting_module_available = attempt_import(
-    'bogus_nonexisting_module', alt_names=['bogus_nem'], defer_check=True
+    'bogus_nonexisting_module', alt_names=['bogus_nem'], defer_import=True
 )

--- a/pyomo/common/tests/deps.py
+++ b/pyomo/common/tests/deps.py
@@ -23,15 +23,16 @@ from pyomo.common.tests.dep_mod import (
     bogus_nonexisting_module_available as has_bogus_nem,
 )
 
-bogus, bogus_available = attempt_import('nonexisting.module.bogus', defer_check=True)
+bogus, bogus_available = attempt_import('nonexisting.module.bogus', defer_import=True)
 
 pkl_test, pkl_available = attempt_import(
-    'nonexisting.module.pickle_test', deferred_submodules=['submod'], defer_check=True
+    'nonexisting.module.pickle_test', deferred_submodules=['submod'], defer_import=True
 )
 
 pyo, pyo_available = attempt_import(
     'pyomo',
     alt_names=['pyo'],
+    defer_import=True,
     deferred_submodules={'version': None, 'common.tests.dep_mod': ['dm']},
 )
 

--- a/pyomo/common/tests/test_dependencies.py
+++ b/pyomo/common/tests/test_dependencies.py
@@ -45,7 +45,7 @@ class TestDependencies(unittest.TestCase):
         module_obj, module_available = attempt_import(
             '__there_is_no_module_named_this__',
             'Testing import of a non-existent module',
-            defer_check=False,
+            defer_import=False,
         )
         self.assertFalse(module_available)
         with self.assertRaisesRegex(
@@ -85,7 +85,7 @@ class TestDependencies(unittest.TestCase):
 
     def test_import_success(self):
         module_obj, module_available = attempt_import(
-            'ply', 'Testing import of ply', defer_check=False
+            'ply', 'Testing import of ply', defer_import=False
         )
         self.assertTrue(module_available)
         import ply
@@ -123,7 +123,7 @@ class TestDependencies(unittest.TestCase):
 
     def test_min_version(self):
         mod, avail = attempt_import(
-            'pyomo.common.tests.dep_mod', minimum_version='1.0', defer_check=False
+            'pyomo.common.tests.dep_mod', minimum_version='1.0', defer_import=False
         )
         self.assertTrue(avail)
         self.assertTrue(inspect.ismodule(mod))
@@ -131,7 +131,7 @@ class TestDependencies(unittest.TestCase):
         self.assertFalse(check_min_version(mod, '2.0'))
 
         mod, avail = attempt_import(
-            'pyomo.common.tests.dep_mod', minimum_version='2.0', defer_check=False
+            'pyomo.common.tests.dep_mod', minimum_version='2.0', defer_import=False
         )
         self.assertFalse(avail)
         self.assertIs(type(mod), ModuleUnavailable)
@@ -146,7 +146,7 @@ class TestDependencies(unittest.TestCase):
             'pyomo.common.tests.dep_mod',
             error_message="Failed import",
             minimum_version='2.0',
-            defer_check=False,
+            defer_import=False,
         )
         self.assertFalse(avail)
         self.assertIs(type(mod), ModuleUnavailable)
@@ -159,10 +159,10 @@ class TestDependencies(unittest.TestCase):
 
         # Verify check_min_version works with deferred imports
 
-        mod, avail = attempt_import('pyomo.common.tests.dep_mod', defer_check=True)
+        mod, avail = attempt_import('pyomo.common.tests.dep_mod', defer_import=True)
         self.assertTrue(check_min_version(mod, '1.0'))
 
-        mod, avail = attempt_import('pyomo.common.tests.dep_mod', defer_check=True)
+        mod, avail = attempt_import('pyomo.common.tests.dep_mod', defer_import=True)
         self.assertFalse(check_min_version(mod, '2.0'))
 
         # Verify check_min_version works when called directly
@@ -174,10 +174,10 @@ class TestDependencies(unittest.TestCase):
         self.assertFalse(check_min_version(mod, '1.0'))
 
     def test_and_or(self):
-        mod0, avail0 = attempt_import('ply', defer_check=True)
-        mod1, avail1 = attempt_import('pyomo.common.tests.dep_mod', defer_check=True)
+        mod0, avail0 = attempt_import('ply', defer_import=True)
+        mod1, avail1 = attempt_import('pyomo.common.tests.dep_mod', defer_import=True)
         mod2, avail2 = attempt_import(
-            'pyomo.common.tests.dep_mod', minimum_version='2.0', defer_check=True
+            'pyomo.common.tests.dep_mod', minimum_version='2.0', defer_import=True
         )
 
         _and = avail0 & avail1
@@ -233,11 +233,11 @@ class TestDependencies(unittest.TestCase):
         def _record_avail(module, avail):
             ans.append(avail)
 
-        mod0, avail0 = attempt_import('ply', defer_check=True, callback=_record_avail)
+        mod0, avail0 = attempt_import('ply', defer_import=True, callback=_record_avail)
         mod1, avail1 = attempt_import(
             'pyomo.common.tests.dep_mod',
             minimum_version='2.0',
-            defer_check=True,
+            defer_import=True,
             callback=_record_avail,
         )
 
@@ -250,7 +250,7 @@ class TestDependencies(unittest.TestCase):
     def test_import_exceptions(self):
         mod, avail = attempt_import(
             'pyomo.common.tests.dep_mod_except',
-            defer_check=True,
+            defer_import=True,
             only_catch_importerror=True,
         )
         with self.assertRaisesRegex(ValueError, "cannot import module"):
@@ -260,7 +260,7 @@ class TestDependencies(unittest.TestCase):
 
         mod, avail = attempt_import(
             'pyomo.common.tests.dep_mod_except',
-            defer_check=True,
+            defer_import=True,
             only_catch_importerror=False,
         )
         self.assertFalse(avail)
@@ -268,7 +268,7 @@ class TestDependencies(unittest.TestCase):
 
         mod, avail = attempt_import(
             'pyomo.common.tests.dep_mod_except',
-            defer_check=True,
+            defer_import=True,
             catch_exceptions=(ImportError, ValueError),
         )
         self.assertFalse(avail)
@@ -280,7 +280,7 @@ class TestDependencies(unittest.TestCase):
         ):
             mod, avail = attempt_import(
                 'pyomo.common.tests.dep_mod_except',
-                defer_check=True,
+                defer_import=True,
                 only_catch_importerror=True,
                 catch_exceptions=(ImportError,),
             )
@@ -288,7 +288,7 @@ class TestDependencies(unittest.TestCase):
     def test_generate_warning(self):
         mod, avail = attempt_import(
             'pyomo.common.tests.dep_mod_except',
-            defer_check=True,
+            defer_import=True,
             only_catch_importerror=False,
         )
 
@@ -324,7 +324,7 @@ class TestDependencies(unittest.TestCase):
     def test_log_warning(self):
         mod, avail = attempt_import(
             'pyomo.common.tests.dep_mod_except',
-            defer_check=True,
+            defer_import=True,
             only_catch_importerror=False,
         )
         log = StringIO()
@@ -366,9 +366,9 @@ class TestDependencies(unittest.TestCase):
 
         def _importer():
             attempted_import.append(True)
-            return attempt_import('pyomo.common.tests.dep_mod', defer_check=False)[0]
+            return attempt_import('pyomo.common.tests.dep_mod', defer_import=False)[0]
 
-        mod, avail = attempt_import('foo', importer=_importer, defer_check=True)
+        mod, avail = attempt_import('foo', importer=_importer, defer_import=True)
 
         self.assertEqual(attempted_import, [])
         self.assertIsInstance(mod, DeferredImportModule)
@@ -401,17 +401,17 @@ class TestDependencies(unittest.TestCase):
         self.assertTrue(inspect.ismodule(deps.dm))
 
         with self.assertRaisesRegex(
-            ValueError, "deferred_submodules is only valid if defer_check==True"
+            ValueError, "deferred_submodules is only valid if defer_import==True"
         ):
             mod, mod_available = attempt_import(
                 'nonexisting.module',
-                defer_check=False,
+                defer_import=False,
                 deferred_submodules={'submod': None},
             )
 
         mod, mod_available = attempt_import(
             'nonexisting.module',
-            defer_check=True,
+            defer_import=True,
             deferred_submodules={'submod.subsubmod': None},
         )
         self.assertIs(type(mod), DeferredImportModule)
@@ -427,7 +427,7 @@ class TestDependencies(unittest.TestCase):
         module_obj, module_available = attempt_import(
             '__there_is_no_module_named_this__',
             'Testing import of a non-existent module',
-            defer_check=False,
+            defer_import=False,
         )
 
         class A_Class(UnavailableClass(module_obj)):

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -631,7 +631,7 @@ class BaselineTestDriver(object):
         cls.package_modules = {}
         packages_used = set(sum(list(cls.package_dependencies.values()), []))
         for package_ in packages_used:
-            pack, pack_avail = attempt_import(package_, defer_check=False)
+            pack, pack_avail = attempt_import(package_, defer_import=False)
             cls.package_available[package_] = pack_avail
             cls.package_modules[package_] = pack
 

--- a/pyomo/contrib/pynumero/dependencies.py
+++ b/pyomo/contrib/pynumero/dependencies.py
@@ -17,7 +17,7 @@ numpy, numpy_available = attempt_import(
     'numpy',
     'Pynumero requires the optional Pyomo dependency "numpy"',
     minimum_version='1.13.0',
-    defer_check=False,
+    defer_import=False,
 )
 
 if not numpy_available:

--- a/pyomo/contrib/pynumero/examples/tests/test_cyipopt_examples.py
+++ b/pyomo/contrib/pynumero/examples/tests/test_cyipopt_examples.py
@@ -35,7 +35,7 @@ pandas, pandas_available = attempt_import(
     'One of the tests below requires a recent version of pandas for'
     ' comparing with a tolerance.',
     minimum_version='1.1.0',
-    defer_check=False,
+    defer_import=False,
 )
 
 from pyomo.contrib.pynumero.asl import AmplInterface

--- a/pyomo/contrib/pynumero/intrinsic.py
+++ b/pyomo/contrib/pynumero/intrinsic.py
@@ -11,9 +11,7 @@
 
 from pyomo.common.dependencies import numpy as np, attempt_import
 
-block_vector = attempt_import(
-    'pyomo.contrib.pynumero.sparse.block_vector', defer_check=True
-)[0]
+block_vector = attempt_import('pyomo.contrib.pynumero.sparse.block_vector')[0]
 
 
 def norm(x, ord=None):

--- a/pyomo/core/base/units_container.py
+++ b/pyomo/core/base/units_container.py
@@ -127,7 +127,6 @@ import pyomo.core.expr as EXPR
 
 pint_module, pint_available = attempt_import(
     'pint',
-    defer_check=True,
     error_message=(
         'The "pint" package failed to import. '
         'This package is necessary to use Pyomo units.'

--- a/pyomo/core/tests/unit/test_numvalue.py
+++ b/pyomo/core/tests/unit/test_numvalue.py
@@ -18,6 +18,7 @@ from math import nan, inf
 
 import pyomo.common.unittest as unittest
 from pyomo.common.dependencies import numpy, numpy_available
+from pyomo.core.base.units_container import pint_available
 
 from pyomo.environ import (
     value,
@@ -640,8 +641,9 @@ True
         _tester('Var() + ref')
         _tester('v = Var(); v.construct(); v.value = ref')
         _tester('p = Param(mutable=True); p.construct(); p.value = ref')
-        _tester('v = Var(units=units.m); v.construct(); v.value = ref')
-        _tester('p = Param(mutable=True, units=units.m); p.construct(); p.value = ref')
+        if pint_available:
+            _tester('v = Var(units=units.m); v.construct(); v.value = ref')
+            _tester('p = Param(mutable=True, units=units.m); p.construct(); p.value = ref')
 
 
 if __name__ == "__main__":

--- a/pyomo/core/tests/unit/test_numvalue.py
+++ b/pyomo/core/tests/unit/test_numvalue.py
@@ -643,7 +643,9 @@ True
         _tester('p = Param(mutable=True); p.construct(); p.value = ref')
         if pint_available:
             _tester('v = Var(units=units.m); v.construct(); v.value = ref')
-            _tester('p = Param(mutable=True, units=units.m); p.construct(); p.value = ref')
+            _tester(
+                'p = Param(mutable=True, units=units.m); p.construct(); p.value = ref'
+            )
 
 
 if __name__ == "__main__":

--- a/pyomo/core/tests/unit/test_numvalue.py
+++ b/pyomo/core/tests/unit/test_numvalue.py
@@ -50,7 +50,16 @@ class MyBogusType(object):
 
 class MyBogusNumericType(MyBogusType):
     def __add__(self, other):
-        return MyBogusNumericType(self.val + float(other))
+        if other.__class__ in native_numeric_types:
+            return MyBogusNumericType(self.val + float(other))
+        else:
+            return NotImplemented
+
+    def __le__(self, other):
+        if other.__class__ in native_numeric_types:
+            return self.val <= float(other)
+        else:
+            return NotImplemented
 
     def __lt__(self, other):
         return self.val < float(other)
@@ -534,6 +543,8 @@ class Test_as_numeric(unittest.TestCase):
         try:
             val = as_numeric(ref)
             self.assertEqual(val().val, 42.0)
+            self.assertIn(MyBogusNumericType, native_numeric_types)
+            self.assertIn(MyBogusNumericType, native_types)
         finally:
             native_numeric_types.remove(MyBogusNumericType)
             native_types.remove(MyBogusNumericType)
@@ -562,10 +573,43 @@ class Test_as_numeric(unittest.TestCase):
     @unittest.skipUnless(numpy_available, "This test requires NumPy")
     def test_automatic_numpy_registration(self):
         cmd = (
-            'import pyomo; from pyomo.core.base import Var, Param; '
-            'from pyomo.core.base.units_container import units; import numpy as np; '
-            'print(np.float64 in pyomo.common.numeric_types.native_numeric_types); '
-            '%s; print(np.float64 in pyomo.common.numeric_types.native_numeric_types)'
+            'from pyomo.common.numeric_types import native_numeric_types as nnt; '
+            'print("float64" in [_.__name__ for _ in nnt]); '
+            'import numpy; '
+            'print("float64" in [_.__name__ for _ in nnt])'
+        )
+
+        rc = subprocess.run(
+            [sys.executable, '-c', cmd],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        self.assertEqual((rc.returncode, rc.stdout), (0, "False\nTrue\n"))
+
+        cmd = (
+            'import numpy; '
+            'from pyomo.common.numeric_types import native_numeric_types as nnt; '
+            'print("float64" in [_.__name__ for _ in nnt])'
+        )
+
+        rc = subprocess.run(
+            [sys.executable, '-c', cmd],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        self.assertEqual((rc.returncode, rc.stdout), (0, "True\n"))
+
+    def test_unknownNumericType_expr_registration(self):
+        cmd = (
+            'import pyomo; '
+            'from pyomo.core.base import Var, Param; '
+            'from pyomo.core.base.units_container import units; '
+            'from pyomo.common.numeric_types import native_numeric_types as nnt; '
+            f'from {__name__} import MyBogusNumericType; '
+            'ref = MyBogusNumericType(42); '
+            'print(MyBogusNumericType in nnt); %s; print(MyBogusNumericType in nnt); '
         )
 
         def _tester(expr):
@@ -575,19 +619,29 @@ class Test_as_numeric(unittest.TestCase):
                 stderr=subprocess.STDOUT,
                 text=True,
             )
-            self.assertEqual((rc.returncode, rc.stdout), (0, "False\nTrue\n"))
+            self.assertEqual(
+                (rc.returncode, rc.stdout),
+                (
+                    0,
+                    '''False
+WARNING: Dynamically registering the following numeric type:
+        pyomo.core.tests.unit.test_numvalue.MyBogusNumericType
+    Dynamic registration is supported for convenience, but there are known
+    limitations to this approach.  We recommend explicitly registering numeric
+    types using RegisterNumericType() or RegisterIntegerType().
+True
+''',
+                ),
+            )
 
-        _tester('Var() <= np.float64(5)')
-        _tester('np.float64(5) <= Var()')
-        _tester('np.float64(5) + Var()')
-        _tester('Var() + np.float64(5)')
-        _tester('v = Var(); v.construct(); v.value = np.float64(5)')
-        _tester('p = Param(mutable=True); p.construct(); p.value = np.float64(5)')
-        _tester('v = Var(units=units.m); v.construct(); v.value = np.float64(5)')
-        _tester(
-            'p = Param(mutable=True, units=units.m); p.construct(); '
-            'p.value = np.float64(5)'
-        )
+        _tester('Var() <= ref')
+        _tester('ref <= Var()')
+        _tester('ref + Var()')
+        _tester('Var() + ref')
+        _tester('v = Var(); v.construct(); v.value = ref')
+        _tester('p = Param(mutable=True); p.construct(); p.value = ref')
+        _tester('v = Var(units=units.m); v.construct(); v.value = ref')
+        _tester('p = Param(mutable=True, units=units.m); p.construct(); p.value = ref')
 
 
 if __name__ == "__main__":

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -41,7 +41,7 @@ from pyomo.opt.results import (
 
 from pyomo.common.dependencies import attempt_import
 
-gdxcc, gdxcc_available = attempt_import('gdxcc', defer_check=True)
+gdxcc, gdxcc_available = attempt_import('gdxcc')
 
 logger = logging.getLogger('pyomo.solvers')
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes IDAES/idaes-pse#1348

## Summary/Motivation:
This PR updates how we handle registration of `numpy` types as native numeric types.  This updates the `attempt_import` machinery to hook into Python's regular `importlib` process.  Now deferred import modules with callbacks (including `numpy`) are registered with a custom module finder that ensures that if they are imported (even by code outside of Pyomo), the post-import callback is triggered.

## Changes proposed in this PR:
- add `DeferredImportCallbackFinder` / `DeferredImportCallbackLoader` to hook into `importlib` and endure deferred import modules with callbacks always have their callbacks called
- rename `attempt_import(defer_check=` to `attempt_import(defer_import=`
- by default `attempt_import` will immediately process modules that have already been imported 

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
