### PR TITLE
Remove Octeract from the list of expected NEOS solvers (and other infrastructure fixes)

### DIFF
--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -361,7 +361,7 @@ jobs:
         echo "*** Install Pyomo dependencies ***"
         # For windows, cannot use newer setuptools because of APPSI compilation issues
         if test "${{matrix.TARGET}}" == 'win'; then
-            CONDA_DEPENDENCIES = "$CONDA_DEPENDENCIES setuptools<74.0.0"
+            CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES setuptools<74.0.0"
         fi
         # Note: this will fail the build if any installation fails (or
         # possibly if it outputs messages to stderr)

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -215,6 +215,8 @@ jobs:
       if: matrix.TARGET == 'win'
       run: |
         echo "SETUPTOOLS_USE_DISTUTILS=local" >> $GITHUB_ENV
+      run: |
+        choco install pkgconfiglite
 
     - name: Set up Python ${{ matrix.python }}
       if: matrix.PYENV == 'pip'

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -75,6 +75,12 @@ jobs:
         other: [""]
         category: [""]
 
+        # win/3.8 conda builds no longer work due to environment not being able
+        # to resolve. We are skipping it now.
+        exclude:
+        - os: windows-latest
+          python: 3.8
+
         include:
         - os: ubuntu-latest
           python: '3.12'

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -87,7 +87,7 @@ jobs:
           TARGET: linux
           PYENV: pip
 
-        - os: macos-13
+        - os: macos-latest
           python: '3.10'
           TARGET: osx
           PYENV: pip

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -359,6 +359,10 @@ jobs:
         done
         echo ""
         echo "*** Install Pyomo dependencies ***"
+        # For windows, cannot use newer setuptools because of APPSI compilation issues
+        if test "${{matrix.TARGET}}" == 'win'; then
+            CONDA_DEPENDENCIES = "$CONDA_DEPENDENCIES setuptools<74.0.0"
+        fi
         # Note: this will fail the build if any installation fails (or
         # possibly if it outputs messages to stderr)
         conda install --update-deps -q -y $CONDA_DEPENDENCIES

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -221,7 +221,6 @@ jobs:
       if: matrix.TARGET == 'win'
       run: |
         echo "SETUPTOOLS_USE_DISTUTILS=local" >> $GITHUB_ENV
-      run: |
         choco install pkgconfiglite
 
     - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -77,6 +77,7 @@ jobs:
         exclude:
         - os: windows-latest
           python: 3.8
+
         include:
         - os: ubuntu-latest
           TARGET: linux
@@ -109,14 +110,6 @@ jobs:
           PACKAGES: openmpi mpi4py
 
         - os: ubuntu-latest
-          python: '3.11'
-          other: /singletest
-          category: "-m 'neos or importtest'"
-          skip_doctest: 1
-          TARGET: linux
-          PYENV: pip
-
-        - os: ubuntu-latest
           python: '3.10'
           other: /cython
           setup_options: --with-cython
@@ -130,6 +123,14 @@ jobs:
           other: /pip
           skip_doctest: 1
           TARGET: win
+          PYENV: pip
+
+        - os: ubuntu-latest
+          python: '3.11'
+          other: /singletest
+          category: "-m 'neos or importtest'"
+          skip_doctest: 1
+          TARGET: linux
           PYENV: pip
 
         - os: ubuntu-latest

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -244,7 +244,6 @@ jobs:
       if: matrix.TARGET == 'win'
       run: |
         echo "SETUPTOOLS_USE_DISTUTILS=local" >> $GITHUB_ENV
-      run: |
         choco install pkgconfiglite
 
     - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -382,6 +382,10 @@ jobs:
         done
         echo ""
         echo "*** Install Pyomo dependencies ***"
+        # For windows, cannot use newer setuptools because of APPSI compilation issues
+        if test "${{matrix.TARGET}}" == 'win'; then
+            CONDA_DEPENDENCIES = "$CONDA_DEPENDENCIES setuptools<74.0.0"
+        fi
         # Note: this will fail the build if any installation fails (or
         # possibly if it outputs messages to stderr)
         conda install --update-deps -q -y $CONDA_DEPENDENCIES

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -384,7 +384,7 @@ jobs:
         echo "*** Install Pyomo dependencies ***"
         # For windows, cannot use newer setuptools because of APPSI compilation issues
         if test "${{matrix.TARGET}}" == 'win'; then
-            CONDA_DEPENDENCIES = "$CONDA_DEPENDENCIES setuptools<74.0.0"
+            CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES setuptools<74.0.0"
         fi
         # Note: this will fail the build if any installation fails (or
         # possibly if it outputs messages to stderr)

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -243,6 +243,8 @@ jobs:
       if: matrix.TARGET == 'win'
       run: |
         echo "SETUPTOOLS_USE_DISTUTILS=local" >> $GITHUB_ENV
+      run: |
+        choco install pkgconfiglite
 
     - name: Set up Python ${{ matrix.python }}
       if: matrix.PYENV == 'pip'

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python: [ 3.8, 3.9, '3.10', '3.11', '3.12' ]
         other: [""]
         category: [""]
