### PR TITLE
NLv2: fix reporting numbers of nonlinear discrete variables

### DIFF
--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -113,6 +113,7 @@ logger = logging.getLogger(__name__)
 TOL = 1e-8
 inf = float('inf')
 minus_inf = -inf
+zero_one = {0, 1}
 
 _CONSTANT = ExprType.CONSTANT
 _MONOMIAL = ExprType.MONOMIAL
@@ -882,7 +883,13 @@ class _NLWriter_impl(object):
             elif v.is_binary():
                 binary_vars.add(_id)
             elif v.is_integer():
-                integer_vars.add(_id)
+                bnd = var_bounds[_id]
+                # Note: integer variables whose bounds are in {0, 1}
+                # should be classified as binary
+                if bnd[1] in zero_one and bnd[0] in zero_one:
+                    binary_vars.add(_id)
+                else:
+                    integer_vars.add(_id)
             else:
                 raise ValueError(
                     f"Variable '{v.name}' has a domain that is not Real, "

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -113,7 +113,7 @@ logger = logging.getLogger(__name__)
 TOL = 1e-8
 inf = float('inf')
 minus_inf = -inf
-zero_one = {0, 1}
+allowable_binary_var_bounds = {(0,0), (0,1), (1,1)}
 
 _CONSTANT = ExprType.CONSTANT
 _MONOMIAL = ExprType.MONOMIAL
@@ -883,10 +883,9 @@ class _NLWriter_impl(object):
             elif v.is_binary():
                 binary_vars.add(_id)
             elif v.is_integer():
-                bnd = var_bounds[_id]
                 # Note: integer variables whose bounds are in {0, 1}
                 # should be classified as binary
-                if bnd[1] in zero_one and bnd[0] in zero_one:
+                if var_bounds[_id] in allowable_binary_var_bounds:
                     binary_vars.add(_id)
                 else:
                     integer_vars.add(_id)

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -113,7 +113,7 @@ logger = logging.getLogger(__name__)
 TOL = 1e-8
 inf = float('inf')
 minus_inf = -inf
-allowable_binary_var_bounds = {(0,0), (0,1), (1,1)}
+allowable_binary_var_bounds = {(0, 0), (0, 1), (1, 1)}
 
 _CONSTANT = ExprType.CONSTANT
 _MONOMIAL = ExprType.MONOMIAL

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -1277,8 +1277,8 @@ class _NLWriter_impl(object):
                 len(linear_binary_vars),
                 len(linear_integer_vars),
                 len(both_vars_nonlinear.intersection(discrete_vars)),
-                len(con_vars_nonlinear.intersection(discrete_vars)),
-                len(obj_vars_nonlinear.intersection(discrete_vars)),
+                len(con_only_nonlinear_vars.intersection(discrete_vars)),
+                len(obj_only_nonlinear_vars.intersection(discrete_vars)),
             )
         )
         #

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -2193,8 +2193,15 @@ G1 3	#o2
         m.x1 = Var(within=Binary)
         m.x2 = Var(within=Integers, bounds=(0, 1))
         m.x3 = Var(within=Integers, bounds=(0, None))
-        m.const = Constraint(expr=((0.7 - (m.c1*m.t1 + m.c2*m.t2)) <= (m.p1*m.t1 + m.p2*m.t2 + m.p1*m.t4 + m.t6*m.t5)))
-        m.OBJ = Objective(expr=(m.p1*m.t1 + m.p2*m.t2 + m.p2*m.t3 + m.x1 + m.x2 + m.x3))
+        m.const = Constraint(
+            expr=(
+                (0.7 - (m.c1 * m.t1 + m.c2 * m.t2))
+                <= (m.p1 * m.t1 + m.p2 * m.t2 + m.p1 * m.t4 + m.t6 * m.t5)
+            )
+        )
+        m.OBJ = Objective(
+            expr=(m.p1 * m.t1 + m.p2 * m.t2 + m.p2 * m.t3 + m.x1 + m.x2 + m.x3)
+        )
 
         OUT = io.StringIO()
         nl_writer.NLWriter().write(m, OUT, symbolic_solver_labels=True)

--- a/pyomo/repn/tests/ampl/test_nlv2.py
+++ b/pyomo/repn/tests/ampl/test_nlv2.py
@@ -42,6 +42,8 @@ from pyomo.environ import (
     Suffix,
     Constraint,
     Expression,
+    Binary,
+    Integers,
 )
 import pyomo.environ as pyo
 
@@ -1266,7 +1268,7 @@ G0 4    #OBJ
  0 0   #network constraints: nonlinear, linear
  0 0 0 #nonlinear vars in constraints, objectives, both
  0 0 0 1       #linear network variables; functions; arith, flags
- 0 4 0 0 0     #discrete variables: binary, integer, nonlinear (b,c,o)
+ 4 0 0 0 0     #discrete variables: binary, integer, nonlinear (b,c,o)
  4 4   #nonzeros in Jacobian, obj. gradient
  6 4   #max name lengths: constraints, variables
  0 0 0 0 0     #common exprs: b,c,o,c1,o1
