### PR TITLE
Disable the use of universal newlines in the ipopt_v2 NL file

### DIFF
--- a/pyomo/contrib/solver/ipopt.py
+++ b/pyomo/contrib/solver/ipopt.py
@@ -307,7 +307,12 @@ class Ipopt(SolverBase):
                 raise RuntimeError(
                     f"NL file with the same name {basename + '.nl'} already exists!"
                 )
-            with open(basename + '.nl', 'w') as nl_file, open(
+            # Note: the ASL has an issue where string constants written
+            # to the NL file (e.g. arguments in external functions) MUST
+            # be terminated with '\n' regardless of platform.  We will
+            # disable universal newlines in the NL file to prevent
+            # Python from mapping those '\n' to '\r\n' on Windows.
+            with open(basename + '.nl', 'w', newline='\n') as nl_file, open(
                 basename + '.row', 'w'
             ) as row_file, open(basename + '.col', 'w') as col_file:
                 timer.start('write_nl_file')


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This resolves an issue reported by IDAES when using strings as arguments to external functions through the ipopt_v2 solver on Windows.  Forcing the EOL character in the generated NL file to always use UNIX-style endings works around an issue in the ASL parser.

## Changes proposed in this PR:
- `ipopt_v2`: force the NL file to be generated with UNIX-style newlines

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
