### PR TITLE
Add URL Checking to Markdown + Doc Files

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -61,6 +61,7 @@ jobs:
         # Exclude Jenkins because it's behind a firewall
         exclude_urls: https://pyomo-jenkins.sandia.gov/
 
+
   build:
     name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.other }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -59,7 +59,7 @@ jobs:
         # How many times to retry a failed request (defaults to 1)
         retry_count: 3
         # Exclude Jenkins because it's behind a firewall
-        exclude_urls: https://pyomo-jenkins.sandia.gov
+        exclude_urls: https://pyomo-jenkins.sandia.gov/
 
   build:
     name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.other }}

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -47,17 +47,7 @@ jobs:
       uses: crate-ci/typos@master
       with: 
         config: ./.github/workflows/typos.toml
-    - name: URL Checker
-      uses: urlstechie/urlchecker-action@0.0.34
-      with:
-        # A comma-separated list of file types to cover in the URL checks
-        file_types: .md,.rst
-        # Choose whether to include file with no URLs in the prints.
-        print_all: false
-        # More verbose summary at the end of a run
-        verbose: true
-        # How many times to retry a failed request (defaults to 1)
-        retry_count: 3
+
 
   build:
     name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.other }}

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -47,7 +47,19 @@ jobs:
       uses: crate-ci/typos@master
       with: 
         config: ./.github/workflows/typos.toml
-
+    - name: URL Checker
+      uses: urlstechie/urlchecker-action@0.0.34
+      with:
+        # A comma-separated list of file types to cover in the URL checks
+        file_types: .md,.rst
+        # Choose whether to include file with no URLs in the prints.
+        print_all: false
+        # More verbose summary at the end of a run
+        verbose: true
+        # How many times to retry a failed request (defaults to 1)
+        retry_count: 3
+        # Exclude Jenkins because it's behind a firewall
+        exclude_urls: https://pyomo-jenkins.sandia.gov
 
   build:
     name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.other }}

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -47,7 +47,17 @@ jobs:
       uses: crate-ci/typos@master
       with: 
         config: ./.github/workflows/typos.toml
-
+    - name: URL Checker
+      uses: urlstechie/urlchecker-action@0.0.34
+      with:
+        # A comma-separated list of file types to cover in the URL checks
+        file_types: .md,.rst
+        # Choose whether to include file with no URLs in the prints.
+        print_all: false
+        # More verbose summary at the end of a run
+        verbose: true
+        # How many times to retry a failed request (defaults to 1)
+        retry_count: 3
 
   build:
     name: ${{ matrix.TARGET }}/${{ matrix.python }}${{ matrix.other }}

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -57,6 +57,19 @@ jobs:
       uses: crate-ci/typos@master
       with: 
         config: ./.github/workflows/typos.toml
+    - name: URL Checker
+      uses: urlstechie/urlchecker-action@0.0.34
+      with:
+        # A comma-separated list of file types to cover in the URL checks
+        file_types: .md,.rst
+        # Choose whether to include file with no URLs in the prints.
+        print_all: false
+        # More verbose summary at the end of a run
+        verbose: true
+        # How many times to retry a failed request (defaults to 1)
+        retry_count: 3
+        # Exclude Jenkins because it's behind a firewall
+        exclude_urls: https://pyomo-jenkins.sandia.gov/
 
 
   build:

--- a/doc/OnlineDocs/contributed_packages/pynumero/pynumero.sparse.block_vector.rst
+++ b/doc/OnlineDocs/contributed_packages/pynumero/pynumero.sparse.block_vector.rst
@@ -77,7 +77,7 @@ NumPy compatible functions:
   * `numpy.arccos() <https://numpy.org/doc/stable/reference/generated/numpy.arccos.html>`_
   * `numpy.sinh() <https://numpy.org/doc/stable/reference/generated/numpy.sinh.html>`_
   * `numpy.cosh() <https://numpy.org/doc/stable/reference/generated/numpy.cosh.html>`_
-  * `numpy.abs() <https://numpy.org/doc/stable/reference/generated/numpy.abs.html>`_
+  * `numpy.abs() <https://numpy.org/doc/stable/reference/generated/numpy.absolute.html>`_
   * `numpy.tanh() <https://numpy.org/doc/stable/reference/generated/numpy.tanh.html>`_
   * `numpy.arccosh() <https://numpy.org/doc/stable/reference/generated/numpy.arccosh.html>`_
   * `numpy.arcsinh() <https://numpy.org/doc/stable/reference/generated/numpy.arcsinh.html>`_

