### PR TITLE
Add missing main call for example file

### DIFF
--- a/pyomo/contrib/parmest/examples/reactor_design/parameter_estimation_example.py
+++ b/pyomo/contrib/parmest/examples/reactor_design/parameter_estimation_example.py
@@ -39,3 +39,7 @@ def main():
     obj, theta, cov = pest.theta_est(calc_cov=True, cov_n=17)
     print(obj)
     print(theta)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Fixes # .

- Add missing main call for the example file

## Summary/Motivation:
The missing main call in the example file prevents the running of the file properly. In accordance with the other example files the main call is added.

## Changes proposed in this PR:
- Add missing main call for the example file

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
