### PR TITLE
Fix a bug in gdp.bigm transformation for nested GDPs

### DIFF
--- a/pyomo/contrib/gdpopt/solve_subproblem.py
+++ b/pyomo/contrib/gdpopt/solve_subproblem.py
@@ -46,6 +46,8 @@ def configure_and_call_solver(model, solver, args, problem_type, timing, time_li
                     solver_args.get('time_limit', float('inf')), remaining
                 )
         try:
+            ## DEBUG
+            solver_args['tee'] = True
             results = opt.solve(model, **solver_args)
         except ValueError as err:
             if 'Cannot load a SolverResults object with bad status: error' in str(err):

--- a/pyomo/contrib/gdpopt/solve_subproblem.py
+++ b/pyomo/contrib/gdpopt/solve_subproblem.py
@@ -46,8 +46,6 @@ def configure_and_call_solver(model, solver, args, problem_type, timing, time_li
                     solver_args.get('time_limit', float('inf')), remaining
                 )
         try:
-            ## DEBUG
-            solver_args['tee'] = True
             results = opt.solve(model, **solver_args)
         except ValueError as err:
             if 'Cannot load a SolverResults object with bad status: error' in str(err):

--- a/pyomo/contrib/gdpopt/tests/test_LBB.py
+++ b/pyomo/contrib/gdpopt/tests/test_LBB.py
@@ -59,6 +59,7 @@ class TestGDPopt_LBB(unittest.TestCase):
         self.assertIsNone(m.d.disjuncts[0].indicator_var.value)
         self.assertIsNone(m.d.disjuncts[1].indicator_var.value)
 
+    @unittest.skipUnless(z3_available, "Z3 SAT solver is not available")
     def test_infeasible_GDP_check_sat(self):
         """Test for infeasible GDP with check_sat option True."""
         m = ConcreteModel()

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -22,8 +22,6 @@ from pyomo.common.log import LoggingIntercept
 from pyomo.common.collections import Bunch
 from pyomo.common.config import ConfigDict, ConfigValue
 from pyomo.common.fileutils import import_file, PYOMO_ROOT_DIR
