### PR TITLE
NLv2: handle presolved independent linear subsystems

### DIFF
--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -1092,7 +1092,7 @@ class _NLWriter_impl(object):
                 # all the constraints from the subsystem.  Because the
                 # free variables in the subsystem are not referenced
                 # anywhere else in the model, they are not part of the
-                # `varaibles` list.  Implicitly "fix" it to an arbitrary
+                # `variables` list.  Implicitly "fix" it to an arbitrary
                 # valid value from the presolved domain (see #3192).
                 if _i not in _vmap:
                     lb, ub = var_bounds[_i]


### PR DESCRIPTION

<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #3192.

## Summary/Motivation:
This resolves the issue in the NL linear presolve for the case where the presolve identifies and removes an underdetermined linear independent subsystem.

## Changes proposed in this PR:
- Set free variables in underdetermined linear independent subsystems to the feasible value closest to 0
- Add tests exercising this logic

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
