### PR TITLE
LegacySolverWrapper: restore 'options' attribute

### DIFF
--- a/pyomo/contrib/solver/base.py
+++ b/pyomo/contrib/solver/base.py
@@ -377,6 +377,14 @@ class LegacySolverWrapper:
     def __exit__(self, t, v, traceback):
         """Exit statement - enables `with` statements."""
 
+    def __setattr__(self, attr, value):
+        # 'options' and 'config' are really singleton attributes.  Map
+        # any assignment to set_value()
+        if attr in ('options', 'config') and attr in self.__dict__:
+            getattr(self, attr).set_value(value)
+        else:
+            super().__setattr__(attr, value)
+
     def _map_config(
         self,
         tee=NOTSET,
@@ -395,7 +403,6 @@ class LegacySolverWrapper:
         writer_config=NOTSET,
     ):
         """Map between legacy and new interface configuration options"""
-        self.config = self.config()
         if 'report_timing' not in self.config:
             self.config.declare(
                 'report_timing', ConfigValue(domain=bool, default=False)
@@ -410,8 +417,6 @@ class LegacySolverWrapper:
             self.config.time_limit = timelimit
         if report_timing is not NOTSET:
             self.config.report_timing = report_timing
-        if self.options is not None:
-            self.config.solver_options.set_value(self.options)
         if (options is not NOTSET) and (solver_options is not NOTSET):
             # There is no reason for a user to be trying to mix both old
             # and new options. That is silly. So we will yell at them.

--- a/pyomo/contrib/solver/base.py
+++ b/pyomo/contrib/solver/base.py
@@ -353,15 +353,20 @@ class LegacySolverWrapper:
             raise NotImplementedError('Still working on this')
         # There is no reason for a user to be trying to mix both old
         # and new options. That is silly. So we will yell at them.
-        self.options = kwargs.pop('options', None)
+        _options = kwargs.pop('options', None)
         if 'solver_options' in kwargs:
-            if self.options is not None:
+            if _options is not None:
                 raise ValueError(
                     "Both 'options' and 'solver_options' were requested. "
                     "Please use one or the other, not both."
                 )
-            self.options = kwargs.pop('solver_options')
+            _options = kwargs.pop('solver_options')
+        if _options is not None:
+            kwargs['solver_options'] = _options
         super().__init__(**kwargs)
+        # Make the legacy 'options' attribute an alias of the new
+        # config.solver_options
+        self.options = self.config.solver_options
 
     #
     # Support "with" statements

--- a/pyomo/contrib/solver/tests/unit/test_base.py
+++ b/pyomo/contrib/solver/tests/unit/test_base.py
@@ -285,73 +285,49 @@ class TestLegacySolverWrapper(unittest.TestCase):
         # Test case 1: Set at instantiation
         solver = _LegacyWrappedSolverBase(options={'max_iter': 6})
         self.assertEqual(solver.options, {'max_iter': 6})
+        self.assertEqual(solver.config.solver_options, {'max_iter': 6})
 
         # Test case 2: Set later
         solver = _LegacyWrappedSolverBase()
         solver.options = {'max_iter': 4, 'foo': 'bar'}
         self.assertEqual(solver.options, {'max_iter': 4, 'foo': 'bar'})
+        self.assertEqual(solver.config.solver_options, {'max_iter': 4, 'foo': 'bar'})
 
         # Test case 3: pass some options to the mapping (aka, 'solve' command)
         solver = _LegacyWrappedSolverBase()
-        config = ConfigDict(implicit=True)
-        config.declare(
-            'solver_options',
-            ConfigDict(implicit=True, description="Options to pass to the solver."),
-        )
-        solver.config = config
         solver._map_config(options={'max_iter': 4})
+        self.assertEqual(solver.options, {'max_iter': 4})
         self.assertEqual(solver.config.solver_options, {'max_iter': 4})
 
         # Test case 4: Set at instantiation and override during 'solve' call
         solver = _LegacyWrappedSolverBase(options={'max_iter': 6})
-        config = ConfigDict(implicit=True)
-        config.declare(
-            'solver_options',
-            ConfigDict(implicit=True, description="Options to pass to the solver."),
-        )
-        solver.config = config
         solver._map_config(options={'max_iter': 4})
+        self.assertEqual(solver.options, {'max_iter': 4})
         self.assertEqual(solver.config.solver_options, {'max_iter': 4})
-        self.assertEqual(solver.options, {'max_iter': 6})
 
         # solver_options are also supported
         # Test case 1: set at instantiation
         solver = _LegacyWrappedSolverBase(solver_options={'max_iter': 6})
         self.assertEqual(solver.options, {'max_iter': 6})
+        self.assertEqual(solver.config.solver_options, {'max_iter': 6})
 
         # Test case 2: pass some solver_options to the mapping (aka, 'solve' command)
         solver = _LegacyWrappedSolverBase()
-        config = ConfigDict(implicit=True)
-        config.declare(
-            'solver_options',
-            ConfigDict(implicit=True, description="Options to pass to the solver."),
-        )
-        solver.config = config
         solver._map_config(solver_options={'max_iter': 4})
+        self.assertEqual(solver.options, {'max_iter': 4})
         self.assertEqual(solver.config.solver_options, {'max_iter': 4})
 
         # Test case 3: Set at instantiation and override during 'solve' call
         solver = _LegacyWrappedSolverBase(solver_options={'max_iter': 6})
-        config = ConfigDict(implicit=True)
-        config.declare(
-            'solver_options',
-            ConfigDict(implicit=True, description="Options to pass to the solver."),
-        )
-        solver.config = config
         solver._map_config(solver_options={'max_iter': 4})
+        self.assertEqual(solver.options, {'max_iter': 4})
         self.assertEqual(solver.config.solver_options, {'max_iter': 4})
-        self.assertEqual(solver.options, {'max_iter': 6})
 
         # users can mix... sort of
         # Test case 1: Initialize with options, solve with solver_options
         solver = _LegacyWrappedSolverBase(options={'max_iter': 6})
-        config = ConfigDict(implicit=True)
-        config.declare(
-            'solver_options',
-            ConfigDict(implicit=True, description="Options to pass to the solver."),
-        )
-        solver.config = config
         solver._map_config(solver_options={'max_iter': 4})
+        self.assertEqual(solver.options, {'max_iter': 4})
         self.assertEqual(solver.config.solver_options, {'max_iter': 4})
 
         # users CANNOT initialize both values at the same time, because how
@@ -363,14 +339,20 @@ class TestLegacySolverWrapper(unittest.TestCase):
             )
         # Test case 2: Passing to `solve`
         solver = _LegacyWrappedSolverBase()
