### PR TITLE
Slightly increase delta for TicTocTimer test

### DIFF
--- a/pyomo/common/tests/test_timing.py
+++ b/pyomo/common/tests/test_timing.py
@@ -180,7 +180,7 @@ class TestTiming(unittest.TestCase):
 
     def test_TicTocTimer_tictoc(self):
         SLEEP = 0.1
-        RES = 0.02  # resolution (seconds): 1/5 the sleep
+        RES = 0.025  # resolution (seconds): 1/4 the sleep
 
         # Note: pypy on GHA occasionally has timing
         # differences of >0.04s


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
Jenkins tests have been consistently failing for the past few days due to `test_TicTocTimer_tictoc`. The delta was set to 0.02, and all failures have been slightly above that (e.g., 0.022). This adjusts the delta to 0.025 to prevent the failures.

## Changes proposed in this PR:
- Change `RES = 0.02` to `RES = 0.025`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