@@ -83,7 +83,7 @@ jobs:
           TARGET: linux
           PYENV: pip
 
-        - os: macos-13
+        - os: macos-latest
           TARGET: osx
           PYENV: pip
 

--- a/examples/pyomobook/gdp-ch/gdp_uc.py
+++ b/examples/pyomobook/gdp-ch/gdp_uc.py
@@ -116,3 +116,8 @@ def obj(m):
 @model.Constraint(model.GENERATORS)
 def nontrivial(m, g):
     return sum(m.Power[g, t] for t in m.TIME) >= len(m.TIME) / 2 * m.MinPower[g]
+
+@model.ConstraintList()
+def nondegenerate(m):
+    for i, g in enumerate(m.GENERATORS):
+        yield m.Power[g, i+1] == 0

--- a/examples/pyomobook/gdp-ch/gdp_uc.py
+++ b/examples/pyomobook/gdp-ch/gdp_uc.py
@@ -117,7 +117,8 @@ def obj(m):
 def nontrivial(m, g):
     return sum(m.Power[g, t] for t in m.TIME) >= len(m.TIME) / 2 * m.MinPower[g]
 
+
 @model.ConstraintList()
 def nondegenerate(m):
     for i, g in enumerate(m.GENERATORS):
-        yield m.Power[g, i+1] == 0
+        yield m.Power[g, i + 1] == 0

--- a/examples/pyomobook/gdp-ch/pyomo.gdp_uc.txt
+++ b/examples/pyomobook/gdp-ch/pyomo.gdp_uc.txt
@@ -22,9 +22,9 @@ Problem:
   Lower bound: 45.0
   Upper bound: 45.0
   Number of objectives: 1
-  Number of constraints: 58
+  Number of constraints: 60
   Number of variables: 24
-  Number of nonzeros: 124
+  Number of nonzeros: 126
   Sense: minimize
 # ----------------------------------------------------------
 #   Solver Information
@@ -34,8 +34,8 @@ Solver:
   Termination condition: optimal
   Statistics: 
     Branch and bound: 
-      Number of bounded subproblems: 15
-      Number of created subproblems: 15
+      Number of bounded subproblems: 9
+      Number of created subproblems: 9
   Error rc: 0
   Time: 0.007754325866699219
 # ----------------------------------------------------------
@@ -51,24 +51,24 @@ Solution:
     obj:
       Value: 45
   Variable:
-    GenOff[g1,2].binary_indicator_var:
+    GenOff[g1,1].binary_indicator_var:
       Value: 1
-    GenOff[g2,1].binary_indicator_var:
+    GenOff[g2,2].binary_indicator_var:
       Value: 1
-    GenOn[g1,1].binary_indicator_var:
+    GenOn[g1,3].binary_indicator_var:
       Value: 1
-    GenOn[g2,3].binary_indicator_var:
+    GenOn[g2,1].binary_indicator_var:
       Value: 1
-    GenStartup[g1,3].binary_indicator_var:
+    GenStartup[g1,2].binary_indicator_var:
       Value: 1
-    GenStartup[g2,2].binary_indicator_var:
+    GenStartup[g2,3].binary_indicator_var:
       Value: 1
-    Power[g1,1]:
-      Value: 10
-    Power[g1,3]:
+    Power[g1,2]:
       Value: 5
-    Power[g2,2]:
+    Power[g1,3]:
       Value: 10
-    Power[g2,3]:
+    Power[g2,1]:
       Value: 20
+    Power[g2,3]:
+      Value: 10
   Constraint: No values

--- a/pyomo/contrib/fme/tests/test_fourier_motzkin_elimination.py
+++ b/pyomo/contrib/fme/tests/test_fourier_motzkin_elimination.py
@@ -562,7 +562,7 @@ class TestFourierMotzkinElimination(unittest.TestCase):
         fme = TransformationFactory('contrib.fourier_motzkin_elimination')
         fme.apply_to(m, vars_to_eliminate=disaggregatedVars, do_integer_arithmetic=True)
         # post-process
-        fme.post_process_fme_constraints(m, SolverFactory('glpk'))
+        fme.post_process_fme_constraints(m, SolverFactory('glpk'), tolerance=-1e-4)
 
         constraints = m._pyomo_contrib_fme_transformation.projected_constraints
         self.assertEqual(len(constraints), 11)

--- a/pyomo/contrib/fme/tests/test_fourier_motzkin_elimination.py
+++ b/pyomo/contrib/fme/tests/test_fourier_motzkin_elimination.py
@@ -562,7 +562,7 @@ class TestFourierMotzkinElimination(unittest.TestCase):
         fme = TransformationFactory('contrib.fourier_motzkin_elimination')
         fme.apply_to(m, vars_to_eliminate=disaggregatedVars, do_integer_arithmetic=True)
         # post-process
-        fme.post_process_fme_constraints(m, SolverFactory('glpk'), tolerance=-1e-4)
+        fme.post_process_fme_constraints(m, SolverFactory('glpk'), tolerance=-1e-6)
 
         constraints = m._pyomo_contrib_fme_transformation.projected_constraints
         self.assertEqual(len(constraints), 11)

