### PR TITLE
Update Release Process Workflow for changes to `pip`

### DIFF
--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.11', '3.12']
+        python-version: ['3.11']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -68,6 +68,13 @@ jobs:
         - wheel-version: 'cp312*'
           TARGET: 'py312'
           GLOBAL_OPTIONS: "--without-cython --with-distributable-extensions"
+
+        exclude:
+        - wheel-version: 'cp311*'
+          os: windows-latest
+        - wheel-version: 'cp312*'
+          os: windows-latest
+
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -78,8 +85,8 @@ jobs:
             CIBW_ARCHS_LINUX: "native"
             CIBW_ARCHS_MACOS: "native arm64"
             CIBW_ARCHS_WINDOWS: "native ARM64"
-            CIBW_SKIP: "cp{311,312}-win32 cp{311,312}-win_amd64 cp{311,312}-win_arm64 *-musllinux*"
             CIBW_BUILD: ${{ matrix.wheel-version }}
+            CIBW_SKIP: "*-musllinux*"
             CIBW_BUILD_VERBOSITY: 1
             CIBW_BEFORE_BUILD: pip install cython pybind11
             CIBW_ENVIRONMENT: PYOMO_SETUP_ARGS="${{ matrix.GLOBAL_OPTIONS }}"
@@ -127,8 +134,8 @@ jobs:
           output-dir: dist
         env:
             CIBW_ARCHS_LINUX: "aarch64"
-            CIBW_SKIP: "*-musllinux*"
             CIBW_BUILD: ${{ matrix.wheel-version }}
+            CIBW_SKIP: "*-musllinux*"
             CIBW_BUILD_VERBOSITY: 1
             CIBW_BEFORE_BUILD: pip install cython pybind11
             CIBW_ENVIRONMENT: PYOMO_SETUP_ARGS="${{ matrix.GLOBAL_OPTIONS }}"

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -28,19 +28,19 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
-          GLOBAL_OPTIONS: '--global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: '--use-pep517 --global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp39*'
           TARGET: 'py39'
-          GLOBAL_OPTIONS: '--global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: '--use-pep517 --global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp310*'
           TARGET: 'py310'
-          GLOBAL_OPTIONS: '--global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: '--use-pep517 --global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp311*'
           TARGET: 'py311'
-          GLOBAL_OPTIONS: '--global-option="--without-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: '--use-pep517 --global-option="--without-cython --with-distributable-extensions"'
         - wheel-version: 'cp312*'
           TARGET: 'py312'
-          GLOBAL_OPTIONS: '--global-option="--without-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: '--use-pep517 --global-option="--without-cython --with-distributable-extensions"'
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -74,19 +74,19 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
-          GLOBAL_OPTIONS: '--global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: '--use-pep517 --global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp39*'
           TARGET: 'py39'
-          GLOBAL_OPTIONS: '--global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: '--use-pep517 --global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp310*'
           TARGET: 'py310'
-          GLOBAL_OPTIONS: '--global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: '--use-pep517 --global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp311*'
           TARGET: 'py311'
-          GLOBAL_OPTIONS: '--global-option="--without-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: '--use-pep517 --global-option="--without-cython --with-distributable-extensions"'
         - wheel-version: 'cp312*'
           TARGET: 'py312'
-          GLOBAL_OPTIONS: '--global-option="--without-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: '--use-pep517 --global-option="--without-cython --with-distributable-extensions"'
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -54,8 +54,7 @@ jobs:
             CIBW_SKIP: "*-musllinux*"
             CIBW_BUILD: ${{ matrix.wheel-version }}
             CIBW_BUILD_VERBOSITY: 1
-            CIBW_BUILD_FRONTEND: "pip; args: --use-pep517"
-            CIBW_BEFORE_BUILD: pip install cython pybind11
+            CIBW_BEFORE_BUILD: pip install pip==23.0.1 cython pybind11
             CIBW_CONFIG_SETTINGS: ${{ matrix.GLOBAL_OPTIONS }}
       - uses: actions/upload-artifact@v4
         with:
@@ -104,8 +103,7 @@ jobs:
             CIBW_SKIP: "*-musllinux*"
             CIBW_BUILD: ${{ matrix.wheel-version }}
             CIBW_BUILD_VERBOSITY: 1
