### PR TITLE
GDP: Don't transform known-to-be infeasible Disjuncts in multiple BigM

### DIFF
--- a/pyomo/gdp/plugins/multiple_bigm.py
+++ b/pyomo/gdp/plugins/multiple_bigm.py
@@ -634,7 +634,10 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
                         scratch.obj.expr = constraint.body - constraint.lower
                         scratch.obj.sense = minimize
                         lower_M = self._solve_disjunct_for_M(
-                            other_disjunct, scratch, unsuccessful_solve_msg, active_disjuncts
+                            other_disjunct,
+                            scratch,
+                            unsuccessful_solve_msg,
+                            active_disjuncts,
                         )
                 if constraint.upper is not None and upper_M is None:
                     # last resort: calculate
@@ -642,7 +645,10 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
                         scratch.obj.expr = constraint.body - constraint.upper
                         scratch.obj.sense = maximize
                         upper_M = self._solve_disjunct_for_M(
-                            other_disjunct, scratch, unsuccessful_solve_msg, active_disjuncts
+                            other_disjunct,
+                            scratch,
+                            unsuccessful_solve_msg,
+                            active_disjuncts,
                         )
                 arg_Ms[constraint, other_disjunct] = (lower_M, upper_M)
                 transBlock._mbm_values[constraint, other_disjunct] = (lower_M, upper_M)

--- a/pyomo/gdp/plugins/multiple_bigm.py
+++ b/pyomo/gdp/plugins/multiple_bigm.py
@@ -12,7 +12,7 @@
 import itertools
 import logging
 
-from pyomo.common.collections import ComponentMap
+from pyomo.common.collections import ComponentMap, ComponentSet
 from pyomo.common.config import ConfigDict, ConfigValue
 from pyomo.common.gc_manager import PauseGC
 from pyomo.common.modeling import unique_component_name
@@ -310,9 +310,12 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
 
         arg_Ms = self._config.bigM if self._config.bigM is not None else {}
 
+        # ESJ: I am relying on the fact that the ComponentSet is going to be
+        # ordered here, but using a set because I will remove infeasible
+        # Disjuncts from it if I encounter them calculating M's.
+        active_disjuncts = ComponentSet(disj for disj in obj.disjuncts if disj.active)
         # First handle the bound constraints if we are dealing with them
         # separately
-        active_disjuncts = [disj for disj in obj.disjuncts if disj.active]
         transformed_constraints = set()
         if self._config.reduce_bound_constraints:
             transformed_constraints = self._transform_bound_constraints(
@@ -585,7 +588,7 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
         ):
             if disjunct is other_disjunct:
                 continue
-            if id(other_disjunct) in scratch_blocks:
+            elif id(other_disjunct) in scratch_blocks:
                 scratch = scratch_blocks[id(other_disjunct)]
             else:
                 scratch = scratch_blocks[id(other_disjunct)] = Block()
@@ -631,7 +634,7 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
                         scratch.obj.expr = constraint.body - constraint.lower
                         scratch.obj.sense = minimize
                         lower_M = self._solve_disjunct_for_M(
-                            other_disjunct, scratch, unsuccessful_solve_msg
+                            other_disjunct, scratch, unsuccessful_solve_msg, active_disjuncts
                         )
                 if constraint.upper is not None and upper_M is None:
                     # last resort: calculate
@@ -639,7 +642,7 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
                         scratch.obj.expr = constraint.body - constraint.upper
                         scratch.obj.sense = maximize
                         upper_M = self._solve_disjunct_for_M(
-                            other_disjunct, scratch, unsuccessful_solve_msg
+                            other_disjunct, scratch, unsuccessful_solve_msg, active_disjuncts
                         )
                 arg_Ms[constraint, other_disjunct] = (lower_M, upper_M)
                 transBlock._mbm_values[constraint, other_disjunct] = (lower_M, upper_M)
@@ -651,9 +654,18 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
         return arg_Ms
 
     def _solve_disjunct_for_M(
-        self, other_disjunct, scratch_block, unsuccessful_solve_msg
+        self, other_disjunct, scratch_block, unsuccessful_solve_msg, active_disjuncts
     ):
+        if not other_disjunct.active:
+            # If a Disjunct is infeasible, we will discover that and deactivate
+            # it when we are calculating the M values. We remove that disjunct
+            # from active_disjuncts inside of the loop in
+            # _calculate_missing_M_values. So that means that we might have
+            # deactivated Disjuncts here that we should skip over.
+            return 0
+
         solver = self._config.solver
+
         results = solver.solve(other_disjunct, load_solutions=False)
         if results.solver.termination_condition is TerminationCondition.infeasible:
             # [2/18/24]: TODO: After the solver rewrite is complete, we will not
