### PR TITLE
Resolve writer performance degradation 

### DIFF
--- a/pyomo/core/kernel/constraint.py
+++ b/pyomo/core/kernel/constraint.py
@@ -160,6 +160,17 @@ class IConstraint(ICategorizedObject):
         ub = self.ub
         return (ub is not None) and (value(ub) != float('inf'))
 
+    def to_bounded_expression(self, evaluate_bounds=False):
+        if evaluate_bounds:
+            lb = self.lb
+            if lb == -float('inf'):
+                lb = None
+            ub = self.ub
+            if ub == float('inf'):
+                ub = None
+            return lb, self.body, ub
+        return self.lower, self.body, self.upper
+
 
 class _MutableBoundsConstraintMixin(object):
     """
@@ -176,9 +187,6 @@ class _MutableBoundsConstraintMixin(object):
     #
     # Define some of the IConstraint abstract methods
     #
-
-    def to_bounded_expression(self):
-        return self.lower, self.body, self.upper
 
     @property
     def lower(self):

--- a/pyomo/repn/beta/matrix.py
+++ b/pyomo/repn/beta/matrix.py
@@ -587,6 +587,11 @@ class _LinearMatrixConstraintData(_LinearConstraintData):
     # Abstract Interface (ConstraintData)
     #
 
+    def to_bounded_expression(self, evaluate_bounds=False):
+        """Access this constraint as a single expression."""
+        # Note that the bounds are always going to be floats...
+        return self.lower, self.body, self.upper
+
     @property
     def body(self):
         """Access the body of a constraint expression."""

--- a/pyomo/repn/plugins/baron_writer.py
+++ b/pyomo/repn/plugins/baron_writer.py
@@ -256,9 +256,9 @@ class ProblemWriter_bar(AbstractProblemWriter):
             suffix_gen = (
                 lambda b: pyomo.core.base.suffix.active_export_suffix_generator(b)
             )
-        r_o_eqns = []
-        c_eqns = []
-        l_eqns = []
+        r_o_eqns = {}
+        c_eqns = {}
+        l_eqns = {}
         branching_priorities_suffixes = []
         for block in all_blocks_list:
             for name, suffix in suffix_gen(block):
@@ -266,13 +266,14 @@ class ProblemWriter_bar(AbstractProblemWriter):
                     branching_priorities_suffixes.append(suffix)
                 elif name == 'constraint_types':
                     for constraint_data, constraint_type in suffix.items():
+                        info = constraint_data.to_bounded_expression(True)
                         if not _skip_trivial(constraint_data):
                             if constraint_type.lower() == 'relaxationonly':
-                                r_o_eqns.append(constraint_data)
+                                r_o_eqns[constraint_data] = info
                             elif constraint_type.lower() == 'convex':
-                                c_eqns.append(constraint_data)
+                                c_eqns[constraint_data] = info
                             elif constraint_type.lower() == 'local':
-                                l_eqns.append(constraint_data)
+                                l_eqns[constraint_data] = info
                             else:
                                 raise ValueError(
                                     "A suffix '%s' contained an invalid value: %s\n"
@@ -294,7 +295,10 @@ class ProblemWriter_bar(AbstractProblemWriter):
                         % (name, _location)
                     )
 
-        non_standard_eqns = r_o_eqns + c_eqns + l_eqns
+        non_standard_eqns = set()
+        non_standard_eqns.update(r_o_eqns)
+        non_standard_eqns.update(c_eqns)
+        non_standard_eqns.update(l_eqns)
 
         #
         # EQUATIONS
@@ -304,7 +308,7 @@ class ProblemWriter_bar(AbstractProblemWriter):
         n_roeqns = len(r_o_eqns)
         n_ceqns = len(c_eqns)
         n_leqns = len(l_eqns)
-        eqns = []
+        eqns = {}
 
         # Alias the constraints by declaration order since Baron does not
         # include the constraint names in the solution file. It is important
@@ -321,14 +325,15 @@ class ProblemWriter_bar(AbstractProblemWriter):
             for constraint_data in block.component_data_objects(
                 Constraint, active=True, sort=sorter, descend_into=False
             ):
-                if (not constraint_data.has_lb()) and (not constraint_data.has_ub()):
+                lb, body, ub = constraint_data.to_bounded_expression(True)
+                if lb is None and ub is None:
                     assert not constraint_data.equality
                     continue  # non-binding, so skip
 
                 if (not _skip_trivial(constraint_data)) and (
                     constraint_data not in non_standard_eqns
                 ):
-                    eqns.append(constraint_data)
+                    eqns[constraint_data] = lb, body, ub
 
                     con_symbol = symbol_map.createSymbol(constraint_data, c_labeler)
                     assert not con_symbol.startswith('.')
@@ -407,12 +412,12 @@ class ProblemWriter_bar(AbstractProblemWriter):
 
         # Equation Definition
         output_file.write('c_e_FIX_ONE_VAR_CONST__:  ONE_VAR_CONST__  == 1;\n')
-        for constraint_data in itertools.chain(eqns, r_o_eqns, c_eqns, l_eqns):
+        for constraint_data, (lb, body, ub) in itertools.chain(
+            eqns.items(), r_o_eqns.items(), c_eqns.items(), l_eqns.items()
+        ):
             variables = OrderedSet()
             # print(symbol_map.byObject.keys())
-            eqn_body = expression_to_string(
-                constraint_data.body, variables, smap=symbol_map
-            )
+            eqn_body = expression_to_string(body, variables, smap=symbol_map)
             # print(symbol_map.byObject.keys())
             referenced_variable_ids.update(variables)
 
@@ -439,22 +444,22 @@ class ProblemWriter_bar(AbstractProblemWriter):
             # Equality constraint
             if constraint_data.equality:
                 eqn_lhs = ''
-                eqn_rhs = ' == ' + ftoa(constraint_data.upper)
+                eqn_rhs = ' == ' + ftoa(ub)
 
             # Greater than constraint
-            elif not constraint_data.has_ub():
-                eqn_rhs = ' >= ' + ftoa(constraint_data.lower)
+            elif ub is None:
+                eqn_rhs = ' >= ' + ftoa(lb)
                 eqn_lhs = ''
 
             # Less than constraint
-            elif not constraint_data.has_lb():
-                eqn_rhs = ' <= ' + ftoa(constraint_data.upper)
+            elif lb is None:
+                eqn_rhs = ' <= ' + ftoa(ub)
                 eqn_lhs = ''
 
             # Double-sided constraint
-            elif constraint_data.has_lb() and constraint_data.has_ub():
-                eqn_lhs = ftoa(constraint_data.lower) + ' <= '
-                eqn_rhs = ' <= ' + ftoa(constraint_data.upper)
+            elif lb is not None and ub is not None:
+                eqn_lhs = ftoa(lb) + ' <= '
+                eqn_rhs = ' <= ' + ftoa(ub)
 
             eqn_string = eqn_lhs + eqn_body + eqn_rhs + ';\n'
             output_file.write(eqn_string)

--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -619,11 +619,12 @@ class ProblemWriter_gams(AbstractProblemWriter):
         # encountered will be added to the var_list due to the labeler
         # defined above.
         for con in model.component_data_objects(Constraint, active=True, sort=sort):
-            if not con.has_lb() and not con.has_ub():
+            lb, body, ub = con.to_bounded_expression(True)
+            if lb is None and ub is None:
                 assert not con.equality
                 continue  # non-binding, so skip
 
-            con_body = as_numeric(con.body)
+            con_body = as_numeric(body)
             if skip_trivial_constraints and con_body.is_fixed():
                 continue
             if linear:
@@ -642,20 +643,20 @@ class ProblemWriter_gams(AbstractProblemWriter):
                 constraint_names.append('%s' % cName)
                 ConstraintIO.write(
                     '%s.. %s =e= %s ;\n'
-                    % (constraint_names[-1], con_body_str, ftoa(con.upper, False))
+                    % (constraint_names[-1], con_body_str, ftoa(ub, False))
                 )
             else:
-                if con.has_lb():
+                if lb is not None:
                     constraint_names.append('%s_lo' % cName)
                     ConstraintIO.write(
                         '%s.. %s =l= %s ;\n'
-                        % (constraint_names[-1], ftoa(con.lower, False), con_body_str)
+                        % (constraint_names[-1], ftoa(lb, False), con_body_str)
                     )
-                if con.has_ub():
+                if ub is not None:
                     constraint_names.append('%s_hi' % cName)
                     ConstraintIO.write(
                         '%s.. %s =l= %s ;\n'
-                        % (constraint_names[-1], con_body_str, ftoa(con.upper, False))
+                        % (constraint_names[-1], con_body_str, ftoa(ub, False))
                     )
 
         obj = list(model.component_data_objects(Objective, active=True, sort=sort))

--- a/pyomo/repn/plugins/lp_writer.py
+++ b/pyomo/repn/plugins/lp_writer.py
@@ -408,10 +408,10 @@ class _LPWriter_impl(object):
             if with_debug_timing and con.parent_component() is not last_parent:
                 timer.toc('Constraint %s', last_parent, level=logging.DEBUG)
                 last_parent = con.parent_component()
-            # Note: Constraint.lb/ub guarantee a return value that is
-            # either a (finite) native_numeric_type, or None
-            lb = con.lb
-            ub = con.ub
+            # Note: Constraint.to_bounded_expression(evaluate_bounds=True)
+            # guarantee a return value that is either a (finite)
+            # native_numeric_type, or None
+            lb, body, ub = con.to_bounded_expression(True)
 
             if lb is None and ub is None:
                 # Note: you *cannot* output trivial (unbounded)
@@ -419,7 +419,7 @@ class _LPWriter_impl(object):
                 # slack variable if skip_trivial_constraints is False,
                 # but that seems rather silly.
                 continue
-            repn = constraint_visitor.walk_expression(con.body)
+            repn = constraint_visitor.walk_expression(body)
             if repn.nonlinear is not None:
                 raise ValueError(
                     f"Model constraint ({con.name}) contains nonlinear terms that "

--- a/pyomo/repn/plugins/nl_writer.py
+++ b/pyomo/repn/plugins/nl_writer.py
@@ -723,14 +723,14 @@ class _NLWriter_impl(object):
                     timer.toc('Constraint %s', last_parent, level=logging.DEBUG)
                 last_parent = con.parent_component()
             scale = scaling_factor(con)
-            expr_info = visitor.walk_expression((con.body, con, 0, scale))
+            # Note: Constraint.to_bounded_expression(evaluate_bounds=True)
+            # guarantee a return value that is either a (finite)
+            # native_numeric_type, or None
+            lb, body, ub = con.to_bounded_expression(True)
+            expr_info = visitor.walk_expression((body, con, 0, scale))
             if expr_info.named_exprs:
                 self._record_named_expression_usage(expr_info.named_exprs, con, 0)
 
-            # Note: Constraint.lb/ub guarantee a return value that is
-            # either a (finite) native_numeric_type, or None
-            lb = con.lb
-            ub = con.ub
             if lb is None and ub is None:  # and self.config.skip_trivial_constraints:
                 continue
             if scale != 1:


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
#3293 introduced a performance degradation into the main writers: because we no longer store the preprocessed lb / body / ub on constraints, separate calls to `lower`, `body`, and `upper` (and `has_lb` / `has_ub`) performed repeated constraint expression standardization.

This PR recovers most of the degradation by making use of a single call to `ConstraintData.to_bounded_expression()`

![image](https://github.com/user-attachments/assets/2362825d-f9f1-4342-8d59-b318fb969cd2)

## Changes proposed in this PR:
- add an `evaluate_bounds` option to `to_bounded_expression()`
- update writers (LP, NL, BAR, and GMS) to make use of `to_bounded_expression()`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