-            CIBW_BUILD_FRONTEND: "pip; args: --use-pep517"
-            CIBW_BEFORE_BUILD: pip install cython pybind11
+            CIBW_BEFORE_BUILD: pip install pip==23.0.1 cython pybind11
             CIBW_CONFIG_SETTINGS: ${{ matrix.GLOBAL_OPTIONS }}
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -14,10 +14,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  WITH_CYTHON: "--with-cython --with-distributable-extensions"
-  WITHOUT_CYTHON: "--without-cython --with-distributable-extensions"
-
 jobs:
 
   native_wheels:
@@ -33,19 +29,19 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
-          GLOBAL_OPTIONS: "$WITH_CYTHON"
+          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
         - wheel-version: 'cp39*'
           TARGET: 'py39'
-          GLOBAL_OPTIONS: "$WITH_CYTHON"
+          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
         - wheel-version: 'cp310*'
           TARGET: 'py310'
-          GLOBAL_OPTIONS: "$WITH_CYTHON"
+          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
         - wheel-version: 'cp311*'
           TARGET: 'py311'
-          GLOBAL_OPTIONS: "$WITHOUT_CYTHON"
+          GLOBAL_OPTIONS: "--without-cython --with-distributable-extensions"
         - wheel-version: 'cp312*'
           TARGET: 'py312'
-          GLOBAL_OPTIONS: "$WITHOUT_CYTHON"
+          GLOBAL_OPTIONS: "--without-cython --with-distributable-extensions"
 
         exclude:
         - wheel-version: 'cp311*'
@@ -86,19 +82,19 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
-          GLOBAL_OPTIONS: "$WITH_CYTHON"
+          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
         - wheel-version: 'cp39*'
           TARGET: 'py39'
-          GLOBAL_OPTIONS: "$WITH_CYTHON"
+          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
         - wheel-version: 'cp310*'
           TARGET: 'py310'
-          GLOBAL_OPTIONS: "$WITH_CYTHON"
+          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
         - wheel-version: 'cp311*'
           TARGET: 'py311'
-          GLOBAL_OPTIONS: "$WITHOUT_CYTHON"
+          GLOBAL_OPTIONS: "--without-cython --with-distributable-extensions"
         - wheel-version: 'cp312*'
           TARGET: 'py312'
-          GLOBAL_OPTIONS: "$WITHOUT_CYTHON"
+          GLOBAL_OPTIONS: "--without-cython --with-distributable-extensions"
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -124,7 +120,7 @@ jobs:
           overwrite: true
 
   pure_python:
