### PR TITLE
Resolve bugs in create_node_with_local_data

### DIFF
--- a/pyomo/core/base/expression.py
+++ b/pyomo/core/base/expression.py
@@ -62,7 +62,7 @@ class NamedExpressionData(numeric_expr.NumericValue):
             return arg
         return arg(exception=exception)
 
-    def create_node_with_local_data(self, values):
+    def create_node_with_local_data(self, values, classtype=None):
         """
         Construct a simple expression after constructing the
         contained expression.
@@ -70,7 +70,9 @@ class NamedExpressionData(numeric_expr.NumericValue):
         This class provides a consistent interface for constructing a
         node, which is used in tree visitor scripts.
         """
-        obj = self.__class__()
+        if classtype is None:
+            classtype = self.parent_component()._ComponentDataClass
+        obj = classtype()
         obj._args_ = values
         return obj
 

--- a/pyomo/core/expr/numeric_expr.py
+++ b/pyomo/core/expr/numeric_expr.py
@@ -1094,7 +1094,7 @@ class MonomialTermExpression(ProductExpression):
             # types, the simplest / fastest thing to do is just defer to
             # the operator dispatcher.
             return operator.mul(*args)
-        return self.__class__(args)
+        return classtype(args)
 
 
 class DivisionExpression(NumericExpression):

--- a/pyomo/core/tests/unit/test_expression.py
+++ b/pyomo/core/tests/unit/test_expression.py
@@ -30,6 +30,7 @@ from pyomo.environ import (
     sum_product,
 )
 from pyomo.core.base.expression import ExpressionData
+from pyomo.core.base.objective import ObjectiveData
 from pyomo.core.expr.compare import compare_expressions, assertExpressionsEqual
 from pyomo.common.tee import capture_output
 
@@ -290,6 +291,35 @@ class TestExpressionData(unittest.TestCase):
         self.assertEqual(inst.obj.expr(), 3.0)
         self.assertEqual(id(inst.obj.expr.arg(1)), id(inst.ec))
 
+    def test_create_node_with_local_data(self):
+        m = ConcreteModel()
+        m.x = Var()
+
+        m.e = Expression(expr=m.x)
+        ee = m.e.create_node_with_local_data([5])
+        self.assertIsNot(m.e, ee)
+        self.assertIs(type(ee), ExpressionData)
+        self.assertEqual(ee._args_, [5])
+
+        m.f = Expression([0], rule=lambda m, i: m.x)
+        ff = m.f[0].create_node_with_local_data([5])
+        self.assertIsNot(m.f, ff)
+        self.assertIsNot(m.f[0], ff)
+        self.assertIs(type(ff), ExpressionData)
+        self.assertEqual(ff._args_, [5])
+
+        m.g = Objective(expr=m.x)
+        gg = m.g.create_node_with_local_data([5])
+        self.assertIsNot(m.g, gg)
+        self.assertIs(type(gg), ObjectiveData)
+        self.assertEqual(gg._args_, [5])
+
+        m.h = Objective([0], rule=lambda m, i: m.x)
+        hh = m.h[0].create_node_with_local_data([5])
+        self.assertIsNot(m.h, hh)
+        self.assertIsNot(m.h[0], hh)
+        self.assertIs(type(hh), ObjectiveData)
+        self.assertEqual(hh._args_, [5])
 
 class TestExpression(unittest.TestCase):
     def setUp(self):

--- a/pyomo/core/tests/unit/test_numeric_expr.py
+++ b/pyomo/core/tests/unit/test_numeric_expr.py
@@ -4313,6 +4313,17 @@ class TestCloneExpression(unittest.TestCase):
             total = counter.count - start
             self.assertEqual(total, 1)
 
+    def test_create_node_with_local_data(self):
+        e = self.m.p * self.m.a
+        self.assertIs(type(e), MonomialTermExpression)
+
+        f = e.create_node_with_local_data([self.m.b, self.m.p])
+        self.assertIs(type(f), MonomialTermExpression)
+        self.assertStructuredAlmostEqual(f._args_, [self.m.p, self.m.b])
+
+        g = e.create_node_with_local_data([self.m.b, self.m.p], ProductExpression)
+        self.assertIs(type(g), ProductExpression)
+        self.assertStructuredAlmostEqual(g._args_, [self.m.b, self.m.p])
 
 #
 # Fixed               - Expr has a fixed value


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
IDAES/idaes-pse#1454 found bugs in `ExpressionData`'s implementation of `create_node_with_local_data()`.  In particular, `ScalarExpression.create_node_with_local_data` was returning an *unconstructed* `ScalarExpression`.  This PR resolves that bug (and another found when debugging `create_node_with_local_data`)

## Changes proposed in this PR:
- `ExpressionData.create_node_with_local_data`: always return a bare `ExpressionData` object, even if the original Expression was a `ScalarExpression`.
- Fixing an issue where `MonomialTermExpression.create_node_with_local_data` was ignoring the user-specified classtype argument
- Test both fixes

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
