### PR TITLE
Fix type registrations for ExternalFunction arguments

### DIFF
--- a/pyomo/common/numeric_types.py
+++ b/pyomo/common/numeric_types.py
@@ -228,13 +228,6 @@ def check_if_logical_type(obj):
     if obj_class in native_types:
         return obj_class in native_logical_types
 
-    if 'numpy' in obj_class.__module__:
-        # trigger the resolution of numpy_available and check if this
-        # type was automatically registered
-        bool(numpy_available)
-        if obj_class in native_types:
-            return obj_class in native_logical_types
-
     try:
         if all(
             (

--- a/pyomo/common/numeric_types.py
+++ b/pyomo/common/numeric_types.py
@@ -50,7 +50,6 @@ native_numeric_types = {int, float}
 native_integer_types = {int}
 native_logical_types = {bool}
 native_complex_types = {complex}
-pyomo_constant_types = set()  # includes NumericConstant
 
 _native_boolean_types = {int, bool, str, bytes}
 relocated_module_attribute(
@@ -61,6 +60,16 @@ relocated_module_attribute(
     "contains types that were convertible to bool, and not types that should "
     "be treated as if they were bool (as was the case for the other "
     "native_*_types sets).  Users likely should use native_logical_types.",
+)
+_pyomo_constant_types = set()  # includes NumericConstant, _PythonCallbackFunctionID
+relocated_module_attribute(
+    'pyomo_constant_types',
+    'pyomo.common.numeric_types._pyomo_constant_types',
+    version='6.7.2.dev0',
+    msg="The pyomo_constant_types set will be removed in the future: the set "
+    "contained only NumericConstant and _PythonCallbackFunctionID, and provided "
+    "no meaningful value to clients or walkers.  Users should likely handle "
+    "these types in the same manner as immutable Params.",
 )
 
 
@@ -338,16 +347,6 @@ def value(obj, exception=True):
     """
     if obj.__class__ in native_types:
         return obj
-    if obj.__class__ in pyomo_constant_types:
-        #
-        # I'm commenting this out for now, but I think we should never expect
-        # to see a numeric constant with value None.
-        #
-        # if exception and obj.value is None:
-        #    raise ValueError(
-        #        "No value for uninitialized NumericConstant object %s"
-        #        % (obj.name,))
-        return obj.value
     #
     # Test if we have a duck typed Pyomo expression
     #

--- a/pyomo/common/numeric_types.py
+++ b/pyomo/common/numeric_types.py
@@ -217,10 +217,10 @@ def check_if_native_type(obj):
 def check_if_logical_type(obj):
     """Test if the argument behaves like a logical type.
 
-    We check for "numeric types" by checking if we can add zero to it
-    without changing the object's type, and that the object compares to
-    0 in a meaningful way.  If that works, then we register the type in
-    :py:attr:`native_numeric_types`.
+    We check for "logical types" by checking if the type returns sane
+    results for Boolean operators (``^``, ``|``, ``&``) and if it maps
+    ``1`` and ``2`` both to the same equivalent instance.  If that
+    works, then we register the type in :py:attr:`native_logical_types`.
 
     """
     obj_class = obj.__class__
@@ -304,9 +304,8 @@ def check_if_numeric_type(obj):
     except:
         pass
     #
-    # ensure that the object is comparable to 0 in a meaningful way
-    # (among other things, this prevents numpy.ndarray objects from
-    # being added to native_numeric_types)
+    # Ensure that the object is comparable to 0 in a meaningful way
+    #
     try:
         if not ((obj < 0) ^ (obj >= 0)):
             return False

--- a/pyomo/common/numeric_types.py
+++ b/pyomo/common/numeric_types.py
@@ -236,13 +236,15 @@ def check_if_logical_type(obj):
             return obj_class in native_logical_types
 
     try:
-        if all((
-            obj_class(1) == obj_class(2),
-            obj_class(False) != obj_class(True),
-            obj_class(False) ^ obj_class(True) == obj_class(True),
-            obj_class(False) | obj_class(True) == obj_class(True),
-            obj_class(False) & obj_class(True) == obj_class(False),
-        )):
+        if all(
+            (
+                obj_class(1) == obj_class(2),
+                obj_class(False) != obj_class(True),
+                obj_class(False) ^ obj_class(True) == obj_class(True),
+                obj_class(False) | obj_class(True) == obj_class(True),
+                obj_class(False) & obj_class(True) == obj_class(False),
+            )
+        ):
             RegisterLogicalType(obj_class)
             return True
     except:
@@ -284,7 +286,7 @@ def check_if_numeric_type(obj):
     # Check if the numeric type behaves like a complex type
     #
     try:
-        if 1.41 < abs(obj_class(1j+1)) < 1.42:
+        if 1.41 < abs(obj_class(1j + 1)) < 1.42:
             RegisterComplexType(obj_class)
             return False
     except:

--- a/pyomo/common/numeric_types.py
+++ b/pyomo/common/numeric_types.py
@@ -229,13 +229,32 @@ def check_if_logical_type(obj):
         return obj_class in native_logical_types
 
     try:
+        # It is not an error if you can't initialize the type from an
+        # int, but if you can, it should map !0 to True
+        if obj_class(1) != obj_class(2):
+            return False
+    except:
+        pass
+
+    try:
+        # Native logical types *must* be hashable
+        hash(obj)
+        # Native logical types must honor standard Boolean operators
         if all(
             (
-                obj_class(1) == obj_class(2),
                 obj_class(False) != obj_class(True),
+                obj_class(False) ^ obj_class(False) == obj_class(False),
                 obj_class(False) ^ obj_class(True) == obj_class(True),
+                obj_class(True) ^ obj_class(False) == obj_class(True),
+                obj_class(True) ^ obj_class(True) == obj_class(False),
+                obj_class(False) | obj_class(False) == obj_class(False),
                 obj_class(False) | obj_class(True) == obj_class(True),
+                obj_class(True) | obj_class(False) == obj_class(True),
+                obj_class(True) | obj_class(True) == obj_class(True),
+                obj_class(False) & obj_class(False) == obj_class(False),
                 obj_class(False) & obj_class(True) == obj_class(False),
+                obj_class(True) & obj_class(False) == obj_class(False),
+                obj_class(True) & obj_class(True) == obj_class(True),
             )
         ):
             RegisterLogicalType(obj_class)

--- a/pyomo/common/numeric_types.py
+++ b/pyomo/common/numeric_types.py
@@ -350,9 +350,7 @@ def value(obj, exception=True):
     #
     # Test if we have a duck typed Pyomo expression
     #
-    try:
-        obj.is_numeric_type()
-    except AttributeError:
+    if not hasattr(obj, 'is_numeric_type'):
         #
         # TODO: Historically we checked for new *numeric* types and
         # raised exceptions for anything else.  That is inconsistent
@@ -367,7 +365,7 @@ def value(obj, exception=True):
                 return None
             raise TypeError(
                 "Cannot evaluate object with unknown type: %s" % obj.__class__.__name__
-            ) from None
+            )
     #
     # Evaluate the expression object
     #

--- a/pyomo/common/tests/test_numeric_types.py
+++ b/pyomo/common/tests/test_numeric_types.py
@@ -1,0 +1,219 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2024
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import pyomo.common.numeric_types as nt
+import pyomo.common.unittest as unittest
+
+from pyomo.common.dependencies import numpy, numpy_available
+from pyomo.core.expr import LinearExpression
+from pyomo.environ import Var
+
+_type_sets = (
+    'native_types',
+    'native_numeric_types',
+    'native_logical_types',
+    'native_integer_types',
+    'native_complex_types',
+)
+
+
+class TestNativeTypes(unittest.TestCase):
+    def setUp(self):
+        bool(numpy_available)
+        for s in _type_sets:
+            setattr(self, s, set(getattr(nt, s)))
+            getattr(nt, s).clear()
+
+    def tearDown(self):
+        for s in _type_sets:
+            getattr(nt, s).clear()
+            getattr(nt, s).update(getattr(nt, s))
+
+    def test_check_if_native_type(self):
+        self.assertEqual(nt.native_types, set())
+        self.assertEqual(nt.native_logical_types, set())
+        self.assertEqual(nt.native_numeric_types, set())
+        self.assertEqual(nt.native_integer_types, set())
+        self.assertEqual(nt.native_complex_types, set())
+
+        self.assertTrue(nt.check_if_native_type("a"))
+        self.assertIn(str, nt.native_types)
+        self.assertNotIn(str, nt.native_logical_types)
+        self.assertNotIn(str, nt.native_numeric_types)
+        self.assertNotIn(str, nt.native_integer_types)
+        self.assertNotIn(str, nt.native_complex_types)
+
+        self.assertTrue(nt.check_if_native_type(1))
+        self.assertIn(int, nt.native_types)
+        self.assertNotIn(int, nt.native_logical_types)
+        self.assertIn(int, nt.native_numeric_types)
+        self.assertIn(int, nt.native_integer_types)
+        self.assertNotIn(int, nt.native_complex_types)
+
+        self.assertTrue(nt.check_if_native_type(1.5))
+        self.assertIn(float, nt.native_types)
+        self.assertNotIn(float, nt.native_logical_types)
+        self.assertIn(float, nt.native_numeric_types)
+        self.assertNotIn(float, nt.native_integer_types)
+        self.assertNotIn(float, nt.native_complex_types)
+
+        self.assertTrue(nt.check_if_native_type(True))
+        self.assertIn(bool, nt.native_types)
+        self.assertIn(bool, nt.native_logical_types)
+        self.assertNotIn(bool, nt.native_numeric_types)
+        self.assertNotIn(bool, nt.native_integer_types)
+        self.assertNotIn(bool, nt.native_complex_types)
+
+        self.assertFalse(nt.check_if_native_type(slice(None, None, None)))
+        self.assertNotIn(slice, nt.native_types)
+        self.assertNotIn(slice, nt.native_logical_types)
+        self.assertNotIn(slice, nt.native_numeric_types)
+        self.assertNotIn(slice, nt.native_integer_types)
+        self.assertNotIn(slice, nt.native_complex_types)
+
+    def test_check_if_logical_type(self):
+        self.assertEqual(nt.native_types, set())
+        self.assertEqual(nt.native_logical_types, set())
+        self.assertEqual(nt.native_numeric_types, set())
+        self.assertEqual(nt.native_integer_types, set())
+        self.assertEqual(nt.native_complex_types, set())
+
+        self.assertFalse(nt.check_if_logical_type("a"))
+        self.assertNotIn(str, nt.native_types)
+        self.assertNotIn(str, nt.native_logical_types)
+        self.assertNotIn(str, nt.native_numeric_types)
+        self.assertNotIn(str, nt.native_integer_types)
+        self.assertNotIn(str, nt.native_complex_types)
+
+        self.assertFalse(nt.check_if_logical_type("a"))
+
+        self.assertTrue(nt.check_if_logical_type(True))
+        self.assertIn(bool, nt.native_types)
+        self.assertIn(bool, nt.native_logical_types)
+        self.assertNotIn(bool, nt.native_numeric_types)
+        self.assertNotIn(bool, nt.native_integer_types)
+        self.assertNotIn(bool, nt.native_complex_types)
+
+        self.assertTrue(nt.check_if_logical_type(True))
+
+        self.assertFalse(nt.check_if_logical_type(1))
+        self.assertNotIn(int, nt.native_types)
+        self.assertNotIn(int, nt.native_logical_types)
+        self.assertNotIn(int, nt.native_numeric_types)
+        self.assertNotIn(int, nt.native_integer_types)
+        self.assertNotIn(int, nt.native_complex_types)
+
+        if numpy_available:
+            self.assertTrue(nt.check_if_logical_type(numpy.bool_(1)))
+            self.assertIn(numpy.bool_, nt.native_types)
+            self.assertIn(numpy.bool_, nt.native_logical_types)
+            self.assertNotIn(numpy.bool_, nt.native_numeric_types)
+            self.assertNotIn(numpy.bool_, nt.native_integer_types)
+            self.assertNotIn(numpy.bool_, nt.native_complex_types)
+
+    def test_check_if_numeric_type(self):
+        self.assertEqual(nt.native_types, set())
+        self.assertEqual(nt.native_logical_types, set())
+        self.assertEqual(nt.native_numeric_types, set())
+        self.assertEqual(nt.native_integer_types, set())
+        self.assertEqual(nt.native_complex_types, set())
+
+        self.assertFalse(nt.check_if_numeric_type("a"))
+        self.assertFalse(nt.check_if_numeric_type("a"))
+        self.assertNotIn(str, nt.native_types)
+        self.assertNotIn(str, nt.native_logical_types)
+        self.assertNotIn(str, nt.native_numeric_types)
+        self.assertNotIn(str, nt.native_integer_types)
+        self.assertNotIn(str, nt.native_complex_types)
+
+        self.assertFalse(nt.check_if_numeric_type(True))
+        self.assertFalse(nt.check_if_numeric_type(True))
+        self.assertNotIn(bool, nt.native_types)
+        self.assertNotIn(bool, nt.native_logical_types)
+        self.assertNotIn(bool, nt.native_numeric_types)
+        self.assertNotIn(bool, nt.native_integer_types)
+        self.assertNotIn(bool, nt.native_complex_types)
+
+        self.assertTrue(nt.check_if_numeric_type(1))
+        self.assertTrue(nt.check_if_numeric_type(1))
+        self.assertIn(int, nt.native_types)
+        self.assertNotIn(int, nt.native_logical_types)
+        self.assertIn(int, nt.native_numeric_types)
+        self.assertIn(int, nt.native_integer_types)
+        self.assertNotIn(int, nt.native_complex_types)
+
+        self.assertTrue(nt.check_if_numeric_type(1.5))
+        self.assertTrue(nt.check_if_numeric_type(1.5))
+        self.assertIn(float, nt.native_types)
+        self.assertNotIn(float, nt.native_logical_types)
+        self.assertIn(float, nt.native_numeric_types)
+        self.assertNotIn(float, nt.native_integer_types)
+        self.assertNotIn(float, nt.native_complex_types)
+
+        self.assertFalse(nt.check_if_numeric_type(1j))
+        self.assertIn(complex, nt.native_types)
+        self.assertNotIn(complex, nt.native_logical_types)
+        self.assertNotIn(complex, nt.native_numeric_types)
+        self.assertNotIn(complex, nt.native_integer_types)
+        self.assertIn(complex, nt.native_complex_types)
+
+        v = Var()
+        v.construct()
+        self.assertFalse(nt.check_if_numeric_type(v))
+        self.assertNotIn(type(v), nt.native_types)
+        self.assertNotIn(type(v), nt.native_logical_types)
+        self.assertNotIn(type(v), nt.native_numeric_types)
+        self.assertNotIn(type(v), nt.native_integer_types)
+        self.assertNotIn(type(v), nt.native_complex_types)
+
+        e = LinearExpression([1])
+        self.assertFalse(nt.check_if_numeric_type(e))
+        self.assertNotIn(type(e), nt.native_types)
+        self.assertNotIn(type(e), nt.native_logical_types)
+        self.assertNotIn(type(e), nt.native_numeric_types)
+        self.assertNotIn(type(e), nt.native_integer_types)
+        self.assertNotIn(type(e), nt.native_complex_types)
+
+        if numpy_available:
+            self.assertFalse(nt.check_if_numeric_type(numpy.bool_(1)))
+            self.assertNotIn(numpy.bool_, nt.native_types)
+            self.assertNotIn(numpy.bool_, nt.native_logical_types)
+            self.assertNotIn(numpy.bool_, nt.native_numeric_types)
+            self.assertNotIn(numpy.bool_, nt.native_integer_types)
+            self.assertNotIn(numpy.bool_, nt.native_complex_types)
+
+            self.assertFalse(nt.check_if_numeric_type(numpy.array([1])))
+            self.assertNotIn(numpy.ndarray, nt.native_types)
+            self.assertNotIn(numpy.ndarray, nt.native_logical_types)
+            self.assertNotIn(numpy.ndarray, nt.native_numeric_types)
+            self.assertNotIn(numpy.ndarray, nt.native_integer_types)
+            self.assertNotIn(numpy.ndarray, nt.native_complex_types)
+
+            self.assertTrue(nt.check_if_numeric_type(numpy.float64(1)))
+            self.assertIn(numpy.float64, nt.native_types)
+            self.assertNotIn(numpy.float64, nt.native_logical_types)
+            self.assertIn(numpy.float64, nt.native_numeric_types)
+            self.assertNotIn(numpy.float64, nt.native_integer_types)
+            self.assertNotIn(numpy.float64, nt.native_complex_types)
+
+            self.assertTrue(nt.check_if_numeric_type(numpy.int64(1)))
+            self.assertIn(numpy.int64, nt.native_types)
+            self.assertNotIn(numpy.int64, nt.native_logical_types)
+            self.assertIn(numpy.int64, nt.native_numeric_types)
+            self.assertIn(numpy.int64, nt.native_integer_types)
+            self.assertNotIn(numpy.int64, nt.native_complex_types)
+
+            self.assertFalse(nt.check_if_numeric_type(numpy.complex128(1)))
+            self.assertIn(numpy.complex128, nt.native_types)
+            self.assertNotIn(numpy.complex128, nt.native_logical_types)
+            self.assertNotIn(numpy.complex128, nt.native_numeric_types)
+            self.assertNotIn(numpy.complex128, nt.native_integer_types)
+            self.assertIn(numpy.complex128, nt.native_complex_types)

--- a/pyomo/common/tests/test_numeric_types.py
+++ b/pyomo/common/tests/test_numeric_types.py
@@ -35,7 +35,7 @@ class TestNativeTypes(unittest.TestCase):
     def tearDown(self):
         for s in _type_sets:
             getattr(nt, s).clear()
-            getattr(nt, s).update(getattr(nt, s))
+            getattr(nt, s).update(getattr(self, s))
 
     def test_check_if_native_type(self):
         self.assertEqual(nt.native_types, set())

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -35,8 +35,8 @@ from pyomo.common.numeric_types import (
     check_if_native_type,
     native_types,
     native_numeric_types,
-    pyomo_constant_types,
     value,
+    _pyomo_constant_types,
 )
 from pyomo.core.expr.numvalue import (
     NonNumericValue,
@@ -495,7 +495,7 @@ class _PythonCallbackFunctionID(NumericConstant):
         return False
 
 
-pyomo_constant_types.add(_PythonCallbackFunctionID)
+_pyomo_constant_types.add(_PythonCallbackFunctionID)
 
 
 class PythonCallbackFunction(ExternalFunction):

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -31,13 +31,16 @@ from ctypes import (
 
 from pyomo.common.autoslots import AutoSlots
 from pyomo.common.fileutils import find_library
-from pyomo.core.expr.numvalue import (
+from pyomo.common.numeric_types import (
+    check_if_native_type,
     native_types,
     native_numeric_types,
     pyomo_constant_types,
+    value,
+)
+from pyomo.core.expr.numvalue import (
     NonNumericValue,
     NumericConstant,
-    value,
 )
 import pyomo.core.expr as EXPR
 from pyomo.core.base.component import Component
@@ -197,14 +200,15 @@ class ExternalFunction(Component):
         pv = False
         for i, arg in enumerate(args_):
             try:
-                # Q: Is there a better way to test if a value is an object
-                #    not in native_types and not a standard expression type?
                 if arg.__class__ in native_types:
                     continue
                 if arg.is_potentially_variable():
                     pv = True
+                continue
             except AttributeError:
-                args_[i] = NonNumericValue(arg)
+                if check_if_native_type(arg):
+                    continue
+            args_[i] = NonNumericValue(arg)
         #
         if pv:
             return EXPR.ExternalFunctionExpression(args_, self)

--- a/pyomo/core/base/external.py
+++ b/pyomo/core/base/external.py
@@ -38,10 +38,7 @@ from pyomo.common.numeric_types import (
     value,
     _pyomo_constant_types,
 )
-from pyomo.core.expr.numvalue import (
-    NonNumericValue,
-    NumericConstant,
-)
+from pyomo.core.expr.numvalue import NonNumericValue, NumericConstant
 import pyomo.core.expr as EXPR
 from pyomo.core.base.component import Component
 from pyomo.core.base.units_container import units

--- a/pyomo/core/base/units_container.py
+++ b/pyomo/core/base/units_container.py
@@ -119,7 +119,6 @@ from pyomo.core.expr.numvalue import (
     value,
     native_types,
     native_numeric_types,
-    pyomo_constant_types,
 )
 from pyomo.core.expr.template_expr import IndexTemplate
 from pyomo.core.expr.visitor import ExpressionValueVisitor
@@ -902,7 +901,7 @@ class PintUnitExtractionVisitor(EXPR.StreamBasedExpressionVisitor):
 
     def beforeChild(self, node, child, child_idx):
         ctype = child.__class__
-        if ctype in native_types or ctype in pyomo_constant_types:
+        if ctype in native_types:
             return False, self._pint_dimensionless
 
         if child.is_expression_type():
@@ -917,7 +916,7 @@ class PintUnitExtractionVisitor(EXPR.StreamBasedExpressionVisitor):
             pint_unit = self._pyomo_units_container._get_pint_units(pyomo_unit)
             return False, pint_unit
 
-        return True, None
+        return False, self._pint_dimensionless
 
     def exitNode(self, node, data):
         """Visitor callback when moving up the expression tree.

--- a/pyomo/core/expr/numvalue.py
+++ b/pyomo/core/expr/numvalue.py
@@ -85,7 +85,7 @@ logger = logging.getLogger('pyomo.core')
 ##------------------------------------------------------------------------
 
 
-class NonNumericValue(object):
+class NonNumericValue(PyomoObject):
     """An object that contains a non-numeric value
 
     Constructor Arguments:
@@ -100,6 +100,8 @@ class NonNumericValue(object):
     def __str__(self):
         return str(self.value)
 
+    def __call__(self, exception=None):
+        return self.value
 
 nonpyomo_leaf_types.add(NonNumericValue)
 

--- a/pyomo/core/expr/numvalue.py
+++ b/pyomo/core/expr/numvalue.py
@@ -103,6 +103,7 @@ class NonNumericValue(PyomoObject):
     def __call__(self, exception=None):
         return self.value
 
+
 nonpyomo_leaf_types.add(NonNumericValue)
 
 

--- a/pyomo/core/expr/numvalue.py
+++ b/pyomo/core/expr/numvalue.py
@@ -28,7 +28,7 @@ from pyomo.common.numeric_types import (
     native_numeric_types,
     native_integer_types,
     native_logical_types,
-    pyomo_constant_types,
+    _pyomo_constant_types,
     check_if_numeric_type,
     value,
 )
@@ -410,7 +410,7 @@ class NumericConstant(NumericValue):
         ostream.write(str(self))
 
 
-pyomo_constant_types.add(NumericConstant)
+_pyomo_constant_types.add(NumericConstant)
 
 # We use as_numeric() so that the constant is also in the cache
 ZeroConstant = as_numeric(0)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This resolves an issue where new numeric types were not being correctly registered if they were initially seen as arguments to an ExternalFunction.  This was part of the cause of IDAES/idaes-pse#1348.

As part of resolving this, the PR adds several new functions, including:
- `check_if_native_type()`
- `check_if_logical_type()`
and improves the logic in `check_if_numeric_type()`.  It also adds `NonNumericValue` to the `PyomoObject` class hierarchy (and defines `__call__()`).

This deprecates the `pyomo_constant_types` set: this set was only used in two locations in the codebase, and neither location actually needed too use the set.

## Changes proposed in this PR:
- (see above)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
