### PR TITLE
Allow APPSI FBBT to handle nested named Expressions

### DIFF
--- a/pyomo/contrib/appsi/cmodel/src/expression.cpp
+++ b/pyomo/contrib/appsi/cmodel/src/expression.cpp
@@ -1789,7 +1789,8 @@ int build_expression_tree(py::handle pyomo_expr,
 
   if (expr_types.expr_type_map[py::type::of(pyomo_expr)].cast<ExprType>() ==
       named_expr)
-    pyomo_expr = pyomo_expr.attr("expr");
+    return build_expression_tree(pyomo_expr.attr("expr"), appsi_expr, var_map,
+                                 param_map, expr_types);
 
   if (appsi_expr->is_leaf()) {
     ;

--- a/pyomo/contrib/appsi/tests/test_fbbt.py
+++ b/pyomo/contrib/appsi/tests/test_fbbt.py
@@ -151,3 +151,16 @@ class TestFBBTPersistent(unittest.TestCase):
         for x in m.x.values():
             self.assertAlmostEqual(x.lb, 0)
             self.assertAlmostEqual(x.ub, 0)
+
+    def test_named_exprs_nest(self):
+        # test for issue #3184
+        m = pe.ConcreteModel()
+        m.x = pe.Var()
+        m.e = pe.Expression(expr=m.x + 1)
+        m.f = pe.Expression(expr=m.e)
+        m.c = pe.Constraint(expr=(0, m.f, 0))
+        it = appsi.fbbt.IntervalTightener()
+        it.perform_fbbt(m)
+        for x in m.x.values():
+            self.assertAlmostEqual(x.lb, -1)
+            self.assertAlmostEqual(x.ub, -1)


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #3184 

## Summary/Motivation:
See #3184

## Changes proposed in this PR:
- Add a test which fails on `main`
- Add recursive call in `build_expression_tree` to handle nested named Expressions in the Pyomo model.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
