### PR TITLE
Allow initialization of indexed sets via a function returning a dict

### DIFF
--- a/doc/OnlineDocs/pyomo_modeling_components/Sets.rst
+++ b/doc/OnlineDocs/pyomo_modeling_components/Sets.rst
@@ -24,6 +24,8 @@ and postpones creation of its members:
 .. doctest::
    :hide:
 
+   >>> # testcode ran in a different scope, so re-run here
+   >>> model.A = pyo.Set()
    >>> # Add some data to the Set
    >>> model.A.update([1,2,3])
 
@@ -465,20 +467,20 @@ needed for the indexed set:
 .. testcode::
 
     def NodesIn_init(m, node):
-        # Create a dict to show NodesOut list for every node
+        # Create a dict to show NodesIn list for every node
         d = {i: [] for i in m.Nodes}
         # loop over the arcs and record the end points
         for i, j in model.Arcs:
-            d[i].append[j]
-        return d
-    model.NodesOut = pyo.Set(model.Nodes, initialize=NodesOut_init)
-
-    def NodesIn_init(m, node):
-        d = {i: [] for i in m.Nodes}
-        for i, j in model.Arcs:
-            d[j].append[i]
+            d[j].append(i)
         return d
     model.NodesIn = pyo.Set(model.Nodes, initialize=NodesIn_init)
+
+    def NodesOut_init(m, node):
+        d = {i: [] for i in m.Nodes}
+        for i, j in model.Arcs:
+            d[i].append(j)
+        return d
+    model.NodesOut = pyo.Set(model.Nodes, initialize=NodesOut_init)
 
 This can also be done efficiently, and perhaps more clearly, using a
 :class:`BuildAction` (for more information, see :ref:`BuildAction`):
@@ -492,8 +494,8 @@ This can also be done efficiently, and perhaps more clearly, using a
 
 .. testcode::
 
-   model.NodesOut = pyo.Set(model.Nodes, within=model.Nodes)
    model.NodesIn = pyo.Set(model.Nodes, within=model.Nodes)
+   model.NodesOut = pyo.Set(model.Nodes, within=model.Nodes)
 
    def Populate_In_and_Out(model):
        # loop over the arcs and record the end points

--- a/doc/OnlineDocs/pyomo_modeling_components/Sets.rst
+++ b/doc/OnlineDocs/pyomo_modeling_components/Sets.rst
@@ -466,7 +466,7 @@ needed for the indexed set:
 
 .. testcode::
 
-    def NodesIn_init(m, node):
+    def NodesIn_init(m):
         # Create a dict to show NodesIn list for every node
         d = {i: [] for i in m.Nodes}
         # loop over the arcs and record the end points
@@ -475,7 +475,7 @@ needed for the indexed set:
         return d
     model.NodesIn = pyo.Set(model.Nodes, initialize=NodesIn_init)
 
-    def NodesOut_init(m, node):
+    def NodesOut_init(m):
         d = {i: [] for i in m.Nodes}
         for i, j in model.Arcs:
             d[i].append(j)

--- a/doc/OnlineDocs/pyomo_modeling_components/Sets.rst
+++ b/doc/OnlineDocs/pyomo_modeling_components/Sets.rst
@@ -452,7 +452,7 @@ for this model, a toy data file (in AMPL "``.dat``" format) would be:
    >>> inst = model.create_instance('src/scripting/Isinglecomm.dat')
 
 This can also be done much more efficiently using initialization functions
-that accept only a model block and return a `dict` with all the information
+that accept only a model block and return a ``dict`` with all the information
 needed for the indexed set:
 
 .. doctest::

--- a/doc/OnlineDocs/pyomo_modeling_components/Sets.rst
+++ b/doc/OnlineDocs/pyomo_modeling_components/Sets.rst
@@ -451,8 +451,37 @@ for this model, a toy data file (in AMPL "``.dat``" format) would be:
 
    >>> inst = model.create_instance('src/scripting/Isinglecomm.dat')
 