-    name: Build pure wheels (${{ matrix.python-version }})
+    name: pure_python_wheel
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -145,7 +141,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: purepython_wheel-${{ matrix.python-version }}
+          name: purepythonwheel
           path: dist/*.whl
           overwrite: true
 

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -28,19 +28,19 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
-          GLOBAL_OPTIONS: '--use-pep517 --global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: ' --global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp39*'
           TARGET: 'py39'
-          GLOBAL_OPTIONS: '--use-pep517 --global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: ' --global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp310*'
           TARGET: 'py310'
-          GLOBAL_OPTIONS: '--use-pep517 --global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: ' --global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp311*'
           TARGET: 'py311'
-          GLOBAL_OPTIONS: '--use-pep517 --global-option="--without-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: ' --global-option="--without-cython --with-distributable-extensions"'
         - wheel-version: 'cp312*'
           TARGET: 'py312'
-          GLOBAL_OPTIONS: '--use-pep517 --global-option="--without-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: ' --global-option="--without-cython --with-distributable-extensions"'
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -54,6 +54,7 @@ jobs:
             CIBW_SKIP: "*-musllinux*"
             CIBW_BUILD: ${{ matrix.wheel-version }}
             CIBW_BUILD_VERBOSITY: 1
+            CIBW_BUILD_FRONTEND: "pip; args: --use-pep517"
             CIBW_BEFORE_BUILD: pip install cython pybind11
             CIBW_CONFIG_SETTINGS: ${{ matrix.GLOBAL_OPTIONS }}
       - uses: actions/upload-artifact@v4
@@ -74,19 +75,19 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
-          GLOBAL_OPTIONS: '--use-pep517 --global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: ' --global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp39*'
           TARGET: 'py39'
-          GLOBAL_OPTIONS: '--use-pep517 --global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: ' --global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp310*'
           TARGET: 'py310'
-          GLOBAL_OPTIONS: '--use-pep517 --global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: ' --global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp311*'
           TARGET: 'py311'
-          GLOBAL_OPTIONS: '--use-pep517 --global-option="--without-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: ' --global-option="--without-cython --with-distributable-extensions"'
         - wheel-version: 'cp312*'
           TARGET: 'py312'
-          GLOBAL_OPTIONS: '--use-pep517 --global-option="--without-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: ' --global-option="--without-cython --with-distributable-extensions"'
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -103,6 +104,7 @@ jobs:
             CIBW_SKIP: "*-musllinux*"
             CIBW_BUILD: ${{ matrix.wheel-version }}
             CIBW_BUILD_VERBOSITY: 1
+            CIBW_BUILD_FRONTEND: "pip; args: --use-pep517"
             CIBW_BEFORE_BUILD: pip install cython pybind11
             CIBW_CONFIG_SETTINGS: ${{ matrix.GLOBAL_OPTIONS }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -58,6 +58,7 @@ jobs:
             CIBW_BUILD: ${{ matrix.wheel-version }}
             CIBW_BUILD_VERBOSITY: 1
             CIBW_BEFORE_BUILD: pip install cython pybind11
+            CIBW_TEST_SKIP: "*{311,312}-win*"
       - uses: actions/upload-artifact@v4
         with:
           name: native_wheels-${{ matrix.os }}-${{ matrix.TARGET }}

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -43,9 +43,6 @@ jobs:
           GLOBAL_OPTIONS: "--without-cython --with-distributable-extensions"
     steps:
       - uses: actions/checkout@v4
-      - name: Set up global variable
-        run: |
-          echo "PIP_GLOBAL_OPTION=${{ matrix.GLOBAL_OPTIONS }}" >> $GITHUB_ENV
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
         with:
@@ -57,6 +54,7 @@ jobs:
             CIBW_SKIP: "*-musllinux*"
             CIBW_BUILD: ${{ matrix.wheel-version }}
             CIBW_BUILD_VERBOSITY: 1
+            CIBW_ENVIRONMENT: PIP_GLOBAL_OPTION="${{ matrix.GLOBAL_OPTIONS }}"
             CIBW_BEFORE_BUILD: pip install cython pybind11
       - uses: actions/upload-artifact@v4
         with:
@@ -91,9 +89,6 @@ jobs:
           PIP_GLOBAL_OPTION: "--without-cython --with-distributable-extensions"
     steps:
       - uses: actions/checkout@v4
-      - name: Set up global variable
-        run: |
-          echo "PIP_GLOBAL_OPTION=${{ matrix.GLOBAL_OPTIONS }}" >> $GITHUB_ENV
       - name: Set up QEMU
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v3
@@ -108,6 +103,7 @@ jobs:
             CIBW_SKIP: "*-musllinux*"
             CIBW_BUILD: ${{ matrix.wheel-version }}
             CIBW_BUILD_VERBOSITY: 1
+            CIBW_ENVIRONMENT: PIP_GLOBAL_OPTION="${{ matrix.GLOBAL_OPTIONS }}"
             CIBW_BEFORE_BUILD: pip install cython pybind11
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -78,7 +78,7 @@ jobs:
             CIBW_ARCHS_LINUX: "native"
             CIBW_ARCHS_MACOS: "native arm64"
             CIBW_ARCHS_WINDOWS: "native ARM64"
-            CIBW_SKIP: "*-musllinux* *{311,312}-win*"
+            CIBW_SKIP: "cp{311,312}-win32 cp{311,312}-win_amd64 cp{311,312}-win_arm64 *-musllinux*"
             CIBW_BUILD: ${{ matrix.wheel-version }}
             CIBW_BUILD_VERBOSITY: 1
             CIBW_BEFORE_BUILD: pip install cython pybind11

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -28,21 +28,24 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
-          GLOBAL_OPTIONS: ' --global-option=--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
         - wheel-version: 'cp39*'
           TARGET: 'py39'
-          GLOBAL_OPTIONS: ' --global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
         - wheel-version: 'cp310*'
           TARGET: 'py310'
-          GLOBAL_OPTIONS: ' --global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
         - wheel-version: 'cp311*'
           TARGET: 'py311'
-          GLOBAL_OPTIONS: ' --global-option="--without-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: "--without-cython --with-distributable-extensions"
         - wheel-version: 'cp312*'
           TARGET: 'py312'
-          GLOBAL_OPTIONS: ' --global-option="--without-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: "--without-cython --with-distributable-extensions"
     steps:
       - uses: actions/checkout@v4
+      - name: Set up global variable
+        run: |
+          echo "PIP_GLOBAL_OPTION=${{ matrix.GLOBAL_OPTIONS }}" >> $GITHUB_ENV
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
         with:
@@ -73,21 +76,24 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
-          GLOBAL_OPTIONS: ' --global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
         - wheel-version: 'cp39*'
           TARGET: 'py39'
-          GLOBAL_OPTIONS: ' --global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
         - wheel-version: 'cp310*'
           TARGET: 'py310'
-          GLOBAL_OPTIONS: ' --global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
         - wheel-version: 'cp311*'
           TARGET: 'py311'
-          GLOBAL_OPTIONS: ' --global-option="--without-cython --with-distributable-extensions"'
+          PIP_GLOBAL_OPTION: "--without-cython --with-distributable-extensions"
         - wheel-version: 'cp312*'
           TARGET: 'py312'
-          GLOBAL_OPTIONS: ' --global-option="--without-cython --with-distributable-extensions"'
+          PIP_GLOBAL_OPTION: "--without-cython --with-distributable-extensions"
     steps:
       - uses: actions/checkout@v4
+      - name: Set up global variable
+        run: |
+          echo "PIP_GLOBAL_OPTION=${{ matrix.GLOBAL_OPTIONS }}" >> $GITHUB_ENV
       - name: Set up QEMU
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -14,9 +14,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  PYOMO_SETUP_ARGS: "--with-cython --with-distributable-extensions"
-
 jobs:
   native_wheels:
     name: Build wheels (${{ matrix.wheel-version }}) on ${{ matrix.os }} for native and cross-compiled architecture
@@ -31,14 +28,19 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
+          GLOBAL_OPTIONS: '--global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp39*'
           TARGET: 'py39'
+          GLOBAL_OPTIONS: '--global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp310*'
           TARGET: 'py310'
+          GLOBAL_OPTIONS: '--global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp311*'
           TARGET: 'py311'
+          GLOBAL_OPTIONS: ''
         - wheel-version: 'cp312*'
           TARGET: 'py312'
+          GLOBAL_OPTIONS: ''
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -53,7 +55,7 @@ jobs:
             CIBW_BUILD: ${{ matrix.wheel-version }}
             CIBW_BUILD_VERBOSITY: 1
             CIBW_BEFORE_BUILD: pip install cython pybind11
-            CIBW_CONFIG_SETTINGS: '--global-option="--with-cython --with-distributable-extensions"'
+            CIBW_CONFIG_SETTINGS: ${{ matrix.GLOBAL_OPTIONS }}
       - uses: actions/upload-artifact@v4
         with:
           name: native_wheels-${{ matrix.os }}-${{ matrix.TARGET }}
@@ -72,14 +74,19 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
+          GLOBAL_OPTIONS: '--global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp39*'
           TARGET: 'py39'
+          GLOBAL_OPTIONS: '--global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp310*'
           TARGET: 'py310'
+          GLOBAL_OPTIONS: '--global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp311*'
           TARGET: 'py311'
+          GLOBAL_OPTIONS: ''
         - wheel-version: 'cp312*'
           TARGET: 'py312'
+          GLOBAL_OPTIONS: ''
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -97,7 +104,7 @@ jobs:
             CIBW_BUILD: ${{ matrix.wheel-version }}
             CIBW_BUILD_VERBOSITY: 1
             CIBW_BEFORE_BUILD: pip install cython pybind11
-            CIBW_CONFIG_SETTINGS: '--global-option="--with-cython --with-distributable-extensions"'
+            CIBW_CONFIG_SETTINGS: ${{ matrix.GLOBAL_OPTIONS }}
       - uses: actions/upload-artifact@v4
         with:
           name: alt_wheels-${{ matrix.os }}-${{ matrix.TARGET }}

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -28,7 +28,7 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
-          GLOBAL_OPTIONS: ' --global-option="--with-cython --with-distributable-extensions"'
+          GLOBAL_OPTIONS: ' --global-option=--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp39*'
           TARGET: 'py39'
           GLOBAL_OPTIONS: ' --global-option="--with-cython --with-distributable-extensions"'
@@ -54,8 +54,7 @@ jobs:
             CIBW_SKIP: "*-musllinux*"
             CIBW_BUILD: ${{ matrix.wheel-version }}
             CIBW_BUILD_VERBOSITY: 1
-            CIBW_BEFORE_BUILD: pip install pip==23.0.1 cython pybind11
-            CIBW_CONFIG_SETTINGS: ${{ matrix.GLOBAL_OPTIONS }}
+            CIBW_BEFORE_BUILD: pip install cython pybind11
       - uses: actions/upload-artifact@v4
         with:
           name: native_wheels-${{ matrix.os }}-${{ matrix.TARGET }}
@@ -103,8 +102,7 @@ jobs:
             CIBW_SKIP: "*-musllinux*"
             CIBW_BUILD: ${{ matrix.wheel-version }}
             CIBW_BUILD_VERBOSITY: 1
-            CIBW_BEFORE_BUILD: pip install pip==23.0.1 cython pybind11
-            CIBW_CONFIG_SETTINGS: ${{ matrix.GLOBAL_OPTIONS }}
+            CIBW_BEFORE_BUILD: pip install cython pybind11
       - uses: actions/upload-artifact@v4
         with:
           name: alt_wheels-${{ matrix.os }}-${{ matrix.TARGET }}

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -54,8 +54,8 @@ jobs:
             CIBW_SKIP: "*-musllinux*"
             CIBW_BUILD: ${{ matrix.wheel-version }}
             CIBW_BUILD_VERBOSITY: 1
-            CIBW_ENVIRONMENT: PIP_GLOBAL_OPTION="${{ matrix.GLOBAL_OPTIONS }}"
             CIBW_BEFORE_BUILD: pip install cython pybind11
+            CIBW_ENVIRONMENT: PIP_GLOBAL_OPTION="${{ matrix.GLOBAL_OPTIONS }}"
       - uses: actions/upload-artifact@v4
         with:
           name: native_wheels-${{ matrix.os }}-${{ matrix.TARGET }}
@@ -103,8 +103,8 @@ jobs:
             CIBW_SKIP: "*-musllinux*"
             CIBW_BUILD: ${{ matrix.wheel-version }}
             CIBW_BUILD_VERBOSITY: 1
-            CIBW_ENVIRONMENT: PIP_GLOBAL_OPTION="${{ matrix.GLOBAL_OPTIONS }}"
             CIBW_BEFORE_BUILD: pip install cython pybind11
+            CIBW_ENVIRONMENT: PIP_GLOBAL_OPTION="${{ matrix.GLOBAL_OPTIONS }}"
       - uses: actions/upload-artifact@v4
         with:
           name: alt_wheels-${{ matrix.os }}-${{ matrix.TARGET }}

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -33,19 +33,19 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
-          GLOBAL_OPTIONS: $WITH_CYTHON
+          GLOBAL_OPTIONS: "$WITH_CYTHON"
         - wheel-version: 'cp39*'
           TARGET: 'py39'
-          GLOBAL_OPTIONS: $WITH_CYTHON
+          GLOBAL_OPTIONS: "$WITH_CYTHON"
         - wheel-version: 'cp310*'
           TARGET: 'py310'
-          GLOBAL_OPTIONS: $WITH_CYTHON
+          GLOBAL_OPTIONS: "$WITH_CYTHON"
         - wheel-version: 'cp311*'
           TARGET: 'py311'
-          GLOBAL_OPTIONS: $WITHOUT_CYTHON
+          GLOBAL_OPTIONS: "$WITHOUT_CYTHON"
         - wheel-version: 'cp312*'
           TARGET: 'py312'
-          GLOBAL_OPTIONS: $WITHOUT_CYTHON
+          GLOBAL_OPTIONS: "$WITHOUT_CYTHON"
 
         exclude:
         - wheel-version: 'cp311*'
@@ -86,19 +86,19 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
-          GLOBAL_OPTIONS: $WITH_CYTHON
+          GLOBAL_OPTIONS: "$WITH_CYTHON"
         - wheel-version: 'cp39*'
           TARGET: 'py39'
-          GLOBAL_OPTIONS: $WITH_CYTHON
+          GLOBAL_OPTIONS: "$WITH_CYTHON"
         - wheel-version: 'cp310*'
           TARGET: 'py310'
-          GLOBAL_OPTIONS: $WITH_CYTHON
+          GLOBAL_OPTIONS: "$WITH_CYTHON"
         - wheel-version: 'cp311*'
           TARGET: 'py311'
-          GLOBAL_OPTIONS: $WITHOUT_CYTHON
+          GLOBAL_OPTIONS: "$WITHOUT_CYTHON"
         - wheel-version: 'cp312*'
           TARGET: 'py312'
-          GLOBAL_OPTIONS: $WITHOUT_CYTHON
+          GLOBAL_OPTIONS: "$WITHOUT_CYTHON"
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pure-python:
+  pure_python:
     name: Build pure wheels (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -22,25 +22,25 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ['3.11', '3.12']
-     steps:
-     - uses: actions/checkout@v4
-     - name: Set up Python ${{ matrix.python-version }}
-       uses: actions/setup-python@v5
-       with:
-         python-version: ${{ matrix.python-version }}
-     - name: Install dependencies
-       run: |
-         python -m pip install --upgrade pip
-         pip install twine wheel setuptools pybind11
-     - name: Build generic tarball
-       run: |
-         python setup.py --without-cython sdist --format=gztar bdist_wheel
-     - name: Upload artifact
-       uses: actions/upload-artifact@v4
-       with:
-         name: purepython_wheel-${{ matrix.python-version }}
-         path: dist/*.whl
-         overwrite: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install twine wheel setuptools pybind11
+      - name: Build generic tarball
+        run: |
+          python setup.py --without-cython sdist --format=gztar bdist_wheel
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: purepython_wheel-${{ matrix.python-version }}
+          path: dist/*.whl
+          overwrite: true
 
   native_wheels:
     name: Build wheels (${{ matrix.wheel-version }}) on ${{ matrix.os }} for native and cross-compiled architecture

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -33,19 +33,19 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
-          GLOBAL_OPTIONS: ${{ env.WITH_CYTHON }}
+          GLOBAL_OPTIONS: $WITH_CYTHON
         - wheel-version: 'cp39*'
           TARGET: 'py39'
-          GLOBAL_OPTIONS: ${{ env.WITH_CYTHON }}
+          GLOBAL_OPTIONS: $WITH_CYTHON
         - wheel-version: 'cp310*'
           TARGET: 'py310'
-          GLOBAL_OPTIONS: ${{ env.WITH_CYTHON }}
+          GLOBAL_OPTIONS: $WITH_CYTHON
         - wheel-version: 'cp311*'
           TARGET: 'py311'
-          GLOBAL_OPTIONS: ${{ env.WITHOUT_CYTHON }}
+          GLOBAL_OPTIONS: $WITHOUT_CYTHON
         - wheel-version: 'cp312*'
           TARGET: 'py312'
-          GLOBAL_OPTIONS: ${{ env.WITHOUT_CYTHON }}
+          GLOBAL_OPTIONS: $WITHOUT_CYTHON
 
         exclude:
         - wheel-version: 'cp311*'
@@ -86,19 +86,19 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
-          GLOBAL_OPTIONS: ${{ env.WITH_CYTHON }}
+          GLOBAL_OPTIONS: $WITH_CYTHON
         - wheel-version: 'cp39*'
           TARGET: 'py39'
-          GLOBAL_OPTIONS: ${{ env.WITH_CYTHON }}
+          GLOBAL_OPTIONS: $WITH_CYTHON
         - wheel-version: 'cp310*'
           TARGET: 'py310'
-          GLOBAL_OPTIONS: ${{ env.WITH_CYTHON }}
+          GLOBAL_OPTIONS: $WITH_CYTHON
         - wheel-version: 'cp311*'
           TARGET: 'py311'
-          GLOBAL_OPTIONS: ${{ env.WITHOUT_CYTHON }}
+          GLOBAL_OPTIONS: $WITHOUT_CYTHON
         - wheel-version: 'cp312*'
           TARGET: 'py312'
-          GLOBAL_OPTIONS: ${{ env.WITHOUT_CYTHON }}
+          GLOBAL_OPTIONS: $WITHOUT_CYTHON
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -37,10 +37,10 @@ jobs:
           GLOBAL_OPTIONS: '--global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp311*'
           TARGET: 'py311'
-          GLOBAL_OPTIONS: ''
+          GLOBAL_OPTIONS: '--global-option="--without-cython --with-distributable-extensions"'
         - wheel-version: 'cp312*'
           TARGET: 'py312'
-          GLOBAL_OPTIONS: ''
+          GLOBAL_OPTIONS: '--global-option="--without-cython --with-distributable-extensions"'
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -83,10 +83,10 @@ jobs:
           GLOBAL_OPTIONS: '--global-option="--with-cython --with-distributable-extensions"'
         - wheel-version: 'cp311*'
           TARGET: 'py311'
-          GLOBAL_OPTIONS: ''
+          GLOBAL_OPTIONS: '--global-option="--without-cython --with-distributable-extensions"'
         - wheel-version: 'cp312*'
           TARGET: 'py312'
-          GLOBAL_OPTIONS: ''
+          GLOBAL_OPTIONS: '--global-option="--without-cython --with-distributable-extensions"'
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -78,11 +78,10 @@ jobs:
             CIBW_ARCHS_LINUX: "native"
             CIBW_ARCHS_MACOS: "native arm64"
             CIBW_ARCHS_WINDOWS: "native ARM64"
-            CIBW_SKIP: "*-musllinux*"
+            CIBW_SKIP: "*-musllinux* *{311,312}-win*"
             CIBW_BUILD: ${{ matrix.wheel-version }}
             CIBW_BUILD_VERBOSITY: 1
             CIBW_BEFORE_BUILD: pip install cython pybind11
-            CIBW_TEST_SKIP: "*{311,312}-win*"
             CIBW_ENVIRONMENT: PYOMO_SETUP_ARGS="${{ matrix.GLOBAL_OPTIONS }}"
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-13]
+        os: [ubuntu-22.04, windows-latest, macos-latest]
         arch: [all]
         wheel-version: ['cp38*', 'cp39*', 'cp310*', 'cp311*', 'cp312*']
 
@@ -57,8 +57,8 @@ jobs:
           output-dir: dist
         env:
             CIBW_ARCHS_LINUX: "native"
-            CIBW_ARCHS_MACOS: "native arm64"
-            CIBW_ARCHS_WINDOWS: "native ARM64"
+            CIBW_ARCHS_MACOS: "x86_64 arm64"
+            CIBW_ARCHS_WINDOWS: "AMD64 ARM64"
             CIBW_BUILD: ${{ matrix.wheel-version }}
             CIBW_SKIP: "*-musllinux*"
             CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -15,13 +15,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pure-python:
+    name: Build pure wheels (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ['3.11', '3.12']
+     steps:
+     - uses: actions/checkout@v4
+     - name: Set up Python ${{ matrix.python-version }}
+       uses: actions/setup-python@v5
+       with:
+         python-version: ${{ matrix.python-version }}
+     - name: Install dependencies
+       run: |
+         python -m pip install --upgrade pip
+         pip install twine wheel setuptools pybind11
+     - name: Build generic tarball
+       run: |
+         python setup.py --without-cython sdist --format=gztar bdist_wheel
+     - name: Upload artifact
+       uses: actions/upload-artifact@v4
+       with:
+         name: purepython_wheel-${{ matrix.python-version }}
+         path: dist/*.whl
+         overwrite: true
+
   native_wheels:
     name: Build wheels (${{ matrix.wheel-version }}) on ${{ matrix.os }} for native and cross-compiled architecture
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-13]
         arch: [all]
         wheel-version: ['cp38*', 'cp39*', 'cp310*', 'cp311*', 'cp312*']
 

--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -14,33 +14,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  WITH_CYTHON: "--with-cython --with-distributable-extensions"
+  WITHOUT_CYTHON: "--without-cython --with-distributable-extensions"
+
 jobs:
-  pure_python:
-    name: Build pure wheels (${{ matrix.python-version }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: ['3.11']
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install twine wheel setuptools pybind11
-      - name: Build generic tarball
-        run: |
-          python setup.py --without-cython sdist --format=gztar bdist_wheel
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: purepython_wheel-${{ matrix.python-version }}
-          path: dist/*.whl
-          overwrite: true
 
   native_wheels:
     name: Build wheels (${{ matrix.wheel-version }}) on ${{ matrix.os }} for native and cross-compiled architecture
@@ -55,19 +33,19 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
-          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
+          GLOBAL_OPTIONS: ${{ env.WITH_CYTHON }}
         - wheel-version: 'cp39*'
           TARGET: 'py39'
-          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
+          GLOBAL_OPTIONS: ${{ env.WITH_CYTHON }}
         - wheel-version: 'cp310*'
           TARGET: 'py310'
-          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
+          GLOBAL_OPTIONS: ${{ env.WITH_CYTHON }}
         - wheel-version: 'cp311*'
           TARGET: 'py311'
-          GLOBAL_OPTIONS: "--without-cython --with-distributable-extensions"
+          GLOBAL_OPTIONS: ${{ env.WITHOUT_CYTHON }}
         - wheel-version: 'cp312*'
           TARGET: 'py312'
-          GLOBAL_OPTIONS: "--without-cython --with-distributable-extensions"
+          GLOBAL_OPTIONS: ${{ env.WITHOUT_CYTHON }}
 
         exclude:
         - wheel-version: 'cp311*'
@@ -108,19 +86,19 @@ jobs:
         include:
         - wheel-version: 'cp38*'
           TARGET: 'py38'
-          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
+          GLOBAL_OPTIONS: ${{ env.WITH_CYTHON }}
         - wheel-version: 'cp39*'
           TARGET: 'py39'
-          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
+          GLOBAL_OPTIONS: ${{ env.WITH_CYTHON }}
         - wheel-version: 'cp310*'
           TARGET: 'py310'
-          GLOBAL_OPTIONS: "--with-cython --with-distributable-extensions"
+          GLOBAL_OPTIONS: ${{ env.WITH_CYTHON }}
         - wheel-version: 'cp311*'
           TARGET: 'py311'
-          GLOBAL_OPTIONS: "--without-cython --with-distributable-extensions"
+          GLOBAL_OPTIONS: ${{ env.WITHOUT_CYTHON }}
         - wheel-version: 'cp312*'
           TARGET: 'py312'
-          GLOBAL_OPTIONS: "--without-cython --with-distributable-extensions"
+          GLOBAL_OPTIONS: ${{ env.WITHOUT_CYTHON }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -142,6 +120,32 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: alt_wheels-${{ matrix.os }}-${{ matrix.TARGET }}
+          path: dist/*.whl
+          overwrite: true
+
+  pure_python:
+    name: Build pure wheels (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install twine wheel setuptools pybind11
+      - name: Build pure python wheel
+        run: |
+          python setup.py --without-cython sdist --format=gztar bdist_wheel
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: purepython_wheel-${{ matrix.python-version }}
           path: dist/*.whl
           overwrite: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.cibuildwheel.config-settings]
+--build-option = "--with-distributable-extensions"
+--build-option = "--with-cython"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,0 @@
-[tool.cibuildwheel.config-settings]
---build-option = "--with-distributable-extensions"
---build-option = "--with-cython"
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [metadata]
 license_files = LICENSE.md
 
-[bdist_wheel]
-universal=1
-
 [tool:pytest]
 filterwarnings = ignore::RuntimeWarning
 junit_family = xunit2

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,9 @@ def check_config_arg(name):
         sys.argv.remove(name)
         return True
     if name in os.getenv('PYOMO_SETUP_ARGS', "").split():
+        print(f"FOUND {name}")
         return True
+    print(f"NOT FOUND {name}")
     return False
 
 
@@ -134,6 +136,7 @@ if check_config_arg('--with-distributable-extensions'):
         )
         ext_modules.append(appsi_extension)
 
+print(f"\nEXTENSIONS: {ext_modules}\n")
 
 class DependenciesCommand(Command):
     """Custom setuptools command

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,12 @@ def get_version():
 
 
 def check_config_arg(name):
+    print(f"SEARCHING FOR '{name}' in '{sys.argv}'")
     if name in sys.argv:
         sys.argv.remove(name)
         return True
+    print(f"SEARCHING FOR '{name}' in '{os.getenv('PYOMO_SETUP_ARGS', "").split()}'")
+    print("    ", os.getenv('PYOMO_SETUP_ARGS', ""))
     if name in os.getenv('PYOMO_SETUP_ARGS', "").split():
         print(f"FOUND {name}")
         return True


### PR DESCRIPTION
## Fixes #3255 

## Summary/Motivation:
There are changes to pip's behavior that make `--with-cython` and `--with-distributable-extensions` ignored in our wheel builder. This introduces changes to fix that behavior and, as a byproduct, introduces the creation of pure Python wheels so windows/3.11+3.12 have a default wheel.

## Changes proposed in this PR:
- Create pure python wheel
- Remove `universal` flag from `setup.cfg`
- Correct behavior in `setup.py` for `PYOMO_SETUP_ARGS` env var
- Generally update release workflow file

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
