### PR TITLE
Bug Fix: `name` and `solutions` attributes

### DIFF
--- a/pyomo/contrib/solver/base.py
+++ b/pyomo/contrib/solver/base.py
@@ -59,7 +59,10 @@ class SolverBase(abc.ABC):
 
     def __init__(self, **kwds) -> None:
         # We allow the user and/or developer to name the solver something else,
-        # if they really desire. Otherwise it defaults to the class name (all lowercase)
+        # if they really desire.
+        # Otherwise it defaults to the name defined when the solver was registered
+        # in the SolverFactory or the class name (all lowercase), whichever is
+        # applicable
         if "name" in kwds:
             self.name = kwds.pop('name')
         elif not hasattr(self, 'name'):

--- a/pyomo/contrib/solver/base.py
+++ b/pyomo/contrib/solver/base.py
@@ -61,10 +61,7 @@ class SolverBase(abc.ABC):
         # We allow the user and/or developer to name the solver something else,
         # if they really desire. Otherwise it defaults to the class name (all lowercase)
         if "name" in kwds:
-            self.name = kwds["name"]
-            kwds.pop('name')
-        else:
-            self.name = type(self).__name__.lower()
+            self.name = kwds.pop('name')
         self.config = self.CONFIG(value=kwds)
 
     #
@@ -499,6 +496,12 @@ class LegacySolverWrapper:
         """Method to handle the preferred action for the solution"""
         symbol_map = SymbolMap()
         symbol_map.default_labeler = NumericLabeler('x')
+        if not hasattr(model, 'solutions'):
+            # This logic gets around Issue #2130 in which
+            # solutions is not an attribute on Blocks
+            from pyomo.core.base.PyomoModel import ModelSolutions
+
+            setattr(model, 'solutions', ModelSolutions(model))
         model.solutions.add_symbol_map(symbol_map)
         legacy_results._smap_id = id(symbol_map)
         delete_legacy_soln = True

--- a/pyomo/contrib/solver/base.py
+++ b/pyomo/contrib/solver/base.py
@@ -14,8 +14,8 @@ import enum
 from typing import Sequence, Dict, Optional, Mapping, NoReturn, List, Tuple
 import os
 
-from pyomo.core.base.constraint import Constraint, _GeneralConstraintData
-from pyomo.core.base.var import Var, _GeneralVarData
+from pyomo.core.base.constraint import _GeneralConstraintData
+from pyomo.core.base.var import _GeneralVarData
 from pyomo.core.base.param import _ParamData
 from pyomo.core.base.block import _BlockData
 from pyomo.core.base.objective import Objective, _GeneralObjectiveData
@@ -62,6 +62,8 @@ class SolverBase(abc.ABC):
         # if they really desire. Otherwise it defaults to the class name (all lowercase)
         if "name" in kwds:
             self.name = kwds.pop('name')
+        elif not hasattr(self, 'name'):
+            self.name = type(self).__name__.lower()
         self.config = self.CONFIG(value=kwds)
 
     #

--- a/pyomo/contrib/solver/factory.py
+++ b/pyomo/contrib/solver/factory.py
@@ -31,6 +31,7 @@ class SolverFactoryClass(Factory):
                 LegacySolver
             )
 
+            cls.name = name
             return cls
 
         return decorator

--- a/pyomo/contrib/solver/factory.py
+++ b/pyomo/contrib/solver/factory.py
@@ -31,6 +31,7 @@ class SolverFactoryClass(Factory):
                 LegacySolver
             )
 
+            # Preserve the preferred name, as registered in the Factory
             cls.name = name
             return cls
 


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
This PR resolves two more bugs in the new solver interfaces: the lack of a `solutions` object on `Block`s and the default name for the legacy wrapper always being `legacysolver`.

## Changes proposed in this PR:
- Correct `name` attribute
- Create a `solutions` attribute
- Remove some unused imports

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
