### PR TITLE
contrib.preprocessing: Fixing bug where variable aggregator did not intersect domains

### DIFF
--- a/pyomo/contrib/preprocessing/plugins/var_aggregator.py
+++ b/pyomo/contrib/preprocessing/plugins/var_aggregator.py
@@ -13,7 +13,8 @@
 
 
 from pyomo.common.collections import ComponentMap, ComponentSet
-from pyomo.core.base import Block, Constraint, VarList, Objective, TransformationFactory
+from pyomo.core.base import (Block, Constraint, VarList, Objective, Reals,
+                             TransformationFactory)
 from pyomo.core.expr import ExpressionReplacementVisitor
 from pyomo.core.expr.numvalue import value
 from pyomo.core.plugins.transform.hierarchy import IsomorphicTransformation
@@ -248,6 +249,12 @@ class VariableAggregator(IsomorphicTransformation):
             # the variables in its equality set.
             z_agg.setlb(max_if_not_None(v.lb for v in eq_set if v.has_lb()))
             z_agg.setub(min_if_not_None(v.ub for v in eq_set if v.has_ub()))
+            # Set the domain of the aggregate variable to the intersection of
+            # the domains of the variables in its equality set
+            domain = Reals
+            for v in eq_set:
+                domain = domain & v.domain
+            z_agg.domain = domain
 
             # Set the fixed status of the aggregate var
             fixed_vars = [v for v in eq_set if v.fixed]

--- a/pyomo/contrib/preprocessing/plugins/var_aggregator.py
+++ b/pyomo/contrib/preprocessing/plugins/var_aggregator.py
@@ -13,8 +13,14 @@
 
 
 from pyomo.common.collections import ComponentMap, ComponentSet
-from pyomo.core.base import (Block, Constraint, VarList, Objective, Reals,
-                             TransformationFactory)
+from pyomo.core.base import (
+    Block,
+    Constraint,
+    VarList,
+    Objective,
+    Reals,
+    TransformationFactory,
+)
 from pyomo.core.expr import ExpressionReplacementVisitor
 from pyomo.core.expr.numvalue import value
 from pyomo.core.plugins.transform.hierarchy import IsomorphicTransformation

--- a/pyomo/contrib/preprocessing/tests/test_var_aggregator.py
+++ b/pyomo/contrib/preprocessing/tests/test_var_aggregator.py
@@ -19,12 +19,16 @@ from pyomo.contrib.preprocessing.plugins.var_aggregator import (
     max_if_not_None,
     min_if_not_None,
 )
+from pyomo.core.expr.compare import assertExpressionsEqual
 from pyomo.environ import (
+    Binary,
     ConcreteModel,
     Constraint,
     ConstraintList,
+    maximize,
     Objective,
     RangeSet,
+    Reals,
     SolverFactory,
     TransformationFactory,
     Var,
@@ -210,6 +214,43 @@ class TestVarAggregate(unittest.TestCase):
         self.assertEqual(m.x.value, 0)
         self.assertEqual(m.y.value, 0)
 
+    def test_binary_inequality(self):
+        m = ConcreteModel()
+        m.x = Var(domain=Binary)
+        m.y = Var(domain=Binary)
+        m.c = Constraint(expr=m.x == m.y)
+        m.o = Objective(expr=0.5*m.x + m.y, sense=maximize)
+        TransformationFactory('contrib.aggregate_vars').apply_to(m)
+        var_to_z = m._var_aggregator_info.var_to_z
+        z = var_to_z[m.x]
+        self.assertIs(var_to_z[m.y], z)
+        self.assertEqual(z.domain, Binary)
+        self.assertEqual(z.lb, 0)
+        self.assertEqual(z.ub, 1)
+        assertExpressionsEqual(
+            self,
+            m.o.expr,
+            0.5 * z + z
+        )
+
+    def test_equality_different_domains(self):
+        m = ConcreteModel()
+        m.x = Var(domain=Reals, bounds=(1, 2))
+        m.y = Var(domain=Binary)
+        m.c = Constraint(expr=m.x == m.y)
+        m.o = Objective(expr=0.5*m.x + m.y, sense=maximize)
+        TransformationFactory('contrib.aggregate_vars').apply_to(m)
+        var_to_z = m._var_aggregator_info.var_to_z
+        z = var_to_z[m.x]
+        self.assertIs(var_to_z[m.y], z)
+        self.assertEqual(z.lb, 1)
+        self.assertEqual(z.ub, 1)
+        self.assertEqual(z.domain, Binary)
+        assertExpressionsEqual(
+            self,
+            m.o.expr,
+            0.5 * z + z
+        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyomo/contrib/preprocessing/tests/test_var_aggregator.py
+++ b/pyomo/contrib/preprocessing/tests/test_var_aggregator.py
@@ -219,7 +219,7 @@ class TestVarAggregate(unittest.TestCase):
         m.x = Var(domain=Binary)
         m.y = Var(domain=Binary)
         m.c = Constraint(expr=m.x == m.y)
-        m.o = Objective(expr=0.5*m.x + m.y, sense=maximize)
+        m.o = Objective(expr=0.5 * m.x + m.y, sense=maximize)
         TransformationFactory('contrib.aggregate_vars').apply_to(m)
         var_to_z = m._var_aggregator_info.var_to_z
         z = var_to_z[m.x]
@@ -227,18 +227,14 @@ class TestVarAggregate(unittest.TestCase):
         self.assertEqual(z.domain, Binary)
         self.assertEqual(z.lb, 0)
         self.assertEqual(z.ub, 1)
-        assertExpressionsEqual(
-            self,
-            m.o.expr,
-            0.5 * z + z
-        )
+        assertExpressionsEqual(self, m.o.expr, 0.5 * z + z)
 
     def test_equality_different_domains(self):
         m = ConcreteModel()
         m.x = Var(domain=Reals, bounds=(1, 2))
         m.y = Var(domain=Binary)
         m.c = Constraint(expr=m.x == m.y)
-        m.o = Objective(expr=0.5*m.x + m.y, sense=maximize)
+        m.o = Objective(expr=0.5 * m.x + m.y, sense=maximize)
         TransformationFactory('contrib.aggregate_vars').apply_to(m)
         var_to_z = m._var_aggregator_info.var_to_z
         z = var_to_z[m.x]
@@ -246,11 +242,8 @@ class TestVarAggregate(unittest.TestCase):
         self.assertEqual(z.lb, 1)
         self.assertEqual(z.ub, 1)
         self.assertEqual(z.domain, Binary)
-        assertExpressionsEqual(
-            self,
-            m.o.expr,
-            0.5 * z + z
-        )
+        assertExpressionsEqual(self, m.o.expr, 0.5 * z + z)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

The `contrib.aggregate_vars` transformation correctly intersected bounds of variables that are linked by equality constraints, but it did not handle domains, meaning that in a model with two binaries linked by an equality transformation, the transformed model was actually a relaxation since integrality for both of the variables was relaxed. This PR fixes this bug by setting the domain of the variable that will be substituted in to the intersection of the domains of all the variables linked by equality.

## Changes proposed in this PR:
- Fixes bug
- Adds a couple tests

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
