### PR TITLE
Guard tests against broken Gurobi licenses

### DIFF
--- a/pyomo/contrib/alternative_solutions/lp_enum_solnpool.py
+++ b/pyomo/contrib/alternative_solutions/lp_enum_solnpool.py
@@ -45,9 +45,7 @@ class NoGoodCutGenerator:
         self.num_solutions = num_solutions
 
     def cut_generator_callback(self, cb_m, cb_opt, cb_where):
-        from gurobipy import GRB
-
-        if cb_where == GRB.Callback.MIPSOL:
+        if cb_where == gurobipy.GRB.Callback.MIPSOL:
             cb_opt.cbGetSolution(vars=self.variables)
             logger.info("***FOUND SOLUTION***")
 

--- a/pyomo/contrib/alternative_solutions/solnpool.py
+++ b/pyomo/contrib/alternative_solutions/solnpool.py
@@ -15,8 +15,6 @@ logger = logging.getLogger(__name__)
 
 from pyomo.common.dependencies import attempt_import
 
-gurobipy, gurobipy_available = attempt_import("gurobipy")
-
 import pyomo.environ as pe
 from pyomo.contrib import appsi
 import pyomo.contrib.alternative_solutions.aos_utils as aos_utils
@@ -67,10 +65,7 @@ def gurobi_generate_solutions(
     #
     # Setup gurobi
     #
-    if not gurobipy_available:
-        raise pyomo.common.errors.ApplicationError("Solver (gurobi) not available")
     opt = appsi.solvers.Gurobi()
-
     if not opt.available():
         raise pyomo.common.errors.ApplicationError("Solver (gurobi) not available")
 

--- a/pyomo/contrib/alternative_solutions/tests/test_lp_enum_solnpool.py
+++ b/pyomo/contrib/alternative_solutions/tests/test_lp_enum_solnpool.py
@@ -9,25 +9,29 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-import pyomo.environ as pe
-import pyomo.opt
+from pyomo.common.dependencies import numpy_available
+from pyomo.common import unittest
 
 import pyomo.contrib.alternative_solutions.tests.test_cases as tc
 from pyomo.contrib.alternative_solutions import lp_enum
 from pyomo.contrib.alternative_solutions import lp_enum_solnpool
+from pyomo.opt import check_available_solvers
 
-from pyomo.common.dependencies import attempt_import
+import pyomo.environ as pe
 
-numpy, numpy_available = attempt_import("numpy")
-gurobipy, gurobi_available = attempt_import("gurobipy")
+# lp_enum_solnpool uses both 'gurobi' and 'appsi_gurobi'
+gurobi_available = len(check_available_solvers('gurobi', 'appsi_gurobi')) == 2
 
 #
 # TODO: Setup detailed tests here
 #
 
 
-def test_here():
-    if numpy_available:
+@unittest.skipUnless(gurobi_available, "Gurobi MIP solver not available")
+@unittest.skipUnless(numpy_available, "NumPy not found")
+class TestLPEnumSolnpool(unittest.TestCase):
+
+    def test_here(self):
         n = tc.get_pentagonal_pyramid_mip()
         n.x.domain = pe.Reals
         n.y.domain = pe.Reals

--- a/pyomo/contrib/alternative_solutions/tests/test_solnpool.py
+++ b/pyomo/contrib/alternative_solutions/tests/test_solnpool.py
@@ -9,21 +9,17 @@
 #  This software is distributed under the 3-clause BSD License.
 #  ___________________________________________________________________________
 
-from pyomo.common.dependencies import numpy as numpy, numpy_available
-
-if numpy_available:
-    from numpy.testing import assert_array_almost_equal
-from pyomo.common.dependencies import attempt_import
-
-gurobipy, gurobipy_available = attempt_import("gurobipy")
-
 from collections import Counter
 
-import pyomo.environ as pe
+from pyomo.common.dependencies import numpy as np, numpy_available
 from pyomo.common import unittest
-
 from pyomo.contrib.alternative_solutions import gurobi_generate_solutions
+from pyomo.contrib.appsi.solvers import Gurobi
+
 import pyomo.contrib.alternative_solutions.tests.test_cases as tc
+import pyomo.environ as pe
+
+gurobipy_available = Gurobi().available()
 
 
 @unittest.skipIf(not gurobipy_available, "Gurobi MIP solver not available")
@@ -51,7 +47,7 @@ class TestSolnPoolUnit(unittest.TestCase):
         objectives = [round(result.objective[1], 2) for result in results]
         actual_solns_by_obj = m.num_ranked_solns
         unique_solns_by_obj = [val for val in Counter(objectives).values()]
-        assert_array_almost_equal(unique_solns_by_obj, actual_solns_by_obj)
+        np.testing.assert_array_almost_equal(unique_solns_by_obj, actual_solns_by_obj)
 
     @unittest.skipIf(not numpy_available, "Numpy not installed")
     def test_ip_num_solutions(self):
@@ -66,7 +62,7 @@ class TestSolnPoolUnit(unittest.TestCase):
         objectives = [round(result.objective[1], 2) for result in results]
         actual_solns_by_obj = [6, 2]
         unique_solns_by_obj = [val for val in Counter(objectives).values()]
-        assert_array_almost_equal(unique_solns_by_obj, actual_solns_by_obj)
+        np.testing.assert_array_almost_equal(unique_solns_by_obj, actual_solns_by_obj)
 
     @unittest.skipIf(not numpy_available, "Numpy not installed")
     def test_mip_feasibility(self):
@@ -80,7 +76,7 @@ class TestSolnPoolUnit(unittest.TestCase):
         objectives = [round(result.objective[1], 2) for result in results]
         actual_solns_by_obj = m.num_ranked_solns
         unique_solns_by_obj = [val for val in Counter(objectives).values()]
-        assert_array_almost_equal(unique_solns_by_obj, actual_solns_by_obj)
+        np.testing.assert_array_almost_equal(unique_solns_by_obj, actual_solns_by_obj)
 
     @unittest.skipIf(not numpy_available, "Numpy not installed")
     def test_mip_rel_feasibility(self):
@@ -95,7 +91,7 @@ class TestSolnPoolUnit(unittest.TestCase):
         objectives = [round(result.objective[1], 2) for result in results]
         actual_solns_by_obj = m.num_ranked_solns[0:2]
         unique_solns_by_obj = [val for val in Counter(objectives).values()]
-        assert_array_almost_equal(unique_solns_by_obj, actual_solns_by_obj)
+        np.testing.assert_array_almost_equal(unique_solns_by_obj, actual_solns_by_obj)
 
     @unittest.skipIf(not numpy_available, "Numpy not installed")
     def test_mip_rel_feasibility_options(self):
@@ -112,7 +108,7 @@ class TestSolnPoolUnit(unittest.TestCase):
         objectives = [round(result.objective[1], 2) for result in results]
         actual_solns_by_obj = m.num_ranked_solns[0:2]
         unique_solns_by_obj = [val for val in Counter(objectives).values()]
-        assert_array_almost_equal(unique_solns_by_obj, actual_solns_by_obj)
+        np.testing.assert_array_almost_equal(unique_solns_by_obj, actual_solns_by_obj)
 
     @unittest.skipIf(not numpy_available, "Numpy not installed")
     def test_mip_abs_feasibility(self):
@@ -127,7 +123,7 @@ class TestSolnPoolUnit(unittest.TestCase):
         objectives = [round(result.objective[1], 2) for result in results]
         actual_solns_by_obj = m.num_ranked_solns[0:3]
         unique_solns_by_obj = [val for val in Counter(objectives).values()]
-        assert_array_almost_equal(unique_solns_by_obj, actual_solns_by_obj)
+        np.testing.assert_array_almost_equal(unique_solns_by_obj, actual_solns_by_obj)
 
     @unittest.skipIf(True, "Ignoring fragile test for solver timeout.")
     def test_mip_no_time(self):

--- a/pyomo/contrib/alternative_solutions/tests/test_solution.py
+++ b/pyomo/contrib/alternative_solutions/tests/test_solution.py
@@ -15,8 +15,8 @@ import pyomo.common.unittest as unittest
 import pyomo.contrib.alternative_solutions.aos_utils as au
 from pyomo.contrib.alternative_solutions import Solution
 
-pyomo.opt.check_available_solvers("gurobi")
 mip_solver = "gurobi"
+mip_available = pyomo.opt.check_available_solvers(mip_solver)
 
 
 class TestSolutionUnit(unittest.TestCase):
@@ -40,10 +40,7 @@ class TestSolutionUnit(unittest.TestCase):
         m.con_z = pe.Constraint(expr=m.z <= 3)
         return m
 
-    @unittest.skipUnless(
-        pe.SolverFactory(mip_solver).available(exception_flag=False),
-        "MIP solver not available",
-    )
+    @unittest.skipUnless(mip_available, "MIP solver not available")
     def test_solution(self):
         """
         Create a Solution Object, call its functions, and ensure the correct

--- a/pyomo/solvers/tests/mip/test_qp.py
+++ b/pyomo/solvers/tests/mip/test_qp.py
@@ -53,7 +53,8 @@ class TestQuadraticModels(unittest.TestCase):
         return m
 
     @unittest.skipUnless(
-        gurobi_lp.available(exception_flag=False), "needs Gurobi LP interface"
+        gurobi_lp.available(exception_flag=False) and gurobi_lp.license_is_valid(),
+        "needs Gurobi LP interface"
     )
     def test_qp_objective_gurobi_lp(self):
         m = self._qp_model()
@@ -61,7 +62,8 @@ class TestQuadraticModels(unittest.TestCase):
         self.assertEqual(m.obj(), results['Problem'][0]['Upper bound'])
 
     @unittest.skipUnless(
-        gurobi_nl.available(exception_flag=False), "needs Gurobi NL interface"
+        gurobi_nl.available(exception_flag=False) and gurobi_nl.license_is_valid(),
+        "needs Gurobi NL interface"
     )
     def test_qp_objective_gurobi_nl(self):
         m = self._qp_model()

--- a/pyomo/solvers/tests/mip/test_qp.py
+++ b/pyomo/solvers/tests/mip/test_qp.py
@@ -54,7 +54,7 @@ class TestQuadraticModels(unittest.TestCase):
 
     @unittest.skipUnless(
         gurobi_lp.available(exception_flag=False) and gurobi_lp.license_is_valid(),
-        "needs Gurobi LP interface"
+        "needs Gurobi LP interface",
     )
     def test_qp_objective_gurobi_lp(self):
         m = self._qp_model()
@@ -63,7 +63,7 @@ class TestQuadraticModels(unittest.TestCase):
 
     @unittest.skipUnless(
         gurobi_nl.available(exception_flag=False) and gurobi_nl.license_is_valid(),
-        "needs Gurobi NL interface"
+        "needs Gurobi NL interface",
     )
     def test_qp_objective_gurobi_nl(self):
         m = self._qp_model()


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes # .

## Summary/Motivation:
This resolves a number of tests that fail when Gurobi (or `gurobipy` is installed on the system, but the license is not currently valid (e.g., expired).

## Changes proposed in this PR:
- Guard tests: skip when Gurobi is present but not licensed
- Simplify some import management in AOS

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
