### PR TITLE
Disable interface/testing for NEOS/octeract

### DIFF
--- a/pyomo/neos/__init__.py
+++ b/pyomo/neos/__init__.py
@@ -30,7 +30,7 @@ doc = {
     'minos': 'SLC NLP solver',
     'minto': 'MILP solver',
     'mosek': 'Interior point NLP solver',
-    'octeract': 'Deterministic global MINLP solver',
+    #'octeract': 'Deterministic global MINLP solver',
     'ooqp': 'Convex QP solver',
     'path': 'Nonlinear MCP solver',
     'snopt': 'SQP NLP solver',

--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -80,7 +80,7 @@ class TestKestrel(unittest.TestCase):
         dockeys = set(doc.keys())
 
         # Octeract interface is disabled, see #3321
-        amplsolvers.pop('octeract')
+        amplsolvers.remove('octeract')
 
         self.assertEqual(amplsolvers, dockeys)
 

--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -149,8 +149,11 @@ class RunAllNEOSSolvers(object):
     def test_mosek(self):
         self._run('mosek')
 
-    def test_octeract(self):
-        self._run('octeract')
+    # [16 Jul 24] Octeract is erroring.  We will disable the interface
+    # (and testing) until we have time to resolve #3321
+    #
+    # def test_octeract(self):
+    #     self._run('octeract')
 
     def test_ooqp(self):
         if self.sense == pyo.maximize:

--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -79,6 +79,9 @@ class TestKestrel(unittest.TestCase):
         doc = pyomo.neos.doc
         dockeys = set(doc.keys())
 
+        # Octeract interface is disabled, see #3321
+        amplsolvers.pop('octeract')
+
         self.assertEqual(amplsolvers, dockeys)
 
         # gamssolvers = set(v[0].lower() for v in tmp if v[1]=='GAMS')


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
The Pyomo interface tests to NEOS/octeract are failing (with little/no error information).  This will disable the interface until #3321 is resolved.

## Changes proposed in this PR:
- Disable NEOS/octeract interface

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
