### PR TITLE
GDP: Fix performance degredation in hull transformation

### DIFF
--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -448,7 +448,7 @@ class Hull_Reformulation(GDP_to_MIP_Transformation):
                     disjunct=obj,
                     bigmConstraint=disaggregated_var_bounds,
                     var_free_indicator=var_free,
-                    var_idx=idx
+                    var_idx=idx,
                 )
                 original_var_info = var.parent_block().private_data()
                 disaggregated_var_map = original_var_info.disaggregated_var_map
@@ -622,15 +622,17 @@ class Hull_Reformulation(GDP_to_MIP_Transformation):
             if var_idx is not None:
                 lb_idx = (var_idx, 'lb')
             bigmConstraint.add(lb_idx, var_free_indicator * lb <= disaggregatedVar)
-            disaggregated_var_info.bigm_constraint_map[
-                disaggregatedVar][disjunct]['lb'] = bigmConstraint[lb_idx]
+            disaggregated_var_info.bigm_constraint_map[disaggregatedVar][disjunct][
+                'lb'
+            ] = bigmConstraint[lb_idx]
         if ub:
             ub_idx = 'ub'
             if var_idx is not None:
                 ub_idx = (var_idx, 'ub')
             bigmConstraint.add(ub_idx, disaggregatedVar <= ub * var_free_indicator)
-            disaggregated_var_info.bigm_constraint_map[
-                disaggregatedVar][disjunct]['ub'] = bigmConstraint[ub_idx]
+            disaggregated_var_info.bigm_constraint_map[disaggregatedVar][disjunct][
+                'ub'
+            ] = bigmConstraint[ub_idx]
 
         # store the mappings from variables to their disaggregated selves on
         # the transformation block

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -447,9 +447,8 @@ class Hull_Reformulation(GDP_to_MIP_Transformation):
                     disaggregatedVar=disaggregated_var,
                     disjunct=obj,
                     bigmConstraint=disaggregated_var_bounds,
-                    lb_idx=(idx, 'lb'),
-                    ub_idx=(idx, 'ub'),
                     var_free_indicator=var_free,
+                    var_idx=idx
                 )
                 original_var_info = var.parent_block().private_data()
                 disaggregated_var_map = original_var_info.disaggregated_var_map
@@ -537,8 +536,6 @@ class Hull_Reformulation(GDP_to_MIP_Transformation):
                 disaggregatedVar=disaggregatedVar,
                 disjunct=obj,
                 bigmConstraint=bigmConstraint,
-                lb_idx='lb',
-                ub_idx='ub',
                 var_free_indicator=obj.indicator_var.get_associated_binary(),
             )
             # update the bigm constraint mappings
@@ -566,8 +563,6 @@ class Hull_Reformulation(GDP_to_MIP_Transformation):
                 disaggregatedVar=var,
                 disjunct=obj,
                 bigmConstraint=bigmConstraint,
-                lb_idx='lb',
-                ub_idx='ub',
                 var_free_indicator=obj.indicator_var.get_associated_binary(),
             )
             # update the bigm constraint mappings
@@ -600,9 +595,8 @@ class Hull_Reformulation(GDP_to_MIP_Transformation):
         disaggregatedVar,
         disjunct,
         bigmConstraint,
-        lb_idx,
-        ub_idx,
         var_free_indicator,
+        var_idx=None,
     ):
         # For updating mappings:
         original_var_info = original_var.parent_block().private_data()
@@ -624,13 +618,19 @@ class Hull_Reformulation(GDP_to_MIP_Transformation):
         disaggregatedVar.setub(max(0, ub))
 
         if lb:
+            lb_idx = 'lb'
+            if var_idx is not None:
+                lb_idx = (var_idx, 'lb')
             bigmConstraint.add(lb_idx, var_free_indicator * lb <= disaggregatedVar)
             disaggregated_var_info.bigm_constraint_map[
-                disaggregatedVar][disjunct][lb_idx] = bigmConstraint[lb_idx]
+                disaggregatedVar][disjunct]['lb'] = bigmConstraint[lb_idx]
         if ub:
+            ub_idx = 'ub'
+            if var_idx is not None:
+                ub_idx = (var_idx, 'ub')
             bigmConstraint.add(ub_idx, disaggregatedVar <= ub * var_free_indicator)
             disaggregated_var_info.bigm_constraint_map[
-                disaggregatedVar][disjunct][ub_idx] = bigmConstraint[ub_idx]
+                disaggregatedVar][disjunct]['ub'] = bigmConstraint[ub_idx]
 
         # store the mappings from variables to their disaggregated selves on
         # the transformation block

