### PR TITLE
CI FIX: Unpin `mpi4py`

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -92,7 +92,7 @@ jobs:
           skip_doctest: 1
           TARGET: linux
           PYENV: conda
-          PACKAGES: mpich mpi4py
+          PACKAGES: openmpi mpi4py
 
         - os: ubuntu-latest
           python: '3.10'

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -92,7 +92,7 @@ jobs:
           skip_doctest: 1
           TARGET: linux
           PYENV: conda
-          PACKAGES: mpi4py==3.1.5
+          PACKAGES: mpich mpi4py
 
         - os: ubuntu-latest
           python: '3.10'

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -93,7 +93,7 @@ jobs:
           skip_doctest: 1
           TARGET: linux
           PYENV: conda
-          PACKAGES: mpi4py==3.1.5
+          PACKAGES: openmpi mpi4py
 
         - os: ubuntu-latest
           python: '3.11'


### PR DESCRIPTION

## Fixes #3236 

## Summary/Motivation:
The `mpi4py` issue goes away if you explicitly specify the library (in this case, `openmpi`).

## Changes proposed in this PR:
- Explicitly install `openmpi`
- Unpin `mpi4py`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
