### PR TITLE
Documentation Tweaks for contrib.alternative_solutions

### DIFF
--- a/doc/OnlineDocs/contributed_packages/alternative_solutions.rst
+++ b/doc/OnlineDocs/contributed_packages/alternative_solutions.rst
@@ -42,7 +42,7 @@ The following functions are defined in the alternative-solutions library:
     * Calculates the bounds on each variable by solving a series of min and max optimization problems where each variable is used as the objective function. This can be applied to any class of problem supported by the selected solver.
 
 
-Usage Example
+Basic Usage Example
 -------------
 
 Many of functions in the alternative-solutions library have similar options, so we simply illustrate the ``enumerate_binary_solutions`` function.  We define a simple knapsack example whose alternative solutions have integer objective values ranging from 0 to 90.
@@ -87,6 +87,53 @@ Each ``Solution`` object contains information about the objective and variables,
        }
    }
 
+
+Gap Usage Example
+-------------
+When we only want some of the solutions based off a tolerance away from optimal, this can be done using the ``abs_opt_gap`` parameter. This is shown in the following simple knapsack examples where the weights and values are the same.
+
+.. doctest::
+   :skipif: not glpk_available
+   
+   >>> import pyomo.environ as pyo
+   >>> import pyomo.contrib.alternative_solutions as aos
+
+   >>> values = [10,9,2,1,1]
+   >>> weights = [10,9,2,1,1]
+ 
+   >>> K = len(values)
+   >>> capacity = 12
+ 
+   >>> m = pyo.ConcreteModel()
+   >>> m.x = pyo.Var(range(K), within=pyo.Binary)
+   >>> m.o = pyo.Objective(expr=sum(values[i] * m.x[i] for i in range(K)), sense=pyo.maximize)
+   >>> m.c = pyo.Constraint(expr=sum(weights[i] * m.x[i] for i in range(K)) <= capacity) 
+ 
+   >>> solns = aos.enumerate_binary_solutions(m, num_solutions=10, solver="glpk", abs_opt_gap = 0.0)
+   >>> assert(len(solns) == 4)
+
+In this example, we only get the four ``Solution`` objects that have an ``objective_value`` of 12.
+Note that while we wanted only those four solutions with no optimality gap, using a gap of half the smallest value (in this case .5) will return the same solutions and avoids any machine precision issues.
+
+.. doctest::
+   :skipif: not glpk_available
+   
+   >>> import pyomo.environ as pyo
+   >>> import pyomo.contrib.alternative_solutions as aos
+
+   >>> values = [10,9,2,1,1]
+   >>> weights = [10,9,2,1,1]
+ 
+   >>> K = len(values)
+   >>> capacity = 12
+ 
+   >>> m = pyo.ConcreteModel()
+   >>> m.x = pyo.Var(range(K), within=pyo.Binary)
+   >>> m.o = pyo.Objective(expr=sum(values[i] * m.x[i] for i in range(K)), sense=pyo.maximize)
+   >>> m.c = pyo.Constraint(expr=sum(weights[i] * m.x[i] for i in range(K)) <= capacity) 
+ 
+   >>> solns = aos.enumerate_binary_solutions(m, num_solutions=10, solver="glpk", abs_opt_gap = 0.5)
+   >>> assert(len(solns) == 4)
 
 Interface Documentation
 -----------------------

--- a/pyomo/contrib/alternative_solutions/balas.py
+++ b/pyomo/contrib/alternative_solutions/balas.py
@@ -36,7 +36,7 @@ def enumerate_binary_solutions(
     Finds alternative optimal solutions for a binary problem using no-good
     cuts.
 
-    This function implements a no-good cuts technique inheriting from Balas's work on Cannonical Cuts:
+    This function implements a no-good cuts technique inheriting from Balas's work on Canonical Cuts:
 
     Balas, Egon, and Robert Jeroslow.
     “Canonical Cuts on the Unit Hypercube.”

--- a/pyomo/contrib/alternative_solutions/balas.py
+++ b/pyomo/contrib/alternative_solutions/balas.py
@@ -42,7 +42,7 @@ def enumerate_binary_solutions(
     “Canonical Cuts on the Unit Hypercube.” 
     SIAM Journal on Applied Mathematics 23, no. 1 (1972): 61–69. 
     http://www.jstor.org/stable/2099623.
-    
+
     Parameters
     ----------
     model : ConcreteModel

--- a/pyomo/contrib/alternative_solutions/balas.py
+++ b/pyomo/contrib/alternative_solutions/balas.py
@@ -35,12 +35,12 @@ def enumerate_binary_solutions(
     """
     Finds alternative optimal solutions for a binary problem using no-good
     cuts.
-    
+
     This function implements a no-good cuts technique inheriting from Balas's work on Cannonical Cuts:
 
-    Balas, Egon, and Robert Jeroslow. 
-    “Canonical Cuts on the Unit Hypercube.” 
-    SIAM Journal on Applied Mathematics 23, no. 1 (1972): 61–69. 
+    Balas, Egon, and Robert Jeroslow.
+    “Canonical Cuts on the Unit Hypercube.”
+    SIAM Journal on Applied Mathematics 23, no. 1 (1972): 61–69.
     http://www.jstor.org/stable/2099623.
 
     Parameters

--- a/pyomo/contrib/alternative_solutions/balas.py
+++ b/pyomo/contrib/alternative_solutions/balas.py
@@ -35,7 +35,14 @@ def enumerate_binary_solutions(
     """
     Finds alternative optimal solutions for a binary problem using no-good
     cuts.
+    
+    This function implements a no-good cuts technique inheriting from Balas's work on Cannonical Cuts:
 
+    Balas, Egon, and Robert Jeroslow. 
+    “Canonical Cuts on the Unit Hypercube.” 
+    SIAM Journal on Applied Mathematics 23, no. 1 (1972): 61–69. 
+    http://www.jstor.org/stable/2099623.
+    
     Parameters
     ----------
     model : ConcreteModel


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .
Adds documentation details to contrib.alternative_solutions 
## Summary/Motivation:
Adds documentation details to contrib.alternative_solutions 

## Changes proposed in this PR:
- Adds citation to contrib/alternative_solutions/balas.py to original Balas 1972 paper "Canonical Cuts on the Unit Hypercube"
- Adds example to documentation for alternative_solutions demonstrating how to use ``abs_opt_gap`` to limit generated solutions to those within a given optimality gap

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