-This can also be done somewhat more efficiently, and perhaps more clearly,
-using a :class:`BuildAction` (for more information, see :ref:`BuildAction`):
+This can also be done much more efficiently using initialization functions
+that accept only a model block and return a `dict` with all the information
+needed for the indexed set:
+
+.. doctest::
+   :hide:
+
+   >>> model = inst
+   >>> del model.NodesIn
+   >>> del model.NodesOut
+
+.. testcode::
+
+    def NodesIn_init(m, node):
+        # Create a dict to show NodesOut list for every node
+        d = {i: [] for i in m.Nodes}
+        # loop over the arcs and record the end points
+        for i, j in model.Arcs:
+            d[i].append[j]
+        return d
+    model.NodesOut = pyo.Set(model.Nodes, initialize=NodesOut_init)
+
+    def NodesIn_init(m, node):
+        d = {i: [] for i in m.Nodes}
+        for i, j in model.Arcs:
+            d[j].append[i]
+        return d
+    model.NodesIn = pyo.Set(model.Nodes, initialize=NodesIn_init)
+
+This can also be done efficiently, and perhaps more clearly, using a
+:class:`BuildAction` (for more information, see :ref:`BuildAction`):
 
 .. doctest::
    :hide:

--- a/doc/OnlineDocs/pyomo_modeling_components/Sets.rst
+++ b/doc/OnlineDocs/pyomo_modeling_components/Sets.rst
@@ -24,8 +24,6 @@ and postpones creation of its members:
 .. doctest::
    :hide:
 
-   >>> # testcode ran in a different scope, so re-run here
-   >>> model.A = pyo.Set()
    >>> # Add some data to the Set
    >>> model.A.update([1,2,3])
 

--- a/examples/doc/samples/case_studies/diet/DietProblem.tex
+++ b/examples/doc/samples/case_studies/diet/DietProblem.tex
@@ -54,7 +54,7 @@ There's one last parameter that must be taken into consideration: how much of ea
 
 The comma indicates that this parameter is over two different sets, and thus is in two dimensions.  When we create the data file, we will be able to fill in how much of each nutrient each food contains.
 
-At this point we have defined our sets and parameters.  However, we have yet to cosnider the amount of food to be bought and eaten.  This is the variable weâre trying to solve for, and thus we create an object of the variable class.  Since this is just recording how much food to purchase, we create a one dimensional variable over food:
+At this point we have defined our sets and parameters.  However, we have yet to consider the amount of food to be bought and eaten.  This is the variable weâre trying to solve for, and thus we create an object of the variable class.  Since this is just recording how much food to purchase, we create a one dimensional variable over food:
 
 \begin{verbatim}model.amount=Var(model.foods, within = NonNegativeReals) \end{verbatim}
 
@@ -62,7 +62,7 @@ We restrict our domain to the non-negative reals.  If we accepted negative numbe
 
 At this point we must start defining the rules associated with our parameters and variables.  We begin with the most important rule, the cost rule, which will tell the model to try and minimize the overall cost.  Logically, the total cost is going to be the sum of how much is spent on each food, and that value in turn is going to be determined by the cost of the food and how much of it is purchased.  For example, if three \$5 hamburgers and two \$1 apples are purchased, than the total cost would be $3 \cdot 5 + 2 \cdot 1 = 17$.  Note that this process is the same as taking the dot product of the amounts vector and the costs vector.
 
-To input this, we must define the cost rule, which we creatively call costRule as 
+To input this, we must define the cost rule, which we creatively call costRule as
 
 \begin{verbatim}def costRule(model):
     return sum(model.costs[n]*model.amount[n] for n in model.foods)
@@ -75,10 +75,10 @@ which will go through and multiply the costs and amounts of each food together a
 
 This line defines the objective of the model as the costRule,  which Pyomo interprets as the value it needs to minimize; in this case it will minimize our costs.  Also, as a note, we defined the objective as ``model.cost'' which is not to be confused with the parameter we defined earlier as ``model.costs,'' despite their similar names.  These are two different values and accidentally giving them the same name will cause problems when trying to solve the problem.
 
-We must also create a rule for the volume consumed.  The construction of this rule is similar to the cost rule as once again we take the dot product, this time between the volume and amount vectors. 
+We must also create a rule for the volume consumed.  The construction of this rule is similar to the cost rule as once again we take the dot product, this time between the volume and amount vectors.
 
 \begin{verbatim}def volumeRule(model):