-from pyomo.contrib.appsi.base import Solver
-from pyomo.contrib.appsi.solvers.gurobi import Gurobi
 from pyomo.contrib.gdpopt.create_oa_subproblems import (
     add_util_block,
     add_disjunct_list,

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -1050,7 +1050,8 @@ class TestGDPopt(unittest.TestCase):
 
         self.assertTrue(fabs(value(eight_process.profit.expr) - 68) <= 1e-2)
 
-    @unittest.skipUnless(Gurobi().available(), "APPSI Gurobi solver is not available")
+    @unittest.skipUnless(Gurobi().available() and Gurobi().license_is_valid(),
+                         "APPSI Gurobi solver is not available")
     def test_auto_persistent_solver(self):
         exfile = import_file(join(exdir, 'eight_process', 'eight_proc_model.py'))
         m = exfile.build_eight_process_flowsheet()

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -1051,9 +1051,11 @@ class TestGDPopt(unittest.TestCase):
 
         self.assertTrue(fabs(value(eight_process.profit.expr) - 68) <= 1e-2)
 
-    @unittest.skipUnless(SolverFactory('appsi_gurobi').available(
-        exception_flag=False) and SolverFactory('appsi_gurobi').license_is_valid(),
-                         "Legacy APPSI Gurobi solver is not available")
+    @unittest.skipUnless(
+        SolverFactory('appsi_gurobi').available(exception_flag=False)
+        and SolverFactory('appsi_gurobi').license_is_valid(),
+        "Legacy APPSI Gurobi solver is not available",
+    )
     def test_auto_persistent_solver(self):
         exfile = import_file(join(exdir, 'eight_process', 'eight_proc_model.py'))
         m = exfile.build_eight_process_flowsheet()

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -22,6 +22,7 @@ from pyomo.common.log import LoggingIntercept
 from pyomo.common.collections import Bunch
 from pyomo.common.config import ConfigDict, ConfigValue
 from pyomo.common.fileutils import import_file, PYOMO_ROOT_DIR
+from pyomo.contrib.appsi.base import Solver
 from pyomo.contrib.appsi.solvers.gurobi import Gurobi
 from pyomo.contrib.gdpopt.create_oa_subproblems import (
     add_util_block,
@@ -1050,8 +1051,9 @@ class TestGDPopt(unittest.TestCase):
 
         self.assertTrue(fabs(value(eight_process.profit.expr) - 68) <= 1e-2)
 
-    @unittest.skipUnless(Gurobi().available() and Gurobi().license_is_valid(),
-                         "APPSI Gurobi solver is not available")
+    @unittest.skipUnless(SolverFactory('appsi_gurobi').available(
+        exception_flag=False) and SolverFactory('appsi_gurobi').license_is_valid(),
+                         "Legacy APPSI Gurobi solver is not available")
     def test_auto_persistent_solver(self):
         exfile = import_file(join(exdir, 'eight_process', 'eight_proc_model.py'))
         m = exfile.build_eight_process_flowsheet()

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -769,7 +769,7 @@ class TestGDPopt(unittest.TestCase):
         )
 
     @unittest.skipUnless(
-        license_is_valid, "No BARON license--8PP logical problem exceeds demo size"
+        license_available, "No BARON license--8PP logical problem exceeds demo size"
     )
     def test_LOA_8PP_logical_default_init(self):
         """Test logic-based outer approximation with 8PP."""
@@ -875,7 +875,7 @@ class TestGDPopt(unittest.TestCase):
         ct.check_8PP_solution(self, eight_process, results)
 
     @unittest.skipUnless(
-        license_is_valid, "No BARON license--8PP logical problem exceeds demo size"
+        license_available, "No BARON license--8PP logical problem exceeds demo size"
     )
     def test_LOA_8PP_logical_maxBinary(self):
         """Test logic-based OA with max_binary initialization."""
@@ -1138,7 +1138,7 @@ class TestGDPoptRIC(unittest.TestCase):
         ct.check_8PP_solution(self, eight_process, results)
 
     @unittest.skipUnless(
-        license_is_valid, "No BARON license--8PP logical problem exceeds demo size"
+        license_available, "No BARON license--8PP logical problem exceeds demo size"
     )
     def test_RIC_8PP_logical_default_init(self):
         """Test logic-based outer approximation with 8PP."""

--- a/pyomo/contrib/gdpopt/tests/test_gdpopt.py
+++ b/pyomo/contrib/gdpopt/tests/test_gdpopt.py
@@ -768,6 +768,9 @@ class TestGDPopt(unittest.TestCase):
             results.solver.termination_condition, TerminationCondition.maxTimeLimit
         )
 
+    @unittest.skipUnless(
+        license_is_valid, "No BARON license--8PP logical problem exceeds demo size"
+    )
     def test_LOA_8PP_logical_default_init(self):
         """Test logic-based outer approximation with 8PP."""
         exfile = import_file(join(exdir, 'eight_process', 'eight_proc_logical.py'))
@@ -871,6 +874,9 @@ class TestGDPopt(unittest.TestCase):
         )
         ct.check_8PP_solution(self, eight_process, results)
 
+    @unittest.skipUnless(
+        license_is_valid, "No BARON license--8PP logical problem exceeds demo size"
+    )
     def test_LOA_8PP_logical_maxBinary(self):
         """Test logic-based OA with max_binary initialization."""
         exfile = import_file(join(exdir, 'eight_process', 'eight_proc_logical.py'))
@@ -1131,6 +1137,9 @@ class TestGDPoptRIC(unittest.TestCase):
         )
         ct.check_8PP_solution(self, eight_process, results)
 
