### PR TITLE
Allow maingo_solvermodel to be imported without maingopy

### DIFF
--- a/pyomo/contrib/appsi/solvers/maingo_solvermodel.py
+++ b/pyomo/contrib/appsi/solvers/maingo_solvermodel.py
@@ -28,15 +28,7 @@ from pyomo.core.kernel.objective import minimize, maximize
 from pyomo.repn.util import valid_expr_ctypes_minlp
 
 
-def _import_maingopy():
-    try:
-        import maingopy
-    except ImportError:
-        raise
-    return maingopy
-
-
-maingopy, maingopy_available = attempt_import("maingopy", importer=_import_maingopy)
+maingopy, maingopy_available = attempt_import("maingopy")
 
 _plusMinusOne = {1, -1}
 
@@ -219,7 +211,7 @@ class ToMAiNGOVisitor(EXPR.ExpressionValueVisitor):
         return sum(values)
 
 
-class SolverModel(maingopy.MAiNGOmodel):
+class SolverModel(maingopy.MAiNGOmodel if maingopy_available else object):
     def __init__(self, var_list, objective, con_list, idmap, logger):
         maingopy.MAiNGOmodel.__init__(self)
         self._var_list = var_list


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This resolves recent test failures in the GHA singletest job.  MAiNGOpy (@MAiNGO-github) released a new version yesterday (8.1) that only included wheels for Windows.  Unfortunately, the MAiNGOpy `setup.py` has an unconditional required import of `skbuild` (which is not present in the Pyomo GHA environment), so the build of `maingopy` fails on Linux & OSX.  This highlighted that the `pyomo.contrib.appsi.solvers.maingo_solvermodel` module is not importable without `maingopy` (leading to the test failure).

This PR resolves that test failure (but not the availability of `maingopy` on GHA Linux / OSX builds).

## Changes proposed in this PR:
- rework the imports of `maingopy` within the `appsi_maingo` solver so that module imports do not fail if `maingopy` is missing

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
