### PR TITLE
March 2024: Typos Update

### DIFF
--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -40,4 +40,28 @@ WRONLY = "WRONLY"
 Hax = "Hax"
 # Big Sur
 Sur = "Sur"
+# Ignore the shorthand ans for and
+ans = "ans"
+# Ignore the keyword arange
+arange = "arange"
+# Ignore IIS
+IIS = "IIS"
+iis = "iis"
+# Ignore PN
+PN = "PN"
+# Ignore hd
+hd = "hd"
+# Ignore opf
+opf = "opf"
+# Ignore FRE
+FRE = "FRE"
+# Ignore MCH
+MCH = "MCH"
+# Ignore RO
+ro = "ro"
+RO = "RO"
+# Ignore EOF - end of file
+EOF = "EOF"
+# Ignore lst as shorthand for list
+lst = "lst"
 # AS NEEDED: Add More Words Below

--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -40,7 +40,7 @@ WRONLY = "WRONLY"
 Hax = "Hax"
 # Big Sur
 Sur = "Sur"
-# Ignore the shorthand ans for and
+# Ignore the shorthand ans for answer
 ans = "ans"
 # Ignore the keyword arange
 arange = "arange"

--- a/pyomo/contrib/latex_printer/__init__.py
+++ b/pyomo/contrib/latex_printer/__init__.py
@@ -9,22 +9,11 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-#  ___________________________________________________________________________
-#
-#  Pyomo: Python Optimization Modeling Objects
-#  Copyright (c) 2008-2023
-#  National Technology and Engineering Solutions of Sandia, LLC
-#  Under the terms of Contract DE-NA0003525 with National Technology and
-#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
-#  rights in this software.
-#  This software is distributed under the 3-clause BSD License.
-#  ___________________________________________________________________________
-
 # Recommended just to build all of the appropriate things
 import pyomo.environ
 
 # Remove one layer of .latex_printer
-# import statemnt is now:
+# import statement is now:
 #   from pyomo.contrib.latex_printer import latex_printer
 try:
     from pyomo.contrib.latex_printer.latex_printer import latex_printer

--- a/pyomo/core/base/component.py
+++ b/pyomo/core/base/component.py
@@ -368,7 +368,7 @@ class _ComponentBase(PyomoObject):
 
     @property
     def name(self):
-        """Get the fully qualifed component name."""
+        """Get the fully qualified component name."""
         return self.getname(fully_qualified=True)
 
     # Adding a setter here to help users adapt to the new
@@ -664,7 +664,7 @@ class Component(_ComponentBase):
 
     @property
     def name(self):
-        """Get the fully qualifed component name."""
+        """Get the fully qualified component name."""
         return self.getname(fully_qualified=True)
 
     # Allow setting a component's name if it is not owned by a parent

--- a/pyomo/core/base/indexed_component.py
+++ b/pyomo/core/base/indexed_component.py
@@ -731,7 +731,7 @@ You can silence this warning by one of three ways:
 
         # this supports "del m.x[:,1]" through a simple recursive call
         if index.__class__ is IndexedComponent_slice:
-            # Assert that this slice ws just generated
+            # Assert that this slice was just generated
             assert len(index._call_stack) == 1
             # Make a copy of the slicer items *before* we start
             # iterating over it (since we will be removing items!).

--- a/pyomo/core/base/reference.py
+++ b/pyomo/core/base/reference.py
@@ -579,7 +579,7 @@ def Reference(reference, ctype=NOTSET):
     :py:class:`IndexedComponent`.
 
     If the indices associated with wildcards in the component slice all
-    refer to the same :py:class:`Set` objects for all data identifed by
+    refer to the same :py:class:`Set` objects for all data identified by
     the slice, then the resulting indexed component will be indexed by
     the product of those sets.  However, if all data do not share common
     set objects, or only a subset of indices in a multidimentional set

--- a/pyomo/gdp/plugins/fix_disjuncts.py
+++ b/pyomo/gdp/plugins/fix_disjuncts.py
@@ -52,7 +52,7 @@ class GDP_Disjunct_Fixer(Transformation):
 
     This reclassifies all disjuncts in the passed model instance as ctype Block
     and deactivates the constraints and disjunctions within inactive disjuncts.
