### PR TITLE
Allow APPSI's cmodel to handle non-mutable parameters in variable and constraint bounds

### DIFF
--- a/pyomo/contrib/appsi/cmodel/src/expression.cpp
+++ b/pyomo/contrib/appsi/cmodel/src/expression.cpp
@@ -1548,7 +1548,10 @@ appsi_operator_from_pyomo_expr(py::handle expr, py::handle var_map,
     break;
   }
   case param: {
-    res = param_map[expr_types.id(expr)].cast<std::shared_ptr<Node>>();
+    if (expr.attr("parent_component")().attr("mutable").cast<bool>())
+        res = param_map[expr_types.id(expr)].cast<std::shared_ptr<Node>>();
+    else
+        res = std::make_shared<Constant>(expr.attr("value").cast<double>());
     break;
   }
   case product: {

--- a/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
+++ b/pyomo/contrib/appsi/solvers/tests/test_persistent_solvers.py
@@ -919,6 +919,27 @@ class TestSolvers(unittest.TestCase):
         self.assertAlmostEqual(m.y.value, 3)
 
     @parameterized.expand(input=_load_tests(all_solvers, only_child_vars_options))
+    def test_bounds_with_immutable_params(
+        self, name: str, opt_class: Type[PersistentSolver], only_child_vars
+    ):
+        # this test is for issue #2574
+        opt: PersistentSolver = opt_class(only_child_vars=only_child_vars)
+        if not opt.available():
+            raise unittest.SkipTest
+        m = pe.ConcreteModel()
+        m.p = pe.Param(mutable=False, initialize=1)
+        m.q = pe.Param([1, 2], mutable=False, initialize=10)
+        m.y = pe.Var()
+        m.y.setlb(m.p)
+        m.y.setub(m.q[1])
+        m.obj = pe.Objective(expr=m.y)
+        res = opt.solve(m)
+        self.assertAlmostEqual(m.y.value, 1)
+        m.y.setlb(m.q[2])
+        res = opt.solve(m)
+        self.assertAlmostEqual(m.y.value, 10)
+
+    @parameterized.expand(input=_load_tests(all_solvers, only_child_vars_options))
     def test_solution_loader(
         self, name: str, opt_class: Type[PersistentSolver], only_child_vars
     ):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #2574

## Summary/Motivation:
See #2574

## Changes proposed in this PR:
- Add test which fails on `main`.
- Check if pyomo `Param` is mutable or not when creating the `cmodel` and create a `Constant` object if it is not mutable.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
