### PR TITLE
Add "mixed" standard form representation

### DIFF
--- a/pyomo/repn/tests/test_standard_form.py
+++ b/pyomo/repn/tests/test_standard_form.py
@@ -256,11 +256,11 @@ class TestLinearStandardFormCompiler(unittest.TestCase):
             [[1, 0, 2, 0], [0, 0, 1, 4], [0, 1, 6, 0], [0, 1, 6, 0], [1, 1, 0, 0]]
         )
         self.assertTrue(np.all(repn.A == ref))
-        print(repn)
-        print(repn.b)
         self.assertTrue(np.all(repn.b == np.array([3, 5, 6, -3, 8])))
         self.assertTrue(np.all(repn.c == np.array([[-1, 0, -5, 0], [1, 0, 0, 15]])))
-        # Note that the solution is a mix of inequality and equality constraints
+        # Note that the mixed_form solution is a mix of inequality and
+        # equality constraints, so we cannot (easily) reuse the
+        # _verify_solutions helper (as in the above cases):
         # self._verify_solution(soln, repn, False)
 
         repn = LinearStandardFormCompiler().write(

--- a/pyomo/repn/tests/test_standard_form.py
+++ b/pyomo/repn/tests/test_standard_form.py
@@ -43,6 +43,19 @@ class TestLinearStandardFormCompiler(unittest.TestCase):
         self.assertTrue(np.all(repn.A == np.array([[-1, -2, 0], [0, 1, 4]])))
         self.assertTrue(np.all(repn.rhs == np.array([-3, 5])))
 
+    def test_almost_dense_linear_model(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var()
+        m.y = pyo.Var([1, 2, 3])
+        m.c = pyo.Constraint(expr=m.x + 2 * m.y[1] + 4 * m.y[3] >= 10)
+        m.d = pyo.Constraint(expr=5 * m.x + 6 * m.y[1] + 8 * m.y[3] <= 20)
+
+        repn = LinearStandardFormCompiler().write(m)
+
+        self.assertTrue(np.all(repn.c == np.array([0, 0, 0])))
+        self.assertTrue(np.all(repn.A == np.array([[-1, -2, -4], [5, 6, 8]])))
+        self.assertTrue(np.all(repn.rhs == np.array([-10, 20])))
+
     def test_linear_model_row_col_order(self):
         m = pyo.ConcreteModel()
         m.x = pyo.Var()

--- a/pyomo/repn/tests/test_standard_form.py
+++ b/pyomo/repn/tests/test_standard_form.py
@@ -245,33 +245,21 @@ class TestLinearStandardFormCompiler(unittest.TestCase):
             m, mixed_form=True, column_order=col_order
         )
 
-        self.assertEqual(repn.rows, [(m.c, -1), (m.d, 1), (m.e, 1), (m.e, -1), (m.f, 0)])
         self.assertEqual(
-            list(map(str, repn.x)),
-            ['x', 'y[0]', 'y[1]', 'y[3]'],
+            repn.rows, [(m.c, -1), (m.d, 1), (m.e, 1), (m.e, -1), (m.f, 0)]
         )
+        self.assertEqual(list(map(str, repn.x)), ['x', 'y[0]', 'y[1]', 'y[3]'])
         self.assertEqual(
-            list(v.bounds for v in repn.x),
-            [(None, None), (0, 10), (-5, 10), (-5, -2)],
+            list(v.bounds for v in repn.x), [(None, None), (0, 10), (-5, 10), (-5, -2)]
         )
         ref = np.array(
-            [
-                [1, 0, 2, 0],
-                [0, 0, 1, 4],
-                [0, 1, 6, 0],
-                [0, 1, 6, 0],
-                [1, 1, 0, 0],
-            ]
+            [[1, 0, 2, 0], [0, 0, 1, 4], [0, 1, 6, 0], [0, 1, 6, 0], [1, 1, 0, 0]]
         )
         self.assertTrue(np.all(repn.A == ref))
         print(repn)
         print(repn.b)
         self.assertTrue(np.all(repn.b == np.array([3, 5, 6, -3, 8])))
-        self.assertTrue(
-            np.all(
-                repn.c == np.array([[-1, 0, -5, 0], [1, 0, 0, 15]])
-            )
-        )
+        self.assertTrue(np.all(repn.c == np.array([[-1, 0, -5, 0], [1, 0, 0, 15]])))
         # Note that the solution is a mix of inequality and equality constraints
         # self._verify_solution(soln, repn, False)
 


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This adds a new option to the "Standard Form" compiler that returns a mix of inequality and equality constraints.  This representation is particularly useful for solver interfaces.  This PR also resolves an error when collapsing unused variables out of the returned matrices.  The new implementation is also slightly more performant.

## Changes proposed in this PR:
- add a "mixed" representation to the standard form compiler
- correct indexing error when removing unused columns from the `A` matrix and `c` vector 

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
