### PR TITLE
Jenkins: update logic for recording SHA, repo owner, and branch name

### DIFF
--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -208,7 +208,10 @@ if test -z "$MODE" -o "$MODE" == test; then
         coverage report -i || exit 1
         coverage xml -i || exit 1
         export OS=`uname`
-        if test -n "$CODECOV_TOKEN"; then
+        if test -z "$PYOMO_SOURCE_SHA"; then
+            PYOMO_SOURCE_SHA=$GIT_COMMIT
+        fi
+        if test -n "$CODECOV_TOKEN" -a -n "$PYOMO_SOURCE_SHA"; then
             CODECOV_JOB_NAME=`echo ${JOB_NAME} | sed -r 's/^(.*autotest_)?Pyomo_([^\/]+).*/\2/'`.$BUILD_NUMBER.$python
             if test -z "$CODECOV_REPO_OWNER"; then
                 CODECOV_REPO_OWNER="pyomo"

--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -212,12 +212,24 @@ if test -z "$MODE" -o "$MODE" == test; then
             PYOMO_SOURCE_SHA=$GIT_COMMIT
         fi
         if test -n "$CODECOV_TOKEN" -a -n "$PYOMO_SOURCE_SHA"; then
-            CODECOV_JOB_NAME=`echo ${JOB_NAME} | sed -r 's/^(.*autotest_)?Pyomo_([^\/]+).*/\2/'`.$BUILD_NUMBER.$python
+            CODECOV_JOB_NAME=$(echo ${JOB_NAME} \
+                | sed -r 's/^(.*autotest_)?Pyomo_([^\/]+).*/\2/').$BUILD_NUMBER.$python
             if test -z "$CODECOV_REPO_OWNER"; then
-                CODECOV_REPO_OWNER="pyomo"
+                if test -n "$PYOMO_SOURCE_REPO"
+                    CODECOV_REPO_OWNER=$(echo $PYOMO_SOURCE_REPO | cut -d '/' -f 4)
+                elif test -n "$GIT_URL"; then
+                    CODECOV_REPO_OWNER=$(echo $GIT_URL | cut -d '/' -f 4)
+                else
+                    CODECOV_REPO_OWNER=""
+                fi
             fi
-            if test -z "CODECOV_SOURCE_BRANCH"; then
-                CODECOV_SOURCE_BRANCH="main"
+            if test -z "$CODECOV_SOURCE_BRANCH"; then
+                CODECOV_SOURCE_BRANCH=$(git branch -av --contains "$PYOMO_SOURCE_SHA" \
+                    | grep "${PYOMO_SOURCE_SHA:0:7}" | grep "/origin/" \
+                    | cut -d '/' -f 3 | cut -d' ' -f 1)
+                if test -z "$CODECOV_SOURCE_BRANCH"; then
+                    CODECOV_SOURCE_BRANCH=main
+                fi
             fi
             i=0
             while /bin/true; do


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This resolves a logic error from #3303 where the git SHA was not being set for the codecov upload when building the main branch.  This also updates how we infer the owing repo and branch name in the Jenkins jobs

## Changes proposed in this PR:
- Update build driver to resolve errors estimating SHA, repo owner, and branch name

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
