### PR TITLE
Resolve errors in LaTeX printer for set operations / multidimensional sets

### DIFF
--- a/pyomo/contrib/latex_printer/latex_printer.py
+++ b/pyomo/contrib/latex_printer/latex_printer.py
@@ -1077,7 +1077,7 @@ def latex_printer(
         if st.parent_block().component(st.name) is st:
             return st.name.replace('_', r'\_')
         if isinstance(st, SetOperator):
-            return _set_op_map[st._operator.strip()].join(
+            return set_operator_map[st._operator.strip()].join(
                 generate_set_name(s, lcm) for s in st.subsets(False)
             )
         else:

--- a/pyomo/contrib/latex_printer/latex_printer.py
+++ b/pyomo/contrib/latex_printer/latex_printer.py
@@ -9,17 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-#  ___________________________________________________________________________
-#
-#  Pyomo: Python Optimization Modeling Objects
-#  Copyright (c) 2008-2023
-#  National Technology and Engineering Solutions of Sandia, LLC
-#  Under the terms of Contract DE-NA0003525 with National Technology and
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
-#  rights in this software.
-#  This software is distributed under the 3-clause BSD License.
-#  ___________________________________________________________________________
-
 import math
 import copy
 import re

--- a/pyomo/contrib/latex_printer/latex_printer.py
+++ b/pyomo/contrib/latex_printer/latex_printer.py
@@ -112,6 +112,7 @@ domainMap = {
     # 'IntegerInterval' :     None    ,
 }
 
+
 def decoder(num, base):
     if int(num) != abs(num):
         # Requiring an integer is nice, but not strictly necessary;

--- a/pyomo/contrib/latex_printer/latex_printer.py
+++ b/pyomo/contrib/latex_printer/latex_printer.py
@@ -406,25 +406,28 @@ class _LatexVisitor(StreamBasedExpressionVisitor):
             )
 
 
+mathbb = r'\mathbb'
+
+
 def analyze_variable(vr):
     domainMap = {
-        'Reals': '\\mathds{R}',
-        'PositiveReals': '\\mathds{R}_{> 0}',
-        'NonPositiveReals': '\\mathds{R}_{\\leq 0}',
-        'NegativeReals': '\\mathds{R}_{< 0}',
-        'NonNegativeReals': '\\mathds{R}_{\\geq 0}',
-        'Integers': '\\mathds{Z}',
-        'PositiveIntegers': '\\mathds{Z}_{> 0}',
-        'NonPositiveIntegers': '\\mathds{Z}_{\\leq 0}',
-        'NegativeIntegers': '\\mathds{Z}_{< 0}',
-        'NonNegativeIntegers': '\\mathds{Z}_{\\geq 0}',
+        'Reals': mathbb + '{R}',
+        'PositiveReals': mathbb + '{R}_{> 0}',
+        'NonPositiveReals': mathbb + '{R}_{\\leq 0}',
+        'NegativeReals': mathbb + '{R}_{< 0}',
+        'NonNegativeReals': mathbb + '{R}_{\\geq 0}',
+        'Integers': mathbb + '{Z}',
+        'PositiveIntegers': mathbb + '{Z}_{> 0}',
+        'NonPositiveIntegers': mathbb + '{Z}_{\\leq 0}',
+        'NegativeIntegers': mathbb + '{Z}_{< 0}',
+        'NonNegativeIntegers': mathbb + '{Z}_{\\geq 0}',
         'Boolean': '\\left\\{ \\text{True} , \\text{False} \\right \\}',
         'Binary': '\\left\\{ 0 , 1 \\right \\}',
         # 'Any': None,
         # 'AnyWithNone': None,
         'EmptySet': '\\varnothing',
-        'UnitInterval': '\\mathds{R}',
-        'PercentFraction': '\\mathds{R}',
+        'UnitInterval': mathbb + '{R}',
+        'PercentFraction': mathbb + '{R}',
         # 'RealInterval' :        None    ,
         # 'IntegerInterval' :     None    ,
     }

--- a/pyomo/contrib/latex_printer/latex_printer.py
+++ b/pyomo/contrib/latex_printer/latex_printer.py
@@ -275,11 +275,11 @@ def handle_functionID_node(visitor, node, *args):
 
 
 def handle_indexTemplate_node(visitor, node, *args):
-    if node._set in ComponentSet(visitor.setMap.keys()):
+    if node._set in visitor.setMap:
         # already detected set, do nothing
         pass
     else:
-        visitor.setMap[node._set] = 'SET%d' % (len(visitor.setMap.keys()) + 1)
+        visitor.setMap[node._set] = 'SET%d' % (len(visitor.setMap) + 1)
 
     return '__I_PLACEHOLDER_8675309_GROUP_%s_%s__' % (
         node._group,
@@ -616,15 +616,15 @@ def latex_printer(
 
     # Cody's backdoor because he got outvoted
     if latex_component_map is not None:
-        if 'use_short_descriptors' in list(latex_component_map.keys()):
+        if 'use_short_descriptors' in latex_component_map:
             if latex_component_map['use_short_descriptors'] == False:
                 use_short_descriptors = False
 
     if latex_component_map is None:
         latex_component_map = ComponentMap()
-        existing_components = ComponentSet([])
+        existing_components = ComponentSet()
     else:
-        existing_components = ComponentSet(list(latex_component_map.keys()))
+        existing_components = ComponentSet(latex_component_map)
 
     isSingle = False
 
@@ -1225,14 +1225,14 @@ def latex_printer(
             )
 
     for ky, vl in new_variableMap.items():
-        if ky not in ComponentSet(latex_component_map.keys()):
+        if ky not in latex_component_map:
             latex_component_map[ky] = vl
     for ky, vl in new_parameterMap.items():
-        if ky not in ComponentSet(latex_component_map.keys()):
+        if ky not in latex_component_map:
             latex_component_map[ky] = vl
 
     rep_dict = {}
-    for ky in ComponentSet(list(reversed(list(latex_component_map.keys())))):
+    for ky in reversed(list(latex_component_map)):
         if isinstance(ky, (pyo.Var, _GeneralVarData)):
             overwrite_value = latex_component_map[ky]
             if ky not in existing_components:

--- a/pyomo/contrib/latex_printer/latex_printer.py
+++ b/pyomo/contrib/latex_printer/latex_printer.py
@@ -776,12 +776,12 @@ def latex_printer(
     for vr in variableList:
         vrIdx += 1
         if isinstance(vr, ScalarVar):
-            variableMap[vr] = 'x_' + str(vrIdx)
+            variableMap[vr] = 'x_' + str(vrIdx) + '_'
         elif isinstance(vr, IndexedVar):
-            variableMap[vr] = 'x_' + str(vrIdx)
+            variableMap[vr] = 'x_' + str(vrIdx) + '_'
             for sd in vr.index_set().data():
                 vrIdx += 1
-                variableMap[vr[sd]] = 'x_' + str(vrIdx)
+                variableMap[vr[sd]] = 'x_' + str(vrIdx) + '_'
         else:
             raise DeveloperError(
                 'Variable is not a variable.  Should not happen.  Contact developers'
@@ -793,12 +793,12 @@ def latex_printer(
     for vr in parameterList:
         pmIdx += 1
         if isinstance(vr, ScalarParam):
-            parameterMap[vr] = 'p_' + str(pmIdx)
+            parameterMap[vr] = 'p_' + str(pmIdx) + '_'
         elif isinstance(vr, IndexedParam):
-            parameterMap[vr] = 'p_' + str(pmIdx)
+            parameterMap[vr] = 'p_' + str(pmIdx) + '_'
             for sd in vr.index_set().data():
                 pmIdx += 1
-                parameterMap[vr[sd]] = 'p_' + str(pmIdx)
+                parameterMap[vr[sd]] = 'p_' + str(pmIdx) + '_'
         else:
             raise DeveloperError(
                 'Parameter is not a parameter.  Should not happen.  Contact developers'

--- a/pyomo/contrib/latex_printer/latex_printer.py
+++ b/pyomo/contrib/latex_printer/latex_printer.py
@@ -1081,7 +1081,7 @@ def latex_printer(
                 generate_set_name(s, lcm) for s in st.subsets(False)
             )
         else:
-            return str(st).replace('_', r'\_').replace('{', '\{').replace('}', '\}')
+            return str(st).replace('_', r'\_').replace('{', r'\{').replace('}', r'\}')
 
     # Handling the iterator indices
     defaultSetLatexNames = ComponentMap()

--- a/pyomo/contrib/latex_printer/tests/test_latex_printer.py
+++ b/pyomo/contrib/latex_printer/tests/test_latex_printer.py
@@ -9,25 +9,16 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-#  ___________________________________________________________________________
-#
-#  Pyomo: Python Optimization Modeling Objects
-#  Copyright (c) 2008-2023
-#  National Technology and Engineering Solutions of Sandia, LLC
-#  Under the terms of Contract DE-NA0003525 with National Technology and
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
-#  rights in this software.
-#  This software is distributed under the 3-clause BSD License.
-#  ___________________________________________________________________________
-
 import io
-import pyomo.common.unittest as unittest
-from pyomo.contrib.latex_printer import latex_printer
-import pyomo.environ as pyo
 from textwrap import dedent
+
+import pyomo.common.unittest as unittest
+import pyomo.core.tests.examples.pmedian_concrete as pmedian_concrete 
+import pyomo.environ as pyo
+
+from pyomo.contrib.latex_printer import latex_printer
 from pyomo.common.tempfiles import TempfileManager
 from pyomo.common.collections.component_map import ComponentMap
-
 from pyomo.environ import (
     Reals,
     PositiveReals,
@@ -796,6 +787,50 @@ class TestLatexPrinter(unittest.TestCase):
         )
 
         self.assertEqual('\n' + pstr + '\n', bstr)
+
+    def test_latexPrinter_pmedian_verbose(self):
+        m = pmedian_concrete.create_model()
+        self.assertEqual(
+            latex_printer(m).strip(),
+            r"""
+\begin{align} 
+    & \min 
+    & & \sum_{ i \in Locations  } \sum_{ j \in Customers  } cost_{i,j} serve\_customer\_from\_location_{i,j} & \label{obj:M1_obj} \\ 
+    & \text{s.t.} 
+    & & \sum_{ i \in Locations  } serve\_customer\_from\_location_{i,j} = 1 &  \qquad \forall j \in Customers \label{con:M1_single_x} \\ 
+    &&& serve\_customer\_from\_location_{i,j} \leq select\_location_{i} &  \qquad \forall i,j \in Locations \times Customers \label{con:M1_bound_y} \\ 
+    &&& \sum_{ i \in Locations  } select\_location_{i} = P & \label{con:M1_num_facilities} \\ 
+    & \text{w.b.} 
+    & & 0.0 \leq serve\_customer\_from\_location \leq 1.0 & \qquad \in \mathds{R} \label{con:M1_serve_customer_from_location_bound} \\ 
+    &&& select\_location & \qquad \in \left\{ 0 , 1 \right \} \label{con:M1_select_location_bound} 
+\end{align}
+            """.strip()
+        )
+
+    def test_latexPrinter_pmedian_concise(self):
+        m = pmedian_concrete.create_model()
+        lcm = ComponentMap()
+        lcm[m.Locations] = ['L', ['n']]
+        lcm[m.Customers] = ['C', ['m']]
+        lcm[m.cost] = 'd'
+        lcm[m.serve_customer_from_location] = 'x'
+        lcm[m.select_location] = 'y'
+        self.assertEqual(
+            latex_printer(m, latex_component_map=lcm).strip(),
+            r"""
+\begin{align} 
+    & \min 
+    & & \sum_{ n \in L  } \sum_{ m \in C  } d_{n,m} x_{n,m} & \label{obj:M1_obj} \\ 
+    & \text{s.t.} 
+    & & \sum_{ n \in L  } x_{n,m} = 1 &  \qquad \forall m \in C \label{con:M1_single_x} \\ 
+    &&& x_{n,m} \leq y_{n} &  \qquad \forall n,m \in L \times C \label{con:M1_bound_y} \\ 
+    &&& \sum_{ n \in L  } y_{n} = P & \label{con:M1_num_facilities} \\ 
+    & \text{w.b.} 
+    & & 0.0 \leq x \leq 1.0 & \qquad \in \mathds{R} \label{con:M1_x_bound} \\ 
+    &&& y & \qquad \in \left\{ 0 , 1 \right \} \label{con:M1_y_bound} 
+\end{align}
+            """.strip()
+        )
 
 
 if __name__ == '__main__':

--- a/pyomo/contrib/latex_printer/tests/test_latex_printer.py
+++ b/pyomo/contrib/latex_printer/tests/test_latex_printer.py
@@ -13,7 +13,7 @@ import io
 from textwrap import dedent
 
 import pyomo.common.unittest as unittest
-import pyomo.core.tests.examples.pmedian_concrete as pmedian_concrete 
+import pyomo.core.tests.examples.pmedian_concrete as pmedian_concrete
 import pyomo.environ as pyo
 
 from pyomo.contrib.latex_printer import latex_printer
@@ -804,7 +804,7 @@ class TestLatexPrinter(unittest.TestCase):
     & & 0.0 \leq serve\_customer\_from\_location \leq 1.0 & \qquad \in \mathds{R} \label{con:M1_serve_customer_from_location_bound} \\ 
     &&& select\_location & \qquad \in \left\{ 0 , 1 \right \} \label{con:M1_select_location_bound} 
 \end{align}
-            """.strip()
+            """.strip(),
         )
 
     def test_latexPrinter_pmedian_concise(self):
@@ -829,7 +829,7 @@ class TestLatexPrinter(unittest.TestCase):
     & & 0.0 \leq x \leq 1.0 & \qquad \in \mathds{R} \label{con:M1_x_bound} \\ 
     &&& y & \qquad \in \left\{ 0 , 1 \right \} \label{con:M1_y_bound} 
 \end{align}
-            """.strip()
+            """.strip(),
         )
 
 

--- a/pyomo/core/tests/examples/pmedian_concrete.py
+++ b/pyomo/core/tests/examples/pmedian_concrete.py
@@ -1,0 +1,70 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2024
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import math
+from pyomo.environ import (
+    ConcreteModel,
+    Param,
+    RangeSet,
+    Var,
+    Reals,
+    Binary,
+    PositiveIntegers,
+)
+
+
+def _cost_rule(model, n, m):
+    # We will assume costs are an arbitrary function of the indices
+    return math.sin(n * 2.33333 + m * 7.99999)
+
+
+def create_model(n=3, m=3, p=2):
+    model = ConcreteModel(name="M1")
+
+    model.N = Param(initialize=n, within=PositiveIntegers)
+    model.M = Param(initialize=m, within=PositiveIntegers)
+    model.P = Param(initialize=p, within=RangeSet(1, model.N), mutable=True)
+
+    model.Locations = RangeSet(1, model.N)
+    model.Customers = RangeSet(1, model.M)
+
+    model.cost = Param(
+        model.Locations, model.Customers, initialize=_cost_rule, within=Reals
+    )
+    model.serve_customer_from_location = Var(
+        model.Locations, model.Customers, bounds=(0.0, 1.0)
+    )
+    model.select_location = Var(model.Locations, within=Binary)
+
+    @model.Objective()
+    def obj(model):
+        return sum(
+            model.cost[n, m] * model.serve_customer_from_location[n, m]
+            for n in model.Locations
+            for m in model.Customers
+        )
+
+    @model.Constraint(model.Customers)
+    def single_x(model, m):
+        return (
+            sum(model.serve_customer_from_location[n, m] for n in model.Locations)
+            == 1.0
+        )
+
+    @model.Constraint(model.Locations, model.Customers)
+    def bound_y(model, n, m):
+        return model.serve_customer_from_location[n, m] <= model.select_location[n]
+
+    @model.Constraint()
+    def num_facilities(model):
+        return sum(model.select_location[n] for n in model.Locations) == model.P
+
+    return model


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This resolves errors in the `latex_printer()` for models with set operators (in particular, `SetProduct` indexing sets) and multidinensional sets.

## Changes proposed in this PR:
- minor performance improvements in internal lookups
- resolve errors naming `IndexTemplate` objects for multidimensionsl sets
- resolve overlapping placeholder IDs for models with > 10 vars or params
- pull out some embedded constants (make it easier to override)
- Improved output of anonymous set expressions
- add test of pmedian (which motivated these changes)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
