### PR TITLE
numpy2.0.0 released: np.float_ deprecated -> changed to np.float64

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -1005,7 +1005,7 @@ def _finalize_numpy(np, available):
     # Register them only if they are present
     if hasattr(np, 'float_'):
         # Prepend to preserve previous functionality
-        _floats.insert(0, np.float_)
+        _floats.insert(0, np.float64)
     if hasattr(np, 'float96'):
         _floats.append(np.float96)
     if hasattr(np, 'float128'):


### PR DESCRIPTION
## Fixes
Makes it numpy 2.0.0 compatible

## Summary/Motivation
```
File "/Applications/QGIS.app/Contents/MacOS/lib/python3.9/site-packages/pyomo/common/dependencies.py", line 803, in _finalize_numpy
    _floats = [np.float_, np.float16, np.float32, np.float64]
File "/Applications/QGIS.app/Contents/MacOS/lib/python3.9/site-packages/numpy/__init__.py", line 397, in __getattr__
    raise AttributeError(
        AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.
```

## Changes proposed in this PR:
```
pyomo$ rg np.float_
    pyomo/common/dependencies.py
    1008:        _floats.insert(0, np.float_)
pyomo$ sed -i -e 's/np.float_/np.float64/' pyomo/common/dependencies.py
pyomo$ rg np.float_

```

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
