### PR TITLE
Remove the `_suppress_ctypes` attribute from Block

### DIFF
--- a/pyomo/contrib/cp/interval_var.py
+++ b/pyomo/contrib/cp/interval_var.py
@@ -206,8 +206,6 @@ class IntervalVar(Block):
 
 class ScalarIntervalVar(IntervalVarData, IntervalVar):
     def __init__(self, *args, **kwds):
-        self._suppress_ctypes = set()
-
         IntervalVarData.__init__(self, self)
         IntervalVar.__init__(self, *args, **kwds)
         self._data[None] = self

--- a/pyomo/contrib/piecewise/piecewise_linear_function.py
+++ b/pyomo/contrib/piecewise/piecewise_linear_function.py
@@ -506,8 +506,6 @@ class ScalarPiecewiseLinearFunction(
     PiecewiseLinearFunctionData, PiecewiseLinearFunction
 ):
     def __init__(self, *args, **kwds):
-        self._suppress_ctypes = set()
-
         PiecewiseLinearFunctionData.__init__(self, self)
         PiecewiseLinearFunction.__init__(self, *args, **kwds)
         self._data[None] = self

--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -960,13 +960,8 @@ class BlockData(ActiveComponentData):
                 % (name, type(val), self.name, type(getattr(self, name)))
             )
         #
-        # Skip the add_component() logic if this is a
-        # component type that is suppressed.
-        #
         _component = self.parent_component()
         _type = val.ctype
-        if _type in _component._suppress_ctypes:
-            return
         #
         # Raise an exception if the component already has a parent.
         #
@@ -1047,12 +1042,6 @@ component, use the block del_component() and add_component() methods.
             idx_info[2] += 1
         else:
             self._ctypes[_type] = [_new_idx, _new_idx, 1]
-        #
-        # Propagate properties to sub-blocks:
-        #   suppressed ctypes
-        #
-        if _type is Block:
-            val._suppress_ctypes |= _component._suppress_ctypes
         #
         # Error, for disabled support implicit rule names
         #
@@ -2029,7 +2018,6 @@ class Block(ActiveIndexedComponent):
 
     def __init__(self, *args, **kwargs):
         """Constructor"""
-        self._suppress_ctypes = set()
         _rule = kwargs.pop('rule', None)
         _options = kwargs.pop('options', None)
         # As concrete applies to the Block at declaration time, we will

--- a/pyomo/gdp/disjunct.py
+++ b/pyomo/gdp/disjunct.py
@@ -502,12 +502,6 @@ class Disjunct(Block):
 
 class ScalarDisjunct(DisjunctData, Disjunct):
     def __init__(self, *args, **kwds):
-        ## FIXME: This is a HACK to get around a chicken-and-egg issue
-        ## where BlockData creates the indicator_var *before*
-        ## Block.__init__ declares the _defer_construction flag.
-        self._defer_construction = True
-        self._suppress_ctypes = set()
-
         DisjunctData.__init__(self, self)
         Disjunct.__init__(self, *args, **kwds)
         self._data[None] = self


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This PR removes the `_suppress_ctypes` attribute from Blocks.  This was a hack put in 15 years ago to support PySP optimizations.  It is not used anywhere in the codebase, or (to our knowledge) in any derived packages.  Leaving it in was causing challenges when users were defining custom Block classes

## Changes proposed in this PR:
- Remove the `_suppress_ctypes` attribute from all BlockData instances

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
