### PR TITLE
Work aroung bug in CyIpopt 1.4.0

### DIFF
--- a/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
+++ b/pyomo/contrib/pynumero/algorithms/solvers/cyipopt_solver.py
@@ -319,7 +319,13 @@ class PyomoCyIpoptSolver(object):
         return True
 
     def version(self):
-        return tuple(int(_) for _ in cyipopt.__version__.split("."))
+        def _int(x):
+            try:
+                return int(x)
+            except:
+                return x
+
+        return tuple(_int(_) for _ in cyipopt_interface.cyipopt.__version__.split("."))
 
     def solve(self, model, **kwds):
         config = self.config(kwds, preserve_implicit=True)

--- a/pyomo/contrib/pynumero/examples/tests/test_cyipopt_examples.py
+++ b/pyomo/contrib/pynumero/examples/tests/test_cyipopt_examples.py
@@ -44,10 +44,12 @@ if not AmplInterface.available():
     raise unittest.SkipTest("Pynumero needs the ASL extension to run CyIpopt tests")
 
 import pyomo.contrib.pynumero.algorithms.solvers.cyipopt_solver as cyipopt_solver
+from pyomo.contrib.pynumero.interfaces.cyipopt_interface import cyipopt_available
 
-if not cyipopt_solver.cyipopt_available:
+if not cyipopt_available:
     raise unittest.SkipTest("PyNumero needs CyIpopt installed to run CyIpopt tests")
 import cyipopt as cyipopt_core
+
 
 example_dir = os.path.join(this_file_dir(), '..')
 

--- a/pyomo/contrib/pynumero/examples/tests/test_cyipopt_examples.py
+++ b/pyomo/contrib/pynumero/examples/tests/test_cyipopt_examples.py
@@ -271,7 +271,7 @@ class TestExamples(unittest.TestCase):
     @unittest.skipIf(
         cyipopt_core.__version__ == "1.4.0",
         "Terminating Ipopt through a user callback is broken in CyIpopt 1.4.0 "
-        "(see mechmotum/cyipopt#249",
+        "(see mechmotum/cyipopt#249)",
     )
     def test_cyipopt_callback_halt(self):
         ex = import_file(

--- a/pyomo/contrib/pynumero/examples/tests/test_cyipopt_examples.py
+++ b/pyomo/contrib/pynumero/examples/tests/test_cyipopt_examples.py
@@ -269,7 +269,7 @@ class TestExamples(unittest.TestCase):
         self.assertAlmostEqual(s.iloc[6], 0, places=3)
 
     @unittest.skipIf(
-        cyipopt_core.__version__ == "1.4.0",
+        cyipopt_solver.PyomoCyIpoptSolver().version() == (1, 4, 0),
         "Terminating Ipopt through a user callback is broken in CyIpopt 1.4.0 "
         "(see mechmotum/cyipopt#249)",
     )

--- a/pyomo/contrib/pynumero/examples/tests/test_cyipopt_examples.py
+++ b/pyomo/contrib/pynumero/examples/tests/test_cyipopt_examples.py
@@ -266,6 +266,11 @@ class TestExamples(unittest.TestCase):
         s = df['ca_bal']
         self.assertAlmostEqual(s.iloc[6], 0, places=3)
 
+    @unittest.skipIf(
+        cyipopt_core.__version__ == "1.4.0",
+        "Terminating Ipopt through a user callback is broken in CyIpopt 1.4.0 "
+        "(see mechmotum/cyipopt#249",
+    )
     def test_cyipopt_callback_halt(self):
         ex = import_file(
             os.path.join(example_dir, 'callback', 'cyipopt_callback_halt.py')


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
CyIpopt 1.4.0 broke terminating CyIpopt by returning False from an intermediate callback.  This PR skips that test when run under 1.4.0.

The CyIpopt bug was reported upstream: https://github.com/mechmotum/cyipopt/issues/249

## Changes proposed in this PR:
- Skip test of termination from intermediate callback under CyIpopt 1.4.0
- Fix error in retrieving cyipopt version
- Resolve import from deprecated path in test

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
