### PR TITLE
Deprecate `pyomo.core.plugins.transform.model.to_standard_form()`

### DIFF
--- a/pyomo/core/plugins/transform/model.py
+++ b/pyomo/core/plugins/transform/model.py
@@ -16,10 +16,17 @@
 # because we may support an explicit matrix representation for models.
 #
 
+from pyomo.common.deprecation import deprecated
 from pyomo.core.base import Objective, Constraint
 import array
 
 
+@deprecated(
+    "to_standard_form() is deprecated.  "
+    "Please use WriterFactory('compile_standard_form')",
+    version='6.7.3.dev0',
+    remove_in='6.8.0',
+)
 def to_standard_form(self):
     """
     Produces a standard-form representation of the model. Returns


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This deprecates the `pyomo.core.plugins.transform.model.to_standard_form()` (and implicitly the entire `pyomo.core.plugins.transform.model` module).  This functionality is not tested at all, and has been replaced by the `WriterFactory('compile_standard_form')` writer.

## Changes proposed in this PR:
- Deprecate `pyomo.core.plugins.transform.model.to_standard_form()` 

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
