### PR TITLE
Simplify Custom PyROS Domain Validators

### DIFF
--- a/pyomo/contrib/pyros/config.py
+++ b/pyomo/contrib/pyros/config.py
@@ -26,71 +26,34 @@ from pyomo.contrib.pyros.uncertainty_sets import UncertaintySet
 default_pyros_solver_logger = setup_pyros_logger()
 
 
-class LoggerType:
+def logger_domain(obj):
     """
-    Domain validator for objects castable to logging.Logger.
+    Domain validator for logger-type arguments.
+
+    This admits any object of type ``logging.Logger``,
+    or which can be cast to ``logging.Logger``.
     """
-
-    def __call__(self, obj):
-        """
-        Cast object to logger.
-
-        Parameters
-        ----------
-        obj : object
-            Object to be cast.
-
-        Returns
-        -------
-        logging.Logger
-            If `str_or_logger` is of type `logging.Logger`,then
-            `str_or_logger` is returned.
-            Otherwise, ``logging.getLogger(str_or_logger)``
-            is returned.
-        """
-        if isinstance(obj, logging.Logger):
-            return obj
-        else:
-            return logging.getLogger(obj)
-
-    def domain_name(self):
-        """Return str briefly describing domain encompassed by self."""
-        return "None, str or logging.Logger"
+    if isinstance(obj, logging.Logger):
+        return obj
+    else:
+        return logging.getLogger(obj)
 
 
-class PositiveIntOrMinusOne:
+logger_domain.domain_name = "None, str or logging.Logger"
+
+
+def positive_int_or_minus_one(obj):
     """
-    Domain validator for objects castable to a
-    strictly positive int or -1.
+    Domain validator for objects castable to a strictly
+    positive int or -1.
     """
+    ans = int(obj)
+    if ans != float(obj) or (ans <= 0 and ans != -1):
+        raise ValueError(f"Expected positive int or -1, but received value {obj!r}")
+    return ans
 
-    def __call__(self, obj):
-        """
-        Cast object to positive int or -1.
 
-        Parameters
-        ----------
-        obj : object
-            Object of interest.
-
-        Returns
-        -------
-        int
-            Positive int, or -1.
-
-        Raises
-        ------
-        ValueError
-            If object not castable to positive int, or -1.
-        """
-        ans = int(obj)
-        if ans != float(obj) or (ans <= 0 and ans != -1):
-            raise ValueError(f"Expected positive int or -1, but received value {obj!r}")
-        return ans
-
-    def domain_name(self):
-        """Return str briefly describing domain encompassed by self."""
-        return "positive int or -1"
+positive_int_or_minus_one.domain_name = "positive int or -1"
 
 
 def mutable_param_validator(param_obj):
@@ -721,7 +684,7 @@ def pyros_config():
         "max_iter",
         ConfigValue(
             default=-1,
-            domain=PositiveIntOrMinusOne(),
+            domain=positive_int_or_minus_one,
             description=(
                 """
                 Iteration limit. If -1 is provided, then no iteration
@@ -766,7 +729,7 @@ def pyros_config():
         "progress_logger",
         ConfigValue(
             default=default_pyros_solver_logger,
-            domain=LoggerType(),
+            domain=logger_domain,
             doc=(
                 """
                 Logger (or name thereof) used for reporting PyROS solver

--- a/pyomo/contrib/pyros/tests/test_config.py
+++ b/pyomo/contrib/pyros/tests/test_config.py
@@ -12,9 +12,9 @@ from pyomo.core.base.param import Param, _ParamData
 from pyomo.contrib.pyros.config import (
     InputDataStandardizer,
     mutable_param_validator,
-    LoggerType,
+    logger_domain,
     SolverNotResolvable,
-    PositiveIntOrMinusOne,
+    positive_int_or_minus_one,
     pyros_config,
     SolverIterable,
     SolverResolvable,
@@ -557,16 +557,22 @@ class TestPositiveIntOrMinusOne(unittest.TestCase):
         """
         Test positive int or -1 validator works as expected.
         """
-        standardizer_func = PositiveIntOrMinusOne()
+        standardizer_func = positive_int_or_minus_one
         self.assertIs(
             standardizer_func(1.0),
             1,
-            msg=(f"{PositiveIntOrMinusOne.__name__} does not standardize as expected."),
+            msg=(
+                f"{positive_int_or_minus_one.__name__} "
+                "does not standardize as expected."
+            ),
         )
         self.assertEqual(
             standardizer_func(-1.00),
             -1,
-            msg=(f"{PositiveIntOrMinusOne.__name__} does not standardize as expected."),
+            msg=(
+                f"{positive_int_or_minus_one.__name__} "
+                "does not standardize as expected."
+            ),
         )
 
         exc_str = r"Expected positive int or -1, but received value.*"
@@ -576,26 +582,26 @@ class TestPositiveIntOrMinusOne(unittest.TestCase):
             standardizer_func(0)
 
 
-class TestLoggerType(unittest.TestCase):
+class TestLoggerDomain(unittest.TestCase):
     """
-    Test logger type validator.
+    Test logger type domain validator.
     """
 
     def test_logger_type(self):
         """
         Test logger type validator.
         """
-        standardizer_func = LoggerType()
+        standardizer_func = logger_domain
         mylogger = logging.getLogger("example")
         self.assertIs(
             standardizer_func(mylogger),
             mylogger,
-            msg=f"{LoggerType.__name__} output not as expected",
+            msg=f"{standardizer_func.__name__} output not as expected",
         )
         self.assertIs(
             standardizer_func(mylogger.name),
             mylogger,
-            msg=f"{LoggerType.__name__} output not as expected",
+            msg=f"{standardizer_func.__name__} output not as expected",
         )
 
         exc_str = r"A logger name must be a string"

--- a/pyomo/contrib/pyros/tests/test_config.py
+++ b/pyomo/contrib/pyros/tests/test_config.py
@@ -558,21 +558,28 @@ class TestPositiveIntOrMinusOne(unittest.TestCase):
         Test positive int or -1 validator works as expected.
         """
         standardizer_func = positive_int_or_minus_one
-        self.assertIs(
-            standardizer_func(1.0),
-            1,
-            msg=(
-                f"{positive_int_or_minus_one.__name__} "
-                "does not standardize as expected."
-            ),
-        )
+        ans = standardizer_func(1.0)
         self.assertEqual(
-            standardizer_func(-1.00),
+            ans,
+            1,
+            msg=f"{positive_int_or_minus_one.__name__} output value not as expected.",
+        )
+        self.assertIs(
+            type(ans),
+            int,
+            msg=f"{positive_int_or_minus_one.__name__} output type not as expected.",
+        )
+
+        ans = standardizer_func(-1.0)
+        self.assertEqual(
+            ans,
             -1,
-            msg=(
-                f"{positive_int_or_minus_one.__name__} "
-                "does not standardize as expected."
-            ),
+            msg=f"{positive_int_or_minus_one.__name__} output value not as expected.",
+        )
+        self.assertIs(
+            type(ans),
+            int,
+            msg=f"{positive_int_or_minus_one.__name__} output type not as expected.",
         )
 
         exc_str = r"Expected positive int or -1, but received value.*"


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Summary/Motivation:

Following #3159 and [this comment](https://github.com/Pyomo/pyomo/pull/3126#discussion_r1496462769) in #3126, this PR simplifies a few custom PyROS domain validators which do not require statefulness.

## Changes proposed in this PR:
Simplify custom PyROS domain validators.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
