### PR TITLE
Support `Param.pprint()` for non-finite Params

### DIFF
--- a/pyomo/core/base/param.py
+++ b/pyomo/core/base/param.py
@@ -894,8 +894,12 @@ class Param(IndexedComponent, IndexedComponent_NDArrayMixin):
             dataGen = lambda k, v: [v._value]
         else:
             dataGen = lambda k, v: [v]
+        if self.index_set().isfinite() or self._default_val is Param.NoValue:
+            _len = len(self)
+        else:
+            _len = 'inf'
         headers = [
-            ("Size", len(self)),
+            ("Size", _len),
             ("Index", self._index_set if self.is_indexed() else None),
             ("Domain", self.domain.name),
             ("Default", default),

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -1572,11 +1572,11 @@ q : Size=0, Index=None, Domain=Any, Default=None, Mutable=False
         self.assertEqual(
             OUT.getvalue(),
             "p : Size=inf, Index=Any, Domain=Any, Default=1, Mutable=False\n"
-            "    Key : Value\n"
+            "    Key : Value\n",
         )
 
         # Other useful checks
-        m.q = Param(Any, default=1, initialize={1:2, 'a':3, 'bb': 4})
+        m.q = Param(Any, default=1, initialize={1: 2, 'a': 3, 'bb': 4})
         OUT = StringIO()
         m.q.pprint(OUT)
         self.assertEqual(
@@ -1585,10 +1585,10 @@ q : Size=0, Index=None, Domain=Any, Default=None, Mutable=False
             "    Key : Value\n"
             "      1 :     2\n"
             "      a :     3\n"
-            "     bb :     4\n"
+            "     bb :     4\n",
         )
 
-        m.r = Param(Any, initialize={1:2, 'a':3, 'bb': 4})
+        m.r = Param(Any, initialize={1: 2, 'a': 3, 'bb': 4})
         OUT = StringIO()
         m.r.pprint(OUT)
         self.assertEqual(
@@ -1597,11 +1597,11 @@ q : Size=0, Index=None, Domain=Any, Default=None, Mutable=False
             "    Key : Value\n"
             "      1 :     2\n"
             "      a :     3\n"
-            "     bb :     4\n"
+            "     bb :     4\n",
         )
 
         # Other useful (mutable) checks
-        m.q = Param(Any, default=1, mutable=True, initialize={1:2, 'a':3, 'bb': 4})
+        m.q = Param(Any, default=1, mutable=True, initialize={1: 2, 'a': 3, 'bb': 4})
         OUT = StringIO()
         m.q.pprint(OUT)
         self.assertEqual(
@@ -1610,10 +1610,10 @@ q : Size=0, Index=None, Domain=Any, Default=None, Mutable=False
             "    Key : Value\n"
             "      1 :     2\n"
             "      a :     3\n"
-            "     bb :     4\n"
+            "     bb :     4\n",
         )
 
-        m.r = Param(Any, mutable=True, initialize={1:2, 'a':3, 'bb': 4})
+        m.r = Param(Any, mutable=True, initialize={1: 2, 'a': 3, 'bb': 4})
         OUT = StringIO()
         m.r.pprint(OUT)
         self.assertEqual(
@@ -1622,7 +1622,7 @@ q : Size=0, Index=None, Domain=Any, Default=None, Mutable=False
             "    Key : Value\n"
             "      1 :     2\n"
             "      a :     3\n"
-            "     bb :     4\n"
+            "     bb :     4\n",
         )
 
 

--- a/pyomo/core/tests/unit/test_param.py
+++ b/pyomo/core/tests/unit/test_param.py
@@ -1561,6 +1561,70 @@ q : Size=0, Index=None, Domain=Any, Default=None, Mutable=False
         m.p = 20
         self.assertEqual(m.x_p.bounds, (0, 20))
 
+    def test_nonfinite_pprint(self):
+        m = ConcreteModel()
+
+        # Test from #3379
+        m.p = Param(Any, default=1)
+        self.assertEqual(m.p['foo'], 1)
+        OUT = StringIO()
+        m.p.pprint(OUT)
+        self.assertEqual(
+            OUT.getvalue(),
+            "p : Size=inf, Index=Any, Domain=Any, Default=1, Mutable=False\n"
+            "    Key : Value\n"
+        )
+
+        # Other useful checks
+        m.q = Param(Any, default=1, initialize={1:2, 'a':3, 'bb': 4})
+        OUT = StringIO()
+        m.q.pprint(OUT)
+        self.assertEqual(
+            OUT.getvalue(),
+            "q : Size=inf, Index=Any, Domain=Any, Default=1, Mutable=False\n"
+            "    Key : Value\n"
+            "      1 :     2\n"
+            "      a :     3\n"
+            "     bb :     4\n"
+        )
+
+        m.r = Param(Any, initialize={1:2, 'a':3, 'bb': 4})
+        OUT = StringIO()
+        m.r.pprint(OUT)
+        self.assertEqual(
+            OUT.getvalue(),
+            "r : Size=3, Index=Any, Domain=Any, Default=None, Mutable=False\n"
+            "    Key : Value\n"
+            "      1 :     2\n"
+            "      a :     3\n"
+            "     bb :     4\n"
+        )
+
+        # Other useful (mutable) checks
+        m.q = Param(Any, default=1, mutable=True, initialize={1:2, 'a':3, 'bb': 4})
+        OUT = StringIO()
+        m.q.pprint(OUT)
+        self.assertEqual(
+            OUT.getvalue(),
+            "q : Size=inf, Index=Any, Domain=Any, Default=1, Mutable=True\n"
+            "    Key : Value\n"
+            "      1 :     2\n"
+            "      a :     3\n"
+            "     bb :     4\n"
+        )
+
+        m.r = Param(Any, mutable=True, initialize={1:2, 'a':3, 'bb': 4})
+        OUT = StringIO()
+        m.r.pprint(OUT)
+        self.assertEqual(
+            OUT.getvalue(),
+            "r : Size=3, Index=Any, Domain=Any, Default=None, Mutable=True\n"
+            "    Key : Value\n"
+            "      1 :     2\n"
+            "      a :     3\n"
+            "     bb :     4\n"
+        )
+
 
 def createNonIndexedParamMethod(func, init_xy, new_xy, tol=1e-10):
     def testMethod(self):


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

<!-- DO NOT DELETE OR IGNORE THIS TEMPLATE. Failing to adhere to this template and provide the necessary information may lead to your Pull Request being closed without consideration. -->

## Fixes #3379 .

## Summary/Motivation:
This resolves an error where non-finite Params were not pretty-printable (because the Param had no `len()`).

## Changes proposed in this PR:
- Correctly print `Size=inf` for non-finite Params
- Test the expected behavior (including example from #3379)

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
