### PR TITLE
Subprocess Timeout Update

### DIFF
--- a/pyomo/contrib/appsi/solvers/ipopt.py
+++ b/pyomo/contrib/appsi/solvers/ipopt.py
@@ -42,7 +42,6 @@ from pyomo.common.errors import PyomoException
 import os
 from pyomo.contrib.appsi.cmodel import cmodel_available
 from pyomo.core.staleflag import StaleFlagManager
-from pyomo.opt.base import subprocess_timeout
 
 
 logger = logging.getLogger(__name__)
@@ -148,6 +147,7 @@ class Ipopt(PersistentSolver):
         self._primal_sol = ComponentMap()
         self._reduced_costs = ComponentMap()
         self._last_results_object: Optional[Results] = None
+        self._version_timeout = 2
 
     def available(self):
         if self.config.executable.path() is None:
@@ -159,7 +159,7 @@ class Ipopt(PersistentSolver):
     def version(self):
         results = subprocess.run(
             [str(self.config.executable), '--version'],
-            timeout=subprocess_timeout,
+            timeout=self._version_timeout,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,

--- a/pyomo/contrib/appsi/solvers/ipopt.py
+++ b/pyomo/contrib/appsi/solvers/ipopt.py
@@ -42,6 +42,7 @@ from pyomo.common.errors import PyomoException
 import os
 from pyomo.contrib.appsi.cmodel import cmodel_available
 from pyomo.core.staleflag import StaleFlagManager
+from pyomo.opt.base import subprocess_timeout
 
 
 logger = logging.getLogger(__name__)
@@ -158,7 +159,7 @@ class Ipopt(PersistentSolver):
     def version(self):
         results = subprocess.run(
             [str(self.config.executable), '--version'],
-            timeout=1,
+            timeout=subprocess_timeout,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,

--- a/pyomo/contrib/solver/ipopt.py
+++ b/pyomo/contrib/solver/ipopt.py
@@ -39,7 +39,6 @@ from pyomo.core.expr.visitor import replace_expressions
 from pyomo.core.expr.numvalue import value
 from pyomo.core.base.suffix import Suffix
 from pyomo.common.collections import ComponentMap
-from pyomo.opt.base import subprocess_timeout
 
 logger = logging.getLogger(__name__)
 
@@ -207,6 +206,7 @@ class Ipopt(SolverBase):
         self._writer = NLWriter()
         self._available_cache = None
         self._version_cache = None
+        self._version_timeout = 2
 
     def available(self, config=None):
         if config is None:
@@ -229,7 +229,7 @@ class Ipopt(SolverBase):
             else:
                 results = subprocess.run(
                     [str(pth), '--version'],
-                    timeout=subprocess_timeout,
+                    timeout=self._version_timeout,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
                     universal_newlines=True,

--- a/pyomo/contrib/solver/ipopt.py
+++ b/pyomo/contrib/solver/ipopt.py
@@ -9,6 +9,7 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
+import logging
 import os
 import subprocess
 import datetime
@@ -38,8 +39,7 @@ from pyomo.core.expr.visitor import replace_expressions
 from pyomo.core.expr.numvalue import value
 from pyomo.core.base.suffix import Suffix
 from pyomo.common.collections import ComponentMap
-
-import logging
+from pyomo.opt.base import subprocess_timeout
 
 logger = logging.getLogger(__name__)
 
@@ -229,7 +229,7 @@ class Ipopt(SolverBase):
             else:
                 results = subprocess.run(
                     [str(pth), '--version'],
-                    timeout=1,
+                    timeout=subprocess_timeout,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
                     universal_newlines=True,

--- a/pyomo/opt/base/__init__.py
+++ b/pyomo/opt/base/__init__.py
@@ -22,3 +22,5 @@ from pyomo.opt.base.solvers import (
 from pyomo.opt.base.results import ReaderFactory, AbstractResultsReader
 from pyomo.opt.base.problem import AbstractProblemWriter, BranchDirection, WriterFactory
 from pyomo.opt.base.formats import ProblemFormat, ResultsFormat, guess_format
+
+subprocess_timeout = 2

--- a/pyomo/opt/base/__init__.py
+++ b/pyomo/opt/base/__init__.py
@@ -22,5 +22,3 @@ from pyomo.opt.base.solvers import (
 from pyomo.opt.base.results import ReaderFactory, AbstractResultsReader
 from pyomo.opt.base.problem import AbstractProblemWriter, BranchDirection, WriterFactory
 from pyomo.opt.base.formats import ProblemFormat, ResultsFormat, guess_format
-
-subprocess_timeout = 2

--- a/pyomo/opt/solver/shellcmd.py
+++ b/pyomo/opt/solver/shellcmd.py
@@ -60,6 +60,7 @@ class SystemCallSolver(OptSolver):
         # a solver plugin may not report execution time.
         self._last_solve_time = None
         self._define_signal_handlers = None
+        self._version_timeout = 2
 
         if executable is not None:
             self.set_executable(name=executable, validate=validate)

--- a/pyomo/solvers/plugins/solvers/CONOPT.py
+++ b/pyomo/solvers/plugins/solvers/CONOPT.py
@@ -16,7 +16,7 @@ from pyomo.common import Executable
 from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
-from pyomo.opt.base import ProblemFormat, ResultsFormat, subprocess_timeout
+from pyomo.opt.base import ProblemFormat, ResultsFormat
 from pyomo.opt.base.solvers import _extract_version, SolverFactory
 from pyomo.opt.results import SolverStatus
 from pyomo.opt.solver import SystemCallSolver
@@ -79,7 +79,7 @@ class CONOPT(SystemCallSolver):
             return _extract_version('')
         results = subprocess.run(
             [solver_exec],
-            timeout=subprocess_timeout,
+            timeout=self._version_timeout,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,

--- a/pyomo/solvers/plugins/solvers/CONOPT.py
+++ b/pyomo/solvers/plugins/solvers/CONOPT.py
@@ -16,7 +16,7 @@ from pyomo.common import Executable
 from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
-from pyomo.opt.base import ProblemFormat, ResultsFormat
+from pyomo.opt.base import ProblemFormat, ResultsFormat, subprocess_timeout
 from pyomo.opt.base.solvers import _extract_version, SolverFactory
 from pyomo.opt.results import SolverStatus
 from pyomo.opt.solver import SystemCallSolver
@@ -79,7 +79,7 @@ class CONOPT(SystemCallSolver):
             return _extract_version('')
         results = subprocess.run(
             [solver_exec],
-            timeout=1,
+            timeout=subprocess_timeout,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -21,13 +21,7 @@ from pyomo.common.errors import ApplicationError
 from pyomo.common.tempfiles import TempfileManager
 
 from pyomo.common.collections import ComponentMap, Bunch
-from pyomo.opt.base import (
-    ProblemFormat,
-    ResultsFormat,
-    OptSolver,
-    BranchDirection,
-    subprocess_timeout,
-)
+from pyomo.opt.base import ProblemFormat, ResultsFormat, OptSolver, BranchDirection
 from pyomo.opt.base.solvers import _extract_version, SolverFactory
 from pyomo.opt.results import (
     SolverResults,
@@ -410,7 +404,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
             return _extract_version('')
         results = subprocess.run(
             [solver_exec, '-c', 'quit'],
-            timeout=subprocess_timeout,
+            timeout=self._version_timeout,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -21,7 +21,13 @@ from pyomo.common.errors import ApplicationError
 from pyomo.common.tempfiles import TempfileManager
 
 from pyomo.common.collections import ComponentMap, Bunch
-from pyomo.opt.base import ProblemFormat, ResultsFormat, OptSolver, BranchDirection
+from pyomo.opt.base import (
+    ProblemFormat,
+    ResultsFormat,
+    OptSolver,
+    BranchDirection,
+    subprocess_timeout,
+)
 from pyomo.opt.base.solvers import _extract_version, SolverFactory
 from pyomo.opt.results import (
     SolverResults,
@@ -404,7 +410,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
             return _extract_version('')
         results = subprocess.run(
             [solver_exec, '-c', 'quit'],
-            timeout=1,
+            timeout=subprocess_timeout,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,

--- a/pyomo/solvers/plugins/solvers/GLPK.py
+++ b/pyomo/solvers/plugins/solvers/GLPK.py
@@ -29,6 +29,7 @@ from pyomo.opt import (
     SolutionStatus,
     ProblemSense,
 )
+from pyomo.opt.base import subprocess_timeout
 from pyomo.opt.base.solvers import _extract_version
 from pyomo.opt.solver import SystemCallSolver
 from pyomo.solvers.mockmip import MockMIP
@@ -137,7 +138,7 @@ class GLPKSHELL(SystemCallSolver):
             [executable, "--version"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            timeout=1,
+            timeout=subprocess_timeout,
             universal_newlines=True,
         )
         return _extract_version(result.stdout)

--- a/pyomo/solvers/plugins/solvers/GLPK.py
+++ b/pyomo/solvers/plugins/solvers/GLPK.py
@@ -19,6 +19,7 @@ from pyomo.common.tempfiles import TempfileManager
 
 from pyomo.common import Executable
 from pyomo.common.collections import Bunch
+from pyomo.common.errors import ApplicationError
 from pyomo.opt import (
     SolverFactory,
     OptSolver,
@@ -29,7 +30,6 @@ from pyomo.opt import (
     SolutionStatus,
     ProblemSense,
 )
-from pyomo.opt.base import subprocess_timeout
 from pyomo.opt.base.solvers import _extract_version
 from pyomo.opt.solver import SystemCallSolver
 from pyomo.solvers.mockmip import MockMIP
@@ -138,7 +138,7 @@ class GLPKSHELL(SystemCallSolver):
             [executable, "--version"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            timeout=subprocess_timeout,
+            timeout=self._version_timeout,
             universal_newlines=True,
         )
         return _extract_version(result.stdout)

--- a/pyomo/solvers/plugins/solvers/IPOPT.py
+++ b/pyomo/solvers/plugins/solvers/IPOPT.py
@@ -16,7 +16,7 @@ from pyomo.common import Executable
 from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
-from pyomo.opt.base import ProblemFormat, ResultsFormat
+from pyomo.opt.base import ProblemFormat, ResultsFormat, subprocess_timeout
 from pyomo.opt.base.solvers import _extract_version, SolverFactory
 from pyomo.opt.results import SolverStatus, SolverResults, TerminationCondition
 from pyomo.opt.solver import SystemCallSolver
@@ -79,7 +79,7 @@ class IPOPT(SystemCallSolver):
             return _extract_version('')
         results = subprocess.run(
             [solver_exec, "-v"],
-            timeout=1,
+            timeout=subprocess_timeout,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,

--- a/pyomo/solvers/plugins/solvers/IPOPT.py
+++ b/pyomo/solvers/plugins/solvers/IPOPT.py
@@ -16,7 +16,7 @@ from pyomo.common import Executable
 from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
-from pyomo.opt.base import ProblemFormat, ResultsFormat, subprocess_timeout
+from pyomo.opt.base import ProblemFormat, ResultsFormat
 from pyomo.opt.base.solvers import _extract_version, SolverFactory
 from pyomo.opt.results import SolverStatus, SolverResults, TerminationCondition
 from pyomo.opt.solver import SystemCallSolver
@@ -79,7 +79,7 @@ class IPOPT(SystemCallSolver):
             return _extract_version('')
         results = subprocess.run(
             [solver_exec, "-v"],
-            timeout=subprocess_timeout,
+            timeout=self._version_timeout,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,

--- a/pyomo/solvers/plugins/solvers/SCIPAMPL.py
+++ b/pyomo/solvers/plugins/solvers/SCIPAMPL.py
@@ -18,7 +18,7 @@ from pyomo.common import Executable
 from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
-from pyomo.opt.base import ProblemFormat, ResultsFormat, subprocess_timeout
+from pyomo.opt.base import ProblemFormat, ResultsFormat
 from pyomo.opt.base.solvers import _extract_version, SolverFactory
 from pyomo.opt.results import (
     SolverStatus,
@@ -103,7 +103,7 @@ class SCIPAMPL(SystemCallSolver):
                 return _extract_version('')
         results = subprocess.run(
             [solver_exec, "--version"],
-            timeout=subprocess_timeout,
+            timeout=self._version_timeout,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,

--- a/pyomo/solvers/plugins/solvers/SCIPAMPL.py
+++ b/pyomo/solvers/plugins/solvers/SCIPAMPL.py
@@ -18,7 +18,7 @@ from pyomo.common import Executable
 from pyomo.common.collections import Bunch
 from pyomo.common.tempfiles import TempfileManager
 
-from pyomo.opt.base import ProblemFormat, ResultsFormat
+from pyomo.opt.base import ProblemFormat, ResultsFormat, subprocess_timeout
 from pyomo.opt.base.solvers import _extract_version, SolverFactory
 from pyomo.opt.results import (
     SolverStatus,
@@ -103,7 +103,7 @@ class SCIPAMPL(SystemCallSolver):
                 return _extract_version('')
         results = subprocess.run(
             [solver_exec, "--version"],
-            timeout=1,
+            timeout=subprocess_timeout,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,


### PR DESCRIPTION
## Fixes #3064 

## Summary/Motivation:
We have a hard-coded timeout of 1 second for system call solvers. This PR updates that to 2, but also puts that timeout in a private-esque attribute so users can adjust it, if necessary. 

## Changes proposed in this PR:
- Create `self._version_timeout` attribute on `SystemCallSolver`
- Set default to 2

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