+    @unittest.skipUnless(
+        license_is_valid, "No BARON license--8PP logical problem exceeds demo size"
+    )
     def test_RIC_8PP_logical_default_init(self):
         """Test logic-based outer approximation with 8PP."""
         exfile = import_file(join(exdir, 'eight_process', 'eight_proc_logical.py'))

--- a/pyomo/contrib/gdpopt/util.py
+++ b/pyomo/contrib/gdpopt/util.py
@@ -553,6 +553,13 @@ def _add_bigm_constraint_to_transformed_model(m, constraint, block):
     # making a Reference to the ComponentData so that it will look like an
     # indexed component for now. If I redesign bigm at some point, then this
     # could be prettier.
-    bigm._transform_constraint(Reference(constraint), parent_disjunct, None, [], [])
+    bigm._transform_constraint(
+        Reference(constraint),
+        parent_disjunct,
+        None,
+        [],
+        [],
+        1 - parent_disjunct.binary_indicator_var,
+    )
     # Now get rid of it because this is a class attribute!
     del bigm._config

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -213,12 +213,7 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
         bigM = self._config.bigM
         for t in preprocessed_targets:
             if t.ctype is Disjunction:
-                self._transform_disjunctionData(
-                    t,
-                    t.index(),
-                    bigM,
-                    gdp_tree,
-                )
+                self._transform_disjunctionData(t, t.index(), bigM, gdp_tree)
 
         # issue warnings about anything that was in the bigM args dict that we
         # didn't use
@@ -275,15 +270,21 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
         # comparing the two relaxations.
         #
         # Transform each component within this disjunct
-        self._transform_block_components(obj, obj, bigM, arg_list, suffix_list,
-                                         indicator_expression)
+        self._transform_block_components(
+            obj, obj, bigM, arg_list, suffix_list, indicator_expression
+        )
 
         # deactivate disjunct to keep the writers happy
         obj._deactivate_without_fixing_indicator()
 
     def _transform_constraint(
-        self, obj, disjunct, bigMargs, arg_list, disjunct_suffix_list,
-            indicator_expression
+        self,
+        obj,
+        disjunct,
+        bigMargs,
+        arg_list,
+        disjunct_suffix_list,
+        indicator_expression,
     ):
         # add constraint to the transformation block, we'll transform it there.
         transBlock = disjunct._transformation_block()
@@ -355,8 +356,13 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
             bigm_src[c] = (lower, upper)
 
             self._add_constraint_expressions(
-                c, i, M, disjunct.binary_indicator_var, newConstraint, constraint_map,
-                indicator_expression=indicator_expression
+                c,
+                i,
+                M,
+                disjunct.binary_indicator_var,
+                newConstraint,
+                constraint_map,
+                indicator_expression=indicator_expression,
             )
 
             # deactivate because we relaxed

--- a/pyomo/gdp/plugins/bigm.py
+++ b/pyomo/gdp/plugins/bigm.py
@@ -217,17 +217,16 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
                     t,
                     t.index(),
                     bigM,
-                    parent_disjunct=gdp_tree.parent(t),
-                    root_disjunct=gdp_tree.root_disjunct(t),
+                    gdp_tree,
                 )
 
         # issue warnings about anything that was in the bigM args dict that we
         # didn't use
         _warn_for_unused_bigM_args(bigM, self.used_args, logger)
 
-    def _transform_disjunctionData(
-        self, obj, index, bigM, parent_disjunct=None, root_disjunct=None
-    ):
+    def _transform_disjunctionData(self, obj, index, bigM, gdp_tree):
+        parent_disjunct = gdp_tree.parent(obj)
+        root_disjunct = gdp_tree.root_disjunct(obj)
         (transBlock, xorConstraint) = self._setup_transform_disjunctionData(
             obj, root_disjunct
         )
@@ -236,7 +235,7 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
         or_expr = 0
         for disjunct in obj.disjuncts:
             or_expr += disjunct.binary_indicator_var
