### PR TITLE
Infrastructure Updates

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -66,7 +66,7 @@ jobs:
           TARGET: linux
           PYENV: pip
 
-        - os: macos-latest
+        - os: macos-13
           python: '3.10'
           TARGET: osx
           PYENV: pip

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -86,7 +86,7 @@ jobs:
           PACKAGES: pytest-qt
 
         - os: ubuntu-latest
-          python: '3.10'
+          python: 3.9
           other: /mpi
           mpi: 3
           skip_doctest: 1

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -86,7 +86,7 @@ jobs:
           PACKAGES: pytest-qt
 
         - os: ubuntu-latest
-          python: 3.9
+          python: '3.10'
           other: /mpi
           mpi: 3
           skip_doctest: 1

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -88,7 +88,7 @@ jobs:
         - os: ubuntu-latest
           python: '3.10'
           other: /mpi
-          mpi: 3
+          mpi: 2
           skip_doctest: 1
           TARGET: linux
           PYENV: conda

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -86,7 +86,7 @@ jobs:
           PACKAGES: pytest-qt
 
         - os: ubuntu-latest
-          python: 3.9
+          python: '3.10'
           other: /mpi
           mpi: 3
           skip_doctest: 1
@@ -333,10 +333,11 @@ jobs:
                 CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $PKG"
             fi
         done
+        echo ""
         echo "*** Install Pyomo dependencies ***"
         # Note: this will fail the build if any installation fails (or
         # possibly if it outputs messages to stderr)
-        conda install --update-deps -q -y $CONDA_DEPENDENCIES
+        conda install --update-deps -y $CONDA_DEPENDENCIES
         if test -z "${{matrix.slim}}"; then
             PYVER=$(echo "py${{matrix.python}}" | sed 's/\.//g')
             echo "Installing for $PYVER"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -88,7 +88,7 @@ jobs:
         - os: ubuntu-latest
           python: '3.10'
           other: /mpi
-          mpi: 2
+          mpi: 3
           skip_doctest: 1
           TARGET: linux
           PYENV: conda
@@ -632,7 +632,7 @@ jobs:
         $PYTHON_EXE -c "from pyomo.dataportal.parse_datacmds import \
             parse_data_commands; parse_data_commands(data='')"
         # Note: if we are testing with openmpi, add '--oversubscribe'
-        mpirun -np ${{matrix.mpi}} pytest -v \
+        mpirun -np ${{matrix.mpi}} -oversubscribe pytest -v \
             --junit-xml=TEST-pyomo-mpi.xml \
             -m "mpi" -W ignore::Warning \
             pyomo `pwd`/pyomo-model-libraries

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -709,12 +709,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
 
         include:
         - os: ubuntu-latest
           TARGET: linux
-        - os: macos-latest
+        - os: macos-13
           TARGET: osx
         - os: windows-latest
           TARGET: win

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -739,12 +739,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
 
         include:
         - os: ubuntu-latest
           TARGET: linux
-        - os: macos-latest
+        - os: macos-13
           TARGET: osx
         - os: windows-latest
           TARGET: win

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         python: [ 3.8, 3.9, '3.10', '3.11', '3.12' ]
         other: [""]
         category: [""]
@@ -69,7 +69,7 @@ jobs:
           TARGET: linux
           PYENV: pip
 
-        - os: macos-latest
+        - os: macos-13
           TARGET: osx
           PYENV: pip
 
@@ -87,7 +87,7 @@ jobs:
           PACKAGES: pytest-qt
 
         - os: ubuntu-latest
-          python: 3.9
+          python: '3.10'
           other: /mpi
           mpi: 3
           skip_doctest: 1
@@ -661,7 +661,7 @@ jobs:
         $PYTHON_EXE -c "from pyomo.dataportal.parse_datacmds import \
             parse_data_commands; parse_data_commands(data='')"
         # Note: if we are testing with openmpi, add '--oversubscribe'
-        mpirun -np ${{matrix.mpi}} pytest -v \
+        mpirun -np ${{matrix.mpi}} -oversubscribe pytest -v \
             --junit-xml=TEST-pyomo-mpi.xml \
             -m "mpi" -W ignore::Warning \
             pyomo `pwd`/pyomo-model-libraries


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
Tests are failing currently because of infrastructure changes. This addresses this.

## Changes proposed in this PR:
- Change `mpi` to python 3.10 instead of 9; add `-oversubscribe`
- Update to `macos-13` runner image

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