-    return sum(model.volumes[n]*model.amount[n] for n in 
+    return sum(model.volumes[n]*model.amount[n] for n in
         model.foods) <= model.max_volume
 
 model.volume = Constraint(rule=volumeRule)
@@ -90,7 +90,7 @@ Finally, we need to add the constraint that ensures we obtain proper amounts of 
 
 \begin{verbatim}
 def nutrientRule(n, model):
-    value = sum(model.nutrient_value[n,f]*model.amount[f] 
+    value = sum(model.nutrient_value[n,f]*model.amount[f]
         for f in model.foods)
     return (model.min_nutrient[n], value, model.max_nutrient[n])
 
@@ -160,7 +160,7 @@ vc          0     30    0;
 
 The amount of spaces between each element is irrelevant (as long as there is at least one) so the matrix should be formatted for ease of reading.
 
-Now that we have finished both the model and the data file save them both. It's convention to give the model file a .py extension and the data file a .dat extension.  
+Now that we have finished both the model and the data file save them both. It's convention to give the model file a .py extension and the data file a .dat extension.
 
 \subsection*{Solution}
 

--- a/examples/doc/samples/case_studies/diet/README.txt
+++ b/examples/doc/samples/case_studies/diet/README.txt
@@ -14,7 +14,7 @@ to import the Pyomo package for use in the code.  The next step is to create an 
 
 {{{
 #!python
-model = AbstractModel() 
+model = AbstractModel()
 }}}
 The rest of our work will be contained within this object.
 
@@ -68,7 +68,7 @@ model.nutrient_value=Param(model.nutrients, model.foods)
 
 The comma indicates that this parameter is over two different sets, and thus is in two dimensions.  When we create the data file, we will be able to fill in how much of each nutrient each food contains.
 
-At this point we have defined our sets and parameters.  However, we have yet to cosnider the amount of food to be bought and eaten.  This is the variable we're trying to solve for, and thus we create an object of the variable class.  Since this is just recording how much food to purchase, we create a one dimensional variable over food:
+At this point we have defined our sets and parameters.  However, we have yet to consider the amount of food to be bought and eaten.  This is the variable we're trying to solve for, and thus we create an object of the variable class.  Since this is just recording how much food to purchase, we create a one dimensional variable over food:
 
 {{{
 #!python
@@ -79,7 +79,7 @@ We restrict our domain to the non-negative reals.  If we accepted negative numbe
 
 At this point we must start defining the rules associated with our parameters and variables.  We begin with the most important rule, the cost rule, which will tell the model to try and minimize the overall cost.  Logically, the total cost is going to be the sum of how much is spent on each food, and that value in turn is going to be determined by the cost of the food and how much of it is purchased.  For example, if three !$5 hamburgers and two !$1 apples are purchased, than the total cost would be 3*5 + 2*1 = 17.  Note that this process is the same as taking the dot product of the amounts vector and the costs vector.
 
-To input this, we must define the cost rule, which we creatively call costRule as 
+To input this, we must define the cost rule, which we creatively call costRule as
 
 {{{
 #!python
@@ -95,7 +95,7 @@ model.cost=Objective(rule=costRule
 
 This line defines the objective of the model as the costRule,  which Pyomo interprets as the value it needs to minimize; in this case it will minimize our costs.  Also, as a note, we defined the objective as "model.cost" which is not to be confused with the parameter we defined earlier as `"model.costs" despite their similar names.  These are two different values and accidentally giving them the same name will cause problems when trying to solve the problem.
 
-We must also create a rule for the volume consumed.  The construction of this rule is similar to the cost rule as once again we take the dot product, this time between the volume and amount vectors. 
+We must also create a rule for the volume consumed.  The construction of this rule is similar to the cost rule as once again we take the dot product, this time between the volume and amount vectors.
 
 {{{
 #!python
@@ -112,7 +112,7 @@ Finally, we need to add the constraint that ensures we obtain proper amounts of 
 {{{
 #!python
 def nutrientRule(n, model):
-    value = sum(model.nutrient_value[n,f]*model.amount[f] 
+    value = sum(model.nutrient_value[n,f]*model.amount[f]
         for f in model.foods)
     return (model.min_nutrient[n], value, model.max_nutrient[n])
 
@@ -179,7 +179,7 @@ vc          0     30    0;
 
 The amount of spaces between each element is irrelevant (as long as there is at least one) so the matrix should be formatted for ease of reading.
 
-Now that we have finished both the model and the data file save them both. It's convention to give the model file a .py extension and the data file a .dat extension.  
+Now that we have finished both the model and the data file save them both. It's convention to give the model file a .py extension and the data file a .dat extension.
 
 == Solution ==
 
@@ -193,7 +193,7 @@ Using Pyomo we quickly find the solution to our diet problem.  Simply run Pyomo 
 # ----------------------------------------------------------
 #   Problem Information
 # ----------------------------------------------------------
-Problem: 
+Problem:
 - Lower bound: 29.44055944
   Upper bound: inf
   Number of objectives: 1
@@ -205,7 +205,7 @@ Problem:
 # ----------------------------------------------------------
 #   Solver Information
 # ----------------------------------------------------------
-Solver: 
+Solver:
 - Status: ok
   Termination condition: unknown
   Error rc: 0
@@ -213,20 +213,20 @@ Solver:
 # ----------------------------------------------------------
 #   Solution Information
 # ----------------------------------------------------------
-Solution: 
+Solution:
 - number of solutions: 1
   number of solutions displayed: 1
 - Gap: 0.0
   Status: optimal
-  Objective: 
-    f: 
+  Objective:
+    f:
       Id: 0
       Value: 29.44055944
-  Variable: 
-    amount[rice]: 
+  Variable:
+    amount[rice]:
       Id: 0
       Value: 9.44056
-    amount[apple]: 
+    amount[apple]:
       Id: 2
       Value: 10
 

--- a/pyomo/core/base/set.py
+++ b/pyomo/core/base/set.py
@@ -2306,7 +2306,10 @@ class Set(IndexedComponent):
                 # from the object it provides (e.g., a dict with all members of
                 # the indexed set). This is similar to
                 # IndexedComponent._construct_from_rule_using_setitem.
-                if self.is_indexed() and type(self._init_values._init) is ScalarCallInitializer:
+                if (
+                    self.is_indexed()
+                    and type(self._init_values._init) is ScalarCallInitializer
+                ):
                     self._init_values = TuplizeValuesInitializer(
                         Initializer(
                             self._init_values._init(self.parent_block(), None),

--- a/pyomo/core/tests/unit/test_sets.py
+++ b/pyomo/core/tests/unit/test_sets.py
@@ -3339,6 +3339,18 @@ class TestSetErrors(PyomoModel):
         model.Y = RangeSet(model.C)
         model.X = Param(model.C, default=0.0)
 
+    def test_setargs6(self):
+        # Test that we can create an indexed set from a function that returns
+        # a dict to define the set
+        model = ConcreteModel()
+        model.A = Set(initialize=[1, 2])
+        model.B = Set(model.A, initialize={1: [2, 3], 2: [3, 4]})
+        model.C = Set(model.A, initialize=lambda m: {x: [x+1, x+2] for x in m.A})
+        # convert to native data types for easier comparison
+        B = {k: v.ordered_data() for (k, v) in model.B.items()}
+        C = {k: v.ordered_data() for (k, v) in model.C.items()}
+        self.assertEqual(B, C)
+
     @unittest.skip("_verify was removed during the set rewrite")
     def test_verify(self):
         a = Set(initialize=[1, 2, 3])

--- a/pyomo/core/tests/unit/test_sets.py
+++ b/pyomo/core/tests/unit/test_sets.py
@@ -3345,7 +3345,7 @@ class TestSetErrors(PyomoModel):
         model = ConcreteModel()
         model.A = Set(initialize=[1, 2])
         model.B = Set(model.A, initialize={1: [2, 3], 2: [3, 4]})
-        model.C = Set(model.A, initialize=lambda m: {x: [x+1, x+2] for x in m.A})
+        model.C = Set(model.A, initialize=lambda m: {x: [x + 1, x + 2] for x in m.A})
         # convert to native data types for easier comparison
         B = {k: v.ordered_data() for (k, v) in model.B.items()}
         C = {k: v.ordered_data() for (k, v) in model.C.items()}


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:

It is possible to construct `Expression` (and possibly `Constraint`) objects by passing a rule function that constructs a dictionary containing all the elements needed to initialize the `Expression`. Pyomo notices that this function only accepts one argument, marks it as constant==True and then later `IndexedComponent._construct_from_rule_using_setitem` calls the function, accepts the dict, and uses that to build the object. However, if you try something similar with indexed sets, it does not initialize correctly from the dictionary and doesn't give an error message. This pull request fixes the `Set()` definition to allow initialization via a function that produces a dictionary or dict-like object.

The examples below use this shared setup:
```
from pyomo.environ import ConcreteModel, Set
model = ConcreteModel()
model.A = Set(initialize=[1, 2])
model.B = Set(model.A, initialize={1: [2, 3], 2: [3, 4]})
model.B.pprint()
B : Size=2, Index=A, Ordered=Insertion
    Key : Dimen : Domain : Size : Members
      1 :     1 :    Any :    2 : {2, 3}
      2 :     1 :    Any :    2 : {3, 4}
```

Here is the current behavior. Pyomo unexpectedly uses the keys of the dict as the return value for any index in `m.C`:

```
model.C = Set(model.A, initialize=lambda m: {x: [x+1, x+2] for x in m.A})
model.C.pprint()
C : Size=2, Index=A, Ordered=Insertion
    Key : Dimen : Domain : Size : Members
      1 :     1 :    Any :    2 : {1, 2}
      2 :     1 :    Any :    2 : {1, 2}
```

Here is the new behavior after this change. Now `m.C` is the same as `m.B`, which is the behavior you would expect if the rule function returns the same dictionary as was used to initialize `m.B`.

```
model.C = Set(model.A, initialize=lambda m: {x: [x+1, x+2] for x in m.A})
model.C.pprint()
C : Size=2, Index=A, Ordered=Insertion
    Key : Dimen : Domain : Size : Members
      1 :     1 :    Any :    2 : {2, 3}
      2 :     1 :    Any :    2 : {3, 4}
```

The new initialization method allows more efficient and more readable code when initializing indexed sets. For example, my project often produces indexed sets from simple sets. The most readable approach to this is along these lines:

```
import pyomo.environ as pyo
model = ConcreteModel()

model.Nodes = pyo.Set(initialize=['A', 'B', 'C'])
model.Arcs = pyo.Set(initialize=[('A', 'B'), ('A', 'C'), ('C', 'B')])

def NodesOut_init(m, node):
    return [j for (i, j) in m.Arcs if i == node]
model.NodesOut = pyo.Set(model.Nodes, initialize=NodesOut_init)
```

The [Pyomo documentation](https://pyomo.readthedocs.io/en/stable/pyomo_modeling_components/Sets.html) shows another approach with similar performance:

```
def NodesOut_init(m, node):
    for i, j in m.Arcs:
        if i == node:
            yield j
model.NodesOut = pyo.Set(model.Nodes, initialize=NodesOut_init)
model.NodesOut.pprint()
```

Both of the above become very slow if there are thousands of Nodes and millions of Arcs, since they scan all Arcs for every Node. The Pyomo documentation recommends this to improve performance:

```
model.NodesOut = pyo.Set(model.Nodes, within=model.Nodes)

def Populate_NodesOut(model):
    # loop over the arcs and record the end points
    for i, j in model.Arcs:
        model.NodesOut[i].add(j)

model.Populate_NodesOut = pyo.BuildAction(rule=Populate_NodesOut)
```

This requires users to understand `BuildActions` and to know that elements can be added to Sets after they are constructed, which is a different pattern from other components.

The new functionality in this pull request enables a simpler way to efficiently construct indexed sets:

```
def NodesOut_init(m):
    # Create a dict to show NodesOut list for every node
    d = {i: [] for i in m.Nodes}
    # loop over the arcs and record the end points
    for i, j in model.Arcs:
        d[i].append[j]
    return d

model.NodesOut = pyo.Set(model.Nodes, initialize=NodesOut_init)
```

In the future, this could enable efficient construction of indexed sets via other methods that expect a component to be initialized from a function, e.g., 

```
@model.Set(model.Nodes)
def NodesOut(m):
    d = {i: [] for i in m.Nodes}
    for i, j in model.Arcs:
        d[i].append[j]
    return d
```

(Currently this last example doesn't work because the `model.Set()` decorator passes the function to `Set()` via `rule` instead of `initialize`.)

## Changes proposed in this PR:
- Revise `Set.construct()` to call the rule function once and then use its result to initialize the indexed set if `self.is_indexed() and type(self._init_values._init) is ScalarCallInitializer`. 
  - The second condition only occurs when Set() is called with a rule that accepts a single argument (the block). In all cases where a set is indexed (the first condition) but the rule function doesn't accept indexes (the second condition), it makes sense to try initializing with the object returned by the function. 
  - This could perhaps be broadened a bit by checking `self._init_values.constant()` and then checking whether `self._init_values._init` uses a function as its initializer. But there doesn't seem to be a clean way to do that, and in all these cases it looks like `self._init_values._init` is of type `ScalarCallInitializer`. The submitted test will catch if this changes.
- Add `pyomo.core.tests.unit.test_sets.TestSetErrors.test_setargs6` to verify that the code above produces the second behavior, not the first.
- Update online documentation to include this new behavior.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