--- a/pyomo/gdp/plugins/hull.py
+++ b/pyomo/gdp/plugins/hull.py
@@ -930,10 +930,9 @@ class Hull_Reformulation(GDP_to_MIP_Transformation):
 
     def get_var_bounds_constraint(self, v, disjunct=None):
         """
-        Returns the IndexedConstraint which sets a disaggregated
-        variable to be within its bounds when its Disjunct is active and to
-        be 0 otherwise. (It is always an IndexedConstraint because each
-        bound becomes a separate constraint.)
+        Returns a dictionary mapping keys 'lb' and/or 'ub' to the Constraints that
+        set a disaggregated variable to be within its lower and upper bounds
+        (respectively) when its Disjunct is active and to be 0 otherwise.
 
         Parameters
         ----------

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -32,7 +32,6 @@ from pyomo.environ import (
     Param,
     Objective,
     TerminationCondition,
-    Reference,
 )
 from pyomo.core.expr.compare import (
     assertExpressionsEqual,

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -530,14 +530,16 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
             mappings[disjBlock[i].disaggregatedVars.x] = disjBlock[i].x_bounds
             if i == 1:  # this disjunct has x, w, and no y
                 mappings[disjBlock[i].disaggregatedVars.w] = disjBlock[i].w_bounds
-                mappings[transBlock._disaggregatedVars[0]] = Reference(
-                    transBlock._boundsConstraints[0, ...]
-                )
+                mappings[transBlock._disaggregatedVars[0]] = {
+                    key: val for key, val in transBlock._boundsConstraints.items() if
+                    key[0] == 0
+                }
             elif i == 0:  # this disjunct has x, y, and no w
                 mappings[disjBlock[i].disaggregatedVars.y] = disjBlock[i].y_bounds
-                mappings[transBlock._disaggregatedVars[1]] = Reference(
-                    transBlock._boundsConstraints[1, ...]
-                )
+                mappings[transBlock._disaggregatedVars[1]] = {
+                    key: val for key, val in transBlock._boundsConstraints.items() if
+                    key[0] == 1
+                }
             for var, cons in mappings.items():
                 returned_cons = hull.get_var_bounds_constraint(var)
                 # This sometimes refers a reference to the right part of a

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -531,14 +531,16 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
             if i == 1:  # this disjunct has x, w, and no y
                 mappings[disjBlock[i].disaggregatedVars.w] = disjBlock[i].w_bounds
                 mappings[transBlock._disaggregatedVars[0]] = {
-                    key: val for key, val in transBlock._boundsConstraints.items() if
-                    key[0] == 0
+                    key: val
+                    for key, val in transBlock._boundsConstraints.items()
+                    if key[0] == 0
                 }
             elif i == 0:  # this disjunct has x, y, and no w
                 mappings[disjBlock[i].disaggregatedVars.y] = disjBlock[i].y_bounds
                 mappings[transBlock._disaggregatedVars[1]] = {
-                    key: val for key, val in transBlock._boundsConstraints.items() if
-                    key[0] == 1
+                    key: val
+                    for key, val in transBlock._boundsConstraints.items()
+                    if key[0] == 1
                 }
             for var, cons in mappings.items():
                 returned_cons = hull.get_var_bounds_constraint(var)

--- a/pyomo/gdp/tests/test_hull.py
+++ b/pyomo/gdp/tests/test_hull.py
@@ -547,6 +547,8 @@ class TwoTermDisj(unittest.TestCase, CommonTests):
                 # themselves might not be the same object. The ConstraintDatas
                 # are though:
                 for key, constraintData in cons.items():
+                    if type(key) is tuple:
+                        key = key[1]
                     self.assertIs(returned_cons[key], constraintData)
 
     def test_create_using_nonlinear(self):


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:

In #3143, I accidentally introduced a performance degradation into `gdp.hull` because of using a `Reference` over a slice in order to map from disaggregated variables to the bound constraints for them. This PR eliminates the use of Reference, taking the hull transformation time on one model down from 150 seconds to 50 seconds.

NOTE: this includes #3365 in an attempt to get tests passing

## Changes proposed in this PR:
- Move the logic for mapping from disaggregated variables to their bound constraints to the `_declare_disaggregated_var_bounds` helper method that actually knows whether we have both lower and upper bounds for the variables.
- No longer using the same keys in the `_boundConstraints` component on the transformation Block as we do in the mappings--the mappings can be pretty and simple ('lb' and 'ub') since they end up public-facing via the `get_var_bounds_constraint` method whereas the actual keys in `_boundsConstraints` can be ugly and unique.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
