### PR TITLE
[WIP] Scale named expressions in scaling transformation

### DIFF
--- a/pyomo/core/tests/transform/test_scaling.py
+++ b/pyomo/core/tests/transform/test_scaling.py
@@ -690,6 +690,21 @@ class TestScaleModelTransformation(unittest.TestCase):
         sf = ScaleModel()._get_float_scaling_factor(m.b1.b2.b3.v3)
         assert sf == float(0.3)
 
+    def test_scaled_named_expressions(self):
+        m = pyo.ConcreteModel()
+        m.x = pyo.Var(initialize=10)
+        m.y = pyo.Var(initialize=0.1)
+        m.inner_expr = pyo.Expression(expr=3 + m.x**2 + m.y)
+        m.sum = pyo.Expression(expr=m.x + m.y + m.inner_expr)
+        m.scaling_factor = pyo.Suffix(direction=pyo.Suffix.EXPORT)
+        m.scaling_factor[m.x] = 0.1
+        m.scaling_factor[m.y] = 10
+        m_scaled = pyo.TransformationFactory('core.scale_model').create_using(
+            m, rename=False
+        )
+        self.assertAlmostEqual(pyo.value(m.sum), 113.2)
+        self.assertAlmostEqual(pyo.value(m_scaled.sum), 113.2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Fixes part of #3344
Corrects scaled variables in named expressions, but does not use scaling factors assigned to named expressions.

## Summary/Motivation:
Expressions in scaled model were incorrect as they would use scaled variables, but wouldn't have the factor necessary to un-apply the scaling in the expression itself. This normally wouldn't lead to incorrect solutions, as constraints removed named expressions when replacing variables with their scaled versions.

## Changes proposed in this PR:
- Don't remove named expressions when scaling
- Don't descend into named expressions when scaling a parent expression
- Scale named expression separately

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
