### PR TITLE
Skip Windows Python 3.8

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -86,6 +86,11 @@ jobs:
         other: [""]
         category: [""]
 
+        # win/3.8 conda builds no longer work due to environment not being able
+        # to resolve. We are skipping it now.
+        exclude:
+        - os: windows-latest
+          python: 3.8
         include:
         - os: ubuntu-latest
           TARGET: linux


### PR DESCRIPTION


## Fixes NA

## Summary/Motivation:
The `win/3.8` conda environment refuses to resolve. Because we have 3.8 coverage with `pip` and there is not a clear fix (since it broke out of nowhere), we are opting to skip it.

## Changes proposed in this PR:
- Exclude `windows-latest` + `python/3.8` job

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
