### PR TITLE
Fix bug in XpressDirect._load_slacks

### DIFF
--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -1036,10 +1036,8 @@ class XpressDirect(DirectSolver):
             if xpress_con in self._range_constraints:
                 ## for xpress, the slack on a range constraint
                 ## is based on the upper bound
-                ## FIXME: This looks like a bug - there is no variable named
-                ## `con` - there is, however, `xpress_con` and `pyomo_con`
-                lb = con.lb
-                ub = con.ub
+                lb = xpress_con.lb
+                ub = xpress_con.ub
                 ub_s = val
                 expr_val = ub - ub_s
                 lb_s = lb - expr_val


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes N/A

## Summary/Motivation:
Fixes a copy-paste bug in XpressDirect when slacks are loaded using `PersistentSolver.load_slacks`.

The bug correction collectly mirrors the behavior in `XpressDirect._postsolve`: https://github.com/Pyomo/pyomo/blob/9fd504a1c93d3e39b22c3b1270887eabc1aef9ae/pyomo/solvers/plugins/solvers/xpress_direct.py#L929-L945

## Changes proposed in this PR:
- Resolve ambiguity on previously identified bug introduced in #1443.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