+        with self.assertRaises(ValueError):
+            solver._map_config(solver_options={'max_iter': 4}, options={'max_iter': 6})
+
+        # Test that assignment to maps to set_vlaue:
+        solver = _LegacyWrappedSolverBase()
         config = ConfigDict(implicit=True)
         config.declare(
             'solver_options',
             ConfigDict(implicit=True, description="Options to pass to the solver."),
         )
         solver.config = config
-        with self.assertRaises(ValueError):
-            solver._map_config(solver_options={'max_iter': 4}, options={'max_iter': 6})
+        solver.config.solver_options.max_iter = 6
+        self.assertEqual(solver.options, {'max_iter': 6})
+        self.assertEqual(solver.config.solver_options, {'max_iter': 6})
 
     def test_map_results(self):
         # Unclear how to test this

--- a/pyomo/contrib/solver/tests/unit/test_base.py
+++ b/pyomo/contrib/solver/tests/unit/test_base.py
@@ -342,7 +342,7 @@ class TestLegacySolverWrapper(unittest.TestCase):
         with self.assertRaises(ValueError):
             solver._map_config(solver_options={'max_iter': 4}, options={'max_iter': 6})
 
-        # Test that assignment to maps to set_vlaue:
+        # Test that assignment to maps to set_value:
         solver = _LegacyWrappedSolverBase()
         config = ConfigDict(implicit=True)
         config.declare(


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
When attempting to use the LegacySolverWrapper in some old user code, we saw that the LegacySolverWrapper did not expose an `options` attribute for accessing / setting the solver options.  This PR adds that attribute to the interface.

## Changes proposed in this PR:
- Add `options` attribute to the LegacySolverWrapper interface

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
