### PR TITLE
Fix: mosek_direct updated to use putqconk instead of putqcon

### DIFF
--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -492,13 +492,10 @@ class MOSEKDirect(DirectSolver):
             ptrb = (0,) + ptre[:-1]
             asubs = tuple(itertools.chain.from_iterable(l_ids))
             avals = tuple(itertools.chain.from_iterable(l_coefs))
-            qcsubi = tuple(itertools.chain.from_iterable(q_is))
-            qcsubj = tuple(itertools.chain.from_iterable(q_js))
-            qcval = tuple(itertools.chain.from_iterable(q_vals))
-            qcsubk = tuple(i for i in sub for j in range(len(q_is[i - con_num])))
             self._solver_model.appendcons(num_lq)
             self._solver_model.putarowlist(sub, ptrb, ptre, asubs, avals)
-            self._solver_model.putqcon(qcsubk, qcsubi, qcsubj, qcval)
+            for k, i, j, v in zip(sub, q_is, q_js, q_vals):
+                self._solver_model.putqconk(k, i, j, v)
             self._solver_model.putconboundlist(sub, bound_types, lbs, ubs)
             for i, s_n in enumerate(sub_names):
                 self._solver_model.putconname(sub[i], s_n)


### PR DESCRIPTION
## Fixes
This fix concerns QCQP models when solved using mosek. In MOSEK's Optimizer API, the putqcon method resets the Q matrix entries for all constraints to zero, while putqconk does so only for k-th constraint. The _add_constraints method in mosek_direct would call putqcon, but this would lead to loss of Q info with every subsequent call to the _add_constraints (if new Q info was given). This is now fixed, because the Q matrix in each constraint is updated in its own call to putqconk.


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