--- a/doc/OnlineDocs/contribution_guide.rst
+++ b/doc/OnlineDocs/contribution_guide.rst
@@ -404,50 +404,10 @@ Contrib packages will be tested along with Pyomo.  If test failures
 arise, then these packages will be disabled and an issue will be
 created to resolve these test failures.
 
-The following two examples illustrate the two ways
-that ``pyomo.contrib`` can be used to integrate third-party
-contributions.
-
-Including External Packages
-+++++++++++++++++++++++++++
-
-The `pyomocontrib_simplemodel
-<https://pyomo-simplemodel.readthedocs.io/en/latest/>`_ package
-is derived from Pyomo, and it defines the class SimpleModel that
-illustrates how Pyomo can be used in a simple, less object-oriented
-manner. Specifically, this class mimics the modeling style supported
-by `PuLP <https://github.com/coin-or/pulp>`_.
-
-While ``pyomocontrib_simplemodel`` can be installed and used separate
-from Pyomo, this package is included in ``pyomo/contrib/simplemodel``.
-This allows this package to be referenced as if were defined as a
-subpackage of ``pyomo.contrib``.  For example::
-
-    from pyomo.contrib.simplemodel import *
-    from math import pi
-
-    m = SimpleModel()
-
-    r = m.var('r', bounds=(0,None))
-    h = m.var('h', bounds=(0,None))
-
-    m += 2*pi*r*(r + h)
-    m += pi*h*r**2 == 355
-
-    status = m.solve("ipopt")
-
-This example illustrates that a package can be distributed separate
-from Pyomo while appearing to be included in the ``pyomo.contrib``
-subpackage.  Pyomo requires a separate directory be defined under
-``pyomo/contrib`` for each such package, and the Pyomo developer
-team will approve the inclusion of third-party packages in this
-manner.
-
-
 Contrib Packages within Pyomo
 +++++++++++++++++++++++++++++
 
-Third-party contributions can also be included directly within the
+Third-party contributions can be included directly within the
 ``pyomo.contrib`` package.  The ``pyomo/contrib/example`` package
 provides an example of how this can be done, including a directory
 for plugins and package tests.  For example, this package can be
@@ -465,7 +425,7 @@ import this package, but if an import failure occurs, Pyomo will
 silently ignore it.  Otherwise, this pyomo package will be treated
 like any other.  Specifically:
 
-* Plugin classes defined in this package are loaded when `pyomo.environ` is loaded.
+* Plugin classes defined in this package are loaded when ``pyomo.environ`` is loaded.
 
 * Tests in this package are run with other Pyomo tests.
 

--- a/doc/OnlineDocs/contribution_guide.rst
+++ b/doc/OnlineDocs/contribution_guide.rst
@@ -412,7 +412,7 @@ Including External Packages
 +++++++++++++++++++++++++++
 
 The `pyomocontrib_simplemodel
-<http://pyomocontrib-simplemodel.readthedocs.io/en/latest/>`_ package
+<https://pyomo-simplemodel.readthedocs.io/en/latest/>`_ package
 is derived from Pyomo, and it defines the class SimpleModel that
 illustrates how Pyomo can be used in a simple, less object-oriented
 manner. Specifically, this class mimics the modeling style supported

--- a/doc/OnlineDocs/modeling_extensions/dae.rst
+++ b/doc/OnlineDocs/modeling_extensions/dae.rst
@@ -738,7 +738,7 @@ supported by CasADi. A list of available integrators for each package is
 given below. Please refer to the `SciPy
 <https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.ode.html>`_
 and `CasADi
-<http://casadi.sourceforge.net/api/html/db/d3d/classcasadi_1_1Integrator.html>`_ documentation directly for the most up-to-date information about
+<https://web.casadi.org/python-api/#integrator>`_ documentation directly for the most up-to-date information about
 these packages and for more information about the various integrators and
 options.
 


### PR DESCRIPTION

## Fixes NA

## Summary/Motivation:
Because I like to make our pre-test linting suite as complicated as possible, this adds yet another element: URL checking! The action in use here checks all Markdown and RST files and makes sure that the URLs work. It ignores pyomo-jenkins, however, because that's behind a firewall. 

## Changes proposed in this PR:
- Check URLs to make sure that they work (in Markdown and RST files)
- Fix broken URLs
- Remove the section on "Including External Packages" because we don't actually support that anymore _and_ the URL for the one example was broken

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
