### PR TITLE
Update GHA to grab gurobipy from PyPI

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -111,14 +111,6 @@ jobs:
           TARGET: win
           PYENV: pip
 
-        - os: ubuntu-latest
-          python: '3.11'
-          other: /singletest
-          category: "-m 'neos or importtest'"
-          skip_doctest: 1
-          TARGET: linux
-          PYENV: pip
-
     steps:
     - name: Checkout Pyomo source
       uses: actions/checkout@v4
@@ -272,7 +264,7 @@ jobs:
         if test -z "${{matrix.slim}}"; then
             python -m pip install --cache-dir cache/pip cplex docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
-            python -m pip install --cache-dir cache/pip gurobipy\
+            python -m pip install --cache-dir cache/pip gurobipy==10.0.3\
                 || echo "WARNING: Gurobi is not available"
             python -m pip install --cache-dir cache/pip xpress \
                 || echo "WARNING: Xpress Community Edition is not available"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -272,8 +272,7 @@ jobs:
         if test -z "${{matrix.slim}}"; then
             python -m pip install --cache-dir cache/pip cplex docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
-            python -m pip install --cache-dir cache/pip \
-                -i https://pypi.gurobi.com gurobipy \
+            python -m pip install --cache-dir cache/pip gurobipy\
                 || echo "WARNING: Gurobi is not available"
             python -m pip install --cache-dir cache/pip xpress \
                 || echo "WARNING: Xpress Community Edition is not available"

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -111,6 +111,14 @@ jobs:
           TARGET: win
           PYENV: pip
 
+        - os: ubuntu-latest
+          python: '3.11'
+          other: /singletest
+          category: "-m 'neos or importtest'"
+          skip_doctest: 1
+          TARGET: linux
+          PYENV: pip
+
     steps:
     - name: Checkout Pyomo source
       uses: actions/checkout@v4
@@ -265,7 +273,7 @@ jobs:
             python -m pip install --cache-dir cache/pip cplex docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
             python -m pip install --cache-dir cache/pip \
-                -i https://pypi.gurobi.com gurobipy==10.0.3 \
+                -i https://pypi.gurobi.com gurobipy \
                 || echo "WARNING: Gurobi is not available"
             python -m pip install --cache-dir cache/pip xpress \
                 || echo "WARNING: Xpress Community Edition is not available"

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -301,8 +301,7 @@ jobs:
         if test -z "${{matrix.slim}}"; then
             python -m pip install --cache-dir cache/pip cplex docplex \
                 || echo "WARNING: CPLEX Community Edition is not available"
-            python -m pip install --cache-dir cache/pip \
-                -i https://pypi.gurobi.com gurobipy==10.0.3 \
+            python -m pip install --cache-dir cache/pip gurobipy==10.0.3 \
                 || echo "WARNING: Gurobi is not available"
             python -m pip install --cache-dir cache/pip xpress \
                 || echo "WARNING: Xpress Community Edition is not available"


### PR DESCRIPTION
## Summary/Motivation:
We currently grab `gurobipy` from pypi.gurobi.com when setting up our pip-based GHA jobs. This recently started causing test failures due to this site not being reachable. The Gurobi Python installation instructions say to grab `gurobipy` straight from PyPI so this PR updates our workflows to do so. 

## Changes proposed in this PR:
- pip install gurobipy directly from PyPI

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