--- a/pyomo/core/kernel/base.py
+++ b/pyomo/core/kernel/base.py
@@ -156,7 +156,7 @@ class ICategorizedObject(AutoSlots.Mixin):
 
         Args:
             fully_qualified (bool): Generate a full name by
-                iterating through all anscestor containers.
+                iterating through all ancestor containers.
                 Default is :const:`False`.
             convert (function): A function that converts a
                 storage key into a string

--- a/pyomo/core/tests/unit/kernel/test_piecewise.py
+++ b/pyomo/core/tests/unit/kernel/test_piecewise.py
@@ -216,8 +216,10 @@ class Test_util(unittest.TestCase):
 
         tri = util.generate_delaunay(vlist, num=3)
         self.assertTrue(isinstance(tri, util.scipy.spatial.Delaunay))
-        self.assertEqual(len(tri.simplices), 62)
-        self.assertEqual(len(tri.points), 27)
+        # we got some simplices
+        self.assertTrue(len(tri.simplices) > 1)
+        # all the given points are accounted for
+        self.assertEqual(len(tri.points) + len(tri.coplanar), 27)
 
         #
         # Check cases where not all variables are bounded

--- a/pyomo/core/tests/unit/kernel/test_piecewise.py
+++ b/pyomo/core/tests/unit/kernel/test_piecewise.py
@@ -209,19 +209,15 @@ class Test_util(unittest.TestCase):
         vlist.append(variable(lb=0, ub=1))
         vlist.append(variable(lb=1, ub=2))
         vlist.append(variable(lb=2, ub=3))
-        if not (util.numpy_available and util.scipy_available):
-            with self.assertRaises(ImportError):
-                util.generate_delaunay(vlist)
-        else:
-            tri = util.generate_delaunay(vlist, num=2)
-            self.assertTrue(isinstance(tri, util.scipy.spatial.Delaunay))
-            self.assertEqual(len(tri.simplices), 6)
-            self.assertEqual(len(tri.points), 8)
+        tri = util.generate_delaunay(vlist, num=2)
+        self.assertTrue(isinstance(tri, util.scipy.spatial.Delaunay))
+        self.assertEqual(len(tri.simplices), 6)
+        self.assertEqual(len(tri.points), 8)
 
-            tri = util.generate_delaunay(vlist, num=3)
-            self.assertTrue(isinstance(tri, util.scipy.spatial.Delaunay))
-            self.assertEqual(len(tri.simplices), 62)
-            self.assertEqual(len(tri.points), 27)
+        tri = util.generate_delaunay(vlist, num=3)
+        self.assertTrue(isinstance(tri, util.scipy.spatial.Delaunay))
+        self.assertEqual(len(tri.simplices), 62)
+        self.assertEqual(len(tri.points), 27)
 
         #
         # Check cases where not all variables are bounded

--- a/pyomo/core/tests/unit/test_sets.py
+++ b/pyomo/core/tests/unit/test_sets.py
@@ -2979,7 +2979,7 @@ class TestSetsInPython3(unittest.TestCase):
         #
         # While deepcopying a model is generally not supported, this is
         # an easy way to ensure that this simple model is cleanly
-        # clonable.
+        # able to be cloned.
         ref = """1 Set Declarations
     INDEX : Size=1, Index=None, Ordered=Insertion
         Key  : Dimen : Domain : Size : Members

--- a/pyomo/neos/tests/test_neos.py
+++ b/pyomo/neos/tests/test_neos.py
@@ -79,9 +79,6 @@ class TestKestrel(unittest.TestCase):
         doc = pyomo.neos.doc
         dockeys = set(doc.keys())
 
-        # Octeract interface is disabled, see #3321
-        amplsolvers.remove('octeract')
-
         self.assertEqual(amplsolvers, dockeys)
 
         # gamssolvers = set(v[0].lower() for v in tmp if v[1]=='GAMS')
@@ -152,8 +149,9 @@ class RunAllNEOSSolvers(object):
     def test_mosek(self):
         self._run('mosek')
 
-    # [16 Jul 24] Octeract is erroring.  We will disable the interface
+    # [16 Jul 24]: Octeract is erroring.  We will disable the interface
     # (and testing) until we have time to resolve #3321
+    # [20 Sep 24]: and appears to have been removed from NEOS
     #
     # def test_octeract(self):
     #     self._run('octeract')


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
As of 19 Sept it appears that Octeract has been removed from the list of AMPL solvers on NEOS.  This PR tracks that change so that our tests continue to run/pass.

While fixing the Octeract issue a number of other infrastructure issues cropped up so this PR also includes several small fixes for those. 

## Changes proposed in this PR:
- Remove expectation that 'octeract' is in the list of NEOS solvers with AMPL interfaces
- Pin setuptools to <74.0.0 for windows due to an issue with compiling APPSI
- Switch to macos-latest runner on GHA
- Remove degeneracy from GDP book example
- Update a fragile test in kernel Delaunay triangulation
- Add a slight negative tolerance to post processing in FME test to address a numerical issue

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
