### PR TITLE
Add a 'Do not delete' Disclaimer to Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Report a bug in Pyomo (command not working as expected, etc.)
 labels: "bug"
 ---
 
-<!-- DO NOT DELETE THIS TEMPLATE.  Failing to adhere to this template and provide the necessary information may lead to your Issue being closed without consideration. -->
+<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE.  Failing to adhere to this template and provide the necessary information may lead to your Issue being closed without consideration. -->
 
 ## Summary
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,6 +4,8 @@ about: Report a bug in Pyomo (command not working as expected, etc.)
 labels: "bug"
 ---
 
+<!-- DO NOT DELETE THIS TEMPLATE.  Failing to adhere to this template and provide the necessary information may lead to your Issue being closed without consideration. -->
+
 ## Summary
 
 <!-- Explain, in a clear and concise way, the command you ran and the result you were trying to achieve.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,6 +5,8 @@ labels: enhancement
 
 ---
 
+<!-- DO NOT DELETE THIS TEMPLATE.  Failing to adhere to this template and provide the necessary information may lead to your Issue being closed without consideration. -->
+
 <!-- BEFORE SUBMITTING AN ENHANCEMENT REQUEST - please browse the open issues and the [Archived Design Discussions wiki page](https://github.com/Pyomo/pyomo/wiki/Archived-Design-Discussions).-->
 
 ## Summary

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,7 +5,7 @@ labels: enhancement
 
 ---
 
-<!-- DO NOT DELETE THIS TEMPLATE.  Failing to adhere to this template and provide the necessary information may lead to your Issue being closed without consideration. -->
+<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE.  Failing to adhere to this template and provide the necessary information may lead to your Issue being closed without consideration. -->
 
 <!-- BEFORE SUBMITTING AN ENHANCEMENT REQUEST - please browse the open issues and the [Archived Design Discussions wiki page](https://github.com/Pyomo/pyomo/wiki/Archived-Design-Discussions).-->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
 <!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
 <!-- ##################################################################### -->
 
-<!-- DO NOT DELETE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->
+<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->
 
 ## Fixes # .
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,8 @@
 <!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
 <!-- ##################################################################### -->
 
+<!-- DO NOT DELETE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->
+
 ## Fixes # .
 
 ## Summary/Motivation:


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes NA

## Summary/Motivation:
We want to make it clear to users that they need to use the templates. This adds a disclaimer that, if the template is deleted, their issue/PR may be closed/ignored.

## Changes proposed in this PR:
- Add disclaimer to templates


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