-            self._transform_disjunct(disjunct, bigM, transBlock)
+            self._transform_disjunct(disjunct, bigM, transBlock, gdp_tree)
 
         if obj.xor:
             xorConstraint[index] = or_expr == 1
@@ -249,7 +248,7 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
         # and deactivate for the writers
         obj.deactivate()
 
-    def _transform_disjunct(self, obj, bigM, transBlock):
+    def _transform_disjunct(self, obj, bigM, transBlock, gdp_tree):
         # We're not using the preprocessed list here, so this could be
         # inactive. We've already done the error checking in preprocessing, so
         # we just skip it here.
@@ -261,6 +260,12 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
 
         relaxationBlock = self._get_disjunct_transformation_block(obj, transBlock)
 
+        indicator_expression = 0
+        node = obj
+        while node is not None:
+            indicator_expression += 1 - node.binary_indicator_var
+            node = gdp_tree.parent_disjunct(node)
+
         # This is crazy, but if the disjunction has been previously
         # relaxed, the disjunct *could* be deactivated.  This is a big
         # deal for Hull, as it uses the component_objects /
@@ -270,13 +275,15 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
         # comparing the two relaxations.
         #
         # Transform each component within this disjunct
-        self._transform_block_components(obj, obj, bigM, arg_list, suffix_list)
+        self._transform_block_components(obj, obj, bigM, arg_list, suffix_list,
+                                         indicator_expression)
 
         # deactivate disjunct to keep the writers happy
         obj._deactivate_without_fixing_indicator()
 
     def _transform_constraint(
-        self, obj, disjunct, bigMargs, arg_list, disjunct_suffix_list
+        self, obj, disjunct, bigMargs, arg_list, disjunct_suffix_list,
+            indicator_expression
     ):
         # add constraint to the transformation block, we'll transform it there.
         transBlock = disjunct._transformation_block()
@@ -348,7 +355,8 @@ class BigM_Transformation(GDP_to_MIP_Transformation, _BigM_MixIn):
             bigm_src[c] = (lower, upper)
 
             self._add_constraint_expressions(
-                c, i, M, disjunct.binary_indicator_var, newConstraint, constraint_map
+                c, i, M, disjunct.binary_indicator_var, newConstraint, constraint_map,
+                indicator_expression=indicator_expression
             )
 
             # deactivate because we relaxed

--- a/pyomo/gdp/plugins/bigm_mixin.py
+++ b/pyomo/gdp/plugins/bigm_mixin.py
@@ -232,7 +232,8 @@ class _BigM_MixIn(object):
         return tuple(M)
 
     def _add_constraint_expressions(
-        self, c, i, M, indicator_var, newConstraint, constraint_map
+        self, c, i, M, indicator_var, newConstraint, constraint_map,
+        indicator_expression=None
     ):
         # Since we are both combining components from multiple blocks and using
         # local names, we need to make sure that the first index for
@@ -244,6 +245,8 @@ class _BigM_MixIn(object):
         # over the constraint indices, but I don't think it matters a lot.)
         unique = len(newConstraint)
         name = c.local_name + "_%s" % unique
+        if indicator_expression is None:
+            indicator_expression = 1 - indicator_var
 
         if c.lower is not None:
             if M[0] is None:
@@ -251,7 +254,7 @@ class _BigM_MixIn(object):
                     "Cannot relax disjunctive constraint '%s' "
                     "because M is not defined." % name
                 )
-            M_expr = M[0] * (1 - indicator_var)
+            M_expr = M[0] * indicator_expression
             newConstraint.add((name, i, 'lb'), c.lower <= c.body - M_expr)
             constraint_map.transformed_constraints[c].append(
                 newConstraint[name, i, 'lb']
@@ -263,7 +266,7 @@ class _BigM_MixIn(object):
                     "Cannot relax disjunctive constraint '%s' "
                     "because M is not defined." % name
                 )
