### PR TITLE
Updates to PyROS Solver Timing System

### DIFF
--- a/pyomo/contrib/pyros/master_problem_methods.py
+++ b/pyomo/contrib/pyros/master_problem_methods.py
@@ -27,6 +27,7 @@ from pyomo.opt import SolverResults
 from pyomo.core.expr import value
 from pyomo.core.base.set_types import NonNegativeIntegers, NonNegativeReals
 from pyomo.contrib.pyros.util import (
+    call_solver,
     selective_clone,
     ObjectiveType,
     pyrosTerminationCondition,
@@ -239,31 +240,18 @@ def solve_master_feasibility_problem(model_data, config):
     else:
         solver = config.local_solver
 
-    timer = TicTocTimer()
-    orig_setting, custom_setting_present = adjust_solver_time_settings(
-        model_data.timing, solver, config
-    )
-    model_data.timing.start_timer("main.master_feasibility")
-    timer.tic(msg=None)
-    try:
-        results = solver.solve(model, tee=config.tee, load_solutions=False)
-    except ApplicationError:
-        # account for possible external subsolver errors
-        # (such as segmentation faults, function evaluation
-        # errors, etc.)
-        config.progress_logger.error(
+    results = call_solver(
+        model=model,
+        solver=solver,
+        config=config,
+        timing_obj=model_data.timing,
+        timer_name="main.master_feasibility",
+        err_msg=(
             f"Optimizer {repr(solver)} encountered exception "
             "attempting to solve master feasibility problem in iteration "
             f"{model_data.iteration}."
-        )
-        raise
-    else:
-        setattr(results.solver, TIC_TOC_SOLVE_TIME_ATTR, timer.toc(msg=None))
-        model_data.timing.stop_timer("main.master_feasibility")
-    finally:
-        revert_solver_max_time_adjustment(
-            solver, orig_setting, custom_setting_present, config
-        )
+        ),
+    )
 
     feasible_terminations = {
         tc.optimal,
@@ -482,28 +470,18 @@ def minimize_dr_vars(model_data, config):
     config.progress_logger.debug(f" Initial DR norm: {value(polishing_obj)}")
 
     # === Solve the polishing model
-    timer = TicTocTimer()
-    orig_setting, custom_setting_present = adjust_solver_time_settings(
-        model_data.timing, solver, config
-    )
-    model_data.timing.start_timer("main.dr_polishing")
-    timer.tic(msg=None)
-    try:
-        results = solver.solve(polishing_model, tee=config.tee, load_solutions=False)
-    except ApplicationError:
-        config.progress_logger.error(
+    results = call_solver(
+        model=polishing_model,
+        solver=solver,
+        config=config,
+        timing_obj=model_data.timing,
+        timer_name="main.dr_polishing",
+        err_msg=(
             f"Optimizer {repr(solver)} encountered an exception "
             "attempting to solve decision rule polishing problem "
             f"in iteration {model_data.iteration}"
-        )
-        raise
-    else:
-        setattr(results.solver, TIC_TOC_SOLVE_TIME_ATTR, timer.toc(msg=None))
-        model_data.timing.stop_timer("main.dr_polishing")
-    finally:
-        revert_solver_max_time_adjustment(
-            solver, orig_setting, custom_setting_present, config
-        )
+        ),
+    )
 
     # interested in the time and termination status for debugging
     # purposes
@@ -726,7 +704,6 @@ def solver_call_master(model_data, config, solver, solve_data):
     solve_mode = "global" if config.solve_master_globally else "local"
     config.progress_logger.debug("Solving master problem")
 
-    timer = TicTocTimer()
     for idx, opt in enumerate(solvers):
         if idx > 0:
             config.progress_logger.warning(
@@ -734,35 +711,18 @@ def solver_call_master(model_data, config, solver, solve_data):
                 f"(solver {idx + 1} of {len(solvers)}) for "
                 f"master problem of iteration {model_data.iteration}."
             )
-        orig_setting, custom_setting_present = adjust_solver_time_settings(
-            model_data.timing, opt, config
-        )
-        model_data.timing.start_timer("main.master")
-        timer.tic(msg=None)
-        try:
-            results = opt.solve(
-                nlp_model,
-                tee=config.tee,
-                load_solutions=False,
-                symbolic_solver_labels=True,
-            )
-        except ApplicationError:
-            # account for possible external subsolver errors
-            # (such as segmentation faults, function evaluation
-            # errors, etc.)
-            config.progress_logger.error(
+        results = call_solver(
+            model=nlp_model,
+            solver=opt,
+            config=config,
+            timing_obj=model_data.timing,
+            timer_name="main.master",
+            err_msg=(
                 f"Optimizer {repr(opt)} ({idx + 1} of {len(solvers)}) "
                 "encountered exception attempting to "
                 f"solve master problem in iteration {model_data.iteration}"
-            )
-            raise
-        else:
-            setattr(results.solver, TIC_TOC_SOLVE_TIME_ATTR, timer.toc(msg=None))
-            model_data.timing.stop_timer("main.master")
-        finally:
-            revert_solver_max_time_adjustment(
-                solver, orig_setting, custom_setting_present, config
-            )
+            ),
+        )
 
         optimal_termination = check_optimal_termination(results)
         infeasible = results.solver.termination_condition == tc.infeasible

--- a/pyomo/contrib/pyros/pyros.py
+++ b/pyomo/contrib/pyros/pyros.py
@@ -330,32 +330,24 @@ class PyROS(object):
             Summary of PyROS termination outcome.
 
         """
-        kwds.update(
-            dict(
-                first_stage_variables=first_stage_variables,
-                second_stage_variables=second_stage_variables,
-                uncertain_params=uncertain_params,
-                uncertainty_set=uncertainty_set,
-                local_solver=local_solver,
-                global_solver=global_solver,
-            )
-        )
-        config, state_vars = self._resolve_and_validate_pyros_args(model, **kwds)
-
-        # === Create data containers
         model_data = ROSolveResults()
-        model_data.timing = Bunch()
-
-        # === Start timer, run the algorithm
         model_data.timing = TimingData()
         with time_code(
             timing_data_obj=model_data.timing,
             code_block_name="main",
             is_main_timer=True,
         ):
-            # output intro and disclaimer
-            self._log_intro(logger=config.progress_logger, level=logging.INFO)
-            self._log_disclaimer(logger=config.progress_logger, level=logging.INFO)
+            kwds.update(
+                dict(
+                    first_stage_variables=first_stage_variables,
+                    second_stage_variables=second_stage_variables,
+                    uncertain_params=uncertain_params,
+                    uncertainty_set=uncertainty_set,
+                    local_solver=local_solver,
+                    global_solver=global_solver,
+                )
+            )
+            config, state_vars = self._resolve_and_validate_pyros_args(model, **kwds)
             self._log_config(
                 logger=config.progress_logger,
                 config=config,

--- a/pyomo/contrib/pyros/separation_problem_methods.py
+++ b/pyomo/contrib/pyros/separation_problem_methods.py
@@ -18,7 +18,6 @@ from pyomo.core.base.objective import Objective, maximize, value
 from pyomo.core.base import Var, Param
 from pyomo.common.collections import ComponentSet, ComponentMap
 from pyomo.common.dependencies import numpy as np
-from pyomo.contrib.pyros.util import ObjectiveType, get_time_from_solver
 from pyomo.contrib.pyros.solve_data import (
     DiscreteSeparationSolveCallResults,
     SeparationSolveCallResults,
@@ -37,9 +36,11 @@ from pyomo.common.errors import ApplicationError
 from pyomo.contrib.pyros.util import ABS_CON_CHECK_FEAS_TOL
 from pyomo.common.timing import TicTocTimer
 from pyomo.contrib.pyros.util import (
-    TIC_TOC_SOLVE_TIME_ATTR,
     adjust_solver_time_settings,
+    call_solver,
+    ObjectiveType,
     revert_solver_max_time_adjustment,
+    TIC_TOC_SOLVE_TIME_ATTR,
 )
 import os
 from copy import deepcopy
@@ -1070,6 +1071,7 @@ def solver_call_separation(
 
     separation_obj.activate()
 
+    solve_mode_adverb = "globally" if solve_globally else "locally"
     solve_call_results = SeparationSolveCallResults(
         solved_globally=solve_globally,
         time_out=False,
@@ -1077,7 +1079,6 @@ def solver_call_separation(
         found_violation=False,
         subsolver_error=False,
     )
-    timer = TicTocTimer()
     for idx, opt in enumerate(solvers):
         if idx > 0:
             config.progress_logger.warning(
@@ -1086,37 +1087,19 @@ def solver_call_separation(
                 f"separation of performance constraint {con_name_repr} "
                 f"in iteration {model_data.iteration}."
             )
-        orig_setting, custom_setting_present = adjust_solver_time_settings(
-            model_data.timing, opt, config
-        )
-        model_data.timing.start_timer(f"main.{solve_mode}_separation")
-        timer.tic(msg=None)
-        try:
-            results = opt.solve(
-                nlp_model,
-                tee=config.tee,
-                load_solutions=False,
-                symbolic_solver_labels=True,
-            )
-        except ApplicationError:
-            # account for possible external subsolver errors
-            # (such as segmentation faults, function evaluation
-            # errors, etc.)
-            adverb = "globally" if solve_globally else "locally"
-            config.progress_logger.error(
+        results = call_solver(
+            model=nlp_model,
+            solver=opt,
+            config=config,
+            timing_obj=model_data.timing,
+            timer_name=f"main.{solve_mode}_separation",
+            err_msg=(
                 f"Optimizer {repr(opt)} ({idx + 1} of {len(solvers)}) "
                 f"encountered exception attempting "
-                f"to {adverb} solve separation problem for constraint "
+                f"to {solve_mode_adverb} solve separation problem for constraint "
                 f"{con_name_repr} in iteration {model_data.iteration}."
-            )
-            raise
-        else:
-            setattr(results.solver, TIC_TOC_SOLVE_TIME_ATTR, timer.toc(msg=None))
-            model_data.timing.stop_timer(f"main.{solve_mode}_separation")
-        finally:
-            revert_solver_max_time_adjustment(
-                opt, orig_setting, custom_setting_present, config
-            )
+            ),
+        )
 
         # record termination condition for this particular solver
         solver_status_dict[str(opt)] = results.solver.termination_condition

--- a/pyomo/contrib/pyros/tests/test_grcs.py
+++ b/pyomo/contrib/pyros/tests/test_grcs.py
@@ -4341,9 +4341,11 @@ class RegressionTest(unittest.TestCase):
         )
 
     @unittest.skipUnless(
-        SolverFactory('gams').license_is_valid()
-        and SolverFactory('baron').license_is_valid(),
-        "Global NLP solver is not available and licensed.",
+        ipopt_available
+        and SolverFactory('gams').license_is_valid()
+        and SolverFactory('baron').license_is_valid()
+        and SolverFactory("scip").license_is_valid(),
+        "IPOPT not available or one of GAMS/BARON/SCIP not licensed",
     )
     def test_pyros_subsolver_time_limit_adjustment(self):
         """

--- a/pyomo/contrib/pyros/tests/test_grcs.py
+++ b/pyomo/contrib/pyros/tests/test_grcs.py
@@ -4398,8 +4398,8 @@ class RegressionTest(unittest.TestCase):
                 results.pyros_termination_condition,
                 pyrosTerminationCondition.robust_optimal,
                 msg=(
-                    f"Returned termination condition with local "
-                    "subsolver {idx + 1} of 2 is not robust_optimal."
+                    "Returned termination condition with local "
+                    f"subsolver {idx + 1} of 2 is not robust_optimal."
                 ),
             )
 

--- a/pyomo/contrib/pyros/util.py
+++ b/pyomo/contrib/pyros/util.py
@@ -397,12 +397,7 @@ def revert_solver_max_time_adjustment(
                 if isinstance(solver, type(SolverFactory("gams", solver_io="shell"))):
                     solver.options[options_key].pop()
             else:
-                # remove the max time specification introduced.
-                # All lines are needed here to completely remove the option
-                # from access through getattr and dictionary reference.
                 delattr(solver.options, options_key)
-                if options_key in solver.options.keys():
-                    del solver.options[options_key]
 
 
 class PreformattedLogger(logging.Logger):

--- a/pyomo/contrib/pyros/util.py
+++ b/pyomo/contrib/pyros/util.py
@@ -312,6 +312,8 @@ def adjust_solver_time_settings(timing_data_obj, solver, config):
                     "max_wall_time" if solver.version() >= (3, 14, 0, 0)
                     else "max_cpu_time"
                 )
+            elif isinstance(solver, SolverFactory.get_class("scip")):
+                options_key = "limits/time"
             else:
                 options_key = None
 
@@ -379,6 +381,8 @@ def revert_solver_max_time_adjustment(
             options_key = "MaxTime"
         elif isinstance(solver, SolverFactory.get_class("ipopt")):
             options_key = "max_cpu_time"
+        elif isinstance(solver, SolverFactory.get_class("scip")):
+            options_key = "limits/time"
         else:
             options_key = None
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Summary/Motivation:

Update PyROS solver timing system, subordinate solver call routines, and subordinate solver time limit adjustment routines.

## Changes proposed in this PR:

- Standardize calls to subordinate solvers across all PyROS subproblem types
- When adjusting PyROS subordinate solver time limits, account for user-specified options
- Add support for SCIP subordinate solver time limit adjustment
- Start main PyROS solver timer just before argument validation begins, rather than just after argument validation is complete

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
