### PR TITLE
Fix: Get SCIP solving time considering float number with some text

### DIFF
--- a/pyomo/solvers/plugins/solvers/SCIPAMPL.py
+++ b/pyomo/solvers/plugins/solvers/SCIPAMPL.py
@@ -455,7 +455,7 @@ class SCIPAMPL(SystemCallSolver):
         solver_status = scip_lines[0][colon_position + 2 : scip_lines[0].index('\n')]
 
         solving_time = float(
-            scip_lines[1][colon_position + 2 : scip_lines[1].index('\n')]
+            scip_lines[1][colon_position + 2 : scip_lines[1].index('\n')].split(' ')[0]
         )
 
         try:

--- a/pyomo/solvers/tests/mip/test_scip.py
+++ b/pyomo/solvers/tests/mip/test_scip.py
@@ -106,6 +106,12 @@ class Test(unittest.TestCase):
         results.write(filename=_out, times=False, format='json')
         self.compare_json(_out, join(currdir, "test_scip_solve_from_instance.baseline"))
 
+    def test_scip_solve_from_instance_with_reoptimization(self):
+        # Test scip with re-optimization option enabled
+        # This case changes the Scip output results which may break the results parser
+        self.scip.options['reoptimization/enable'] = True
+        self.test_scip_solve_from_instance()
+
 
 if __name__ == "__main__":
     deleteFiles = False


### PR DESCRIPTION
This fix does not change previous behavior and handles the case of a string with a float number plus some text.
Fix #3233 

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.