### PR TITLE
Fix PyROS Iteration Logging for Edge Case Involving Discrete Sets 

### DIFF
--- a/pyomo/contrib/pyros/pyros_algorithm_methods.py
+++ b/pyomo/contrib/pyros/pyros_algorithm_methods.py
@@ -805,7 +805,7 @@ def ROSolver_iterative_solve(model_data, config):
             len(scaled_violations) == len(separation_model.util.performance_constraints)
             and not separation_results.subsolver_error
             and not separation_results.time_out
-        )
+        ) or separation_results.all_discrete_scenarios_exhausted
 
         iter_log_record = IterationLogRecord(
             iteration=k,

--- a/pyomo/contrib/pyros/separation_problem_methods.py
+++ b/pyomo/contrib/pyros/separation_problem_methods.py
@@ -649,6 +649,7 @@ def perform_separation_loop(model_data, config, solve_globally):
                 solver_call_results=ComponentMap(),
                 solved_globally=solve_globally,
                 worst_case_perf_con=None,
+                all_discrete_scenarios_exhausted=True,
             )
 
         perf_con_to_maximize = sorted_priority_groups[

--- a/pyomo/contrib/pyros/solve_data.py
+++ b/pyomo/contrib/pyros/solve_data.py
@@ -347,7 +347,7 @@ class SeparationLoopResults:
     solver_call_results : ComponentMap
         Mapping from performance constraints to corresponding
         ``SeparationSolveCallResults`` objects.
-        worst_case_perf_con : None or Constraint
+    worst_case_perf_con : None or Constraint
         Performance constraint mapped to ``SeparationSolveCallResults``
         object in `self` corresponding to maximally violating
         separation problem solution.

--- a/pyomo/contrib/pyros/solve_data.py
+++ b/pyomo/contrib/pyros/solve_data.py
@@ -347,16 +347,23 @@ class SeparationLoopResults:
     solver_call_results : ComponentMap
         Mapping from performance constraints to corresponding
         ``SeparationSolveCallResults`` objects.
-    worst_case_perf_con : None or int, optional
+        worst_case_perf_con : None or Constraint
         Performance constraint mapped to ``SeparationSolveCallResults``
         object in `self` corresponding to maximally violating
         separation problem solution.
+    all_discrete_scenarios_exhausted : bool, optional
+        For problems with discrete uncertainty sets,
+        True if all scenarios were explicitly accounted for in master
+        (which occurs if there have been
+        as many PyROS iterations as there are scenarios in the set)
+        False otherwise.
 
     Attributes
     ----------
     solver_call_results
     solved_globally
     worst_case_perf_con
+    all_discrete_scenarios_exhausted
     found_violation
     violating_param_realization
     scaled_violations
@@ -365,11 +372,18 @@ class SeparationLoopResults:
     time_out
     """
 
-    def __init__(self, solved_globally, solver_call_results, worst_case_perf_con):
+    def __init__(
+        self,
+        solved_globally,
+        solver_call_results,
+        worst_case_perf_con,
+        all_discrete_scenarios_exhausted=False,
+    ):
         """Initialize self (see class docstring)."""
         self.solver_call_results = solver_call_results
         self.solved_globally = solved_globally
         self.worst_case_perf_con = worst_case_perf_con
+        self.all_discrete_scenarios_exhausted = all_discrete_scenarios_exhausted
 
     @property
     def found_violation(self):
@@ -598,6 +612,17 @@ class SeparationResults:
             Attribute value.
         """
         return getattr(self.main_loop_results, attr_name, None)
+
+    @property
+    def all_discrete_scenarios_exhausted(self):
+        """
+        bool : For problems where the uncertainty set is of type
+        DiscreteScenarioSet,
+        True if last master problem solved explicitly
+        accounts for all scenarios in the uncertainty set,
+        False otherwise.
+        """
+        return self.get_violating_attr("all_discrete_scenarios_exhausted")
 
     @property
     def worst_case_perf_con(self):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Summary/Motivation:

If PyROS is invoked with an instance of `DiscreteScenarioSet` passed through argument `uncertainty_set`, then due to currently implemented algorithmic efficiencies, all separation problems are skipped in the event the iteration number is equal to one less than the number of scenarios in the uncertainty set. In this case, the `#CViol` entry in the final line of the iteration log should be `0`, rather than `0+`, which is what is currently printed.

For example, if the `DiscreteScenarioSet` has only a single scenario, and the first PyROS iteration is successfully completed, then the iteration log will currently read: 

```
Itn  Objective    1-Stg Shift  2-Stg Shift  #CViol  Max Viol     Wall Time (s)
------------------------------------------------------------------------------
0    X.XXXXe+XX   X.XXXXe+XX   X.XXXXe+XX   0+      -            XX.XXX
```

(where the `X`s are placeholders) rather than the desired output:

```
Itn  Objective    1-Stg Shift  2-Stg Shift  #CViol  Max Viol     Wall Time (s)
------------------------------------------------------------------------------
0    X.XXXXe+XX   X.XXXXe+XX   X.XXXXe+XX   0       -            XX.XXX
```

## Changes proposed in this PR:
- Fix/simplify PyROS iteration logs for `DiscreteScenarioSet` edge case.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