-            M_expr = M[1] * (1 - indicator_var)
+            M_expr = M[1] * indicator_expression
             newConstraint.add((name, i, 'ub'), c.body - M_expr <= c.upper)
             constraint_map.transformed_constraints[c].append(
                 newConstraint[name, i, 'ub']

--- a/pyomo/gdp/plugins/bigm_mixin.py
+++ b/pyomo/gdp/plugins/bigm_mixin.py
@@ -232,8 +232,14 @@ class _BigM_MixIn(object):
         return tuple(M)
 
     def _add_constraint_expressions(
-        self, c, i, M, indicator_var, newConstraint, constraint_map,
-        indicator_expression=None
+        self,
+        c,
+        i,
+        M,
+        indicator_var,
+        newConstraint,
+        constraint_map,
+        indicator_expression=None,
     ):
         # Since we are both combining components from multiple blocks and using
         # local names, we need to make sure that the first index for

--- a/pyomo/gdp/tests/test_bigm.py
+++ b/pyomo/gdp/tests/test_bigm.py
@@ -1885,7 +1885,7 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         assertExpressionsEqual(
             self,
             cons.body,
-            variable - float(M) * (1 - indicator_var.get_associated_binary())
+            variable - float(M) * (1 - indicator_var.get_associated_binary()),
         )
 
     def check_inner_xor_constraint(self, inner_disjunction, outer_disjunct, bigm):
@@ -1953,11 +1953,7 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
                                             ),
                                             1,
                                             EXPR.MonomialTermExpression(
-                                                (
-                                                    -1,
-                                                    m.disjunct[1]
-                                                    .binary_indicator_var,
-                                                )
+                                                (-1, m.disjunct[1].binary_indicator_var)
                                             ),
                                         ]
                                     ),
@@ -1971,8 +1967,15 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         assertExpressionsEqual(
             self,
             cons1ub.expr,
-            m.z - 10.0*(1 - m.disjunct[1].innerdisjunct[0].binary_indicator_var +
-                        1 - m.disjunct[1].binary_indicator_var) <= 0.0
+            m.z
+            - 10.0
+            * (
+                1
+                - m.disjunct[1].innerdisjunct[0].binary_indicator_var
+                + 1
+                - m.disjunct[1].binary_indicator_var
+            )
+            <= 0.0,
         )
 
         cons2 = bigm.get_transformed_constraints(m.disjunct[1].innerdisjunct[1].c)
@@ -1981,8 +1984,15 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         assertExpressionsEqual(
             self,
             cons2lb.expr,
-            5.0 <= m.z - (-5.0)*(1 - m.disjunct[1].innerdisjunct[1].binary_indicator_var
-                              + 1 - m.disjunct[1].binary_indicator_var)
+            5.0
+            <= m.z
+            - (-5.0)
+            * (
+                1
+                - m.disjunct[1].innerdisjunct[1].binary_indicator_var
+                + 1
+                - m.disjunct[1].binary_indicator_var
+            ),
         )
 
         cons3 = bigm.get_transformed_constraints(m.simpledisjunct.innerdisjunct0.c)
@@ -1991,8 +2001,15 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         assertExpressionsEqual(
             self,
             cons3ub.expr,
-            m.x - 7.0*(1 - m.simpledisjunct.innerdisjunct0.binary_indicator_var + 1 -
-                       m.simpledisjunct.binary_indicator_var) <= 2.0
+            m.x
+            - 7.0
+            * (
+                1
+                - m.simpledisjunct.innerdisjunct0.binary_indicator_var
+                + 1
+                - m.simpledisjunct.binary_indicator_var
+            )
+            <= 2.0,
         )
 
         cons4 = bigm.get_transformed_constraints(m.simpledisjunct.innerdisjunct1.c)
