### PR TITLE
Set maxDiff=None on the base TestCase class

### DIFF
--- a/pyomo/common/tests/test_config.py
+++ b/pyomo/common/tests/test_config.py
@@ -2098,7 +2098,6 @@ endBlock{}
                 "generate_documentation is deprecated.",
                 LOG,
             )
-        self.maxDiff = None
         # print(test)
         self.assertEqual(test, reference)
 
@@ -2113,7 +2112,6 @@ endBlock{}
                 )
             )
         self.assertEqual(LOG.getvalue(), "")
-        self.maxDiff = None
         # print(test)
         self.assertEqual(test, reference)
 
@@ -2159,7 +2157,6 @@ endBlock{}
                 "generate_documentation is deprecated.",
                 LOG,
             )
-        self.maxDiff = None
         # print(test)
         self.assertEqual(test, reference)
 
@@ -2577,7 +2574,6 @@ Scenario definition:
         parser = argparse.ArgumentParser(prog='tester')
         self.config.initialize_argparse(parser)
         help = parser.format_help()
-        self.maxDiff = None
         self.assertIn(
             """
   -h, --help            show this help message and exit
@@ -3106,8 +3102,6 @@ c: 1.0
             cfg2.declare_from({})
 
     def test_docstring_decorator(self):
-        self.maxDiff = None
-
         @document_kwargs_from_configdict('CONFIG')
         class ExampleClass(object):
             CONFIG = ExampleConfig()

--- a/pyomo/common/tests/test_log.py
+++ b/pyomo/common/tests/test_log.py
@@ -511,7 +511,6 @@ would be line-wrapped
             "\n"
             "    quote block\n"
         )
-        self.maxDiff = None
         self.assertEqual(self.stream.getvalue(), ans)
 
 

--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -107,7 +107,6 @@ class TestTiming(unittest.TestCase):
                 m.y = Var(Any, dense=False)
                 xfrm.apply_to(m)
             result = out.getvalue().strip()
-            self.maxDiff = None
             for l, r in zip(result.splitlines(), ref.splitlines()):
                 self.assertRegex(str(l.strip()), str(r.strip()))
         finally:
@@ -122,7 +121,6 @@ class TestTiming(unittest.TestCase):
             m.y = Var(Any, dense=False)
             xfrm.apply_to(m)
             result = os.getvalue().strip()
-            self.maxDiff = None
             for l, r in zip(result.splitlines(), ref.splitlines()):
                 self.assertRegex(str(l.strip()), str(r.strip()))
         finally:
@@ -135,7 +133,6 @@ class TestTiming(unittest.TestCase):
             m.y = Var(Any, dense=False)
             xfrm.apply_to(m)
             result = os.getvalue().strip()
-            self.maxDiff = None
             for l, r in zip(result.splitlines(), ref.splitlines()):
                 self.assertRegex(str(l.strip()), str(r.strip()))
             self.assertEqual(buf.getvalue().strip(), "")
@@ -172,7 +169,6 @@ class TestTiming(unittest.TestCase):
                     xfrm.apply_to(m)
                 self.assertEqual(OUT.getvalue(), "")
                 result = OS.getvalue().strip()
-                self.maxDiff = None
                 for l, r in zip_longest(result.splitlines(), ref.splitlines()):
                     self.assertRegex(str(l.strip()), str(r.strip()))
             # Active reporting is False: the previous log should not have changed

--- a/pyomo/common/unittest.py
+++ b/pyomo/common/unittest.py
@@ -498,6 +498,10 @@ class TestCase(_unittest.TestCase):
 
     __doc__ += _unittest.TestCase.__doc__
 
+    # By default, we always want to spend the time to create the full
+    # diff of the test reault and the baseline
+    maxDiff = None
+
     def assertStructuredAlmostEqual(
         self,
         first,

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -2667,7 +2667,6 @@ class TestBlock(unittest.TestCase):
 
 5 Declarations: a1_IDX a3_IDX c a b
 """
-        self.maxDiff = None
         self.assertEqual(ref, buf.getvalue())
 
     @unittest.skipIf(not 'glpk' in solvers, "glpk solver is not available")

--- a/pyomo/core/tests/unit/test_numeric_expr.py
+++ b/pyomo/core/tests/unit/test_numeric_expr.py
@@ -1424,7 +1424,6 @@ class TestGenerate_SumExpression(unittest.TestCase):
         e1 = m.a * m.p
         e2 = m.b - m.c
         e = e2 - e1
-        self.maxDiff = None
         self.assertExpressionsEqual(
             e,
             LinearExpression(

--- a/pyomo/core/tests/unit/test_reference.py
+++ b/pyomo/core/tests/unit/test_reference.py
@@ -1280,7 +1280,6 @@ class TestReference(unittest.TestCase):
             normalize_index.flatten = _old_flatten
 
     def test_pprint_nonfinite_sets(self):
-        self.maxDiff = None
         m = ConcreteModel()
         m.v = Var(NonNegativeIntegers, dense=False)
         m.ref = Reference(m.v)
@@ -1322,7 +1321,6 @@ class TestReference(unittest.TestCase):
 
     def test_pprint_nonfinite_sets_ctypeNone(self):
         # test issue #2039
-        self.maxDiff = None
         m = ConcreteModel()
         m.v = Var(NonNegativeIntegers, dense=False)
         m.ref = Reference(m.v, ctype=None)

--- a/pyomo/core/tests/unit/test_set.py
+++ b/pyomo/core/tests/unit/test_set.py
@@ -6267,7 +6267,6 @@ c : Size=3, Index=CHOICES, Active=True
 
     @unittest.skipIf(NamedTuple is None, "typing module not available")
     def test_issue_938(self):
-        self.maxDiff = None
         NodeKey = NamedTuple('NodeKey', [('id', int)])
         ArcKey = NamedTuple('ArcKey', [('node_from', NodeKey), ('node_to', NodeKey)])
 

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -1096,7 +1096,6 @@ class Test_NLWriter(unittest.TestCase):
         m.c1 = Constraint([1, 2], rule=lambda m, i: sum(m.x.values()) == 1)
         m.c2 = Constraint(expr=m.p * m.x[1] ** 2 + m.x[2] ** 3 <= 100)
 
-        self.maxDiff = None
         OUT = io.StringIO()
         with capture_output() as LOG:
             with report_timing(level=logging.DEBUG):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
By default, unittest assertions (severely) truncate the diff error message when a comparison test fails.  As we (almost?) always want to see the full diff in order to diagnose the test failure, we end up sprinkling `self.maxDiff = None` throughout the codebase.  This PR adds the flag to the base `TestCase` class.

## Changes proposed in this PR:
- set `maxDiff = None` in `pyomo.common.unittest.TestCase`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
