### PR TITLE
Bug fix: Issue 3336 - Inconsistent use of `result` and `results`

### DIFF
--- a/pyomo/opt/base/solvers.py
+++ b/pyomo/opt/base/solvers.py
@@ -470,8 +470,8 @@ class OptSolver(object):
         Set the current results format (if it's valid for the current
         problem format).
         """
-        if (self._problem_format in self._valid_results_formats) and (
-            format in self._valid_results_formats[self._problem_format]
+        if (self._problem_format in self._valid_result_formats) and (
+            format in self._valid_result_formats[self._problem_format]
         ):
             self._results_format = format
         else:

--- a/pyomo/opt/tests/base/test_solver.py
+++ b/pyomo/opt/tests/base/test_solver.py
@@ -109,7 +109,7 @@ class OptSolverDebug(unittest.TestCase):
     def test_set_results_format(self):
         opt = pyomo.opt.SolverFactory("stest1")
         opt._valid_problem_formats = ['a']
-        opt._valid_results_formats = {'a': 'b'}
+        opt._valid_result_formats = {'a': 'b'}
         self.assertEqual(opt.problem_format(), None)
         try:
             opt.set_results_format('b')


### PR DESCRIPTION

## Fixes #3336 

## Summary/Motivation:
This PR fixes the bug pointed out by @sstroemer (and I am astounded that it was never hit before).

## Changes proposed in this PR:
- Correct the misuse of `_valid_results_formats` to `_valid_result_formats`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
