### PR TITLE
NFC: Add link to the HOMOWP companion notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ version, we will remove testing for that Python version.
 
 * [Pyomo Workshop Slides](https://github.com/Pyomo/pyomo-tutorials/blob/main/Pyomo-Workshop-December-2023.pdf)
 * [Prof. Jeffrey Kantor's Pyomo Cookbook](https://jckantor.github.io/ND-Pyomo-Cookbook/)
+* The [companion notebooks](https://mobook.github.io/MO-book/intro.html)
+  for *Hands-On Mathematical Optimization with Python*
 * [Pyomo Gallery](https://github.com/Pyomo/PyomoGallery)
 
 ### Getting Help

--- a/doc/OnlineDocs/tutorial_examples.rst
+++ b/doc/OnlineDocs/tutorial_examples.rst
@@ -9,7 +9,9 @@ Additional Pyomo tutorials and examples can be found at the following links:
 `Prof. Jeffrey Kantor's Pyomo Cookbook
 <https://jckantor.github.io/ND-Pyomo-Cookbook/>`_
 
-`Pyomo Gallery
-<https://github.com/Pyomo/PyomoGallery>`_
+The `companion notebooks <https://mobook.github.io/MO-book/intro.html>`_
+for *Hands-On Mathematical Optimization with Python*
+
+`Pyomo Gallery <https://github.com/Pyomo/PyomoGallery>`_
 
 


### PR DESCRIPTION

<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This adds a link to the companion notebooks for the textbook *Hands-on Mathematical Optimization with Python* (Postek, Zocca, Gromicho, and Kantor) to the list of examples  and tutorials.  The notebooks include links to directly run / explore them on Google Collab.

## Changes proposed in this PR:
- Add link to HOMOWP companion notebooks

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
