### PR TITLE
Fix division-by-0 bug in linear walker

### DIFF
--- a/pyomo/repn/linear.py
+++ b/pyomo/repn/linear.py
@@ -292,7 +292,7 @@ def _handle_division_constant_constant(visitor, node, arg1, arg2):
 
 
 def _handle_division_ANY_constant(visitor, node, arg1, arg2):
-    arg1[1].multiplier /= arg2[1]
+    arg1[1].multiplier = apply_node_operation(node, (arg1[1].multiplier, arg2[1]))
     return arg1
 
 

--- a/pyomo/repn/tests/test_linear.py
+++ b/pyomo/repn/tests/test_linear.py
@@ -1436,6 +1436,22 @@ class TestLinear(unittest.TestCase):
         m.z = Var()
         m.y.fix(1)
 
+        expr = (m.x + 1) / m.p
+        cfg = VisitorConfig()
+        with LoggingIntercept() as LOG:
+            repn = LinearRepnVisitor(*cfg).walk_expression(expr)
+        self.assertEqual(
+            LOG.getvalue(),
+            "Exception encountered evaluating expression 'div(1, 0)'\n"
+            "\tmessage: division by zero\n"
+            "\texpression: (x + 1)/p\n",
+        )
+        self.assertEqual(repn.multiplier, 1)
+        self.assertEqual(str(repn.constant), 'InvalidNumber(nan)')
+        self.assertEqual(len(repn.linear), 1)
+        self.assertEqual(str(repn.linear[id(m.x)]), 'InvalidNumber(nan)')
+        self.assertEqual(repn.nonlinear, None)
+
         expr = m.y + m.x + m.z + ((3 * m.x) / m.p) / m.y
         cfg = VisitorConfig()
         with LoggingIntercept() as LOG:


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

This fixes a bug in the linear walker where a certain case of division by 0 (dividing a generic expression (not monomial) by a constant) wasn't trapped and propagated as an invalid number.

## Changes proposed in this PR:
- Fixes the bug
- Adds a test

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