@@ -669,6 +681,7 @@ class MultipleBigMTransformation(GDP_to_MIP_Transformation, _BigM_MixIn):
                     "Disjunct '%s' is infeasible, deactivating." % other_disjunct.name
                 )
                 other_disjunct.deactivate()
+                active_disjuncts.remove(other_disjunct)
                 M = 0
             else:
                 # This is a solver that might report

--- a/pyomo/gdp/tests/test_mbigm.py
+++ b/pyomo/gdp/tests/test_mbigm.py
@@ -1033,8 +1033,7 @@ class EdgeCases(unittest.TestCase):
         assertExpressionsEqual(
             self,
             cons[0].expr,
-            21 + m.x - m.y
-            <= 12.0 * m.disjunction.disjuncts[2].binary_indicator_var,
+            21 + m.x - m.y <= 12.0 * m.disjunction.disjuncts[2].binary_indicator_var,
         )
 
         cons = mbm.get_transformed_constraints(m.disjunction.disjuncts[2].constraint[1])
@@ -1042,14 +1041,12 @@ class EdgeCases(unittest.TestCase):
         assertExpressionsEqual(
             self,
             cons[0].expr,
-            - 12.0 * m.disjunction_disjuncts[1].binary_indicator_var
-            <= m.x - (m.y - 9),
+            -12.0 * m.disjunction_disjuncts[1].binary_indicator_var <= m.x - (m.y - 9),
         )
         assertExpressionsEqual(
             self,
             cons[1].expr,
-            m.x - (m.y - 9)
-            <= - 12.0 * m.disjunction_disjuncts[1].binary_indicator_var,
+            m.x - (m.y - 9) <= -12.0 * m.disjunction_disjuncts[1].binary_indicator_var,
         )
 
     @unittest.skipUnless(

--- a/pyomo/gdp/tests/test_mbigm.py
+++ b/pyomo/gdp/tests/test_mbigm.py
@@ -1019,10 +1019,13 @@ class EdgeCases(unittest.TestCase):
             out.getvalue().strip(),
         )
 
-        # We just fixed the infeasible by to False
+        # We just fixed the infeasible disjunct to False
         self.assertFalse(m.disjunction.disjuncts[0].active)
         self.assertTrue(m.disjunction.disjuncts[0].indicator_var.fixed)
         self.assertFalse(value(m.disjunction.disjuncts[0].indicator_var))
+
+        # We didn't actually transform the infeasible disjunct
+        self.assertIsNone(m.disjunction.disjuncts[0].transformation_block)
 
         # the remaining constraints are transformed correctly.
         cons = mbm.get_transformed_constraints(m.disjunction.disjuncts[1].constraint[1])
@@ -1031,18 +1034,14 @@ class EdgeCases(unittest.TestCase):
             self,
             cons[0].expr,
             21 + m.x - m.y
-            <= 0 * m.disjunction.disjuncts[0].binary_indicator_var
-            + 12.0 * m.disjunction.disjuncts[2].binary_indicator_var,
+            <= 12.0 * m.disjunction.disjuncts[2].binary_indicator_var,
         )
 
         cons = mbm.get_transformed_constraints(m.disjunction.disjuncts[2].constraint[1])
         self.assertEqual(len(cons), 2)
-        print(cons[0].expr)
-        print(cons[1].expr)
         assertExpressionsEqual(
             self,
             cons[0].expr,
-            0.0 * m.disjunction_disjuncts[0].binary_indicator_var
             - 12.0 * m.disjunction_disjuncts[1].binary_indicator_var
             <= m.x - (m.y - 9),
         )
@@ -1050,8 +1049,7 @@ class EdgeCases(unittest.TestCase):
             self,
             cons[1].expr,
             m.x - (m.y - 9)
-            <= 0.0 * m.disjunction_disjuncts[0].binary_indicator_var
-            - 12.0 * m.disjunction_disjuncts[1].binary_indicator_var,
+            <= - 12.0 * m.disjunction_disjuncts[1].binary_indicator_var,
         )
 
     @unittest.skipUnless(


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

It's possible to discover that a Disjunct is infeasible in `gdp.mbigm` when calculating M values, since we solve each Disjunct for each disjunctive constraint in the same Disjunction. If we discovered that a Disjunct was infeasible during this process, we were deactivating it, but failing to remove it from the list of "active Disjuncts" that we are transforming. So nothing was mathematically wrong, but we were doing extra work transforming Disjuncts that couldn't possibly be selected. And, as a bonus, if you set baron as the solver for calculating M's, you could run into #3313, which is how we figured this out....

## Changes proposed in this PR:
- Converts the `active_disjuncts` list to a `ComponentSet` so that it's easy to remove things from it if they get deactivated.
- Adds a check when solving Disjuncts to calculate M's that we have not encountered a previously-deactivated Disjunct, since we actually deactivate things as we iterate through them.
- Adds a check in the tests that we don't transform Disjuncts we discover as infeasible during M calculations.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
