### PR TITLE
Update guard for pint import to possibly avoid recursion error

### DIFF
--- a/pyomo/contrib/viewer/tests/test_data_model_item.py
+++ b/pyomo/contrib/viewer/tests/test_data_model_item.py
@@ -46,15 +46,10 @@ import pyomo.environ as pyo
 from pyomo.contrib.viewer.model_browser import ComponentDataItem
 from pyomo.contrib.viewer.ui_data import UIData
 from pyomo.common.dependencies import DeferredImportError
-
-try:
-    x = pyo.units.m
-    units_available = True
-except DeferredImportError:
-    units_available = False
+from pyomo.core.base.units_container import pint_available
 
 
-@unittest.skipIf(not units_available, "Pyomo units are not available")
+@unittest.skipIf(not pint_available, "Pyomo units are not available")
 class TestDataModelItem(unittest.TestCase):
     def setUp(self):
         # Borrowed this test model from the trust region tests

--- a/pyomo/contrib/viewer/tests/test_data_model_tree.py
+++ b/pyomo/contrib/viewer/tests/test_data_model_tree.py
@@ -42,12 +42,7 @@ import pyomo.environ as pyo
 from pyomo.contrib.viewer.model_browser import ComponentDataModel
 import pyomo.contrib.viewer.qt as myqt
 from pyomo.common.dependencies import DeferredImportError
-
-try:
-    _x = pyo.units.m
-    units_available = True
-except DeferredImportError:
-    units_available = False
+from pyomo.core.base.units_container import pint_available
 
 available = myqt.available
 
@@ -63,7 +58,7 @@ else:
             pass
 
 
-@unittest.skipIf(not available or not units_available, "PyQt or units not available")
+@unittest.skipIf(not available or not pint_available, "PyQt or units not available")
 class TestDataModel(unittest.TestCase):
     def setUp(self):
         # Borrowed this test model from the trust region tests


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Might fix #3274

## Summary/Motivation:
It is not at all clear how #3274 is generating a recursion error.  However, this might resolve the symptom by avoiding reliance on the `UnitsContainer.__getattribute__` at the module level in the Viewer tests.

## Changes proposed in this PR:
- directly check for `pint` availability instead of relying on the UnitsContainer indirection

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
