### PR TITLE
Fix typo in Jenkins driver

### DIFF
--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -215,10 +215,10 @@ if test -z "$MODE" -o "$MODE" == test; then
             CODECOV_JOB_NAME=$(echo ${JOB_NAME} \
                 | sed -r 's/^(.*autotest_)?Pyomo_([^\/]+).*/\2/').$BUILD_NUMBER.$python
             if test -z "$CODECOV_REPO_OWNER"; then
-                if test -n "$PYOMO_SOURCE_REPO"
-                    CODECOV_REPO_OWNER=$(echo $PYOMO_SOURCE_REPO | cut -d '/' -f 4)
+                if test -n "$PYOMO_SOURCE_REPO"; then
+                    CODECOV_REPO_OWNER=$(echo "$PYOMO_SOURCE_REPO" | cut -d '/' -f 4)
                 elif test -n "$GIT_URL"; then
-                    CODECOV_REPO_OWNER=$(echo $GIT_URL | cut -d '/' -f 4)
+                    CODECOV_REPO_OWNER=$(echo "$GIT_URL" | cut -d '/' -f 4)
                 else
                     CODECOV_REPO_OWNER=""
                 fi


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
Fix a typo in the bash driver (missing "`; then`")

## Changes proposed in this PR:
- Fix a typo introduced in #3311

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