@@ -2001,8 +2018,15 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         assertExpressionsEqual(
             self,
             cons4lb.expr,
-            m.x - (-13.0)*(1 - m.simpledisjunct.innerdisjunct1.binary_indicator_var
-                           + 1 - m.simpledisjunct.binary_indicator_var) >= 4.0
+            m.x
+            - (-13.0)
+            * (
+                1
+                - m.simpledisjunct.innerdisjunct1.binary_indicator_var
+                + 1
+                - m.simpledisjunct.binary_indicator_var
+            )
+            >= 4.0,
         )
 
         # Here we check that the xor constraint from
@@ -2132,7 +2156,12 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         assertExpressionsEqual(
             self,
             cons.expr,
-            m.x[1]**2 + m.x[2]**2 + m.x[3]**2 + m.x[4]**2 - 143.0*(1 - m.disj1.binary_indicator_var) <= 1.0
+            m.x[1] ** 2
+            + m.x[2] ** 2
+            + m.x[3] ** 2
+            + m.x[4] ** 2
+            - 143.0 * (1 - m.disj1.binary_indicator_var)
+            <= 1.0,
         )
 
         disj2c = bigm.get_transformed_constraints(m.disjunct_block.disj2.c)
@@ -2141,7 +2170,12 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         assertExpressionsEqual(
             self,
             cons.expr,
-            (3 - m.x[1])**2 + (3 - m.x[2])**2 + (3 - m.x[3])**2 + (3 - m.x[4])**2 - 99.0*(1 - m.disjunct_block.disj2.binary_indicator_var) <= 1.0
+            (3 - m.x[1]) ** 2
+            + (3 - m.x[2]) ** 2
+            + (3 - m.x[3]) ** 2
+            + (3 - m.x[4]) ** 2
+            - 99.0 * (1 - m.disjunct_block.disj2.binary_indicator_var)
+            <= 1.0,
         )
 
         # inner disjunction constraints
