### PR TITLE
Fix pyomo import with NumPy v2.0 or greater

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -999,7 +999,11 @@ def _finalize_numpy(np, available):
         # registration here (to bypass the deprecation warning) until we
         # finally remove all support for it
         numeric_types._native_boolean_types.add(t)
-    _floats = [np.float_, np.float16, np.float32, np.float64]
+    _floats = []
+    # numpy 2.0.0 removed np.float_
+    if np.__version__ < '2.0.0':
+        _floats.append(np.float_)
+    _floats.extend([np.float16, np.float32, np.float64])
     # float96 and float128 may or may not be defined in this particular
     # numpy build (it depends on platform and version).
     # Register them only if they are present
@@ -1013,7 +1017,11 @@ def _finalize_numpy(np, available):
         # registration here (to bypass the deprecation warning) until we
         # finally remove all support for it
         numeric_types._native_boolean_types.add(t)
-    _complex = [np.complex_, np.complex64, np.complex128]
+    _complex = []
+    # numpy 2.0.0 removed np.complex_
+    if np.__version__ < '2.0.0':
+        _complex.append(np.complex_)
+    _complex.extend([np.complex64, np.complex128])
     # complex192 and complex256 may or may not be defined in this
     # particular numpy build (it depends on platform and version).
     # Register them only if they are present


### PR DESCRIPTION
## Fixes #3290 
import pyomo with NumPy 2.0

## Summary/Motivation:

NumPy 2.0 has removed `np.float_` and `np.complex_` 

## Error demonstration (with NumPy 2.0):
```python
import numpy as np
import pyomo
AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.. Did you mean: 'float16'?
```
## Changes proposed in this PR:

Here I set a version check before including them

Per the release notes: https://numpy.org/devdocs/release/2.0.0-notes.html

- Alias np.float_ has been removed. Use np.float64 instead.
- Alias np.complex_ has been removed. Use np.complex128 instead.

Now
```python
import numpy as np
import pyomo
```
Does not raise any errors

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
