### PR TITLE
ComponentData backwards compatibility

### DIFF
--- a/pyomo/common/deprecation.py
+++ b/pyomo/common/deprecation.py
@@ -542,7 +542,7 @@ class RenamedClass(type):
 
         if new_class is None and '__renamed__new_class__' not in classdict:
             if not any(
-                hasattr(base, '__renamed__new_class__')
+                hasattr(mro, '__renamed__new_class__')
                 for mro in itertools.chain.from_iterable(
                     base.__mro__ for base in renamed_bases
                 )

--- a/pyomo/common/tests/test_deprecated.py
+++ b/pyomo/common/tests/test_deprecated.py
@@ -529,7 +529,10 @@ class TestRenamedClass(unittest.TestCase):
         out = StringIO()
         with LoggingIntercept(out):
 
-            class DeprecatedClassSubSubclass(DeprecatedClassSubclass):
+            class otherClass:
+                pass
+
+            class DeprecatedClassSubSubclass(DeprecatedClassSubclass, otherClass):
                 attr = 'DeprecatedClassSubSubclass'
 
         self.assertEqual(out.getvalue(), "")

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -2412,8 +2412,8 @@ def declare_custom_block(name, new_ctype=None):
 
         # Declare Indexed and Scalar versions of the custom blocks.  We
         # will register them both with the calling module scope, and
-        # with the CustomBlock (so that __new__ can route the object
-        # creation to the correct class)
+        # with the CustomBlock (so that CustomBlock.__new__ can route
+        # the object creation to the correct class)
         c._indexed_custom_block = type(c)("Indexed" + name, (c,), {})
         c._scalar_custom_block = type(c)(
             "Scalar" + name, (ScalarCustomBlockMixin, cls, c), {}

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -2391,13 +2391,13 @@ def declare_custom_block(name, new_ctype=None):
         # this is the decorator function that creates the block
         # component classes
 
-        # Declare the new Block (derived from CustomBlock) corresponding
-        # to the BlockData that we are decorating
+        # Declare the new Block component (derived from CustomBlock)
+        # corresponding to the BlockData that we are decorating
         #
         # Note the use of `type(CustomBlock)` to pick up the metaclass
         # that was used to create the CustomBlock (in general, it should
         # be `type`)
-        c = type(CustomBlock)(
+        comp = type(CustomBlock)(
             name,  # name of new class
             (CustomBlock,),  # base classes
             # class body definitions (populate the new class' __dict__)
@@ -2413,9 +2413,9 @@ def declare_custom_block(name, new_ctype=None):
 
         if new_ctype is not None:
             if new_ctype is True:
-                c._default_ctype = c
+                comp._default_ctype = comp
             elif isinstance(new_ctype, type):
-                c._default_ctype = new_ctype
+                comp._default_ctype = new_ctype
             else:
                 raise ValueError(
                     "Expected new_ctype to be either type "
@@ -2426,23 +2426,23 @@ def declare_custom_block(name, new_ctype=None):
         # will register them both with the calling module scope, and
         # with the CustomBlock (so that CustomBlock.__new__ can route
         # the object creation to the correct class)
-        c._indexed_custom_block = type(c)(
+        comp._indexed_custom_block = type(comp)(
             "Indexed" + name,
-            (c,),
+            (comp,),
             {  # ensure the created class is associated with the calling module
                 "__module__": block_data.__module__
             },
         )
-        c._scalar_custom_block = type(c)(
+        comp._scalar_custom_block = type(comp)(
             "Scalar" + name,
-            (ScalarCustomBlockMixin, block_data, c),
+            (ScalarCustomBlockMixin, block_data, comp),
             {  # ensure the created class is associated with the calling module
                 "__module__": block_data.__module__
             },
         )
 
         # Register the new Block types in the same module as the BlockData
-        for _cls in (c, c._indexed_custom_block, c._scalar_custom_block):
+        for _cls in (comp, comp._indexed_custom_block, comp._scalar_custom_block):
             setattr(sys.modules[block_data.__module__], _cls.__name__, _cls)
         return block_data
 

--- a/pyomo/core/expr/numvalue.py
+++ b/pyomo/core/expr/numvalue.py
@@ -45,6 +45,16 @@ relocated_module_attribute(
     "native_*_types sets).  Users likely should use native_logical_types.",
 )
 relocated_module_attribute(
+    'pyomo_constant_types',
+    'pyomo.common.numeric_types._pyomo_constant_types',
+    version='6.7.2.dev0',
+    f_globals=globals(),
+    msg="The pyomo_constant_types set will be removed in the future: the set "
+    "contained only NumericConstant and _PythonCallbackFunctionID, and provided "
+    "no meaningful value to clients or walkers.  Users should likely handle "
+    "these types in the same manner as immutable Params.",
+)
+relocated_module_attribute(
     'RegisterNumericType',
     'pyomo.common.numeric_types.RegisterNumericType',
     version='6.6.0',

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -2998,12 +2998,12 @@ class TestBlock(unittest.TestCase):
         self.assertEqual(LOG.getvalue(), "")
 
         # Test that we can derive from a ScalarCustomBlock
-        class DerivedScalarTstingBlock(ScalarTestingBlock):
+        class DerivedScalarTestingBlock(ScalarTestingBlock):
             pass
 
         with LoggingIntercept() as LOG:
-            obj = DerivedScalarTstingBlock()
-        self.assertIs(type(obj), DerivedScalarTstingBlock)
+            obj = DerivedScalarTestingBlock()
+        self.assertIs(type(obj), DerivedScalarTestingBlock)
         self.assertEqual(LOG.getvalue().strip(), "TestingBlockData.__init__")
 
     def test_override_pprint(self):

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -2986,6 +2986,9 @@ class TestBlock(unittest.TestCase):
         self.assertIn('TestingBlock', globals())
         self.assertIn('ScalarTestingBlock', globals())
         self.assertIn('IndexedTestingBlock', globals())
+        self.assertIs(TestingBlock.__module__, __name__)
+        self.assertIs(ScalarTestingBlock.__module__, __name__)
+        self.assertIs(IndexedTestingBlock.__module__, __name__)
 
         with LoggingIntercept() as LOG:
             obj = TestingBlock()

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -3009,7 +3009,35 @@ class TestBlock(unittest.TestCase):
         self.assertIs(type(obj), DerivedScalarTestingBlock)
         self.assertEqual(LOG.getvalue().strip(), "TestingBlockData.__init__")
 
-    def test_override_pprint(self):
+    def test_custom_block_ctypes(self):
+        @declare_custom_block('TestingBlock')
+        class TestingBlockData(BlockData):
+            pass
+
+        self.assertIs(TestingBlock().ctype, Block)
+
+        @declare_custom_block('TestingBlock', True)
+        class TestingBlockData(BlockData):
+            pass
+
+        self.assertIs(TestingBlock().ctype, TestingBlock)
+
+        @declare_custom_block('TestingBlock', Constraint)
+        class TestingBlockData(BlockData):
+            pass
+
+        self.assertIs(TestingBlock().ctype, Constraint)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"Expected new_ctype to be either type or 'True'; received: \[\]",
+        ):
+
+            @declare_custom_block('TestingBlock', [])
+            class TestingBlockData(BlockData):
+                pass
+
+    def test_custom_block_override_pprint(self):
         @declare_custom_block('TempBlock')
         class TempBlockData(BlockData):
             def pprint(self, ostream=None, verbose=False, prefix=""):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This resolved several backwards compatibility issues introduced in #3221:

## Changes proposed in this PR:
- resolve a bug in `RenamedClass` where it failed when a class that derived off the renamed class had multiple base classes
- the implementation of `declare_custom_block` used meta classes, which conflicted with the use of meta classes in RenamedClass.  This removes the use of meta classes in `declare_custom_block`
- re-add a deprecation path for `pyomo_constant_types` in `pyomo.core.expr.numvalue`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