@@ -2153,7 +2187,18 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         assertExpressionsEqual(
             self,
             cons.expr,
-            m.x[1]**2 + m.x[2]**2 + m.x[3]**2 + m.x[4]**2 - 143.0*(1 - m.disjunct_block.disj2.disjunction_disjuncts[0].binary_indicator_var + 1 - m.disjunct_block.disj2.binary_indicator_var) <= 1.0
+            m.x[1] ** 2
+            + m.x[2] ** 2
+            + m.x[3] ** 2
+            + m.x[4] ** 2
+            - 143.0
+            * (
+                1
+                - m.disjunct_block.disj2.disjunction_disjuncts[0].binary_indicator_var
+                + 1
+                - m.disjunct_block.disj2.binary_indicator_var
+            )
+            <= 1.0,
         )
 
         innerd2c = bigm.get_transformed_constraints(
@@ -2164,7 +2209,18 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         assertExpressionsEqual(
             self,
             cons.expr,
-            (3 - m.x[1])**2 + (3 - m.x[2])**2 + (3 - m.x[3])**2 + (3 - m.x[4])**2 - 99.0*(1 - m.disjunct_block.disj2.disjunction_disjuncts[1].binary_indicator_var + 1 - m.disjunct_block.disj2.binary_indicator_var) <= 1.0
+            (3 - m.x[1]) ** 2
+            + (3 - m.x[2]) ** 2
+            + (3 - m.x[3]) ** 2
+            + (3 - m.x[4]) ** 2
+            - 99.0
+            * (
+                1
+                - m.disjunct_block.disj2.disjunction_disjuncts[1].binary_indicator_var
+                + 1
+                - m.disjunct_block.disj2.binary_indicator_var
+            )
+            <= 1.0,
         )
 
     def test_hierarchical_badly_ordered_targets(self):
@@ -2211,17 +2267,20 @@ class DisjunctionInDisjunct(unittest.TestCase, CommonTests):
         m.right.disjunction = Disjunction(expr=[m.right.left, m.right.right])
         m.disjunction = Disjunction(expr=[m.left, m.right])
 
-        m.equiv_left = LogicalConstraint(expr=m.left.left.indicator_var.equivalent_to(
-            m.right.left.indicator_var))
-        m.equiv_right = LogicalConstraint(expr=m.left.right.indicator_var.equivalent_to(
-            m.right.right.indicator_var))
+        m.equiv_left = LogicalConstraint(
+            expr=m.left.left.indicator_var.equivalent_to(m.right.left.indicator_var)
+        )
+        m.equiv_right = LogicalConstraint(
+            expr=m.left.right.indicator_var.equivalent_to(m.right.right.indicator_var)
+        )
 
         m.obj = Objective(expr=m.x)
 
         TransformationFactory('gdp.bigm').apply_to(m)
         results = SolverFactory('gurobi').solve(m)
-        self.assertEqual(results.solver.termination_condition,
-                         TerminationCondition.optimal)
+        self.assertEqual(
+            results.solver.termination_condition, TerminationCondition.optimal
+        )
         self.assertTrue(value(m.right.indicator_var))
         self.assertFalse(value(m.left.indicator_var))
         self.assertTrue(value(m.right.right.indicator_var))

--- a/pyomo/gdp/util.py
+++ b/pyomo/gdp/util.py
@@ -144,13 +144,13 @@ class GDPTree:
         Arg:
             u : A node in the tree
         """
+        if u in self._parent:
+            return self._parent[u]
         if u not in self._vertices:
             raise ValueError(
                 "'%s' is not a vertex in the GDP tree. Cannot "
                 "retrieve its parent." % u
             )
-        if u in self._parent:
-            return self._parent[u]
         else:
             return None
 


### PR DESCRIPTION
## Fixes .

## Summary/Motivation:

The `gdp.bigm` transformation was only relaxing constraints on nested Disjuncts when the constraint's Disjunct was not selected. This is wrong--the constraint also needs to be relaxed when *any* parent Disjunct is not selected (when the nested indicator vars are not local to their parent Disjunct). For example, consider:
```math
\begin{align}
\min \quad &x \\
\text{s.t.} \quad 
&\begin{bmatrix}
Y_1 \\
\begin{bmatrix}
Z_1 \\
x \geq 12
\end{bmatrix}
\lor
\begin{bmatrix}
Z_2 \\
x \geq 9
\end{bmatrix}
\end{bmatrix}
\lor
\begin{bmatrix}
Y_2 \\
\begin{bmatrix}
Z_3 \\
x \geq 11
\end{bmatrix}
\lor
\begin{bmatrix}
Z_4 \\
x \geq 8
\end{bmatrix}
\end{bmatrix} \\
&Z_1 \iff Z_3 \\
&Z_2 \iff Z_4 \\
&0 \leq x \leq 30
\end{align}
```
The optimal solution should be $x=8$, with $Y_2$, $Z_4$, and $Z_2$ True and the other Booleans False. But if the $x \geq 9$ constraint is not relaxed when $Y_1$ is False, then we wrongly conclude that $x = 9$ is optimal. This PR adds parent Disjunct indicator variables to the big-M term so that this happens properly. So in the example, we write the transformed constraint as:
```math
x \geq 9 - 9(1 - z_2 + 1 - y_1)
```

(Note that another way to fix this would be to put transformed constraints onto their parent Disjunct and simply let them get transformed again when the parent is transformed, but I opted against that because we don't need to recalculate the M value--we know what it is, we just need the BigM term to be ''activated'' when anything in the GDP tree above is False.)

## Changes proposed in this PR:
- Changes constraint expressions for nested GDPs in bigm transformation
- Adds a test using the example above
- Fixes a few tests that were wrongly assuming that the nested indicator vars were local.
- Changes the arguments to `_transform_constraint` which changes some (suboptimal) code in GDPopt.
- The formulation of the 8 process example with logical constraints now exceeds baron demo size, so we skip those tests in GDPopt now when we don't have a baron license.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