@@ -2165,6 +2167,136 @@ G1 3	#o2
 0 0
 1 0
 2 0
+""",
+                OUT.getvalue(),
+            )
+        )
+
+    def test_discrete_var_tabulation(self):
+        # This tests an error reported in #3235
+        #
+        # Among other issues, this verifies that nonlinear discrete
+        # variables are tabulated correctly (header line 7), and that
+        # integer variables with bounds in {0, 1} are mapped to binary
+        # variables.
+        m = ConcreteModel()
+        m.p1 = Var(bounds=(0.85, 1.15))
+        m.p2 = Var(bounds=(0.68, 0.92))
+        m.c1 = Var(bounds=(-0.0, 0.7))
+        m.c2 = Var(bounds=(-0.0, 0.7))
+        m.t1 = Var(within=Binary, bounds=(0, 1))
+        m.t2 = Var(within=Binary, bounds=(0, 1))
+        m.t3 = Var(within=Binary, bounds=(0, 1))
+        m.t4 = Var(within=Binary, bounds=(0, 1))
+        m.t5 = Var(within=Integers, bounds=(0, None))
+        m.t6 = Var(within=Integers, bounds=(0, None))
+        m.x1 = Var(within=Binary)
+        m.x2 = Var(within=Integers, bounds=(0, 1))
+        m.x3 = Var(within=Integers, bounds=(0, None))
+        m.const = Constraint(expr=((0.7 - (m.c1*m.t1 + m.c2*m.t2)) <= (m.p1*m.t1 + m.p2*m.t2 + m.p1*m.t4 + m.t6*m.t5)))
+        m.OBJ = Objective(expr=(m.p1*m.t1 + m.p2*m.t2 + m.p2*m.t3 + m.x1 + m.x2 + m.x3))
+
+        OUT = io.StringIO()
+        nl_writer.NLWriter().write(m, OUT, symbolic_solver_labels=True)
+
+        self.assertEqual(
+            *nl_diff(
+                """g3 1 1 0	# problem unknown
+ 13 1 1 0 0    #vars, constraints, objectives, ranges, eqns
+ 1 1 0 0 0 0   #nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0   #network constraints: nonlinear, linear
+ 9 10 4        #nonlinear vars in constraints, objectives, both
+ 0 0 0 1       #linear network variables; functions; arith, flags
+ 2 1 2 3 1     #discrete variables: binary, integer, nonlinear (b,c,o)
+ 9 8   #nonzeros in Jacobian, obj. gradient
+ 5 2   #max name lengths: constraints, variables
+ 0 0 0 0 0     #common exprs: b,c,o,c1,o1
+C0     #const
+o0     #+
+o16    #-
+o0     #+
+o2     #*
+v4     #c1
+v2     #t1
+o2     #*
+v5     #c2
+v3     #t2
+o16    #-
+o54    #sumlist
+4      #(n)
+o2     #*
+v0     #p1
+v2     #t1
+o2     #*
+v1     #p2
+v3     #t2
+o2     #*
+v0     #p1
+v6     #t4
+o2     #*
+v7     #t6
+v8     #t5
+O0 0   #OBJ
+o54    #sumlist
+3      #(n)
+o2     #*
+v0     #p1
+v2     #t1
+o2     #*
+v1     #p2
+v3     #t2
+o2     #*
+v1     #p2
+v9     #t3
+x0     #initial guess
+r      #1 ranges (rhs's)
+1 -0.7 #const
+b      #13 bounds (on variables)
+0 0.85 1.15    #p1
+0 0.68 0.92    #p2
+0 0 1  #t1
+0 0 1  #t2
+0 -0.0 0.7     #c1
+0 -0.0 0.7     #c2
+0 0 1  #t4
+2 0    #t6
+2 0    #t5
+0 0 1  #t3
+0 0 1  #x1
+0 0 1  #x2
+2 0    #x3
+k12    #intermediate Jacobian column lengths
+1
+2
+3
+4
+5
+6
+7
+8
+9
+9
+9
+9
+J0 9   #const
+0 0
+1 0
+2 0
+3 0
+4 0
+5 0
+6 0
+7 0
+8 0
+G0 8   #OBJ
+0 0
+1 0
+2 0
+3 0
+9 0
+10 1
+11 1
+12 1
 """,
                 OUT.getvalue(),
             )


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #3235

## Summary/Motivation:
This resolves an error in how we were reporting the numbers of nonlinear discrete variables that was causing some MINLP solvers to crash.  It also ensures that Integer variables whose domains are in `[0, 1]` are reported as being binary (matching AMPL's behavior).

These changes are covered by a new test, the baseline of which was verified against AMPL's generated NL file.

## Changes proposed in this PR:
- correct reporting of nonlinear discrete variables
- report integer variables with domains in [0, 1] as binary
- add / update tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
