### PR TITLE
Add links to the Pyomo Book Springer page

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ version, we will remove testing for that Python version.
 
 ### Tutorials and Examples
 
+* [Pyomo — Optimization Modeling in Python](https://link.springer.com/book/10.1007/978-3-030-68928-5)
 * [Pyomo Workshop Slides](https://github.com/Pyomo/pyomo-tutorials/blob/main/Pyomo-Workshop-December-2023.pdf)
 * [Prof. Jeffrey Kantor's Pyomo Cookbook](https://jckantor.github.io/ND-Pyomo-Cookbook/)
 * The [companion notebooks](https://mobook.github.io/MO-book/intro.html)

--- a/doc/OnlineDocs/bibliography.rst
+++ b/doc/OnlineDocs/bibliography.rst
@@ -39,6 +39,8 @@ Bibliography
                   John D. Siirola, Jean-Paul Watson, and David L. Woodruff.
                   Pyomo - Optimization Modeling in Python, 3rd Edition.
                   Vol. 67. Springer, 2021.
+                  doi: `10.1007/978-3-030-68928-5
+                  <https://doi.org/10.1007/978-3-030-68928-5>`_
 
 .. [PyomoJournal] William E. Hart, Jean-Paul Watson, David L. Woodruff.
                   "Pyomo: modeling and solving mathematical programs in

--- a/doc/OnlineDocs/tutorial_examples.rst
+++ b/doc/OnlineDocs/tutorial_examples.rst
@@ -3,15 +3,18 @@ Pyomo Tutorial Examples
 
 Additional Pyomo tutorials and examples can be found at the following links:
 
-`Pyomo Workshop Slides and Exercises
-<https://github.com/Pyomo/pyomo-tutorials>`_
+* `Pyomo — Optimization Modeling in Python
+  <https://link.springer.com/book/10.1007/978-3-030-68928-5>`_ ([PyomoBookIII]_)
 
-`Prof. Jeffrey Kantor's Pyomo Cookbook
-<https://jckantor.github.io/ND-Pyomo-Cookbook/>`_
+* `Pyomo Workshop Slides and Exercises
+  <https://github.com/Pyomo/pyomo-tutorials>`_
 
-The `companion notebooks <https://mobook.github.io/MO-book/intro.html>`_
-for *Hands-On Mathematical Optimization with Python*
+* `Prof. Jeffrey Kantor's Pyomo Cookbook
+  <https://jckantor.github.io/ND-Pyomo-Cookbook/>`_
 
-`Pyomo Gallery <https://github.com/Pyomo/PyomoGallery>`_
+* The `companion notebooks <https://mobook.github.io/MO-book/intro.html>`_
+  for *Hands-On Mathematical Optimization with Python*
+
+* `Pyomo Gallery <https://github.com/Pyomo/PyomoGallery>`_
 
 


### PR DESCRIPTION
## Fixes #3209 (maybe?)

## Summary/Motivation:
This (maybe) addresses the request in 3209. The Pyomo book doesn't have a link to it anywhere - just a reference. This adds a link in the bibliography and adds the book as the first item in all "Tutorials and Examples" lists.

## Changes proposed in this PR:
- Update docs to add Pyomo Book Springer link page
- Turns the tutorials/example page on RTD into an actual list

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
