### PR TITLE
Reorder definitions to avoid `NameError` in some situations

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -965,7 +965,6 @@ def _finalize_matplotlib(module, available):
     import matplotlib.pyplot
     import matplotlib.pylab
     import matplotlib.backends
-    import matplotlib.cm  # explicit import required for matplotlib>=3.9.0
 
 
 def _finalize_numpy(np, available):

--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -965,6 +965,7 @@ def _finalize_matplotlib(module, available):
     import matplotlib.pyplot
     import matplotlib.pylab
     import matplotlib.backends
+    import matplotlib.cm  # explicit import required for matplotlib>=3.9.0
 
 
 def _finalize_numpy(np, available):

--- a/pyomo/contrib/community_detection/detection.py
+++ b/pyomo/contrib/community_detection/detection.py
@@ -580,7 +580,7 @@ class CommunityMap(object):
                 pos = nx.spring_layout(model_graph)
 
         # Define color_map
-        color_map = plt.cm.get_cmap('viridis', len(numbered_community_map))
+        color_map = plt.get_cmap('viridis', len(numbered_community_map))
 
         # Create the figure and draw the graph
         fig = plt.figure()

--- a/pyomo/core/expr/sympy_tools.py
+++ b/pyomo/core/expr/sympy_tools.py
@@ -9,7 +9,6 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 import operator
-import sys
 from math import prod as _prod
 
 import pyomo.core.expr as EXPR

--- a/pyomo/core/expr/sympy_tools.py
+++ b/pyomo/core/expr/sympy_tools.py
@@ -10,12 +10,13 @@
 #  ___________________________________________________________________________
 import operator
 import sys
+from math import prod as _prod
 
+import pyomo.core.expr as EXPR
 from pyomo.common import DeveloperError
 from pyomo.common.collections import ComponentMap
 from pyomo.common.dependencies import attempt_import
 from pyomo.common.errors import NondifferentiableError
-import pyomo.core.expr as EXPR
 from pyomo.core.expr.numvalue import value, native_types
 
 #
@@ -111,18 +112,6 @@ def _configure_sympy(sympy, available):
 
 
 sympy, sympy_available = attempt_import('sympy', callback=_configure_sympy)
-
-
-if sys.version_info[:2] < (3, 8):
-
-    def _prod(args):
-        ans = 1
-        for arg in args:
-            ans *= arg
-        return ans
-
-else:
-    from math import prod as _prod
 
 
 def _nondifferentiable(x):

--- a/pyomo/core/expr/sympy_tools.py
+++ b/pyomo/core/expr/sympy_tools.py
@@ -28,6 +28,25 @@ _pyomo_operator_map = {}
 _functionMap = {}
 
 
+def _nondifferentiable(x):
+    if type(x[1]) is tuple:
+        # sympy >= 1.3 returns tuples (var, order)
+        wrt = x[1][0]
+    else:
+        # early versions of sympy returned the bare var
+        wrt = x[1]
+    raise NondifferentiableError(
+        "The sub-expression '%s' is not differentiable with respect to %s" % (x[0], wrt)
+    )
+
+
+def _external_fcn(*x):
+    raise TypeError(
+        "Expressions containing external functions are not convertible to "
+        f"sympy expressions (found 'f{x}')"
+    )
+
+
 def _configure_sympy(sympy, available):
     if not available:
         return
@@ -111,25 +130,6 @@ def _configure_sympy(sympy, available):
 
 
 sympy, sympy_available = attempt_import('sympy', callback=_configure_sympy)
-
-
-def _nondifferentiable(x):
-    if type(x[1]) is tuple:
-        # sympy >= 1.3 returns tuples (var, order)
-        wrt = x[1][0]
-    else:
-        # early versions of sympy returned the bare var
-        wrt = x[1]
-    raise NondifferentiableError(
-        "The sub-expression '%s' is not differentiable with respect to %s" % (x[0], wrt)
-    )
-
-
-def _external_fcn(*x):
-    raise TypeError(
-        "Expressions containing external functions are not convertible to "
-        f"sympy expressions (found 'f{x}')"
-    )
 
 
 class PyomoSympyBimap(object):

--- a/setup.py
+++ b/setup.py
@@ -264,7 +264,9 @@ setup_kwargs = dict(
             'ipython',  # contrib.viewer
             # Note: matplotlib 3.6.1 has bug #24127, which breaks
             # seaborn's histplot (triggering parmest failures)
-            'matplotlib!=3.6.1',
+            # Note: minimum version from community_detection use of
+            # matplotlib.pyplot.get_cmap()
+            'matplotlib>=3.6.0,!=3.6.1',
             # network, incidence_analysis, community_detection
             # Note: networkx 3.2 is Python>-3.9, but there is a broken
             # 3.2 package on conda-forge that will get implicitly


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes #3262

## Summary/Motivation:
This reorders some definitions to avoid a `NameError` reported by users.

## Changes proposed in this PR:
- reorder imports / definitions
- remove compatibility code needed for Python < 3.8 (no longer supported by Pyomo)
- [unrelated] resolve deprecated use of `pyplot.cm.get_cmap()` in `community_detection` (deprecation path removed in matplotlib 3.9.0)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