-    In addition, it transforms relvant LogicalConstraints and BooleanVars so
+    In addition, it transforms relevant LogicalConstraints and BooleanVars so
     that the resulting model is a (MI)(N)LP (where it is only mixed-integer
     if the model contains integer-domain Vars or BooleanVars which were not
     indicator_vars of Disjuncs.

--- a/pyomo/gdp/tests/models.py
+++ b/pyomo/gdp/tests/models.py
@@ -840,7 +840,7 @@ def makeAnyIndexedDisjunctionOfDisjunctDatas():
     build from DisjunctDatas. Identical mathematically to
     makeDisjunctionOfDisjunctDatas.
 
-    Used to test that the right things happen for a case where soemone
+    Used to test that the right things happen for a case where someone
     implements an algorithm which iteratively generates disjuncts and
     retransforms"""
     m = ConcreteModel()

--- a/pyomo/network/foqus_graph.py
+++ b/pyomo/network/foqus_graph.py
@@ -358,9 +358,9 @@ class FOQUSGraph(object):
         done = False
         for i in range(len(sccNodes)):
             for j in range(len(sccNodes)):
-                for ine in ie[i]:
+                for in_e in ie[i]:
                     for oute in oe[j]:
-                        if ine == oute:
+                        if in_e == oute:
                             adj[j].append(i)
                             adjR[i].append(j)
                             done = True

--- a/pyomo/network/foqus_graph.py
+++ b/pyomo/network/foqus_graph.py
@@ -359,8 +359,8 @@ class FOQUSGraph(object):
         for i in range(len(sccNodes)):
             for j in range(len(sccNodes)):
                 for in_e in ie[i]:
-                    for oute in oe[j]:
-                        if in_e == oute:
+                    for out_e in oe[j]:
+                        if in_e == out_e:
                             adj[j].append(i)
                             adjR[i].append(j)
                             done = True

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -198,8 +198,8 @@ class GAMSDirect(_GAMSSolver):
             return _extract_version('')
         from gams import GamsWorkspace
 
-        ws = GamsWorkspace()
-        version = tuple(int(i) for i in ws._version.split('.')[:4])
+        workspace = GamsWorkspace()
+        version = tuple(int(i) for i in workspace._version.split('.')[:4])
         while len(version) < 4:
             version += (0,)
         return version
@@ -209,8 +209,8 @@ class GAMSDirect(_GAMSSolver):
         try:
             from gams import GamsWorkspace, DebugLevel
 
-            ws = GamsWorkspace(debug=DebugLevel.Off, working_directory=tmpdir)
-            t1 = ws.add_job_from_string(self._simple_model(n))
+            workspace = GamsWorkspace(debug=DebugLevel.Off, working_directory=tmpdir)
+            t1 = workspace.add_job_from_string(self._simple_model(n))
             t1.run()
             return True
         except:
@@ -330,12 +330,12 @@ class GAMSDirect(_GAMSSolver):
         if tmpdir is not None and os.path.exists(tmpdir):
             newdir = False
 
-        ws = GamsWorkspace(
+        workspace = GamsWorkspace(
             debug=DebugLevel.KeepFiles if keepfiles else DebugLevel.Off,
             working_directory=tmpdir,
         )
 
-        t1 = ws.add_job_from_string(output_file.getvalue())
+        t1 = workspace.add_job_from_string(output_file.getvalue())
 
         try:
             with OutputStream(tee=tee, logfile=logfile) as output_stream:
@@ -349,7 +349,7 @@ class GAMSDirect(_GAMSSolver):
                 # Always name working directory or delete files,
                 # regardless of any errors.
                 if keepfiles:
-                    print("\nGAMS WORKING DIRECTORY: %s\n" % ws.working_directory)
+                    print("\nGAMS WORKING DIRECTORY: %s\n" % workspace.working_directory)
                 elif tmpdir is not None:
                     # Garbage collect all references to t1.out_db
                     # So that .gdx file can be deleted
@@ -359,7 +359,7 @@ class GAMSDirect(_GAMSSolver):
         except:
             # Catch other errors and remove files first
             if keepfiles:
-                print("\nGAMS WORKING DIRECTORY: %s\n" % ws.working_directory)
+                print("\nGAMS WORKING DIRECTORY: %s\n" % workspace.working_directory)
             elif tmpdir is not None:
                 # Garbage collect all references to t1.out_db
                 # So that .gdx file can be deleted
@@ -398,7 +398,7 @@ class GAMSDirect(_GAMSSolver):
         extract_rc = 'rc' in model_suffixes
 
         results = SolverResults()
-        results.problem.name = os.path.join(ws.working_directory, t1.name + '.gms')
+        results.problem.name = os.path.join(workspace.working_directory, t1.name + '.gms')
         results.problem.lower_bound = t1.out_db["OBJEST"].find_record().value
         results.problem.upper_bound = t1.out_db["OBJEST"].find_record().value
         results.problem.number_of_variables = t1.out_db["NUMVAR"].find_record().value
@@ -587,7 +587,7 @@ class GAMSDirect(_GAMSSolver):
         results.solution.insert(soln)
 
         if keepfiles:
-            print("\nGAMS WORKING DIRECTORY: %s\n" % ws.working_directory)
+            print("\nGAMS WORKING DIRECTORY: %s\n" % workspace.working_directory)
         elif tmpdir is not None:
             # Garbage collect all references to t1.out_db
             # So that .gdx file can be deleted

--- a/pyomo/solvers/plugins/solvers/GAMS.py
+++ b/pyomo/solvers/plugins/solvers/GAMS.py
@@ -349,7 +349,9 @@ class GAMSDirect(_GAMSSolver):
                 # Always name working directory or delete files,
                 # regardless of any errors.
                 if keepfiles:
-                    print("\nGAMS WORKING DIRECTORY: %s\n" % workspace.working_directory)
+                    print(
+                        "\nGAMS WORKING DIRECTORY: %s\n" % workspace.working_directory
+                    )
                 elif tmpdir is not None:
                     # Garbage collect all references to t1.out_db
                     # So that .gdx file can be deleted
@@ -398,7 +400,9 @@ class GAMSDirect(_GAMSSolver):
         extract_rc = 'rc' in model_suffixes
 
         results = SolverResults()
-        results.problem.name = os.path.join(workspace.working_directory, t1.name + '.gms')
+        results.problem.name = os.path.join(
+            workspace.working_directory, t1.name + '.gms'
+        )
         results.problem.lower_bound = t1.out_db["OBJEST"].find_record().value
         results.problem.upper_bound = t1.out_db["OBJEST"].find_record().value
         results.problem.number_of_variables = t1.out_db["NUMVAR"].find_record().value


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
The March 2024 typos update was incorporated / just released. This addresses our now failing linting tests.

## Changes proposed in this PR:
- Ignore erroneous errors
- Fix actual errors
- Change usage of `ws` to `workspace` because I do want us to catch if someone spells `was` wrong

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
